### PR TITLE
[IOTDB-6020] Improve the front-end process of mpp query, fix more corner cases, fix sonar code smells

### DIFF
--- a/.github/workflows/sonar-coveralls.yml
+++ b/.github/workflows/sonar-coveralls.yml
@@ -5,21 +5,21 @@ name: Sonar-Coveralls
 
 on:
   push:
-    branches:
-      - master
-      - "rel/*"
-      - "new_*"
+#    branches:
+#      - master
+#      - "rel/*"
+#      - "new_*"
     paths-ignore:
       - "docs/**"
       - 'site/**'
-  pull_request:
-    branches:
-      - master
-      - "rel/*"
-      - "new_*"
-    paths-ignore:
-      - "docs/**"
-      - 'site/**'
+#  pull_request:
+#    branches:
+#      - master
+#      - "rel/*"
+#      - "new_*"
+#    paths-ignore:
+#      - "docs/**"
+#      - 'site/**'
   # allow manually run the action:
   workflow_dispatch:
 

--- a/.github/workflows/sonar-coveralls.yml
+++ b/.github/workflows/sonar-coveralls.yml
@@ -5,21 +5,21 @@ name: Sonar-Coveralls
 
 on:
   push:
-#    branches:
-#      - master
-#      - "rel/*"
-#      - "new_*"
+    branches:
+      - master
+      - "rel/*"
+      - "new_*"
     paths-ignore:
       - "docs/**"
       - 'site/**'
-#  pull_request:
-#    branches:
-#      - master
-#      - "rel/*"
-#      - "new_*"
-#    paths-ignore:
-#      - "docs/**"
-#      - 'site/**'
+  pull_request:
+    branches:
+      - master
+      - "rel/*"
+      - "new_*"
+    paths-ignore:
+      - "docs/**"
+      - 'site/**'
   # allow manually run the action:
   workflow_dispatch:
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/AbstractFragInsStateTracker.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/AbstractFragInsStateTracker.java
@@ -65,10 +65,6 @@ public abstract class AbstractFragInsStateTracker implements IFragInstanceStateT
     this.localhostInternalPort = IoTDBDescriptor.getInstance().getConfig().getInternalPort();
   }
 
