### PR TITLE
[IOTDB-5996] Fix time display of show queries

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/source/ShowQueriesOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/source/ShowQueriesOperator.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.db.mpp.execution.operator.OperatorContext;
 import org.apache.iotdb.db.mpp.plan.Coordinator;
 import org.apache.iotdb.db.mpp.plan.execution.IQueryExecution;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNodeId;
+import org.apache.iotdb.db.utils.TimestampPrecisionUtils;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.block.TsBlock;
 import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
@@ -33,6 +34,7 @@ import org.apache.iotdb.tsfile.utils.Binary;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.iotdb.tsfile.read.common.block.TsBlockBuilderStatus.DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES;
 
@@ -125,7 +127,9 @@ public class ShowQueriesOperator implements SourceOperator {
       int DataNodeId = Integer.parseInt(splits[splits.length - 1]);
 
       for (IQueryExecution queryExecution : queryExecutions) {
-        timeColumnBuilder.writeLong(queryExecution.getStartExecutionTime());
+        timeColumnBuilder.writeLong(
+            TimestampPrecisionUtils.convertToCurrPrecision(
+                queryExecution.getStartExecutionTime(), TimeUnit.MILLISECONDS));
         columnBuilders[0].writeBinary(Binary.valueOf(queryExecution.getQueryId()));
         columnBuilders[1].writeInt(DataNodeId);
         columnBuilders[2].writeFloat(

--- a/server/src/main/java/org/apache/iotdb/db/utils/TimestampPrecisionUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/TimestampPrecisionUtils.java
@@ -10,7 +10,7 @@ public class TimestampPrecisionUtils {
 
   @FunctionalInterface
   private interface ConvertFunction<T1, T2, R> {
-    public R apply(T1 t1, T2 t2);
+    R apply(T1 t1, T2 t2);
   }
 
   private static final ConvertFunction<Long, TimeUnit, Long> convertFunction;

--- a/server/src/main/java/org/apache/iotdb/db/utils/TimestampPrecisionUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/TimestampPrecisionUtils.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.iotdb.db.utils;
 
 import org.apache.iotdb.commons.conf.CommonDescriptor;

--- a/server/src/main/java/org/apache/iotdb/db/utils/TimestampPrecisionUtils.java
+++ b/server/src/main/java/org/apache/iotdb/db/utils/TimestampPrecisionUtils.java
@@ -1,0 +1,39 @@
+package org.apache.iotdb.db.utils;
+
+import org.apache.iotdb.commons.conf.CommonDescriptor;
+
+import java.util.concurrent.TimeUnit;
+
+public class TimestampPrecisionUtils {
+  private static final String timestampPrecision =
+      CommonDescriptor.getInstance().getConfig().getTimestampPrecision();
+
+  @FunctionalInterface
+  private interface ConvertFunction<T1, T2, R> {
+    public R apply(T1 t1, T2 t2);
+  }
+
+  private static final ConvertFunction<Long, TimeUnit, Long> convertFunction;
+
+  static {
+    switch (timestampPrecision) {
+      case "ms":
+        convertFunction = TimeUnit.MILLISECONDS::convert;
+        break;
+      case "ns":
+        convertFunction = TimeUnit.NANOSECONDS::convert;
+        break;
+      case "us":
+        convertFunction = TimeUnit.MICROSECONDS::convert;
+        break;
+        // this case will never reach
+      default:
+        convertFunction = null;
+    }
+  }
+
+  /** convert specific precision timestamp to current precision timestamp */
+  public static long convertToCurrPrecision(long sourceTime, TimeUnit sourceUnit) {
+    return convertFunction.apply(sourceTime, sourceUnit);
+  }
+}


### PR DESCRIPTION
doc: https://apache-iotdb.feishu.cn/docx/K7L0dzczGoeib3xPdpRc5EOvnTc
fix test:
1C3D, each DataNode has different timestamp precision, all display are correct.
<img width="964" alt="image" src="https://github.com/apache/iotdb/assets/60659567/ae4237b9-20f5-49f5-a637-c61be2457a61">
<img width="943" alt="image" src="https://github.com/apache/iotdb/assets/60659567/d43fab3f-c6a0-4dfa-8595-6c1926998dc0">

