### PR TITLE
[IOTDB-6104] Remove tmp directory for udf query completely while query end

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/TemporaryQueryDataFileService.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/TemporaryQueryDataFileService.java
@@ -83,7 +83,7 @@ public class TemporaryQueryDataFileService implements IService {
       }
     }
     try {
-      FileUtils.cleanDirectory(SystemFileFactory.INSTANCE.getFile(getDirName(queryId)));
+      FileUtils.deleteDirectory(SystemFileFactory.INSTANCE.getFile(getDirName(queryId)));
     } catch (IOException e) {
       logger.warn(
           String.format("Failed to clean dir in method deregister(%s), because %s", queryId, e));


### PR DESCRIPTION
We use `deleteDirectory` instead of `cleanDirectory`.

`cleanDirectory` will only delete all the files in that directory, but will not delete the directory itself.

`deleteDirectory` will delete a directory recursively, including itself.