### PR TITLE
Release chunk data buffer after copy page data from it in aligned series FastCompaction 

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/AlignedSeriesCompactionExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/AlignedSeriesCompactionExecutor.java
@@ -266,6 +266,7 @@ public class AlignedSeriesCompactionExecutor extends SeriesCompactionExecutor {
       timePageHeaders.add(pageHeader);
       compressedTimePageDatas.add(compressedPageData);
     }
+    timeChunk.releaseChunkDataBuffer();
 
     // deserialize value chunks
     List<Chunk> valueChunks = chunkMetadataElement.valueChunks;
@@ -301,6 +302,7 @@ public class AlignedSeriesCompactionExecutor extends SeriesCompactionExecutor {
           compressedValuePageDatas.get(i).add(compressedPageData);
         }
       }
+      valueChunk.releaseChunkDataBuffer();
     }
 
     // add aligned pages into page queue
@@ -322,7 +324,7 @@ public class AlignedSeriesCompactionExecutor extends SeriesCompactionExecutor {
               alignedPageHeaders,
               compressedTimePageDatas.get(i),
               alignedPageDatas,
-              new AlignedChunkReader(timeChunk, valueChunks),
+              new AlignedChunkReader(timeChunk, valueChunks, false),
               chunkMetadataElement,
               i == timePageHeaders.size() - 1,
               chunkMetadataElement.priority));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/AlignedSeriesCompactionExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/AlignedSeriesCompactionExecutor.java
