### PR TITLE
[To rel/1.2] Make error messages more detailed when creating and upserting templates

### DIFF
--- a/confignode/src/test/java/org/apache/iotdb/confignode/persistence/schema/TemplateTableTest.java
+++ b/confignode/src/test/java/org/apache/iotdb/confignode/persistence/schema/TemplateTableTest.java
@@ -88,6 +88,21 @@ public class TemplateTableTest {
     }
   }
 
+  @Test
+  public void testDuplicatePath() {
+    List<String> measurements = Arrays.asList("s1", "s1");
+    List<TSDataType> dataTypes = Arrays.asList(TSDataType.FLOAT, TSDataType.BOOLEAN);
+    List<TSEncoding> encodings = Arrays.asList(TSEncoding.RLE, TSEncoding.PLAIN);
+    List<CompressionType> compressors =
+        Arrays.asList(CompressionType.SNAPPY, CompressionType.SNAPPY);
+    try {
+      new Template("template", measurements, dataTypes, encodings, compressors);
+      Assert.fail("expect IllegalPathException");
+    } catch (IllegalPathException e) {
+      // do nothing
+    }
+  }
+
   private Template newSchemaTemplate(String name) throws IllegalPathException {
     List<String> measurements = Arrays.asList(name + "_" + "temperature", name + "_" + "status");
     List<TSDataType> dataTypes = Arrays.asList(TSDataType.FLOAT, TSDataType.BOOLEAN);

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBSchemaTemplateIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBSchemaTemplateIT.java
@@ -800,4 +800,32 @@ public class IoTDBSchemaTemplateIT extends AbstractSchemaIT {
       Assert.assertTrue(expectedResult.isEmpty());
     }
   }
+
+  @Test
+  public void testAlterTemplateTimeseries() throws Exception {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("SET SCHEMA TEMPLATE t1 TO root.sg1.d1;");
+      statement.execute("CREATE TIMESERIES OF SCHEMA TEMPLATE ON root.sg1.d1;");
+      try {
+        statement.execute(
+            "ALTER timeseries root.sg1.d1.s1 UPSERT tags(s0_tag1=s0_tag1, s0_tag2=s0_tag2) attributes(s0_attr1=s0_attr1, s0_attr2=s0_attr2);");
+        Assert.fail("expect exception because the template timeseries does not support tag");
+      } catch (Exception e) {
+        Assert.assertTrue(
+            e.getMessage()
+                .contains(
+                    "Cannot alter template timeseries [root.sg1.d1.s1] since schema template [t1] already set on path [root.sg1.d1]"));
+      }
+      try {
+        statement.execute("ALTER timeseries root.sg1.d1.s1 UPSERT ALIAS=s0Alias;");
+        Assert.fail("expect exception because the template timeseries does not support alias");
+      } catch (Exception e) {
+        Assert.assertTrue(
+            e.getMessage()
+                .contains(
+                    "Cannot alter template timeseries [root.sg1.d1.s1] since schema template [t1] already set on path [root.sg1.d1]"));
+      }
+    }
+  }
 }

--- a/server/src/main/java/org/apache/iotdb/db/metadata/template/Template.java
+++ b/server/src/main/java/org/apache/iotdb/db/metadata/template/Template.java
@@ -73,6 +73,9 @@ public class Template implements Serializable {
     this.schemaMap = new ConcurrentHashMap<>();
     this.name = name;
     for (int i = 0; i < measurements.size(); i++) {
+      if (schemaMap.containsKey(measurements.get(i))) {
+        throw new IllegalPathException("Path duplicated: " + measurements.get(i));
+      }
       IMeasurementSchema schema =
           new MeasurementSchema(
               measurements.get(i), dataTypes.get(i), encodings.get(i), compressors.get(i));

--- a/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
+++ b/server/src/main/java/org/apache/iotdb/db/mpp/plan/analyze/AnalyzeVisitor.java
@@ -2100,9 +2100,17 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     Analysis analysis = new Analysis();
     analysis.setStatement(alterTimeSeriesStatement);
 
-    if (alterTimeSeriesStatement.getAlias() != null) {
-      checkIsTemplateCompatible(
-          alterTimeSeriesStatement.getPath(), alterTimeSeriesStatement.getAlias());
+    Pair<Template, PartialPath> templateInfo =
+        schemaFetcher.checkTemplateSetAndPreSetInfo(
+            alterTimeSeriesStatement.getPath(), alterTimeSeriesStatement.getAlias());
+    if (templateInfo != null) {
+      throw new RuntimeException(
+          new TemplateImcompatibeException(
+              String.format(
+                  "Cannot alter template timeseries [%s] since schema template [%s] already set on path [%s].",
+                  alterTimeSeriesStatement.getPath().getFullPath(),
+                  templateInfo.left.getName(),
+                  templateInfo.right)));
     }
 
     PathPatternTree patternTree = new PathPatternTree();


### PR DESCRIPTION
## Description

* Print duplicated path when creating template 
![image](https://github.com/apache/iotdb/assets/43774645/2758507b-1b8b-4082-9e23-fa9e7cac84e1)

* Print reasons for not supporting upsert timeseries
![image](https://github.com/apache/iotdb/assets/43774645/5c420ad7-f53d-44d9-ab8b-6f0d1c7252f0)
