### PR TITLE
[To rel/1.2][IOTDB-5931] Pipe: async execute pipeHandleLeaderChange and pipeHandleMetaChange to avoid causing heartbeats to timeout

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
@@ -834,51 +834,35 @@ public class ProcedureManager {
     }
   }
 
-  public TSStatus pipeHandleLeaderChange(
+  public void pipeHandleLeaderChange(
       Map<TConsensusGroupId, Pair<Integer, Integer>> dataRegionGroupToOldAndNewLeaderPairMap) {
     try {
-      long procedureId =
+      final long procedureId =
           executor.submitProcedure(
               new PipeHandleLeaderChangeProcedure(dataRegionGroupToOldAndNewLeaderPairMap));
-      List<TSStatus> statusList = new ArrayList<>();
-      boolean isSucceed =
-          waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-      if (isSucceed) {
-        return RpcUtils.SUCCESS_STATUS;
-      } else {
-        return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
-            .setMessage(statusList.get(0).getMessage());
-      }
+      LOGGER.info("PipeHandleLeaderChangeProcedure was submitted, procedureId: {}.", procedureId);
     } catch (Exception e) {
-      return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
+      LOGGER.warn("PipeHandleLeaderChangeProcedure was failed to submit.", e);
+    }
+  }
+
+  public void pipeHandleMetaChange(
+      int dataNodeId, @NotNull List<ByteBuffer> pipeMetaByteBufferListFromDataNode) {
+    try {
+      final long procedureId =
+          executor.submitProcedure(
+              new PipeHandleMetaChangeProcedure(dataNodeId, pipeMetaByteBufferListFromDataNode));
+      LOGGER.info("PipeHandleMetaChangeProcedure was submitted, procedureId: {}.", procedureId);
+    } catch (Exception e) {
+      LOGGER.warn("PipeHandleMetaChangeProcedure was failed to submit.", e);
     }
   }
 
   public TSStatus pipeMetaSync() {
     try {
-      long procedureId = executor.submitProcedure(new PipeMetaSyncProcedure());
-      List<TSStatus> statusList = new ArrayList<>();
-      boolean isSucceed =
-          waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-      if (isSucceed) {
-        return RpcUtils.SUCCESS_STATUS;
-      } else {
-        return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
-            .setMessage(statusList.get(0).getMessage());
-      }
-    } catch (Exception e) {
-      return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
-    }
-  }
-
-  public TSStatus pipeHandleMetaChange(
-      int dataNodeId, @NotNull List<ByteBuffer> pipeMetaByteBufferListFromDataNode) {
-    try {
-      long procedureId =
-          executor.submitProcedure(
-              new PipeHandleMetaChangeProcedure(dataNodeId, pipeMetaByteBufferListFromDataNode));
-      List<TSStatus> statusList = new ArrayList<>();
-      boolean isSucceed =
+      final long procedureId = executor.submitProcedure(new PipeMetaSyncProcedure());
+      final List<TSStatus> statusList = new ArrayList<>();
+      final boolean isSucceed =
           waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
       if (isSucceed) {
         return RpcUtils.SUCCESS_STATUS;

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
@@ -94,7 +94,6 @@ import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.tsfile.utils.Binary;
 import org.apache.iotdb.tsfile.utils.Pair;
 
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -847,11 +846,12 @@ public class ProcedureManager {
   }
 
   public void pipeHandleMetaChange(
-      int dataNodeId, @NotNull List<ByteBuffer> pipeMetaByteBufferListFromDataNode) {
+      boolean needWriteConsensusOnConfigNodes, boolean needPushPipeMetaToDataNodes) {
     try {
       final long procedureId =
           executor.submitProcedure(
-              new PipeHandleMetaChangeProcedure(dataNodeId, pipeMetaByteBufferListFromDataNode));
+              new PipeHandleMetaChangeProcedure(
+                  needWriteConsensusOnConfigNodes, needPushPipeMetaToDataNodes));
       LOGGER.info("PipeHandleMetaChangeProcedure was submitted, procedureId: {}.", procedureId);
     } catch (Exception e) {
       LOGGER.warn("PipeHandleMetaChangeProcedure was failed to submit.", e);

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/runtime/PipeHeartbeatParser.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/runtime/PipeHeartbeatParser.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.confignode.manager.pipe.runtime;
+
+import org.apache.iotdb.common.rpc.thrift.TConsensusGroupId;
+import org.apache.iotdb.commons.exception.pipe.PipeRuntimeConnectorCriticalException;
+import org.apache.iotdb.commons.exception.pipe.PipeRuntimeCriticalException;
+import org.apache.iotdb.commons.exception.pipe.PipeRuntimeException;
+import org.apache.iotdb.commons.pipe.task.meta.PipeMeta;
+import org.apache.iotdb.commons.pipe.task.meta.PipeStaticMeta;
+import org.apache.iotdb.commons.pipe.task.meta.PipeStatus;
+import org.apache.iotdb.commons.pipe.task.meta.PipeTaskMeta;
+import org.apache.iotdb.confignode.consensus.response.pipe.task.PipeTableResp;
+import org.apache.iotdb.confignode.manager.ConfigManager;
+
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class PipeHeartbeatParser {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PipeHeartbeatParser.class);
+
+  private final ConfigManager configManager;
+
+  private long heartbeatCounter;
+  private int registeredDataNodeNumber;
+
+  private final AtomicBoolean needWriteConsensusOnConfigNodes;
+  private final AtomicBoolean needPushPipeMetaToDataNodes;
+
+  PipeHeartbeatParser(ConfigManager configManager) {
+    this.configManager = configManager;
+
+    heartbeatCounter = 0;
+    registeredDataNodeNumber = 1;
+
+    needWriteConsensusOnConfigNodes = new AtomicBoolean(false);
+    needPushPipeMetaToDataNodes = new AtomicBoolean(false);
+  }
+
+  public synchronized void parseHeartbeat(
+      int dataNodeId, @NotNull List<ByteBuffer> pipeMetaByteBufferListFromDataNode) {
+    final long heartbeatCount = ++heartbeatCounter;
+
+    final AtomicBoolean canSubmitHandleMetaChangeProcedure = new AtomicBoolean(false);
+    // registeredDataNodeNumber can not be 0 when the method is called
+    if (heartbeatCount % registeredDataNodeNumber == 0) {
+      canSubmitHandleMetaChangeProcedure.set(true);
+
+      // registeredDataNodeNumber may be changed, update it here when we can submit procedure
+      registeredDataNodeNumber = configManager.getNodeManager().getRegisteredDataNodeCount();
+      if (registeredDataNodeNumber <= 0) {
+        LOGGER.warn(
+            "registeredDataNodeNumber is {} when parseHeartbeat from data node (id={}).",
+            registeredDataNodeNumber,
+            dataNodeId);
+        // registeredDataNodeNumber can not be set to 0 in this class, otherwise may cause
+        // DivideByZeroException
+        registeredDataNodeNumber = 1;
+      }
+    }
+
+    if (pipeMetaByteBufferListFromDataNode.isEmpty()
+        && !(canSubmitHandleMetaChangeProcedure.get()
+            && (needWriteConsensusOnConfigNodes.get() || needPushPipeMetaToDataNodes.get()))) {
+      return;
+    }
+
+    PipeRuntimeCoordinator.PROCEDURE_SUBMITTER.submit(
+        () -> {
+          if (!pipeMetaByteBufferListFromDataNode.isEmpty()) {
+            parseHeartbeatAndSaveMetaChangeLocally(dataNodeId, pipeMetaByteBufferListFromDataNode);
+          }
+
+          if (canSubmitHandleMetaChangeProcedure.get()
+              && (needWriteConsensusOnConfigNodes.get() || needPushPipeMetaToDataNodes.get())) {
+            configManager
+                .getProcedureManager()
+                .pipeHandleMetaChange(
+                    needWriteConsensusOnConfigNodes.get(), needPushPipeMetaToDataNodes.get());
+
+            // reset flags after procedure is submitted
+            needWriteConsensusOnConfigNodes.set(false);
+            needPushPipeMetaToDataNodes.set(false);
+          }
+        });
+  }
+
+  private void parseHeartbeatAndSaveMetaChangeLocally(
+      int dataNodeId, @NotNull List<ByteBuffer> pipeMetaByteBufferListFromDataNode) {
+    final Map<PipeStaticMeta, PipeMeta> pipeMetaMapFromDataNode = new HashMap<>();
+    for (ByteBuffer byteBuffer : pipeMetaByteBufferListFromDataNode) {
+      final PipeMeta pipeMeta = PipeMeta.deserialize(byteBuffer);
+      pipeMetaMapFromDataNode.put(pipeMeta.getStaticMeta(), pipeMeta);
+    }
+
+    for (final PipeMeta pipeMetaOnConfigNode :
+        configManager
+            .getPipeManager()
+            .getPipeTaskCoordinator()
+            .getPipeTaskInfo()
+            .getPipeMetaList()) {
+      final PipeMeta pipeMetaFromDataNode =
+          pipeMetaMapFromDataNode.get(pipeMetaOnConfigNode.getStaticMeta());
+      if (pipeMetaFromDataNode == null) {
+        LOGGER.info(
+            "PipeRuntimeCoordinator meets error in updating pipeMetaKeeper, "
+                + "pipeMetaFromDataNode is null, pipeMetaOnConfigNode: {}",
+            pipeMetaOnConfigNode);
+        continue;
+      }
+
+      final Map<TConsensusGroupId, PipeTaskMeta> pipeTaskMetaMapOnConfigNode =
+          pipeMetaOnConfigNode.getRuntimeMeta().getConsensusGroupIdToTaskMetaMap();
+      final Map<TConsensusGroupId, PipeTaskMeta> pipeTaskMetaMapFromDataNode =
+          pipeMetaFromDataNode.getRuntimeMeta().getConsensusGroupIdToTaskMetaMap();
+      for (final Map.Entry<TConsensusGroupId, PipeTaskMeta> runtimeMetaOnConfigNode :
+          pipeTaskMetaMapOnConfigNode.entrySet()) {
+        if (runtimeMetaOnConfigNode.getValue().getLeaderDataNodeId() != dataNodeId) {
+          continue;
+        }
+
+        final PipeTaskMeta runtimeMetaFromDataNode =
+            pipeTaskMetaMapFromDataNode.get(runtimeMetaOnConfigNode.getKey());
+        if (runtimeMetaFromDataNode == null) {
+          LOGGER.warn(
+              "PipeRuntimeCoordinator meets error in updating pipeMetaKeeper, "
+                  + "runtimeMetaFromDataNode is null, runtimeMetaOnConfigNode: {}",
+              runtimeMetaOnConfigNode);
+          continue;
+        }
+
+        // update progress index
+        if (!runtimeMetaOnConfigNode
+            .getValue()
+            .getProgressIndex()
+            .isAfter(runtimeMetaFromDataNode.getProgressIndex())) {
+          LOGGER.info(
+              "Updating progress index for (pipe name: {}, consensus group id: {}) ... Progress index on config node: {}, progress index from data node: {}",
+              pipeMetaOnConfigNode.getStaticMeta().getPipeName(),
+              runtimeMetaOnConfigNode.getKey(),
+              runtimeMetaOnConfigNode.getValue().getProgressIndex(),
+              runtimeMetaFromDataNode.getProgressIndex());
+          LOGGER.info(
+              "Progress index for (pipe name: {}, consensus group id: {}) is updated to {}",
+              pipeMetaOnConfigNode.getStaticMeta().getPipeName(),
+              runtimeMetaOnConfigNode.getKey(),
+              runtimeMetaOnConfigNode
+                  .getValue()
+                  .updateProgressIndex(runtimeMetaFromDataNode.getProgressIndex()));
+
+          needWriteConsensusOnConfigNodes.set(true);
+        }
+
+        // update runtime exception
+        final PipeTaskMeta pipeTaskMetaOnConfigNode = runtimeMetaOnConfigNode.getValue();
+        pipeTaskMetaOnConfigNode.clearExceptionMessages();
+        for (final PipeRuntimeException exception :
+            runtimeMetaFromDataNode.getExceptionMessages()) {
+
+          pipeTaskMetaOnConfigNode.trackExceptionMessage(exception);
+
+          if (exception instanceof PipeRuntimeCriticalException) {
+            final String pipeName = pipeMetaOnConfigNode.getStaticMeta().getPipeName();
+            if (!pipeMetaOnConfigNode
+                .getRuntimeMeta()
+                .getStatus()
+                .get()
+                .equals(PipeStatus.STOPPED)) {
+              pipeMetaOnConfigNode.getRuntimeMeta().getStatus().set(PipeStatus.STOPPED);
+
+              needWriteConsensusOnConfigNodes.set(true);
+              needPushPipeMetaToDataNodes.set(true);
+
+              LOGGER.warn(
+                  String.format(
+                      "Detect PipeRuntimeCriticalException %s from DataNode, stop pipe %s.",
+                      exception, pipeName));
+            }
+
+            if (exception instanceof PipeRuntimeConnectorCriticalException) {
+              ((PipeTableResp)
+                      configManager
+                          .getPipeManager()
+                          .getPipeTaskCoordinator()
+                          .getPipeTaskInfo()
+                          .showPipes())
+                  .filter(true, pipeName).getAllPipeMeta().stream()
+                      .map(pipeMeta -> pipeMeta.getRuntimeMeta().getStatus())
+                      .filter(status -> !status.get().equals(PipeStatus.STOPPED))
+                      .forEach(
+                          status -> {
+                            status.set(PipeStatus.STOPPED);
+
+                            needWriteConsensusOnConfigNodes.set(true);
+                            needPushPipeMetaToDataNodes.set(true);
+
+                            LOGGER.warn(
+                                String.format(
+                                    "Detect PipeRuntimeConnectorCriticalException %s from DataNode, stop pipe %s.",
+                                    exception, pipeName));
+                          });
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/runtime/PipeLeaderChangeHandler.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/runtime/PipeLeaderChangeHandler.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.confignode.manager.pipe.runtime;
+
+import org.apache.iotdb.common.rpc.thrift.TConsensusGroupId;
+import org.apache.iotdb.common.rpc.thrift.TConsensusGroupType;
+import org.apache.iotdb.confignode.manager.ConfigManager;
+import org.apache.iotdb.confignode.manager.load.subscriber.IClusterStatusSubscriber;
+import org.apache.iotdb.confignode.manager.load.subscriber.RouteChangeEvent;
+import org.apache.iotdb.confignode.manager.load.subscriber.StatisticsChangeEvent;
+import org.apache.iotdb.metrics.utils.IoTDBMetricsUtils;
+import org.apache.iotdb.tsfile.utils.Pair;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PipeLeaderChangeHandler implements IClusterStatusSubscriber {
+
+  private final ConfigManager configManager;
+
+  PipeLeaderChangeHandler(ConfigManager configManager) {
+    this.configManager = configManager;
+  }
+
+  @Override
+  public void onClusterStatisticsChanged(StatisticsChangeEvent event) {
+    // do nothing, because pipe task is not related to statistics
+  }
+
+  @Override
+  public void onRegionGroupLeaderChanged(RouteChangeEvent event) {
+    // if no pipe task, return
+    if (configManager.getPipeManager().getPipeTaskCoordinator().getPipeTaskInfo().isEmpty()) {
+      return;
+    }
+
+    // we only care about data region leader change
+    final Map<TConsensusGroupId, Pair<Integer, Integer>> dataRegionGroupToOldAndNewLeaderPairMap =
+        new HashMap<>();
+    event
+        .getLeaderMap()
+        .forEach(
+            (regionGroupId, pair) -> {
+              if (regionGroupId.getType().equals(TConsensusGroupType.DataRegion)) {
+                final String databaseName =
+                    configManager.getPartitionManager().getRegionStorageGroup(regionGroupId);
+                if (databaseName != null && !databaseName.equals(IoTDBMetricsUtils.DATABASE)) {
+                  // pipe only collect user's data, filter metric database here.
+                  dataRegionGroupToOldAndNewLeaderPairMap.put(
+                      regionGroupId,
+                      new Pair<>( // null or -1 means empty origin leader
+                          pair.left == null ? -1 : pair.left,
+                          pair.right == null ? -1 : pair.right));
+                }
+              }
+            });
+
+    // if no data region leader change, return
+    if (dataRegionGroupToOldAndNewLeaderPairMap.isEmpty()) {
+      return;
+    }
+
+    // submit procedure in an async way to avoid blocking the caller
+    PipeRuntimeCoordinator.PROCEDURE_SUBMITTER.submit(
+        () ->
+            configManager
+                .getProcedureManager()
+                .pipeHandleLeaderChange(dataRegionGroupToOldAndNewLeaderPairMap));
+  }
+}

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/runtime/PipeMetaSyncer.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/runtime/PipeMetaSyncer.java
@@ -40,7 +40,7 @@ public class PipeMetaSyncer {
 
   private static final ScheduledExecutorService SYNC_EXECUTOR =
       IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor(
-          ThreadName.PIPE_META_SYNC_SERVICE.getName());
+          ThreadName.PIPE_RUNTIME_META_SYNCER.getName());
   private static final long INITIAL_SYNC_DELAY_MINUTES =
       PipeConfig.getInstance().getPipeMetaSyncerInitialSyncDelayMinutes();
   private static final long SYNC_INTERVAL_MINUTES =
@@ -50,7 +50,7 @@ public class PipeMetaSyncer {
 
   private Future<?> metaSyncFuture;
 
-  public PipeMetaSyncer(ConfigManager configManager) {
+  PipeMetaSyncer(ConfigManager configManager) {
     this.configManager = configManager;
   }
 

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/runtime/PipeRuntimeCoordinator.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/runtime/PipeRuntimeCoordinator.java
@@ -21,18 +21,14 @@ package org.apache.iotdb.confignode.manager.pipe.runtime;
 
 import org.apache.iotdb.common.rpc.thrift.TConsensusGroupId;
 import org.apache.iotdb.common.rpc.thrift.TConsensusGroupType;
-import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.confignode.manager.ConfigManager;
 import org.apache.iotdb.confignode.manager.load.subscriber.IClusterStatusSubscriber;
 import org.apache.iotdb.confignode.manager.load.subscriber.RouteChangeEvent;
 import org.apache.iotdb.confignode.manager.load.subscriber.StatisticsChangeEvent;
 import org.apache.iotdb.metrics.utils.IoTDBMetricsUtils;
-import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.tsfile.utils.Pair;
 
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -40,8 +36,6 @@ import java.util.List;
 import java.util.Map;
 
 public class PipeRuntimeCoordinator implements IClusterStatusSubscriber {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(PipeRuntimeCoordinator.class);
 
   private final ConfigManager configManager;
 
@@ -90,23 +84,9 @@ public class PipeRuntimeCoordinator implements IClusterStatusSubscriber {
       return;
     }
 
-    final TSStatus result =
-        configManager
-            .getProcedureManager()
-            .pipeHandleLeaderChange(dataRegionGroupToOldAndNewLeaderPairMap);
-    if (result.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
-      LOGGER.warn(
-          "PipeRuntimeCoordinator meets error in handling data region leader change, status: ({})",
-          result);
-    }
-  }
-
-  public void startPipeMetaSync() {
-    pipeMetaSyncer.start();
-  }
-
-  public void stopPipeMetaSync() {
-    pipeMetaSyncer.stop();
+    configManager
+        .getProcedureManager()
+        .pipeHandleLeaderChange(dataRegionGroupToOldAndNewLeaderPairMap);
   }
 
   /**
@@ -117,13 +97,16 @@ public class PipeRuntimeCoordinator implements IClusterStatusSubscriber {
    */
   public void parseHeartbeat(
       int dataNodeId, @NotNull List<ByteBuffer> pipeMetaByteBufferListFromDataNode) {
-    final TSStatus result =
-        configManager
-            .getProcedureManager()
-            .pipeHandleMetaChange(dataNodeId, pipeMetaByteBufferListFromDataNode);
-    if (result.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
-      LOGGER.warn(
-          "PipeTaskCoordinator meets error in handling pipe meta change, status: ({})", result);
-    }
+    configManager
+        .getProcedureManager()
+        .pipeHandleMetaChange(dataNodeId, pipeMetaByteBufferListFromDataNode);
+  }
+
+  public void startPipeMetaSync() {
+    pipeMetaSyncer.start();
+  }
+
+  public void stopPipeMetaSync() {
+    pipeMetaSyncer.stop();
   }
 }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/AbstractOperatePipeProcedureV2.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/AbstractOperatePipeProcedureV2.java
@@ -51,7 +51,7 @@ public abstract class AbstractOperatePipeProcedureV2
   private static final Logger LOGGER =
       LoggerFactory.getLogger(AbstractOperatePipeProcedureV2.class);
 
-  private static final int RETRY_THRESHOLD = 3;
+  private static final int RETRY_THRESHOLD = 1;
 
   // only used in rollback to reduce the number of network calls
   protected boolean isRollbackFromOperateOnDataNodesSuccessful = false;

--- a/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/runtime/PipeHandleMetaChangeProcedureTest.java
+++ b/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/runtime/PipeHandleMetaChangeProcedureTest.java
@@ -22,7 +22,6 @@ package org.apache.iotdb.confignode.procedure.impl.pipe.runtime;
 import org.apache.iotdb.common.rpc.thrift.TConsensusGroupId;
 import org.apache.iotdb.common.rpc.thrift.TConsensusGroupType;
 import org.apache.iotdb.commons.consensus.index.impl.MinimumProgressIndex;
-import org.apache.iotdb.commons.pipe.task.meta.PipeMeta;
 import org.apache.iotdb.commons.pipe.task.meta.PipeRuntimeMeta;
 import org.apache.iotdb.commons.pipe.task.meta.PipeStaticMeta;
 import org.apache.iotdb.commons.pipe.task.meta.PipeTaskMeta;
@@ -34,7 +33,6 @@ import org.junit.Test;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
@@ -78,10 +76,7 @@ public class PipeHandleMetaChangeProcedureTest {
               }
             });
 
-    PipeHandleMetaChangeProcedure proc =
-        new PipeHandleMetaChangeProcedure(
-            123,
-            Collections.singletonList(new PipeMeta(pipeStaticMeta, pipeRuntimeMeta).serialize()));
+    PipeHandleMetaChangeProcedure proc = new PipeHandleMetaChangeProcedure(true, false);
 
     try {
       proc.serialize(outputStream);

--- a/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/ThreadName.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/ThreadName.java
@@ -99,17 +99,15 @@ public enum ThreadName {
   GRPC_DEFAULT_EXECUTOR("grpc-default-executor"),
   GPRC_DEFAULT_WORKER_ELG("grpc-default-worker-ELG"),
   GROUP_MANAGEMENT("groupManagement"),
-
   // -------------------------- Compute --------------------------
   PIPE_ASSIGNER_EXECUTOR_POOL("Pipe-Assigner-Executor-Pool"),
   PIPE_PROCESSOR_EXECUTOR_POOL("Pipe-Processor-Executor-Pool"),
   PIPE_CONNECTOR_EXECUTOR_POOL("Pipe-Connector-Executor-Pool"),
   PIPE_SUBTASK_CALLBACK_EXECUTOR_POOL("Pipe-SubTask-Callback-Executor-Pool"),
-  EXT_PIPE_PLUGIN_WORKER("ExtPipePlugin-Worker"),
+  PIPE_RUNTIME_META_SYNCER("Pipe-Runtime-Meta-Syncer"),
+  PIPE_RUNTIME_PROCEDURE_SUBMITTER("Pipe-Runtime-Procedure-Submitter"),
+  PIPE_WAL_RESOURCE_TTL_CHECKER("Pipe-WAL-Resource-TTL-Checker"),
   WINDOW_EVALUATION_SERVICE("WindowEvaluationTaskPoolManager"),
-  // -------------------------- Sync --------------------------
-  SYNC_SENDER_PIPE("Sync-Pipe"),
-  SYNC_SENDER_HEARTBEAT("Sync-Heartbeat"),
   // -------------------------- JVM --------------------------
   // NOTICE: The thread name of jvm cannot be edited here!
   // We list the thread name here just for distinguishing what module the thread belongs to.
@@ -144,8 +142,6 @@ public enum ThreadName {
   MLNODE_RPC_SERVICE("MLNodeRpc-Service"),
   IOTDB_SHUTDOWN_HOOK("IoTDB-Shutdown-Hook"),
   STORAGE_ENGINE_RECOVER_TRIGGER("StorageEngine-RecoverTrigger"),
-  PIPE_META_SYNC_SERVICE("Pipe-Meta-Sync-Service"),
-  PIPE_WAL_RESOURCE_TTL_CHECKER_SERVICE("Pipe-WAL-Resource-TTL-Checker-Service"),
   // the unknown thread name is used for metrics
   UNKOWN("UNKNOWN");
 
@@ -231,10 +227,11 @@ public enum ThreadName {
               PIPE_PROCESSOR_EXECUTOR_POOL,
               PIPE_CONNECTOR_EXECUTOR_POOL,
               PIPE_SUBTASK_CALLBACK_EXECUTOR_POOL,
-              EXT_PIPE_PLUGIN_WORKER,
+              PIPE_RUNTIME_META_SYNCER,
+              PIPE_RUNTIME_PROCEDURE_SUBMITTER,
+              PIPE_WAL_RESOURCE_TTL_CHECKER,
               WINDOW_EVALUATION_SERVICE));
-  private static Set<ThreadName> syncThreadNames =
-      new HashSet<>(Arrays.asList(SYNC_SENDER_PIPE, SYNC_SENDER_HEARTBEAT));
+
   private static Set<ThreadName> jvmThreadNames =
       new HashSet<>(
           Arrays.asList(
@@ -292,7 +289,6 @@ public enum ThreadName {
           iotConsensusThrreadNames,
           ratisThreadNames,
           computeThreadNames,
-          syncThreadNames,
           jvmThreadNames,
           metricsThreadNames,
           otherThreadNames

--- a/server/src/main/java/org/apache/iotdb/db/pipe/resource/wal/PipeWALResourceManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/pipe/resource/wal/PipeWALResourceManager.java
@@ -22,7 +22,7 @@ public class PipeWALResourceManager implements AutoCloseable {
 
   private static final ScheduledExecutorService PIPE_WAL_RESOURCE_TTL_CHECKER =
       IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor(
-          ThreadName.PIPE_WAL_RESOURCE_TTL_CHECKER_SERVICE.getName());
+          ThreadName.PIPE_WAL_RESOURCE_TTL_CHECKER.getName());
   private final ScheduledFuture<?> ttlCheckerFuture;
 
   public PipeWALResourceManager() {


### PR DESCRIPTION
To master: https://github.com/apache/iotdb/pull/10203

For more details, see:

[[IOTDB-5931](https://issues.apache.org/jira/browse/IOTDB-5931)] The "show cluster" command displays nodes with "Unknown" status, but these nodes can still perform read and write operations normally (https://issues.apache.org/jira/browse/IOTDB-5931)