### PR TITLE
[IOTDB-6083] Pipe: make PipeRawTabletInsertionEvent able to report progress to avoid losing data

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/EnrichedEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/EnrichedEvent.java
@@ -36,7 +36,7 @@ public abstract class EnrichedEvent implements Event {
 
   private final AtomicInteger referenceCount;
 
-  private final PipeTaskMeta pipeTaskMeta;
+  protected final PipeTaskMeta pipeTaskMeta;
 
   private final String pattern;
 
@@ -132,6 +132,8 @@ public abstract class EnrichedEvent implements Event {
       PipeTaskMeta pipeTaskMeta, String pattern);
 
   public void reportException(PipeRuntimeException pipeRuntimeException) {
-    PipeAgent.runtime().report(this.pipeTaskMeta, pipeRuntimeException);
+    if (pipeTaskMeta != null) {
+      PipeAgent.runtime().report(this.pipeTaskMeta, pipeRuntimeException);
+    }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/EnrichedEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/EnrichedEvent.java
@@ -102,7 +102,7 @@ public abstract class EnrichedEvent implements Event {
    */
   public abstract boolean internallyDecreaseResourceReferenceCount(String holderMessage);
 
-  private void reportProgress() {
+  protected void reportProgress() {
     if (pipeTaskMeta != null) {
       pipeTaskMeta.updateProgressIndex(getProgressIndex());
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEvent.java
@@ -38,9 +38,8 @@ public class PipeRawTabletInsertionEvent extends EnrichedEvent implements Tablet
   private final Tablet tablet;
   private final boolean isAligned;
   private final boolean needToReport;
-  private final String pattern;
 
-  private PipeTsFileInsertionEvent sourceEvent;
+  private final EnrichedEvent sourceEvent;
   private TabletInsertionDataContainer dataContainer;
 
   public PipeRawTabletInsertionEvent(Tablet tablet, boolean isAligned) {
@@ -64,7 +63,7 @@ public class PipeRawTabletInsertionEvent extends EnrichedEvent implements Tablet
       Tablet tablet,
       boolean isAligned,
       PipeTaskMeta pipeTaskMeta,
-      PipeTsFileInsertionEvent sourceEvent,
+      EnrichedEvent sourceEvent,
       boolean needToReport,
       String pattern) {
     super(pipeTaskMeta, pattern);
@@ -72,7 +71,6 @@ public class PipeRawTabletInsertionEvent extends EnrichedEvent implements Tablet
     this.isAligned = isAligned;
     this.sourceEvent = sourceEvent;
     this.needToReport = needToReport;
-    this.pattern = pattern;
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEvent.java
@@ -163,7 +163,9 @@ public class PipeTsFileInsertionEvent extends EnrichedEvent implements TsFileIns
     try {
       if (dataContainer == null) {
         waitForTsFileClose();
-        dataContainer = new TsFileInsertionDataContainer(tsFile, getPattern(), startTime, endTime);
+        dataContainer =
+            new TsFileInsertionDataContainer(
+                tsFile, getPattern(), pipeTaskMeta, this, startTime, endTime);
       }
       return dataContainer.toTabletInsertionEvents();
     } catch (InterruptedException e) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/TsFileInsertionDataContainer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/TsFileInsertionDataContainer.java
@@ -195,10 +195,14 @@ public class TsFileInsertionDataContainer implements AutoCloseable {
             final TabletInsertionEvent next;
 
             if (!hasNext()) {
-              next = new PipeRawTabletInsertionEvent(tablet, isAligned, pipeTaskMeta, sourceEvent);
+              next =
+                  new PipeRawTabletInsertionEvent(
+                      tablet, isAligned, pipeTaskMeta, sourceEvent, true);
               close();
             } else {
-              next = new PipeRawTabletInsertionEvent(tablet, isAligned);
+              next =
+                  new PipeRawTabletInsertionEvent(
+                      tablet, isAligned, pipeTaskMeta, sourceEvent, false);
             }
 
             return next;


### PR DESCRIPTION
Currently, only events that extends EnrichedEvent can report progresses and failures, but PipeRawTabletInsertionEvent does not extend EnrichedEvent, which may lose data when failure occurs. This PR makes PipeRawTabletInsertionEvent extend EnrichedEvent to enable reporting progresses and failures.