### PR TITLE
[IOTDB-5970] Fix the info of order by when sortkey doesn't exist

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
@@ -1287,7 +1287,8 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       if (!lastQueryColumnNames.contains(sortKey.toUpperCase())) {
         throw new SemanticException(
             String.format(
-                "%s in ORDER BY clause should exist in the result of last query.", sortKey));
+                "SortKey:%s in ORDER BY clause should exist in the result of last query.",
+                sortKey));
       }
     }
   }
@@ -1304,8 +1305,8 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       if (expressions.size() != 1) {
         throw new SemanticException(
             String.format(
-                "%s in ORDER BY clause should exist and indicate only one value",
-                expressionForItem.getExpressionString()));
+                "SortKey:%s in ORDER BY clause should indicate one value, got %d",
+                expressionForItem.getExpressionString(), expressions.size()));
       }
       expressionForItem = ExpressionAnalyzer.removeAliasFromExpression(expressions.get(0));
       TSDataType dataType = analyzeExpression(analysis, expressionForItem);
@@ -1417,8 +1418,8 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
         if (expressions.size() != 1) {
           throw new SemanticException(
               String.format(
-                  "One sort item in order by should only indicate one value, got %s value(s)",
-                  expressions.size()));
+                  "SortKey:%s in ORDER BY clause should indicate one value, got %s",
+                  expressionForItem.getExpressionString(), expressions.size()));
         }
         expressionForItem = expressions.get(0);
         TSDataType dataType = analyzeExpression(analysis, expressionForItem);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
@@ -1287,8 +1287,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       if (!lastQueryColumnNames.contains(sortKey.toUpperCase())) {
         throw new SemanticException(
             String.format(
-                "SortKey:%s in ORDER BY clause should exist in the result of last query.",
-                sortKey));
+                "%s in order by clause doesn't exist in the result of last query.", sortKey));
       }
     }
   }
@@ -1302,17 +1301,22 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       // Expression in a sortItem only indicates one column
       List<Expression> expressions =
           ExpressionAnalyzer.bindSchemaForExpression(expressionForItem, schemaTree);
-      if (expressions.size() != 1) {
+      if (expressions.size() == 0) {
         throw new SemanticException(
             String.format(
-                "SortKey:%s in ORDER BY clause should indicate one value, got %d",
-                expressionForItem.getExpressionString(), expressions.size()));
+                "%s in order by clause doesn't exist.", expressionForItem.getExpressionString()));
+      }
+      if (expressions.size() > 1) {
+        throw new SemanticException(
+            String.format(
+                "%s in order by clause shouldn't refer to more than one timeseries.",
+                expressionForItem.getExpressionString()));
       }
       expressionForItem = ExpressionAnalyzer.removeAliasFromExpression(expressions.get(0));
       TSDataType dataType = analyzeExpression(analysis, expressionForItem);
       if (!dataType.isComparable()) {
         throw new SemanticException(
-            String.format("The data type of sort item %s is not comparable", dataType));
+            String.format("The data type of %s is not comparable", dataType));
       }
       orderByExpressions.add(expressionForItem);
     }
@@ -1415,17 +1419,22 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
         List<Expression> expressions =
             ExpressionAnalyzer.concatDeviceAndBindSchemaForExpression(
                 expressionForItem, device, schemaTree);
-        if (expressions.size() != 1) {
+        if (expressions.size() == 0) {
           throw new SemanticException(
               String.format(
-                  "SortKey:%s in ORDER BY clause should indicate one value, got %s",
-                  expressionForItem.getExpressionString(), expressions.size()));
+                  "%s in order by clause doesn't exist.", expressionForItem.getExpressionString()));
+        }
+        if (expressions.size() > 1) {
+          throw new SemanticException(
+              String.format(
+                  "%s in order by clause shouldn't refer to more than one timeseries.",
+                  expressionForItem.getExpressionString()));
         }
         expressionForItem = expressions.get(0);
         TSDataType dataType = analyzeExpression(analysis, expressionForItem);
         if (!dataType.isComparable()) {
           throw new SemanticException(
-              String.format("The data type of sort item %s is not comparable", dataType));
+              String.format("The data type of %s is not comparable", dataType));
         }
 
         Expression devicerViewExpression =

