### PR TITLE
[To rel/1.1] fix tsfileResource error after delete device in sequence working memtable

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/TsFileResource.java
@@ -1112,8 +1112,17 @@ public class TsFileResource {
     }
   }
 
-  public void updateEndTime(Map<String, Long> times) {
-    for (Map.Entry<String, Long> entry : times.entrySet()) {
+  public void deleteRemovedDeviceAndUpdateEndTime(Map<String, Long> lastTimeForEachDevice) {
+    ITimeIndex newTimeIndex = CONFIG.getTimeIndexLevel().getTimeIndex();
+    for (Map.Entry<String, Long> entry : lastTimeForEachDevice.entrySet()) {
+      newTimeIndex.updateStartTime(entry.getKey(), timeIndex.getStartTime(entry.getKey()));
+      newTimeIndex.updateEndTime(entry.getKey(), entry.getValue());
+    }
+    timeIndex = newTimeIndex;
+  }
+
+  public void updateEndTime(Map<String, Long> lastTimeForEachDevice) {
+    for (Map.Entry<String, Long> entry : lastTimeForEachDevice.entrySet()) {
       timeIndex.updateEndTime(entry.getKey(), entry.getValue());
     }
   }

--- a/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/DataRegionTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/engine/storagegroup/DataRegionTest.java
@@ -1119,6 +1119,33 @@ public class DataRegionTest {
   }
 
   @Test
+  public void testDeleteDataInSeqWorkingMemtable()
+      throws IllegalPathException, WriteProcessException, IOException {
+    for (int j = 100; j < 200; j++) {
+      TSRecord record = new TSRecord(j, "root.vehicle.d0");
+      record.addTuple(DataPoint.getDataPoint(TSDataType.INT32, measurementId, String.valueOf(j)));
+      dataRegion.insert(buildInsertRowNodeByTSRecord(record));
+    }
+    for (int j = 100; j < 200; j++) {
+      TSRecord record = new TSRecord(j, "root.vehicle.d199");
+      record.addTuple(DataPoint.getDataPoint(TSDataType.INT32, measurementId, String.valueOf(j)));
+      dataRegion.insert(buildInsertRowNodeByTSRecord(record));
+    }
+    TsFileResource tsFileResource = dataRegion.getTsFileManager().getTsFileList(true).get(0);
+
+    // delete data which is not in working memtable
+    dataRegion.deleteByDevice(new PartialPath("root.vehicle.d0.s0"), 50, 99, 0, null);
+    dataRegion.deleteByDevice(new PartialPath("root.vehicle.d200.s0"), 50, 70, 0, null);
+
+    // delete data which is in working memtable
+    dataRegion.deleteByDevice(new PartialPath("root.vehicle.d199.*"), 50, 500, 0, null);
+
+    dataRegion.syncCloseAllWorkingTsFileProcessors();
+    Assert.assertFalse(tsFileResource.getModFile().exists());
+    Assert.assertFalse(tsFileResource.getDevices().contains("root.vehicle.d199"));
+  }
+
+  @Test
   public void testFlushingEmptyMemtable()
       throws IllegalPathException, WriteProcessException, IOException {
     for (int j = 100; j < 200; j++) {


### PR DESCRIPTION
## Description

This bug will cause TsfileResource contains a device with endTime=Long.minValue. 

To reproduce, execute the following sql:

```
insert into root.sg.d1(time,s1) values(1,2)
insert into root.sg.d2(time,s1) values(1,2)
insert into root.sg.d3(time,s1) values(1,2)
delete from root.sg.d2.*
flush
```
Then use TsFileResourcePrinter to print the resource file.
```
Analyzing /Users/ht/Documents/iotdb/data/datanode/data/sequence/root.sg/2/0/1685960618341-1-0-0.tsfile ...

Resource plan index range [9223372036854775807, -9223372036854775808]
device root.sg.d2, start time 1 (1970-01-01T08:00:00.001), end time -9223372036854775808 (-292275055-05-17T00:52:47.192)
device root.sg.d3, start time 1 (1970-01-01T08:00:00.001), end time 1 (1970-01-01T08:00:00.001)

Analyzing the resource file folder data/datanode/data/sequence/root.sg/2/0 finished.

Process finished with exit code 0
```