### PR TITLE
[IOTDB-6149] Fix incorrect output of UDF with multiple inputs

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/udf/IoTDBUDFWindowQueryIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/udf/IoTDBUDFWindowQueryIT.java
@@ -27,7 +27,6 @@ import org.apache.iotdb.itbase.constant.UDFTestConstant;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -165,16 +164,12 @@ public class IoTDBUDFWindowQueryIT {
     testSlidingSizeWindow(3 * ITERATION_TIMES);
   }
 
-  // todo: remove ignore when exception handler in IT finishes
   @Test
-  @Ignore
   public void testSlidingSizeWindow7() {
     testSlidingSizeWindow(0);
   }
 
-  // todo: remove ignore when fixed
   @Test
-  @Ignore
   public void testSlidingSizeWindow8() {
     testSlidingSizeWindow(-ITERATION_TIMES);
   }
@@ -308,34 +303,29 @@ public class IoTDBUDFWindowQueryIT {
   }
 
   @Test
-  @Ignore
   public void testSlidingTimeWindow9() {
     testSlidingTimeWindow(
         (int) (0.01 * ITERATION_TIMES), (int) (0.05 * ITERATION_TIMES), ITERATION_TIMES / 2, 0);
   }
 
   @Test
-  @Ignore
   public void testSlidingTimeWindow10() {
     testSlidingTimeWindow(
         (int) (-0.01 * ITERATION_TIMES), (int) (0.05 * ITERATION_TIMES), 0, ITERATION_TIMES / 2);
   }
 
   @Test
-  @Ignore
   public void testSlidingTimeWindow11() {
     testSlidingTimeWindow(
         (int) (0.01 * ITERATION_TIMES), (int) (-0.05 * ITERATION_TIMES), 0, ITERATION_TIMES / 2);
   }
 
   @Test
-  @Ignore
   public void testSlidingTimeWindow12() {
     testSlidingTimeWindow((int) (0.01 * ITERATION_TIMES), 0, 0, ITERATION_TIMES / 2);
   }
 
   @Test
-  @Ignore
   public void testSlidingTimeWindow13() {
     testSlidingTimeWindow(0, (int) (0.05 * ITERATION_TIMES), 0, ITERATION_TIMES / 2);
   }
@@ -356,6 +346,10 @@ public class IoTDBUDFWindowQueryIT {
             UDFTestConstant.DISPLAY_WINDOW_END_KEY,
             displayWindowEnd);
 
+    int expectedCnt =
+        slidingStep <= 0
+            ? 0
+            : (int) Math.ceil((displayWindowEnd - displayWindowBegin) / (double) slidingStep);
     try (Connection conn = EnvFactory.getEnv().getConnection();
         Statement statement = conn.createStatement();
         ResultSet resultSet = statement.executeQuery(sql)) {
@@ -377,6 +371,7 @@ public class IoTDBUDFWindowQueryIT {
         assertEquals(expectedAccumulation, (int) (Double.parseDouble(resultSet.getString(2))));
         ++count;
       }
+      assertEquals(expectedCnt, count);
     } catch (SQLException throwable) {
       if (slidingStep > 0 && timeInterval > 0 && displayWindowEnd >= displayWindowBegin) {
         fail(throwable.getMessage());
@@ -413,6 +408,7 @@ public class IoTDBUDFWindowQueryIT {
 
         ++count;
       }
+      assertEquals(expectedCnt, count);
     } catch (SQLException throwable) {
       if (slidingStep > 0 && timeInterval > 0 && displayWindowEnd >= displayWindowBegin) {
         fail(throwable.getMessage());
@@ -473,7 +469,6 @@ public class IoTDBUDFWindowQueryIT {
   }
 
   @Test
-  @Ignore
   public void testSlidingTimeWindowWithTimeIntervalOnly6() {
     testSlidingTimeWindowWithTimeIntervalOnly(-ITERATION_TIMES);
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/intermediate/MultiInputColumnIntermediateLayer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/intermediate/MultiInputColumnIntermediateLayer.java
@@ -519,15 +519,17 @@ public class MultiInputColumnIntermediateLayer extends IntermediateLayer
       @Override
       public YieldableState yield() throws Exception {
         if (isFirstIteration) {
-          if (rowRecordList.size() == 0 && nextWindowTimeBegin == Long.MIN_VALUE) {
+          if (rowRecordList.size() == 0) {
             final YieldableState yieldableState =
                 LayerCacheUtils.yieldRow(udfInputDataSet, rowRecordList);
             if (yieldableState != YieldableState.YIELDABLE) {
               return yieldableState;
             }
-            // display window begin should be set to the same as the min timestamp of the query
-            // result set
-            nextWindowTimeBegin = rowRecordList.getTime(0);
+            if (nextWindowTimeBegin == Long.MIN_VALUE) {
+              // display window begin should be set to the same as the min timestamp of the query
+              // result set
+              nextWindowTimeBegin = rowRecordList.getTime(0);
+            }
           }
           hasAtLeastOneRow = rowRecordList.size() != 0;
           isFirstIteration = false;


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/IOTDB-6149
This pr fixed the incorrect initialization when calculating expressions with UDF which has multiple inputs.
How to reproduce:
1. Create a function with UDF that uses SlidingTimeWinodw AccessStrategy and takes multiple expressions as input.
2. Run a query using this function with multiple inputs like: select func(s1, s2) from root.sg
3. See if the ouput is correct.

Because UDFWindowIT#testSlidingTimeWindow did not check the cnt of expected rows, this bug could not be detected by the IT. I add the check in this PR now.
Also, In this pr, I removed some of the @Ignore annotions of UDFWindowIT since the exception handler of IT framework is finished as mentioned in the todo annotation.