### PR TITLE
Pipe: use PipeTaskCoordinatorLock instead of ReentrantLock for multi thread sync

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/task/PipeTaskCoordinator.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/task/PipeTaskCoordinator.java
@@ -38,7 +38,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.ReentrantLock;
 
 public class PipeTaskCoordinator {
 
@@ -49,13 +48,13 @@ public class PipeTaskCoordinator {
   // NEVER EXPOSE THIS DIRECTLY TO THE OUTSIDE
   private final PipeTaskInfo pipeTaskInfo;
 
-  private final ReentrantLock pipeTaskCoordinatorLock;
+  private final PipeTaskCoordinatorLock pipeTaskCoordinatorLock;
   private AtomicReference<PipeTaskInfo> pipeTaskInfoHolder;
 
   public PipeTaskCoordinator(ConfigManager configManager, PipeTaskInfo pipeTaskInfo) {
     this.configManager = configManager;
     this.pipeTaskInfo = pipeTaskInfo;
-    this.pipeTaskCoordinatorLock = new ReentrantLock(true);
+    this.pipeTaskCoordinatorLock = new PipeTaskCoordinatorLock();
   }
 
   /**

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/task/PipeTaskCoordinator.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/task/PipeTaskCoordinator.java
@@ -65,7 +65,6 @@ public class PipeTaskCoordinator {
    */
   public AtomicReference<PipeTaskInfo> lock() {
     pipeTaskCoordinatorLock.lock();
-    LOGGER.info("Pipe task coordinator locked.");
 
     pipeTaskInfoHolder = new AtomicReference<>(pipeTaskInfo);
     return pipeTaskInfoHolder;
@@ -85,7 +84,6 @@ public class PipeTaskCoordinator {
 
     try {
       pipeTaskCoordinatorLock.unlock();
-      LOGGER.info("Pipe task coordinator unlocked.");
       return true;
     } catch (IllegalMonitorStateException ignored) {
       // This is thrown if unlock() is called without lock() called first.

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/task/PipeTaskCoordinatorLock.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/task/PipeTaskCoordinatorLock.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.confignode.manager.pipe.task;
+
+import org.apache.iotdb.pipe.api.exception.PipeException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.LinkedBlockingDeque;
+
+/**
+ * PipeTaskCoordinatorLock is a cross thread lock for pipe task coordinator. It is used to ensure
+ * that only one thread can execute the pipe task coordinator at the same time.
+ */
+public class PipeTaskCoordinatorLock {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PipeTaskCoordinatorLock.class);
+
+  private final BlockingDeque<Object> deque = new LinkedBlockingDeque<>(1);
+  private final Object object = new Object();
+
+  void lock() {
+    try {
+      deque.put(object);
+      LOGGER.info("Lock acquired by thread {}", Thread.currentThread().getName());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new PipeException(String.format("Interrupted while waiting for lock: %s", e));
+    }
+  }
+
+  void unlock() {
+    deque.poll();
+    LOGGER.info("Lock released by thread {}", Thread.currentThread().getName());
+  }
+}


### PR DESCRIPTION
As title.