### PR TITLE
[IOTDB-6021] Pipe: NPE when sync TEXT timeseries with null fields between IoTDB instances using file mode with pattern filter

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/TsFileInsertionDataTabletIterator.java
+++ b/server/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/TsFileInsertionDataTabletIterator.java
@@ -128,11 +128,10 @@ public class TsFileInsertionDataTabletIterator implements Iterator<Tablet> {
       final int fieldSize = fields.size();
       for (int i = 0; i < fieldSize; i++) {
         final Field field = fields.get(i);
-        if (field == null || field.getDataType() == null) {
-          tablet.bitMaps[i].mark(rowIndex);
-        } else {
-          tablet.addValue(measurements.get(i), rowIndex, field.getObjectValue(field.getDataType()));
-        }
+        tablet.addValue(
+            measurements.get(i),
+            rowIndex,
+            field == null ? null : field.getObjectValue(field.getDataType()));
       }
 
       tablet.rowSize++;

--- a/server/src/main/java/org/apache/iotdb/db/pipe/task/subtask/PipeConnectorSubtask.java
+++ b/server/src/main/java/org/apache/iotdb/db/pipe/task/subtask/PipeConnectorSubtask.java
@@ -160,6 +160,11 @@ public class PipeConnectorSubtask extends PipeSubtask {
         // stop current pipe task if failed to reconnect to the target system after MAX_RETRY_TIMES
         return;
       }
+    } else {
+      LOGGER.warn(
+          "A non-PipeConnectionException occurred, exception message: {}",
+          throwable.getMessage(),
+          throwable);
     }
 
     // handle other exceptions as usual

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/record/Tablet.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/record/Tablet.java
@@ -586,6 +586,8 @@ public class Tablet {
               boolean isNotNull = BytesUtils.byteToBool(ReadWriteIOUtils.readByte(byteBuffer));
               if (isNotNull) {
                 binaryValues[index] = ReadWriteIOUtils.readBinary(byteBuffer);
+              } else {
+                binaryValues[index] = Binary.EMPTY_VALUE;
               }
             }
             values[i] = binaryValues;


### PR DESCRIPTION
# version

```
commit 3f321225a28cb5c35f3d22d8db2d0f5f45282447 (HEAD -> rel_1.2, origin/rel/1.2, origin/rc/1.2.0.1)
Author: yschengzi <87161145+yschengzi@users.noreply.github.com>
Date: Tue Jun 20 22:14:32 2023 +0800
```

# how to reproduce 

source:

```sql
insert into root.a.b1(time, s1, s2) values (1, '123', null) (2, null, '456')

insert into root.a.b2(time, s1, s2) values (1, '123', null) (2, null, '456')

insert into root.a.b3(time, s1, s2) values (1, '123', null) (2, null, '456')

flush

create pipe p1 with collector ('collector'='iotdb_collector', 'collector.realtime.mode'='file', 'collector.pattern'='root.a.b2') with connector ('connector'='iotdb_thrift_connector_v1','connector.ip'='127.0.0.1', 'connector.port'='6668')

start pipe p1
```

NPE occurs!

# how it likes

![image](https://github.com/apache/iotdb/assets/30497621/e6741aeb-dde1-4a18-857e-1cf2c437bb07)
