### PR TITLE
[To rel/1.1][IOTDB-6015][IOTDB-6023] load TsFile bugs: Not checking whether the tsfile data loaded locally is in the same time partition during the loading process & LoadTsFilePieceNode error when loading tsfile with empty value chunks

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/load/TsFileSplitter.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/load/TsFileSplitter.java
@@ -229,7 +229,7 @@ public class TsFileSplitter {
             chunkMetadata = offset2ChunkMetadata.get(chunkOffset - Byte.BYTES);
             header = reader.readChunkHeader(marker);
             if (header.getDataSize() == 0) {
-              handleEmptyValueChunk(header, pageIndex2ChunkData);
+              handleEmptyValueChunk(header, pageIndex2ChunkData, chunkMetadata);
               break;
             }
 
@@ -421,12 +421,16 @@ public class TsFileSplitter {
   }
 
   private void handleEmptyValueChunk(
-      ChunkHeader header, Map<Integer, List<AlignedChunkData>> pageIndex2ChunkData) {
+      ChunkHeader header,
+      Map<Integer, List<AlignedChunkData>> pageIndex2ChunkData,
+      IChunkMetadata chunkMetadata)
+      throws IOException {
     Set<ChunkData> allChunkData = new HashSet<>();
     for (Map.Entry<Integer, List<AlignedChunkData>> entry : pageIndex2ChunkData.entrySet()) {
       for (AlignedChunkData alignedChunkData : entry.getValue()) {
         if (!allChunkData.contains(alignedChunkData)) {
           alignedChunkData.addValueChunk(header);
+          alignedChunkData.writeEntireChunk(ByteBuffer.allocate(0), chunkMetadata);
           allChunkData.add(alignedChunkData);
         }
       }


### PR DESCRIPTION
See the following links for more details:
* [IOTDB-6015] Not checking whether the tsfile data loaded locally is in the same time partition during the loading process (https://github.com/apache/iotdb/pull/10249) (cherry picked from commit https://github.com/apache/iotdb/commit/56faa8ef61b2cae499d1ef42fe994a8c4c9bc9c2)
* [IOTDB-6023] LoadTsFilePieceNode error when loading tsfile with empty value chunks (https://github.com/apache/iotdb/pull/10281) (cherry picked from commit https://github.com/apache/iotdb/commit/11755a10f5f237ba5dbdc4c4562222117e06dc9c)