### PR TITLE
[Metric] Fix missing IoTConsensus metric items

### DIFF
--- a/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/LogDispatcherThreadMetrics.java
+++ b/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/LogDispatcherThreadMetrics.java
@@ -91,24 +91,26 @@ public class LogDispatcherThreadMetrics implements IMetricSet {
   }
 
   private void bindStageHistogram(AbstractMetricService metricService) {
-    metricService.getOrCreateHistogram(
-        Metric.STAGE.toString(),
-        MetricLevel.IMPORTANT,
-        Tag.NAME.toString(),
-        Metric.IOT_CONSENSUS.toString(),
-        Tag.TYPE.toString(),
-        "constructBatch",
-        Tag.REGION.toString(),
-        peerGroupId);
-    metricService.getOrCreateHistogram(
-        Metric.STAGE.toString(),
-        MetricLevel.IMPORTANT,
-        Tag.NAME.toString(),
-        Metric.IOT_CONSENSUS.toString(),
-        Tag.TYPE.toString(),
-        "syncLogTimePerRequest",
-        Tag.REGION.toString(),
-        peerGroupId);
+    constructBatchHistogram =
+        metricService.getOrCreateHistogram(
+            Metric.STAGE.toString(),
+            MetricLevel.IMPORTANT,
+            Tag.NAME.toString(),
+            Metric.IOT_CONSENSUS.toString(),
+            Tag.TYPE.toString(),
+            "constructBatch",
+            Tag.REGION.toString(),
+            peerGroupId);
+    syncLogTimePerRequestHistogram =
+        metricService.getOrCreateHistogram(
+            Metric.STAGE.toString(),
+            MetricLevel.IMPORTANT,
+            Tag.NAME.toString(),
+            Metric.IOT_CONSENSUS.toString(),
+            Tag.TYPE.toString(),
+            "syncLogTimePerRequest",
+            Tag.REGION.toString(),
+            peerGroupId);
   }
 
   private void unbindStageHistogram(AbstractMetricService metricService) {


### PR DESCRIPTION
Currently, two core metric items of iotconsensus related to synchronization speed are missing
<img width="709" alt="image" src="https://github.com/apache/iotdb/assets/32640567/e2ec9717-bec2-4a8e-91c6-b8eb1877dc3b">
