### PR TITLE
[To rel/1.2][IOTDB-6119] Add ConfigNode leader service check

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
@@ -224,6 +224,9 @@ public class ConfigRegionStateMachine
           () -> configManager.getPipeManager().getPipeRuntimeCoordinator().startPipeMetaSync());
       threadPool.submit(
           () -> configManager.getPipeManager().getPipeRuntimeCoordinator().startPipeHeartbeat());
+
+      configManager.getConsensusManager().setLeaderServiceReady(true);
+
     } else {
       LOGGER.info(
           "Current node [nodeId:{}, ip:port: {}] is not longer the leader, "
@@ -231,6 +234,8 @@ public class ConfigRegionStateMachine
           currentNodeId,
           currentNodeTEndPoint,
           newLeaderId);
+
+      configManager.getConsensusManager().setLeaderServiceReady(false);
 
       // Stop leader scheduling services
       configManager.getPipeManager().getPipeRuntimeCoordinator().stopPipeMetaSync();

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/consensus/ConsensusManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/consensus/ConsensusManager.java
@@ -56,6 +56,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.iotdb.consensus.ConsensusFactory.SIMPLE_CONSENSUS;
 
@@ -72,6 +73,8 @@ public class ConsensusManager {
 
   private final IManager configManager;
   private IConsensus consensusImpl;
+
+  private final AtomicBoolean isLeaderServiceReady = new AtomicBoolean(false);
 
   public ConsensusManager(IManager configManager, ConfigRegionStateMachine stateMachine)
       throws IOException {
@@ -353,7 +356,7 @@ public class ConsensusManager {
   public TSStatus confirmLeader() {
     TSStatus result = new TSStatus();
 
-    if (isLeader()) {
+    if (isLeader() && isLeaderServiceReady.get()) {
       return result.setCode(TSStatusCode.SUCCESS_STATUS.getStatusCode());
     } else {
       result.setCode(TSStatusCode.REDIRECTION_RECOMMEND.getStatusCode());
@@ -367,6 +370,10 @@ public class ConsensusManager {
 
       return result;
     }
+  }
+
+  public void setLeaderServiceReady(boolean isLeaderServiceReady) {
+    this.isLeaderServiceReady.set(isLeaderServiceReady);
   }
 
   public ConsensusGroupId getConsensusGroupId() {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/consensus/ConsensusManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/consensus/ConsensusManager.java
@@ -74,6 +74,9 @@ public class ConsensusManager {
   private final IManager configManager;
   private IConsensus consensusImpl;
 
+  // TODO: This AtomicBoolean only ensure all leader services are ready
+  // TODO: But it doesn't ensure the ConfigNode-leader can read the latest data
+  // TODO: All read request should go through the ConsensusManager to ensure linearizability
   private final AtomicBoolean isLeaderServiceReady = new AtomicBoolean(false);
 
   public ConsensusManager(IManager configManager, ConfigRegionStateMachine stateMachine)

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/PartitionBalancer.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/PartitionBalancer.java
@@ -43,6 +43,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -190,7 +191,7 @@ public class PartitionBalancer {
               .put(seriesPartitionEntry.getKey(), seriesPartitionTable);
         }
       } finally {
-        allotTable.releaseLock();
+        Optional.ofNullable(allotTable).ifPresent(DataPartitionPolicyTable::releaseLock);
       }
       result.put(database, dataPartitionTable);
     }


### PR DESCRIPTION
The ConfigNode-leader can't provide services until all of its leader services are ready. Therefore there should add another AtomicBoolean to mark the leader services' status.