### PR TITLE
[To rel/1.2][IOTDB-6000] Control the RegionGroup number of system Database

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/schema/ClusterSchemaManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/schema/ClusterSchemaManager.java
@@ -76,6 +76,7 @@ import org.apache.iotdb.db.metadata.template.TemplateInternalRPCUpdateType;
 import org.apache.iotdb.db.metadata.template.TemplateInternalRPCUtil;
 import org.apache.iotdb.db.metadata.template.alter.TemplateExtendInfo;
 import org.apache.iotdb.db.utils.SchemaUtils;
+import org.apache.iotdb.metrics.utils.IoTDBMetricsUtils;
 import org.apache.iotdb.mpp.rpc.thrift.TUpdateTemplateReq;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
@@ -400,14 +401,20 @@ public class ClusterSchemaManager {
     int databaseNum = databaseSchemaMap.size();
 
     for (TDatabaseSchema databaseSchema : databaseSchemaMap.values()) {
-      if (!isDatabaseExist(databaseSchema.getName())) {
-        // filter the pre deleted database
+      if (!isDatabaseExist(databaseSchema.getName())
+          || databaseSchema.getName().equals(IoTDBMetricsUtils.DATABASE)) {
+        // filter the pre deleted database and the system database
         databaseNum--;
       }
     }
 
     AdjustMaxRegionGroupNumPlan adjustMaxRegionGroupNumPlan = new AdjustMaxRegionGroupNumPlan();
     for (TDatabaseSchema databaseSchema : databaseSchemaMap.values()) {
+      if (databaseSchema.getName().equals(IoTDBMetricsUtils.DATABASE)) {
+        // filter the system database
+        continue;
+      }
+
       try {
         // Adjust maxSchemaRegionGroupNum for each Database.
         // All Databases share the DataNodes equally.

--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
@@ -164,6 +164,7 @@ import org.apache.iotdb.confignode.rpc.thrift.TUpdateModelStateReq;
 import org.apache.iotdb.confignode.service.ConfigNode;
 import org.apache.iotdb.consensus.common.response.ConsensusGenericResponse;
 import org.apache.iotdb.db.mpp.plan.statement.AuthorType;
+import org.apache.iotdb.metrics.utils.IoTDBMetricsUtils;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
 
@@ -280,6 +281,7 @@ public class ConfigNodeRPCServiceProcessor implements IConfigNodeRPCService.Ifac
   @Override
   public TSStatus setDatabase(TDatabaseSchema databaseSchema) {
     TSStatus errorResp = null;
+    boolean isSystemDatabase = databaseSchema.getName().equals(IoTDBMetricsUtils.DATABASE);
 
     // Set default configurations if necessary
     if (!databaseSchema.isSetTTL()) {
@@ -290,7 +292,9 @@ public class ConfigNodeRPCServiceProcessor implements IConfigNodeRPCService.Ifac
               .setMessage("Failed to create database. The TTL should be positive.");
     }
 
-    if (!databaseSchema.isSetSchemaReplicationFactor()) {
+    if (isSystemDatabase) {
+      databaseSchema.setSchemaReplicationFactor(1);
+    } else if (!databaseSchema.isSetSchemaReplicationFactor()) {
       databaseSchema.setSchemaReplicationFactor(CONFIG_NODE_CONFIG.getSchemaReplicationFactor());
     } else if (databaseSchema.getSchemaReplicationFactor() <= 0) {
       errorResp =
@@ -299,7 +303,9 @@ public class ConfigNodeRPCServiceProcessor implements IConfigNodeRPCService.Ifac
                   "Failed to create database. The schemaReplicationFactor should be positive.");
     }
 
-    if (!databaseSchema.isSetDataReplicationFactor()) {
+    if (isSystemDatabase) {
+      databaseSchema.setDataReplicationFactor(1);
+    } else if (!databaseSchema.isSetDataReplicationFactor()) {
       databaseSchema.setDataReplicationFactor(CONFIG_NODE_CONFIG.getDataReplicationFactor());
     } else if (databaseSchema.getDataReplicationFactor() <= 0) {
       errorResp =
@@ -317,7 +323,9 @@ public class ConfigNodeRPCServiceProcessor implements IConfigNodeRPCService.Ifac
                   "Failed to create database. The timePartitionInterval should be positive.");
     }
 
-    if (!databaseSchema.isSetMinSchemaRegionGroupNum()) {
+    if (isSystemDatabase) {
+      databaseSchema.setMinSchemaRegionGroupNum(1);
+    } else if (!databaseSchema.isSetMinSchemaRegionGroupNum()) {
       databaseSchema.setMinSchemaRegionGroupNum(
           CONFIG_NODE_CONFIG.getDefaultSchemaRegionGroupNumPerDatabase());
     } else if (databaseSchema.getMinSchemaRegionGroupNum() <= 0) {
@@ -327,7 +335,9 @@ public class ConfigNodeRPCServiceProcessor implements IConfigNodeRPCService.Ifac
                   "Failed to create database. The schemaRegionGroupNum should be positive.");
     }
 
-    if (!databaseSchema.isSetMinDataRegionGroupNum()) {
+    if (isSystemDatabase) {
+      databaseSchema.setMinDataRegionGroupNum(1);
+    } else if (!databaseSchema.isSetMinDataRegionGroupNum()) {
       databaseSchema.setMinDataRegionGroupNum(
           CONFIG_NODE_CONFIG.getDefaultDataRegionGroupNumPerDatabase());
     } else if (databaseSchema.getMinDataRegionGroupNum() <= 0) {


### PR DESCRIPTION
The number of SchemaRegionGroups and DataRegionGroups in system Database should always be 1.

**Test environment:**

- region_group_extension_policy=CUSTOM
- default_region_group_num=5
- metric_reporter_list=IOTDB

**Before fix:**
![image](https://github.com/apache/iotdb/assets/33111881/652698c6-e675-4981-ac48-0282a942cc83)

**After fix:**
![image](https://github.com/apache/iotdb/assets/33111881/66a89b44-5701-4530-9722-e811f327d83a)
