### PR TITLE
[To rel/1.2] Refactoring DeleteOutdatedFileTask in WalNode

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/checkpoint/CheckpointManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/checkpoint/CheckpointManager.java
@@ -88,7 +88,7 @@ public class CheckpointManager implements AutoCloseable {
     logHeader();
   }
 
-  private List<MemTableInfo> snapshotMemTableInfos() {
+  public List<MemTableInfo> snapshotMemTableInfos() {
     infoLock.lock();
     try {
       return new ArrayList<>(memTableId2Info.values());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
@@ -309,10 +309,12 @@ public class WALNode implements IWALNode {
 
     private void summarizeExecuteResult() {
       if (filesShouldDelete.length == 0) {
-        logger.info(
-            "wal node-{}:no wal file was found that should be deleted,current first valid version id is {}",
-            identifier,
-            firstValidVersionId);
+        if (logger.isDebugEnabled()) {
+          logger.debug(
+              "wal node-{}:no wal file was found that should be deleted, current first valid version id is {}",
+              identifier,
+              firstValidVersionId);
+        }
         return;
       }
 
@@ -322,7 +324,7 @@ public class WALNode implements IWALNode {
           StringBuilder summary =
               new StringBuilder(
                   String.format(
-                      "wal node-%s delete outdated files summary:the range that should be removed is: [%d,%d],delete successful is [%s],end file index is: [%s].The following reasons influenced the result: %s",
+                      "wal node-%s delete outdated files summary:the range that should be removed is: [%d,%d], delete successful is [%s], end file index is: [%s].The following reasons influenced the result: %s",
                       identifier,
                       WALFileUtils.parseVersionId(filesShouldDelete[0].getName()),
                       WALFileUtils.parseVersionId(
@@ -333,7 +335,7 @@ public class WALNode implements IWALNode {
 
           if (!pinnedMemTableIds.isEmpty()) {
             summary
-                .append("- MemTable has been flushed but pinned by PIPE,the MemTableId list is : ")
+                .append("- MemTable has been flushed but pinned by PIPE, the MemTableId list is : ")
                 .append(StringUtils.join(pinnedMemTableIds, ","))
                 .append(".")
                 .append(System.getProperty("line.separator"));
@@ -341,7 +343,7 @@ public class WALNode implements IWALNode {
           if (fileIndexAfterFilterSafelyDeleteIndex < filesShouldDelete.length) {
             summary.append(
                 String.format(
-                    "- The data in the wal file was not consumed by the consensus group,current search index is %d,safely delete index is %d",
+                    "- The data in the wal file was not consumed by the consensus group,current search index is %d, safely delete index is %d",
                     getCurrentSearchIndex(), safelyDeletedSearchIndex));
           }
           String summaryLog = summary.toString();


### PR DESCRIPTION
This commit reconstructs the execution logic of DeleteOutdatedFileTask, abstracting the collation logic into the following steps:

Delete obsolete wal files
Update the valid information ratio
Determine whether snapshot or flush is required based on the valid information ratio
Summarize the execution result and export it
In addition, there are two updates:

The initial assignment process of the property is moved to the constructor, which makes the code look cleaner.
If the retry process after snapshot or flush is deleted, it is difficult to execute statistics containing multiple retry results at a time.