### PR TITLE
[IOTDB-6088] Load: Optimize the schema creation process

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -161,7 +161,7 @@ public class IoTDBConfig {
   /** The proportion of write memory for loading TsFile */
   private double loadTsFileProportion = 0.125;
 
-  private final int maxLoadingDeviceNumber = 10000;
+  private int maxLoadingTimeseriesNumber = 2000;
 
   /**
    * If memory cost of data region increased more than proportion of {@linkplain
@@ -3236,8 +3236,12 @@ public class IoTDBConfig {
     return loadTsFileProportion;
   }
 
-  public int getMaxLoadingDeviceNumber() {
-    return maxLoadingDeviceNumber;
+  public int getMaxLoadingTimeseriesNumber() {
+    return maxLoadingTimeseriesNumber;
+  }
+
+  public void setMaxLoadingTimeseriesNumber(int maxLoadingTimeseriesNumber) {
+    this.maxLoadingTimeseriesNumber = maxLoadingTimeseriesNumber;
   }
 
   public static String getEnvironmentVariables() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -898,6 +898,12 @@ public class IoTDBDescriptor {
       conf.setIntoOperationExecutionThreadCount(2);
     }
 
+    conf.setMaxLoadingTimeseriesNumber(
+        Integer.parseInt(
+            properties.getProperty(
+                "max_loading_timeseries_number",
+                String.valueOf(conf.getMaxLoadingTimeseriesNumber()))));
+
     conf.setExtPipeDir(properties.getProperty("ext_pipe_dir", conf.getExtPipeDir()).trim());
 
     // At the same time, set TSFileConfig

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
@@ -2494,6 +2494,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
 
     Map<String, Map<MeasurementSchema, File>> device2Schemas = new HashMap<>();
     Map<String, Pair<Boolean, File>> device2IsAligned = new HashMap<>();
+    int tsfileNum = loadTsFileStatement.getTsFiles().size();
 
     // analyze tsfile metadata
     for (File tsFile : loadTsFileStatement.getTsFiles()) {
@@ -2507,9 +2508,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
                 tsFile.getPath()));
       }
       try {
-        TsFileResource resource =
-            analyzeTsFile(loadTsFileStatement, tsFile, device2Schemas, device2IsAligned);
-        loadTsFileStatement.addTsFileResource(resource);
+        analyzeTsFile(loadTsFileStatement, tsFile, device2Schemas, device2IsAligned, context);
       } catch (IllegalArgumentException e) {
         logger.warn(
             String.format(
@@ -2522,13 +2521,23 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
         throw new SemanticException(
             String.format("Parse file %s to resource error", tsFile.getPath()));
       }
-      if (device2Schemas.size() > CONFIG.getMaxLoadingDeviceNumber()) {
-        autoCreateAndVerifySchema(loadTsFileStatement, device2Schemas, device2IsAligned, context);
+
+      int index = loadTsFileStatement.getTsFiles().indexOf(tsFile) + 1;
+
+      if (index == tsfileNum) {
+        break;
       }
+
+      double progressPercentage = index * 100.00 / tsfileNum;
+
+      logger.info(
+          "Load - Analysis Stage: {}/{} tsfiles have been analyzed, progress: {}%",
+          index, tsfileNum, String.format("%.2f", progressPercentage));
     }
 
-    autoCreateAndVerifySchema(loadTsFileStatement, device2Schemas, device2IsAligned, context);
-
+    logger.info(
+        "Load - Analysis Stage:{}/{} tsfiles have been analyzed, progress: {}%",
+        tsfileNum, tsfileNum, "100.00");
     // load function will query data partition in scheduler
     Analysis analysis = new Analysis();
     analysis.setStatement(loadTsFileStatement);
@@ -2590,23 +2599,38 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     return analysis;
   }
 
-  private TsFileResource analyzeTsFile(
+  private void analyzeTsFile(
       LoadTsFileStatement statement,
       File tsFile,
       Map<String, Map<MeasurementSchema, File>> device2Schemas,
-      Map<String, Pair<Boolean, File>> device2IsAligned)
+      Map<String, Pair<Boolean, File>> device2IsAligned,
+      MPPQueryContext context)
       throws IOException, VerifyMetadataException {
     try (TsFileSequenceReader reader = new TsFileSequenceReader(tsFile.getAbsolutePath())) {
-      Map<String, List<TimeseriesMetadata>> device2Metadata = reader.getAllTimeseriesMetadata(true);
+      TsFileResource tsFileResource = new TsFileResource(tsFile);
+      final boolean isAlreadyExistBeforeLoad = tsFileResource.resourceFileExists();
+      boolean isDeserializeDone = false;
 
+      Map<String, List<TimeseriesMetadata>> device2Metadata = reader.getAllTimeseriesMetadata(true);
       if (IoTDBDescriptor.getInstance().getConfig().isAutoCreateSchemaEnabled()
           || statement.isVerifySchema()) {
         // construct schema
+        int deviceSize = device2Metadata.size();
+        int deviceCount = 0;
+        int timeseriesCount = 0;
+
         for (Map.Entry<String, List<TimeseriesMetadata>> entry : device2Metadata.entrySet()) {
           String device = entry.getKey();
+          deviceCount++;
           List<TimeseriesMetadata> timeseriesMetadataList = entry.getValue();
           boolean isAligned = false;
-          for (TimeseriesMetadata timeseriesMetadata : timeseriesMetadataList) {
+
+          int timeseriesMetadataListSize = timeseriesMetadataList.size();
+
+          for (int timeseriesIndex = 0;
+              timeseriesIndex < timeseriesMetadataListSize;
+              timeseriesIndex++) {
+            TimeseriesMetadata timeseriesMetadata = timeseriesMetadataList.get(timeseriesIndex);
             TSDataType dataType = timeseriesMetadata.getTsDataType();
             if (!dataType.equals(TSDataType.VECTOR)) {
               Pair<CompressionType, TSEncoding> pair =
@@ -2620,15 +2644,62 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
               device2Schemas
                   .computeIfAbsent(device, o -> new HashMap<>())
                   .put(measurementSchema, tsFile);
+              timeseriesCount++;
             } else {
               isAligned = true;
             }
+
+            // if the number of timeseries exceeds the threshold or loop to the last timeseries of
+            // the last device, we
+            // should create and verify schema , and clean the device2Schemas and device2IsAligned
+            // map.
+            if (timeseriesCount > CONFIG.getMaxLoadingTimeseriesNumber()
+                || (deviceCount == deviceSize
+                    && timeseriesIndex == timeseriesMetadataListSize - 1)) {
+
+              // check if the device has the same aligned definition in all tsfiles
+              if (isDeviceAligned(device2IsAligned, device, tsFile, isAligned)) {
+                // if the tsfile has tsfile resource before loading, we should deserialize it only
+                // once.
+                if (isAlreadyExistBeforeLoad) {
+                  if (!isDeserializeDone) {
+                    tsFileResource.deserialize();
+                    statement.addTsFileResource(tsFileResource);
+                    isDeserializeDone = true;
+                  }
+
+                  // if the tsfile has no tsfile resource before loading, we should construct it.
+                } else if (!tsFileResource.resourceFileExists()) {
+                  tsFileResource = constructTsFileResource(tsFile, device2Metadata, reader);
+
+                  // the tsfile resource is created when loading, so we just need to update the
+                  // resource.
+                } else {
+                  FileLoaderUtils.updateTsFileResource(device2Metadata, tsFileResource);
+                }
+
+                tsFileResource.setStatus(TsFileResourceStatus.NORMAL);
+
+                autoCreateAndVerifySchema(statement, device2Schemas, device2IsAligned, context);
+                timeseriesCount = 0;
+              } else {
+                throw new VerifyMetadataException(
+                    String.format(
+                        "Device %s has different aligned definition in tsFile %s and other TsFile.",
+                        device, tsFile.getParentFile()));
+              }
+
+              logger.info(
+                  "Load - Create and Verify Schemas Stage: the device {} in tsfile {} have been created and verified.",
+                  entry.getKey(),
+                  tsFile.getName());
+            }
           }
-          boolean finalIsAligned = isAligned;
-          if (!device2IsAligned
-              .computeIfAbsent(device, o -> new Pair<>(finalIsAligned, tsFile))
-              .left
-              .equals(isAligned)) {
+
+          // when the number of devices does not exceed the threshold and it's not the last
+          // timeseries of the last device, we also need to check if the device has the same aligned
+          // definition in all tsfiles before going to the next device loop.
+          if (!isDeviceAligned(device2IsAligned, device, tsFile, isAligned)) {
             throw new VerifyMetadataException(
                 String.format(
                     "Device %s has different aligned definition in tsFile %s and other TsFile.",
@@ -2636,8 +2707,18 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
           }
         }
       }
-      return constructTsFileResource(tsFile, device2Metadata, reader);
     }
+  }
+
+  private boolean isDeviceAligned(
+      Map<String, Pair<Boolean, File>> device2IsAligned,
+      String device,
+      File tsFile,
+      boolean isAligned) {
+    return device2IsAligned
+        .computeIfAbsent(device, o -> new Pair<>(isAligned, tsFile))
+        .left
+        .equals(isAligned);
   }
 
   private TsFileResource constructTsFileResource(


### PR DESCRIPTION
## Description
The load phase loads all the schemas of one device into memory at once, which causes createMultiTimeseries to be too large when the amount of tsfile is huge.
![image](https://github.com/apache/iotdb/assets/42286868/b9a99736-47c2-4291-a2b7-ad288f4cc35f)

## Solution
1. granularity changed from `devices` to `timeseries`
2. set threshold to limit the number of timeseries when creating a schema once
3. add logger to show the load progress info