### PR TITLE
[IOTDB-5986] Pipe: fix "show pipe p1" shows multiple pipes

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/response/pipe/task/PipeTableResp.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/response/pipe/task/PipeTableResp.java
@@ -49,7 +49,7 @@ public class PipeTableResp implements DataSet {
   }
 
   public PipeTableResp filter(Boolean whereClause, String pipeName) {
-    if (whereClause == null) {
+    if (whereClause == null || !whereClause) {
       if (pipeName == null) {
         return this;
       } else {


### PR DESCRIPTION
Fix the following issue where `show pipe p1` shows both pipe p1 and p2. 
See https://issues.apache.org/jira/browse/IOTDB-5986
Before:
![image](https://github.com/apache/iotdb/assets/55695098/2a379c63-25ab-450c-b5e1-c700b0f75f58)
![image](https://github.com/apache/iotdb/assets/55695098/294ff66d-f36e-4251-8f1a-4f596bad7478)

After:
<img width="1153" alt="image" src="https://github.com/apache/iotdb/assets/55695098/07f39eb1-a2b2-411b-b830-2981a9dbe957">
