### PR TITLE
[IOTDB-6156] Fixed TConfiguration invalidly in Thrift AsyncServer For IoTConsensus

### DIFF
--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/RpcTransportFactory.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/RpcTransportFactory.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.rpc;
 
+import org.apache.thrift.transport.TMemoryInputTransport;
 import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
@@ -46,7 +47,31 @@ public class RpcTransportFactory extends TTransportFactory {
 
   @Override
   public TTransport getTransport(TTransport trans) throws TTransportException {
+    updateConfigurationForAsyncServerIfNecessary(trans);
     return inner.getTransport(trans);
+  }
+
+  /**
+   * The Thrift AsyncServer uses TMemoryInputTransport (<a
+   * href="https://github.com/apache/thrift/blob/master/lib/java/src/main/java/org/apache/thrift/server/AbstractNonblockingServer.java#L291">...</a>),
+   * which employs the default configuration and performs size checks during the read and write
+   * processes. This behavior is not in line with our expectations of manually adjusting certain
+   * parameters. Therefore, special handling is required for it in this function.
+   *
+   * @param trans TTransport
+   */
+  private void updateConfigurationForAsyncServerIfNecessary(TTransport trans) {
+    if (trans instanceof TMemoryInputTransport) {
+      trans
+          .getConfiguration()
+          .setRecursionLimit(TConfigurationConst.defaultTConfiguration.getRecursionLimit());
+      trans
+          .getConfiguration()
+          .setMaxMessageSize(TConfigurationConst.defaultTConfiguration.getMaxMessageSize());
+      trans
+          .getConfiguration()
+          .setMaxFrameSize(TConfigurationConst.defaultTConfiguration.getMaxFrameSize());
+    }
   }
 
   public TTransport getTransportWithNoTimeout(String ip, int port) throws TTransportException {


### PR DESCRIPTION
see [jira](https://issues.apache.org/jira/browse/IOTDB-6156)