### PR TITLE
[IOTDB-6023] Pipe: Fix load tsfile while handling empty value chunk

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/load/TsFileSplitter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/load/TsFileSplitter.java
@@ -230,7 +230,8 @@ public class TsFileSplitter {
             chunkMetadata = offset2ChunkMetadata.get(chunkOffset - Byte.BYTES);
             header = reader.readChunkHeader(marker);
             if (header.getDataSize() == 0) {
-              handleEmptyValueChunk(header, pageIndex2ChunkData, chunkMetadata);
+              handleEmptyValueChunk(
+                  header, pageIndex2ChunkData, chunkMetadata, isTimeChunkNeedDecode);
               break;
             }
 
@@ -423,14 +424,17 @@ public class TsFileSplitter {
   private void handleEmptyValueChunk(
       ChunkHeader header,
       Map<Integer, List<AlignedChunkData>> pageIndex2ChunkData,
-      IChunkMetadata chunkMetadata)
+      IChunkMetadata chunkMetadata,
+      boolean isTimeChunkNeedDecode)
       throws IOException {
     Set<ChunkData> allChunkData = new HashSet<>();
     for (Map.Entry<Integer, List<AlignedChunkData>> entry : pageIndex2ChunkData.entrySet()) {
       for (AlignedChunkData alignedChunkData : entry.getValue()) {
         if (!allChunkData.contains(alignedChunkData)) {
           alignedChunkData.addValueChunk(header);
-          alignedChunkData.writeEntireChunk(ByteBuffer.allocate(0), chunkMetadata);
+          if (!isTimeChunkNeedDecode) {
+            alignedChunkData.writeEntireChunk(ByteBuffer.allocate(0), chunkMetadata);
+          }
           allChunkData.add(alignedChunkData);
         }
       }


### PR DESCRIPTION
add isTimeChunkNeedDecode to handle whether need to writeEntireChunk.

<img width="722" alt="image" src="https://github.com/apache/iotdb/assets/42286868/4d4bfd5e-35b7-46a4-a58d-178d80a8ffcf">
