### PR TITLE
fix session sessionDataSet unclose when use export tsfile tool

### DIFF
--- a/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/ExportTsFile.java
+++ b/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/ExportTsFile.java
@@ -278,11 +278,9 @@ public class ExportTsFile extends AbstractTsFileTool {
    */
   private static void dumpResult(String sql, int index) {
     final String path = targetDirectory + targetFile + index + ".tsfile";
-    try {
-      SessionDataSet sessionDataSet = session.executeQueryStatement(sql, timeout);
+    try (SessionDataSet sessionDataSet = session.executeQueryStatement(sql, timeout)) {
       long start = System.currentTimeMillis();
       writeTsFileFile(sessionDataSet, path);
-      sessionDataSet.closeOperationHandle();
       long end = System.currentTimeMillis();
       IoTPrinter.println("Export completely!cost: " + (end - start) + " ms.");
     } catch (StatementExecutionException
@@ -317,10 +315,12 @@ public class ExportTsFile extends AbstractTsFileTool {
         TSDataType tsDataType = getTsDataType(columnTypes.get(i));
         Path path = new Path(column, true);
         String deviceId = path.getDevice();
-        List<Field> deviceList =
-            session.executeQueryStatement("show devices " + deviceId, timeout).next().getFields();
-        if (deviceList.size() > 1 && "true".equals(deviceList.get(1).getStringValue())) {
-          deviceFilterSet.add(deviceId);
+        try (SessionDataSet deviceDataSet =
+            session.executeQueryStatement("show devices " + deviceId, timeout)) {
+          List<Field> deviceList = deviceDataSet.next().getFields();
+          if (deviceList.size() > 1 && "true".equals(deviceList.get(1).getStringValue())) {
+            deviceFilterSet.add(deviceId);
+          }
         }
         MeasurementSchema measurementSchema =
             new MeasurementSchema(path.getMeasurement(), tsDataType);


### PR DESCRIPTION
Fixed that the SessionDataSet was not closed after querying the IoTDB using the TsFile export tool. It should be closed after the query is completed when the Session query is normally used.


**Before this:**

Do not close the SessionDataSet after querying using Seesion.

**After this:**
Close the SessionDataSet after querying with Seesion.