### PR TITLE
[IOTDB-5910] Fix compaction scheduler thread pool is not shutdown when aborting compaction

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -2648,6 +2648,9 @@ public class DataRegion implements IDataRegionForQuery {
         Thread.currentThread().interrupt();
       }
     }
+    if (timedCompactionScheduleTask != null) {
+      timedCompactionScheduleTask.shutdownNow();
+    }
   }
 
   public TsFileManager getTsFileResourceManager() {


### PR DESCRIPTION
## Description
Before this change, the `compaction scheduler thread pool` is not considered when aborting compaction. Thus, if a DataRegion is deleted, the scheduler thread is overflow.

This PR fix this issue.