### PR TITLE
[IOTDB-6064] Pipe: Fix deadlock in rolling back procedures concurrently

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/task/PipeTaskCoordinator.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/task/PipeTaskCoordinator.java
@@ -73,14 +73,22 @@ public class PipeTaskCoordinator {
   /**
    * Unlock the pipe task coordinator. Calling this method will clear the pipe task info holder,
    * which means that the holder will be null after calling this method.
+   *
+   * @return true if successfully unlocked, false if current thread is not holding the lock.
    */
-  public void unlock() {
+  public boolean unlock() {
     if (pipeTaskInfoHolder != null) {
       pipeTaskInfoHolder.set(null);
       pipeTaskInfoHolder = null;
     }
 
-    pipeTaskCoordinatorLock.unlock();
+    try {
+      pipeTaskCoordinatorLock.unlock();
+    } catch (IllegalMonitorStateException ignored) {
+      // This is thrown if unlock() is called without lock() called first.
+      return false;
+    }
+    return true;
   }
 
   /* Caller should ensure that the method is called in the lock {@link #lock()}. */

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/task/PipeTaskCoordinator.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/task/PipeTaskCoordinator.java
@@ -86,6 +86,7 @@ public class PipeTaskCoordinator {
       pipeTaskCoordinatorLock.unlock();
     } catch (IllegalMonitorStateException ignored) {
       // This is thrown if unlock() is called without lock() called first.
+      LOGGER.warn("This thread is not holding the lock.");
       return false;
     }
     return true;

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/task/PipeTaskCoordinator.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/task/PipeTaskCoordinator.java
@@ -84,12 +84,12 @@ public class PipeTaskCoordinator {
 
     try {
       pipeTaskCoordinatorLock.unlock();
+      return true;
     } catch (IllegalMonitorStateException ignored) {
       // This is thrown if unlock() is called without lock() called first.
       LOGGER.warn("This thread is not holding the lock.");
       return false;
     }
-    return true;
   }
 
   /* Caller should ensure that the method is called in the lock {@link #lock()}. */

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
@@ -365,6 +365,7 @@ public class ProcedureExecutor<Env> {
                 break;
               case LOCK_EVENT_WAIT:
                 LOG.info("LOCK_EVENT_WAIT can't rollback child running for {}", proc);
+                break;
               case LOCK_YIELD_WAIT:
                 scheduler.yield(proc);
                 break;

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
@@ -347,6 +347,10 @@ public class ProcedureExecutor<Env> {
           switch (executeRootStackRollback(rootProcId, rootProcStack)) {
             case LOCK_ACQUIRED:
               break;
+            case LOCK_EVENT_WAIT:
+              LOG.info("LOCK_EVENT_WAIT rollback " + proc);
+              rootProcStack.unsetRollback();
+              break;
             case LOCK_YIELD_WAIT:
               rootProcStack.unsetRollback();
               scheduler.yield(proc);

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/AbstractOperatePipeProcedureV2.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/AbstractOperatePipeProcedureV2.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.confignode.procedure.exception.ProcedureException;
 import org.apache.iotdb.confignode.procedure.exception.ProcedureSuspendedException;
 import org.apache.iotdb.confignode.procedure.exception.ProcedureYieldException;
 import org.apache.iotdb.confignode.procedure.impl.node.AbstractNodeProcedure;
+import org.apache.iotdb.confignode.procedure.state.ProcedureLockState;
 import org.apache.iotdb.confignode.procedure.state.pipe.task.OperatePipeTaskState;
 import org.apache.iotdb.mpp.rpc.thrift.TPushPipeMetaResp;
 import org.apache.iotdb.pipe.api.exception.PipeException;
@@ -68,6 +69,51 @@ public abstract class AbstractOperatePipeProcedureV2
   // putting it here is just for convenience
   protected AtomicReference<PipeTaskInfo> pipeTaskInfo;
 
+  @Override
+  protected ProcedureLockState acquireLock(ConfigNodeProcedureEnv configNodeProcedureEnv) {
+    configNodeProcedureEnv.getSchedulerLock().lock();
+    try {
+      if (configNodeProcedureEnv.getNodeLock().tryLock(this)) {
+        pipeTaskInfo =
+            configNodeProcedureEnv
+                .getConfigManager()
+                .getPipeManager()
+                .getPipeTaskCoordinator()
+                .lock();
+        LOGGER.info("procedureId {} acquire lock.", getProcId());
+        return ProcedureLockState.LOCK_ACQUIRED;
+      }
+      configNodeProcedureEnv.getNodeLock().waitProcedure(this);
+      LOGGER.info("procedureId {} wait for lock.", getProcId());
+      return ProcedureLockState.LOCK_EVENT_WAIT;
+    } finally {
+      configNodeProcedureEnv.getSchedulerLock().unlock();
+    }
+  }
+
+  @Override
+  protected void releaseLock(ConfigNodeProcedureEnv configNodeProcedureEnv) {
+    configNodeProcedureEnv.getSchedulerLock().lock();
+    try {
+      LOGGER.info("procedureId {} release lock.", getProcId());
+      if (pipeTaskInfo != null
+          && !configNodeProcedureEnv
+              .getConfigManager()
+              .getPipeManager()
+              .getPipeTaskCoordinator()
+              .unlock()) {
+        LOGGER.warn("unlock() is called without lock() called first.");
+      }
+      if (configNodeProcedureEnv.getNodeLock().releaseLock(this)) {
+        configNodeProcedureEnv
+            .getNodeLock()
+            .wakeWaitingProcedures(configNodeProcedureEnv.getScheduler());
+      }
+    } finally {
+      configNodeProcedureEnv.getSchedulerLock().unlock();
+    }
+  }
+
   protected abstract PipeTaskOperation getOperation();
 
   /**
@@ -103,7 +149,6 @@ public abstract class AbstractOperatePipeProcedureV2
     try {
       switch (state) {
         case VALIDATE_TASK:
-          pipeTaskInfo = env.getConfigManager().getPipeManager().getPipeTaskCoordinator().lock();
           executeFromValidateTask(env);
           setNextState(OperatePipeTaskState.CALCULATE_INFO_FOR_TASK);
           break;
@@ -117,7 +162,6 @@ public abstract class AbstractOperatePipeProcedureV2
           break;
         case OPERATE_ON_DATA_NODES:
           executeFromOperateOnDataNodes(env);
-          env.getConfigManager().getPipeManager().getPipeTaskCoordinator().unlock();
           return Flow.NO_MORE_STATE;
         default:
           throw new UnsupportedOperationException(
@@ -160,11 +204,7 @@ public abstract class AbstractOperatePipeProcedureV2
       throws IOException, InterruptedException, ProcedureException {
     switch (state) {
       case VALIDATE_TASK:
-        try {
-          rollbackFromValidateTask(env);
-        } finally {
-          env.getConfigManager().getPipeManager().getPipeTaskCoordinator().unlock();
-        }
+        rollbackFromValidateTask(env);
         break;
       case CALCULATE_INFO_FOR_TASK:
         rollbackFromCalculateInfoForTask(env);

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/AbstractOperatePipeProcedureV2.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/AbstractOperatePipeProcedureV2.java
@@ -96,13 +96,12 @@ public abstract class AbstractOperatePipeProcedureV2
     configNodeProcedureEnv.getSchedulerLock().lock();
     try {
       LOGGER.info("procedureId {} release lock.", getProcId());
-      if (pipeTaskInfo != null
-          && !configNodeProcedureEnv
-              .getConfigManager()
-              .getPipeManager()
-              .getPipeTaskCoordinator()
-              .unlock()) {
-        LOGGER.warn("unlock() is called without lock() called first.");
+      if (pipeTaskInfo != null) {
+        configNodeProcedureEnv
+            .getConfigManager()
+            .getPipeManager()
+            .getPipeTaskCoordinator()
+            .unlock();
       }
       if (configNodeProcedureEnv.getNodeLock().releaseLock(this)) {
         configNodeProcedureEnv


### PR DESCRIPTION
Fix:
- Add a case in executeProcedure, referring to https://github.com/apache/hbase
- Modify lock control of pipe procedures to avoid deadlock in failed procedures