### PR TITLE
[IOTDB-6108] Fix AlignedTVList memory calculation is imprecise

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
@@ -668,7 +668,7 @@ public class TsFileProcessor {
       }
       long acquireArray;
       if (alignedMemChunk.alignedListSize() % PrimitiveArrayManager.ARRAY_SIZE == 0) {
-        acquireArray = (end - start) / PrimitiveArrayManager.ARRAY_SIZE + 1;
+        acquireArray = (end - start) / PrimitiveArrayManager.ARRAY_SIZE + 1L;
       } else {
         acquireArray =
             (end

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
@@ -464,42 +464,54 @@ public class TsFileProcessor {
     long memTableIncrement = 0L;
     long textDataIncrement = 0L;
     long chunkMetadataIncrement = 0L;
-    AlignedWritableMemChunk alignedMemChunk = null;
     // get device id
     IDeviceID deviceID = getDeviceID(deviceId);
-
     if (workMemTable.checkIfChunkDoesNotExist(deviceID, AlignedPath.VECTOR_PLACEHOLDER)) {
+      // for new device of this mem table
       // ChunkMetadataIncrement
       chunkMetadataIncrement +=
           ChunkMetadata.calculateRamSize(AlignedPath.VECTOR_PLACEHOLDER, TSDataType.VECTOR)
               * dataTypes.length;
       memTableIncrement += AlignedTVList.alignedTvListArrayMemCost(dataTypes);
+      for (int i = 0; i < dataTypes.length; i++) {
+        // skip failed Measurements
+        if (dataTypes[i] == null || measurements[i] == null) {
+          continue;
+        }
+        // TEXT data mem size
+        if (dataTypes[i] == TSDataType.TEXT && values[i] != null) {
+          textDataIncrement += MemUtils.getBinarySize((Binary) values[i]);
+        }
+      }
     } else {
-      // here currentChunkPointNum >= 1
-      long currentChunkPointNum =
-          workMemTable.getCurrentTVListSize(deviceID, AlignedPath.VECTOR_PLACEHOLDER);
-      memTableIncrement +=
-          (currentChunkPointNum % PrimitiveArrayManager.ARRAY_SIZE) == 0
-              ? AlignedTVList.alignedTvListArrayMemCost(dataTypes)
-              : 0;
-      alignedMemChunk =
+      // for existed device of this mem table
+      AlignedWritableMemChunk alignedMemChunk =
           ((AlignedWritableMemChunkGroup) workMemTable.getMemTableMap().get(deviceID))
               .getAlignedMemChunk();
-    }
-    for (int i = 0; i < dataTypes.length; i++) {
-      // skip failed Measurements
-      if (dataTypes[i] == null || measurements[i] == null) {
-        continue;
+      List<TSDataType> dataTypesInTVList = new ArrayList<>();
+      for (int i = 0; i < dataTypes.length; i++) {
+        // skip failed Measurements
+        if (dataTypes[i] == null || measurements[i] == null) {
+          continue;
+        }
+
+        // extending the column of aligned mem chunk
+        if (!alignedMemChunk.containsMeasurement(measurements[i])) {
+          memTableIncrement +=
+              (alignedMemChunk.alignedListSize() / PrimitiveArrayManager.ARRAY_SIZE + 1)
+                  * AlignedTVList.valueListArrayMemCost(dataTypes[i]);
+          dataTypesInTVList.add(dataTypes[i]);
+        }
+        // TEXT data mem size
+        if (dataTypes[i] == TSDataType.TEXT && values[i] != null) {
+          textDataIncrement += MemUtils.getBinarySize((Binary) values[i]);
+        }
       }
-      // extending the column of aligned mem chunk
-      if (alignedMemChunk != null && !alignedMemChunk.containsMeasurement(measurements[i])) {
+      // here currentChunkPointNum >= 1
+      if ((alignedMemChunk.alignedListSize() % PrimitiveArrayManager.ARRAY_SIZE) == 0) {
+        dataTypesInTVList.addAll(((AlignedTVList) alignedMemChunk.getTVList()).getTsDataTypes());
         memTableIncrement +=
-            (alignedMemChunk.alignedListSize() / PrimitiveArrayManager.ARRAY_SIZE + 1)
-                * dataTypes[i].getDataTypeSize();
-      }
-      // TEXT data mem size
-      if (dataTypes[i] == TSDataType.TEXT && values[i] != null) {
-        textDataIncrement += MemUtils.getBinarySize((Binary) values[i]);
+            AlignedTVList.alignedTvListArrayMemCost(dataTypesInTVList.toArray(new TSDataType[0]));
       }
     }
     updateMemoryInfo(memTableIncrement, chunkMetadataIncrement, textDataIncrement);
@@ -586,8 +598,9 @@ public class TsFileProcessor {
         long acquireArray =
             (end - start - 1 + (currentChunkPointNum % PrimitiveArrayManager.ARRAY_SIZE))
                 / PrimitiveArrayManager.ARRAY_SIZE;
-        memIncrements[0] +=
-            acquireArray == 0 ? 0 : acquireArray * TVList.tvListArrayMemCost(dataType);
+        if (acquireArray != 0) {
+          memIncrements[0] += acquireArray * TVList.tvListArrayMemCost(dataType);
+        }
       }
     }
     // TEXT data size
@@ -605,7 +618,6 @@ public class TsFileProcessor {
       int end,
       long[] memIncrements,
       Object[] columns) {
-    AlignedWritableMemChunk vectorMemChunk = null;
     // memIncrements = [memTable, text, chunk metadata] respectively
     if (workMemTable.checkIfChunkDoesNotExist(deviceId, AlignedPath.VECTOR_PLACEHOLDER)) {
       // ChunkMetadataIncrement
@@ -615,43 +627,62 @@ public class TsFileProcessor {
       memIncrements[0] +=
           ((end - start) / PrimitiveArrayManager.ARRAY_SIZE + 1)
               * AlignedTVList.alignedTvListArrayMemCost(dataTypes);
-    } else {
-      int currentChunkPointNum =
-          (int) workMemTable.getCurrentTVListSize(deviceId, AlignedPath.VECTOR_PLACEHOLDER);
-      if (currentChunkPointNum % PrimitiveArrayManager.ARRAY_SIZE == 0) {
-        memIncrements[0] +=
-            ((end - start) / PrimitiveArrayManager.ARRAY_SIZE + 1)
-                * AlignedTVList.alignedTvListArrayMemCost(dataTypes);
-      } else {
-        int acquireArray =
-            (end - start - 1 + (currentChunkPointNum % PrimitiveArrayManager.ARRAY_SIZE))
-                / PrimitiveArrayManager.ARRAY_SIZE;
-        memIncrements[0] +=
-            acquireArray == 0
-                ? 0
-                : acquireArray * AlignedTVList.alignedTvListArrayMemCost(dataTypes);
+      for (int i = 0; i < dataTypes.length; i++) {
+        TSDataType dataType = dataTypes[i];
+        String measurement = measurementIds[i];
+        Object column = columns[i];
+        if (dataType == null || column == null || measurement == null) {
+          continue;
+        }
+        // TEXT data size
+        if (dataType == TSDataType.TEXT) {
+          Binary[] binColumn = (Binary[]) columns[i];
+          memIncrements[1] += MemUtils.getBinaryColumnSize(binColumn, start, end);
+        }
       }
-      vectorMemChunk =
+
+    } else {
+      AlignedWritableMemChunk alignedMemChunk =
           ((AlignedWritableMemChunkGroup) workMemTable.getMemTableMap().get(deviceId))
               .getAlignedMemChunk();
-    }
-    for (int i = 0; i < dataTypes.length; i++) {
-      TSDataType dataType = dataTypes[i];
-      String measurement = measurementIds[i];
-      Object column = columns[i];
-      if (dataType == null || column == null || measurement == null) {
-        continue;
+      List<TSDataType> dataTypesInTVList = new ArrayList<>();
+      for (int i = 0; i < dataTypes.length; i++) {
+        TSDataType dataType = dataTypes[i];
+        String measurement = measurementIds[i];
+        Object column = columns[i];
+        if (dataType == null || column == null || measurement == null) {
+          continue;
+        }
+        // extending the column of aligned mem chunk
+        if (!alignedMemChunk.containsMeasurement(measurementIds[i])) {
+          memIncrements[0] +=
+              (alignedMemChunk.alignedListSize() / PrimitiveArrayManager.ARRAY_SIZE + 1)
+                  * AlignedTVList.valueListArrayMemCost(dataType);
+          dataTypesInTVList.add(dataType);
+        }
+        // TEXT data size
+        if (dataType == TSDataType.TEXT) {
+          Binary[] binColumn = (Binary[]) columns[i];
+          memIncrements[1] += MemUtils.getBinaryColumnSize(binColumn, start, end);
+        }
       }
-      // extending the column of aligned mem chunk
-      if (vectorMemChunk != null && !vectorMemChunk.containsMeasurement(measurementIds[i])) {
+      long acquireArray;
+      if (alignedMemChunk.alignedListSize() % PrimitiveArrayManager.ARRAY_SIZE == 0) {
+        acquireArray = (end - start) / PrimitiveArrayManager.ARRAY_SIZE + 1;
+      } else {
+        acquireArray =
+            (end
+                    - start
+                    - 1
+                    + (alignedMemChunk.alignedListSize() % PrimitiveArrayManager.ARRAY_SIZE))
+                / PrimitiveArrayManager.ARRAY_SIZE;
+      }
+      if (acquireArray != 0) {
+        dataTypesInTVList.addAll(((AlignedTVList) alignedMemChunk.getTVList()).getTsDataTypes());
         memIncrements[0] +=
-            (vectorMemChunk.alignedListSize() / PrimitiveArrayManager.ARRAY_SIZE + 1)
-                * dataType.getDataTypeSize();
-      }
-      // TEXT data size
-      if (dataType == TSDataType.TEXT) {
-        Binary[] binColumn = (Binary[]) columns[i];
-        memIncrements[1] += MemUtils.getBinaryColumnSize(binColumn, start, end);
+            acquireArray
+                * AlignedTVList.alignedTvListArrayMemCost(
+                    dataTypesInTVList.toArray(new TSDataType[0]));
       }
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
@@ -510,8 +510,7 @@ public class TsFileProcessor {
       // here currentChunkPointNum >= 1
       if ((alignedMemChunk.alignedListSize() % PrimitiveArrayManager.ARRAY_SIZE) == 0) {
         dataTypesInTVList.addAll(((AlignedTVList) alignedMemChunk.getTVList()).getTsDataTypes());
-        memTableIncrement +=
-            AlignedTVList.alignedTvListArrayMemCost(dataTypesInTVList.toArray(new TSDataType[0]));
+        memTableIncrement += AlignedTVList.alignedTvListArrayMemCost(dataTypesInTVList);
       }
     }
     updateMemoryInfo(memTableIncrement, chunkMetadataIncrement, textDataIncrement);
@@ -680,9 +679,7 @@ public class TsFileProcessor {
       if (acquireArray != 0) {
         dataTypesInTVList.addAll(((AlignedTVList) alignedMemChunk.getTVList()).getTsDataTypes());
         memIncrements[0] +=
-            acquireArray
-                * AlignedTVList.alignedTvListArrayMemCost(
-                    dataTypesInTVList.toArray(new TSDataType[0]));
+            acquireArray * AlignedTVList.alignedTvListArrayMemCost(dataTypesInTVList);
       }
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
@@ -855,6 +855,35 @@ public abstract class AlignedTVList extends TVList {
   }
 
   /**
+   * Get the single alignedTVList array mem cost by give types.
+   *
+   * @param types the types in the vector
+   * @return AlignedTvListArrayMemSize
+   */
+  public static long alignedTvListArrayMemCost(List<TSDataType> types) {
+    long size = 0;
+    // value array mem size
+    for (TSDataType type : types) {
+      if (type != null) {
+        size += (long) PrimitiveArrayManager.ARRAY_SIZE * (long) type.getDataTypeSize();
+      }
+    }
+    // size is 0 when all types are null
+    if (size == 0) {
+      return size;
+    }
+    // time array mem size
+    size += PrimitiveArrayManager.ARRAY_SIZE * 8L;
+    // index array mem size
+    size += PrimitiveArrayManager.ARRAY_SIZE * 4L;
+    // array headers mem size
+    size += (long) NUM_BYTES_ARRAY_HEADER * (2 + types.size());
+    // Object references size in ArrayList
+    size += (long) NUM_BYTES_OBJECT_REF * (2 + types.size());
+    return size;
+  }
+
+  /**
    * Get the single column array mem cost by give type.
    *
    * @param type the type of the value column

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
@@ -854,6 +854,23 @@ public abstract class AlignedTVList extends TVList {
     return size;
   }
 
+  /**
+   * Get the single column array mem cost by give type.
+   *
+   * @param type the type of the value column
+   * @return valueListArrayMemCost
+   */
+  public static long valueListArrayMemCost(TSDataType type) {
+    long size = 0;
+    // value array mem size
+    size += (long) PrimitiveArrayManager.ARRAY_SIZE * (long) type.getDataTypeSize();
+    // array headers mem size
+    size += NUM_BYTES_ARRAY_HEADER;
+    // Object references size in ArrayList
+    size += NUM_BYTES_OBJECT_REF;
+    return size;
+  }
+
   /** Build TsBlock by column. */
   public TsBlock buildTsBlock(
       int floatPrecision, List<TSEncoding> encodingList, List<List<TimeRange>> deletionList) {


### PR DESCRIPTION
## Description

When insert data into AlignedTVList like this way.
Insert 1000 rows of d1.s1 by aligned tablet interface, then insert 1000 rows of d1.s2, then then insert 1000 rows of d1.s3.
![image](https://github.com/apache/iotdb/assets/25913899/008ebbf6-80bb-485e-9510-7faa4858c55b)



The current logic will only calculate the black and purple part of memory cost. 

Beside, the calculation of purple part is not correct.

The correct calculation is acquired array number * memory size of an array, however, the current is acquired array number * memory size of a data point.