### PR TITLE
[To rel/1.1] Change the threshold of candidate size of seq tsfile in cross space

### DIFF
--- a/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -590,7 +590,10 @@ cluster_name=defaultCluster
 # Datatype: int
 # candidate_compaction_task_queue_size = 50
 
-# The target tsfile size in compaction
+# This parameter is used in two places:
+# 1. The target tsfile size of inner space compaction.
+# 2. The candidate size of seq tsfile in cross space compaction will be smaller than target_compaction_file_size * 1.5.
+# In most cases, the target file size of cross compaction won't exceed this threshold, and if it does, it will not be much larger than it.
 # default is 2GB
 # Datatype: long, Unit: byte
 # target_compaction_file_size=2147483648

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/impl/RewriteCrossSpaceCompactionSelector.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/selector/impl/RewriteCrossSpaceCompactionSelector.java
@@ -230,7 +230,7 @@ public class RewriteCrossSpaceCompactionSelector implements ICrossSpaceSelector 
 
     long totalFileSize = unseqFile.getTsFileSize();
     for (TsFileResource f : seqFiles) {
-      if (f.getTsFileSize() >= config.getTargetCompactionFileSize()) {
+      if (f.getTsFileSize() >= config.getTargetCompactionFileSize() * 1.5) {
         // to avoid serious write amplification caused by cross space compaction, we restrict that
         // seq files are no longer be compacted when the size reaches the threshold.
         return false;


### PR DESCRIPTION
## Description
The threshold of candidate size of seq tsfile in cross space compaction is changed to `target_compaction_file_size * 1.5` in this PR.
Before this change, some cross compaction task won't be executed because of this limitation, which lead to accumulation of  lots of unseq files.