### PR TITLE
[IOTDB-6050] ClassNotFound when use csv import-csv.sh in cluster

### DIFF
--- a/iotdb-client/cli/pom.xml
+++ b/iotdb-client/cli/pom.xml
@@ -160,7 +160,7 @@
                                 <filter>
                                     <artifact>org.apache.iotdb:iotdb-server</artifact>
                                     <includes>
-                                        <include>org/apache/iotdb/db/qp/utils/*</include>
+                                        <include>org/apache/iotdb/db/utils/*</include>
                                     </includes>
                                 </filter>
                             </filters>


### PR DESCRIPTION
details see:   https://issues.apache.org/jira/browse/IOTDB-6050
when I merge code then our tester find the import-csv.sh run failed,  Exception is ClassNotFoud

reason : in this merged pr: https://github.com/apache/iotdb/pull/8600

the package 'org.apache.iotdb.db.qp.utils' renamed to 'org.apache.iotdb.db.utils'

but  iotdb-cli moudle pom.xml is not changed, so  shade jar has no classes in new package. 