### PR TITLE
[To rel/1.2] Fix count timeseries group by level return incorrect result

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/CountGroupByLevelMergeOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/CountGroupByLevelMergeOperator.java
@@ -90,8 +90,7 @@ public class CountGroupByLevelMergeOperator implements ProcessOperator {
       throw new NoSuchElementException();
     }
     if (resultTsBlockList != null) {
-      currentIndex++;
-      return resultTsBlockList.get(currentIndex - 1);
+      return resultTsBlockList.get(currentIndex++);
     }
 
     boolean allChildrenConsumed = true;

--- a/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/CountGroupByLevelScanOperator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/execution/operator/schema/CountGroupByLevelScanOperator.java
@@ -34,6 +34,7 @@ import org.apache.iotdb.tsfile.utils.Binary;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -104,9 +105,14 @@ public class CountGroupByLevelScanOperator<T extends ISchemaInfo> implements Sou
       try {
         ListenableFuture<?> readerBlocked = schemaReader.isBlocked();
         if (!readerBlocked.isDone()) {
+          SettableFuture<?> settableFuture = SettableFuture.create();
           readerBlocked.addListener(
-              () -> next = constructTsBlockAndClearMap(countMap), directExecutor());
-          return readerBlocked;
+              () -> {
+                next = constructTsBlockAndClearMap(countMap);
+                settableFuture.set(null);
+              },
+              directExecutor());
+          return settableFuture;
         } else if (schemaReader.hasNext()) {
           ISchemaInfo schemaInfo = schemaReader.next();
           PartialPath path = schemaInfo.getPartialPath();
@@ -181,7 +187,7 @@ public class CountGroupByLevelScanOperator<T extends ISchemaInfo> implements Sou
 
   @Override
   public boolean isFinished() throws Exception {
-    return !hasNextWithTimer();
+    return isFinished;
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
@@ -2804,6 +2804,9 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     SchemaPartition schemaPartitionInfo = partitionFetcher.getSchemaPartition(patternTree);
 
     analysis.setSchemaPartitionInfo(schemaPartitionInfo);
+    Map<Integer, Template> templateMap =
+        schemaFetcher.checkAllRelatedTemplate(countLevelTimeSeriesStatement.getPathPattern());
+    analysis.setRelatedTemplateInfo(templateMap);
     analysis.setRespDatasetHeader(DatasetHeaderFactory.getCountLevelTimeSeriesHeader());
     return analysis;
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LogicalPlanBuilder.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LogicalPlanBuilder.java
@@ -1166,10 +1166,19 @@ public class LogicalPlanBuilder {
   }
 
   public LogicalPlanBuilder planLevelTimeSeriesCountSource(
-      PartialPath partialPath, boolean prefixPath, int level, SchemaFilter schemaFilter) {
+      PartialPath partialPath,
+      boolean prefixPath,
+      int level,
+      SchemaFilter schemaFilter,
+      Map<Integer, Template> templateMap) {
     this.root =
         new LevelTimeSeriesCountNode(
-            context.getQueryId().genPlanNodeId(), partialPath, prefixPath, level, schemaFilter);
+            context.getQueryId().genPlanNodeId(),
+            partialPath,
+            prefixPath,
+            level,
+            schemaFilter,
+            templateMap);
     return this;
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LogicalPlanVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/LogicalPlanVisitor.java
@@ -616,7 +616,8 @@ public class LogicalPlanVisitor extends StatementVisitor<PlanNode, MPPQueryConte
             countLevelTimeSeriesStatement.getPathPattern(),
             countLevelTimeSeriesStatement.isPrefixPath(),
             countLevelTimeSeriesStatement.getLevel(),
-            countLevelTimeSeriesStatement.getSchemaFilter())
+            countLevelTimeSeriesStatement.getSchemaFilter(),
+            analysis.getRelatedTemplateInfo())
         .planCountMerge()
         .getRoot();
   }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/OperatorTreeGenerator.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/OperatorTreeGenerator.java
@@ -669,7 +669,7 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
         operatorContext,
         node.getLevel(),
         SchemaSourceFactory.getTimeSeriesSchemaSource(
-            node.getPath(), node.isPrefixPath(), node.getSchemaFilter(), null));
+            node.getPath(), node.isPrefixPath(), node.getSchemaFilter(), node.getTemplateMap()));
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/metedata/read/LevelTimeSeriesCountNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/planner/plan/node/metedata/read/LevelTimeSeriesCountNode.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.mpp.plan.planner.plan.node.metedata.read;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.schema.filter.SchemaFilter;
+import org.apache.iotdb.db.metadata.template.Template;
 import org.apache.iotdb.db.mpp.common.header.ColumnHeader;
 import org.apache.iotdb.db.mpp.common.header.ColumnHeaderConstant;
 import org.apache.iotdb.db.mpp.plan.planner.plan.node.PlanNode;
