### PR TITLE
fix inaccurate statistics for monitoring the number of unseq Tsfile on cross compaction

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/exception/CompactionExceptionHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/exception/CompactionExceptionHandler.java
@@ -226,14 +226,9 @@ public class CompactionExceptionHandler {
       return false;
     }
 
-    // delete source files
-    for (TsFileResource resource : sourceSeqResourceList) {
-      resource.remove();
-    }
-    for (TsFileResource resource : sourceUnseqResourceList) {
-      resource.remove();
-    }
-
+    // delete sources file
+    CompactionUtils.deleteSourceTsFileAndUpdateFileMetrics(
+        sourceSeqResourceList, sourceUnseqResourceList);
     // delete compaction mods files
     CompactionUtils.deleteCompactionModsFile(sourceSeqResourceList, sourceUnseqResourceList);
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
@@ -350,19 +350,6 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
     return equalsOtherTask((CrossSpaceCompactionTask) other);
   }
 
-  private long[] deleteOldFiles(List<TsFileResource> tsFileResourceList) {
-    long[] size = new long[tsFileResourceList.size()];
-    for (int i = 0, length = tsFileResourceList.size(); i < length; ++i) {
-      TsFileResource tsFileResource = tsFileResourceList.get(i);
-      size[i] = tsFileResource.getTsFileSize();
-      tsFileResource.remove();
-      LOGGER.info(
-          "[CrossSpaceCompaction] Delete TsFile :{}.",
-          tsFileResource.getTsFile().getAbsolutePath());
-    }
-    return size;
-  }
-
   private void releaseReadAndLockWrite(List<TsFileResource> tsFileResourceList) {
     for (TsFileResource tsFileResource : tsFileResourceList) {
       tsFileResource.readUnlock();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
@@ -213,14 +213,8 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
           }
         }
 
-        long[] sequenceFileSize = deleteOldFiles(selectedSequenceFiles);
-        List<String> fileNames = new ArrayList<>(selectedSequenceFiles.size());
-        selectedSequenceFiles.forEach(x -> fileNames.add(x.getTsFile().getName()));
-        FileMetrics.getInstance().deleteFile(sequenceFileSize, true, fileNames);
-        fileNames.clear();
-        selectedUnsequenceFiles.forEach(x -> fileNames.add(x.getTsFile().getName()));
-        long[] unsequenceFileSize = deleteOldFiles(selectedUnsequenceFiles);
-        FileMetrics.getInstance().deleteFile(unsequenceFileSize, false, fileNames);
+        CompactionUtils.deleteSourceTsFileAndUpdateFileMetrics(
+            selectedSequenceFiles, selectedUnsequenceFiles);
         CompactionUtils.deleteCompactionModsFile(selectedSequenceFiles, selectedUnsequenceFiles);
 
         for (TsFileResource targetResource : targetTsfileResourceList) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
@@ -231,13 +231,6 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
             "{}-{} [Compaction] compaction finish, start to delete old files",
             storageGroupName,
             dataRegionId);
-        // delete the old files
-        long[] sizeList = new long[selectedTsFileResourceList.size()];
-        for (int i = 0, size = selectedTsFileResourceList.size(); i < size; ++i) {
-          sizeList[i] = selectedTsFileResourceList.get(i).getTsFileSize();
-        }
-        CompactionUtils.deleteTsFilesInDisk(
-            selectedTsFileResourceList, storageGroupName + "-" + dataRegionId);
         CompactionUtils.deleteModificationForSourceFile(
             selectedTsFileResourceList, storageGroupName + "-" + dataRegionId);
 
@@ -255,12 +248,7 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
           // target resource is empty after compaction, then delete it
           targetTsFileResource.remove();
         }
-        List<String> fileNames = new ArrayList<>();
-        for (TsFileResource resource : selectedTsFileResourceList) {
-          fileNames.add(resource.getTsFile().getName());
-        }
-        FileMetrics.getInstance().deleteFile(sizeList, sequence, fileNames);
-
+        CompactionUtils.deleteSourceTsFileAndUpdateFileMetrics(selectedTsFileResourceList);
         CompactionMetrics.getInstance().recordSummaryInfo(summary);
 
         double costTime = (System.currentTimeMillis() - startTime) / 1000.0d;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
