### PR TITLE
[To rel/1.1] update maxBytesPerFragmentInstance in setAllocateMemoryForRead of IoTDBConfig 

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -1540,6 +1540,7 @@ public class IoTDBConfig {
 
   public void setQueryThreadCount(int queryThreadCount) {
     this.queryThreadCount = queryThreadCount;
+    this.maxBytesPerFragmentInstance = this.allocateMemoryForDataExchange / queryThreadCount;
   }
 
   public void setDegreeOfParallelism(int degreeOfParallelism) {
@@ -2126,6 +2127,7 @@ public class IoTDBConfig {
 
   public void setAllocateMemoryForDataExchange(long allocateMemoryForDataExchange) {
     this.allocateMemoryForDataExchange = allocateMemoryForDataExchange;
+    this.maxBytesPerFragmentInstance = allocateMemoryForDataExchange / queryThreadCount;
   }
 
   public long getAllocateMemoryForTimeIndex() {

--- a/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/server/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -1892,6 +1892,7 @@ public class IoTDBConfig {
     this.allocateMemoryForCoordinator = allocateMemoryForRead * 50 / 1001;
     this.allocateMemoryForOperators = allocateMemoryForRead * 200 / 1001;
     this.allocateMemoryForDataExchange = allocateMemoryForRead * 200 / 1001;
+    this.maxBytesPerFragmentInstance = this.allocateMemoryForDataExchange / queryThreadCount;
     this.allocateMemoryForTimeIndex = allocateMemoryForRead * 200 / 1001;
   }
 


### PR DESCRIPTION
maxBytesPerFragmentInstance should also be updated when updating allocatedMemoryForRead.