### PR TITLE
[IOTDB-6068] Pipe: Failed to load tsfile with first page is empty in a chunk

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/load/AlignedChunkData.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/load/AlignedChunkData.java
@@ -179,8 +179,11 @@ public class AlignedChunkData implements ChunkData {
   @Override
   public void writeEntirePage(PageHeader pageHeader, ByteBuffer pageData) throws IOException {
     pageNumbers.set(pageNumbers.size() - 1, pageNumbers.get(pageNumbers.size() - 1) + 1);
+    // serialize needDecode==false
     dataSize += ReadWriteIOUtils.write(false, stream);
+    // serialize pageHeader
     dataSize += pageHeader.serializeTo(stream);
+    // serialize pageData
     dataSize += ReadWriteIOUtils.write(pageData, stream);
   }
 
@@ -191,6 +194,7 @@ public class AlignedChunkData implements ChunkData {
     satisfiedLengthQueue.offer(satisfiedLength);
     long startTime = timePartitionSlot.getStartTime();
     long endTime = startTime + TimePartitionUtils.getTimePartitionInterval();
+    // serialize needDecode==true
     dataSize += ReadWriteIOUtils.write(true, stream);
     dataSize += ReadWriteIOUtils.write(satisfiedLength, stream);
 
@@ -210,6 +214,7 @@ public class AlignedChunkData implements ChunkData {
     long startTime = timePartitionSlot.getStartTime();
     long endTime = startTime + TimePartitionUtils.getTimePartitionInterval();
     int satisfiedLength = satisfiedLengthQueue.poll();
+    // serialize needDecode==true
     dataSize += ReadWriteIOUtils.write(true, stream);
     dataSize += ReadWriteIOUtils.write(satisfiedLength, stream);
     satisfiedLengthQueue.offer(satisfiedLength);
@@ -219,7 +224,7 @@ public class AlignedChunkData implements ChunkData {
         break;
       }
       if (times[i] >= startTime) {
-        if (values[i] == null) {
+        if (values.length == 0 || values[i] == null) {
           dataSize += ReadWriteIOUtils.write(true, stream);
         } else {
           dataSize += ReadWriteIOUtils.write(false, stream);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/load/TsFileSplitter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/load/TsFileSplitter.java
@@ -262,19 +262,15 @@ public class TsFileSplitter {
               }
               if (alignedChunkDataList.size() == 1) { // write entire page
                 // write the entire page if it's not an empty page.
-                if (!isEmptyPage(pageHeader)) {
-                  alignedChunkDataList
-                      .get(0)
-                      .writeEntirePage(pageHeader, reader.readCompressedPage(pageHeader));
-                }
+                alignedChunkDataList
+                    .get(0)
+                    .writeEntirePage(pageHeader, reader.readCompressedPage(pageHeader));
               } else { // decode page
                 long[] times = pageIndex2Times.get(pageIndex);
                 TsPrimitiveType[] values =
                     decodeValuePage(reader, header, pageHeader, times, valueDecoder);
                 for (AlignedChunkData alignedChunkData : alignedChunkDataList) {
-                  if (!isEmptyPage(pageHeader)) {
-                    alignedChunkData.writeDecodeValuePage(times, values, header.getDataType());
-                  }
+                  alignedChunkData.writeDecodeValuePage(times, values, header.getDataType());
                 }
               }
               long pageDataSize = pageHeader.getSerializedPageSize();

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/file/header/PageHeader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/file/header/PageHeader.java
@@ -120,6 +120,9 @@ public class PageHeader {
   public int serializeTo(OutputStream outputStream) throws IOException {
     int length = 0;
     length += ReadWriteForEncodingUtils.writeUnsignedVarInt(uncompressedSize, outputStream);
+    if (uncompressedSize == 0) { // Empty Page
+      return length;
+    }
     length += ReadWriteForEncodingUtils.writeUnsignedVarInt(compressedSize, outputStream);
     length += statistics.serialize(outputStream);
     return length;

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ValueChunkWriter.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ValueChunkWriter.java
@@ -209,13 +209,17 @@ public class ValueChunkWriter {
           "start to flush a page header into buffer, buffer position {} ", pageBuffer.size());
       // serialize pageHeader  see writePageToPageBuffer method
       if (numOfPages == 0) { // record the firstPageStatistics
-        if (header.getStatistics() != null) {
-          this.firstPageStatistics = header.getStatistics();
-        }
+
         this.sizeWithoutStatistic +=
             ReadWriteForEncodingUtils.writeUnsignedVarInt(header.getUncompressedSize(), pageBuffer);
-        this.sizeWithoutStatistic +=
-            ReadWriteForEncodingUtils.writeUnsignedVarInt(header.getCompressedSize(), pageBuffer);
+
+        if (header.getStatistics() == null) {
+          this.firstPageStatistics = null;
+        } else {
+          this.firstPageStatistics = header.getStatistics();
+          this.sizeWithoutStatistic +=
+              ReadWriteForEncodingUtils.writeUnsignedVarInt(header.getCompressedSize(), pageBuffer);
+        }
       } else if (numOfPages == 1) { // put the firstPageStatistics into pageBuffer
         if (firstPageStatistics != null) {
           byte[] b = pageBuffer.toByteArray();
@@ -225,21 +229,27 @@ public class ValueChunkWriter {
           pageBuffer.write(b, this.sizeWithoutStatistic, b.length - this.sizeWithoutStatistic);
         }
         ReadWriteForEncodingUtils.writeUnsignedVarInt(header.getUncompressedSize(), pageBuffer);
-        ReadWriteForEncodingUtils.writeUnsignedVarInt(header.getCompressedSize(), pageBuffer);
-        header.getStatistics().serialize(pageBuffer);
+        if (header.getUncompressedSize() != 0) {
+          ReadWriteForEncodingUtils.writeUnsignedVarInt(header.getCompressedSize(), pageBuffer);
+          header.getStatistics().serialize(pageBuffer);
+        }
+
         firstPageStatistics = null;
       } else {
         ReadWriteForEncodingUtils.writeUnsignedVarInt(header.getUncompressedSize(), pageBuffer);
-        ReadWriteForEncodingUtils.writeUnsignedVarInt(header.getCompressedSize(), pageBuffer);
-        header.getStatistics().serialize(pageBuffer);
+        if (header.getUncompressedSize() != 0) {
+          ReadWriteForEncodingUtils.writeUnsignedVarInt(header.getCompressedSize(), pageBuffer);
+          header.getStatistics().serialize(pageBuffer);
+        }
       }
       logger.debug(
           "finish to flush a page header {} of time page into buffer, buffer position {} ",
           header,
           pageBuffer.size());
 
-      statistics.mergeStatistics(header.getStatistics());
-
+      if (header.getStatistics() != null) {
+        statistics.mergeStatistics(header.getStatistics());
+      }
     } catch (IOException e) {
       throw new PageException("IO Exception in writeDataPageHeader,ignore this page", e);
     }


### PR DESCRIPTION
in previous pr: https://github.com/apache/iotdb/pull/10487, We only considered the case where the empty page is at the end of an aligned chunk, and it's not well thought out. Empty page is skipped, causing problems with rewriting tsfile on datanode

case not considered: 
<img width="537" alt="image" src="https://github.com/apache/iotdb/assets/42286868/df89a698-c889-4afd-afe2-41f3aba957f1">

in this pr, we consider all the position of empty pages in an aligned chunk, and handle the empty page through write an empty page into the chunk.
