### PR TITLE
Fix a bug of Writing Metrics

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/metrics/WritingMetrics.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/metrics/WritingMetrics.java
@@ -407,6 +407,7 @@ public class WritingMetrics implements IMetricSet {
                 MetricService.getInstance()
                     .remove(
                         MetricType.HISTOGRAM,
+                        Metric.WAL_NODE_INFO.toString(),
                         Tag.NAME.toString(),
                         name,
                         Tag.TYPE.toString(),


### PR DESCRIPTION
## Description
Modify the parameter to call remove when remove WALNodeInfoMetrics
