### PR TITLE
[To rel/1.2] Change default charset encoding to UTF-8 in start-datanode.bat 

### DIFF
--- a/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
+++ b/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
@@ -55,6 +55,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.concurrent.TimeUnit;
 
 public class ConfigNode implements ConfigNodeMBean {
@@ -90,6 +91,10 @@ public class ConfigNode implements ConfigNodeMBean {
         "{} environment variables: {}",
         ConfigNodeConstant.GLOBAL_NAME,
         ConfigNodeConfig.getEnvironmentVariables());
+    LOGGER.info(
+        "{} default charset is: {}",
+        ConfigNodeConstant.GLOBAL_NAME,
+        Charset.defaultCharset().displayName());
     new ConfigNodeCommandLine().doMain(args);
   }
 

--- a/server/src/assembly/resources/sbin/start-datanode.bat
+++ b/server/src/assembly/resources/sbin/start-datanode.bat
@@ -205,7 +205,9 @@ set JAVA_OPTS=-ea^
  -DIOTDB_HOME="%IOTDB_HOME%"^
  -DTSFILE_HOME="%IOTDB_HOME%"^
  -DTSFILE_CONF="%IOTDB_CONF%"^
- -DIOTDB_CONF="%IOTDB_CONF%"
+ -DIOTDB_CONF="%IOTDB_CONF%"^
+ -Dsun.jnu.encoding=UTF-8^
+ -Dfile.encoding=UTF-8
 
 @REM ----------------------------------------------------------------------------
 @REM ***** CLASSPATH library setting *****

--- a/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/server/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -92,6 +92,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -145,6 +146,7 @@ public class DataNode implements DataNodeMBean {
 
   public static void main(String[] args) {
     logger.info("IoTDB-DataNode environment variables: {}", IoTDBConfig.getEnvironmentVariables());
+    logger.info("IoTDB-DataNode default charset is: {}", Charset.defaultCharset().displayName());
     new DataNodeServerCommandLine().doMain(args);
   }
 


### PR DESCRIPTION
## Description
1. Change default charset encoding to UTF-8 in `start-datanode.bat`
2. Add log when DataNode/ConfigNode starts to print the default charset

![image](https://github.com/apache/iotdb/assets/18027703/81875f5a-192a-433d-86e9-53b49e145c67)


NOTICE: Before this change, the explicit setting has only been added in `start-confignode.bat`. To keep the setting is consistent between DataNode and ConfigNode, we add the explicit charset encoding setting in script for windows. 

<img width="571" alt="image" src="https://github.com/apache/iotdb/assets/18027703/08c697df-8dcd-4d2d-93f9-49df19fe835a">
