### PR TITLE
[To rel/1.2] Fix error msg of altering not existing view

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/client/async/handlers/rpc/SchemaUpdateRPCHandler.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/client/async/handlers/rpc/SchemaUpdateRPCHandler.java
@@ -54,10 +54,10 @@ public class SchemaUpdateRPCHandler extends AsyncTSStatusRPCHandler {
       LOGGER.info("Successfully {} on DataNode: {}", requestType, formattedTargetLocation);
     } else if (tsStatus.getCode() == TSStatusCode.MULTIPLE_ERROR.getStatusCode()) {
       dataNodeLocationMap.remove(requestId);
-      LOGGER.error(
+      LOGGER.warn(
           "Failed to {} on DataNode {}, {}", requestType, formattedTargetLocation, tsStatus);
     } else {
-      LOGGER.error(
+      LOGGER.warn(
           "Failed to {} on DataNode {}, {}", requestType, formattedTargetLocation, tsStatus);
     }
     countDownLatch.countDown();
@@ -73,7 +73,7 @@ public class SchemaUpdateRPCHandler extends AsyncTSStatusRPCHandler {
             + targetDataNode.getInternalEndPoint()
             + "}"
             + e.getMessage();
-    LOGGER.error(errorMsg);
+    LOGGER.warn(errorMsg);
 
     countDownLatch.countDown();
     responseMap.put(

--- a/server/src/main/java/org/apache/iotdb/db/metadata/visitor/SchemaExecutionVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/visitor/SchemaExecutionVisitor.java
@@ -475,7 +475,7 @@ public class SchemaExecutionVisitor extends PlanVisitor<TSStatus, ISchemaRegion>
         schemaRegion.alterLogicalView(
             SchemaRegionWritePlanFactory.getAlterLogicalViewPlan(entry.getKey(), entry.getValue()));
       } catch (MetadataException e) {
-        logger.error("{}: MetaData error: ", IoTDBConstant.GLOBAL_DB_NAME, e);
+        logger.warn("{}: MetaData error: ", IoTDBConstant.GLOBAL_DB_NAME, e);
         failingStatus.add(RpcUtils.getStatus(e.getErrorCode(), e.getMessage()));
       }
     }


### PR DESCRIPTION
## Description

### Before this pr

```
IoTDB> alter view root.view(v1.c1, v1.c2, v2.c1, v2.c2) as select s1,s2 from root.db.d1, root.db1.d1;
Msg: 507: Alter view [root.view.v2.c2] failed when [Alter view] because all replicaset of schemaRegion 1 failed. [TDataNodeLocation(dataNodeId:1, clientRpcEndPoint:TEndPoint(ip:127.0.0.1, port:6667), internalEndPoint:TEndPoint(ip:127.0.0.1, port:10730), mPPDataExchangeEndPoint:
TEndPoint(ip:127.0.0.1, port:10740), dataRegionConsensusEndPoint:TEndPoint(ip:127.0.0.1, port:10760), schemaRegionConsensusEndPoint:TEndPoint(ip:127.0.0.1, port:10750))]
```

### After this pr

```
IoTDB> alter view root.view(v1.c1, v1.c2, v2.c1, v2.c2) as select s1,s2 from root.db.d1, root.db1.d1;
Msg: 708: Batch process failed:[TSStatus(code:508, message:Path [root.view.v1.c2] does not exist), TSStatus(code:508, message:Path [root.view.v2.c2] does not exist), TSStatus(code:508, message:Path [root.view.v1.c1] does not exist), TSStatus(code:508, message:Path [root.view.v2
.c1] does not exist)]
```
