### PR TITLE
[IOTDB-6112] Fix Limit & Offset push down doesn't take effect while there exist time filter

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/AlignedSeriesScanUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/AlignedSeriesScanUtil.java
@@ -141,12 +141,11 @@ public class AlignedSeriesScanUtil extends SeriesScanUtil {
         && !isFileOverlapped()
         && !firstTimeSeriesMetadata.isModified()) {
       Filter queryFilter = scanOptions.getQueryFilter();
-      if (queryFilter != null) {
-        if (!queryFilter.satisfy(firstTimeSeriesMetadata.getStatistics())) {
-          skipCurrentFile();
-        }
-      } else {
+      Statistics statistics = firstTimeSeriesMetadata.getStatistics();
+      if (queryFilter == null || queryFilter.allSatisfy(statistics)) {
         skipOffsetByTimeSeriesMetadata();
+      } else if (!queryFilter.satisfy(statistics)) {
+        skipCurrentFile();
       }
     }
   }
@@ -178,12 +177,11 @@ public class AlignedSeriesScanUtil extends SeriesScanUtil {
   protected void filterFirstChunkMetadata() throws IOException {
     if (firstChunkMetadata != null && !isChunkOverlapped() && !firstChunkMetadata.isModified()) {
       Filter queryFilter = scanOptions.getQueryFilter();
-      if (queryFilter != null) {
-        if (!queryFilter.satisfy(firstChunkMetadata.getStatistics())) {
-          skipCurrentChunk();
-        }
-      } else {
+      Statistics statistics = firstChunkMetadata.getStatistics();
+      if (queryFilter == null || queryFilter.allSatisfy(statistics)) {
         skipOffsetByChunkMetadata();
+      } else if (!queryFilter.satisfy(statistics)) {
+        skipCurrentChunk();
       }
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/MemAlignedPageReader.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/MemAlignedPageReader.java
@@ -99,17 +99,16 @@ public class MemAlignedPageReader implements IPageReader, IAlignedPageReader {
   }
 
   private boolean pageSatisfy() {
-    if (valueFilter != null) {
-      return valueFilter.satisfy(getStatistics());
-    } else {
+    Statistics<? extends Serializable> statistics = getStatistics();
+    if (valueFilter == null || valueFilter.allSatisfy(statistics)) {
       // For aligned series, When we only read some measurements under an aligned device, if the
       // values of these queried measurements at a timestamp are all null, the timestamp will not be
       // selected.
       // NOTE: if we change the read semantic in the future for aligned series, we need to remove
       // this check here.
       long rowCount = getTimeStatistics().getCount();
-      for (Statistics<? extends Serializable> statistics : getValueStatisticsList()) {
-        if (statistics == null || statistics.hasNullValue(rowCount)) {
+      for (Statistics<? extends Serializable> vStatistics : getValueStatisticsList()) {
+        if (vStatistics == null || vStatistics.hasNullValue(rowCount)) {
           return true;
         }
       }
@@ -118,9 +117,12 @@ public class MemAlignedPageReader implements IPageReader, IAlignedPageReader {
       if (paginationController.hasCurOffset(rowCount)) {
         paginationController.consumeOffset(rowCount);
         return false;
+      } else {
+        return true;
       }
+    } else {
+      return valueFilter.satisfy(statistics);
     }
-    return true;
   }
 
   @Override

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/AlignedPageReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/AlignedPageReader.java
@@ -118,18 +118,16 @@ public class AlignedPageReader implements IPageReader, IAlignedPageReader {
   }
 
   private boolean pageSatisfy() {
-    if (filter != null) {
-      // TODO accept valueStatisticsList to filter
-      return filter.satisfy(getStatistics());
-    } else {
+    Statistics statistics = getStatistics();
+    if (filter == null || filter.allSatisfy(statistics)) {
       // For aligned series, When we only query some measurements under an aligned device, if the
       // values of these queried measurements at a timestamp are all null, the timestamp will not be
       // selected.
       // NOTE: if we change the query semantic in the future for aligned series, we need to remove
       // this check here.
       long rowCount = getTimeStatistics().getCount();
-      for (Statistics statistics : getValueStatisticsList()) {
-        if (statistics == null || statistics.hasNullValue(rowCount)) {
+      for (Statistics vStatistics : getValueStatisticsList()) {
+        if (vStatistics == null || vStatistics.hasNullValue(rowCount)) {
           return true;
         }
       }
@@ -138,9 +136,13 @@ public class AlignedPageReader implements IPageReader, IAlignedPageReader {
       if (paginationController.hasCurOffset(rowCount)) {
         paginationController.consumeOffset(rowCount);
         return false;
+      } else {
+        return true;
       }
+    } else {
+      // TODO accept valueStatisticsList to filter
+      return filter.satisfy(statistics);
     }
-    return true;
   }
 
   @Override


### PR DESCRIPTION
Previously, for aligned time series, we only use statistics to skip offset while the queryFilter is null, however if the query filter is time filter, it can also use that.