### PR TITLE
fixed incorrect judgment when mods files were removed causing log inaccuracies

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/modification/ModificationFile.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/modification/ModificationFile.java
@@ -137,7 +137,7 @@ public class ModificationFile implements AutoCloseable {
   public void remove() throws IOException {
     close();
     boolean deleted = FSFactoryProducer.getFSFactory().getFile(filePath).delete();
-    if (deleted) {
+    if (!deleted) {
       logger.warn("Delete ModificationFile {} failed.", filePath);
     }
   }


### PR DESCRIPTION
When the File is deleted normally, the result returned by the File.delete () method should be true instead of false.Print only if file deletion fails should be"Delete ModificationFile {} failed."