### PR TITLE
[To rel/1.2] Release chunk data buffer after copy page data from it in aligned series FastCompaction

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/AlignedSeriesCompactionExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/AlignedSeriesCompactionExecutor.java
@@ -40,7 +40,6 @@ import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
 import org.apache.iotdb.tsfile.file.metadata.IChunkMetadata;
 import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 import org.apache.iotdb.tsfile.read.common.Chunk;
-import org.apache.iotdb.tsfile.read.reader.chunk.AlignedChunkReader;
 import org.apache.iotdb.tsfile.read.reader.chunk.ChunkReader;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
@@ -266,6 +265,7 @@ public class AlignedSeriesCompactionExecutor extends SeriesCompactionExecutor {
       timePageHeaders.add(pageHeader);
       compressedTimePageDatas.add(compressedPageData);
     }
+    timeChunk.releaseChunkDataBuffer();
 
     // deserialize value chunks
     List<Chunk> valueChunks = chunkMetadataElement.valueChunks;
@@ -301,6 +301,7 @@ public class AlignedSeriesCompactionExecutor extends SeriesCompactionExecutor {
           compressedValuePageDatas.get(i).add(compressedPageData);
         }
       }
+      valueChunk.releaseChunkDataBuffer();
     }
 
     // add aligned pages into page queue
@@ -322,12 +323,10 @@ public class AlignedSeriesCompactionExecutor extends SeriesCompactionExecutor {
               alignedPageHeaders,
               compressedTimePageDatas.get(i),
               alignedPageDatas,
-              new AlignedChunkReader(timeChunk, valueChunks),
               chunkMetadataElement,
               i == timePageHeaders.size() - 1,
               chunkMetadataElement.priority));
     }
