### PR TITLE
[To rel/1.2] [IOTDB-6090] add memory estimator on inner space compaction

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/AbstractCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/AbstractCompactionTask.java
@@ -57,6 +57,8 @@ public abstract class AbstractCompactionTask {
   protected boolean crossTask;
   protected boolean innerSeqTask;
 
+  protected long memoryCost = 0L;
+
   protected AbstractCompactionTask(
       String storageGroupName,
       String dataRegionId,

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
@@ -61,7 +61,6 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
   protected List<TsFileResource> holdWriteLockList = new ArrayList<>();
   protected double selectedSeqFileSize = 0;
   protected double selectedUnseqFileSize = 0;
-  protected long memoryCost = 0L;
 
   @SuppressWarnings("squid:S107")
   public CrossSpaceCompactionTask(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
@@ -20,8 +20,6 @@
 package org.apache.iotdb.db.storageengine.dataregion.compaction.execute.task;
 
 import org.apache.iotdb.commons.conf.IoTDBConstant;
-import org.apache.iotdb.db.conf.IoTDBConfig;
-import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.service.metrics.CompactionMetrics;
 import org.apache.iotdb.db.service.metrics.FileMetrics;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.exception.CompactionExceptionHandler;
@@ -474,23 +472,9 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
           return false;
         }
       }
-
-      IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
-      long memoryBudget =
-          (long)
-              ((double) SystemInfo.getInstance().getMemorySizeForCompaction()
-                  / config.getCompactionThreadCount()
-                  * config.getUsableCompactionMemoryProportion());
       long estimateMemoryCost =
           innerSpaceEstimator.estimateInnerCompactionMemory(selectedTsFileResourceList);
-      if (estimateMemoryCost > memoryBudget) {
-        LOGGER.warn(
-            "estimate memory cost greater than memory budget,estimate memory cost is {},memory budget is {}",
-            estimateMemoryCost,
-            memoryBudget);
-        return false;
-      }
-      SystemInfo.getInstance().addCompactionMemoryCost(memCost, 60);
+      SystemInfo.getInstance().addCompactionMemoryCost(estimateMemoryCost, 60);
       SystemInfo.getInstance().addCompactionFileNum(selectedTsFileResourceList.size(), 60);
     } catch (Exception e) {
       if (e instanceof InterruptedException) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
@@ -461,7 +461,7 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
       resetCompactionCandidateStatusForAllSourceFiles();
       return false;
     }
-    long memCost = 0;
+    long estimateMemoryCost = 0;
     try {
       for (int i = 0; i < selectedTsFileResourceList.size(); ++i) {
         TsFileResource resource = selectedTsFileResourceList.get(i);
@@ -472,7 +472,7 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
           return false;
         }
       }
-      long estimateMemoryCost =
+      estimateMemoryCost =
           innerSpaceEstimator.estimateInnerCompactionMemory(selectedTsFileResourceList);
       SystemInfo.getInstance().addCompactionMemoryCost(estimateMemoryCost, 60);
       SystemInfo.getInstance().addCompactionFileNum(selectedTsFileResourceList.size(), 60);
@@ -484,7 +484,7 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
         LOGGER.info("No enough memory for current compaction task {}", this, e);
       } else if (e instanceof CompactionFileCountExceededException) {
         LOGGER.info("No enough file num for current compaction task {}", this, e);
-        SystemInfo.getInstance().resetCompactionMemoryCost(memCost);
+        SystemInfo.getInstance().resetCompactionMemoryCost(estimateMemoryCost);
       }
       resetCompactionCandidateStatusForAllSourceFiles();
       releaseAllLocksAndResetStatus();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
@@ -491,7 +491,6 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
         LOGGER.info("No enough file num for current compaction task {}", this, e);
         SystemInfo.getInstance().resetCompactionMemoryCost(memoryCost);
       }
-      resetCompactionCandidateStatusForAllSourceFiles();
       releaseAllLocksAndResetStatus();
       return false;
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.storageengine.dataregion.compaction.execute.task;
 
 import org.apache.iotdb.commons.conf.IoTDBConstant;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.service.metrics.CompactionMetrics;
 import org.apache.iotdb.db.service.metrics.FileMetrics;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.exception.CompactionExceptionHandler;
@@ -97,10 +98,12 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
     this.selectedTsFileResourceList = selectedTsFileResourceList;
     this.sequence = sequence;
     this.performer = performer;
