### PR TITLE
Add database limit threshold configuration and check when creating new database.

### DIFF
--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/MppCommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/MppCommonConfig.java
@@ -353,4 +353,10 @@ public class MppCommonConfig extends MppBaseConfig implements CommonConfig {
     setProperty("cluster_schema_limit_threshold", String.valueOf(clusterSchemaLimitThreshold));
     return this;
   }
+
+  @Override
+  public CommonConfig setDatabaseLimitThreshold(long databaseLimitThreshold) {
+    setProperty("database_limit_threshold", String.valueOf(databaseLimitThreshold));
+    return this;
+  }
 }

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/MppSharedCommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/MppSharedCommonConfig.java
@@ -365,4 +365,11 @@ public class MppSharedCommonConfig implements CommonConfig {
     cnConfig.setClusterSchemaLimitThreshold(clusterSchemaLimitThreshold);
     return this;
   }
+
+  @Override
+  public CommonConfig setDatabaseLimitThreshold(long databaseLimitThreshold) {
+    dnConfig.setDatabaseLimitThreshold(databaseLimitThreshold);
+    cnConfig.setDatabaseLimitThreshold(databaseLimitThreshold);
+    return this;
+  }
 }

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/remote/RemoteCommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/remote/RemoteCommonConfig.java
@@ -261,4 +261,9 @@ public class RemoteCommonConfig implements CommonConfig {
   public CommonConfig setClusterSchemaLimitThreshold(long clusterSchemaLimitThreshold) {
     return this;
   }
+
+  @Override
+  public CommonConfig setDatabaseLimitThreshold(long databaseLimitThreshold) {
+    return this;
+  }
 }

