### PR TITLE
[To rel/1.2] [IOTDB-6141] Optimize the large time range raw query performance

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/AbstractOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/AbstractOperator.java
@@ -75,6 +75,9 @@ public abstract class AbstractOperator implements Operator {
 
   public TsBlock getResultFromRetainedTsBlock() {
     TsBlock res;
+    if (maxTupleSizeOfTsBlock == -1) {
+      initializeMaxTsBlockLength(retainedTsBlock);
+    }
     if (retainedTsBlock.getPositionCount() - startOffset <= maxTupleSizeOfTsBlock) {
       res = retainedTsBlock.subTsBlock(startOffset);
       retainedTsBlock = null;

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/TsBlockBuilder.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/TsBlockBuilder.java
@@ -47,7 +47,7 @@ public class TsBlockBuilder {
   // This could be any other small number.
   private static final int DEFAULT_INITIAL_EXPECTED_ENTRIES = 8;
 
-  private static final int MAX_LINE_NUMBER =
+  public static final int MAX_LINE_NUMBER =
       TSFileDescriptor.getInstance().getConfig().getMaxTsBlockLineNumber();
 
   private TimeColumnBuilder timeColumnBuilder;

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/Int32ArrayColumnEncoder.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/Int32ArrayColumnEncoder.java
@@ -80,14 +80,26 @@ public class Int32ArrayColumnEncoder implements ColumnEncoder {
     TSDataType dataType = column.getDataType();
     int positionCount = column.getPositionCount();
     if (TSDataType.INT32.equals(dataType)) {
-      for (int i = 0; i < positionCount; i++) {
-        if (!column.isNull(i)) {
+      if (column.mayHaveNull()) {
+        for (int i = 0; i < positionCount; i++) {
+          if (!column.isNull(i)) {
+            output.writeInt(column.getInt(i));
+          }
+        }
+      } else {
+        for (int i = 0; i < positionCount; i++) {
           output.writeInt(column.getInt(i));
         }
       }
     } else if (TSDataType.FLOAT.equals(dataType)) {
-      for (int i = 0; i < positionCount; i++) {
-        if (!column.isNull(i)) {
+      if (column.mayHaveNull()) {
+        for (int i = 0; i < positionCount; i++) {
+          if (!column.isNull(i)) {
+            output.writeInt(Float.floatToIntBits(column.getFloat(i)));
+          }
+        }
+      } else {
+        for (int i = 0; i < positionCount; i++) {
           output.writeInt(Float.floatToIntBits(column.getFloat(i)));
         }
       }

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/TsBlockSerde.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/TsBlockSerde.java
@@ -87,7 +87,12 @@ public class TsBlockSerde {
    * @return Serialized tsblock.
    */
   public ByteBuffer serialize(TsBlock tsBlock) throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    if (tsBlock.getRetainedSizeInBytes() > Integer.MAX_VALUE) {
+      throw new IllegalStateException(
+          "TsBlock should not be that large: " + tsBlock.getRetainedSizeInBytes());
+    }
+    ByteArrayOutputStream byteArrayOutputStream =
+        new ByteArrayOutputStream((int) tsBlock.getRetainedSizeInBytes());
     DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
 
     // Value column count.

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/AlignedPageReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/AlignedPageReader.java
@@ -202,7 +202,9 @@ public class AlignedPageReader implements IPageReader, IAlignedPageReader {
         // not included
         int readEndIndex =
             (paginationController.hasCurLimit()
-                    && (paginationController.getCurLimit() < timeBatch.length - readStartIndex + 1))
+                    && (paginationController.getCurLimit() > 0
+                        && paginationController.getCurLimit()
+                            < timeBatch.length - readStartIndex + 1))
                 ? readStartIndex + (int) paginationController.getCurLimit()
                 : timeBatch.length;
         if (paginationController.hasCurLimit()) {

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/AlignedPageReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/AlignedPageReader.java
@@ -167,93 +167,132 @@ public class AlignedPageReader implements IPageReader, IAlignedPageReader {
 
   @Override
   public TsBlock getAllSatisfiedData() throws IOException {
-    builder.reset();
     if (!pageSatisfy()) {
       return builder.build();
     }
 
     long[] timeBatch = timePageReader.getNextTimeBatch();
 
-    // if all the sub sensors' value are null in current row, just discard it
-    // if !filter.satisfy, discard this row
-    boolean[] keepCurrentRow = new boolean[timeBatch.length];
-    if (filter == null) {
-      Arrays.fill(keepCurrentRow, true);
-    } else {
-      for (int i = 0, n = timeBatch.length; i < n; i++) {
-        keepCurrentRow[i] = filter.satisfy(timeBatch[i], null);
-      }
-    }
-
-    boolean[][] isDeleted = null;
-    if (valueCount != 0) {
-      // using bitMap in valuePageReaders to indicate whether columns of current row are all null.
-      byte[] bitmask = new byte[(timeBatch.length - 1) / 8 + 1];
-      Arrays.fill(bitmask, (byte) 0x00);
-      isDeleted = new boolean[valueCount][timeBatch.length];
-      for (int columnIndex = 0; columnIndex < valueCount; columnIndex++) {
-        ValuePageReader pageReader = valuePageReaderList.get(columnIndex);
-        if (pageReader != null) {
-          byte[] bitmap = pageReader.getBitmap();
-          pageReader.fillIsDeleted(timeBatch, isDeleted[columnIndex]);
-
-          for (int i = 0, n = isDeleted[columnIndex].length; i < n; i++) {
-            if (isDeleted[columnIndex][i]) {
-              int shift = i % 8;
-              bitmap[i / 8] = (byte) (bitmap[i / 8] & (~(MASK >>> shift)));
-            }
-          }
-          for (int i = 0, n = bitmask.length; i < n; i++) {
-            bitmask[i] = (byte) (bitmap[i] | bitmask[i]);
-          }
-        }
-      }
-
-      for (int i = 0, n = bitmask.length; i < n; i++) {
-        if (bitmask[i] == (byte) 0xFF) {
-          // 8 rows are not all null, do nothing
-        } else if (bitmask[i] == (byte) 0x00) {
-          for (int j = 0; j < 8 && (i * 8 + j < keepCurrentRow.length); j++) {
-            keepCurrentRow[i * 8 + j] = false;
-          }
-        } else {
-          for (int j = 0; j < 8 && (i * 8 + j < keepCurrentRow.length); j++) {
-            if (((bitmask[i] & 0xFF) & (MASK >>> j)) == 0) {
-              keepCurrentRow[i * 8 + j] = false;
-            }
-          }
-        }
-      }
-    }
-
-    // construct time column
-    int readEndIndex = timeBatch.length;
-    for (int i = 0; i < timeBatch.length; i++) {
-      if (keepCurrentRow[i]) {
+    if (queryAllSensors && !isModified) {
+      // skip all the page
+      if (paginationController.hasCurOffset(timeBatch.length)) {
+        paginationController.consumeOffset(timeBatch.length);
+      } else {
+        // consume the remaining offset
         if (paginationController.hasCurOffset()) {
-          paginationController.consumeOffset();
-          keepCurrentRow[i] = false;
-        } else if (paginationController.hasCurLimit()) {
+          paginationController.consumeOffset(paginationController.getCurOffset());
+        }
+        int readStartIndex =
+            paginationController.hasCurOffset() ? (int) paginationController.getCurOffset() : 0;
+        // not included
+        int readEndIndex =
+            (paginationController.hasCurLimit()
+                    && (paginationController.getCurLimit() < timeBatch.length - readStartIndex + 1))
+                ? readStartIndex + (int) paginationController.getCurLimit()
+                : timeBatch.length;
+        if (paginationController.hasCurLimit()) {
+          paginationController.consumeLimit(readEndIndex - readStartIndex);
+        }
+        // construct time column
+        for (int i = readStartIndex; i < readEndIndex; i++) {
           builder.getTimeColumnBuilder().writeLong(timeBatch[i]);
           builder.declarePosition();
-          paginationController.consumeLimit();
-        } else {
-          readEndIndex = i;
-          break;
+        }
+        // construct value columns
+        for (int i = 0; i < valueCount; i++) {
+          ValuePageReader pageReader = valuePageReaderList.get(i);
+          if (pageReader != null) {
+            pageReader.writeColumnBuilderWithNextBatch(
+                readStartIndex, readEndIndex, builder.getColumnBuilder(i));
+          } else {
+            for (int j = readStartIndex; j < readEndIndex; j++) {
+              builder.getColumnBuilder(i).appendNull();
+            }
+          }
         }
       }
-    }
-
-    // construct value columns
-    for (int i = 0; i < valueCount; i++) {
-      ValuePageReader pageReader = valuePageReaderList.get(i);
-      if (pageReader != null) {
-        pageReader.writeColumnBuilderWithNextBatch(
-            readEndIndex, builder.getColumnBuilder(i), keepCurrentRow, isDeleted[i]);
+    } else {
+      // if all the sub sensors' value are null in current row, just discard it
+      // if !filter.satisfy, discard this row
+      boolean[] keepCurrentRow = new boolean[timeBatch.length];
+      if (filter == null) {
+        Arrays.fill(keepCurrentRow, true);
       } else {
-        for (int j = 0; j < readEndIndex; j++) {
-          if (keepCurrentRow[j]) {
-            builder.getColumnBuilder(i).appendNull();
+        for (int i = 0, n = timeBatch.length; i < n; i++) {
+          keepCurrentRow[i] = filter.satisfy(timeBatch[i], null);
+        }
+      }
+
+      boolean[][] isDeleted = null;
+      if (valueCount != 0) {
+        // using bitMap in valuePageReaders to indicate whether columns of current row are all null.
+        byte[] bitmask = new byte[(timeBatch.length - 1) / 8 + 1];
+        Arrays.fill(bitmask, (byte) 0x00);
+        isDeleted = new boolean[valueCount][timeBatch.length];
+        for (int columnIndex = 0; columnIndex < valueCount; columnIndex++) {
+          ValuePageReader pageReader = valuePageReaderList.get(columnIndex);
+          if (pageReader != null) {
+            byte[] bitmap = pageReader.getBitmap();
+            pageReader.fillIsDeleted(timeBatch, isDeleted[columnIndex]);
+
+            for (int i = 0, n = isDeleted[columnIndex].length; i < n; i++) {
+              if (isDeleted[columnIndex][i]) {
+                int shift = i % 8;
+                bitmap[i / 8] = (byte) (bitmap[i / 8] & (~(MASK >>> shift)));
+              }
+            }
+            for (int i = 0, n = bitmask.length; i < n; i++) {
+              bitmask[i] = (byte) (bitmap[i] | bitmask[i]);
+            }
+          }
+        }
+
+        for (int i = 0, n = bitmask.length; i < n; i++) {
+          if (bitmask[i] == (byte) 0xFF) {
+            // 8 rows are not all null, do nothing
+          } else if (bitmask[i] == (byte) 0x00) {
+            for (int j = 0; j < 8 && (i * 8 + j < keepCurrentRow.length); j++) {
+              keepCurrentRow[i * 8 + j] = false;
+            }
+          } else {
+            for (int j = 0; j < 8 && (i * 8 + j < keepCurrentRow.length); j++) {
+              if (((bitmask[i] & 0xFF) & (MASK >>> j)) == 0) {
+                keepCurrentRow[i * 8 + j] = false;
+              }
+            }
+          }
+        }
+      }
+
+      // construct time column
+      int readEndIndex = timeBatch.length;
+      for (int i = 0; i < timeBatch.length; i++) {
+        if (keepCurrentRow[i]) {
+          if (paginationController.hasCurOffset()) {
+            paginationController.consumeOffset();
+            keepCurrentRow[i] = false;
+          } else if (paginationController.hasCurLimit()) {
+            builder.getTimeColumnBuilder().writeLong(timeBatch[i]);
+            builder.declarePosition();
+            paginationController.consumeLimit();
+          } else {
+            readEndIndex = i;
+            break;
+          }
+        }
+      }
+
+      // construct value columns
+      for (int i = 0; i < valueCount; i++) {
+        ValuePageReader pageReader = valuePageReaderList.get(i);
+        if (pageReader != null) {
+          pageReader.writeColumnBuilderWithNextBatch(
+              readEndIndex, builder.getColumnBuilder(i), keepCurrentRow, isDeleted[i]);
+        } else {
+          for (int j = 0; j < readEndIndex; j++) {
+            if (keepCurrentRow[j]) {
+              builder.getColumnBuilder(i).appendNull();
+            }
           }
         }
       }
@@ -316,6 +355,6 @@ public class AlignedPageReader implements IPageReader, IAlignedPageReader {
 
   @Override
   public void initTsBlockBuilder(List<TSDataType> dataTypes) {
-    builder = new TsBlockBuilder(dataTypes);
+    builder = new TsBlockBuilder((int) timePageReader.getStatistics().getCount(), dataTypes);
   }
 }

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/AlignedPageReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/AlignedPageReader.java
@@ -201,13 +201,11 @@ public class AlignedPageReader implements IPageReader, IAlignedPageReader {
         paginationController.consumeOffset(readStartIndex);
         // not included
         int readEndIndex =
-            (paginationController.hasCurLimit()
-                    && (paginationController.getCurLimit() > 0
-                        && paginationController.getCurLimit()
-                            < timeBatch.length - readStartIndex + 1))
+            (paginationController.hasCurLimit() && paginationController.getCurLimit() > 0)
+                    && (paginationController.getCurLimit() < timeBatch.length - readStartIndex + 1)
                 ? readStartIndex + (int) paginationController.getCurLimit()
                 : timeBatch.length;
-        if (paginationController.hasCurLimit()) {
+        if (paginationController.hasCurLimit() && paginationController.getCurLimit() > 0) {
           paginationController.consumeLimit((long) readEndIndex - readStartIndex);
         }
         // construct time column

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/ValuePageReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/ValuePageReader.java
@@ -330,67 +330,129 @@ public class ValuePageReader {
   }
 
   public void writeColumnBuilderWithNextBatch(
-      int readStartIndex, int readEndIndex, ColumnBuilder columnBuilder) {
+      int readStartIndex, int readEndIndex, ColumnBuilder columnBuilder, boolean[] satisfied) {
     if (valueBuffer == null) {
       for (int i = readStartIndex; i < readEndIndex; i++) {
-        columnBuilder.appendNull();
+        if (satisfied[i - readStartIndex]) {
+          columnBuilder.appendNull();
+        }
       }
       return;
     }
 
     switch (dataType) {
       case BOOLEAN:
+        // skip useless data
+        for (int i = 0; i < readStartIndex; i++) {
+          valueDecoder.readBoolean(valueBuffer);
+        }
+
         for (int i = readStartIndex; i < readEndIndex; i++) {
           if (((bitmap[i / 8] & 0xFF) & (MASK >>> (i % 8))) == 0) {
-            columnBuilder.appendNull();
+            if (satisfied[i - readStartIndex]) {
+              columnBuilder.appendNull();
+            }
             continue;
           }
-          columnBuilder.writeBoolean(valueDecoder.readBoolean(valueBuffer));
+          boolean aBoolean = valueDecoder.readBoolean(valueBuffer);
+          if (satisfied[i - readStartIndex]) {
+            columnBuilder.writeBoolean(aBoolean);
+          }
         }
         break;
       case INT32:
+        // skip useless data
+        for (int i = 0; i < readStartIndex; i++) {
+          valueDecoder.readInt(valueBuffer);
+        }
+
         for (int i = readStartIndex; i < readEndIndex; i++) {
           if (((bitmap[i / 8] & 0xFF) & (MASK >>> (i % 8))) == 0) {
-            columnBuilder.appendNull();
+            if (satisfied[i - readStartIndex]) {
+              columnBuilder.appendNull();
+            }
             continue;
           }
-          columnBuilder.writeInt(valueDecoder.readInt(valueBuffer));
+          int aInt = valueDecoder.readInt(valueBuffer);
+          if (satisfied[i - readStartIndex]) {
+            columnBuilder.writeInt(aInt);
+          }
         }
         break;
       case INT64:
+        // skip useless data
+        for (int i = 0; i < readStartIndex; i++) {
+          valueDecoder.readLong(valueBuffer);
+        }
+
         for (int i = readStartIndex; i < readEndIndex; i++) {
           if (((bitmap[i / 8] & 0xFF) & (MASK >>> (i % 8))) == 0) {
-            columnBuilder.appendNull();
+            if (satisfied[i - readStartIndex]) {
+              columnBuilder.appendNull();
+            }
             continue;
           }
-          columnBuilder.writeLong(valueDecoder.readLong(valueBuffer));
+          long aLong = valueDecoder.readLong(valueBuffer);
+          if (satisfied[i - readStartIndex]) {
+            columnBuilder.writeLong(aLong);
+          }
         }
         break;
       case FLOAT:
+        // skip useless data
+        for (int i = 0; i < readStartIndex; i++) {
+          valueDecoder.readFloat(valueBuffer);
+        }
+
         for (int i = readStartIndex; i < readEndIndex; i++) {
           if (((bitmap[i / 8] & 0xFF) & (MASK >>> (i % 8))) == 0) {
-            columnBuilder.appendNull();
+            if (satisfied[i - readStartIndex]) {
+              columnBuilder.appendNull();
+            }
             continue;
           }
-          columnBuilder.writeFloat(valueDecoder.readFloat(valueBuffer));
+          float aFloat = valueDecoder.readFloat(valueBuffer);
+          if (satisfied[i - readStartIndex]) {
+            columnBuilder.writeFloat(aFloat);
+          }
         }
         break;
       case DOUBLE:
+        // skip useless data
+        for (int i = 0; i < readStartIndex; i++) {
+          valueDecoder.readDouble(valueBuffer);
+        }
+
         for (int i = readStartIndex; i < readEndIndex; i++) {
           if (((bitmap[i / 8] & 0xFF) & (MASK >>> (i % 8))) == 0) {
-            columnBuilder.appendNull();
+            if (satisfied[i - readStartIndex]) {
+              columnBuilder.appendNull();
+            }
             continue;
           }
-          columnBuilder.writeDouble(valueDecoder.readDouble(valueBuffer));
+          double aDouble = valueDecoder.readDouble(valueBuffer);
+          if (satisfied[i - readStartIndex]) {
+            columnBuilder.writeDouble(aDouble);
+          }
         }
         break;
       case TEXT:
+        // skip useless data
+        for (int i = 0; i < readStartIndex; i++) {
+          valueDecoder.readBinary(valueBuffer);
+        }
+
         for (int i = readStartIndex; i < readEndIndex; i++) {
           if (((bitmap[i / 8] & 0xFF) & (MASK >>> (i % 8))) == 0) {
-            columnBuilder.appendNull();
+            if (satisfied[i - readStartIndex]) {
+              columnBuilder.appendNull();
+            }
             continue;
           }
-          columnBuilder.writeBinary(valueDecoder.readBinary(valueBuffer));
+          Binary aBinary = valueDecoder.readBinary(valueBuffer);
+          if (satisfied[i - readStartIndex]) {
+            columnBuilder.writeBinary(aBinary);
+          }
         }
         break;
       default:

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/ValuePageReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/ValuePageReader.java
@@ -337,33 +337,64 @@ public class ValuePageReader {
       }
       return;
     }
-    for (int i = readStartIndex; i < readEndIndex; i++) {
-      if (((bitmap[i / 8] & 0xFF) & (MASK >>> (i % 8))) == 0) {
-        columnBuilder.appendNull();
-        continue;
-      }
-      switch (dataType) {
-        case BOOLEAN:
+
+    switch (dataType) {
+      case BOOLEAN:
+        for (int i = readStartIndex; i < readEndIndex; i++) {
+          if (((bitmap[i / 8] & 0xFF) & (MASK >>> (i % 8))) == 0) {
+            columnBuilder.appendNull();
+            continue;
+          }
           columnBuilder.writeBoolean(valueDecoder.readBoolean(valueBuffer));
-          break;
-        case INT32:
+        }
+        break;
+      case INT32:
+        for (int i = readStartIndex; i < readEndIndex; i++) {
+          if (((bitmap[i / 8] & 0xFF) & (MASK >>> (i % 8))) == 0) {
+            columnBuilder.appendNull();
+            continue;
+          }
           columnBuilder.writeInt(valueDecoder.readInt(valueBuffer));
-          break;
-        case INT64:
+        }
+        break;
+      case INT64:
+        for (int i = readStartIndex; i < readEndIndex; i++) {
+          if (((bitmap[i / 8] & 0xFF) & (MASK >>> (i % 8))) == 0) {
+            columnBuilder.appendNull();
+            continue;
+          }
           columnBuilder.writeLong(valueDecoder.readLong(valueBuffer));
-          break;
-        case FLOAT:
+        }
+        break;
+      case FLOAT:
+        for (int i = readStartIndex; i < readEndIndex; i++) {
+          if (((bitmap[i / 8] & 0xFF) & (MASK >>> (i % 8))) == 0) {
+            columnBuilder.appendNull();
+            continue;
+          }
           columnBuilder.writeFloat(valueDecoder.readFloat(valueBuffer));
-          break;
-        case DOUBLE:
+        }
+        break;
+      case DOUBLE:
+        for (int i = readStartIndex; i < readEndIndex; i++) {
+          if (((bitmap[i / 8] & 0xFF) & (MASK >>> (i % 8))) == 0) {
+            columnBuilder.appendNull();
+            continue;
+          }
           columnBuilder.writeDouble(valueDecoder.readDouble(valueBuffer));
-          break;
-        case TEXT:
+        }
+        break;
+      case TEXT:
+        for (int i = readStartIndex; i < readEndIndex; i++) {
+          if (((bitmap[i / 8] & 0xFF) & (MASK >>> (i % 8))) == 0) {
+            columnBuilder.appendNull();
+            continue;
+          }
           columnBuilder.writeBinary(valueDecoder.readBinary(valueBuffer));
-          break;
-        default:
-          throw new UnSupportedDataTypeException(String.valueOf(dataType));
-      }
+        }
+        break;
+      default:
+        throw new UnSupportedDataTypeException(String.valueOf(dataType));
     }
   }
 

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/series/PaginationController.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/series/PaginationController.java
@@ -60,6 +60,14 @@ public class PaginationController {
     curOffset--;
   }
 
+  public long getCurOffset() {
+    return curOffset;
+  }
+
+  public long getCurLimit() {
+    return curLimit;
+  }
+
   public void consumeLimit() {
     if (hasLimit) {
       curLimit--;


### PR DESCRIPTION
### Description
We do a cpu profiling for a large time range raw query case(each sql involves about 8,640,000 points and there are 30 concurrent client to do that kind of query at the same time. And found three potential performance improvement point:

1. We can init the TsBlockBuilder with the count in PageStatistics which can avoid the Array.growCapacity();
![image](https://github.com/apache/iotdb/assets/16079446/28bf9876-6f7c-4ff6-8e11-6ca5a6b24752)

2. In AlignedPageReader, if any sensors we queried has the same count with time columnn and we don't do the delete operation, there won't exist all null row, so we can save that overhead.
<img width="909" alt="image" src="https://github.com/apache/iotdb/assets/16079446/c427c305-16b6-493c-903b-412c076bcffb">

3. while serializing TsBlock, we can also estimate the initial capacity using `TsBlock.getRetainedSize()`.
<img width="969" alt="image" src="https://github.com/apache/iotdb/assets/16079446/fc2f5084-1a17-43cd-aa68-1e6e4d980fd9">

4. AlignedSeriesScanOperator can directly pass the TsBlock getting from AlignedSeriesScanUtil instead of rebuilding a new TsBlock while the TsBlock is large enough. Previously, we want to using the rebuilding process to combine many little TsBlock into a larger one, however if the TsBlock is large enough, this operation can be totally removed.
<img width="832" alt="image" src="https://github.com/apache/iotdb/assets/16079446/a7023578-16d0-4be5-aeb5-54b1bd4348f5">




### Optimization result:

The experiment configuration can be seen in this [issue](https://issues.apache.org/jira/browse/IOTDB-6141) description, there is about **20.8%** improvement

#### Before
<img width="1206" alt="image" src="https://github.com/apache/iotdb/assets/16079446/40efd53a-b4b0-48a6-b935-5e12fee70f73">

#### After
<img width="1219" alt="image" src="https://github.com/apache/iotdb/assets/16079446/4afbb7e7-2ac9-40c1-94f0-ac2068aa5faf">