@@ -231,6 +231,7 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
             "{}-{} [Compaction] compaction finish, start to delete old files",
             storageGroupName,
             dataRegionId);
+        CompactionUtils.deleteSourceTsFileAndUpdateFileMetrics(selectedTsFileResourceList);
         CompactionUtils.deleteModificationForSourceFile(
             selectedTsFileResourceList, storageGroupName + "-" + dataRegionId);
 
@@ -248,7 +249,6 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
           // target resource is empty after compaction, then delete it
           targetTsFileResource.remove();
         }
-        CompactionUtils.deleteSourceTsFileAndUpdateFileMetrics(selectedTsFileResourceList);
         CompactionMetrics.getInstance().recordSummaryInfo(summary);
 
         double costTime = (System.currentTimeMillis() - startTime) / 1000.0d;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/CompactionUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/CompactionUtils.java
@@ -466,7 +466,7 @@ public class CompactionUtils {
       sequenceFileNames.add(tsFileResource.getTsFile().getName());
       tsFileResource.remove();
       logger.info(
-          "[Compaction] delete unSequence file :{}", tsFileResource.getTsFile().getAbsolutePath());
+          "[Compaction] delete sequence file :{}", tsFileResource.getTsFile().getAbsolutePath());
     }
     FileMetrics.getInstance().deleteFile(sequenceFileSize, true, sequenceFileNames);
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/CompactionUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/CompactionUtils.java
@@ -445,29 +445,45 @@ public class CompactionUtils {
     // delete unSeq file
     long[] unSequenceFileSize = new long[sourceUnseqResourceList.size()];
     List<String> unSequenceFileNames = new ArrayList<>();
+    boolean removeSuccess = true;
     for (int i = 0; i < sourceUnseqResourceList.size(); i++) {
       TsFileResource tsFileResource = sourceUnseqResourceList.get(i);
-      unSequenceFileSize[i] = tsFileResource.getTsFileSize();
-      unSequenceFileNames.add(tsFileResource.getTsFile().getName());
-      tsFileResource.remove();
+      if (!tsFileResource.remove()) {
+        removeSuccess = false;
+        logger.warn(
+            "[Compaction] delete unSequence file failed,file path is {}",
+            tsFileResource.getTsFile().getAbsolutePath());
+      }
       logger.info(
           "[Compaction] delete unSequence file :{}", tsFileResource.getTsFile().getAbsolutePath());
+      unSequenceFileSize[i] = tsFileResource.getTsFileSize();
+      unSequenceFileNames.add(tsFileResource.getTsFile().getName());
     }
-    FileMetrics.getInstance().deleteFile(unSequenceFileSize, false, unSequenceFileNames);
+    if (removeSuccess) {
+      FileMetrics.getInstance().deleteFile(unSequenceFileSize, false, unSequenceFileNames);
+    }
   }
 
   public static void deleteSourceTsFileAndUpdateFileMetrics(
       List<TsFileResource> sourceSeqResourceList) {
     long[] sequenceFileSize = new long[sourceSeqResourceList.size()];
     List<String> sequenceFileNames = new ArrayList<>();
+    boolean removeSuccess = true;
     for (int i = 0; i < sourceSeqResourceList.size(); i++) {
       TsFileResource tsFileResource = sourceSeqResourceList.get(i);
-      sequenceFileSize[i] = tsFileResource.getTsFileSize();
-      sequenceFileNames.add(tsFileResource.getTsFile().getName());
-      tsFileResource.remove();
+      if (!tsFileResource.remove()) {
+        removeSuccess = false;
+        logger.warn(
+            "[Compaction] delete sequence file failed,file path is {}",
+            tsFileResource.getTsFile().getAbsolutePath());
+      }
       logger.info(
           "[Compaction] delete sequence file :{}", tsFileResource.getTsFile().getAbsolutePath());
+      sequenceFileSize[i] = tsFileResource.getTsFileSize();
+      sequenceFileNames.add(tsFileResource.getTsFile().getName());
     }
-    FileMetrics.getInstance().deleteFile(sequenceFileSize, true, sequenceFileNames);
+    if (removeSuccess) {
+      FileMetrics.getInstance().deleteFile(sequenceFileSize, true, sequenceFileNames);
+    }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/CompactionUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/CompactionUtils.java
@@ -436,4 +436,38 @@ public class CompactionUtils {
     }
     return true;
   }
