### PR TITLE
Remove  redundant new Path in query process

### DIFF
--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -354,17 +354,17 @@ public class TsFileSequenceReader implements AutoCloseable {
     return deviceMetadata;
   }
 
-  public TimeseriesMetadata readTimeseriesMetadata(Path path, boolean ignoreNotExists)
-      throws IOException {
+  public TimeseriesMetadata readTimeseriesMetadata(
+      String device, String measurement, boolean ignoreNotExists) throws IOException {
     readFileMetadata();
     MetadataIndexNode deviceMetadataIndexNode = tsFileMetaData.getMetadataIndex();
     Pair<MetadataIndexEntry, Long> metadataIndexPair =
-        getMetadataAndEndOffset(deviceMetadataIndexNode, path.getDevice(), true, true);
+        getMetadataAndEndOffset(deviceMetadataIndexNode, device, true, true);
     if (metadataIndexPair == null) {
       if (ignoreNotExists) {
         return null;
       }
-      throw new IOException("Device {" + path.getDevice() + "} is not in tsFileMetaData");
+      throw new IOException("Device {" + device + "} is not in tsFileMetaData");
     }
     ByteBuffer buffer = readData(metadataIndexPair.left.getOffset(), metadataIndexPair.right);
     MetadataIndexNode metadataIndexNode = deviceMetadataIndexNode;
@@ -375,8 +375,7 @@ public class TsFileSequenceReader implements AutoCloseable {
         logger.error(METADATA_INDEX_NODE_DESERIALIZE_ERROR, file);
         throw e;
       }
-      metadataIndexPair =
-          getMetadataAndEndOffset(metadataIndexNode, path.getMeasurement(), false, false);
+      metadataIndexPair = getMetadataAndEndOffset(metadataIndexNode, measurement, false, false);
     }
     if (metadataIndexPair == null) {
       return null;
@@ -393,8 +392,7 @@ public class TsFileSequenceReader implements AutoCloseable {
       }
     }
     // return null if path does not exist in the TsFile
-    int searchResult =
-        binarySearchInTimeseriesMetadataList(timeseriesMetadataList, path.getMeasurement());
+    int searchResult = binarySearchInTimeseriesMetadataList(timeseriesMetadataList, measurement);
     return searchResult >= 0 ? timeseriesMetadataList.get(searchResult) : null;
   }
 
@@ -456,9 +454,10 @@ public class TsFileSequenceReader implements AutoCloseable {
   }
 
   /* Find the leaf node that contains path, return all the sensors in that leaf node which are also in allSensors set */
