### PR TITLE
Remove cancelled/done MemoryReservationFuture from the queue when freeing memory

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/memory/MemoryPool.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/memory/MemoryPool.java
@@ -334,6 +334,7 @@ public class MemoryPool {
       MemoryReservationFuture<Void> future = iterator.next();
       synchronized (future) {
         if (future.isCancelled() || future.isDone()) {
+          iterator.remove();
           continue;
         }
         long bytesToReserve = future.getBytesToReserve();


### PR DESCRIPTION
If the MemoryReservationFuture has been cancelled or done when freeing memory, we should remove it from the queue, or it may lead to memory leak as showed in the following pic: The queries have finished, but the memory_reservation_size did not decrease.
<img width="559" alt="截屏2023-09-14 11 29 34" src="https://github.com/apache/iotdb/assets/108499334/828d1281-6fe5-47a6-b3a7-9d66307743e3">