+
+  public static void deleteSourceTsFileAndUpdateFileMetrics(
+      List<TsFileResource> sourceSeqResourceList, List<TsFileResource> sourceUnseqResourceList) {
+    // delete seq file
+    deleteSourceTsFileAndUpdateFileMetrics(sourceSeqResourceList);
+
+    // delete unSeq file
+    long[] unSequenceFileSize = new long[sourceUnseqResourceList.size()];
+    List<String> unSequenceFileNames = new ArrayList<>();
+    for (int i = 0; i < sourceUnseqResourceList.size(); i++) {
+      TsFileResource tsFileResource = sourceUnseqResourceList.get(i);
+      unSequenceFileSize[i] = tsFileResource.getTsFileSize();
+      unSequenceFileNames.add(tsFileResource.getTsFile().getName());
+      tsFileResource.remove();
+      logger.info(
+          "[Compaction] delete unSequence file :{}", tsFileResource.getTsFile().getAbsolutePath());
+    }
+    FileMetrics.getInstance().deleteFile(unSequenceFileSize, false, unSequenceFileNames);
+  }
+
+  public static void deleteSourceTsFileAndUpdateFileMetrics(
+      List<TsFileResource> sourceSeqResourceList) {
+    long[] sequenceFileSize = new long[sourceSeqResourceList.size()];
+    List<String> sequenceFileNames = new ArrayList<>();
+    for (int i = 0; i < sourceSeqResourceList.size(); i++) {
+      TsFileResource tsFileResource = sourceSeqResourceList.get(i);
+      sequenceFileSize[i] = tsFileResource.getTsFileSize();
+      sequenceFileNames.add(tsFileResource.getTsFile().getName());
+      tsFileResource.remove();
+      logger.info(
+          "[Compaction] delete unSequence file :{}", tsFileResource.getTsFile().getAbsolutePath());
+    }
+    FileMetrics.getInstance().deleteFile(sequenceFileSize, true, sequenceFileNames);
+  }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/CompactionUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/CompactionUtils.java
@@ -453,11 +453,13 @@ public class CompactionUtils {
         logger.warn(
             "[Compaction] delete unSequence file failed,file path is {}",
             tsFileResource.getTsFile().getAbsolutePath());
+      } else {
+        logger.info(
+            "[Compaction] delete unSequence file :{}",
+            tsFileResource.getTsFile().getAbsolutePath());
+        unSequenceFileSize[i] = tsFileResource.getTsFileSize();
+        unSequenceFileNames.add(tsFileResource.getTsFile().getName());
       }
-      logger.info(
-          "[Compaction] delete unSequence file :{}", tsFileResource.getTsFile().getAbsolutePath());
-      unSequenceFileSize[i] = tsFileResource.getTsFileSize();
-      unSequenceFileNames.add(tsFileResource.getTsFile().getName());
     }
     if (removeSuccess) {
       FileMetrics.getInstance().deleteFile(unSequenceFileSize, false, unSequenceFileNames);
@@ -476,11 +478,12 @@ public class CompactionUtils {
         logger.warn(
             "[Compaction] delete sequence file failed,file path is {}",
             tsFileResource.getTsFile().getAbsolutePath());
+      } else {
+        logger.info(
+            "[Compaction] delete sequence file :{}", tsFileResource.getTsFile().getAbsolutePath());
+        sequenceFileSize[i] = tsFileResource.getTsFileSize();
+        sequenceFileNames.add(tsFileResource.getTsFile().getName());
       }
-      logger.info(
-          "[Compaction] delete sequence file :{}", tsFileResource.getTsFile().getAbsolutePath());
-      sequenceFileSize[i] = tsFileResource.getTsFileSize();
-      sequenceFileNames.add(tsFileResource.getTsFile().getName());
     }
     if (removeSuccess) {
       FileMetrics.getInstance().deleteFile(sequenceFileSize, true, sequenceFileNames);


### PR DESCRIPTION
When an exception occurs in the execution of a cross-space task, when some source files exist and all target files have been generated, the system will decide to delete the remaining source files. When the source files are deleted, the number of files in the monitoring system is not updated, and it should be updated