### PR TITLE
fix the error in wal throttle log which print wrong threshold

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/WALManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/WALManager.java
@@ -181,7 +181,7 @@ public class WALManager implements IService {
       logger.warn(
           "WAL disk usage {} is larger than the iot_consensus_throttle_threshold_in_byte {}, please check your write load, iot consensus and the pipe module. It's better to allocate more disk for WAL.",
           getTotalDiskUsage(),
-          config.getThrottleThreshold());
+          getThrottleThreshold());
     }
   }
 
@@ -204,7 +204,11 @@ public class WALManager implements IService {
   }
 
   public boolean shouldThrottle() {
-    return getTotalDiskUsage() >= config.getThrottleThreshold() * 0.8;
+    return getTotalDiskUsage() >= getThrottleThreshold();
+  }
+
+  public long getThrottleThreshold() {
+    return (long) (config.getThrottleThreshold() * 0.8);
   }
 
   public long getTotalDiskUsage() {


### PR DESCRIPTION
## Description

Before this change, the log print original max_wal_size when throttling down. Actually its use `max_wal_size * 0.8` as the threshold of throttle down.

This PR fix this isssue. 
