### PR TITLE
Support not checking `isAligned` in insertion

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/metadata/cache/TimeSeriesSchemaCache.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/cache/TimeSeriesSchemaCache.java
@@ -166,7 +166,6 @@ public class TimeSeriesSchemaCache {
       ISchemaComputation schemaComputation) {
     List<Integer> indexOfMissingMeasurements = new ArrayList<>();
     List<String> missedPathStringList = new ArrayList<>();
-    final AtomicBoolean isFirstMeasurement = new AtomicBoolean(true);
     Pair<Integer, Integer> beginToEnd = schemaComputation.getRangeOfLogicalViewSchemaListRecorded();
     List<LogicalViewSchema> logicalViewSchemaList = schemaComputation.getLogicalViewSchemaList();
     List<Integer> indexListOfLogicalViewPaths = schemaComputation.getIndexListOfLogicalViewPaths();
@@ -198,10 +197,9 @@ public class TimeSeriesSchemaCache {
               if (value == null) {
                 indexOfMissingMeasurements.add(recordMissingIndex);
               } else {
-                if (isFirstMeasurement.get()) {
-                  schemaComputation.computeDevice(value.isAligned());
-                  isFirstMeasurement.getAndSet(false);
-                }
+                // Can not call function computeDevice here, because the value is source of one
+                // view, but schemaComputation is the device in this insert statement. The
+                // computation between them is miss matched.
                 if (value.isLogicalView()) {
                   // does not support views in views
                   throw new RuntimeException(

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
@@ -289,7 +289,7 @@ public class MTreeBelowSGCachedImpl {
 
           if (device.isDevice() && device.getAsDeviceMNode().isAligned()) {
             throw new AlignedTimeseriesException(
-                "timeseries under this entity is aligned, please use createAlignedTimeseries or change entity.",
+                "timeseries under this device is aligned, please use createAlignedTimeseries or change device.",
                 device.getFullPath());
           }
 
@@ -371,7 +371,7 @@ public class MTreeBelowSGCachedImpl {
 
           if (device.isDevice() && !device.getAsDeviceMNode().isAligned()) {
             throw new AlignedTimeseriesException(
-                "Timeseries under this entity is not aligned, please use createTimeseries or change entity.",
+                "Timeseries under this device is not aligned, please use createTimeseries or change device.",
                 devicePath.getFullPath());
           }
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
@@ -238,7 +238,7 @@ public class MTreeBelowSGMemoryImpl {
 
       if (device.isDevice() && device.getAsDeviceMNode().isAligned()) {
         throw new AlignedTimeseriesException(
-            "timeseries under this entity is aligned, please use createAlignedTimeseries or change entity.",
+            "timeseries under this device is aligned, please use createAlignedTimeseries or change device.",
             device.getFullPath());
       }
 
@@ -318,7 +318,7 @@ public class MTreeBelowSGMemoryImpl {
 
       if (device.isDevice() && !device.getAsDeviceMNode().isAligned()) {
         throw new AlignedTimeseriesException(
-            "Timeseries under this entity is not aligned, please use createTimeseries or change entity.",
+            "Timeseries under this device is not aligned, please use createTimeseries or change device.",
             devicePath.getFullPath());
       }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/ClusterSchemaTree.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/common/schematree/ClusterSchemaTree.java
@@ -176,9 +176,7 @@ public class ClusterSchemaTree implements ISchemaTree {
     if (cur == null) {
       return indexOfTargetMeasurements;
     }
-    if (cur.isEntity()) {
-      schemaComputation.computeDevice(cur.getAsEntityNode().isAligned());
-    }
+    boolean firstNonViewMeasurement = true;
     List<Integer> indexOfMissingMeasurements = new ArrayList<>();
     SchemaNode node;
     for (int index : indexOfTargetMeasurements) {
@@ -186,6 +184,12 @@ public class ClusterSchemaTree implements ISchemaTree {
       if (node == null) {
         indexOfMissingMeasurements.add(index);
       } else {
+        if (firstNonViewMeasurement) {
+          if (!node.getAsMeasurementNode().isLogicalView()) {
+            schemaComputation.computeDevice(cur.getAsEntityNode().isAligned());
+            firstNonViewMeasurement = false;
+          }
+        }
         schemaComputation.computeMeasurement(index, node.getAsMeasurementNode());
       }
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/schema/ISchemaValidation.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/schema/ISchemaValidation.java
@@ -40,6 +40,12 @@ public interface ISchemaValidation extends ISchemaComputationWithAutoCreation {
     validateMeasurementSchema(index, measurementSchemaInfo, isAligned);
   }
 
+  /**
+   * Record the real value of <code>isAligned</code> of this device. This will change the value of
+   * <code>isAligned</code> in this insert statement.
+   *
+   * @param isAligned The real value of attribute <code>isAligned</code> of this device schema
+   */
   void validateDeviceSchema(boolean isAligned);
 
   void validateMeasurementSchema(int index, IMeasurementSchemaInfo measurementSchemaInfo);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertRowStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertRowStatement.java
@@ -24,7 +24,6 @@ import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.schema.view.LogicalViewSchema;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
-import org.apache.iotdb.db.exception.metadata.AlignedTimeseriesException;
 import org.apache.iotdb.db.exception.metadata.DataTypeMismatchException;
 import org.apache.iotdb.db.exception.metadata.PathNotExistException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
@@ -278,6 +277,7 @@ public class InsertRowStatement extends InsertBaseStatement implements ISchemaVa
       statement.setTime(this.time);
       statement.setNeedInferType(this.isNeedInferType);
       statement.setDevicePath(entry.getKey());
+      statement.setAligned(this.isAligned);
       Object[] values = new Object[pairList.size()];
       String[] measurements = new String[pairList.size()];
       MeasurementSchema[] measurementSchemas = new MeasurementSchema[pairList.size()];
@@ -354,14 +354,7 @@ public class InsertRowStatement extends InsertBaseStatement implements ISchemaVa
 
   @Override
   public void validateDeviceSchema(boolean isAligned) {
-    if (this.isAligned != isAligned) {
-      throw new SemanticException(
-          new AlignedTimeseriesException(
-              String.format(
-                  "timeseries under this device are%s aligned, " + "please use %s interface",
-                  isAligned ? "" : " not", isAligned ? "aligned" : "non-aligned"),
-              devicePath.getFullPath()));
-    }
+    this.isAligned = isAligned;
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertTabletStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertTabletStatement.java
@@ -21,7 +21,6 @@ package org.apache.iotdb.db.mpp.plan.statement.crud;
 import org.apache.iotdb.common.rpc.thrift.TTimePartitionSlot;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.schema.view.LogicalViewSchema;
-import org.apache.iotdb.db.exception.metadata.AlignedTimeseriesException;
 import org.apache.iotdb.db.exception.metadata.DataTypeMismatchException;
 import org.apache.iotdb.db.exception.metadata.PathNotExistException;
 import org.apache.iotdb.db.exception.sql.SemanticException;
@@ -221,6 +220,7 @@ public class InsertTabletStatement extends InsertBaseStatement implements ISchem
       statement.setTimes(this.times);
       statement.setDevicePath(entry.getKey());
       statement.setRowCount(this.rowCount);
+      statement.setAligned(this.isAligned);
       Object[] columns = new Object[pairList.size()];
       String[] measurements = new String[pairList.size()];
       BitMap[] bitMaps = new BitMap[pairList.size()];
@@ -323,14 +323,7 @@ public class InsertTabletStatement extends InsertBaseStatement implements ISchem
 
   @Override
   public void validateDeviceSchema(boolean isAligned) {
-    if (this.isAligned != isAligned) {
-      throw new SemanticException(
-          new AlignedTimeseriesException(
-              String.format(
-                  "timeseries under this device are%s aligned, " + "please use %s interface",
-                  isAligned ? "" : " not", isAligned ? "aligned" : "non-aligned"),
-              devicePath.getFullPath()));
-    }
+    this.isAligned = isAligned;
   }
 
   @Override


### PR DESCRIPTION
### Support not checking `isAligned` in insertion.
Support not checking `isAligned` in insertion.
Fix insertion failure when using alias series caused by `isAligned` checks.

create an aligned timeseries:
```
IoTDB> create ALIGNED timeseries root.db.d01(s01 INT32 encoding=RLE);
Msg: The statement is executed successfully.
IoTDB> show devices;
+-----------+---------+
|     Device|IsAligned|
+-----------+---------+
|root.db.d01|     true|
+-----------+---------+
Total line number = 1
It costs 0.186s
IoTDB> show timeseries root.**;
+---------------+-----+--------+--------+--------+-----------+----+----------+--------+------------------+--------+
|     Timeseries|Alias|Database|DataType|Encoding|Compression|Tags|Attributes|Deadband|DeadbandParameters|ViewType|
+---------------+-----+--------+--------+--------+-----------+----+----------+--------+------------------+--------+
|root.db.d01.s01| null| root.db|   INT32|     RLE|     SNAPPY|null|      null|    null|              null|        |
+---------------+-----+--------+--------+--------+-----------+----+----------+--------+------------------+--------+
Total line number = 1
It costs 0.026s
```

can not create timeseries which is not aligned under this device (same with before):
```
IoTDB> create timeseries root.db.d01.s_not_align INT32 encoding=RLE;
Msg: 609: timeseries under this device is aligned, please use createAlignedTimeseries or change device. (Path: root.db.d01)
IoTDB>
```

it's safe to use aligned or non-aligned interface.
```
IoTDB> insert into root.db.d01(timestamp,s01) values(1, 36);
Msg: The statement is executed successfully.
IoTDB> insert into root.db.d01(timestamp,s01) aligned values(2, 37);
Msg: The statement is executed successfully.
IoTDB>
```

user can use view to insert aligned or ono-aligned values:
```
IoTDB> create view root.myview.d01.s01 as root.db.d01.s01;
Msg: The statement is executed successfully.
IoTDB> insert into root.myview.d01(timestamp,s01) values(3, 38);
Msg: The statement is executed successfully.
IoTDB> insert into root.myview.d01(timestamp,s01) aligned values(4, 99);
Msg: The statement is executed successfully.
IoTDB>
```
