### PR TITLE
[IOTDB-5983] Refactor error info in GROUP BY/ORDER BY in align by device

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/groupby/IoTDBGroupByConditionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/groupby/IoTDBGroupByConditionIT.java
@@ -407,4 +407,48 @@ public class IoTDBGroupByConditionIT {
       fail(e.getMessage());
     }
   }
+
+  private void errorTest(String sql, String error) {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.executeQuery(sql);
+    } catch (Exception e) {
+      assertEquals(error, e.getMessage());
+    }
+  }
+
+  @Test
+  public void errorTest1() {
+    errorTest(
+        "select first_value(soc) from root.** group by condition(charging_status!=0,KEEP>2,ignoreNull=false)",
+        "701: root.**.charging_status != 0 in group by clause shouldn't refer to more than one timeseries.");
+  }
+
+  @Test
+  public void errorTest2() {
+    errorTest(
+        "select first_value(soc) from root.sg.beijing.car01 group by condition(count(charging_status)!=0,KEEP>2,ignoreNull=false)",
+        "701: Aggregation expression shouldn't exist in group by clause");
+  }
+
+  @Test
+  public void errorTest3() {
+    errorTest(
+        "select first_value(soc) from root.sg.beijing.car01 group by condition(s1!=0,KEEP>2,ignoreNull=false)",
+        "701: root.sg.beijing.car01.s1 != 0 in group by clause doesn't exist.");
+  }
+
+  @Test
+  public void errorTest4() {
+    errorTest(
+        "select first_value(soc) from root.sg.beijing.car01 group by condition(s1!=0,KEEP>2,ignoreNull=false) align by device",
+        "701: s1 != 0 in group by clause doesn't exist.");
+  }
+
+  @Test
+  public void errorTest5() {
+    errorTest(
+        "select first_value(soc) from root.sg.beijing.car01 group by condition(root.sg.beijing.car01.soc!=0,KEEP>2,ignoreNull=false) align by device",
+        "701: ALIGN BY DEVICE: the suffix paths can only be measurement or one-level wildcard");
+  }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/groupby/IoTDBGroupByCountIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/groupby/IoTDBGroupByCountIT.java
@@ -411,4 +411,48 @@ public class IoTDBGroupByCountIT {
     normalTestWithAlignByDevice(res, sql, false);
     normalTestWithAlignByDevice(res, sql2, true);
   }
+
+  private void errorTest(String sql, String error) {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.executeQuery(sql);
+    } catch (Exception e) {
+      assertEquals(error, e.getMessage());
+    }
+  }
+
+  @Test
+  public void errorTest1() {
+    errorTest(
+        "select count(temperature) from root.** group by count(soc, 2)",
+        "701: root.**.soc in group by clause shouldn't refer to more than one timeseries.");
+  }
+
+  @Test
+  public void errorTest2() {
+    errorTest(
+        "select count(soc) from root.sg.beijing.car01 group by count(count(soc),2)",
+        "701: Aggregation expression shouldn't exist in group by clause");
+  }
+
+  @Test
+  public void errorTest3() {
+    errorTest(
+        "select count(soc) from root.sg.beijing.car01 group by count(s1,2)",
+        "701: root.sg.beijing.car01.s1 in group by clause doesn't exist.");
+  }
+
+  @Test
+  public void errorTest4() {
+    errorTest(
+        "select count(soc) from root.sg.beijing.car01 group by count(s1,2) align by device",
+        "701: s1 in group by clause doesn't exist.");
+  }
+
+  @Test
+  public void errorTest5() {
+    errorTest(
+        "select count(soc) from root.sg.beijing.car01 group by count(root.sg.beijing.car01.soc,2) align by device",
+        "701: ALIGN BY DEVICE: the suffix paths can only be measurement or one-level wildcard");
+  }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/groupby/IoTDBGroupByVariationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/groupby/IoTDBGroupByVariationIT.java
@@ -486,7 +486,7 @@ public class IoTDBGroupByVariationIT {
   public void errorTest1() {
     errorTest(
         "select avg(temperature) from root.ln.wf01.wt01 group by variation(*)",
-        "701: Expression in group by should indicate one value");
+        "701: root.ln.wf01.wt01.* in group by clause shouldn't refer to more than one timeseries.");
   }
 
   @Test
@@ -494,6 +494,27 @@ public class IoTDBGroupByVariationIT {
     errorTest(
         "select avg(temperature) from root.ln.wf01.wt01 group by variation(avg(temperature))",
         "701: Aggregation expression shouldn't exist in group by clause");
+  }
+
+  @Test
+  public void errorTest3() {
+    errorTest(
+        "select avg(temperature) from root.ln.wf01.wt01 group by variation(s1,2)",
+        "701: root.ln.wf01.wt01.s1 in group by clause doesn't exist.");
+  }
+
+  @Test
+  public void errorTest4() {
+    errorTest(
+        "select avg(temperature) from root.ln.wf01.wt01 group by variation(s1,2) align by device",
+        "701: s1 in group by clause doesn't exist.");
+  }
+
+  @Test
+  public void errorTest5() {
+    errorTest(
+        "select avg(temperature) from root.ln.wf01.wt01 group by variation(root.ln.wf01.wt01.s1,2) align by device",
+        "701: ALIGN BY DEVICE: the suffix paths can only be measurement or one-level wildcard");
   }
 
   @Test

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
@@ -1349,8 +1349,15 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
             ExpressionAnalyzer.concatDeviceAndBindSchemaForExpression(
                 expression, device, schemaTree);
 
