### PR TITLE
Speed up metadata queries that do not require pulling raw information from the view

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/DataNodeInternalRPCServiceImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/DataNodeInternalRPCServiceImpl.java
@@ -778,7 +778,8 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
                 }
                 for (PartialPath pattern : filteredPatternTree.getAllPathPatterns()) {
                   ISchemaSource<ITimeSeriesSchemaInfo> schemaSource =
-                      SchemaSourceFactory.getTimeSeriesSchemaSource(pattern);
+                      SchemaSourceFactory.getTimeSeriesSchemaCountSource(
+                          pattern, false, null, null);
                   try (ISchemaReader<ITimeSeriesSchemaInfo> schemaReader =
                       schemaSource.getSchemaReader(schemaRegion)) {
                     if (schemaReader.hasNext()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/source/LogicalViewSchemaSource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/source/LogicalViewSchemaSource.java
@@ -71,7 +71,8 @@ public class LogicalViewSchemaSource implements ISchemaSource<ITimeSeriesSchemaI
               offset,
               false,
               SchemaFilterFactory.and(
-                  schemaFilter, SchemaFilterFactory.createViewTypeFilter(ViewType.VIEW))));
+                  schemaFilter, SchemaFilterFactory.createViewTypeFilter(ViewType.VIEW)),
+              true));
     } catch (MetadataException e) {
       throw new SchemaExecutionException(e.getMessage(), e);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/source/SchemaSourceFactory.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/source/SchemaSourceFactory.java
@@ -33,20 +33,16 @@ public class SchemaSourceFactory {
 
   private SchemaSourceFactory() {}
 
-  public static ISchemaSource<ITimeSeriesSchemaInfo> getTimeSeriesSchemaSource(
-      PartialPath pathPattern) {
-    return new TimeSeriesSchemaSource(pathPattern, false, 0, 0, null, null);
-  }
-
-  public static ISchemaSource<ITimeSeriesSchemaInfo> getTimeSeriesSchemaSource(
+  public static ISchemaSource<ITimeSeriesSchemaInfo> getTimeSeriesSchemaCountSource(
       PartialPath pathPattern,
       boolean isPrefixMatch,
       SchemaFilter schemaFilter,
       Map<Integer, Template> templateMap) {
-    return new TimeSeriesSchemaSource(pathPattern, isPrefixMatch, 0, 0, schemaFilter, templateMap);
+    return new TimeSeriesSchemaSource(
+        pathPattern, isPrefixMatch, 0, 0, schemaFilter, templateMap, false);
   }
 
-  public static ISchemaSource<ITimeSeriesSchemaInfo> getTimeSeriesSchemaSource(
+  public static ISchemaSource<ITimeSeriesSchemaInfo> getTimeSeriesSchemaScanSource(
       PartialPath pathPattern,
       boolean isPrefixMatch,
       long limit,
@@ -54,7 +50,7 @@ public class SchemaSourceFactory {
       SchemaFilter schemaFilter,
       Map<Integer, Template> templateMap) {
     return new TimeSeriesSchemaSource(
-        pathPattern, isPrefixMatch, limit, offset, schemaFilter, templateMap);
+        pathPattern, isPrefixMatch, limit, offset, schemaFilter, templateMap, true);
   }
 
   public static ISchemaSource<IDeviceSchemaInfo> getDeviceSchemaSource(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/source/TimeSeriesSchemaSource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/source/TimeSeriesSchemaSource.java
@@ -45,13 +45,11 @@ public class TimeSeriesSchemaSource implements ISchemaSource<ITimeSeriesSchemaIn
 
   private final PartialPath pathPattern;
   private final boolean isPrefixMatch;
-
   private final long limit;
   private final long offset;
-
   private final SchemaFilter schemaFilter;
-
   private final Map<Integer, Template> templateMap;
+  private final boolean needViewDetail;
 
   TimeSeriesSchemaSource(
       PartialPath pathPattern,
@@ -59,16 +57,15 @@ public class TimeSeriesSchemaSource implements ISchemaSource<ITimeSeriesSchemaIn
       long limit,
       long offset,
       SchemaFilter schemaFilter,
-      Map<Integer, Template> templateMap) {
+      Map<Integer, Template> templateMap,
+      boolean needViewDetail) {
     this.pathPattern = pathPattern;
     this.isPrefixMatch = isPrefixMatch;
-
     this.limit = limit;
     this.offset = offset;
-
     this.schemaFilter = schemaFilter;
-
     this.templateMap = templateMap;
+    this.needViewDetail = needViewDetail;
   }
 
   @Override
@@ -76,7 +73,13 @@ public class TimeSeriesSchemaSource implements ISchemaSource<ITimeSeriesSchemaIn
     try {
       return schemaRegion.getTimeSeriesReader(
           SchemaRegionReadPlanFactory.getShowTimeSeriesPlan(
-              pathPattern, templateMap, limit, offset, isPrefixMatch, schemaFilter));
+              pathPattern,
+              templateMap,
+              limit,
+              offset,
+              isPrefixMatch,
+              schemaFilter,
+              needViewDetail));
     } catch (MetadataException e) {
       throw new SchemaExecutionException(e.getMessage(), e);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/OperatorTreeGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/OperatorTreeGenerator.java
@@ -549,7 +549,7 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
     return new SchemaQueryScanOperator<>(
         node.getPlanNodeId(),
         operatorContext,
-        SchemaSourceFactory.getTimeSeriesSchemaSource(
+        SchemaSourceFactory.getTimeSeriesSchemaScanSource(
             node.getPath(),
             node.isPrefixPath(),
             node.getLimit(),
@@ -644,7 +644,7 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
     return new SchemaCountOperator<>(
         node.getPlanNodeId(),
         operatorContext,
-        SchemaSourceFactory.getTimeSeriesSchemaSource(
+        SchemaSourceFactory.getTimeSeriesSchemaCountSource(
             node.getPath(), node.isPrefixPath(), node.getSchemaFilter(), node.getTemplateMap()));
   }
 
@@ -663,7 +663,7 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
         node.getPlanNodeId(),
         operatorContext,
         node.getLevel(),
-        SchemaSourceFactory.getTimeSeriesSchemaSource(
+        SchemaSourceFactory.getTimeSeriesSchemaCountSource(
             node.getPath(), node.isPrefixPath(), node.getSchemaFilter(), node.getTemplateMap()));
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/mem/MTreeBelowSGMemoryImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/mem/MTreeBelowSGMemoryImpl.java
@@ -1008,7 +1008,8 @@ public class MTreeBelowSGMemoryImpl {
 
     collector.setTemplateMap(showTimeSeriesPlan.getRelatedTemplate(), nodeFactory);
     ISchemaReader<ITimeSeriesSchemaInfo> reader =
-        new TimeseriesReaderWithViewFetch(collector, showTimeSeriesPlan.getSchemaFilter());
+        new TimeseriesReaderWithViewFetch(
+            collector, showTimeSeriesPlan.getSchemaFilter(), showTimeSeriesPlan.needViewDetail());
     if (showTimeSeriesPlan.getLimit() > 0 || showTimeSeriesPlan.getOffset() > 0) {
       return new SchemaReaderLimitOffsetWrapper<>(
           reader, showTimeSeriesPlan.getLimit(), showTimeSeriesPlan.getOffset());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/MTreeBelowSGCachedImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/MTreeBelowSGCachedImpl.java
@@ -1147,7 +1147,8 @@ public class MTreeBelowSGCachedImpl {
 
     collector.setTemplateMap(showTimeSeriesPlan.getRelatedTemplate(), nodeFactory);
     ISchemaReader<ITimeSeriesSchemaInfo> reader =
-        new TimeseriesReaderWithViewFetch(collector, showTimeSeriesPlan.getSchemaFilter());
+        new TimeseriesReaderWithViewFetch(
+            collector, showTimeSeriesPlan.getSchemaFilter(), showTimeSeriesPlan.needViewDetail());
     if (showTimeSeriesPlan.getLimit() > 0 || showTimeSeriesPlan.getOffset() > 0) {
       return new SchemaReaderLimitOffsetWrapper<>(
           reader, showTimeSeriesPlan.getLimit(), showTimeSeriesPlan.getOffset());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/read/req/IShowTimeSeriesPlan.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/read/req/IShowTimeSeriesPlan.java
@@ -27,6 +27,8 @@ import java.util.Map;
 
 public interface IShowTimeSeriesPlan extends IShowSchemaPlan {
 
+  boolean needViewDetail();
+
   SchemaFilter getSchemaFilter();
 
   Map<Integer, Template> getRelatedTemplate();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/read/req/SchemaRegionReadPlanFactory.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/read/req/SchemaRegionReadPlanFactory.java
@@ -57,13 +57,13 @@ public class SchemaRegionReadPlanFactory {
 
   @TestOnly
   public static IShowTimeSeriesPlan getShowTimeSeriesPlan(PartialPath path) {
-    return new ShowTimeSeriesPlanImpl(path, Collections.emptyMap(), 0, 0, false, null);
+    return new ShowTimeSeriesPlanImpl(path, Collections.emptyMap(), 0, 0, false, null, false);
   }
 
   @TestOnly
   public static IShowTimeSeriesPlan getShowTimeSeriesPlan(
       PartialPath path, Map<Integer, Template> relatedTemplate) {
-    return new ShowTimeSeriesPlanImpl(path, relatedTemplate, 0, 0, false, null);
+    return new ShowTimeSeriesPlanImpl(path, relatedTemplate, 0, 0, false, null, false);
   }
 
   @TestOnly
@@ -75,7 +75,8 @@ public class SchemaRegionReadPlanFactory {
         0,
         0,
         false,
-        SchemaFilterFactory.createTagFilter(key, value, isContains));
+        SchemaFilterFactory.createTagFilter(key, value, isContains),
+        false);
   }
 
   public static IShowTimeSeriesPlan getShowTimeSeriesPlan(
@@ -84,9 +85,10 @@ public class SchemaRegionReadPlanFactory {
       long limit,
       long offset,
       boolean isPrefixMatch,
-      SchemaFilter schemaFilter) {
+      SchemaFilter schemaFilter,
+      boolean needViewDetail) {
     return new ShowTimeSeriesPlanImpl(
-        path, relatedTemplate, limit, offset, isPrefixMatch, schemaFilter);
+        path, relatedTemplate, limit, offset, isPrefixMatch, schemaFilter, needViewDetail);
   }
 
   public static IShowNodesPlan getShowNodesPlan(PartialPath path) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/read/req/impl/ShowTimeSeriesPlanImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/read/req/impl/ShowTimeSeriesPlanImpl.java
@@ -34,6 +34,7 @@ public class ShowTimeSeriesPlanImpl extends AbstractShowSchemaPlanImpl
   private final Map<Integer, Template> relatedTemplate;
 
   private final SchemaFilter schemaFilter;
+  private final boolean needViewDetail;
 
   public ShowTimeSeriesPlanImpl(
       PartialPath path,
@@ -41,10 +42,17 @@ public class ShowTimeSeriesPlanImpl extends AbstractShowSchemaPlanImpl
       long limit,
       long offset,
       boolean isPrefixMatch,
-      SchemaFilter schemaFilter) {
+      SchemaFilter schemaFilter,
+      boolean needViewDetail) {
     super(path, limit, offset, isPrefixMatch);
     this.relatedTemplate = relatedTemplate;
     this.schemaFilter = schemaFilter;
+    this.needViewDetail = needViewDetail;
+  }
+
+  @Override
+  public boolean needViewDetail() {
+    return needViewDetail;
   }
 
   @Override

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionBasicTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionBasicTest.java
@@ -814,7 +814,8 @@ public class SchemaRegionBasicTest extends AbstractSchemaRegionTest {
                 0,
                 0,
                 false,
-                SchemaFilterFactory.createPathContainsFilter("s")));
+                SchemaFilterFactory.createPathContainsFilter("s"),
+                false));
     expectedPathList =
         new HashSet<>(
             Arrays.asList(
@@ -841,7 +842,8 @@ public class SchemaRegionBasicTest extends AbstractSchemaRegionTest {
                 0,
                 0,
                 false,
-                SchemaFilterFactory.createPathContainsFilter("1")));
+                SchemaFilterFactory.createPathContainsFilter("1"),
+                false));
     expectedPathList =
         new HashSet<>(
             Arrays.asList(
@@ -867,7 +869,8 @@ public class SchemaRegionBasicTest extends AbstractSchemaRegionTest {
                 0,
                 0,
                 false,
-                SchemaFilterFactory.createPathContainsFilter("laptop.d")));
+                SchemaFilterFactory.createPathContainsFilter("laptop.d"),
+                false));
     expectedPathList =
         new HashSet<>(
             Arrays.asList(
@@ -895,7 +898,8 @@ public class SchemaRegionBasicTest extends AbstractSchemaRegionTest {
                 0,
                 0,
                 false,
-                SchemaFilterFactory.createDataTypeFilter(TSDataType.INT64)));
+                SchemaFilterFactory.createDataTypeFilter(TSDataType.INT64),
+                false));
     expectedPathList =
         new HashSet<>(
             Arrays.asList(
@@ -923,7 +927,8 @@ public class SchemaRegionBasicTest extends AbstractSchemaRegionTest {
                 0,
                 0,
                 false,
-                SchemaFilterFactory.createDataTypeFilter(TSDataType.BOOLEAN)));
+                SchemaFilterFactory.createDataTypeFilter(TSDataType.BOOLEAN),
+                false));
     expectedPathList = new HashSet<>(Collections.emptyList());
     expectedSize = expectedPathList.size();
     Assert.assertEquals(expectedSize, result.size());

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionTestUtil.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionTestUtil.java
@@ -162,7 +162,7 @@ public class SchemaRegionTestUtil {
     try (ISchemaReader<ITimeSeriesSchemaInfo> timeSeriesReader =
         schemaRegion.getTimeSeriesReader(
             SchemaRegionReadPlanFactory.getShowTimeSeriesPlan(
-                pathPattern, templateMap, 0, 0, isPrefixMatch, null)); ) {
+                pathPattern, templateMap, 0, 0, isPrefixMatch, null, false))) {
       long count = 0;
       while (timeSeriesReader.hasNext()) {
         timeSeriesReader.next();
@@ -195,7 +195,7 @@ public class SchemaRegionTestUtil {
     try (ISchemaReader<ITimeSeriesSchemaInfo> timeSeriesReader =
         schemaRegion.getTimeSeriesReader(
             SchemaRegionReadPlanFactory.getShowTimeSeriesPlan(
-                pathPattern, null, 0, 0, isPrefixMatch, null)); ) {
+                pathPattern, null, 0, 0, isPrefixMatch, null, false))) {
       Map<PartialPath, Long> countMap = new HashMap<>();
       while (timeSeriesReader.hasNext()) {
         ITimeSeriesSchemaInfo timeSeriesSchemaInfo = timeSeriesReader.next();

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/schema/SchemaQueryScanOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/schema/SchemaQueryScanOperatorTest.java
@@ -195,7 +195,7 @@ public class SchemaQueryScanOperatorTest {
       operatorContext.setDriverContext(
           new SchemaDriverContext(fragmentInstanceContext, schemaRegion, 0));
       ISchemaSource<ITimeSeriesSchemaInfo> timeSeriesSchemaSource =
-          SchemaSourceFactory.getTimeSeriesSchemaSource(
+          SchemaSourceFactory.getTimeSeriesSchemaScanSource(
               partialPath, false, 10, 0, null, Collections.emptyMap());
       SchemaOperatorTestUtil.mockGetSchemaReader(
           timeSeriesSchemaSource, showTimeSeriesResults.iterator(), schemaRegion, true);


### PR DESCRIPTION
## Description

cherry pick #10370 

This PR introduces a switch needFetch for TimeseriesReaderWithViewFetch. 
```java
  /**
   * There is no need to pull the original sequence information from the view if needFetch is false.
   * The default is false if not filtered by DataType.
   */
  private final boolean needFetch;
```
If needFetch is false, the original information from the view will not be pulled asynchronously, speeding up metadata queries.