### PR TITLE
factor the mods file size into the cross-space merge memory estimate

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/ReadPointCrossCompactionEstimator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/ReadPointCrossCompactionEstimator.java
@@ -119,9 +119,15 @@ public class ReadPointCrossCompactionEstimator extends AbstractCrossSpaceEstimat
       return 0;
     }
     // it means the max size of a timeseries in this file when reading all of its chunk into memory.
-    return compressionRatio
-        * concurrentSeriesNum
-        * (unseqResource.getTsFileSize() * fileInfo.maxSeriesChunkNum / fileInfo.totalChunkNum);
+
+    long resourceFileSize =
+        compressionRatio
+            * concurrentSeriesNum
+            * (unseqResource.getTsFileSize() * fileInfo.maxSeriesChunkNum / fileInfo.totalChunkNum);
+
+    // add mod file size
+    long modFileSize = unseqResource.getModFile().getSize();
+    return resourceFileSize + modFileSize;
   }
 
   /**
@@ -167,6 +173,9 @@ public class ReadPointCrossCompactionEstimator extends AbstractCrossSpaceEstimat
         cost += seqFileCost;
         maxCostOfReadingSeqFile = seqFileCost;
       }
+
+      // add mod file size
+      cost += seqResource.getModFile().getSize();
     }
     return cost;
   }


### PR DESCRIPTION
In the existing memory estimation method, the memory estimation required for seq files,unSeq files, and target files is estimated respectively. The mods file size of the source file is not factored into the memory estimate. This optimization takes the mods file size into account in memory estimates. See the documentation for details:https://apache-iotdb.feishu.cn/docx/UTkZd9ynbo99o6xuzNVc90wlnxg