### PR TITLE
Fix write performance reduced caused by netty

### DIFF
--- a/iotdb-core/metrics/interface/pom.xml
+++ b/iotdb-core/metrics/interface/pom.xml
@@ -89,12 +89,14 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver-dns-native-macos</artifactId>
             <version>${netty.version}</version>
+            <classifier>osx-x86_64</classifier>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
             <version>${netty.version}</version>
+            <classifier>linux-x86_64</classifier>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/iotdb-core/metrics/micrometer-metrics/pom.xml
+++ b/iotdb-core/metrics/micrometer-metrics/pom.xml
@@ -113,12 +113,14 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver-dns-native-macos</artifactId>
             <version>${netty.version}</version>
+            <classifier>osx-x86_64</classifier>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
             <version>${netty.version}</version>
+            <classifier>linux-x86_64</classifier>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,9 @@
         <felix.version>5.1.8</felix.version>
         <snappy.version>1.1.8.4</snappy.version>
         <zstd-jni.version>1.5.4-2</zstd-jni.version>
-        <netty.version>4.1.94.Final</netty.version>
+        <netty.version>4.1.82.Final</netty.version>
+        <netty-buffer.version>4.1.94.Final</netty-buffer.version>
+        <netty-common.version>4.1.94.Final</netty-common.version>
         <!-- URL of the ASF SonarQube server -->
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.organization>apache</sonar.organization>
@@ -314,12 +316,12 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-buffer</artifactId>
-                <version>${netty.version}</version>
+                <version>${netty-buffer.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-common</artifactId>
-                <version>${netty.version}</version>
+                <version>${netty-common.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.annotation</groupId>


### PR DESCRIPTION
## Description

When upgrade all netty packages to version 4.1.94.Final,  the write performance will reduced.
![image](https://github.com/apache/iotdb/assets/25913899/71e04c73-66b8-4fa8-a5d4-2f90aa18ea74)

We can see the net speed will be lower because of it.

![image](https://github.com/apache/iotdb/assets/25913899/708b461b-4881-4157-9c2c-14a1a302eaa9)

After this PR, the net speed will recover.

![qPLMjQsl97](https://github.com/apache/iotdb/assets/25913899/bce18cc2-5a3c-4e4a-bc31-b390ea0da0de)

