### PR TITLE
[To rel/1.2] Pipe: Fix ConcurrentModificationException caused by concurrently iterating through CachedSchemaPatternMatcher.extractors when an PipeHeartbeatEvent is being assigned (#11074)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/matcher/CachedSchemaPatternMatcher.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/matcher/CachedSchemaPatternMatcher.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class CachedSchemaPatternMatcher implements PipeDataRegionMatcher {
@@ -46,7 +47,10 @@ public class CachedSchemaPatternMatcher implements PipeDataRegionMatcher {
 
   public CachedSchemaPatternMatcher() {
     this.lock = new ReentrantReadWriteLock();
-    this.extractors = new HashSet<>();
+    // Should be thread-safe because the extractors will be returned by {@link #match} and
+    // iterated by {@link #assignToExtractor}, at the same time the extractors may be added or
+    // removed by {@link #register} and {@link #deregister}.
+    this.extractors = new CopyOnWriteArraySet<>();
     this.deviceToExtractorsCache =
         Caffeine.newBuilder()
             .maximumSize(PipeConfig.getInstance().getPipeExtractorMatcherCacheSize())


### PR DESCRIPTION
…ating through CachedSchemaPatternMatcher.extractors when an PipeHeartbeatEvent is being assigned (#11074)

* try to fix ConcurrentModificationException when assigning PipeHeartbeatEvent

* Update CachedSchemaPatternMatcher.java

---------

Co-authored-by: 马子坤 <55695098+DanielWang2035@users.noreply.github.com>
(cherry picked from commit ac0dd9d3111ee551594bfa2686db4b8896bfd7fe)
