### PR TITLE
Pipe: include creation time in PipeProcessorSubtask#taskID to avoid task scheduling issues after 1000+ pipes' creating and dropping

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/stage/PipeTaskProcessorStage.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/stage/PipeTaskProcessorStage.java
@@ -85,6 +85,11 @@ public class PipeTaskProcessorStage extends PipeTaskStage {
       throw new PipeException(e.getMessage(), e);
     }
 
+    // Should add creation time in taskID, because subtasks are stored in the hashmap
+    // PipeProcessorSubtaskWorker.subtasks, and deleted subtasks will be removed by
+    // a timed thread. If a pipe is deleted and created again before its subtask is
+    // removed, the new subtask will have the same pipeName and dataRegionId as the
+    // old one, so we need creationTime to make their hash code different in the map.
     final String taskId = pipeName + "_" + dataRegionId + "_" + creationTime;
     final PipeEventCollector pipeConnectorOutputEventCollector =
         new PipeEventCollector(pipeConnectorOutputPendingQueue);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/stage/PipeTaskProcessorStage.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/stage/PipeTaskProcessorStage.java
@@ -85,7 +85,7 @@ public class PipeTaskProcessorStage extends PipeTaskStage {
       throw new PipeException(e.getMessage(), e);
     }
 
-    final String taskId = pipeName + "_" + dataRegionId;
+    final String taskId = pipeName + "_" + dataRegionId + "_" + creationTime;
     final PipeEventCollector pipeConnectorOutputEventCollector =
         new PipeEventCollector(pipeConnectorOutputPendingQueue);
     this.pipeProcessorSubtask =


### PR DESCRIPTION
To reproduce:
- create 1000 devices and write some data
- create and start 1000 pipes, their patterns matching the devices
- drop all pipes
- delete all data on receiver side
- create and start the same pipes again
- execute queries on receiver side, and the data are NOT transferred.