### PR TITLE
[IOTDB-5997] Improve efficiency of ConfigNode PartitionInfo loadSnapshot

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
@@ -480,7 +480,16 @@ public class ConfigPlanExecutor {
         x -> {
           boolean takeSnapshotResult = true;
           try {
+            long startTime = System.currentTimeMillis();
+            LOGGER.info(
+                "[ConfigNodeSnapshot] Start to take snapshot for {} into {}",
+                x.getClass().getName(),
+                snapshotDir.getAbsolutePath());
             takeSnapshotResult = x.processTakeSnapshot(snapshotDir);
+            LOGGER.info(
+                "[ConfigNodeSnapshot] Finish to take snapshot for {}, time consumption: {} ms",
+                x.getClass().getName(),
+                System.currentTimeMillis() - startTime);
           } catch (TException | IOException e) {
             LOGGER.error("Take snapshot error: {}", e.getMessage());
             takeSnapshotResult = false;
@@ -493,7 +502,7 @@ public class ConfigPlanExecutor {
           }
         });
     if (result.get()) {
-      LOGGER.info("Task snapshot success, snapshotDir: {}", snapshotDir);
+      LOGGER.info("[ConfigNodeSnapshot] Task snapshot success, snapshotDir: {}", snapshotDir);
     }
     return result.get();
   }
@@ -513,10 +522,13 @@ public class ConfigPlanExecutor {
             x -> {
               try {
                 long startTime = System.currentTimeMillis();
-                LOGGER.info("[LoadSnapshot] Start to load snapshot for {}", x.getClass().getName());
+                LOGGER.info(
+                    "[ConfigNodeSnapshot] Start to load snapshot for {} from {}",
+                    x.getClass().getName(),
+                    latestSnapshotRootDir.getAbsolutePath());
                 x.processLoadSnapshot(latestSnapshotRootDir);
                 LOGGER.info(
-                    "[LoadSnapshot] Load snapshot for {} cost {} ms",
+                    "[ConfigNodeSnapshot] Load snapshot for {} cost {} ms",
                     x.getClass().getName(),
                     System.currentTimeMillis() - startTime);
               } catch (TException | IOException e) {
@@ -525,7 +537,9 @@ public class ConfigPlanExecutor {
               }
             });
     if (result.get()) {
-      LOGGER.info("Load snapshot success, latestSnapshotRootDir: {}", latestSnapshotRootDir);
+      LOGGER.info(
+          "[ConfigNodeSnapshot] Load snapshot success, latestSnapshotRootDir: {}",
+          latestSnapshotRootDir);
     }
   }
 

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
@@ -512,7 +512,13 @@ public class ConfigPlanExecutor {
         .forEach(
             x -> {
               try {
+                long startTime = System.currentTimeMillis();
+                LOGGER.info("[LoadSnapshot] Start to load snapshot for {}", x.getClass().getName());
                 x.processLoadSnapshot(latestSnapshotRootDir);
+                LOGGER.info(
+                    "[LoadSnapshot] Load snapshot for {} cost {} ms",
+                    x.getClass().getName(),
+                    System.currentTimeMillis() - startTime);
               } catch (TException | IOException e) {
                 result.set(false);
                 LOGGER.error("Load snapshot error: {}", e.getMessage());

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
@@ -71,10 +71,11 @@ import org.apache.thrift.transport.TIOStreamTransport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -99,6 +100,9 @@ import java.util.stream.Collectors;
 public class PartitionInfo implements SnapshotProcessor {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PartitionInfo.class);
+
+  // Allocate 8MB buffer for load snapshot of PartitionInfo
+  private static final int PARTITION_TABLE_BUFFER_SIZE = 8 * 1024 * 1024;
 
   /** For Cluster Partition */
   // For allocating Regions
@@ -825,7 +829,9 @@ public class PartitionInfo implements SnapshotProcessor {
       return;
     }
 
-    try (FileInputStream fileInputStream = new FileInputStream(snapshotFile);
+    try (BufferedInputStream fileInputStream =
+            new BufferedInputStream(
+                Files.newInputStream(snapshotFile.toPath()), PARTITION_TABLE_BUFFER_SIZE);
         TIOStreamTransport tioStreamTransport = new TIOStreamTransport(fileInputStream)) {
       TProtocol protocol = new TBinaryProtocol(tioStreamTransport);
       // before restoring a snapshot, clear all old data

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
@@ -102,7 +102,7 @@ public class PartitionInfo implements SnapshotProcessor {
   private static final Logger LOGGER = LoggerFactory.getLogger(PartitionInfo.class);
 
   // Allocate 8MB buffer for load snapshot of PartitionInfo
-  private static final int PARTITION_TABLE_BUFFER_SIZE = 8 * 1024 * 1024;
+  private static final int PARTITION_TABLE_BUFFER_SIZE = 32 * 1024 * 1024;
 
   /** For Cluster Partition */
   // For allocating Regions


### PR DESCRIPTION
Use BufferedInputStream(with 32MB buffer) instead of FileInputStream in PartitionInfo

**Before improvement:**
```
2023-06-15 15:46:03,342 [ForkJoinPool.commonPool-worker-115] INFO  o.a.i.c.p.e.ConfigPlanExecutor:518 - [LoadSnapshot] Load snapshot for org.apache.iotdb.confignode.persistence.partition.PartitionInfo cost 219083 ms
```
Load snapshot of PartitionInfo costs more than 200s

**After improvement:**
```
2023-06-15 18:35:02,676 [ForkJoinPool.commonPool-worker-115] INFO  o.a.i.c.p.e.ConfigPlanExecutor:530 - [ConfigNodeSnapshot] Load snapshot for org.apache.iotdb.confignode.persistence.partition.PartitionInfo cost 12881 ms
```
Load snapshot of PartitionInfo costs only 13s