### PR TITLE
[To rel/1.2] [IOTDB-5975] Fix NPE in cpu metrics

### DIFF
--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/cpu/CpuUsageMetrics.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/cpu/CpuUsageMetrics.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.metrics.metricsets.cpu;
 
 import org.apache.iotdb.metrics.AbstractMetricService;
+import org.apache.iotdb.metrics.config.MetricConfigDescriptor;
 import org.apache.iotdb.metrics.metricsets.IMetricSet;
 import org.apache.iotdb.metrics.type.AutoGauge;
 import org.apache.iotdb.metrics.utils.MetricLevel;
@@ -143,6 +144,11 @@ public class CpuUsageMetrics implements IMetricSet {
   }
 
   private synchronized void checkAndMayUpdate() {
+    if (!MetricLevel.higherOrEqual(
+        MetricLevel.IMPORTANT,
+        MetricConfigDescriptor.getInstance().getMetricConfig().getMetricLevel())) {
+      return;
+    }
     long currentTime = System.currentTimeMillis();
     if (currentTime - lastUpdateTime.get() > UPDATE_INTERVAL) {
       lastUpdateTime.set(currentTime);

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/cpu/CpuUsageMetrics.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/cpu/CpuUsageMetrics.java
@@ -246,11 +246,11 @@ public class CpuUsageMetrics implements IMetricSet {
       long id = threadInfo.getThreadId();
       long beforeCpuTime = beforeThreadCpuTime.getOrDefault(id, 0L);
       long afterCpuTime = afterThreadCpuTime.get(id);
-      long beforeUserTime = beforeThreadUserTime.getOrDefault(id, 0L);
-      long afterUserTime = afterThreadUserTime.get(id);
       if (afterCpuTime < beforeCpuTime) {
         continue;
       }
+      long beforeUserTime = beforeThreadUserTime.getOrDefault(id, 0L);
+      long afterUserTime = afterThreadUserTime.get(id);
       totalIncrementTime += afterCpuTime - beforeCpuTime;
       String module = getThreadModuleById(id, threadInfo);
       String pool = getThreadPoolById(id, threadInfo);

--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/DataNodeMetricsHelper.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/DataNodeMetricsHelper.java
@@ -33,12 +33,14 @@ import org.apache.iotdb.db.mpp.metric.QueryPlanCostMetricSet;
 import org.apache.iotdb.db.mpp.metric.QueryRelatedResourceMetricSet;
 import org.apache.iotdb.db.mpp.metric.QueryResourceMetricSet;
 import org.apache.iotdb.db.mpp.metric.SeriesScanCostMetricSet;
+import org.apache.iotdb.metrics.config.MetricConfigDescriptor;
 import org.apache.iotdb.metrics.metricsets.UpTimeMetrics;
 import org.apache.iotdb.metrics.metricsets.cpu.CpuUsageMetrics;
 import org.apache.iotdb.metrics.metricsets.disk.DiskMetrics;
 import org.apache.iotdb.metrics.metricsets.jvm.JvmMetrics;
 import org.apache.iotdb.metrics.metricsets.logback.LogbackMetrics;
 import org.apache.iotdb.metrics.metricsets.net.NetMetrics;
+import org.apache.iotdb.metrics.utils.MetricLevel;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -75,16 +77,20 @@ public class DataNodeMetricsHelper {
   }
 
   private static void initCpuMetrics() {
-    List<String> threadModules = new ArrayList<>();
-    Arrays.stream(DataNodeThreadModule.values()).forEach(x -> threadModules.add(x.toString()));
-    List<String> pools = new ArrayList<>();
-    Arrays.stream(ThreadName.values()).forEach(x -> pools.add(x.name()));
-    MetricService.getInstance()
-        .addMetricSet(
-            new CpuUsageMetrics(
-                threadModules,
-                pools,
-                x -> ThreadName.getModuleTheThreadBelongs(x).toString(),
-                x -> ThreadName.getThreadPoolTheThreadBelongs(x).name()));
+    if (MetricLevel.higherOrEqual(
+        MetricLevel.IMPORTANT,
+        MetricConfigDescriptor.getInstance().getMetricConfig().getMetricLevel())) {
+      List<String> threadModules = new ArrayList<>();
+      Arrays.stream(DataNodeThreadModule.values()).forEach(x -> threadModules.add(x.toString()));
+      List<String> pools = new ArrayList<>();
+      Arrays.stream(ThreadName.values()).forEach(x -> pools.add(x.name()));
+      MetricService.getInstance()
+          .addMetricSet(
+              new CpuUsageMetrics(
+                  threadModules,
+                  pools,
+                  x -> ThreadName.getModuleTheThreadBelongs(x).toString(),
+                  x -> ThreadName.getThreadPoolTheThreadBelongs(x).name()));
+    }
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/DataNodeMetricsHelper.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/DataNodeMetricsHelper.java
@@ -33,14 +33,12 @@ import org.apache.iotdb.db.mpp.metric.QueryPlanCostMetricSet;
 import org.apache.iotdb.db.mpp.metric.QueryRelatedResourceMetricSet;
 import org.apache.iotdb.db.mpp.metric.QueryResourceMetricSet;
 import org.apache.iotdb.db.mpp.metric.SeriesScanCostMetricSet;
-import org.apache.iotdb.metrics.config.MetricConfigDescriptor;
 import org.apache.iotdb.metrics.metricsets.UpTimeMetrics;
 import org.apache.iotdb.metrics.metricsets.cpu.CpuUsageMetrics;
 import org.apache.iotdb.metrics.metricsets.disk.DiskMetrics;
 import org.apache.iotdb.metrics.metricsets.jvm.JvmMetrics;
 import org.apache.iotdb.metrics.metricsets.logback.LogbackMetrics;
 import org.apache.iotdb.metrics.metricsets.net.NetMetrics;
-import org.apache.iotdb.metrics.utils.MetricLevel;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -77,20 +75,17 @@ public class DataNodeMetricsHelper {
   }
 
   private static void initCpuMetrics() {
-    if (MetricLevel.higherOrEqual(
-        MetricLevel.IMPORTANT,
-        MetricConfigDescriptor.getInstance().getMetricConfig().getMetricLevel())) {
-      List<String> threadModules = new ArrayList<>();
-      Arrays.stream(DataNodeThreadModule.values()).forEach(x -> threadModules.add(x.toString()));
-      List<String> pools = new ArrayList<>();
-      Arrays.stream(ThreadName.values()).forEach(x -> pools.add(x.name()));
-      MetricService.getInstance()
-          .addMetricSet(
-              new CpuUsageMetrics(
-                  threadModules,
-                  pools,
-                  x -> ThreadName.getModuleTheThreadBelongs(x).toString(),
-                  x -> ThreadName.getThreadPoolTheThreadBelongs(x).name()));
-    }
+
+    List<String> threadModules = new ArrayList<>();
+    Arrays.stream(DataNodeThreadModule.values()).forEach(x -> threadModules.add(x.toString()));
+    List<String> pools = new ArrayList<>();
+    Arrays.stream(ThreadName.values()).forEach(x -> pools.add(x.name()));
+    MetricService.getInstance()
+        .addMetricSet(
+            new CpuUsageMetrics(
+                threadModules,
+                pools,
+                x -> ThreadName.getModuleTheThreadBelongs(x).toString(),
+                x -> ThreadName.getThreadPoolTheThreadBelongs(x).name()));
   }
 }


### PR DESCRIPTION
See [IOTDB-5975](https://issues.apache.org/jira/browse/IOTDB-5975).

The reason for this bug is that, when a thread is no longer alive, the result of `ThreadMXBean.getThreadInfoById` will return null for this thread. To solve this bug, I check the return value and filter the null value out of the result.