### PR TITLE
Fix the NPE issue when taking snapshot in WAL combined with Aligned Binary

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
@@ -1021,7 +1021,17 @@ public abstract class AlignedTVList extends TVList {
         switch (dataTypes.get(columnIndex)) {
           case TEXT:
             Binary valueT = ((Binary[]) columnValues.get(arrayIndex))[elementIndex];
-            WALWriteUtils.write(valueT, buffer);
+            // In some scenario, the Binary in AlignedTVList will be null if this field is empty in
+            // current row. We need to handle this scenario to get rid of NPE. See the similar issue
+            // here: https://github.com/apache/iotdb/pull/9884
+            // Furthermore, we use an empty Binary as a placeholder here. It won't lead to data
+            // error because whether this field is null or not is decided by the bitMap rather than
+            // the object's value here.
+            if (valueT != null) {
+              WALWriteUtils.write(valueT, buffer);
+            } else {
+              WALWriteUtils.write(new Binary(new byte[0]), buffer);
+            }
             break;
           case FLOAT:
             float valueF = ((float[]) columnValues.get(arrayIndex))[elementIndex];


### PR DESCRIPTION
## Description
In some scenario, the Binary in AlignedTVList will be null if this field is empty in current row. We need to handle this scenario to get rid of NPE in WAL snapshot taking stage. 

See a similar issue here: https://github.com/apache/iotdb/pull/9884 

**Current fix**: we use an empty Binary as a placeholder here. It won't lead to data error because whether this field is null or not is decided by the bitMap rather than the object's value here.