### PR TITLE
Improve UT coverage for query engine

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/QueryId.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/QueryId.java
@@ -33,7 +33,7 @@ import static java.util.Objects.requireNonNull;
 
 public class QueryId {
 
-  public static final QueryId mockQueryId = QueryId.valueOf("mock_query_id");
+  public static final QueryId MOCK_QUERY_ID = QueryId.valueOf("mock_query_id");
 
   private final String id;
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/exception/CpuNotEnoughException.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/exception/CpuNotEnoughException.java
@@ -20,10 +20,11 @@
 package org.apache.iotdb.db.queryengine.exception;
 
 import org.apache.iotdb.commons.exception.IoTDBException;
+import org.apache.iotdb.rpc.TSStatusCode;
 
 public class CpuNotEnoughException extends IoTDBException {
 
-  public CpuNotEnoughException(String message, int errorCode) {
-    super(message, errorCode);
+  public CpuNotEnoughException(String message) {
+    super(message, TSStatusCode.QUERY_CPU_QUERY_NOT_ENOUGH.getStatusCode(), true);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/QueryIdGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/QueryIdGenerator.java
@@ -19,7 +19,6 @@
 
 package org.apache.iotdb.db.queryengine.execution;
 
-import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.queryengine.common.QueryId;
 
 import javax.annotation.concurrent.GuardedBy;
@@ -56,14 +55,9 @@ public class QueryIdGenerator {
   @GuardedBy("this")
   private int counter;
 
-  public QueryIdGenerator() {
-    int dataNode = IoTDBDescriptor.getInstance().getConfig().getDataNodeId();
+  public QueryIdGenerator(int dataNode) {
     checkArgument(dataNode != -1, "DataNodeId should be init first!");
     this.dataNodeId = String.valueOf(dataNode);
-  }
-
-  public String getCoordinatorId() {
-    return dataNodeId;
   }
 
   /**
@@ -116,7 +110,7 @@ public class QueryIdGenerator {
     return TIMESTAMP_FORMAT.format(Instant.ofEpochMilli(milli));
   }
 
-  protected long nowInMillis() {
+  private long nowInMillis() {
     // avoid problems with the clock moving backwards
     return BASE_SYSTEM_TIME_MILLIS + NANOSECONDS.toMillis(System.nanoTime() - BASE_NANO_TIME);
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceManager.java
@@ -25,6 +25,8 @@ import org.apache.iotdb.commons.concurrent.threadpool.ScheduledExecutorUtil;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.queryengine.common.FragmentInstanceId;
 import org.apache.iotdb.db.queryengine.execution.driver.IDriver;
+import org.apache.iotdb.db.queryengine.execution.exchange.MPPDataExchangeManager;
+import org.apache.iotdb.db.queryengine.execution.exchange.MPPDataExchangeService;
 import org.apache.iotdb.db.queryengine.execution.exchange.sink.ISink;
 import org.apache.iotdb.db.queryengine.execution.schedule.DriverScheduler;
 import org.apache.iotdb.db.queryengine.execution.schedule.IDriverScheduler;
@@ -74,6 +76,9 @@ public class FragmentInstanceManager {
   private final CounterStat failedInstances = new CounterStat();
 
   private final ExecutorService intoOperationExecutor;
+
+  private final MPPDataExchangeManager exchangeManager =
+      MPPDataExchangeService.getInstance().getMPPDataExchangeManager();
 
   private static final QueryExecutionMetricSet QUERY_EXECUTION_METRIC_SET =
       QueryExecutionMetricSet.getInstance();
@@ -162,7 +167,8 @@ public class FragmentInstanceManager {
                       sink,
                       stateMachine,
                       failedInstances,
-                      instance.getTimeOut());
+                      instance.getTimeOut(),
+                      exchangeManager);
                 } catch (Throwable t) {
                   logger.warn("error when create FragmentInstanceExecution.", t);
                   stateMachine.failed(t);
@@ -225,7 +231,8 @@ public class FragmentInstanceManager {
                     sink,
                     stateMachine,
                     failedInstances,
-                    instance.getTimeOut());
+                    instance.getTimeOut(),
+                    exchangeManager);
               } catch (Throwable t) {
                 logger.warn("Execute error caused by ", t);
                 stateMachine.failed(t);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/SeriesScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/SeriesScanOperator.java
@@ -20,9 +20,7 @@
 package org.apache.iotdb.db.queryengine.execution.operator.source;
 
 import org.apache.iotdb.commons.path.PartialPath;
-import org.apache.iotdb.db.queryengine.execution.driver.DriverContext;
 import org.apache.iotdb.db.queryengine.execution.operator.OperatorContext;
-import org.apache.iotdb.db.queryengine.execution.operator.factory.SourceOperatorFactory;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.parameter.SeriesScanOptions;
 import org.apache.iotdb.db.queryengine.plan.statement.component.Ordering;
@@ -33,79 +31,11 @@ import org.apache.iotdb.tsfile.read.common.block.column.Column;
 import org.apache.iotdb.tsfile.read.common.block.column.ColumnBuilder;
 import org.apache.iotdb.tsfile.read.common.block.column.TimeColumn;
 import org.apache.iotdb.tsfile.read.common.block.column.TimeColumnBuilder;
-import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 
 import java.io.IOException;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.base.Preconditions.checkState;
-import static java.util.Objects.requireNonNull;
-
 public class SeriesScanOperator extends AbstractDataSourceOperator {
-
-  public static class SeriesScanOperatorFactory implements SourceOperatorFactory {
-    private final int operatorId;
-    private final PlanNodeId sourceId;
-    private final PartialPath seriesPath;
-    private final Set<String> allSensors;
-    private final Filter timeFilter;
-    private final Filter valueFilter;
-    private final boolean ascending;
-    private boolean closed;
-
-    public SeriesScanOperatorFactory(
-        int operatorId,
-        PlanNodeId sourceId,
-        PartialPath seriesPath,
-        Set<String> allSensors,
-        Filter timeFilter,
-        Filter valueFilter,
-        boolean ascending) {
-      this.operatorId = operatorId;
-      this.sourceId = requireNonNull(sourceId, "sourceId is null");
-      this.seriesPath = requireNonNull(seriesPath, "seriesPath is null");
-      this.allSensors = requireNonNull(allSensors, "allSensors is null");
-      this.timeFilter = timeFilter;
-      this.valueFilter = valueFilter;
-      this.ascending = ascending;
-    }
-
-    public int getOperatorId() {
-      return operatorId;
-    }
-
-    @Override
-    public PlanNodeId getSourceId() {
-      return sourceId;
-    }
-
-    public String getOperatorType() {
-      return SeriesScanOperator.class.getSimpleName();
-    }
-
-    @Override
-    public SourceOperator createOperator(DriverContext driverContext) {
-      checkState(!closed, "Factory is already closed");
-      SeriesScanOptions.Builder scanOptionsBuilder = new SeriesScanOptions.Builder();
-      scanOptionsBuilder.withAllSensors(allSensors);
-      scanOptionsBuilder.withGlobalTimeFilter(timeFilter);
-      scanOptionsBuilder.withQueryFilter(valueFilter);
-      OperatorContext operatorContext =
-          driverContext.addOperatorContext(operatorId, sourceId, getOperatorType());
-      return new SeriesScanOperator(
-          operatorContext,
-          sourceId,
-          seriesPath,
-          ascending ? Ordering.ASC : Ordering.DESC,
-          scanOptionsBuilder.build());
-    }
-
-    @Override
-    public void noMoreOperators() {
-      closed = true;
-    }
-  }
 
   private final TsBlockBuilder builder;
   private boolean finished = false;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/DriverScheduler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/DriverScheduler.java
@@ -47,7 +47,6 @@ import org.apache.iotdb.db.queryengine.metric.DriverSchedulerMetricSet;
 import org.apache.iotdb.db.storageengine.rescon.quotas.DataNodeThrottleQuotaManager;
 import org.apache.iotdb.db.utils.SetThreadName;
 import org.apache.iotdb.mpp.rpc.thrift.TFragmentInstanceId;
-import org.apache.iotdb.rpc.TSStatusCode;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
@@ -250,15 +249,13 @@ public class DriverScheduler implements IDriverScheduler, IService {
           .getThrottleQuotaLimit()
           .checkCpu(sessionInfo.getUserName(), usedCpu.get())) {
         throw new CpuNotEnoughException(
-            "There is not enough cpu to execute current fragment instance",
-            TSStatusCode.QUERY_CPU_QUERY_NOT_ENOUGH.ordinal());
+            "There is not enough cpu to execute current fragment instance");
       }
       if (!DataNodeThrottleQuotaManager.getInstance()
           .getThrottleQuotaLimit()
           .checkMemory(sessionInfo.getUserName(), estimatedMemory.get())) {
         throw new MemoryNotEnoughException(
-            "There is not enough memory to execute current fragment instance",
-            TSStatusCode.QUOTA_MEM_QUERY_NOT_ENOUGH.getStatusCode());
+            "There is not enough memory to execute current fragment instance");
       }
     }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/Coordinator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/Coordinator.java
@@ -83,7 +83,8 @@ public class Coordinator {
   private final ExecutorService writeOperationExecutor;
   private final ScheduledExecutorService scheduledExecutor;
 
-  private final QueryIdGenerator queryIdGenerator = new QueryIdGenerator();
+  private final QueryIdGenerator queryIdGenerator =
+      new QueryIdGenerator(IoTDBDescriptor.getInstance().getConfig().getDataNodeId());
 
   private static final Coordinator INSTANCE = new Coordinator();
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/Analyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/Analyzer.java
@@ -25,7 +25,7 @@ import org.apache.iotdb.db.queryengine.plan.analyze.schema.ClusterSchemaFetcher;
 import org.apache.iotdb.db.queryengine.plan.analyze.schema.ISchemaFetcher;
 import org.apache.iotdb.db.queryengine.plan.statement.Statement;
 
-import static org.apache.iotdb.db.queryengine.common.QueryId.mockQueryId;
+import static org.apache.iotdb.db.queryengine.common.QueryId.MOCK_QUERY_ID;
 import static org.apache.iotdb.db.queryengine.metric.QueryPlanCostMetricSet.ANALYZER;
 
 /** Analyze the statement and generate Analysis. */
@@ -60,7 +60,7 @@ public class Analyzer {
 
   public static Analyzer getAnalyzer() {
     return new Analyzer(
-        new MPPQueryContext(mockQueryId),
+        new MPPQueryContext(MOCK_QUERY_ID),
         ClusterPartitionFetcher.getInstance(),
         ClusterSchemaFetcher.getInstance());
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LocalExecutionPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LocalExecutionPlanner.java
@@ -30,7 +30,6 @@ import org.apache.iotdb.db.queryengine.plan.analyze.TypeProvider;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.schemaengine.schemaregion.ISchemaRegion;
 import org.apache.iotdb.db.utils.SetThreadName;
-import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -116,8 +115,7 @@ public class LocalExecutionPlanner {
         throw new MemoryNotEnoughException(
             String.format(
                 "There is not enough memory to execute current fragment instance, current remaining free memory is %d, estimated memory usage for current fragment instance is %d",
-                freeMemoryForOperators, estimatedMemorySize),
-            TSStatusCode.MPP_MEMORY_NOT_ENOUGH.getStatusCode());
+                freeMemoryForOperators, estimatedMemorySize));
       } else {
         freeMemoryForOperators -= estimatedMemorySize;
         if (LOGGER.isDebugEnabled()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/metadata/MemChunkMetadataLoader.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/metadata/MemChunkMetadataLoader.java
@@ -75,7 +75,7 @@ public class MemChunkMetadataLoader implements IChunkMetadataLoader {
       List<ReadOnlyMemChunk> memChunks = resource.getReadOnlyMemChunk(seriesPath);
       if (memChunks != null) {
         for (ReadOnlyMemChunk readOnlyMemChunk : memChunks) {
-          if (!memChunks.isEmpty()) {
+          if (!readOnlyMemChunk.isEmpty()) {
             chunkMetadataList.add(readOnlyMemChunk.getChunkMetaData());
           }
         }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/exception/mpp/FragmentInstanceDispatchExceptionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/exception/mpp/FragmentInstanceDispatchExceptionTest.java
@@ -20,17 +20,18 @@
 package org.apache.iotdb.db.exception.mpp;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
+import org.apache.iotdb.rpc.TSStatusCode;
 
-public class FragmentInstanceDispatchException extends Exception {
+import org.junit.Test;
 
-  private final TSStatus failureStatus;
+import static org.junit.Assert.assertEquals;
 
-  public FragmentInstanceDispatchException(TSStatus failureStatus) {
-    super(failureStatus.getMessage());
-    this.failureStatus = failureStatus;
-  }
+public class FragmentInstanceDispatchExceptionTest {
 
-  public TSStatus getFailureStatus() {
-    return failureStatus;
+  @Test
+  public void testFragmentInstanceDispatchException() {
+    TSStatus a = new TSStatus(TSStatusCode.NO_AVAILABLE_REGION_GROUP.getStatusCode());
+    FragmentInstanceDispatchException e = new FragmentInstanceDispatchException(a);
+    assertEquals(TSStatusCode.NO_AVAILABLE_REGION_GROUP.getStatusCode(), e.getFailureStatus().code);
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/exception/CpuNotEnoughExceptionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/exception/CpuNotEnoughExceptionTest.java
@@ -19,12 +19,19 @@
 
 package org.apache.iotdb.db.queryengine.exception;
 
-import org.apache.iotdb.commons.exception.IoTDBException;
 import org.apache.iotdb.rpc.TSStatusCode;
 
-public class MemoryNotEnoughException extends IoTDBException {
+import org.junit.Test;
 
-  public MemoryNotEnoughException(String message) {
-    super(message, TSStatusCode.QUOTA_MEM_QUERY_NOT_ENOUGH.getStatusCode(), true);
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CpuNotEnoughExceptionTest {
+
+  @Test
+  public void testCpuNotEnoughExceptionStatusCode() {
+    CpuNotEnoughException e = new CpuNotEnoughException("test");
+    assertEquals(TSStatusCode.QUERY_CPU_QUERY_NOT_ENOUGH.getStatusCode(), e.getErrorCode());
+    assertTrue(e.isUserException());
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/exception/MemoryNotEnoughExceptionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/exception/MemoryNotEnoughExceptionTest.java
@@ -19,12 +19,19 @@
 
 package org.apache.iotdb.db.queryengine.exception;
 
-import org.apache.iotdb.commons.exception.IoTDBException;
 import org.apache.iotdb.rpc.TSStatusCode;
 
-public class MemoryNotEnoughException extends IoTDBException {
+import org.junit.Test;
 
-  public MemoryNotEnoughException(String message) {
-    super(message, TSStatusCode.QUOTA_MEM_QUERY_NOT_ENOUGH.getStatusCode(), true);
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MemoryNotEnoughExceptionTest {
+
+  @Test
+  public void testMemoryNotEnoughExceptionStatusCode() {
+    MemoryNotEnoughException e = new MemoryNotEnoughException("test");
+    assertEquals(TSStatusCode.QUOTA_MEM_QUERY_NOT_ENOUGH.getStatusCode(), e.getErrorCode());
+    assertTrue(e.isUserException());
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/QueryIdGeneratorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/QueryIdGeneratorTest.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -17,20 +17,20 @@
  * under the License.
  */
 
-package org.apache.iotdb.db.queryengine.execution.operator.factory;
+package org.apache.iotdb.db.queryengine.execution;
 
-import org.apache.iotdb.db.queryengine.execution.driver.DriverContext;
-import org.apache.iotdb.db.queryengine.execution.operator.source.SourceOperator;
-import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
+import org.apache.iotdb.db.queryengine.common.QueryId;
 
-public interface SourceOperatorFactory extends OperatorFactory {
-  PlanNodeId getSourceId();
+import org.junit.Test;
 
-  @Override
-  SourceOperator createOperator(DriverContext driverContext);
+import static org.junit.Assert.assertTrue;
 
-  @Override
-  default OperatorFactory duplicate() {
-    throw new UnsupportedOperationException("Source operator factories cannot be duplicated");
+public class QueryIdGeneratorTest {
+
+  @Test
+  public void testGenerator() {
+    QueryIdGenerator generator = new QueryIdGenerator(1);
+    QueryId queryId = generator.createNextQueryId();
+    assertTrue(queryId.toString().endsWith("_00000_1"));
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/executor/RegionReadExecutorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/executor/RegionReadExecutorTest.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.execution.executor;
+
+import org.apache.iotdb.commons.consensus.ConsensusGroupId;
+import org.apache.iotdb.commons.consensus.DataRegionId;
+import org.apache.iotdb.commons.consensus.SchemaRegionId;
+import org.apache.iotdb.consensus.IConsensus;
+import org.apache.iotdb.consensus.common.response.ConsensusReadResponse;
+import org.apache.iotdb.consensus.exception.ConsensusException;
+import org.apache.iotdb.db.queryengine.common.FragmentInstanceId;
+import org.apache.iotdb.db.queryengine.common.PlanFragmentId;
+import org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceInfo;
+import org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceManager;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.FragmentInstance;
+import org.apache.iotdb.db.storageengine.dataregion.VirtualDataRegion;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.apache.iotdb.db.queryengine.common.QueryId.MOCK_QUERY_ID;
+import static org.apache.iotdb.db.queryengine.execution.executor.RegionReadExecutor.ERROR_MSG_FORMAT;
+import static org.apache.iotdb.db.queryengine.execution.executor.RegionReadExecutor.RESPONSE_NULL_ERROR_MSG;
+import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceState.RUNNING;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RegionReadExecutorTest {
+
+  @Test
+  public void testSuccessfulExecute() {
+
+    // data query
+    ConsensusGroupId dataRegionGroupId = new DataRegionId(1);
+    FragmentInstanceId fragmentInstanceId =
+        new FragmentInstanceId(new PlanFragmentId(MOCK_QUERY_ID, 0), "0");
+    FragmentInstance fragmentInstance = Mockito.mock(FragmentInstance.class);
+    Mockito.when(fragmentInstance.getId()).thenReturn(fragmentInstanceId);
+
+    IConsensus dataRegionConsensus = Mockito.mock(IConsensus.class);
+    IConsensus schemaRegionConsensus = Mockito.mock(IConsensus.class);
+    FragmentInstanceManager fragmentInstanceManager = Mockito.mock(FragmentInstanceManager.class);
+
+    RegionReadExecutor executor =
+        new RegionReadExecutor(dataRegionConsensus, schemaRegionConsensus, fragmentInstanceManager);
+
+    ConsensusReadResponse readResponse = Mockito.mock(ConsensusReadResponse.class);
+    Mockito.when(readResponse.isSuccess()).thenReturn(true);
+    FragmentInstanceInfo fragmentInstanceInfo = Mockito.mock(FragmentInstanceInfo.class);
+    Mockito.when(readResponse.getDataset()).thenReturn(fragmentInstanceInfo);
+    Mockito.when(fragmentInstanceInfo.getState()).thenReturn(RUNNING);
+    Mockito.when(fragmentInstanceInfo.getMessage()).thenReturn("data-success");
+
+    Mockito.when(dataRegionConsensus.read(dataRegionGroupId, fragmentInstance))
+        .thenReturn(readResponse);
+
+    RegionExecutionResult res = executor.execute(dataRegionGroupId, fragmentInstance);
+
+    assertTrue(res.isAccepted());
+    assertEquals("data-success", res.getMessage());
+
+    // schema query
+    ConsensusGroupId schemaRegionGroupId = new SchemaRegionId(1);
+
+    Mockito.when(readResponse.isSuccess()).thenReturn(true);
+    Mockito.when(readResponse.getDataset()).thenReturn(fragmentInstanceInfo);
+    Mockito.when(fragmentInstanceInfo.getState()).thenReturn(RUNNING);
+    Mockito.when(fragmentInstanceInfo.getMessage()).thenReturn("schema-success");
+
+    Mockito.when(schemaRegionConsensus.read(schemaRegionGroupId, fragmentInstance))
+        .thenReturn(readResponse);
+
+    res = executor.execute(schemaRegionGroupId, fragmentInstance);
+
+    assertTrue(res.isAccepted());
+    assertEquals("schema-success", res.getMessage());
+  }
+
+  @Test
+  public void testResponseNullExecute() {
+
+    // data query
+    ConsensusGroupId dataRegionGroupId = new DataRegionId(1);
+    FragmentInstanceId fragmentInstanceId =
+        new FragmentInstanceId(new PlanFragmentId(MOCK_QUERY_ID, 0), "0");
+    FragmentInstance fragmentInstance = Mockito.mock(FragmentInstance.class);
+    Mockito.when(fragmentInstance.getId()).thenReturn(fragmentInstanceId);
+
+    IConsensus dataRegionConsensus = Mockito.mock(IConsensus.class);
+    IConsensus schemaRegionConsensus = Mockito.mock(IConsensus.class);
+    FragmentInstanceManager fragmentInstanceManager = Mockito.mock(FragmentInstanceManager.class);
+
+    RegionReadExecutor executor =
+        new RegionReadExecutor(dataRegionConsensus, schemaRegionConsensus, fragmentInstanceManager);
+
+    Mockito.when(dataRegionConsensus.read(dataRegionGroupId, fragmentInstance)).thenReturn(null);
+
+    RegionExecutionResult res = executor.execute(dataRegionGroupId, fragmentInstance);
+
+    assertFalse(res.isAccepted());
+    assertEquals(RESPONSE_NULL_ERROR_MSG, res.getMessage());
+
+    // schema query
+    ConsensusGroupId schemaRegionGroupId = new SchemaRegionId(1);
+
+    Mockito.when(schemaRegionConsensus.read(schemaRegionGroupId, fragmentInstance))
+        .thenReturn(null);
+
+    res = executor.execute(schemaRegionGroupId, fragmentInstance);
+
+    assertFalse(res.isAccepted());
+    assertEquals(RESPONSE_NULL_ERROR_MSG, res.getMessage());
+  }
+
+  @Test
+  public void testFailedExecute() {
+
+    // data query
+    ConsensusGroupId dataRegionGroupId = new DataRegionId(1);
+    FragmentInstanceId fragmentInstanceId =
+        new FragmentInstanceId(new PlanFragmentId(MOCK_QUERY_ID, 0), "0");
+    FragmentInstance fragmentInstance = Mockito.mock(FragmentInstance.class);
+    Mockito.when(fragmentInstance.getId()).thenReturn(fragmentInstanceId);
+
+    IConsensus dataRegionConsensus = Mockito.mock(IConsensus.class);
+    IConsensus schemaRegionConsensus = Mockito.mock(IConsensus.class);
+    FragmentInstanceManager fragmentInstanceManager = Mockito.mock(FragmentInstanceManager.class);
+
+    RegionReadExecutor executor =
+        new RegionReadExecutor(dataRegionConsensus, schemaRegionConsensus, fragmentInstanceManager);
+
+    ConsensusReadResponse readResponse = Mockito.mock(ConsensusReadResponse.class);
+    Mockito.when(readResponse.isSuccess()).thenReturn(false);
+    Mockito.when(readResponse.getException()).thenReturn(new ConsensusException("data-exception"));
+
+    Mockito.when(dataRegionConsensus.read(dataRegionGroupId, fragmentInstance))
+        .thenReturn(readResponse);
+
+    RegionExecutionResult res = executor.execute(dataRegionGroupId, fragmentInstance);
+
+    assertFalse(res.isAccepted());
+    assertEquals(String.format(ERROR_MSG_FORMAT, "data-exception"), res.getMessage());
+
+    // schema query
+    ConsensusGroupId schemaRegionGroupId = new SchemaRegionId(1);
+
+    Mockito.when(readResponse.isSuccess()).thenReturn(false);
+    Mockito.when(readResponse.getException()).thenReturn(null);
+
+    Mockito.when(schemaRegionConsensus.read(schemaRegionGroupId, fragmentInstance))
+        .thenReturn(readResponse);
+
+    res = executor.execute(schemaRegionGroupId, fragmentInstance);
+
+    assertFalse(res.isAccepted());
+    assertEquals(String.format(ERROR_MSG_FORMAT, ""), res.getMessage());
+  }
+
+  @Test
+  public void testExceptionHappened() {
+
+    ConsensusGroupId dataRegionGroupId = new DataRegionId(1);
+    FragmentInstanceId fragmentInstanceId =
+        new FragmentInstanceId(new PlanFragmentId(MOCK_QUERY_ID, 0), "0");
+    FragmentInstance fragmentInstance = Mockito.mock(FragmentInstance.class);
+    Mockito.when(fragmentInstance.getId()).thenReturn(fragmentInstanceId);
+
+    IConsensus dataRegionConsensus = Mockito.mock(IConsensus.class);
+    IConsensus schemaRegionConsensus = Mockito.mock(IConsensus.class);
+    FragmentInstanceManager fragmentInstanceManager = Mockito.mock(FragmentInstanceManager.class);
+
+    RegionReadExecutor executor =
+        new RegionReadExecutor(dataRegionConsensus, schemaRegionConsensus, fragmentInstanceManager);
+
+    Mockito.when(dataRegionConsensus.read(dataRegionGroupId, fragmentInstance))
+        .thenThrow(new RuntimeException("Unknown"));
+
+    RegionExecutionResult res = executor.execute(dataRegionGroupId, fragmentInstance);
+
+    assertFalse(res.isAccepted());
+    assertEquals(String.format(ERROR_MSG_FORMAT, "Unknown"), res.getMessage());
+  }
+
+  @Test
+  public void testVirtualDataRegion() {
+    // successfully
+    FragmentInstanceId fragmentInstanceId =
+        new FragmentInstanceId(new PlanFragmentId(MOCK_QUERY_ID, 0), "0");
+    FragmentInstance fragmentInstance = Mockito.mock(FragmentInstance.class);
+    Mockito.when(fragmentInstance.getId()).thenReturn(fragmentInstanceId);
+
+    IConsensus dataRegionConsensus = Mockito.mock(IConsensus.class);
+    IConsensus schemaRegionConsensus = Mockito.mock(IConsensus.class);
+    FragmentInstanceManager fragmentInstanceManager = Mockito.mock(FragmentInstanceManager.class);
+
+    RegionReadExecutor executor =
+        new RegionReadExecutor(dataRegionConsensus, schemaRegionConsensus, fragmentInstanceManager);
+
+    FragmentInstanceInfo fragmentInstanceInfo = Mockito.mock(FragmentInstanceInfo.class);
+    Mockito.when(fragmentInstanceInfo.getState()).thenReturn(RUNNING);
+    Mockito.when(fragmentInstanceInfo.getMessage()).thenReturn("data-success");
+
+    Mockito.when(
+            fragmentInstanceManager.execDataQueryFragmentInstance(
+                fragmentInstance, VirtualDataRegion.getInstance()))
+        .thenReturn(fragmentInstanceInfo);
+
+    RegionExecutionResult res = executor.execute(fragmentInstance);
+
+    assertTrue(res.isAccepted());
+    assertEquals("data-success", res.getMessage());
+
+    // failure
+
+    Mockito.when(
+            fragmentInstanceManager.execDataQueryFragmentInstance(
+                fragmentInstance, VirtualDataRegion.getInstance()))
+        .thenThrow(new RuntimeException("Unknown"));
+
+    res = executor.execute(fragmentInstance);
+
+    assertFalse(res.isAccepted());
+    assertEquals(String.format(ERROR_MSG_FORMAT, "Unknown"), res.getMessage());
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/executor/RegionWriteExecutorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/executor/RegionWriteExecutorTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.execution.executor;
+
+import org.apache.iotdb.common.rpc.thrift.TSStatus;
+import org.apache.iotdb.commons.consensus.ConsensusGroupId;
+import org.apache.iotdb.commons.consensus.DataRegionId;
+import org.apache.iotdb.commons.exception.IllegalPathException;
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.consensus.IConsensus;
+import org.apache.iotdb.consensus.common.response.ConsensusWriteResponse;
+import org.apache.iotdb.db.protocol.thrift.impl.DataNodeRegionManager;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertRowNode;
+import org.apache.iotdb.db.schemaengine.SchemaEngine;
+import org.apache.iotdb.db.schemaengine.template.ClusterTemplateManager;
+import org.apache.iotdb.db.trigger.executor.TriggerFireResult;
+import org.apache.iotdb.db.trigger.executor.TriggerFireVisitor;
+import org.apache.iotdb.rpc.TSStatusCode;
+import org.apache.iotdb.trigger.api.enums.TriggerEvent;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class RegionWriteExecutorTest {
+
+  @Test
+  public void testInsertRowNode() {
+
+    IConsensus dataRegionConsensus = Mockito.mock(IConsensus.class);
+    IConsensus schemaRegionConsensus = Mockito.mock(IConsensus.class);
+    DataNodeRegionManager regionManager = Mockito.mock(DataNodeRegionManager.class);
+    SchemaEngine schemaEngine = Mockito.mock(SchemaEngine.class);
+    ClusterTemplateManager clusterTemplateManager = Mockito.mock(ClusterTemplateManager.class);
+    TriggerFireVisitor triggerFireVisitor = Mockito.mock(TriggerFireVisitor.class);
+
+    RegionWriteExecutor executor =
+        new RegionWriteExecutor(
+            dataRegionConsensus,
+            schemaRegionConsensus,
+            regionManager,
+            schemaEngine,
+            clusterTemplateManager,
+            triggerFireVisitor);
+
+    ConsensusGroupId dataRegionGroupId = new DataRegionId(1);
+    InsertRowNode planNode = null;
+    try {
+      planNode = getInsertRowNode();
+    } catch (IllegalPathException e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+
+    Mockito.when(regionManager.getRegionLock(dataRegionGroupId))
+        .thenReturn(new ReentrantReadWriteLock());
+
+    ConsensusWriteResponse writeResponse = Mockito.mock(ConsensusWriteResponse.class);
+    Mockito.when(dataRegionConsensus.write(dataRegionGroupId, planNode)).thenReturn(writeResponse);
+
+    Mockito.when(writeResponse.getStatus()).thenReturn(null);
+
+    RegionExecutionResult res = executor.execute(dataRegionGroupId, planNode);
+    assertFalse(res.isAccepted());
+
+    Mockito.when(triggerFireVisitor.process(planNode, TriggerEvent.BEFORE_INSERT))
+        .thenReturn(TriggerFireResult.TERMINATION);
+    res = executor.execute(dataRegionGroupId, planNode);
+    assertFalse(res.isAccepted());
+
+    Mockito.when(triggerFireVisitor.process(planNode, TriggerEvent.BEFORE_INSERT))
+        .thenReturn(TriggerFireResult.SUCCESS);
+    Mockito.when(writeResponse.isSuccessful()).thenReturn(true);
+    Mockito.when(triggerFireVisitor.process(planNode, TriggerEvent.AFTER_INSERT))
+        .thenReturn(TriggerFireResult.TERMINATION);
+    res = executor.execute(dataRegionGroupId, planNode);
+    assertFalse(res.isAccepted());
+
+    Mockito.when(triggerFireVisitor.process(planNode, TriggerEvent.AFTER_INSERT))
+        .thenReturn(TriggerFireResult.SUCCESS);
+    Mockito.when(writeResponse.getStatus())
+        .thenReturn(new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode()));
+    res = executor.execute(dataRegionGroupId, planNode);
+    assertTrue(res.isAccepted());
+  }
+
+  private InsertRowNode getInsertRowNode() throws IllegalPathException {
+    long time = 110L;
+    TSDataType[] dataTypes =
+        new TSDataType[] {
+          TSDataType.DOUBLE,
+          TSDataType.FLOAT,
+          TSDataType.INT64,
+          TSDataType.INT32,
+          TSDataType.BOOLEAN,
+        };
+
+    Object[] columns = new Object[5];
+    columns[0] = 1.0;
+    columns[1] = 2.0f;
+    columns[2] = 10000L;
+    columns[3] = 100;
+    columns[4] = false;
+
+    return new InsertRowNode(
+        new PlanNodeId("1"),
+        new PartialPath("root.isp.d1"),
+        false,
+        new String[] {"s1", "s2", "s3", "s4", "s5"},
+        dataTypes,
+        time,
+        columns,
+        false);
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInfoTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInfoTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.execution.fragment;
+
+import org.apache.iotdb.db.queryengine.common.PlanFragmentId;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.PlanFragment;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class FragmentInfoTest {
+
+  @Test
+  public void testFragmentInfo() {
+
+    PlanFragmentId stageId = Mockito.mock(PlanFragmentId.class);
+    PlanFragment plan = Mockito.mock(PlanFragment.class);
+    FragmentInfo fragmentInfo = new FragmentInfo(stageId, FragmentState.RUNNING, plan, null);
+    assertEquals(stageId, fragmentInfo.getStageId());
+    assertEquals(FragmentState.RUNNING, fragmentInfo.getState());
+    assertEquals(plan, fragmentInfo.getPlan());
+    assertNull(fragmentInfo.getChildrenFragments());
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceExecutionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceExecutionTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.execution.fragment;
+
+import org.apache.iotdb.commons.concurrent.IoTDBThreadPoolFactory;
+import org.apache.iotdb.db.queryengine.common.FragmentInstanceId;
+import org.apache.iotdb.db.queryengine.common.PlanFragmentId;
+import org.apache.iotdb.db.queryengine.exception.CpuNotEnoughException;
+import org.apache.iotdb.db.queryengine.exception.MemoryNotEnoughException;
+import org.apache.iotdb.db.queryengine.execution.driver.IDriver;
+import org.apache.iotdb.db.queryengine.execution.exchange.MPPDataExchangeManager;
+import org.apache.iotdb.db.queryengine.execution.exchange.sink.ISink;
+import org.apache.iotdb.db.queryengine.execution.schedule.IDriverScheduler;
+import org.apache.iotdb.db.storageengine.dataregion.DataRegion;
+
+import io.airlift.stats.CounterStat;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+import static org.apache.iotdb.db.queryengine.common.QueryId.MOCK_QUERY_ID;
+import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class FragmentInstanceExecutionTest {
+
+  @Test
+  public void testFragmentInstanceExecution() {
+    ExecutorService instanceNotificationExecutor =
+        IoTDBThreadPoolFactory.newFixedThreadPool(1, "test-instance-notification");
+    try {
+      IDriverScheduler scheduler = Mockito.mock(IDriverScheduler.class);
+      FragmentInstanceId instanceId =
+          new FragmentInstanceId(new PlanFragmentId(MOCK_QUERY_ID, 0), "0");
+      FragmentInstanceStateMachine stateMachine =
+          new FragmentInstanceStateMachine(instanceId, instanceNotificationExecutor);
+      DataRegion dataRegion = Mockito.mock(DataRegion.class);
+      FragmentInstanceContext fragmentInstanceContext =
+          createFragmentInstanceContext(instanceId, stateMachine);
+      fragmentInstanceContext.initializeNumOfDrivers(1);
+      fragmentInstanceContext.setMayHaveTmpFile(true);
+      fragmentInstanceContext.setDataRegion(dataRegion);
+      List<IDriver> drivers = Collections.emptyList();
+      ISink sinkHandle = Mockito.mock(ISink.class);
+      CounterStat failedInstances = new CounterStat();
+      long timeOut = -1;
+      MPPDataExchangeManager exchangeManager = Mockito.mock(MPPDataExchangeManager.class);
+      FragmentInstanceExecution execution =
+          FragmentInstanceExecution.createFragmentInstanceExecution(
+              scheduler,
+              instanceId,
+              fragmentInstanceContext,
+              drivers,
+              sinkHandle,
+              stateMachine,
+              failedInstances,
+              timeOut,
+              exchangeManager);
+      assertEquals(FragmentInstanceState.RUNNING, execution.getInstanceState());
+      FragmentInstanceInfo instanceInfo = execution.getInstanceInfo();
+      assertEquals(FragmentInstanceState.RUNNING, instanceInfo.getState());
+      assertEquals(fragmentInstanceContext.getEndTime(), instanceInfo.getEndTime());
+      assertEquals(fragmentInstanceContext.getFailedCause(), instanceInfo.getMessage());
+      assertEquals(fragmentInstanceContext.getFailureInfoList(), instanceInfo.getFailureInfoList());
+
+      assertEquals(fragmentInstanceContext.getStartTime(), execution.getStartTime());
+      assertEquals(timeOut, execution.getTimeoutInMs());
+      assertEquals(stateMachine, execution.getStateMachine());
+
+      fragmentInstanceContext.decrementNumOfUnClosedDriver();
+
+      stateMachine.failed(new RuntimeException("Unknown"));
+
+      assertTrue(execution.getInstanceState().isFailed());
+
+      List<FragmentInstanceFailureInfo> failureInfoList =
+          execution.getInstanceInfo().getFailureInfoList();
+
+      assertEquals(1, failureInfoList.size());
+      assertEquals("Unknown", failureInfoList.get(0).getMessage());
+      assertEquals("Unknown", failureInfoList.get(0).toException().getMessage());
+
+    } catch (CpuNotEnoughException | MemoryNotEnoughException e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    } finally {
+      instanceNotificationExecutor.shutdown();
+    }
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceStateMachineTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceStateMachineTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.execution.fragment;
+
+import org.apache.iotdb.commons.concurrent.IoTDBThreadPoolFactory;
+import org.apache.iotdb.db.queryengine.common.FragmentInstanceId;
+import org.apache.iotdb.db.queryengine.common.PlanFragmentId;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+
+import static org.apache.iotdb.db.queryengine.common.QueryId.MOCK_QUERY_ID;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class FragmentInstanceStateMachineTest {
+
+  @Test
+  public void testToFinished() {
+    ExecutorService instanceNotificationExecutor =
+        IoTDBThreadPoolFactory.newFixedThreadPool(1, "test-instance-notification");
+    try {
+      FragmentInstanceId instanceId =
+          new FragmentInstanceId(new PlanFragmentId(MOCK_QUERY_ID, 0), "0");
+      long time1 = System.currentTimeMillis();
+      FragmentInstanceStateMachine stateMachine =
+          new FragmentInstanceStateMachine(instanceId, instanceNotificationExecutor);
+      long time2 = System.currentTimeMillis();
+
+      assertEquals(FragmentInstanceState.RUNNING, stateMachine.getState());
+      assertTrue(stateMachine.getCreatedTime() >= time1 && stateMachine.getCreatedTime() <= time2);
+
+      assertEquals(instanceId, stateMachine.getFragmentInstanceId());
+
+      ListenableFuture<FragmentInstanceState> future =
+          stateMachine.getStateChange(FragmentInstanceState.RUNNING);
+
+      stateMachine.transitionToFlushing();
+      assertEquals(FragmentInstanceState.FLUSHING, stateMachine.getState());
+      assertEquals(FragmentInstanceState.FLUSHING, future.get());
+
+      stateMachine.addSourceTaskFailureListener(
+          Mockito.mock(FragmentInstanceFailureListener.class));
+      stateMachine.sourceTaskFailed(instanceId, new RuntimeException("Unknown"));
+
+      stateMachine.finished();
+      assertEquals(FragmentInstanceState.FINISHED, stateMachine.getState());
+
+    } catch (ExecutionException | InterruptedException e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    } finally {
+      instanceNotificationExecutor.shutdown();
+    }
+  }
+
+  @Test
+  public void testToCancel() {
+    ExecutorService instanceNotificationExecutor =
+        IoTDBThreadPoolFactory.newFixedThreadPool(1, "test-instance-notification");
+    try {
+      FragmentInstanceId instanceId =
+          new FragmentInstanceId(new PlanFragmentId(MOCK_QUERY_ID, 0), "0");
+      FragmentInstanceStateMachine stateMachine =
+          new FragmentInstanceStateMachine(instanceId, instanceNotificationExecutor);
+
+      assertEquals(FragmentInstanceState.RUNNING, stateMachine.getState());
+
+      stateMachine.cancel();
+
+      assertEquals(FragmentInstanceState.CANCELLED, stateMachine.getState());
+
+    } finally {
+      instanceNotificationExecutor.shutdown();
+    }
+  }
+
+  @Test
+  public void testToAbort() {
+    ExecutorService instanceNotificationExecutor =
+        IoTDBThreadPoolFactory.newFixedThreadPool(1, "test-instance-notification");
+    try {
+      FragmentInstanceId instanceId =
+          new FragmentInstanceId(new PlanFragmentId(MOCK_QUERY_ID, 0), "0");
+      FragmentInstanceStateMachine stateMachine =
+          new FragmentInstanceStateMachine(instanceId, instanceNotificationExecutor);
+
+      assertEquals(FragmentInstanceState.RUNNING, stateMachine.getState());
+
+      stateMachine.abort();
+
+      assertEquals(FragmentInstanceState.ABORTED, stateMachine.getState());
+
+    } finally {
+      instanceNotificationExecutor.shutdown();
+    }
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/buffer/BloomFilterCacheTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/buffer/BloomFilterCacheTest.java
@@ -16,9 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iotdb.db.storageengine.cache;
+package org.apache.iotdb.db.storageengine.buffer;
 
-import org.apache.iotdb.db.storageengine.buffer.BloomFilterCache;
 import org.apache.iotdb.db.storageengine.dataregion.read.control.FileReaderManager;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/buffer/CacheHitRatioMonitorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/buffer/CacheHitRatioMonitorTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.storageengine.buffer;
+
+import org.apache.iotdb.commons.exception.StartupException;
+import org.apache.iotdb.commons.service.ServiceType;
+import org.apache.iotdb.db.storageengine.dataregion.flush.FlushManager;
+import org.apache.iotdb.db.storageengine.rescon.memory.MemTableManager;
+import org.apache.iotdb.db.storageengine.rescon.memory.SystemInfo;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class CacheHitRatioMonitorTest {
+
+  @Test
+  public void testCacheHitRatioMonitor() {
+    final double delta = 0.000001;
+    ChunkCache.getInstance().clear();
+    TimeSeriesMetadataCache.getInstance().clear();
+    BloomFilterCache.getInstance().clear();
+
+    CacheHitRatioMonitor cacheHitRatioMonitor = CacheHitRatioMonitor.getInstance();
+    try {
+      cacheHitRatioMonitor.start();
+      assertEquals(ServiceType.CACHE_HIT_RATIO_DISPLAY_SERVICE, cacheHitRatioMonitor.getID());
+      assertTrue(
+          cacheHitRatioMonitor.getChunkHitRatio() >= 0.0d
+              && cacheHitRatioMonitor.getChunkHitRatio() <= 1.0d);
+      assertTrue(cacheHitRatioMonitor.getChunkEvictionCount() >= 0);
+      assertEquals(
+          ChunkCache.getInstance().getMaxMemory(), cacheHitRatioMonitor.getChunkCacheMaxMemory());
+      assertTrue(cacheHitRatioMonitor.getChunkCacheAverageLoadPenalty() >= 0.0);
+      assertTrue(cacheHitRatioMonitor.getChunkCacheAverageSize() >= 0);
+
+      assertTrue(
+          cacheHitRatioMonitor.getTimeSeriesMetadataHitRatio() >= 0.0d
+              && cacheHitRatioMonitor.getTimeSeriesMetadataHitRatio() <= 1.0d);
+      assertTrue(cacheHitRatioMonitor.getTimeSeriesMetadataCacheEvictionCount() >= 0);
+      assertEquals(
+          TimeSeriesMetadataCache.getInstance().getMaxMemory(),
+          cacheHitRatioMonitor.getTimeSeriesMetadataCacheMaxMemory());
+      assertTrue(cacheHitRatioMonitor.getTimeSeriesCacheAverageLoadPenalty() >= 0.0);
+      assertTrue(cacheHitRatioMonitor.getTimeSeriesMetaDataCacheAverageSize() >= 0);
+
+      assertTrue(
+          cacheHitRatioMonitor.getBloomFilterHitRatio() >= 0.0d
+              && cacheHitRatioMonitor.getBloomFilterHitRatio() <= 1.0d);
+      assertTrue(cacheHitRatioMonitor.getBloomFilterCacheEvictionCount() >= 0);
+      assertEquals(
+          BloomFilterCache.getInstance().getMaxMemory(),
+          cacheHitRatioMonitor.getBloomFilterCacheMaxMemory());
+      assertTrue(cacheHitRatioMonitor.getBloomFilterCacheAverageLoadPenalty() >= 0.0);
+      assertTrue(cacheHitRatioMonitor.getBloomFilterCacheAverageSize() >= 0);
+
+      assertEquals(
+          SystemInfo.getInstance().getTotalMemTableSize(),
+          cacheHitRatioMonitor.getTotalMemTableSize());
+      assertEquals(
+          SystemInfo.getInstance().getFlushThershold(),
+          cacheHitRatioMonitor.getFlushThershold(),
+          delta);
+      assertEquals(
+          SystemInfo.getInstance().getRejectThershold(),
+          cacheHitRatioMonitor.getRejectThershold(),
+          delta);
+      assertEquals(
+          FlushManager.getInstance().getNumberOfWorkingTasks(),
+          cacheHitRatioMonitor.flushingMemTableNum());
+      assertEquals(
+          MemTableManager.getInstance().getCurrentMemtableNumber(),
+          cacheHitRatioMonitor.totalMemTableNum());
+
+    } catch (StartupException e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    } finally {
+      cacheHitRatioMonitor.stop();
+    }
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/buffer/ChunkCacheTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/buffer/ChunkCacheTest.java
@@ -17,12 +17,10 @@
  * under the License.
  */
 
-package org.apache.iotdb.db.storageengine.cache;
+package org.apache.iotdb.db.storageengine.buffer;
 
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.db.exception.StorageEngineException;
-import org.apache.iotdb.db.storageengine.buffer.ChunkCache;
-import org.apache.iotdb.db.storageengine.buffer.TimeSeriesMetadataCache;
 import org.apache.iotdb.db.storageengine.dataregion.read.control.FileReaderManager;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResourceStatus;

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/buffer/TimeSeriesMetadataCacheTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/buffer/TimeSeriesMetadataCacheTest.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -17,22 +17,12 @@
  * under the License.
  */
 
-package org.apache.iotdb.db.queryengine.execution.operator.factory;
+package org.apache.iotdb.db.storageengine.buffer;
 
-import org.apache.iotdb.db.queryengine.execution.driver.DriverContext;
-import org.apache.iotdb.db.queryengine.execution.operator.Operator;
+import org.junit.Test;
 
-public interface OperatorFactory {
-  Operator createOperator(DriverContext driverContext);
+public class TimeSeriesMetadataCacheTest {
 
-  /**
-   * Declare that createOperator will not be called any more and release any resources associated
-   * with this factory.
-   *
-   * <p>This method will be called only once. Implementation doesn't need to worry about duplicate
-   * invocations.
-   */
-  void noMoreOperators();
-
-  OperatorFactory duplicate();
+  @Test
+  public void testTimeSeriesMetadataCache() {}
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/MemAlignedChunkLoaderTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/MemAlignedChunkLoaderTest.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.storageengine.dataregion.read.reader.chunk;
+
+import org.apache.iotdb.db.storageengine.dataregion.memtable.AlignedReadOnlyMemChunk;
+import org.apache.iotdb.tsfile.file.metadata.AlignedChunkMetadata;
+import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.file.metadata.statistics.Statistics;
+import org.apache.iotdb.tsfile.read.common.BatchData;
+import org.apache.iotdb.tsfile.read.common.block.TsBlock;
+import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
+import org.apache.iotdb.tsfile.read.reader.IPageReader;
+import org.apache.iotdb.tsfile.utils.Binary;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.iotdb.tsfile.read.reader.series.PaginationController.UNLIMITED_PAGINATION_CONTROLLER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+public class MemAlignedChunkLoaderTest {
+
+  private static final String BINARY_STR = "ty love zm";
+
+  @Test
+  public void testMemAlignedChunkLoader() throws IOException {
+    AlignedReadOnlyMemChunk chunk = Mockito.mock(AlignedReadOnlyMemChunk.class);
+    ChunkMetadata chunkMetadata = Mockito.mock(ChunkMetadata.class);
+
+    MemAlignedChunkLoader memAlignedChunkLoader = new MemAlignedChunkLoader(chunk);
+    try {
+      memAlignedChunkLoader.loadChunk(chunkMetadata);
+      fail();
+    } catch (UnsupportedOperationException e) {
+      assertNull(e.getMessage());
+    }
+
+    AlignedChunkMetadata chunkMetadata1 = Mockito.mock(AlignedChunkMetadata.class);
+
+    Mockito.when(chunk.getTsBlock()).thenReturn(buildTsBlock());
+    Mockito.when(chunk.getChunkMetaData()).thenReturn(chunkMetadata1);
+    Statistics statistics1 = Mockito.mock(Statistics.class);
+    Mockito.when(statistics1.hasNullValue(2)).thenReturn(true);
+    Statistics statistics2 = Mockito.mock(Statistics.class);
+    Mockito.when(statistics2.hasNullValue(2)).thenReturn(true);
+    Statistics statistics3 = Mockito.mock(Statistics.class);
+    Mockito.when(statistics3.hasNullValue(2)).thenReturn(true);
+    Statistics statistics4 = Mockito.mock(Statistics.class);
+    Mockito.when(statistics4.hasNullValue(2)).thenReturn(true);
+    Statistics statistics5 = Mockito.mock(Statistics.class);
+    Mockito.when(statistics5.hasNullValue(2)).thenReturn(true);
+    Statistics statistics6 = Mockito.mock(Statistics.class);
+    Mockito.when(statistics6.hasNullValue(2)).thenReturn(true);
+
+    Statistics timeStatistics = Mockito.mock(Statistics.class);
+    Mockito.when(timeStatistics.getCount()).thenReturn(2L);
+
+    Mockito.when(chunkMetadata1.getStatistics()).thenReturn(timeStatistics);
+    Mockito.when(chunkMetadata1.getTimeStatistics()).thenReturn(timeStatistics);
+    Mockito.when(chunkMetadata1.getStatistics(0)).thenReturn(statistics1);
+    Mockito.when(chunkMetadata1.getValueStatisticsList())
+        .thenReturn(
+            Arrays.asList(
+                statistics1, statistics2, statistics3, statistics4, statistics5, statistics6));
+
+    MemAlignedChunkReader chunkReader =
+        (MemAlignedChunkReader) memAlignedChunkLoader.getChunkReader(chunkMetadata1, null);
+
+    try {
+      chunkReader.hasNextSatisfiedPage();
+      fail();
+    } catch (IOException e) {
+      assertEquals("mem chunk reader does not support this method", e.getMessage());
+    }
+
+    try {
+      chunkReader.nextPageData();
+      fail();
+    } catch (IOException e) {
+      assertEquals("mem chunk reader does not support this method", e.getMessage());
+    }
+
+    List<IPageReader> pageReaderList = chunkReader.loadPageReaderList();
+    assertEquals(1, pageReaderList.size());
+
+    MemAlignedPageReader pageReader = (MemAlignedPageReader) pageReaderList.get(0);
+
+    pageReader.initTsBlockBuilder(
+        Arrays.asList(
+            TSDataType.BOOLEAN,
+            TSDataType.INT32,
+            TSDataType.INT64,
+            TSDataType.FLOAT,
+            TSDataType.DOUBLE,
+            TSDataType.TEXT));
+
+    BatchData batchData = pageReader.getAllSatisfiedPageData();
+    assertEquals(2, batchData.length());
+    assertEquals(1L, batchData.getTimeByIndex(0));
+    assertEquals(2L, batchData.getTimeByIndex(1));
+
+    batchData = pageReader.getAllSatisfiedPageData(false);
+    assertEquals(2, batchData.length());
+    assertEquals(BatchData.BatchDataType.DESC_READ, batchData.getBatchDataType());
+    assertEquals(1L, batchData.getTimeByIndex(0));
+    assertEquals(2L, batchData.getTimeByIndex(1));
+
+    TsBlock tsBlock = pageReader.getAllSatisfiedData();
+    assertEquals(2, tsBlock.getPositionCount());
+    assertEquals(1L, tsBlock.getTimeColumn().getLong(0));
+    assertEquals(2L, tsBlock.getTimeColumn().getLong(1));
+
+    assertEquals(timeStatistics, pageReader.getStatistics());
+    assertEquals(statistics1, pageReader.getStatistics(0));
+    assertEquals(timeStatistics, pageReader.getTimeStatistics());
+    assertFalse(pageReader.isModified());
+    pageReader.setLimitOffset(UNLIMITED_PAGINATION_CONTROLLER);
+    pageReader.setFilter(null);
+
+    memAlignedChunkLoader.close();
+  }
+
+  private TsBlock buildTsBlock() {
+    TsBlockBuilder builder =
+        new TsBlockBuilder(
+            Arrays.asList(
+                TSDataType.BOOLEAN,
+                TSDataType.INT32,
+                TSDataType.INT64,
+                TSDataType.FLOAT,
+                TSDataType.DOUBLE,
+                TSDataType.TEXT));
+    builder.getTimeColumnBuilder().writeLong(1L);
+    builder.getColumnBuilder(0).writeBoolean(true);
+    builder.getColumnBuilder(1).writeInt(1);
+    builder.getColumnBuilder(2).writeLong(1L);
+    builder.getColumnBuilder(3).writeFloat(1.1f);
+    builder.getColumnBuilder(4).appendNull();
+    builder.getColumnBuilder(5).writeBinary(new Binary(BINARY_STR));
+    builder.declarePosition();
+    builder.getTimeColumnBuilder().writeLong(2L);
+    builder.getColumnBuilder(0).appendNull();
+    builder.getColumnBuilder(1).appendNull();
+    builder.getColumnBuilder(2).appendNull();
+    builder.getColumnBuilder(3).appendNull();
+    builder.getColumnBuilder(4).writeDouble(3.14d);
+    builder.getColumnBuilder(5).appendNull();
+    builder.declarePosition();
+    return builder.build();
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/MemChunkLoaderTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/MemChunkLoaderTest.java
@@ -1,0 +1,456 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.storageengine.dataregion.read.reader.chunk;
+
+import org.apache.iotdb.db.storageengine.dataregion.memtable.ReadOnlyMemChunk;
+import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.file.metadata.statistics.Statistics;
+import org.apache.iotdb.tsfile.read.common.BatchData;
+import org.apache.iotdb.tsfile.read.common.block.TsBlock;
+import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
+import org.apache.iotdb.tsfile.read.reader.IPageReader;
+import org.apache.iotdb.tsfile.utils.Binary;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.iotdb.tsfile.read.reader.series.PaginationController.UNLIMITED_PAGINATION_CONTROLLER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+public class MemChunkLoaderTest {
+
+  private static final String BINARY_STR = "ty love zm";
+
+  @Test
+  public void testBooleanMemChunkLoader() throws IOException {
+    ReadOnlyMemChunk chunk = Mockito.mock(ReadOnlyMemChunk.class);
+    ChunkMetadata chunkMetadata = Mockito.mock(ChunkMetadata.class);
+
+    MemChunkLoader memChunkLoader = new MemChunkLoader(chunk);
+    try {
+      memChunkLoader.loadChunk(chunkMetadata);
+      fail();
+    } catch (UnsupportedOperationException e) {
+      assertNull(e.getMessage());
+    }
+
+    ChunkMetadata chunkMetadata1 = Mockito.mock(ChunkMetadata.class);
+
+    Mockito.when(chunk.getTsBlock()).thenReturn(buildBooleanTsBlock());
+    Mockito.when(chunk.getChunkMetaData()).thenReturn(chunkMetadata1);
+    Mockito.when(chunk.getPointReader()).thenReturn(null);
+    Statistics statistics = Mockito.mock(Statistics.class);
+    Mockito.when(statistics.getCount()).thenReturn(2L);
+
+    Mockito.when(chunkMetadata1.getStatistics()).thenReturn(statistics);
+    Mockito.when(chunkMetadata1.getDataType()).thenReturn(TSDataType.BOOLEAN);
+
+    MemChunkReader chunkReader =
+        (MemChunkReader) memChunkLoader.getChunkReader(chunkMetadata1, null);
+
+    List<IPageReader> pageReaderList = chunkReader.loadPageReaderList();
+    assertEquals(1, pageReaderList.size());
+
+    MemPageReader pageReader = (MemPageReader) pageReaderList.get(0);
+
+    pageReader.initTsBlockBuilder(Collections.singletonList(TSDataType.BOOLEAN));
+
+    BatchData batchData = pageReader.getAllSatisfiedPageData();
+    assertEquals(2, batchData.length());
+    assertEquals(1L, batchData.getTimeByIndex(0));
+    assertEquals(2L, batchData.getTimeByIndex(1));
+
+    batchData = pageReader.getAllSatisfiedPageData(false);
+    assertEquals(2, batchData.length());
+    assertEquals(BatchData.BatchDataType.DESC_READ, batchData.getBatchDataType());
+    assertEquals(1L, batchData.getTimeByIndex(0));
+    assertEquals(2L, batchData.getTimeByIndex(1));
+
+    TsBlock tsBlock = pageReader.getAllSatisfiedData();
+    assertEquals(2, tsBlock.getPositionCount());
+    assertEquals(1L, tsBlock.getTimeColumn().getLong(0));
+    assertEquals(2L, tsBlock.getTimeColumn().getLong(1));
+
+    assertFalse(pageReader.isModified());
+    pageReader.setLimitOffset(UNLIMITED_PAGINATION_CONTROLLER);
+    pageReader.setFilter(null);
+
+    memChunkLoader.close();
+  }
+
+  private TsBlock buildBooleanTsBlock() {
+    TsBlockBuilder builder = new TsBlockBuilder(Collections.singletonList(TSDataType.BOOLEAN));
+    builder.getTimeColumnBuilder().writeLong(1L);
+    builder.getColumnBuilder(0).writeBoolean(true);
+    builder.declarePosition();
+    builder.getTimeColumnBuilder().writeLong(2L);
+    builder.getColumnBuilder(0).writeBoolean(false);
+    builder.declarePosition();
+    return builder.build();
+  }
+
+  @Test
+  public void testInt32MemChunkLoader() throws IOException {
+    ReadOnlyMemChunk chunk = Mockito.mock(ReadOnlyMemChunk.class);
+    ChunkMetadata chunkMetadata = Mockito.mock(ChunkMetadata.class);
+
+    MemChunkLoader memChunkLoader = new MemChunkLoader(chunk);
+    try {
+      memChunkLoader.loadChunk(chunkMetadata);
+      fail();
+    } catch (UnsupportedOperationException e) {
+      assertNull(e.getMessage());
+    }
+
+    ChunkMetadata chunkMetadata1 = Mockito.mock(ChunkMetadata.class);
+
+    Mockito.when(chunk.getTsBlock()).thenReturn(buildInt32TsBlock());
+    Mockito.when(chunk.getChunkMetaData()).thenReturn(chunkMetadata1);
+    Mockito.when(chunk.getPointReader()).thenReturn(null);
+    Statistics statistics = Mockito.mock(Statistics.class);
+    Mockito.when(statistics.getCount()).thenReturn(2L);
+
+    Mockito.when(chunkMetadata1.getStatistics()).thenReturn(statistics);
+    Mockito.when(chunkMetadata1.getDataType()).thenReturn(TSDataType.INT32);
+
+    MemChunkReader chunkReader =
+        (MemChunkReader) memChunkLoader.getChunkReader(chunkMetadata1, null);
+
+    List<IPageReader> pageReaderList = chunkReader.loadPageReaderList();
+    assertEquals(1, pageReaderList.size());
+
+    MemPageReader pageReader = (MemPageReader) pageReaderList.get(0);
+
+    pageReader.initTsBlockBuilder(Collections.singletonList(TSDataType.INT32));
+
+    BatchData batchData = pageReader.getAllSatisfiedPageData();
+    assertEquals(2, batchData.length());
+    assertEquals(1L, batchData.getTimeByIndex(0));
+    assertEquals(2L, batchData.getTimeByIndex(1));
+
+    batchData = pageReader.getAllSatisfiedPageData(false);
+    assertEquals(2, batchData.length());
+    assertEquals(BatchData.BatchDataType.DESC_READ, batchData.getBatchDataType());
+    assertEquals(1L, batchData.getTimeByIndex(0));
+    assertEquals(2L, batchData.getTimeByIndex(1));
+
+    TsBlock tsBlock = pageReader.getAllSatisfiedData();
+    assertEquals(2, tsBlock.getPositionCount());
+    assertEquals(1L, tsBlock.getTimeColumn().getLong(0));
+    assertEquals(2L, tsBlock.getTimeColumn().getLong(1));
+
+    assertFalse(pageReader.isModified());
+    pageReader.setLimitOffset(UNLIMITED_PAGINATION_CONTROLLER);
+    pageReader.setFilter(null);
+
+    memChunkLoader.close();
+  }
+
+  private TsBlock buildInt32TsBlock() {
+    TsBlockBuilder builder = new TsBlockBuilder(Collections.singletonList(TSDataType.INT32));
+    builder.getTimeColumnBuilder().writeLong(1L);
+    builder.getColumnBuilder(0).writeInt(1);
+    builder.declarePosition();
+    builder.getTimeColumnBuilder().writeLong(2L);
+    builder.getColumnBuilder(0).writeInt(2);
+    builder.declarePosition();
+    return builder.build();
+  }
+
+  @Test
+  public void testInt64MemChunkLoader() throws IOException {
+    ReadOnlyMemChunk chunk = Mockito.mock(ReadOnlyMemChunk.class);
+    ChunkMetadata chunkMetadata = Mockito.mock(ChunkMetadata.class);
+
+    MemChunkLoader memChunkLoader = new MemChunkLoader(chunk);
+    try {
+      memChunkLoader.loadChunk(chunkMetadata);
+      fail();
+    } catch (UnsupportedOperationException e) {
+      assertNull(e.getMessage());
+    }
+
+    ChunkMetadata chunkMetadata1 = Mockito.mock(ChunkMetadata.class);
+
+    Mockito.when(chunk.getTsBlock()).thenReturn(buildInt64TsBlock());
+    Mockito.when(chunk.getChunkMetaData()).thenReturn(chunkMetadata1);
+    Mockito.when(chunk.getPointReader()).thenReturn(null);
+    Statistics statistics = Mockito.mock(Statistics.class);
+    Mockito.when(statistics.getCount()).thenReturn(2L);
+
+    Mockito.when(chunkMetadata1.getStatistics()).thenReturn(statistics);
+    Mockito.when(chunkMetadata1.getDataType()).thenReturn(TSDataType.INT64);
+
+    MemChunkReader chunkReader =
+        (MemChunkReader) memChunkLoader.getChunkReader(chunkMetadata1, null);
+
+    List<IPageReader> pageReaderList = chunkReader.loadPageReaderList();
+    assertEquals(1, pageReaderList.size());
+
+    MemPageReader pageReader = (MemPageReader) pageReaderList.get(0);
+
+    pageReader.initTsBlockBuilder(Collections.singletonList(TSDataType.INT64));
+
+    BatchData batchData = pageReader.getAllSatisfiedPageData();
+    assertEquals(2, batchData.length());
+    assertEquals(1L, batchData.getTimeByIndex(0));
+    assertEquals(2L, batchData.getTimeByIndex(1));
+
+    batchData = pageReader.getAllSatisfiedPageData(false);
+    assertEquals(2, batchData.length());
+    assertEquals(BatchData.BatchDataType.DESC_READ, batchData.getBatchDataType());
+    assertEquals(1L, batchData.getTimeByIndex(0));
+    assertEquals(2L, batchData.getTimeByIndex(1));
+
+    TsBlock tsBlock = pageReader.getAllSatisfiedData();
+    assertEquals(2, tsBlock.getPositionCount());
+    assertEquals(1L, tsBlock.getTimeColumn().getLong(0));
+    assertEquals(2L, tsBlock.getTimeColumn().getLong(1));
+
+    assertFalse(pageReader.isModified());
+    pageReader.setLimitOffset(UNLIMITED_PAGINATION_CONTROLLER);
+    pageReader.setFilter(null);
+
+    memChunkLoader.close();
+  }
+
+  private TsBlock buildInt64TsBlock() {
+    TsBlockBuilder builder = new TsBlockBuilder(Collections.singletonList(TSDataType.INT64));
+    builder.getTimeColumnBuilder().writeLong(1L);
+    builder.getColumnBuilder(0).writeLong(1L);
+    builder.declarePosition();
+    builder.getTimeColumnBuilder().writeLong(2L);
+    builder.getColumnBuilder(0).writeLong(2L);
+    builder.declarePosition();
+    return builder.build();
+  }
+
+  @Test
+  public void testFloatMemChunkLoader() throws IOException {
+    ReadOnlyMemChunk chunk = Mockito.mock(ReadOnlyMemChunk.class);
+    ChunkMetadata chunkMetadata = Mockito.mock(ChunkMetadata.class);
+
+    MemChunkLoader memChunkLoader = new MemChunkLoader(chunk);
+    try {
+      memChunkLoader.loadChunk(chunkMetadata);
+      fail();
+    } catch (UnsupportedOperationException e) {
+      assertNull(e.getMessage());
+    }
+
+    ChunkMetadata chunkMetadata1 = Mockito.mock(ChunkMetadata.class);
+
+    Mockito.when(chunk.getTsBlock()).thenReturn(buildFloatTsBlock());
+    Mockito.when(chunk.getChunkMetaData()).thenReturn(chunkMetadata1);
+    Mockito.when(chunk.getPointReader()).thenReturn(null);
+    Statistics statistics = Mockito.mock(Statistics.class);
+    Mockito.when(statistics.getCount()).thenReturn(2L);
+
+    Mockito.when(chunkMetadata1.getStatistics()).thenReturn(statistics);
+    Mockito.when(chunkMetadata1.getDataType()).thenReturn(TSDataType.FLOAT);
+
+    MemChunkReader chunkReader =
+        (MemChunkReader) memChunkLoader.getChunkReader(chunkMetadata1, null);
+
+    List<IPageReader> pageReaderList = chunkReader.loadPageReaderList();
+    assertEquals(1, pageReaderList.size());
+
+    MemPageReader pageReader = (MemPageReader) pageReaderList.get(0);
+
+    pageReader.initTsBlockBuilder(Collections.singletonList(TSDataType.FLOAT));
+
+    BatchData batchData = pageReader.getAllSatisfiedPageData();
+    assertEquals(2, batchData.length());
+    assertEquals(1L, batchData.getTimeByIndex(0));
+    assertEquals(2L, batchData.getTimeByIndex(1));
+
+    batchData = pageReader.getAllSatisfiedPageData(false);
+    assertEquals(2, batchData.length());
+    assertEquals(BatchData.BatchDataType.DESC_READ, batchData.getBatchDataType());
+    assertEquals(1L, batchData.getTimeByIndex(0));
+    assertEquals(2L, batchData.getTimeByIndex(1));
+
+    TsBlock tsBlock = pageReader.getAllSatisfiedData();
+    assertEquals(2, tsBlock.getPositionCount());
+    assertEquals(1L, tsBlock.getTimeColumn().getLong(0));
+    assertEquals(2L, tsBlock.getTimeColumn().getLong(1));
+
+    assertFalse(pageReader.isModified());
+    pageReader.setLimitOffset(UNLIMITED_PAGINATION_CONTROLLER);
+    pageReader.setFilter(null);
+
+    memChunkLoader.close();
+  }
+
+  private TsBlock buildFloatTsBlock() {
+    TsBlockBuilder builder = new TsBlockBuilder(Collections.singletonList(TSDataType.FLOAT));
+    builder.getTimeColumnBuilder().writeLong(1L);
+    builder.getColumnBuilder(0).writeFloat(1.1f);
+    builder.declarePosition();
+    builder.getTimeColumnBuilder().writeLong(2L);
+    builder.getColumnBuilder(0).writeFloat(2.1f);
+    builder.declarePosition();
+    return builder.build();
+  }
+
+  @Test
+  public void testDoubleMemChunkLoader() throws IOException {
+    ReadOnlyMemChunk chunk = Mockito.mock(ReadOnlyMemChunk.class);
+    ChunkMetadata chunkMetadata = Mockito.mock(ChunkMetadata.class);
+
+    MemChunkLoader memChunkLoader = new MemChunkLoader(chunk);
+    try {
+      memChunkLoader.loadChunk(chunkMetadata);
+      fail();
+    } catch (UnsupportedOperationException e) {
+      assertNull(e.getMessage());
+    }
+
+    ChunkMetadata chunkMetadata1 = Mockito.mock(ChunkMetadata.class);
+
+    Mockito.when(chunk.getTsBlock()).thenReturn(buildDoubleTsBlock());
+    Mockito.when(chunk.getChunkMetaData()).thenReturn(chunkMetadata1);
+    Mockito.when(chunk.getPointReader()).thenReturn(null);
+    Statistics statistics = Mockito.mock(Statistics.class);
+    Mockito.when(statistics.getCount()).thenReturn(2L);
+
+    Mockito.when(chunkMetadata1.getStatistics()).thenReturn(statistics);
+    Mockito.when(chunkMetadata1.getDataType()).thenReturn(TSDataType.DOUBLE);
+
+    MemChunkReader chunkReader =
+        (MemChunkReader) memChunkLoader.getChunkReader(chunkMetadata1, null);
+
+    List<IPageReader> pageReaderList = chunkReader.loadPageReaderList();
+    assertEquals(1, pageReaderList.size());
+
+    MemPageReader pageReader = (MemPageReader) pageReaderList.get(0);
+
+    pageReader.initTsBlockBuilder(Collections.singletonList(TSDataType.DOUBLE));
+
+    BatchData batchData = pageReader.getAllSatisfiedPageData();
+    assertEquals(2, batchData.length());
+    assertEquals(1L, batchData.getTimeByIndex(0));
+    assertEquals(2L, batchData.getTimeByIndex(1));
+
+    batchData = pageReader.getAllSatisfiedPageData(false);
+    assertEquals(2, batchData.length());
+    assertEquals(BatchData.BatchDataType.DESC_READ, batchData.getBatchDataType());
+    assertEquals(1L, batchData.getTimeByIndex(0));
+    assertEquals(2L, batchData.getTimeByIndex(1));
+
+    TsBlock tsBlock = pageReader.getAllSatisfiedData();
+    assertEquals(2, tsBlock.getPositionCount());
+    assertEquals(1L, tsBlock.getTimeColumn().getLong(0));
+    assertEquals(2L, tsBlock.getTimeColumn().getLong(1));
+
+    assertFalse(pageReader.isModified());
+    pageReader.setLimitOffset(UNLIMITED_PAGINATION_CONTROLLER);
+    pageReader.setFilter(null);
+
+    memChunkLoader.close();
+  }
+
+  private TsBlock buildDoubleTsBlock() {
+    TsBlockBuilder builder = new TsBlockBuilder(Collections.singletonList(TSDataType.DOUBLE));
+    builder.getTimeColumnBuilder().writeLong(1L);
+    builder.getColumnBuilder(0).writeDouble(1.1d);
+    builder.declarePosition();
+    builder.getTimeColumnBuilder().writeLong(2L);
+    builder.getColumnBuilder(0).writeDouble(2.1d);
+    builder.declarePosition();
+    return builder.build();
+  }
+
+  @Test
+  public void testTextMemChunkLoader() throws IOException {
+    ReadOnlyMemChunk chunk = Mockito.mock(ReadOnlyMemChunk.class);
+    ChunkMetadata chunkMetadata = Mockito.mock(ChunkMetadata.class);
+
+    MemChunkLoader memChunkLoader = new MemChunkLoader(chunk);
+    try {
+      memChunkLoader.loadChunk(chunkMetadata);
+      fail();
+    } catch (UnsupportedOperationException e) {
+      assertNull(e.getMessage());
+    }
+
+    ChunkMetadata chunkMetadata1 = Mockito.mock(ChunkMetadata.class);
+
+    Mockito.when(chunk.getTsBlock()).thenReturn(buildTextTsBlock());
+    Mockito.when(chunk.getChunkMetaData()).thenReturn(chunkMetadata1);
+    Mockito.when(chunk.getPointReader()).thenReturn(null);
+    Statistics statistics = Mockito.mock(Statistics.class);
+    Mockito.when(statistics.getCount()).thenReturn(2L);
+
+    Mockito.when(chunkMetadata1.getStatistics()).thenReturn(statistics);
+    Mockito.when(chunkMetadata1.getDataType()).thenReturn(TSDataType.TEXT);
+
+    MemChunkReader chunkReader =
+        (MemChunkReader) memChunkLoader.getChunkReader(chunkMetadata1, null);
+
+    List<IPageReader> pageReaderList = chunkReader.loadPageReaderList();
+    assertEquals(1, pageReaderList.size());
+
+    MemPageReader pageReader = (MemPageReader) pageReaderList.get(0);
+
+    pageReader.initTsBlockBuilder(Collections.singletonList(TSDataType.TEXT));
+
+    BatchData batchData = pageReader.getAllSatisfiedPageData();
+    assertEquals(2, batchData.length());
+    assertEquals(1L, batchData.getTimeByIndex(0));
+    assertEquals(2L, batchData.getTimeByIndex(1));
+
+    batchData = pageReader.getAllSatisfiedPageData(false);
+    assertEquals(2, batchData.length());
+    assertEquals(BatchData.BatchDataType.DESC_READ, batchData.getBatchDataType());
+    assertEquals(1L, batchData.getTimeByIndex(0));
+    assertEquals(2L, batchData.getTimeByIndex(1));
+
+    TsBlock tsBlock = pageReader.getAllSatisfiedData();
+    assertEquals(2, tsBlock.getPositionCount());
+    assertEquals(1L, tsBlock.getTimeColumn().getLong(0));
+    assertEquals(2L, tsBlock.getTimeColumn().getLong(1));
+
+    assertFalse(pageReader.isModified());
+    pageReader.setLimitOffset(UNLIMITED_PAGINATION_CONTROLLER);
+    pageReader.setFilter(null);
+
+    memChunkLoader.close();
+  }
+
+  private TsBlock buildTextTsBlock() {
+    TsBlockBuilder builder = new TsBlockBuilder(Collections.singletonList(TSDataType.TEXT));
+    builder.getTimeColumnBuilder().writeLong(1L);
+    builder.getColumnBuilder(0).writeBinary(new Binary(BINARY_STR));
+    builder.declarePosition();
+    builder.getTimeColumnBuilder().writeLong(2L);
+    builder.getColumnBuilder(0).writeBinary(new Binary(BINARY_STR));
+    builder.declarePosition();
+    return builder.build();
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/metadata/MemAlignedChunkMetadataLoaderTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/metadata/MemAlignedChunkMetadataLoaderTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.storageengine.dataregion.read.reader.chunk.metadata;
+
+import org.apache.iotdb.commons.path.AlignedPath;
+import org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext;
+import org.apache.iotdb.db.storageengine.dataregion.memtable.ReadOnlyMemChunk;
+import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
+import org.apache.iotdb.tsfile.file.metadata.AlignedChunkMetadata;
+import org.apache.iotdb.tsfile.file.metadata.AlignedTimeSeriesMetadata;
+import org.apache.iotdb.tsfile.file.metadata.IChunkMetadata;
+import org.apache.iotdb.tsfile.file.metadata.ITimeSeriesMetadata;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class MemAlignedChunkMetadataLoaderTest {
+
+  @Test
+  public void testLoadChunkMetadataList() {
+    AlignedPath path = Mockito.mock(AlignedPath.class);
+    TsFileResource resource = Mockito.mock(TsFileResource.class);
+    FragmentInstanceContext context = Mockito.mock(FragmentInstanceContext.class);
+    List<IChunkMetadata> chunkMetadataList1 = new ArrayList<>();
+    IChunkMetadata chunkMetadata1 = Mockito.mock(AlignedChunkMetadata.class);
+    chunkMetadataList1.add(chunkMetadata1);
+
+    Mockito.when(resource.getChunkMetadataList(path)).thenReturn(chunkMetadataList1);
+
+    Mockito.when(chunkMetadata1.needSetChunkLoader()).thenReturn(true);
+    Mockito.when(resource.getTsFilePath()).thenReturn("1-1-0-0.tsfile");
+    Mockito.when(resource.isClosed()).thenReturn(false);
+    Mockito.when(context.isDebug()).thenReturn(false);
+
+    List<ReadOnlyMemChunk> memChunks = new ArrayList<>();
+    ReadOnlyMemChunk readOnlyMemChunk = Mockito.mock(ReadOnlyMemChunk.class);
+    memChunks.add(readOnlyMemChunk);
+    Mockito.when(readOnlyMemChunk.isEmpty()).thenReturn(false);
+    Mockito.when(resource.getReadOnlyMemChunk(path)).thenReturn(memChunks);
+
+    IChunkMetadata chunkMetadata2 = Mockito.mock(AlignedChunkMetadata.class);
+    Mockito.when(readOnlyMemChunk.getChunkMetaData()).thenReturn(chunkMetadata2);
+    Mockito.when(resource.getVersion()).thenReturn(1L);
+
+    MemChunkMetadataLoader loader = new MemChunkMetadataLoader(resource, path, context, null);
+    ITimeSeriesMetadata timeSeriesMetadata = Mockito.mock(AlignedTimeSeriesMetadata.class);
+
+    List<IChunkMetadata> chunkMetadataList = loader.loadChunkMetadataList(timeSeriesMetadata);
+
+    assertEquals(2, chunkMetadataList.size());
+    assertEquals(chunkMetadata1, chunkMetadataList.get(0));
+    assertEquals(chunkMetadata2, chunkMetadataList.get(1));
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/metadata/MemChunkMetadataLoaderTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/metadata/MemChunkMetadataLoaderTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.storageengine.dataregion.read.reader.chunk.metadata;
+
+import org.apache.iotdb.commons.path.MeasurementPath;
+import org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext;
+import org.apache.iotdb.db.storageengine.dataregion.memtable.ReadOnlyMemChunk;
+import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
+import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
+import org.apache.iotdb.tsfile.file.metadata.IChunkMetadata;
+import org.apache.iotdb.tsfile.file.metadata.ITimeSeriesMetadata;
+import org.apache.iotdb.tsfile.file.metadata.TimeseriesMetadata;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class MemChunkMetadataLoaderTest {
+
+  @Test
+  public void testLoadChunkMetadataList() {
+    MeasurementPath path = Mockito.mock(MeasurementPath.class);
+    TsFileResource resource = Mockito.mock(TsFileResource.class);
+    FragmentInstanceContext context = Mockito.mock(FragmentInstanceContext.class);
+    List<IChunkMetadata> chunkMetadataList1 = new ArrayList<>();
+    IChunkMetadata chunkMetadata1 = Mockito.mock(ChunkMetadata.class);
+    chunkMetadataList1.add(chunkMetadata1);
+
+    Mockito.when(resource.getChunkMetadataList(path)).thenReturn(chunkMetadataList1);
+
+    Mockito.when(chunkMetadata1.needSetChunkLoader()).thenReturn(true);
+    Mockito.when(resource.getTsFilePath()).thenReturn("1-1-0-0.tsfile");
+    Mockito.when(resource.isClosed()).thenReturn(false);
+    Mockito.when(context.isDebug()).thenReturn(false);
+
+    List<ReadOnlyMemChunk> memChunks = new ArrayList<>();
+    ReadOnlyMemChunk readOnlyMemChunk = Mockito.mock(ReadOnlyMemChunk.class);
+    memChunks.add(readOnlyMemChunk);
+    Mockito.when(readOnlyMemChunk.isEmpty()).thenReturn(false);
+    Mockito.when(resource.getReadOnlyMemChunk(path)).thenReturn(memChunks);
+
+    IChunkMetadata chunkMetadata2 = Mockito.mock(ChunkMetadata.class);
+    Mockito.when(readOnlyMemChunk.getChunkMetaData()).thenReturn(chunkMetadata2);
+    Mockito.when(resource.getVersion()).thenReturn(1L);
+
+    MemChunkMetadataLoader loader = new MemChunkMetadataLoader(resource, path, context, null);
+    ITimeSeriesMetadata timeSeriesMetadata = Mockito.mock(TimeseriesMetadata.class);
+
+    List<IChunkMetadata> chunkMetadataList = loader.loadChunkMetadataList(timeSeriesMetadata);
+
+    assertEquals(2, chunkMetadataList.size());
+    assertEquals(chunkMetadata1, chunkMetadataList.get(0));
+    assertEquals(chunkMetadata2, chunkMetadataList.get(1));
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/QueryDataSetUtilsTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/QueryDataSetUtilsTest.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.utils;
+
+import org.apache.iotdb.commons.exception.IoTDBException;
+import org.apache.iotdb.db.queryengine.plan.execution.IQueryExecution;
+import org.apache.iotdb.service.rpc.thrift.TSQueryDataSet;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.read.common.block.TsBlock;
+import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
+import org.apache.iotdb.tsfile.read.common.block.column.TsBlockSerde;
+import org.apache.iotdb.tsfile.utils.Binary;
+import org.apache.iotdb.tsfile.utils.Pair;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class QueryDataSetUtilsTest {
+
+  private static final String BINARY_STR = "ty love zm";
+
+  @Test
+  public void testConvertTsBlockByFetchSize() throws IoTDBException, IOException {
+
+    Pair<TSQueryDataSet, Boolean> res =
+        QueryDataSetUtils.convertTsBlockByFetchSize(buildQueryExecution(), 10);
+
+    compareRes(res);
+  }
+
+  private IQueryExecution buildQueryExecution() throws IoTDBException, IOException {
+    IQueryExecution queryExecution = Mockito.mock(IQueryExecution.class);
+    Mockito.when(queryExecution.getOutputValueColumnCount()).thenReturn(6);
+    TsBlockBuilder builder =
+        new TsBlockBuilder(
+            Arrays.asList(
+                TSDataType.BOOLEAN,
+                TSDataType.INT32,
+                TSDataType.INT64,
+                TSDataType.FLOAT,
+                TSDataType.DOUBLE,
+                TSDataType.TEXT));
+    builder.getTimeColumnBuilder().writeLong(1L);
+    builder.getColumnBuilder(0).writeBoolean(true);
+    builder.getColumnBuilder(1).writeInt(1);
+    builder.getColumnBuilder(2).writeLong(1L);
+    builder.getColumnBuilder(3).writeFloat(1.1f);
+    builder.getColumnBuilder(4).appendNull();
+    builder.getColumnBuilder(5).writeBinary(new Binary(BINARY_STR));
+    builder.declarePosition();
+    builder.getTimeColumnBuilder().writeLong(2L);
+    builder.getColumnBuilder(0).appendNull();
+    builder.getColumnBuilder(1).appendNull();
+    builder.getColumnBuilder(2).appendNull();
+    builder.getColumnBuilder(3).appendNull();
+    builder.getColumnBuilder(4).writeDouble(3.14d);
+    builder.getColumnBuilder(5).appendNull();
+    builder.declarePosition();
+    Mockito.when(queryExecution.getBatchResult())
+        .thenReturn(Optional.of(builder.build()), Optional.empty());
+    Mockito.when(queryExecution.getByteBufferBatchResult())
+        .thenReturn(Optional.of(new TsBlockSerde().serialize(builder.build())), Optional.empty());
+    return queryExecution;
+  }
+
+  private void compareRes(Pair<TSQueryDataSet, Boolean> res) {
+    final double delta = 0.00001d;
+    assertEquals(true, res.right);
+    assertEquals(Long.BYTES * 2, res.left.time.limit());
+    assertEquals(1L, res.left.time.getLong());
+    assertEquals(2L, res.left.time.getLong());
+    assertEquals(6, res.left.valueList.size());
+    assertEquals(6, res.left.bitmapList.size());
+
+    assertEquals(Byte.BYTES, res.left.valueList.get(0).limit());
+    assertEquals(Byte.BYTES, res.left.bitmapList.get(0).limit());
+    assertEquals((byte) 1, res.left.valueList.get(0).get());
+    assertEquals((byte) 0x80, res.left.bitmapList.get(0).get());
+
+    assertEquals(Integer.BYTES, res.left.valueList.get(1).limit());
+    assertEquals(Byte.BYTES, res.left.bitmapList.get(1).limit());
+    assertEquals(1, res.left.valueList.get(1).getInt());
+    assertEquals((byte) 0x80, res.left.bitmapList.get(1).get());
+
+    assertEquals(Long.BYTES, res.left.valueList.get(2).limit());
+    assertEquals(Byte.BYTES, res.left.bitmapList.get(2).limit());
+    assertEquals(1L, res.left.valueList.get(2).getLong());
+    assertEquals((byte) 0x80, res.left.bitmapList.get(2).get());
+
+    assertEquals(Float.BYTES, res.left.valueList.get(3).limit());
+    assertEquals(Byte.BYTES, res.left.bitmapList.get(3).limit());
+    assertEquals(1.1f, res.left.valueList.get(3).getFloat(), delta);
+    assertEquals((byte) 0x80, res.left.bitmapList.get(3).get());
+
+    assertEquals(Double.BYTES, res.left.valueList.get(4).limit());
+    assertEquals(Byte.BYTES, res.left.bitmapList.get(4).limit());
+    assertEquals(3.14d, res.left.valueList.get(4).getDouble(), delta);
+    assertEquals((byte) 0x40, res.left.bitmapList.get(4).get());
+
+    assertEquals(Byte.BYTES, res.left.bitmapList.get(5).limit());
+    assertEquals(Integer.BYTES + 10, res.left.valueList.get(5).limit());
+    assertEquals(10, res.left.valueList.get(5).getInt());
+    byte[] bytes = new byte[10];
+    res.left.valueList.get(5).get(bytes);
+    assertEquals(BINARY_STR, new String(bytes));
+    assertEquals((byte) 0x80, res.left.bitmapList.get(5).get());
+  }
+
+  @Test
+  public void testConvertQueryResultByFetchSize() throws IoTDBException, IOException {
+
+    Pair<List<ByteBuffer>, Boolean> res =
+        QueryDataSetUtils.convertQueryResultByFetchSize(buildQueryExecution(), 10);
+
+    compareTsBlock(res);
+  }
+
+  private void compareTsBlock(Pair<List<ByteBuffer>, Boolean> res) {
+    final double delta = 0.00001d;
+
+    assertEquals(true, res.right);
+    assertEquals(1, res.left.size());
+
+    TsBlockSerde serde = new TsBlockSerde();
+    TsBlock tsBlock = serde.deserialize(res.left.get(0));
+
+    assertEquals(2, tsBlock.getPositionCount());
+
+    assertEquals(1L, tsBlock.getTimeColumn().getLong(0));
+    assertEquals(2L, tsBlock.getTimeColumn().getLong(1));
+
+    assertFalse(tsBlock.getColumn(0).isNull(0));
+    assertTrue(tsBlock.getColumn(0).getBoolean(0));
+    assertTrue(tsBlock.getColumn(0).isNull(1));
+
+    assertFalse(tsBlock.getColumn(1).isNull(0));
+    assertEquals(1, tsBlock.getColumn(1).getInt(0));
+    assertTrue(tsBlock.getColumn(1).isNull(1));
+
+    assertFalse(tsBlock.getColumn(2).isNull(0));
+    assertEquals(1L, tsBlock.getColumn(2).getLong(0));
+    assertTrue(tsBlock.getColumn(2).isNull(1));
+
+    assertFalse(tsBlock.getColumn(3).isNull(0));
+    assertEquals(1.1f, tsBlock.getColumn(3).getFloat(0), delta);
+    assertTrue(tsBlock.getColumn(3).isNull(1));
+
+    assertTrue(tsBlock.getColumn(4).isNull(0));
+    assertFalse(tsBlock.getColumn(4).isNull(1));
+    assertEquals(3.14d, tsBlock.getColumn(4).getDouble(1), delta);
+
+    assertFalse(tsBlock.getColumn(5).isNull(0));
+    assertEquals(new Binary(BINARY_STR), tsBlock.getColumn(5).getBinary(0));
+    assertTrue(tsBlock.getColumn(5).isNull(1));
+  }
+}


### PR DESCRIPTION
The following packages' UT coverage are improved:

- iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/exception
- iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/dirver
- iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/executor
- iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment
- iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/factory
- iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process
- iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/OperatorContext.java
- iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/QueryIdGenerator.java
- iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/QueryStateMachine.java
- iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/StateMachine.java
- iotdb-core/datanode/src/main/java/org/apache/iotdb/db/exception/mpp
- iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/buffer
- iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read
- iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/constant
- iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/QueryDataSetUtils.java
- iotdb-core/datanode/target/generated-sources/freemarker/org/apache/iotdb/db/queryengine/execution/operatror
- iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/statistics

