### PR TITLE
fix judgment time range is intersect,when TimeRange is Long.MIN_VALUE or Long.MAX_VALUE,TimeRange cannot be merged due to overflow behavior

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/modification/Deletion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/modification/Deletion.java
@@ -44,6 +44,10 @@ public class Deletion extends Modification implements Cloneable {
   public Deletion(PartialPath path, long fileOffset, long endTime) {
     super(Type.DELETION, path, fileOffset);
     this.timeRange = new TimeRange(Long.MIN_VALUE, endTime);
+    this.timeRange.setLeftClose(false);
+    if (endTime == Long.MAX_VALUE) {
+      this.timeRange.setRightClose(false);
+    }
   }
 
   /**
@@ -56,6 +60,12 @@ public class Deletion extends Modification implements Cloneable {
   public Deletion(PartialPath path, long fileOffset, long startTime, long endTime) {
     super(Type.DELETION, path, fileOffset);
     this.timeRange = new TimeRange(startTime, endTime);
+    if (startTime == Long.MIN_VALUE) {
+      this.timeRange.setLeftClose(false);
+    }
+    if (endTime == Long.MAX_VALUE) {
+      this.timeRange.setRightClose(false);
+    }
   }
 
   public long getStartTime() {

--- a/iotdb-core/tsfile/src/test/java/org/apache/iotdb/tsfile/read/common/TimeRangeTest.java
+++ b/iotdb-core/tsfile/src/test/java/org/apache/iotdb/tsfile/read/common/TimeRangeTest.java
@@ -448,4 +448,45 @@ public class TimeRangeTest {
     Assert.assertTrue(new TimeRange(0, 3).compareTo(new TimeRange(1, 2)) < 0);
     Assert.assertTrue(new TimeRange(5, 6).compareTo(new TimeRange(5, 6)) == 0);
   }
+
+  @Test
+  /*
+   * test min is Long.MIN_VALUE
+   */
+  public void intersect8() {
+    TimeRange r1 = new TimeRange(Long.MIN_VALUE, 3);
+    r1.setLeftClose(false);
+    TimeRange r2 = new TimeRange(Long.MIN_VALUE, 5);
+    r2.setLeftClose(false);
+    assertTrue(r1.intersects(r2));
+    assertTrue(r2.intersects(r1));
+  }
+
+  @Test
+  /*
+   * test max is Long.MAX_VALUE
+   */
+  public void intersect9() {
+    TimeRange r1 = new TimeRange(1, Long.MAX_VALUE);
+    r1.setRightClose(false);
+    TimeRange r2 = new TimeRange(3, Long.MAX_VALUE);
+    r2.setRightClose(false);
+    assertTrue(r1.intersects(r2));
+    assertTrue(r2.intersects(r1));
+  }
+
+  @Test
+  /*
+   * test min is Long.MIN_VALUE and max is Long.MAX_VALUE
+   */
+  public void intersect10() {
+    TimeRange r1 = new TimeRange(Long.MIN_VALUE, Long.MAX_VALUE);
+    r1.setLeftClose(false);
+    r1.setRightClose(false);
+    TimeRange r2 = new TimeRange(Long.MIN_VALUE, Long.MAX_VALUE);
+    r2.setLeftClose(false);
+    r2.setRightClose(false);
+    assertTrue(r1.intersects(r2));
+    assertTrue(r2.intersects(r1));
+  }
 }


### PR DESCRIPTION
When comparing whether two Deletion objects overlap, the start time and end time in the TimeRange class are used. When the start time is the minimum value of Long or the end time is the maximum value of Long, the result is problematic because the start time or end time exceeds the range of Long. This fix is to specify TimeRange as an open interval when creating the Deletion to prevent Long overflows.