### PR TITLE
[IOTDB-6074] Ignore error message when TagManager createSnapshot

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/mem/snapshot/MemMTreeSnapshotUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/mem/snapshot/MemMTreeSnapshotUtil.java
@@ -31,6 +31,7 @@ import org.apache.iotdb.commons.schema.node.utils.IMNodeFactory;
 import org.apache.iotdb.commons.schema.node.utils.IMNodeIterator;
 import org.apache.iotdb.commons.schema.node.visitor.MNodeVisitor;
 import org.apache.iotdb.commons.schema.view.LogicalViewSchema;
+import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.db.schemaengine.SchemaConstant;
 import org.apache.iotdb.db.schemaengine.rescon.MemSchemaRegionStatistics;
 import org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.mem.MemMTreeStore;
@@ -51,7 +52,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.file.Files;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.function.Consumer;
@@ -85,7 +85,7 @@ public class MemMTreeSnapshotUtil {
           new BufferedOutputStream(new FileOutputStream(snapshotTmp))) {
         serializeTo(store, outputStream);
       }
-      if (snapshot.exists() && !deleteFile(snapshot)) {
+      if (snapshot.exists() && !FileUtils.deleteFileIfExist(snapshot)) {
         logger.error(
             "Failed to delete old snapshot {} while creating mtree snapshot.", snapshot.getName());
         return false;
@@ -95,27 +95,17 @@ public class MemMTreeSnapshotUtil {
             "Failed to rename {} to {} while creating mtree snapshot.",
             snapshotTmp.getName(),
             snapshot.getName());
-        deleteFile(snapshot);
+        FileUtils.deleteFileIfExist(snapshot);
         return false;
       }
 
       return true;
     } catch (IOException e) {
       logger.error("Failed to create mtree snapshot due to {}", e.getMessage(), e);
-      deleteFile(snapshot);
+      FileUtils.deleteFileIfExist(snapshot);
       return false;
     } finally {
-      deleteFile(snapshotTmp);
-    }
-  }
-
-  private static boolean deleteFile(File snapshot) {
-    try {
-      Files.deleteIfExists(snapshot.toPath());
-      return true;
-    } catch (IOException e) {
-      logger.error(e.getMessage(), e);
-      return false;
+      FileUtils.deleteFileIfExist(snapshotTmp);
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/tag/TagManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/tag/TagManager.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.commons.schema.filter.impl.TagFilter;
 import org.apache.iotdb.commons.schema.node.IMNode;
 import org.apache.iotdb.commons.schema.node.role.IMeasurementMNode;
 import org.apache.iotdb.commons.schema.tree.SchemaIterator;
+import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.db.schemaengine.SchemaConstant;
 import org.apache.iotdb.db.schemaengine.schemaregion.read.req.IShowTimeSeriesPlan;
 import org.apache.iotdb.db.schemaengine.schemaregion.read.resp.info.ITimeSeriesSchemaInfo;
@@ -39,7 +40,6 @@ import org.apache.iotdb.db.schemaengine.schemaregion.read.resp.reader.impl.Schem
 import org.apache.iotdb.db.schemaengine.schemaregion.read.resp.reader.impl.TimeseriesReaderWithViewFetch;
 import org.apache.iotdb.tsfile.utils.Pair;
 
-import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,7 +87,7 @@ public class TagManager {
         SystemFileFactory.INSTANCE.getFile(targetDir, SchemaConstant.TAG_LOG_SNAPSHOT_TMP);
     try {
       tagLogFile.copyTo(tagLogSnapshotTmp);
-      if (tagLogSnapshot.exists() && !tagLogSnapshot.delete()) {
+      if (tagLogSnapshot.exists() && !FileUtils.deleteFileIfExist(tagLogSnapshot)) {
         logger.warn(
             "Failed to delete old snapshot {} while creating tagManager snapshot.",
             tagLogSnapshot.getName());
@@ -98,7 +98,7 @@ public class TagManager {
             "Failed to rename {} to {} while creating tagManager snapshot.",
             tagLogSnapshotTmp.getName(),
             tagLogSnapshot.getName());
-        if (!tagLogSnapshot.delete()) {
+        if (!FileUtils.deleteFileIfExist(tagLogSnapshot)) {
           logger.warn("Failed to delete {} after renaming failure.", tagLogSnapshot.getName());
         }
         return false;
@@ -107,14 +107,14 @@ public class TagManager {
       return true;
     } catch (IOException e) {
       logger.error("Failed to create tagManager snapshot due to {}", e.getMessage(), e);
-      if (!tagLogSnapshot.delete()) {
+      if (!FileUtils.deleteFileIfExist(tagLogSnapshot)) {
         logger.warn(
             "Failed to delete {} after creating tagManager snapshot failure.",
             tagLogSnapshot.getName());
       }
       return false;
     } finally {
-      if (!tagLogSnapshotTmp.delete()) {
+      if (!FileUtils.deleteFileIfExist(tagLogSnapshotTmp)) {
         logger.warn("Failed to delete {}.", tagLogSnapshotTmp.getName());
       }
     }
@@ -130,7 +130,7 @@ public class TagManager {
     }
 
     try {
-      FileUtils.copyFile(tagSnapshot, tagFile);
+      org.apache.commons.io.FileUtils.copyFile(tagSnapshot, tagFile);
       return new TagManager(sgSchemaDirPath);
     } catch (IOException e) {
       if (!tagFile.delete()) {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/FileUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/FileUtils.java
@@ -42,6 +42,16 @@ public class FileUtils {
 
   private FileUtils() {}
 
+  public static boolean deleteFileIfExist(File file) {
+    try {
+      Files.deleteIfExists(file.toPath());
+      return true;
+    } catch (IOException e) {
+      logger.error(e.getMessage(), e);
+      return false;
+    }
+  }
+
   public static void deleteDirectory(File folder) {
     if (folder.isDirectory()) {
       for (File file : folder.listFiles()) {


### PR DESCRIPTION
## Description

Error message should not be printed when the tmp file does not exist.

![image](https://github.com/apache/iotdb/assets/43774645/56db6c37-6d3c-46fa-889f-9246feb35abe)

