### PR TITLE
[IOTDB-6153] Added multi-line support in cli

### DIFF
--- a/iotdb-client/cli/src/main/java/org/apache/iotdb/cli/AbstractCli.java
+++ b/iotdb-client/cli/src/main/java/org/apache/iotdb/cli/AbstractCli.java
@@ -124,6 +124,8 @@ public abstract class AbstractCli {
 
   static int lastProcessStatus = CODE_OK;
 
+  static final String delimiter = ";";
+
   static void init() {
     keywordSet.add("-" + HOST_ARGS);
     keywordSet.add("-" + HELP_ARGS);
@@ -739,7 +741,7 @@ public abstract class AbstractCli {
     if (s == null) {
       return true;
     }
-    String[] cmds = s.trim().split(";");
+    String[] cmds = s.trim().split(delimiter);
     for (String cmd : cmds) {
       if (cmd != null && !"".equals(cmd.trim())) {
         OperationResult result = handleInputCmd(cmd, connection);

--- a/iotdb-client/cli/src/main/java/org/apache/iotdb/cli/Cli.java
+++ b/iotdb-client/cli/src/main/java/org/apache/iotdb/cli/Cli.java
@@ -188,9 +188,11 @@ public class Cli extends AbstractCli {
   }
 
   private static boolean readerReadLine(LineReader reader, IoTDBConnection connection) {
-    String s;
+    String s = "";
     try {
-      s = reader.readLine(IOTDB_CLI_PREFIX + "> ", null);
+      while (!s.endsWith(delimiter)) {
+        s = s.concat(reader.readLine(IOTDB_CLI_PREFIX + "> ", null));
+      }
       boolean continues = processCommand(s, connection);
       if (!continues) {
         return true;


### PR DESCRIPTION
## IOTDB-6153
Now the cli will cache the message if the message does not end with ";".
Test image:
![image](https://github.com/apache/iotdb/assets/87789683/7292fdd1-2c33-441a-8b18-3f735d4cb55b)


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
