### PR TITLE
[To rel/1.2] Fix view snapshot recover

### DIFF
--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/ReadWriteIOUtils.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/ReadWriteIOUtils.java
@@ -89,6 +89,17 @@ public class ReadWriteIOUtils {
     return flag == 1;
   }
 
+  /** read a Boolean from byteBuffer. */
+  public static Boolean readBoolObject(InputStream inputStream) throws IOException {
+    int flag = inputStream.read();
+    if (flag == 1) {
+      return true;
+    } else if (flag == 0) {
+      return false;
+    }
+    return null;
+  }
+
   /** read a bool from byteBuffer. */
   public static boolean readBool(ByteBuffer buffer) {
     byte a = buffer.get();


### PR DESCRIPTION
## Description

### Problem
After restarting DataNode, the isAligned attribute of a device with only view reveals false rather than null.

### Cause
Wrong method was used when loading schema region snapshot, thus false rather null was set into a DeviceNode.

### Solution
Fix the recover process of schema region snapshot.