### PR TITLE
Upgrade guava to avoid vulnerability issue

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -223,7 +223,7 @@ org.apache.commons:commons-lang3:3.8.1
 commons-lang:commons-lang:2.6
 com.nimbusds:content-type:2.0
 com.google.code.gson:gson:2.8.6
-com.google.guava.guava:24.1.1
+com.google.guava.guava:32.1.2-jre
 com.fasterxml.jackson.core:jackson-annotations:2.10.0
 com.fasterxml.jackson.core:jackson-core:2.10.0
 com.fasterxml.jackson.core:jackson-databind:2.10.0

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <common.logging.version>1.1.3</common.logging.version>
         <common.pool2.version>2.11.1</common.pool2.version>
         <org.slf4j.version>1.7.36</org.slf4j.version>
-        <guava.version>24.1.1</guava.version>
+        <guava.version>32.1.2-jre</guava.version>
         <jline.version>3.21.0</jline.version>
         <jetty.version>9.4.51.v20230217</jetty.version>
         <dropwizard.metrics.version>4.2.7</dropwizard.metrics.version>
@@ -250,7 +250,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>[${guava.version},)</version>
+                <version>${guava.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.lmax</groupId>


### PR DESCRIPTION
## Description

There are some vulnerability issues about early versions of guava. This PR is upgrading it to latest version.
https://mvnrepository.com/artifact/com.google.guava/guava
![image](https://github.com/apache/iotdb/assets/25913899/6d5bc784-f99d-45ed-a9d5-89d25ad0d67f)
