### PR TITLE
[To rel/1.2][IOTDB-6021] Pipe: NPE when sync TEXT timeseries with null fields between IoTDB instances using file mode with pattern filter (#10269)

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/TsFileInsertionDataTabletIterator.java
+++ b/server/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/TsFileInsertionDataTabletIterator.java
@@ -128,11 +128,10 @@ public class TsFileInsertionDataTabletIterator implements Iterator<Tablet> {
       final int fieldSize = fields.size();
       for (int i = 0; i < fieldSize; i++) {
         final Field field = fields.get(i);
-        if (field == null || field.getDataType() == null) {
-          tablet.bitMaps[i].mark(rowIndex);
-        } else {
-          tablet.addValue(measurements.get(i), rowIndex, field.getObjectValue(field.getDataType()));
-        }
+        tablet.addValue(
+            measurements.get(i),
+            rowIndex,
+            field == null ? null : field.getObjectValue(field.getDataType()));
       }
 
       tablet.rowSize++;

--- a/server/src/main/java/org/apache/iotdb/db/pipe/task/subtask/PipeConnectorSubtask.java
+++ b/server/src/main/java/org/apache/iotdb/db/pipe/task/subtask/PipeConnectorSubtask.java
@@ -138,6 +138,11 @@ public class PipeConnectorSubtask extends PipeSubtask {
         // is dropped or the process is running normally.
         return;
       }
+    } else {
+      LOGGER.warn(
+          "A non-PipeConnectionException occurred, exception message: {}",
+          throwable.getMessage(),
+          throwable);
     }
 
     // handle other exceptions as usual

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/write/record/Tablet.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/write/record/Tablet.java
@@ -586,6 +586,8 @@ public class Tablet {
               boolean isNotNull = BytesUtils.byteToBool(ReadWriteIOUtils.readByte(byteBuffer));
               if (isNotNull) {
                 binaryValues[index] = ReadWriteIOUtils.readBinary(byteBuffer);
+              } else {
+                binaryValues[index] = Binary.EMPTY_VALUE;
               }
             }
             values[i] = binaryValues;


### PR DESCRIPTION
See #10269 for more details.

(cherry picked from commit 06d353158c788833509ffcc5c3d9dfa623be19b1)
