### PR TITLE
[IOTDB-6013] Pipe: pipe-related threads (pools) should not be initialized unless necessary

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/runtime/PipeHeartbeatParser.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/runtime/PipeHeartbeatParser.java
@@ -90,24 +90,29 @@ public class PipeHeartbeatParser {
       return;
     }
 
-    PipeRuntimeCoordinator.PROCEDURE_SUBMITTER.submit(
-        () -> {
-          if (!pipeMetaByteBufferListFromDataNode.isEmpty()) {
-            parseHeartbeatAndSaveMetaChangeLocally(dataNodeId, pipeMetaByteBufferListFromDataNode);
-          }
+    configManager
+        .getPipeManager()
+        .getPipeRuntimeCoordinator()
+        .getProcedureSubmitter()
+        .submit(
+            () -> {
+              if (!pipeMetaByteBufferListFromDataNode.isEmpty()) {
+                parseHeartbeatAndSaveMetaChangeLocally(
+                    dataNodeId, pipeMetaByteBufferListFromDataNode);
+              }
 
-          if (canSubmitHandleMetaChangeProcedure.get()
-              && (needWriteConsensusOnConfigNodes.get() || needPushPipeMetaToDataNodes.get())) {
-            configManager
-                .getProcedureManager()
-                .pipeHandleMetaChange(
-                    needWriteConsensusOnConfigNodes.get(), needPushPipeMetaToDataNodes.get());
+              if (canSubmitHandleMetaChangeProcedure.get()
+                  && (needWriteConsensusOnConfigNodes.get() || needPushPipeMetaToDataNodes.get())) {
+                configManager
+                    .getProcedureManager()
+                    .pipeHandleMetaChange(
+                        needWriteConsensusOnConfigNodes.get(), needPushPipeMetaToDataNodes.get());
 
-            // reset flags after procedure is submitted
-            needWriteConsensusOnConfigNodes.set(false);
-            needPushPipeMetaToDataNodes.set(false);
-          }
-        });
+                // reset flags after procedure is submitted
+                needWriteConsensusOnConfigNodes.set(false);
+                needPushPipeMetaToDataNodes.set(false);
+              }
+            });
   }
 
   private void parseHeartbeatAndSaveMetaChangeLocally(
@@ -197,9 +202,9 @@ public class PipeHeartbeatParser {
               needPushPipeMetaToDataNodes.set(true);
 
               LOGGER.warn(
-                  String.format(
-                      "Detect PipeRuntimeCriticalException %s from DataNode, stop pipe %s.",
-                      exception, pipeName));
+                  "Detect PipeRuntimeCriticalException {} from DataNode, stop pipe {}.",
+                  exception,
+                  pipeName);
             }
 
             if (exception instanceof PipeRuntimeConnectorCriticalException) {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/runtime/PipeLeaderChangeHandler.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/runtime/PipeLeaderChangeHandler.java
@@ -78,10 +78,14 @@ public class PipeLeaderChangeHandler implements IClusterStatusSubscriber {
     }
 
     // submit procedure in an async way to avoid blocking the caller
-    PipeRuntimeCoordinator.PROCEDURE_SUBMITTER.submit(
-        () ->
-            configManager
-                .getProcedureManager()
-                .pipeHandleLeaderChange(dataRegionGroupToOldAndNewLeaderPairMap));
+    configManager
+        .getPipeManager()
+        .getPipeRuntimeCoordinator()
+        .getProcedureSubmitter()
+        .submit(
+            () ->
+                configManager
+                    .getProcedureManager()
+                    .pipeHandleLeaderChange(dataRegionGroupToOldAndNewLeaderPairMap));
   }
 }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/runtime/PipeRuntimeCoordinator.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/runtime/PipeRuntimeCoordinator.java