-        if (groupByExpressionsOfOneDevice.size() != 1) {
-          throw new SemanticException("Expression in group by should indicate one value");
+        if (groupByExpressionsOfOneDevice.size() == 0) {
+          throw new SemanticException(
+              String.format("%s in group by clause doesn't exist.", expression));
+        }
+        if (groupByExpressionsOfOneDevice.size() > 1) {
+          throw new SemanticException(
+              String.format(
+                  "%s in group by clause shouldn't refer to more than one timeseries.",
+                  expression));
         }
         Expression groupByExpressionOfOneDevice = groupByExpressionsOfOneDevice.get(0);
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
@@ -1471,8 +1471,16 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       // Expression in group by variation clause only indicates one column
       List<Expression> expressions =
           ExpressionAnalyzer.bindSchemaForExpression(groupByExpression, schemaTree);
-      if (expressions.size() != 1) {
-        throw new SemanticException("Expression in group by should indicate one value");
+      if (expressions.size() == 0) {
+        throw new SemanticException(
+            String.format(
+                "%s in group by clause doesn't exist.", groupByExpression.getExpressionString()));
+      }
+      if (expressions.size() > 1) {
+        throw new SemanticException(
+            String.format(
+                "%s in group by clause shouldn't refer to more than one timeseries.",
+                groupByExpression.getExpressionString()));
       }
       // Aggregation expression shouldn't exist in group by clause.
       List<Expression> aggregationExpression =

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/QueryStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/QueryStatement.java
@@ -423,7 +423,7 @@ public class QueryStatement extends Statement {
     int expressionIndex = 0;
     for (SortItem sortItem : sortItems) {
       SortItem newSortItem =
-              new SortItem(sortItem.getSortKey(), sortItem.getOrdering(), sortItem.getNullOrdering());
+          new SortItem(sortItem.getSortKey(), sortItem.getOrdering(), sortItem.getNullOrdering());
       if (sortItem.isExpression()) {
         newSortItem.setExpression(sortItemExpressions[expressionIndex]);
         expressionIndex++;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/QueryStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/QueryStatement.java
@@ -223,10 +223,6 @@ public class QueryStatement extends Statement {
     this.orderByComponent = orderByComponent;
   }
 
-  public ResultSetFormat getResultSetFormat() {
-    return resultSetFormat;
-  }
-
   public void setResultSetFormat(ResultSetFormat resultSetFormat) {
     this.resultSetFormat = resultSetFormat;
   }
@@ -311,9 +307,7 @@ public class QueryStatement extends Statement {
 
   private boolean hasAggregationFunction(Expression expression) {
     if (expression instanceof FunctionExpression) {
-      if (!expression.isBuiltInAggregationFunctionExpression()) {
-        return false;
-      }
+      return expression.isBuiltInAggregationFunctionExpression();
     } else {
       if (expression instanceof TimeSeriesOperand) {
         return false;
@@ -333,10 +327,6 @@ public class QueryStatement extends Statement {
 
   public boolean hasOrderByExpression() {
     return !getExpressionSortItemList().isEmpty();
-  }
-
-  public boolean isAlignByTime() {
-    return resultSetFormat == ResultSetFormat.ALIGN_BY_TIME;
   }
 
   public boolean isAlignByDevice() {
@@ -431,10 +421,9 @@ public class QueryStatement extends Statement {
     List<SortItem> sortItems = getSortItemList();
     List<SortItem> newSortItems = new ArrayList<>();
     int expressionIndex = 0;
-    for (int i = 0; i < sortItems.size(); i++) {
-      SortItem sortItem = sortItems.get(i);
+    for (SortItem sortItem : sortItems) {
       SortItem newSortItem =
-          new SortItem(sortItem.getSortKey(), sortItem.getOrdering(), sortItem.getNullOrdering());
+              new SortItem(sortItem.getSortKey(), sortItem.getOrdering(), sortItem.getNullOrdering());
       if (sortItem.isExpression()) {
         newSortItem.setExpression(sortItemExpressions[expressionIndex]);
         expressionIndex++;
@@ -574,6 +563,15 @@ public class QueryStatement extends Statement {
       try {
         for (ResultColumn resultColumn : selectComponent.getResultColumns()) {
           ExpressionAnalyzer.checkIsAllMeasurement(resultColumn.getExpression());
+        }
+        if (hasGroupByExpression()) {
+          ExpressionAnalyzer.checkIsAllMeasurement(
+              getGroupByComponent().getControlColumnExpression());
+        }
+        if (hasOrderByExpression()) {
+          for (Expression expression : getExpressionSortItemList()) {
+            ExpressionAnalyzer.checkIsAllMeasurement(expression);
+          }
         }
         if (getWhereCondition() != null) {
           ExpressionAnalyzer.checkIsAllMeasurement(getWhereCondition().getPredicate());


### PR DESCRIPTION
This PR includes the following change of info when the expression in align by device is not one level:
Before:
```md
IOTDB> select status,temperature from root.** order by wt02.temperature align by device
Msg: 701: wt02.temperature in order by clausse doesn't exist.
```
```md
IOTDB> select count(status) from root.** group by count(root.ln.wt01.wf01.status,5) align by device
Msg: 701: Expression in group by should indicate one value
```
```md
IOTDB> select count(status) from root.** group by count(s1,5) align by device
(s1 doesn't exist in the result)
Msg: 701: Expression in group by should indicate one value
```
After:
```md
IOTDB> select status,temperature from root.** order by wt02.temperature align by device
Msg: 701: ALIGN BY DEVICE: the suffix paths can only be measurement or one-level wildcard
```
```md
IOTDB> select count(status) from root.** group by count(root.ln.wt01.wf01.status,5) align by device
Msg: 701: ALIGN BY DEVICE: the suffix paths can only be measurement or one-level wildcard
```
```md
IOTDB> select count(status) from root.** group by count(s1,5) align by device
(s1 doesn't exist in the result)
Msg: 701: s1 in group by clause doesn't exist.
```
