### PR TITLE
[To rel/1.2][IOTDB-5997] Improve efficiency of ConfigNode PartitionInfo loadSnapshot

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
@@ -480,7 +480,16 @@ public class ConfigPlanExecutor {
         x -> {
           boolean takeSnapshotResult = true;
           try {
+            long startTime = System.currentTimeMillis();
+            LOGGER.info(
+                "[ConfigNodeSnapshot] Start to take snapshot for {} into {}",
+                x.getClass().getName(),
+                snapshotDir.getAbsolutePath());
             takeSnapshotResult = x.processTakeSnapshot(snapshotDir);
+            LOGGER.info(
+                "[ConfigNodeSnapshot] Finish to take snapshot for {}, time consumption: {} ms",
+                x.getClass().getName(),
+                System.currentTimeMillis() - startTime);
           } catch (TException | IOException e) {
             LOGGER.error("Take snapshot error: {}", e.getMessage());
             takeSnapshotResult = false;
@@ -493,7 +502,7 @@ public class ConfigPlanExecutor {
           }
         });
     if (result.get()) {
-      LOGGER.info("Task snapshot success, snapshotDir: {}", snapshotDir);
+      LOGGER.info("[ConfigNodeSnapshot] Task snapshot success, snapshotDir: {}", snapshotDir);
     }
     return result.get();
   }
@@ -512,14 +521,25 @@ public class ConfigPlanExecutor {
         .forEach(
             x -> {
               try {
+                long startTime = System.currentTimeMillis();
+                LOGGER.info(
+                    "[ConfigNodeSnapshot] Start to load snapshot for {} from {}",
+                    x.getClass().getName(),
+                    latestSnapshotRootDir.getAbsolutePath());
                 x.processLoadSnapshot(latestSnapshotRootDir);
+                LOGGER.info(
+                    "[ConfigNodeSnapshot] Load snapshot for {} cost {} ms",
+                    x.getClass().getName(),
+                    System.currentTimeMillis() - startTime);
               } catch (TException | IOException e) {
                 result.set(false);
                 LOGGER.error("Load snapshot error: {}", e.getMessage());
               }
             });
     if (result.get()) {
-      LOGGER.info("Load snapshot success, latestSnapshotRootDir: {}", latestSnapshotRootDir);
+      LOGGER.info(
+          "[ConfigNodeSnapshot] Load snapshot success, latestSnapshotRootDir: {}",
+          latestSnapshotRootDir);
     }
   }
 


### PR DESCRIPTION
Use BufferedInputStream(with 32MB buffer) instead of FileInputStream in PartitionInfo

**Before improvement:**
```
2023-06-15 15:46:03,342 [ForkJoinPool.commonPool-worker-115] INFO  o.a.i.c.p.e.ConfigPlanExecutor:518 - [LoadSnapshot] Load snapshot for org.apache.iotdb.confignode.persistence.partition.PartitionInfo cost 219083 ms
```
Load snapshot of PartitionInfo costs more than 200s

**After improvement:**
```
2023-06-15 18:35:02,676 [ForkJoinPool.commonPool-worker-115] INFO  o.a.i.c.p.e.ConfigPlanExecutor:530 - [ConfigNodeSnapshot] Load snapshot for org.apache.iotdb.confignode.persistence.partition.PartitionInfo cost 12881 ms
```
Load snapshot of PartitionInfo costs only 13s