### PR TITLE
Fix dataMigrationExample wrong concurrency error

### DIFF
--- a/example/session/src/main/java/org/apache/iotdb/DataMigrationExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/DataMigrationExample.java
@@ -62,7 +62,8 @@ public class DataMigrationExample {
       throws IoTDBConnectionException, StatementExecutionException, ExecutionException,
           InterruptedException {
 
-    ExecutorService executorService = Executors.newFixedThreadPool(CONCURRENCY + 1);
+    // the thread used for dataMigration must be smaller than session pool size
+    ExecutorService executorService = Executors.newFixedThreadPool(CONCURRENCY);
 
     String path = "root.**";
 


### PR DESCRIPTION
The example for data migration may generate warnings, causing the data import to fail. Now, I have made corrections to the example and added comments.
![image](https://github.com/apache/iotdb/assets/38746920/45616fd7-5ba5-488a-a767-6427120c42f4)
