### PR TITLE
Fix count timeseries group by level return incorrect result

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBSchemaTemplateIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBSchemaTemplateIT.java
@@ -771,4 +771,33 @@ public class IoTDBSchemaTemplateIT extends AbstractSchemaIT {
       Assert.assertTrue(expectedResult.isEmpty());
     }
   }
+
+  @Test
+  public void testLevelCountWithTemplate() throws Exception {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("SET SCHEMA TEMPLATE t1 TO root.sg1.d1");
+      statement.execute("SET SCHEMA TEMPLATE t2 TO root.sg1.d2");
+      statement.execute("SET SCHEMA TEMPLATE t3 TO root.sg1.d3");
+      // create timeseries of schema template
+      statement.execute("CREATE TIMESERIES OF SCHEMA TEMPLATE ON root.sg1.d1");
+      statement.execute("CREATE TIMESERIES OF SCHEMA TEMPLATE ON root.sg1.d2");
+      statement.execute("CREATE TIMESERIES OF SCHEMA TEMPLATE ON root.sg1.d3");
+      // count
+      Set<String> expectedResult =
+          new HashSet<>(Arrays.asList("root.sg1.d1,2", "root.sg1.d2,2", "root.sg1.d3,1"));
+      try (ResultSet resultSet =
+          statement.executeQuery("COUNT TIMESERIES root.sg1.** group by level=2")) {
+        while (resultSet.next()) {
+          String actualResult =
+              resultSet.getString(ColumnHeaderConstant.COLUMN)
+                  + ","
+                  + resultSet.getString(ColumnHeaderConstant.COUNT_TIMESERIES);
+          Assert.assertTrue(expectedResult.contains(actualResult));
+          expectedResult.remove(actualResult);
+        }
+      }
+      Assert.assertTrue(expectedResult.isEmpty());
+    }
+  }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/CountGroupByLevelMergeOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/CountGroupByLevelMergeOperator.java
@@ -86,8 +86,7 @@ public class CountGroupByLevelMergeOperator implements ProcessOperator {
       throw new NoSuchElementException();
     }
     if (resultTsBlockList != null) {
-      currentIndex++;
-      return resultTsBlockList.get(currentIndex - 1);
+      return resultTsBlockList.get(currentIndex++);
     }
 
     boolean allChildrenConsumed = true;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/CountGroupByLevelScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/CountGroupByLevelScanOperator.java
@@ -62,6 +62,7 @@ public class CountGroupByLevelScanOperator<T extends ISchemaInfo> implements Sou
   private ISchemaReader<T> schemaReader;
   private ListenableFuture<?> isBlocked;
   private TsBlock next;
