### PR TITLE
[To rel/1.1] Release chunk data buffer after copy page data from it in aligned series FastCompaction

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/AlignedSeriesCompactionExecutor.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/AlignedSeriesCompactionExecutor.java
@@ -38,7 +38,6 @@ import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
 import org.apache.iotdb.tsfile.file.metadata.IChunkMetadata;
 import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
 import org.apache.iotdb.tsfile.read.common.Chunk;
-import org.apache.iotdb.tsfile.read.reader.chunk.AlignedChunkReader;
 import org.apache.iotdb.tsfile.read.reader.chunk.ChunkReader;
 import org.apache.iotdb.tsfile.utils.Pair;
 import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
@@ -232,6 +231,7 @@ public class AlignedSeriesCompactionExecutor extends SeriesCompactionExecutor {
       timePageHeaders.add(pageHeader);
       compressedTimePageDatas.add(compressedPageData);
     }
+    timeChunk.releaseChunkDataBuffer();
 
     // deserialize value chunks
     List<Chunk> valueChunks = chunkMetadataElement.valueChunks;
@@ -267,6 +267,7 @@ public class AlignedSeriesCompactionExecutor extends SeriesCompactionExecutor {
           compressedValuePageDatas.get(i).add(compressedPageData);
         }
       }
+      valueChunk.releaseChunkDataBuffer();
     }
 
     // add aligned pages into page queue
@@ -288,12 +289,10 @@ public class AlignedSeriesCompactionExecutor extends SeriesCompactionExecutor {
               alignedPageHeaders,
               compressedTimePageDatas.get(i),
               alignedPageDatas,
-              new AlignedChunkReader(timeChunk, valueChunks),
               chunkMetadataElement,
               i == timePageHeaders.size() - 1,
               chunkMetadataElement.priority));
     }
-    chunkMetadataElement.clearChunks();
   }
 
   @Override

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/element/PageElement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/element/PageElement.java
@@ -109,6 +109,9 @@ public class PageElement {
     if (this.iChunkReader instanceof ChunkReader) {
       this.batchData = ((ChunkReader) iChunkReader).readPageData(pageHeader, pageData);
     } else {
+      // In order to save memory, AlignedChunkReader is not used here.
+      // If the variable 'iChunkReader' is null, it means that it is
+      // currently an aligned series.
       this.pointReader = getAlignedPagePointReader();
     }
   }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/element/PageElement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/element/PageElement.java
@@ -18,15 +18,20 @@
  */
 package org.apache.iotdb.db.engine.compaction.execute.utils.executor.fast.element;
 
+import org.apache.iotdb.tsfile.compress.IUnCompressor;
+import org.apache.iotdb.tsfile.encoding.decoder.Decoder;
 import org.apache.iotdb.tsfile.file.header.ChunkHeader;
 import org.apache.iotdb.tsfile.file.header.PageHeader;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.Chunk;
 import org.apache.iotdb.tsfile.read.common.TimeRange;
 import org.apache.iotdb.tsfile.read.common.block.TsBlock;
 import org.apache.iotdb.tsfile.read.reader.IChunkReader;
 import org.apache.iotdb.tsfile.read.reader.IPointReader;
-import org.apache.iotdb.tsfile.read.reader.chunk.AlignedChunkReader;
 import org.apache.iotdb.tsfile.read.reader.chunk.ChunkReader;
+import org.apache.iotdb.tsfile.read.reader.page.LazyLoadAlignedPagePointReader;
+import org.apache.iotdb.tsfile.read.reader.page.TimePageReader;
+import org.apache.iotdb.tsfile.read.reader.page.ValuePageReader;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -111,7 +116,7 @@ public class PageElement {
         valueDeleteIntervalList.add(valueChunk == null ? null : valueChunk.getDeleteIntervalList());
       }
       this.pointReader =
