### PR TITLE
[IOTDB-6061] Fix the instability failure caused by initServer in IoTConsensus UT not binding to the corresponding port

### DIFF
--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/ReplicateTest.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/ReplicateTest.java
@@ -271,6 +271,6 @@ public class ReplicateTest {
         }
       }
     }
-    Assert.fail(String.format("can not find port for node %d after 60s", i + 1));
+    Assert.fail(String.format("can not find port for node %d after 240s", i + 1));
   }
 }

--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/ReplicateTest.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/ReplicateTest.java
@@ -44,6 +44,7 @@ import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public class ReplicateTest {
   private static final long CHECK_POINT_GAP = 500;
@@ -51,7 +52,9 @@ public class ReplicateTest {
 
   private final ConsensusGroupId gid = new DataRegionId(1);
 
-  private int basePort = 9000 + 3;
+  private int basePort = 6000 + 3;
+
+  private final long timeout = TimeUnit.SECONDS.toMillis(240);
 
   private List<Peer> peers =
       Arrays.asList(
@@ -88,7 +91,7 @@ public class ReplicateTest {
 
   private void initServer() throws IOException {
     for (int i = 0; i < peers.size(); i++) {
-      waitPortAvailable(i);
+      findPortAvailable(i);
       int finalI = i;
       servers.add(
           (IoTConsensus)
@@ -251,10 +254,10 @@ public class ReplicateTest {
     Assert.assertEquals(stateMachines.get(2).getData(), stateMachines.get(1).getData());
   }
 
-  private void waitPortAvailable(int i) {
+  private void findPortAvailable(int i) {
     long start = System.currentTimeMillis();
-    while (System.currentTimeMillis() - start < 60 * 1000) {
-      try (ServerSocket ignored = new ServerSocket(this.peers.get(i).getEndpoint().port)) {
+    while (System.currentTimeMillis() - start < timeout) {
+      try (ServerSocket ignored = new ServerSocket(peers.get(i).getEndpoint().port)) {
         return;
       } catch (IOException e) {
         // Port is already in use, wait and retry

--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/StabilityTest.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/StabilityTest.java
@@ -49,13 +49,15 @@ public class StabilityTest {
 
   private IConsensus consensusImpl;
 
+  private final int basePort = 6320;
+
   public void constructConsensus() throws IOException {
     consensusImpl =
         ConsensusFactory.getConsensusImpl(
                 ConsensusFactory.IOT_CONSENSUS,
                 ConsensusConfig.newBuilder()
                     .setThisNodeId(1)
-                    .setThisNode(new TEndPoint("0.0.0.0", 9000))
+                    .setThisNode(new TEndPoint("0.0.0.0", basePort))
                     .setStorageDir(storageDir.getAbsolutePath())
                     .setConsensusGroupType(TConsensusGroupType.DataRegion)
                     .build(),
@@ -90,7 +92,7 @@ public class StabilityTest {
   public void peerTest() throws Exception {
     consensusImpl.createPeer(
         dataRegionId,
-        Collections.singletonList(new Peer(dataRegionId, 1, new TEndPoint("0.0.0.0", 9000))));
+        Collections.singletonList(new Peer(dataRegionId, 1, new TEndPoint("0.0.0.0", basePort))));
 
     consensusImpl.deletePeer(dataRegionId);
 
@@ -102,7 +104,8 @@ public class StabilityTest {
     ConsensusGenericResponse response =
         consensusImpl.createPeer(
             dataRegionId,
-            Collections.singletonList(new Peer(dataRegionId, 1, new TEndPoint("0.0.0.0", 9000))));
+            Collections.singletonList(
+                new Peer(dataRegionId, 1, new TEndPoint("0.0.0.0", basePort))));
     Assert.assertTrue(response.isSuccess());
     consensusImpl.deletePeer(dataRegionId);
   }
@@ -110,7 +113,7 @@ public class StabilityTest {
   public void snapshotTest() throws IOException {
     consensusImpl.createPeer(
         dataRegionId,
-        Collections.singletonList(new Peer(dataRegionId, 1, new TEndPoint("0.0.0.0", 9000))));
+        Collections.singletonList(new Peer(dataRegionId, 1, new TEndPoint("0.0.0.0", basePort))));
     consensusImpl.triggerSnapshot(dataRegionId);
 
     File dataDir = new File(IoTConsensus.buildPeerDir(storageDir, dataRegionId));
@@ -135,7 +138,7 @@ public class StabilityTest {
   public void snapshotUpgradeTest() throws Exception {
     consensusImpl.createPeer(
         dataRegionId,
-        Collections.singletonList(new Peer(dataRegionId, 1, new TEndPoint("0.0.0.0", 9000))));
+        Collections.singletonList(new Peer(dataRegionId, 1, new TEndPoint("0.0.0.0", basePort))));
     consensusImpl.triggerSnapshot(dataRegionId);
     long oldSnapshotIndex = System.currentTimeMillis();
     String oldSnapshotDirName =

--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/StabilityTest.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/StabilityTest.java
@@ -49,7 +49,7 @@ public class StabilityTest {
 
   private IConsensus consensusImpl;
 
-  private final int basePort = 6320;
+  private final int basePort = 9000;
 
   public void constructConsensus() throws IOException {
     consensusImpl =


### PR DESCRIPTION
## Description

see [jira](https://issues.apache.org/jira/browse/IOTDB-6061)