### PR TITLE
[To rel/1.2] [IOTDB-6125] Fix DataPartition allocation bug when insert big batch data

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/partition/IoTDBAutoRegionGroupExtensionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/partition/IoTDBAutoRegionGroupExtensionIT.java
@@ -160,14 +160,12 @@ public class IoTDBAutoRegionGroupExtensionIT {
     }
 
     // The number of SchemaRegionGroups should not less than the testMinSchemaRegionGroupNum
-    TShowRegionResp showRegionReq =
+    TShowRegionResp resp =
         client.showRegion(
             new TShowRegionReq().setConsensusGroupType(TConsensusGroupType.SchemaRegion));
-    Assert.assertEquals(
-        TSStatusCode.SUCCESS_STATUS.getStatusCode(), showRegionReq.getStatus().getCode());
+    Assert.assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), resp.getStatus().getCode());
     Map<String, AtomicInteger> regionCounter = new ConcurrentHashMap<>();
-    showRegionReq
-        .getRegionInfoList()
+    resp.getRegionInfoList()
         .forEach(
             regionInfo ->
                 regionCounter
@@ -178,14 +176,12 @@ public class IoTDBAutoRegionGroupExtensionIT {
         (sg, regionCount) -> Assert.assertTrue(regionCount.get() >= testMinSchemaRegionGroupNum));
 
     // The number of DataRegionGroups should not less than the testMinDataRegionGroupNum
-    showRegionReq =
+    resp =
         client.showRegion(
             new TShowRegionReq().setConsensusGroupType(TConsensusGroupType.DataRegion));
-    Assert.assertEquals(
-        TSStatusCode.SUCCESS_STATUS.getStatusCode(), showRegionReq.getStatus().getCode());
+    Assert.assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), resp.getStatus().getCode());
     regionCounter.clear();
-    showRegionReq
-        .getRegionInfoList()
+    resp.getRegionInfoList()
         .forEach(
             regionInfo ->
                 regionCounter

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/partition/DataPartitionPolicyTable.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/partition/DataPartitionPolicyTable.java
@@ -25,6 +25,9 @@ import org.apache.iotdb.commons.structure.BalanceTreeMap;
 import org.apache.iotdb.confignode.conf.ConfigNodeConfig;
 import org.apache.iotdb.confignode.conf.ConfigNodeDescriptor;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -33,6 +36,8 @@ import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
 
 public class DataPartitionPolicyTable {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DataPartitionPolicyTable.class);
 
   private static final ConfigNodeConfig CONF = ConfigNodeDescriptor.getInstance().getConf();
   private static final int SERIES_SLOT_NUM = CONF.getSeriesSlotNum();
@@ -69,6 +74,12 @@ public class DataPartitionPolicyTable {
     dataAllotMap.put(seriesPartitionSlot, regionGroupId);
     seriesPartitionSlotCounter.put(
         regionGroupId, seriesPartitionSlotCounter.get(regionGroupId) + 1);
+    LOGGER.info(
+        "[ActivateDataAllotTable] Activate SeriesPartitionSlot {} "
+            + "to RegionGroup {}, SeriesPartitionSlot Count: {}",
+        seriesPartitionSlot,
+        regionGroupId,
+        seriesPartitionSlotCounter.get(regionGroupId));
     return regionGroupId;
   }
 
@@ -102,6 +113,8 @@ public class DataPartitionPolicyTable {
       int mu = SERIES_SLOT_NUM / dataRegionGroups.size();
       for (TSeriesPartitionSlot seriesPartitionSlot : seriesPartitionSlots) {
         if (!dataAllotMap.containsKey(seriesPartitionSlot)) {
+          // Skip unallocated SeriesPartitionSlot
+          // They will be activated when allocating DataPartition
           continue;
         }
 
@@ -109,6 +122,7 @@ public class DataPartitionPolicyTable {
         int seriesPartitionSlotCount = seriesPartitionSlotCounter.get(regionGroupId);
         if (seriesPartitionSlotCount > mu) {
           // Remove from dataAllotMap if the number of SeriesSlots is greater than mu
+          // They will be re-activated when allocating DataPartition
           dataAllotMap.remove(seriesPartitionSlot);
           seriesPartitionSlotCounter.put(regionGroupId, seriesPartitionSlotCount - 1);
         }
@@ -141,6 +155,19 @@ public class DataPartitionPolicyTable {
     } finally {
       dataAllotTableLock.unlock();
     }
+  }
+
+  public void logDataAllotTable(String database) {
+    seriesPartitionSlotCounter
+        .keySet()
+        .forEach(
+            regionGroupId ->
+                LOGGER.info(
+                    "[ReBalanceDataAllotTable] Database: {}, "
+                        + "RegionGroupId: {}, SeriesPartitionSlot Count: {}",
+                    database,
+                    regionGroupId,
+                    seriesPartitionSlotCounter.get(regionGroupId)));
   }
 
   public void acquireLock() {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
@@ -565,12 +565,12 @@ public class PartitionManager {
                 Math.min(
                     unassignedPartitionSlotsCount, minRegionGroupNum - allocatedRegionGroupCount);
         allotmentMap.put(database, delta);
-      }
 
-      // 2. The average number of partitions held by each Region will be greater than the
-      // expected average number after the partition allocation is completed
-      if (allocatedRegionGroupCount < maxRegionGroupNum
+      } else if (allocatedRegionGroupCount < maxRegionGroupNum
           && slotCount / allocatedRegionGroupCount > maxSlotCount / maxRegionGroupNum) {
+        // 2. The average number of partitions held by each Region will be greater than the
+        // expected average number after the partition allocation is completed.
+
         // The delta is equal to the smallest integer solution that satisfies the inequality:
         // slotCount / (allocatedRegionGroupCount + delta) < maxSlotCount / maxRegionGroupNum
         int delta =
@@ -583,13 +583,11 @@ public class PartitionManager {
                             slotCount * maxRegionGroupNum / maxSlotCount
                                 - allocatedRegionGroupCount)));
         allotmentMap.put(database, delta);
-        continue;
-      }
 
-      // 3. All RegionGroups in the specified Database are disabled currently
-      if (allocatedRegionGroupCount
+      } else if (allocatedRegionGroupCount
               == filterRegionGroupThroughStatus(database, RegionGroupStatus.Disabled).size()
           && allocatedRegionGroupCount < maxRegionGroupNum) {
+        // 3. All RegionGroups in the specified Database are disabled currently
         allotmentMap.put(database, 1);
       }
     }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/structure/BalanceTreeMap.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/structure/BalanceTreeMap.java
@@ -77,6 +77,10 @@ public class BalanceTreeMap<K, V extends Comparable<V>> {
     return keyValueMap.getOrDefault(key, null);
   }
 
+  public Set<K> keySet() {
+    return keyValueMap.keySet();
+  }
+
   public boolean containsKey(K key) {
     return keyValueMap.containsKey(key);
   }


### PR DESCRIPTION
The DataPartitions will be allocated un-balanced if the user insert a big batch data to the cluster firstly. Because the RegionGroup quickly-extension-policy doesn't extend enough RegionGroups for the special case.

In this PR, the RegionGroup extension policy will always ensure the database have enough RegionGroups for allocate new Partitions balancely.

And this PR also add some concise log to record the DataAllotTable