### PR TITLE
[IOTDB-6085] NullPointerException in readAsync when Ratis leader is changing

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/cq/CQManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/cq/CQManager.java
@@ -117,6 +117,15 @@ public class CQManager {
   }
 
   public void startCQScheduler() {
+    try {
+      /*
+        TODO: remove this after fixing IOTDB-6085
+        sleep here because IOTDB-6085: NullPointerException in readAsync when Ratis leader is changing
+      */
+      Thread.sleep(1000);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
     lock.writeLock().lock();
     try {
       // 1. shutdown previous cq schedule thread pool
@@ -156,6 +165,11 @@ public class CQManager {
           // consensus layer related errors
           LOGGER.warn(
               "Unexpected error happened while fetching cq list: ", response.getException());
+          try {
+            Thread.sleep(500);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
         }
       }
 


### PR DESCRIPTION
see [jira](https://issues.apache.org/jira/browse/IOTDB-6085)