### PR TITLE
Add default charset setting in start-datanode.bat and print default charset when starting

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
@@ -55,6 +55,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.concurrent.TimeUnit;
 
 public class ConfigNode implements ConfigNodeMBean {
@@ -90,6 +91,10 @@ public class ConfigNode implements ConfigNodeMBean {
         "{} environment variables: {}",
         ConfigNodeConstant.GLOBAL_NAME,
         ConfigNodeConfig.getEnvironmentVariables());
+    LOGGER.info(
+        "{} default charset is: {}",
+        ConfigNodeConstant.GLOBAL_NAME,
+        Charset.defaultCharset().displayName());
     new ConfigNodeCommandLine().doMain(args);
   }
 

--- a/iotdb-core/datanode/src/assembly/resources/sbin/start-datanode.bat
+++ b/iotdb-core/datanode/src/assembly/resources/sbin/start-datanode.bat
@@ -205,7 +205,9 @@ set JAVA_OPTS=-ea^
  -DIOTDB_HOME="%IOTDB_HOME%"^
  -DTSFILE_HOME="%IOTDB_HOME%"^
  -DTSFILE_CONF="%IOTDB_CONF%"^
- -DIOTDB_CONF="%IOTDB_CONF%"
+ -DIOTDB_CONF="%IOTDB_CONF%"^
+ -Dsun.jnu.encoding=UTF-8^
+ -Dfile.encoding=UTF-8
 
 @REM ----------------------------------------------------------------------------
 @REM ***** CLASSPATH library setting *****

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -91,6 +91,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -144,6 +145,7 @@ public class DataNode implements DataNodeMBean {
 
   public static void main(String[] args) {
     logger.info("IoTDB-DataNode environment variables: {}", IoTDBConfig.getEnvironmentVariables());
+    logger.info("IoTDB-DataNode default charset is: {}", Charset.defaultCharset().displayName());
     new DataNodeServerCommandLine().doMain(args);
   }
 


### PR DESCRIPTION
refer PR https://github.com/apache/iotdb/pull/10051

## Description
1. Change default charset encoding to UTF-8 in `start-datanode.bat`
2. Add log when DataNode/ConfigNode starts to print the default charset

![image](https://github.com/apache/iotdb/assets/18027703/81875f5a-192a-433d-86e9-53b49e145c67)


NOTICE: Before this change, the explicit setting has only been added in `start-confignode.bat`. To keep the setting is consistent between DataNode and ConfigNode, we add the explicit charset encoding setting in script for windows. 
