### PR TITLE
[To rel/1.2] Fix show paths using template return partition result

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
@@ -3157,7 +3157,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
 
     analysis.setSpecifiedTemplateRelatedPathPatternList(specifiedPatternList);
 
-    SchemaPartition partition = partitionFetcher.getOrCreateSchemaPartition(patternTree);
+    SchemaPartition partition = partitionFetcher.getSchemaPartition(patternTree);
     analysis.setSchemaPartitionInfo(partition);
     if (partition.isEmpty()) {
       analysis.setFinishQueryAfterAnalyze(true);


### PR DESCRIPTION
## Description

<img width="1330" alt="image" src="https://github.com/apache/iotdb/assets/43774645/cbd2a276-ae58-49b1-8e97-a167f6630b8c">

This issue is due to the incorrect use of the getOrCreateSchemaPartition interface when pulling schema partitions. The getOrCreateSchemaPartition interface ignores the pathPattern with suffix **. This pr resolve this problem.
