### PR TITLE
[To rel/1.2] Change default encoder of INT32 and INT64 from RLE to TS_2DIFF

### DIFF
--- a/docs/UserGuide/Operate-Metadata/Auto-Create-MetaData.md
+++ b/docs/UserGuide/Operate-Metadata/Auto-Create-MetaData.md
@@ -101,8 +101,8 @@ Illustrated as the following figure:
 | Data Type | iotdb-datanode.properties  | Default |
 |:---|:---------------------------|:---|
 | BOOLEAN | default\_boolean\_encoding | RLE |
-| INT32 | default\_int32\_encoding   | RLE |
-| INT64 | default\_int64\_encoding   | RLE |
+| INT32 | default\_int32\_encoding   | TS_2DIFF |
+| INT64 | default\_int64\_encoding   | TS_2DIFF |
 | FLOAT | default\_float\_encoding   | GORILLA |
 | DOUBLE | default\_double\_encoding  | GORILLA |
 | TEXT | default\_text\_encoding    | PLAIN |

--- a/docs/zh/UserGuide/Operate-Metadata/Auto-Create-MetaData.md
+++ b/docs/zh/UserGuide/Operate-Metadata/Auto-Create-MetaData.md
@@ -100,8 +100,8 @@
 | 数据类型 | iotdb-datanode.properties配置项 | 默认值 |
 |:---|:-----------------------------|:---|
 | BOOLEAN | default\_boolean\_encoding   | RLE |