--- a/integration-test/src/main/java/org/apache/iotdb/itbase/env/CommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/itbase/env/CommonConfig.java
@@ -112,6 +112,8 @@ public interface CommonConfig {
 
   CommonConfig setClusterSchemaLimitThreshold(long clusterSchemaLimitThreshold);
 
+  CommonConfig setDatabaseLimitThreshold(long databaseLimitThreshold);
+
   CommonConfig setQuotaEnable(boolean quotaEnable);
 
   CommonConfig setSortBufferSize(long sortBufferSize);

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBDatabaseQuotaIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBDatabaseQuotaIT.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.it.schema;
+
+import org.apache.iotdb.it.env.EnvFactory;
+import org.apache.iotdb.util.AbstractSchemaIT;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+
+import java.sql.Connection;
+import java.sql.Statement;
+
+public class IoTDBDatabaseQuotaIT extends AbstractSchemaIT {
+  public IoTDBDatabaseQuotaIT(SchemaTestMode schemaTestMode) {
+    super(schemaTestMode);
+  }
+
+  @Parameterized.BeforeParam
+  public static void before() throws Exception {
+    setUpEnvironment();
+    EnvFactory.getEnv().getConfig().getCommonConfig().setDatabaseLimitThreshold(2);
+    EnvFactory.getEnv().initClusterEnvironment();
+  }
+
+  @Parameterized.AfterParam
+  public static void after() throws Exception {
+    EnvFactory.getEnv().cleanClusterEnvironment();
+    tearDownEnvironment();
+  }
+
+  @Test
+  public void testClusterSchemaQuota() {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("create database root.db1;");
+      statement.execute("insert into root.db2.device(time,s1) values(1,5);");
+      try {
+        statement.execute("create database root.db3;");
+        Assert.fail("root.db3 should not be created.");
+      } catch (Exception e) {
+        Assert.assertTrue(
+            e.getMessage()
+                .contains(
+                    "The current database number has exceeded the cluster quota. The maximum number of cluster databases allowed is 2, Please review your configuration database_limit_threshold or delete some existing database to comply with the quota."));
+      }
+      try {
+        statement.execute("insert into root.db3.device(time,s1) values(1,5);");
+        Assert.fail("root.db3 should not be created.");
+      } catch (Exception e) {
+        Assert.assertTrue(
+            e.getMessage()
+                .contains(
+                    "The current database number has exceeded the cluster quota. The maximum number of cluster databases allowed is 2, Please review your configuration database_limit_threshold or delete some existing database to comply with the quota."));
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assert.fail(e.getMessage());
+    }
+  }
+}

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -486,6 +486,7 @@ public class ConfigManager implements IManager {
     clusterParameters.setTimestampPrecision(COMMON_CONF.getTimestampPrecision());
     clusterParameters.setSchemaEngineMode(COMMON_CONF.getSchemaEngineMode());
     clusterParameters.setTagAttributeTotalSize(COMMON_CONF.getTagAttributeTotalSize());
+    clusterParameters.setDatabaseLimitThreshold(COMMON_CONF.getDatabaseLimitThreshold());
     return clusterParameters;
   }
 
@@ -1112,6 +1113,10 @@ public class ConfigManager implements IManager {
 
     if (clusterParameters.getTagAttributeTotalSize() != COMMON_CONF.getTagAttributeTotalSize()) {
       return errorStatus.setMessage(errorPrefix + "tag_attribute_total_size" + errorSuffix);
+    }
+
+    if (clusterParameters.getDatabaseLimitThreshold() != COMMON_CONF.getDatabaseLimitThreshold()) {
+      return errorStatus.setMessage(errorPrefix + "database_limit_threshold" + errorSuffix);
     }
 
     return null;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/exception/metadata/SchemaQuotaExceededException.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/exception/metadata/SchemaQuotaExceededException.java
@@ -24,6 +24,8 @@ import org.apache.iotdb.commons.schema.ClusterSchemaQuotaLevel;
 import org.apache.iotdb.rpc.TSStatusCode;
 
 public class SchemaQuotaExceededException extends MetadataException {
+
+  // used for timeseries/device limit
   public SchemaQuotaExceededException(ClusterSchemaQuotaLevel level, long limit) {
     super(
         String.format(
@@ -32,6 +34,18 @@ public class SchemaQuotaExceededException extends MetadataException {
                 + "Please review your configuration "
                 + "or delete some existing time series to comply with the quota.",
             level.toString(), limit),
+        TSStatusCode.SCHEMA_QUOTA_EXCEEDED.getStatusCode());
+  }
+
+  // used for database limit
+  public SchemaQuotaExceededException(long limit) {
+    super(
+        String.format(
+            "The current database number has exceeded the cluster quota. "
+                + "The maximum number of cluster databases allowed is %d, "
+                + "Please review your configuration database_limit_threshold "
+                + "or delete some existing database to comply with the quota.",
+            limit),
         TSStatusCode.SCHEMA_QUOTA_EXCEEDED.getStatusCode());
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/SchemaConstant.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/SchemaConstant.java
@@ -20,6 +20,7 @@ package org.apache.iotdb.db.schemaengine;
 
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.db.conf.IoTDBConfig;
 
 public class SchemaConstant {
 
@@ -54,6 +55,8 @@ public class SchemaConstant {
 
   public static final String[] ALL_RESULT_NODES = new String[] {"root", "**"};
   public static final PartialPath ALL_MATCH_PATTERN = new PartialPath(new String[] {"root", "**"});
+  public static final PartialPath SYSTEM_DATABASE_PATTERN =
+      new PartialPath(IoTDBConfig.SYSTEM_DATABASE.split("\\."));
 
   public static final int NON_TEMPLATE = -1;
   public static final int ALL_TEMPLATE = -2;

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -302,6 +302,12 @@ cluster_name=defaultCluster
 # -1 means the system does not impose a limit on the maximum number of time series.
 # cluster_schema_limit_threshold=-1
 
+# This configuration parameter sets the maximum number of Cluster Databases allowed.
+# The value should be a positive integer representing the desired threshold.
+# When the threshold is reached, users will be prohibited from creating new databases.
+# -1 means unlimited.
+# database_limit_threshold = -1
+
 ####################
 ### Configurations for creating schema automatically
 ####################

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -173,6 +173,9 @@ public class CommonConfig {
   // Max size for tag and attribute of one time series
   private int tagAttributeTotalSize = 700;
 
+  // maximum number of Cluster Databases allowed
+  private int databaseLimitThreshold = -1;
+
   CommonConfig() {
     // Empty constructor
   }
@@ -611,5 +614,13 @@ public class CommonConfig {
 
   public void setTagAttributeTotalSize(int tagAttributeTotalSize) {
     this.tagAttributeTotalSize = tagAttributeTotalSize;
+  }
+
+  public int getDatabaseLimitThreshold() {
+    return databaseLimitThreshold;
+  }
+
+  public void setDatabaseLimitThreshold(int databaseLimitThreshold) {
+    this.databaseLimitThreshold = databaseLimitThreshold;
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -234,6 +234,10 @@ public class CommonDescriptor {
         Long.parseLong(
             properties.getProperty(
                 "time_partition_interval", String.valueOf(config.getTimePartitionInterval()))));
+    config.setDatabaseLimitThreshold(
+        Integer.parseInt(
+            properties.getProperty(
+                "database_limit_threshold", String.valueOf(config.getDatabaseLimitThreshold()))));
   }
 
   private void loadPipeProps(Properties properties) {

--- a/iotdb-protocol/thrift-confignode/src/main/thrift/confignode.thrift
+++ b/iotdb-protocol/thrift-confignode/src/main/thrift/confignode.thrift
@@ -358,6 +358,7 @@ struct TClusterParameters {
   15: required string timestampPrecision
   16: optional string schemaEngineMode
   17: optional i32 tagAttributeTotalSize
+  18: optional i32 databaseLimitThreshold
 }
 
 struct TConfigNodeRegisterReq {


### PR DESCRIPTION
## Design and Docs

https://apache-iotdb.feishu.cn/docx/Mu3JdyJivowHhwxpxPgc2vDen5e

## Demo

set database_limit_threshold=2

```sql
IoTDB> create database root.sg1
Msg: The statement is executed successfully.

IoTDB> create database root.sg2
Msg: The statement is executed successfully.

IoTDB> show databases
+--------+----+-----------------------+---------------------+---------------------+
|Database| TTL|SchemaReplicationFactor|DataReplicationFactor|TimePartitionInterval|
+--------+----+-----------------------+---------------------+---------------------+
|root.sg1|null|                      3|                    3|            604800000|
|root.sg2|null|                      3|                    3|            604800000|
+--------+----+-----------------------+---------------------+---------------------+
Total line number = 2
It costs 1.273s

IoTDB> create database root.sg3
Msg: 526: The current database number has exceeded the cluster quota. The maximum number of cluster databases allowed is 2,Please review your configuration database_limit_thresholdor delete some existing database to comply with the quota.

IoTDB> insert into root.db3.device(time,s2) values(now(),5)
Msg: 526: The current database number has exceeded the cluster quota. The maximum number of cluster databases allowed is 2, Please review your configuration database_limit_threshold or delete some existing database to comply with the quota.
```

- If database_limit_threshold is changed to a larger value, new Database creation is allowed after reboot.
- If database_limit_threshold is changed to a smaller value you can reboot normally, but new Database creation is not allowed after reboot.