### PR TITLE
[IOTDB-6011] Move default database from IoTDBMetricsUtils to IoTDBConfig

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.confignode.manager.load.balancer.RegionBalancer;
 import org.apache.iotdb.confignode.manager.load.balancer.router.leader.ILeaderBalancer;
 import org.apache.iotdb.confignode.manager.load.balancer.router.priority.IPriorityBalancer;
 import org.apache.iotdb.confignode.manager.partition.RegionGroupExtensionPolicy;
+import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.metrics.config.MetricConfigDescriptor;
 import org.apache.iotdb.metrics.utils.NodeType;
 
@@ -134,7 +135,8 @@ public class ConfigNodeDescriptor {
         MetricConfigDescriptor.getInstance().loadProps(commonProperties);
         MetricConfigDescriptor.getInstance()
             .getMetricConfig()
-            .updateRpcInstance(conf.getClusterName(), NodeType.CONFIGNODE);
+            .updateRpcInstance(
+                conf.getClusterName(), NodeType.CONFIGNODE, IoTDBConfig.SYSTEM_DATABASE);
       }
     } else {
       LOGGER.warn(

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/runtime/PipeLeaderChangeHandler.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/runtime/PipeLeaderChangeHandler.java
@@ -25,7 +25,7 @@ import org.apache.iotdb.confignode.manager.ConfigManager;
 import org.apache.iotdb.confignode.manager.load.subscriber.IClusterStatusSubscriber;
 import org.apache.iotdb.confignode.manager.load.subscriber.RouteChangeEvent;
 import org.apache.iotdb.confignode.manager.load.subscriber.StatisticsChangeEvent;
-import org.apache.iotdb.metrics.utils.IoTDBMetricsUtils;
+import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.tsfile.utils.Pair;
 
 import java.util.HashMap;
@@ -61,7 +61,7 @@ public class PipeLeaderChangeHandler implements IClusterStatusSubscriber {
               if (regionGroupId.getType().equals(TConsensusGroupType.DataRegion)) {
                 final String databaseName =
                     configManager.getPartitionManager().getRegionStorageGroup(regionGroupId);
-                if (databaseName != null && !databaseName.equals(IoTDBMetricsUtils.DATABASE)) {
+                if (databaseName != null && !databaseName.equals(IoTDBConfig.SYSTEM_DATABASE)) {
                   // pipe only collect user's data, filter metric database here.
                   dataRegionGroupToOldAndNewLeaderPairMap.put(
                       regionGroupId,

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/schema/ClusterSchemaManager.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/schema/ClusterSchemaManager.java
@@ -72,12 +72,12 @@ import org.apache.iotdb.confignode.rpc.thrift.TGetAllTemplatesResp;
 import org.apache.iotdb.confignode.rpc.thrift.TGetPathsSetTemplatesResp;
 import org.apache.iotdb.confignode.rpc.thrift.TGetTemplateResp;
 import org.apache.iotdb.confignode.rpc.thrift.TShowDatabaseResp;
+import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.metadata.template.Template;
 import org.apache.iotdb.db.metadata.template.TemplateInternalRPCUpdateType;
 import org.apache.iotdb.db.metadata.template.TemplateInternalRPCUtil;
 import org.apache.iotdb.db.metadata.template.alter.TemplateExtendInfo;
 import org.apache.iotdb.db.utils.SchemaUtils;
-import org.apache.iotdb.metrics.utils.IoTDBMetricsUtils;
 import org.apache.iotdb.mpp.rpc.thrift.TUpdateTemplateReq;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
@@ -403,7 +403,7 @@ public class ClusterSchemaManager {
 
     for (TDatabaseSchema databaseSchema : databaseSchemaMap.values()) {
       if (!isDatabaseExist(databaseSchema.getName())
-          || databaseSchema.getName().equals(IoTDBMetricsUtils.DATABASE)) {
+          || databaseSchema.getName().equals(IoTDBConfig.SYSTEM_DATABASE)) {
         // filter the pre deleted database and the system database
         databaseNum--;
       }
@@ -411,7 +411,7 @@ public class ClusterSchemaManager {
 
     AdjustMaxRegionGroupNumPlan adjustMaxRegionGroupNumPlan = new AdjustMaxRegionGroupNumPlan();
     for (TDatabaseSchema databaseSchema : databaseSchemaMap.values()) {
-      if (databaseSchema.getName().equals(IoTDBMetricsUtils.DATABASE)) {
+      if (databaseSchema.getName().equals(IoTDBConfig.SYSTEM_DATABASE)) {
         // filter the system database
         continue;
       }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/CreatePipeProcedureV2.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/CreatePipeProcedureV2.java
@@ -35,7 +35,7 @@ import org.apache.iotdb.confignode.procedure.impl.pipe.PipeTaskOperation;
 import org.apache.iotdb.confignode.procedure.store.ProcedureType;
 import org.apache.iotdb.confignode.rpc.thrift.TCreatePipeReq;
 import org.apache.iotdb.consensus.common.response.ConsensusWriteResponse;
-import org.apache.iotdb.metrics.utils.IoTDBMetricsUtils;
+import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.pipe.api.exception.PipeException;
 import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
@@ -111,7 +111,7 @@ public class CreatePipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
                     env.getConfigManager()
                         .getPartitionManager()
                         .getRegionStorageGroup(regionGroupId);
-                if (databaseName != null && !databaseName.equals(IoTDBMetricsUtils.DATABASE)) {
+                if (databaseName != null && !databaseName.equals(IoTDBConfig.SYSTEM_DATABASE)) {
                   // pipe only collect user's data, filter metric database here.
                   consensusGroupIdToTaskMetaMap.put(
                       regionGroupId,

--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
@@ -163,8 +163,8 @@ import org.apache.iotdb.confignode.rpc.thrift.TUpdateModelInfoReq;
 import org.apache.iotdb.confignode.rpc.thrift.TUpdateModelStateReq;
 import org.apache.iotdb.confignode.service.ConfigNode;
 import org.apache.iotdb.consensus.common.response.ConsensusGenericResponse;
+import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.mpp.plan.statement.AuthorType;
-import org.apache.iotdb.metrics.utils.IoTDBMetricsUtils;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
 
@@ -281,7 +281,7 @@ public class ConfigNodeRPCServiceProcessor implements IConfigNodeRPCService.Ifac
   @Override
   public TSStatus setDatabase(TDatabaseSchema databaseSchema) {
     TSStatus errorResp = null;
-    boolean isSystemDatabase = databaseSchema.getName().equals(IoTDBMetricsUtils.DATABASE);
+    boolean isSystemDatabase = databaseSchema.getName().equals(IoTDBConfig.SYSTEM_DATABASE);
 
     // Set default configurations if necessary
     if (!databaseSchema.isSetTTL()) {

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/config/MetricConfig.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/config/MetricConfig.java
@@ -70,6 +70,7 @@ public class MetricConfig {
   private int nodeId = 0;
 
   private long upTimeInNs = 0;
+  private String internalDatabase = "root.__system";
 
   public MetricConfig() {
     // try to get pid of iotdb instance
@@ -161,10 +162,15 @@ public class MetricConfig {
     return upTimeInNs;
   }
 
+  public String getInternalDatabase() {
+    return internalDatabase;
+  }
+
   /** Update rpc address and rpc port of monitored node. */
-  public void updateRpcInstance(String clusterName, NodeType nodeType) {
+  public void updateRpcInstance(String clusterName, NodeType nodeType, String internalDatabase) {
     this.clusterName = clusterName;
     this.nodeType = nodeType;
+    this.internalDatabase = internalDatabase;
   }
 
   public void setNodeId(int nodeId) {

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/reporter/iotdb/IoTDBSessionReporter.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/reporter/iotdb/IoTDBSessionReporter.java
@@ -46,6 +46,8 @@ import java.util.concurrent.TimeUnit;
 
 public class IoTDBSessionReporter extends IoTDBReporter {
   private static final Logger LOGGER = LoggerFactory.getLogger(IoTDBSessionReporter.class);
+  private static final MetricConfig metricConfig =
+      MetricConfigDescriptor.getInstance().getMetricConfig();
   private static final MetricConfig.IoTDBReporterConfig ioTDBReporterConfig =
       MetricConfigDescriptor.getInstance().getMetricConfig().getIotdbReporterConfig();
   private Future<?> currentServiceFuture;
@@ -66,12 +68,13 @@ public class IoTDBSessionReporter extends IoTDBReporter {
             ioTDBReporterConfig.getPassword(),
             ioTDBReporterConfig.getMaxConnectionNumber());
     try (SessionDataSetWrapper result =
-        this.sessionPool.executeQueryStatement("SHOW DATABASES " + IoTDBMetricsUtils.DATABASE)) {
+        this.sessionPool.executeQueryStatement(
+            "SHOW DATABASES " + metricConfig.getInternalDatabase())) {
       if (!result.hasNext()) {
         try (SessionDataSetWrapper result2 =
             this.sessionPool.executeQueryStatement(
                 "CREATE "
-                    + IoTDBMetricsUtils.DATABASE
+                    + metricConfig.getInternalDatabase()
                     + " WITH SCHEMA_REPLICATION_FACTOR=1, DATA_REPLICATION_FACTOR=1, SCHEMA_REGION_GROUP_NUM=1, DATA_REGION_GROUP_NUM=1")) {
           if (!result2.hasNext()) {
             LOGGER.error("IoTDBSessionReporter checkOrCreateDatabase failed.");

--- a/metrics/interface/src/main/java/org/apache/iotdb/metrics/utils/IoTDBMetricsUtils.java
+++ b/metrics/interface/src/main/java/org/apache/iotdb/metrics/utils/IoTDBMetricsUtils.java
@@ -30,7 +30,6 @@ import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.DOUBLE_BACK
 public class IoTDBMetricsUtils {
   private static final MetricConfig METRIC_CONFIG =
       MetricConfigDescriptor.getInstance().getMetricConfig();
-  public static final String DATABASE = "root.__system";
 
   /** Generate the path of metric by metricInfo. */
   public static String generatePath(MetricInfo metricInfo) {
@@ -71,7 +70,7 @@ public class IoTDBMetricsUtils {
   private static StringBuilder generateMetric(String name) {
     StringBuilder stringBuilder = new StringBuilder();
     stringBuilder
-        .append(DATABASE)
+        .append(METRIC_CONFIG.getInternalDatabase())
         .append(".")
         .append(METRIC_CONFIG.getIotdbReporterConfig().getLocation())
         .append(".`")

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -91,6 +91,7 @@ public class IoTDBConfig {
       "([" + PATH_SEPARATOR + "])?" + NODE_NAME_MATCHER + "(" + PARTIAL_NODE_MATCHER + ")*";
 
   public static final Pattern NODE_PATTERN = Pattern.compile(NODE_MATCHER);
+  public static final String SYSTEM_DATABASE = "root.__system";
 
   /** whether to enable the mqtt service. */
   private boolean enableMQTTService = false;

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -193,7 +193,8 @@ public class IoTDBDescriptor {
         MetricConfigDescriptor.getInstance().loadProps(commonProperties);
         MetricConfigDescriptor.getInstance()
             .getMetricConfig()
-            .updateRpcInstance(conf.getClusterName(), NodeType.DATANODE);
+            .updateRpcInstance(
+                conf.getClusterName(), NodeType.DATANODE, IoTDBConfig.SYSTEM_DATABASE);
       }
     } else {
       logger.warn(

--- a/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/flush/MemTableFlushTask.java
@@ -31,7 +31,6 @@ import org.apache.iotdb.db.exception.runtime.FlushRunTimeException;
 import org.apache.iotdb.db.metadata.idtable.entry.IDeviceID;
 import org.apache.iotdb.db.rescon.SystemInfo;
 import org.apache.iotdb.db.service.metrics.WritingMetrics;
-import org.apache.iotdb.metrics.utils.IoTDBMetricsUtils;
 import org.apache.iotdb.metrics.utils.MetricLevel;
 import org.apache.iotdb.tsfile.write.chunk.IChunkWriter;
 import org.apache.iotdb.tsfile.write.writer.RestorableTsFileIOWriter;
@@ -279,7 +278,7 @@ public class MemTableFlushTask {
             Thread.currentThread().interrupt();
           }
 
-          if (!storageGroup.startsWith(IoTDBMetricsUtils.DATABASE)) {
+          if (!storageGroup.startsWith(IoTDBConfig.SYSTEM_DATABASE)) {
             int lastIndex = storageGroup.lastIndexOf("-");
             if (lastIndex == -1) {
               lastIndex = storageGroup.length();

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SourceRewriter.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/distribution/SourceRewriter.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.path.PathPatternTree;
+import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.mpp.common.MPPQueryContext;
 import org.apache.iotdb.db.mpp.plan.analyze.Analysis;
 import org.apache.iotdb.db.mpp.plan.expression.Expression;
@@ -63,7 +64,6 @@ import org.apache.iotdb.db.mpp.plan.planner.plan.parameter.AggregationStep;
 import org.apache.iotdb.db.mpp.plan.planner.plan.parameter.CrossSeriesAggregationDescriptor;
 import org.apache.iotdb.db.mpp.plan.statement.component.Ordering;
 import org.apache.iotdb.db.mpp.plan.statement.crud.QueryStatement;
-import org.apache.iotdb.metrics.utils.IoTDBMetricsUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -313,7 +313,7 @@ public class SourceRewriter extends SimplePlanNodeRewriter<DistributionPlanConte
           .getSchemaPartitionMap()
           .forEach(
               (storageGroup, deviceGroup) -> {
-                if (storageGroup.equals(IoTDBMetricsUtils.DATABASE)) {
+                if (storageGroup.equals(IoTDBConfig.SYSTEM_DATABASE)) {
                   deviceGroup.forEach(
                       (deviceGroupId, schemaRegionReplicaSet) ->
                           regionsOfSystemDatabase.add(schemaRegionReplicaSet));
@@ -353,7 +353,7 @@ public class SourceRewriter extends SimplePlanNodeRewriter<DistributionPlanConte
           .getSchemaPartitionMap()
           .forEach(
               (storageGroup, deviceGroup) -> {
-                if (storageGroup.equals(IoTDBMetricsUtils.DATABASE)) {
+                if (storageGroup.equals(IoTDBConfig.SYSTEM_DATABASE)) {
                   deviceGroup.forEach(
                       (deviceGroupId, schemaRegionReplicaSet) ->
                           regionsOfSystemDatabase.add(schemaRegionReplicaSet));
@@ -384,7 +384,7 @@ public class SourceRewriter extends SimplePlanNodeRewriter<DistributionPlanConte
           });
       if (!regionsOfSystemDatabase.isEmpty()) {
         List<PartialPath> filteredPathPatternList =
-            filterPathPattern(patternTree, IoTDBMetricsUtils.DATABASE);
+            filterPathPattern(patternTree, IoTDBConfig.SYSTEM_DATABASE);
         regionsOfSystemDatabase.forEach(
             region -> {
               addSchemaSourceNode(

--- a/server/src/main/java/org/apache/iotdb/db/service/metrics/IoTDBInternalLocalReporter.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/metrics/IoTDBInternalLocalReporter.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.confignode.rpc.thrift.TShowDatabaseResp;
 import org.apache.iotdb.db.client.ConfigNodeClient;
 import org.apache.iotdb.db.client.ConfigNodeClientManager;
 import org.apache.iotdb.db.client.ConfigNodeInfo;
+import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.mpp.common.SessionInfo;
 import org.apache.iotdb.db.mpp.plan.Coordinator;
@@ -44,7 +45,6 @@ import org.apache.iotdb.db.query.control.SessionManager;
 import org.apache.iotdb.metrics.config.MetricConfigDescriptor;
 import org.apache.iotdb.metrics.reporter.iotdb.IoTDBInternalReporter;
 import org.apache.iotdb.metrics.utils.InternalReporterType;
-import org.apache.iotdb.metrics.utils.IoTDBMetricsUtils;
 import org.apache.iotdb.metrics.utils.ReporterType;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.TSStatusCode;
@@ -87,11 +87,11 @@ public class IoTDBInternalLocalReporter extends IoTDBInternalReporter {
     try (ConfigNodeClient client =
         configNodeClientManager.borrowClient(ConfigNodeInfo.CONFIG_REGION_ID)) {
       TShowDatabaseResp showDatabaseResp =
-          client.showDatabase(Arrays.asList(IoTDBMetricsUtils.DATABASE.split("\\.")));
+          client.showDatabase(Arrays.asList(IoTDBConfig.SYSTEM_DATABASE.split("\\.")));
       if (TSStatusCode.SUCCESS_STATUS.getStatusCode() == showDatabaseResp.getStatus().getCode()
           && showDatabaseResp.getDatabaseInfoMapSize() == 0) {
         TDatabaseSchema databaseSchema = new TDatabaseSchema();
-        databaseSchema.setName(IoTDBMetricsUtils.DATABASE);
+        databaseSchema.setName(IoTDBConfig.SYSTEM_DATABASE);
         databaseSchema.setSchemaReplicationFactor(1);
         databaseSchema.setDataReplicationFactor(1);
         databaseSchema.setMaxSchemaRegionGroupNum(1);


### PR DESCRIPTION
It's more suitable to manage default database in IoTDBConfig instead of IoTDBMetricsUtils