### PR TITLE
[RatisConsensus] Unify read timeout to Thrift connection timeout

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/consensus/ConsensusManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/consensus/ConsensusManager.java
@@ -23,6 +23,8 @@ import org.apache.iotdb.common.rpc.thrift.TConfigNodeLocation;
 import org.apache.iotdb.common.rpc.thrift.TConsensusGroupType;
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
+import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.consensus.ConfigRegionId;
 import org.apache.iotdb.commons.consensus.ConsensusGroupId;
 import org.apache.iotdb.commons.exception.BadNodeUrlException;
@@ -62,6 +64,7 @@ public class ConsensusManager {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ConsensusManager.class);
   private static final ConfigNodeConfig CONF = ConfigNodeDescriptor.getInstance().getConf();
+  private static final CommonConfig COMMON_CONF = CommonDescriptor.getInstance().getConfig();
   private static final int SEED_CONFIG_NODE_ID = 0;
   /** There is only one ConfigNodeGroup */
   public static final ConsensusGroupId DEFAULT_CONSENSUS_GROUP_ID =
@@ -179,6 +182,14 @@ public class ConsensusManager {
                               .setImpl(
                                   RatisConfig.Impl.newBuilder()
                                       .setTriggerSnapshotFileSize(CONF.getConfigNodeRatisLogMax())
+                                      .build())
+                              .setRead(
+                                  RatisConfig.Read.newBuilder()
+                                      // use thrift connection timeout to unify read timeout
+                                      .setReadTimeout(
+                                          TimeDuration.valueOf(
+                                              COMMON_CONF.getConnectionTimeoutInMS(),
+                                              TimeUnit.MILLISECONDS))
                                       .build())
                               .build())
                       .setStorageDir(CONF.getConsensusDir())

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/DataRegionConsensusImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/DataRegionConsensusImpl.java
@@ -185,6 +185,14 @@ public class DataRegionConsensusImpl {
                                       .setBufferByteLimit(
                                           conf.getDataRatisConsensusLogAppenderBufferSizeMax())
                                       .build())
+                              .setRead(
+                                  RatisConfig.Read.newBuilder()
+                                      // use thrift connection timeout to unify read timeout
+                                      .setReadTimeout(
+                                          TimeDuration.valueOf(
+                                              conf.getConnectionTimeoutInMS(),
+                                              TimeUnit.MILLISECONDS))
+                                      .build())
                               .build())
                       .build(),
                   DataRegionConsensusImpl::createDataRegionStateMachine)

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/SchemaRegionConsensusImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/SchemaRegionConsensusImpl.java
@@ -135,6 +135,14 @@ public class SchemaRegionConsensusImpl {
                                       .setBufferByteLimit(
                                           conf.getSchemaRatisConsensusLogAppenderBufferSizeMax())
                                       .build())
+                              .setRead(
+                                  RatisConfig.Read.newBuilder()
+                                      // use thrift connection timeout to unify read timeout
+                                      .setReadTimeout(
+                                          TimeDuration.valueOf(
+                                              conf.getConnectionTimeoutInMS(),
+                                              TimeUnit.MILLISECONDS))
+                                      .build())
                               .build())
                       .setStorageDir(conf.getSchemaRegionConsensusDir())
                       .build(),


### PR DESCRIPTION
Currently RatisConsensus supports read timeout.
We should let it be consistent with our default request timeout, i.e. Thrift connection timeout.