-| INT32 | default\_int32\_encoding     | RLE |
-| INT64 | default\_int64\_encoding     | RLE |
+| INT32 | default\_int32\_encoding     | TS_2DIFF |
+| INT64 | default\_int64\_encoding     | TS_2DIFF |
 | FLOAT | default\_float\_encoding     | GORILLA |
 | DOUBLE | default\_double\_encoding    | GORILLA |
 | TEXT | default\_text\_encoding      | PLAIN |

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBMetadataFetchIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBMetadataFetchIT.java
@@ -131,7 +131,7 @@ public class IoTDBMetadataFetchIT extends AbstractSchemaIT {
                 Arrays.asList(
                     "root.ln.wf01.wt01.status,null,root.ln.wf01.wt01,BOOLEAN,PLAIN,LZ4,null,null,null,null,BASE,",
                     "root.ln.wf01.wt01.temperature,null,root.ln.wf01.wt01,FLOAT,RLE,SNAPPY,null,null,null,null,BASE,",
-                    "root.ln.wf01.wt02.s1,null,root.ln.wf01.wt02,INT32,RLE,LZ4,null,null,null,null,BASE,",
+                    "root.ln.wf01.wt02.s1,null,root.ln.wf01.wt02,INT32,TS_2DIFF,LZ4,null,null,null,null,BASE,",
                     "root.ln.wf01.wt02.s2,null,root.ln.wf01.wt02,DOUBLE,GORILLA,LZ4,null,null,null,null,BASE,")),
             new HashSet<>(
                 Arrays.asList(
@@ -141,7 +141,7 @@ public class IoTDBMetadataFetchIT extends AbstractSchemaIT {
                 Arrays.asList(
                     "root.ln.wf01.wt01.status,null,root.ln.wf01.wt01,BOOLEAN,PLAIN,LZ4,null,null,null,null,BASE,",
                     "root.ln.wf01.wt01.temperature,null,root.ln.wf01.wt01,FLOAT,RLE,SNAPPY,null,null,null,null,BASE,",
-                    "root.ln.wf01.wt02.s1,null,root.ln.wf01.wt02,INT32,RLE,LZ4,null,null,null,null,BASE,",
+                    "root.ln.wf01.wt02.s1,null,root.ln.wf01.wt02,INT32,TS_2DIFF,LZ4,null,null,null,null,BASE,",
                     "root.ln.wf01.wt02.s2,null,root.ln.wf01.wt02,DOUBLE,GORILLA,LZ4,null,null,null,null,BASE,",
                     "root.ln1.wf01.wt01.status,null,root.ln1.wf01.wt01,BOOLEAN,PLAIN,LZ4,null,null,null,null,BASE,",
                     "root.ln1.wf01.wt01.temperature,null,root.ln1.wf01.wt01,FLOAT,RLE,SNAPPY,null,null,null,null,BASE,",
@@ -717,7 +717,7 @@ public class IoTDBMetadataFetchIT extends AbstractSchemaIT {
           "create aligned timeseries root.sg.d(s1(alias1) int32 tags('tag1'='v1', 'tag2'='v2'), s2 double attributes('attr3'='v3'))");
       String[] expected =
           new String[] {
-            "root.sg.d.s1,alias1,root.sg,INT32,RLE,LZ4,{\"tag1\":\"v1\",\"tag2\":\"v2\"},null,null,null,BASE,",
+            "root.sg.d.s1,alias1,root.sg,INT32,TS_2DIFF,LZ4,{\"tag1\":\"v1\",\"tag2\":\"v2\"},null,null,null,BASE,",
             "root.sg.d.s2,null,root.sg,DOUBLE,GORILLA,LZ4,null,{\"attr3\":\"v3\"},null,null,BASE,"
           };
 
@@ -785,7 +785,7 @@ public class IoTDBMetadataFetchIT extends AbstractSchemaIT {
       Set<String> standard =
           new HashSet<>(
               Arrays.asList(
-                  "root.sg1.d0.s0,null,root.sg1,INT32,RLE,LZ4,null,null,null,null,BASE,\n",
+                  "root.sg1.d0.s0,null,root.sg1,INT32,TS_2DIFF,LZ4,null,null,null,null,BASE,\n",
                   "root.sg1.d0.s1,null,root.sg1,INT32,PLAIN,LZ4,null,null,SDT,{compdev=2},BASE,\n",
                   "root.sg1.d0.s2,null,root.sg1,INT32,PLAIN,LZ4,null,null,SDT,{compdev=0.01, compmintime=2, compmaxtime=15},BASE,\n"));
       try (ResultSet resultSet = statement.executeQuery("SHOW TIMESERIES root.sg1.d0.*")) {

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBSchemaTemplateIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBSchemaTemplateIT.java
@@ -147,11 +147,11 @@ public class IoTDBSchemaTemplateIT extends AbstractSchemaIT {
       Set<String> expectedResult =
           new HashSet<>(
               Arrays.asList(
-                  "root.sg1.d1.s1,INT64,RLE,LZ4",
+                  "root.sg1.d1.s1,INT64,TS_2DIFF,LZ4",
                   "root.sg1.d1.s2,DOUBLE,GORILLA,LZ4",
-                  "root.sg1.d2.s1,INT64,RLE,LZ4",
+                  "root.sg1.d2.s1,INT64,TS_2DIFF,LZ4",
                   "root.sg1.d2.s2,DOUBLE,GORILLA,LZ4",
-                  "root.sg1.d3.s1,INT64,RLE,LZ4"));
+                  "root.sg1.d3.s1,INT64,TS_2DIFF,LZ4"));
 
       try (ResultSet resultSet = statement.executeQuery("SHOW TIMESERIES root.sg1.**"); ) {
         while (resultSet.next()) {
@@ -230,9 +230,9 @@ public class IoTDBSchemaTemplateIT extends AbstractSchemaIT {
       Set<String> expectedResult =
           new HashSet<>(
               Arrays.asList(
-                  "root.sg1.d1.s1,INT64,RLE,LZ4",
+                  "root.sg1.d1.s1,INT64,TS_2DIFF,LZ4",
                   "root.sg1.d1.s2,DOUBLE,GORILLA,LZ4",
-                  "root.sg1.d2.s1,INT64,RLE,LZ4",
+                  "root.sg1.d2.s1,INT64,TS_2DIFF,LZ4",
                   "root.sg1.d2.s2,DOUBLE,GORILLA,LZ4"));
 
       try (ResultSet resultSet = statement.executeQuery("SHOW TIMESERIES root.sg1.**")) {
@@ -316,7 +316,7 @@ public class IoTDBSchemaTemplateIT extends AbstractSchemaIT {
   public void testShowNodesInSchemaTemplate() throws SQLException {
     // set schema template
     Set<String> expectedResultSet =
-        new HashSet<>(Arrays.asList("s1,INT64,RLE,LZ4", "s2,DOUBLE,GORILLA,LZ4"));
+        new HashSet<>(Arrays.asList("s1,INT64,TS_2DIFF,LZ4", "s2,DOUBLE,GORILLA,LZ4"));
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement();
         ResultSet resultSet = statement.executeQuery("SHOW NODES IN SCHEMA TEMPLATE t1")) {
@@ -466,7 +466,8 @@ public class IoTDBSchemaTemplateIT extends AbstractSchemaIT {
 
       expectedResult =
           new HashSet<>(
-              Arrays.asList("root.sg1.d1.s1,INT64,RLE,LZ4", "root.sg1.d2.s1,INT64,RLE,LZ4"));
+              Arrays.asList(
+                  "root.sg1.d1.s1,INT64,TS_2DIFF,LZ4", "root.sg1.d2.s1,INT64,TS_2DIFF,LZ4"));
 
       try (ResultSet resultSet = statement.executeQuery("SHOW TIMESERIES root.**.s1")) {
         while (resultSet.next()) {
@@ -519,7 +520,8 @@ public class IoTDBSchemaTemplateIT extends AbstractSchemaIT {
       }
       Assert.assertTrue(expectedResult.isEmpty());
 
-      expectedResult = new HashSet<>(Collections.singletonList("root.sg1.d1.s1,INT64,RLE,LZ4"));
+      expectedResult =
+          new HashSet<>(Collections.singletonList("root.sg1.d1.s1,INT64,TS_2DIFF,LZ4"));
 
       try (ResultSet resultSet = statement.executeQuery("SHOW TIMESERIES root.**.s1")) {
         while (resultSet.next()) {
@@ -683,11 +685,11 @@ public class IoTDBSchemaTemplateIT extends AbstractSchemaIT {
       Set<String> expectedResult =
           new HashSet<>(
               Arrays.asList(
-                  "root.sg1.d1.s1,INT64,RLE,LZ4",
+                  "root.sg1.d1.s1,INT64,TS_2DIFF,LZ4",
                   "root.sg1.d1.s2,DOUBLE,GORILLA,LZ4",
-                  "root.sg2.d2.s1,INT64,RLE,LZ4",
+                  "root.sg2.d2.s1,INT64,TS_2DIFF,LZ4",
                   "root.sg2.d2.s2,DOUBLE,GORILLA,LZ4",
-                  "root.sg3.d3.s1,INT64,RLE,LZ4"));
+                  "root.sg3.d3.s1,INT64,TS_2DIFF,LZ4"));
 
       try (ResultSet resultSet = statement.executeQuery("SHOW TIMESERIES root.sg*.*.s*")) {
         while (resultSet.next()) {
@@ -706,7 +708,8 @@ public class IoTDBSchemaTemplateIT extends AbstractSchemaIT {
       Assert.assertTrue(expectedResult.isEmpty());
       expectedResult =
           new HashSet<>(
-              Arrays.asList("root.sg1.d1.s1,INT64,RLE,LZ4", "root.sg1.d1.s2,DOUBLE,GORILLA,LZ4"));
+              Arrays.asList(
+                  "root.sg1.d1.s1,INT64,TS_2DIFF,LZ4", "root.sg1.d1.s2,DOUBLE,GORILLA,LZ4"));
 
       try (ResultSet resultSet = statement.executeQuery("SHOW TIMESERIES root.sg1.d1.s*")) {
         while (resultSet.next()) {
@@ -749,7 +752,7 @@ public class IoTDBSchemaTemplateIT extends AbstractSchemaIT {
       Set<String> expectedResult =
           new HashSet<>(
               Arrays.asList(
-                  "root.sg1.d.s1,INT32,RLE,LZ4",
+                  "root.sg1.d.s1,INT32,TS_2DIFF,LZ4",
                   "root.sg1.d.s2,FLOAT,GORILLA,LZ4",
                   "root.sg1.d.s3,FLOAT,GORILLA,LZ4"));
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -637,10 +637,10 @@ public class IoTDBConfig {
   private TSEncoding defaultBooleanEncoding = TSEncoding.RLE;
 
   /** INT32 encoding when creating schema automatically is enabled */
-  private TSEncoding defaultInt32Encoding = TSEncoding.RLE;
+  private TSEncoding defaultInt32Encoding = TSEncoding.TS_2DIFF;
 
   /** INT64 encoding when creating schema automatically is enabled */
-  private TSEncoding defaultInt64Encoding = TSEncoding.RLE;
+  private TSEncoding defaultInt64Encoding = TSEncoding.TS_2DIFF;
 
   /** FLOAT encoding when creating schema automatically is enabled */
   private TSEncoding defaultFloatEncoding = TSEncoding.GORILLA;

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -345,11 +345,11 @@ cluster_name=defaultCluster
 
 # INT32 encoding when creating schema automatically is enabled
 # Datatype: TSEncoding
-# default_int32_encoding=RLE
+# default_int32_encoding=TS_2DIFF
 
 # INT64 encoding when creating schema automatically is enabled
 # Datatype: TSEncoding
-# default_int64_encoding=RLE
+# default_int64_encoding=TS_2DIFF
 
 # FLOAT encoding when creating schema automatically is enabled
 # Datatype: TSEncoding


### PR DESCRIPTION
We found that in most user cases TS_2DIFF has better compression rate than RLE for INT32 and INT64 type, so we change the default encoder of INT32 and INT64 from RLE to TS_2DIFF