### PR TITLE
[To rel/1.2] Fix SchemaTree.hasView check during query analysis

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/ClusterSchemaTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/ClusterSchemaTree.java
@@ -267,7 +267,9 @@ public class ClusterSchemaTree implements ISchemaTree {
           }
           measurementNode.setTagMap(tagMap);
           child = measurementNode;
-          this.hasLogicalMeasurementPath = true;
+          if (schema.isLogicalView()) {
+            this.hasLogicalMeasurementPath = true;
+          }
         } else if (i == nodes.length - 2) {
           SchemaEntityNode entityNode = new SchemaEntityNode(nodes[i]);
           entityNode.setAligned(isAligned);

--- a/server/src/test/java/org/apache/iotdb/db/mpp/common/schematree/ClusterSchemaTreeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/common/schematree/ClusterSchemaTreeTest.java
@@ -21,6 +21,8 @@ package org.apache.iotdb.db.mpp.common.schematree;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.schema.view.LogicalViewSchema;
+import org.apache.iotdb.commons.schema.view.viewExpression.leaf.TimeSeriesViewOperand;
 import org.apache.iotdb.db.mpp.common.schematree.node.SchemaEntityNode;
 import org.apache.iotdb.db.mpp.common.schematree.node.SchemaInternalNode;
 import org.apache.iotdb.db.mpp.common.schematree.node.SchemaMeasurementNode;
@@ -727,5 +729,24 @@ public class ClusterSchemaTreeTest {
           boolean isPrefixMatch) {
     return SchemaTreeVisitorFactory.createSchemaTreeMeasurementVisitor(
         root, pathPattern, isPrefixMatch, slimit, soffset);
+  }
+
+  @Test
+  public void testHasView() throws IllegalPathException {
+    ClusterSchemaTree schemaTree = new ClusterSchemaTree();
+    schemaTree.appendSingleMeasurement(
+        new PartialPath("root.db.db.s1"),
+        new MeasurementSchema("s1", TSDataType.INT32),
+        null,
+        null,
+        false);
+    Assert.assertFalse(schemaTree.hasLogicalViewMeasurement());
+    schemaTree.appendSingleMeasurement(
+        new PartialPath("root.db.view.s1"),
+        new LogicalViewSchema("s1", new TimeSeriesViewOperand("root.db.d.s1")),
+        null,
+        null,
+        false);
+    Assert.assertTrue(schemaTree.hasLogicalViewMeasurement());
   }
 }


### PR DESCRIPTION
## Description

When constructing a SchemaTree, there's mistake on setting value ```hasViewMeasurement```, which results in the useless check in query without view.

Fix ```hasViewMeasurement``` updation.