### PR TITLE
Change default compressor to LZ4

### DIFF
--- a/docs/UserGuide/Reference/Common-Config-Manual.md
+++ b/docs/UserGuide/Reference/Common-Config-Manual.md
@@ -1243,8 +1243,8 @@ Different configuration parameters take effect in the following three ways:
 |    Name     | compressor                                                             |
 |:-----------:|:-----------------------------------------------------------------------|
 | Description | Data compression method; Time compression method in aligned timeseries |
-|    Type     | Enum String : "UNCOMPRESSED", "SNAPPY", "LZ4", "ZSTD", "LZMA2"         |
-|   Default   | SNAPPY                                                                 |
+|    Type     | Enum String : "UNCOMPRESSED", "SNAPPY", "LZ4", "GZIP" ,"ZSTD", "LZMA2"        |
+|   Default   | LZ4                                                                    |
 |  Effective  | hot-load                                                               |
 
 * bloomFilterErrorRate

--- a/docs/UserGuide/Reference/SQL-Reference.md
+++ b/docs/UserGuide/Reference/SQL-Reference.md
@@ -91,7 +91,7 @@ propertyClause
     ;
 DataTypeValue: BOOLEAN | DOUBLE | FLOAT | INT32 | INT64 | TEXT
 EncodingValue: GORILLA | PLAIN | RLE | TS_2DIFF | REGULAR
-CompressorValue: UNCOMPRESSED | SNAPPY
+CompressorValue: UNCOMPRESSED | SNAPPY | LZ4 | GZIP | ZSTD | LZMA2
 AttributesType: SDT | COMPDEV | COMPMINTIME | COMPMAXTIME
 PropertyValue: ID | constant
 Eg: CREATE TIMESERIES root.ln.wf01.wt01.status WITH DATATYPE=BOOLEAN, ENCODING=PLAIN

--- a/docs/zh/UserGuide/Reference/Common-Config-Manual.md
+++ b/docs/zh/UserGuide/Reference/Common-Config-Manual.md
@@ -1269,12 +1269,12 @@ IoTDB ConfigNode 和 DataNode 的公共配置参数位于 `conf` 目录下。
 
 * compressor
 
-|   名字   | compressor                                                   |
-|:------:|:-------------------------------------------------------------|
-|   描述   | 数据压缩方法; 对齐序列中时间列的压缩方法                                        |
-|   类型   | 枚举 String : "UNCOMPRESSED", "SNAPPY", "LZ4", "ZSTD", "LZMA2" |
-|  默认值   | SNAPPY                                                       |
-| 改后生效方式 | 热加载                                                          |
+|   名字   | compressor                                                           |
+|:------:|:---------------------------------------------------------------------|
+|   描述   | 数据压缩方法; 对齐序列中时间列的压缩方法                                                |
+|   类型   | 枚举 String : "UNCOMPRESSED", "SNAPPY", "LZ4", "GZIP" ,"ZSTD", "LZMA2" |
+|  默认值   | LZ4                                                                  |
+| 改后生效方式 | 热加载                                                                  |
 
 * max\_degree\_of\_index\_node
 

--- a/docs/zh/UserGuide/Reference/SQL-Reference.md
+++ b/docs/zh/UserGuide/Reference/SQL-Reference.md
@@ -80,7 +80,7 @@ propertyClause
     ;
 DataTypeValue: BOOLEAN | DOUBLE | FLOAT | INT32 | INT64 | TEXT
 EncodingValue: GORILLA | PLAIN | RLE | TS_2DIFF | REGULAR
