### PR TITLE
Fix SchemaFileSketchTool is not found

### DIFF
--- a/iotdb-core/datanode/src/assembly/resources/tools/schema/print-pb-tree-file.sh
+++ b/iotdb-core/datanode/src/assembly/resources/tools/schema/print-pb-tree-file.sh
@@ -45,7 +45,7 @@ for f in ${IOTDB_HOME}/lib/*.jar; do
   CLASSPATH=${CLASSPATH}":"$f
 done
 
-MAIN_CLASS=org.apache.iotdb.db.tools.schema.SchemaFileSketchTool
+MAIN_CLASS=org.apache.iotdb.db.tools.schema.PBTreeFileSketchTool
 
 "$JAVA" -cp "$CLASSPATH" "$MAIN_CLASS" "$@"
 exit $?


### PR DESCRIPTION
`SchemaFileSketchTool` is renamed to `PBTreeFileSketchTool`.

<img width="1326" alt="image" src="https://github.com/apache/iotdb/assets/16079446/9abd6c00-7c30-43d8-b8d2-75423794c248">
