### PR TITLE
[To rel/1.2] Add schema_ engine_mode config to iotdb-commons.properties and User-Guide

### DIFF
--- a/docs/UserGuide/Reference/Common-Config-Manual.md
+++ b/docs/UserGuide/Reference/Common-Config-Manual.md
@@ -371,6 +371,15 @@ Different configuration parameters take effect in the following three ways:
 
 ### Schema Engine Configuration
 
+* schema\_engine\_mode
+
+|名字| schema\_engine\_mode |
+|:---:|:---|
+|Description| Schema engine mode, supporting Memory and Schema_File modes; Schema_File mode support evict the timeseries schema temporarily not used in memory at runtime, and load it into memory from disk when needed. This parameter must be the same on all DataNodes in one cluster.|
+|Type| string |
+|Default| Memory |
+|Effective| Only allowed to be modified in first start up |
+
 * mlog\_buffer\_size
 
 |Name| mlog\_buffer\_size |

--- a/docs/zh/UserGuide/Reference/Common-Config-Manual.md
+++ b/docs/zh/UserGuide/Reference/Common-Config-Manual.md
@@ -364,6 +364,15 @@ IoTDB ConfigNode 和 DataNode 的公共配置参数位于 `conf` 目录下。
 
 #### 元数据引擎配置
 
+* schema\_engine\_mode
+
+|名字| schema\_engine\_mode |
+|:---:|:---|
+|描述| 元数据引擎的运行模式，支持 Memory 和 Schema_File两种模式；Schema_File 模式下支持将内存中暂时不用的序列元数据实时置换到磁盘上，需要使用时再加载进内存；此参数在集群中所有的 DataNode 上务必保持相同。|
+|类型| string |
+|默认值| Memory |
+|改后生效方式|仅允许在第一次启动服务前修改|
+
 * mlog\_buffer\_size
 
 |名字| mlog\_buffer\_size |

--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -248,6 +248,11 @@ cluster_name=defaultCluster
 ### Schema Engine Configuration
 ####################
 
+# The schema management mode of schema engine. Currently support Memory and Schema_File.
+# This config of all DataNodes in one cluster must keep same.
+# Datatype: string
+# schema_engine_mode=Memory
+
 # thread pool size for read operation in DataNode's coordinator.
 # Datatype: int
 # coordinator_read_executor_size=20


### PR DESCRIPTION
## Description

Since the schema_file mode of schema engine is ready for release, add schema_ engine_mode config to iotdb-commons.properties and User-Guide.

reference https://apache-iotdb.feishu.cn/docx/RcPzdulXuozjzCx8GrCccVT6nph