+  private boolean isFinished;
 
   public CountGroupByLevelScanOperator(
       PlanNodeId sourceId,
@@ -136,6 +137,7 @@ public class CountGroupByLevelScanOperator<T extends ISchemaInfo> implements Sou
         } else {
           if (countMap.isEmpty()) {
             next = null;
+            isFinished = true;
           } else {
             next = constructTsBlockAndClearMap(countMap);
           }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/CountGroupByLevelScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/CountGroupByLevelScanOperator.java
@@ -35,6 +35,7 @@ import org.apache.iotdb.tsfile.utils.Binary;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -104,9 +105,14 @@ public class CountGroupByLevelScanOperator<T extends ISchemaInfo> implements Sou
       try {
         ListenableFuture<?> readerBlocked = schemaReader.isBlocked();
         if (!readerBlocked.isDone()) {
+          SettableFuture<?> settableFuture = SettableFuture.create();
           readerBlocked.addListener(
-              () -> next = constructTsBlockAndClearMap(countMap), directExecutor());
-          return readerBlocked;
+              () -> {
+                next = constructTsBlockAndClearMap(countMap);
+                settableFuture.set(null);
+              },
+              directExecutor());
+          return settableFuture;
         } else if (schemaReader.hasNext()) {
           ISchemaInfo schemaInfo = schemaReader.next();
           PartialPath path = schemaInfo.getPartialPath();
@@ -180,7 +186,7 @@ public class CountGroupByLevelScanOperator<T extends ISchemaInfo> implements Sou
 
   @Override
   public boolean isFinished() throws Exception {
-    return !hasNextWithTimer();
+    return isFinished;
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/SchemaQueryScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/SchemaQueryScanOperator.java
@@ -34,6 +34,7 @@ import org.apache.iotdb.tsfile.read.common.block.TsBlock;
 import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
 
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
 
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -157,13 +158,15 @@ public class SchemaQueryScanOperator<T extends ISchemaInfo> implements SourceOpe
       try {
         ListenableFuture<?> readerBlocked = schemaReader.isBlocked();
         if (!readerBlocked.isDone()) {
+          SettableFuture<?> settableFuture = SettableFuture.create();
           readerBlocked.addListener(
               () -> {
                 next = tsBlockBuilder.build();
                 tsBlockBuilder.reset();
+                settableFuture.set(null);
               },
               directExecutor());
-          return readerBlocked;
+          return settableFuture;
         } else if (schemaReader.hasNext()) {
           T element = schemaReader.next();
           setColumns(element, tsBlockBuilder);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/SchemaQueryScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/SchemaQueryScanOperator.java
@@ -69,25 +69,6 @@ public class SchemaQueryScanOperator<T extends ISchemaInfo> implements SourceOpe
   private TsBlock next;
   private boolean isFinished;
 
-  protected SchemaQueryScanOperator(
-      PlanNodeId sourceId,
-      OperatorContext operatorContext,
-      int limit,
-      int offset,
-      PartialPath partialPath,
-      boolean isPrefixPath,
-      List<TSDataType> outputDataTypes) {
-    this.operatorContext = operatorContext;
-    this.limit = limit;
-    this.offset = offset;
-    this.partialPath = partialPath;
-    this.isPrefixPath = isPrefixPath;
-    this.sourceId = sourceId;
-    this.outputDataTypes = outputDataTypes;
-    this.schemaSource = null;
-    this.tsBlockBuilder = new TsBlockBuilder(outputDataTypes);
-  }
-
   public SchemaQueryScanOperator(
       PlanNodeId sourceId, OperatorContext operatorContext, ISchemaSource<T> schemaSource) {
     this.sourceId = sourceId;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
@@ -2846,6 +2846,9 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     SchemaPartition schemaPartitionInfo = partitionFetcher.getSchemaPartition(patternTree);
 
     analysis.setSchemaPartitionInfo(schemaPartitionInfo);
+    Map<Integer, Template> templateMap =
+        schemaFetcher.checkAllRelatedTemplate(countLevelTimeSeriesStatement.getPathPattern());
+    analysis.setRelatedTemplateInfo(templateMap);
     analysis.setRespDatasetHeader(DatasetHeaderFactory.getCountLevelTimeSeriesHeader());
     return analysis;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LogicalPlanBuilder.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LogicalPlanBuilder.java
@@ -1166,10 +1166,19 @@ public class LogicalPlanBuilder {
   }
 
   public LogicalPlanBuilder planLevelTimeSeriesCountSource(
-      PartialPath partialPath, boolean prefixPath, int level, SchemaFilter schemaFilter) {
+      PartialPath partialPath,
+      boolean prefixPath,
+      int level,
+      SchemaFilter schemaFilter,
+      Map<Integer, Template> templateMap) {
     this.root =
         new LevelTimeSeriesCountNode(
-            context.getQueryId().genPlanNodeId(), partialPath, prefixPath, level, schemaFilter);
+            context.getQueryId().genPlanNodeId(),
+            partialPath,
+            prefixPath,
+            level,
+            schemaFilter,
+            templateMap);
     return this;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LogicalPlanVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LogicalPlanVisitor.java
@@ -616,7 +616,8 @@ public class LogicalPlanVisitor extends StatementVisitor<PlanNode, MPPQueryConte
             countLevelTimeSeriesStatement.getPathPattern(),
             countLevelTimeSeriesStatement.isPrefixPath(),
             countLevelTimeSeriesStatement.getLevel(),
-            countLevelTimeSeriesStatement.getSchemaFilter())
+            countLevelTimeSeriesStatement.getSchemaFilter(),
+            analysis.getRelatedTemplateInfo())
         .planCountMerge()
         .getRoot();
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/OperatorTreeGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/OperatorTreeGenerator.java
@@ -664,7 +664,7 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
         operatorContext,
         node.getLevel(),
         SchemaSourceFactory.getTimeSeriesSchemaSource(
-            node.getPath(), node.isPrefixPath(), node.getSchemaFilter(), null));
+            node.getPath(), node.isPrefixPath(), node.getSchemaFilter(), node.getTemplateMap()));
   }
 
   @Override

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/plan/node/metadata/read/SchemaCountNodeSerdeTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/plan/node/metadata/read/SchemaCountNodeSerdeTest.java
@@ -77,7 +77,12 @@ public class SchemaCountNodeSerdeTest {
     ExchangeNode exchangeNode = new ExchangeNode(new PlanNodeId("exchange"));
     LevelTimeSeriesCountNode levelTimeSeriesCountNode =
         new LevelTimeSeriesCountNode(
-            new PlanNodeId("timeseriesCount"), new PartialPath("root.sg.device0"), true, 10, null);
+            new PlanNodeId("timeseriesCount"),
+            new PartialPath("root.sg.device0"),
+            true,
+            10,
+            null,
+            Collections.emptyMap());
     IdentitySinkNode sinkNode =
         new IdentitySinkNode(
             new PlanNodeId("sink"),


### PR DESCRIPTION
## Description

cherry-pick #10347 

Fix count timeseries group by level return incorrect result.

If time series is associated with schema template, we should add template info to traverser.
ListenableFuture.addListener will execute asynchronously, which may result in a deprecated member variable next being obtained at the time of hasNext().