### PR TITLE
[To rel/1.2] Avoid useless query in SchemaRegion when executing show child nodes

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
@@ -129,6 +129,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -537,7 +538,19 @@ public class ConfigPlanExecutor {
       Pair<Set<TSchemaNode>, Set<PartialPath>> matchedChildInNextLevel =
           clusterSchemaInfo.getChildNodePathInNextLevel(partialPath);
       alreadyMatchedNode = matchedChildInNextLevel.left;
-      needMatchedNode = matchedChildInNextLevel.right;
+      if (!partialPath.hasMultiLevelMatchWildcard()) {
+        needMatchedNode = new HashSet<>();
+        for (PartialPath databasePath : matchedChildInNextLevel.right) {
+          if (databasePath.getNodeLength() == partialPath.getNodeLength() + 1) {
+            // this database node is already the target child node, no need to traverse its schema
+            // region
+            continue;
+          }
+          needMatchedNode.add(databasePath);
+        }
+      } else {
+        needMatchedNode = matchedChildInNextLevel.right;
+      }
     } else {
       // count nodes
       Pair<List<PartialPath>, Set<PartialPath>> matchedChildInNextLevel =

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/partition/IoTDBPartitionGetterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/partition/IoTDBPartitionGetterIT.java
@@ -487,7 +487,7 @@ public class IoTDBPartitionGetterIT {
           TSStatusCode.SUCCESS_STATUS.getStatusCode(), nodeManagementResp.getStatus().getCode());
       Assert.assertEquals(storageGroupNum, nodeManagementResp.getMatchedNodeSize());
       Assert.assertNotNull(nodeManagementResp.getSchemaRegionMap());
-      Assert.assertEquals(2, nodeManagementResp.getSchemaRegionMapSize());
+      Assert.assertEquals(0, nodeManagementResp.getSchemaRegionMapSize());
     }
   }
 }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/path/PartialPath.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/path/PartialPath.java
@@ -114,6 +114,16 @@ public class PartialPath extends Path implements Comparable<Path>, Cloneable {
     return false;
   }
 
+  public boolean hasMultiLevelMatchWildcard() {
+    for (String node : nodes) {
+      // *, ** , d*, *d*
+      if (PathPatternUtil.hasMultiLevelMatchWildcard(node)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   // e.g. root.db.d.s, root.db.d.*, root.db.d.s*, not include patterns like root.db.d.**
   public boolean hasExplicitDevice() {
     if (nodes[nodes.length - 1].equals(MULTI_LEVEL_PATH_WILDCARD)) {

--- a/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternUtil.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternUtil.java
@@ -36,6 +36,10 @@ public class PathPatternUtil {
     return node.startsWith(ONE_LEVEL_PATH_WILDCARD) || node.endsWith(ONE_LEVEL_PATH_WILDCARD);
   }
 
+  public static boolean hasMultiLevelMatchWildcard(String node) {
+    return node.startsWith(ONE_LEVEL_PATH_WILDCARD);
+  }
+
   /**
    * Determine if a node pattern matches a node name.
    *


### PR DESCRIPTION
## Description

When executing show child nodes, ConfigMTree will return the matched child node and related databases, the SchemaRegion of which may contain more matched child nodes. 

If a database node is already the matched child node and the given path pattern doesn't contains multi-level-match wildcard, there's no need to check its SchemaRegion.

Add this mechanism to ConfigPlanExecutor.    