### PR TITLE
[IOTDB-6008] Added receiver address check in pipe creation

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/utils/NodeUrlUtils.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/utils/NodeUrlUtils.java
@@ -208,6 +208,9 @@ public class NodeUrlUtils {
   }
 
   public static boolean endPointEquals(TEndPoint t1, TEndPoint t2) {
+    if (t1 == null || t2 == null) {
+      return false;
+    }
     return (isLocalAddress(t1.getIp())
             && isLocalAddress(t2.getIp())
             && t1.getPort() == t2.getPort())

--- a/node-commons/src/main/java/org/apache/iotdb/commons/utils/NodeUrlUtils.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/utils/NodeUrlUtils.java
@@ -76,9 +76,15 @@ public class NodeUrlUtils {
       throw new BadNodeUrlException(String.format("Bad endpoint url: %s", endPointUrl));
     }
     String ip = split[0];
+    if (!isLegalIP(ip)) {
+      throw new BadNodeUrlException(String.format("Bad node url: %s", endPointUrl));
+    }
     TEndPoint result;
     try {
       int port = Integer.parseInt(split[1]);
+      if (!isLegalPort(port)) {
+        throw new BadNodeUrlException(String.format("Bad node url: %s", endPointUrl));
+      }
       result = new TEndPoint(ip, port);
     } catch (NumberFormatException e) {
       logger.warn("Illegal endpoint url format: {}", endPointUrl);
@@ -186,6 +192,26 @@ public class NodeUrlUtils {
   public static List<TConfigNodeLocation> parseTConfigNodeUrls(String configNodeUrls)
       throws BadNodeUrlException {
     return parseTConfigNodeUrls(Arrays.asList(configNodeUrls.split(";")));
+  }
+
+  public static boolean isLegalIP(String ip) {
+    String regex =
+        "^(1\\d{2}|2[0-4]\\d|25[0-5]|[1-9]\\d|[1-9])\\."
+            + "(1\\d{2}|2[0-4]\\d|25[0-5]|[1-9]\\d|\\d)\\."
+            + "(1\\d{2}|2[0-4]\\d|25[0-5]|[1-9]\\d|\\d)\\."
+            + "(1\\d{2}|2[0-4]\\d|25[0-5]|[1-9]\\d|\\d)$";
+    return ip.equals("localhost") || ip.matches(regex);
+  }
+
+  public static boolean isLegalPort(int port) {
+    return port >= 0 && port <= 65535;
+  }
+
+  public static boolean endPointEquals(TEndPoint t1, TEndPoint t2) {
+    return (isLocalAddress(t1.getIp())
+            && isLocalAddress(t2.getIp())
+            && t1.getPort() == t2.getPort())
+        || t1.equals(t2);
   }
 
   public static boolean isLocalAddress(String ip) {


### PR DESCRIPTION
## IOTDB-6008
Checked the followings of the receiver address:

- Presence
- Legality
- Identity to existing end points

And added IP and port check in NodeUrlUtils.java.

### Tests
![image](https://github.com/apache/iotdb/assets/87789683/b4df2231-7ece-4598-af54-41b2c1e9ff65)


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