--- a/site/src/main/.vuepress/sidebar/V1.0.x/en.ts
+++ b/site/src/main/.vuepress/sidebar/V1.0.x/en.ts
@@ -138,7 +138,6 @@ export const enSidebar = {
         { text: 'Where Condition', link: 'Where-Condition' },
         { text: 'Group By', link: 'Group-By' },
         { text: 'Having Condition', link: 'Having-Condition' },
-        // { text:  'Order By', link: 'Order-By' },
         { text: 'Fill Null Value', link: 'Fill' },
         { text: 'Pagination', link: 'Pagination' },
         { text: 'Select Into', link: 'Select-Into' },

--- a/site/src/main/.vuepress/sidebar/V1.0.x/zh.ts
+++ b/site/src/main/.vuepress/sidebar/V1.0.x/zh.ts
@@ -138,7 +138,6 @@ export const zhSidebar = {
         { text: '查询过滤条件', link: 'Where-Condition' },
         { text: '分段分组聚合', link: 'Group-By' },
         { text: '聚合结果过滤', link: 'Having-Condition' },
-        // { text:'结果集排序', link: 'Order-By' },
         { text: '结果集补空值', link: 'Fill' },
         { text: '结果集分页', link: 'Pagination' },
         { text: '查询写回', link: 'Select-Into' },

--- a/site/src/main/.vuepress/sidebar/V1.1.x/en.ts
+++ b/site/src/main/.vuepress/sidebar/V1.1.x/en.ts
@@ -148,7 +148,7 @@ export const enSidebar = {
         { text: 'Where Condition', link: 'Where-Condition' },
         { text: 'Group By', link: 'Group-By' },
         { text: 'Having Condition', link: 'Having-Condition' },
-        // { text:  'Order By', link: 'Order-By' },
+        { text: 'Order By', link: 'Order-By' },
         { text: 'Fill Null Value', link: 'Fill' },
         { text: 'Pagination', link: 'Pagination' },
         { text: 'Select Into', link: 'Select-Into' },

--- a/site/src/main/.vuepress/sidebar/V1.1.x/zh.ts
+++ b/site/src/main/.vuepress/sidebar/V1.1.x/zh.ts
@@ -148,7 +148,7 @@ export const zhSidebar = {
         { text: '查询过滤条件', link: 'Where-Condition' },
         { text: '分段分组聚合', link: 'Group-By' },
         { text: '聚合结果过滤', link: 'Having-Condition' },
-        // { text:'结果集排序', link: 'Order-By' },
+        { text: '结果集排序', link: 'Order-By' },
         { text: '结果集补空值', link: 'Fill' },
         { text: '结果集分页', link: 'Pagination' },
         { text: '查询写回', link: 'Select-Into' },

--- a/site/src/main/.vuepress/sidebar/V1.2.x/en.ts
+++ b/site/src/main/.vuepress/sidebar/V1.2.x/en.ts
@@ -148,7 +148,7 @@ export const enSidebar = {
         { text: 'Where Condition', link: 'Where-Condition' },
         { text: 'Group By', link: 'Group-By' },
         { text: 'Having Condition', link: 'Having-Condition' },
-        // { text:  'Order By', link: 'Order-By' },
+        { text: 'Order By', link: 'Order-By' },
         { text: 'Fill Null Value', link: 'Fill' },
         { text: 'Pagination', link: 'Pagination' },
         { text: 'Select Into', link: 'Select-Into' },

--- a/site/src/main/.vuepress/sidebar/V1.2.x/zh.ts
+++ b/site/src/main/.vuepress/sidebar/V1.2.x/zh.ts
@@ -148,7 +148,7 @@ export const zhSidebar = {
         { text: '查询过滤条件', link: 'Where-Condition' },
         { text: '分段分组聚合', link: 'Group-By' },
         { text: '聚合结果过滤', link: 'Having-Condition' },
-        // { text:'结果集排序', link: 'Order-By' },
+        { text: '结果集排序', link: 'Order-By' },
         { text: '结果集补空值', link: 'Fill' },
         { text: '结果集分页', link: 'Pagination' },
         { text: '查询写回', link: 'Select-Into' },

--- a/site/src/main/.vuepress/sidebar/en.ts
+++ b/site/src/main/.vuepress/sidebar/en.ts
@@ -154,7 +154,7 @@ export const enSidebar = sidebar({
         { text: 'Where Condition', link: 'Where-Condition' },
         { text: 'Group By', link: 'Group-By' },
         { text: 'Having Condition', link: 'Having-Condition' },
-        // { text:  'Order By', link: 'Order-By' },
+        { text: 'Order By', link: 'Order-By' },
         { text: 'Fill Null Value', link: 'Fill' },
         { text: 'Pagination', link: 'Pagination' },
         { text: 'Select Into', link: 'Select-Into' },

--- a/site/src/main/.vuepress/sidebar/zh.ts
+++ b/site/src/main/.vuepress/sidebar/zh.ts
@@ -154,7 +154,7 @@ export const zhSidebar = sidebar({
         { text: '查询过滤条件', link: 'Where-Condition' },
         { text: '分段分组聚合', link: 'Group-By' },
         { text: '聚合结果过滤', link: 'Having-Condition' },
-        // { text:'结果集排序', link: 'Order-By' },
+        { text: '结果集排序', link: 'Order-By' },
         { text: '结果集补空值', link: 'Fill' },
         { text: '结果集分页', link: 'Pagination' },
         { text: '查询写回', link: 'Select-Into' },


### PR DESCRIPTION
This pr fix the info when the sortkey doesn't exist and fix the docs in site of order by.
The original output in normal query:
```md
IoTDB> select soc,vehicle_status from root.sg.beijing.car01 order by s1
Msg: 701: One sort item in order by should only indicate one value
```
In last query:
```md
IoTDB> select last soc,vehicle_status from root.sg.beijing.car01 order by s1
Msg: 301: ComparatorChains must contain at least one Comparator
```
Which won't show the info about the problem of sortKey, after this pr the info should be:
```md
IoTDB> select soc,vehicle_status from root.sg.beijing.car01 order by s1
Msg: 701: root.**.s1 in order by clause doesn't exist.
```
```md
IoTDB> select soc,vehicle_status from root.** order by soc
Msg: 701: root.**.soc in order by clause shouldn't refer to more than one timeseries.
```
```md
IoTDB> select last soc,vehicle_status from root.sg.beijing.car01 order by s1
Msg: 701: s1 in order by clause doesn't exist in the result of last query.
```

