### PR TITLE
Add size threshold to control wal disk usage

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/wal/WALManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/WALManager.java
@@ -176,7 +176,7 @@ public class WALManager implements IService {
     for (WALNode walNode : walNodes) {
       walNode.deleteOutdatedFiles();
     }
-    if (getTotalDiskUsage() >= config.getThrottleThreshold()) {
+    if (shouldThrottle()) {
       logger.warn(
           "WAL disk usage {} is larger than the iot_consensus_throttle_threshold_in_byte {}, please check your write load, iot consensus and the pipe module. It's better to allocate more disk for WAL.",
           getTotalDiskUsage(),
@@ -199,6 +199,10 @@ public class WALManager implements IService {
         }
       }
     }
+  }
+
+  public boolean shouldThrottle() {
+    return getTotalDiskUsage() >= config.getThrottleThreshold();
   }
 
   public long getTotalDiskUsage() {

--- a/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/wal/node/WALNode.java
@@ -267,7 +267,7 @@ public class WALNode implements IWALNode {
       // update first valid version id by snapshotting or flushing memTable,
       // then delete old .wal files again
       if (effectiveInfoRatio < config.getWalMinEffectiveInfoRatio()
-          || WALManager.getInstance().getTotalDiskUsage() >= config.getThrottleThreshold()) {
+          || WALManager.getInstance().shouldThrottle()) {
         logger.debug(
             "Effective information ratio {} (active memTables cost is {}, flushed memTables cost is {}) of wal node-{} is below wal min effective info ratio {}, some memTables will be snapshot or flushed.",
             effectiveInfoRatio,


### PR DESCRIPTION
To control the total disk usage of wal, we should introduce size threshold to control wal.

1. First delete the files of the largest disk uasge wal node.
2. Snapshot or flush memtable when wal disk usage reaches the threshold.
3. Skip delete operation when wal is pinned by the iot consensus or pipe.