### PR TITLE
Pipe: avoid overriding wal entries when loading entries from different wal nodes

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
@@ -790,6 +790,10 @@ public class WALNode implements IWALNode {
     checkpointManager.close();
   }
 
+  public String getIdentifier() {
+    return identifier;
+  }
+
   public File getLogDirectory() {
     return logDirectory;
   }

--- a/server/src/main/java/org/apache/iotdb/db/wal/utils/WALEntryHandler.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/utils/WALEntryHandler.java
@@ -94,11 +94,18 @@ public class WALEntryHandler {
       }
     }
     // read from the wal file
+    InsertNode node = null;
     try {
-      return walEntryPosition.readInsertNodeViaCache();
+      node = walEntryPosition.readInsertNodeViaCache();
     } catch (Exception e) {
       throw new WALPipeException("Fail to get value because the file content isn't correct.", e);
     }
+
+    if (node == null) {
+      throw new WALPipeException(
+          String.format("Fail to get the wal value of the position %s.", walEntryPosition));
+    }
+    return node;
   }
 
   public long getMemTableId() {

--- a/server/src/main/java/org/apache/iotdb/db/wal/utils/WALEntryPosition.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/utils/WALEntryPosition.java
@@ -34,6 +34,7 @@ import java.util.Objects;
  */
 public class WALEntryPosition {
   private static final WALInsertNodeCache CACHE = WALInsertNodeCache.getInstance();
+  private volatile String identifier = "";
   private volatile long walFileVersionId = -1;
   private volatile long position;
   private volatile int size;
@@ -44,7 +45,8 @@ public class WALEntryPosition {
 
   public WALEntryPosition() {}
 
-  public WALEntryPosition(long walFileVersionId, long position, int size) {
+  public WALEntryPosition(String identifier, long walFileVersionId, long position, int size) {
+    this.identifier = identifier;
     this.walFileVersionId = walFileVersionId;
     this.position = position;
     this.size = size;
@@ -111,11 +113,16 @@ public class WALEntryPosition {
 
   public void setWalNode(WALNode walNode) {
     this.walNode = walNode;
+    this.identifier = walNode.getIdentifier();
   }
 
   public void setEntryPosition(long walFileVersionId, long position) {
     this.position = position;
     this.walFileVersionId = walFileVersionId;
+  }
+
+  public String getIdentifier() {
+    return identifier;
   }
 
   public long getWalFileVersionId() {
@@ -140,7 +147,7 @@ public class WALEntryPosition {
 
   @Override
   public int hashCode() {
-    return Objects.hash(walFileVersionId, position);
+    return Objects.hash(identifier, walFileVersionId, position);
   }
 
   @Override
@@ -152,6 +159,8 @@ public class WALEntryPosition {
       return false;
     }
     WALEntryPosition that = (WALEntryPosition) o;
-    return walFileVersionId == that.walFileVersionId && position == that.position;
+    return identifier.equals(that.identifier)
+        && walFileVersionId == that.walFileVersionId
+        && position == that.position;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/wal/utils/WALInsertNodeCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/utils/WALInsertNodeCache.java
@@ -52,7 +52,7 @@ public class WALInsertNodeCache {
   private final LoadingCache<WALEntryPosition, InsertNode> lruCache;
 
   /** ids of all pinned memTables */
-  private final Set<Long> memTablesNeedSearch = ConcurrentHashMap.newKeySet();;
+  private final Set<Long> memTablesNeedSearch = ConcurrentHashMap.newKeySet();
 
   private WALInsertNodeCache() {
     lruCache =
@@ -142,7 +142,9 @@ public class WALInsertNodeCache {
               buffer.clear();
               InsertNode node = parse(buffer);
               if (node != null) {
-                res.put(new WALEntryPosition(walFileVersionId, position, size), node);
+                res.put(
+                    new WALEntryPosition(pos.getIdentifier(), walFileVersionId, position, size),
+                    node);
               }
             }
             position += size;

--- a/server/src/test/java/org/apache/iotdb/db/wal/buffer/WALBufferCommonTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/buffer/WALBufferCommonTest.java
@@ -95,6 +95,7 @@ public abstract class WALBufferCommonTest {
     for (Future<Void> future : futures) {
       future.get();
     }
+    executorService.shutdown();
     // wait a moment
     while (!walBuffer.isAllWALEntriesConsumed()) {
       Thread.sleep(1_000);

--- a/server/src/test/java/org/apache/iotdb/db/wal/checkpoint/CheckpointManagerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/checkpoint/CheckpointManagerTest.java
@@ -114,6 +114,7 @@ public class CheckpointManagerTest {
     for (Future<Void> future : futures) {
       future.get();
     }
+    executorService.shutdown();
     // check first valid version id
     assertEquals(memTablesNum / 2, checkpointManager.getFirstValidWALVersionId());
     // recover info from checkpoint file

--- a/server/src/test/java/org/apache/iotdb/db/wal/node/ConsensusReqReaderTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/node/ConsensusReqReaderTest.java
@@ -227,6 +227,7 @@ public class ConsensusReqReaderTest {
     InsertRowNode insertRowNode = getInsertRowNode(devicePath);
     walNode.log(0, insertRowNode); // put -1 after 6
     Assert.assertTrue(future.get());
+    checkThread.shutdown();
   }
 
   @Test
@@ -272,6 +273,7 @@ public class ConsensusReqReaderTest {
     insertRowNode = getInsertRowNode(devicePath);
     walNode.log(0, insertRowNode); // put -1 after 6
     Assert.assertTrue(future.get());
+    checkThread.shutdown();
   }
 
   @Test

--- a/server/src/test/java/org/apache/iotdb/db/wal/node/WALNodeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/node/WALNodeTest.java
@@ -117,6 +117,7 @@ public class WALNodeTest {
     for (Future<Void> future : futures) {
       future.get();
     }
+    executorService.shutdown();
     // wait a moment
     while (!walNode.isAllWALEntriesConsumed()) {
       Thread.sleep(1_000);
@@ -247,6 +248,7 @@ public class WALNodeTest {
     for (Future<Void> future : futures) {
       future.get();
     }
+    executorService.shutdown();
     // recover info from checkpoint file
     Map<Long, MemTableInfo> actualMemTableId2Info =
         CheckpointRecoverUtils.recoverMemTableInfo(new File(logDirectory)).getMemTableId2Info();

--- a/server/src/test/java/org/apache/iotdb/db/wal/recover/WALRecoverManagerTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/wal/recover/WALRecoverManagerTest.java
@@ -177,6 +177,7 @@ public class WALRecoverManagerTest {
     for (Future<Void> future : futures) {
       future.get();
     }
+    executorService.shutdown();
     // wait a moment
     while (!walBuffer.isAllWALEntriesConsumed()) {
       Thread.sleep(1_000);
@@ -235,6 +236,7 @@ public class WALRecoverManagerTest {
     for (Future<Void> future : futures) {
       future.get();
     }
+    executorService.shutdown();
     // wait a moment
     while (!walBuffer.isAllWALEntriesConsumed()) {
       Thread.sleep(1_000);


### PR DESCRIPTION
This bug is caused by that wal entries with same version id and position are overrided by others from different wal nodes. To fix this, we should add identifier in the WALEntryPosition.