### PR TITLE
[To rel/1.2][IOTDB-6144] Adjust the default thrift timeout parameter to 60s 

### DIFF
--- a/iotdb-core/confignode/src/assembly/resources/conf/iotdb-confignode.properties
+++ b/iotdb-core/confignode/src/assembly/resources/conf/iotdb-confignode.properties
@@ -98,7 +98,7 @@ cn_target_config_node_list=127.0.0.1:10710
 
 # Thrift socket and connection timeout between raft nodes, in milliseconds.
 # Datatype: int
-# cn_connection_timeout_ms=20000
+# cn_connection_timeout_ms=60000
 
 # selector thread (TAsyncClientManager) nums for async thread in a clientManager
 # Datatype: int

--- a/iotdb-core/datanode/src/assembly/resources/conf/iotdb-datanode.properties
+++ b/iotdb-core/datanode/src/assembly/resources/conf/iotdb-datanode.properties
@@ -107,7 +107,7 @@ dn_target_config_node_list=127.0.0.1:10710
 
 # Thrift socket and connection timeout between raft nodes, in milliseconds.
 # Datatype: int
-# dn_connection_timeout_ms=20000
+# dn_connection_timeout_ms=60000
 
 # selector thread (TAsyncClientManager) nums for async thread in a clientManager
 # Datatype: int

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -909,7 +909,7 @@ public class IoTDBConfig {
   private int mppDataExchangeKeepAliveTimeInMs = 1000;
 
   /** Thrift socket and connection timeout between data node and config node. */
-  private int connectionTimeoutInMS = (int) TimeUnit.SECONDS.toMillis(20);
+  private int connectionTimeoutInMS = (int) TimeUnit.SECONDS.toMillis(60);
 
   /**
    * ClientManager will have so many selector threads (TAsyncClientManager) to distribute to its

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -98,7 +98,7 @@ public class CommonConfig {
   private long[] tierTTLInMs = {Long.MAX_VALUE};
 
   /** Thrift socket and connection timeout between data node and config node. */
-  private int connectionTimeoutInMS = (int) TimeUnit.SECONDS.toMillis(20);
+  private int connectionTimeoutInMS = (int) TimeUnit.SECONDS.toMillis(60);
 
   /**
    * ClientManager will have so many selector threads (TAsyncClientManager) to distribute to its


### PR DESCRIPTION
cherry-pick [pr](https://github.com/apache/iotdb/pull/11091)