### PR TITLE
[IOTDB-6072] Load: workaround to CPU 100% after loading tsfile when using JDK8 runtime

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/load/LoadTsFileManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/load/LoadTsFileManager.java
@@ -78,7 +78,7 @@ public class LoadTsFileManager {
     this.loadDir = SystemFileFactory.INSTANCE.getFile(CONFIG.getLoadTsFileDir());
     this.uuid2WriterManager = new ConcurrentHashMap<>();
     this.cleanupExecutors =
-        IoTDBThreadPoolFactory.newScheduledThreadPool(0, LoadTsFileManager.class.getName());
+        IoTDBThreadPoolFactory.newScheduledThreadPool(1, LoadTsFileManager.class.getName());
     this.uuid2Future = new ConcurrentHashMap<>();
 
     recover();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/StorageEngine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/StorageEngine.java
@@ -140,7 +140,7 @@ public class StorageEngine implements IService {
   private List<FlushListener> customFlushListeners = new ArrayList<>();
   private int recoverDataRegionNum = 0;
 
-  private LoadTsFileManager loadTsFileManager = new LoadTsFileManager();
+  private LoadTsFileManager loadTsFileManager;
 
   private StorageEngine() {}
 
@@ -781,7 +781,7 @@ public class StorageEngine implements IService {
     TSStatus status = new TSStatus();
 
     try {
-      loadTsFileManager.writeToDataRegion(getDataRegion(dataRegionId), pieceNode, uuid);
+      getLoadTsFileManager().writeToDataRegion(getDataRegion(dataRegionId), pieceNode, uuid);
     } catch (IOException e) {
       logger.error(
           String.format(
@@ -802,7 +802,7 @@ public class StorageEngine implements IService {
     try {
       switch (loadCommand) {
         case EXECUTE:
-          if (loadTsFileManager.loadAll(uuid)) {
+          if (getLoadTsFileManager().loadAll(uuid)) {
             status = RpcUtils.SUCCESS_STATUS;
           } else {
             status.setCode(TSStatusCode.LOAD_FILE_ERROR.getStatusCode());
@@ -813,7 +813,7 @@ public class StorageEngine implements IService {
           }
           break;
         case ROLLBACK:
-          if (loadTsFileManager.deleteAll(uuid)) {
+          if (getLoadTsFileManager().deleteAll(uuid)) {
             status = RpcUtils.SUCCESS_STATUS;
           } else {
             status.setCode(TSStatusCode.LOAD_FILE_ERROR.getStatusCode());
@@ -873,6 +873,17 @@ public class StorageEngine implements IService {
             dataRegionDisk.put(dataRegionId.getId(), dataRegion.countRegionDiskSize());
           }
         });
+  }
+
+  private LoadTsFileManager getLoadTsFileManager() {
+    if (loadTsFileManager == null) {
+      synchronized (LoadTsFileManager.class) {
+        if (loadTsFileManager == null) {
+          loadTsFileManager = new LoadTsFileManager();
+        }
+      }
+    }
+    return loadTsFileManager;
   }
 
   static class InstanceHolder {


### PR DESCRIPTION
## Description
After loading tsfile, it causes 100% load on one CPU core.

## Reason
it was a bug in JDK1.8.

[JDK-8129861](https://bugs.openjdk.java.net/browse/JDK-8129861)
[JDK-8022642](https://bugs.openjdk.java.net/browse/JDK-8022642)

## Solution
1. set corePoolSize to 1 to avoid high processor load
2. lazy initialization: init loadTsFileManager  on first call