### PR TITLE
[IOTDB-6125] Fix DataPartition allocation bug when insert big batch data

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/partition/DataPartitionPolicyTable.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/partition/DataPartitionPolicyTable.java
@@ -75,7 +75,8 @@ public class DataPartitionPolicyTable {
     seriesPartitionSlotCounter.put(
         regionGroupId, seriesPartitionSlotCounter.get(regionGroupId) + 1);
     LOGGER.info(
-        "[ActivateDataAllotTable] Activate SeriesPartitionSlot {} to RegionGroup {}, SeriesPartitionSlot Count: {}",
+        "[ActivateDataAllotTable] Activate SeriesPartitionSlot {} "
+            + "to RegionGroup {}, SeriesPartitionSlot Count: {}",
         seriesPartitionSlot,
         regionGroupId,
         seriesPartitionSlotCounter.get(regionGroupId));
@@ -162,7 +163,8 @@ public class DataPartitionPolicyTable {
         .forEach(
             regionGroupId ->
                 LOGGER.info(
-                    "[ReBalanceDataAllotTable] Database: {}, RegionGroupId: {}, SeriesPartitionSlot Count: {}",
+                    "[ReBalanceDataAllotTable] Database: {}, "
+                        + "RegionGroupId: {}, SeriesPartitionSlot Count: {}",
                     database,
                     regionGroupId,
                     seriesPartitionSlotCounter.get(regionGroupId)));

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/structure/BalanceTreeMap.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/structure/BalanceTreeMap.java
@@ -77,6 +77,10 @@ public class BalanceTreeMap<K, V extends Comparable<V>> {
     return keyValueMap.getOrDefault(key, null);
   }
 
+  public Set<K> keySet() {
+    return keyValueMap.keySet();
+  }
+
   public boolean containsKey(K key) {
     return keyValueMap.containsKey(key);
   }


### PR DESCRIPTION
The DataPartitions will be allocated un-balanced if the user insert a big batch data to the cluster firstly. Because the RegionGroup quickly-extension-policy doesn't extend enough RegionGroups for the special case.




In this PR, the RegionGroup extension policy will always ensure the database have enough RegionGroups for allocate new Partitions balancely.




And this PR also add some concise log to record the DataAllotTable