### PR TITLE
[To rel/1.2][IOTDB-6023] Pipe:  Fix load tsfile error while handling empty value chunk 

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/load/TsFileSplitter.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/load/TsFileSplitter.java
@@ -229,7 +229,8 @@ public class TsFileSplitter {
             chunkMetadata = offset2ChunkMetadata.get(chunkOffset - Byte.BYTES);
             header = reader.readChunkHeader(marker);
             if (header.getDataSize() == 0) {
-              handleEmptyValueChunk(header, pageIndex2ChunkData, chunkMetadata);
+              handleEmptyValueChunk(
+                  header, pageIndex2ChunkData, chunkMetadata, isTimeChunkNeedDecode);
               break;
             }
 
@@ -423,14 +424,18 @@ public class TsFileSplitter {
   private void handleEmptyValueChunk(
       ChunkHeader header,
       Map<Integer, List<AlignedChunkData>> pageIndex2ChunkData,
-      IChunkMetadata chunkMetadata)
+      IChunkMetadata chunkMetadata,
+      boolean isTimeChunkNeedDecode)
       throws IOException {
     Set<ChunkData> allChunkData = new HashSet<>();
     for (Map.Entry<Integer, List<AlignedChunkData>> entry : pageIndex2ChunkData.entrySet()) {
       for (AlignedChunkData alignedChunkData : entry.getValue()) {
         if (!allChunkData.contains(alignedChunkData)) {
           alignedChunkData.addValueChunk(header);
-          alignedChunkData.writeEntireChunk(ByteBuffer.allocate(0), chunkMetadata);
+          if (!isTimeChunkNeedDecode) {
+            alignedChunkData.writeEntireChunk(ByteBuffer.allocate(0), chunkMetadata);
+          }
+
           allChunkData.add(alignedChunkData);
         }
       }


### PR DESCRIPTION
add isTimeChunkNeedDecode to handle whether need to writeEntireChunk.
<img width="821" alt="image" src="https://github.com/apache/iotdb/assets/42286868/31a0df50-7263-4800-a6e3-d3f5de31fc75">

