### PR TITLE
[RatisConsensus] use warn_and_return to enable cluster restart when log corruption can be ignored

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/utils/Utils.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/utils/Utils.java
@@ -292,5 +292,8 @@ public class Utils {
 
     RaftServerConfigKeys.setSleepDeviationThreshold(
         properties, config.getUtils().getSleepDeviationThresholdMs());
+
+    RaftServerConfigKeys.Log.setCorruptionPolicy(
+        properties, RaftServerConfigKeys.Log.CorruptionPolicy.WARN_AND_RETURN);
   }
 }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/utils/Utils.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/utils/Utils.java
@@ -269,6 +269,8 @@ public class Utils {
     RaftServerConfigKeys.Log.setForceSyncNum(properties, config.getLog().getForceSyncNum());
     RaftServerConfigKeys.Log.setUnsafeFlushEnabled(
         properties, config.getLog().isUnsafeFlushEnabled());
+    RaftServerConfigKeys.Log.setCorruptionPolicy(
+        properties, RaftServerConfigKeys.Log.CorruptionPolicy.WARN_AND_RETURN);
 
     RaftServerConfigKeys.Log.Appender.setBufferByteLimit(
         properties, config.getLeaderLogAppender().getBufferByteLimit());
@@ -292,8 +294,5 @@ public class Utils {
 
     RaftServerConfigKeys.setSleepDeviationThreshold(
         properties, config.getUtils().getSleepDeviationThresholdMs());
-
-    RaftServerConfigKeys.Log.setCorruptionPolicy(
-        properties, RaftServerConfigKeys.Log.CorruptionPolicy.WARN_AND_RETURN);
   }
 }


### PR DESCRIPTION
See the details in https://issues.apache.org/jira/browse/RATIS-1879 