### PR TITLE
[To rel/1.2] Fix error msg when select into view and normal timeseries failed

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
@@ -2118,11 +2118,11 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     context.setQueryType(QueryType.WRITE);
     Analysis analysis = new Analysis();
     validateSchema(analysis, insertTabletStatement);
-    InsertBaseStatement realStatement = insertTabletStatement.removeLogicalView();
-    analysis.setStatement(realStatement);
+    InsertBaseStatement realStatement = removeLogicalView(analysis, insertTabletStatement);
     if (analysis.isFinishQueryAfterAnalyze()) {
       return analysis;
     }
+    analysis.setStatement(realStatement);
 
     if (realStatement instanceof InsertTabletStatement) {
       InsertTabletStatement realInsertTabletStatement = (InsertTabletStatement) realStatement;
@@ -2143,11 +2143,11 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     context.setQueryType(QueryType.WRITE);
     Analysis analysis = new Analysis();
     validateSchema(analysis, insertRowStatement);
-    InsertBaseStatement realInsertStatement = insertRowStatement.removeLogicalView();
-    analysis.setStatement(realInsertStatement);
+    InsertBaseStatement realInsertStatement = removeLogicalView(analysis, insertRowStatement);
     if (analysis.isFinishQueryAfterAnalyze()) {
       return analysis;
     }
+    analysis.setStatement(realInsertStatement);
 
     if (realInsertStatement instanceof InsertRowStatement) {
       InsertRowStatement realInsertRowStatement = (InsertRowStatement) realInsertStatement;
@@ -2190,11 +2190,11 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     Analysis analysis = new Analysis();
     validateSchema(analysis, insertRowsStatement);
     InsertRowsStatement realInsertRowsStatement =
-        (InsertRowsStatement) insertRowsStatement.removeLogicalView();
-    analysis.setStatement(realInsertRowsStatement);
+        (InsertRowsStatement) removeLogicalView(analysis, insertRowsStatement);
     if (analysis.isFinishQueryAfterAnalyze()) {
       return analysis;
     }
+    analysis.setStatement(realInsertRowsStatement);
 
     return computeAnalysisForInsertRows(analysis, realInsertRowsStatement);
   }
@@ -2228,11 +2228,11 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     Analysis analysis = new Analysis();
     validateSchema(analysis, insertMultiTabletsStatement);
     InsertMultiTabletsStatement realStatement =
-        (InsertMultiTabletsStatement) insertMultiTabletsStatement.removeLogicalView();
-    analysis.setStatement(realStatement);
+        (InsertMultiTabletsStatement) removeLogicalView(analysis, insertMultiTabletsStatement);
     if (analysis.isFinishQueryAfterAnalyze()) {
       return analysis;
     }
+    analysis.setStatement(realStatement);
 
     return computeAnalysisForMultiTablets(analysis, realStatement);
   }
@@ -2243,11 +2243,12 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     context.setQueryType(QueryType.WRITE);
     Analysis analysis = new Analysis();
     validateSchema(analysis, insertRowsOfOneDeviceStatement);
-    InsertBaseStatement realInsertStatement = insertRowsOfOneDeviceStatement.removeLogicalView();
-    analysis.setStatement(realInsertStatement);
+    InsertBaseStatement realInsertStatement =
+        removeLogicalView(analysis, insertRowsOfOneDeviceStatement);
     if (analysis.isFinishQueryAfterAnalyze()) {
       return analysis;
     }
