### PR TITLE
[IOTDB-5576] Some node missed out when deleting after updating

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/mem/snapshot/MemMTreeSnapshotUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/mem/snapshot/MemMTreeSnapshotUtil.java
@@ -110,7 +110,7 @@ public class MemMTreeSnapshotUtil {
 
   private static boolean deleteFile(File snapshot) {
     try {
-      Files.delete(snapshot.toPath());
+      Files.deleteIfExists(snapshot.toPath());
       return true;
     } catch (IOException e) {
       logger.error(e.getMessage(), e);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/CacheManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/CacheManager.java
@@ -287,17 +287,20 @@ public abstract class CacheManager implements ICacheManager {
   }
 
   private void collectVolatileNodes(ICachedMNode node, List<ICachedMNode> nodesToPersist) {
-    if(node.isMeasurement()){
+    if (node.isMeasurement()) {
       return;
     }
     Iterator<ICachedMNode> bufferIterator =
         getCachedMNodeContainer(node).getChildrenBufferIterator();
-    nodesToPersist.add(node);
-
-    ICachedMNode child;
-    while (bufferIterator.hasNext()) {
-      child = bufferIterator.next();
-      collectVolatileNodes(child, nodesToPersist);
+    if (bufferIterator.hasNext()) {
+      nodesToPersist.add(node);
+      ICachedMNode child;
+      while (bufferIterator.hasNext()) {
+        child = bufferIterator.next();
+        collectVolatileNodes(child, nodesToPersist);
+      }
+    } else {
+      addToNodeCache(getCacheEntry(node), node);
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/CacheManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/CacheManager.java
@@ -302,8 +302,10 @@ public abstract class CacheManager implements ICacheManager {
     } else {
       // add back to cache
       CacheEntry cacheEntry = getCacheEntry(node);
-      while (cacheEntry != null && !isInNodeCache(cacheEntry)) {
-        addToNodeCache(cacheEntry, node);
+      while (!node.isDatabase()) {
+        if (cacheEntry != null && !isInNodeCache(cacheEntry)) {
+          addToNodeCache(cacheEntry, node);
+        }
         node = node.getParent();
         cacheEntry = getCacheEntry(node);
       }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/CacheManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/CacheManager.java
@@ -300,7 +300,13 @@ public abstract class CacheManager implements ICacheManager {
         collectVolatileNodes(child, nodesToPersist);
       }
     } else {
-      addToNodeCache(getCacheEntry(node), node);
+      // add back to cache
+      CacheEntry cacheEntry = getCacheEntry(node);
+      while (cacheEntry != null && !isInNodeCache(cacheEntry)) {
+        addToNodeCache(cacheEntry, node);
+        node = node.getParent();
+        cacheEntry = getCacheEntry(node);
+      }
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/CacheManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/CacheManager.java
@@ -287,12 +287,12 @@ public abstract class CacheManager implements ICacheManager {
   }
 
   private void collectVolatileNodes(ICachedMNode node, List<ICachedMNode> nodesToPersist) {
+    if(node.isMeasurement()){
+      return;
+    }
     Iterator<ICachedMNode> bufferIterator =
         getCachedMNodeContainer(node).getChildrenBufferIterator();
-
-    if (bufferIterator.hasNext()) {
-      nodesToPersist.add(node);
-    }
+    nodesToPersist.add(node);
 
     ICachedMNode child;
     while (bufferIterator.hasNext()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/CacheMemoryManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/CacheMemoryManager.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.pbtree.cache;
 import org.apache.iotdb.commons.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.commons.concurrent.ThreadName;
 import org.apache.iotdb.commons.concurrent.threadpool.WrappedThreadPoolExecutor;
+import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.schemaengine.metric.SchemaEngineCachedMetric;
 import org.apache.iotdb.db.schemaengine.rescon.CachedSchemaEngineStatistics;
@@ -337,5 +338,22 @@ public class CacheMemoryManager {
 
   public static CacheMemoryManager getInstance() {
     return CacheMemoryManager.GlobalCacheManagerHolder.INSTANCE;
+  }
+
+  @TestOnly
+  public void forceFlushAndRelease() {
+    releaseFlushStrategy =
+        new IReleaseFlushStrategy() {
+          @Override
+          public boolean isExceedReleaseThreshold() {
+            return true;
+          }
+
+          @Override
+          public boolean isExceedFlushThreshold() {
+            return true;
+          }
+        };
+    registerFlushTask();
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/AbstractSchemaRegionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/AbstractSchemaRegionTest.java
@@ -52,8 +52,8 @@ public abstract class AbstractSchemaRegionTest {
   @Parameterized.Parameters(name = "{0}")
   public static List<SchemaRegionTestParams> getTestModes() {
     return Arrays.asList(
-//        new SchemaRegionTestParams("MemoryMode", "Memory", -1, true),
-//        new SchemaRegionTestParams("PBTree-FullMemory", "PBTree", 10000, true),
+        new SchemaRegionTestParams("MemoryMode", "Memory", -1, true),
+        new SchemaRegionTestParams("PBTree-FullMemory", "PBTree", 10000, true),
         new SchemaRegionTestParams("PBTree-PartialMemory", "PBTree", 3, true),
         new SchemaRegionTestParams("PBTree-NonMemory", "PBTree", 0, true));
   }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/AbstractSchemaRegionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/AbstractSchemaRegionTest.java
@@ -52,8 +52,8 @@ public abstract class AbstractSchemaRegionTest {
   @Parameterized.Parameters(name = "{0}")
   public static List<SchemaRegionTestParams> getTestModes() {
     return Arrays.asList(
-        new SchemaRegionTestParams("MemoryMode", "Memory", -1, true),
-        new SchemaRegionTestParams("PBTree-FullMemory", "PBTree", 10000, true),
+//        new SchemaRegionTestParams("MemoryMode", "Memory", -1, true),
+//        new SchemaRegionTestParams("PBTree-FullMemory", "PBTree", 10000, true),
         new SchemaRegionTestParams("PBTree-PartialMemory", "PBTree", 3, true),
         new SchemaRegionTestParams("PBTree-NonMemory", "PBTree", 0, true));
   }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaStatisticsTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaStatisticsTest.java
@@ -39,7 +39,6 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaStatisticsTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaStatisticsTest.java
@@ -161,6 +161,7 @@ public class SchemaStatisticsTest extends AbstractSchemaRegionTest {
     Assert.assertEquals(1, schemaRegion2.getSchemaRegionStatistics().getSchemaRegionId());
     checkPBTreeStatistics(engineStatistics);
   }
+
   @Test
   public void testMemoryStatistics() throws Exception {
     ISchemaRegion schemaRegion1 = getSchemaRegion("root.sg1", 0);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaStatisticsTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaStatisticsTest.java
@@ -100,13 +100,15 @@ public class SchemaStatisticsTest extends AbstractSchemaRegionTest {
               : CacheMNodeFactory.getInstance();
       // schemaRegion1
       IMNode<?> sg1 =
-          nodeFactory.createDatabaseDeviceMNode(
+          nodeFactory.createDatabaseMNode(
               null, "sg1", CommonDescriptor.getInstance().getConfig().getDefaultTTLInMs());
       sg1.setFullPath("root.sg1");
       long size1 = sg1.estimateSize();
-      IMNode<?> tmp =
+      IMNode<?> tmp = nodeFactory.createDeviceMNode(sg1, "v");
+      size1 += tmp.estimateSize();
+      tmp =
           nodeFactory.createMeasurementMNode(
-              sg1.getAsDeviceMNode(),
+              tmp.getAsDeviceMNode(),
               "d0",
               new MeasurementSchema(
                   "d0", TSDataType.INT64, TSEncoding.PLAIN, CompressionType.SNAPPY),
@@ -114,7 +116,9 @@ public class SchemaStatisticsTest extends AbstractSchemaRegionTest {
       size1 += tmp.estimateSize();
       tmp = nodeFactory.createInternalMNode(sg1.getAsMNode(), "d1");
       size1 += tmp.estimateSize();
-      tmp = nodeFactory.createDeviceMNode(tmp, "s2");
+      tmp = nodeFactory.createInternalMNode(tmp, "s2");
+      size1 += tmp.estimateSize();
+      tmp = nodeFactory.createDeviceMNode(tmp, "v");
       size1 += tmp.estimateSize();
       size1 +=
           nodeFactory
@@ -132,7 +136,9 @@ public class SchemaStatisticsTest extends AbstractSchemaRegionTest {
               null, "sg2", CommonDescriptor.getInstance().getConfig().getDefaultTTLInMs());
       sg2.setFullPath("root.sg2");
       long size2 = sg2.estimateSize();
-      tmp = nodeFactory.createDeviceMNode(sg2, "d1");
+      tmp = nodeFactory.createInternalMNode(sg2, "d1");
+      size2 += tmp.estimateSize();
+      tmp = nodeFactory.createDeviceMNode(tmp, "v");
       size2 += tmp.estimateSize();
       size2 +=
           nodeFactory
@@ -143,7 +149,9 @@ public class SchemaStatisticsTest extends AbstractSchemaRegionTest {
                       "s3", TSDataType.INT64, TSEncoding.PLAIN, CompressionType.SNAPPY),
                   null)
               .estimateSize();
-      tmp = nodeFactory.createDeviceMNode(sg2, "d2");
+      tmp = nodeFactory.createInternalMNode(sg2, "d2");
+      size2 += tmp.estimateSize();
+      tmp = nodeFactory.createDeviceMNode(tmp, "v");
       size2 += tmp.estimateSize();
       size2 +=
           nodeFactory

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaStatisticsTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaStatisticsTest.java
@@ -55,7 +55,6 @@ public class SchemaStatisticsTest extends AbstractSchemaRegionTest {
   }
 
   @Test
-  @Ignore
   public void testMemoryStatistics() throws Exception {
     ISchemaRegion schemaRegion1 = getSchemaRegion("root.sg1", 0);
     ISchemaRegion schemaRegion2 = getSchemaRegion("root.sg2", 1);
@@ -74,8 +73,8 @@ public class SchemaStatisticsTest extends AbstractSchemaRegionTest {
     schemaRegion1.deleteTimeseriesInBlackList(patternTree);
     schemaRegion2.deleteTimeseriesInBlackList(patternTree);
 
-    if (testParams.getTestModeName().equals("SchemaFile-PartialMemory")
-        || testParams.getTestModeName().equals("SchemaFile-NonMemory")) {
+    if (testParams.getTestModeName().equals("PBTree-PartialMemory")
+        || testParams.getTestModeName().equals("PBTree-NonMemory")) {
 
       IMNodeFactory<?> nodeFactory = CacheMNodeFactory.getInstance();
       // wait release and flush task
@@ -161,10 +160,10 @@ public class SchemaStatisticsTest extends AbstractSchemaRegionTest {
     }
     Assert.assertEquals(0, schemaRegion1.getSchemaRegionStatistics().getSchemaRegionId());
     Assert.assertEquals(1, schemaRegion2.getSchemaRegionStatistics().getSchemaRegionId());
-    checkSchemaFileStatistics(engineStatistics);
+    checkPBTreeStatistics(engineStatistics);
   }
 
-  private void checkSchemaFileStatistics(ISchemaEngineStatistics engineStatistics) {
+  private void checkPBTreeStatistics(ISchemaEngineStatistics engineStatistics) {
     if (engineStatistics instanceof CachedSchemaEngineStatistics) {
       CachedSchemaEngineStatistics cachedEngineStatistics =
           (CachedSchemaEngineStatistics) engineStatistics;
@@ -231,7 +230,7 @@ public class SchemaStatisticsTest extends AbstractSchemaRegionTest {
   }
 
   @Test
-  public void testSchemaFileNodeStatistics() throws Exception {
+  public void testPBTreeNodeStatistics() throws Exception {
     if (testParams.getSchemaEngineMode().equals("PBTree")) {
       ISchemaRegion schemaRegion1 = getSchemaRegion("root.sg1", 0);
       ISchemaRegion schemaRegion2 = getSchemaRegion("root.sg2", 1);


### PR DESCRIPTION
## Description

Fix bug occurs in `SchemaStatisticsTest`

https://apache-iotdb.feishu.cn/docx/Ykibdd0ehox4qSxsPOAcc8JGnyg

<img width="739" alt="image" src="https://github.com/apache/iotdb/assets/43774645/219c1a5a-8b7e-4508-a277-004406b90c60">


After troubleshooting, this was caused by PBTree memory management in the corner case of update then delete.

When updating measurement, PBTree management will remove the device from the cache and add it to the buffer.

When removing measurement, PBTree management removes the device's node from the device's updated buffer.

Therefore, when flushing, although the device node is regarded as volatile not, it will not be collected because it has no children. We need to add it back to the cache, otherwise the device node will not be unpinable, resulting in incorrect statistics.