-    if (this.performer instanceof ReadChunkCompactionPerformer) {
-      innerSpaceEstimator = new ReadChunkInnerCompactionEstimator();
-    } else if (!sequence) {
-      innerSpaceEstimator = new FastCompactionInnerCompactionEstimator();
+    if (IoTDBDescriptor.getInstance().getConfig().isEnableCompactionMemControl()) {
+      if (this.performer instanceof ReadChunkCompactionPerformer) {
+        innerSpaceEstimator = new ReadChunkInnerCompactionEstimator();
+      } else if (!sequence && this.performer instanceof FastCompactionInnerCompactionEstimator) {
+        innerSpaceEstimator = new FastCompactionInnerCompactionEstimator();
+      }
     }
     isHoldingReadLock = new boolean[selectedTsFileResourceList.size()];
     isHoldingWriteLock = new boolean[selectedTsFileResourceList.size()];

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
@@ -99,7 +99,7 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
     this.performer = performer;
     if (this.performer instanceof ReadChunkCompactionPerformer) {
       innerSpaceEstimator = new ReadChunkInnerCompactionEstimator();
-    } else {
+    } else if (!sequence) {
       innerSpaceEstimator = new FastCompactionInnerCompactionEstimator();
     }
     isHoldingReadLock = new boolean[selectedTsFileResourceList.size()];
@@ -473,7 +473,9 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
           return false;
         }
       }
-      memoryCost = innerSpaceEstimator.estimateInnerCompactionMemory(selectedTsFileResourceList);
+      if (innerSpaceEstimator != null) {
+        memoryCost = innerSpaceEstimator.estimateInnerCompactionMemory(selectedTsFileResourceList);
+      }
       SystemInfo.getInstance().addCompactionMemoryCost(memoryCost, 60);
       SystemInfo.getInstance().addCompactionFileNum(selectedTsFileResourceList.size(), 60);
     } catch (Exception e) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/AbstractCompactionEstimator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/AbstractCompactionEstimator.java
@@ -52,7 +52,8 @@ public abstract class AbstractCompactionEstimator {
       List<TsFileResource> seqResources, TsFileResource unseqResource) throws IOException;
 
   /** Estimate the memory cost of compacting the source files in inner space compaction task. */
