### PR TITLE
[IOTDB-6152] Add IoTConsensus Sync Log Timer

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -904,8 +904,7 @@ public class IoTConsensusServerImpl {
           }
         }
         long sortTime = System.nanoTime();
-        ioTConsensusServerMetrics.recordSortCost(
-            (sortTime - insertStartTime) / request.getInsertNodes().size());
+        ioTConsensusServerMetrics.recordSortCost(sortTime - insertStartTime);
         logger.debug(
             "source = {}, region = {}, queue size {}, startSyncIndex = {}, endSyncIndex = {}",
             sourcePeerId,
@@ -917,8 +916,7 @@ public class IoTConsensusServerImpl {
         for (IConsensusRequest insertNode : request.getInsertNodes()) {
           subStatus.add(stateMachine.write(insertNode));
         }
-        ioTConsensusServerMetrics.recordApplyCost(
-            (System.nanoTime() - sortTime) / request.getInsertNodes().size());
+        ioTConsensusServerMetrics.recordApplyCost(System.nanoTime() - sortTime);
         queueSortCondition.signalAll();
         return new TSStatus().setSubStatus(subStatus);
       } finally {

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -904,7 +904,8 @@ public class IoTConsensusServerImpl {
           }
         }
         long sortTime = System.nanoTime();
-        ioTConsensusServerMetrics.recordSortCost(sortTime - insertStartTime);
+        ioTConsensusServerMetrics.recordSortCost(
+            (sortTime - insertStartTime) / request.getInsertNodes().size());
         logger.debug(
             "source = {}, region = {}, queue size {}, startSyncIndex = {}, endSyncIndex = {}",
             sourcePeerId,
@@ -916,7 +917,8 @@ public class IoTConsensusServerImpl {
         for (IConsensusRequest insertNode : request.getInsertNodes()) {
           subStatus.add(stateMachine.write(insertNode));
         }
-        ioTConsensusServerMetrics.recordApplyCost(System.nanoTime() - sortTime);
+        ioTConsensusServerMetrics.recordApplyCost(
+            (System.nanoTime() - sortTime) / request.getInsertNodes().size());
         queueSortCondition.signalAll();
         return new TSStatus().setSubStatus(subStatus);
       } finally {

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -906,12 +906,13 @@ public class IoTConsensusServerImpl {
         long sortTime = System.nanoTime();
         ioTConsensusServerMetrics.recordSortCost(sortTime - insertStartTime);
         logger.debug(
-            "source = {}, region = {}, queue size {}, startSyncIndex = {}, endSyncIndex = {}",
+            "source = {}, region = {}, queue size {}, startSyncIndex = {}, endSyncIndex = {}, sortTime = {} ms",
             sourcePeerId,
             consensusGroupId,
             requestCache.size(),
             request.getStartSyncIndex(),
-            request.getEndSyncIndex());
+            request.getEndSyncIndex(),
+            TimeUnit.NANOSECONDS.toMillis(sortTime - insertStartTime));
         List<TSStatus> subStatus = new LinkedList<>();
         for (IConsensusRequest insertNode : request.getInsertNodes()) {
           subStatus.add(stateMachine.write(insertNode));

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerMetrics.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerMetrics.java
@@ -37,7 +37,7 @@ public class IoTConsensusServerMetrics implements IMetricSet {
   private Histogram writeStateMachineHistogram = DoNothingMetricManager.DO_NOTHING_HISTOGRAM;
   private Histogram offerRequestToQueueHistogram = DoNothingMetricManager.DO_NOTHING_HISTOGRAM;
   private Histogram consensusWriteHistogram = DoNothingMetricManager.DO_NOTHING_HISTOGRAM;
-  private static final String IOT_SYNC_LOG = Metric.IOT_SYNC_LOG.toString();
+  private static final String IOT_RECEIVE_LOG = Metric.IOT_RECEIVE_LOG.toString();
   private Timer deserializeTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
   private Timer sortTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
   private Timer applyTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
@@ -193,7 +193,7 @@ public class IoTConsensusServerMetrics implements IMetricSet {
     // bind sync log timers
     deserializeTimer =
         metricService.getOrCreateTimer(
-            IOT_SYNC_LOG,
+            IOT_RECEIVE_LOG,
             MetricLevel.IMPORTANT,
             Tag.STAGE.toString(),
             DESERIALIZE,
@@ -201,7 +201,7 @@ public class IoTConsensusServerMetrics implements IMetricSet {
             impl.getConsensusGroupId());
     sortTimer =
         metricService.getOrCreateTimer(
-            IOT_SYNC_LOG,
+            IOT_RECEIVE_LOG,
             MetricLevel.IMPORTANT,
             Tag.STAGE.toString(),
             SORT,
@@ -209,7 +209,7 @@ public class IoTConsensusServerMetrics implements IMetricSet {
             impl.getConsensusGroupId());
     applyTimer =
         metricService.getOrCreateTimer(
-            IOT_SYNC_LOG,
+            IOT_RECEIVE_LOG,
             MetricLevel.IMPORTANT,
             Tag.STAGE.toString(),
             APPLY,
@@ -322,21 +322,21 @@ public class IoTConsensusServerMetrics implements IMetricSet {
     // unbind sync log timers
     metricService.remove(
         MetricType.TIMER,
-        IOT_SYNC_LOG,
+        IOT_RECEIVE_LOG,
         Tag.STAGE.toString(),
         DESERIALIZE,
         Tag.REGION.toString(),
         impl.getConsensusGroupId());
     metricService.remove(
         MetricType.TIMER,
-        IOT_SYNC_LOG,
+        IOT_RECEIVE_LOG,
         Tag.STAGE.toString(),
         SORT,
         Tag.REGION.toString(),
         impl.getConsensusGroupId());
     metricService.remove(
         MetricType.TIMER,
-        IOT_SYNC_LOG,
+        IOT_RECEIVE_LOG,
         Tag.STAGE.toString(),
         APPLY,
         Tag.REGION.toString(),

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerMetrics.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerMetrics.java
@@ -24,7 +24,6 @@ import org.apache.iotdb.commons.service.metric.enums.Tag;
 import org.apache.iotdb.metrics.AbstractMetricService;
 import org.apache.iotdb.metrics.impl.DoNothingMetricManager;
 import org.apache.iotdb.metrics.metricsets.IMetricSet;
-import org.apache.iotdb.metrics.type.Histogram;
 import org.apache.iotdb.metrics.type.Timer;
 import org.apache.iotdb.metrics.utils.MetricLevel;
 import org.apache.iotdb.metrics.utils.MetricType;
@@ -32,11 +31,11 @@ import org.apache.iotdb.metrics.utils.MetricType;
 public class IoTConsensusServerMetrics implements IMetricSet {
   private final IoTConsensusServerImpl impl;
 
-  private Histogram getStateMachineLockHistogram = DoNothingMetricManager.DO_NOTHING_HISTOGRAM;
-  private Histogram checkingBeforeWriteHistogram = DoNothingMetricManager.DO_NOTHING_HISTOGRAM;
-  private Histogram writeStateMachineHistogram = DoNothingMetricManager.DO_NOTHING_HISTOGRAM;
-  private Histogram offerRequestToQueueHistogram = DoNothingMetricManager.DO_NOTHING_HISTOGRAM;
-  private Histogram consensusWriteHistogram = DoNothingMetricManager.DO_NOTHING_HISTOGRAM;
+  private Timer getStateMachineLockTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
+  private Timer checkingBeforeWriteTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
+  private Timer writeStateMachineTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
+  private Timer offerRequestToQueueTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
+  private Timer consensusWriteTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
   private static final String IOT_RECEIVE_LOG = Metric.IOT_RECEIVE_LOG.toString();
   private Timer deserializeTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
   private Timer sortTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
@@ -66,14 +65,14 @@ public class IoTConsensusServerMetrics implements IMetricSet {
   @Override
   public void bindTo(AbstractMetricService metricService) {
     bindAutoGauge(metricService);
-    bindStageHistogram(metricService);
+    bindStageTimer(metricService);
     bindSyncLogTimer(metricService);
   }
 
   @Override
   public void unbindFrom(AbstractMetricService metricService) {
     unbindAutoGauge(metricService);
-    unbindStageHistogram(metricService);
+    unbindStageTimer(metricService);
     unbindSyncLogTimer(metricService);
   }
 
@@ -136,9 +135,9 @@ public class IoTConsensusServerMetrics implements IMetricSet {
         "LogEntriesFromQueue");
   }
 
-  private void bindStageHistogram(AbstractMetricService metricService) {
-    getStateMachineLockHistogram =
-        metricService.getOrCreateHistogram(
+  private void bindStageTimer(AbstractMetricService metricService) {
+    getStateMachineLockTimer =
+        metricService.getOrCreateTimer(
             Metric.STAGE.toString(),
             MetricLevel.IMPORTANT,
             Tag.NAME.toString(),
@@ -147,8 +146,8 @@ public class IoTConsensusServerMetrics implements IMetricSet {
             "getStateMachineLock",
             Tag.REGION.toString(),
             impl.getConsensusGroupId());
-    checkingBeforeWriteHistogram =
-        metricService.getOrCreateHistogram(
+    checkingBeforeWriteTimer =
+        metricService.getOrCreateTimer(
             Metric.STAGE.toString(),
             MetricLevel.IMPORTANT,
             Tag.NAME.toString(),
@@ -157,8 +156,8 @@ public class IoTConsensusServerMetrics implements IMetricSet {
             "checkingBeforeWrite",
             Tag.REGION.toString(),
             impl.getConsensusGroupId());
-    writeStateMachineHistogram =
-        metricService.getOrCreateHistogram(
+    writeStateMachineTimer =
+        metricService.getOrCreateTimer(
             Metric.STAGE.toString(),
             MetricLevel.IMPORTANT,
             Tag.NAME.toString(),
@@ -167,8 +166,8 @@ public class IoTConsensusServerMetrics implements IMetricSet {
             "writeStateMachine",
             Tag.REGION.toString(),
             impl.getConsensusGroupId());
-    offerRequestToQueueHistogram =
-        metricService.getOrCreateHistogram(
+    offerRequestToQueueTimer =
+        metricService.getOrCreateTimer(
             Metric.STAGE.toString(),
             MetricLevel.IMPORTANT,
             Tag.NAME.toString(),
@@ -177,8 +176,8 @@ public class IoTConsensusServerMetrics implements IMetricSet {
             "offerRequestToQueue",
             Tag.REGION.toString(),
             impl.getConsensusGroupId());
-    consensusWriteHistogram =
-        metricService.getOrCreateHistogram(
+    consensusWriteTimer =
+        metricService.getOrCreateTimer(
             Metric.STAGE.toString(),
             MetricLevel.IMPORTANT,
             Tag.NAME.toString(),
@@ -265,14 +264,14 @@ public class IoTConsensusServerMetrics implements IMetricSet {
         "LogEntriesFromQueue");
   }
 
-  private void unbindStageHistogram(AbstractMetricService metricService) {
-    getStateMachineLockHistogram = DoNothingMetricManager.DO_NOTHING_HISTOGRAM;
-    checkingBeforeWriteHistogram = DoNothingMetricManager.DO_NOTHING_HISTOGRAM;
-    writeStateMachineHistogram = DoNothingMetricManager.DO_NOTHING_HISTOGRAM;
-    offerRequestToQueueHistogram = DoNothingMetricManager.DO_NOTHING_HISTOGRAM;
-    consensusWriteHistogram = DoNothingMetricManager.DO_NOTHING_HISTOGRAM;
+  private void unbindStageTimer(AbstractMetricService metricService) {
+    getStateMachineLockTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
+    checkingBeforeWriteTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
+    writeStateMachineTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
+    offerRequestToQueueTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
+    consensusWriteTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
     metricService.remove(
-        MetricType.HISTOGRAM,
+        MetricType.TIMER,
         Metric.STAGE.toString(),
         Tag.NAME.toString(),
         Metric.IOT_CONSENSUS.toString(),
@@ -281,7 +280,7 @@ public class IoTConsensusServerMetrics implements IMetricSet {
         Tag.REGION.toString(),
         impl.getConsensusGroupId());
     metricService.remove(
-        MetricType.HISTOGRAM,
+        MetricType.TIMER,
         Metric.STAGE.toString(),
         Tag.NAME.toString(),
         Metric.IOT_CONSENSUS.toString(),
@@ -290,7 +289,7 @@ public class IoTConsensusServerMetrics implements IMetricSet {
         Tag.REGION.toString(),
         impl.getConsensusGroupId());
     metricService.remove(
-        MetricType.HISTOGRAM,
+        MetricType.TIMER,
         Metric.STAGE.toString(),
         Tag.NAME.toString(),
         Metric.IOT_CONSENSUS.toString(),
@@ -299,7 +298,7 @@ public class IoTConsensusServerMetrics implements IMetricSet {
         Tag.REGION.toString(),
         impl.getConsensusGroupId());
     metricService.remove(
-        MetricType.HISTOGRAM,
+        MetricType.TIMER,
         Metric.STAGE.toString(),
         Tag.NAME.toString(),
         Metric.IOT_CONSENSUS.toString(),
@@ -308,7 +307,7 @@ public class IoTConsensusServerMetrics implements IMetricSet {
         Tag.REGION.toString(),
         impl.getConsensusGroupId());
     metricService.remove(
-        MetricType.HISTOGRAM,
+        MetricType.TIMER,
         Metric.STAGE.toString(),
         Tag.NAME.toString(),
         Metric.IOT_CONSENSUS.toString(),
@@ -343,23 +342,23 @@ public class IoTConsensusServerMetrics implements IMetricSet {
         impl.getConsensusGroupId());
   }
 
-  public void recordGetStateMachineLockTime(long time) {
-    getStateMachineLockHistogram.update(time);
+  public void recordGetStateMachineLockTime(long costTimeInNanos) {
+    getStateMachineLockTimer.updateNanos(costTimeInNanos);
   }
 
-  public void recordCheckingBeforeWriteTime(long time) {
-    checkingBeforeWriteHistogram.update(time);
+  public void recordCheckingBeforeWriteTime(long costTimeInNanos) {
+    checkingBeforeWriteTimer.updateNanos(costTimeInNanos);
   }
 
-  public void recordWriteStateMachineTime(long time) {
-    writeStateMachineHistogram.update(time);
+  public void recordWriteStateMachineTime(long costTimeInNanos) {
+    writeStateMachineTimer.updateNanos(costTimeInNanos);
   }
 
-  public void recordOfferRequestToQueueTime(long time) {
-    offerRequestToQueueHistogram.update(time);
+  public void recordOfferRequestToQueueTime(long costTimeInNanos) {
+    offerRequestToQueueTimer.updateNanos(costTimeInNanos);
   }
 
-  public void recordConsensusWriteTime(long time) {
-    consensusWriteHistogram.update(time);
+  public void recordConsensusWriteTime(long costTimeInNanos) {
+    consensusWriteTimer.updateNanos(costTimeInNanos);
   }
 }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/client/DispatchLogHandler.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/client/DispatchLogHandler.java
@@ -66,8 +66,7 @@ public class DispatchLogHandler implements AsyncMethodCallback<TSyncLogEntriesRe
       // update safely deleted search index after current sync index is updated by removeBatch
       thread.updateSafelyDeletedSearchIndex();
     }
-    logDispatcherThreadMetrics.recordSyncLogTimePerRequest(
-        (System.nanoTime() - createTime) / batch.getLogEntries().size());
+    logDispatcherThreadMetrics.recordSyncLogTimePerRequest(System.nanoTime() - createTime);
   }
 
   private boolean needRetry(int statusCode) {

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/LogDispatcher.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/LogDispatcher.java
@@ -323,8 +323,7 @@ public class LogDispatcher {
               }
             }
           }
-          logDispatcherThreadMetrics.recordConstructBatchTime(
-              (System.nanoTime() - startTime) / batch.getLogEntries().size());
+          logDispatcherThreadMetrics.recordConstructBatchTime(System.nanoTime() - startTime);
           // we may block here if the synchronization pipeline is full
           syncStatus.addNextBatch(batch);
           logEntriesFromWAL.addAndGet(batch.getLogEntriesNumFromWAL());

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/LogDispatcherThreadMetrics.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/LogDispatcherThreadMetrics.java
@@ -93,21 +93,21 @@ public class LogDispatcherThreadMetrics implements IMetricSet {
   private void bindStageTimer(AbstractMetricService metricService) {
     constructBatchTimer =
         metricService.getOrCreateTimer(
-            Metric.STAGE.toString(),
+            Metric.IOT_SEND_LOG.toString(),
             MetricLevel.IMPORTANT,
             Tag.NAME.toString(),
             Metric.IOT_CONSENSUS.toString(),
-            Tag.TYPE.toString(),
+            Tag.STAGE.toString(),
             "constructBatch",
             Tag.REGION.toString(),
             peerGroupId);
     syncLogTimePerRequestTimer =
         metricService.getOrCreateTimer(
-            Metric.STAGE.toString(),
+            Metric.IOT_SEND_LOG.toString(),
             MetricLevel.IMPORTANT,
             Tag.NAME.toString(),
             Metric.IOT_CONSENSUS.toString(),
-            Tag.TYPE.toString(),
+            Tag.STAGE.toString(),
             "syncLogTimePerRequest",
             Tag.REGION.toString(),
             peerGroupId);
@@ -116,19 +116,19 @@ public class LogDispatcherThreadMetrics implements IMetricSet {
   private void unbindStageTimer(AbstractMetricService metricService) {
     metricService.remove(
         MetricType.TIMER,
-        Metric.STAGE.toString(),
+        Metric.IOT_SEND_LOG.toString(),
         Tag.NAME.toString(),
         Metric.IOT_CONSENSUS.toString(),
-        Tag.TYPE.toString(),
+        Tag.STAGE.toString(),
         "constructBatch",
         Tag.REGION.toString(),
         peerGroupId);
     metricService.remove(
         MetricType.TIMER,
-        Metric.STAGE.toString(),
+        Metric.IOT_SEND_LOG.toString(),
         Tag.NAME.toString(),
         Metric.IOT_CONSENSUS.toString(),
-        Tag.TYPE.toString(),
+        Tag.STAGE.toString(),
         "syncLogTimePerRequest",
         Tag.REGION.toString(),
         peerGroupId);

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/service/IoTConsensusRPCServiceProcessor.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/service/IoTConsensusRPCServiceProcessor.java
@@ -119,7 +119,8 @@ public class IoTConsensusRPCServiceProcessor implements IoTConsensusIService.Asy
       IConsensusRequest deserializedRequest =
           impl.getStateMachine().deserializeRequest(logEntriesInThisBatch);
       impl.getIoTConsensusServerMetrics()
-          .recordDeserializeCost(System.nanoTime() - buildRequestTime);
+          .recordDeserializeCost(
+              (System.nanoTime() - buildRequestTime) / logEntriesInThisBatch.getRequests().size());
       TSStatus writeStatus =
           impl.syncLog(logEntriesInThisBatch.getSourcePeerId(), deserializedRequest);
       logger.debug(

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/service/IoTConsensusRPCServiceProcessor.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/service/IoTConsensusRPCServiceProcessor.java
@@ -115,8 +115,11 @@ public class IoTConsensusRPCServiceProcessor implements IoTConsensusIService.Asy
                             : ByteBufferConsensusRequest::new)
                     .collect(Collectors.toList())));
       }
+      long buildRequestTime = System.nanoTime();
       IConsensusRequest deserializedRequest =
           impl.getStateMachine().deserializeRequest(logEntriesInThisBatch);
+      impl.getIoTConsensusServerMetrics()
+          .recordDeserializeCost(System.nanoTime() - buildRequestTime);
       TSStatus writeStatus =
           impl.syncLog(logEntriesInThisBatch.getSourcePeerId(), deserializedRequest);
       logger.debug(

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/service/IoTConsensusRPCServiceProcessor.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/service/IoTConsensusRPCServiceProcessor.java
@@ -119,8 +119,7 @@ public class IoTConsensusRPCServiceProcessor implements IoTConsensusIService.Asy
       IConsensusRequest deserializedRequest =
           impl.getStateMachine().deserializeRequest(logEntriesInThisBatch);
       impl.getIoTConsensusServerMetrics()
-          .recordDeserializeCost(
-              (System.nanoTime() - buildRequestTime) / logEntriesInThisBatch.getRequests().size());
+          .recordDeserializeCost(System.nanoTime() - buildRequestTime);
       TSStatus writeStatus =
           impl.syncLog(logEntriesInThisBatch.getSourcePeerId(), deserializedRequest);
       logger.debug(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/metric/enums/Metric.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/metric/enums/Metric.java
@@ -45,6 +45,7 @@ public enum Metric {
   // consensus related
   STAGE("stage"),
   IOT_CONSENSUS("iot_consensus"),
+  IOT_SYNC_LOG("iot_sync_log"),
   RATIS_CONSENSUS_WRITE("ratis_consensus_write"),
   RATIS_CONSENSUS_READ("ratis_consensus_read"),
   // storage engine related

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/metric/enums/Metric.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/metric/enums/Metric.java
@@ -45,7 +45,7 @@ public enum Metric {
   // consensus related
   STAGE("stage"),
   IOT_CONSENSUS("iot_consensus"),
-  IOT_SYNC_LOG("iot_sync_log"),
+  IOT_RECEIVE_LOG("iot_receive_log"),
   RATIS_CONSENSUS_WRITE("ratis_consensus_write"),
   RATIS_CONSENSUS_READ("ratis_consensus_read"),
   // storage engine related

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/metric/enums/Metric.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/metric/enums/Metric.java
@@ -45,6 +45,7 @@ public enum Metric {
   // consensus related
   STAGE("stage"),
   IOT_CONSENSUS("iot_consensus"),
+  IOT_SEND_LOG("iot_send_log"),
   IOT_RECEIVE_LOG("iot_receive_log"),
   RATIS_CONSENSUS_WRITE("ratis_consensus_write"),
   RATIS_CONSENSUS_READ("ratis_consensus_read"),


### PR DESCRIPTION
## Description

When the IoT follower receives a syncLogEntries request, it will go through three stages: deserialize, sort and apply. This pr adds this three timers.
