### PR TITLE
Fix memory leak when deleting database in PB_Tree mode

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/CachedMTreeStore.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/CachedMTreeStore.java
@@ -457,6 +457,7 @@ public class CachedMTreeStore implements IMTreeStore<ICachedMNode> {
   public void clear() {
     lock.writeLock();
     try {
+      CacheMemoryManager.getInstance().clearCachedMTreeStore(this);
       regionStatistics.setCacheManager(null);
       cacheManager.clear(root);
       root = null;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/CacheManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/CacheManager.java
@@ -486,6 +486,7 @@ public abstract class CacheManager implements ICacheManager {
   public void clear(ICachedMNode root) {
     clearMNodeInMemory(root);
     clearNodeCache();
+    nodeBuffer.setUpdatedStorageGroupMNode(null);
     nodeBuffer.clear();
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/CacheMemoryManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/CacheMemoryManager.java
@@ -86,6 +86,10 @@ public class CacheMemoryManager {
     return cacheManager;
   }
 
+  public void clearCachedMTreeStore(CachedMTreeStore store) {
+    storeList.remove(store);
+  }
+
   public void init(ISchemaEngineStatistics engineStatistics) {
     flushSemaphore = new FiniteSemaphore(2, 0);
     releaseSemaphore = new FiniteSemaphore(2, 0);


### PR DESCRIPTION
## Description


In PB_Tree mode, when a SchemaRegion is deleted, the corresponding MTree needs to be deleted, and all references holding MTreeStore need to be released so that the deprecated objects can be GC.