### PR TITLE
[To rel/1.2] fix datanode status is ReadOnly because the disk is full

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/FolderManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/FolderManager.java
@@ -63,6 +63,7 @@ public class FolderManager {
     } catch (DiskSpaceInsufficientException e) {
       logger.error("All folders are full, change system mode to read-only.", e);
       CommonDescriptor.getInstance().getConfig().setNodeStatus(NodeStatus.ReadOnly);
+      CommonDescriptor.getInstance().getConfig().setStatusReason(NodeStatus.DISK_FULL);
       throw e;
     }
   }
@@ -73,6 +74,7 @@ public class FolderManager {
     } catch (DiskSpaceInsufficientException e) {
       logger.error("All folders are full, change system mode to read-only.", e);
       CommonDescriptor.getInstance().getConfig().setNodeStatus(NodeStatus.ReadOnly);
+      CommonDescriptor.getInstance().getConfig().setStatusReason(NodeStatus.DISK_FULL);
       throw e;
     }
   }


### PR DESCRIPTION
When the system Disk availability is insufficient, the heartbeat mechanism sets the system status to `ReadOnly(DiskFull)`, and the DataNode itself sets the system status to `ReadOnly` or `ReadOnly(DiskFull)` when it allocates a new directory. These two states make the user feel confused as to why the different states occur. This fix is that the unified system state is `ReadOnly(DiskFull)` when disk availability is low.

## Test

### Test method
1. Start a cluster of any size
2. Keep writing data until the disk availability is below the configured `disk_space_warning_threshold`
3. Start the CLI and run `show cluster` to check whether the node status is `ReadOnly(DiskFull)`. The expected result is `ReadOnly(DiskFull)`

### Before this change
**Description:** 
When the disk availability is insufficient and `DirectoryStrategy` is `SequenceStrategy`, the system state may be `ReadOnly` or `ReadOnly(DiskFull)`
**Snapshot:**
<img width="780" alt="image" src="https://github.com/apache/iotdb/assets/34238279/76c9c008-499d-402d-b982-7d09aec27a19">


### After this change
**Description:**
When the disk availability is insufficient and `DirectoryStrategy` is `SequenceStrategy`, the system state must be `ReadOnly(DiskFull)`
**Snapshot:**
<img width="882" alt="image" src="https://github.com/apache/iotdb/assets/34238279/b268e9a9-b3eb-43ec-8ade-dc867e1b8de6">


