### PR TITLE
[To rel/1.2][IOTDB-6017] Pipe: separate pipe heartbeat from cluster heartbeat (#10285)

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/client/DataNodeRequestType.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/client/DataNodeRequestType.java
@@ -68,6 +68,7 @@ public enum DataNodeRequestType {
 
   /** Pipe Task */
   PUSH_PIPE_META,
+  PIPE_HEARTBEAT,
 
   /** CQ */
   EXECUTE_CQ,

--- a/confignode/src/main/java/org/apache/iotdb/confignode/client/async/AsyncDataNodeClientPool.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/client/async/AsyncDataNodeClientPool.java
@@ -36,6 +36,7 @@ import org.apache.iotdb.confignode.client.async.handlers.rpc.AsyncTSStatusRPCHan
 import org.apache.iotdb.confignode.client.async.handlers.rpc.CheckTimeSeriesExistenceRPCHandler;
 import org.apache.iotdb.confignode.client.async.handlers.rpc.CountPathsUsingTemplateRPCHandler;
 import org.apache.iotdb.confignode.client.async.handlers.rpc.FetchSchemaBlackListRPCHandler;
+import org.apache.iotdb.confignode.client.async.handlers.rpc.PipeHeartbeatRPCHandler;
 import org.apache.iotdb.confignode.client.async.handlers.rpc.SchemaUpdateRPCHandler;
 import org.apache.iotdb.mpp.rpc.thrift.TActiveTriggerInstanceReq;
 import org.apache.iotdb.mpp.rpc.thrift.TAlterViewReq;
@@ -59,6 +60,7 @@ import org.apache.iotdb.mpp.rpc.thrift.TDropTriggerInstanceReq;
 import org.apache.iotdb.mpp.rpc.thrift.TFetchSchemaBlackListReq;
 import org.apache.iotdb.mpp.rpc.thrift.TInactiveTriggerInstanceReq;
 import org.apache.iotdb.mpp.rpc.thrift.TInvalidateMatchedSchemaCacheReq;
+import org.apache.iotdb.mpp.rpc.thrift.TPipeHeartbeatReq;
 import org.apache.iotdb.mpp.rpc.thrift.TPushPipeMetaReq;
 import org.apache.iotdb.mpp.rpc.thrift.TRegionLeaderChangeReq;
 import org.apache.iotdb.mpp.rpc.thrift.TRegionRouteReq;
@@ -228,6 +230,12 @@ public class AsyncDataNodeClientPool {
           client.pushPipeMeta(
               (TPushPipeMetaReq) clientHandler.getRequest(requestId),
               (AsyncTSStatusRPCHandler)
+                  clientHandler.createAsyncRPCHandler(requestId, targetDataNode));
+          break;
+        case PIPE_HEARTBEAT:
+          client.pipeHeartbeat(
+              (TPipeHeartbeatReq) clientHandler.getRequest(requestId),
+              (PipeHeartbeatRPCHandler)
                   clientHandler.createAsyncRPCHandler(requestId, targetDataNode));
           break;
         case MERGE:

--- a/confignode/src/main/java/org/apache/iotdb/confignode/client/async/handlers/AsyncClientHandler.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/client/async/handlers/AsyncClientHandler.java
@@ -26,10 +26,12 @@ import org.apache.iotdb.confignode.client.async.handlers.rpc.AsyncTSStatusRPCHan
 import org.apache.iotdb.confignode.client.async.handlers.rpc.CheckTimeSeriesExistenceRPCHandler;
 import org.apache.iotdb.confignode.client.async.handlers.rpc.CountPathsUsingTemplateRPCHandler;
 import org.apache.iotdb.confignode.client.async.handlers.rpc.FetchSchemaBlackListRPCHandler;
+import org.apache.iotdb.confignode.client.async.handlers.rpc.PipeHeartbeatRPCHandler;
 import org.apache.iotdb.confignode.client.async.handlers.rpc.SchemaUpdateRPCHandler;
 import org.apache.iotdb.mpp.rpc.thrift.TCheckTimeSeriesExistenceResp;
 import org.apache.iotdb.mpp.rpc.thrift.TCountPathsUsingTemplateResp;
 import org.apache.iotdb.mpp.rpc.thrift.TFetchSchemaBlackListResp;
+import org.apache.iotdb.mpp.rpc.thrift.TPipeHeartbeatResp;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -196,6 +198,14 @@ public class AsyncClientHandler<Q, R> {
             targetDataNode,
             dataNodeLocationMap,
             (Map<Integer, TCheckTimeSeriesExistenceResp>) responseMap,
+            countDownLatch);
+      case PIPE_HEARTBEAT:
+        return new PipeHeartbeatRPCHandler(
+            requestType,
+            requestId,
+            targetDataNode,
+            dataNodeLocationMap,
+            (Map<Integer, TPipeHeartbeatResp>) responseMap,
             countDownLatch);
       case SET_TTL:
       case CREATE_DATA_REGION:

--- a/confignode/src/main/java/org/apache/iotdb/confignode/client/async/handlers/rpc/PipeHeartbeatRPCHandler.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/client/async/handlers/rpc/PipeHeartbeatRPCHandler.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.confignode.client.async.handlers.rpc;
+
+import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
+import org.apache.iotdb.confignode.client.DataNodeRequestType;
+import org.apache.iotdb.mpp.rpc.thrift.TPipeHeartbeatResp;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+public class PipeHeartbeatRPCHandler extends AbstractAsyncRPCHandler<TPipeHeartbeatResp> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PipeHeartbeatRPCHandler.class);
+
+  public PipeHeartbeatRPCHandler(
+      DataNodeRequestType requestType,
+      int requestId,
+      TDataNodeLocation targetDataNode,
+      Map<Integer, TDataNodeLocation> dataNodeLocationMap,
+      Map<Integer, TPipeHeartbeatResp> responseMap,
+      CountDownLatch countDownLatch) {
+    super(requestType, requestId, targetDataNode, dataNodeLocationMap, responseMap, countDownLatch);
+  }
+
+  @Override
+  public void onComplete(TPipeHeartbeatResp response) {
+    // Put response
+    responseMap.put(requestId, response);
+    dataNodeLocationMap.remove(requestId);
+    LOGGER.info("Successfully {} on DataNode: {}", requestType, formattedTargetLocation);
+
+    // Always CountDown
+    countDownLatch.countDown();
+  }
+
+  @Override
+  public void onError(Exception e) {
+    LOGGER.error(
+        "Failed to "
+            + requestType
+            + " on DataNode: "
+            + formattedTargetLocation
+            + ", exception: "
+            + e.getMessage());
+
+    // Always CountDown
+    countDownLatch.countDown();
+  }
+}

--- a/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
@@ -221,6 +221,8 @@ public class ConfigRegionStateMachine
 
       threadPool.submit(
           () -> configManager.getPipeManager().getPipeRuntimeCoordinator().startPipeMetaSync());
+      threadPool.submit(
+          () -> configManager.getPipeManager().getPipeRuntimeCoordinator().startPipeHeartbeat());
     } else {
       LOGGER.info(
           "Current node [nodeId:{}, ip:port: {}] is not longer the leader, the new leader is [nodeId:{}]",
@@ -230,6 +232,7 @@ public class ConfigRegionStateMachine
 
       // Stop leader scheduling services
       configManager.getPipeManager().getPipeRuntimeCoordinator().stopPipeMetaSync();
+      configManager.getPipeManager().getPipeRuntimeCoordinator().stopPipeHeartbeat();
       configManager.getLoadManager().stopLoadServices();
       configManager.getProcedureManager().shiftExecutor(false);
       configManager.getRetryFailedTasksThread().stopRetryFailedTasksService();

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/service/HeartbeatService.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/service/HeartbeatService.java
@@ -127,9 +127,11 @@ public class HeartbeatService {
     heartbeatReq.setSchemaQuotaCount(configManager.getClusterSchemaManager().getSchemaQuotaCount());
     // We collect pipe meta in every 100 heartbeat loop
     heartbeatReq.setNeedPipeMetaList(
-        heartbeatCounter.get()
-                % PipeConfig.getInstance().getHeartbeatLoopCyclesForCollectingPipeMeta()
-            == 0);
+        !PipeConfig.getInstance().isSeperatedPipeHeartbeatEnabled()
+            && heartbeatCounter.get()
+                    % PipeConfig.getInstance()
+                        .getPipeHeartbeatIntervalSecondsForCollectingPipeMeta()
+                == 0);
     if (!configManager.getClusterQuotaManager().hasSpaceQuotaLimit()) {
       heartbeatReq.setSchemaRegionIds(configManager.getClusterQuotaManager().getSchemaRegionIds());
       heartbeatReq.setDataRegionIds(configManager.getClusterQuotaManager().getDataRegionIds());

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/runtime/PipeHeartbeatScheduler.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/runtime/PipeHeartbeatScheduler.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.confignode.manager.pipe.runtime;
+
+import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
+import org.apache.iotdb.commons.concurrent.IoTDBThreadPoolFactory;
+import org.apache.iotdb.commons.concurrent.ThreadName;
+import org.apache.iotdb.commons.concurrent.threadpool.ScheduledExecutorUtil;
+import org.apache.iotdb.commons.pipe.config.PipeConfig;
+import org.apache.iotdb.confignode.client.DataNodeRequestType;
+import org.apache.iotdb.confignode.client.async.AsyncDataNodeClientPool;
+import org.apache.iotdb.confignode.client.async.handlers.AsyncClientHandler;
+import org.apache.iotdb.confignode.manager.ConfigManager;
+import org.apache.iotdb.mpp.rpc.thrift.TPipeHeartbeatReq;
+import org.apache.iotdb.mpp.rpc.thrift.TPipeHeartbeatResp;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class PipeHeartbeatScheduler {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PipeHeartbeatScheduler.class);
+
+  private static final boolean IS_SEPERATED_PIPE_HEARTBEAT_ENABLED =
+      PipeConfig.getInstance().isSeperatedPipeHeartbeatEnabled();
+  private static final long HEARTBEAT_INTERVAL_SECONDS =
+      PipeConfig.getInstance().getPipeHeartbeatIntervalSecondsForCollectingPipeMeta();
+
+  private static final ScheduledExecutorService HEARTBEAT_EXECUTOR =
+      IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor(
+          ThreadName.PIPE_RUNTIME_HEARTBEAT.getName());
+
+  private final ConfigManager configManager;
+  private final PipeHeartbeatParser pipeHeartbeatParser;
+
+  private Future<?> heartbeatFuture;
+
+  PipeHeartbeatScheduler(ConfigManager configManager) {
+    this.configManager = configManager;
+    this.pipeHeartbeatParser = new PipeHeartbeatParser(configManager);
+  }
+
+  public synchronized void start() {
+    if (IS_SEPERATED_PIPE_HEARTBEAT_ENABLED && heartbeatFuture == null) {
+      heartbeatFuture =
+          ScheduledExecutorUtil.safelyScheduleWithFixedDelay(
+              HEARTBEAT_EXECUTOR,
+              this::heartbeat,
+              HEARTBEAT_INTERVAL_SECONDS,
+              HEARTBEAT_INTERVAL_SECONDS,
+              TimeUnit.SECONDS);
+      LOGGER.info("PipeHeartbeat is started successfully.");
+    }
+  }
+
+  private synchronized void heartbeat() {
+    if (configManager.getPipeManager().getPipeTaskCoordinator().getPipeTaskInfo().isEmpty()) {
+      return;
+    }
+
+    final Map<Integer, TDataNodeLocation> dataNodeLocationMap =
+        configManager.getNodeManager().getRegisteredDataNodeLocations();
+    final TPipeHeartbeatReq request = new TPipeHeartbeatReq(System.currentTimeMillis());
+    LOGGER.info(String.format("Collecting pipe heartbeat %s from data nodes", request.heartbeatId));
+
+    final AsyncClientHandler<TPipeHeartbeatReq, TPipeHeartbeatResp> clientHandler =
+        new AsyncClientHandler<>(DataNodeRequestType.PIPE_HEARTBEAT, request, dataNodeLocationMap);
+    AsyncDataNodeClientPool.getInstance().sendAsyncRequestToDataNodeWithRetry(clientHandler);
+    clientHandler
+        .getResponseMap()
+        .forEach(
+            (dataNodeId, resp) ->
+                pipeHeartbeatParser.parseHeartbeat(dataNodeId, resp.getPipeMetaList()));
+  }
+
+  public synchronized void stop() {
+    if (IS_SEPERATED_PIPE_HEARTBEAT_ENABLED && heartbeatFuture != null) {
+      heartbeatFuture.cancel(false);
+      heartbeatFuture = null;
+      LOGGER.info("PipeHeartbeat is stopped successfully.");
+    }
+  }
+
+  public void parseHeartbeat(int dataNodeId, List<ByteBuffer> pipeMetaByteBufferListFromDataNode) {
+    pipeHeartbeatParser.parseHeartbeat(dataNodeId, pipeMetaByteBufferListFromDataNode);
+  }
+}

--- a/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/runtime/PipeLeaderChangeHandler.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/runtime/PipeLeaderChangeHandler.java
@@ -61,13 +61,16 @@ public class PipeLeaderChangeHandler implements IClusterStatusSubscriber {
               if (regionGroupId.getType().equals(TConsensusGroupType.DataRegion)) {
                 final String databaseName =
                     configManager.getPartitionManager().getRegionStorageGroup(regionGroupId);
+                // pipe only collect user's data, filter metric database here.
                 if (databaseName != null && !databaseName.equals(IoTDBConfig.SYSTEM_DATABASE)) {
-                  // pipe only collect user's data, filter metric database here.
-                  dataRegionGroupToOldAndNewLeaderPairMap.put(
-                      regionGroupId,
-                      new Pair<>( // null or -1 means empty origin leader
-                          pair.left == null ? -1 : pair.left,
-                          pair.right == null ? -1 : pair.right));
+                  // null or -1 means empty origin leader
+                  final int oldLeaderDataNodeId = (pair.left == null ? -1 : pair.left);
+                  final int newLeaderDataNodeId = (pair.right == null ? -1 : pair.right);
+
+                  if (oldLeaderDataNodeId != newLeaderDataNodeId) {
+                    dataRegionGroupToOldAndNewLeaderPairMap.put(
+                        regionGroupId, new Pair<>(oldLeaderDataNodeId, newLeaderDataNodeId));
+                  }
                 }
               }
             });

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipeTaskInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipeTaskInfo.java
@@ -54,7 +54,7 @@ public class PipeTaskInfo implements SnapshotProcessor {
   private static final Logger LOGGER = LoggerFactory.getLogger(PipeTaskInfo.class);
   private static final String SNAPSHOT_FILE_NAME = "pipe_task_info.bin";
 
-  private final ReentrantLock pipeTaskInfoLock = new ReentrantLock();
+  private final ReentrantLock pipeTaskInfoLock = new ReentrantLock(true);
 
   private final PipeMetaKeeper pipeMetaKeeper;
 

--- a/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
@@ -96,7 +96,7 @@ public class ConfigNodeProcedureEnv {
   /** pipe operation lock */
   private final LockQueue pipeLock = new LockQueue();
 
-  private final ReentrantLock schedulerLock = new ReentrantLock();
+  private final ReentrantLock schedulerLock = new ReentrantLock(true);
 
   private final ConfigManager configManager;
 

--- a/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/runtime/PipeHandleLeaderChangeProcedure.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/runtime/PipeHandleLeaderChangeProcedure.java
@@ -124,28 +124,14 @@ public class PipeHandleLeaderChangeProcedure extends AbstractOperatePipeProcedur
   protected void rollbackFromWriteConfigNodeConsensus(ConfigNodeProcedureEnv env) {
     LOGGER.info("PipeHandleLeaderChangeProcedure: rollbackFromHandleOnConfigNodes");
 
-    final Map<TConsensusGroupId, Integer> oldDataRegionGroupIdToLeaderDataRegionIdMap =
-        new HashMap<>();
-    dataRegionGroupToOldAndNewLeaderPairMap.forEach(
-        (regionGroupId, oldNewLeaderPair) ->
-            oldDataRegionGroupIdToLeaderDataRegionIdMap.put(
-                regionGroupId, oldNewLeaderPair.getLeft()));
-
-    final PipeHandleLeaderChangePlan pipeHandleLeaderChangePlan =
-        new PipeHandleLeaderChangePlan(oldDataRegionGroupIdToLeaderDataRegionIdMap);
-
-    final ConsensusWriteResponse response =
-        env.getConfigManager().getConsensusManager().write(pipeHandleLeaderChangePlan);
-    if (!response.isSuccessful()) {
-      throw new PipeException(response.getErrorMessage());
-    }
+    // nothing to do
   }
 
   @Override
   protected void rollbackFromOperateOnDataNodes(ConfigNodeProcedureEnv env) {
     LOGGER.info("PipeHandleLeaderChangeProcedure: rollbackFromCreateOnDataNodes");
 
-    pushPipeMetaToDataNodesIgnoreException(env);
+    // nothing to do
   }
 
   @Override

--- a/iotdb-protocol/thrift/src/main/thrift/datanode.thrift
+++ b/iotdb-protocol/thrift/src/main/thrift/datanode.thrift
@@ -265,6 +265,14 @@ struct THeartbeatResp {
   10: optional list<binary> pipeMetaList
 }
 
+struct TPipeHeartbeatReq {
+  1: required i64 heartbeatId
+}
+
+struct TPipeHeartbeatResp {
+  1: required list<binary> pipeMetaList
+}
+
 enum TSchemaLimitLevel{
     DEVICE,
     TIMESERIES
@@ -796,6 +804,11 @@ service IDataNodeRPCService {
   * Send pipeMetas to DataNodes, for synchronization
   */
   common.TSStatus pushPipeMeta(TPushPipeMetaReq req)
+
+  /**
+  * ConfigNode will ask DataNode for pipe meta in every few seconds
+  **/
+  TPipeHeartbeatResp pipeHeartbeat(TPipeHeartbeatReq req)
 
  /**
   * Execute CQ on DataNode

--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -977,8 +977,12 @@ cluster_name=defaultCluster
 # The size of the pending queue for the PipeConnector to store the events.
 # pipe_connector_pending_queue_size=1024
 
-# The number of heartbeat loop cycles before collecting pipe meta once
-# pipe_heartbeat_loop_cycles_for_collecting_pipe_meta=100
+# True if the pipe heartbeat is seperated from the cluster's heartbeat, false the pipe heartbeat is
+# merged with the cluster's heartbeat.
+# pipe_heartbeat_seperated_mode_enabled=true
+
+# The interval time between the heartbeat that collecting pipe meta (in seconds).
+# pipe_heartbeat_interval_seconds_for_collecting_pipe_meta=100
 
 # The initial delay before starting the PipeMetaSyncer service.
 # pipe_meta_syncer_initial_sync_delay_minutes=3

--- a/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/ThreadName.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/ThreadName.java
@@ -108,6 +108,7 @@ public enum ThreadName {
   PIPE_CONNECTOR_EXECUTOR_POOL("Pipe-Connector-Executor-Pool"),
   PIPE_SUBTASK_CALLBACK_EXECUTOR_POOL("Pipe-SubTask-Callback-Executor-Pool"),
   PIPE_RUNTIME_META_SYNCER("Pipe-Runtime-Meta-Syncer"),
+  PIPE_RUNTIME_HEARTBEAT("Pipe-Runtime-Heartbeat"),
   PIPE_RUNTIME_PROCEDURE_SUBMITTER("Pipe-Runtime-Procedure-Submitter"),
   PIPE_WAL_RESOURCE_TTL_CHECKER("Pipe-WAL-Resource-TTL-Checker"),
   WINDOW_EVALUATION_SERVICE("WindowEvaluationTaskPoolManager"),

--- a/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -160,7 +160,8 @@ public class CommonConfig {
   private long pipeConnectorRetryIntervalMs = 1000L;
   private int pipeConnectorPendingQueueSize = 1024;
 
-  private int pipeHeartbeatLoopCyclesForCollectingPipeMeta = 100;
+  private boolean isSeperatedPipeHeartbeatEnabled = true;
+  private int pipeHeartbeatIntervalSecondsForCollectingPipeMeta = 100;
   private long pipeMetaSyncerInitialSyncDelayMinutes = 3;
   private long pipeMetaSyncerSyncIntervalMinutes = 3;
 
@@ -499,14 +500,22 @@ public class CommonConfig {
     this.pipeConnectorReadFileBufferSize = pipeConnectorReadFileBufferSize;
   }
 
-  public int getPipeHeartbeatLoopCyclesForCollectingPipeMeta() {
-    return pipeHeartbeatLoopCyclesForCollectingPipeMeta;
+  public boolean isSeperatedPipeHeartbeatEnabled() {
+    return isSeperatedPipeHeartbeatEnabled;
   }
 
-  public void setPipeHeartbeatLoopCyclesForCollectingPipeMeta(
-      int pipeHeartbeatLoopCyclesForCollectingPipeMeta) {
-    this.pipeHeartbeatLoopCyclesForCollectingPipeMeta =
-        pipeHeartbeatLoopCyclesForCollectingPipeMeta;
+  public void setSeperatedPipeHeartbeatEnabled(boolean isSeperatedPipeHeartbeatEnabled) {
+    this.isSeperatedPipeHeartbeatEnabled = isSeperatedPipeHeartbeatEnabled;
+  }
+
+  public int getPipeHeartbeatIntervalSecondsForCollectingPipeMeta() {
+    return pipeHeartbeatIntervalSecondsForCollectingPipeMeta;
+  }
+
+  public void setPipeHeartbeatIntervalSecondsForCollectingPipeMeta(
+      int pipeHeartbeatIntervalSecondsForCollectingPipeMeta) {
+    this.pipeHeartbeatIntervalSecondsForCollectingPipeMeta =
+        pipeHeartbeatIntervalSecondsForCollectingPipeMeta;
   }
 
   public long getPipeMetaSyncerInitialSyncDelayMinutes() {

--- a/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -304,11 +304,16 @@ public class CommonDescriptor {
                 "pipe_connector_pending_queue_size",
                 String.valueOf(config.getPipeConnectorPendingQueueSize()))));
 
-    config.setPipeHeartbeatLoopCyclesForCollectingPipeMeta(
+    config.setSeperatedPipeHeartbeatEnabled(
+        Boolean.parseBoolean(
+            properties.getProperty(
+                "pipe_heartbeat_seperated_mode_enabled",
+                String.valueOf(config.isSeperatedPipeHeartbeatEnabled()))));
+    config.setPipeHeartbeatIntervalSecondsForCollectingPipeMeta(
         Integer.parseInt(
             properties.getProperty(
-                "pipe_heartbeat_loop_cycles_for_collecting_pipe_meta",
-                String.valueOf(config.getPipeHeartbeatLoopCyclesForCollectingPipeMeta()))));
+                "pipe_heartbeat_interval_seconds_for_collecting_pipe_meta",
+                String.valueOf(config.getPipeHeartbeatIntervalSecondsForCollectingPipeMeta()))));
     config.setPipeMetaSyncerInitialSyncDelayMinutes(
         Long.parseLong(
             properties.getProperty(

--- a/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeConfig.java
+++ b/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeConfig.java
@@ -87,8 +87,12 @@ public class PipeConfig {
 
   /////////////////////////////// Meta Consistency ///////////////////////////////
 
-  public int getHeartbeatLoopCyclesForCollectingPipeMeta() {
-    return COMMON_CONFIG.getPipeHeartbeatLoopCyclesForCollectingPipeMeta();
+  public boolean isSeperatedPipeHeartbeatEnabled() {
+    return COMMON_CONFIG.isSeperatedPipeHeartbeatEnabled();
+  }
+
+  public int getPipeHeartbeatIntervalSecondsForCollectingPipeMeta() {
+    return COMMON_CONFIG.getPipeHeartbeatIntervalSecondsForCollectingPipeMeta();
   }
 
   public long getPipeMetaSyncerInitialSyncDelayMinutes() {
@@ -129,9 +133,10 @@ public class PipeConfig {
     LOGGER.info("PipeConnectorRetryIntervalMs: {}", getPipeConnectorRetryIntervalMs());
     LOGGER.info("PipeConnectorPendingQueueSize: {}", getPipeConnectorPendingQueueSize());
 
+    LOGGER.info("SeperatedPipeHeartbeatEnabled: {}", isSeperatedPipeHeartbeatEnabled());
     LOGGER.info(
-        "HeartbeatLoopCyclesForCollectingPipeMeta: {}",
-        getHeartbeatLoopCyclesForCollectingPipeMeta());
+        "PipeHeartbeatIntervalSecondsForCollectingPipeMeta: {}",
+        getPipeHeartbeatIntervalSecondsForCollectingPipeMeta());
     LOGGER.info(
         "PipeMetaSyncerInitialSyncDelayMinutes: {}", getPipeMetaSyncerInitialSyncDelayMinutes());
     LOGGER.info("PipeMetaSyncerSyncIntervalMinutes: {}", getPipeMetaSyncerSyncIntervalMinutes());

--- a/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeInternalRPCServiceImpl.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/thrift/impl/DataNodeInternalRPCServiceImpl.java
@@ -174,6 +174,8 @@ import org.apache.iotdb.mpp.rpc.thrift.TLoadCommandReq;
 import org.apache.iotdb.mpp.rpc.thrift.TLoadResp;
 import org.apache.iotdb.mpp.rpc.thrift.TLoadSample;
 import org.apache.iotdb.mpp.rpc.thrift.TMaintainPeerReq;
+import org.apache.iotdb.mpp.rpc.thrift.TPipeHeartbeatReq;
+import org.apache.iotdb.mpp.rpc.thrift.TPipeHeartbeatResp;
 import org.apache.iotdb.mpp.rpc.thrift.TPushPipeMetaReq;
 import org.apache.iotdb.mpp.rpc.thrift.TRegionLeaderChangeReq;
 import org.apache.iotdb.mpp.rpc.thrift.TRegionRouteReq;
@@ -941,6 +943,13 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
       LOGGER.error("Error occurred when pushing pipe meta", e);
       return RpcUtils.getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR, e.getMessage());
     }
+  }
+
+  @Override
+  public TPipeHeartbeatResp pipeHeartbeat(TPipeHeartbeatReq req) throws TException {
+    final TPipeHeartbeatResp resp = new TPipeHeartbeatResp();
+    PipeAgent.task().collectPipeMetaList(req, resp);
+    return resp;
   }
 
   private TSStatus executeInternalSchemaTask(


### PR DESCRIPTION
# Version
commit 3f321225a28cb5c35f3d22d8db2d0f5f45282447 (HEAD -> rel_1.2, origin/rel/1.2, origin/rc/1.2.0.1)
Author: yschengzi <87161145+yschengzi@users.noreply.github.com>
Date: Tue Jun 20 22:14:32 2023 +0800

# Steps to Reproduce
1. Default Configuration: Source iotdb - 3C3D 2 Replicas, Target iotdb - 1C1D
2. Create metadata in the target iotdb
3. Create 100 real-time pipes and start them in the source iotdb
4. Use benchmark to create metadata and write data in the source iotdb. Benchmark Configuration: Device: 100, Sensor: 10, Database: 1, Align Sequence

# Issues:
1. One node became unknown
2. Even if a node is unknown, it should still be able to write

# Expected Result
Cluster nodes should not become abnormal, and even if they do, they should still be able to write normally.

---------

* separate pipe heartbeat from cluster heartbeat

* fix: IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor

* remove rollback logic in PipeHandleLeaderChangeProcedure to avoid meta lost when restarting cluster

* do not submit leader change procedure when leader is not changed

* change lock in abstract pipe procedure and procedure to fair lock

---------

Co-authored-by: Steve Yurong Su <rong@apache.org>
(cherry picked from commit 268c6b88f92e0099cb9c907bd84dc0c5b28d3d1e)