@@ -250,19 +250,18 @@ public class AlignedSeriesCompactionExecutor extends SeriesCompactionExecutor {
     // deserialize time chunk
     Chunk timeChunk = chunkMetadataElement.chunk;
 
-    ChunkReader timeChunkReader = new ChunkReader(timeChunk);
-    ByteBuffer timeChunkDataBuffer = timeChunk.getData();
-    ChunkHeader timeChunkHeader = timeChunk.getHeader();
-    while (timeChunkDataBuffer.remaining() > 0) {
+    ChunkReader chunkReader = new ChunkReader(timeChunk);
+    ByteBuffer chunkDataBuffer = timeChunk.getData();
+    ChunkHeader chunkHeader = timeChunk.getHeader();
+    while (chunkDataBuffer.remaining() > 0) {
       // deserialize a PageHeader from chunkDataBuffer
       PageHeader pageHeader;
-      if (((byte) (timeChunkHeader.getChunkType() & 0x3F))
-          == MetaMarker.ONLY_ONE_PAGE_CHUNK_HEADER) {
-        pageHeader = PageHeader.deserializeFrom(timeChunkDataBuffer, timeChunk.getChunkStatistic());
+      if (((byte) (chunkHeader.getChunkType() & 0x3F)) == MetaMarker.ONLY_ONE_PAGE_CHUNK_HEADER) {
+        pageHeader = PageHeader.deserializeFrom(chunkDataBuffer, timeChunk.getChunkStatistic());
       } else {
-        pageHeader = PageHeader.deserializeFrom(timeChunkDataBuffer, timeChunkHeader.getDataType());
+        pageHeader = PageHeader.deserializeFrom(chunkDataBuffer, chunkHeader.getDataType());
       }
-      ByteBuffer compressedPageData = timeChunkReader.readPageDataWithoutUncompressing(pageHeader);
+      ByteBuffer compressedPageData = chunkReader.readPageDataWithoutUncompressing(pageHeader);
       timePageHeaders.add(pageHeader);
       compressedTimePageDatas.add(compressedPageData);
     }
@@ -278,30 +277,26 @@ public class AlignedSeriesCompactionExecutor extends SeriesCompactionExecutor {
         compressedValuePageDatas.add(null);
         continue;
       }
-      timeChunkReader = new ChunkReader(valueChunk);
-      timeChunkDataBuffer = valueChunk.getData();
-      timeChunkHeader = valueChunk.getHeader();
+      chunkReader = new ChunkReader(valueChunk);
+      chunkDataBuffer = valueChunk.getData();
+      chunkHeader = valueChunk.getHeader();
 
       valuePageHeaders.add(new ArrayList<>());
       compressedValuePageDatas.add(new ArrayList<>());
-      while (timeChunkDataBuffer.remaining() > 0) {
+      while (chunkDataBuffer.remaining() > 0) {
         // deserialize a PageHeader from chunkDataBuffer
         PageHeader pageHeader;
-        if (((byte) (timeChunkHeader.getChunkType() & 0x3F))
-            == MetaMarker.ONLY_ONE_PAGE_CHUNK_HEADER) {
-          pageHeader =
-              PageHeader.deserializeFrom(timeChunkDataBuffer, valueChunk.getChunkStatistic());
+        if (((byte) (chunkHeader.getChunkType() & 0x3F)) == MetaMarker.ONLY_ONE_PAGE_CHUNK_HEADER) {
+          pageHeader = PageHeader.deserializeFrom(chunkDataBuffer, valueChunk.getChunkStatistic());
         } else {
-          pageHeader =
-              PageHeader.deserializeFrom(timeChunkDataBuffer, timeChunkHeader.getDataType());
+          pageHeader = PageHeader.deserializeFrom(chunkDataBuffer, chunkHeader.getDataType());
         }
         if (pageHeader.getCompressedSize() == 0) {
           // empty value page
           valuePageHeaders.get(i).add(null);
           compressedValuePageDatas.get(i).add(null);
         } else {
-          ByteBuffer compressedPageData =
-              timeChunkReader.readPageDataWithoutUncompressing(pageHeader);
+          ByteBuffer compressedPageData = chunkReader.readPageDataWithoutUncompressing(pageHeader);
           valuePageHeaders.get(i).add(pageHeader);
           compressedValuePageDatas.get(i).add(compressedPageData);
         }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/element/PageElement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/element/PageElement.java
@@ -113,6 +113,9 @@ public class PageElement {
     if (this.iChunkReader instanceof ChunkReader) {
       this.batchData = ((ChunkReader) iChunkReader).readPageData(pageHeader, pageData);
     } else {
+      // In order to save memory, AlignedChunkReader is not used here.
+      // If the variable 'iChunkReader' is null, it means that it is
+      // currently an aligned series.
       this.pointReader = getAlignedPagePointReader();
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/element/PageElement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/element/PageElement.java
@@ -110,10 +110,10 @@ public class PageElement {
   }
 
   public void deserializePage() throws IOException {
-    if (this.iChunkReader == null) {
-      this.pointReader = getAlignedPagePointReader();
-    } else {
+    if (this.iChunkReader instanceof ChunkReader) {
       this.batchData = ((ChunkReader) iChunkReader).readPageData(pageHeader, pageData);
+    } else {
+      this.pointReader = getAlignedPagePointReader();
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/element/PageElement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/element/PageElement.java
@@ -105,7 +105,7 @@ public class PageElement {
   }
 
   public void deserializePage() throws IOException {
-    if (iChunkReader instanceof AlignedChunkReader) {
+    if (this.iChunkReader == null) {
       List<ChunkHeader> valueChunkHeaderList =
           new ArrayList<>(chunkMetadataElement.valueChunks.size());
       List<List<TimeRange>> valueDeleteIntervalList =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/element/PageElement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/element/PageElement.java
@@ -111,53 +111,36 @@ public class PageElement {
 
   public void deserializePage() throws IOException {
     if (this.iChunkReader == null) {
-      List<ChunkHeader> valueChunkHeaderList =
-          new ArrayList<>(chunkMetadataElement.valueChunks.size());
-      List<List<TimeRange>> valueDeleteIntervalList =
-          new ArrayList<>(chunkMetadataElement.valueChunks.size());
-      for (Chunk valueChunk : chunkMetadataElement.valueChunks) {
-        valueChunkHeaderList.add(valueChunk == null ? null : valueChunk.getHeader());
-        valueDeleteIntervalList.add(valueChunk == null ? null : valueChunk.getDeleteIntervalList());
-      }
-      this.pointReader =
-          getAlignedPagePointReader(
-              chunkMetadataElement.chunk.getHeader(),
-              valueChunkHeaderList,
-              valueDeleteIntervalList,
-              pageHeader,
-              valuePageHeaders,
-              pageData,
-              valuePageDatas);
+      this.pointReader = getAlignedPagePointReader();
     } else {
       this.batchData = ((ChunkReader) iChunkReader).readPageData(pageHeader, pageData);
     }
   }
 
-  private IPointReader getAlignedPagePointReader(
-      ChunkHeader timeChunkHeader,
-      List<ChunkHeader> valueChunkHeaderList,
-      List<List<TimeRange>> valueDeleteIntervalList,
-      PageHeader timePageHeader,
-      List<PageHeader> valuePageHeaders,
-      ByteBuffer compressedTimePageData,
-      List<ByteBuffer> compressedValuePageDatas)
-      throws IOException {
-
+  private IPointReader getAlignedPagePointReader() throws IOException {
+    // construct time page reader
+    ChunkHeader timeChunkHeader = chunkMetadataElement.chunk.getHeader();
     IUnCompressor timeUnCompressor =
         IUnCompressor.getUnCompressor(timeChunkHeader.getCompressionType());
     Decoder timeDecoder =
         Decoder.getDecoderByType(timeChunkHeader.getEncodingType(), timeChunkHeader.getDataType());
     ByteBuffer uncompressedTimePageData =
-        uncompressPageData(timePageHeader, timeUnCompressor, compressedTimePageData);
+        uncompressPageData(pageHeader, timeUnCompressor, pageData);
     TimePageReader timePageReader =
-        new TimePageReader(timePageHeader, uncompressedTimePageData, timeDecoder);
+        new TimePageReader(pageHeader, uncompressedTimePageData, timeDecoder);
+    // release compressed time page data
+    pageData = null;
 
-    List<ValuePageReader> valuePageReaders = new ArrayList<>(valueChunkHeaderList.size());
+    // construct value page readers
+    List<ValuePageReader> valuePageReaders = new ArrayList<>(valuePageHeaders.size());
     for (int i = 0; i < valuePageHeaders.size(); i++) {
       if (valuePageHeaders.get(i) == null) {
         valuePageReaders.add(null);
       } else {
-        ChunkHeader valueChunkHeader = valueChunkHeaderList.get(i);
+        // the data buffer of all chunk has been released
+        Chunk valueChunk = chunkMetadataElement.valueChunks.get(i);
+        ChunkHeader valueChunkHeader = valueChunk.getHeader();
+        List<TimeRange> valueDeleteIntervalList = valueChunk.getDeleteIntervalList();
         TSDataType valueType = valueChunkHeader.getDataType();
         Decoder valuePageDecoder =
             Decoder.getDecoderByType(valueChunkHeader.getEncodingType(), valueType);
@@ -165,16 +148,17 @@ public class PageElement {
             uncompressPageData(
                 valuePageHeaders.get(i),
                 IUnCompressor.getUnCompressor(valueChunkHeader.getCompressionType()),
-                compressedValuePageDatas.get(i));
+                valuePageDatas.get(i));
         ValuePageReader valuePageReader =
             new ValuePageReader(
                 valuePageHeaders.get(i), uncompressedPageData, valueType, valuePageDecoder);
-        if (valueDeleteIntervalList != null) {
-          valuePageReader.setDeleteIntervalList(valueDeleteIntervalList.get(i));
-        }
+        valuePageReader.setDeleteIntervalList(valueDeleteIntervalList);
         valuePageReaders.add(valuePageReader);
+        // release compressed value page data
+        valuePageDatas.set(i, null);
       }
     }
+
     return new LazyLoadAlignedPagePointReader(timePageReader, valuePageReaders);
   }
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/FastCompactionPerformerWithInconsistentCompressionTypeAndEncodingTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/FastCompactionPerformerWithInconsistentCompressionTypeAndEncodingTest.java
@@ -71,6 +71,64 @@ public class FastCompactionPerformerWithInconsistentCompressionTypeAndEncodingTe
     super.tearDown();
   }
 
+  public static void main(String[] args) throws IOException, InterruptedException, MetadataException, WriteProcessException, StorageEngineException {
+    FastCompactionPerformerWithInconsistentCompressionTypeAndEncodingTest t = new FastCompactionPerformerWithInconsistentCompressionTypeAndEncodingTest();
+    t.setUp();
+
+    t.test41();
+
+    t.tearDown();
+  }
+
+  @Test
+  public void test41() throws MetadataException, IOException, WriteProcessException {
+
+    List<String> list = new ArrayList<>();
+    for (int i = 0; i < 2000; i++) {
+      list.add("s" + i);
+    }
+    TimeRange[] file1Chunk1 =
+        new TimeRange[] {
+            new TimeRange(10000, 15000), new TimeRange(16000, 19000), new TimeRange(20000, 29000)
+        };
+    TsFileResource seqResource1 =
+        generateSingleAlignedSeriesFile(
+            "d0",
+            list,
+            new TimeRange[][] { file1Chunk1 },
+            TSEncoding.PLAIN,
+            CompressionType.LZ4,
+            true);
+    seqResources.add(seqResource1);
+
+    TimeRange[] file2Chunk1 =
+        new TimeRange[] {
+            new TimeRange(10000, 15000), new TimeRange(16000, 19000), new TimeRange(20000, 29000)
+        };
+    TsFileResource unseqResource =
+        generateSingleAlignedSeriesFile(
+            "d0",
+            list,
+            new TimeRange[][] { file2Chunk1 },
+            TSEncoding.PLAIN,
+            CompressionType.UNCOMPRESSED,
+            true);
+    unseqResources.add(unseqResource);
+
+    CrossSpaceCompactionTask task =
+        new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            seqResources,
+            unseqResources,
+            new FastCompactionPerformer(true),
+            new AtomicInteger(0),
+            0,
+            0);
+
+    Assert.assertTrue(task.start());
+  }
+
   @Test
   public void test1() throws MetadataException, IOException, WriteProcessException {
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/FastCompactionPerformerWithInconsistentCompressionTypeAndEncodingTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/FastCompactionPerformerWithInconsistentCompressionTypeAndEncodingTest.java
@@ -71,64 +71,6 @@ public class FastCompactionPerformerWithInconsistentCompressionTypeAndEncodingTe
     super.tearDown();
   }
 
-  public static void main(String[] args) throws IOException, InterruptedException, MetadataException, WriteProcessException, StorageEngineException {
-    FastCompactionPerformerWithInconsistentCompressionTypeAndEncodingTest t = new FastCompactionPerformerWithInconsistentCompressionTypeAndEncodingTest();
-    t.setUp();
-
-    t.test41();
-
-    t.tearDown();
-  }
-
-  @Test
-  public void test41() throws MetadataException, IOException, WriteProcessException {
-
-    List<String> list = new ArrayList<>();
-    for (int i = 0; i < 2000; i++) {
-      list.add("s" + i);
-    }
-    TimeRange[] file1Chunk1 =
-        new TimeRange[] {
-            new TimeRange(10000, 15000), new TimeRange(16000, 19000), new TimeRange(20000, 29000)
-        };
-    TsFileResource seqResource1 =
-        generateSingleAlignedSeriesFile(
-            "d0",
-            list,
-            new TimeRange[][] { file1Chunk1 },
-            TSEncoding.PLAIN,
-            CompressionType.LZ4,
-            true);
-    seqResources.add(seqResource1);
-
-    TimeRange[] file2Chunk1 =
-        new TimeRange[] {
-            new TimeRange(10000, 15000), new TimeRange(16000, 19000), new TimeRange(20000, 29000)
-        };
-    TsFileResource unseqResource =
-        generateSingleAlignedSeriesFile(
-            "d0",
-            list,
-            new TimeRange[][] { file2Chunk1 },
-            TSEncoding.PLAIN,
-            CompressionType.UNCOMPRESSED,
-            true);
-    unseqResources.add(unseqResource);
-
-    CrossSpaceCompactionTask task =
-        new CrossSpaceCompactionTask(
-            0,
-            tsFileManager,
-            seqResources,
-            unseqResources,
-            new FastCompactionPerformer(true),
-            new AtomicInteger(0),
-            0,
-            0);
-
-    Assert.assertTrue(task.start());
-  }
-
   @Test
   public void test1() throws MetadataException, IOException, WriteProcessException {
 

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/Chunk.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/Chunk.java
@@ -148,4 +148,8 @@ public class Chunk {
   public Statistics getChunkStatistic() {
     return chunkStatistic;
   }
+
+  public void releaseChunkDataBuffer() {
+    this.chunkData = null;
+  }
 }

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/chunk/AlignedChunkReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/chunk/AlignedChunkReader.java
@@ -72,12 +72,8 @@ public class AlignedChunkReader implements IChunkReader {
    * compaction.
    */
   public AlignedChunkReader(Chunk timeChunk, List<Chunk> valueChunkList) {
-    this(timeChunk, valueChunkList, true);
-  }
-
-  public AlignedChunkReader(Chunk timeChunk, List<Chunk> valueChunkList, boolean referChunkData) {
     this.filter = null;
-    this.timeChunkDataBuffer = referChunkData ? timeChunk.getData() : null;
+    this.timeChunkDataBuffer =timeChunk.getData();
     this.valueDeleteIntervalList = new ArrayList<>();
     this.timeChunkHeader = timeChunk.getHeader();
     this.timeUnCompressor = IUnCompressor.getUnCompressor(timeChunkHeader.getCompressionType());
@@ -86,9 +82,7 @@ public class AlignedChunkReader implements IChunkReader {
     valueChunkList.forEach(
         chunk -> {
           valueChunkHeaderList.add(chunk == null ? null : chunk.getHeader());
-          if (referChunkData) {
-            valueChunkDataBufferList.add(chunk == null ? null : chunk.getData());
-          }
+          valueChunkDataBufferList.add(chunk == null ? null : chunk.getData());
           valueDeleteIntervalList.add(chunk == null ? null : chunk.getDeleteIntervalList());
         });
   }

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/chunk/AlignedChunkReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/chunk/AlignedChunkReader.java
@@ -73,7 +73,7 @@ public class AlignedChunkReader implements IChunkReader {
    */
   public AlignedChunkReader(Chunk timeChunk, List<Chunk> valueChunkList) {
     this.filter = null;
-    this.timeChunkDataBuffer =timeChunk.getData();
+    this.timeChunkDataBuffer = timeChunk.getData();
     this.valueDeleteIntervalList = new ArrayList<>();
     this.timeChunkHeader = timeChunk.getHeader();
     this.timeUnCompressor = IUnCompressor.getUnCompressor(timeChunkHeader.getCompressionType());

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/chunk/AlignedChunkReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/chunk/AlignedChunkReader.java
@@ -283,13 +283,20 @@ public class AlignedChunkReader implements IChunkReader {
   }
 
   /** Read data from compressed page data. Uncompress the page and decode it to tsblock data. */
-  public IPointReader getPagePointReader(
+  public static IPointReader getPagePointReader(
+      ChunkHeader timeChunkHeader,
+      List<ChunkHeader> valueChunkHeaderList,
+      List<List<TimeRange>> valueDeleteIntervalList,
       PageHeader timePageHeader,
       List<PageHeader> valuePageHeaders,
       ByteBuffer compressedTimePageData,
       List<ByteBuffer> compressedValuePageDatas)
       throws IOException {
 
+    IUnCompressor timeUnCompressor =
+        IUnCompressor.getUnCompressor(timeChunkHeader.getCompressionType());
+    Decoder timeDecoder =
+        Decoder.getDecoderByType(timeChunkHeader.getEncodingType(), timeChunkHeader.getDataType());
     // uncompress time page data
     ByteBuffer uncompressedTimePageData =
         uncompressPageData(timePageHeader, timeUnCompressor, compressedTimePageData);
@@ -332,7 +339,7 @@ public class AlignedChunkReader implements IChunkReader {
     return alignedPageReader.getLazyPointReader();
   }
 
-  private ByteBuffer uncompressPageData(
+  private static ByteBuffer uncompressPageData(
       PageHeader pageHeader, IUnCompressor unCompressor, ByteBuffer compressedPageData)
       throws IOException {
     int compressedPageBodyLength = pageHeader.getCompressedSize();

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/chunk/AlignedChunkReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/chunk/AlignedChunkReader.java
@@ -72,8 +72,12 @@ public class AlignedChunkReader implements IChunkReader {
    * compaction.
    */
   public AlignedChunkReader(Chunk timeChunk, List<Chunk> valueChunkList) {
+    this(timeChunk, valueChunkList, true);
+  }
+
+  public AlignedChunkReader(Chunk timeChunk, List<Chunk> valueChunkList, boolean referChunkData) {
     this.filter = null;
-    this.timeChunkDataBuffer = timeChunk.getData();
+    this.timeChunkDataBuffer = referChunkData ? timeChunk.getData() : null;
     this.valueDeleteIntervalList = new ArrayList<>();
     this.timeChunkHeader = timeChunk.getHeader();
     this.timeUnCompressor = IUnCompressor.getUnCompressor(timeChunkHeader.getCompressionType());
@@ -82,7 +86,9 @@ public class AlignedChunkReader implements IChunkReader {
     valueChunkList.forEach(
         chunk -> {
           valueChunkHeaderList.add(chunk == null ? null : chunk.getHeader());
-          valueChunkDataBufferList.add(chunk == null ? null : chunk.getData());
+          if (referChunkData) {
+            valueChunkDataBufferList.add(chunk == null ? null : chunk.getData());
+          }
           valueDeleteIntervalList.add(chunk == null ? null : chunk.getDeleteIntervalList());
         });
   }

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/AlignedPageReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/AlignedPageReader.java
@@ -32,7 +32,6 @@ import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.apache.iotdb.tsfile.read.filter.operator.AndFilter;
 import org.apache.iotdb.tsfile.read.reader.IAlignedPageReader;
 import org.apache.iotdb.tsfile.read.reader.IPageReader;
-import org.apache.iotdb.tsfile.read.reader.IPointReader;
 import org.apache.iotdb.tsfile.read.reader.series.PaginationController;
 import org.apache.iotdb.tsfile.utils.TsPrimitiveType;
 
@@ -159,10 +158,6 @@ public class AlignedPageReader implements IPageReader, IAlignedPageReader {
       // TODO accept valueStatisticsList to filter
       return filter.satisfy(statistics);
     }
-  }
-
-  public IPointReader getLazyPointReader() throws IOException {
-    return new LazyLoadAlignedPagePointReader(timePageReader, valuePageReaderList);
   }
 
   @Override


### PR DESCRIPTION
## Description
When FastCompaction deserializes a overlapped Chunk into the Page queue, the ByteBuffer.get() method is called from the Chunk's Buffer to copy the data of each Page. After copy, the Page is wrapped into a PageElement and put into the pageQueue, but the timeChunk and valueChunks are passed into a new instance of AlignedChunkReader, which causes the clearChunks method to be called at the end of the method is not effective. The reference of each Chunk is still held by AlignedChunkReader and cannot be released. At this time, there is 2 times the chunk size of data in the memory.
## Fix
Release chunk data buffer after copy page data from it.