### PR TITLE
Fix error update alias in PB_Tree WrappedSegment

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/WrappedSegment.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/WrappedSegment.java
@@ -259,12 +259,11 @@ public class WrappedSegment extends Segment<ICachedMNode> {
     // update alias-key list accordingly
     if (oriAlias != null) {
       aliasKeyList.remove(binarySearchPairList(aliasKeyList, oriAlias));
-
-      uBuffer.clear();
-      String alias = RecordUtils.getRecordAlias(uBuffer);
-      if (alias != null) {
-        aliasKeyList.add(binaryInsertPairList(aliasKeyList, alias), new Pair<>(alias, key));
-      }
+    }
+    uBuffer.clear();
+    String alias = RecordUtils.getRecordAlias(uBuffer);
+    if (alias != null) {
+      aliasKeyList.add(binaryInsertPairList(aliasKeyList, alias), new Pair<>(alias, key));
     }
 
     return idx;

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/WrappedSegmentTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/WrappedSegmentTest.java
@@ -70,8 +70,8 @@ public class WrappedSegmentTest {
     sf.updateRecord("s1", RecordUtils.node2Buffer(node));
     node.getAsMeasurementMNode().setAlias("alias2");
     sf.updateRecord("s1", RecordUtils.node2Buffer(node));
-    ByteBuffer buffer = sf.getRecord("s1");
-    ICachedMNode node1 = RecordUtils.buffer2Node("s1", buffer);
+    Assert.assertEquals(null, sf.getRecordByAlias("alias1"));
+    ICachedMNode node1 = sf.getRecordByAlias("alias2");
     Assert.assertTrue(node1.isMeasurement());
     Assert.assertEquals("alias2", node1.getAsMeasurementMNode().getAlias());
   }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/WrappedSegmentTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/WrappedSegmentTest.java
@@ -62,6 +62,21 @@ public class WrappedSegmentTest {
   }
 
   @Test
+  public void testUpdateAlias() throws MetadataException {
+    WrappedSegment sf = new WrappedSegment(500);
+    ICachedMNode node = getMeasurementNode(null, "s1", null);
+    sf.insertRecord("s1", RecordUtils.node2Buffer(node));
+    node.getAsMeasurementMNode().setAlias("alias1");
+    sf.updateRecord("s1", RecordUtils.node2Buffer(node));
+    node.getAsMeasurementMNode().setAlias("alias2");
+    sf.updateRecord("s1", RecordUtils.node2Buffer(node));
+    ByteBuffer buffer = sf.getRecord("s1");
+    ICachedMNode node1 = RecordUtils.buffer2Node("s1", buffer);
+    Assert.assertTrue(node1.isMeasurement());
+    Assert.assertEquals("alias2", node1.getAsMeasurementMNode().getAlias());
+  }
+
+  @Test
   public void flatTreeInsert() throws MetadataException {
     WrappedSegment sf = new WrappedSegment(500);
     ICachedMNode rNode = virtualFlatMTree(10);


### PR DESCRIPTION
## Description

The aliasKeyList in PBTree WrappedSegment maintains an index on aliases. The indexes in the aliasKeyList should be updated when updating the Record. However, the current implementation forgets to update the index in the aliasKeyList when the original Alias is null, which is a logical bug.

This PR fixes this bug and adds unit tests.