### PR TITLE
[RatisConsensus] Bump ratis snapshot version to 2.5.2-8efe8a1-SNAPSHOT

### DIFF
--- a/iotdb-core/consensus/pom.xml
+++ b/iotdb-core/consensus/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <ratis.version>2.5.2-8d897ea-SNAPSHOT</ratis.version>
+        <ratis.version>2.5.2-8efe8a1-SNAPSHOT</ratis.version>
         <consensus.test.skip>false</consensus.test.skip>
         <consensus.it.skip>${consensus.test.skip}</consensus.it.skip>
         <consensus.ut.skip>${consensus.test.skip}</consensus.ut.skip>


### PR DESCRIPTION
commits diff refer to https://github.com/apache/ratis/compare/release-2.5.1...snapshot-branch2