### PR TITLE
Add UT for template related logic on ConfigNode

### DIFF
--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/schema/ClusterSchemaInfoTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/schema/ClusterSchemaInfoTest.java
@@ -20,18 +20,26 @@
 package org.apache.iotdb.confignode.persistence.schema;
 
 import org.apache.iotdb.commons.exception.IllegalPathException;
+import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.utils.PathUtils;
 import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlanType;
 import org.apache.iotdb.confignode.consensus.request.read.database.GetDatabasePlan;
 import org.apache.iotdb.confignode.consensus.request.read.template.GetPathsSetTemplatePlan;
+import org.apache.iotdb.confignode.consensus.request.read.template.GetTemplateSetInfoPlan;
 import org.apache.iotdb.confignode.consensus.request.write.database.DatabaseSchemaPlan;
 import org.apache.iotdb.confignode.consensus.request.write.template.CreateSchemaTemplatePlan;
+import org.apache.iotdb.confignode.consensus.request.write.template.PreSetSchemaTemplatePlan;
 import org.apache.iotdb.confignode.consensus.request.write.template.SetSchemaTemplatePlan;
+import org.apache.iotdb.confignode.consensus.response.template.AllTemplateSetInfoResp;
+import org.apache.iotdb.confignode.consensus.response.template.TemplateInfoResp;
+import org.apache.iotdb.confignode.consensus.response.template.TemplateSetInfoResp;
 import org.apache.iotdb.confignode.rpc.thrift.TDatabaseSchema;
 import org.apache.iotdb.db.schemaengine.template.Template;
+import org.apache.iotdb.db.schemaengine.template.TemplateInternalRPCUtil;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.iotdb.tsfile.utils.Pair;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
@@ -41,7 +49,9 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -148,5 +158,73 @@ public class ClusterSchemaInfoTest {
     List<CompressionType> compressors =
         Arrays.asList(CompressionType.SNAPPY, CompressionType.SNAPPY);
     return new Template(name, measurements, dataTypes, encodings, compressors);
+  }
+
+  @Test
+  public void testTemplateSetAndRead() throws Exception {
+    Template t1 =
+        new Template(
+            "t1",
+            Arrays.asList("s1", "s2"),
+            Arrays.asList(TSDataType.INT32, TSDataType.BOOLEAN),
+            Arrays.asList(TSEncoding.GORILLA, TSEncoding.PLAIN),
+            Arrays.asList(CompressionType.GZIP, CompressionType.SNAPPY));
+    Template t2 =
+        new Template(
+            "t2",
+            Arrays.asList("s1", "s2", "s3"),
+            Arrays.asList(TSDataType.INT32, TSDataType.BOOLEAN, TSDataType.TEXT),
+            Arrays.asList(TSEncoding.GORILLA, TSEncoding.PLAIN, TSEncoding.DIFF),
+            Arrays.asList(CompressionType.GZIP, CompressionType.SNAPPY, CompressionType.LZ4));
+
+    clusterSchemaInfo.createSchemaTemplate(new CreateSchemaTemplatePlan(t1.serialize().array()));
+    clusterSchemaInfo.createSchemaTemplate(new CreateSchemaTemplatePlan(t2.serialize().array()));
+
+    clusterSchemaInfo.createDatabase(
+        new DatabaseSchemaPlan(
+            ConfigPhysicalPlanType.CreateDatabase, new TDatabaseSchema("root.db1")));
+    clusterSchemaInfo.createDatabase(
+        new DatabaseSchemaPlan(
+            ConfigPhysicalPlanType.CreateDatabase, new TDatabaseSchema("root.db2")));
+
+    clusterSchemaInfo.setSchemaTemplate(new SetSchemaTemplatePlan("t1", "root.db1"));
+    clusterSchemaInfo.preSetSchemaTemplate(new PreSetSchemaTemplatePlan("t2", "root.db2"));
+
+    TemplateInfoResp templateInfoResp = clusterSchemaInfo.getAllTemplates();
+    List<Template> templateList = templateInfoResp.getTemplateList();
+    templateList.sort(Comparator.comparing(Template::getName));
+    Assert.assertEquals(2, templateList.size());
+    Assert.assertEquals(t1, templateList.get(0));
+    Assert.assertEquals(t2, templateList.get(1));
+
+    AllTemplateSetInfoResp allTemplateSetInfoResp = clusterSchemaInfo.getAllTemplateSetInfo();
+    Map<Template, List<Pair<String, Boolean>>> map =
+        TemplateInternalRPCUtil.parseAddAllTemplateSetInfoBytes(
+            ByteBuffer.wrap(allTemplateSetInfoResp.getTemplateInfo()));
+    Assert.assertEquals(2, map.size());
+    for (Template template : map.keySet()) {
+      Assert.assertEquals(1, map.get(template).size());
+      if (template.getName().equals("t1")) {
+        Assert.assertEquals("root.db1", map.get(template).get(0).left);
+        Assert.assertFalse("root.db1", map.get(template).get(0).right);
+      } else if (template.getName().equals("t2")) {
+        Assert.assertEquals("root.db2", map.get(template).get(0).left);
+        Assert.assertTrue(map.get(template).get(0).right);
+      }
+    }
+
+    List<PartialPath> pathList =
+        Arrays.asList(
+            new PartialPath("root.db1"),
+            new PartialPath("root.db1.**"),
+            new PartialPath("root.db2"),
+            new PartialPath("root.db2.**"));
+    Template[] templates = new Template[] {t1, t1, t2, t2};
+    TemplateSetInfoResp templateSetInfoResp =
+        clusterSchemaInfo.getTemplateSetInfo(new GetTemplateSetInfoPlan(pathList));
+    Map<PartialPath, List<Template>> templateSetMap = templateSetInfoResp.getPatternTemplateMap();
+    for (int i = 0; i < pathList.size(); i++) {
+      Assert.assertEquals(templates[i], templateSetMap.get(pathList.get(i)).get(0));
+    }
   }
 }

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/schema/DeactivateTemplateProcedureTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/schema/DeactivateTemplateProcedureTest.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iotdb.confignode.procedure.impl;
+package org.apache.iotdb.confignode.procedure.impl.schema;
 
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/schema/DeleteDatabaseProcedureTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/schema/DeleteDatabaseProcedureTest.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iotdb.confignode.procedure.impl;
+package org.apache.iotdb.confignode.procedure.impl.schema;
 
 import org.apache.iotdb.confignode.procedure.impl.schema.DeleteDatabaseProcedure;
 import org.apache.iotdb.confignode.procedure.store.ProcedureFactory;

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/schema/DeleteTimeSeriesProcedureTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/schema/DeleteTimeSeriesProcedureTest.java
@@ -17,16 +17,13 @@
  * under the License.
  */
 
