### PR TITLE
[To rel/1.1] Remove multi-IP initialization in session pool of client-py

### DIFF
--- a/client-py/SessionPoolExample.py
+++ b/client-py/SessionPoolExample.py
@@ -120,7 +120,7 @@ port = "6667"
 username = "root"
 password = "root"
 pool_config = PoolConfig(host=ip, port=port, user_name=username, password=password, fetch_size=1024,
-                         time_zone="Asia/Shanghai", max_retry=3)
+                         time_zone="UTC+8", max_retry=3)
 max_pool_size = 5
 wait_timeout_in_ms = 3000
 

--- a/client-py/SessionPoolExample.py
+++ b/client-py/SessionPoolExample.py
@@ -1,0 +1,144 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import threading
+
+from iotdb.SessionPool import PoolConfig, SessionPool
+from iotdb.utils.IoTDBConstants import TSDataType, TSEncoding, Compressor
+
+STORAGE_GROUP_NAME = "root.test"
+
+
+def prepare_data():
+    print("create database")
+    # Get a session from the pool
+    session = session_pool.get_session()
+
+    session.set_storage_group(STORAGE_GROUP_NAME)
+    session.create_time_series(
+        "root.test.d0.s0", TSDataType.BOOLEAN, TSEncoding.PLAIN, Compressor.SNAPPY
+    )
+    session.create_time_series(
+        "root.test.d0.s1", TSDataType.INT32, TSEncoding.PLAIN, Compressor.SNAPPY
+    )
+    session.create_time_series(
+        "root.test.d0.s2", TSDataType.INT64, TSEncoding.PLAIN, Compressor.SNAPPY
+    )
+
+    # create multi time series
+    # setting multiple time series once.
+    ts_path_lst = [
+        "root.test.d1.s0",
+        "root.test.d1.s1",
+        "root.test.d1.s2",
+        "root.test.d1.s3"
+    ]
+    data_type_lst = [
+        TSDataType.BOOLEAN,
+        TSDataType.INT32,
+        TSDataType.INT64,
+        TSDataType.FLOAT
+    ]
+    encoding_lst = [TSEncoding.PLAIN for _ in range(len(data_type_lst))]
+    compressor_lst = [Compressor.SNAPPY for _ in range(len(data_type_lst))]
+    session.create_multi_time_series(
+        ts_path_lst, data_type_lst, encoding_lst, compressor_lst
+    )
+
+    # delete time series root.test.d1.s3
+    session.delete_time_series(["root.test.d1.s3"])
+
+    print("now the timeseries are:")
+    # show result
+    res = session.execute_query_statement("show timeseries root.test.**")
+    while res.has_next():
+        print(res.next())
+
+    session_pool.put_back(session)
+
+
+def insert_data(num: int):
+    print("insert data for root.test.d" + str(num))
+    device = ["root.test.d" + str(num)]
+    measurements = ["s0", "s1", "s2"]
+    values = [False, 10, 11]
+    data_types = [
+        TSDataType.BOOLEAN,
+        TSDataType.INT32,
+        TSDataType.INT64
+    ]
+    # Get a session from the pool
+    session = session_pool.get_session()
+    session.insert_records(device, [1], [measurements], [data_types], [values])
+
+    session_pool.put_back(session)
+
+
+def query_data():
+    # Get a session from the pool
+    session = session_pool.get_session()
+
+    print("get data from root.test.d0")
+    res = session.execute_query_statement("select * from root.test.d0")
+    while res.has_next():
+        print(res.next())
+
+    print("get data from root.test.d1")
+    res = session.execute_query_statement("select * from root.test.d1")
+    while res.has_next():
+        print(res.next())
+
+    session_pool.put_back(session)
+
+
+def delete_data():
+    session = session_pool.get_session()
+    session.delete_storage_group(STORAGE_GROUP_NAME)
+    print("data has been deleted. now the devices are:")
+    res = session.execute_statement("show devices root.test.**")
+    while res.has_next():
+        print(res.next())
+    session_pool.put_back(session)
+
+
+ip = "127.0.0.1"
+port = "6667"
+username = "root"
+password = "root"
+pool_config = PoolConfig(host=ip, port=port, user_name=username, password=password, fetch_size=1024,
+                         time_zone="Asia/Shanghai", max_retry=3)
+max_pool_size = 5
+wait_timeout_in_ms = 3000
+
+# Create a session pool
+session_pool = SessionPool(pool_config, max_pool_size, wait_timeout_in_ms)
+
+prepare_data()
+
+insert_thread1 = threading.Thread(target=insert_data, args=(0,))
+insert_thread2 = threading.Thread(target=insert_data, args=(1,))
+
+insert_thread1.start()
+insert_thread2.start()
+
+insert_thread1.join()
+insert_thread2.join()
+
+query_data()
+delete_data()
+session_pool.close()
+print("example is finished!")

