### PR TITLE
Fix issue where the metric module failed to catch exceptions at startup

### DIFF
--- a/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/reporter/prometheus/PrometheusReporter.java
+++ b/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/reporter/prometheus/PrometheusReporter.java
@@ -63,6 +63,7 @@ public class PrometheusReporter implements Reporter {
   }
 
   @Override
+  @SuppressWarnings("java:S1181")
   public boolean start() {
     if (httpServer != null) {
       LOGGER.warn("PrometheusReporter already start!");
@@ -80,7 +81,9 @@ public class PrometheusReporter implements Reporter {
                           "/metrics",
                           (request, response) -> response.sendString(Mono.just(scrape()))))
               .bindNow();
-    } catch (Exception e) {
+    } catch (Throwable e) {
+      // catch Throwable rather than Exception here because the code above might cause a
+      // NoClassDefFoundError
       httpServer = null;
       LOGGER.warn("PrometheusReporter failed to start, because ", e);
       return false;


### PR DESCRIPTION
![img_v2_722e5fe8-d460-41d0-b459-f3a55b0a053g](https://github.com/apache/iotdb/assets/32640567/82901076-5b52-4897-863d-200c2c91197e)