-  public abstract void start();
-
-  public abstract void abort();
-
   protected FragmentInstanceInfo fetchInstanceInfo(FragmentInstance instance)
       throws ClientManagerException, TException {
     TEndPoint endPoint = instance.getHostDataNode().internalEndPoint;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/AsyncSendPlanNodeHandler.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/AsyncSendPlanNodeHandler.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.iotdb.db.mpp.plan.scheduler;
 
 import org.apache.iotdb.commons.service.metric.PerformanceOverviewMetrics;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/ClusterScheduler.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/ClusterScheduler.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.iotdb.db.mpp.plan.scheduler;
 
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
@@ -23,9 +24,7 @@ import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.client.IClientManager;
 import org.apache.iotdb.commons.client.async.AsyncDataNodeInternalServiceClient;
 import org.apache.iotdb.commons.client.sync.SyncDataNodeInternalServiceClient;
-import org.apache.iotdb.db.mpp.common.FragmentInstanceId;
 import org.apache.iotdb.db.mpp.common.MPPQueryContext;
-import org.apache.iotdb.db.mpp.common.PlanFragmentId;
 import org.apache.iotdb.db.mpp.execution.QueryStateMachine;
 import org.apache.iotdb.db.mpp.execution.fragment.FragmentInfo;
 import org.apache.iotdb.db.mpp.metric.QueryExecutionMetricSet;
@@ -177,16 +176,4 @@ public class ClusterScheduler implements IScheduler {
   public FragmentInfo getFragmentInfo() {
     return null;
   }
-
-  @Override
-  public void abortFragmentInstance(FragmentInstanceId instanceId, Throwable failureCause) {}
-
-  @Override
-  public void cancelFragment(PlanFragmentId planFragmentId) {}
-
-  // Send the instances to other nodes
-  private void sendFragmentInstances() {}
-
-  // After sending, start to collect the states of these fragment instances
-  private void startMonitorInstances() {}
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/FragmentInstanceDispatcherImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/FragmentInstanceDispatcherImpl.java
@@ -81,6 +81,10 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
   private static final PerformanceOverviewMetrics PERFORMANCE_OVERVIEW_METRICS =
       PerformanceOverviewMetrics.getInstance();
 
+  private static final String DISPATCH_FAILED = "[DispatchFailed]";
+
+  private static final String UNEXPECTED_ERRORS = "Unexpected errors: ";
+
   public FragmentInstanceDispatcherImpl(
       QueryType type,
       MPPQueryContext queryContext,
@@ -119,11 +123,11 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
       } catch (FragmentInstanceDispatchException e) {
         return immediateFuture(new FragInstanceDispatchResult(e.getFailureStatus()));
       } catch (Throwable t) {
-        logger.warn("[DispatchFailed]", t);
+        logger.warn(DISPATCH_FAILED, t);
         return immediateFuture(
             new FragInstanceDispatchResult(
                 RpcUtils.getStatus(
-                    TSStatusCode.INTERNAL_SERVER_ERROR, "Unexpected errors: " + t.getMessage())));
+                    TSStatusCode.INTERNAL_SERVER_ERROR, UNEXPECTED_ERRORS + t.getMessage())));
       } finally {
         QUERY_EXECUTION_METRIC_SET.recordExecutionCost(
             DISPATCH_READ, System.nanoTime() - startTime);
@@ -149,10 +153,10 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
           }
         }
       } catch (Throwable t) {
-        logger.warn("[DispatchFailed]", t);
+        logger.warn(DISPATCH_FAILED, t);
         failureStatusList.add(
             RpcUtils.getStatus(
-                TSStatusCode.INTERNAL_SERVER_ERROR, "Unexpected errors: " + t.getMessage()));
+                TSStatusCode.INTERNAL_SERVER_ERROR, UNEXPECTED_ERRORS + t.getMessage()));
       }
     }
     if (failureStatusList.isEmpty()) {
@@ -194,10 +198,10 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
         } catch (FragmentInstanceDispatchException e) {
           dataNodeFailureList.add(e.getFailureStatus());
         } catch (Throwable t) {
-          logger.warn("[DispatchFailed]", t);
+          logger.warn(DISPATCH_FAILED, t);
           dataNodeFailureList.add(
               RpcUtils.getStatus(
-                  TSStatusCode.INTERNAL_SERVER_ERROR, "Unexpected errors: " + t.getMessage()));
+                  TSStatusCode.INTERNAL_SERVER_ERROR, UNEXPECTED_ERRORS + t.getMessage()));
         }
       }
       PERFORMANCE_OVERVIEW_METRICS.recordScheduleLocalCost(

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/IScheduler.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/IScheduler.java
@@ -18,8 +18,6 @@
  */
 package org.apache.iotdb.db.mpp.plan.scheduler;
 
-import org.apache.iotdb.db.mpp.common.FragmentInstanceId;
-import org.apache.iotdb.db.mpp.common.PlanFragmentId;
 import org.apache.iotdb.db.mpp.execution.fragment.FragmentInfo;
 
 import io.airlift.units.Duration;
@@ -33,8 +31,4 @@ public interface IScheduler {
   Duration getTotalCpuTime();
 
   FragmentInfo getFragmentInfo();
-
-  void abortFragmentInstance(FragmentInstanceId instanceId, Throwable failureCause);
-
-  void cancelFragment(PlanFragmentId planFragmentId);
 }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/load/LoadTsFileDispatcherImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/load/LoadTsFileDispatcherImpl.java
@@ -68,6 +68,7 @@ public class LoadTsFileDispatcherImpl implements IFragInstanceDispatcher {
   private final IClientManager<TEndPoint, SyncDataNodeInternalServiceClient>
       internalServiceClientManager;
   private final ExecutorService executor;
+  private static final String NODE_CONNECTION_ERROR = "can't connect to node {}";
 
   public LoadTsFileDispatcherImpl(
       IClientManager<TEndPoint, SyncDataNodeInternalServiceClient> internalServiceClientManager) {
@@ -140,10 +141,10 @@ public class LoadTsFileDispatcherImpl implements IFragInstanceDispatcher {
         throw new FragmentInstanceDispatchException(loadResp.status);
       }
     } catch (ClientManagerException | TException e) {
-      logger.warn("can't connect to node {}", endPoint, e);
+      logger.warn(NODE_CONNECTION_ERROR, endPoint, e);
       TSStatus status = new TSStatus();
       status.setCode(TSStatusCode.DISPATCH_ERROR.getStatusCode());
-      status.setMessage("can't connect to node {}" + endPoint);
+      status.setMessage(NODE_CONNECTION_ERROR + endPoint);
       throw new FragmentInstanceDispatchException(status);
     }
   }
@@ -227,11 +228,12 @@ public class LoadTsFileDispatcherImpl implements IFragInstanceDispatcher {
         throw new FragmentInstanceDispatchException(loadResp.status);
       }
     } catch (ClientManagerException | TException e) {
-      logger.warn("can't connect to node {}", endPoint, e);
+      logger.warn(NODE_CONNECTION_ERROR, endPoint, e);
       TSStatus status = new TSStatus();
       status.setCode(TSStatusCode.DISPATCH_ERROR.getStatusCode());
       status.setMessage(
-          "can't connect to node {}, please reset longer dn_connection_timeout_ms in iotdb-common.properties and restart iotdb."
+          NODE_CONNECTION_ERROR
+              + "please reset longer dn_connection_timeout_ms in iotdb-common.properties and restart iotdb."
               + endPoint);
       throw new FragmentInstanceDispatchException(status);
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/load/LoadTsFileScheduler.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/load/LoadTsFileScheduler.java
@@ -35,7 +35,6 @@ import org.apache.iotdb.db.engine.load.ChunkData;
 import org.apache.iotdb.db.engine.load.TsFileData;
 import org.apache.iotdb.db.engine.load.TsFileSplitter;
 import org.apache.iotdb.db.exception.mpp.FragmentInstanceDispatchException;
-import org.apache.iotdb.db.mpp.common.FragmentInstanceId;
 import org.apache.iotdb.db.mpp.common.MPPQueryContext;
 import org.apache.iotdb.db.mpp.common.PlanFragmentId;
 import org.apache.iotdb.db.mpp.execution.QueryStateMachine;
@@ -162,15 +161,17 @@ public class LoadTsFileScheduler implements IScheduler {
         }
         if (isLoadSingleTsFileSuccess) {
           logger.info(
-              String.format(
-                  "Load TsFile %s Successfully, load process [%s/%s]",
-                  node.getTsFileResource().getTsFilePath(), i + 1, tsFileNodeListSize));
+              "Load TsFile {} Successfully, load process [{}/{}]",
+              node.getTsFileResource().getTsFilePath(),
+              i + 1,
+              tsFileNodeListSize);
         } else {
           isLoadSuccess = false;
           logger.warn(
-              String.format(
-                  "Can not Load TsFile %s, load process [%s/%s]",
-                  node.getTsFileResource().getTsFilePath(), i + 1, tsFileNodeListSize));
+              "Can not Load TsFile {}, load process [{}/{}]",
+              node.getTsFileResource().getTsFilePath(),
+              i + 1,
+              tsFileNodeListSize);
         }
       } catch (Exception e) {
         isLoadSuccess = false;
@@ -236,12 +237,12 @@ public class LoadTsFileScheduler implements IScheduler {
       if (!result.isSuccessful()) {
         // TODO: retry.
         logger.warn(
-            String.format(
-                "Dispatch one piece to ReplicaSet %s error. Result status code %s. Result status message %s. Dispatch piece node error:%n%s",
-                replicaSet,
-                TSStatusCode.representOf(result.getFailureStatus().getCode()).name(),
-                result.getFailureStatus().getMessage(),
-                pieceNode));
+            "Dispatch one piece to ReplicaSet {} error. Result status code {}. "
+                + "Result status message {}. Dispatch piece node error:%n{}",
+            replicaSet,
+            TSStatusCode.representOf(result.getFailureStatus().getCode()).name(),
+            result.getFailureStatus().getMessage(),
+            pieceNode);
         if (result.getFailureStatus().getSubStatus() != null) {
           for (TSStatus status : result.getFailureStatus().getSubStatus()) {
             logger.warn(
@@ -287,13 +288,13 @@ public class LoadTsFileScheduler implements IScheduler {
       if (!result.isSuccessful()) {
         // TODO: retry.
         logger.warn(
-            String.format(
-                "Dispatch load command %s of TsFile %s error to replicaSets %s error. Result status code %s. Result status message %s.",
-                loadCommandReq,
-                tsFile,
-                allReplicaSets,
-                TSStatusCode.representOf(result.getFailureStatus().getCode()).name(),
-                result.getFailureStatus().getMessage()));
+            "Dispatch load command {} of TsFile {} error to replicaSets {} error. "
+                + "Result status code {}, Result status message {}.",
+            loadCommandReq,
+            tsFile,
+            allReplicaSets,
+            TSStatusCode.representOf(result.getFailureStatus().getCode()).name(),
+            result.getFailureStatus().getMessage());
         TSStatus status = result.getFailureStatus();
         status.setMessage(
             String.format("Load %s error in 2nd phase. Because ", tsFile) + status.getMessage());
@@ -327,7 +328,8 @@ public class LoadTsFileScheduler implements IScheduler {
     } catch (FragmentInstanceDispatchException e) {
       logger.warn(
           String.format(
-              "Dispatch tsFile %s error to local error. Result status code %s. Result status message %s.",
+              "Dispatch tsFile %s error to local error. Result status code %s. "
+                  + "Result status message %s.",
               node.getTsFileResource().getTsFile(),
               TSStatusCode.representOf(e.getFailureStatus().getCode()).name(),
               e.getFailureStatus().getMessage()));
@@ -349,12 +351,6 @@ public class LoadTsFileScheduler implements IScheduler {
   public FragmentInfo getFragmentInfo() {
     return null;
   }
-
-  @Override
-  public void abortFragmentInstance(FragmentInstanceId instanceId, Throwable failureCause) {}
-
-  @Override
-  public void cancelFragment(PlanFragmentId planFragmentId) {}
 
   public enum LoadCommand {
     EXECUTE,

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/load/LoadTsFileScheduler.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/scheduler/load/LoadTsFileScheduler.java
@@ -327,12 +327,11 @@ public class LoadTsFileScheduler implements IScheduler {
       dispatcher.dispatchLocally(instance);
     } catch (FragmentInstanceDispatchException e) {
       logger.warn(
-          String.format(
-              "Dispatch tsFile %s error to local error. Result status code %s. "
-                  + "Result status message %s.",
-              node.getTsFileResource().getTsFile(),
-              TSStatusCode.representOf(e.getFailureStatus().getCode()).name(),
-              e.getFailureStatus().getMessage()));
+          "Dispatch tsFile {} error to local error. Result status code {}. "
+              + "Result status message {}.",
+          node.getTsFileResource().getTsFile(),
+          TSStatusCode.representOf(e.getFailureStatus().getCode()).name(),
+          e.getFailureStatus().getMessage());
       stateMachine.transitionToFailed(e.getFailureStatus());
       return false;
     }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/QueryStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/QueryStatement.java
@@ -549,8 +549,13 @@ public class QueryStatement extends Statement {
           != ResultColumn.ColumnType.AGGREGATION) {
         throw new SemanticException("Expression of HAVING clause must to be an Aggregation");
       }
+      if (!isAggregationQuery()) {
+        throw new SemanticException(
+            "Expression of HAVING clause can not be used in NonAggregationQuery");
+      }
       try {
-        if (isGroupByLevel()) { // check path in SELECT and HAVING only have one node
+        if (isGroupByLevel()) {
+          // check path in SELECT and HAVING only have one node
           for (ResultColumn resultColumn : getSelectComponent().getResultColumns()) {
             ExpressionAnalyzer.checkIsAllMeasurement(resultColumn.getExpression());
           }
@@ -578,6 +583,9 @@ public class QueryStatement extends Statement {
         }
         if (getWhereCondition() != null) {
           ExpressionAnalyzer.checkIsAllMeasurement(getWhereCondition().getPredicate());
+        }
+        if (hasHaving()) {
+          ExpressionAnalyzer.checkIsAllMeasurement(getHavingCondition().getPredicate());
         }
       } catch (SemanticException e) {
         throw new SemanticException("ALIGN BY DEVICE: " + e.getMessage());

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/QueryStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/crud/QueryStatement.java
@@ -333,10 +333,6 @@ public class QueryStatement extends Statement {
     return resultSetFormat == ResultSetFormat.ALIGN_BY_DEVICE;
   }
 
-  public boolean disableAlign() {
-    return resultSetFormat == ResultSetFormat.DISABLE_ALIGN;
-  }
-
   public boolean isOrderByTime() {
     return orderByComponent != null && orderByComponent.isOrderByTime();
   }
@@ -469,14 +465,11 @@ public class QueryStatement extends Statement {
     return useWildcard;
   }
 
-  private static final String RAW_AGGREGATION_HYBRID_QUERY_ERROR_MSG =
+  public static final String RAW_AGGREGATION_HYBRID_QUERY_ERROR_MSG =
       "Raw data and aggregation hybrid query is not supported.";
 
   public void semanticCheck() {
     if (isAggregationQuery()) {
-      if (disableAlign()) {
-        throw new SemanticException("AGGREGATION doesn't support disable align clause.");
-      }
       if (groupByComponent != null && isGroupByLevel()) {
         throw new SemanticException("GROUP BY CLAUSES doesn't support GROUP BY LEVEL now.");
       }
@@ -539,7 +532,7 @@ public class QueryStatement extends Statement {
       Expression whereExpression = getWhereCondition().getPredicate();
       if (ExpressionAnalyzer.identifyOutputColumnType(whereExpression, true)
           == ResultColumn.ColumnType.AGGREGATION) {
-        throw new SemanticException("aggregate functions are not supported in WHERE clause");
+        throw new SemanticException("Aggregate functions are not supported in WHERE clause");
       }
     }
 
@@ -600,9 +593,6 @@ public class QueryStatement extends Statement {
       if (isAlignByDevice()) {
         throw new SemanticException("Last query doesn't support align by device.");
       }
-      if (disableAlign()) {
-        throw new SemanticException("Disable align cannot be applied to LAST query.");
-      }
       for (ResultColumn resultColumn : selectComponent.getResultColumns()) {
         Expression expression = resultColumn.getExpression();
         if (!(expression instanceof TimeSeriesOperand)) {
@@ -630,19 +620,16 @@ public class QueryStatement extends Statement {
 
     if (isSelectInto()) {
       if (getSeriesLimit() > 0) {
-        throw new SemanticException("select into: slimit clauses are not supported.");
+        throw new SemanticException("Select into: slimit clauses are not supported.");
       }
       if (getSeriesOffset() > 0) {
-        throw new SemanticException("select into: soffset clauses are not supported.");
-      }
-      if (disableAlign()) {
-        throw new SemanticException("select into: disable align clauses are not supported.");
+        throw new SemanticException("Select into: soffset clauses are not supported.");
       }
       if (isLastQuery()) {
-        throw new SemanticException("select into: last clauses are not supported.");
+        throw new SemanticException("Select into: last clauses are not supported.");
       }
       if (isGroupByTag()) {
-        throw new SemanticException("select into: GROUP BY TAGS clause are not supported.");
+        throw new SemanticException("Select into: GROUP BY TAGS clause are not supported.");
       }
     }
   }

--- a/server/src/test/java/org/apache/iotdb/db/mpp/plan/statement/QueryStatementTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/plan/statement/QueryStatementTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.mpp.plan.statement;
+
+import org.apache.iotdb.db.exception.sql.SemanticException;
+import org.apache.iotdb.db.mpp.plan.parser.StatementGenerator;
+import org.apache.iotdb.db.mpp.plan.statement.crud.QueryStatement;
+import org.apache.iotdb.tsfile.utils.Pair;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.iotdb.db.mpp.plan.statement.crud.QueryStatement.RAW_AGGREGATION_HYBRID_QUERY_ERROR_MSG;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class QueryStatementTest {
+
+  private static final Logger logger = LoggerFactory.getLogger(QueryStatementTest.class);
+
+  private static final String ALIGN_BY_DEVICE_ONE_LEVEL_ERROR =
+      "ALIGN BY DEVICE: the suffix paths can only be measurement or one-level wildcard";
+
+  @Test
+  public void semanticCheckTest() {
+    List<Pair<String, String>> errorSqlWithMessages =
+        Arrays.asList(
+            new Pair<>(
+                "SELECT s1 FROM root.sg.d1 GROUP BY ([2017-11-01T00:00:00, 2017-11-07T23:00:00),1d)",
+                "Common queries and aggregated queries are not allowed to appear at the same time"),
+            new Pair<>(
+                "SELECT count(s1),s2 FROM root.sg.d1", RAW_AGGREGATION_HYBRID_QUERY_ERROR_MSG),
+
+            // test for where clause
+            new Pair<>(
+                "SELECT s1 FROM root.sg.d1 WHERE count(s1) > 0",
+                "Aggregate functions are not supported in WHERE clause"),
+
+            // test for having clause
+            new Pair<>(
+                "SELECT s1 FROM root.sg.d1 HAVING(s1 > 0)",
+                "Expression of HAVING clause must to be an Aggregation"),
+            new Pair<>(
+                "SELECT s1 FROM root.sg.d1 HAVING(count(s1) > 0)",
+                "Expression of HAVING clause can not be used in NonAggregationQuery"),
+            new Pair<>(
+                "SELECT count(d1.s1) FROM root.sg.d1 GROUP BY level=1 HAVING (count(s1) > 0)",
+                "When Having used with GroupByLevel: the suffix paths can only be measurement or one-level wildcard"),
+            new Pair<>(
+                "SELECT count(s1) FROM root.sg.d1 GROUP BY level=1 HAVING (count(sg.d1.s1) > 0)",
+                "When Having used with GroupByLevel: the suffix paths can only be measurement or one-level wildcard"),
+
+            // test for align by device clause
+            new Pair<>(
+                "SELECT d1.s1 FROM root.sg.d1 align by device", ALIGN_BY_DEVICE_ONE_LEVEL_ERROR),
+            new Pair<>(
+                "SELECT count(s1) FROM root.sg.d1 group by variation(sg.s1) align by device",
+                ALIGN_BY_DEVICE_ONE_LEVEL_ERROR),
+            new Pair<>(
+                "SELECT s1 FROM root.sg.d1 order by root.sg.d1.s1 align by device",
+                ALIGN_BY_DEVICE_ONE_LEVEL_ERROR),
+            new Pair<>(
+                "SELECT s1 FROM root.sg.d1 where root.sg.d1.s1 > 0 align by device",
+                ALIGN_BY_DEVICE_ONE_LEVEL_ERROR),
+            new Pair<>(
+                "SELECT count(s1) FROM root.sg.d1 having(count(root.sg.d1.s1) > 0) align by device",
+                ALIGN_BY_DEVICE_ONE_LEVEL_ERROR),
+            new Pair<>(
+                "SELECT s1 FROM root.sg.d1 order by timeseries align by device",
+                "Sorting by timeseries is only supported in last queries."),
+
+            // test for last query
+            new Pair<>(
+                "SELECT last s1 FROM root.sg.d1 align by device",
+                "Last query doesn't support align by device."),
+            new Pair<>(
+                "SELECT last s1+s2 FROM root.sg.d1",
+                "Last queries can only be applied on raw time series."),
+            new Pair<>(
+                "SELECT last s1 FROM root.sg.d1 order by device",
+                "Sorting by device is only supported in ALIGN BY DEVICE queries."),
+            new Pair<>(
+                "SELECT last s1 FROM root.sg.d1 SLIMIT 1 SOFFSET 2",
+                "SLIMIT and SOFFSET can not be used in LastQuery."),
+
+            // test for select into clause
+            new Pair<>(
+                "SELECT s1 INTO root.sg.d2(t1) FROM root.sg.d1 SLIMIT 5",
+                "Select into: slimit clauses are not supported."),
+            new Pair<>(
+                "SELECT s1 INTO root.sg.d2(t1) FROM root.sg.d1 SOFFSET 6",
+                "Select into: soffset clauses are not supported."),
+            new Pair<>(
+                "SELECT last s1 INTO root.sg.d2(t1) FROM root.sg.d1",
+                "Select into: last clauses are not supported."),
+            new Pair<>(
+                "SELECT count(s1) INTO root.sg.d2(t1) FROM root.sg.d1 GROUP BY TAGS(a)",
+                "Select into: GROUP BY TAGS clause are not supported."),
+            new Pair<>(
+                "SELECT s1 FROM root.sg.d1 order by timeseries",
+                "Sorting by timeseries is only supported in last queries."),
+            new Pair<>(
+                "SELECT s1 FROM root.sg.d1 order by device",
+                "Sorting by device is only supported in ALIGN BY DEVICE queries."));
+
+    for (Pair<String, String> pair : errorSqlWithMessages) {
+      String errorSql = pair.left;
+      String errorMsg = pair.right;
+      try {
+        checkErrorQuerySql(errorSql);
+      } catch (SemanticException e) {
+        assertEquals(errorMsg, e.getMessage());
+      } catch (Exception ex) {
+        logger.error("Meets error in test sql: {}", errorSql, ex);
+        fail();
+      }
+    }
+  }
+
+  private void checkErrorQuerySql(String sql) {
+    QueryStatement statement =
+        (QueryStatement) StatementGenerator.createStatement(sql, ZonedDateTime.now().getOffset());
+    statement.semanticCheck();
+  }
+}

--- a/server/src/test/java/org/apache/iotdb/db/utils/ErrorHandlingUtilsTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/utils/ErrorHandlingUtilsTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.utils;
+
+import org.apache.iotdb.common.rpc.thrift.TSStatus;
+import org.apache.iotdb.db.conf.OperationType;
+import org.apache.iotdb.db.exception.StorageGroupNotReadyException;
+import org.apache.iotdb.db.exception.metadata.PathNotExistException;
+import org.apache.iotdb.db.exception.query.QueryProcessException;
+import org.apache.iotdb.db.exception.sql.SemanticException;
+import org.apache.iotdb.rpc.TSStatusCode;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.apache.iotdb.db.utils.ErrorHandlingUtils.onIoTDBException;
+import static org.apache.iotdb.db.utils.ErrorHandlingUtils.onNonQueryException;
+import static org.apache.iotdb.db.utils.ErrorHandlingUtils.onNpeOrUnexpectedException;
+import static org.apache.iotdb.db.utils.ErrorHandlingUtils.onQueryException;
+import static org.junit.Assert.assertEquals;
+
+public class ErrorHandlingUtilsTest {
+
+  @Test
+  public void onNpeOrUnexpectedExceptionTest() {
+    TSStatus status =
+        onNpeOrUnexpectedException(
+            new IOException("test-IOException"),
+            OperationType.EXECUTE_STATEMENT,
+            TSStatusCode.EXECUTE_STATEMENT_ERROR);
+    assertEquals(TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode(), status.getCode());
+
+    status =
+        onNpeOrUnexpectedException(
+            new NullPointerException("test-NullPointerException"),
+            OperationType.EXECUTE_STATEMENT,
+            TSStatusCode.EXECUTE_STATEMENT_ERROR);
+    assertEquals(TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode(), status.getCode());
+
+    status =
+        onNpeOrUnexpectedException(
+            new RuntimeException("test-RuntimeException"),
+            OperationType.EXECUTE_STATEMENT,
+            TSStatusCode.EXECUTE_STATEMENT_ERROR);
+    assertEquals(TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode(), status.getCode());
+  }
+
+  @Test
+  public void onQueryExceptionTest() {
+    TSStatus status =
+        onQueryException(
+            new StorageGroupNotReadyException("test-StorageGroupNotReadyException", 0),
+            OperationType.EXECUTE_STATEMENT);
+    assertEquals(TSStatusCode.STORAGE_ENGINE_NOT_READY.getStatusCode(), status.getCode());
+
+    status =
+        onQueryException(
+            new SemanticException("test-SemanticException"), OperationType.EXECUTE_STATEMENT);
+    assertEquals(TSStatusCode.SEMANTIC_ERROR.getStatusCode(), status.getCode());
+  }
+
+  @Test
+  public void onNonQueryExceptionTest() {
+    TSStatus status =
+        onNonQueryException(
+            new PathNotExistException("test-PathNotExistException"),
+            OperationType.EXECUTE_STATEMENT);
+    assertEquals(TSStatusCode.PATH_NOT_EXIST.getStatusCode(), status.getCode());
+  }
+
+  @Test
+  public void onIoTDBExceptionTest() {
+    TSStatus status =
+        onIoTDBException(
+            new QueryProcessException("test-QueryProcessException"),
+            OperationType.EXECUTE_STATEMENT,
+            TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode());
+    assertEquals(TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode(), status.getCode());
+  }
+}

--- a/tsfile/src/test/java/org/apache/iotdb/tsfile/exception/TsFileExceptionTest.java
+++ b/tsfile/src/test/java/org/apache/iotdb/tsfile/exception/TsFileExceptionTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.tsfile.exception;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class TsFileExceptionTest {
+
+    private static final String MOCK = "mock";
+
+    @Test
+    public void testTsFileStatisticsMistakesException() {
+        TsFileStatisticsMistakesException e = new TsFileStatisticsMistakesException(MOCK);
+        assertEquals(MOCK, e.getMessage());
+    }
+
+    @Test
+    public void testTsFileRuntimeException() {
+        TsFileRuntimeException e = new TsFileRuntimeException(MOCK);
+        assertEquals(MOCK, e.getMessage());
+    }
+
+    @Test
+    public void testPathParseException() {
+        PathParseException e = new PathParseException(MOCK);
+        assertEquals("mock is not a legal path.", e.getMessage());
+    }
+
+    @Test
+    public void testNullFieldException() {
+        NullFieldException e = new NullFieldException();
+        assertEquals("Field is null", e.getMessage());
+    }
+
+    @Test
+    public void testNotImplementedException() {
+        NotImplementedException e = new NotImplementedException(MOCK);
+        assertEquals(MOCK, e.getMessage());
+    }
+
+    @Test
+    public void testNotCompatibleTsFileException() {
+        NotCompatibleTsFileException e = new NotCompatibleTsFileException(MOCK);
+        assertEquals(MOCK, e.getMessage());
+    }
+
+    @Test
+    public void testTsFileStatisticsMistakesException() {
+        TsFileStatisticsMistakesException e = new TsFileStatisticsMistakesException(MOCK);
+        assertEquals(MOCK, e.getMessage());
+    }
+    @Test
+    public void testTsFileRuntimeException() {
+        TsFileRuntimeException e = new TsFileRuntimeException(MOCK);
+        assertEquals(MOCK, e.getMessage());
+    }
+    @Test
+    public void testNotCompatibleTsFileException() {
+        NotCompatibleTsFileException e = new NotCompatibleTsFileException(MOCK);
+        assertEquals(MOCK, e.getMessage());
+    }
+    @Test
+    public void testNotCompatibleTsFileException() {
+        NotCompatibleTsFileException e = new NotCompatibleTsFileException(MOCK);
+        assertEquals(MOCK, e.getMessage());
+    }
+    @Test
+    public void testNotCompatibleTsFileException() {
+        NotCompatibleTsFileException e = new NotCompatibleTsFileException(MOCK);
+        assertEquals(MOCK, e.getMessage());
+    }
+    @Test
+    public void testNotCompatibleTsFileException() {
+        NotCompatibleTsFileException e = new NotCompatibleTsFileException(MOCK);
+        assertEquals(MOCK, e.getMessage());
+    }
+    @Test
+    public void testNotCompatibleTsFileException() {
+        NotCompatibleTsFileException e = new NotCompatibleTsFileException(MOCK);
+        assertEquals(MOCK, e.getMessage());
+    }
+    @Test
+    public void testNotCompatibleTsFileException() {
+        NotCompatibleTsFileException e = new NotCompatibleTsFileException(MOCK);
+        assertEquals(MOCK, e.getMessage());
+    }
+    @Test
+    public void testNotCompatibleTsFileException() {
+        NotCompatibleTsFileException e = new NotCompatibleTsFileException(MOCK);
+        assertEquals(MOCK, e.getMessage());
+    }
+    @Test
+    public void testNotCompatibleTsFileException() {
+        NotCompatibleTsFileException e = new NotCompatibleTsFileException(MOCK);
+        assertEquals(MOCK, e.getMessage());
+    }
+
+
+}


### PR DESCRIPTION
## Description

**1）Fix the error result in raw query with having clause.**
Before:
![image](https://github.com/apache/iotdb/assets/6756545/080c3c75-cb77-4a49-9419-3b1875b78869)
After:
![image](https://github.com/apache/iotdb/assets/6756545/45a4865a-e87f-40a6-a21e-26c5b8149384)

**2）Fix the error in align by device query with having clause**
Before:
![image](https://github.com/apache/iotdb/assets/6756545/bb5b0479-da3e-4ccd-99f5-29c457c40e67)
After:
![image](https://github.com/apache/iotdb/assets/6756545/a0eb7365-36e6-4bac-823a-1cdb2814a352)

3）Improve the UT coverage rate of  `QueryStatement` and `StatementGenerator`

4）Remove the usage of `disableAlign()` method, because this method is no longer supported in 1.1+.