### PR TITLE
[To rel/1.2] Remove some useless configs

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -800,9 +800,6 @@ public class IoTDBConfig {
 
   private int thriftDefaultBufferSize = RpcUtils.THRIFT_DEFAULT_BUF_CAPACITY;
 
-  /** time interval in minute for calculating query frequency. Unit: minute */
-  private int frequencyIntervalInMinute = 1;
-
   /** time cost(ms) threshold for slow query. Unit: millisecond */
   private long slowQueryThreshold = 30000;
 
@@ -2523,14 +2520,6 @@ public class IoTDBConfig {
 
   public void setMaxWaitingTimeWhenInsertBlocked(int maxWaitingTimeWhenInsertBlocked) {
     this.maxWaitingTimeWhenInsertBlockedInMs = maxWaitingTimeWhenInsertBlocked;
-  }
-
-  public int getFrequencyIntervalInMinute() {
-    return frequencyIntervalInMinute;
-  }
-
-  public void setFrequencyIntervalInMinute(int frequencyIntervalInMinute) {
-    this.frequencyIntervalInMinute = frequencyIntervalInMinute;
   }
 
   public long getSlowQueryThreshold() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -805,12 +805,6 @@ public class IoTDBDescriptor {
             properties.getProperty(
                 "dn_thrift_init_buffer_size", String.valueOf(conf.getThriftDefaultBufferSize()))));
 
-    conf.setFrequencyIntervalInMinute(
-        Integer.parseInt(
-            properties.getProperty(
-                "frequency_interval_in_minute",
-                String.valueOf(conf.getFrequencyIntervalInMinute()))));
-
     conf.setSlowQueryThreshold(
         Long.parseLong(
             properties.getProperty(
@@ -1485,13 +1479,6 @@ public class IoTDBDescriptor {
 
       // update tsfile-format config
       loadTsFileProps(properties);
-
-      // update frequency_interval_in_minute
-      conf.setFrequencyIntervalInMinute(
-          Integer.parseInt(
-              properties.getProperty(
-                  "frequency_interval_in_minute",
-                  Integer.toString(conf.getFrequencyIntervalInMinute()))));
       // update slow_query_threshold
       conf.setSlowQueryThreshold(
           Long.parseLong(

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -808,18 +808,6 @@ cluster_name=defaultCluster
 # And it is also used as the default compressor of time column in aligned timeseries.
 # compressor=LZ4
 
-# time interval in minute for calculating query frequency
-# Datatype: int
-# frequency_interval_in_minute=1
-
-# Signal-noise-ratio (SNR) of FREQ encoding
-# Datatype: double
-# freq_snr=40.0
-
-# Block size of FREQ encoding
-# Datatype: integer
-# freq_block_size=1024
-
 ####################
 ### Authorization Configuration
 ####################


### PR DESCRIPTION
## Description

Remove the following useless configs in iotdb-common.properties.

* frequency_interval_in_minute
* freq_snr
* freq_block_size