### PR TITLE
Fix show paths using template return partition result

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
@@ -3199,7 +3199,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
 
     analysis.setSpecifiedTemplateRelatedPathPatternList(specifiedPatternList);
 
-    SchemaPartition partition = partitionFetcher.getOrCreateSchemaPartition(patternTree);
+    SchemaPartition partition = partitionFetcher.getSchemaPartition(patternTree);
     analysis.setSchemaPartitionInfo(partition);
     if (partition.isEmpty()) {
       analysis.setFinishQueryAfterAnalyze(true);


### PR DESCRIPTION
## Description

cherry-pick #10330 


<img width="1330" alt="image" src="https://github.com/apache/iotdb/assets/43774645/cbd2a276-ae58-49b1-8e97-a167f6630b8c">

This issue is due to the incorrect use of the getOrCreateSchemaPartition interface when pulling schema partitions. The getOrCreateSchemaPartition interface ignores the pathPattern with suffix **. This pr resolve this problem.