-  public abstract long estimateInnerCompactionMemory(List<TsFileResource> resources);
+  public abstract long estimateInnerCompactionMemory(List<TsFileResource> resources)
+      throws IOException;
 
   /**
    * Construct a new or get an existing TsFileSequenceReader of a TsFile.

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/AbstractInnerSpaceEstimator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/AbstractInnerSpaceEstimator.java
@@ -23,8 +23,10 @@ import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.storageengine.dataregion.modification.ModificationFile;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
+import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -41,6 +43,17 @@ public abstract class AbstractInnerSpaceEstimator extends AbstractCompactionEsti
       List<TsFileResource> seqResources, TsFileResource unseqResource) throws IOException {
     throw new RuntimeException(
         "This kind of estimator cannot be used to estimate cross space compaction task");
+  }
+
+  protected InnerCompactionTaskInfo calculatingReadChunkCompactionTaskInfo(
+      List<TsFileResource> resources) throws IOException {
+    List<FileInfo> fileInfoList = new ArrayList<>();
+    for (TsFileResource resource : resources) {
+      TsFileSequenceReader reader = getFileReader(resource);
+      FileInfo fileInfo = CompactionEstimateUtils.getSeriesAndDeviceChunkNum(reader);
+      fileInfoList.add(fileInfo);
+    }
+    return new InnerCompactionTaskInfo(resources, fileInfoList);
   }
 
   protected static class InnerCompactionTaskInfo {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/AbstractInnerSpaceEstimator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/AbstractInnerSpaceEstimator.java
@@ -36,8 +36,16 @@ import java.util.List;
 public abstract class AbstractInnerSpaceEstimator extends AbstractCompactionEstimator {
   protected IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
 
-  public abstract long estimateInnerCompactionMemory(List<TsFileResource> resources)
-      throws IOException;
+  public long estimateInnerCompactionMemory(List<TsFileResource> resources) throws IOException {
+    InnerCompactionTaskInfo taskInfo = calculatingCompactionTaskInfo(resources);
+    long cost = calculatingMetadataMemoryCost(taskInfo);
+    cost += calculatingDataMemoryCost(taskInfo);
+    return cost;
+  }
+
+  public abstract long calculatingMetadataMemoryCost(InnerCompactionTaskInfo taskInfo);
+
+  public abstract long calculatingDataMemoryCost(InnerCompactionTaskInfo taskInfo);
 
   public long estimateCrossCompactionMemory(
       List<TsFileResource> seqResources, TsFileResource unseqResource) throws IOException {
@@ -45,8 +53,8 @@ public abstract class AbstractInnerSpaceEstimator extends AbstractCompactionEsti
         "This kind of estimator cannot be used to estimate cross space compaction task");
   }
 
-  protected InnerCompactionTaskInfo calculatingReadChunkCompactionTaskInfo(
-      List<TsFileResource> resources) throws IOException {
+  protected InnerCompactionTaskInfo calculatingCompactionTaskInfo(List<TsFileResource> resources)
+      throws IOException {
     List<FileInfo> fileInfoList = new ArrayList<>();
     for (TsFileResource resource : resources) {
       TsFileSequenceReader reader = getFileReader(resource);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/AbstractInnerSpaceEstimator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/AbstractInnerSpaceEstimator.java
@@ -29,7 +29,8 @@ import java.util.List;
  * its corresponding implementation.
  */
 public abstract class AbstractInnerSpaceEstimator extends AbstractCompactionEstimator {
-  public abstract long estimateInnerCompactionMemory(List<TsFileResource> resources);
+  public abstract long estimateInnerCompactionMemory(List<TsFileResource> resources)
+      throws IOException;
 
   public long estimateCrossCompactionMemory(
       List<TsFileResource> seqResources, TsFileResource unseqResource) throws IOException {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/CompactionEstimateUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/CompactionEstimateUtils.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.iotdb.db.storageengine.dataregion.compaction.selector.estimator;
 
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/CompactionEstimateUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/CompactionEstimateUtils.java
@@ -1,7 +1,6 @@
 package org.apache.iotdb.db.storageengine.dataregion.compaction.selector.estimator;
 
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
-import org.apache.iotdb.tsfile.file.metadata.IChunkMetadata;
 import org.apache.iotdb.tsfile.file.metadata.TimeseriesMetadata;
 import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/CompactionEstimateUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/CompactionEstimateUtils.java
@@ -1,0 +1,78 @@
+package org.apache.iotdb.db.storageengine.dataregion.compaction.selector.estimator;
+
+import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
+import org.apache.iotdb.tsfile.file.metadata.IChunkMetadata;
+import org.apache.iotdb.tsfile.file.metadata.TimeseriesMetadata;
+import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class CompactionEstimateUtils {
+
+  /**
+   * Get the details of the tsfile, the returned array contains the following elements in sequence:
+   *
+   * <p>total chunk num in this tsfile
+   *
+   * <p>max chunk num of one timeseries in this tsfile
+   *
+   * <p>max aligned series num in one device. If there is no aligned series in this file, then it
+   * turns to be -1.
+   *
+   * <p>max chunk num of one device in this tsfile
+   *
+   * @throws IOException if io errors occurred
+   */
+  public static FileInfo getSeriesAndDeviceChunkNum(TsFileSequenceReader reader)
+      throws IOException {
+    int totalChunkNum = 0;
+    int maxChunkNum = 0;
+    int maxAlignedSeriesNumInDevice = -1;
+    int maxDeviceChunkNum = 0;
+    Map<String, List<TimeseriesMetadata>> deviceMetadata = reader.getAllTimeseriesMetadata(true);
+    for (Map.Entry<String, List<TimeseriesMetadata>> entry : deviceMetadata.entrySet()) {
+      int deviceChunkNum = 0;
+      List<TimeseriesMetadata> deviceTimeseriesMetadata = entry.getValue();
+      if (deviceTimeseriesMetadata.get(0).getMeasurementId().equals("")) {
+        // aligned device
+        maxAlignedSeriesNumInDevice =
+            Math.max(maxAlignedSeriesNumInDevice, deviceTimeseriesMetadata.size());
+      }
+      for (TimeseriesMetadata timeseriesMetadata : deviceTimeseriesMetadata) {
+        deviceChunkNum += timeseriesMetadata.getChunkMetadataList().size();
+        totalChunkNum += timeseriesMetadata.getChunkMetadataList().size();
+        maxChunkNum = Math.max(maxChunkNum, timeseriesMetadata.getChunkMetadataList().size());
+      }
+      maxDeviceChunkNum = Math.max(maxDeviceChunkNum, deviceChunkNum);
+    }
+    long averageChunkMetadataSize =
+        totalChunkNum == 0 ? 0 : reader.getAllMetadataSize() / totalChunkNum;
+    return new FileInfo(
+        totalChunkNum,
+        maxChunkNum,
+        maxAlignedSeriesNumInDevice,
+        maxDeviceChunkNum,
+        averageChunkMetadataSize);
+  }
+
+  public static boolean addReadLock(List<TsFileResource> resources) {
+    for (int i = 0; i < resources.size(); i++) {
+      TsFileResource resource = resources.get(i);
+      resource.readLock();
+      if (resource.isDeleted()) {
+        // release read lock
+        for (int j = 0; j <= i; j++) {
+          resources.get(j).readUnlock();
+        }
+        return false;
+      }
+    }
+    return true;
+  }
+
+  public static void releaseReadLock(List<TsFileResource> resources) {
+    resources.forEach(TsFileResource::readUnlock);
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/FastCompactionInnerCompactionEstimator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/FastCompactionInnerCompactionEstimator.java
@@ -21,46 +21,37 @@ package org.apache.iotdb.db.storageengine.dataregion.compaction.selector.estimat
 
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
-import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.storageengine.rescon.memory.SystemInfo;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.List;
 
 public class FastCompactionInnerCompactionEstimator extends AbstractInnerSpaceEstimator {
   private static final Logger logger =
       LoggerFactory.getLogger(IoTDBConstant.COMPACTION_LOGGER_NAME);
 
   @Override
-  public long estimateInnerCompactionMemory(List<TsFileResource> resources) throws IOException {
-    if (resources.isEmpty()) {
-      return -1L;
-    }
-    long cost = 0;
-    InnerCompactionTaskInfo taskInfo = calculatingReadChunkCompactionTaskInfo(resources);
-    cost += calculatingMultiDeviceIteratorCost(taskInfo);
-    cost += calculatingFastCompactionCost(resources.size(), taskInfo.getMaxConcurrentSeriesNum());
-    cost += calculatingWriteTargetFileCost(taskInfo, resources.size());
-    return cost;
+  public long calculatingMetadataMemoryCost(InnerCompactionTaskInfo taskInfo) {
+    return taskInfo.getFileInfoList().size()
+        * taskInfo.getMaxChunkMetadataNumInDevice()
+        * taskInfo.getMaxChunkMetadataSize();
   }
 
-  private long calculatingMultiDeviceIteratorCost(InnerCompactionTaskInfo taskInfo) {
-    long cost = 0;
-    cost +=
-        taskInfo.getFileInfoList().size()
-            * taskInfo.getMaxChunkMetadataNumInDevice()
-            * taskInfo.getMaxChunkMetadataSize();
-    cost += taskInfo.getModificationFileSize();
+  @Override
+  public long calculatingDataMemoryCost(InnerCompactionTaskInfo taskInfo) {
+    long cost =
+        config.getTargetChunkSize()
+            * taskInfo.getFileInfoList().size()
+            * Math.max(config.getSubCompactionTaskNum(), taskInfo.getMaxConcurrentSeriesNum())
+            * compressionRatio;
     return cost;
   }
 
   private long calculatingFastCompactionCost(int fileSize, int maxSeriesNumber) {
     return config.getTargetChunkSize()
         * fileSize
-        * Math.max(config.getSubCompactionTaskNum(), maxSeriesNumber);
+        * Math.max(config.getSubCompactionTaskNum(), maxSeriesNumber)
+        * compressionRatio;
   }
 
   private long calculatingWriteTargetFileCost(InnerCompactionTaskInfo taskInfo, int fileSize) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/FastCompactionInnerCompactionEstimator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/FastCompactionInnerCompactionEstimator.java
@@ -35,7 +35,7 @@ public class FastCompactionInnerCompactionEstimator extends AbstractInnerSpaceEs
   }
 
   /**
-   * The metadata algorithm is: (targetChunkSize * fileSize * compressionRatio * maxSeriesNumber) +
+   * The data algorithm is: (targetChunkSize * fileSize * compressionRatio * maxSeriesNumber) +
    * modsFileSize
    *
    * @return estimate data memory cost

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/FastCompactionInnerCompactionEstimator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/FastCompactionInnerCompactionEstimator.java
@@ -23,13 +23,11 @@ import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.storageengine.rescon.memory.SystemInfo;
-import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 public class FastCompactionInnerCompactionEstimator extends AbstractInnerSpaceEstimator {
@@ -47,17 +45,6 @@ public class FastCompactionInnerCompactionEstimator extends AbstractInnerSpaceEs
     cost += calculatingFastCompactionCost(resources.size(), taskInfo.getMaxConcurrentSeriesNum());
     cost += calculatingWriteTargetFileCost(taskInfo, resources.size());
     return cost;
-  }
-
-  private InnerCompactionTaskInfo calculatingReadChunkCompactionTaskInfo(
-      List<TsFileResource> resources) throws IOException {
-    List<FileInfo> fileInfoList = new ArrayList<>();
-    for (TsFileResource resource : resources) {
-      TsFileSequenceReader reader = getFileReader(resource);
-      FileInfo fileInfo = CompactionEstimateUtils.getSeriesAndDeviceChunkNum(reader);
-      fileInfoList.add(fileInfo);
-    }
-    return new InnerCompactionTaskInfo(resources, fileInfoList);
   }
 
   private long calculatingMultiDeviceIteratorCost(InnerCompactionTaskInfo taskInfo) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/FastCompactionInnerCompactionEstimator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/FastCompactionInnerCompactionEstimator.java
@@ -45,8 +45,7 @@ public class FastCompactionInnerCompactionEstimator extends AbstractInnerSpaceEs
     long cost =
         config.getTargetChunkSize()
             * taskInfo.getFileInfoList().size()
-            * Math.max(config.getSubCompactionTaskNum(), taskInfo.getMaxConcurrentSeriesNum())
-            * compressionRatio;
+            * Math.max(config.getSubCompactionTaskNum(), taskInfo.getMaxConcurrentSeriesNum());
     cost += taskInfo.getModificationFileSize();
     return cost;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/FileInfo.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/FileInfo.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.iotdb.db.storageengine.dataregion.compaction.selector.estimator;
 
 public class FileInfo {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/FileInfo.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/FileInfo.java
@@ -1,0 +1,29 @@
+package org.apache.iotdb.db.storageengine.dataregion.compaction.selector.estimator;
+
+public class FileInfo {
+  // total chunk num in this tsfile
+  int totalChunkNum = 0;
+  // max chunk num of one timeseries in this tsfile
+  int maxSeriesChunkNum = 0;
+  // max aligned series num in one device. If there is no aligned series in this file, then it
+  // turns to be -1.
+  int maxAlignedSeriesNumInDevice = -1;
+  // max chunk num of one device in this tsfile
+  @SuppressWarnings("squid:S1068")
+  int maxDeviceChunkNum = 0;
+
+  long averageChunkMetadataSize = 0;
+
+  public FileInfo(
+      int totalChunkNum,
+      int maxSeriesChunkNum,
+      int maxAlignedSeriesNumInDevice,
+      int maxDeviceChunkNum,
+      long averageChunkMetadataSize) {
+    this.totalChunkNum = totalChunkNum;
+    this.maxSeriesChunkNum = maxSeriesChunkNum;
+    this.maxAlignedSeriesNumInDevice = maxAlignedSeriesNumInDevice;
+    this.maxDeviceChunkNum = maxDeviceChunkNum;
+    this.averageChunkMetadataSize = averageChunkMetadataSize;
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/ReadChunkInnerCompactionEstimator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/ReadChunkInnerCompactionEstimator.java
@@ -21,31 +21,14 @@ package org.apache.iotdb.db.storageengine.dataregion.compaction.selector.estimat
 
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
-import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.storageengine.rescon.memory.SystemInfo;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.util.List;
-
 public class ReadChunkInnerCompactionEstimator extends AbstractInnerSpaceEstimator {
   private static final Logger logger =
       LoggerFactory.getLogger(IoTDBConstant.COMPACTION_LOGGER_NAME);
-
-  @Override
-  public long estimateInnerCompactionMemory(List<TsFileResource> resources) throws IOException {
-    if (resources.isEmpty()) {
-      return -1L;
-    }
-    long cost = 0;
-    InnerCompactionTaskInfo taskInfo = calculatingReadChunkCompactionTaskInfo(resources);
-    cost += calculatingMultiDeviceIteratorCost(taskInfo);
-    cost += calculatingReadChunkCost();
-    cost += calculatingWriteTargetFileCost(taskInfo);
-    return cost;
-  }
 
   private long calculatingMultiDeviceIteratorCost(InnerCompactionTaskInfo taskInfo) {
     long cost = 0;
@@ -73,5 +56,15 @@ public class ReadChunkInnerCompactionEstimator extends AbstractInnerSpaceEstimat
                 * IoTDBDescriptor.getInstance().getConfig().getChunkMetadataSizeProportion());
     cost += sizeForFileWriter;
     return cost;
+  }
+
+  @Override
+  public long calculatingMetadataMemoryCost(InnerCompactionTaskInfo taskInfo) {
+    return 0;
+  }
+
+  @Override
+  public long calculatingDataMemoryCost(InnerCompactionTaskInfo taskInfo) {
+    return 0;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/ReadChunkInnerCompactionEstimator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/ReadChunkInnerCompactionEstimator.java
@@ -19,16 +19,10 @@
 
 package org.apache.iotdb.db.storageengine.dataregion.compaction.selector.estimator;
 
-import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.storageengine.rescon.memory.SystemInfo;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class ReadChunkInnerCompactionEstimator extends AbstractInnerSpaceEstimator {
-  private static final Logger logger =
-      LoggerFactory.getLogger(IoTDBConstant.COMPACTION_LOGGER_NAME);
 
   @Override
   public long calculatingMetadataMemoryCost(InnerCompactionTaskInfo taskInfo) {
@@ -38,8 +32,6 @@ public class ReadChunkInnerCompactionEstimator extends AbstractInnerSpaceEstimat
         taskInfo.getFileInfoList().size()
             * taskInfo.getMaxChunkMetadataNumInDevice()
             * taskInfo.getMaxChunkMetadataSize();
-    // add modification file size
-    cost += taskInfo.getModificationFileSize();
 
     // add ChunkMetadata size of targetFileWriter
     long sizeForFileWriter =
@@ -55,8 +47,13 @@ public class ReadChunkInnerCompactionEstimator extends AbstractInnerSpaceEstimat
   @Override
   public long calculatingDataMemoryCost(InnerCompactionTaskInfo taskInfo) {
     // add max target chunk size and max source chunk size
-    return 2
-        * taskInfo.getMaxConcurrentSeriesNum()
-        * IoTDBDescriptor.getInstance().getConfig().getTargetChunkSize();
+    long cost =
+        2
+            * taskInfo.getMaxConcurrentSeriesNum()
+            * IoTDBDescriptor.getInstance().getConfig().getTargetChunkSize();
+
+    // add modification file size
+    cost += taskInfo.getModificationFileSize();
+    return cost;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/ReadChunkInnerCompactionEstimator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/ReadChunkInnerCompactionEstimator.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.storageengine.dataregion.compaction.selector.estimator;
+
+import org.apache.iotdb.commons.conf.IoTDBConstant;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.storageengine.dataregion.modification.ModificationFile;
+import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
+import org.apache.iotdb.db.storageengine.rescon.memory.SystemInfo;
+import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ReadChunkInnerCompactionEstimator extends AbstractInnerSpaceEstimator {
+  private static final Logger logger =
+      LoggerFactory.getLogger(IoTDBConstant.COMPACTION_LOGGER_NAME);
+
+  @Override
+  public long estimateInnerCompactionMemory(List<TsFileResource> resources) throws IOException {
+    if (resources.isEmpty()) {
+      return -1L;
+    }
+    long cost = 0;
+    ReadChunkCompactionTaskInfo taskInfo = calculatingReadChunkCompactionTaskInfo(resources);
+    cost += calculatingMultiDeviceIteratorCost(taskInfo);
+    cost += calculatingReadChunkCost();
+    cost += calculatingWriteTargetFileCost(taskInfo);
+    return cost;
+  }
+
+  private ReadChunkCompactionTaskInfo calculatingReadChunkCompactionTaskInfo(
+      List<TsFileResource> resources) throws IOException {
+    List<FileInfo> fileInfoList = new ArrayList<>();
+    for (TsFileResource resource : resources) {
+      TsFileSequenceReader reader = getFileReader(resource);
+      FileInfo fileInfo = CompactionEstimateUtils.getSeriesAndDeviceChunkNum(reader);
+      fileInfoList.add(fileInfo);
+    }
+    return new ReadChunkCompactionTaskInfo(resources, fileInfoList);
+  }
+
+  private long calculatingMultiDeviceIteratorCost(ReadChunkCompactionTaskInfo taskInfo) {
+    long cost = 0;
+    cost +=
+        taskInfo.getFileInfoList().size()
+            * taskInfo.getMaxChunkMetadataNumInDevice()
+            * taskInfo.getMaxChunkMetadataSize();
+    cost += taskInfo.getModificationFileSize();
+    return cost;
+  }
+
+  private long calculatingReadChunkCost() {
+    return IoTDBDescriptor.getInstance().getConfig().getTargetChunkSize();
+  }
+
+  private long calculatingWriteTargetFileCost(ReadChunkCompactionTaskInfo taskInfo) {
+    long cost =
+        taskInfo.getMaxConcurrentSeriesNum()
+            * IoTDBDescriptor.getInstance().getConfig().getTargetChunkSize();
+
+
+    long sizeForFileWriter =
+        (long)
+            ((double) SystemInfo.getInstance().getMemorySizeForCompaction()
+                / IoTDBDescriptor.getInstance().getConfig().getCompactionThreadCount()
+                * IoTDBDescriptor.getInstance().getConfig().getChunkMetadataSizeProportion());
+    cost += sizeForFileWriter;
+    return cost;
+  }
+
+  private static class ReadChunkCompactionTaskInfo {
+    private final List<FileInfo> fileInfoList;
+    private int maxConcurrentSeriesNum = 1;
+    private long maxChunkMetadataSize = 0;
+    private int maxChunkMetadataNumInDevice = 0;
+    private long modificationFileSize = 0;
+
+    private ReadChunkCompactionTaskInfo(
+        List<TsFileResource> resources, List<FileInfo> fileInfoList) {
+      this.fileInfoList = fileInfoList;
+      for (TsFileResource resource : resources) {
+        ModificationFile modificationFile = resource.getModFile();
+        if (modificationFile.exists()) {
+          modificationFileSize += modificationFile.getSize();
+        }
+      }
+      for (FileInfo fileInfo : fileInfoList) {
+        maxConcurrentSeriesNum =
+            Math.max(maxConcurrentSeriesNum, fileInfo.maxAlignedSeriesNumInDevice);
+        maxChunkMetadataNumInDevice =
+            Math.max(maxChunkMetadataNumInDevice, fileInfo.maxDeviceChunkNum);
+        maxChunkMetadataSize = Math.max(maxChunkMetadataSize, fileInfo.averageChunkMetadataSize);
+      }
+    }
+
+    public int getMaxChunkMetadataNumInDevice() {
+      return maxChunkMetadataNumInDevice;
+    }
+
+    public long getMaxChunkMetadataSize() {
+      return maxChunkMetadataSize;
+    }
+
+    public List<FileInfo> getFileInfoList() {
+      return fileInfoList;
+    }
+
+    public int getMaxConcurrentSeriesNum() {
+      return maxConcurrentSeriesNum;
+    }
+
+    public long getModificationFileSize() {
+      return modificationFileSize;
+    }
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/CompactionSchedulerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/CompactionSchedulerTest.java
@@ -101,7 +101,7 @@ public class CompactionSchedulerTest {
         .getConfig()
         .setInnerUnseqCompactionPerformer(InnerUnseqCompactionPerformer.READ_POINT);
     IoTDBDescriptor.getInstance().getConfig().setMinCrossCompactionUnseqFileLevel(0);
-    IoTDBDescriptor.getInstance().getConfig().setEnableMemControl(false);
+    IoTDBDescriptor.getInstance().getConfig().setEnableCompactionMemControl(false);
     CompactionTaskManager.getInstance().start();
     while (CompactionTaskManager.getInstance().getExecutingTaskCount() > 0) {
       try {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/CompactionSchedulerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/CompactionSchedulerTest.java
@@ -101,6 +101,7 @@ public class CompactionSchedulerTest {
         .getConfig()
         .setInnerUnseqCompactionPerformer(InnerUnseqCompactionPerformer.READ_POINT);
     IoTDBDescriptor.getInstance().getConfig().setMinCrossCompactionUnseqFileLevel(0);
+    IoTDBDescriptor.getInstance().getConfig().setEnableMemControl(false);
     CompactionTaskManager.getInstance().start();
     while (CompactionTaskManager.getInstance().getExecutingTaskCount() > 0) {
       try {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/utils/CompactionTaskMemCostEstimatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/utils/CompactionTaskMemCostEstimatorTest.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.storageengine.dataregion.compaction.utils;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.AbstractCompactionTest;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.selector.estimator.FastCompactionInnerCompactionEstimator;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.selector.estimator.ReadChunkInnerCompactionEstimator;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
@@ -65,6 +66,29 @@ public class CompactionTaskMemCostEstimatorTest extends AbstractCompactionTest {
     tsFileManager.addAll(seqResources, true);
     List<TsFileResource> tsFileList = tsFileManager.getTsFileList(true);
     long cost = new ReadChunkInnerCompactionEstimator().estimateInnerCompactionMemory(tsFileList);
+    Assert.assertTrue(cost > 0);
+  }
+
+  @Test
+  public void testEstimateFastCompactionInnerSpaceCompactionTaskMemCost()
+      throws IOException, MetadataException, WriteProcessException {
+    createFiles(3, 10, 5, 100000, 0, 0, 50, 50, true, true);
+    tsFileManager.addAll(seqResources, true);
+    List<TsFileResource> tsFileList = tsFileManager.getTsFileList(true);
+    System.out.println(tsFileList.get(0).getTsFile().getAbsolutePath());
+    long cost =
+        new FastCompactionInnerCompactionEstimator().estimateInnerCompactionMemory(tsFileList);
+    Assert.assertTrue(cost > 0);
+  }
+
+  @Test
+  public void testEstimateFastCompactionInnerSpaceCompactionTaskMemCost2()
+      throws IOException, MetadataException, WriteProcessException {
+    createFiles(3, 10, 5, 100, 0, 0, 50, 50, false, true);
+    tsFileManager.addAll(seqResources, true);
+    List<TsFileResource> tsFileList = tsFileManager.getTsFileList(true);
+    long cost =
+        new FastCompactionInnerCompactionEstimator().estimateInnerCompactionMemory(tsFileList);
     Assert.assertTrue(cost > 0);
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/utils/CompactionTaskMemCostEstimatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/utils/CompactionTaskMemCostEstimatorTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.storageengine.dataregion.compaction.utils;
+
+import org.apache.iotdb.commons.exception.MetadataException;
+import org.apache.iotdb.db.exception.StorageEngineException;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.AbstractCompactionTest;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.selector.estimator.ReadChunkInnerCompactionEstimator;
+import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
+import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+public class CompactionTaskMemCostEstimatorTest extends AbstractCompactionTest {
+
+  @Before
+  public void setUp() throws IOException, WriteProcessException, MetadataException, InterruptedException {
+    super.setUp();
+  }
+
+  @After
+  public void tearDown() throws IOException, StorageEngineException {
+    super.tearDown();
+  }
+
+  @Test
+  public void testEstimateReadChunkInnerSpaceCompactionTaskMemCost() throws IOException, MetadataException, WriteProcessException {
+    createFiles(3, 10, 5, 100000, 0, 0, 50, 50, true, true);
+    tsFileManager.addAll(seqResources, true);
+    List<TsFileResource> tsFileList = tsFileManager.getTsFileList(true);
+    System.out.println(tsFileList.get(0).getTsFile().getAbsolutePath());
+    long cost = new ReadChunkInnerCompactionEstimator().estimateInnerCompactionMemory(tsFileList);
+    Assert.assertTrue(cost > 0);
+  }
+
+  @Test
+  public void testEstimateReadChunkInnerSpaceCompactionTaskMemCost2() throws IOException, MetadataException, WriteProcessException {
+    createFiles(3, 10, 5, 100, 0, 0, 50, 50, false, true);
+    tsFileManager.addAll(seqResources, true);
+    List<TsFileResource> tsFileList = tsFileManager.getTsFileList(true);
+    long cost = new ReadChunkInnerCompactionEstimator().estimateInnerCompactionMemory(tsFileList);
+    Assert.assertTrue(cost > 0);
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/utils/CompactionTaskMemCostEstimatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/utils/CompactionTaskMemCostEstimatorTest.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.storageengine.dataregion.compaction.AbstractCompactio
 import org.apache.iotdb.db.storageengine.dataregion.compaction.selector.estimator.ReadChunkInnerCompactionEstimator;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -36,7 +37,8 @@ import java.util.List;
 public class CompactionTaskMemCostEstimatorTest extends AbstractCompactionTest {
 
   @Before
-  public void setUp() throws IOException, WriteProcessException, MetadataException, InterruptedException {
+  public void setUp()
+      throws IOException, WriteProcessException, MetadataException, InterruptedException {
     super.setUp();
   }
 
@@ -46,7 +48,8 @@ public class CompactionTaskMemCostEstimatorTest extends AbstractCompactionTest {
   }
 
   @Test
-  public void testEstimateReadChunkInnerSpaceCompactionTaskMemCost() throws IOException, MetadataException, WriteProcessException {
+  public void testEstimateReadChunkInnerSpaceCompactionTaskMemCost()
+      throws IOException, MetadataException, WriteProcessException {
     createFiles(3, 10, 5, 100000, 0, 0, 50, 50, true, true);
     tsFileManager.addAll(seqResources, true);
     List<TsFileResource> tsFileList = tsFileManager.getTsFileList(true);
@@ -56,7 +59,8 @@ public class CompactionTaskMemCostEstimatorTest extends AbstractCompactionTest {
   }
 
   @Test
-  public void testEstimateReadChunkInnerSpaceCompactionTaskMemCost2() throws IOException, MetadataException, WriteProcessException {
+  public void testEstimateReadChunkInnerSpaceCompactionTaskMemCost2()
+      throws IOException, MetadataException, WriteProcessException {
     createFiles(3, 10, 5, 100, 0, 0, 50, 50, false, true);
     tsFileManager.addAll(seqResources, true);
     List<TsFileResource> tsFileList = tsFileManager.getTsFileList(true);

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -228,9 +228,7 @@ public class TsFileSequenceReader implements AutoCloseable {
     return fileMetadataSize;
   }
 
-  /**
-   * Return the tsfile meta data size of this tsfile.
-   */
+  /** Return the tsfile meta data size of this tsfile. */
   public long getFileMetadataSize() throws IOException {
     return tsFileInput.size() - getFileMetadataPos();
   }

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -229,11 +229,21 @@ public class TsFileSequenceReader implements AutoCloseable {
   }
 
   /**
-   * Return the whole meta data size of this tsfile, including ChunkMetadata, TimeseriesMetadata and
-   * etc.
+   * Return the tsfile meta data size of this tsfile.
    */
   public long getFileMetadataSize() throws IOException {
     return tsFileInput.size() - getFileMetadataPos();
+  }
+
+  /**
+   * Return the whole meta data size of this tsfile, including ChunkMetadata, TimeseriesMetadata and
+   * etc.
+   */
+  public long getAllMetadataSize() throws IOException {
+    if (tsFileMetaData == null) {
+      readFileMetadata();
+    }
+    return tsFileInput.size() - tsFileMetaData.getMetaOffset();
   }
 
   /** this function does not modify the position of the file reader. */


### PR DESCRIPTION
## Description
For in-space merge, the memory evaluation process is added. At the beginning of task execution, the system evaluates the memory size of the task to determine whether the evaluation result is smaller than the configured maximum memory size. If the evaluation result is smaller than the configured maximum memory size, the task can be executed normally. Added two memory estimators, the ReadChunkEstimator and the FastCompactionEstimator, which will be used when performer of the merge task is ReadChunk. Otherwise, use FastCompactionEstimator
see https://github.com/apache/iotdb/pull/10688