### PR TITLE
[IOTDB-6097] Pipe: Avoid subscrption running with the pattern option causing OOM & Fix de/ser of RecoverProgressIndex

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/PipeRealtimeDataRegionHybridExtractor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/PipeRealtimeDataRegionHybridExtractor.java
@@ -81,7 +81,7 @@ public class PipeRealtimeDataRegionHybridExtractor extends PipeRealtimeDataRegio
     }
 
     if (!event.getTsFileEpoch().getState(this).equals(TsFileEpoch.State.USING_TSFILE)
-        && !pendingQueue.offer(event)) {
+        && !pendingQueue.waitedOffer(event)) {
       LOGGER.warn(
           "extractTabletInsertion: pending queue of PipeRealtimeDataRegionHybridExtractor {} "
               + "has reached capacity, discard tablet event {}, current state {}",
@@ -101,7 +101,7 @@ public class PipeRealtimeDataRegionHybridExtractor extends PipeRealtimeDataRegio
             state ->
                 state.equals(TsFileEpoch.State.EMPTY) ? TsFileEpoch.State.USING_TSFILE : state);
 
-    if (!pendingQueue.offer(event)) {
+    if (!pendingQueue.waitedOffer(event)) {
       LOGGER.warn(
           "extractTsFileInsertion: pending queue of PipeRealtimeDataRegionHybridExtractor {} "
               + "has reached capacity, discard TsFile event {}, current state {}",

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/PipeRealtimeDataRegionLogExtractor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/PipeRealtimeDataRegionLogExtractor.java
@@ -51,7 +51,7 @@ public class PipeRealtimeDataRegionLogExtractor extends PipeRealtimeDataRegionEx
       return;
     }
 
-    if (!pendingQueue.offer(event)) {
+    if (!pendingQueue.waitedOffer(event)) {
       LOGGER.warn(
           "extract: pending queue of PipeRealtimeDataRegionLogExtractor {} "
               + "has reached capacity, discard tablet event {}, current state {}",

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/PipeRealtimeDataRegionTsFileExtractor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/PipeRealtimeDataRegionTsFileExtractor.java
@@ -51,7 +51,7 @@ public class PipeRealtimeDataRegionTsFileExtractor extends PipeRealtimeDataRegio
       return;
     }
 
-    if (!pendingQueue.offer(event)) {
+    if (!pendingQueue.waitedOffer(event)) {
       LOGGER.warn(
           "extract: pending queue of PipeRealtimeDataRegionTsFileExtractor {} "
               + "has reached capacity, discard TsFile event {}, current state {}",

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/connection/BlockingPendingQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/connection/BlockingPendingQueue.java
@@ -41,15 +41,25 @@ public abstract class BlockingPendingQueue<E extends Event> {
     this.pendingQueue = pendingQueue;
   }
 
-  public boolean offer(E event) {
-    boolean isAdded = false;
+  public boolean waitedOffer(E event) {
     try {
-      isAdded = pendingQueue.offer(event, MAX_BLOCKING_TIME_MS, TimeUnit.MILLISECONDS);
+      return pendingQueue.offer(event, MAX_BLOCKING_TIME_MS, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
       LOGGER.info("pending queue offer is interrupted.", e);
       Thread.currentThread().interrupt();
+      return false;
     }
-    return isAdded;
+  }
+
+  public boolean directOffer(E event) {
+    try {
+      pendingQueue.put(event);
+      return true;
+    } catch (InterruptedException e) {
+      LOGGER.info("pending queue offer is interrupted.", e);
+      Thread.currentThread().interrupt();
+      return false;
+    }
   }
 
   public E directPoll() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/connection/BlockingPendingQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/connection/BlockingPendingQueue.java
@@ -52,11 +52,15 @@ public abstract class BlockingPendingQueue<E extends Event> {
   }
 
   public boolean directOffer(E event) {
+    return pendingQueue.offer(event);
+  }
+
+  public boolean put(E event) {
     try {
       pendingQueue.put(event);
       return true;
     } catch (InterruptedException e) {
-      LOGGER.info("pending queue offer is interrupted.", e);
+      LOGGER.info("pending queue put is interrupted.", e);
       Thread.currentThread().interrupt();
       return false;
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/connection/PipeEventCollector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/connection/PipeEventCollector.java
@@ -20,16 +20,27 @@
 package org.apache.iotdb.db.pipe.task.connection;
 
 import org.apache.iotdb.db.pipe.event.EnrichedEvent;
+import org.apache.iotdb.db.pipe.event.common.tablet.PipeRawTabletInsertionEvent;
 import org.apache.iotdb.pipe.api.collector.EventCollector;
 import org.apache.iotdb.pipe.api.event.Event;
-import org.apache.iotdb.pipe.api.exception.PipeException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedList;
+import java.util.Queue;
 
 public class PipeEventCollector implements EventCollector {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(PipeEventCollector.class);
+
   private final BoundedBlockingPendingQueue<Event> pendingQueue;
+
+  private final Queue<Event> bufferQueue;
 
   public PipeEventCollector(BoundedBlockingPendingQueue<Event> pendingQueue) {
     this.pendingQueue = pendingQueue;
+    bufferQueue = new LinkedList<>();
   }
 
   @Override
@@ -38,8 +49,44 @@ public class PipeEventCollector implements EventCollector {
       ((EnrichedEvent) event).increaseReferenceCount(PipeEventCollector.class.getName());
     }
 
-    if (!pendingQueue.directOffer(event)) {
-      throw new PipeException("Unexpected error: interrupted while offering event to queue");
+    while (!bufferQueue.isEmpty()) {
+      final Event bufferedEvent = bufferQueue.peek();
+      // Try to put already buffered events into pending queue, if pending queue is full, wait for
+      // pending queue to be available with timeout.
+      if (pendingQueue.waitedOffer(bufferedEvent)) {
+        bufferQueue.poll();
+      } else {
+        // If timeout, we judge whether the new event is a PipeRawTabletInsertionEvent. If it is,
+        // we wait for pending queue to be available without timeout until the pending queue is
+        // available. We don't put PipeRawTabletInsertionEvent into buffer queue, because it is
+        // memory consuming, holding too many PipeRawTabletInsertionEvent in buffer queue may cause
+        // OOM.
+        if (event instanceof PipeRawTabletInsertionEvent) {
+          if (pendingQueue.put(bufferedEvent)) {
+            bufferQueue.poll();
+          } else {
+            LOGGER.warn("interrupted when putting event into pending queue, event: {}", event);
+            bufferQueue.offer(event);
+            return;
+          }
+        } else {
+          bufferQueue.offer(event);
+          return;
+        }
+      }
+    }
+
+    if (!pendingQueue.waitedOffer(event)) {
+      // PipeRawTabletInsertionEvent is memory consuming, so we should not put it into buffer queue
+      // when pending queue is full. Otherwise, it may cause OOM.
+      if (event instanceof PipeRawTabletInsertionEvent) {
+        if (!pendingQueue.put(event)) {
+          LOGGER.warn("interrupted when putting event into pending queue, event: {}", event);
+          bufferQueue.offer(event);
+        }
+      } else {
+        bufferQueue.offer(event);
+      }
     }
   }
 }

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -962,7 +962,7 @@ cluster_name=defaultCluster
 # pipe_hardlink_wal_enabled=false
 
 # The row size of tablets created in pipe transfer.
-# pipe_data_structure_tablet_row_size=65536
+# pipe_data_structure_tablet_row_size=16384
 
 # The maximum number of threads that can be used to execute the pipe subtasks in PipeSubtaskExecutor.
 # pipe_subtask_executor_max_thread_num=5
@@ -983,11 +983,11 @@ cluster_name=defaultCluster
 # pipe_extractor_matcher_cache_size=1024
 
 # The capacity for the number of tablet events that can be stored in the pending queue of the hybrid realtime extractor.
-# pipe_extractor_pending_queue_capacity=128
+# pipe_extractor_pending_queue_capacity=16
 
 # The limit for the number of tablet events that can be held in the pending queue of the hybrid realtime extractor.
 # Noted that: this should be less than or equals to realtimeExtractorPendingQueueCapacity
-# pipe_extractor_pending_queue_tablet_limit=64
+# pipe_extractor_pending_queue_tablet_limit=8
 
 # The connection timeout (in milliseconds) for the thrift client.
 # pipe_connector_timeout_ms=900000
@@ -999,7 +999,7 @@ cluster_name=defaultCluster
 # pipe_connector_retry_interval_ms=1000
 
 # The size of the pending queue for the PipeConnector to store the events.
-# pipe_connector_pending_queue_size=1024
+# pipe_connector_pending_queue_size=16
 
 # If the thrift RPC compression is enabled.
 # pipe_async_connector_rpc_thrift_compression_enabled=false

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -158,14 +158,14 @@ public class CommonConfig {
 
   private int pipeExtractorAssignerDisruptorRingBufferSize = 65536;
   private int pipeExtractorMatcherCacheSize = 1024;
-  private int pipeExtractorPendingQueueCapacity = 128;
+  private int pipeExtractorPendingQueueCapacity = 16;
   private int pipeExtractorPendingQueueTabletLimit = pipeExtractorPendingQueueCapacity / 2;
-  private int pipeDataStructureTabletRowSize = 65536;
+  private int pipeDataStructureTabletRowSize = 16384;
 
   private long pipeConnectorTimeoutMs = 15 * 60 * 1000L; // 15 minutes
   private int pipeConnectorReadFileBufferSize = 8388608;
   private long pipeConnectorRetryIntervalMs = 1000L;
-  private int pipeConnectorPendingQueueSize = 1024;
+  private int pipeConnectorPendingQueueSize = 16;
 
   private boolean pipeAsyncConnectorRPCThriftCompressionEnabled = false;
   private int pipeAsyncConnectorSelectorNumber = 1;

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/RecoverProgressIndex.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/RecoverProgressIndex.java
@@ -189,7 +189,7 @@ public class RecoverProgressIndex implements ProgressIndex {
     for (int i = 0; i < size; i++) {
       final int dataNodeId = ReadWriteIOUtils.readInt(byteBuffer);
       final SimpleProgressIndex simpleProgressIndex =
-          SimpleProgressIndex.deserializeFrom(byteBuffer);
+          (SimpleProgressIndex) ProgressIndexType.deserializeFrom(byteBuffer);
       recoverProgressIndex.dataNodeId2LocalIndex.put(dataNodeId, simpleProgressIndex);
     }
     return recoverProgressIndex;
@@ -200,7 +200,8 @@ public class RecoverProgressIndex implements ProgressIndex {
     final int size = ReadWriteIOUtils.readInt(stream);
     for (int i = 0; i < size; i++) {
       final int dataNodeId = ReadWriteIOUtils.readInt(stream);
-      final SimpleProgressIndex simpleProgressIndex = SimpleProgressIndex.deserializeFrom(stream);
+      final SimpleProgressIndex simpleProgressIndex =
+          (SimpleProgressIndex) ProgressIndexType.deserializeFrom(stream);
       recoverProgressIndex.dataNodeId2LocalIndex.put(dataNodeId, simpleProgressIndex);
     }
     return recoverProgressIndex;


### PR DESCRIPTION
This commit fixes 2 issues:

* Subscrption running with the pattern option may cause OOM

  How to reproduce:
  
  1. execute sql:
  ```
  create pipe test1 
  with extractor (
    'extractor.history.enable'='false', 
    'extractor'='iotdb-extractor', 
    'extractor.realtime.mode'='log',
    'extractor.pattern'='root'
  ) 
  with connector (
    'connector'='iotdb-thrift-connector-v1',
    'connector.node-urls'='127.0.0.1:6668'
  );

  start pipe test1;
  ```

  2. run benchmark: 1 database, 10 devices, 10 measurements.

* java.lang.UnsupportedOperationException: Unsupported PipeRuntimeException type 0 caused by de/ser issue of RecoverProgressIndex
  <img width="1194" alt="image" src="https://github.com/apache/iotdb/assets/30497621/d2d35ee7-293b-4594-92f3-fc10b2aa8313">