-          AlignedChunkReader.getPagePointReader(
+          getAlignedPagePointReader(
               chunkMetadataElement.chunk.getHeader(),
               valueChunkHeaderList,
               valueDeleteIntervalList,
@@ -122,5 +127,72 @@ public class PageElement {
     } else {
       this.batchData = ((ChunkReader) iChunkReader).readPageData(pageHeader, pageData);
     }
+  }
+
+  private IPointReader getAlignedPagePointReader(
+      ChunkHeader timeChunkHeader,
+      List<ChunkHeader> valueChunkHeaderList,
+      List<List<TimeRange>> valueDeleteIntervalList,
+      PageHeader timePageHeader,
+      List<PageHeader> valuePageHeaders,
+      ByteBuffer compressedTimePageData,
+      List<ByteBuffer> compressedValuePageDatas)
+      throws IOException {
+
+    IUnCompressor timeUnCompressor =
+        IUnCompressor.getUnCompressor(timeChunkHeader.getCompressionType());
+    Decoder timeDecoder =
+        Decoder.getDecoderByType(timeChunkHeader.getEncodingType(), timeChunkHeader.getDataType());
+    ByteBuffer uncompressedTimePageData =
+        uncompressPageData(timePageHeader, timeUnCompressor, compressedTimePageData);
+    TimePageReader timePageReader =
+        new TimePageReader(timePageHeader, uncompressedTimePageData, timeDecoder);
+
+    List<ValuePageReader> valuePageReaders = new ArrayList<>(valueChunkHeaderList.size());
+    for (int i = 0; i < valuePageHeaders.size(); i++) {
+      if (valuePageHeaders.get(i) == null) {
+        valuePageReaders.add(null);
+      } else {
+        ChunkHeader valueChunkHeader = valueChunkHeaderList.get(i);
+        TSDataType valueType = valueChunkHeader.getDataType();
+        Decoder valuePageDecoder =
+            Decoder.getDecoderByType(valueChunkHeader.getEncodingType(), valueType);
+        ByteBuffer uncompressedPageData =
+            uncompressPageData(
+                valuePageHeaders.get(i),
+                IUnCompressor.getUnCompressor(valueChunkHeader.getCompressionType()),
+                compressedValuePageDatas.get(i));
+        ValuePageReader valuePageReader =
+            new ValuePageReader(
+                valuePageHeaders.get(i), uncompressedPageData, valueType, valuePageDecoder);
+        if (valueDeleteIntervalList != null) {
+          valuePageReader.setDeleteIntervalList(valueDeleteIntervalList.get(i));
+        }
+        valuePageReaders.add(valuePageReader);
+      }
+    }
+    return new LazyLoadAlignedPagePointReader(timePageReader, valuePageReaders);
+  }
+
+  private ByteBuffer uncompressPageData(
+      PageHeader header, IUnCompressor unCompressor, ByteBuffer compressedPageData)
+      throws IOException {
+    int compressedPageBodyLength = header.getCompressedSize();
+    byte[] uncompressedPageData = new byte[header.getUncompressedSize()];
+    try {
+      unCompressor.uncompress(
+          compressedPageData.array(), 0, compressedPageBodyLength, uncompressedPageData, 0);
+    } catch (Exception e) {
+      throw new IOException(
+          "Uncompress error! uncompress size: "
+              + header.getUncompressedSize()
+              + "compressed size: "
+              + header.getCompressedSize()
+              + "page header: "
+              + header
+              + e.getMessage());
+    }
+
+    return ByteBuffer.wrap(uncompressedPageData);
   }
 }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/element/PageElement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/element/PageElement.java
