### PR TITLE
update maxBytesPerFragmentInstance in setAllocateMemoryForRead of IoTDBConfig

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -1544,6 +1544,7 @@ public class IoTDBConfig {
 
   public void setQueryThreadCount(int queryThreadCount) {
     this.queryThreadCount = queryThreadCount;
+    this.maxBytesPerFragmentInstance = allocateMemoryForDataExchange / queryThreadCount;
   }
 
   public void setDegreeOfParallelism(int degreeOfParallelism) {
@@ -1877,7 +1878,7 @@ public class IoTDBConfig {
     this.allocateMemoryForCoordinator = allocateMemoryForRead * 50 / 1001;
     this.allocateMemoryForOperators = allocateMemoryForRead * 200 / 1001;
     this.allocateMemoryForDataExchange = allocateMemoryForRead * 200 / 1001;
-    this.maxBytesPerFragmentInstance = this.allocateMemoryForDataExchange / queryThreadCount;
+    this.maxBytesPerFragmentInstance = allocateMemoryForDataExchange / queryThreadCount;
     this.allocateMemoryForTimeIndex = allocateMemoryForRead * 200 / 1001;
   }
 
@@ -2111,6 +2112,7 @@ public class IoTDBConfig {
 
   public void setAllocateMemoryForDataExchange(long allocateMemoryForDataExchange) {
     this.allocateMemoryForDataExchange = allocateMemoryForDataExchange;
+    this.maxBytesPerFragmentInstance = allocateMemoryForDataExchange / queryThreadCount;
   }
 
   public long getAllocateMemoryForTimeIndex() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -1877,6 +1877,7 @@ public class IoTDBConfig {
     this.allocateMemoryForCoordinator = allocateMemoryForRead * 50 / 1001;
     this.allocateMemoryForOperators = allocateMemoryForRead * 200 / 1001;
     this.allocateMemoryForDataExchange = allocateMemoryForRead * 200 / 1001;
+    this.maxBytesPerFragmentInstance = this.allocateMemoryForDataExchange / queryThreadCount;
     this.allocateMemoryForTimeIndex = allocateMemoryForRead * 200 / 1001;
   }
 


### PR DESCRIPTION
maxBytesPerFragmentInstance should also be updated when updating allocatedMemoryForRead.