### PR TITLE
[To rel/1.1][IOTDB-6061] Fix the instability failure caused by initServer in IoTConsensus UT not binding to the corresponding port 

### DIFF
--- a/consensus/src/test/java/org/apache/iotdb/consensus/iot/ReplicateTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/iot/ReplicateTest.java
@@ -43,12 +43,15 @@ import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public class ReplicateTest {
   private static final long CHECK_POINT_GAP = 500;
   private final Logger logger = LoggerFactory.getLogger(ReplicateTest.class);
 
   private final ConsensusGroupId gid = new DataRegionId(1);
+
+  private static final long timeout = TimeUnit.SECONDS.toMillis(300);
 
   private final List<Peer> peers =
       Arrays.asList(
@@ -251,7 +254,7 @@ public class ReplicateTest {
 
   private static void waitPortAvailable(int port) {
     long start = System.currentTimeMillis();
-    while (System.currentTimeMillis() - start < 60 * 1000) {
+    while (System.currentTimeMillis() - start < timeout) {
       try (ServerSocket ignored = new ServerSocket(port)) {
         return;
       } catch (IOException e) {
@@ -263,6 +266,6 @@ public class ReplicateTest {
         }
       }
     }
-    Assert.fail(String.format("can not bind port %d after 60s", port));
+    Assert.fail(String.format("can not bind port %d after 300s", port));
   }
 }

--- a/consensus/src/test/java/org/apache/iotdb/consensus/iot/StabilityTest.java
+++ b/consensus/src/test/java/org/apache/iotdb/consensus/iot/StabilityTest.java
@@ -48,13 +48,15 @@ public class StabilityTest {
 
   private IConsensus consensusImpl;
 
+  private final int basePort = 9000;
+
   public void constructConsensus() throws IOException {
     consensusImpl =
         ConsensusFactory.getConsensusImpl(
                 ConsensusFactory.IOT_CONSENSUS,
                 ConsensusConfig.newBuilder()
                     .setThisNodeId(1)
-                    .setThisNode(new TEndPoint("0.0.0.0", 9000))
+                    .setThisNode(new TEndPoint("0.0.0.0", basePort))
                     .setStorageDir(storageDir.getAbsolutePath())
                     .build(),
                 gid -> new TestStateMachine())
@@ -88,7 +90,7 @@ public class StabilityTest {
   public void peerTest() throws Exception {
     consensusImpl.createPeer(
         dataRegionId,
-        Collections.singletonList(new Peer(dataRegionId, 1, new TEndPoint("0.0.0.0", 9000))));
+        Collections.singletonList(new Peer(dataRegionId, 1, new TEndPoint("0.0.0.0", basePort))));
 
     consensusImpl.deletePeer(dataRegionId);
 
@@ -100,7 +102,8 @@ public class StabilityTest {
     ConsensusGenericResponse response =
         consensusImpl.createPeer(
             dataRegionId,
-            Collections.singletonList(new Peer(dataRegionId, 1, new TEndPoint("0.0.0.0", 9000))));
+            Collections.singletonList(
+                new Peer(dataRegionId, 1, new TEndPoint("0.0.0.0", basePort))));
     Assert.assertTrue(response.isSuccess());
     consensusImpl.deletePeer(dataRegionId);
   }
@@ -108,7 +111,7 @@ public class StabilityTest {
   public void snapshotTest() throws IOException {
     consensusImpl.createPeer(
         dataRegionId,
-        Collections.singletonList(new Peer(dataRegionId, 1, new TEndPoint("0.0.0.0", 9000))));
+        Collections.singletonList(new Peer(dataRegionId, 1, new TEndPoint("0.0.0.0", basePort))));
     consensusImpl.triggerSnapshot(dataRegionId);
 
     File dataDir = new File(IoTConsensus.buildPeerDir(storageDir, dataRegionId));
@@ -133,7 +136,7 @@ public class StabilityTest {
   public void snapshotUpgradeTest() throws Exception {
     consensusImpl.createPeer(
         dataRegionId,
-        Collections.singletonList(new Peer(dataRegionId, 1, new TEndPoint("0.0.0.0", 9000))));
+        Collections.singletonList(new Peer(dataRegionId, 1, new TEndPoint("0.0.0.0", basePort))));
     consensusImpl.triggerSnapshot(dataRegionId);
     long oldSnapshotIndex = System.currentTimeMillis();
     String oldSnapshotDirName =


### PR DESCRIPTION
cherry-pick [pr](https://github.com/apache/iotdb/pull/10530)