### PR TITLE
[IOTDB-6034] Format LoadStatistics logs and add ClusterIT

### DIFF
--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/AbstractEnv.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/AbstractEnv.java
@@ -314,6 +314,14 @@ public abstract class AbstractEnv implements BaseEnv {
         getWriteConnection(null, username, password), getReadConnections(null, username, password));
   }
 
+  @Override
+  public Connection getConnectionWithSpecifiedDataNode(
+      DataNodeWrapper dataNode, String username, String password) throws SQLException {
+    return new ClusterTestConnection(
+        getWriteConnectionWithSpecifiedDataNode(dataNode, null, username, password),
+        getReadConnections(null, username, password));
+  }
+
   private Connection getConnection(String endpoint, int queryTimeout) throws SQLException {
     IoTDBConnection connection =
         (IoTDBConnection)
@@ -387,6 +395,12 @@ public abstract class AbstractEnv implements BaseEnv {
       dataNode = this.dataNodeWrapperList.get(0);
     }
 
+    return getWriteConnectionWithSpecifiedDataNode(dataNode, version, username, password);
+  }
+
+  protected NodeConnection getWriteConnectionWithSpecifiedDataNode(
+      DataNodeWrapper dataNode, Constant.Version version, String username, String password)
+      throws SQLException {
     String endpoint = dataNode.getIp() + ":" + dataNode.getPort();
     Connection writeConnection =
         DriverManager.getConnection(

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/remote/RemoteServerEnv.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/remote/RemoteServerEnv.java
@@ -106,6 +106,12 @@ public class RemoteServerEnv implements BaseEnv {
   }
 
   @Override
+  public Connection getConnectionWithSpecifiedDataNode(
+      DataNodeWrapper dataNode, String username, String password) throws SQLException {
+    return getConnection(username, password);
+  }
+
+  @Override
   public Connection getConnection(Constant.Version version, String username, String password)
       throws SQLException {
     Connection connection = null;

--- a/integration-test/src/main/java/org/apache/iotdb/itbase/env/BaseEnv.java
+++ b/integration-test/src/main/java/org/apache/iotdb/itbase/env/BaseEnv.java
@@ -56,7 +56,15 @@ public interface BaseEnv {
     return getConnection("root", "root");
   }
 
+  default Connection getConnectionWithSpecifiedDataNode(DataNodeWrapper dataNode)
+      throws SQLException {
+    return getConnectionWithSpecifiedDataNode(dataNode, "root", "root");
+  }
+
   Connection getConnection(String username, String password) throws SQLException;
+
+  Connection getConnectionWithSpecifiedDataNode(
+      DataNodeWrapper dataNode, String username, String password) throws SQLException;
 
   default Connection getConnection(Constant.Version version) throws SQLException {
     return getConnection(version, "root", "root");

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/region/RegionGroupStatistics.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/region/RegionGroupStatistics.java
@@ -27,6 +27,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -64,6 +66,10 @@ public class RegionGroupStatistics {
 
   public Map<Integer, RegionStatistics> getRegionStatisticsMap() {
     return regionStatisticsMap;
+  }
+
+  public List<Integer> getRegionIds() {
+    return new ArrayList<>(regionStatisticsMap.keySet());
   }
 
   public static RegionGroupStatistics generateDefaultRegionGroupStatistics() {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/service/StatisticsService.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/service/StatisticsService.java
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -180,7 +181,8 @@ public class StatisticsService implements IClusterStatusSubscriber {
     LOGGER.info("[NodeStatistics] NodeStatisticsMap: ");
     for (Map.Entry<Integer, Pair<NodeStatistics, NodeStatistics>> nodeCacheEntry :
         differentNodeStatisticsMap.entrySet()) {
-      if (!nodeCacheEntry.getValue().getRight().equals(nodeCacheEntry.getValue().getLeft())) {
+      if (!Objects.equals(
+          nodeCacheEntry.getValue().getRight(), nodeCacheEntry.getValue().getLeft())) {
         LOGGER.info(
             "[NodeStatistics]\t {}: {}->{}",
             "nodeId{" + nodeCacheEntry.getKey() + "}",
@@ -196,10 +198,9 @@ public class StatisticsService implements IClusterStatusSubscriber {
     LOGGER.info("[RegionGroupStatistics] RegionGroupStatisticsMap: ");
     for (Map.Entry<TConsensusGroupId, Pair<RegionGroupStatistics, RegionGroupStatistics>>
         regionGroupStatisticsEntry : differentRegionGroupStatisticsMap.entrySet()) {
-      if (!regionGroupStatisticsEntry
-          .getValue()
-          .getRight()
-          .equals(regionGroupStatisticsEntry.getValue().getLeft())) {
+      if (!Objects.equals(
+          regionGroupStatisticsEntry.getValue().getRight(),
+          regionGroupStatisticsEntry.getValue().getLeft())) {
         LOGGER.info(
             "[RegionGroupStatistics]\t RegionGroup {}: {} -> {}",
             regionGroupStatisticsEntry.getKey(),
@@ -208,7 +209,7 @@ public class StatisticsService implements IClusterStatusSubscriber {
 
         List<Integer> leftIds = regionGroupStatisticsEntry.getValue().getLeft().getRegionIds();
         List<Integer> rightIds = regionGroupStatisticsEntry.getValue().getRight().getRegionIds();
-        for (int leftId : leftIds) {
+        for (Integer leftId : leftIds) {
           if (!rightIds.contains(leftId)) {
             LOGGER.info(
                 "[RegionGroupStatistics]\t Region in DataNode {}: {} -> null",
@@ -222,7 +223,7 @@ public class StatisticsService implements IClusterStatusSubscriber {
                 regionGroupStatisticsEntry.getValue().getRight().getRegionStatus(leftId));
           }
         }
-        for (int rightId : rightIds) {
+        for (Integer rightId : rightIds) {
           if (!leftIds.contains(rightId)) {
             LOGGER.info(
                 "[RegionGroupStatistics]\t Region in DataNode {}: null -> {}",
@@ -244,7 +245,8 @@ public class StatisticsService implements IClusterStatusSubscriber {
     LOGGER.info("[RegionLeader] RegionLeaderMap: ");
     for (Map.Entry<TConsensusGroupId, Pair<Integer, Integer>> regionLeaderEntry :
         leaderMap.entrySet()) {
-      if (!regionLeaderEntry.getValue().getRight().equals(regionLeaderEntry.getValue().getLeft())) {
+      if (!Objects.equals(
+          regionLeaderEntry.getValue().getRight(), regionLeaderEntry.getValue().getLeft())) {
         LOGGER.info(
             "[RegionLeader]\t {}: {}->{}",
             regionLeaderEntry.getKey(),
@@ -259,10 +261,8 @@ public class StatisticsService implements IClusterStatusSubscriber {
     LOGGER.info("[RegionPriority] RegionPriorityMap: ");
     for (Map.Entry<TConsensusGroupId, Pair<TRegionReplicaSet, TRegionReplicaSet>>
         regionPriorityEntry : priorityMap.entrySet()) {
-      if (!regionPriorityEntry
-          .getValue()
-          .getRight()
-          .equals(regionPriorityEntry.getValue().getLeft())) {
+      if (!Objects.equals(
+          regionPriorityEntry.getValue().getRight(), regionPriorityEntry.getValue().getLeft())) {
         LOGGER.info(
             "[RegionPriority]\t {}: {}->{}",
             regionPriorityEntry.getKey(),

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/service/StatisticsService.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/service/StatisticsService.java
@@ -36,7 +36,6 @@ import org.apache.iotdb.confignode.manager.load.balancer.RouteBalancer;
 import org.apache.iotdb.confignode.manager.load.cache.LoadCache;
 import org.apache.iotdb.confignode.manager.load.cache.node.NodeStatistics;
 import org.apache.iotdb.confignode.manager.load.cache.region.RegionGroupStatistics;
-import org.apache.iotdb.confignode.manager.load.cache.region.RegionStatistics;
 import org.apache.iotdb.confignode.manager.load.subscriber.IClusterStatusSubscriber;
 import org.apache.iotdb.confignode.manager.load.subscriber.RouteChangeEvent;
 import org.apache.iotdb.confignode.manager.load.subscriber.StatisticsChangeEvent;
@@ -48,6 +47,7 @@ import com.google.common.eventbus.EventBus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
@@ -180,10 +180,13 @@ public class StatisticsService implements IClusterStatusSubscriber {
     LOGGER.info("[NodeStatistics] NodeStatisticsMap: ");
     for (Map.Entry<Integer, Pair<NodeStatistics, NodeStatistics>> nodeCacheEntry :
         differentNodeStatisticsMap.entrySet()) {
-      LOGGER.info(
-          "[NodeStatistics]\t {}={}",
-          "nodeId{" + nodeCacheEntry.getKey() + "}",
-          nodeCacheEntry.getValue().getRight());
+      if (!nodeCacheEntry.getValue().getRight().equals(nodeCacheEntry.getValue().getLeft())) {
+        LOGGER.info(
+            "[NodeStatistics]\t {}: {}->{}",
+            "nodeId{" + nodeCacheEntry.getKey() + "}",
+            nodeCacheEntry.getValue().getLeft(),
+            nodeCacheEntry.getValue().getRight());
+      }
     }
   }
 
@@ -193,14 +196,40 @@ public class StatisticsService implements IClusterStatusSubscriber {
     LOGGER.info("[RegionGroupStatistics] RegionGroupStatisticsMap: ");
     for (Map.Entry<TConsensusGroupId, Pair<RegionGroupStatistics, RegionGroupStatistics>>
         regionGroupStatisticsEntry : differentRegionGroupStatisticsMap.entrySet()) {
-      LOGGER.info("[RegionGroupStatistics]\t RegionGroup: {}", regionGroupStatisticsEntry.getKey());
-      LOGGER.info("[RegionGroupStatistics]\t {}", regionGroupStatisticsEntry.getValue());
-      for (Map.Entry<Integer, RegionStatistics> regionStatisticsEntry :
-          regionGroupStatisticsEntry.getValue().getRight().getRegionStatisticsMap().entrySet()) {
+      if (!regionGroupStatisticsEntry
+          .getValue()
+          .getRight()
+          .equals(regionGroupStatisticsEntry.getValue().getLeft())) {
         LOGGER.info(
-            "[RegionGroupStatistics]\t dataNodeId{}={}",
-            regionStatisticsEntry.getKey(),
-            regionStatisticsEntry.getValue());
+            "[RegionGroupStatistics]\t RegionGroup {}: {} -> {}",
+            regionGroupStatisticsEntry.getKey(),
+            regionGroupStatisticsEntry.getValue().getLeft().getRegionGroupStatus(),
+            regionGroupStatisticsEntry.getValue().getRight().getRegionGroupStatus());
+
+        List<Integer> leftIds = regionGroupStatisticsEntry.getValue().getLeft().getRegionIds();
+        List<Integer> rightIds = regionGroupStatisticsEntry.getValue().getRight().getRegionIds();
+        for (int leftId : leftIds) {
+          if (!rightIds.contains(leftId)) {
+            LOGGER.info(
+                "[RegionGroupStatistics]\t Region in DataNode {}: {} -> null",
+                leftId,
+                regionGroupStatisticsEntry.getValue().getLeft().getRegionStatus(leftId));
+          } else {
+            LOGGER.info(
+                "[RegionGroupStatistics]\t Region in DataNode {}: {} -> {}",
+                leftId,
+                regionGroupStatisticsEntry.getValue().getLeft().getRegionStatus(leftId),
+                regionGroupStatisticsEntry.getValue().getRight().getRegionStatus(leftId));
+          }
+        }
+        for (int rightId : rightIds) {
+          if (!leftIds.contains(rightId)) {
+            LOGGER.info(
+                "[RegionGroupStatistics]\t Region in DataNode {}: null -> {}",
+                rightId,
+                regionGroupStatisticsEntry.getValue().getRight().getRegionStatus(rightId));
+          }
+        }
       }
     }
   }
@@ -215,11 +244,13 @@ public class StatisticsService implements IClusterStatusSubscriber {
     LOGGER.info("[RegionLeader] RegionLeaderMap: ");
     for (Map.Entry<TConsensusGroupId, Pair<Integer, Integer>> regionLeaderEntry :
         leaderMap.entrySet()) {
-      LOGGER.info(
-          "[RegionLeader]\t {}: {}->{}",
-          regionLeaderEntry.getKey(),
-          regionLeaderEntry.getValue().getLeft(),
-          regionLeaderEntry.getValue().getRight());
+      if (!regionLeaderEntry.getValue().getRight().equals(regionLeaderEntry.getValue().getLeft())) {
+        LOGGER.info(
+            "[RegionLeader]\t {}: {}->{}",
+            regionLeaderEntry.getKey(),
+            regionLeaderEntry.getValue().getLeft(),
+            regionLeaderEntry.getValue().getRight());
+      }
     }
   }
 
@@ -228,12 +259,22 @@ public class StatisticsService implements IClusterStatusSubscriber {
     LOGGER.info("[RegionPriority] RegionPriorityMap: ");
     for (Map.Entry<TConsensusGroupId, Pair<TRegionReplicaSet, TRegionReplicaSet>>
         regionPriorityEntry : priorityMap.entrySet()) {
-      LOGGER.info(
-          "[RegionPriority]\t {}={}",
-          regionPriorityEntry.getKey(),
-          regionPriorityEntry.getValue().getRight().getDataNodeLocations().stream()
-              .map(TDataNodeLocation::getDataNodeId)
-              .collect(Collectors.toList()));
+      if (!regionPriorityEntry
+          .getValue()
+          .getRight()
+          .equals(regionPriorityEntry.getValue().getLeft())) {
+        LOGGER.info(
+            "[RegionPriority]\t {}: {}->{}",
+            regionPriorityEntry.getKey(),
+            regionPriorityEntry.getValue().getLeft() == null
+                ? "null"
+                : regionPriorityEntry.getValue().getLeft().getDataNodeLocations().stream()
+                    .map(TDataNodeLocation::getDataNodeId)
+                    .collect(Collectors.toList()),
+            regionPriorityEntry.getValue().getRight().getDataNodeLocations().stream()
+                .map(TDataNodeLocation::getDataNodeId)
+                .collect(Collectors.toList()));
+      }
     }
   }
 


### PR DESCRIPTION
Format LoadStatistics logs to improve readability. Add ClusterIT to make sure the leader of DataRegionGroup will re-distribute as long as some DataNodes turn into ReadOnly Status.

**LoadStatistics log examples:**
```
2023-06-29 10:38:34,820 [pool-2-thread-3] INFO  o.a.i.c.m.l.s.StatisticsService:180 - [NodeStatistics] NodeStatisticsMap:  
2023-06-29 10:38:34,821 [pool-2-thread-3] INFO  o.a.i.c.m.l.s.StatisticsService:184 - [NodeStatistics]	 nodeId{1}: NodeStatistics{loadScore=9223372036854775807, status=Unknown, statusReason='null'}->NodeStatistics{loadScore=0, status=Running, statusReason='null'} 
2023-06-29 10:38:45,906 [pool-2-thread-2] INFO  o.a.i.c.m.l.s.StatisticsService:244 - [RegionLeader] RegionLeaderMap:  
2023-06-29 10:38:45,906 [pool-2-thread-2] INFO  o.a.i.c.m.l.s.StatisticsService:248 - [RegionLeader]	 TConsensusGroupId(type:SchemaRegion, id:0): -1->1 
2023-06-29 10:38:45,906 [pool-2-thread-2] INFO  o.a.i.c.m.l.s.StatisticsService:259 - [RegionPriority] RegionPriorityMap:  
2023-06-29 10:38:45,907 [pool-2-thread-2] INFO  o.a.i.c.m.l.s.StatisticsService:266 - [RegionPriority]	 TConsensusGroupId(type:SchemaRegion, id:0): null->[1, 2, 3] 
2023-06-29 10:38:45,908 [pool-2-thread-1] INFO  o.a.i.c.m.l.s.StatisticsService:196 - [RegionGroupStatistics] RegionGroupStatisticsMap: 
2023-06-29 10:38:45,908 [pool-2-thread-1] INFO  o.a.i.c.m.l.s.StatisticsService:203 - [RegionGroupStatistics]	 RegionGroup TConsensusGroupId(type:SchemaRegion, id:0): Disabled -> Running 
2023-06-29 10:38:45,908 [pool-2-thread-1] INFO  o.a.i.c.m.l.s.StatisticsService:227 - [RegionGroupStatistics]	 Region in DataNode 1: null -> Running 
2023-06-29 10:38:45,908 [pool-2-thread-1] INFO  o.a.i.c.m.l.s.StatisticsService:227 - [RegionGroupStatistics]	 Region in DataNode 2: null -> Running 
2023-06-29 10:38:45,908 [pool-2-thread-1] INFO  o.a.i.c.m.l.s.StatisticsService:227 - [RegionGroupStatistics]	 Region in DataNode 3: null -> Running 
2023-06-29 10:40:00,239 [pool-2-thread-4] INFO  o.a.i.c.m.l.s.StatisticsService:180 - [NodeStatistics] NodeStatisticsMap:  
2023-06-29 10:40:00,239 [pool-2-thread-4] INFO  o.a.i.c.m.l.s.StatisticsService:184 - [NodeStatistics]	 nodeId{1}: NodeStatistics{loadScore=0, status=Running, statusReason='null'}->NodeStatistics{loadScore=9223372036854775807, status=ReadOnly, statusReason='null'} 
2023-06-29 10:40:00,239 [pool-2-thread-4] INFO  o.a.i.c.m.l.s.StatisticsService:196 - [RegionGroupStatistics] RegionGroupStatisticsMap:  
2023-06-29 10:40:00,239 [pool-2-thread-4] INFO  o.a.i.c.m.l.s.StatisticsService:203 - [RegionGroupStatistics]	 RegionGroup TConsensusGroupId(type:DataRegion, id:5): Running -> Discouraged 
2023-06-29 10:40:00,239 [pool-2-thread-4] INFO  o.a.i.c.m.l.s.StatisticsService:218 - [RegionGroupStatistics]	 Region in DataNode 1: Running -> ReadOnly 
2023-06-29 10:40:00,239 [pool-2-thread-4] INFO  o.a.i.c.m.l.s.StatisticsService:218 - [RegionGroupStatistics]	 Region in DataNode 2: Running -> Running 
2023-06-29 10:40:00,239 [pool-2-thread-4] INFO  o.a.i.c.m.l.s.StatisticsService:218 - [RegionGroupStatistics]	 Region in DataNode 3: Running -> Running 
```