### PR TITLE
Pipe: Fix ConcurrentModificationException caused by concurrently iterating through CachedSchemaPatternMatcher.extractors when an PipeHeartbeatEvent is being assigned

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/matcher/CachedSchemaPatternMatcher.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/matcher/CachedSchemaPatternMatcher.java
@@ -47,6 +47,9 @@ public class CachedSchemaPatternMatcher implements PipeDataRegionMatcher {
 
   public CachedSchemaPatternMatcher() {
     this.lock = new ReentrantReadWriteLock();
+    // Should be thread-safe because the extractors will be returned by {@link #match} and
+    // iterated by {@link #assignToExtractor}, at the same time the extractors may be added or
+    // removed by {@link #register} and {@link #deregister}.
     this.extractors = new CopyOnWriteArraySet<>();
     this.deviceToExtractorsCache =
         Caffeine.newBuilder()

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/matcher/CachedSchemaPatternMatcher.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/matcher/CachedSchemaPatternMatcher.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class CachedSchemaPatternMatcher implements PipeDataRegionMatcher {
@@ -46,7 +47,7 @@ public class CachedSchemaPatternMatcher implements PipeDataRegionMatcher {
 
   public CachedSchemaPatternMatcher() {
     this.lock = new ReentrantReadWriteLock();
-    this.extractors = new HashSet<>();
+    this.extractors = new CopyOnWriteArraySet<>();
     this.deviceToExtractorsCache =
         Caffeine.newBuilder()
             .maximumSize(PipeConfig.getInstance().getPipeExtractorMatcherCacheSize())


### PR DESCRIPTION
As title.