### PR TITLE
[To rel/1.2][IOTDB-6088] Load: Optimize the schema creation process & Avoid OOM and ratis createMultiTimeseriesPlan bufferSize too large

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -161,7 +161,7 @@ public class IoTDBConfig {
   /** The proportion of write memory for loading TsFile */
   private double loadTsFileProportion = 0.125;
 
-  private final int maxLoadingDeviceNumber = 10000;
+  private int maxLoadingTimeseriesNumber = 2000;
 
   /**
    * If memory cost of data region increased more than proportion of {@linkplain
@@ -3237,8 +3237,12 @@ public class IoTDBConfig {
     return loadTsFileProportion;
   }
 
-  public int getMaxLoadingDeviceNumber() {
-    return maxLoadingDeviceNumber;
+  public int getMaxLoadingTimeseriesNumber() {
+    return maxLoadingTimeseriesNumber;
+  }
+
+  public void setMaxLoadingTimeseriesNumber(int maxLoadingTimeseriesNumber) {
+    this.maxLoadingTimeseriesNumber = maxLoadingTimeseriesNumber;
   }
 
   public static String getEnvironmentVariables() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -898,6 +898,12 @@ public class IoTDBDescriptor {
       conf.setIntoOperationExecutionThreadCount(2);
     }
 
+    conf.setMaxLoadingTimeseriesNumber(
+        Integer.parseInt(
+            properties.getProperty(
+                "max_loading_timeseries_number",
+                String.valueOf(conf.getMaxLoadingTimeseriesNumber()))));
+
     conf.setExtPipeDir(properties.getProperty("ext_pipe_dir", conf.getExtPipeDir()).trim());
 
     // At the same time, set TSFileConfig


### PR DESCRIPTION
cherry-pick: https://github.com/apache/iotdb/pull/10715