### PR TITLE
[To rel/1.2][IOTDB-6010] Fix NPE and IndexOutOfRange Exception in CPU metrics

### DIFF
--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/cpu/CpuUsageMetrics.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/cpu/CpuUsageMetrics.java
@@ -251,12 +251,12 @@ public class CpuUsageMetrics implements IMetricSet {
     for (ThreadInfo threadInfo : threadInfos) {
       long id = threadInfo.getThreadId();
       long beforeCpuTime = beforeThreadCpuTime.getOrDefault(id, 0L);
-      long afterCpuTime = afterThreadCpuTime.get(id);
-      if (afterCpuTime < beforeCpuTime) {
+      long afterCpuTime = afterThreadCpuTime.getOrDefault(id, 0L);
+      if (afterCpuTime < beforeCpuTime || afterCpuTime == 0L) {
         continue;
       }
       long beforeUserTime = beforeThreadUserTime.getOrDefault(id, 0L);
-      long afterUserTime = afterThreadUserTime.get(id);
+      long afterUserTime = afterThreadUserTime.getOrDefault(id, 0L);
       totalIncrementTime += afterCpuTime - beforeCpuTime;
       String module = getThreadModuleById(id, threadInfo);
       String pool = getThreadPoolById(id, threadInfo);

--- a/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/ThreadName.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/ThreadName.java
@@ -305,7 +305,6 @@ public enum ThreadName {
           DataNodeThreadModule.IOT_CONSENSUS,
           DataNodeThreadModule.RATIS_CONSENSUS,
           DataNodeThreadModule.COMPUTE,
-          DataNodeThreadModule.SYNC,
           DataNodeThreadModule.JVM,
           DataNodeThreadModule.METRICS,
           DataNodeThreadModule.OTHER


### PR DESCRIPTION
See [IOTDB-6010](https://issues.apache.org/jira/browse/IOTDB-6010).

The reason for npe is that when getting cpu time from map, we use `get` but not `getOrDefault`, which may cause NPE.

The reason for IndexOutOfBound Exception is that, the size of module map array and thread name array is not the same.