### PR TITLE
[IOTDB-6042] Pipe: fix CreationTime display error using non-default time_precision when executing show pipes

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/response/pipe/task/PipeTableResp.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/response/pipe/task/PipeTableResp.java
@@ -20,10 +20,12 @@
 package org.apache.iotdb.confignode.consensus.response.pipe.task;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.pipe.task.meta.PipeMeta;
 import org.apache.iotdb.commons.pipe.task.meta.PipeRuntimeMeta;
 import org.apache.iotdb.commons.pipe.task.meta.PipeStaticMeta;
 import org.apache.iotdb.commons.pipe.task.meta.PipeTaskMeta;
+import org.apache.iotdb.commons.utils.CommonDateTimeUtils;
 import org.apache.iotdb.confignode.rpc.thrift.TGetAllPipeInfoResp;
 import org.apache.iotdb.confignode.rpc.thrift.TShowPipeInfo;
 import org.apache.iotdb.confignode.rpc.thrift.TShowPipeResp;
@@ -114,7 +116,9 @@ public class PipeTableResp implements DataSet {
       showPipeInfoList.add(
           new TShowPipeInfo(
               staticMeta.getPipeName(),
-              staticMeta.getCreationTime(),
+              CommonDateTimeUtils.convertMilliTimeWithPrecision(
+                  staticMeta.getCreationTime(),
+                  CommonDescriptor.getInstance().getConfig().getTimestampPrecision()),
               runtimeMeta.getStatus().get().name(),
               staticMeta.getExtractorParameters().toString(),
               staticMeta.getProcessorParameters().toString(),

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/response/pipe/task/PipeTableResp.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/response/pipe/task/PipeTableResp.java
@@ -20,12 +20,10 @@
 package org.apache.iotdb.confignode.consensus.response.pipe.task;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
-import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.pipe.task.meta.PipeMeta;
 import org.apache.iotdb.commons.pipe.task.meta.PipeRuntimeMeta;
 import org.apache.iotdb.commons.pipe.task.meta.PipeStaticMeta;
 import org.apache.iotdb.commons.pipe.task.meta.PipeTaskMeta;
-import org.apache.iotdb.commons.utils.CommonDateTimeUtils;
 import org.apache.iotdb.confignode.rpc.thrift.TGetAllPipeInfoResp;
 import org.apache.iotdb.confignode.rpc.thrift.TShowPipeInfo;
 import org.apache.iotdb.confignode.rpc.thrift.TShowPipeResp;
@@ -116,9 +114,7 @@ public class PipeTableResp implements DataSet {
       showPipeInfoList.add(
           new TShowPipeInfo(
               staticMeta.getPipeName(),
-              CommonDateTimeUtils.convertMilliTimeWithPrecision(
-                  staticMeta.getCreationTime(),
-                  CommonDescriptor.getInstance().getConfig().getTimestampPrecision()),
+              staticMeta.getCreationTime(),
               runtimeMeta.getStatus().get().name(),
               staticMeta.getExtractorParameters().toString(),
               staticMeta.getProcessorParameters().toString(),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/sys/pipe/ShowPipeTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/sys/pipe/ShowPipeTask.java
@@ -66,7 +66,8 @@ public class ShowPipeTask implements IConfigTask {
       builder.getColumnBuilder(0).writeBinary(new Binary(tPipeInfo.getId()));
       builder
           .getColumnBuilder(1)
-          .writeBinary(new Binary(DateTimeUtils.convertLongToDate(tPipeInfo.getCreationTime())));
+          .writeBinary(
+              new Binary(DateTimeUtils.convertLongToDate(tPipeInfo.getCreationTime(), "ms")));
       builder.getColumnBuilder(2).writeBinary(new Binary(tPipeInfo.getState()));
       builder.getColumnBuilder(3).writeBinary(new Binary(tPipeInfo.getPipeExtractor()));
       builder.getColumnBuilder(4).writeBinary(new Binary(tPipeInfo.getPipeProcessor()));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/DateTimeUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/DateTimeUtils.java
@@ -665,17 +665,21 @@ public class DateTimeUtils {
     }
   }
 
-  public static String convertLongToDate(long timestamp) {
-    String timePrecision = CommonDescriptor.getInstance().getConfig().getTimestampPrecision();
-    switch (timePrecision) {
+  public static String convertLongToDate(long timestampInMs) {
+    return convertLongToDate(
+        timestampInMs, CommonDescriptor.getInstance().getConfig().getTimestampPrecision());
+  }
+
+  public static String convertLongToDate(long timestampInMs, String targetPrecision) {
+    switch (targetPrecision) {
       case "ns":
-        timestamp /= 1000_000;
+        timestampInMs /= 1000_000;
         break;
       case "us":
-        timestamp /= 1000;
+        timestampInMs /= 1000;
         break;
     }
-    return LocalDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneId.systemDefault())
+    return LocalDateTime.ofInstant(Instant.ofEpochMilli(timestampInMs), ZoneId.systemDefault())
         .toString();
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/DateTimeUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/DateTimeUtils.java
@@ -665,21 +665,21 @@ public class DateTimeUtils {
     }
   }
 
-  public static String convertLongToDate(long timestampInMs) {
+  public static String convertLongToDate(long timestamp) {
     return convertLongToDate(
-        timestampInMs, CommonDescriptor.getInstance().getConfig().getTimestampPrecision());
+        timestamp, CommonDescriptor.getInstance().getConfig().getTimestampPrecision());
   }
 
-  public static String convertLongToDate(long timestampInMs, String targetPrecision) {
-    switch (targetPrecision) {
+  public static String convertLongToDate(long timestamp, String sourcePrecision) {
+    switch (sourcePrecision) {
       case "ns":
-        timestampInMs /= 1000_000;
+        timestamp /= 1000_000;
         break;
       case "us":
-        timestampInMs /= 1000;
+        timestamp /= 1000;
         break;
     }
-    return LocalDateTime.ofInstant(Instant.ofEpochMilli(timestampInMs), ZoneId.systemDefault())
+    return LocalDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneId.systemDefault())
         .toString();
   }
 


### PR DESCRIPTION
see https://timechor.feishu.cn/docx/Hhqbd84saoPTmHxCXuCcHQKgnBg
see https://issues.apache.org/jira/browse/IOTDB-6042
after (timestamp_precision=ns):
<img width="1137" alt="image" src="https://github.com/apache/iotdb/assets/55695098/c832311e-87d0-43a8-a50e-d9c3c51cce2b">

