### PR TITLE
[IOTDB-6077]: Stop script addition -f

### DIFF
--- a/iotdb-core/confignode/src/assembly/resources/sbin/stop-confignode.sh
+++ b/iotdb-core/confignode/src/assembly/resources/sbin/stop-confignode.sh
@@ -34,6 +34,24 @@ else
   exit 1
 fi
 
+force=""
+
+while true; do
+    case "$1" in
+        -f)
+            force="yes"
+            break
+        ;;
+        "")
+            #if we do not use getopt, we then have to process the case that there is no argument.
+            #in some systems, when there is no argument, shift command may throw error, so we skip directly
+            #all others are args to the program
+            PARAMS=$*
+            break
+        ;;
+    esac
+done
+
 PID_VERIFY=$(ps ax | grep -i 'ConfigNode' | grep java | grep -v grep | awk '{print $1}')
 if [ -z "$PID" ]; then
   echo "No ConfigNode to stop"
@@ -42,8 +60,13 @@ if [ -z "$PID" ]; then
   fi
   exit 1
 elif [[ "${PID_VERIFY}" =~ ${PID} ]]; then
-  kill -s TERM "$PID"
-  echo "Close ConfigNode, PID:" "$PID"
+  if [[ "${force}" == "yes" ]]; then
+    kill -9 "$PID"
+    echo "Force to stop ConfigNode, PID:" "$PID"
+  else
+    kill -s TERM "$PID"
+    echo "Stop ConfigNode, PID:" "$PID"
+  fi
 else
   echo "No ConfigNode to stop"
   exit 1

--- a/iotdb-core/datanode/src/assembly/resources/sbin/stop-datanode.sh
+++ b/iotdb-core/datanode/src/assembly/resources/sbin/stop-datanode.sh
@@ -21,6 +21,24 @@
 DATANODE_CONF="`dirname "$0"`/../conf"
 dn_rpc_port=`sed '/^dn_rpc_port=/!d;s/.*=//' ${DATANODE_CONF}/iotdb-datanode.properties`
 
+force=""
+
+while true; do
+    case "$1" in
+        -f)
+            force="yes"
+            break
+        ;;
+        "")
+            #if we do not use getopt, we then have to process the case that there is no argument.
+            #in some systems, when there is no argument, shift command may throw error, so we skip directly
+            #all others are args to the program
+            PARAMS=$*
+            break
+        ;;
+    esac
+done
+
 echo "Check whether the rpc_port is used..., port is" $dn_rpc_port
 
 if  type lsof > /dev/null 2>&1 ; then
@@ -42,8 +60,13 @@ if [ -z "$PID" ]; then
   fi
   exit 1
 elif [[ "${PID_VERIFY}" =~ ${PID} ]]; then
-  kill -s TERM "$PID"
-  echo "Stop DataNode, PID:" "$PID"
+  if [[ "${force}" == "yes" ]]; then
+    kill -9 "$PID"
+    echo "Force to stop DataNode, PID:" "$PID"
+  else
+    kill -s TERM "$PID"
+    echo "Stop DataNode, PID:" "$PID"
+  fi
 else
   echo "No DataNode to stop"
   exit 1

--- a/iotdb-core/node-commons/src/assembly/resources/sbin/stop-standalone.sh
+++ b/iotdb-core/node-commons/src/assembly/resources/sbin/stop-standalone.sh
@@ -22,6 +22,25 @@ if [ -z "${IOTDB_HOME}" ]; then
   export IOTDB_HOME="`dirname "$0"`/.."
 fi
 
+
+force=""
+
+while true; do
+    case "$1" in
+        -f)
+            force="yes"
+            break
+        ;;
+        "")
+            #if we do not use getopt, we then have to process the case that there is no argument.
+            #in some systems, when there is no argument, shift command may throw error, so we skip directly
+            #all others are args to the program
+            PARAMS=$*
+            break
+        ;;
+    esac
+done
+
 if [ -f "$IOTDB_HOME/sbin/stop-confignode.sh" ]; then
   export CONFIGNODE_STOP_PATH="$IOTDB_HOME/sbin/stop-confignode.sh"
 else
@@ -36,5 +55,13 @@ else
   exit 0
 fi
 
-bash "$CONFIGNODE_STOP_PATH"
-bash "$DATANODE_STOP_PATH"
+
+
+if [[ "${force}" == "yes" ]]; then
+  echo "Force stop all nodes"
+  bash "$CONFIGNODE_STOP_PATH" -f
+  bash "$DATANODE_STOP_PATH" -f
+else
+  bash "$CONFIGNODE_STOP_PATH"
+  bash "$DATANODE_STOP_PATH"
+fi


### PR DESCRIPTION
support `./sbin/stop-confignode.sh -f`

support `./sbin/stop-datanode.sh -f`

support `./sbin/stop-standalone.sh -f`
![image](https://github.com/apache/iotdb/assets/19721744/f72f6922-caf1-4f8f-ac2f-6c84338c52ca)
![image](https://github.com/apache/iotdb/assets/19721744/f62687b0-9b7c-4353-b676-3a574901a207)
![image](https://github.com/apache/iotdb/assets/19721744/fbe9a005-2f6c-489f-b464-46b1e750e9f8)
