### PR TITLE
Fix incorrect package path for modelInferenceException

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/exception/runtime/IntoProcessException.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/exception/runtime/IntoProcessException.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iotdb.db.exception;
+package org.apache.iotdb.db.exception.runtime;
 
 public class IntoProcessException extends RuntimeException {
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/exception/runtime/ModelInferenceProcessException.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/exception/runtime/ModelInferenceProcessException.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iotdb.db.exception;
+package org.apache.iotdb.db.exception.runtime;
 
 public class ModelInferenceProcessException extends RuntimeException {
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/exception/runtime/WriteLockFailedException.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/exception/runtime/WriteLockFailedException.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iotdb.db.exception;
+package org.apache.iotdb.db.exception.runtime;
 
 public class WriteLockFailedException extends RuntimeException {
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/client/DataNodeInternalClient.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/client/DataNodeInternalClient.java
@@ -22,7 +22,7 @@ package org.apache.iotdb.db.protocol.client;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.conf.IoTDBConstant.ClientVersion;
 import org.apache.iotdb.db.auth.AuthorityChecker;
-import org.apache.iotdb.db.exception.IntoProcessException;
+import org.apache.iotdb.db.exception.runtime.IntoProcessException;
 import org.apache.iotdb.db.protocol.session.IClientSession;
 import org.apache.iotdb.db.protocol.session.InternalClientSession;
 import org.apache.iotdb.db.protocol.session.SessionManager;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/AbstractIntoOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/AbstractIntoOperator.java
@@ -23,7 +23,7 @@ import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
-import org.apache.iotdb.db.exception.IntoProcessException;
+import org.apache.iotdb.db.exception.runtime.IntoProcessException;
 import org.apache.iotdb.db.protocol.client.DataNodeInternalClient;
 import org.apache.iotdb.db.queryengine.execution.operator.Operator;
 import org.apache.iotdb.db.queryengine.execution.operator.OperatorContext;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/ml/ForecastOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/ml/ForecastOperator.java
@@ -22,7 +22,7 @@ package org.apache.iotdb.db.queryengine.execution.operator.process.ml;
 import org.apache.iotdb.commons.client.mlnode.MLNodeClient;
 import org.apache.iotdb.commons.client.mlnode.MLNodeClientManager;
 import org.apache.iotdb.commons.client.mlnode.MLNodeInfo;
-import org.apache.iotdb.db.exception.ModelInferenceProcessException;
+import org.apache.iotdb.db.exception.runtime.ModelInferenceProcessException;
 import org.apache.iotdb.db.queryengine.execution.operator.Operator;
 import org.apache.iotdb.db.queryengine.execution.operator.OperatorContext;
 import org.apache.iotdb.db.queryengine.execution.operator.process.ProcessOperator;


### PR DESCRIPTION
Currently ModelInferenceException lies in a wrong path of storageengine/dataregion/exception
After this pr, it will be moved to org.apache.iotdb.db.exception.runtime.
![image](https://github.com/apache/iotdb/assets/51467236/3c416819-2a92-4aa5-b71f-3071c4d1ca07)
