### PR TITLE
[IOTDB-5999] System properties patch

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeStartupCheck.java
@@ -74,6 +74,10 @@ public class ConfigNodeStartupCheck extends StartupChecks {
     checkGlobalConfig();
     createDirsIfNecessary();
     if (SystemPropertiesUtils.isRestarted()) {
+      /* Always restore ClusterName and ConfigNodeId first */
+      CONF.setClusterName(SystemPropertiesUtils.loadClusterNameWhenRestarted());
+      CONF.setConfigNodeId(SystemPropertiesUtils.loadConfigNodeIdWhenRestarted());
+
       SystemPropertiesUtils.checkSystemProperties();
     }
   }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
@@ -109,10 +109,6 @@ public class ConfigNode implements ConfigNodeMBean {
       if (SystemPropertiesUtils.isRestarted()) {
         LOGGER.info("{} is in restarting process...", ConfigNodeConstant.GLOBAL_NAME);
 
-        /* Always restore ClusterName and ConfigNodeId first */
-        CONF.setClusterName(SystemPropertiesUtils.loadClusterNameWhenRestarted());
-        CONF.setConfigNodeId(SystemPropertiesUtils.loadConfigNodeIdWhenRestarted());
-
         if (!SystemPropertiesUtils.isSeedConfigNode()) {
           // The non-seed-ConfigNodes should send restart request
           sendRestartConfigNodeRequest();


### PR DESCRIPTION
The ConfigNode should restore cluster_name and config_node_id at the first step of restart.