### PR TITLE
Fix semantic incompatibility when AtomicReference replaces volatile

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -208,7 +208,7 @@ public class ConfigManager implements IManager {
   private static final CommonConfig COMMON_CONF = CommonDescriptor.getInstance().getConfig();
 
   /** Manage PartitionTable read/write requests through the ConsensusLayer. */
-  private AtomicReference<ConsensusManager> consensusManager;
+  private final AtomicReference<ConsensusManager> consensusManager = new AtomicReference<>();
 
   /** Manage cluster node. */
   private final NodeManager nodeManager;
@@ -305,12 +305,11 @@ public class ConfigManager implements IManager {
   }
 
   public void initConsensusManager() throws IOException {
-    ConsensusManager consensusManager = new ConsensusManager(this, this.stateMachine);
-    this.consensusManager = new AtomicReference<>(consensusManager);
+    this.consensusManager.set(new ConsensusManager(this, this.stateMachine));
   }
 
   public void close() throws IOException {
-    if (consensusManager != null) {
+    if (consensusManager.get() != null) {
       consensusManager.get().close();
     }
     if (partitionManager != null) {
@@ -1122,7 +1121,7 @@ public class ConfigManager implements IManager {
   public TSStatus createPeerForConsensusGroup(List<TConfigNodeLocation> configNodeLocations) {
     for (int i = 0; i < 30; i++) {
       try {
-        if (consensusManager == null) {
+        if (consensusManager.get() == null) {
           Thread.sleep(1000);
         } else {
           // When add non Seed-ConfigNode to the ConfigNodeGroup, the parameter should be emptyList

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/Procedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/Procedure.java
@@ -64,7 +64,7 @@ public abstract class Procedure<Env> implements Comparable<Procedure<Env>> {
   private volatile long timeout = NO_TIMEOUT;
   private volatile long lastUpdate;
 
-  private AtomicReference<byte[]> result = null;
+  private final AtomicReference<byte[]> result = new AtomicReference<>();
   private volatile boolean locked = false;
   private boolean lockedWhenLoading = false;
 
@@ -173,7 +173,7 @@ public abstract class Procedure<Env> implements Comparable<Procedure<Env>> {
     }
 
     // result
-    if (result != null) {
+    if (result.get() != null) {
       stream.writeInt(result.get().length);
       stream.write(result.get());
     } else {
@@ -652,7 +652,7 @@ public abstract class Procedure<Env> implements Comparable<Procedure<Env>> {
    * @param result the serialized result that will be passed to the client
    */
   protected void setResult(byte[] result) {
-    this.result = new AtomicReference<>(result);
+    this.result.set(result);
   }
 
   /**

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RequestMessage.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RequestMessage.java
@@ -30,7 +30,7 @@ import java.util.concurrent.atomic.AtomicReference;
 class RequestMessage implements Message {
 
   private final IConsensusRequest actualRequest;
-  private AtomicReference<ByteString> serializedContent = new AtomicReference<>();
+  private final AtomicReference<ByteString> serializedContent = new AtomicReference<>();
 
   RequestMessage(IConsensusRequest request) {
     this.actualRequest = request;
@@ -45,9 +45,8 @@ class RequestMessage implements Message {
     if (serializedContent.get() == null) {
       synchronized (this) {
         if (serializedContent.get() == null) {
-          serializedContent =
-              new AtomicReference<>(
-                  UnsafeByteOperations.unsafeWrap(actualRequest.serializeToByteBuffer()));
+          serializedContent.set(
+              UnsafeByteOperations.unsafeWrap(actualRequest.serializeToByteBuffer()));
         }
       }
     }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ResponseMessage.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ResponseMessage.java
@@ -38,7 +38,7 @@ class ResponseMessage implements Message {
    */
   private final Object contentHolder;
 
-  private AtomicReference<ByteString> serializedData = new AtomicReference<>();
+  private final AtomicReference<ByteString> serializedData = new AtomicReference<>();
   private final Logger logger = LoggerFactory.getLogger(ResponseMessage.class);
 
   ResponseMessage(Object content) {
@@ -57,8 +57,7 @@ class ResponseMessage implements Message {
           assert contentHolder instanceof TSStatus;
           TSStatus status = (TSStatus) contentHolder;
           try {
-            serializedData =
-                new AtomicReference<>(ByteString.copyFrom(Utils.serializeTSStatus(status)));
+            serializedData.set(ByteString.copyFrom(Utils.serializeTSStatus(status)));
           } catch (TException e) {
             logger.warn("serialize TSStatus failed {}", status);
           }


### PR DESCRIPTION
The previous code might cause an error like this
![img_v2_1cd40617-e4b9-4602-b083-4bb3d3b20bcg](https://github.com/apache/iotdb/assets/32640567/482a02ba-9c7c-4364-9dac-d8e5fcd296f8)
