### PR TITLE
Fix default labels in prometheus reporter when metrics has no tag

### DIFF
--- a/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/reporter/prometheus/PrometheusTextWriter.java
+++ b/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/reporter/prometheus/PrometheusTextWriter.java
@@ -68,23 +68,23 @@ class PrometheusTextWriter extends FilterWriter {
   public void writeSample(String name, Map<String, String> labels, Object value)
       throws IOException {
     write(name);
+    write('{');
+    write("cluster=\"");
+    write(METRIC_CONFIG.getClusterName());
+    write("\",nodeType=\"");
+    write(METRIC_CONFIG.getNodeType().toString());
+    write("\",nodeId=\"");
+    write(String.valueOf(METRIC_CONFIG.getNodeId()));
+    write("\",");
     if (labels.size() > 0) {
-      write('{');
-      write("cluster=\"");
-      write(METRIC_CONFIG.getClusterName());
-      write("\",nodeType=\"");
-      write(METRIC_CONFIG.getNodeType().toString());
-      write("\",nodeId=\"");
-      write(String.valueOf(METRIC_CONFIG.getNodeId()));
-      write("\",");
       for (Map.Entry<String, String> entry : labels.entrySet()) {
         write(entry.getKey());
         write("=\"");
         write(entry.getValue());
         write("\",");
       }
-      write('}');
     }
+    write('}');
     write(' ');
     write(value.toString());
     write('\n');


### PR DESCRIPTION
Fix default labels in prometheus reporter when metrics has no tag