### PR TITLE
Keep special case consistent between  `LastDataQueryForOneDevice` and others

### DIFF
--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -895,7 +895,7 @@ public class Session implements ISession {
       if (enableRedirection
           && !deviceIdToEndpoint.isEmpty()
           && deviceIdToEndpoint.get(device) != null) {
-        logger.warn("Session can not connect to {}", deviceIdToEndpoint.get(device));
+        logger.warn(SESSION_CANNOT_CONNECT, deviceIdToEndpoint.get(device));
         deviceIdToEndpoint.remove(device);
 
         // reconnect with default connection

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
@@ -3093,6 +3093,10 @@ public class SessionPool implements ISessionPool {
       } catch (StatementExecutionException | RuntimeException e) {
         putBack(session);
         throw e;
+      } catch (Throwable e) {
+        logger.error(EXECUTE_LASTDATAQUERY_ERROR, e);
+        putBack(session);
+        throw new RuntimeException(e);
       }
     }
     // never go here


### PR DESCRIPTION
The time span of https://github.com/apache/iotdb/pull/10600 is too large and other interface has changed uniformly.