### PR TITLE
[IOTDB-6130] Delete data by specific pattern didn't work

### DIFF
--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTree.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTree.java
@@ -220,11 +220,6 @@ public class PathPatternTree {
         return;
       }
     }
-    if (curNode.isWildcard()) {
-      resultNodesSet.add(new ArrayList<>(nodes));
-      nodes.remove(nodes.size() - 1);
-      return;
-    }
     for (PathPatternNode<Void, VoidSerializer> childNode : curNode.getChildren().values()) {
       searchDevicePath(childNode, nodes, resultNodesSet);
     }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTree.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTree.java
@@ -186,11 +186,6 @@ public class PathPatternTree {
         return;
       }
     }
-    if (curNode.isWildcard()) {
-      results.add(convertNodesToString(nodes));
-      nodes.remove(nodes.size() - 1);
-      return;
-    }
     for (PathPatternNode<Void, VoidSerializer> childNode : curNode.getChildren().values()) {
       searchDevicePattern(childNode, nodes, results);
     }

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/path/PathPatternTreeTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/path/PathPatternTreeTest.java
@@ -58,7 +58,7 @@ public class PathPatternTreeTest {
             new PartialPath("root.sg1.*.t1.s1"),
             new PartialPath("root.sg1.d2.t1.s1")),
         Arrays.asList(new PartialPath("root.sg1.d1.t2.s2"), new PartialPath("root.sg1.*.t1.s1")),
-        Arrays.asList(new PartialPath("root.sg1.d1.t2"), new PartialPath("root.sg1.*")),
+        Arrays.asList(new PartialPath("root.sg1.d1.t2"), new PartialPath("root.sg1.*.t1")),
         true);
   }
 


### PR DESCRIPTION
## Description
Execute the following sql, you will see data of root.sg.d2.s1 doesn't delete by `delete from root.*.*.s1`.

```
IoTDB> insert into root.sg.d2(time,s1,s2) values(1,2,3)
Msg: The statement is executed successfully.
IoTDB> flush
Msg: The statement is executed successfully.
IoTDB> select ** from root
+-----------------------------+-------------+-------------+
|                         Time|root.sg.d2.s1|root.sg.d2.s2|
+-----------------------------+-------------+-------------+
|1970-01-01T08:00:00.001+08:00|          2.0|          3.0|
+-----------------------------+-------------+-------------+
Total line number = 1
It costs 0.153s
IoTDB> delete from root.*.*.s1
Msg: The statement is executed successfully.
IoTDB> select ** from root
+-----------------------------+-------------+-------------+
|                         Time|root.sg.d2.s1|root.sg.d2.s2|
+-----------------------------+-------------+-------------+
|1970-01-01T08:00:00.001+08:00|          2.0|          3.0|
+-----------------------------+-------------+-------------+
Total line number = 1
It costs 0.013s
IoTDB> delete from root.**.s1
Msg: The statement is executed successfully.
IoTDB> select ** from root
+-----------------------------+-------------+-------------+
|                         Time|root.sg.d2.s1|root.sg.d2.s2|
+-----------------------------+-------------+-------------+
|1970-01-01T08:00:00.001+08:00|         null|          3.0|
+-----------------------------+-------------+-------------+
Total line number = 1
It costs 0.018s
```