+    analysis.setStatement(realInsertStatement);
 
     if (realInsertStatement instanceof InsertRowsOfOneDeviceStatement) {
       InsertRowsOfOneDeviceStatement realStatement =
@@ -2289,6 +2290,23 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       logger.warn(partialInsertMessage);
       analysis.setFailStatus(
           RpcUtils.getStatus(TSStatusCode.METADATA_ERROR.getStatusCode(), partialInsertMessage));
+    }
+  }
+
+  private InsertBaseStatement removeLogicalView(
+      Analysis analysis, InsertBaseStatement insertBaseStatement) {
+    try {
+      return insertBaseStatement.removeLogicalView();
+    } catch (SemanticException e) {
+      analysis.setFinishQueryAfterAnalyze(true);
+      if (e.getCause() instanceof IoTDBException) {
+        IoTDBException exception = (IoTDBException) e.getCause();
+        analysis.setFailStatus(
+            RpcUtils.getStatus(exception.getErrorCode(), exception.getMessage()));
+      } else {
+        analysis.setFailStatus(RpcUtils.getStatus(TSStatusCode.METADATA_ERROR, e.getMessage()));
+      }
+      return insertBaseStatement;
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertBaseStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertBaseStatement.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.exception.metadata.DataTypeMismatchException;
 import org.apache.iotdb.db.exception.metadata.DuplicateInsertException;
 import org.apache.iotdb.db.exception.metadata.PathNotExistException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
+import org.apache.iotdb.db.exception.sql.SemanticException;
 import org.apache.iotdb.db.mpp.plan.analyze.schema.ISchemaValidation;
 import org.apache.iotdb.db.mpp.plan.statement.Statement;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -340,7 +341,7 @@ public abstract class InsertBaseStatement extends Statement {
         boolean measurementNotExists = measurementSet.add(thisPair.left);
         if (!measurementNotExists) {
           PartialPath devicePath = entry.getKey();
-          throw new RuntimeException(
+          throw new SemanticException(
               new DuplicateInsertException(devicePath.getFullPath(), thisPair.left));
         }
       }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertMultiTabletsStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertMultiTabletsStatement.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.mpp.plan.statement.crud;
 
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.exception.metadata.DuplicateInsertException;
+import org.apache.iotdb.db.exception.sql.SemanticException;
 import org.apache.iotdb.db.mpp.plan.analyze.schema.ISchemaValidation;
 import org.apache.iotdb.db.mpp.plan.statement.StatementType;
 import org.apache.iotdb.db.mpp.plan.statement.StatementVisitor;
@@ -167,7 +168,7 @@ public class InsertMultiTabletsStatement extends InsertBaseStatement {
       for (String measurement : insertTablet.measurements) {
         boolean notExist = measurementSet.add(measurement);
         if (!notExist) {
-          throw new RuntimeException(new DuplicateInsertException(device, measurement));
+          throw new SemanticException(new DuplicateInsertException(device, measurement));
         }
       }
       mapFromDeviceToMeasurements.put(device, measurementSet);

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertRowsStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/InsertRowsStatement.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.mpp.plan.statement.crud;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.exception.metadata.DuplicateInsertException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
+import org.apache.iotdb.db.exception.sql.SemanticException;
 import org.apache.iotdb.db.mpp.plan.analyze.schema.ISchemaValidation;
 import org.apache.iotdb.db.mpp.plan.statement.StatementType;
 import org.apache.iotdb.db.mpp.plan.statement.StatementVisitor;
@@ -178,7 +179,7 @@ public class InsertRowsStatement extends InsertBaseStatement {
       for (String measurement : insertRow.measurements) {
         boolean notExist = measurementSet.add(measurement);
         if (!notExist) {
-          throw new RuntimeException(new DuplicateInsertException(device, measurement));
+          throw new SemanticException(new DuplicateInsertException(device, measurement));
         }
       }
       mapFromDeviceToMeasurements.put(device, measurementSet);


### PR DESCRIPTION
## Description

### Before this pr

```
IoTDB> select c1,c2,c3,c4 into root.view.v1(c1,c2,c3,c4)  from root.view.v1;
Msg: 301: Error occurred while inserting tablets in SELECT INTO: [EXECUTE_STATEMENT_ERROR(301)] Exception occurred: insertTablets failed. org.apache.iotdb.db.exception.metadata.DuplicateInsertException: Insertion is illegal because measurement [s0] under device [root.db.d1] is duplicate.
```

### After this pr

```
IoTDB> select c1,c2,c3,c4 into root.view.v1(c1,c2,c3,c4)  from root.view.v1;
Msg: 301: Error occurred while inserting tablets in SELECT INTO: Insertion is illegal because measurement [s0] under device [root.db.d1] is duplicate.

```