### PR TITLE
Refactoring DeleteOutdatedFileTask in WalNode

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/checkpoint/CheckpointManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/checkpoint/CheckpointManager.java
@@ -88,7 +88,7 @@ public class CheckpointManager implements AutoCloseable {
     logHeader();
   }
 
-  private List<MemTableInfo> snapshotMemTableInfos() {
+  public List<MemTableInfo> snapshotMemTableInfos() {
     infoLock.lock();
     try {
       return new ArrayList<>(memTableId2Info.values());
@@ -314,20 +314,6 @@ public class CheckpointManager implements AutoCloseable {
       }
     }
     return oldestMemTableInfo;
-  }
-
-  /**
-   * Get version id of first valid .wal file
-   *
-   * @return Return {@link Long#MIN_VALUE} if no file is valid
-   */
-  public long getFirstValidWALVersionId() {
-    List<MemTableInfo> memTableInfos = snapshotMemTableInfos();
-    long firstValidVersionId = memTableInfos.isEmpty() ? Long.MIN_VALUE : Long.MAX_VALUE;
-    for (MemTableInfo memTableInfo : memTableInfos) {
-      firstValidVersionId = Math.min(firstValidVersionId, memTableInfo.getFirstFileVersionId());
-    }
-    return firstValidVersionId;
   }
 
   /** Get total cost of active memTables. */

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/checkpoint/CheckpointManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/checkpoint/CheckpointManager.java
@@ -316,6 +316,20 @@ public class CheckpointManager implements AutoCloseable {
     return oldestMemTableInfo;
   }
 
+  /**
+   * Get version id of first valid .wal file
+   *
+   * @return Return {@link Long#MIN_VALUE} if no file is valid
+   */
+  public long getFirstValidWALVersionId() {
+    List<MemTableInfo> memTableInfos = snapshotMemTableInfos();
+    long firstValidVersionId = memTableInfos.isEmpty() ? Long.MIN_VALUE : Long.MAX_VALUE;
+    for (MemTableInfo memTableInfo : memTableInfos) {
+      firstValidVersionId = Math.min(firstValidVersionId, memTableInfo.getFirstFileVersionId());
+    }
+    return firstValidVersionId;
+  }
+
   /** Get total cost of active memTables. */
   public long getTotalCostOfActiveMemTables() {
     List<MemTableInfo> memTableInfos = snapshotMemTableInfos();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
@@ -229,7 +229,6 @@ public class WALNode implements IWALNode {
 
     private int fileIndexAfterFilterSafelyDeleteIndex = Integer.MAX_VALUE;
     private List<String> successfullyDeleted = new ArrayList<>();
-    private List<String> failDeleted = new ArrayList<>();
     private long deleteFileSize = 0;
 
     public DeleteOutdatedFileTask() {
@@ -361,7 +360,6 @@ public class WALNode implements IWALNode {
           deleteFileSize += fileSize;
           successfullyDeleted.add(filesShouldDelete[i].getName());
         } else {
-          failDeleted.add(filesShouldDelete[i].getName());
           logger.info(
               "Fail to delete outdated wal file {} of wal node-{}.",
               filesShouldDelete[i],

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/checkpoint/CheckpointManagerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/checkpoint/CheckpointManagerTest.java
@@ -116,7 +116,7 @@ public class CheckpointManagerTest {
     }
     executorService.shutdown();
     // check first valid version id
-    assertEquals(memTablesNum / 2, checkpointManager.getFirstValidWALVersionId());
+    //    assertEquals(memTablesNum / 2, checkpointManager.getFirstValidWALVersionId());
     // recover info from checkpoint file
     Map<Long, MemTableInfo> actualMemTableId2Info =
         CheckpointRecoverUtils.recoverMemTableInfo(new File(logDirectory)).getMemTableId2Info();
@@ -151,7 +151,7 @@ public class CheckpointManagerTest {
       }
     }
     // check first valid version id
-    assertEquals(5, checkpointManager.getFirstValidWALVersionId());
+    //    assertEquals(5, checkpointManager.getFirstValidWALVersionId());
     // check checkpoint files
     assertFalse(
         new File(logDirectory + File.separator + CheckpointFileUtils.getLogFileName(0)).exists());

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/checkpoint/CheckpointManagerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/checkpoint/CheckpointManagerTest.java
@@ -116,7 +116,7 @@ public class CheckpointManagerTest {
     }
     executorService.shutdown();
     // check first valid version id
-    //    assertEquals(memTablesNum / 2, checkpointManager.getFirstValidWALVersionId());
+    assertEquals(memTablesNum / 2, checkpointManager.getFirstValidWALVersionId());
     // recover info from checkpoint file
     Map<Long, MemTableInfo> actualMemTableId2Info =
         CheckpointRecoverUtils.recoverMemTableInfo(new File(logDirectory)).getMemTableId2Info();
@@ -151,7 +151,7 @@ public class CheckpointManagerTest {
       }
     }
     // check first valid version id
-    //    assertEquals(5, checkpointManager.getFirstValidWALVersionId());
+    assertEquals(5, checkpointManager.getFirstValidWALVersionId());
     // check checkpoint files
     assertFalse(
         new File(logDirectory + File.separator + CheckpointFileUtils.getLogFileName(0)).exists());


### PR DESCRIPTION
This commit reconstructs the execution logic of DeleteOutdatedFileTask, abstracting the collation logic into the following steps:
1. Delete obsolete wal files
2. Update the valid information ratio
3. Determine whether snapshot or flush is required based on the valid information ratio
4. Summarize the execution result and export it

In addition, there are two updates:
1. The initial assignment process of the property is moved to the constructor, which makes the code look cleaner.
2. If the retry process after snapshot or flush is deleted, it is difficult to execute statistics containing multiple retry results at a time.