### PR TITLE
[To rel/1.2][IOTDB-6030] Improve efficiency of ConfigNode PartitionInfo takeSnapshot

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
@@ -476,33 +476,31 @@ public class ConfigPlanExecutor {
     }
 
     AtomicBoolean result = new AtomicBoolean(true);
-    snapshotProcessorList
-        .parallelStream()
-        .forEach(
-            x -> {
-              boolean takeSnapshotResult = true;
-              try {
-                long startTime = System.currentTimeMillis();
-                LOGGER.info(
-                    "[ConfigNodeSnapshot] Start to take snapshot for {} into {}",
-                    x.getClass().getName(),
-                    snapshotDir.getAbsolutePath());
-                takeSnapshotResult = x.processTakeSnapshot(snapshotDir);
-                LOGGER.info(
-                    "[ConfigNodeSnapshot] Finish to take snapshot for {}, time consumption: {} ms",
-                    x.getClass().getName(),
-                    System.currentTimeMillis() - startTime);
-              } catch (TException | IOException e) {
-                LOGGER.error("Take snapshot error: {}", e.getMessage());
-                takeSnapshotResult = false;
-              } finally {
-                // If any snapshot fails, the whole fails
-                // So this is just going to be false
-                if (!takeSnapshotResult) {
-                  result.set(false);
-                }
-              }
-            });
+    snapshotProcessorList.forEach(
+        x -> {
+          boolean takeSnapshotResult = true;
+          try {
+            long startTime = System.currentTimeMillis();
+            LOGGER.info(
+                "[ConfigNodeSnapshot] Start to take snapshot for {} into {}",
+                x.getClass().getName(),
+                snapshotDir.getAbsolutePath());
+            takeSnapshotResult = x.processTakeSnapshot(snapshotDir);
+            LOGGER.info(
+                "[ConfigNodeSnapshot] Finish to take snapshot for {}, time consumption: {} ms",
+                x.getClass().getName(),
+                System.currentTimeMillis() - startTime);
+          } catch (TException | IOException e) {
+            LOGGER.error("Take snapshot error: {}", e.getMessage());
+            takeSnapshotResult = false;
+          } finally {
+            // If any snapshot fails, the whole fails
+            // So this is just going to be false
+            if (!takeSnapshotResult) {
+              result.set(false);
+            }
+          }
+        });
     if (result.get()) {
       LOGGER.info("[ConfigNodeSnapshot] Task snapshot success, snapshotDir: {}", snapshotDir);
     }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
@@ -476,31 +476,33 @@ public class ConfigPlanExecutor {
     }
 
     AtomicBoolean result = new AtomicBoolean(true);
-    snapshotProcessorList.forEach(
-        x -> {
-          boolean takeSnapshotResult = true;
-          try {
-            long startTime = System.currentTimeMillis();
-            LOGGER.info(
-                "[ConfigNodeSnapshot] Start to take snapshot for {} into {}",
-                x.getClass().getName(),
-                snapshotDir.getAbsolutePath());
-            takeSnapshotResult = x.processTakeSnapshot(snapshotDir);
-            LOGGER.info(
-                "[ConfigNodeSnapshot] Finish to take snapshot for {}, time consumption: {} ms",
-                x.getClass().getName(),
-                System.currentTimeMillis() - startTime);
-          } catch (TException | IOException e) {
-            LOGGER.error("Take snapshot error: {}", e.getMessage());
-            takeSnapshotResult = false;
-          } finally {
-            // If any snapshot fails, the whole fails
-            // So this is just going to be false
-            if (!takeSnapshotResult) {
-              result.set(false);
-            }
-          }
-        });
+    snapshotProcessorList
+        .parallelStream()
+        .forEach(
+            x -> {
+              boolean takeSnapshotResult = true;
+              try {
+                long startTime = System.currentTimeMillis();
+                LOGGER.info(
+                    "[ConfigNodeSnapshot] Start to take snapshot for {} into {}",
+                    x.getClass().getName(),
+                    snapshotDir.getAbsolutePath());
+                takeSnapshotResult = x.processTakeSnapshot(snapshotDir);
+                LOGGER.info(
+                    "[ConfigNodeSnapshot] Finish to take snapshot for {}, time consumption: {} ms",
+                    x.getClass().getName(),
+                    System.currentTimeMillis() - startTime);
+              } catch (TException | IOException e) {
+                LOGGER.error("Take snapshot error: {}", e.getMessage());
+                takeSnapshotResult = false;
+              } finally {
+                // If any snapshot fails, the whole fails
+                // So this is just going to be false
+                if (!takeSnapshotResult) {
+                  result.set(false);
+                }
+              }
+            });
     if (result.get()) {
       LOGGER.info("[ConfigNodeSnapshot] Task snapshot success, snapshotDir: {}", snapshotDir);
     }

--- a/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
@@ -72,8 +72,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -780,7 +780,9 @@ public class PartitionInfo implements SnapshotProcessor {
     // snapshot operation.
     File tmpFile = new File(snapshotFile.getAbsolutePath() + "-" + UUID.randomUUID());
 
-    try (FileOutputStream fileOutputStream = new FileOutputStream(tmpFile);
+    try (BufferedOutputStream fileOutputStream =
+            new BufferedOutputStream(
+                Files.newOutputStream(tmpFile.toPath()), PARTITION_TABLE_BUFFER_SIZE);
         TIOStreamTransport tioStreamTransport = new TIOStreamTransport(fileOutputStream)) {
       TProtocol protocol = new TBinaryProtocol(tioStreamTransport);
 


### PR DESCRIPTION
Use BufferedOutputStream(with 32MB buffer) instead of FileInputStream in PartitionInfo

**Before Optimization:**
```
2023-06-27 09:52:50,996 [0@group-000000000000-StateMachineUpdater] INFO  o.a.i.c.p.e.ConfigPlanExecutor:489 - [ConfigNodeSnapshot] Finish to take snapshot for org.apache.iotdb.confignode.persistence.partition.PartitionInfo, time consumption: 441904 ms
```

**After Optimization:**
```
2023-06-27 14:25:56,211 [ForkJoinPool.commonPool-worker-115] INFO  o.a.i.c.p.e.ConfigPlanExecutor:490 - [ConfigNodeSnapshot] Finish to take snapshot for org.apache.iotdb.confignode.persistence.partition.PartitionInfo, time consumption: 8330 ms
```