### PR TITLE
[To rel/1.1][IOTDB-6072] Load: workaround to CPU 100% after loading tsfile when using JDK8 runtime

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/load/LoadTsFileManager.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/load/LoadTsFileManager.java
@@ -71,7 +71,7 @@ public class LoadTsFileManager {
     this.loadDir = SystemFileFactory.INSTANCE.getFile(config.getLoadTsFileDir());
     this.uuid2WriterManager = new ConcurrentHashMap<>();
     this.cleanupExecutors =
-        IoTDBThreadPoolFactory.newScheduledThreadPool(0, LoadTsFileManager.class.getName());
+        IoTDBThreadPoolFactory.newScheduledThreadPool(1, LoadTsFileManager.class.getName());
     this.uuid2Future = new ConcurrentHashMap<>();
 
     recover();


### PR DESCRIPTION
cherry-pick: [pr](https://github.com/apache/iotdb/pull/10624)