### PR TITLE
Override existing jar instead of deleting it when registering UDF

### DIFF
--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/executable/ExecutableManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/executable/ExecutableManager.java
@@ -224,8 +224,8 @@ public class ExecutableManager {
   }
 
   /**
-   * Create and save the file if the specified file does not exist, or this method does will
-   * override the existing file.
+   * Create and save the file if the specified file does not exist, or this method will override the
+   * existing file.
    */
   protected void saveToDir(ByteBuffer byteBuffer, String destination) throws IOException {
     try {
@@ -234,7 +234,7 @@ public class ExecutableManager {
         Files.createFile(path);
       }
       // FileOutPutStream is not in append mode by default, so the file will be overridden if it
-      // already exists which is reasonable for us.
+      // already exists.
       try (FileOutputStream outputStream = new FileOutputStream(destination)) {
         outputStream.getChannel().write(byteBuffer);
       }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/executable/ExecutableManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/executable/ExecutableManager.java
@@ -223,11 +223,18 @@ public class ExecutableManager {
     }
   }
 
+  /**
+   * Create and save the file if the specified file does not exist, or this method does will
+   * override the existing file.
+   */
   protected void saveToDir(ByteBuffer byteBuffer, String destination) throws IOException {
     try {
       Path path = Paths.get(destination);
-      Files.deleteIfExists(path);
-      Files.createFile(path);
+      if (!Files.exists(path)) {
+        Files.createFile(path);
+      }
+      // FileOutPutStream is not in append mode by default, so the file will be overridden if it
+      // already exists which is reasonable for us.
       try (FileOutputStream outputStream = new FileOutputStream(destination)) {
         outputStream.getChannel().write(byteBuffer);
       }


### PR DESCRIPTION
On some OS systems(eg.windows), it is not possible to delete a file when it is open or in use. The Jar file will be used by the acitive UDFClassLoader and can not be deleted On windows, which will lead to the failure of the CreateFunctionTask.