### PR TITLE
Fix reconnect logic of python client

### DIFF
--- a/iotdb-client/client-py/iotdb/sqlalchemy/IoTDBSQLCompiler.py
+++ b/iotdb-client/client-py/iotdb/sqlalchemy/IoTDBSQLCompiler.py
@@ -66,9 +66,7 @@ class IoTDBSQLCompiler(SQLCompiler):
 
         kwargs["within_columns_clause"] = False
 
-        compile_state = select_stmt._compile_state_factory(
-            select_stmt, self, **kwargs
-        )
+        compile_state = select_stmt._compile_state_factory(select_stmt, self, **kwargs)
         select_stmt = compile_state.statement
 
         toplevel = not self.stack
@@ -101,9 +99,9 @@ class IoTDBSQLCompiler(SQLCompiler):
         entry = self._default_stack_entry if toplevel else self.stack[-1]
 
         populate_result_map = need_column_expressions = (
-                toplevel
-                or entry.get("need_result_map_for_compound", False)
-                or entry.get("need_result_map_for_nested", False)
+            toplevel
+            or entry.get("need_result_map_for_compound", False)
+            or entry.get("need_result_map_for_nested", False)
         )
 
         # indicates there is a CompoundSelect in play and we are not the
@@ -181,22 +179,22 @@ class IoTDBSQLCompiler(SQLCompiler):
                     [
                         name
                         for (
-                        key,
-                        proxy_name,
-                        fallback_label_name,
-                        name,
-                        repeated,
-                    ) in compile_state.columns_plus_names
+                            key,
+                            proxy_name,
+                            fallback_label_name,
+                            name,
+                            repeated,
+                        ) in compile_state.columns_plus_names
                     ],
                     [
                         name
                         for (
-                        key,
-                        proxy_name,
-                        fallback_label_name,
-                        name,
-                        repeated,
-                    ) in compile_state_wraps_for.columns_plus_names
+                            key,
+                            proxy_name,
+                            fallback_label_name,
+                            name,
+                            repeated,
+                        ) in compile_state_wraps_for.columns_plus_names
                     ],
                 )
             )
@@ -236,18 +234,18 @@ class IoTDBSQLCompiler(SQLCompiler):
         inner_columns = list(
             filter(
                 lambda x: "Time"
-                          not in x.replace(self.preparer.initial_quote, "").split(),
+                not in x.replace(self.preparer.initial_quote, "").split(),
                 inner_columns,
             )
         )
 
         if inner_columns and time_column_index:
             inner_columns[-1] = (
-                    inner_columns[-1]
-                    + " \n FROM Time Index "
-                    + " ".join(time_column_index)
-                    + " \n FROM Time Name "
-                    + " ".join(time_column_names)
+                inner_columns[-1]
+                + " \n FROM Time Index "
+                + " ".join(time_column_index)
+                + " \n FROM Time Name "
+                + " ".join(time_column_names)
             )
 
         text = self._compose_select_body(
@@ -274,11 +272,11 @@ class IoTDBSQLCompiler(SQLCompiler):
         if self.ctes and (not is_embedded_select or toplevel):
             nesting_level = len(self.stack) if not toplevel else None
             text = (
-                    self._render_cte_clause(
-                        nesting_level=nesting_level,
-                        visiting_cte=kwargs.get("visiting_cte"),
-                    )
-                    + text
+                self._render_cte_clause(
+                    nesting_level=nesting_level,
+                    visiting_cte=kwargs.get("visiting_cte"),
+                )
+                + text
             )
 
         if select_stmt._suffixes:


### PR DESCRIPTION
## Description

The reconnect method was copied from Java version, but there are some logic bugs in Python Client, which are caused by the following reasons.

1. The for loop of Python is different with Java. 
For example, `for i in range(0, 5)` in Python not equals to `for (int i = 0; i < 5; i++)` in Java. When `i` was set to `-1` in the loop, `i` would be changed back in the range but not in Java.

2. The random method is different between Python and Java. `random.randint(0, a)` in Python means getting a number in range [0, a]. However, in Java `random.nextInt(a)` means getting a number in range [0, a).