### PR TITLE
Fix a  a coding pattern that could possibly have security impact

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/directories/TierManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/directories/TierManager.java
@@ -220,13 +220,12 @@ public class TierManager {
     if (!file.exists()) {
       return getTiersNum() - 1;
     }
-
-    String filePath;
+    Path filePath;
     try {
-      filePath = file.getCanonicalPath();
+      filePath = file.getCanonicalFile().toPath();
     } catch (IOException e) {
       logger.error("Fail to get canonical path of data dir {}", file, e);
-      filePath = file.getPath();
+      filePath = file.toPath();
     }
 
     for (Map.Entry<String, Integer> entry : seqDir2TierLevel.entrySet()) {


### PR DESCRIPTION
## Description
This PR fix a coding pattern that could possibly have security impact. This issue allows a malicious actor to potentially break out of the expected directory. The impact is limited to sibling directories. For example, `userControlled.getCanonicalPath().startsWith("/user/out")` will allow an attacker to access a directory with a name like `/user/outnot.

## Why?
To demonstrate this vulnerability, consider `"/user/outnot".startsWith("/user/out")`. The check is bypassed although `/outnot` is not under the `/out` directory. It's important to understand that the terminating slash may be removed when using various `String` representations of the `File` object. 
For example, on Linux, `println(new File("/var"))` will print `/var`, but `println(new File("/var", "/")` will print `/var/`; however, `println(new File("/var", "/").getCanonicalPath())` will print `/var`.