@@ -106,10 +106,10 @@ public class PageElement {
   }
 
   public void deserializePage() throws IOException {
-    if (this.iChunkReader == null) {
-      this.pointReader = getAlignedPagePointReader();
-    } else {
+    if (this.iChunkReader instanceof ChunkReader) {
       this.batchData = ((ChunkReader) iChunkReader).readPageData(pageHeader, pageData);
+    } else {
+      this.pointReader = getAlignedPagePointReader();
     }
   }
 

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/element/PageElement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/element/PageElement.java
@@ -18,7 +18,10 @@
  */
 package org.apache.iotdb.db.engine.compaction.execute.utils.executor.fast.element;
 
+import org.apache.iotdb.tsfile.file.header.ChunkHeader;
 import org.apache.iotdb.tsfile.file.header.PageHeader;
+import org.apache.iotdb.tsfile.read.common.Chunk;
+import org.apache.iotdb.tsfile.read.common.TimeRange;
 import org.apache.iotdb.tsfile.read.common.block.TsBlock;
 import org.apache.iotdb.tsfile.read.reader.IChunkReader;
 import org.apache.iotdb.tsfile.read.reader.IPointReader;
@@ -27,6 +30,7 @@ import org.apache.iotdb.tsfile.read.reader.chunk.ChunkReader;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.List;
 
 public class PageElement {
@@ -82,7 +86,6 @@ public class PageElement {
       List<PageHeader> valuePageHeaders,
       ByteBuffer timePageData,
       List<ByteBuffer> valuePageDatas,
-      AlignedChunkReader alignedChunkReader,
       ChunkMetadataElement chunkMetadataElement,
       boolean isLastPage,
       long priority) {
@@ -91,7 +94,6 @@ public class PageElement {
     this.pageData = timePageData;
     this.valuePageDatas = valuePageDatas;
     this.priority = priority;
-    this.iChunkReader = alignedChunkReader;
     this.startTime = pageHeader.getStartTime();
     this.chunkMetadataElement = chunkMetadataElement;
     this.isLastPage = isLastPage;
@@ -100,9 +102,23 @@ public class PageElement {
 
   public void deserializePage() throws IOException {
     if (iChunkReader instanceof AlignedChunkReader) {
+      List<ChunkHeader> valueChunkHeaderList =
+          new ArrayList<>(chunkMetadataElement.valueChunks.size());
+      List<List<TimeRange>> valueDeleteIntervalList =
+          new ArrayList<>(chunkMetadataElement.valueChunks.size());
+      for (Chunk valueChunk : chunkMetadataElement.valueChunks) {
+        valueChunkHeaderList.add(valueChunk == null ? null : valueChunk.getHeader());
+        valueDeleteIntervalList.add(valueChunk == null ? null : valueChunk.getDeleteIntervalList());
+      }
       this.pointReader =
-          ((AlignedChunkReader) iChunkReader)
-              .getPagePointReader(pageHeader, valuePageHeaders, pageData, valuePageDatas);
+          AlignedChunkReader.getPagePointReader(
+              chunkMetadataElement.chunk.getHeader(),
+              valueChunkHeaderList,
+              valueDeleteIntervalList,
+              pageHeader,
+              valuePageHeaders,
+              pageData,
+              valuePageDatas);
     } else {
       this.batchData = ((ChunkReader) iChunkReader).readPageData(pageHeader, pageData);
     }

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/element/PageElement.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/utils/executor/fast/element/PageElement.java
@@ -101,7 +101,7 @@ public class PageElement {
   }
 
   public void deserializePage() throws IOException {
-    if (iChunkReader instanceof AlignedChunkReader) {
+    if (this.iChunkReader == null) {
       List<ChunkHeader> valueChunkHeaderList =
           new ArrayList<>(chunkMetadataElement.valueChunks.size());
       List<List<TimeRange>> valueDeleteIntervalList =

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/Chunk.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/Chunk.java
@@ -158,4 +158,8 @@ public class Chunk {
   public void setFromOldFile(boolean isFromOldFile) {
     this.isFromOldFile = isFromOldFile;
   }
+
+  public void releaseChunkDataBuffer() {
+    this.chunkData = null;
+  }
 }

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/chunk/AlignedChunkReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/chunk/AlignedChunkReader.java
@@ -272,13 +272,20 @@ public class AlignedChunkReader implements IChunkReader {
   }
 
   /** Read data from compressed page data. Uncompress the page and decode it to tsblock data. */
-  public IPointReader getPagePointReader(
+  public static IPointReader getPagePointReader(
+      ChunkHeader timeChunkHeader,
+      List<ChunkHeader> valueChunkHeaderList,
+      List<List<TimeRange>> valueDeleteIntervalList,
       PageHeader timePageHeader,
       List<PageHeader> valuePageHeaders,
       ByteBuffer compressedTimePageData,
       List<ByteBuffer> compressedValuePageDatas)
       throws IOException {
 
+    IUnCompressor timeUnCompressor =
+        IUnCompressor.getUnCompressor(timeChunkHeader.getCompressionType());
+    Decoder timeDecoder =
+        Decoder.getDecoderByType(timeChunkHeader.getEncodingType(), timeChunkHeader.getDataType());
     // uncompress time page data
     ByteBuffer uncompressedTimePageData =
         uncompressPageData(timePageHeader, timeUnCompressor, compressedTimePageData);
@@ -320,7 +327,7 @@ public class AlignedChunkReader implements IChunkReader {
     return alignedPageReader.getLazyPointReader();
   }
 
-  private ByteBuffer uncompressPageData(
+  private static ByteBuffer uncompressPageData(
       PageHeader pageHeader, IUnCompressor unCompressor, ByteBuffer compressedPageData)
       throws IOException {
     int compressedPageBodyLength = pageHeader.getCompressedSize();

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/chunk/AlignedChunkReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/chunk/AlignedChunkReader.java
@@ -33,7 +33,6 @@ import org.apache.iotdb.tsfile.read.common.TimeRange;
 import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.apache.iotdb.tsfile.read.reader.IChunkReader;
 import org.apache.iotdb.tsfile.read.reader.IPageReader;
-import org.apache.iotdb.tsfile.read.reader.IPointReader;
 import org.apache.iotdb.tsfile.read.reader.page.AlignedPageReader;
 
 import java.io.IOException;
@@ -269,84 +268,6 @@ public class AlignedChunkReader implements IChunkReader {
             filter);
     alignedPageReader.setDeleteIntervalList(valueDeleteIntervalList);
     return alignedPageReader;
-  }
-
-  /** Read data from compressed page data. Uncompress the page and decode it to tsblock data. */
-  public static IPointReader getPagePointReader(
-      ChunkHeader timeChunkHeader,
-      List<ChunkHeader> valueChunkHeaderList,
-      List<List<TimeRange>> valueDeleteIntervalList,
-      PageHeader timePageHeader,
-      List<PageHeader> valuePageHeaders,
-      ByteBuffer compressedTimePageData,
-      List<ByteBuffer> compressedValuePageDatas)
-      throws IOException {
-
-    IUnCompressor timeUnCompressor =
-        IUnCompressor.getUnCompressor(timeChunkHeader.getCompressionType());
-    Decoder timeDecoder =
-        Decoder.getDecoderByType(timeChunkHeader.getEncodingType(), timeChunkHeader.getDataType());
-    // uncompress time page data
-    ByteBuffer uncompressedTimePageData =
-        uncompressPageData(timePageHeader, timeUnCompressor, compressedTimePageData);
-    // uncompress value page datas
-    List<ByteBuffer> uncompressedValuePageDatas = new ArrayList<>();
-    List<TSDataType> valueTypes = new ArrayList<>();
-    List<Decoder> valueDecoders = new ArrayList<>();
-    for (int i = 0; i < valuePageHeaders.size(); i++) {
-      if (valuePageHeaders.get(i) == null) {
-        uncompressedValuePageDatas.add(null);
-        valueTypes.add(TSDataType.BOOLEAN);
-        valueDecoders.add(null);
-      } else {
-        ChunkHeader valueChunkHeader = valueChunkHeaderList.get(i);
-        uncompressedValuePageDatas.add(
-            uncompressPageData(
-                valuePageHeaders.get(i),
-                IUnCompressor.getUnCompressor(valueChunkHeader.getCompressionType()),
-                compressedValuePageDatas.get(i)));
-        TSDataType valueType = valueChunkHeader.getDataType();
-        valueDecoders.add(Decoder.getDecoderByType(valueChunkHeader.getEncodingType(), valueType));
-        valueTypes.add(valueType);
-      }
-    }
-
-    // decode page data
-    AlignedPageReader alignedPageReader =
-        new AlignedPageReader(
-            timePageHeader,
-            uncompressedTimePageData,
-            timeDecoder,
-            valuePageHeaders,
-            uncompressedValuePageDatas,
-            valueTypes,
-            valueDecoders,
-            null);
-    alignedPageReader.initTsBlockBuilder(valueTypes);
-    alignedPageReader.setDeleteIntervalList(valueDeleteIntervalList);
-    return alignedPageReader.getLazyPointReader();
-  }
-
-  private static ByteBuffer uncompressPageData(
-      PageHeader pageHeader, IUnCompressor unCompressor, ByteBuffer compressedPageData)
-      throws IOException {
-    int compressedPageBodyLength = pageHeader.getCompressedSize();
-    byte[] uncompressedPageData = new byte[pageHeader.getUncompressedSize()];
-    try {
-      unCompressor.uncompress(
-          compressedPageData.array(), 0, compressedPageBodyLength, uncompressedPageData, 0);
-    } catch (Exception e) {
-      throw new IOException(
-          "Uncompress error! uncompress size: "
-              + pageHeader.getUncompressedSize()
-              + "compressed size: "
-              + pageHeader.getCompressedSize()
-              + "page header: "
-              + pageHeader
-              + e.getMessage());
-    }
-
-    return ByteBuffer.wrap(uncompressedPageData);
   }
 
   /**

--- a/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/AlignedPageReader.java
+++ b/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/AlignedPageReader.java
@@ -31,7 +31,6 @@ import org.apache.iotdb.tsfile.read.filter.basic.Filter;
 import org.apache.iotdb.tsfile.read.filter.operator.AndFilter;
 import org.apache.iotdb.tsfile.read.reader.IAlignedPageReader;
 import org.apache.iotdb.tsfile.read.reader.IPageReader;
-import org.apache.iotdb.tsfile.read.reader.IPointReader;
 import org.apache.iotdb.tsfile.read.reader.series.PaginationController;
 import org.apache.iotdb.tsfile.utils.TsPrimitiveType;
 
@@ -139,10 +138,6 @@ public class AlignedPageReader implements IPageReader, IAlignedPageReader {
       }
     }
     return true;
-  }
-
-  public IPointReader getLazyPointReader() throws IOException {
-    return new LazyLoadAlignedPagePointReader(timePageReader, valuePageReaderList);
   }
 
   @Override


### PR DESCRIPTION
## Description
https://github.com/apache/iotdb/pull/11046
When FastCompaction deserializes a overlapped Chunk into the Page queue, the ByteBuffer.get() method is called from the Chunk's Buffer to copy the data of each Page. After copy, the Page is wrapped into a PageElement and put into the pageQueue, but the timeChunk and valueChunks are passed into a new instance of AlignedChunkReader, which causes the clearChunks method to be called at the end of the method is not effective. The reference of each Chunk is still held by AlignedChunkReader and cannot be released. At this time, there is 2 times the chunk size of data in the memory.
## Fix
Release chunk data buffer after copy page data from it.