### PR TITLE
Improve RatisConsensus UT coverage

### DIFF
--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RatisConsensusTest.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RatisConsensusTest.java
@@ -156,6 +156,7 @@ public class RatisConsensusTest {
     servers.get(0).addPeer(group.getGroupId(), peers.get(1));
     servers.get(1).transferLeader(group.getGroupId(), peers.get(1));
     servers.get(0).removePeer(group.getGroupId(), peers.get(0));
+    Assert.assertEquals(servers.get(1).getLeader(gid).getNodeId(), peers.get(1).getNodeId());
     servers.get(0).deletePeer(group.getGroupId());
   }
 


### PR DESCRIPTION
<img width="581" alt="image" src="https://github.com/apache/iotdb/assets/48054931/6d60bc89-089e-4958-b3f6-5bf925d15a30">

After this patch, the total coverage of ratis consensus is 80%.