### PR TITLE
[To rel/1.2] fix wal npe when memTable has flushed.

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
@@ -381,7 +381,9 @@ public class WALNode implements IWALNode {
         return false;
       }
       IMemTable oldestMemTable = oldestMemTableInfo.getMemTable();
-
+      if (oldestMemTable == null) {
+        return false;
+      }
       // get memTable's virtual database processor
       File oldestTsFile =
           FSFactoryProducer.getFSFactory().getFile(oldestMemTableInfo.getTsFilePath());
@@ -455,7 +457,7 @@ public class WALNode implements IWALNode {
           "CheckpointManager$DeleteOutdatedFileTask.snapshotOrFlushOldestMemTable");
       try {
         // make sure snapshot is made before memTable flush operation
-        synchronized (this) {
+        synchronized (memTableInfo) {
           if (memTable != null && memTable.getFlushStatus() != FlushStatus.WORKING) {
             return;
           }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
@@ -458,7 +458,7 @@ public class WALNode implements IWALNode {
       try {
         // make sure snapshot is made before memTable flush operation
         synchronized (memTableInfo) {
-          if (memTable != null && memTable.getFlushStatus() != FlushStatus.WORKING) {
+          if (memTable == null || memTable.getFlushStatus() != FlushStatus.WORKING) {
             return;
           }
 


### PR DESCRIPTION
wal obtains IMemTable from memTableInfo twice when deleting obsolete files. The IMemTable is not null when it is obtained the first time, but the imemtable may have been flushed when it is obtained the second time. As a result, the obtained value is null, resulting in NPE