### PR TITLE
Stop generating FilterExpression if we don't specify the time filter in last query session api

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/ClientRPCServiceImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/ClientRPCServiceImpl.java
@@ -952,7 +952,7 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
       paths.add(req.deviceId + "." + sensor);
     }
     TSLastDataQueryReq tsLastDataQueryReq =
-        new TSLastDataQueryReq(req.sessionId, paths, 0, req.statementId);
+        new TSLastDataQueryReq(req.sessionId, paths, Long.MIN_VALUE, req.statementId);
     tsLastDataQueryReq.setFetchSize(req.fetchSize);
     tsLastDataQueryReq.setEnableRedirectQuery(req.enableRedirectQuery);
     tsLastDataQueryReq.setLegalPathNodes(req.legalPathNodes);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/parser/StatementGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/parser/StatementGenerator.java
@@ -197,18 +197,21 @@ public class StatementGenerator {
         new ResultColumn(
             new TimeSeriesOperand(new PartialPath("", false)), ResultColumn.ColumnType.RAW));
 
-    // set query filter
-    WhereCondition whereCondition = new WhereCondition();
-    GreaterEqualExpression predicate =
-        new GreaterEqualExpression(
-            new TimestampOperand(),
-            new ConstantOperand(TSDataType.INT64, Long.toString(lastDataQueryReq.getTime())));
-    whereCondition.setPredicate(predicate);
-
     QueryStatement lastQueryStatement = new QueryStatement();
+
+    if (lastDataQueryReq.getTime() != Long.MIN_VALUE) {
+      // set query filter
+      WhereCondition whereCondition = new WhereCondition();
+      GreaterEqualExpression predicate =
+          new GreaterEqualExpression(
+              new TimestampOperand(),
+              new ConstantOperand(TSDataType.INT64, Long.toString(lastDataQueryReq.getTime())));
+      whereCondition.setPredicate(predicate);
+      lastQueryStatement.setWhereCondition(whereCondition);
+    }
+
     lastQueryStatement.setSelectComponent(selectComponent);
     lastQueryStatement.setFromComponent(fromComponent);
-    lastQueryStatement.setWhereCondition(whereCondition);
     PERFORMANCE_OVERVIEW_METRICS.recordParseCost(System.nanoTime() - startTime);
 
     return lastQueryStatement;


### PR DESCRIPTION
Generate TimeFilterExpression defaultly, we  stop us from putting NullCacheEntry in LastCache. 