### PR TITLE
[IOTDB-5999] system.properties patch

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/SystemPropertiesUtils.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/SystemPropertiesUtils.java
@@ -215,6 +215,7 @@ public class SystemPropertiesUtils {
     Properties systemProperties = getSystemProperties();
 
     systemProperties.setProperty("iotdb_version", IoTDBConstant.VERSION);
+    systemProperties.setProperty("commit_id", IoTDBConstant.BUILD_INFO);
 
     // Cluster configuration
     systemProperties.setProperty("cluster_name", conf.getClusterName());

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -293,7 +293,6 @@ public class DataNode implements DataNodeMBean {
     try {
       IoTDBStartCheck.getInstance().checkSystemConfig();
       IoTDBStartCheck.getInstance().checkDirectory();
-      IoTDBStartCheck.getInstance().serializeGlobalConfig(configurationResp.globalConfig);
       if (!config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)) {
         // In current implementation, only IoTConsensus need separated memory from Consensus
         IoTDBDescriptor.getInstance().reclaimConsensusMemory();


### PR DESCRIPTION
**confignode-system.properties:**
```
#Tue Jun 20 10:44:45 CST 2023
cn_internal_address=127.0.0.1
config_node_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus
schema_engine_mode=Memory
time_partition_interval=604800000
tag_attribute_total_size=700
config_node_id=0
series_partition_slot_num=1000
config_node_list=0,127.0.0.1\:10710,127.0.0.1\:10720
timestamp_precision=ms
series_partition_executor_class=org.apache.iotdb.commons.partition.executor.hash.BKDRHashExecutor
commit_id=0bf7d75-dev
iotdb_version=1.3.0-SNAPSHOT
cn_internal_port=10710
schema_region_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus
is_seed_config_node=true
cn_consensus_port=10720
data_region_consensus_protocol_class=org.apache.iotdb.consensus.iot.IoTConsensus
cluster_name=defaultCluster
```

**system.properties:**
```
#System properties:
#Tue Jun 20 10:44:49 CST 2023
data_node_id=1
config_node_list=127.0.0.1\:10710
iotdb_version=1.3.0-SNAPSHOT
dn_mpp_data_exchange_port=10740
dn_internal_address=127.0.0.1
dn_data_region_consensus_port=10760
dn_schema_region_consensus_port=10750
dn_rpc_address=0.0.0.0
dn_rpc_port=6667
dn_internal_port=10730
commit_id=0bf7d75-dev
cluster_name=defaultCluster
```