-package org.apache.iotdb.confignode.procedure.impl;
+package org.apache.iotdb.confignode.procedure.impl.schema;
 
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
-import org.apache.iotdb.confignode.procedure.impl.schema.UnsetTemplateProcedure;
+import org.apache.iotdb.commons.path.PathPatternTree;
+import org.apache.iotdb.confignode.procedure.impl.schema.DeleteTimeSeriesProcedure;
 import org.apache.iotdb.confignode.procedure.store.ProcedureType;
-import org.apache.iotdb.db.schemaengine.template.Template;
-import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
-import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
-import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -35,41 +32,37 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.List;
 
-public class UnsetTemplateProcedureTest {
+public class DeleteTimeSeriesProcedureTest {
 
   @Test
   public void serializeDeserializeTest() throws IllegalPathException, IOException {
     String queryId = "1";
-    Template template = new Template();
-    template.setId(0);
-    template.setName("t1");
-    template.addMeasurements(
-        new String[] {"s1", "s2"},
-        new TSDataType[] {TSDataType.INT32, TSDataType.FLOAT},
-        new TSEncoding[] {TSEncoding.PLAIN, TSEncoding.BITMAP},
-        new CompressionType[] {CompressionType.UNCOMPRESSED, CompressionType.GZIP});
-    PartialPath path = new PartialPath("root.sg");
-    UnsetTemplateProcedure unsetTemplateProcedure =
-        new UnsetTemplateProcedure(queryId, template, path);
+    PathPatternTree patternTree = new PathPatternTree();
+    patternTree.appendPathPattern(new PartialPath("root.sg1.**"));
+    patternTree.appendPathPattern(new PartialPath("root.sg2.*.s1"));
+    patternTree.constructTree();
+    DeleteTimeSeriesProcedure deleteTimeSeriesProcedure =
+        new DeleteTimeSeriesProcedure(queryId, patternTree);
 
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
-    unsetTemplateProcedure.serialize(dataOutputStream);
+    deleteTimeSeriesProcedure.serialize(dataOutputStream);
 
     ByteBuffer byteBuffer = ByteBuffer.wrap(byteArrayOutputStream.toByteArray());
 
     Assert.assertEquals(
-        ProcedureType.UNSET_TEMPLATE_PROCEDURE.getTypeCode(), byteBuffer.getShort());
+        ProcedureType.DELETE_TIMESERIES_PROCEDURE.getTypeCode(), byteBuffer.getShort());
 
-    UnsetTemplateProcedure deserializedProcedure = new UnsetTemplateProcedure();
+    DeleteTimeSeriesProcedure deserializedProcedure = new DeleteTimeSeriesProcedure();
     deserializedProcedure.deserialize(byteBuffer);
 
     Assert.assertEquals(queryId, deserializedProcedure.getQueryId());
-    Assert.assertEquals(template.getId(), deserializedProcedure.getTemplateId());
-    Assert.assertEquals(template.getName(), deserializedProcedure.getTemplateName());
-    Assert.assertEquals(
-        template.getSchemaMap(), deserializedProcedure.getTemplate().getSchemaMap());
-    Assert.assertEquals(path, deserializedProcedure.getPath());
+
+    List<PartialPath> pathList = deserializedProcedure.getPatternTree().getAllPathPatterns();
+    pathList.sort(PartialPath::compareTo);
+    Assert.assertEquals("root.sg1.**", pathList.get(0).getFullPath());
+    Assert.assertEquals("root.sg2.*.s1", pathList.get(1).getFullPath());
   }
 }


### PR DESCRIPTION
## Description

Add UT to improve code coverage of the following package:
1. iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/response/template
2. iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/schema