### PR TITLE
[To rel/0.13] [IOTDB-5844] Fix always waiting when cannot allocate memory for compaction

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/RewriteCrossSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/cross/rewrite/task/RewriteCrossSpaceCompactionTask.java
@@ -89,8 +89,9 @@ public class RewriteCrossSpaceCompactionTask extends AbstractCrossSpaceCompactio
   protected void doCompaction() throws Exception {
     try {
       SystemInfo.getInstance().addCompactionMemoryCost(memoryCost);
-    } catch (InterruptedException e) {
+    } catch (Exception e) {
       logger.error("Thread get interrupted when allocating memory for compaction", e);
+      releaseAllLock();
       return;
     }
     try {

--- a/server/src/main/java/org/apache/iotdb/db/rescon/SystemInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/rescon/SystemInfo.java
@@ -282,10 +282,20 @@ public class SystemInfo {
       return;
     }
     long originSize = this.compactionMemoryCost.get();
+    long waittingTime = 0L;
     while (originSize + memoryCost > memorySizeForCompaction
         || !compactionMemoryCost.compareAndSet(originSize, originSize + memoryCost)) {
       Thread.sleep(100);
       originSize = this.compactionMemoryCost.get();
+      waittingTime += 100L;
+      if (waittingTime >= 60_000L) {
+        throw new RuntimeException(
+            "Cannot get enough memory for compaction, want "
+                + memoryCost
+                + " bytes but only "
+                + (memorySizeForCompaction - compactionMemoryCost.get())
+                + " bytes left.");
+      }
     }
   }
 


### PR DESCRIPTION
See [IOTDB-5844](https://issues.apache.org/jira/browse/IOTDB-5844).

To address this issue, we have added a timeout mechanism to the memory allocation step in the compaction process. If sufficient memory is not allocated within a certain amount of time, a CompactionMemoryNotEnoughException will be thrown, an error log will be printed, and the compaction task will be abandoned.