### PR TITLE
[IOTDB-6075] Pipe: File resource races when different tsfile load operations concurrently modify the same tsfile at receiver

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -1075,7 +1075,8 @@ public class IoTDBConfig {
   private double maxMemoryRatioForQueue = 0.6;
 
   /** Pipe related */
-  private String pipeReceiveFileDir = systemDir + File.separator + "pipe";
+  private String pipeReceiveFileDir =
+      systemDir + File.separator + "pipe" + File.separator + "receiver";
 
   /** Resource control */
   private boolean quotaEnable = false;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/receiver/PipeReceiverAgent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/receiver/PipeReceiverAgent.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.pipe.agent.receiver;
 
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.pipe.connector.IoTDBThriftConnectorRequestVersion;
 import org.apache.iotdb.db.pipe.connector.v1.IoTDBThriftReceiverV1;
 import org.apache.iotdb.db.queryengine.plan.analyze.IPartitionFetcher;
@@ -28,8 +29,12 @@ import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.service.rpc.thrift.TPipeTransferReq;
 import org.apache.iotdb.service.rpc.thrift.TPipeTransferResp;
 
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
 
 public class PipeReceiverAgent {
 
@@ -85,6 +90,25 @@ public class PipeReceiverAgent {
     if (receiver != null) {
       receiver.handleExit();
       receiverThreadLocal.remove();
+    }
+  }
+
+  public void cleanPipeReceiverDir() {
+    final File receiverFileDir =
+        new File(IoTDBDescriptor.getInstance().getConfig().getPipeReceiverFileDir());
+
+    try {
+      FileUtils.deleteDirectory(receiverFileDir);
+      LOGGER.info("Clean pipe receiver dir {} successfully.", receiverFileDir);
+    } catch (Exception e) {
+      LOGGER.warn("Clean pipe receiver dir {} failed.", receiverFileDir, e);
+    }
+
+    try {
+      FileUtils.forceMkdir(receiverFileDir);
+      LOGGER.info("Create pipe receiver dir {} successfully.", receiverFileDir);
+    } catch (IOException e) {
+      LOGGER.warn("Create pipe receiver dir {} failed.", receiverFileDir, e);
     }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/runtime/PipeRuntimeAgent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/runtime/PipeRuntimeAgent.java
@@ -51,6 +51,7 @@ public class PipeRuntimeAgent implements IService {
 
   public synchronized void preparePipeResources(
       ResourcesInformationHolder resourcesInformationHolder) throws StartupException {
+    PipeAgent.receiver().cleanPipeReceiverDir();
     PipeHardlinkFileDirStartupCleaner.clean();
     PipeAgentLauncher.launchPipePluginAgent(resourcesInformationHolder);
     simpleConsensusProgressIndexAssigner.start();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/v1/IoTDBThriftConnectorClient.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/v1/IoTDBThriftConnectorClient.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.pipe.connector.v1;
 
 import org.apache.iotdb.commons.client.ThriftClient;
 import org.apache.iotdb.commons.client.property.ThriftClientProperty;
+import org.apache.iotdb.commons.pipe.config.PipeConfig;
 import org.apache.iotdb.rpc.RpcTransportFactory;
 import org.apache.iotdb.rpc.TConfigurationConst;
 import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
@@ -42,7 +43,7 @@ public class IoTDBThriftConnectorClient extends IClientRPCService.Client
                         TConfigurationConst.defaultTConfiguration,
                         ipAddress,
                         port,
-                        property.getConnectionTimeoutMs()))));
+                        (int) PipeConfig.getInstance().getPipeConnectorTimeoutMs()))));
     getInputProtocol().getTransport().open();
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/v1/IoTDBThriftConnectorV1.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/v1/IoTDBThriftConnectorV1.java
@@ -86,7 +86,11 @@ public class IoTDBThriftConnectorV1 implements PipeConnector {
   @Override
   public void handshake() throws Exception {
     if (client != null) {
-      client.close();
+      try {
+        client.close();
+      } catch (Exception e) {
+        LOGGER.warn("Close client error, because: {}", e.getMessage(), e);
+      }
     }
 
     client =
@@ -105,6 +109,8 @@ public class IoTDBThriftConnectorV1 implements PipeConnector {
                   CommonDescriptor.getInstance().getConfig().getTimestampPrecision()));
       if (resp.getStatus().getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         throw new PipeException(String.format("Handshake error, result status %s.", resp.status));
+      } else {
+        LOGGER.info("Handshake success. Target server ip: {}, port: {}", ipAddress, port);
       }
     } catch (TException e) {
       throw new PipeConnectionException(
@@ -248,6 +254,8 @@ public class IoTDBThriftConnectorV1 implements PipeConnector {
     if (resp.getStatus().getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
       throw new PipeException(
           String.format("Seal file %s error, result status %s.", tsFile, resp.getStatus()));
+    } else {
+      LOGGER.info("Successfully transferred file {}.", tsFile);
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/v1/IoTDBThriftReceiverV1.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/v1/IoTDBThriftReceiverV1.java
@@ -441,6 +441,7 @@ public class IoTDBThriftReceiverV1 implements IoTDBThriftReceiver {
       } catch (Exception e) {
         LOGGER.warn("IoTDBThriftReceiverV1#handleExit: close writing file writer error.", e);
       }
+      writingFileWriter = null;
     } else {
       LOGGER.info(
           "IoTDBThriftReceiverV1#handleExit: writing file writer is null. No need to close.");
@@ -456,12 +457,34 @@ public class IoTDBThriftReceiverV1 implements IoTDBThriftReceiver {
         LOGGER.warn(
             "IoTDBThriftReceiverV1#handleExit: delete file {} error.", writingFile.getPath());
       }
+      writingFile = null;
     } else {
       LOGGER.info("IoTDBThriftReceiverV1#handleExit: writing file is null. No need to delete.");
     }
 
-    writingFileWriter = null;
-    writingFile = null;
+    // clear the original receiver file dir if exists
+    if (receiverFileDirWithIdSuffix.get() != null) {
+      if (receiverFileDirWithIdSuffix.get().exists()) {
+        try {
+          Files.delete(receiverFileDirWithIdSuffix.get().toPath());
+          LOGGER.info(
+              "IoTDBThriftReceiverV1#handleExit: original receiver file dir {} was deleted.",
+              receiverFileDirWithIdSuffix.get().getPath());
+        } catch (IOException e) {
+          LOGGER.warn(
+              "IoTDBThriftReceiverV1#handleExit: delete original receiver file dir {} error.",
+              receiverFileDirWithIdSuffix.get().getPath());
+        }
+      } else {
+        LOGGER.info(
+            "IoTDBThriftReceiverV1#handleExit: original receiver file dir {} does not exist. No need to delete.",
+            receiverFileDirWithIdSuffix.get().getPath());
+      }
+      receiverFileDirWithIdSuffix.set(null);
+    } else {
+      LOGGER.info(
+          "IoTDBThriftReceiverV1#handleExit: original receiver file dir is null. No need to delete.");
+    }
 
     LOGGER.info("IoTDBThriftReceiverV1#handleExit: receiver exited.");
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/v1/IoTDBThriftReceiverV1.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/v1/IoTDBThriftReceiverV1.java
@@ -50,13 +50,21 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class IoTDBThriftReceiverV1 implements IoTDBThriftReceiver {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IoTDBThriftReceiverV1.class);
 
   private static final IoTDBConfig IOTDB_CONFIG = IoTDBDescriptor.getInstance().getConfig();
-  private static final String RECEIVER_FILE_DIR = IOTDB_CONFIG.getPipeReceiverFileDir();
+  private static final String RECEIVER_FILE_BASE_DIR = IOTDB_CONFIG.getPipeReceiverFileDir();
+  private static final AtomicReference<File> receiverFileDirWithIdSuffix = new AtomicReference<>();
+
+  // Used to generate transfer id, which is used to identify a receiver thread.
+  private static final AtomicLong RECEIVER_ID_GENERATOR = new AtomicLong(0);
+  private final AtomicLong receiverId = new AtomicLong(0);
 
   private File writingFile;
   private RandomAccessFile writingFileWriter;
@@ -87,10 +95,12 @@ public class IoTDBThriftReceiverV1 implements IoTDBThriftReceiver {
 
     // unknown request type, which means the request can not be handled by this receiver,
     // maybe the version of the receiver is not compatible with the sender
-    return new TPipeTransferResp(
+    final TSStatus status =
         RpcUtils.getStatus(
             TSStatusCode.PIPE_TYPE_ERROR,
-            String.format("Unknown transfer type %s.", rawRequestType)));
+            String.format("Unknown PipeRequestType %s.", rawRequestType));
+    LOGGER.warn("Unknown PipeRequestType, response status = {}.", status);
+    return new TPipeTransferResp(status);
   }
 
   private TPipeTransferResp handleTransferHandshake(PipeTransferHandshakeReq req) {
@@ -98,17 +108,59 @@ public class IoTDBThriftReceiverV1 implements IoTDBThriftReceiver {
         .getConfig()
         .getTimestampPrecision()
         .equals(req.getTimestampPrecision())) {
-      String msg =
-          String.format(
-              "IoTDB receiver's timestamp precision %s, "
-                  + "connector's timestamp precision %s. validation fails.",
-              CommonDescriptor.getInstance().getConfig().getTimestampPrecision(),
-              req.getTimestampPrecision());
-      LOGGER.warn(msg);
-      return new TPipeTransferResp(RpcUtils.getStatus(TSStatusCode.PIPE_HANDSHAKE_ERROR, msg));
+      final TSStatus status =
+          RpcUtils.getStatus(
+              TSStatusCode.PIPE_HANDSHAKE_ERROR,
+              String.format(
+                  "IoTDB receiver's timestamp precision %s, "
+                      + "connector's timestamp precision %s. Validation fails.",
+                  CommonDescriptor.getInstance().getConfig().getTimestampPrecision(),
+                  req.getTimestampPrecision()));
+      LOGGER.warn("Handshake failed, response status = {}.", status);
+      return new TPipeTransferResp(status);
     }
 
-    LOGGER.info("Handshake successfully.");
+    receiverId.set(RECEIVER_ID_GENERATOR.incrementAndGet());
+
+    // clear the original receiver file dir if exists
+    if (receiverFileDirWithIdSuffix.get() != null) {
+      if (receiverFileDirWithIdSuffix.get().exists()) {
+        try {
+          Files.delete(receiverFileDirWithIdSuffix.get().toPath());
+          LOGGER.info(
+              "Original receiver file dir {} was deleted.",
+              receiverFileDirWithIdSuffix.get().getPath());
+        } catch (IOException e) {
+          LOGGER.warn(
+              "Failed to delete original receiver file dir {}, because {}.",
+              receiverFileDirWithIdSuffix.get().getPath(),
+              e.getMessage());
+        }
+      } else {
+        LOGGER.info(
+            "Original receiver file dir {} is not existed. No need to delete.",
+            receiverFileDirWithIdSuffix.get().getPath());
+      }
+      receiverFileDirWithIdSuffix.set(null);
+    } else {
+      LOGGER.info("Current receiver file dir is null. No need to delete.");
+    }
+
+    // create a new receiver file dir
+    final File newReceiverDir = new File(RECEIVER_FILE_BASE_DIR, Long.toString(receiverId.get()));
+    if (!newReceiverDir.exists()) {
+      if (newReceiverDir.mkdirs()) {
+        LOGGER.info("Receiver file dir {} was created.", newReceiverDir.getPath());
+      } else {
+        LOGGER.error("Failed to create receiver file dir {}.", newReceiverDir.getPath());
+      }
+    }
+    receiverFileDirWithIdSuffix.set(newReceiverDir);
+
+    LOGGER.info(
+        "Handshake successfully, receiver id = {}, receiver file dir = {}.",
+        receiverId,
+        newReceiverDir.getPath());
     return new TPipeTransferResp(RpcUtils.SUCCESS_STATUS);
   }
 
@@ -134,24 +186,25 @@ public class IoTDBThriftReceiverV1 implements IoTDBThriftReceiver {
       updateWritingFileIfNeeded(req.getFileName());
 
       if (!isWritingFileOffsetCorrect(req.getStartWritingOffset())) {
-        return PipeTransferFilePieceResp.toTPipeTransferResp(
+        final TSStatus status =
             RpcUtils.getStatus(
                 TSStatusCode.PIPE_TRANSFER_FILE_OFFSET_RESET,
                 String.format(
-                    "request sender reset file reader's offset from %s to %s.",
-                    req.getStartWritingOffset(), writingFileWriter.length())),
-            writingFileWriter.length());
+                    "Request sender to reset file reader's offset from %s to %s.",
+                    req.getStartWritingOffset(), writingFileWriter.length()));
+        LOGGER.warn("File offset reset requested by receiver, response status = {}.", status);
+        return PipeTransferFilePieceResp.toTPipeTransferResp(status, writingFileWriter.length());
       }
 
       writingFileWriter.write(req.getFilePiece());
       return PipeTransferFilePieceResp.toTPipeTransferResp(
           RpcUtils.SUCCESS_STATUS, writingFileWriter.length());
     } catch (Exception e) {
-      LOGGER.warn(String.format("failed to write file piece from req %s.", req), e);
+      LOGGER.warn(String.format("Failed to write file piece from req %s.", req), e);
       final TSStatus status =
           RpcUtils.getStatus(
               TSStatusCode.PIPE_TRANSFER_FILE_ERROR,
-              String.format("failed to write file piece, because %s", e.getMessage()));
+              String.format("Failed to write file piece, because %s", e.getMessage()));
       try {
         return PipeTransferFilePieceResp.toTPipeTransferResp(
             status, PipeTransferFilePieceResp.ERROR_END_OFFSET);
@@ -166,30 +219,60 @@ public class IoTDBThriftReceiverV1 implements IoTDBThriftReceiver {
       return;
     }
 
+    LOGGER.info(
+        "Writing file {} is not existed or name is not correct, try to create it. "
+            + "Current writing file is {}.",
+        fileName,
+        writingFile == null ? "null" : writingFile.getPath());
+
+    // close current writing file writer
     if (writingFileWriter != null) {
       writingFileWriter.close();
       writingFileWriter = null;
-    }
-    if (writingFile != null && writingFile.exists()) {
-      if (writingFile.delete()) {
-        LOGGER.info("original file {} was deleted.", writingFile.getPath());
-      } else {
-        LOGGER.warn("failed to delete original file {}.", writingFile.getPath());
-      }
-      writingFile = null;
+      LOGGER.info(
+          "Current writing file writer {} was closed.",
+          writingFile == null ? "null" : writingFile.getPath());
+    } else {
+      LOGGER.info("Current writing file writer is null. No need to close.");
     }
 
-    final File receiveDir = new File(RECEIVER_FILE_DIR);
-    if (!receiveDir.exists()) {
-      if (receiveDir.mkdirs()) {
-        LOGGER.info("receiver file dir {} was created.", receiveDir.getPath());
+    // delete current writing file
+    if (writingFile != null) {
+      if (writingFile.exists()) {
+        try {
+          Files.delete(writingFile.toPath());
+          LOGGER.info("Original writing file {} was deleted.", writingFile.getPath());
+        } catch (IOException e) {
+          LOGGER.warn(
+              "Failed to delete original writing file {}, because {}.",
+              writingFile.getPath(),
+              e.getMessage());
+        }
       } else {
-        LOGGER.warn("failed to create receiver file dir {}.", receiveDir.getPath());
+        LOGGER.info("Original file {} is not existed. No need to delete.", writingFile.getPath());
+      }
+      writingFile = null;
+    } else {
+      LOGGER.info("Current writing file is null. No need to delete.");
+    }
+
+    // make sure receiver file dir exists
+    // this may be useless, because receiver file dir is created when handshake. just in case.
+    if (!receiverFileDirWithIdSuffix.get().exists()) {
+      if (receiverFileDirWithIdSuffix.get().mkdirs()) {
+        LOGGER.info(
+            "Receiver file dir {} was created.", receiverFileDirWithIdSuffix.get().getPath());
+      } else {
+        LOGGER.error(
+            "Failed to create receiver file dir {}.", receiverFileDirWithIdSuffix.get().getPath());
       }
     }
-    writingFile = new File(RECEIVER_FILE_DIR, fileName);
+
+    writingFile = new File(receiverFileDirWithIdSuffix.get(), fileName);
     writingFileWriter = new RandomAccessFile(writingFile, "rw");
-    LOGGER.info("start to write transferring file {}.", writingFile.getPath());
+    LOGGER.info(
+        "Writing file {} was created. Ready to write transferring file piece.",
+        writingFile.getPath());
   }
 
   private boolean isFileExistedAndNameCorrect(String fileName) {
@@ -197,7 +280,15 @@ public class IoTDBThriftReceiverV1 implements IoTDBThriftReceiver {
   }
 
   private boolean isWritingFileOffsetCorrect(long offset) throws IOException {
-    return writingFileWriter.length() == offset;
+    final boolean offsetCorrect = writingFileWriter.length() == offset;
+    if (!offsetCorrect) {
+      LOGGER.warn(
+          "Writing file {}'s offset is {}, but request sender's offset is {}.",
+          writingFile.getPath(),
+          writingFileWriter.length(),
+          offset);
+    }
+    return offsetCorrect;
   }
 
   private TPipeTransferResp handleTransferFileSeal(
@@ -206,31 +297,37 @@ public class IoTDBThriftReceiverV1 implements IoTDBThriftReceiver {
       ISchemaFetcher schemaFetcher) {
     try {
       if (!isWritingFileAvailable()) {
-        return new TPipeTransferResp(
+        final TSStatus status =
             RpcUtils.getStatus(
                 TSStatusCode.PIPE_TRANSFER_FILE_ERROR,
                 String.format(
-                    "failed to seal file, because writing file %s is not available.",
-                    req.getFileName())));
+                    "Failed to seal file, because writing file %s is not available.",
+                    req.getFileName()));
+        LOGGER.warn(status.getMessage());
+        return new TPipeTransferResp(status);
       }
 
       if (!isFileExistedAndNameCorrect(req.getFileName())) {
-        return new TPipeTransferResp(
+        final TSStatus status =
             RpcUtils.getStatus(
                 TSStatusCode.PIPE_TRANSFER_FILE_ERROR,
                 String.format(
-                    "failed to seal file %s, but writing file is %s.",
-                    req.getFileName(), writingFile)));
+                    "Failed to seal file %s, but writing file is %s.",
+                    req.getFileName(), writingFile));
+        LOGGER.warn(status.getMessage());
+        return new TPipeTransferResp(status);
       }
 
       if (!isWritingFileOffsetCorrect(req.getFileLength())) {
-        return new TPipeTransferResp(
+        final TSStatus status =
             RpcUtils.getStatus(
                 TSStatusCode.PIPE_TRANSFER_FILE_ERROR,
                 String.format(
-                    "failed to seal file because the length of file is not correct. "
-                        + "the original file has length %s, but receiver file has length %s.",
-                    req.getFileLength(), writingFileWriter.length())));
+                    "Failed to seal file %s, because the length of file is not correct. "
+                        + "The original file has length %s, but receiver file has length %s.",
+                    req.getFileName(), req.getFileLength(), writingFileWriter.length()));
+        LOGGER.warn(status.getMessage());
+        return new TPipeTransferResp(status);
       }
 
       final LoadTsFileStatement statement = new LoadTsFileStatement(writingFile.getAbsolutePath());