-    chunkMetadataElement.clearChunks();
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/element/PageElement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/element/PageElement.java
@@ -113,6 +113,9 @@ public class PageElement {
     if (this.iChunkReader instanceof ChunkReader) {
       this.batchData = ((ChunkReader) iChunkReader).readPageData(pageHeader, pageData);
     } else {
+      // In order to save memory, AlignedChunkReader is not used here.
+      // If the variable 'iChunkReader' is null, it means that it is
+      // currently an aligned series.
       this.pointReader = getAlignedPagePointReader();
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/element/PageElement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/element/PageElement.java
@@ -110,10 +110,10 @@ public class PageElement {
   }
 
   public void deserializePage() throws IOException {
-    if (this.iChunkReader == null) {
-      this.pointReader = getAlignedPagePointReader();
-    } else {
+    if (this.iChunkReader instanceof ChunkReader) {
       this.batchData = ((ChunkReader) iChunkReader).readPageData(pageHeader, pageData);
+    } else {
+      this.pointReader = getAlignedPagePointReader();
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/element/PageElement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/element/PageElement.java
@@ -105,7 +105,7 @@ public class PageElement {
   }
 
   public void deserializePage() throws IOException {
-    if (iChunkReader instanceof AlignedChunkReader) {
+    if (this.iChunkReader == null) {
       List<ChunkHeader> valueChunkHeaderList =
           new ArrayList<>(chunkMetadataElement.valueChunks.size());
       List<List<TimeRange>> valueDeleteIntervalList =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/element/PageElement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/element/PageElement.java
@@ -111,53 +111,36 @@ public class PageElement {
 
   public void deserializePage() throws IOException {
     if (this.iChunkReader == null) {
-      List<ChunkHeader> valueChunkHeaderList =
-          new ArrayList<>(chunkMetadataElement.valueChunks.size());
-      List<List<TimeRange>> valueDeleteIntervalList =
-          new ArrayList<>(chunkMetadataElement.valueChunks.size());
-      for (Chunk valueChunk : chunkMetadataElement.valueChunks) {
-        valueChunkHeaderList.add(valueChunk == null ? null : valueChunk.getHeader());
-        valueDeleteIntervalList.add(valueChunk == null ? null : valueChunk.getDeleteIntervalList());
-      }
-      this.pointReader =
-          getAlignedPagePointReader(
-              chunkMetadataElement.chunk.getHeader(),
-              valueChunkHeaderList,
-              valueDeleteIntervalList,
-              pageHeader,
-              valuePageHeaders,
-              pageData,
-              valuePageDatas);
+      this.pointReader = getAlignedPagePointReader();
     } else {
       this.batchData = ((ChunkReader) iChunkReader).readPageData(pageHeader, pageData);
     }
   }
 
-  private IPointReader getAlignedPagePointReader(
-      ChunkHeader timeChunkHeader,
-      List<ChunkHeader> valueChunkHeaderList,
-      List<List<TimeRange>> valueDeleteIntervalList,
-      PageHeader timePageHeader,
-      List<PageHeader> valuePageHeaders,
-      ByteBuffer compressedTimePageData,
-      List<ByteBuffer> compressedValuePageDatas)
-      throws IOException {
-
+  private IPointReader getAlignedPagePointReader() throws IOException {
+    // construct time page reader
+    ChunkHeader timeChunkHeader = chunkMetadataElement.chunk.getHeader();
     IUnCompressor timeUnCompressor =
         IUnCompressor.getUnCompressor(timeChunkHeader.getCompressionType());
     Decoder timeDecoder =
         Decoder.getDecoderByType(timeChunkHeader.getEncodingType(), timeChunkHeader.getDataType());
     ByteBuffer uncompressedTimePageData =
-        uncompressPageData(timePageHeader, timeUnCompressor, compressedTimePageData);
+        uncompressPageData(pageHeader, timeUnCompressor, pageData);
     TimePageReader timePageReader =
-        new TimePageReader(timePageHeader, uncompressedTimePageData, timeDecoder);
+        new TimePageReader(pageHeader, uncompressedTimePageData, timeDecoder);
+    // release compressed time page data
+    pageData = null;
 
-    List<ValuePageReader> valuePageReaders = new ArrayList<>(valueChunkHeaderList.size());
+    // construct value page readers
+    List<ValuePageReader> valuePageReaders = new ArrayList<>(valuePageHeaders.size());
     for (int i = 0; i < valuePageHeaders.size(); i++) {
       if (valuePageHeaders.get(i) == null) {
         valuePageReaders.add(null);
       } else {
-        ChunkHeader valueChunkHeader = valueChunkHeaderList.get(i);
+        // the data buffer of all chunk has been released
+        Chunk valueChunk = chunkMetadataElement.valueChunks.get(i);
+        ChunkHeader valueChunkHeader = valueChunk.getHeader();
+        List<TimeRange> valueDeleteIntervalList = valueChunk.getDeleteIntervalList();
         TSDataType valueType = valueChunkHeader.getDataType();
         Decoder valuePageDecoder =
             Decoder.getDecoderByType(valueChunkHeader.getEncodingType(), valueType);
@@ -165,16 +148,17 @@ public class PageElement {
             uncompressPageData(
                 valuePageHeaders.get(i),
                 IUnCompressor.getUnCompressor(valueChunkHeader.getCompressionType()),
-                compressedValuePageDatas.get(i));
+                valuePageDatas.get(i));
         ValuePageReader valuePageReader =
             new ValuePageReader(
                 valuePageHeaders.get(i), uncompressedPageData, valueType, valuePageDecoder);
-        if (valueDeleteIntervalList != null) {
-          valuePageReader.setDeleteIntervalList(valueDeleteIntervalList.get(i));
-        }
+        valuePageReader.setDeleteIntervalList(valueDeleteIntervalList);
         valuePageReaders.add(valuePageReader);
+        // release compressed value page data
+        valuePageDatas.set(i, null);
       }
     }
+
     return new LazyLoadAlignedPagePointReader(timePageReader, valuePageReaders);
   }
 

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/Chunk.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/Chunk.java
@@ -148,4 +148,8 @@ public class Chunk {
   public Statistics getChunkStatistic() {
     return chunkStatistic;
   }
+
+  public void releaseChunkDataBuffer() {
+    this.chunkData = null;
+  }
 }

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/chunk/AlignedChunkReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/chunk/AlignedChunkReader.java
@@ -277,13 +277,20 @@ public class AlignedChunkReader implements IChunkReader {
   }
 
   /** Read data from compressed page data. Uncompress the page and decode it to tsblock data. */
-  public IPointReader getPagePointReader(
+  public static IPointReader getPagePointReader(
+      ChunkHeader timeChunkHeader,
+      List<ChunkHeader> valueChunkHeaderList,
+      List<List<TimeRange>> valueDeleteIntervalList,
       PageHeader timePageHeader,
       List<PageHeader> valuePageHeaders,
       ByteBuffer compressedTimePageData,
       List<ByteBuffer> compressedValuePageDatas)
       throws IOException {
 
+    IUnCompressor timeUnCompressor =
+        IUnCompressor.getUnCompressor(timeChunkHeader.getCompressionType());
+    Decoder timeDecoder =
+        Decoder.getDecoderByType(timeChunkHeader.getEncodingType(), timeChunkHeader.getDataType());
     // uncompress time page data
     ByteBuffer uncompressedTimePageData =
         uncompressPageData(timePageHeader, timeUnCompressor, compressedTimePageData);
@@ -326,7 +333,7 @@ public class AlignedChunkReader implements IChunkReader {
     return alignedPageReader.getLazyPointReader();
   }
 
-  private ByteBuffer uncompressPageData(
+  private static ByteBuffer uncompressPageData(
       PageHeader pageHeader, IUnCompressor unCompressor, ByteBuffer compressedPageData)
       throws IOException {
     int compressedPageBodyLength = pageHeader.getCompressedSize();

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/AlignedPageReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/AlignedPageReader.java
@@ -32,7 +32,6 @@ import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.apache.iotdb.tsfile.read.filter.operator.AndFilter;
 import org.apache.iotdb.tsfile.read.reader.IAlignedPageReader;
 import org.apache.iotdb.tsfile.read.reader.IPageReader;
-import org.apache.iotdb.tsfile.read.reader.IPointReader;
 import org.apache.iotdb.tsfile.read.reader.series.PaginationController;
 import org.apache.iotdb.tsfile.utils.TsPrimitiveType;
 
@@ -159,10 +158,6 @@ public class AlignedPageReader implements IPageReader, IAlignedPageReader {
       // TODO accept valueStatisticsList to filter
       return filter.satisfy(statistics);
     }
-  }
-
-  public IPointReader getLazyPointReader() throws IOException {
-    return new LazyLoadAlignedPagePointReader(timePageReader, valuePageReaderList);
   }
 
   @Override


### PR DESCRIPTION
## Description
https://github.com/apache/iotdb/pull/11046
When FastCompaction deserializes a overlapped Chunk into the Page queue, the ByteBuffer.get() method is called from the Chunk's Buffer to copy the data of each Page. After copy, the Page is wrapped into a PageElement and put into the pageQueue, but the timeChunk and valueChunks are passed into a new instance of AlignedChunkReader, which causes the clearChunks method to be called at the end of the method is not effective. The reference of each Chunk is still held by AlignedChunkReader and cannot be released. At this time, there is 2 times the chunk size of data in the memory.
## Fix
Release chunk data buffer after copy page data from it.