--- a/client-py/iotdb/SessionPool.py
+++ b/client-py/iotdb/SessionPool.py
@@ -27,6 +27,7 @@ DEFAULT_MULTIPIE = 5
 DEFAULT_FETCH_SIZE = 5000
 DEFAULT_MAX_RETRY = 3
 DEFAULT_TIME_ZONE = "Asia/Shanghai"
+HAS_SESSION_POOL = False
 logger = logging.getLogger("IoTDB")
 
 
@@ -53,6 +54,8 @@ class SessionPool(object):
         self.__queue = Queue(max_pool_size)
         self.__lock = Lock()
         self.__closed = False
+        global HAS_SESSION_POOL
+        HAS_SESSION_POOL = True
 
     def __construct_session(self) -> Session:
         return Session(self.__pool_config.host, self.__pool_config.port, self.__pool_config.user_name,
@@ -105,6 +108,8 @@ class SessionPool(object):
             raise ConnectionError("SessionPool has already been closed, please close the session manually.")
 
         if session.is_open():
+            if session in self.__queue:
+                raise AttributeError("Session has already been put back to the pool.")
             self.__queue.put(session)
         else:
             self.__lock.acquire()
@@ -118,9 +123,13 @@ class SessionPool(object):
             self.__pool_size -= 1
         self.__closed = True
         logger.info("SessionPool has been closed successfully.")
+        global HAS_SESSION_POOL
+        HAS_SESSION_POOL = False
 
 
 def create_session_pool(pool_config: PoolConfig, max_pool_size: int, wait_timeout_in_ms: int) -> SessionPool:
+    if HAS_SESSION_POOL:
+        raise ConnectionError("SessionPool has already been created.")
     if max_pool_size <= 0:
         max_pool_size = multiprocessing.cpu_count() * DEFAULT_MULTIPIE
     return SessionPool(pool_config, max_pool_size, wait_timeout_in_ms)

--- a/client-py/iotdb/SessionPool.py
+++ b/client-py/iotdb/SessionPool.py
@@ -27,7 +27,6 @@ DEFAULT_MULTIPIE = 5
 DEFAULT_FETCH_SIZE = 5000
 DEFAULT_MAX_RETRY = 3
 DEFAULT_TIME_ZONE = "Asia/Shanghai"
-HAS_SESSION_POOL = False
 logger = logging.getLogger("IoTDB")
 
 
@@ -54,8 +53,6 @@ class SessionPool(object):
         self.__queue = Queue(max_pool_size)
         self.__lock = Lock()
         self.__closed = False
-        global HAS_SESSION_POOL
-        HAS_SESSION_POOL = True
 
     def __construct_session(self) -> Session:
         return Session(self.__pool_config.host, self.__pool_config.port, self.__pool_config.user_name,
@@ -121,13 +118,9 @@ class SessionPool(object):
             self.__pool_size -= 1
         self.__closed = True
         logger.info("SessionPool has been closed successfully.")
-        global HAS_SESSION_POOL
-        HAS_SESSION_POOL = False
 
 
 def create_session_pool(pool_config: PoolConfig, max_pool_size: int, wait_timeout_in_ms: int) -> SessionPool:
-    if HAS_SESSION_POOL:
-        raise ConnectionError("SessionPool has already been created.")
     if max_pool_size <= 0:
         max_pool_size = multiprocessing.cpu_count() * DEFAULT_MULTIPIE
     return SessionPool(pool_config, max_pool_size, wait_timeout_in_ms)

--- a/client-py/iotdb/SessionPool.py
+++ b/client-py/iotdb/SessionPool.py
@@ -19,7 +19,7 @@ import logging
 import multiprocessing
 import time
 from queue import Queue
-from multiprocessing import Lock
+from threading import Lock
 
 from iotdb.Session import Session
 
@@ -53,7 +53,6 @@ class SessionPool(object):
         self.__pool_size = 0
         self.__queue = Queue(max_pool_size)
         self.__lock = Lock()
-        self.__q_lock = Lock()
         self.__closed = False
 
     def __construct_session(self) -> Session:
@@ -64,11 +63,9 @@ class SessionPool(object):
         return session
 
     def __poll_session(self) -> Session | None:
-        self.__q_lock.acquire()
         q = None
         if not self.__queue.empty():
             q = self.__queue.get(block=False)
-        self.__q_lock.release()
         return q
 
     def get_session(self) -> Session:
@@ -81,27 +78,24 @@ class SessionPool(object):
 
         session = self.__poll_session()
         while session is None:
-            self.__lock.acquire()
-            if self.__pool_size < self.__max_pool_size:
-                self.__pool_size += 1
-                should_create = True
-                self.__lock.release()
-                break
-            else:
-                self.__lock.release()
-                if time.time() - start > self.__wait_timeout_in_ms:
-                    raise TimeoutError("Wait to get session timeout in SessionPool, current pool size: {0}"
-                                       .format(self.__max_pool_size))
-                time.sleep(1)
+            with self.__lock:
+                if self.__pool_size < self.__max_pool_size:
+                    self.__pool_size += 1
+                    should_create = True
+                    break
+                else:
+                    if time.time() - start > self.__wait_timeout_in_ms:
+                        raise TimeoutError("Wait to get session timeout in SessionPool, current pool size: {0}"
+                                           .format(self.__max_pool_size))
+                    time.sleep(1)
             session = self.__poll_session()
 
         if should_create:
             try:
                 session = self.__construct_session()
             except Exception as e:
-                self.__lock.acquire()
-                self.__pool_size -= 1
-                self.__lock.release()
+                with self.__lock:
+                    self.__pool_size -= 1
                 raise e
 
         return session
@@ -112,23 +106,17 @@ class SessionPool(object):
             raise ConnectionError("SessionPool has already been closed, please close the session manually.")
 
         if session.is_open():
-            self.__q_lock.acquire()
             self.__queue.put(session)
-            self.__q_lock.release()
         else:
-            self.__lock.acquire()
-            self.__pool_size -= 1
-            self.__lock.release()
+            with self.__lock:
+                self.__pool_size -= 1
 
     def close(self):
-        self.__q_lock.acquire()
-        self.__lock.acquire()
-        while not self.__queue.empty():
-            session = self.__queue.get(block=False)
-            session.close()
-            self.__pool_size -= 1
-        self.__q_lock.release()
-        self.__lock.release()
+        with self.__lock:
+            while not self.__queue.empty():
+                session = self.__queue.get(block=False)
+                session.close()
+                self.__pool_size -= 1
         self.__closed = True
         logger.info("SessionPool has been closed successfully.")
 

--- a/client-py/iotdb/SessionPool.py
+++ b/client-py/iotdb/SessionPool.py
@@ -33,7 +33,7 @@ logger = logging.getLogger("IoTDB")
 class PoolConfig(object):
     def __init__(self, host: str, port: str, user_name: str, password: str,
                  fetch_size: int = DEFAULT_FETCH_SIZE, time_zone: str = DEFAULT_TIME_ZONE,
-                 max_retry: int = DEFAULT_MAX_RETRY):
+                 max_retry: int = DEFAULT_MAX_RETRY, enable_compression=False):
         self.host = host
         self.port = port
         self.user_name = user_name
@@ -41,6 +41,7 @@ class PoolConfig(object):
         self.fetch_size = fetch_size
         self.time_zone = time_zone
         self.max_retry = max_retry
+        self.enable_compression = enable_compression
 
 
 class SessionPool(object):
@@ -56,8 +57,11 @@ class SessionPool(object):
         self.__closed = False
 
     def __construct_session(self) -> Session:
-        return Session(self.__pool_config.host, self.__pool_config.port, self.__pool_config.user_name,
-                       self.__pool_config.password, self.__pool_config.fetch_size, self.__pool_config.time_zone)
+        session = Session(self.__pool_config.host, self.__pool_config.port, self.__pool_config.user_name,
+                          self.__pool_config.password, self.__pool_config.fetch_size, self.__pool_config.time_zone)
+        session.open(self.__pool_config.enable_compression)
+
+        return session
 
     def __poll_session(self) -> Session | None:
         self.__q_lock.acquire()

--- a/client-py/iotdb/SessionPool.py
+++ b/client-py/iotdb/SessionPool.py
@@ -31,14 +31,11 @@ logger = logging.getLogger("IoTDB")
 
 
 class PoolConfig(object):
-    def __init__(self, host: str, ip: str, user_name: str, password: str, node_urls: list = None,
+    def __init__(self, host: str, port: str, user_name: str, password: str,
                  fetch_size: int = DEFAULT_FETCH_SIZE, time_zone: str = DEFAULT_TIME_ZONE,
                  max_retry: int = DEFAULT_MAX_RETRY):
         self.host = host
-        self.ip = ip
-        if node_urls is None:
-            node_urls = []
-        self.node_urls = node_urls
+        self.port = port
         self.user_name = user_name
         self.password = password
         self.fetch_size = fetch_size
@@ -58,14 +55,8 @@ class SessionPool(object):
         self.__closed = False
 
     def __construct_session(self) -> Session:
-        if len(self.__pool_config.node_urls) > 0:
-            return Session.init_from_node_urls(self.__pool_config.node_urls, self.__pool_config.user_name,
-                                               self.__pool_config.password, self.__pool_config.fetch_size,
-                                               self.__pool_config.time_zone)
-
-        else:
-            return Session(self.__pool_config.host, self.__pool_config.ip, self.__pool_config.user_name,
-                           self.__pool_config.password, self.__pool_config.fetch_size, self.__pool_config.time_zone)
+        return Session(self.__pool_config.host, self.__pool_config.port, self.__pool_config.user_name,
+                       self.__pool_config.password, self.__pool_config.fetch_size, self.__pool_config.time_zone)
 
     def __poll_session(self) -> Session | None:
         if self.__queue.empty():

--- a/client-py/iotdb/SessionPool.py
+++ b/client-py/iotdb/SessionPool.py
@@ -108,8 +108,6 @@ class SessionPool(object):
             raise ConnectionError("SessionPool has already been closed, please close the session manually.")
 
         if session.is_open():
-            if session in self.__queue:
-                raise AttributeError("Session has already been put back to the pool.")
             self.__queue.put(session)
         else:
             self.__lock.acquire()

--- a/client-py/iotdb/SessionPool.py
+++ b/client-py/iotdb/SessionPool.py
@@ -26,7 +26,7 @@ from iotdb.Session import Session
 DEFAULT_MULTIPIE = 5
 DEFAULT_FETCH_SIZE = 5000
 DEFAULT_MAX_RETRY = 3
-DEFAULT_TIME_ZONE = "Asia/Shanghai"
+DEFAULT_TIME_ZONE = "UTC+8"
 logger = logging.getLogger("IoTDB")
 
 

--- a/client-py/tests/test_session.py
+++ b/client-py/tests/test_session.py
@@ -59,7 +59,7 @@ def session_test(use_session_pool=False):
         db: IoTDBContainer
 
         if use_session_pool:
-            pool_config = PoolConfig(db.get_container_host_ip(), db.get_exposed_port(6667), "root", "root", None, 1024,
+            pool_config = PoolConfig(db.get_container_host_ip(), db.get_exposed_port(6667), "root", "root", 1024,
                                      "Asia/Shanghai", 3)
             session_pool = create_session_pool(pool_config, 1, 3000)
             session = session_pool.get_session()

--- a/client-py/tests/test_session_pool.py
+++ b/client-py/tests/test_session_pool.py
@@ -70,21 +70,3 @@ def test_session_pool():
         assert is_closed is True
 
         session3.close()
-
-
-def test_multi_create():
-    with IoTDBContainer(CONTAINER_NAME) as db:
-        db: IoTDBContainer
-        max_pool_size = 2
-        pool_config = PoolConfig(db.get_container_host_ip(), db.get_exposed_port(6667), "root", "root",
-                                 1024, "Asia/Shanghai", 3)
-        session_pool = create_session_pool(pool_config, max_pool_size, 3000)
-        try:
-            create_session_pool(pool_config, max_pool_size, 3000)
-        except ConnectionError as e:
-            assert str(e) == "SessionPool has already been created."
-
-        session_pool.close()
-
-        session_pool2 = create_session_pool(pool_config, max_pool_size, 3000)
-        session_pool2.close()

--- a/client-py/tests/test_session_pool.py
+++ b/client-py/tests/test_session_pool.py
@@ -48,7 +48,6 @@ def test_session_pool():
 
         Thread(target=lambda: session_pool.put_back(session2)).start()
         session3 = session_pool.get_session()
-        session3.open(False)
         assert session3.is_open() is True
 
         session_pool.close()

--- a/client-py/tests/test_session_pool.py
+++ b/client-py/tests/test_session_pool.py
@@ -28,15 +28,12 @@ def test_session_pool():
         db: IoTDBContainer
         max_pool_size = 2
         pool_config = PoolConfig(db.get_container_host_ip(), db.get_exposed_port(6667), "root", "root",
-                                 1024, "Asia/Shanghai", 3)
+                                 1024, "UTC+8", 3)
         session_pool = create_session_pool(pool_config, max_pool_size, 3000)
         session = session_pool.get_session()
-        session.open(False)
         assert session.is_open() is True
 
         session2 = session_pool.get_session()
-        session2.open(False)
-        assert session2.is_open() is True
 
         timeout = False
         try:

--- a/client-py/tests/test_session_pool.py
+++ b/client-py/tests/test_session_pool.py
@@ -35,7 +35,8 @@ def test_session_pool():
         assert session.is_open() is True
 
         session2 = session_pool.get_session()
-        assert session2 is not None
+        session2.open(False)
+        assert session2.is_open() is True
 
         timeout = False
         try:
@@ -47,7 +48,8 @@ def test_session_pool():
 
         Thread(target=lambda: session_pool.put_back(session2)).start()
         session3 = session_pool.get_session()
-        assert session3 is not None
+        session3.open(False)
+        assert session3.is_open() is True
 
         session_pool.close()
 
@@ -66,6 +68,8 @@ def test_session_pool():
             is_closed = True
             assert str(e) == "SessionPool has already been closed, please close the session manually."
         assert is_closed is True
+
+        session3.close()
 
 
 def test_multi_create():

--- a/client-py/tests/test_session_pool.py
+++ b/client-py/tests/test_session_pool.py
@@ -49,14 +49,6 @@ def test_session_pool():
         session3 = session_pool.get_session()
         assert session3 is not None
 
-        check = False
-        try:
-            session_pool.put_back(session2)
-        except AttributeError as e:
-            check = True
-            assert str(e) == "Session has already been put back to the pool."
-        assert check is True
-
         session_pool.close()
 
         is_closed = False


### PR DESCRIPTION
Session.init_from_node_urls() is not supported in rel/1.1, so we should remove it in session pool.