-  public List<TimeseriesMetadata> readTimeseriesMetadata(Path path, Set<String> allSensors)
-      throws IOException {
-    Pair<MetadataIndexEntry, Long> metadataIndexPair = getLeafMetadataIndexPair(path);
+  public List<TimeseriesMetadata> readTimeseriesMetadata(
+      String device, String measurement, Set<String> allSensors) throws IOException {
+    Pair<MetadataIndexEntry, Long> metadataIndexPair =
+        getLeafMetadataIndexPair(device, measurement);
     if (metadataIndexPair == null) {
       return Collections.emptyList();
     }
@@ -482,11 +481,12 @@ public class TsFileSequenceReader implements AutoCloseable {
   }
 
   /* Get leaf MetadataIndexPair which contains path */
-  private Pair<MetadataIndexEntry, Long> getLeafMetadataIndexPair(Path path) throws IOException {
+  private Pair<MetadataIndexEntry, Long> getLeafMetadataIndexPair(String device, String measurement)
+      throws IOException {
     readFileMetadata();
     MetadataIndexNode deviceMetadataIndexNode = tsFileMetaData.getMetadataIndex();
     Pair<MetadataIndexEntry, Long> metadataIndexPair =
-        getMetadataAndEndOffset(deviceMetadataIndexNode, path.getDevice(), true, true);
+        getMetadataAndEndOffset(deviceMetadataIndexNode, device, true, true);
     if (metadataIndexPair == null) {
       return null;
     }
@@ -499,8 +499,7 @@ public class TsFileSequenceReader implements AutoCloseable {
         logger.error(METADATA_INDEX_NODE_DESERIALIZE_ERROR, file);
         throw e;
       }
-      metadataIndexPair =
-          getMetadataAndEndOffset(metadataIndexNode, path.getMeasurement(), false, false);
+      metadataIndexPair = getMetadataAndEndOffset(metadataIndexNode, measurement, false, false);
     }
     return metadataIndexPair;
   }
@@ -1912,7 +1911,8 @@ public class TsFileSequenceReader implements AutoCloseable {
    */
   public List<ChunkMetadata> getChunkMetadataList(Path path, boolean ignoreNotExists)
       throws IOException {
-    TimeseriesMetadata timeseriesMetaData = readTimeseriesMetadata(path, ignoreNotExists);
+    TimeseriesMetadata timeseriesMetaData =
+        readTimeseriesMetadata(path.getDevice(), path.getMeasurement(), ignoreNotExists);
     if (timeseriesMetaData == null) {
       return Collections.emptyList();
     }

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -356,48 +356,10 @@ public class TsFileSequenceReader implements AutoCloseable {
 
   /** @deprecated Use {@link #readTimeseriesMetadata(String, String, boolean)} instead. */
   @Deprecated
+  @SuppressWarnings("java:S1133") // suppress warn of deprecation
   public TimeseriesMetadata readTimeseriesMetadata(Path path, boolean ignoreNotExists)
       throws IOException {
-    readFileMetadata();
-    MetadataIndexNode deviceMetadataIndexNode = tsFileMetaData.getMetadataIndex();
-    Pair<MetadataIndexEntry, Long> metadataIndexPair =
-        getMetadataAndEndOffset(deviceMetadataIndexNode, path.getDevice(), true, true);
-    if (metadataIndexPair == null) {
-      if (ignoreNotExists) {
-        return null;
-      }
-      throw new IOException("Device {" + path.getDevice() + "} is not in tsFileMetaData");
-    }
-    ByteBuffer buffer = readData(metadataIndexPair.left.getOffset(), metadataIndexPair.right);
-    MetadataIndexNode metadataIndexNode = deviceMetadataIndexNode;
-    if (!metadataIndexNode.getNodeType().equals(MetadataIndexNodeType.LEAF_MEASUREMENT)) {
-      try {
-        metadataIndexNode = MetadataIndexNode.deserializeFrom(buffer);
-      } catch (Exception e) {
-        logger.error(METADATA_INDEX_NODE_DESERIALIZE_ERROR, file);
-        throw e;
-      }
-      metadataIndexPair =
-          getMetadataAndEndOffset(metadataIndexNode, path.getMeasurement(), false, false);
-    }
-    if (metadataIndexPair == null) {
-      return null;
-    }
-    List<TimeseriesMetadata> timeseriesMetadataList = new ArrayList<>();
-    buffer = readData(metadataIndexPair.left.getOffset(), metadataIndexPair.right);
-    while (buffer.hasRemaining()) {
-      try {
-        timeseriesMetadataList.add(TimeseriesMetadata.deserializeFrom(buffer, true));
-      } catch (Exception e) {
-        logger.error(
-            "Something error happened while deserializing TimeseriesMetadata of file {}", file);
-        throw e;
-      }
-    }
-    // return null if path does not exist in the TsFile
-    int searchResult =
-        binarySearchInTimeseriesMetadataList(timeseriesMetadataList, path.getMeasurement());
-    return searchResult >= 0 ? timeseriesMetadataList.get(searchResult) : null;
+    return readTimeseriesMetadata(path.getDevice(), path.getMeasurement(), ignoreNotExists);
   }
 
   public TimeseriesMetadata readTimeseriesMetadata(

--- a/iotdb-core/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TimeSeriesMetadataReadTest.java
+++ b/iotdb-core/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TimeSeriesMetadataReadTest.java
@@ -72,7 +72,8 @@ public class TimeSeriesMetadataReadTest {
     // the Max Degree Of Index Node is set to be 3, so the leaf node should only contains 3 sensors
     // s4 should not be returned as result
     set.add("s4");
-    List<TimeseriesMetadata> timeseriesMetadataList = reader.readTimeseriesMetadata(path, set);
+    List<TimeseriesMetadata> timeseriesMetadataList =
+        reader.readTimeseriesMetadata(path.getDevice(), path.getMeasurement(), set);
     Assert.assertEquals(3, timeseriesMetadataList.size());
     for (int i = 1; i <= timeseriesMetadataList.size(); i++) {
       Assert.assertEquals("s" + i, timeseriesMetadataList.get(i - 1).getMeasurementId());
@@ -85,7 +86,8 @@ public class TimeSeriesMetadataReadTest {
     // this is a fake one, this file doesn't contain this measurement
     // so the result is not supposed to contain this measurement's timeseries metadata
     set.add("s8");
-    timeseriesMetadataList = reader.readTimeseriesMetadata(path, set);
+    timeseriesMetadataList =
+        reader.readTimeseriesMetadata(path.getDevice(), path.getMeasurement(), set);
     Assert.assertEquals(2, timeseriesMetadataList.size());
     for (int i = 5; i < 7; i++) {
       Assert.assertEquals("s" + i, timeseriesMetadataList.get(i - 5).getMeasurementId());


### PR DESCRIPTION
 The cost of new Path is too large, we need to avoid redundant of it.