### PR TITLE
[IOTDB-6098] Fix a possible flush error when using aligned timeseries

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBInsertAlignedValues2IT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBInsertAlignedValues2IT.java
@@ -113,4 +113,16 @@ public class IoTDBInsertAlignedValues2IT {
       }
     }
   }
+
+  @Test
+  public void testInsertAlignedWithEmptyPage2() throws SQLException {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("insert into root.sg.d1(time, s1,s2) aligned values(1,'aa','bb')");
+      statement.execute("insert into root.sg.d1(time, s1,s2) aligned values(1,'aa','bb')");
+      statement.execute("insert into root.sg.d1(time, s1,s2) aligned values(1,'aa','bb')");
+      statement.execute("flush");
+      statement.execute("insert into root.sg.d1(time, s1,s2) aligned values(1,'aa','bb')");
+    }
+  }
 }

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/page/TimePageWriter.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/page/TimePageWriter.java
@@ -71,7 +71,9 @@ public class TimePageWriter {
     for (int i = arrayOffset; i < batchSize + arrayOffset; i++) {
       timeEncoder.encode(timestamps[i], timeOut);
     }
-    statistics.update(timestamps, batchSize, arrayOffset);
+    if (batchSize != 0) {
+      statistics.update(timestamps, batchSize, arrayOffset);
+    }
   }
 
   /** flush all data remained in encoders. */


### PR DESCRIPTION
## Description
![WJex1jTxHy](https://github.com/apache/iotdb/assets/25913899/0c56b986-7ee0-4cc4-b16e-19ed62d347c3)


To reproduce, set `max_number_of_points_in_page = 2`.

Then execute the following sqls:
```sql
insert into root.sg.d1(time, s1,s2) aligned values(1,'aa','bb')
insert into root.sg.d1(time, s1,s2) aligned values(1,'aa','bb')
insert into root.sg.d1(time, s1,s2) aligned values(1,'aa','bb')
flush
```

The reason of this bug is sometimes time page may be empty, we do not need to update the statistics. 
 