### PR TITLE
Fix compaction speed calculation

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
@@ -241,7 +241,9 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
             storageGroupName,
             dataRegionId,
             String.format("%.2f", costTime),
-            String.format("%.2f", (selectedSeqFileSize + selectedUnseqFileSize) / 1024.0d / 1024.0d / costTime),
+            String.format(
+                "%.2f",
+                (selectedSeqFileSize + selectedUnseqFileSize) / 1024.0d / 1024.0d / costTime),
             summary);
       }
       if (logFile.exists()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
@@ -232,7 +232,7 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
 
         CompactionMetrics.getInstance().recordSummaryInfo(summary);
 
-        long costTime = (System.currentTimeMillis() - startTime) / 1000;
+        double costTime = (System.currentTimeMillis() - startTime) / 1000.0d;
 
         LOGGER.info(
             "{}-{} [Compaction] CrossSpaceCompaction task finishes successfully, "
@@ -240,8 +240,8 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
                 + "compaction speed is {} MB/s, {}",
             storageGroupName,
             dataRegionId,
-            costTime,
-            (selectedSeqFileSize + selectedUnseqFileSize) / 1024 / 1024 / costTime,
+            String.format("%.2f", costTime),
+            String.format("%.2f", (selectedSeqFileSize + selectedUnseqFileSize) / 1024 / 1024 / costTime),
             summary);
       }
       if (logFile.exists()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
@@ -241,7 +241,7 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
             storageGroupName,
             dataRegionId,
             String.format("%.2f", costTime),
-            String.format("%.2f", (selectedSeqFileSize + selectedUnseqFileSize) / 1024 / 1024 / costTime),
+            String.format("%.2f", (selectedSeqFileSize + selectedUnseqFileSize) / 1024.0d / 1024.0d / costTime),
             summary);
       }
       if (logFile.exists()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
@@ -279,8 +279,8 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
             dataRegionId,
             sequence ? "Sequence" : "Unsequence",
             targetTsFileResource.getTsFile().getName(),
-            costTime,
-            selectedFileSize / 1024.0d / 1024.0d / costTime,
+            String.format("%.2f", costTime),
+            String.format("%.2f", selectedFileSize / 1024.0d / 1024.0d / costTime),
             summary);
       }
       if (logFile.exists()) {


### PR DESCRIPTION
## Description
Fix compaction speed calculation.
The variable 'costTime' is 0, which makes the result of compaction speed is Infinity.
![img_v2_70395cfc-b963-441a-9771-d46566b5e30g](https://github.com/apache/iotdb/assets/55970239/2a5c885a-d265-4b98-b746-9b421603f9de)


![img_v2_e2c77b29-e250-4939-9a36-de7507db64dg](https://github.com/apache/iotdb/assets/55970239/50e7d712-a0ce-4817-b3c5-f80a50c2d5c4)
## Fix 
Change the data type of 'costTime' to double, and keep two decimal places in log.
