### PR TITLE
[To rel/1.2] Refactor SchemaScanOperator to do asynchronous fetch and return isBlock v2

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/CountGroupByLevelScanOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/CountGroupByLevelScanOperator.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.metadata.query.info.ISchemaInfo;
 import org.apache.iotdb.db.metadata.query.reader.ISchemaReader;
 import org.apache.iotdb.db.mpp.execution.driver.SchemaDriverContext;
+import org.apache.iotdb.db.mpp.execution.fragment.FragmentInstanceManager;
 import org.apache.iotdb.db.mpp.execution.operator.OperatorContext;
 import org.apache.iotdb.db.mpp.execution.operator.schema.source.ISchemaSource;
 import org.apache.iotdb.db.mpp.execution.operator.source.SourceOperator;
@@ -33,6 +34,8 @@ import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
 import org.apache.iotdb.tsfile.utils.Binary;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -51,12 +54,13 @@ public class CountGroupByLevelScanOperator<T extends ISchemaInfo> implements Sou
 
   private final PlanNodeId sourceId;
   private final OperatorContext operatorContext;
-
   private final int level;
-
   private final ISchemaSource<T> schemaSource;
 
   private ISchemaReader<T> schemaReader;
+  private ListenableFuture<?> isBlocked;
+  private TsBlock next;
+  private boolean isFinished;
 
   public CountGroupByLevelScanOperator(
       PlanNodeId sourceId,
@@ -67,6 +71,7 @@ public class CountGroupByLevelScanOperator<T extends ISchemaInfo> implements Sou
     this.operatorContext = operatorContext;
     this.level = level;
     this.schemaSource = schemaSource;
+    this.isFinished = false;
   }
 
   @Override
@@ -80,19 +85,84 @@ public class CountGroupByLevelScanOperator<T extends ISchemaInfo> implements Sou
   }
 
   @Override
+  public ListenableFuture<?> isBlocked() {
+    if (isBlocked == null) {
+      isBlocked = tryGetNext();
+    }
+    return isBlocked;
+  }
+
+  /**
+   * Try to get next TsBlock. If the next is not ready, return a future. After success, {@link
+   * CountGroupByLevelScanOperator#next} will be set.
+   */
+  private ListenableFuture<?> tryGetNext() {
+    if (schemaReader == null) {
+      schemaReader = createTimeSeriesReader();
+    }
+    return Futures.submit(
+        () -> {
+          Map<PartialPath, Long> countMap = new HashMap<>();
+          T schemaInfo;
+          PartialPath path;
+          PartialPath levelPath;
+          while (schemaReader.hasNext()) {
+            schemaInfo = schemaReader.next();
+            path = schemaInfo.getPartialPath();
+            if (path.getNodeLength() < level) {
+              continue;
+            }
+            levelPath = new PartialPath(Arrays.copyOf(path.getNodes(), level + 1));
+            countMap.compute(
+                levelPath,
+                (k, v) -> {
+                  if (v == null) {
+                    return 1L;
+                  } else {
+                    return v + 1;
+                  }
+                });
+            if (countMap.size() == DEFAULT_BATCH_SIZE) {
+              break;
+            }
+          }
+          TsBlockBuilder tsBlockBuilder = new TsBlockBuilder(OUTPUT_DATA_TYPES);
+          for (Map.Entry<PartialPath, Long> entry : countMap.entrySet()) {
+            tsBlockBuilder.getTimeColumnBuilder().writeLong(0L);
+            tsBlockBuilder
+                .getColumnBuilder(0)
+                .writeBinary(new Binary(entry.getKey().getFullPath()));
+            tsBlockBuilder.getColumnBuilder(1).writeLong(entry.getValue());
+            tsBlockBuilder.declarePosition();
+          }
+          if (!tsBlockBuilder.isEmpty()) {
+            isFinished = true;
+            next = null;
+          } else {
+            next = tsBlockBuilder.build();
+          }
+        },
+        FragmentInstanceManager.getInstance().getIntoOperationExecutor());
+  }
+
+  @Override
   public TsBlock next() throws Exception {
     if (!hasNext()) {
       throw new NoSuchElementException();
     }
-    return generateResult();
+    TsBlock ret = next;
+    next = null;
+    isBlocked = null;
+    return ret;
   }
 
   @Override
   public boolean hasNext() throws Exception {
-    if (schemaReader == null) {
-      schemaReader = createTimeSeriesReader();
+    isBlocked().get(); // make sure the next is ready
+    if (!schemaReader.isSuccess()) {
+      throw new RuntimeException(schemaReader.getFailure());
     }
-    return schemaReader.hasNext();
+    return next != null;
   }
 
   public ISchemaReader<T> createTimeSeriesReader() {
@@ -100,48 +170,9 @@ public class CountGroupByLevelScanOperator<T extends ISchemaInfo> implements Sou
         ((SchemaDriverContext) operatorContext.getDriverContext()).getSchemaRegion());
   }
 
