### PR TITLE
[To rel/1.2] Skip compaction resources overlap validation if a task is UnSequenceSpaceTask

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
@@ -183,7 +183,7 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
 
         CompactionValidator validator = CompactionValidator.getInstance();
         if (!validator.validateCompaction(
-            tsFileManager, targetTsfileResourceList, storageGroupName, timePartition)) {
+            tsFileManager, targetTsfileResourceList, storageGroupName, timePartition, false)) {
           LOGGER.error(
               "Failed to pass compaction validation, "
                   + "source sequence files is: {}, "

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
@@ -196,7 +196,7 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
 
         CompactionValidator validator = CompactionValidator.getInstance();
         if (!validator.validateCompaction(
-            tsFileManager, targetTsFileList, storageGroupName, timePartition)) {
+            tsFileManager, targetTsFileList, storageGroupName, timePartition, !sequence)) {
           LOGGER.error(
               "Failed to pass compaction validation, source files is: {}, target files is {}",
               selectedTsFileResourceList,

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/validator/CompactionValidator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/validator/CompactionValidator.java
@@ -32,7 +32,8 @@ public interface CompactionValidator {
       TsFileManager manager,
       List<TsFileResource> targetTsFileList,
       String storageGroupName,
-      long timePartition)
+      long timePartition,
+      boolean isInnerUnSequenceSpaceTask)
       throws IOException;
 
   static CompactionValidator getInstance() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/validator/NoneCompactionValidator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/validator/NoneCompactionValidator.java
@@ -39,7 +39,7 @@ public class NoneCompactionValidator implements CompactionValidator {
       List<TsFileResource> targetTsFileList,
       String storageGroupName,
       long timePartition,
-      boolean isInnerSequenceSpaceTask) {
+      boolean isInnerUnSequenceSpaceTask) {
     return true;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/validator/NoneCompactionValidator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/validator/NoneCompactionValidator.java
@@ -38,7 +38,8 @@ public class NoneCompactionValidator implements CompactionValidator {
       TsFileManager manager,
       List<TsFileResource> targetTsFileList,
       String storageGroupName,
-      long timePartition) {
+      long timePartition,
+      boolean isInnerSequenceSpaceTask) {
     return true;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/validator/ResourceAndTsfileCompactionValidator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/validator/ResourceAndTsfileCompactionValidator.java
@@ -40,8 +40,12 @@ public class ResourceAndTsfileCompactionValidator implements CompactionValidator
       TsFileManager manager,
       List<TsFileResource> targetTsFileList,
       String storageGroupName,
-      long timePartition)
+      long timePartition,
+      boolean isInnerUnSequenceSpaceTask)
       throws IOException {
+    if (isInnerUnSequenceSpaceTask) {
+      return CompactionUtils.validateTsFiles(targetTsFileList);
+    }
     return CompactionUtils.validateTsFileResources(manager, storageGroupName, timePartition)
         && CompactionUtils.validateTsFiles(targetTsFileList);
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/validator/ResourceOnlyCompactionValidator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/validator/ResourceOnlyCompactionValidator.java
@@ -40,8 +40,12 @@ public class ResourceOnlyCompactionValidator implements CompactionValidator {
       TsFileManager manager,
       List<TsFileResource> targetTsFileList,
       String storageGroupName,
-      long timePartition)
+      long timePartition,
+      boolean isInnerUnSequenceSpaceTask)
       throws IOException {
+    if (isInnerUnSequenceSpaceTask) {
+      return true;
+    }
     return CompactionUtils.validateTsFileResources(manager, storageGroupName, timePartition);
   }
 


### PR DESCRIPTION
## Description
Skip compaction resources overlap validation if a task is UnSequenceSpaceTask
https://github.com/apache/iotdb/pull/10708
