### PR TITLE
[To rel/1.2][IOTDB-6078] Load: Allow different chunks have different compressor and encoder & Load time chunk using compressor recorded in chunk header

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/load/AlignedChunkData.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/load/AlignedChunkData.java
@@ -277,8 +277,15 @@ public class AlignedChunkData implements ChunkData {
 
   private void buildChunkWriter(InputStream stream) throws IOException, PageException {
     List<IMeasurementSchema> measurementSchemaList = new ArrayList<>();
+    IMeasurementSchema timeSchema = null;
     for (ChunkHeader chunkHeader : chunkHeaderList) {
       if (TSDataType.VECTOR.equals(chunkHeader.getDataType())) {
+        timeSchema =
+            new MeasurementSchema(
+                chunkHeader.getMeasurementID(),
+                chunkHeader.getDataType(),
+                chunkHeader.getEncodingType(),
+                chunkHeader.getCompressionType());
         continue;
       }
       measurementSchemaList.add(
@@ -288,7 +295,7 @@ public class AlignedChunkData implements ChunkData {
               chunkHeader.getEncodingType(),
               chunkHeader.getCompressionType()));
     }
-    chunkWriter = new AlignedChunkWriterImpl(measurementSchemaList);
+    chunkWriter = new AlignedChunkWriterImpl(timeSchema, measurementSchemaList);
     timeBatch = new ArrayList<>();
     int chunkHeaderSize = chunkHeaderList.size();
     for (int i = 0; i < chunkHeaderSize; i++) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
@@ -2817,19 +2817,19 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
               originSchema.getType().name());
         }
         if (!tsFileSchema.getEncodingType().equals(originSchema.getEncodingType())) {
-          throw new VerifyMetadataException(
+          logger.warn(
+              "Encoding type not match, measurement: {}, TsFile: {}, TsFile encoding: {}, origin encoding: {}",
               measurementPath,
-              "Encoding",
-              tsFileSchema.getEncodingType().name(),
               entry.getValue().get(tsFileSchema).getPath(),
+              tsFileSchema.getEncodingType().name(),
               originSchema.getEncodingType().name());
         }
         if (!tsFileSchema.getCompressor().equals(originSchema.getCompressor())) {
-          throw new VerifyMetadataException(
+          logger.warn(
+              "Compression type not match, measurement: {}, TsFile: {}, TsFile compression: {}, origin compression: {}",
               measurementPath,
-              "Compress type",
-              tsFileSchema.getCompressor().name(),
               entry.getValue().get(tsFileSchema).getPath(),
+              tsFileSchema.getCompressor().name(),
               originSchema.getCompressor().name());
         }
       }

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/AlignedChunkWriterImpl.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/AlignedChunkWriterImpl.java
@@ -110,7 +110,7 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
   }
 
   /**
-   * This is used to write 0-level file. The compression of the time column is 'SNAPPY' in the
+   * This is used to write 0-level file. The compression of the time column is 'LZ4' in the
    * configuration by default. The encoding of the time column is 'TS_2DIFF' in the configuration by
    * default.
    *


### PR DESCRIPTION
cherry-pick: https://github.com/apache/iotdb/pull/10649