@@ -31,22 +31,38 @@ import org.jetbrains.annotations.NotNull;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class PipeRuntimeCoordinator implements IClusterStatusSubscriber {
 
   // shared thread pool in the runtime package
-  static final ExecutorService PROCEDURE_SUBMITTER =
-      IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor(
-          ThreadName.PIPE_RUNTIME_PROCEDURE_SUBMITTER.getName());
+  private static final AtomicReference<ExecutorService> procedureSubmitterHolder =
+      new AtomicReference<>();
+  private final ExecutorService procedureSubmitter;
 
   private final PipeLeaderChangeHandler pipeLeaderChangeHandler;
   private final PipeHeartbeatParser pipeHeartbeatParser;
   private final PipeMetaSyncer pipeMetaSyncer;
 
   public PipeRuntimeCoordinator(ConfigManager configManager) {
+    if (procedureSubmitterHolder.get() == null) {
+      synchronized (PipeRuntimeCoordinator.class) {
+        if (procedureSubmitterHolder.get() == null) {
+          procedureSubmitterHolder.set(
+              IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor(
+                  ThreadName.PIPE_RUNTIME_PROCEDURE_SUBMITTER.getName()));
+        }
+      }
+    }
+    procedureSubmitter = procedureSubmitterHolder.get();
+
     pipeLeaderChangeHandler = new PipeLeaderChangeHandler(configManager);
     pipeHeartbeatParser = new PipeHeartbeatParser(configManager);
     pipeMetaSyncer = new PipeMetaSyncer(configManager);
+  }
+
+  public ExecutorService getProcedureSubmitter() {
+    return procedureSubmitter;
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/pipe/connector/v2/IoTDBThriftConnectorV2.java
+++ b/server/src/main/java/org/apache/iotdb/db/pipe/connector/v2/IoTDBThriftConnectorV2.java
@@ -71,14 +71,15 @@ import static org.apache.iotdb.db.pipe.config.constant.PipeConnectorConstant.CON
 public class IoTDBThriftConnectorV2 implements PipeConnector {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IoTDBThriftConnectorV2.class);
+  private static final String FAILED_TO_BORROW_CLIENT_FORMATTER =
+      "Failed to borrow client from client pool for receiver %s:%s.";
 
   private static final CommonConfig COMMON_CONFIG = CommonDescriptor.getInstance().getConfig();
 
-  private static final IClientManager<TEndPoint, AsyncPipeDataTransferServiceClient>
-      ASYNC_PIPE_DATA_TRANSFER_CLIENT_MANAGER =
-          new IClientManager.Factory<TEndPoint, AsyncPipeDataTransferServiceClient>()
-              .createClientManager(
-                  new ClientPoolFactory.AsyncPipeDataTransferServiceClientPoolFactory());
+  private static volatile IClientManager<TEndPoint, AsyncPipeDataTransferServiceClient>
+      asyncPipeDataTransferClientManagerHolder;
+  private final IClientManager<TEndPoint, AsyncPipeDataTransferServiceClient>
+      asyncPipeDataTransferClientManager;
 
   private final AtomicBoolean isClosed = new AtomicBoolean(false);
 
@@ -88,6 +89,21 @@ public class IoTDBThriftConnectorV2 implements PipeConnector {
       new PriorityQueue<>(Comparator.comparing(o -> o.left));
 
   private List<TEndPoint> nodeUrls;
+
+  public IoTDBThriftConnectorV2() {
+    if (asyncPipeDataTransferClientManagerHolder == null) {
+      synchronized (IoTDBThriftConnectorV2.class) {
+        if (asyncPipeDataTransferClientManagerHolder == null) {
+          asyncPipeDataTransferClientManagerHolder =
+              new IClientManager.Factory<TEndPoint, AsyncPipeDataTransferServiceClient>()
+                  .createClientManager(
+                      new ClientPoolFactory.AsyncPipeDataTransferServiceClientPoolFactory());
+        }
+      }
+    }
+
+    asyncPipeDataTransferClientManager = asyncPipeDataTransferClientManagerHolder;
+  }
 
   public synchronized void commit(long requestCommitId, @Nullable EnrichedEvent enrichedEvent) {
     commitQueue.offer(
@@ -148,11 +164,11 @@ public class IoTDBThriftConnectorV2 implements PipeConnector {
         throw new PipeException(String.format("Handshake error, result status %s.", resp.status));
       }
     } catch (TException e) {
-      LOGGER.warn(
+      throw new PipeConnectionException(
           String.format(
-              "Connect to receiver %s:%s error.", firstNodeUrl.getIp(), firstNodeUrl.getPort()),
+              "Connect to receiver %s:%s error: %s",
+              e.getMessage(), firstNodeUrl.getIp(), firstNodeUrl.getPort()),
           e);
-      throw new PipeConnectionException(e.getMessage(), e);
     }
   }
 
@@ -201,7 +217,7 @@ public class IoTDBThriftConnectorV2 implements PipeConnector {
 
     try {
       final AsyncPipeDataTransferServiceClient client =
-          ASYNC_PIPE_DATA_TRANSFER_CLIENT_MANAGER.borrowClient(targetNodeUrl);
+          asyncPipeDataTransferClientManager.borrowClient(targetNodeUrl);
 
       try {
         pipeTransferInsertNodeReqHandler.transfer(client);
@@ -216,8 +232,7 @@ public class IoTDBThriftConnectorV2 implements PipeConnector {
       pipeTransferInsertNodeReqHandler.onError(ex);
       LOGGER.warn(
           String.format(
-              "Failed to borrow client from client pool for receiver %s:%s.",
-              targetNodeUrl.getIp(), targetNodeUrl.getPort()),
+              FAILED_TO_BORROW_CLIENT_FORMATTER, targetNodeUrl.getIp(), targetNodeUrl.getPort()),
           ex);
     }
   }
@@ -229,7 +244,7 @@ public class IoTDBThriftConnectorV2 implements PipeConnector {
 
     try {
       final AsyncPipeDataTransferServiceClient client =
-          ASYNC_PIPE_DATA_TRANSFER_CLIENT_MANAGER.borrowClient(targetNodeUrl);
+          asyncPipeDataTransferClientManager.borrowClient(targetNodeUrl);
 
       try {
         pipeTransferTabletReqHandler.transfer(client);
@@ -244,8 +259,7 @@ public class IoTDBThriftConnectorV2 implements PipeConnector {
       pipeTransferTabletReqHandler.onError(ex);
       LOGGER.warn(
           String.format(
-              "Failed to borrow client from client pool for receiver %s:%s.",
-              targetNodeUrl.getIp(), targetNodeUrl.getPort()),
+              FAILED_TO_BORROW_CLIENT_FORMATTER, targetNodeUrl.getIp(), targetNodeUrl.getPort()),
           ex);
     }
   }
@@ -275,7 +289,7 @@ public class IoTDBThriftConnectorV2 implements PipeConnector {
 
     try {
       final AsyncPipeDataTransferServiceClient client =
-          ASYNC_PIPE_DATA_TRANSFER_CLIENT_MANAGER.borrowClient(targetNodeUrl);
+          asyncPipeDataTransferClientManager.borrowClient(targetNodeUrl);
 
       try {
         pipeTransferTsFileInsertionEventHandler.transfer(client);
@@ -290,8 +304,7 @@ public class IoTDBThriftConnectorV2 implements PipeConnector {
       pipeTransferTsFileInsertionEventHandler.onError(ex);
       LOGGER.warn(
           String.format(
-              "Failed to borrow client from client pool for receiver %s:%s.",
-              targetNodeUrl.getIp(), targetNodeUrl.getPort()),
+              FAILED_TO_BORROW_CLIENT_FORMATTER, targetNodeUrl.getIp(), targetNodeUrl.getPort()),
           ex);
     }
   }


### PR DESCRIPTION
The number of resident threads has increased, which is not expected.

There is an asynchronous client thread pool introduced to improve the performance limit of syncing data from Pipe to another iotdb instance, similar to the asynchronous client thread pool of IoTConsensus. It can be seen in the compute thread monitoring item. However, there is a problem that initialization should not be performed when it is not necessary.

![img_v2_bb93106b-0579-440c-9a1b-930c712722eg](https://github.com/apache/iotdb/assets/30497621/f1111fab-53e1-476d-8054-b3b732eb82bf)

![img_v2_107c1459-bdd9-4f5b-ba50-d7bf88b75c8g](https://github.com/apache/iotdb/assets/30497621/ddf70892-86af-4d47-a3ef-69725ce1db64)
