### PR TITLE
Remove useless dependency bugsnag

### DIFF
--- a/iotdb-core/datanode/pom.xml
+++ b/iotdb-core/datanode/pom.xml
@@ -275,6 +275,10 @@
                     <groupId>io.dropwizard.metrics</groupId>
                     <artifactId>metrics-jvm</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.bugsnag</groupId>
+                    <artifactId>bugsnag</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- for mocked test-->


### PR DESCRIPTION
The bugsnag dependency is of no use to us, so we will remove the dependency

- Bugsnag (https://www.bugsnag.com/platforms/java, https://github.com/bugsnag/bugsnag-java) is an error monitoring platform designed for real-time monitoring and tracking of errors and crashes within applications. It provides cross-platform error monitoring and reporting tools that assist development teams in swiftly identifying and resolving issues in applications, thereby delivering a more stable and efficient application experience. When errors, crashes, or exceptions occur during application runtime, Bugsnag captures and automatically reports relevant error information, including error stack traces, environmental details, user data, and more. Development teams can utilize Bugsnag's console to review error reports, analyze error trends, set up alert notifications, and other functionalities, enabling them to promptly respond to and rectify issues.

- moquette-broker (https://github.com/moquette-io/moquette) is a Java-based implementation of an MQTT broker used to construct MQTT (Message Queuing Telemetry Transport) message broker servers. MQTT is a lightweight messaging protocol commonly employed for communication in low-bandwidth or unstable network environments. moquette-broker allows users to establish their own MQTT broker servers, facilitating the implementation of MQTT's publish and subscribe mechanisms. It supports various functionalities such as handling connections from MQTT clients, message routing, subscription management, message pushing, and more. moquette-broker relies on Bugsnag (https://github.com/moquette-io/moquette/blob/main/broker/src/main/java/io/moquette/broker/BugSnagErrorsHandler.java#L38) to automatically report relevant error information when exceptions arise, subsequently visualizing this information on the monitoring platform.