### PR TITLE
[IOTDB-6032] fix PipeHardlinkFileDirStartupCleaner slow startup

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/pipe/agent/runtime/PipeAgentLauncher.java
+++ b/server/src/main/java/org/apache/iotdb/db/pipe/agent/runtime/PipeAgentLauncher.java
@@ -60,6 +60,8 @@ class PipeAgentLauncher {
 
   public static synchronized void launchPipePluginAgent(
       ResourcesInformationHolder resourcesInformationHolder) throws StartupException {
+    long time = System.currentTimeMillis();
+    LOGGER.info("Start to launch pipe plugin agent");
     initPipePluginRelatedInstances();
 
     if (resourcesInformationHolder.getPipePluginMetaList() == null
@@ -67,10 +69,16 @@ class PipeAgentLauncher {
       return;
     }
 
+    time = System.currentTimeMillis();
+
     final List<PipePluginMeta> uninstalledOrConflictedPipePluginMetaList =
         getUninstalledOrConflictedPipePluginMetaList(resourcesInformationHolder);
+    LOGGER.info(
+        "Finish to get uninstalled or conflicted pipe plugin meta list, cost {} ms",
+        System.currentTimeMillis() - time);
     int index = 0;
     while (index < uninstalledOrConflictedPipePluginMetaList.size()) {
+      time = System.currentTimeMillis();
       List<PipePluginMeta> curList = new ArrayList<>();
       int offset = 0;
       while (offset < ResourcesInformationHolder.getJarNumOfOneRpc()
@@ -80,16 +88,21 @@ class PipeAgentLauncher {
       }
       index += (offset + 1);
       fetchAndSavePipePluginJars(curList);
+      LOGGER.info(
+          "Finish to fetch and save pipe plugin jars, cost {} ms",
+          System.currentTimeMillis() - time);
     }
 
     // create instances of pipe plugins and do registration
     try {
+      time = System.currentTimeMillis();
       for (PipePluginMeta meta : resourcesInformationHolder.getPipePluginMetaList()) {
         if (meta.isBuiltin()) {
           continue;
         }
         PipeAgent.plugin().doRegister(meta);
       }
+      LOGGER.info("Finish to register pipe plugin, cost {} ms", System.currentTimeMillis() - time);
     } catch (Exception e) {
       throw new StartupException(e);
     }

--- a/server/src/main/java/org/apache/iotdb/db/pipe/resource/file/PipeHardlinkFileDirStartupCleaner.java
+++ b/server/src/main/java/org/apache/iotdb/db/pipe/resource/file/PipeHardlinkFileDirStartupCleaner.java
@@ -28,8 +28,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.util.concurrent.CompletableFuture;
 
 public class PipeHardlinkFileDirStartupCleaner {
+
+  private static boolean isCleaned = false;
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(PipeHardlinkFileDirStartupCleaner.class);
@@ -39,19 +42,39 @@ public class PipeHardlinkFileDirStartupCleaner {
    * PipeConfig.PIPE_TSFILE_DIR_NAME directory.
    */
   public static void clean() {
+    isCleaned = false;
+    CompletableFuture.runAsync(PipeHardlinkFileDirStartupCleaner::doClean);
+  }
+
+  private static void doClean() {
+    long totalStartTs = System.currentTimeMillis();
     for (String dataDir : IoTDBDescriptor.getInstance().getConfig().getDataDirs()) {
-      for (File file :
-          FileUtils.listFilesAndDirs(
-              new File(dataDir), DirectoryFileFilter.INSTANCE, DirectoryFileFilter.INSTANCE)) {
-        if (file.isDirectory()
-            && file.getName().equals(PipeConfig.getInstance().getPipeHardlinkTsFileDirName())) {
-          LOGGER.info(
-              "pipe hardlink tsfile dir found, deleting it: {}, result: {}",
-              file,
-              FileUtils.deleteQuietly(file));
+      LOGGER.info("PipeHardlinkFileDirStartupCleaner.clean started, dataDir: {}", dataDir);
+      try {
+        for (File file :
+            FileUtils.listFilesAndDirs(
+                new File(dataDir), DirectoryFileFilter.INSTANCE, DirectoryFileFilter.INSTANCE)) {
+          if (file.isDirectory()
+              && file.getName().equals(PipeConfig.getInstance().getPipeHardlinkTsFileDirName())) {
+            LOGGER.info(
+                "pipe hardlink tsfile dir found, deleting it: {}, result: {}",
+                file,
+                FileUtils.deleteQuietly(file));
+          }
         }
+      } catch (Exception e) {
+        LOGGER.warn("PipeHardlinkFileDirStartupCleaner.clean failed", e);
       }
     }
+    LOGGER.info(
+        "PipeHardlinkFileDirStartupCleaner finished, total cost: {}ms",
+        System.currentTimeMillis() - totalStartTs);
+
+    isCleaned = true;
+  }
+
+  public static boolean isHardlinkCleaned() {
+    return isCleaned;
   }
 
   private PipeHardlinkFileDirStartupCleaner() {

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -521,7 +521,8 @@ public class DataNode implements DataNodeMBean {
     logger.info(
         "IoTDB DataNode is setting up, some databases may not be ready now, please wait several seconds...");
 
-    while (!StorageEngine.getInstance().isAllSgReady()) {
+    while (!StorageEngine.getInstance().isAllSgReady()
+        || !PipeAgent.runtime().isHardlinkCleaned()) {
       try {
         TimeUnit.MILLISECONDS.sleep(1000);
       } catch (InterruptedException e) {


### PR DESCRIPTION
1. execute pipehardlinkFileStartupCleaner.clean asynchronously.
2. add loggers to print execution time of Pipe when DataNode starts up.
3. before all data regions are ready to provide services, check whether pipehardlink files are cleaned.