### PR TITLE
[IOTDB-6056] Pipe: Failed to load tsfile with empty pages (NPE occurs when loading)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/load/TsFileSplitter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/load/TsFileSplitter.java
@@ -261,15 +261,20 @@ public class TsFileSplitter {
                 }
               }
               if (alignedChunkDataList.size() == 1) { // write entire page
-                alignedChunkDataList
-                    .get(0)
-                    .writeEntirePage(pageHeader, reader.readCompressedPage(pageHeader));
+                // write the entire page if it's not an empty page.
+                if (!isEmptyPage(pageHeader)) {
+                  alignedChunkDataList
+                      .get(0)
+                      .writeEntirePage(pageHeader, reader.readCompressedPage(pageHeader));
+                }
               } else { // decode page
                 long[] times = pageIndex2Times.get(pageIndex);
                 TsPrimitiveType[] values =
                     decodeValuePage(reader, header, pageHeader, times, valueDecoder);
                 for (AlignedChunkData alignedChunkData : alignedChunkDataList) {
-                  alignedChunkData.writeDecodeValuePage(times, values, header.getDataType());
+                  if (!isEmptyPage(pageHeader)) {
+                    alignedChunkData.writeDecodeValuePage(times, values, header.getDataType());
+                  }
                 }
               }
               long pageDataSize = pageHeader.getSerializedPageSize();
@@ -439,6 +444,19 @@ public class TsFileSplitter {
         }
       }
     }
+  }
+
+  /**
+   * handle empty page in aligned chunk, if uncompressedSize and compressedSize are both 0, and the
+   * statistics is null, then the page is empty.
+   *
+   * @param pageHeader page header
+   * @return true if the page is empty
+   */
+  private boolean isEmptyPage(PageHeader pageHeader) {
+    return pageHeader.getUncompressedSize() == 0
+        && pageHeader.getCompressedSize() == 0
+        && pageHeader.getStatistics() == null;
   }
 
   private TsPrimitiveType[] decodeValuePage(


### PR DESCRIPTION
**bug**：
<img width="825" alt="image" src="https://github.com/apache/iotdb/assets/42286868/b43e5d13-c160-4e2f-af51-e0c147616bd1">
![image](https://github.com/apache/iotdb/assets/42286868/e16d68ba-5650-42b7-879b-bb11ea4566b1)

**reason**：
we didn't handle empty pages in aligned chunk

**solution**:
add `if` statement to judge the page is empty or not, and write the entire page when it is not an empty page