### PR TITLE
[To rel/1.2][IOTDB-6023] Pipe: Load serialize error when meeting empty value chunk

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/load/TsFileSplitter.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/load/TsFileSplitter.java
@@ -229,7 +229,7 @@ public class TsFileSplitter {
             chunkMetadata = offset2ChunkMetadata.get(chunkOffset - Byte.BYTES);
             header = reader.readChunkHeader(marker);
             if (header.getDataSize() == 0) {
-              handleEmptyValueChunk(header, pageIndex2ChunkData);
+              handleEmptyValueChunk(header, pageIndex2ChunkData, chunkMetadata);
               break;
             }
 
@@ -421,12 +421,16 @@ public class TsFileSplitter {
   }
 
   private void handleEmptyValueChunk(
-      ChunkHeader header, Map<Integer, List<AlignedChunkData>> pageIndex2ChunkData) {
+      ChunkHeader header,
+      Map<Integer, List<AlignedChunkData>> pageIndex2ChunkData,
+      IChunkMetadata chunkMetadata)
+      throws IOException {
     Set<ChunkData> allChunkData = new HashSet<>();
     for (Map.Entry<Integer, List<AlignedChunkData>> entry : pageIndex2ChunkData.entrySet()) {
       for (AlignedChunkData alignedChunkData : entry.getValue()) {
         if (!allChunkData.contains(alignedChunkData)) {
           alignedChunkData.addValueChunk(header);
+          alignedChunkData.writeEntireChunk(ByteBuffer.allocate(0), chunkMetadata);
           allChunkData.add(alignedChunkData);
         }
       }


### PR DESCRIPTION
This PR contains:
- In the split tsfile logic of load, if there is an empty value chunk, the empty ByteBuffer and the corresponding statistics should be written, not nothing, which will cause the deserialization to fail

这个 PR 包含：
- 在 load 的拆分 tsfile 逻辑中，如果出现了 empty value chunk，应当写入空的 ByteBuffer 和对应的 statistics，而不是什么都不写，不写将导致反序列化失败，并引起以下错误
![img_v2_3097374d-4b7c-4eaa-913a-5d30e84cd4bg](https://github.com/apache/iotdb/assets/87161145/3726a6fe-5f94-47e4-ae24-04854917327c)

Cherry pick from #10281 