### PR TITLE
reduce wal log output level

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
@@ -309,10 +309,12 @@ public class WALNode implements IWALNode {
 
     private void summarizeExecuteResult() {
       if (filesShouldDelete.length == 0) {
-        logger.debug(
-            "wal node-{}:no wal file was found that should be deleted, current first valid version id is {}",
-            identifier,
-            firstValidVersionId);
+        if (logger.isDebugEnabled()) {
+          logger.debug(
+              "wal node-{}:no wal file was found that should be deleted, current first valid version id is {}",
+              identifier,
+              firstValidVersionId);
+        }
         return;
       }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
@@ -309,8 +309,8 @@ public class WALNode implements IWALNode {
 
     private void summarizeExecuteResult() {
       if (filesShouldDelete.length == 0) {
-        logger.info(
-            "wal node-{}:no wal file was found that should be deleted,current first valid version id is {}",
+        logger.debug(
+            "wal node-{}:no wal file was found that should be deleted, current first valid version id is {}",
             identifier,
             firstValidVersionId);
         return;
@@ -322,7 +322,7 @@ public class WALNode implements IWALNode {
           StringBuilder summary =
               new StringBuilder(
                   String.format(
-                      "wal node-%s delete outdated files summary:the range that should be removed is: [%d,%d],delete successful is [%s],end file index is: [%s].The following reasons influenced the result: %s",
+                      "wal node-%s delete outdated files summary:the range that should be removed is: [%d,%d], delete successful is [%s], end file index is: [%s].The following reasons influenced the result: %s",
                       identifier,
                       WALFileUtils.parseVersionId(filesShouldDelete[0].getName()),
                       WALFileUtils.parseVersionId(
@@ -333,7 +333,7 @@ public class WALNode implements IWALNode {
 
           if (!pinnedMemTableIds.isEmpty()) {
             summary
-                .append("- MemTable has been flushed but pinned by PIPE,the MemTableId list is : ")
+                .append("- MemTable has been flushed but pinned by PIPE, the MemTableId list is : ")
                 .append(StringUtils.join(pinnedMemTableIds, ","))
                 .append(".")
                 .append(System.getProperty("line.separator"));
@@ -341,7 +341,7 @@ public class WALNode implements IWALNode {
           if (fileIndexAfterFilterSafelyDeleteIndex < filesShouldDelete.length) {
             summary.append(
                 String.format(
-                    "- The data in the wal file was not consumed by the consensus group,current search index is %d,safely delete index is %d",
+                    "- The data in the wal file was not consumed by the consensus group,current search index is %d, safely delete index is %d",
                     getCurrentSearchIndex(), safelyDeletedSearchIndex));
           }
           String summaryLog = summary.toString();


### PR DESCRIPTION
info logs are often printed unnecessarily when no outdated WAL files have been deleted. This fix will reduce the log level to debug. In addition, some optimization of the printed log content.

<img width="1207" alt="image" src="https://github.com/apache/iotdb/assets/34238279/6effc569-3a73-4860-beea-99890e40d290">
