### PR TITLE
[To rel/1.2] Fixed wal triggering disk threshold loop too many times

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/WALManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/WALManager.java
@@ -172,6 +172,9 @@ public class WALManager implements IService {
   }
 
   private void deleteOutdatedFiles() {
+    // Normally, only need to delete the expired file once. When the WAL disk file size exceeds the
+    // threshold, the system continues to delete expired files until the disk size is smaller than
+    // the threshold.
     boolean firstLoop = true;
     while (firstLoop || shouldThrottle()) {
       List<WALNode> walNodes = walNodesManager.getNodesSnapshot();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/WALManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/WALManager.java
@@ -172,16 +172,20 @@ public class WALManager implements IService {
   }
 
   private void deleteOutdatedFiles() {
-    List<WALNode> walNodes = walNodesManager.getNodesSnapshot();
-    walNodes.sort((node1, node2) -> Long.compare(node2.getDiskUsage(), node1.getDiskUsage()));
-    for (WALNode walNode : walNodes) {
-      walNode.deleteOutdatedFiles();
-    }
-    if (shouldThrottle()) {
-      logger.warn(
-          "WAL disk usage {} is larger than the iot_consensus_throttle_threshold_in_byte {}, please check your write load, iot consensus and the pipe module. It's better to allocate more disk for WAL.",
-          getTotalDiskUsage(),
-          getThrottleThreshold());
+    boolean firstLoop = true;
+    while (firstLoop || shouldThrottle()) {
+      List<WALNode> walNodes = walNodesManager.getNodesSnapshot();
+      walNodes.sort((node1, node2) -> Long.compare(node2.getDiskUsage(), node1.getDiskUsage()));
+      for (WALNode walNode : walNodes) {
+        walNode.deleteOutdatedFiles();
+      }
+      if (firstLoop && shouldThrottle()) {
+        logger.warn(
+            "WAL disk usage {} is larger than the iot_consensus_throttle_threshold_in_byte {}, please check your write load, iot consensus and the pipe module. It's better to allocate more disk for WAL.",
+            getTotalDiskUsage(),
+            getThrottleThreshold());
+      }
+      firstLoop = false;
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
@@ -267,10 +267,7 @@ public class WALNode implements IWALNode {
     public void run() {
       // The intent of the loop execution here is to try to get as many memTable flush or snapshot
       // as possible when the valid information ratio is less than the configured value.
-      // In addition, if the disk space used by wal exceeds the limit threshold, resulting in a
-      // write rejection, the task will continue to attempt to delete expired files until the
-      // threshold is no longer exceeded
-      while (recursionTime < MAX_RECURSION_TIME || WALManager.getInstance().shouldThrottle()) {
+      while (recursionTime < MAX_RECURSION_TIME) {
         // init delete outdated file task fields
         init();
 
@@ -286,8 +283,7 @@ public class WALNode implements IWALNode {
         // decide whether to snapshot or flush based on the effective info ration and throttle
         // threshold
         if (trySnapshotOrFlushMemTable()
-            && safelyDeletedSearchIndex != DEFAULT_SAFELY_DELETED_SEARCH_INDEX
-            && !WALManager.getInstance().shouldThrottle()) {
+            && safelyDeletedSearchIndex != DEFAULT_SAFELY_DELETED_SEARCH_INDEX) {
           return;
         }
         recursionTime++;


### PR DESCRIPTION
Fix wal triggering disk threshold too many times loop, when the threshold is triggered, the original motivation is to keep trying to delete expired files. However, when a WalNode has no files to delete, and the Wal disk file size still exceeds the threshold, the task cannot exit the loop.

Wal disk thresholds are more properly managed by Wal Manager. So this change moves this logic into the Wal Manager.

## Test

### Test method
1. edit `iotdb-common.properties`, add `iot_consensus_throttle_threshold_in_byte=1073741824`(1GB) param;
2. start a 1C1D or 3C3D cluster
3. enable heavy writes (such as 10 clients) through the Grafana plugin or directly view the `data/datanode/wal` directory, with the expectation that WAL files will be sorted when they exceed 'iot_consensus_throttle_threshold_in_byte * 0.8'. Until it is less than this value

### Before this change
**Description:** 
More than `iot_consensus_throttle_threshold_in_byte * 0.8` will be sorted, but may only be sorted once, and prevent the next sorting.Prior to this, the logic was that when the disk size exceeded `iot_consensus_throttle_threshold_in_byte * 0.8`, it would be held, but cycled through a single WalNode. When there are no files to delete in WalNode and the WAL disk file threshold is still higher, the loop cannot exit normally.
**Snapshot:**
<img width="1719" alt="image" src="https://github.com/apache/iotdb/assets/34238279/799f1fc8-a57b-43fe-9a6a-ee33c3965574">

### After this change
**Description:**
Move the threshold determination logic from WalNode and ensure that the loop exits normally.It is unreasonable to judge the threshold condition in WalNode, because it does not know the disk occupation of other walnodes. WalManager manages all Walnodes, and wal file throttle is the perspective of all walnodes, not a single WalNode, it is more reasonable to judge in WalManager. When the value is higher than the threshold, continue to try to delete expired files. When the value is lower than the threshold, exit the loop.
**Snapshot:**
<img width="1734" alt="image" src="https://github.com/apache/iotdb/assets/34238279/3c5d0ebe-ab3c-4a82-a464-7ef0f025ee48">

