### PR TITLE
Fix recover last flush time map bug

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -1943,7 +1943,7 @@ public class DataRegion implements IDataRegionForQuery {
         deviceEndTime = startAndEndTime.getRight();
       } else {
         String deviceId = device.getFullPath();
-        if (!tsFileResource.mayContainsDevice(deviceId)) {
+        if (tsFileResource.definitelyNotContains(deviceId)) {
           // resource does not contain this device
           continue;
         }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/HashLastFlushTimeMap.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/HashLastFlushTimeMap.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class HashLastFlushTimeMap implements ILastFlushTimeMap {
 
@@ -231,8 +232,9 @@ public class HashLastFlushTimeMap implements ILastFlushTimeMap {
         tsFileManager.getOrCreateSequenceListByTimePartition(partitionId);
 
     for (int i = tsFileResourceList.size() - 1; i >= 0; i--) {
-      if (tsFileResourceList.get(i).timeIndex.mayContainsDevice(devicePath)) {
-        return tsFileResourceList.get(i).timeIndex.getEndTime(devicePath);
+      Set<String> deviceSet = tsFileResourceList.get(i).getDevices();
+      if (deviceSet.contains(devicePath)) {
+        return tsFileResourceList.get(i).getEndTime(devicePath);
       }
     }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/performer/impl/FastCompactionPerformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/performer/impl/FastCompactionPerformer.java
@@ -120,7 +120,7 @@ public class FastCompactionPerformer
         // actually exist but the judgment return device being existed.
         sortedSourceFiles.addAll(seqFiles);
         sortedSourceFiles.addAll(unseqFiles);
-        sortedSourceFiles.removeIf(x -> !x.mayContainsDevice(device));
+        sortedSourceFiles.removeIf(x -> x.definitelyNotContains(device));
         sortedSourceFiles.sort(Comparator.comparingLong(x -> x.getStartTime(device)));
 
         boolean isAligned = deviceInfo.right;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
@@ -96,7 +96,7 @@ public class TsFileResource {
   protected TsFileResource next;
 
   /** time index */
-  public ITimeIndex timeIndex;
+  private ITimeIndex timeIndex;
 
   @SuppressWarnings("squid:S3077")
   private volatile ModificationFile modFile;
@@ -492,11 +492,12 @@ public class TsFileResource {
   }
 
   /**
-   * Whether this TsFileResource contains this device, if false, it must not contain this device, if
-   * true, it may or may not contain this device
+   * Whether this TsFile definitely not contains this device, if ture, it must not contain this
+   * device, if false, it may or may not contain this device Notice: using method be CAREFULLY and
+   * you really understand the meaning!!!!!
    */
-  public boolean mayContainsDevice(String device) {
-    return timeIndex.mayContainsDevice(device);
+  public boolean definitelyNotContains(String device) {
+    return timeIndex.definitelyNotContains(device);
   }
 
   /**
@@ -800,7 +801,7 @@ public class TsFileResource {
 
   /** @return true if the device is contained in the TsFile */
   public boolean isSatisfied(String deviceId, Filter timeFilter, boolean isSeq, boolean debug) {
-    if (!mayContainsDevice(deviceId)) {
+    if (definitelyNotContains(deviceId)) {
       if (debug) {
         DEBUG_LOGGER.info(
             "Path: {} file {} is not satisfied because of no device!", deviceId, file);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/timeindex/DeviceTimeIndex.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/timeindex/DeviceTimeIndex.java
@@ -362,8 +362,8 @@ public class DeviceTimeIndex implements ITimeIndex {
   }
 
   @Override
-  public boolean mayContainsDevice(String device) {
-    return deviceToIndex.containsKey(device);
+  public boolean definitelyNotContains(String device) {
+    return !deviceToIndex.containsKey(device);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/timeindex/FileTimeIndex.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/timeindex/FileTimeIndex.java
@@ -224,8 +224,8 @@ public class FileTimeIndex implements ITimeIndex {
   }
 
   @Override
-  public boolean mayContainsDevice(String device) {
-    return true;
+  public boolean definitelyNotContains(String device) {
+    return false;
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/timeindex/ITimeIndex.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/timeindex/ITimeIndex.java
@@ -188,10 +188,11 @@ public interface ITimeIndex {
   int compareDegradePriority(ITimeIndex timeIndex);
 
   /**
-   * Whether this TsFile contains this device, if false, it must not contain this device, if true,
-   * it may or may not contain this device
+   * Whether this TsFile definitely not contains this device, if ture, it must not contain this
+   * device, if false, it may or may not contain this device Notice: using method be CAREFULLY and
+   * you really understand the meaning!!!!!
    */
-  boolean mayContainsDevice(String device);
+  boolean definitelyNotContains(String device);
 
   /**
    * @return null if the deviceId doesn't exist, otherwise index 0 is startTime, index 1 is endTime

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/LastFlushTimeMapTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/LastFlushTimeMapTest.java
@@ -19,169 +19,122 @@
 
 package org.apache.iotdb.db.storageengine.dataregion;
 
+import org.apache.iotdb.commons.consensus.DataRegionId;
+import org.apache.iotdb.commons.exception.IllegalPathException;
+import org.apache.iotdb.db.exception.WriteProcessException;
+import org.apache.iotdb.db.storageengine.StorageEngine;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.schedule.CompactionTaskManager;
+import org.apache.iotdb.db.storageengine.dataregion.memtable.TsFileProcessor;
+import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
+import org.apache.iotdb.db.utils.EnvironmentUtils;
+import org.apache.iotdb.db.utils.constant.TestConstant;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.write.record.TSRecord;
+import org.apache.iotdb.tsfile.write.record.datapoint.DataPoint;
+
+import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.util.List;
+
 public class LastFlushTimeMapTest {
 
-    public LastFlushTimeMapTest() {}
+  private DataRegion dataRegion;
 
-    @Test
-    public void testSequenceInsert()
-        throws MetadataException, QueryProcessException, StorageEngineException {
-      insertData(0);
-      insertData(10);
-      PhysicalPlan flushPlan = processor.parseSQLToPhysicalPlan("flush");
-      executor.processNonQuery(flushPlan);
+  private String storageGroup = "root.vehicle.d0";
+  private String measurementId = "s0";
+  private String systemDir = TestConstant.OUTPUT_DATA_DIR.concat("info");
 
-      insertData(20);
+  @Before
+  public void setUp() throws Exception {
+    EnvironmentUtils.envSetUp();
+    dataRegion = new DataRegionTest.DummyDataRegion(systemDir, storageGroup);
+    StorageEngine.getInstance().setDataRegion(new DataRegionId(0), dataRegion);
+    CompactionTaskManager.getInstance().start();
+  }
 
-      DataRegion storageGroupProcessor =
-          StorageEngine.getInstance().getProcessor(new PartialPath("root.isp.d1"));
-      assertEquals(2, storageGroupProcessor.getSequenceFileList().size());
-      assertEquals(0, storageGroupProcessor.getUnSequenceFileList().size());
+  @After
+  public void tearDown() throws Exception {
+    if (dataRegion != null) {
+      dataRegion.syncDeleteDataFiles();
+      StorageEngine.getInstance().deleteDataRegion(new DataRegionId(0));
+    }
+    EnvironmentUtils.cleanDir(TestConstant.OUTPUT_DATA_DIR);
+    CompactionTaskManager.getInstance().stop();
+    EnvironmentUtils.cleanEnv();
+  }
+
+  @Test
+  public void testRecoverLastFlushTimeMapFromDeviceTimeIndex()
+      throws IOException, IllegalPathException, WriteProcessException {
+    TSRecord record = new TSRecord(10000, "root.vehicle.d0");
+    record.addTuple(DataPoint.getDataPoint(TSDataType.INT32, measurementId, String.valueOf(1000)));
+    dataRegion.insert(DataRegionTest.buildInsertRowNodeByTSRecord(record));
+    dataRegion.syncCloseAllWorkingTsFileProcessors();
+
+    record = new TSRecord(9999, "root.vehicle.d1");
+    record.addTuple(DataPoint.getDataPoint(TSDataType.INT32, measurementId, String.valueOf(1000)));
+    dataRegion.insert(DataRegionTest.buildInsertRowNodeByTSRecord(record));
+    dataRegion.syncCloseAllWorkingTsFileProcessors();
+
+    for (int j = 1; j <= 10; j++) {
+      record = new TSRecord(j, "root.vehicle.d0");
+      record.addTuple(DataPoint.getDataPoint(TSDataType.INT32, measurementId, String.valueOf(j)));
+      dataRegion.insert(DataRegionTest.buildInsertRowNodeByTSRecord(record));
     }
 
-    @Test
-    public void testUnSequenceInsert()
-        throws MetadataException, QueryProcessException, StorageEngineException {
-      insertData(100);
-      PhysicalPlan flushPlan = processor.parseSQLToPhysicalPlan("flush");
-      executor.processNonQuery(flushPlan);
+    for (TsFileProcessor tsfileProcessor : dataRegion.getWorkUnsequenceTsFileProcessors()) {
+      tsfileProcessor.syncFlush();
+    }
+    Assert.assertEquals(
+        10000, dataRegion.getLastFlushTimeMap().getFlushedTime(0, "root.vehicle.d0"));
 
-      insertData(20);
+    dataRegion.getLastFlushTimeMap().clearFlushedTime();
+    dataRegion.getLastFlushTimeMap().checkAndCreateFlushedTimePartition(0);
+    Assert.assertEquals(
+        10000, dataRegion.getLastFlushTimeMap().getFlushedTime(0, "root.vehicle.d0"));
+  }
 
-      DataRegion storageGroupProcessor =
-          StorageEngine.getInstance().getProcessor(new PartialPath("root.isp.d1"));
-      assertEquals(1, storageGroupProcessor.getSequenceFileList().size());
-      assertEquals(1, storageGroupProcessor.getUnSequenceFileList().size());
+  @Test
+  public void testRecoverLastFlushTimeMapFromFileTimeIndex()
+      throws IOException, IllegalPathException, WriteProcessException {
+    TSRecord record = new TSRecord(10000, "root.vehicle.d0");
+    record.addTuple(DataPoint.getDataPoint(TSDataType.INT32, measurementId, String.valueOf(1000)));
+    dataRegion.insert(DataRegionTest.buildInsertRowNodeByTSRecord(record));
+    dataRegion.syncCloseAllWorkingTsFileProcessors();
+
+    record = new TSRecord(9999, "root.vehicle.d1");
+    record.addTuple(DataPoint.getDataPoint(TSDataType.INT32, measurementId, String.valueOf(1000)));
+    dataRegion.insert(DataRegionTest.buildInsertRowNodeByTSRecord(record));
+    dataRegion.syncCloseAllWorkingTsFileProcessors();
+
+    for (int j = 1; j <= 10; j++) {
+      record = new TSRecord(j, "root.vehicle.d0");
+      record.addTuple(DataPoint.getDataPoint(TSDataType.INT32, measurementId, String.valueOf(j)));
+      dataRegion.insert(DataRegionTest.buildInsertRowNodeByTSRecord(record));
     }
 
-    @Test
-    public void testSequenceAndUnSequenceInsert()
-        throws MetadataException, QueryProcessException, StorageEngineException {
-      // sequence
-      insertData(100);
-      PhysicalPlan flushPlan = processor.parseSQLToPhysicalPlan("flush");
-      executor.processNonQuery(flushPlan);
-
-      // sequence
-      insertData(120);
-      executor.processNonQuery(flushPlan);
-
-      // unsequence
-      insertData(20);
-      // sequence
-      insertData(130);
-      executor.processNonQuery(flushPlan);
-
-      // sequence
-      insertData(150);
-      // unsequence
-      insertData(90);
-
-      DataRegion storageGroupProcessor =
-          StorageEngine.getInstance().getProcessor(new PartialPath("root.isp.d1"));
-      assertEquals(4, storageGroupProcessor.getSequenceFileList().size());
-      assertEquals(2, storageGroupProcessor.getUnSequenceFileList().size());
-      assertEquals(1, storageGroupProcessor.getWorkSequenceTsFileProcessors().size());
-      assertEquals(1, storageGroupProcessor.getWorkUnsequenceTsFileProcessors().size());
+    for (TsFileProcessor tsfileProcessor : dataRegion.getWorkUnsequenceTsFileProcessors()) {
+      tsfileProcessor.syncFlush();
     }
+    dataRegion.syncCloseAllWorkingTsFileProcessors();
+    Assert.assertEquals(
+        10000, dataRegion.getLastFlushTimeMap().getFlushedTime(0, "root.vehicle.d0"));
 
-    @Test
-    public void testDeletePartition()
-        throws MetadataException, QueryProcessException, StorageEngineException {
-      insertData(100);
-      PhysicalPlan flushPlan = processor.parseSQLToPhysicalPlan("flush");
-      executor.processNonQuery(flushPlan);
-      insertData(20);
-      insertData(120);
-
-      DataRegion storageGroupProcessor =
-          StorageEngine.getInstance().getProcessor(new PartialPath("root.isp.d1"));
-
-      assertEquals(
-          103L, storageGroupProcessor.getLastFlushTimeMap().getFlushedTime(0L, "root.isp.d1"));
-      assertEquals(
-          103L, storageGroupProcessor.getLastFlushTimeMap().getGlobalFlushedTime("root.isp.d1"));
-
-      // delete time partition
-      Set<Long> deletedPartition = new HashSet<>();
-      deletedPartition.add(0L);
-      DeletePartitionPlan deletePartitionPlan =
-          new DeletePartitionPlan(new PartialPath("root.isp"), deletedPartition);
-      executor.processNonQuery(deletePartitionPlan);
-
-      assertEquals(
-          123L, storageGroupProcessor.getLastFlushTimeMap().getGlobalFlushedTime("root.isp.d1"));
+    dataRegion.getLastFlushTimeMap().clearFlushedTime();
+    dataRegion.getLastFlushTimeMap().checkAndCreateFlushedTimePartition(0);
+    List<TsFileResource> seqs = dataRegion.getSequenceFileList();
+    for (TsFileResource res : seqs) {
+      res.degradeTimeIndex();
     }
-
-    @Test
-    public void testRecoverFlushTime() {
-      insertData(100);
-      PhysicalPlan flushPlan = processor.parseSQLToPhysicalPlan("flush");
-      executor.processNonQuery(flushPlan);
-      DataRegion storageGroupProcessor =
-          StorageEngine.getInstance().getProcessor(new PartialPath("root.isp"));
-      assertEquals(
-          103L, storageGroupProcessor.getLastFlushTimeMap().getFlushedTime(0l, "root.isp.d1"));
-
-      storageGroupProcessor.getLastFlushTimeMap().removePartition(0l);
-      storageGroupProcessor.getLastFlushTimeMap().checkAndCreateFlushedTimePartition(0l);
-      assertEquals(
-          103L, storageGroupProcessor.getLastFlushTimeMap().getFlushedTime(0l, "root.isp.d1"));
+    List<TsFileResource> unseqs = dataRegion.getUnSequenceFileList();
+    for (TsFileResource res : unseqs) {
+      res.degradeTimeIndex();
     }
-
-    protected void insertData(long initTime) throws IllegalPathException, QueryProcessException {
-
-      long[] times = new long[] {initTime, initTime + 1, initTime + 2, initTime + 3};
-      List<Integer> dataTypes = new ArrayList<>();
-      dataTypes.add(TSDataType.DOUBLE.ordinal());
-      dataTypes.add(TSDataType.FLOAT.ordinal());
-      dataTypes.add(TSDataType.INT64.ordinal());
-      dataTypes.add(TSDataType.INT32.ordinal());
-      dataTypes.add(TSDataType.BOOLEAN.ordinal());
-      dataTypes.add(TSDataType.TEXT.ordinal());
-
-      Object[] columns = new Object[6];
-      columns[0] = new double[4];
-      columns[1] = new float[4];
-      columns[2] = new long[4];
-      columns[3] = new int[4];
-      columns[4] = new boolean[4];
-      columns[5] = new Binary[4];
-
-      for (int r = 0; r < 4; r++) {
-        ((double[]) columns[0])[r] = 10.0 + r;
-        ((float[]) columns[1])[r] = 20 + r;
-        ((long[]) columns[2])[r] = 100000 + r;
-        ((int[]) columns[3])[r] = 1000 + r;
-        ((boolean[]) columns[4])[r] = false;
-        ((Binary[]) columns[5])[r] = new Binary("mm" + r);
-      }
-
-      InsertTabletPlan tabletPlan =
-          new InsertTabletPlan(
-              new PartialPath("root.isp.d1"),
-              new String[] {"s1", "s2", "s3", "s4", "s5", "s6"},
-              dataTypes);
-      tabletPlan.setTimes(times);
-      tabletPlan.setColumns(columns);
-      tabletPlan.setRowCount(times.length);
-
-      executor.insertTablet(tabletPlan);
-    }
-
-    protected void insertRecord(String devicePath, long time)
-        throws IllegalPathException, QueryProcessException {
-      InsertRowPlan insertRowPlan =
-          new InsertRowPlan(
-              new PartialPath(devicePath),
-              time,
-              new String[] {"s1", "s2", "s3"},
-              new TSDataType[] {TSDataType.INT32, TSDataType.INT32, TSDataType.INT32},
-              new String[] {"1", "1", "1"});
-
-      executor.insert(insertRowPlan);
-    }
+    Assert.assertEquals(
+        10000, dataRegion.getLastFlushTimeMap().getFlushedTime(0, "root.vehicle.d0"));
+  }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/LastFlushTimeMapTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/LastFlushTimeMapTest.java
@@ -19,205 +19,169 @@
 
 package org.apache.iotdb.db.storageengine.dataregion;
 
+import org.junit.Before;
+import org.junit.Test;
+
 public class LastFlushTimeMapTest {
-  //  protected PlanExecutor executor = new PlanExecutor();
-  //
-  //  protected final Planner processor = new Planner();
-  //
-  //  public LastFlushTimeMapTest() throws QueryProcessException {}
-  //
-  //  @Before
-  //  public void before() {
-  //    IoTDBDescriptor.getInstance().getConfig().setAutoCreateSchemaEnabled(true);
-  //    EnvironmentUtils.envSetUp();
-  //  }
-  //
-  //  @Test
-  //  public void testSequenceInsert()
-  //      throws MetadataException, QueryProcessException, StorageEngineException {
-  //    insertData(0);
-  //    insertData(10);
-  //    PhysicalPlan flushPlan = processor.parseSQLToPhysicalPlan("flush");
-  //    executor.processNonQuery(flushPlan);
-  //
-  //    insertData(20);
-  //
-  //    DataRegion storageGroupProcessor =
-  //        StorageEngine.getInstance().getProcessor(new PartialPath("root.isp.d1"));
-  //    assertEquals(2, storageGroupProcessor.getSequenceFileList().size());
-  //    assertEquals(0, storageGroupProcessor.getUnSequenceFileList().size());
-  //  }
-  //
-  //  @Test
-  //  public void testUnSequenceInsert()
-  //      throws MetadataException, QueryProcessException, StorageEngineException {
-  //    insertData(100);
-  //    PhysicalPlan flushPlan = processor.parseSQLToPhysicalPlan("flush");
-  //    executor.processNonQuery(flushPlan);
-  //
-  //    insertData(20);
-  //
-  //    DataRegion storageGroupProcessor =
-  //        StorageEngine.getInstance().getProcessor(new PartialPath("root.isp.d1"));
-  //    assertEquals(1, storageGroupProcessor.getSequenceFileList().size());
-  //    assertEquals(1, storageGroupProcessor.getUnSequenceFileList().size());
-  //  }
-  //
-  //  @Test
-  //  public void testSequenceAndUnSequenceInsert()
-  //      throws MetadataException, QueryProcessException, StorageEngineException {
-  //    // sequence
-  //    insertData(100);
-  //    PhysicalPlan flushPlan = processor.parseSQLToPhysicalPlan("flush");
-  //    executor.processNonQuery(flushPlan);
-  //
-  //    // sequence
-  //    insertData(120);
-  //    executor.processNonQuery(flushPlan);
-  //
-  //    // unsequence
-  //    insertData(20);
-  //    // sequence
-  //    insertData(130);
-  //    executor.processNonQuery(flushPlan);
-  //
-  //    // sequence
-  //    insertData(150);
-  //    // unsequence
-  //    insertData(90);
-  //
-  //    DataRegion storageGroupProcessor =
-  //        StorageEngine.getInstance().getProcessor(new PartialPath("root.isp.d1"));
-  //    assertEquals(4, storageGroupProcessor.getSequenceFileList().size());
-  //    assertEquals(2, storageGroupProcessor.getUnSequenceFileList().size());
-  //    assertEquals(1, storageGroupProcessor.getWorkSequenceTsFileProcessors().size());
-  //    assertEquals(1, storageGroupProcessor.getWorkUnsequenceTsFileProcessors().size());
-  //  }
-  //
-  //  @Test
-  //  public void testDeletePartition()
-  //      throws MetadataException, QueryProcessException, StorageEngineException {
-  //    insertData(100);
-  //    PhysicalPlan flushPlan = processor.parseSQLToPhysicalPlan("flush");
-  //    executor.processNonQuery(flushPlan);
-  //    insertData(20);
-  //    insertData(120);
-  //
-  //    DataRegion storageGroupProcessor =
-  //        StorageEngine.getInstance().getProcessor(new PartialPath("root.isp.d1"));
-  //
-  //    assertEquals(
-  //        103L, storageGroupProcessor.getLastFlushTimeMap().getFlushedTime(0L, "root.isp.d1"));
-  //    assertEquals(
-  //        103L, storageGroupProcessor.getLastFlushTimeMap().getGlobalFlushedTime("root.isp.d1"));
-  //
-  //    // delete time partition
-  //    Set<Long> deletedPartition = new HashSet<>();
-  //    deletedPartition.add(0L);
-  //    DeletePartitionPlan deletePartitionPlan =
-  //        new DeletePartitionPlan(new PartialPath("root.isp"), deletedPartition);
-  //    executor.processNonQuery(deletePartitionPlan);
-  //
-  //    assertEquals(
-  //        123L, storageGroupProcessor.getLastFlushTimeMap().getGlobalFlushedTime("root.isp.d1"));
-  //  }
-  //
-  //  @Test
-  //  public void testMemoryCalculation()
-  //      throws QueryProcessException, IllegalPathException, StorageEngineException,
-  //          StorageGroupNotSetException {
-  //    insertRecord("root.sg.d1", 100L);
-  //    DataRegion storageGroupProcessor =
-  //        StorageEngine.getInstance().getProcessor(new PartialPath("root.sg"));
-  //    assertEquals(98l, storageGroupProcessor.getLastFlushTimeMap().getMemSize(0L));
-  //
-  //    storageGroupProcessor.getLastFlushTimeMap().getFlushedTime(0L, "root.sg.d100");
-  //    storageGroupProcessor.getLastFlushTimeMap().getFlushedTime(0L, "root.sg.d101");
-  //    assertEquals(302l, storageGroupProcessor.getLastFlushTimeMap().getMemSize(0L));
-  //
-  //    storageGroupProcessor.getLastFlushTimeMap().setOneDeviceFlushedTime(0L, "root.sg.d102", 0L);
-  //    HashMap<String, Long> updateMap = new HashMap<>();
-  //    updateMap.put("root.sg.d103", 1L);
-  //    updateMap.put("root.sg.d100", 1L);
-  //    storageGroupProcessor.getLastFlushTimeMap().setMultiDeviceFlushedTime(0L, updateMap);
-  //    storageGroupProcessor.getLastFlushTimeMap().updateFlushedTime(0L, "root.sg.d103", 2L);
-  //    storageGroupProcessor.getLastFlushTimeMap().updateFlushedTime(0L, "root.sg.d104", 2L);
-  //    assertEquals(608L, storageGroupProcessor.getLastFlushTimeMap().getMemSize(0L));
-  //  }
-  //
-  //  @Test
-  //  public void testRecoverFlushTime()
-  //      throws QueryProcessException, IllegalPathException, StorageEngineException,
-  //          StorageGroupNotSetException {
-  //    insertData(100);
-  //    PhysicalPlan flushPlan = processor.parseSQLToPhysicalPlan("flush");
-  //    executor.processNonQuery(flushPlan);
-  //    DataRegion storageGroupProcessor =
-  //        StorageEngine.getInstance().getProcessor(new PartialPath("root.isp"));
-  //    assertEquals(
-  //        103L, storageGroupProcessor.getLastFlushTimeMap().getFlushedTime(0l, "root.isp.d1"));
-  //
-  //    storageGroupProcessor.getLastFlushTimeMap().removePartition(0l);
-  //    storageGroupProcessor.getLastFlushTimeMap().checkAndCreateFlushedTimePartition(0l);
-  //    assertEquals(
-  //        103L, storageGroupProcessor.getLastFlushTimeMap().getFlushedTime(0l, "root.isp.d1"));
-  //  }
-  //
-  //  @After
-  //  public void clean() throws IOException, StorageEngineException {
-  //    EnvironmentUtils.cleanEnv();
-  //  }
-  //
-  //  protected void insertData(long initTime) throws IllegalPathException, QueryProcessException {
-  //
-  //    long[] times = new long[] {initTime, initTime + 1, initTime + 2, initTime + 3};
-  //    List<Integer> dataTypes = new ArrayList<>();
-  //    dataTypes.add(TSDataType.DOUBLE.ordinal());
-  //    dataTypes.add(TSDataType.FLOAT.ordinal());
-  //    dataTypes.add(TSDataType.INT64.ordinal());
-  //    dataTypes.add(TSDataType.INT32.ordinal());
-  //    dataTypes.add(TSDataType.BOOLEAN.ordinal());
-  //    dataTypes.add(TSDataType.TEXT.ordinal());
-  //
-  //    Object[] columns = new Object[6];
-  //    columns[0] = new double[4];
-  //    columns[1] = new float[4];
-  //    columns[2] = new long[4];
-  //    columns[3] = new int[4];
-  //    columns[4] = new boolean[4];
-  //    columns[5] = new Binary[4];
-  //
-  //    for (int r = 0; r < 4; r++) {
-  //      ((double[]) columns[0])[r] = 10.0 + r;
-  //      ((float[]) columns[1])[r] = 20 + r;
-  //      ((long[]) columns[2])[r] = 100000 + r;
-  //      ((int[]) columns[3])[r] = 1000 + r;
-  //      ((boolean[]) columns[4])[r] = false;
-  //      ((Binary[]) columns[5])[r] = new Binary("mm" + r);
-  //    }
-  //
-  //    InsertTabletPlan tabletPlan =
-  //        new InsertTabletPlan(
-  //            new PartialPath("root.isp.d1"),
-  //            new String[] {"s1", "s2", "s3", "s4", "s5", "s6"},
-  //            dataTypes);
-  //    tabletPlan.setTimes(times);
-  //    tabletPlan.setColumns(columns);
-  //    tabletPlan.setRowCount(times.length);
-  //
-  //    executor.insertTablet(tabletPlan);
-  //  }
-  //
-  //  protected void insertRecord(String devicePath, long time)
-  //      throws IllegalPathException, QueryProcessException {
-  //    InsertRowPlan insertRowPlan =
-  //        new InsertRowPlan(
-  //            new PartialPath(devicePath),
-  //            time,
-  //            new String[] {"s1", "s2", "s3"},
-  //            new TSDataType[] {TSDataType.INT32, TSDataType.INT32, TSDataType.INT32},
-  //            new String[] {"1", "1", "1"});
-  //
-  //    executor.insert(insertRowPlan);
-  //  }
+
+    public LastFlushTimeMapTest() {}
+
+    @Test
+    public void testSequenceInsert()
+        throws MetadataException, QueryProcessException, StorageEngineException {
+      insertData(0);
+      insertData(10);
+      PhysicalPlan flushPlan = processor.parseSQLToPhysicalPlan("flush");
+      executor.processNonQuery(flushPlan);
+
+      insertData(20);
+
+      DataRegion storageGroupProcessor =
+          StorageEngine.getInstance().getProcessor(new PartialPath("root.isp.d1"));
+      assertEquals(2, storageGroupProcessor.getSequenceFileList().size());
+      assertEquals(0, storageGroupProcessor.getUnSequenceFileList().size());
+    }
+
+    @Test
+    public void testUnSequenceInsert()
+        throws MetadataException, QueryProcessException, StorageEngineException {
+      insertData(100);
+      PhysicalPlan flushPlan = processor.parseSQLToPhysicalPlan("flush");
+      executor.processNonQuery(flushPlan);
+
+      insertData(20);
+
+      DataRegion storageGroupProcessor =
+          StorageEngine.getInstance().getProcessor(new PartialPath("root.isp.d1"));
+      assertEquals(1, storageGroupProcessor.getSequenceFileList().size());
+      assertEquals(1, storageGroupProcessor.getUnSequenceFileList().size());
+    }
+
+    @Test
+    public void testSequenceAndUnSequenceInsert()
+        throws MetadataException, QueryProcessException, StorageEngineException {
+      // sequence
+      insertData(100);
+      PhysicalPlan flushPlan = processor.parseSQLToPhysicalPlan("flush");
+      executor.processNonQuery(flushPlan);
+
+      // sequence
+      insertData(120);
+      executor.processNonQuery(flushPlan);
+
+      // unsequence
+      insertData(20);
+      // sequence
+      insertData(130);
+      executor.processNonQuery(flushPlan);
+
+      // sequence
+      insertData(150);
+      // unsequence
+      insertData(90);
+
+      DataRegion storageGroupProcessor =
+          StorageEngine.getInstance().getProcessor(new PartialPath("root.isp.d1"));
+      assertEquals(4, storageGroupProcessor.getSequenceFileList().size());
+      assertEquals(2, storageGroupProcessor.getUnSequenceFileList().size());
+      assertEquals(1, storageGroupProcessor.getWorkSequenceTsFileProcessors().size());
+      assertEquals(1, storageGroupProcessor.getWorkUnsequenceTsFileProcessors().size());
+    }
+
+    @Test
+    public void testDeletePartition()
+        throws MetadataException, QueryProcessException, StorageEngineException {
+      insertData(100);
+      PhysicalPlan flushPlan = processor.parseSQLToPhysicalPlan("flush");
+      executor.processNonQuery(flushPlan);
+      insertData(20);
+      insertData(120);
+
+      DataRegion storageGroupProcessor =
+          StorageEngine.getInstance().getProcessor(new PartialPath("root.isp.d1"));
+
+      assertEquals(
+          103L, storageGroupProcessor.getLastFlushTimeMap().getFlushedTime(0L, "root.isp.d1"));
+      assertEquals(
+          103L, storageGroupProcessor.getLastFlushTimeMap().getGlobalFlushedTime("root.isp.d1"));
+
+      // delete time partition
+      Set<Long> deletedPartition = new HashSet<>();
+      deletedPartition.add(0L);
+      DeletePartitionPlan deletePartitionPlan =
+          new DeletePartitionPlan(new PartialPath("root.isp"), deletedPartition);
+      executor.processNonQuery(deletePartitionPlan);
+
+      assertEquals(
+          123L, storageGroupProcessor.getLastFlushTimeMap().getGlobalFlushedTime("root.isp.d1"));
+    }
+
+    @Test
+    public void testRecoverFlushTime() {
+      insertData(100);
+      PhysicalPlan flushPlan = processor.parseSQLToPhysicalPlan("flush");
+      executor.processNonQuery(flushPlan);
+      DataRegion storageGroupProcessor =
+          StorageEngine.getInstance().getProcessor(new PartialPath("root.isp"));
+      assertEquals(
+          103L, storageGroupProcessor.getLastFlushTimeMap().getFlushedTime(0l, "root.isp.d1"));
+
+      storageGroupProcessor.getLastFlushTimeMap().removePartition(0l);
+      storageGroupProcessor.getLastFlushTimeMap().checkAndCreateFlushedTimePartition(0l);
+      assertEquals(
+          103L, storageGroupProcessor.getLastFlushTimeMap().getFlushedTime(0l, "root.isp.d1"));
+    }
+
+    protected void insertData(long initTime) throws IllegalPathException, QueryProcessException {
+
+      long[] times = new long[] {initTime, initTime + 1, initTime + 2, initTime + 3};
+      List<Integer> dataTypes = new ArrayList<>();
+      dataTypes.add(TSDataType.DOUBLE.ordinal());
+      dataTypes.add(TSDataType.FLOAT.ordinal());
+      dataTypes.add(TSDataType.INT64.ordinal());
+      dataTypes.add(TSDataType.INT32.ordinal());
+      dataTypes.add(TSDataType.BOOLEAN.ordinal());
+      dataTypes.add(TSDataType.TEXT.ordinal());
+
+      Object[] columns = new Object[6];
+      columns[0] = new double[4];
+      columns[1] = new float[4];
+      columns[2] = new long[4];
+      columns[3] = new int[4];
+      columns[4] = new boolean[4];
+      columns[5] = new Binary[4];
+
+      for (int r = 0; r < 4; r++) {
+        ((double[]) columns[0])[r] = 10.0 + r;
+        ((float[]) columns[1])[r] = 20 + r;
+        ((long[]) columns[2])[r] = 100000 + r;
+        ((int[]) columns[3])[r] = 1000 + r;
+        ((boolean[]) columns[4])[r] = false;
+        ((Binary[]) columns[5])[r] = new Binary("mm" + r);
+      }
+
+      InsertTabletPlan tabletPlan =
+          new InsertTabletPlan(
+              new PartialPath("root.isp.d1"),
+              new String[] {"s1", "s2", "s3", "s4", "s5", "s6"},
+              dataTypes);
+      tabletPlan.setTimes(times);
+      tabletPlan.setColumns(columns);
+      tabletPlan.setRowCount(times.length);
+
+      executor.insertTablet(tabletPlan);
+    }
+
+    protected void insertRecord(String devicePath, long time)
+        throws IllegalPathException, QueryProcessException {
+      InsertRowPlan insertRowPlan =
+          new InsertRowPlan(
+              new PartialPath(devicePath),
+              time,
+              new String[] {"s1", "s2", "s3"},
+              new TSDataType[] {TSDataType.INT32, TSDataType.INT32, TSDataType.INT32},
+              new String[] {"1", "1", "1"});
+
+      executor.insert(insertRowPlan);
+    }
 }


### PR DESCRIPTION
## Description

When recover the last flush time map from two sequence TsFiles. 
 * TsFile A only contains device1 with end time = 10000
 * TsFile B only contains device2 with end time = 9999

And the resources of these two TsFiles have been downgrade to FileTimeIndex.

The previous code will use TsFile B with end time = 9999 to recover the last flush time of device1, which would cause sequence files overlapped.