### PR TITLE
[IOTDB-6115] Fix Limit & Offset push down doesn't take effect while there exist null value

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/AlignedSeriesScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/AlignedSeriesScanOperator.java
@@ -46,12 +46,17 @@ public class AlignedSeriesScanOperator extends AbstractDataSourceOperator {
       PlanNodeId sourceId,
       AlignedPath seriesPath,
       Ordering scanOrder,
-      SeriesScanOptions seriesScanOptions) {
+      SeriesScanOptions seriesScanOptions,
+      boolean queryAllSensors) {
     this.sourceId = sourceId;
     this.operatorContext = context;
     this.seriesScanUtil =
         new AlignedSeriesScanUtil(
-            seriesPath, scanOrder, seriesScanOptions, context.getInstanceContext());
+            seriesPath,
+            scanOrder,
+            seriesScanOptions,
+            context.getInstanceContext(),
+            queryAllSensors);
     // time + all value columns
     this.builder = new TsBlockBuilder(seriesScanUtil.getTsDataTypeList());
     this.valueColumnCount = seriesPath.getColumnNum();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/AlignedSeriesScanUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/AlignedSeriesScanUtil.java
@@ -53,7 +53,7 @@ public class AlignedSeriesScanUtil extends SeriesScanUtil {
   // device, we
   // can use statistics to skip.
   // it's only exact while using limit & offset push down
-  private boolean queryAllSensors = false;
+  private final boolean queryAllSensors;
 
   public AlignedSeriesScanUtil(
       PartialPath seriesPath,
@@ -138,7 +138,7 @@ public class AlignedSeriesScanUtil extends SeriesScanUtil {
       Set<String> allSensors)
       throws IOException {
     return FileLoaderUtils.loadTimeSeriesMetadata(
-        resource, (AlignedPath) seriesPath, context, filter);
+        resource, (AlignedPath) seriesPath, context, filter, queryAllSensors);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/Analysis.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/Analysis.java
@@ -255,6 +255,10 @@ public class Analysis {
   // extra message from config node, queries wll be sent to these Running DataNodes
   private List<TDataNodeLocation> runningDataNodeLocations;
 
+  // used for limit and offset push down optimizer, if we select all columns from aligned device, we
+  // can use statistics to skip
+  private boolean lastLevelUseWildcard = false;
+
   public Analysis() {
     this.finishQueryAfterAnalyze = false;
   }
@@ -731,5 +735,13 @@ public class Analysis {
 
   public Map<String, Set<Expression>> getDeviceToOutputExpressions() {
     return deviceToOutputExpressions;
+  }
+
+  public boolean isLastLevelUseWildcard() {
+    return lastLevelUseWildcard;
+  }
+
+  public void setLastLevelUseWildcard(boolean lastLevelUseWildcard) {
+    this.lastLevelUseWildcard = lastLevelUseWildcard;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
@@ -226,6 +226,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
   @Override
   public Analysis visitQuery(QueryStatement queryStatement, MPPQueryContext context) {
     Analysis analysis = new Analysis();
+    analysis.setLastLevelUseWildcard(queryStatement.isLastLevelUseWildcard());
     try {
       // check for semantic errors
       queryStatement.semanticCheck();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/parser/ASTVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/parser/ASTVisitor.java
@@ -263,6 +263,8 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
 
   private boolean useWildcard = false;
 
+  private boolean lastLevelUseWildcard = false;
+
   public void setZoneId(ZoneId zoneId) {
     this.zoneId = zoneId;
   }
@@ -1390,6 +1392,7 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
     }
 
     queryStatement.setUseWildcard(useWildcard);
+    queryStatement.setLastLevelUseWildcard(lastLevelUseWildcard);
     return queryStatement;
   }
 
@@ -1937,6 +1940,11 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
       for (int i = 0; i < nodeNames.size(); i++) {
         path[i] = parseNodeName(nodeNames.get(i));
       }
+    }
+    if (!lastLevelUseWildcard
+        && !nodeNames.isEmpty()
+        && !nodeNames.get(nodeNames.size() - 1).wildcard().isEmpty()) {
+      lastLevelUseWildcard = true;
     }
     return new PartialPath(path);
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LogicalPlanBuilder.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LogicalPlanBuilder.java
@@ -168,7 +168,10 @@ public class LogicalPlanBuilder {
   }
 
   public LogicalPlanBuilder planRawDataSource(
-      Set<Expression> sourceExpressions, Ordering scanOrder, Filter timeFilter) {
+      Set<Expression> sourceExpressions,
+      Ordering scanOrder,
+      Filter timeFilter,
+      boolean lastLevelUseWildcard) {
     List<PlanNode> sourceNodeList = new ArrayList<>();
     List<PartialPath> selectedPaths =
         sourceExpressions.stream()
@@ -187,7 +190,10 @@ public class LogicalPlanBuilder {
       } else if (path instanceof AlignedPath) { // aligned series
         AlignedSeriesScanNode alignedSeriesScanNode =
             new AlignedSeriesScanNode(
-                context.getQueryId().genPlanNodeId(), (AlignedPath) path, scanOrder);
+                context.getQueryId().genPlanNodeId(),
+                (AlignedPath) path,
+                scanOrder,
+                lastLevelUseWildcard);
         alignedSeriesScanNode.setTimeFilter(timeFilter);
         // TODO: push down value filter
         alignedSeriesScanNode.setValueFilter(timeFilter);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LogicalPlanVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LogicalPlanVisitor.java
@@ -234,7 +234,8 @@ public class LogicalPlanVisitor extends StatementVisitor<PlanNode, MPPQueryConte
               .planRawDataSource(
                   sourceExpressions,
                   queryStatement.getResultTimeOrder(),
-                  analysis.getGlobalTimeFilter())
+                  analysis.getGlobalTimeFilter(),
+                  analysis.isLastLevelUseWildcard())
               .planWhereAndSourceTransform(
                   whereExpression,
                   sourceTransformExpressions,
@@ -255,7 +256,8 @@ public class LogicalPlanVisitor extends StatementVisitor<PlanNode, MPPQueryConte
                 .planRawDataSource(
                     sourceExpressions,
                     queryStatement.getResultTimeOrder(),
-                    analysis.getGlobalTimeFilter())
+                    analysis.getGlobalTimeFilter(),
+                    analysis.isLastLevelUseWildcard())
                 .planWhereAndSourceTransform(
                     whereExpression,
                     sourceTransformExpressions,

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/OperatorTreeGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/OperatorTreeGenerator.java
@@ -344,7 +344,8 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
             node.getPlanNodeId(),
             seriesPath,
             node.getScanOrder(),
-            seriesScanOptionsBuilder.build());
+            seriesScanOptionsBuilder.build(),
+            node.isQueryAllSensors());
 
     ((DataDriverContext) context.getDriverContext()).addSourceOperator(seriesScanOperator);
     ((DataDriverContext) context.getDriverContext()).addPath(seriesPath);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/PlanGraphPrinter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/PlanGraphPrinter.java
@@ -125,6 +125,7 @@ public class PlanGraphPrinter extends PlanVisitor<List<String>, PlanGraphPrinter
     if (offset > 0) {
       boxValue.add(String.format("Offset: %s", offset));
     }
+    boxValue.add(String.format("QueryAllSensors: %s", node.isQueryAllSensors()));
     boxValue.add(printRegion(node.getRegionReplicaSet()));
     return render(node, boxValue, context);
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/QueryStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/QueryStatement.java
@@ -114,6 +114,10 @@ public class QueryStatement extends Statement {
 
   private boolean useWildcard = true;
 
+  // used for limit and offset push down optimizer, if we select all columns from aligned device, we
+  // can use statistics to skip
+  private boolean lastLevelUseWildcard = false;
+
   public QueryStatement() {
     this.statementType = StatementType.QUERY;
   }
@@ -463,6 +467,14 @@ public class QueryStatement extends Statement {
 
   public boolean useWildcard() {
     return useWildcard;
+  }
+
+  public boolean isLastLevelUseWildcard() {
+    return lastLevelUseWildcard;
+  }
+
+  public void setLastLevelUseWildcard(boolean lastLevelUseWildcard) {
+    this.lastLevelUseWildcard = lastLevelUseWildcard;
   }
 
   public static final String RAW_AGGREGATION_HYBRID_QUERY_ERROR_MSG =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AlignedReadOnlyMemChunk.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AlignedReadOnlyMemChunk.java
@@ -45,6 +45,12 @@ public class AlignedReadOnlyMemChunk extends ReadOnlyMemChunk {
 
   private final List<TSDataType> dataTypes;
 
+  // only used for limit and offset push down optimizer, if we select all columns from aligned
+  // device, we
+  // can use statistics to skip.
+  // it's only exact while using limit & offset push down
+  private boolean queryAllSensors;
+
   /**
    * The constructor for Aligned type.
    *
@@ -146,7 +152,7 @@ public class AlignedReadOnlyMemChunk extends ReadOnlyMemChunk {
     }
     IChunkMetadata alignedChunkMetadata =
         new AlignedChunkMetadata(timeChunkMetadata, valueChunkMetadataList);
-    alignedChunkMetadata.setChunkLoader(new MemAlignedChunkLoader(this));
+    alignedChunkMetadata.setChunkLoader(new MemAlignedChunkLoader(this, queryAllSensors));
     alignedChunkMetadata.setVersion(Long.MAX_VALUE);
     cachedMetaData = alignedChunkMetadata;
   }
@@ -159,5 +165,9 @@ public class AlignedReadOnlyMemChunk extends ReadOnlyMemChunk {
   @Override
   public IPointReader getPointReader() {
     return tsBlock.getTsBlockAlignedRowIterator();
+  }
+
+  public void setQueryAllSensors(boolean queryAllSensors) {
+    this.queryAllSensors = queryAllSensors;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/DiskAlignedChunkLoader.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/DiskAlignedChunkLoader.java
@@ -40,11 +40,19 @@ import static org.apache.iotdb.db.queryengine.metric.SeriesScanCostMetricSet.INI
 public class DiskAlignedChunkLoader implements IChunkLoader {
 
   private final boolean debug;
+
+  // only used for limit and offset push down optimizer, if we select all columns from aligned
+  // device, we
+  // can use statistics to skip.
+  // it's only exact while using limit & offset push down
+  private final boolean queryAllSensors;
+
   private static final SeriesScanCostMetricSet SERIES_SCAN_COST_METRIC_SET =
       SeriesScanCostMetricSet.getInstance();
 
-  public DiskAlignedChunkLoader(boolean debug) {
+  public DiskAlignedChunkLoader(boolean debug, boolean queryAllSensors) {
     this.debug = debug;
+    this.queryAllSensors = queryAllSensors;
   }
 
   @Override
@@ -75,7 +83,8 @@ public class DiskAlignedChunkLoader implements IChunkLoader {
       }
 
       long t2 = System.nanoTime();
-      IChunkReader chunkReader = new AlignedChunkReader(timeChunk, valueChunkList, timeFilter);
+      IChunkReader chunkReader =
+          new AlignedChunkReader(timeChunk, valueChunkList, timeFilter, queryAllSensors);
       SERIES_SCAN_COST_METRIC_SET.recordSeriesScanCost(
           INIT_CHUNK_READER_ALIGNED_DISK, System.nanoTime() - t2);
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/MemAlignedChunkReader.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/MemAlignedChunkReader.java
@@ -33,16 +33,18 @@ import java.util.List;
 /** To read aligned chunk data in memory. */
 public class MemAlignedChunkReader implements IChunkReader {
 
-  private List<IPageReader> pageReaderList;
+  private final List<IPageReader> pageReaderList;
 
-  public MemAlignedChunkReader(AlignedReadOnlyMemChunk readableChunk, Filter filter) {
+  public MemAlignedChunkReader(
+      AlignedReadOnlyMemChunk readableChunk, Filter filter, boolean queryAllSensors) {
     // we treat one ReadOnlyMemChunk as one Page
     this.pageReaderList =
         Collections.singletonList(
             new MemAlignedPageReader(
                 readableChunk.getTsBlock(),
                 (AlignedChunkMetadata) readableChunk.getChunkMetaData(),
-                filter));
+                filter,
+                queryAllSensors));
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/MemAlignedPageReader.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/MemAlignedPageReader.java
@@ -101,16 +101,21 @@ public class MemAlignedPageReader implements IPageReader, IAlignedPageReader {
   private boolean pageSatisfy() {
     Statistics<? extends Serializable> statistics = getStatistics();
     if (valueFilter == null || valueFilter.allSatisfy(statistics)) {
-      // For aligned series, When we only read some measurements under an aligned device, if the
-      // values of these queried measurements at a timestamp are all null, the timestamp will not be
-      // selected.
-      // NOTE: if we change the read semantic in the future for aligned series, we need to remove
+      // For aligned series, When we only query some measurements under an aligned device, if any
+      // values of these queried measurements has the same value count as the time column, the
+      // timestamp will be selected.
+      // NOTE: if we change the query semantic in the future for aligned series, we need to remove
       // this check here.
       long rowCount = getTimeStatistics().getCount();
+      boolean canUse = getValueStatisticsList().isEmpty();
       for (Statistics<? extends Serializable> vStatistics : getValueStatisticsList()) {
-        if (vStatistics == null || vStatistics.hasNullValue(rowCount)) {
-          return true;
+        if (vStatistics != null && !vStatistics.hasNullValue(rowCount)) {
+          canUse = true;
+          break;
         }
+      }
+      if (!canUse) {
+        return true;
       }
       // When the number of points in all value pages is the same as that in the time page, it means
       // that there is no null value, and all timestamps will be selected.

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/FileLoaderUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/FileLoaderUtils.java
@@ -201,7 +201,11 @@ public class FileLoaderUtils {
    * @throws IOException IOException may be thrown while reading it from disk.
    */
   public static AlignedTimeSeriesMetadata loadTimeSeriesMetadata(
-      TsFileResource resource, AlignedPath alignedPath, QueryContext context, Filter filter)
+      TsFileResource resource,
+      AlignedPath alignedPath,
+      QueryContext context,
+      Filter filter,
+      boolean queryAllSensors)
       throws IOException {
     final long t1 = System.nanoTime();
     boolean loadFromMem = false;
@@ -209,14 +213,16 @@ public class FileLoaderUtils {
       AlignedTimeSeriesMetadata alignedTimeSeriesMetadata;
       // If the tsfile is closed, we need to load from tsfile
       if (resource.isClosed()) {
-        alignedTimeSeriesMetadata = loadFromDisk(resource, alignedPath, context, filter);
+        alignedTimeSeriesMetadata =
+            loadFromDisk(resource, alignedPath, context, filter, queryAllSensors);
       } else { // if the tsfile is unclosed, we just get it directly from TsFileResource
         loadFromMem = true;
         alignedTimeSeriesMetadata =
             (AlignedTimeSeriesMetadata) resource.getTimeSeriesMetadata(alignedPath);
         if (alignedTimeSeriesMetadata != null) {
           alignedTimeSeriesMetadata.setChunkMetadataLoader(
-              new MemAlignedChunkMetadataLoader(resource, alignedPath, context, filter));
+              new MemAlignedChunkMetadataLoader(
+                  resource, alignedPath, context, filter, queryAllSensors));
         }
       }
 
@@ -252,7 +258,11 @@ public class FileLoaderUtils {
   }
 
   private static AlignedTimeSeriesMetadata loadFromDisk(
-      TsFileResource resource, AlignedPath alignedPath, QueryContext context, Filter filter)
+      TsFileResource resource,
+      AlignedPath alignedPath,
+      QueryContext context,
+      Filter filter,
+      boolean queryAllSensors)
       throws IOException {
     AlignedTimeSeriesMetadata alignedTimeSeriesMetadata = null;
     // load all the TimeseriesMetadata of vector, the first one is for time column and the
@@ -293,7 +303,8 @@ public class FileLoaderUtils {
         alignedTimeSeriesMetadata =
             new AlignedTimeSeriesMetadata(timeColumn, valueTimeSeriesMetadataList);
         alignedTimeSeriesMetadata.setChunkMetadataLoader(
-            new DiskAlignedChunkMetadataLoader(resource, alignedPath, context, filter));
+            new DiskAlignedChunkMetadataLoader(
+                resource, alignedPath, context, filter, queryAllSensors));
       }
     }
     return alignedTimeSeriesMetadata;

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/AlignedSeriesScanOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/AlignedSeriesScanOperatorTest.java
@@ -127,7 +127,8 @@ public class AlignedSeriesScanOperatorTest {
               planNodeId,
               alignedPath,
               Ordering.ASC,
-              getDefaultSeriesScanOptions(alignedPath));
+              getDefaultSeriesScanOptions(alignedPath),
+              false);
       seriesScanOperator.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
       seriesScanOperator
           .getOperatorContext()
@@ -220,7 +221,8 @@ public class AlignedSeriesScanOperatorTest {
               planNodeId1,
               alignedPath1,
               Ordering.ASC,
-              getDefaultSeriesScanOptions(alignedPath1));
+              getDefaultSeriesScanOptions(alignedPath1),
+              false);
       seriesScanOperator1.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
       seriesScanOperator1
           .getOperatorContext()
@@ -241,7 +243,8 @@ public class AlignedSeriesScanOperatorTest {
               planNodeId2,
               alignedPath2,
               Ordering.ASC,
-              getDefaultSeriesScanOptions(alignedPath2));
+              getDefaultSeriesScanOptions(alignedPath2),
+              false);
       seriesScanOperator2.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
       seriesScanOperator2
           .getOperatorContext()
@@ -509,7 +512,8 @@ public class AlignedSeriesScanOperatorTest {
               planNodeId1,
               alignedPath1,
               Ordering.DESC,
-              getDefaultSeriesScanOptions(alignedPath1));
+              getDefaultSeriesScanOptions(alignedPath1),
+              false);
       seriesScanOperator1.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
       seriesScanOperator1
           .getOperatorContext()
@@ -530,7 +534,8 @@ public class AlignedSeriesScanOperatorTest {
               planNodeId2,
               alignedPath2,
               Ordering.DESC,
-              getDefaultSeriesScanOptions(alignedPath2));
+              getDefaultSeriesScanOptions(alignedPath2),
+              false);
       seriesScanOperator2.initQueryDataSource(new QueryDataSource(seqResources, unSeqResources));
       seriesScanOperator2
           .getOperatorContext()

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OperatorMemoryTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OperatorMemoryTest.java
@@ -191,7 +191,8 @@ public class OperatorMemoryTest {
               planNodeId,
               alignedPath,
               Ordering.ASC,
-              SeriesScanOptions.getDefaultSeriesScanOptions(alignedPath));
+              SeriesScanOptions.getDefaultSeriesScanOptions(alignedPath),
+              false);
 
       long maxPeekMemory =
           Math.max(

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/plan/QueryLogicalPlanUtil.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/plan/QueryLogicalPlanUtil.java
@@ -172,7 +172,10 @@ public class QueryLogicalPlanUtil {
             Ordering.ASC));
     sourceNodeList.add(
         new AlignedSeriesScanNode(
-            queryId.genPlanNodeId(), (AlignedPath) schemaMap.get("root.sg.d2.a"), Ordering.ASC));
+            queryId.genPlanNodeId(),
+            (AlignedPath) schemaMap.get("root.sg.d2.a"),
+            Ordering.ASC,
+            false));
 
     for (PlanNode sourceNode : sourceNodeList) {
       if (sourceNode instanceof SeriesScanNode) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/MemAlignedChunkLoaderTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/MemAlignedChunkLoaderTest.java
@@ -52,7 +52,7 @@ public class MemAlignedChunkLoaderTest {
     AlignedReadOnlyMemChunk chunk = Mockito.mock(AlignedReadOnlyMemChunk.class);
     ChunkMetadata chunkMetadata = Mockito.mock(ChunkMetadata.class);
 
-    MemAlignedChunkLoader memAlignedChunkLoader = new MemAlignedChunkLoader(chunk);
+    MemAlignedChunkLoader memAlignedChunkLoader = new MemAlignedChunkLoader(chunk, false);
     try {
       memAlignedChunkLoader.loadChunk(chunkMetadata);
       fail();

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileAlignedSeriesReaderIterator.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileAlignedSeriesReaderIterator.java
@@ -82,7 +82,7 @@ public class TsFileAlignedSeriesReaderIterator {
     }
 
     AlignedChunkReader chunkReader =
-        new AlignedChunkReader(timeChunk, Arrays.asList(valueChunks), null);
+        new AlignedChunkReader(timeChunk, Arrays.asList(valueChunks), null, false);
 
     return new NextAlignedChunkInfo(chunkReader, totalSize, notNullChunkNum, totalPointNum);
   }

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/chunk/AlignedChunkReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/chunk/AlignedChunkReader.java
@@ -92,7 +92,8 @@ public class AlignedChunkReader implements IChunkReader {
    *
    * @param filter filter
    */
-  public AlignedChunkReader(Chunk timeChunk, List<Chunk> valueChunkList, Filter filter)
+  public AlignedChunkReader(
+      Chunk timeChunk, List<Chunk> valueChunkList, Filter filter, boolean queryAllSensors)
       throws IOException {
     this.filter = filter;
     this.timeChunkDataBuffer = timeChunk.getData();
@@ -108,7 +109,7 @@ public class AlignedChunkReader implements IChunkReader {
           valueChunkStatisticsList.add(chunk == null ? null : chunk.getChunkStatistic());
           valueDeleteIntervalList.add(chunk == null ? null : chunk.getDeleteIntervalList());
         });
-    initAllPageReaders(timeChunk.getChunkStatistic(), valueChunkStatisticsList);
+    initAllPageReaders(timeChunk.getChunkStatistic(), valueChunkStatisticsList, queryAllSensors);
   }
 
   /**
@@ -132,12 +133,14 @@ public class AlignedChunkReader implements IChunkReader {
           valueChunkStatisticsList.add(chunk == null ? null : chunk.getChunkStatistic());
           valueDeleteIntervalList.add(chunk == null ? null : chunk.getDeleteIntervalList());
         });
-    initAllPageReaders(timeChunk.getChunkStatistic(), valueChunkStatisticsList);
+    initAllPageReaders(timeChunk.getChunkStatistic(), valueChunkStatisticsList, false);
   }
 
   /** construct all the page readers in this chunk */
   private void initAllPageReaders(
-      Statistics timeChunkStatistics, List<Statistics> valueChunkStatisticsList)
+      Statistics timeChunkStatistics,
+      List<Statistics> valueChunkStatisticsList,
+      boolean queryAllSensors)
       throws IOException {
     // construct next satisfied page header
     while (timeChunkDataBuffer.remaining() > 0) {
@@ -176,7 +179,7 @@ public class AlignedChunkReader implements IChunkReader {
       // if the current page satisfies
       if (exits && timePageSatisfied(timePageHeader)) {
         AlignedPageReader alignedPageReader =
-            constructPageReaderForNextPage(timePageHeader, valuePageHeaderList);
+            constructPageReaderForNextPage(timePageHeader, valuePageHeaderList, queryAllSensors);
         if (alignedPageReader != null) {
           pageReaderList.add(alignedPageReader);
         }
@@ -213,7 +216,8 @@ public class AlignedChunkReader implements IChunkReader {
   }
 
   private AlignedPageReader constructPageReaderForNextPage(
-      PageHeader timePageHeader, List<PageHeader> valuePageHeader) throws IOException {
+      PageHeader timePageHeader, List<PageHeader> valuePageHeader, boolean queryAllSensors)
+      throws IOException {
     PageInfo timePageInfo = new PageInfo();
     getPageInfo(timePageHeader, timeChunkDataBuffer, timeChunkHeader, timePageInfo);
     PageInfo valuePageInfo = new PageInfo();

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/chunk/AlignedChunkReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/chunk/AlignedChunkReader.java
@@ -270,7 +270,8 @@ public class AlignedChunkReader implements IChunkReader {
             valuePageDataList,
             valueDataTypeList,
             valueDecoderList,
-            filter);
+            filter,
+            queryAllSensors);
     alignedPageReader.setDeleteIntervalList(valueDeleteIntervalList);
     return alignedPageReader;
   }
@@ -318,7 +319,8 @@ public class AlignedChunkReader implements IChunkReader {
             uncompressedValuePageDatas,
             valueTypes,
             valueDecoders,
-            null);
+            null,
+            false);
     alignedPageReader.initTsBlockBuilder(valueTypes);
     alignedPageReader.setDeleteIntervalList(valueDeleteIntervalList);
     return alignedPageReader.getAllSatisfiedData();

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/AlignedPageReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/AlignedPageReader.java
@@ -50,6 +50,12 @@ public class AlignedPageReader implements IPageReader, IAlignedPageReader {
   private final List<ValuePageReader> valuePageReaderList;
   private final int valueCount;
 
+  // only used for limit and offset push down optimizer, if we select all columns from aligned
+  // device, we
+  // can use statistics to skip.
+  // it's only exact while using limit & offset push down
+  private final boolean queryAllSensors;
+
   private Filter filter;
   private PaginationController paginationController = UNLIMITED_PAGINATION_CONTROLLER;
 
@@ -67,7 +73,8 @@ public class AlignedPageReader implements IPageReader, IAlignedPageReader {
       List<ByteBuffer> valuePageDataList,
       List<TSDataType> valueDataTypeList,
       List<Decoder> valueDecoderList,
-      Filter filter) {
+      Filter filter,
+      boolean queryAllSensors) {
     timePageReader = new TimePageReader(timePageHeader, timePageData, timeDecoder);
     isModified = timePageReader.isModified();
     valuePageReaderList = new ArrayList<>(valuePageHeaderList.size());
@@ -87,6 +94,7 @@ public class AlignedPageReader implements IPageReader, IAlignedPageReader {
     }
     this.filter = filter;
     this.valueCount = valuePageReaderList.size();
+    this.queryAllSensors = queryAllSensors;
   }
 
   @Override
@@ -126,11 +134,13 @@ public class AlignedPageReader implements IPageReader, IAlignedPageReader {
       // NOTE: if we change the query semantic in the future for aligned series, we need to remove
       // this check here.
       long rowCount = getTimeStatistics().getCount();
-      boolean canUse = getValueStatisticsList().isEmpty();
-      for (Statistics vStatistics : getValueStatisticsList()) {
-        if (vStatistics != null && !vStatistics.hasNullValue(rowCount)) {
-          canUse = true;
-          break;
+      boolean canUse = queryAllSensors || getValueStatisticsList().isEmpty();
+      if (!canUse) {
+        for (Statistics vStatistics : getValueStatisticsList()) {
+          if (vStatistics != null && !vStatistics.hasNullValue(rowCount)) {
+            canUse = true;
+            break;
+          }
         }
       }
       if (!canUse) {

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/series/FileSeriesReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/series/FileSeriesReader.java
@@ -56,7 +56,7 @@ public class FileSeriesReader extends AbstractFileSeriesReader {
       for (IChunkMetadata metadata : alignedChunkMetadata.getValueChunkMetadataList()) {
         valueChunkList.add(chunkLoader.loadChunk((ChunkMetadata) metadata));
       }
-      this.chunkReader = new AlignedChunkReader(timeChunk, valueChunkList, filter);
+      this.chunkReader = new AlignedChunkReader(timeChunk, valueChunkList, filter, false);
     }
   }
 

--- a/iotdb-core/tsfile/src/test/java/org/apache/iotdb/tsfile/write/TsFileIntegrityCheckingTool.java
+++ b/iotdb-core/tsfile/src/test/java/org/apache/iotdb/tsfile/write/TsFileIntegrityCheckingTool.java
@@ -224,7 +224,8 @@ public class TsFileIntegrityCheckingTool {
                   reader.readMemChunk((ChunkMetadata) valueChunkMetadataList.get(chunkIdx));
               // construct an aligned chunk reader using time chunk and value chunk
               IChunkReader chunkReader =
-                  new AlignedChunkReader(timeChunk, Collections.singletonList(valueChunk), null);
+                  new AlignedChunkReader(
+                      timeChunk, Collections.singletonList(valueChunk), null, false);
               // verify the values
               List<Pair<Long, TsPrimitiveType>> originValue = originDataChunks.get(chunkIdx);
               for (int valIdx = 0; chunkReader.hasNextSatisfiedPage(); ) {

--- a/pom.xml
+++ b/pom.xml
@@ -395,7 +395,6 @@
                 <artifactId>jackson-core-asl</artifactId>
                 <version>${jackson-core-asl.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>


### PR DESCRIPTION
If we query all sensors of one device or any queried sensor has the same value count as the time column, we can use the statistics to skip.