### PR TITLE
Fix aligned last  query

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBAlignedLastQueryIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBAlignedLastQueryIT.java
@@ -329,4 +329,15 @@ public class IoTDBAlignedLastQueryIT {
       fail(e.getMessage());
     }
   }
+
+  @Test
+  public void cacheHitTest() {
+    selectAllAlignedLastTest();
+    selectAllAlignedAndNonAlignedLastTest();
+    selectSomeAlignedAndNonAlignedLastWithTimeFilterTest();
+    selectSomeAlignedLastTest1();
+    selectSomeAlignedLastTest2();
+    selectSomeAlignedLastWithTimeFilterTest();
+    selectSomeAlignedAndNonAlignedLastWithTimeFilterTest();
+  }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/last/IoTDBLastQueryLastCacheIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/last/IoTDBLastQueryLastCacheIT.java
@@ -157,4 +157,11 @@ public class IoTDBLastQueryLastCacheIT {
         };
     resultSetEqualTest("select last * from root.sg;", expectedHeader, retArray);
   }
+
+  @Test
+  public void cacheHitTest() {
+    testLastQuery();
+    testLastQueryOrderByTimeDesc();
+    testLastQuery1();
+  }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/OperatorTreeGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/OperatorTreeGenerator.java
@@ -235,6 +235,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -2216,7 +2217,7 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
           timeValuePair = DATA_NODE_SCHEMA_CACHE.getLastCache(measurementPath);
           if (timeValuePair == null) {
             context.dataNodeQueryContext.addUnCachePath(
-                measurementPath, node.getDataNodeSeriesScanNum());
+                measurementPath, new AtomicInteger(node.getDataNodeSeriesScanNum().get()));
           }
         }
       } finally {


### PR DESCRIPTION
Cause: The `DataNodeSeriesScanNum` of different series in one `AlignedLastQueryScanNode` are same (p1), the update and judges depend on it are unexpected (p2) .
![25d061fd-5086-4700-b658-9192ca503469](https://github.com/apache/iotdb/assets/60659567/1e306ae5-a3b0-4061-a2d2-86e8cf9c929f)
<img width="1044" alt="image" src="https://github.com/apache/iotdb/assets/60659567/654be28a-9926-4cd1-a06a-718a964da208">

