### PR TITLE
Delete unused compaction recover code

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -757,17 +757,6 @@ public class DataRegion implements IDataRegionForQuery {
     try (SealedTsFileRecoverPerformer recoverPerformer =
         new SealedTsFileRecoverPerformer(sealedTsFile)) {
       recoverPerformer.recover();
-      // pick up crashed compaction target files
-      if (recoverPerformer.hasCrashed()) {
-        if (TsFileResource.getInnerCompactionCount(sealedTsFile.getTsFile().getName()) > 0) {
-          tsFileManager.addForRecover(sealedTsFile, isSeq);
-          return;
-        } else {
-          logger.warn(
-              "Sealed TsFile {} has crashed at zero level, truncate and recover it.",
-              sealedTsFile.getTsFilePath());
-        }
-      }
       sealedTsFile.close();
       tsFileManager.add(sealedTsFile, isSeq);
       tsFileResourceManager.registerSealedTsFileResource(sealedTsFile);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileManager.java
@@ -46,9 +46,6 @@ public class TsFileManager {
   private TreeMap<Long, TsFileResourceList> sequenceFiles = new TreeMap<>();
   private TreeMap<Long, TsFileResourceList> unsequenceFiles = new TreeMap<>();
 
-  private List<TsFileResource> sequenceRecoverTsFileResources = new ArrayList<>();
-  private List<TsFileResource> unsequenceRecoverTsFileResources = new ArrayList<>();
-
   private boolean allowCompaction = true;
   private AtomicLong currentCompactionTaskSerialId = new AtomicLong(0);
 
@@ -184,14 +181,6 @@ public class TsFileManager {
           .keepOrderInsert(tsFileResource);
     } finally {
       writeUnlock();
-    }
-  }
-
-  public void addForRecover(TsFileResource tsFileResource, boolean sequence) {
-    if (sequence) {
-      sequenceRecoverTsFileResources.add(tsFileResource);
-    } else {
-      unsequenceRecoverTsFileResources.add(tsFileResource);
     }
   }
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/inner/sizetiered/SizeTieredCompactionRecoverTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/inner/sizetiered/SizeTieredCompactionRecoverTest.java
@@ -182,7 +182,6 @@ public class SizeTieredCompactionRecoverTest extends AbstractInnerSpaceCompactio
     out.truncate(((long) (targetTsFileResource.getTsFileSize() * 0.9)));
     out.close();
 
-    tsFileManager.addForRecover(targetTsFileResource, true);
     new CompactionRecoverTask(COMPACTION_TEST_SG, "0", tsFileManager, compactionLogFile, true)
         .doCompaction();
     path =
@@ -1141,7 +1140,6 @@ public class SizeTieredCompactionRecoverTest extends AbstractInnerSpaceCompactio
                             + IoTDBConstant.INNER_COMPACTION_TMP_FILE_SUFFIX)));
     sizeTieredCompactionLogger.logFiles(
         Collections.singletonList(targetTsFileResource), STR_TARGET_FILES);
-    tsFileManager.addForRecover(targetTsFileResource, true);
     sizeTieredCompactionLogger.close();
     MeasurementPath path =
         SchemaTestUtils.getMeasurementPath(


### PR DESCRIPTION
## Description
Delete unused compaction recover code.
![image](https://github.com/apache/iotdb/assets/55970239/507ad655-ba1f-4046-b3c3-9c48fb0e169a)

When a sealed tsfile's level is greater than zero, it will enter an outdated code block, which cause the file not be added into  tsFileManager.  As a result, any operation performed on this tsfile in system is not effecetive.