### PR TITLE
Optimize the speed of delete by pattern

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -1851,14 +1851,26 @@ public class DataRegion implements IDataRegionForQuery {
       List<TsFileResource> sealedTsFileResource = new ArrayList<>();
       List<TsFileResource> unsealedTsFileResource = new ArrayList<>();
       separateTsFile(sealedTsFileResource, unsealedTsFileResource);
-
+      // deviceMatchInfo is used for filter the matched deviceId in TsFileResource
+      // deviceMatchInfo contains the DeviceId means this device matched the pattern
+      Set<String> deviceMatchInfo = new HashSet<>();
       deleteDataInFiles(
-          unsealedTsFileResource, deletion, devicePaths, updatedModFiles, timePartitionFilter);
+          unsealedTsFileResource,
+          deletion,
+          devicePaths,
+          updatedModFiles,
+          timePartitionFilter,
+          deviceMatchInfo);
       writeUnlock();
       hasReleasedLock = true;
 
       deleteDataInFiles(
-          sealedTsFileResource, deletion, devicePaths, updatedModFiles, timePartitionFilter);
+          sealedTsFileResource,
+          deletion,
+          devicePaths,
+          updatedModFiles,
+          timePartitionFilter,
+          deviceMatchInfo);
 
     } catch (Exception e) {
       // roll back
@@ -1916,16 +1928,24 @@ public class DataRegion implements IDataRegionForQuery {
       Set<PartialPath> devicePaths,
       long deleteStart,
       long deleteEnd,
-      TimePartitionFilter timePartitionFilter) {
+      TimePartitionFilter timePartitionFilter,
+      Set<String> deviceMatchInfo) {
     if (timePartitionFilter != null
         && !timePartitionFilter.satisfy(databaseName, tsFileResource.getTimePartition())) {
       return true;
     }
+    long fileStartTime = tsFileResource.getTimeIndex().getMinStartTime();
+    long fileEndTime = tsFileResource.getTimeIndex().getMaxEndTime();
 
     for (PartialPath device : devicePaths) {
       long deviceStartTime, deviceEndTime;
       if (device.hasWildcard()) {
-        Pair<Long, Long> startAndEndTime = tsFileResource.getPossibleStartTimeAndEndTime(device);
+        if (deleteEnd < fileStartTime || deleteStart > fileEndTime) {
+          // time range of file has not overlapped with the deletion
+          return true;
+        }
+        Pair<Long, Long> startAndEndTime =
+            tsFileResource.getPossibleStartTimeAndEndTime(device, deviceMatchInfo);
         if (startAndEndTime == null) {
           continue;
         }
@@ -1962,7 +1982,8 @@ public class DataRegion implements IDataRegionForQuery {
       Deletion deletion,
       Set<PartialPath> devicePaths,
       List<ModificationFile> updatedModFiles,
-      TimePartitionFilter timePartitionFilter)
+      TimePartitionFilter timePartitionFilter,
+      Set<String> deviceMatchInfo)
       throws IOException {
     for (TsFileResource tsFileResource : tsFileResourceList) {
       if (canSkipDelete(
@@ -1970,7 +1991,8 @@ public class DataRegion implements IDataRegionForQuery {
           devicePaths,
           deletion.getStartTime(),
           deletion.getEndTime(),
-          timePartitionFilter)) {
+          timePartitionFilter,
+          deviceMatchInfo)) {
         continue;
       }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -1940,9 +1940,17 @@ public class DataRegion implements IDataRegionForQuery {
     for (PartialPath device : devicePaths) {
       long deviceStartTime, deviceEndTime;
       if (device.hasWildcard()) {
-        if (deleteEnd < fileStartTime || deleteStart > fileEndTime) {
-          // time range of file has not overlapped with the deletion
-          return true;
+        if (!tsFileResource.isClosed() && fileEndTime == Long.MIN_VALUE) {
+          // unsealed seq file
+          if (deleteEnd < fileStartTime) {
+            // time range of file has not overlapped with the deletion
+            return true;
+          }
+        } else {
+          if (deleteEnd < fileStartTime || deleteStart > fileEndTime) {
+            // time range of file has not overlapped with the deletion
+            return true;
+          }
         }
         Pair<Long, Long> startAndEndTime =
             tsFileResource.getPossibleStartTimeAndEndTime(device, deviceMatchInfo);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
@@ -503,8 +503,9 @@ public class TsFileResource {
    * Get the min start time and max end time of devices matched by given devicePattern. If there's
    * no device matched by given pattern, return null.
    */
-  public Pair<Long, Long> getPossibleStartTimeAndEndTime(PartialPath devicePattern) {
-    return timeIndex.getPossibleStartTimeAndEndTime(devicePattern);
+  public Pair<Long, Long> getPossibleStartTimeAndEndTime(
+      PartialPath devicePattern, Set<String> deviceMatchInfo) {
+    return timeIndex.getPossibleStartTimeAndEndTime(devicePattern, deviceMatchInfo);
   }
 
   public boolean isClosed() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/timeindex/FileTimeIndex.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/timeindex/FileTimeIndex.java
@@ -234,7 +234,8 @@ public class FileTimeIndex implements ITimeIndex {
   }
 
   @Override
-  public Pair<Long, Long> getPossibleStartTimeAndEndTime(PartialPath devicePattern) {
+  public Pair<Long, Long> getPossibleStartTimeAndEndTime(
+      PartialPath devicePattern, Set<String> deviceMatchInfo) {
     return new Pair<>(startTime, endTime);
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/timeindex/ITimeIndex.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/timeindex/ITimeIndex.java
@@ -198,7 +198,8 @@ public interface ITimeIndex {
    */
   long[] getStartAndEndTime(String deviceId);
 
-  Pair<Long, Long> getPossibleStartTimeAndEndTime(PartialPath devicePattern);
+  Pair<Long, Long> getPossibleStartTimeAndEndTime(
+      PartialPath devicePattern, Set<String> deviceMatchInfo);
 
   /**
    * Get TimeIndex Type


### PR DESCRIPTION
## Description

When IoTDB has data of 100,000 devices, 20k devices in each tsfile, 163 tsfiles total, execute a delete sql like `delete from root.db.** where time<1970-1-01T08:01:01.000+08:00`. No data actually matches the time filter.  The execution will takes over **20 hours**. 


The reason of this issue is the process of matching DeviceId in TsFileResource and the pattern `root.db.**` takes too match time. For this scenario , it will match 20k * 163 = 3,260,000 times.

This PR is fixing the above issue. We can use a hashset to record the match deviceId info for this delete operation. The maximum matching times will be reduced to the device number 100,000.

Plus, we can use a file level time filter to skip the device check before the deviceId matching.

After this fixing, the execution only takes **8 seconds**.
![img_v2_5221de63-ecfa-469c-aad5-42b9c7f615dg](https://github.com/apache/iotdb/assets/25913899/9bc9b3ae-9233-4733-952a-72b57361dedc)
