### PR TITLE
[To rel/1.1] Fix not decreasing file size after ttl delete file

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/storagegroup/DataRegion.java
@@ -1572,6 +1572,7 @@ public class DataRegion implements IDataRegionForQuery {
     if (resource.tryWriteLock()) {
       try {
         // try to delete physical data file
+        long fileSize = resource.getTsFileSize();
         resource.remove();
         tsFileManager.remove(resource, isSeq);
         logger.info(
@@ -1580,6 +1581,7 @@ public class DataRegion implements IDataRegionForQuery {
             new Date(ttlLowerBound),
             dataTTL,
             config.getTimestampPrecision());
+        TsFileMetricManager.getInstance().deleteFile(fileSize, isSeq, 1);
       } finally {
         resource.writeUnlock();
       }


### PR DESCRIPTION
# Overview
In IoTDB, the size and count of all deleted TsFiles should be deducted in TsFileMetrics. Users have noticed discrepancies between the TsFile size and count displayed on the monitoring panel and the actual file size and count on the disk. This inconsistency is due to the fact that the changes in file size and count were not recorded in TsFileMetrics when files were deleted due to TTL (Time-To-Live) expiry.
# How to reproduce the bug 
Launch an IoTDB instance and write data to it while setting the TTL. Once the TTL takes effect, you will notice the mismatch between the data reflected in the monitor and the actual data on the disk.