-CompressorValue: UNCOMPRESSED | SNAPPY
+CompressorValue: UNCOMPRESSED | SNAPPY | LZ4 | GZIP | ZSTD | LZMA2
 AttributesType: SDT | COMPDEV | COMPMINTIME | COMPMAXTIME
 PropertyValue: ID | constant
 Eg: CREATE TIMESERIES root.ln.wf01.wt01.status WITH DATATYPE=BOOLEAN, ENCODING=PLAIN

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBCreateAlignedTimeseriesIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBCreateAlignedTimeseriesIT.java
@@ -67,8 +67,7 @@ public class IoTDBCreateAlignedTimeseriesIT extends AbstractSchemaIT {
   public void testCreateAlignedTimeseries() throws Exception {
     String[] timeSeriesArray =
         new String[] {
-          "root.sg1.d1.vector1.s1,FLOAT,PLAIN,UNCOMPRESSED",
-          "root.sg1.d1.vector1.s2,INT64,RLE,SNAPPY"
+          "root.sg1.d1.vector1.s1,FLOAT,PLAIN,UNCOMPRESSED", "root.sg1.d1.vector1.s2,INT64,RLE,LZ4"
         };
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
@@ -94,7 +93,7 @@ public class IoTDBCreateAlignedTimeseriesIT extends AbstractSchemaIT {
   public void testCreateAlignedTimeseriesWithDeletion() throws Exception {
     String[] timeSeriesArray =
         new String[] {
-          "root.sg1.d1.vector1.s1,DOUBLE,PLAIN,SNAPPY", "root.sg1.d1.vector1.s2,INT64,RLE,SNAPPY"
+          "root.sg1.d1.vector1.s1,DOUBLE,PLAIN,SNAPPY", "root.sg1.d1.vector1.s2,INT64,RLE,LZ4"
         };
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBExtendTemplateIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBExtendTemplateIT.java
@@ -101,10 +101,10 @@ public class IoTDBExtendTemplateIT extends AbstractSchemaIT {
           new Set[] {
             new HashSet<>(
                 Arrays.asList(
-                    "root.db.d1.s1,null,root.db,INT64,PLAIN,SNAPPY,null,null,null,null,BASE,",
-                    "root.db.d1.s2,null,root.db,DOUBLE,RLE,SNAPPY,null,null,null,null,BASE,",
-                    "root.db.d1.s3,null,root.db,INT64,RLE,SNAPPY,null,null,null,null,BASE,",
-                    "root.db.d1.s4,null,root.db,DOUBLE,GORILLA,SNAPPY,null,null,null,null,BASE,"))
+                    "root.db.d1.s1,null,root.db,INT64,PLAIN,LZ4,null,null,null,null,BASE,",
+                    "root.db.d1.s2,null,root.db,DOUBLE,RLE,LZ4,null,null,null,null,BASE,",
+                    "root.db.d1.s3,null,root.db,INT64,RLE,LZ4,null,null,null,null,BASE,",
+                    "root.db.d1.s4,null,root.db,DOUBLE,GORILLA,LZ4,null,null,null,null,BASE,"))
           };
       for (int n = 0; n < sqls.length; n++) {
         String sql = sqls[n];
@@ -154,18 +154,18 @@ public class IoTDBExtendTemplateIT extends AbstractSchemaIT {
           new Set[] {
             new HashSet<>(
                 Arrays.asList(
-                    "root.db.d1.s1,null,root.db,INT64,PLAIN,SNAPPY,null,null,null,null,BASE,",
-                    "root.db.d1.s2,null,root.db,DOUBLE,RLE,SNAPPY,null,null,null,null,BASE,",
-                    "root.db.d1.s3,null,root.db,FLOAT,GORILLA,SNAPPY,null,null,null,null,BASE,",
-                    "root.db.d1.s4,null,root.db,FLOAT,GORILLA,SNAPPY,null,null,null,null,BASE,",
-                    "root.db.d1.s5,null,root.db,FLOAT,GORILLA,SNAPPY,null,null,null,null,BASE,",
-                    "root.db.d2.s1,null,root.db,INT64,PLAIN,SNAPPY,null,null,null,null,BASE,",
-                    "root.db.d2.s2,null,root.db,DOUBLE,RLE,SNAPPY,null,null,null,null,BASE,",
-                    "root.db.d2.s3,null,root.db,FLOAT,GORILLA,SNAPPY,null,null,null,null,BASE,",
-                    "root.db.d2.s4,null,root.db,FLOAT,GORILLA,SNAPPY,null,null,null,null,BASE,",
-                    "root.db.d2.s5,null,root.db,FLOAT,GORILLA,SNAPPY,null,null,null,null,BASE,",
-                    "root.db1.d1.s2,null,root.db1,FLOAT,GORILLA,SNAPPY,null,null,null,null,BASE,",
-                    "root.db1.d1.s3,null,root.db1,FLOAT,GORILLA,SNAPPY,null,null,null,null,BASE,"))
+                    "root.db.d1.s1,null,root.db,INT64,PLAIN,LZ4,null,null,null,null,BASE,",
+                    "root.db.d1.s2,null,root.db,DOUBLE,RLE,LZ4,null,null,null,null,BASE,",
+                    "root.db.d1.s3,null,root.db,FLOAT,GORILLA,LZ4,null,null,null,null,BASE,",
+                    "root.db.d1.s4,null,root.db,FLOAT,GORILLA,LZ4,null,null,null,null,BASE,",
+                    "root.db.d1.s5,null,root.db,FLOAT,GORILLA,LZ4,null,null,null,null,BASE,",
+                    "root.db.d2.s1,null,root.db,INT64,PLAIN,LZ4,null,null,null,null,BASE,",
+                    "root.db.d2.s2,null,root.db,DOUBLE,RLE,LZ4,null,null,null,null,BASE,",
+                    "root.db.d2.s3,null,root.db,FLOAT,GORILLA,LZ4,null,null,null,null,BASE,",
+                    "root.db.d2.s4,null,root.db,FLOAT,GORILLA,LZ4,null,null,null,null,BASE,",
+                    "root.db.d2.s5,null,root.db,FLOAT,GORILLA,LZ4,null,null,null,null,BASE,",
+                    "root.db1.d1.s2,null,root.db1,FLOAT,GORILLA,LZ4,null,null,null,null,BASE,",
+                    "root.db1.d1.s3,null,root.db1,FLOAT,GORILLA,LZ4,null,null,null,null,BASE,"))
           };
       for (int n = 0; n < sqls.length; n++) {
         String sql = sqls[n];

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBMetadataFetchIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBMetadataFetchIT.java
@@ -126,40 +126,40 @@ public class IoTDBMetadataFetchIT extends AbstractSchemaIT {
           new Set[] {
             new HashSet<>(
                 Collections.singletonList(
-                    "root.ln.wf01.wt01.status,null,root.ln.wf01.wt01,BOOLEAN,PLAIN,SNAPPY,null,null,null,null,BASE,")),
+                    "root.ln.wf01.wt01.status,null,root.ln.wf01.wt01,BOOLEAN,PLAIN,LZ4,null,null,null,null,BASE,")),
             new HashSet<>(
                 Arrays.asList(
-                    "root.ln.wf01.wt01.status,null,root.ln.wf01.wt01,BOOLEAN,PLAIN,SNAPPY,null,null,null,null,BASE,",
+                    "root.ln.wf01.wt01.status,null,root.ln.wf01.wt01,BOOLEAN,PLAIN,LZ4,null,null,null,null,BASE,",
                     "root.ln.wf01.wt01.temperature,null,root.ln.wf01.wt01,FLOAT,RLE,SNAPPY,null,null,null,null,BASE,",
-                    "root.ln.wf01.wt02.s1,null,root.ln.wf01.wt02,INT32,RLE,SNAPPY,null,null,null,null,BASE,",
-                    "root.ln.wf01.wt02.s2,null,root.ln.wf01.wt02,DOUBLE,GORILLA,SNAPPY,null,null,null,null,BASE,")),
+                    "root.ln.wf01.wt02.s1,null,root.ln.wf01.wt02,INT32,RLE,LZ4,null,null,null,null,BASE,",
+                    "root.ln.wf01.wt02.s2,null,root.ln.wf01.wt02,DOUBLE,GORILLA,LZ4,null,null,null,null,BASE,")),
             new HashSet<>(
                 Arrays.asList(
-                    "root.ln.wf01.wt01.status,null,root.ln.wf01.wt01,BOOLEAN,PLAIN,SNAPPY,null,null,null,null,BASE,",
+                    "root.ln.wf01.wt01.status,null,root.ln.wf01.wt01,BOOLEAN,PLAIN,LZ4,null,null,null,null,BASE,",
                     "root.ln.wf01.wt01.temperature,null,root.ln.wf01.wt01,FLOAT,RLE,SNAPPY,null,null,null,null,BASE,")),
             new HashSet<>(
                 Arrays.asList(
-                    "root.ln.wf01.wt01.status,null,root.ln.wf01.wt01,BOOLEAN,PLAIN,SNAPPY,null,null,null,null,BASE,",
+                    "root.ln.wf01.wt01.status,null,root.ln.wf01.wt01,BOOLEAN,PLAIN,LZ4,null,null,null,null,BASE,",
                     "root.ln.wf01.wt01.temperature,null,root.ln.wf01.wt01,FLOAT,RLE,SNAPPY,null,null,null,null,BASE,",
-                    "root.ln.wf01.wt02.s1,null,root.ln.wf01.wt02,INT32,RLE,SNAPPY,null,null,null,null,BASE,",
-                    "root.ln.wf01.wt02.s2,null,root.ln.wf01.wt02,DOUBLE,GORILLA,SNAPPY,null,null,null,null,BASE,",
-                    "root.ln1.wf01.wt01.status,null,root.ln1.wf01.wt01,BOOLEAN,PLAIN,SNAPPY,null,null,null,null,BASE,",
+                    "root.ln.wf01.wt02.s1,null,root.ln.wf01.wt02,INT32,RLE,LZ4,null,null,null,null,BASE,",
+                    "root.ln.wf01.wt02.s2,null,root.ln.wf01.wt02,DOUBLE,GORILLA,LZ4,null,null,null,null,BASE,",
+                    "root.ln1.wf01.wt01.status,null,root.ln1.wf01.wt01,BOOLEAN,PLAIN,LZ4,null,null,null,null,BASE,",
                     "root.ln1.wf01.wt01.temperature,null,root.ln1.wf01.wt01,FLOAT,RLE,SNAPPY,null,null,null,null,BASE,",
-                    "root.ln2.wf01.wt01.status,null,root.ln2.wf01.wt01,BOOLEAN,PLAIN,SNAPPY,null,null,null,null,BASE,",
+                    "root.ln2.wf01.wt01.status,null,root.ln2.wf01.wt01,BOOLEAN,PLAIN,LZ4,null,null,null,null,BASE,",
                     "root.ln2.wf01.wt01.temperature,null,root.ln2.wf01.wt01,FLOAT,RLE,SNAPPY,null,null,null,null,BASE,")),
             new HashSet<>(),
             new HashSet<>(
                 Arrays.asList(
-                    "root.ln.wf01.wt01.status,null,root.ln.wf01.wt01,BOOLEAN,PLAIN,SNAPPY,null,null,null,null,BASE,",
-                    "root.ln1.wf01.wt01.status,null,root.ln1.wf01.wt01,BOOLEAN,PLAIN,SNAPPY,null,null,null,null,BASE,",
-                    "root.ln2.wf01.wt01.status,null,root.ln2.wf01.wt01,BOOLEAN,PLAIN,SNAPPY,null,null,null,null,BASE,")),
+                    "root.ln.wf01.wt01.status,null,root.ln.wf01.wt01,BOOLEAN,PLAIN,LZ4,null,null,null,null,BASE,",
+                    "root.ln1.wf01.wt01.status,null,root.ln1.wf01.wt01,BOOLEAN,PLAIN,LZ4,null,null,null,null,BASE,",
+                    "root.ln2.wf01.wt01.status,null,root.ln2.wf01.wt01,BOOLEAN,PLAIN,LZ4,null,null,null,null,BASE,")),
             new HashSet<>(
                 Arrays.asList(
-                    "root.ln.wf01.wt01.status,null,root.ln.wf01.wt01,BOOLEAN,PLAIN,SNAPPY,null,null,null,null,BASE,",
+                    "root.ln.wf01.wt01.status,null,root.ln.wf01.wt01,BOOLEAN,PLAIN,LZ4,null,null,null,null,BASE,",
                     "root.ln.wf01.wt01.temperature,null,root.ln.wf01.wt01,FLOAT,RLE,SNAPPY,null,null,null,null,BASE,")),
             new HashSet<>(
                 Collections.singletonList(
-                    "root.ln.wf01.wt01.status,null,root.ln.wf01.wt01,BOOLEAN,PLAIN,SNAPPY,null,null,null,null,BASE,"))
+                    "root.ln.wf01.wt01.status,null,root.ln.wf01.wt01,BOOLEAN,PLAIN,LZ4,null,null,null,null,BASE,"))
           };
       for (int n = 0; n < sqls.length; n++) {
         String sql = sqls[n];
@@ -715,8 +715,8 @@ public class IoTDBMetadataFetchIT extends AbstractSchemaIT {
           "create aligned timeseries root.sg.d(s1(alias1) int32 tags('tag1'='v1', 'tag2'='v2'), s2 double attributes('attr3'='v3'))");
       String[] expected =
           new String[] {
-            "root.sg.d.s1,alias1,root.sg,INT32,RLE,SNAPPY,{\"tag1\":\"v1\",\"tag2\":\"v2\"},null,null,null,BASE,",
-            "root.sg.d.s2,null,root.sg,DOUBLE,GORILLA,SNAPPY,null,{\"attr3\":\"v3\"},null,null,BASE,"
+            "root.sg.d.s1,alias1,root.sg,INT32,RLE,LZ4,{\"tag1\":\"v1\",\"tag2\":\"v2\"},null,null,null,BASE,",
+            "root.sg.d.s2,null,root.sg,DOUBLE,GORILLA,LZ4,null,{\"attr3\":\"v3\"},null,null,BASE,"
           };
 
       int num = 0;
@@ -746,7 +746,7 @@ public class IoTDBMetadataFetchIT extends AbstractSchemaIT {
           new HashSet<>(
               Arrays.asList(
                   "root.ln.wf01.wt01.temperature,null,root.ln.wf01.wt01,FLOAT,RLE,SNAPPY,null,null,null,null,BASE,",
-                  "root.ln.wf01.wt01.status,null,root.ln.wf01.wt01,BOOLEAN,PLAIN,SNAPPY,null,null,null,null,BASE,"));
+                  "root.ln.wf01.wt01.status,null,root.ln.wf01.wt01,BOOLEAN,PLAIN,LZ4,null,null,null,null,BASE,"));
       try (ResultSet resultSet = statement.executeQuery(sql)) {
         ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
         while (resultSet.next()) {
@@ -783,9 +783,9 @@ public class IoTDBMetadataFetchIT extends AbstractSchemaIT {
       Set<String> standard =
           new HashSet<>(
               Arrays.asList(
-                  "root.sg1.d0.s0,null,root.sg1,INT32,RLE,SNAPPY,null,null,null,null,BASE,\n",
-                  "root.sg1.d0.s1,null,root.sg1,INT32,PLAIN,SNAPPY,null,null,SDT,{compdev=2},BASE,\n",
-                  "root.sg1.d0.s2,null,root.sg1,INT32,PLAIN,SNAPPY,null,null,SDT,{compdev=0.01, compmintime=2, compmaxtime=15},BASE,\n"));
+                  "root.sg1.d0.s0,null,root.sg1,INT32,RLE,LZ4,null,null,null,null,BASE,\n",
+                  "root.sg1.d0.s1,null,root.sg1,INT32,PLAIN,LZ4,null,null,SDT,{compdev=2},BASE,\n",
+                  "root.sg1.d0.s2,null,root.sg1,INT32,PLAIN,LZ4,null,null,SDT,{compdev=0.01, compmintime=2, compmaxtime=15},BASE,\n"));
       try (ResultSet resultSet = statement.executeQuery("SHOW TIMESERIES root.sg1.d0.*")) {
         ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
         while (resultSet.next()) {

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBSchemaTemplateIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBSchemaTemplateIT.java
@@ -147,11 +147,11 @@ public class IoTDBSchemaTemplateIT extends AbstractSchemaIT {
       Set<String> expectedResult =
           new HashSet<>(
               Arrays.asList(
-                  "root.sg1.d1.s1,INT64,RLE,SNAPPY",
-                  "root.sg1.d1.s2,DOUBLE,GORILLA,SNAPPY",
-                  "root.sg1.d2.s1,INT64,RLE,SNAPPY",
-                  "root.sg1.d2.s2,DOUBLE,GORILLA,SNAPPY",
-                  "root.sg1.d3.s1,INT64,RLE,SNAPPY"));
+                  "root.sg1.d1.s1,INT64,RLE,LZ4",
+                  "root.sg1.d1.s2,DOUBLE,GORILLA,LZ4",
+                  "root.sg1.d2.s1,INT64,RLE,LZ4",
+                  "root.sg1.d2.s2,DOUBLE,GORILLA,LZ4",
+                  "root.sg1.d3.s1,INT64,RLE,LZ4"));
 
       try (ResultSet resultSet = statement.executeQuery("SHOW TIMESERIES root.sg1.**"); ) {
         while (resultSet.next()) {
@@ -230,10 +230,10 @@ public class IoTDBSchemaTemplateIT extends AbstractSchemaIT {
       Set<String> expectedResult =
           new HashSet<>(
               Arrays.asList(
-                  "root.sg1.d1.s1,INT64,RLE,SNAPPY",
-                  "root.sg1.d1.s2,DOUBLE,GORILLA,SNAPPY",
-                  "root.sg1.d2.s1,INT64,RLE,SNAPPY",
-                  "root.sg1.d2.s2,DOUBLE,GORILLA,SNAPPY"));
+                  "root.sg1.d1.s1,INT64,RLE,LZ4",
+                  "root.sg1.d1.s2,DOUBLE,GORILLA,LZ4",
+                  "root.sg1.d2.s1,INT64,RLE,LZ4",
+                  "root.sg1.d2.s2,DOUBLE,GORILLA,LZ4"));
 
       try (ResultSet resultSet = statement.executeQuery("SHOW TIMESERIES root.sg1.**")) {
         while (resultSet.next()) {
@@ -316,7 +316,7 @@ public class IoTDBSchemaTemplateIT extends AbstractSchemaIT {
   public void testShowNodesInSchemaTemplate() throws SQLException {
     // set schema template
     Set<String> expectedResultSet =
-        new HashSet<>(Arrays.asList("s1,INT64,RLE,SNAPPY", "s2,DOUBLE,GORILLA,SNAPPY"));
+        new HashSet<>(Arrays.asList("s1,INT64,RLE,LZ4", "s2,DOUBLE,GORILLA,LZ4"));
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement();
         ResultSet resultSet = statement.executeQuery("SHOW NODES IN SCHEMA TEMPLATE t1")) {
@@ -466,7 +466,7 @@ public class IoTDBSchemaTemplateIT extends AbstractSchemaIT {
 
       expectedResult =
           new HashSet<>(
-              Arrays.asList("root.sg1.d1.s1,INT64,RLE,SNAPPY", "root.sg1.d2.s1,INT64,RLE,SNAPPY"));
+              Arrays.asList("root.sg1.d1.s1,INT64,RLE,LZ4", "root.sg1.d2.s1,INT64,RLE,LZ4"));
 
       try (ResultSet resultSet = statement.executeQuery("SHOW TIMESERIES root.**.s1")) {
         while (resultSet.next()) {
@@ -519,7 +519,7 @@ public class IoTDBSchemaTemplateIT extends AbstractSchemaIT {
       }
       Assert.assertTrue(expectedResult.isEmpty());
 
-      expectedResult = new HashSet<>(Collections.singletonList("root.sg1.d1.s1,INT64,RLE,SNAPPY"));
+      expectedResult = new HashSet<>(Collections.singletonList("root.sg1.d1.s1,INT64,RLE,LZ4"));
 
       try (ResultSet resultSet = statement.executeQuery("SHOW TIMESERIES root.**.s1")) {
         while (resultSet.next()) {
@@ -683,11 +683,11 @@ public class IoTDBSchemaTemplateIT extends AbstractSchemaIT {
       Set<String> expectedResult =
           new HashSet<>(
               Arrays.asList(
-                  "root.sg1.d1.s1,INT64,RLE,SNAPPY",
-                  "root.sg1.d1.s2,DOUBLE,GORILLA,SNAPPY",
-                  "root.sg2.d2.s1,INT64,RLE,SNAPPY",
-                  "root.sg2.d2.s2,DOUBLE,GORILLA,SNAPPY",
-                  "root.sg3.d3.s1,INT64,RLE,SNAPPY"));
+                  "root.sg1.d1.s1,INT64,RLE,LZ4",
+                  "root.sg1.d1.s2,DOUBLE,GORILLA,LZ4",
+                  "root.sg2.d2.s1,INT64,RLE,LZ4",
+                  "root.sg2.d2.s2,DOUBLE,GORILLA,LZ4",
+                  "root.sg3.d3.s1,INT64,RLE,LZ4"));
 
       try (ResultSet resultSet = statement.executeQuery("SHOW TIMESERIES root.sg*.*.s*")) {
         while (resultSet.next()) {
@@ -706,8 +706,7 @@ public class IoTDBSchemaTemplateIT extends AbstractSchemaIT {
       Assert.assertTrue(expectedResult.isEmpty());
       expectedResult =
           new HashSet<>(
-              Arrays.asList(
-                  "root.sg1.d1.s1,INT64,RLE,SNAPPY", "root.sg1.d1.s2,DOUBLE,GORILLA,SNAPPY"));
+              Arrays.asList("root.sg1.d1.s1,INT64,RLE,LZ4", "root.sg1.d1.s2,DOUBLE,GORILLA,LZ4"));
 
       try (ResultSet resultSet = statement.executeQuery("SHOW TIMESERIES root.sg1.d1.s*")) {
         while (resultSet.next()) {
@@ -750,9 +749,9 @@ public class IoTDBSchemaTemplateIT extends AbstractSchemaIT {
       Set<String> expectedResult =
           new HashSet<>(
               Arrays.asList(
-                  "root.sg1.d.s1,INT32,RLE,SNAPPY",
-                  "root.sg1.d.s2,FLOAT,GORILLA,SNAPPY",
-                  "root.sg1.d.s3,FLOAT,GORILLA,SNAPPY"));
+                  "root.sg1.d.s1,INT32,RLE,LZ4",
+                  "root.sg1.d.s2,FLOAT,GORILLA,LZ4",
+                  "root.sg1.d.s3,FLOAT,GORILLA,LZ4"));
 
       try (ResultSet resultSet = statement.executeQuery("SHOW TIMESERIES root.sg*.*.s*")) {
         while (resultSet.next()) {

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBSortedShowTimeseriesIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBSortedShowTimeseriesIT.java
@@ -138,19 +138,19 @@ public class IoTDBSortedShowTimeseriesIT extends AbstractSchemaIT {
                 + "is a gpu\",\"unit\":\"cores\"},{\"H_Alarm\":\"99.9\",\"M_Alarm\":\"44.4\"}",
             "root.turbine.d0.s4,tpu0,root.turbine,FLOAT,RLE,SNAPPY,{\"description\":\"turbine this "
                 + "is a tpu\",\"unit\":\"cores\"},{\"H_Alarm\":\"99.9\",\"M_Alarm\":\"44.4\"}",
-            "root.turbine.d1.s0,status,root.turbine,INT32,RLE,SNAPPY,{\"description\":\"turbine this "
+            "root.turbine.d1.s0,status,root.turbine,INT32,RLE,LZ4,{\"description\":\"turbine this "
                 + "is a test3\"},{\"H_Alarm\":\"9\",\"M_Alarm\":\"5\"}",
             "root.turbine.d2.s0,temperature,root.turbine,FLOAT,RLE,SNAPPY,{\"description\":\"turbine"
                 + " d2 this is a test1\",\"unit\":\"f\"},{\"MinValue\":\"1\",\"MaxValue\":\"100\"}",
             "root.turbine.d2.s1,power,root.turbine,FLOAT,RLE,SNAPPY,{\"description\":\"turbine d2 this"
                 + " is a test2\",\"unit\":\"kw\"},{\"MinValue\":\"44.4\",\"MaxValue\":\"99.9\"}",
-            "root.turbine.d2.s3,status,root.turbine,INT32,RLE,SNAPPY,{\"description\":\"turbine d2"
+            "root.turbine.d2.s3,status,root.turbine,INT32,RLE,LZ4,{\"description\":\"turbine d2"
                 + " this is a test3\"},{\"MinValue\":\"5\",\"MaxValue\":\"9\"}",
             "root.ln.d0.s0,temperature,root.ln,FLOAT,RLE,SNAPPY,{\"description\":\"ln this is a "
                 + "test1\",\"unit\":\"c\"},{\"H_Alarm\":\"1000\",\"M_Alarm\":\"500\"}",
             "root.ln.d0.s1,power,root.ln,FLOAT,RLE,SNAPPY,{\"description\":\"ln this is a test2\",\""
                 + "unit\":\"w\"},{\"H_Alarm\":\"9.9\",\"M_Alarm\":\"4.4\"}",
-            "root.ln.d1.s0,status,root.ln,INT32,RLE,SNAPPY,{\"description\":\"ln this is a test3\"},"
+            "root.ln.d1.s0,status,root.ln,INT32,RLE,LZ4,{\"description\":\"ln this is a test3\"},"
                 + "{\"H_Alarm\":\"90\",\"M_Alarm\":\"50\"}");
 
     List<String> retArray2 =
@@ -159,7 +159,7 @@ public class IoTDBSortedShowTimeseriesIT extends AbstractSchemaIT {
                 + "this is a test1\",\"unit\":\"f\"},{\"MinValue\":\"1\",\"MaxValue\":\"100\"}",
             "root.turbine.d2.s1,power,root.turbine,FLOAT,RLE,SNAPPY,{\"description\":\"turbine d2 this "
                 + "is a test2\",\"unit\":\"kw\"},{\"MinValue\":\"44.4\",\"MaxValue\":\"99.9\"}",
-            "root.turbine.d2.s3,status,root.turbine,INT32,RLE,SNAPPY,{\"description\":\"turbine d2 this "
+            "root.turbine.d2.s3,status,root.turbine,INT32,RLE,LZ4,{\"description\":\"turbine d2 this "
                 + "is a test3\"},{\"MinValue\":\"5\",\"MaxValue\":\"9\"}",
             "root.turbine.d0.s4,tpu0,root.turbine,FLOAT,RLE,SNAPPY,{\"description\":\"turbine this is a"
                 + " tpu\",\"unit\":\"cores\"},{\"H_Alarm\":\"99.9\",\"M_Alarm\":\"44.4\"}",
@@ -171,13 +171,13 @@ public class IoTDBSortedShowTimeseriesIT extends AbstractSchemaIT {
                 + "test2\",\"unit\":\"kw\"},{\"H_Alarm\":\"99.9\",\"M_Alarm\":\"44.4\"}",
             "root.turbine.d0.s0,temperature,root.turbine,FLOAT,RLE,SNAPPY,{\"description\":\"turbine"
                 + " this is a test1\",\"unit\":\"f\"},{\"H_Alarm\":\"100\",\"M_Alarm\":\"50\"}",
-            "root.turbine.d1.s0,status,root.turbine,INT32,RLE,SNAPPY,{\"description\":\"turbine this is a "
+            "root.turbine.d1.s0,status,root.turbine,INT32,RLE,LZ4,{\"description\":\"turbine this is a "
                 + "test3\"},{\"H_Alarm\":\"9\",\"M_Alarm\":\"5\"}",
             "root.ln.d0.s0,temperature,root.ln,FLOAT,RLE,SNAPPY,{\"description\":\"ln this is a test1\""
                 + ",\"unit\":\"c\"},{\"H_Alarm\":\"1000\",\"M_Alarm\":\"500\"}",
             "root.ln.d0.s1,power,root.ln,FLOAT,RLE,SNAPPY,{\"description\":\"ln this is a test2\",\""
                 + "unit\":\"w\"},{\"H_Alarm\":\"9.9\",\"M_Alarm\":\"4.4\"}",
-            "root.ln.d1.s0,status,root.ln,INT32,RLE,SNAPPY,{\"description\":\"ln this is a test3\"},"
+            "root.ln.d1.s0,status,root.ln,INT32,RLE,LZ4,{\"description\":\"ln this is a test3\"},"
                 + "{\"H_Alarm\":\"90\",\"M_Alarm\":\"50\"}");
 
     try (Connection connection = EnvFactory.getEnv().getConnection();
@@ -251,7 +251,7 @@ public class IoTDBSortedShowTimeseriesIT extends AbstractSchemaIT {
                     + " this is a test1\",\"unit\":\"f\"},{\"MinValue\":\"1\",\"MaxValue\":\"100\"}",
                 "root.turbine.d2.s1,power,root.turbine,FLOAT,RLE,SNAPPY,{\"description\":\"turbine d2 this "
                     + "is a test2\",\"unit\":\"kw\"},{\"MinValue\":\"44.4\",\"MaxValue\":\"99.9\"}",
-                "root.turbine.d2.s3,status,root.turbine,INT32,RLE,SNAPPY,{\"description\":\"turbine d2 this "
+                "root.turbine.d2.s3,status,root.turbine,INT32,RLE,LZ4,{\"description\":\"turbine d2 this "
                     + "is a test3\"},{\"MinValue\":\"5\",\"MaxValue\":\"9\"}",
                 "root.turbine.d0.s4,tpu0,root.turbine,FLOAT,RLE,SNAPPY,{\"description\":\"turbine this is a "
                     + "tpu\",\"unit\":\"cores\"},{\"H_Alarm\":\"99.9\",\"M_Alarm\":\"44.4\"}",

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBTagIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBTagIT.java
@@ -122,7 +122,7 @@ public class IoTDBTagIT extends AbstractSchemaIT {
         Arrays.asList(
             "root.turbine.d2.s1,temperature,root.turbine,FLOAT,RLE,SNAPPY,{\"tag1\":\"t1\","
                 + "\"tag2\":\"t2\"},{\"attr2\":\"a2\",\"attr1\":\"a1\"}",
-            "root.turbine.d2.s2,status,root.turbine,INT32,RLE,SNAPPY,{\"tag2\":\"t2\","
+            "root.turbine.d2.s2,status,root.turbine,INT32,RLE,LZ4,{\"tag2\":\"t2\","
                 + "\"tag3\":\"t3\"},{\"attr4\":\"a4\",\"attr3\":\"a3\"}");
     String sql1 =
         "create timeseries root.turbine.d2.s1(temperature) with datatype=FLOAT, encoding=RLE, compression=SNAPPY "
@@ -176,7 +176,7 @@ public class IoTDBTagIT extends AbstractSchemaIT {
         Arrays.asList(
             "root.turbine.d2.s1,temperature,root.turbine,FLOAT,RLE,SNAPPY,{\"tag1\":\"t1\",\""
                 + "tag2\":\"t2\"},{\"attr2\":\"a2\",\"attr1\":\"a1\"}",
-            "root.turbine.d2.s2,status,root.turbine,INT32,RLE,SNAPPY,{\"tag2\":\"t2\",\"tag3\""
+            "root.turbine.d2.s2,status,root.turbine,INT32,RLE,LZ4,{\"tag2\":\"t2\",\"tag3\""
                 + ":\"t3\"},{\"attr4\":\"a4\",\"attr3\":\"a3\"}");
     String sql1 =
         "create timeseries root.turbine.d2.s1(temperature) with datatype=FLOAT, encoding=RLE, compression=SNAPPY "
@@ -405,7 +405,7 @@ public class IoTDBTagIT extends AbstractSchemaIT {
         Arrays.asList(
             "root.turbine.d7.s1,temperature,root.turbine,FLOAT,RLE,SNAPPY,"
                 + "{\"tag1\":\"t1\",\"tag2\":\"t2\"},{\"attr2\":\"a2\",\"attr1\":\"a1\"}",
-            "root.turbine.d7.s2,status,root.turbine,INT32,RLE,SNAPPY,{\"tag2\""
+            "root.turbine.d7.s2,status,root.turbine,INT32,RLE,LZ4,{\"tag2\""
                 + ":\"t2\",\"tag3\":\"t3\"},{\"attr4\":\"a4\",\"attr3\":\"a3\"}");
     List<String> ret2 =
         Collections.singletonList(
@@ -488,7 +488,7 @@ public class IoTDBTagIT extends AbstractSchemaIT {
         Arrays.asList(
             "root.turbine.d7.s1,temperature,root.turbine,FLOAT,RLE,SNAPPY,"
                 + "{\"tag1\":\"t1\",\"tag2\":\"t2\"},{\"attr2\":\"a2\",\"attr1\":\"a1\"}",
-            "root.turbine.d7.s2,status,root.turbine,INT32,RLE,SNAPPY,"
+            "root.turbine.d7.s2,status,root.turbine,INT32,RLE,LZ4,"
                 + "{\"tag2\":\"t2\",\"tag3\":\"t3\"},{\"attr4\":\"a4\",\"attr3\":\"a3\"}");
     List<String> ret2 =
         Collections.singletonList(
@@ -573,19 +573,19 @@ public class IoTDBTagIT extends AbstractSchemaIT {
                 + "this is a test1\",\"unit\":\"f\"},{\"H_Alarm\":\"100\",\"M_Alarm\":\"50\"}",
             "root.turbine.d0.s1,power,root.turbine,FLOAT,RLE,SNAPPY,{\"description\":\"turbine this "
                 + "is a test2\",\"unit\":\"kw\"},{\"H_Alarm\":\"99.9\",\"M_Alarm\":\"44.4\"}",
-            "root.turbine.d1.s0,status,root.turbine,INT32,RLE,SNAPPY,{\"description\":\"turbine this "
+            "root.turbine.d1.s0,status,root.turbine,INT32,RLE,LZ4,{\"description\":\"turbine this "
                 + "is a test3\"},{\"H_Alarm\":\"9\",\"M_Alarm\":\"5\"}",
             "root.turbine.d2.s0,temperature,root.turbine,FLOAT,RLE,SNAPPY,{\"description\":\"turbine "
                 + "d2 this is a test1\",\"unit\":\"f\"},{\"MinValue\":\"1\",\"MaxValue\":\"100\"}",
             "root.turbine.d2.s1,power,root.turbine,FLOAT,RLE,SNAPPY,{\"description\":\"turbine d2 this"
                 + " is a test2\",\"unit\":\"kw\"},{\"MinValue\":\"44.4\",\"MaxValue\":\"99.9\"}",
-            "root.turbine.d2.s3,status,root.turbine,INT32,RLE,SNAPPY,{\"description\":\"turbine d2 "
+            "root.turbine.d2.s3,status,root.turbine,INT32,RLE,LZ4,{\"description\":\"turbine d2 "
                 + "this is a test3\"},{\"MinValue\":\"5\",\"MaxValue\":\"9\"}",
             "root.ln.d0.s0,temperature,root.ln,FLOAT,RLE,SNAPPY,{\"description\":\"ln this is a "
                 + "test1\",\"unit\":\"c\"},{\"H_Alarm\":\"1000\",\"M_Alarm\":\"500\"}",
             "root.ln.d0.s1,power,root.ln,FLOAT,RLE,SNAPPY,{\"description\":\"ln this is a "
                 + "test2\",\"unit\":\"w\"},{\"H_Alarm\":\"9.9\",\"M_Alarm\":\"4.4\"}",
-            "root.ln.d1.s0,status,root.ln,INT32,RLE,SNAPPY,{\"description\":\"ln this is a test3\"},"
+            "root.ln.d1.s0,status,root.ln,INT32,RLE,LZ4,{\"description\":\"ln this is a test3\"},"
                 + "{\"H_Alarm\":\"90\",\"M_Alarm\":\"50\"}");
 
     Set<String> ret2 = new HashSet<>();

--- a/integration-test/src/test/java/org/apache/iotdb/util/AbstractSchemaIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/util/AbstractSchemaIT.java
@@ -57,7 +57,7 @@ public abstract class AbstractSchemaIT {
 
   @Parameterized.Parameters(name = "SchemaEngineMode={0}")
   public static Iterable<SchemaTestMode> data() {
-    return Arrays.asList(SchemaTestMode.Memory, SchemaTestMode.PBTree);
+    return Arrays.asList(SchemaTestMode.Memory);
   }
 
   public AbstractSchemaIT(SchemaTestMode schemaTestMode) {

--- a/integration-test/src/test/java/org/apache/iotdb/util/AbstractSchemaIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/util/AbstractSchemaIT.java
@@ -57,7 +57,7 @@ public abstract class AbstractSchemaIT {
 
   @Parameterized.Parameters(name = "SchemaEngineMode={0}")
   public static Iterable<SchemaTestMode> data() {
-    return Arrays.asList(SchemaTestMode.Memory);
+    return Arrays.asList(SchemaTestMode.Memory, SchemaTestMode.PBTree);
   }
 
   public AbstractSchemaIT(SchemaTestMode schemaTestMode) {

--- a/integration-test/src/test/java/org/apache/iotdb/zeppelin/it/IoTDBInterpreterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/zeppelin/it/IoTDBInterpreterIT.java
@@ -308,12 +308,12 @@ public class IoTDBInterpreterIT {
     InterpreterResult actual = interpreter.internalInterpret("show timeseries", null);
     String gt =
         "Timeseries\tAlias\tDatabase\tDataType\tEncoding\tCompression\tTags\tAttributes\tDeadband\tDeadbandParameters\tViewType\n"
-            + "root.test.wf01.wt01.temperature\tnull\troot.test.wf01\tFLOAT\tGORILLA\tSNAPPY\tnull\tnull\tnull\tnull\tBASE\n"
-            + "root.test.wf01.wt01.status\tnull\troot.test.wf01\tBOOLEAN\tRLE\tSNAPPY\tnull\tnull\tnull\tnull\tBASE\n"
-            + "root.test.wf01.wt01.hardware\tnull\troot.test.wf01\tFLOAT\tGORILLA\tSNAPPY\tnull\tnull\tnull\tnull\tBASE\n"
-            + "root.test.wf02.wt02.temperature\tnull\troot.test.wf02\tFLOAT\tGORILLA\tSNAPPY\tnull\tnull\tnull\tnull\tBASE\n"
-            + "root.test.wf02.wt02.status\tnull\troot.test.wf02\tBOOLEAN\tRLE\tSNAPPY\tnull\tnull\tnull\tnull\tBASE\n"
-            + "root.test.wf02.wt02.hardware\tnull\troot.test.wf02\tFLOAT\tGORILLA\tSNAPPY\tnull\tnull\tnull\tnull\tBASE";
+            + "root.test.wf01.wt01.temperature\tnull\troot.test.wf01\tFLOAT\tGORILLA\tLZ4\tnull\tnull\tnull\tnull\tBASE\n"
+            + "root.test.wf01.wt01.status\tnull\troot.test.wf01\tBOOLEAN\tRLE\tLZ4\tnull\tnull\tnull\tnull\tBASE\n"
+            + "root.test.wf01.wt01.hardware\tnull\troot.test.wf01\tFLOAT\tGORILLA\tLZ4\tnull\tnull\tnull\tnull\tBASE\n"
+            + "root.test.wf02.wt02.temperature\tnull\troot.test.wf02\tFLOAT\tGORILLA\tLZ4\tnull\tnull\tnull\tnull\tBASE\n"
+            + "root.test.wf02.wt02.status\tnull\troot.test.wf02\tBOOLEAN\tRLE\tLZ4\tnull\tnull\tnull\tnull\tBASE\n"
+            + "root.test.wf02.wt02.hardware\tnull\troot.test.wf02\tFLOAT\tGORILLA\tLZ4\tnull\tnull\tnull\tnull\tBASE";
     Assert.assertNotNull(actual);
     Assert.assertEquals(Code.SUCCESS, actual.code());
     Assert.assertEquals(gt, actual.message().get(0).getData());

--- a/iotdb-client/client-py/tests/test_dataframe.py
+++ b/iotdb-client/client-py/tests/test_dataframe.py
@@ -82,7 +82,7 @@ def test_non_time_query():
                 "root.device0",
                 "FLOAT",
                 "GORILLA",
-                "SNAPPY",
+                "LZ4",
                 None,
                 None,
                 None,

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/WrappedSegmentTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/WrappedSegmentTest.java
@@ -71,7 +71,7 @@ public class WrappedSegmentTest {
 
     ByteBuffer recMid01 = sf.getRecord("mid1");
     Assert.assertEquals(
-        "[measurementNode, alias: mid1als, type: FLOAT, encoding: PLAIN, compressor: SNAPPY]",
+        "[measurementNode, alias: mid1als, type: FLOAT, encoding: PLAIN, compressor: LZ4]",
         RecordUtils.buffer2String(recMid01));
 
     int resInsertNode = sf.insertRecord(rNode.getName(), RecordUtils.node2Buffer(rNode));
@@ -85,7 +85,7 @@ public class WrappedSegmentTest {
     System.out.println(nsf);
     ByteBuffer nrec = nsf.getRecord("mid1");
     Assert.assertEquals(
-        "[measurementNode, alias: mid1als, type: FLOAT, encoding: PLAIN, compressor: SNAPPY]",
+        "[measurementNode, alias: mid1als, type: FLOAT, encoding: PLAIN, compressor: LZ4]",
         RecordUtils.buffer2String(nsf.getRecord("mid1")));
     Assert.assertEquals(
         "[entityNode, not aligned, not using template.]",

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/tools/TsFileSelfCheckToolTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/tools/TsFileSelfCheckToolTest.java
@@ -216,7 +216,7 @@ public class TsFileSelfCheckToolTest {
     byte[] serialArr = bo.toByteArray();
     // timeseriesMetadata begins at 878364
     // randomly modify timeseriesMetadata region
-    raf.seek(963375);
+    raf.seek(965844);
     raf.write(serialArr, 0, serialArr.length);
     bo.close();
     raf.close();

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -803,9 +803,9 @@ cluster_name=defaultCluster
 # value_encoder=PLAIN
 
 # Compression configuration
-# Data compression method, supports UNCOMPRESSED, SNAPPY, ZSTD, LZMA2 or LZ4. Default value is SNAPPY
+# Data compression method, supports UNCOMPRESSED, SNAPPY, ZSTD, LZMA2 or LZ4. Default value is LZ4
 # And it is also used as the default compressor of time column in aligned timeseries.
-# compressor=SNAPPY
+# compressor=LZ4
 
 # time interval in minute for calculating query frequency
 # Datatype: int

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileConfig.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/common/conf/TSFileConfig.java
@@ -112,7 +112,7 @@ public class TSFileConfig implements Serializable {
   /** Default DFT satisfy rate is 0.1 */
   private double dftSatisfyRate = 0.1;
   /** Data compression method, TsFile supports UNCOMPRESSED, SNAPPY, ZSTD or LZ4. */
-  private CompressionType compressor = CompressionType.SNAPPY;
+  private CompressionType compressor = CompressionType.LZ4;
   /** Line count threshold for checking page memory occupied size. */
   private int pageCheckSizeThreshold = 100;
   /** Default endian value is BIG_ENDIAN. */


### PR DESCRIPTION
## Description

Change default compressor to LZ4 accoording to the experiment result in https://apache-iotdb.feishu.cn/docx/ThmHdPKw9oJv95xvLhWco2WnnLh

![image](https://github.com/apache/iotdb/assets/43774645/7a205a2e-d1b0-4377-b5f2-1eb284a97225)

![image](https://github.com/apache/iotdb/assets/43774645/828ee877-bcbd-4fca-977b-01810a940585)


(The two images above are from Jinzhao Xiao, Yuxiang Huang, Changyu Hu, Shaoxu Song, Xiangdong Huang, Jianmin Wang. Time Series Data Encoding for Efficient Storage: A Comparative Analysis in Apache IoTDB. International Conference on Very Large Data Bases, VLDB, 2022. [[paper](https://sxsong.github.io/doc/22vldb-encoding.pdf)] )
