### PR TITLE
[IOTDB-5965] Pipe: failed to transfer insert node when using schema template

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/pipe/core/connector/impl/iotdb/v1/request/PipeTransferInsertNodeReq.java
+++ b/server/src/main/java/org/apache/iotdb/db/pipe/core/connector/impl/iotdb/v1/request/PipeTransferInsertNodeReq.java
@@ -50,8 +50,9 @@ public class PipeTransferInsertNodeReq extends TPipeTransferReq {
       statement.setMeasurements(node.getMeasurements());
       statement.setDataTypes(node.getDataTypes());
       statement.setValues(node.getValues());
-      statement.setNeedInferType(true);
+      statement.setNeedInferType(node.isNeedInferType());
       statement.setAligned(node.isAligned());
+      statement.setMeasurementSchemas(node.getMeasurementSchemas());
       return statement;
     }
 
@@ -67,6 +68,7 @@ public class PipeTransferInsertNodeReq extends TPipeTransferReq {
       statement.setRowCount(node.getRowCount());
       statement.setDataTypes(node.getDataTypes());
       statement.setAligned(node.isAligned());
+      statement.setMeasurementSchemas(node.getMeasurementSchemas());
       return statement;
     }
 


### PR DESCRIPTION
See IOTDB-5965 for more details.

![image](https://github.com/apache/iotdb/assets/30497621/99e8d371-8053-4232-aec8-eb4806e50888)

