### PR TITLE
Fix a concurrent bug when recover last flush time and compact

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/HashLastFlushTimeMap.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/HashLastFlushTimeMap.java
@@ -20,15 +20,12 @@
 package org.apache.iotdb.db.storageengine.dataregion;
 
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileManager;
-import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class HashLastFlushTimeMap implements ILastFlushTimeMap {
 
@@ -228,19 +225,9 @@ public class HashLastFlushTimeMap implements ILastFlushTimeMap {
   }
 
   private long recoverFlushTime(long partitionId, String devicePath) {
-    List<TsFileResource> tsFileResourceList =
-        tsFileManager.getOrCreateSequenceListByTimePartition(partitionId);
-
-    for (int i = tsFileResourceList.size() - 1; i >= 0; i--) {
-      Set<String> deviceSet = tsFileResourceList.get(i).getDevices();
-      if (deviceSet.contains(devicePath)) {
-        return tsFileResourceList.get(i).getEndTime(devicePath);
-      }
-    }
-
     long memCost = HASHMAP_NODE_BASIC_SIZE + 2L * devicePath.length();
     memCostForEachPartition.compute(partitionId, (k, v) -> v == null ? memCost : v + memCost);
-    return Long.MIN_VALUE;
+    return tsFileManager.recoverFlushTimeFromTsFileResource(partitionId, devicePath);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileManager.java
@@ -92,6 +92,23 @@ public class TsFileManager {
     }
   }
 
+  public long recoverFlushTimeFromTsFileResource(long partitionId, String devicePath) {
+    writeLock("recoverFlushTimeFromTsFileResource");
+    try {
+      List<TsFileResource> tsFileResourceList =
+          sequenceFiles.computeIfAbsent(partitionId, l -> new TsFileResourceList());
+      for (int i = tsFileResourceList.size() - 1; i >= 0; i--) {
+        Set<String> deviceSet = tsFileResourceList.get(i).getDevices();
+        if (deviceSet.contains(devicePath)) {
+          return tsFileResourceList.get(i).getEndTime(devicePath);
+        }
+      }
+    } finally {
+      writeUnlock();
+    }
+    return Long.MIN_VALUE;
+  }
+
   public Iterator<TsFileResource> getIterator(boolean sequence) {
     readLock();
     try {


### PR DESCRIPTION
## Description

![img_v2_5c7a784d-aeae-4609-9692-f3e181c71a3g](https://github.com/apache/iotdb/assets/25913899/e02d85ea-24ac-4baa-96fb-2665ec52afb8)

The bug of this reason is when recover the last flush time from TsFileResource and the compaction change the TsFileList in TsFileManager at the same time.
