### PR TITLE
[IOTDB-6122] Pipe: Progress Index markers an incorrect value when load a tsfile with tsfileResource

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/runtime/PipeRuntimeAgent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/runtime/PipeRuntimeAgent.java
@@ -96,8 +96,14 @@ public class PipeRuntimeAgent implements IService {
   }
 
   ////////////////////// Recover ProgressIndex Assigner //////////////////////
-
   public void assignRecoverProgressIndexForTsFileRecovery(TsFileResource tsFileResource) {
+    tsFileResource.recoverProgressIndex(
+        new RecoverProgressIndex(
+            DATA_NODE_ID,
+            simpleConsensusProgressIndexAssigner.getSimpleProgressIndexForTsFileRecovery()));
+  }
+
+  public void assignUpdateProgressIndexForTsFileRecovery(TsFileResource tsFileResource) {
     tsFileResource.updateProgressIndex(
         new RecoverProgressIndex(
             DATA_NODE_ID,

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
@@ -1189,6 +1189,14 @@ public class TsFileResource {
             : maxProgressIndex.updateToMinimumIsAfterProgressIndex(progressIndex));
   }
 
+  public void recoverProgressIndex(ProgressIndex progressIndex) {
+    if (progressIndex == null) {
+      return;
+    }
+
+    maxProgressIndex = progressIndex;
+  }
+
   public ProgressIndex getMaxProgressIndexAfterClose() throws IllegalStateException {
     if (getStatus().equals(TsFileResourceStatus.UNCLOSED)) {
       throw new IllegalStateException(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/file/UnsealedTsFileRecoverPerformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/file/UnsealedTsFileRecoverPerformer.java
@@ -250,7 +250,7 @@ public class UnsealedTsFileRecoverPerformer extends AbstractTsFileRecoverPerform
         }
 
         // set recover progress index for pipe
-        PipeAgent.runtime().assignRecoverProgressIndexForTsFileRecovery(tsFileResource);
+        PipeAgent.runtime().assignUpdateProgressIndexForTsFileRecovery(tsFileResource);
 
         // if we put following codes in the 'if' clause above, this file can be continued writing
         // into it


### PR DESCRIPTION
## Description
When we load a tsfile , if it has a tsFileResource, there are two cases in tsFileResource: 
 1. it doesn't have a progress index, we just give it one from system.
 2. it has a progress index, the index shouldn't be loaded, it should be **recovered** instead of updating.