### PR TITLE
use Boolean for isAligned

### DIFF
--- a/node-commons/src/main/java/org/apache/iotdb/commons/path/MeasurementPath.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/path/MeasurementPath.java
@@ -49,7 +49,7 @@ public class MeasurementPath extends PartialPath {
 
   private Map<String, String> tagMap;
 
-  private boolean isUnderAlignedEntity = false;
+  private Boolean isUnderAlignedEntity = false;
 
   // alias of measurement, null pointer cannot be serialized in thrift so empty string is instead
   private String measurementAlias = "";
@@ -76,7 +76,7 @@ public class MeasurementPath extends PartialPath {
   public MeasurementPath(
       PartialPath measurementPath,
       IMeasurementSchema measurementSchema,
-      boolean isUnderAlignedEntity) {
+      Boolean isUnderAlignedEntity) {
     super(measurementPath.getNodes());
     this.measurementSchema = measurementSchema;
     this.isUnderAlignedEntity = isUnderAlignedEntity;
@@ -149,10 +149,13 @@ public class MeasurementPath extends PartialPath {
   }
 
   public boolean isUnderAlignedEntity() {
+    if (isUnderAlignedEntity == null) {
+      return false;
+    }
     return isUnderAlignedEntity;
   }
 
-  public void setUnderAlignedEntity(boolean underAlignedEntity) {
+  public void setUnderAlignedEntity(Boolean underAlignedEntity) {
     isUnderAlignedEntity = underAlignedEntity;
   }
 
@@ -264,7 +267,7 @@ public class MeasurementPath extends PartialPath {
     if (isNull == 1) {
       measurementPath.tagMap = ReadWriteIOUtils.readMap(byteBuffer);
     }
-    measurementPath.isUnderAlignedEntity = ReadWriteIOUtils.readBool(byteBuffer);
+    measurementPath.isUnderAlignedEntity = ReadWriteIOUtils.readBoolObject(byteBuffer);
     measurementPath.measurementAlias = ReadWriteIOUtils.readString(byteBuffer);
     measurementPath.nodes = partialPath.getNodes();
     measurementPath.device = partialPath.getDevice();

--- a/node-commons/src/main/java/org/apache/iotdb/commons/schema/node/common/AbstractDatabaseDeviceMNode.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/schema/node/common/AbstractDatabaseDeviceMNode.java
@@ -262,11 +262,20 @@ public abstract class AbstractDatabaseDeviceMNode<N extends IMNode<N>, BasicNode
 
   @Override
   public boolean isAligned() {
+    Boolean align = databaseDeviceInfo.isAligned();
+    if (align == null) {
+      return false;
+    }
+    return align;
+  }
+
+  @Override
+  public Boolean isAlignedNullable() {
     return databaseDeviceInfo.isAligned();
   }
 
   @Override
-  public void setAligned(boolean isAligned) {
+  public void setAligned(Boolean isAligned) {
     databaseDeviceInfo.setAligned(isAligned);
   }
 

--- a/node-commons/src/main/java/org/apache/iotdb/commons/schema/node/common/AbstractDeviceMNode.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/schema/node/common/AbstractDeviceMNode.java
@@ -252,11 +252,20 @@ public abstract class AbstractDeviceMNode<N extends IMNode<N>, BasicNode extends
 
   @Override
   public boolean isAligned() {
+    Boolean align = deviceInfo.isAligned();
+    if (align == null) {
+      return false;
+    }
+    return align;
+  }
+
+  @Override
+  public Boolean isAlignedNullable() {
     return deviceInfo.isAligned();
   }
 
   @Override
-  public void setAligned(boolean isAligned) {
+  public void setAligned(Boolean isAligned) {
     deviceInfo.setAligned(isAligned);
   }
 

--- a/node-commons/src/main/java/org/apache/iotdb/commons/schema/node/common/AbstractMeasurementMNode.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/schema/node/common/AbstractMeasurementMNode.java
@@ -82,7 +82,7 @@ public abstract class AbstractMeasurementMNode<N extends IMNode<N>, BasicNode ex
   @Override
   public MeasurementPath getMeasurementPath() {
     MeasurementPath result = new MeasurementPath(getPartialPath(), getSchema());
-    result.setUnderAlignedEntity(getParent().getAsDeviceMNode().isAligned());
+    result.setUnderAlignedEntity(getParent().getAsDeviceMNode().isAlignedNullable());
     return result;
   }
 

--- a/node-commons/src/main/java/org/apache/iotdb/commons/schema/node/info/IDeviceInfo.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/schema/node/info/IDeviceInfo.java
@@ -60,9 +60,9 @@ public interface IDeviceInfo<N extends IMNode<N>> {
 
   void deactivateTemplate();
 
-  boolean isAligned();
+  Boolean isAligned();
 
-  void setAligned(boolean isAligned);
+  void setAligned(Boolean isAligned);
 
   int estimateSize();
 }

--- a/node-commons/src/main/java/org/apache/iotdb/commons/schema/node/role/IDeviceMNode.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/schema/node/role/IDeviceMNode.java
@@ -53,5 +53,7 @@ public interface IDeviceMNode<N extends IMNode<N>> extends IMNode<N> {
 
   boolean isAligned();
 
-  void setAligned(boolean isAligned);
+  Boolean isAlignedNullable();
+
+  void setAligned(Boolean isAligned);
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mnode/mem/info/DeviceInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mnode/mem/info/DeviceInfo.java
@@ -49,7 +49,7 @@ public class DeviceInfo<N extends IMNode<N>> implements IDeviceInfo<N> {
   @SuppressWarnings("squid:S3077")
   private transient volatile Map<String, IMeasurementMNode<N>> aliasChildren = null;
 
-  private volatile boolean isAligned = false;
+  private volatile Boolean isAligned = false;
 
   @Override
   public void moveDataToNewMNode(IDeviceMNode<N> newMNode) {
@@ -168,12 +168,12 @@ public class DeviceInfo<N extends IMNode<N>> implements IDeviceInfo<N> {
   }
 
   @Override
-  public boolean isAligned() {
+  public Boolean isAligned() {
     return isAligned;
   }
 
   @Override
-  public void setAligned(boolean isAligned) {
+  public void setAligned(Boolean isAligned) {
     this.isAligned = isAligned;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGCachedImpl.java
@@ -1024,7 +1024,7 @@ public class MTreeBelowSGCachedImpl {
 
           protected IDeviceSchemaInfo collectEntity(IDeviceMNode<ICachedMNode> node) {
             PartialPath device = getPartialPathFromRootToNode(node.getAsMNode());
-            return new ShowDevicesResult(device.getFullPath(), node.isAligned());
+            return new ShowDevicesResult(device.getFullPath(), node.isAlignedNullable());
           }
         };
     if (showDevicesPlan.usingSchemaTemplate()) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/MTreeBelowSGMemoryImpl.java
@@ -236,7 +236,9 @@ public class MTreeBelowSGMemoryImpl {
         }
       }
 
-      if (device.isDevice() && device.getAsDeviceMNode().isAligned()) {
+      if (device.isDevice()
+          && device.getAsDeviceMNode().isAlignedNullable() != null
+          && device.getAsDeviceMNode().isAligned()) {
         throw new AlignedTimeseriesException(
             "timeseries under this device is aligned, please use createAlignedTimeseries or change device.",
             device.getFullPath());
@@ -250,6 +252,11 @@ public class MTreeBelowSGMemoryImpl {
         if (entityMNode.isDatabase()) {
           replaceStorageGroupMNode(entityMNode.getAsDatabaseMNode());
         }
+      }
+
+      // create a non-aligned timeseries
+      if (entityMNode.isAlignedNullable() == null) {
+        entityMNode.setAligned(false);
       }
 
       IMeasurementMNode<IMemMNode> measurementMNode =
@@ -316,7 +323,9 @@ public class MTreeBelowSGMemoryImpl {
         }
       }
 
-      if (device.isDevice() && !device.getAsDeviceMNode().isAligned()) {
+      if (device.isDevice()
+          && device.getAsDeviceMNode().isAlignedNullable() != null
+          && !device.getAsDeviceMNode().isAligned()) {
         throw new AlignedTimeseriesException(
             "Timeseries under this device is not aligned, please use createTimeseries or change device.",
             devicePath.getFullPath());
@@ -331,6 +340,11 @@ public class MTreeBelowSGMemoryImpl {
         if (entityMNode.isDatabase()) {
           replaceStorageGroupMNode(entityMNode.getAsDatabaseMNode());
         }
+      }
+
+      // create a non-aligned timeseries
+      if (entityMNode.isAlignedNullable() == null) {
+        entityMNode.setAligned(true);
       }
 
       for (int i = 0; i < measurements.size(); i++) {
@@ -486,13 +500,17 @@ public class MTreeBelowSGMemoryImpl {
     IMemMNode curNode = entityMNode.getAsMNode();
     if (!entityMNode.isUseTemplate()) {
       boolean hasMeasurement = false;
+      boolean hasNonViewMeasurement = false;
       IMemMNode child;
       IMNodeIterator<IMemMNode> iterator = store.getChildrenIterator(curNode);
       while (iterator.hasNext()) {
         child = iterator.next();
         if (child.isMeasurement()) {
           hasMeasurement = true;
-          break;
+          if (!child.getAsMeasurementMNode().isLogicalView()) {
+            hasNonViewMeasurement = true;
+            break;
+          }
         }
       }
 
@@ -503,6 +521,9 @@ public class MTreeBelowSGMemoryImpl {
             replaceStorageGroupMNode(curNode.getAsDatabaseMNode());
           }
         }
+      } else if (!hasNonViewMeasurement) {
+        // has some measurement but they are all logical view
+        entityMNode.setAligned(null);
       }
     }
 
@@ -863,7 +884,7 @@ public class MTreeBelowSGMemoryImpl {
 
           protected IDeviceSchemaInfo collectEntity(IDeviceMNode<IMemMNode> node) {
             PartialPath device = getPartialPathFromRootToNode(node.getAsMNode());
-            return new ShowDevicesResult(device.getFullPath(), node.isAligned());
+            return new ShowDevicesResult(device.getFullPath(), node.isAlignedNullable());
           }
         };
     if (showDevicesPlan.usingSchemaTemplate()) {
@@ -1062,6 +1083,9 @@ public class MTreeBelowSGMemoryImpl {
         if (entityMNode.isDatabase()) {
           replaceStorageGroupMNode(entityMNode.getAsDatabaseMNode());
         }
+        // this parent has no measurement before. The leafName is his first child who is a logical
+        // view.
+        entityMNode.setAligned(null);
       }
 
       IMeasurementMNode<IMemMNode> measurementMNode =

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/snapshot/MemMTreeSnapshotUtil.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/snapshot/MemMTreeSnapshotUtil.java
@@ -312,7 +312,7 @@ public class MemMTreeSnapshotUtil {
         serializeBasicMNode(node.getBasicMNode(), outputStream);
         ReadWriteIOUtils.write(node.getSchemaTemplateIdWithState(), outputStream);
         ReadWriteIOUtils.write(node.isUseTemplate(), outputStream);
-        ReadWriteIOUtils.write(node.isAligned(), outputStream);
+        ReadWriteIOUtils.write(node.isAlignedNullable(), outputStream);
         // database node in schemaRegion doesn't store any database schema
         return true;
       } catch (IOException e) {
@@ -329,7 +329,7 @@ public class MemMTreeSnapshotUtil {
         serializeBasicMNode(node.getBasicMNode(), outputStream);
         ReadWriteIOUtils.write(node.getSchemaTemplateIdWithState(), outputStream);
         ReadWriteIOUtils.write(node.isUseTemplate(), outputStream);
-        ReadWriteIOUtils.write(node.isAligned(), outputStream);
+        ReadWriteIOUtils.write(node.isAlignedNullable(), outputStream);
         return true;
       } catch (IOException e) {
         logger.error(SERIALIZE_ERROR_INFO, e);

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/MockSchemaFile.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/store/disk/schemafile/MockSchemaFile.java
@@ -189,12 +189,12 @@ public class MockSchemaFile implements ISchemaFile {
       ICachedMNode result =
           nodeFactory.createDatabaseDeviceMNode(
               null, node.getName(), node.getAsDatabaseMNode().getDataTTL());
-      result.getAsDeviceMNode().setAligned(node.getAsDeviceMNode().isAligned());
+      result.getAsDeviceMNode().setAligned(node.getAsDeviceMNode().isAlignedNullable());
       cloneInternalMNodeData(node, result);
       return result;
     } else if (node.isDevice()) {
       ICachedMNode result = nodeFactory.createDeviceMNode(null, node.getName()).getAsMNode();
-      result.getAsDeviceMNode().setAligned(node.getAsDeviceMNode().isAligned());
+      result.getAsDeviceMNode().setAligned(node.getAsDeviceMNode().isAlignedNullable());
       cloneInternalMNodeData(node, result);
       return result;
     } else if (node.isDatabase()) {

--- a/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/collector/MeasurementCollector.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/mtree/traverser/collector/MeasurementCollector.java
@@ -59,7 +59,7 @@ public abstract class MeasurementCollector<R, N extends IMNode<N>>
     MeasurementPath retPath =
         new MeasurementPath(
             getPartialPathFromRootToNode(currentNode.getAsMNode()), currentNode.getSchema());
-    retPath.setUnderAlignedEntity(par.getAsDeviceMNode().isAligned());
+    retPath.setUnderAlignedEntity(par.getAsDeviceMNode().isAlignedNullable());
     return retPath;
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/plan/schemaregion/result/ShowDevicesResult.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/plan/schemaregion/result/ShowDevicesResult.java
@@ -23,14 +23,14 @@ import org.apache.iotdb.db.metadata.query.info.IDeviceSchemaInfo;
 import java.util.Objects;
 
 public class ShowDevicesResult extends ShowSchemaResult implements IDeviceSchemaInfo {
-  private boolean isAligned;
+  private Boolean isAligned;
 
-  public ShowDevicesResult(String name, boolean isAligned) {
+  public ShowDevicesResult(String name, Boolean isAligned) {
     super(name);
     this.isAligned = isAligned;
   }
 
-  public boolean isAligned() {
+  public Boolean isAligned() {
     return isAligned;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/metadata/query/info/IDeviceSchemaInfo.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/query/info/IDeviceSchemaInfo.java
@@ -21,5 +21,5 @@ package org.apache.iotdb.db.metadata.query.info;
 
 public interface IDeviceSchemaInfo extends ISchemaInfo {
 
-  boolean isAligned();
+  Boolean isAligned();
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/ReadWriteIOUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/ReadWriteIOUtils.java
@@ -95,6 +95,17 @@ public class ReadWriteIOUtils {
     return a == 1;
   }
 
+  /** read a Boolean from byteBuffer. */
+  public static Boolean readBoolObject(ByteBuffer buffer) {
+    byte a = buffer.get();
+    if (a == 1) {
+      return true;
+    } else if (a == 0) {
+      return false;
+    }
+    return null;
+  }
+
   /** read a byte from byteBuffer. */
   public static byte readByte(ByteBuffer buffer) {
     return buffer.get();
@@ -185,7 +196,9 @@ public class ReadWriteIOUtils {
    * write a int value to outputStream according to flag. If flag is true, write 1, else write 0.
    */
   public static int write(Boolean flag, OutputStream outputStream) throws IOException {
-    if (Boolean.TRUE.equals(flag)) {
+    if (flag == null) {
+      outputStream.write(2);
+    } else if (Boolean.TRUE.equals(flag)) {
       outputStream.write(1);
     } else {
       outputStream.write(0);
@@ -196,7 +209,9 @@ public class ReadWriteIOUtils {
   /** write a byte to byteBuffer according to flag. If flag is true, write 1, else write 0. */
   public static int write(Boolean flag, ByteBuffer buffer) {
     byte a;
-    if (Boolean.TRUE.equals(flag)) {
+    if (flag == null) {
+      a = 2;
+    } else if (Boolean.TRUE.equals(flag)) {
       a = 1;
     } else {
       a = 0;


### PR DESCRIPTION
修改了isAligned属性的存储方式，由原本的boolean改为Boolean，因此可以存储空值。 注意事项如下：

## 目的
目的是将只含有视图的设备，其isAligned值显示为`null`。

### 修改范围
只修改了MeasurementPath 和DeviceInfo中的存储值，其他地方是没变的。
但其实为了达到目的，只需要改动DeviceInfo这部分；MeasurementPath是顺带改了，修改了成员变量，但对外获取isAligned的接口没变（详见下一小节）。

### 尽可能减少了对原有系统的冲击
Measurement获取isUnderAlignedEntity时使用的函数返回值依旧为boolean，不可能为空，因为返回前做了判断；IDeviceMNode的isAligned接口保持不变，返回值依旧为boolean，同样是在返回前做了费控判断。
**注意，为空时默认返回false**，这和原有系统行为一致，原本的纯视图设备isAligned返回false。

## 修改了序列化方法。
新增readBoolObject用于读取Boolean类，写入则使用的是原有接口write。为了保证兼容性，true序列化为1，false序列化为0，空值序列化为2
.需要注意的是，序列化Boolean时没有使用readObject或者write object这种接口，这是为了兼容旧系统。
 **没能找到对DeviceNode的反序列化方法，这里可能该漏了**，但实际测试时，重启时发现null值的保存是成功的。

## 关于isAligned的状态的转化。 
不使用视图时，isAligned只可能为true或者false；
创建视图并且自动创建了设备时，说明该设备之前没有measurement作为孩子，所以这个视图是第一个作为孩子的measurement，因此它的isAligned是null；删除一个设备下所有非视图序列并且保留视图时，isAligned自动转换为null。

做了本地测试如下：

d01、d03是非对齐设备，d02和d04是对齐设备。

1. 在d01、d02创建时间序列显示正常
```
IoTDB> create timeseries root.db.d01.s01 INT32 encoding=RLE;
Msg: The statement is executed successfully.
IoTDB> create timeseries root.db.d01.s02 INT32 encoding=RLE;
Msg: The statement is executed successfully.
IoTDB>
IoTDB> create aligned timeseries root.db.d02(s01 INT32 encoding=RLE, s02 INT32 encoding=RLE);
Msg: The statement is executed successfully.
IoTDB>
IoTDB> show devices;
+-----------+---------+
|     Device|IsAligned|
+-----------+---------+
|root.db.d01|    false|
|root.db.d02|     true|
+-----------+---------+
Total line number = 2
It costs 0.010s
IoTDB>
```

2. 在已有序列的设备d01、d02下创建视图都ok
```
IoTDB> create view root.db.d01.s_view AS root.db.d01.s01;
Msg: The statement is executed successfully.
IoTDB> create view root.db.d02.s_view AS root.db.d02.s01;
Msg: The statement is executed successfully.
IoTDB>
IoTDB> show devices;
+-----------+---------+
|     Device|IsAligned|
+-----------+---------+
|root.db.d01|    false|
|root.db.d02|     true|
+-----------+---------+
Total line number = 2
It costs 0.013s
IoTDB>
```

3. 创建只含有视图的设备d03、d04，show device显示null
```
IoTDB> create view root.db.d03.s_view AS root.db.d01.s01;
Msg: The statement is executed successfully.
IoTDB> create view root.db.d04.s_view AS root.db.d01.s01;
Msg: The statement is executed successfully.
IoTDB>
IoTDB> show devices;
+-----------+---------+
|     Device|IsAligned|
+-----------+---------+
|root.db.d01|    false|
|root.db.d03|     null|
|root.db.d02|     true|
|root.db.d04|     null|
+-----------+---------+
Total line number = 4
It costs 0.017s
IoTDB>
```

4. 在只含有视图的设备d03下创建非对齐时间序列，在只含有视图的设备d04下创建对齐时间序列
```
IoTDB> create timeseries root.db.d03.s01 INT32 encoding=RLE;
Msg: The statement is executed successfully.
IoTDB> create aligned timeseries root.db.d04(s01 INT32 encoding=RLE);
Msg: The statement is executed successfully.
IoTDB>
IoTDB> show devices;
+-----------+---------+
|     Device|IsAligned|
+-----------+---------+
|root.db.d01|    false|
|root.db.d03|    false|
|root.db.d02|     true|
|root.db.d04|     true|
+-----------+---------+
Total line number = 4
It costs 0.015s
IoTDB>
```

5. 删除d03和d04下所有时间序列（不删除视图）
```
IoTDB> delete timeseries root.db.d03.s01;
Msg: The statement is executed successfully.
IoTDB> delete timeseries root.db.d04.s01;
Msg: The statement is executed successfully.
IoTDB>
IoTDB> show devices;
+-----------+---------+
|     Device|IsAligned|
+-----------+---------+
|root.db.d01|    false|
|root.db.d03|     null|
|root.db.d02|     true|
|root.db.d04|     null|
+-----------+---------+
Total line number = 4
It costs 0.017s
IoTDB>

```