@@ -249,18 +346,38 @@ public class IoTDBThriftReceiverV1 implements IoTDBThriftReceiver {
       statement.setDeleteAfterLoad(true);
       statement.setVerifySchema(true);
       statement.setAutoCreateDatabase(false);
-      return new TPipeTransferResp(executeStatement(statement, partitionFetcher, schemaFetcher));
+
+      final TSStatus status = executeStatement(statement, partitionFetcher, schemaFetcher);
+      if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+        LOGGER.info("Seal file {} successfully.", writingFile.getAbsolutePath());
+      } else {
+        LOGGER.warn(
+            "Failed to seal file {}, because {}.",
+            writingFile.getAbsolutePath(),
+            status.getMessage());
+      }
+      return new TPipeTransferResp(status);
     } catch (IOException e) {
-      LOGGER.warn(String.format("failed to seal file %s from req %s.", writingFile, req), e);
+      LOGGER.warn(String.format("Failed to seal file %s from req %s.", writingFile, req), e);
       return new TPipeTransferResp(
           RpcUtils.getStatus(
               TSStatusCode.PIPE_TRANSFER_FILE_ERROR,
-              String.format("failed to seal file %s because %s", writingFile, e.getMessage())));
+              String.format("Failed to seal file %s because %s", writingFile, e.getMessage())));
     }
   }
 
   private boolean isWritingFileAvailable() {
-    return writingFile != null && writingFile.exists() && writingFileWriter != null;
+    final boolean isWritingFileAvailable =
+        writingFile != null && writingFile.exists() && writingFileWriter != null;
+    if (!isWritingFileAvailable) {
+      LOGGER.info(
+          "Writing file {} is not available. Writing file is null: {}, writing file exists: {}, writing file writer is null: {}.",
+          writingFile,
+          writingFile == null,
+          writingFile != null && writingFile.exists(),
+          writingFileWriter == null);
+    }
+    return isWritingFileAvailable;
   }
 
   private TSStatus executeStatement(
@@ -292,17 +409,36 @@ public class IoTDBThriftReceiverV1 implements IoTDBThriftReceiver {
 
   @Override
   public synchronized void handleExit() {
-    try {
-      if (writingFileWriter != null) {
+    if (writingFileWriter != null) {
+      try {
         writingFileWriter.close();
+        LOGGER.info("IoTDBThriftReceiverV1#handleExit: writing file writer was closed.");
+      } catch (Exception e) {
+        LOGGER.warn("IoTDBThriftReceiverV1#handleExit: close writing file writer error.", e);
       }
-      if (writingFile != null && !writingFile.delete()) {
+    } else {
+      LOGGER.info(
+          "IoTDBThriftReceiverV1#handleExit: writing file writer is null. No need to close.");
+    }
+
+    if (writingFile != null) {
+      try {
+        Files.delete(writingFile.toPath());
+        LOGGER.info(
+            "IoTDBThriftReceiverV1#handleExit: writing file {} was deleted.",
+            writingFile.getPath());
+      } catch (Exception e) {
         LOGGER.warn(
             "IoTDBThriftReceiverV1#handleExit: delete file {} error.", writingFile.getPath());
       }
-    } catch (IOException e) {
-      LOGGER.warn("IoTDBThriftReceiverV1#handleExit: meeting errors on handleExit().", e);
+    } else {
+      LOGGER.info("IoTDBThriftReceiverV1#handleExit: writing file is null. No need to delete.");
     }
+
+    writingFileWriter = null;
+    writingFile = null;
+
+    LOGGER.info("IoTDBThriftReceiverV1#handleExit: receiver exited.");
   }
 
   @Override

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -984,6 +984,9 @@ cluster_name=defaultCluster
 # Noted that: this should be less than or equals to realtimeExtractorPendingQueueCapacity
 # pipe_extractor_pending_queue_tablet_limit=64
 
+# The connection timeout (in milliseconds) for the thrift client.
+# pipe_connector_timeout_ms=900000
+
 # The buffer size used for reading file during file transfer.
 # pipe_connector_read_file_buffer_size=8388608
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -156,6 +156,7 @@ public class CommonConfig {
   private int pipeExtractorPendingQueueTabletLimit = pipeExtractorPendingQueueCapacity / 2;
   private int pipeDataStructureTabletRowSize = 65536;
 
+  private long pipeConnectorTimeoutMs = 15 * 60 * 1000L; // 15 minutes
   private int pipeConnectorReadFileBufferSize = 8388608;
   private long pipeConnectorRetryIntervalMs = 1000L;
   private int pipeConnectorPendingQueueSize = 1024;
@@ -505,6 +506,14 @@ public class CommonConfig {
 
   public void setPipeExtractorPendingQueueTabletLimit(int pipeExtractorPendingQueueTabletLimit) {
     this.pipeExtractorPendingQueueTabletLimit = pipeExtractorPendingQueueTabletLimit;
+  }
+
+  public long getPipeConnectorTimeoutMs() {
+    return pipeConnectorTimeoutMs;
+  }
+
+  public void setPipeConnectorTimeoutMs(long pipeConnectorTimeoutMs) {
+    this.pipeConnectorTimeoutMs = pipeConnectorTimeoutMs;
   }
 
   public int getPipeConnectorReadFileBufferSize() {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -297,6 +297,10 @@ public class CommonDescriptor {
                 "pipe_extractor_pending_queue_tablet_limit",
                 String.valueOf(config.getPipeExtractorPendingQueueTabletLimit()))));
 
+    config.setPipeConnectorTimeoutMs(
+        Long.parseLong(
+            properties.getProperty(
+                "pipe_connector_timeout_ms", String.valueOf(config.getPipeConnectorTimeoutMs()))));
     config.setPipeConnectorReadFileBufferSize(
         Integer.parseInt(
             properties.getProperty(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeConfig.java
@@ -79,6 +79,10 @@ public class PipeConfig {
 
   /////////////////////////////// Connector ///////////////////////////////
 
+  public long getPipeConnectorTimeoutMs() {
+    return COMMON_CONFIG.getPipeConnectorTimeoutMs();
+  }
+
   public int getPipeConnectorReadFileBufferSize() {
     return COMMON_CONFIG.getPipeConnectorReadFileBufferSize();
   }


### PR DESCRIPTION
### How does it look like

![image](https://github.com/apache/iotdb/assets/30497621/9d027b80-5628-4577-900a-cc17c12f1837)

The pipe stopped and can not be restarted.

### How to reproduce

* Sender's connection timeout at sender < load operation cost time at receiver
* A sender's load tsfile request is timeout, but the request's execution can not be terminated when timeout
* Sender will retry to send a load tsfile request, which will load the same tsfile that cause the timeout before
* Serveral load tsfile requests are concurrently executing at the receiver
* The load operation performed earlier deletes files that need to be loaded
* The load operation performed later (a retry) wants to read the tsfile, but the tsfile was deleted, which may cause exception like: 
writing file sequence-root.bw-6-2735-1686907665964-1-8-8.tsfile is not available

### My fixes

* Add a parameter in iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties to control the connection timeout.
* Set the pipe connection timeout between sender and receiver to 15 mins to allow long time-cost load operation.
* Redesign the pipe receiver's dir to avoid file resource races when different tsfile load operations concurrently modify the same tsfile