### PR TITLE
[To rel/1.2] Pipe: Clear reference count of on-the-fly EnrichedEvent in queues when pipe is dropped (#11077)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/EnrichedEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/EnrichedEvent.java
@@ -77,9 +77,9 @@ public abstract class EnrichedEvent implements Event {
   public abstract boolean internallyIncreaseResourceReferenceCount(String holderMessage);
 
   /**
-   * Decrease the reference count of this event. If the reference count is decreased to 0, the event
-   * can be recycled and the data stored in the event is not safe to use, the processing progress of
-   * the event should be reported to the pipe task meta.
+   * Decrease the reference count of this event by 1. If the reference count is decreased to 0, the
+   * event can be recycled and the data stored in the event is not safe to use, the processing
+   * progress of the event should be reported to the pipe task meta.
    *
    * @param holderMessage the message of the invoker
    * @return true if the reference count is decreased successfully, false otherwise
@@ -92,6 +92,26 @@ public abstract class EnrichedEvent implements Event {
         reportProgress();
       }
       referenceCount.decrementAndGet();
+    }
+    return isSuccessful;
+  }
+
+  /**
+   * Decrease the reference count of this event to 0. The event can be recycled and the data stored
+   * in the event is not safe to use, the processing progress of the event should be reported to the
+   * pipe task meta.
+   *
+   * @param holderMessage the message of the invoker
+   * @return true if the reference count is decreased successfully, false otherwise
+   */
+  public boolean clearReferenceCount(String holderMessage) {
+    boolean isSuccessful = true;
+    synchronized (this) {
+      if (referenceCount.get() >= 1) {
+        isSuccessful = internallyDecreaseResourceReferenceCount(holderMessage);
+        reportProgress();
+      }
+      referenceCount.set(0);
     }
     return isSuccessful;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/realtime/PipeRealtimeEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/realtime/PipeRealtimeEvent.java
@@ -101,10 +101,18 @@ public class PipeRealtimeEvent extends EnrichedEvent {
   @Override
   public boolean decreaseReferenceCount(String holderMessage) {
     // This method must be overridden, otherwise during the real-time data extraction stage, the
-    // current PipeRealtimeEvent rather than the member variable EnrichedEvent will increase
+    // current PipeRealtimeEvent rather than the member variable EnrichedEvent will decrease
     // the reference count, resulting in errors in the reference count of the EnrichedEvent
     // contained in this PipeRealtimeEvent during the processor and connector stages.
     return event.decreaseReferenceCount(holderMessage);
+  }
+
+  @Override
+  public boolean clearReferenceCount(String holderMessage) {
+    // This method must be overridden, otherwise during the real-time data extraction stage, the
+    // current PipeRealtimeEvent rather than the member variable EnrichedEvent will clear
+    // the reference count.
+    return event.clearReferenceCount(holderMessage);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/historical/PipeHistoricalDataRegionTsFileExtractor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/historical/PipeHistoricalDataRegionTsFileExtractor.java
@@ -277,7 +277,7 @@ public class PipeHistoricalDataRegionTsFileExtractor implements PipeHistoricalDa
   }
 
   @Override
-  public Event supply() {
+  public synchronized Event supply() {
     if (pendingQueue == null) {
       return null;
     }
@@ -290,8 +290,11 @@ public class PipeHistoricalDataRegionTsFileExtractor implements PipeHistoricalDa
   }
 
   @Override
-  public void close() {
+  public synchronized void close() {
     if (pendingQueue != null) {
+      pendingQueue.forEach(
+          event ->
+              event.clearReferenceCount(PipeHistoricalDataRegionTsFileExtractor.class.getName()));
       pendingQueue.clear();
       pendingQueue = null;
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/PipeRealtimeDataRegionExtractor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/PipeRealtimeDataRegionExtractor.java
@@ -22,12 +22,19 @@ package org.apache.iotdb.db.pipe.extractor.realtime;
 import org.apache.iotdb.commons.pipe.task.meta.PipeTaskMeta;
 import org.apache.iotdb.db.pipe.config.constant.PipeExtractorConstant;
 import org.apache.iotdb.db.pipe.config.plugin.env.PipeTaskExtractorRuntimeEnvironment;
+import org.apache.iotdb.db.pipe.event.EnrichedEvent;
 import org.apache.iotdb.db.pipe.event.realtime.PipeRealtimeEvent;
 import org.apache.iotdb.db.pipe.extractor.realtime.listener.PipeInsertionDataNodeListener;
+import org.apache.iotdb.db.pipe.task.connection.UnboundedBlockingPendingQueue;
 import org.apache.iotdb.pipe.api.PipeExtractor;
 import org.apache.iotdb.pipe.api.customizer.configuration.PipeExtractorRuntimeConfiguration;
 import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameterValidator;
 import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameters;
+import org.apache.iotdb.pipe.api.event.Event;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public abstract class PipeRealtimeDataRegionExtractor implements PipeExtractor {
 
@@ -37,6 +44,13 @@ public abstract class PipeRealtimeDataRegionExtractor implements PipeExtractor {
   protected String pipeName;
   protected String dataRegionId;
   protected PipeTaskMeta pipeTaskMeta;
+
+  // This queue is used to store pending events extracted by the method extract(). The method
+  // supply() will poll events from this queue and send them to the next pipe plugin.
+  protected final UnboundedBlockingPendingQueue<Event> pendingQueue =
+      new UnboundedBlockingPendingQueue<>();
+
+  protected final AtomicBoolean isClosed = new AtomicBoolean(false);
 
   protected PipeRealtimeDataRegionExtractor() {
     // Do nothing
@@ -70,10 +84,43 @@ public abstract class PipeRealtimeDataRegionExtractor implements PipeExtractor {
   @Override
   public void close() throws Exception {
     PipeInsertionDataNodeListener.getInstance().stopListenAndAssign(dataRegionId, this);
+
+    synchronized (isClosed) {
+      clearPendingQueue();
+      isClosed.set(true);
+    }
+  }
+
+  private void clearPendingQueue() {
+    final List<Event> eventsToDrop = new ArrayList<>(pendingQueue.size());
+
+    // processor stage is closed later than extractor stage, {@link supply()} may be called after
+    // processor stage is closed. To avoid concurrent issues, we should clear the pending queue
+    // before clearing all the reference count of the events in the pending queue.
+    pendingQueue.forEach(eventsToDrop::add);
+    pendingQueue.clear();
+
+    eventsToDrop.forEach(
+        event -> {
+          if (event instanceof EnrichedEvent) {
+            ((EnrichedEvent) event)
+                .clearReferenceCount(PipeRealtimeDataRegionExtractor.class.getName());
+          }
+        });
   }
 
   /** @param event the event from the storage engine */
-  public abstract void extract(PipeRealtimeEvent event);
+  public final void extract(PipeRealtimeEvent event) {
+    doExtract(event);
+
+    synchronized (isClosed) {
+      if (isClosed.get()) {
+        clearPendingQueue();
+      }
+    }
+  }
+
+  protected abstract void doExtract(PipeRealtimeEvent event);
 
   public abstract boolean isNeedListenToTsFile();
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/PipeRealtimeDataRegionFakeExtractor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/PipeRealtimeDataRegionFakeExtractor.java
@@ -49,7 +49,7 @@ public class PipeRealtimeDataRegionFakeExtractor extends PipeRealtimeDataRegionE
   }
 
   @Override
-  public void extract(PipeRealtimeEvent event) {
+  protected void doExtract(PipeRealtimeEvent event) {
     // do nothing
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/PipeRealtimeDataRegionHybridExtractor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/PipeRealtimeDataRegionHybridExtractor.java
@@ -25,7 +25,6 @@ import org.apache.iotdb.db.pipe.agent.PipeAgent;
 import org.apache.iotdb.db.pipe.event.common.heartbeat.PipeHeartbeatEvent;
 import org.apache.iotdb.db.pipe.event.realtime.PipeRealtimeEvent;
 import org.apache.iotdb.db.pipe.extractor.realtime.epoch.TsFileEpoch;
-import org.apache.iotdb.db.pipe.task.connection.UnboundedBlockingPendingQueue;
 import org.apache.iotdb.pipe.api.event.Event;
 import org.apache.iotdb.pipe.api.event.dml.insertion.TabletInsertionEvent;
 import org.apache.iotdb.pipe.api.event.dml.insertion.TsFileInsertionEvent;
@@ -38,16 +37,8 @@ public class PipeRealtimeDataRegionHybridExtractor extends PipeRealtimeDataRegio
   private static final Logger LOGGER =
       LoggerFactory.getLogger(PipeRealtimeDataRegionHybridExtractor.class);
 
-  // This queue is used to store pending events extracted by the method extract(). The method
-  // supply() will poll events from this queue and send them to the next pipe plugin.
-  private final UnboundedBlockingPendingQueue<Event> pendingQueue;
-
-  public PipeRealtimeDataRegionHybridExtractor() {
-    this.pendingQueue = new UnboundedBlockingPendingQueue<>();
-  }
-
   @Override
-  public void extract(PipeRealtimeEvent event) {
+  protected void doExtract(PipeRealtimeEvent event) {
     final Event eventToExtract = event.getEvent();
 
     if (eventToExtract instanceof TabletInsertionEvent) {
@@ -306,11 +297,5 @@ public class PipeRealtimeDataRegionHybridExtractor extends PipeRealtimeDataRegio
 
       return null;
     }
-  }
-
-  @Override
-  public void close() throws Exception {
-    super.close();
-    pendingQueue.clear();
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/PipeRealtimeDataRegionLogExtractor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/PipeRealtimeDataRegionLogExtractor.java
@@ -24,7 +24,6 @@ import org.apache.iotdb.db.pipe.agent.PipeAgent;
 import org.apache.iotdb.db.pipe.event.common.heartbeat.PipeHeartbeatEvent;
 import org.apache.iotdb.db.pipe.event.realtime.PipeRealtimeEvent;
 import org.apache.iotdb.db.pipe.extractor.realtime.epoch.TsFileEpoch;
-import org.apache.iotdb.db.pipe.task.connection.UnboundedBlockingPendingQueue;
 import org.apache.iotdb.pipe.api.event.Event;
 import org.apache.iotdb.pipe.api.event.dml.insertion.TabletInsertionEvent;
 
@@ -36,16 +35,8 @@ public class PipeRealtimeDataRegionLogExtractor extends PipeRealtimeDataRegionEx
   private static final Logger LOGGER =
       LoggerFactory.getLogger(PipeRealtimeDataRegionLogExtractor.class);
 
-  // This queue is used to store pending events extracted by the method extract(). The method
-  // supply() will poll events from this queue and send them to the next pipe plugin.
-  private final UnboundedBlockingPendingQueue<Event> pendingQueue;
-
-  public PipeRealtimeDataRegionLogExtractor() {
-    this.pendingQueue = new UnboundedBlockingPendingQueue<>();
-  }
-
   @Override
-  public void extract(PipeRealtimeEvent event) {
+  protected void doExtract(PipeRealtimeEvent event) {
     if (event.getEvent() instanceof PipeHeartbeatEvent) {
       extractHeartbeat(event);
       return;
@@ -152,11 +143,5 @@ public class PipeRealtimeDataRegionLogExtractor extends PipeRealtimeDataRegionEx
 
     // means the pending queue is empty.
     return null;
-  }
-
-  @Override
-  public void close() throws Exception {
-    super.close();
-    pendingQueue.clear();
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/PipeRealtimeDataRegionTsFileExtractor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/PipeRealtimeDataRegionTsFileExtractor.java
@@ -24,7 +24,6 @@ import org.apache.iotdb.db.pipe.agent.PipeAgent;
 import org.apache.iotdb.db.pipe.event.common.heartbeat.PipeHeartbeatEvent;
 import org.apache.iotdb.db.pipe.event.realtime.PipeRealtimeEvent;
 import org.apache.iotdb.db.pipe.extractor.realtime.epoch.TsFileEpoch;
-import org.apache.iotdb.db.pipe.task.connection.UnboundedBlockingPendingQueue;
 import org.apache.iotdb.pipe.api.event.Event;
 import org.apache.iotdb.pipe.api.event.dml.insertion.TsFileInsertionEvent;
 
@@ -36,16 +35,8 @@ public class PipeRealtimeDataRegionTsFileExtractor extends PipeRealtimeDataRegio
   private static final Logger LOGGER =
       LoggerFactory.getLogger(PipeRealtimeDataRegionTsFileExtractor.class);
 
-  // This queue is used to store pending events extracted by the method extract(). The method
-  // supply() will poll events from this queue and send them to the next pipe plugin.
-  private final UnboundedBlockingPendingQueue<Event> pendingQueue;
-
-  public PipeRealtimeDataRegionTsFileExtractor() {
-    this.pendingQueue = new UnboundedBlockingPendingQueue<>();
-  }
-
   @Override
-  public void extract(PipeRealtimeEvent event) {
+  protected void doExtract(PipeRealtimeEvent event) {
     if (event.getEvent() instanceof PipeHeartbeatEvent) {
       extractHeartbeat(event);
       return;
@@ -152,11 +143,5 @@ public class PipeRealtimeDataRegionTsFileExtractor extends PipeRealtimeDataRegio
 
     // means the pending queue is empty.
     return null;
-  }
-
-  @Override
-  public void close() throws Exception {
-    super.close();
-    pendingQueue.clear();
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/connection/BlockingPendingQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/connection/BlockingPendingQueue.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 public abstract class BlockingPendingQueue<E extends Event> {
 
@@ -83,6 +84,10 @@ public abstract class BlockingPendingQueue<E extends Event> {
 
   public void clear() {
     pendingQueue.clear();
+  }
+
+  public void forEach(Consumer<? super E> action) {
+    pendingQueue.forEach(action);
   }
 
   public int size() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/connection/PipeEventCollector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/connection/PipeEventCollector.java
@@ -27,7 +27,7 @@ import org.apache.iotdb.pipe.api.event.Event;
 import java.util.Deque;
 import java.util.LinkedList;
 
-public class PipeEventCollector implements EventCollector {
+public class PipeEventCollector implements EventCollector, AutoCloseable {
 
   private final BoundedBlockingPendingQueue<Event> pendingQueue;
 
@@ -86,5 +86,15 @@ public class PipeEventCollector implements EventCollector {
       }
     }
     return false;
+  }
+
+  public synchronized void close() {
+    bufferQueue.forEach(
+        event -> {
+          if (event instanceof EnrichedEvent) {
+            ((EnrichedEvent) event).clearReferenceCount(PipeEventCollector.class.getName());
+          }
+        });
+    bufferQueue.clear();
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/connector/PipeConnectorSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/connector/PipeConnectorSubtask.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.pipe.event.EnrichedEvent;
 import org.apache.iotdb.db.pipe.event.common.heartbeat.PipeHeartbeatEvent;
 import org.apache.iotdb.db.pipe.execution.scheduler.PipeSubtaskScheduler;
 import org.apache.iotdb.db.pipe.task.connection.BoundedBlockingPendingQueue;
+import org.apache.iotdb.db.pipe.task.connection.PipeEventCollector;
 import org.apache.iotdb.db.pipe.task.subtask.DecoratingLock;
 import org.apache.iotdb.db.pipe.task.subtask.PipeSubtask;
 import org.apache.iotdb.db.utils.ErrorHandlingUtils;
@@ -237,14 +238,22 @@ public class PipeConnectorSubtask extends PipeSubtask {
   public synchronized void close() {
     try {
       outputPipeConnector.close();
-
-      // Should be called after outputPipeConnector.close()
-      super.close();
     } catch (Exception e) {
       LOGGER.info(
           "Error occurred during closing PipeConnector, perhaps need to check whether the "
               + "implementation of PipeConnector is correct according to the pipe-api description.",
           e);
+    } finally {
+      inputPendingQueue.forEach(
+          event -> {
+            if (event instanceof EnrichedEvent) {
+              ((EnrichedEvent) event).clearReferenceCount(PipeEventCollector.class.getName());
+            }
+          });
+      inputPendingQueue.clear();
+
+      // Should be called after outputPipeConnector.close()
+      super.close();
     }
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/extractor/CachedSchemaPatternMatcherTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/extractor/CachedSchemaPatternMatcherTest.java
@@ -156,7 +156,7 @@ public class CachedSchemaPatternMatcherTest {
     }
 
     @Override
-    public void extract(PipeRealtimeEvent event) {
+    protected void doExtract(PipeRealtimeEvent event) {
       final boolean[] match = {false};
       event
           .getSchemaInfo()


### PR DESCRIPTION
Co-authored-by: Steve Yurong Su <rong@apache.org>
(cherry picked from commit c4ff2b13449deab7d20613e31c9ccfecf8128021)
