### PR TITLE
[To rel/1.2] Fix slow creation of view when using batch creation sql

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
@@ -282,6 +282,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
         QueryPlanCostMetricSet.getInstance()
             .recordPlanCost(SCHEMA_FETCHER, System.nanoTime() - startTime);
       }
+      analysis.setSchemaTree(schemaTree);
 
       // extract global time filter from query filter and determine if there is a value filter
       analyzeGlobalTimeFilter(analysis, queryStatement);
@@ -3243,18 +3244,11 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
    * Compute how many paths exist, get the schema tree and the number of existed paths.
    *
    * @param pathList the path you want to check
-   * @param context the context of your analyzer
+   * @param schemaTree fetched when analyze query
    * @return a pair of ISchemaTree, and the number of exist paths.
    */
   private Pair<ISchemaTree, Integer> fetchSchemaOfPathsAndCount(
-      List<PartialPath> pathList, MPPQueryContext context) {
-    PathPatternTree pathPatternTree = new PathPatternTree();
-    for (PartialPath path : pathList) {
-      // already parsed as precise path, not path pattern
-      pathPatternTree.appendFullPath(path);
-    }
-    ISchemaTree schemaTree = this.schemaFetcher.fetchSchema(pathPatternTree, context);
-
+      List<PartialPath> pathList, ISchemaTree schemaTree) {
     // search each path, make sure they all exist.
     int numOfExistPaths = 0;
     for (PartialPath path : pathList) {
@@ -3291,6 +3285,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
   private Pair<List<Expression>, Analysis> analyzeQueryInLogicalViewStatement(
       Analysis analysis, QueryStatement queryStatement, MPPQueryContext context) {
     Analysis queryAnalysis = this.visitQuery(queryStatement, context);
+    analysis.setSchemaTree(queryAnalysis.getSchemaTree());
     // get all expression from resultColumns
     List<Pair<Expression, String>> outputExpressions = queryAnalysis.getOutputExpressions();
     if (queryAnalysis.isFailed()) {
@@ -3321,8 +3316,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     return new Pair<>(expressionList, analysis);
   }
 
-  private void checkViewsInSource(
-      Analysis analysis, List<Expression> sourceExpressionList, MPPQueryContext context) {
+  private void checkViewsInSource(Analysis analysis, List<Expression> sourceExpressionList) {
     List<PartialPath> pathsNeedCheck = new ArrayList<>();
     for (Expression expression : sourceExpressionList) {
       if (expression instanceof TimeSeriesOperand) {
@@ -3330,7 +3324,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       }
     }
     Pair<ISchemaTree, Integer> schemaOfNeedToCheck =
-        fetchSchemaOfPathsAndCount(pathsNeedCheck, context);
+        fetchSchemaOfPathsAndCount(pathsNeedCheck, analysis.getSchemaTree());
     if (schemaOfNeedToCheck.right != pathsNeedCheck.size()) {
       // some source paths is not exist, and could not fetch schema.
       analysis.setFinishQueryAfterAnalyze(true);
@@ -3453,7 +3447,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
 
     // make sure there is no view in source
     List<Expression> sourceExpressionList = createLogicalViewStatement.getSourceExpressionList();
-    checkViewsInSource(analysis, sourceExpressionList, context);
+    checkViewsInSource(analysis, sourceExpressionList);
     if (analysis.isFinishQueryAfterAnalyze()) {
       return analysis;
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
@@ -3250,7 +3250,8 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       List<PartialPath> pathList, MPPQueryContext context) {
     PathPatternTree pathPatternTree = new PathPatternTree();
     for (PartialPath path : pathList) {
-      pathPatternTree.appendPathPattern(path);
+      // already parsed as precise path, not path pattern
+      pathPatternTree.appendFullPath(path);
     }
     ISchemaTree schemaTree = this.schemaFetcher.fetchSchema(pathPatternTree, context);
 
@@ -3258,7 +3259,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     int numOfExistPaths = 0;
     for (PartialPath path : pathList) {
       Pair<List<MeasurementPath>, Integer> pathPair = schemaTree.searchMeasurementPaths(path);
-      numOfExistPaths += pathPair.left.size() > 0 ? 1 : 0;
+      numOfExistPaths += !pathPair.left.isEmpty() ? 1 : 0;
     }
     return new Pair<>(schemaTree, numOfExistPaths);
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
@@ -3243,12 +3243,20 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
   /**
    * Compute how many paths exist, get the schema tree and the number of existed paths.
    *
-   * @param pathList the path you want to check
-   * @param schemaTree fetched when analyze query
    * @return a pair of ISchemaTree, and the number of exist paths.
    */
   private Pair<ISchemaTree, Integer> fetchSchemaOfPathsAndCount(
-      List<PartialPath> pathList, ISchemaTree schemaTree) {
+      List<PartialPath> pathList, Analysis analysis, MPPQueryContext context) {
+    ISchemaTree schemaTree = analysis.getSchemaTree();
+    if (schemaTree == null) {
+      // source is not represented by query, thus has not done fetch schema.
+      PathPatternTree pathPatternTree = new PathPatternTree();
+      for (PartialPath path : pathList) {
+        pathPatternTree.appendPathPattern(path);
+      }
+      schemaTree = this.schemaFetcher.fetchSchema(pathPatternTree, context);
+    }
+
     // search each path, make sure they all exist.
     int numOfExistPaths = 0;
     for (PartialPath path : pathList) {
@@ -3316,7 +3324,8 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     return new Pair<>(expressionList, analysis);
   }
 
-  private void checkViewsInSource(Analysis analysis, List<Expression> sourceExpressionList) {
+  private void checkViewsInSource(
+      Analysis analysis, List<Expression> sourceExpressionList, MPPQueryContext context) {
     List<PartialPath> pathsNeedCheck = new ArrayList<>();
     for (Expression expression : sourceExpressionList) {
       if (expression instanceof TimeSeriesOperand) {
@@ -3324,7 +3333,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       }
     }
     Pair<ISchemaTree, Integer> schemaOfNeedToCheck =
-        fetchSchemaOfPathsAndCount(pathsNeedCheck, analysis.getSchemaTree());
+        fetchSchemaOfPathsAndCount(pathsNeedCheck, analysis, context);
     if (schemaOfNeedToCheck.right != pathsNeedCheck.size()) {
       // some source paths is not exist, and could not fetch schema.
       analysis.setFinishQueryAfterAnalyze(true);
@@ -3447,7 +3456,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
 
     // make sure there is no view in source
     List<Expression> sourceExpressionList = createLogicalViewStatement.getSourceExpressionList();
-    checkViewsInSource(analysis, sourceExpressionList);
+    checkViewsInSource(analysis, sourceExpressionList, context);
     if (analysis.isFinishQueryAfterAnalyze()) {
       return analysis;
     }


### PR DESCRIPTION
## Description


### Cause

When constructing pattern tree for partition fetch from configNode, the interface invoked was appendPathPattern, which takes n^2 time complexity.

### Solution

When the source clause of createView is a query statement, use the schema tree fetched during analyze query of createViewStatement, and this already contains all source timeseries.

When  the source clause of createView is not a query statement, use appendFullPath to construct pattern tree, since all the given paths are precise timeseries paths.
