### PR TITLE
Fix duplicate insertion bug caused by view

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/exception/metadata/DuplicateInsertException.java
+++ b/server/src/main/java/org/apache/iotdb/db/exception/metadata/DuplicateInsertException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.exception.metadata;
+
+import org.apache.iotdb.commons.exception.MetadataException;
+import org.apache.iotdb.rpc.TSStatusCode;
+
+public class DuplicateInsertException extends MetadataException {
+
+  private static final String DUPLICATE_INSERTION_WRONG_MESSAGE =
+      "Insertion is illegal because measurement [%s] under device [%s] is duplicate.";
+
+  public DuplicateInsertException(String device, String measurement) {
+    super(
+        String.format(DUPLICATE_INSERTION_WRONG_MESSAGE, measurement, device),
+        TSStatusCode.UNSUPPORTED_OPERATION.getStatusCode(),
+        true);
+  }
+}

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertMultiTabletsStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertMultiTabletsStatement.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.mpp.plan.statement.crud;
 
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.db.exception.metadata.DuplicateInsertException;
 import org.apache.iotdb.db.mpp.plan.analyze.schema.ISchemaValidation;
 import org.apache.iotdb.db.mpp.plan.statement.StatementType;
 import org.apache.iotdb.db.mpp.plan.statement.StatementVisitor;
@@ -27,7 +28,11 @@ import org.apache.iotdb.tsfile.exception.NotImplementedException;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class InsertMultiTabletsStatement extends InsertBaseStatement {
@@ -138,8 +143,34 @@ public class InsertMultiTabletsStatement extends InsertBaseStatement {
     if (!needSplit) {
       return this;
     }
+    validateInsertTabletList(mergedList);
     InsertMultiTabletsStatement splitResult = new InsertMultiTabletsStatement();
     splitResult.setInsertTabletStatementList(mergedList);
     return splitResult;
+  }
+
+  /**
+   * Check given InsertRowStatement list, make sure no duplicate time series in those statements. If
+   * there are duplicate measurements, throw DuplicateInsertException.
+   */
+  public static void validateInsertTabletList(List<InsertTabletStatement> insertTabletList) {
+    if (insertTabletList == null) {
+      return;
+    }
+    Map<String, Set<String>> mapFromDeviceToMeasurements = new HashMap<>();
+    for (InsertTabletStatement insertTablet : insertTabletList) {
+      String device = insertTablet.devicePath.getFullPath();
+      Set<String> measurementSet = mapFromDeviceToMeasurements.get(device);
+      if (measurementSet == null) {
+        measurementSet = new HashSet<>();
+      }
+      for (String measurement : insertTablet.measurements) {
+        boolean notExist = measurementSet.add(measurement);
+        if (!notExist) {
+          throw new RuntimeException(new DuplicateInsertException(device, measurement));
+        }
+      }
+      mapFromDeviceToMeasurements.put(device, measurementSet);
+    }
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertRowsOfOneDeviceStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertRowsOfOneDeviceStatement.java
@@ -151,6 +151,7 @@ public class InsertRowsOfOneDeviceStatement extends InsertBaseStatement {
         List<InsertRowStatement> childSplitResult = child.getSplitList();
         mergedList.addAll(childSplitResult);
       }
+      InsertRowsStatement.validateInsertRowList(mergedList);
       InsertRowsStatement splitResult = new InsertRowsStatement();
       splitResult.setInsertRowStatementList(mergedList);
       return splitResult;


### PR DESCRIPTION
Before supporting the view, duplicate measurements are checked during the semantic analysis phase. After supporting the view, there may be duplicate writes, but semantic analysis cannot detect them. 
Now in the analysis phase, a secondary check for duplicate measurements has been added.

create timeseries and views:
```
IoTDB> create timeseries root.db.d01.s01 INT32 encoding=RLE;
Msg: The statement is executed successfully.
IoTDB> create view root.db.d01.view_s01_a AS root.db.d01.s01;
Msg: The statement is executed successfully.
IoTDB> create view root.db.d01.view_s01_b AS root.db.d01.s01;
Msg: The statement is executed successfully.
```

normal insertion
```
IoTDB> insert into root.db.d01(timestamp,s01) values(1, 36);
Msg: The statement is executed successfully.
IoTDB> insert into root.db.d01(timestamp,view_s01_a) values(2, 36);
Msg: The statement is executed successfully.
IoTDB> insert into root.db.d01(timestamp,view_s01_b) values(3, 36);
Msg: The statement is executed successfully.
```

previous semantic validate
```
IoTDB> insert into root.db.d01(timestamp, s01, s01) values(4, 36, 37);
Msg: 701: Insertion contains duplicated measurement: s01
```

new added validation:
```
IoTDB> insert into root.db.d01(timestamp, s01, view_s01_a) values(4, 36, 37);
Msg: 300: Insert statement is illegal because measurement [s01] under device [root.db.d01] is duplicate.
IoTDB> insert into root.db.d01(timestamp, s01, view_s01_b) values(4, 36, 37);
Msg: 300: Insert statement is illegal because measurement [s01] under device [root.db.d01] is duplicate.
IoTDB> insert into root.db.d01(timestamp, view_s01_a, view_s01_b) values(4, 36, 37);
Msg: 300: Insert statement is illegal because measurement [s01] under device [root.db.d01] is duplicate.
IoTDB>
```