### PR TITLE
Fix sonar bugs and code smells in confignode module about cq

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/write/cq/ActiveCQPlan.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/write/cq/ActiveCQPlan.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.iotdb.confignode.consensus.request.write.cq;
 
 import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlan;
@@ -71,9 +72,15 @@ public class ActiveCQPlan extends ConfigPhysicalPlan {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    if (!super.equals(o)) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
     ActiveCQPlan that = (ActiveCQPlan) o;
     return cqId.equals(that.cqId) && md5.equals(that.md5);
   }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/write/cq/AddCQPlan.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/write/cq/AddCQPlan.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.iotdb.confignode.consensus.request.write.cq;
 
 import org.apache.iotdb.commons.utils.ThriftCommonsSerDeUtils;
@@ -82,9 +83,15 @@ public class AddCQPlan extends ConfigPhysicalPlan {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    if (!super.equals(o)) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
     AddCQPlan addCQPlan = (AddCQPlan) o;
     return firstExecutionTime == addCQPlan.firstExecutionTime
         && Objects.equals(req, addCQPlan.req)

--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/write/cq/DropCQPlan.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/write/cq/DropCQPlan.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.iotdb.confignode.consensus.request.write.cq;
 
 import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlan;
@@ -79,9 +80,15 @@ public class DropCQPlan extends ConfigPhysicalPlan {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    if (!super.equals(o)) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
     DropCQPlan that = (DropCQPlan) o;
     return cqId.equals(that.cqId) && Objects.equals(md5, that.md5);
   }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/write/cq/ShowCQPlan.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/write/cq/ShowCQPlan.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.iotdb.confignode.consensus.request.write.cq;
 
 import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlan;
@@ -38,5 +39,7 @@ public class ShowCQPlan extends ConfigPhysicalPlan {
   }
 
   @Override
-  protected void deserializeImpl(ByteBuffer buffer) throws IOException {}
+  protected void deserializeImpl(ByteBuffer buffer) throws IOException {
+    // no customized field to deserialize from
+  }
 }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/write/cq/UpdateCQLastExecTimePlan.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/write/cq/UpdateCQLastExecTimePlan.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.iotdb.confignode.consensus.request.write.cq;
 
 import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlan;
@@ -81,9 +82,15 @@ public class UpdateCQLastExecTimePlan extends ConfigPhysicalPlan {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    if (!super.equals(o)) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
     UpdateCQLastExecTimePlan that = (UpdateCQLastExecTimePlan) o;
     return executionTime == that.executionTime && cqId.equals(that.cqId) && md5.equals(that.md5);
   }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
@@ -53,7 +53,6 @@ import org.apache.iotdb.confignode.consensus.request.write.confignode.RemoveConf
 import org.apache.iotdb.confignode.consensus.request.write.cq.ActiveCQPlan;
 import org.apache.iotdb.confignode.consensus.request.write.cq.AddCQPlan;
 import org.apache.iotdb.confignode.consensus.request.write.cq.DropCQPlan;
-import org.apache.iotdb.confignode.consensus.request.write.cq.ShowCQPlan;
 import org.apache.iotdb.confignode.consensus.request.write.cq.UpdateCQLastExecTimePlan;
 import org.apache.iotdb.confignode.consensus.request.write.database.AdjustMaxRegionGroupNumPlan;
 import org.apache.iotdb.confignode.consensus.request.write.database.DatabaseSchemaPlan;
@@ -271,7 +270,7 @@ public class ConfigPlanExecutor {
       case GetSeriesSlotList:
         return partitionInfo.getSeriesSlotList((GetSeriesSlotListPlan) req);
       case SHOW_CQ:
-        return cqInfo.showCQ((ShowCQPlan) req);
+        return cqInfo.showCQ();
       case GetFunctionTable:
         return udfInfo.getUDFTable();
       case GetFunctionJar:

--- a/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/cq/CreateCQProcedure.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/cq/CreateCQProcedure.java
@@ -86,7 +86,8 @@ public class CreateCQProcedure extends AbstractNodeProcedure<CreateCQState> {
     try {
       switch (state) {
         case INIT:
-          return addCQ(env);
+          addCQ(env);
+          return Flow.HAS_MORE_STATE;
         case INACTIVE:
           CQScheduleTask cqScheduleTask =
               new CQScheduleTask(req, firstExecutionTime, md5, executor, env.getConfigManager());
@@ -117,7 +118,7 @@ public class CreateCQProcedure extends AbstractNodeProcedure<CreateCQState> {
     return Flow.HAS_MORE_STATE;
   }
 
-  private Flow addCQ(ConfigNodeProcedureEnv env) {
+  private void addCQ(ConfigNodeProcedureEnv env) {
     ConsensusWriteResponse response =
         env.getConfigManager()
             .getConsensusManager()
@@ -130,11 +131,9 @@ public class CreateCQProcedure extends AbstractNodeProcedure<CreateCQState> {
       } else if (res.code == TSStatusCode.CQ_AlREADY_EXIST.getStatusCode()) {
         LOGGER.info("Failed to init CQ {} because such cq already exists", req.cqId);
         setFailure(new ProcedureException(new IoTDBException(res.message, res.code)));
-        return Flow.HAS_MORE_STATE;
       } else {
         LOGGER.warn("Failed to init CQ {} because of unknown reasons {}", req.cqId, res);
         setFailure(new ProcedureException(new IoTDBException(res.message, res.code)));
-        return Flow.HAS_MORE_STATE;
       }
     } else {
       LOGGER.warn(
@@ -142,9 +141,7 @@ public class CreateCQProcedure extends AbstractNodeProcedure<CreateCQState> {
           req.cqId,
           response.getException());
       setFailure(new ProcedureException(response.getException()));
-      return Flow.HAS_MORE_STATE;
     }
-    return Flow.NO_MORE_STATE;
   }
 
   private void activeCQ(ConfigNodeProcedureEnv env) {

--- a/confignode/src/main/java/org/apache/iotdb/confignode/procedure/state/cq/CreateCQState.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/procedure/state/cq/CreateCQState.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.iotdb.confignode.procedure.state.cq;
 
 public enum CreateCQState {


### PR DESCRIPTION
This pr aims to fix sonar bugs and code smells in confignode module about cq, including the following packages:

- confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/cq
- confignode/src/main/java/org/apache/iotdb/confignode/procedure/state/cq
- confignode/src/main/java/org/apache/iotdb/confignode/persistence/cq
- confignode/src/main/java/org/apache/iotdb/confignode/manager/cq
- confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/write/cq
- confignode/src/main/java/org/apache/iotdb/confignode/consensus/response/cq