### PR TITLE
[To rel/1.2] Fix authority check of altering view

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/parser/ASTVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/parser/ASTVisitor.java
@@ -1081,10 +1081,9 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
 
       return alterLogicalViewStatement;
     } else {
-      AlterTimeSeriesStatement alterTimeSeriesStatement = new AlterTimeSeriesStatement();
+      AlterTimeSeriesStatement alterTimeSeriesStatement = new AlterTimeSeriesStatement(true);
       alterTimeSeriesStatement.setPath(parseFullPath(ctx.fullPath()));
       parseAlterClause(ctx.alterClause(), alterTimeSeriesStatement);
-      alterTimeSeriesStatement.setAlterView(true);
       if (alterTimeSeriesStatement.getAlias() != null) {
         throw new SemanticException("View doesn't support alias.");
       }

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/metadata/AlterTimeSeriesStatement.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/statement/metadata/AlterTimeSeriesStatement.java
@@ -53,11 +53,22 @@ public class AlterTimeSeriesStatement extends Statement {
   private Map<String, String> tagsMap;
   private Map<String, String> attributesMap;
 
-  private boolean isAlterView = false;
+  private final boolean isAlterView;
 
   public AlterTimeSeriesStatement() {
     super();
+    isAlterView = false;
     statementType = StatementType.ALTER_TIMESERIES;
+  }
+
+  public AlterTimeSeriesStatement(boolean isAlterView) {
+    super();
+    this.isAlterView = isAlterView;
+    if (isAlterView) {
+      statementType = StatementType.ALTER_LOGICAL_VIEW;
+    } else {
+      statementType = StatementType.ALTER_TIMESERIES;
+    }
   }
 
   @Override
@@ -115,10 +126,6 @@ public class AlterTimeSeriesStatement extends Statement {
 
   public boolean isAlterView() {
     return isAlterView;
-  }
-
-  public void setAlterView(boolean alterView) {
-    isAlterView = alterView;
   }
 
   @Override


### PR DESCRIPTION
## Description


### Problem

```
alter view root.view.v1.c1 upsert tags(city=beijing, description='this is a capital') attributes(speed=100, color=red);
Msg: 803: No permissions for this operation, please add privilege ALTER_TIMESERIES
```

### Cause

Such operation currently is implemented based on altering timeseries, which results in the authority module get ALTER_TIMESERIES operation type rather than ALTER_VIEW operation type.

### Solution

Return ALTER_VIEW operation type when the AlterTimeSeriesStatement is used for altering view.