@@ -32,23 +33,28 @@ import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class LevelTimeSeriesCountNode extends SchemaQueryScanNode {
   private final int level;
   private final SchemaFilter schemaFilter;
+  private final Map<Integer, Template> templateMap;
 
   public LevelTimeSeriesCountNode(
       PlanNodeId id,
       PartialPath partialPath,
       boolean isPrefixPath,
       int level,
-      SchemaFilter schemaFilter) {
+      SchemaFilter schemaFilter,
+      Map<Integer, Template> templateMap) {
     super(id, partialPath, isPrefixPath);
     this.level = level;
     this.schemaFilter = schemaFilter;
+    this.templateMap = templateMap;
   }
 
   public SchemaFilter getSchemaFilter() {
@@ -59,9 +65,14 @@ public class LevelTimeSeriesCountNode extends SchemaQueryScanNode {
     return level;
   }
 
+  public Map<Integer, Template> getTemplateMap() {
+    return templateMap;
+  }
+
   @Override
   public PlanNode clone() {
-    return new LevelTimeSeriesCountNode(getPlanNodeId(), path, isPrefixPath, level, schemaFilter);
+    return new LevelTimeSeriesCountNode(
+        getPlanNodeId(), path, isPrefixPath, level, schemaFilter, templateMap);
   }
 
   @Override
@@ -78,6 +89,10 @@ public class LevelTimeSeriesCountNode extends SchemaQueryScanNode {
     ReadWriteIOUtils.write(isPrefixPath, byteBuffer);
     ReadWriteIOUtils.write(level, byteBuffer);
     SchemaFilter.serialize(schemaFilter, byteBuffer);
+    ReadWriteIOUtils.write(templateMap.size(), byteBuffer);
+    for (Template template : templateMap.values()) {
+      template.serialize(byteBuffer);
+    }
   }
 
   @Override
@@ -87,6 +102,10 @@ public class LevelTimeSeriesCountNode extends SchemaQueryScanNode {
     ReadWriteIOUtils.write(isPrefixPath, stream);
     ReadWriteIOUtils.write(level, stream);
     SchemaFilter.serialize(schemaFilter, stream);
+    ReadWriteIOUtils.write(templateMap.size(), stream);
+    for (Template template : templateMap.values()) {
+      template.serialize(stream);
+    }
   }
 
   public static PlanNode deserialize(ByteBuffer buffer) {
@@ -100,8 +119,17 @@ public class LevelTimeSeriesCountNode extends SchemaQueryScanNode {
     boolean isPrefixPath = ReadWriteIOUtils.readBool(buffer);
     int level = ReadWriteIOUtils.readInt(buffer);
     SchemaFilter schemaFilter = SchemaFilter.deserialize(buffer);
+    int templateNum = ReadWriteIOUtils.readInt(buffer);
+    Map<Integer, Template> templateMap = new HashMap<>();
+    Template template;
+    for (int i = 0; i < templateNum; i++) {
+      template = new Template();
+      template.deserialize(buffer);
+      templateMap.put(template.getId(), template);
+    }
     PlanNodeId planNodeId = PlanNodeId.deserialize(buffer);
-    return new LevelTimeSeriesCountNode(planNodeId, path, isPrefixPath, level, schemaFilter);
+    return new LevelTimeSeriesCountNode(
+        planNodeId, path, isPrefixPath, level, schemaFilter, templateMap);
   }
 
   @Override

--- a/server/src/test/java/org/apache/iotdb/db/mpp/plan/plan/node/metadata/read/SchemaCountNodeSerdeTest.java
+++ b/server/src/test/java/org/apache/iotdb/db/mpp/plan/plan/node/metadata/read/SchemaCountNodeSerdeTest.java
@@ -76,7 +76,12 @@ public class SchemaCountNodeSerdeTest {
     ExchangeNode exchangeNode = new ExchangeNode(new PlanNodeId("exchange"));
     LevelTimeSeriesCountNode levelTimeSeriesCountNode =
         new LevelTimeSeriesCountNode(
-            new PlanNodeId("timeseriesCount"), new PartialPath("root.sg.device0"), true, 10, null);
+            new PlanNodeId("timeseriesCount"),
+            new PartialPath("root.sg.device0"),
+            true,
+            10,
+            null,
+            null);
     IdentitySinkNode sinkNode =
         new IdentitySinkNode(
             new PlanNodeId("sink"),


### PR DESCRIPTION
## Description

Fix count timeseries group by level return incorrect result.

* If time series is associated with schema template, we should add template info to traverser.
* ListenableFuture.addListener will execute asynchronously, which may result in a deprecated member variable `next` being obtained at the time of `hasNext()`.