### PR TITLE
Fixed wal triggering disk threshold loop too many times

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/WALManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/WALManager.java
@@ -172,16 +172,20 @@ public class WALManager implements IService {
   }
 
   private void deleteOutdatedFiles() {
-    List<WALNode> walNodes = walNodesManager.getNodesSnapshot();
-    walNodes.sort((node1, node2) -> Long.compare(node2.getDiskUsage(), node1.getDiskUsage()));
-    for (WALNode walNode : walNodes) {
-      walNode.deleteOutdatedFiles();
-    }
-    if (shouldThrottle()) {
-      logger.warn(
-          "WAL disk usage {} is larger than the iot_consensus_throttle_threshold_in_byte {}, please check your write load, iot consensus and the pipe module. It's better to allocate more disk for WAL.",
-          getTotalDiskUsage(),
-          getThrottleThreshold());
+    boolean firstLoop = true;
+    while (firstLoop || shouldThrottle()) {
+      List<WALNode> walNodes = walNodesManager.getNodesSnapshot();
+      walNodes.sort((node1, node2) -> Long.compare(node2.getDiskUsage(), node1.getDiskUsage()));
+      for (WALNode walNode : walNodes) {
+        walNode.deleteOutdatedFiles();
+      }
+      if (firstLoop && shouldThrottle()) {
+        logger.warn(
+            "WAL disk usage {} is larger than the iot_consensus_throttle_threshold_in_byte {}, please check your write load, iot consensus and the pipe module. It's better to allocate more disk for WAL.",
+            getTotalDiskUsage(),
+            getThrottleThreshold());
+      }
+      firstLoop = false;
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
@@ -270,7 +270,7 @@ public class WALNode implements IWALNode {
       // In addition, if the disk space used by wal exceeds the limit threshold, resulting in a
       // write rejection, the task will continue to attempt to delete expired files until the
       // threshold is no longer exceeded
-      while (recursionTime < MAX_RECURSION_TIME || WALManager.getInstance().shouldThrottle()) {
+      while (recursionTime < MAX_RECURSION_TIME) {
         // init delete outdated file task fields
         init();
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
@@ -286,8 +286,7 @@ public class WALNode implements IWALNode {
         // decide whether to snapshot or flush based on the effective info ration and throttle
         // threshold
         if (trySnapshotOrFlushMemTable()
-            && safelyDeletedSearchIndex != DEFAULT_SAFELY_DELETED_SEARCH_INDEX
-            && !WALManager.getInstance().shouldThrottle()) {
+            && safelyDeletedSearchIndex != DEFAULT_SAFELY_DELETED_SEARCH_INDEX) {
           return;
         }
         recursionTime++;


### PR DESCRIPTION
Fix wal triggering disk threshold too many times loop, when the threshold is triggered, the original motivation is to keep trying to delete expired files. However, when a WalNode has no files to delete, and the Wal disk file size still exceeds the threshold, the task cannot exit the loop.

Wal disk thresholds are more properly managed by Wal Manager. So this change moves this logic into the Wal Manager.