### PR TITLE
[To rel/1.1] Fix compaction speed calculation

### DIFF
--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/CrossSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/CrossSpaceCompactionTask.java
@@ -228,14 +228,14 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
 
         CompactionMetricsManager.getInstance().updateSummary(summary);
 
-        long costTime = (System.currentTimeMillis() - startTime) / 1000;
+        double costTime = (System.currentTimeMillis() - startTime) / 1000.0d;
 
         LOGGER.info(
             "{}-{} [Compaction] CrossSpaceCompaction task finishes successfully, time cost is {} s, compaction speed is {} MB/s, {}",
             storageGroupName,
             dataRegionId,
-            costTime,
-            (selectedSeqFileSize + selectedUnseqFileSize) / 1024 / 1024 / costTime,
+            String.format("%.2f", costTime),
+            String.format("%.2f", (selectedSeqFileSize + selectedUnseqFileSize) / 1024 / 1024 / costTime),
             summary);
       }
       if (logFile.exists()) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/CrossSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/CrossSpaceCompactionTask.java
@@ -235,7 +235,7 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
             storageGroupName,
             dataRegionId,
             String.format("%.2f", costTime),
-            String.format("%.2f", (selectedSeqFileSize + selectedUnseqFileSize) / 1024 / 1024 / costTime),
+            String.format("%.2f", (selectedSeqFileSize + selectedUnseqFileSize) / 1024.0d / 1024.0d / costTime),
             summary);
       }
       if (logFile.exists()) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/CrossSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/CrossSpaceCompactionTask.java
@@ -235,7 +235,9 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
             storageGroupName,
             dataRegionId,
             String.format("%.2f", costTime),
-            String.format("%.2f", (selectedSeqFileSize + selectedUnseqFileSize) / 1024.0d / 1024.0d / costTime),
+            String.format(
+                "%.2f",
+                (selectedSeqFileSize + selectedUnseqFileSize) / 1024.0d / 1024.0d / costTime),
             summary);
       }
       if (logFile.exists()) {

--- a/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/InnerSpaceCompactionTask.java
+++ b/server/src/main/java/org/apache/iotdb/db/engine/compaction/execute/task/InnerSpaceCompactionTask.java
@@ -284,8 +284,8 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
             dataRegionId,
             sequence ? "Sequence" : "Unsequence",
             targetTsFileResource.getTsFile().getName(),
-            costTime,
-            selectedFileSize / 1024.0d / 1024.0d / costTime,
+            String.format("%.2f", costTime),
+            String.format("%.2f", selectedFileSize / 1024.0d / 1024.0d / costTime),
             summary);
       }
       if (logFile.exists()) {


### PR DESCRIPTION
## Description
Fix compaction speed calculation.
The variable 'costTime' is 0, which makes the result of compaction speed is Infinity.
![img_v2_70395cfc-b963-441a-9771-d46566b5e30g](https://github.com/apache/iotdb/assets/55970239/892b1d84-e623-4bfe-9b52-aab0eafc570d)
![img_v2_e2c77b29-e250-4939-9a36-de7507db64dg](https://github.com/apache/iotdb/assets/55970239/0d8b60af-f61d-429d-b076-e4c10f20f8f9)
## Fix 
Change the data type of 'costTime' to double, and keep two decimal places in log.