-  private TsBlock generateResult() {
-    Map<PartialPath, Long> countMap = new HashMap<>();
-    T schemaInfo;
-    PartialPath path;
-    PartialPath levelPath;
-    while (schemaReader.hasNext()) {
-      schemaInfo = schemaReader.next();
-      path = schemaInfo.getPartialPath();
-      if (path.getNodeLength() < level) {
-        continue;
-      }
-      levelPath = new PartialPath(Arrays.copyOf(path.getNodes(), level + 1));
-      countMap.compute(
-          levelPath,
-          (k, v) -> {
-            if (v == null) {
-              return 1L;
-            } else {
-              return v + 1;
-            }
-          });
-      if (countMap.size() == DEFAULT_BATCH_SIZE) {
-        break;
-      }
-    }
-    if (!schemaReader.isSuccess()) {
-      throw new RuntimeException(schemaReader.getFailure());
-    }
-
-    TsBlockBuilder tsBlockBuilder = new TsBlockBuilder(OUTPUT_DATA_TYPES);
-    for (Map.Entry<PartialPath, Long> entry : countMap.entrySet()) {
-      tsBlockBuilder.getTimeColumnBuilder().writeLong(0L);
-      tsBlockBuilder.getColumnBuilder(0).writeBinary(new Binary(entry.getKey().getFullPath()));
-      tsBlockBuilder.getColumnBuilder(1).writeLong(entry.getValue());
-      tsBlockBuilder.declarePosition();
-    }
-    return tsBlockBuilder.build();
-  }
-
   @Override
   public boolean isFinished() throws Exception {
-    return !hasNextWithTimer();
+    return isFinished;
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaCountOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaCountOperator.java
@@ -126,7 +126,7 @@ public class SchemaCountOperator<T extends ISchemaInfo> implements SourceOperato
 
   @Override
   public boolean hasNext() throws Exception {
-    isBlocked.get(); // make sure the next is ready
+    isBlocked().get(); // make sure the next is ready
     if (!schemaReader.isSuccess()) {
       throw new RuntimeException(schemaReader.getFailure());
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaQueryScanOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaQueryScanOperator.java
@@ -64,6 +64,7 @@ public class SchemaQueryScanOperator<T extends ISchemaInfo> implements SourceOpe
 
   private ListenableFuture<Void> isBlocked;
   private TsBlock next;
+  private boolean isFinished;
 
   protected SchemaQueryScanOperator(
       PlanNodeId sourceId,
@@ -159,7 +160,12 @@ public class SchemaQueryScanOperator<T extends ISchemaInfo> implements SourceOpe
               break;
             }
           }
-          next = tsBlockBuilder.isEmpty()?null:tsBlockBuilder.build();
+          if (!tsBlockBuilder.isEmpty()) {
+            isFinished = true;
+            next = null;
+          } else {
+            next = tsBlockBuilder.build();
+          }
         },
         FragmentInstanceManager.getInstance().getIntoOperationExecutor());
   }
@@ -186,7 +192,7 @@ public class SchemaQueryScanOperator<T extends ISchemaInfo> implements SourceOpe
 
   @Override
   public boolean isFinished() throws Exception {
-    return !hasNextWithTimer();
+    return isFinished;
   }
 
   @Override
@@ -223,7 +229,7 @@ public class SchemaQueryScanOperator<T extends ISchemaInfo> implements SourceOpe
   public void close() throws Exception {
     if (schemaReader != null) {
       schemaReader.close();
-//      schemaReader = null;
+      schemaReader = null;
     }
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaQueryScanOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/SchemaQueryScanOperator.java
@@ -159,7 +159,7 @@ public class SchemaQueryScanOperator<T extends ISchemaInfo> implements SourceOpe
               break;
             }
           }
-          next = tsBlockBuilder.build();
+          next = tsBlockBuilder.isEmpty()?null:tsBlockBuilder.build();
         },
         FragmentInstanceManager.getInstance().getIntoOperationExecutor());
   }
@@ -177,7 +177,7 @@ public class SchemaQueryScanOperator<T extends ISchemaInfo> implements SourceOpe
 
   @Override
   public boolean hasNext() throws Exception {
-    isBlocked.get(); // make sure the next is ready
+    isBlocked().get(); // make sure the next is ready
     if (!schemaReader.isSuccess()) {
       throw new RuntimeException(schemaReader.getFailure());
     }
@@ -223,7 +223,7 @@ public class SchemaQueryScanOperator<T extends ISchemaInfo> implements SourceOpe
   public void close() throws Exception {
     if (schemaReader != null) {
       schemaReader.close();
-      schemaReader = null;
+//      schemaReader = null;
     }
   }
 }


### PR DESCRIPTION
## Description


Refactor SchemaScanOperator to do asynchronous fetch and return isBlock v2.

Only modify Operator's isBlocked to an asynchronous fetch procedure. 
* Pros: Fewer code changes. 
* Cons: Returns blocked even if asynchronous fetch is not required, which may cause thread switching overhead for mpp scheduling.
