### PR TITLE
Pipe: Add a configuration parameter to control the number of rows of the tablet used within the pipe module

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/row/PipeRowCollector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/row/PipeRowCollector.java
@@ -55,7 +55,7 @@ public class PipeRowCollector implements RowCollector {
           new Tablet(
               deviceId,
               measurementSchemaList,
-              PipeConfig.getInstance().getPipeExtractorTabletRowSize());
+              PipeConfig.getInstance().getPipeDataStructureTabletRowSize());
       isAligned = pipeRow.isAligned();
       tablet.initBitMaps();
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/row/PipeRowCollector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/row/PipeRowCollector.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.pipe.event.common.row;
 
+import org.apache.iotdb.commons.pipe.config.PipeConfig;
 import org.apache.iotdb.db.pipe.event.common.tablet.PipeRawTabletInsertionEvent;
 import org.apache.iotdb.pipe.api.access.Row;
 import org.apache.iotdb.pipe.api.collector.RowCollector;
@@ -50,7 +51,11 @@ public class PipeRowCollector implements RowCollector {
       final String deviceId = pipeRow.getDeviceId();
       final List<MeasurementSchema> measurementSchemaList =
           new ArrayList<>(Arrays.asList(measurementSchemaArray));
-      tablet = new Tablet(deviceId, measurementSchemaList);
+      tablet =
+          new Tablet(
+              deviceId,
+              measurementSchemaList,
+              PipeConfig.getInstance().getPipeExtractorTabletRowSize());
       isAligned = pipeRow.isAligned();
       tablet.initBitMaps();
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/TsFileInsertionDataTabletIterator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/TsFileInsertionDataTabletIterator.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.pipe.event.common.tsfile;
 
+import org.apache.iotdb.commons.pipe.config.PipeConfig;
 import org.apache.iotdb.pipe.api.exception.PipeException;
 import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -114,7 +115,8 @@ public class TsFileInsertionDataTabletIterator implements Iterator<Tablet> {
           measurementDataTypeMap.get(deviceId + TsFileConstant.PATH_SEPARATOR + measurement);
       schemas.add(new MeasurementSchema(measurement, dataType));
     }
-    final Tablet tablet = new Tablet(deviceId, schemas);
+    final Tablet tablet =
+        new Tablet(deviceId, schemas, PipeConfig.getInstance().getPipeExtractorTabletRowSize());
     tablet.initBitMaps();
 
     while (queryDataSet.hasNext()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/TsFileInsertionDataTabletIterator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/TsFileInsertionDataTabletIterator.java
@@ -116,7 +116,7 @@ public class TsFileInsertionDataTabletIterator implements Iterator<Tablet> {
       schemas.add(new MeasurementSchema(measurement, dataType));
     }
     final Tablet tablet =
-        new Tablet(deviceId, schemas, PipeConfig.getInstance().getPipeExtractorTabletRowSize());
+        new Tablet(deviceId, schemas, PipeConfig.getInstance().getPipeDataStructureTabletRowSize());
     tablet.initBitMaps();
 
     while (queryDataSet.hasNext()) {

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -972,6 +972,9 @@ cluster_name=defaultCluster
 # Noted that: this should be less than or equals to realtimeExtractorPendingQueueCapacity
 # pipe_extractor_pending_queue_tablet_limit=64
 
+# The row size of tablets created in the extractor stage.
+# pipe_extractor_tablet_row_size=65536
+
 # The buffer size used for reading file during file transfer.
 # pipe_connector_read_file_buffer_size=8388608
 

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -947,6 +947,9 @@ cluster_name=defaultCluster
 # The directory is located in the data directory of IoTDB.
 # pipe_hardlink_tsfile_dir_name=pipe
 
+# The row size of tablets created in pipe transfer.
+# pipe_data_structure_tablet_row_size=65536
+
 # The maximum number of threads that can be used to execute the pipe subtasks in PipeSubtaskExecutor.
 # pipe_subtask_executor_max_thread_num=5
 
@@ -971,9 +974,6 @@ cluster_name=defaultCluster
 # The limit for the number of tablet events that can be held in the pending queue of the hybrid realtime extractor.
 # Noted that: this should be less than or equals to realtimeExtractorPendingQueueCapacity
 # pipe_extractor_pending_queue_tablet_limit=64
-
-# The row size of tablets created in the extractor stage.
-# pipe_extractor_tablet_row_size=65536
 
 # The buffer size used for reading file during file transfer.
 # pipe_connector_read_file_buffer_size=8388608

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -154,6 +154,7 @@ public class CommonConfig {
   private int pipeExtractorMatcherCacheSize = 1024;
   private int pipeExtractorPendingQueueCapacity = 128;
   private int pipeExtractorPendingQueueTabletLimit = pipeExtractorPendingQueueCapacity / 2;
+  private int pipeExtractorTabletRowSize = 65536;
 
   private int pipeConnectorReadFileBufferSize = 8388608;
   private long pipeConnectorRetryIntervalMs = 1000L;
@@ -491,6 +492,14 @@ public class CommonConfig {
 
   public void setPipeExtractorPendingQueueTabletLimit(int pipeExtractorPendingQueueTabletLimit) {
     this.pipeExtractorPendingQueueTabletLimit = pipeExtractorPendingQueueTabletLimit;
+  }
+
+  public int getPipeExtractorTabletRowSize() {
+    return pipeExtractorTabletRowSize;
+  }
+
+  public void setPipeExtractorTabletRowSize(int pipeExtractorTabletRowSize) {
+    this.pipeExtractorTabletRowSize = pipeExtractorTabletRowSize;
   }
 
   public int getPipeConnectorReadFileBufferSize() {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -154,7 +154,7 @@ public class CommonConfig {
   private int pipeExtractorMatcherCacheSize = 1024;
   private int pipeExtractorPendingQueueCapacity = 128;
   private int pipeExtractorPendingQueueTabletLimit = pipeExtractorPendingQueueCapacity / 2;
-  private int pipeExtractorTabletRowSize = 65536;
+  private int pipeDataStructureTabletRowSize = 65536;
 
   private int pipeConnectorReadFileBufferSize = 8388608;
   private long pipeConnectorRetryIntervalMs = 1000L;
@@ -460,6 +460,14 @@ public class CommonConfig {
     this.pipeHardlinkTsFileDirName = pipeHardlinkTsFileDirName;
   }
 
+  public int getPipeDataStructureTabletRowSize() {
+    return pipeDataStructureTabletRowSize;
+  }
+
+  public void setPipeDataStructureTabletRowSize(int pipeDataStructureTabletRowSize) {
+    this.pipeDataStructureTabletRowSize = pipeDataStructureTabletRowSize;
+  }
+
   public int getPipeExtractorAssignerDisruptorRingBufferSize() {
     return pipeExtractorAssignerDisruptorRingBufferSize;
   }
@@ -492,14 +500,6 @@ public class CommonConfig {
 
   public void setPipeExtractorPendingQueueTabletLimit(int pipeExtractorPendingQueueTabletLimit) {
     this.pipeExtractorPendingQueueTabletLimit = pipeExtractorPendingQueueTabletLimit;
-  }
-
-  public int getPipeExtractorTabletRowSize() {
-    return pipeExtractorTabletRowSize;
-  }
-
-  public void setPipeExtractorTabletRowSize(int pipeExtractorTabletRowSize) {
-    this.pipeExtractorTabletRowSize = pipeExtractorTabletRowSize;
   }
 
   public int getPipeConnectorReadFileBufferSize() {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -240,6 +240,11 @@ public class CommonDescriptor {
     config.setPipeHardlinkTsFileDirName(
         properties.getProperty(
             "pipe_hardlink_tsfile_dir_name", config.getPipeHardlinkTsFileDirName()));
+    config.setPipeDataStructureTabletRowSize(
+        Integer.parseInt(
+            properties.getProperty(
+                "pipe_data_structure_tablet_row_size",
+                String.valueOf(config.getPipeDataStructureTabletRowSize()))));
 
     config.setPipeSubtaskExecutorMaxThreadNum(
         Integer.parseInt(
@@ -287,11 +292,6 @@ public class CommonDescriptor {
             properties.getProperty(
                 "pipe_extractor_pending_queue_tablet_limit",
                 String.valueOf(config.getPipeExtractorPendingQueueTabletLimit()))));
-    config.setPipeExtractorTabletRowSize(
-        Integer.parseInt(
-            properties.getProperty(
-                "pipe_extractor_tablet_row_size",
-                String.valueOf(config.getPipeExtractorTabletRowSize()))));
 
     config.setPipeConnectorReadFileBufferSize(
         Integer.parseInt(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -287,6 +287,11 @@ public class CommonDescriptor {
             properties.getProperty(
                 "pipe_extractor_pending_queue_tablet_limit",
                 String.valueOf(config.getPipeExtractorPendingQueueTabletLimit()))));
+    config.setPipeExtractorTabletRowSize(
+        Integer.parseInt(
+            properties.getProperty(
+                "pipe_extractor_tablet_row_size",
+                String.valueOf(config.getPipeExtractorTabletRowSize()))));
 
     config.setPipeConnectorReadFileBufferSize(
         Integer.parseInt(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeConfig.java
@@ -71,6 +71,10 @@ public class PipeConfig {
     return COMMON_CONFIG.getPipeExtractorPendingQueueTabletLimit();
   }
 
+  public int getPipeExtractorTabletRowSize() {
+    return COMMON_CONFIG.getPipeExtractorTabletRowSize();
+  }
+
   /////////////////////////////// Connector ///////////////////////////////
 
   public int getPipeConnectorReadFileBufferSize() {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeConfig.java
@@ -35,6 +35,12 @@ public class PipeConfig {
     return COMMON_CONFIG.getPipeHardlinkTsFileDirName();
   }
 
+  /////////////////////////////// Tablet ///////////////////////////////
+
+  public int getPipeDataStructureTabletRowSize() {
+    return COMMON_CONFIG.getPipeDataStructureTabletRowSize();
+  }
+
   /////////////////////////////// Subtask Executor ///////////////////////////////
 
   public int getPipeSubtaskExecutorMaxThreadNum() {
@@ -69,10 +75,6 @@ public class PipeConfig {
 
   public int getPipeExtractorPendingQueueTabletLimit() {
     return COMMON_CONFIG.getPipeExtractorPendingQueueTabletLimit();
-  }
-
-  public int getPipeExtractorTabletRowSize() {
-    return COMMON_CONFIG.getPipeExtractorTabletRowSize();
   }
 
   /////////////////////////////// Connector ///////////////////////////////


### PR DESCRIPTION
Currently, tablets in pipe transfer are created with default rowSize. If data fransfer load is high, there  will be too many thrift requests of tablet transfer. So we can add a knob to specify rowSize of pipe tablets.