### PR TITLE
[To rel/1.2][IOTDB-6075] Pipe: File resource races when different tsfile load operations concurrently modify the same tsfile at receiver (#10629)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -1075,7 +1075,8 @@ public class IoTDBConfig {
   private double maxMemoryRatioForQueue = 0.6;
 
   /** Pipe related */
-  private String pipeReceiveFileDir = systemDir + File.separator + "pipe";
+  private String pipeReceiveFileDir =
+      systemDir + File.separator + "pipe" + File.separator + "receiver";
 
   /** Resource control */
   private boolean quotaEnable = false;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/receiver/PipeReceiverAgent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/receiver/PipeReceiverAgent.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.pipe.agent.receiver;
 
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.pipe.connector.IoTDBThriftConnectorRequestVersion;
 import org.apache.iotdb.db.pipe.connector.v1.IoTDBThriftReceiverV1;
 import org.apache.iotdb.db.queryengine.plan.analyze.IPartitionFetcher;
@@ -28,8 +29,12 @@ import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.service.rpc.thrift.TPipeTransferReq;
 import org.apache.iotdb.service.rpc.thrift.TPipeTransferResp;
 
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
 
 public class PipeReceiverAgent {
 
@@ -85,6 +90,25 @@ public class PipeReceiverAgent {
     if (receiver != null) {
       receiver.handleExit();
       receiverThreadLocal.remove();
+    }
+  }
+
+  public void cleanPipeReceiverDir() {
+    final File receiverFileDir =
+        new File(IoTDBDescriptor.getInstance().getConfig().getPipeReceiverFileDir());
+
+    try {
+      FileUtils.deleteDirectory(receiverFileDir);
+      LOGGER.info("Clean pipe receiver dir {} successfully.", receiverFileDir);
+    } catch (Exception e) {
+      LOGGER.warn("Clean pipe receiver dir {} failed.", receiverFileDir, e);
+    }
+
+    try {
+      FileUtils.forceMkdir(receiverFileDir);
+      LOGGER.info("Create pipe receiver dir {} successfully.", receiverFileDir);
+    } catch (IOException e) {
+      LOGGER.warn("Create pipe receiver dir {} failed.", receiverFileDir, e);
     }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/runtime/PipeRuntimeAgent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/runtime/PipeRuntimeAgent.java
@@ -51,6 +51,7 @@ public class PipeRuntimeAgent implements IService {
 
   public synchronized void preparePipeResources(
       ResourcesInformationHolder resourcesInformationHolder) throws StartupException {
+    PipeAgent.receiver().cleanPipeReceiverDir();
     PipeHardlinkFileDirStartupCleaner.clean();
     PipeAgentLauncher.launchPipePluginAgent(resourcesInformationHolder);
     simpleConsensusProgressIndexAssigner.start();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/v1/IoTDBThriftConnectorClient.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/v1/IoTDBThriftConnectorClient.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.pipe.connector.v1;
 
 import org.apache.iotdb.commons.client.ThriftClient;
 import org.apache.iotdb.commons.client.property.ThriftClientProperty;
+import org.apache.iotdb.commons.pipe.config.PipeConfig;
 import org.apache.iotdb.rpc.RpcTransportFactory;
 import org.apache.iotdb.rpc.TConfigurationConst;
 import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
@@ -42,7 +43,7 @@ public class IoTDBThriftConnectorClient extends IClientRPCService.Client
                         TConfigurationConst.defaultTConfiguration,
                         ipAddress,
                         port,
-                        property.getConnectionTimeoutMs()))));
+                        (int) PipeConfig.getInstance().getPipeConnectorTimeoutMs()))));
     getInputProtocol().getTransport().open();
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/v1/IoTDBThriftConnectorV1.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/v1/IoTDBThriftConnectorV1.java
@@ -86,7 +86,11 @@ public class IoTDBThriftConnectorV1 implements PipeConnector {
   @Override
   public void handshake() throws Exception {
     if (client != null) {
-      client.close();
+      try {
+        client.close();
+      } catch (Exception e) {
+        LOGGER.warn("Close client error, because: {}", e.getMessage(), e);
+      }
     }
 
     client =
@@ -105,6 +109,8 @@ public class IoTDBThriftConnectorV1 implements PipeConnector {
                   CommonDescriptor.getInstance().getConfig().getTimestampPrecision()));
       if (resp.getStatus().getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         throw new PipeException(String.format("Handshake error, result status %s.", resp.status));
+      } else {
+        LOGGER.info("Handshake success. Target server ip: {}, port: {}", ipAddress, port);
       }
     } catch (TException e) {
       throw new PipeConnectionException(
@@ -248,6 +254,8 @@ public class IoTDBThriftConnectorV1 implements PipeConnector {
     if (resp.getStatus().getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
       throw new PipeException(
           String.format("Seal file %s error, result status %s.", tsFile, resp.getStatus()));
+    } else {
+      LOGGER.info("Successfully transferred file {}.", tsFile);
     }
   }
 

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -984,6 +984,9 @@ cluster_name=defaultCluster
 # Noted that: this should be less than or equals to realtimeExtractorPendingQueueCapacity
 # pipe_extractor_pending_queue_tablet_limit=64
 
+# The connection timeout (in milliseconds) for the thrift client.
+# pipe_connector_timeout_ms=900000
+
 # The buffer size used for reading file during file transfer.
 # pipe_connector_read_file_buffer_size=8388608
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -156,6 +156,7 @@ public class CommonConfig {
   private int pipeExtractorPendingQueueTabletLimit = pipeExtractorPendingQueueCapacity / 2;
   private int pipeDataStructureTabletRowSize = 65536;
 
+  private long pipeConnectorTimeoutMs = 15 * 60 * 1000L; // 15 minutes
   private int pipeConnectorReadFileBufferSize = 8388608;
   private long pipeConnectorRetryIntervalMs = 1000L;
   private int pipeConnectorPendingQueueSize = 1024;
@@ -505,6 +506,14 @@ public class CommonConfig {
 
   public void setPipeExtractorPendingQueueTabletLimit(int pipeExtractorPendingQueueTabletLimit) {
     this.pipeExtractorPendingQueueTabletLimit = pipeExtractorPendingQueueTabletLimit;
+  }
+
+  public long getPipeConnectorTimeoutMs() {
+    return pipeConnectorTimeoutMs;
+  }
+
+  public void setPipeConnectorTimeoutMs(long pipeConnectorTimeoutMs) {
+    this.pipeConnectorTimeoutMs = pipeConnectorTimeoutMs;
   }
 
   public int getPipeConnectorReadFileBufferSize() {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -297,6 +297,10 @@ public class CommonDescriptor {
                 "pipe_extractor_pending_queue_tablet_limit",
                 String.valueOf(config.getPipeExtractorPendingQueueTabletLimit()))));
 
+    config.setPipeConnectorTimeoutMs(
+        Long.parseLong(
+            properties.getProperty(
+                "pipe_connector_timeout_ms", String.valueOf(config.getPipeConnectorTimeoutMs()))));
     config.setPipeConnectorReadFileBufferSize(
         Integer.parseInt(
             properties.getProperty(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeConfig.java
@@ -79,6 +79,10 @@ public class PipeConfig {
 
   /////////////////////////////// Connector ///////////////////////////////
 
+  public long getPipeConnectorTimeoutMs() {
+    return COMMON_CONFIG.getPipeConnectorTimeoutMs();
+  }
+
   public int getPipeConnectorReadFileBufferSize() {
     return COMMON_CONFIG.getPipeConnectorReadFileBufferSize();
   }


### PR DESCRIPTION
* Add a parameter in iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties to control the connection timeout.
* Set the pipe connection timeout between sender and receiver to 15 mins to allow long time-cost load operation.
* Redesign the pipe receiver's dir to avoid file resource races when different tsfile load operations concurrently modify the same tsfile.

(cherry picked from commit 1e11ab64cc176220646f244a76d1a4cfde35b239)
