### PR TITLE
Fix potential memory leak in MemoryPool

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/exchange/MPPDataExchangeManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/exchange/MPPDataExchangeManager.java
@@ -551,7 +551,7 @@ public class MPPDataExchangeManager implements IMPPDataExchangeManager {
   public void deRegisterFragmentInstanceFromMemoryPool(String queryId, String fragmentInstanceId) {
     localMemoryManager
         .getQueryPool()
-        .deRegisterFragmentInstanceToQueryMemoryMap(queryId, fragmentInstanceId);
+        .deRegisterFragmentInstanceFromQueryMemoryMap(queryId, fragmentInstanceId);
   }
 
   public LocalMemoryManager getLocalMemoryManager() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/exchange/sink/SinkChannel.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/exchange/sink/SinkChannel.java
@@ -258,7 +258,7 @@ public class SinkChannel implements ISinkChannel {
     }
     sequenceIdToTsBlock.clear();
     if (blocked != null) {
-      bufferRetainedSizeInBytes -= localMemoryManager.getQueryPool().tryComplete(blocked);
+      bufferRetainedSizeInBytes -= localMemoryManager.getQueryPool().tryCancel(blocked);
     }
     if (bufferRetainedSizeInBytes > 0) {
       localMemoryManager

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/memory/MemoryPool.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/memory/MemoryPool.java
@@ -307,31 +307,6 @@ public class MemoryPool {
     return ((MemoryReservationFuture<Void>) future).getBytesToReserve();
   }
 
-  /**
-   * Complete the specified memory reservation. If the reservation has finished, do nothing.
-   *
-   * @param future The future returned from {@link #reserve(String, String, String, long, long)}
-   * @return If the future has not complete, return the number of bytes being reserved. Otherwise,
-   *     return 0.
-   */
-  @SuppressWarnings("squid:S2445")
-  public synchronized long tryComplete(ListenableFuture<Void> future) {
-    // add synchronized on the future to avoid that the future is concurrently completed by
-    // MemoryPool.free() which may lead to memory leak.
-    synchronized (future) {
-      Validate.notNull(future);
-      // If the future is not a MemoryReservationFuture, it must have been completed.
-      if (future.isDone()) {
-        return 0L;
-      }
-      Validate.isTrue(
-          future instanceof MemoryReservationFuture,
-          "invalid future type " + future.getClass().getSimpleName());
-      ((MemoryReservationFuture<Void>) future).set(null);
-    }
-    return ((MemoryReservationFuture<Void>) future).getBytesToReserve();
-  }
-
   public void free(String queryId, String fragmentInstanceId, String planNodeId, long bytes) {
     Validate.notNull(queryId);
     Validate.isTrue(bytes > 0L);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/memory/MemoryPool.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/memory/MemoryPool.java
@@ -199,7 +199,7 @@ public class MemoryPool {
         for (Long memoryReserved : fragmentRelatedMemory.values()) {
           if (memoryReserved != 0) {
             throw new MemoryLeakException(
-                "PlanNode related memory is not zero when deregister FI from query memory pool.");
+                "PlanNode related memory is not zero when trying to deregister FI from query memory pool. QueryId is : {}, FragmentInstanceId is : {}, PlanNode related memory is : {}.");
           }
         }
       }


### PR DESCRIPTION
If we do not add syncronized on the future of MemoryPool.tryCancel(), it may lead to memory leak like this:
When close method of SharedTsBlockQueue is invoked, it will update bufferRetainedSizeInBytes using the value returned by tryCancel because if the MemoryReservationFuture is not completed, it means that the size of TsBlock is added wrongly.(Memory used by that TsBlock is not registered in MemoryPool since reserving memory failed)
<img width="760" alt="截屏2023-07-26 11 19 18" src="https://github.com/apache/iotdb/assets/108499334/c212b6d1-637b-445d-ac2a-2afacdb38826">
However, it's possible that the MemoryReservationFuture is completed by MemoryPool.free concurrently and then the free method registers the TsBlock in MemoryPool while tryCancel still returns the size of TsBlock, leading to remaining records in the MemoryReservationMap.
