### PR TITLE
[IOTDB-6151] Move datanode system.properties

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBStartCheck.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBStartCheck.java
@@ -60,6 +60,7 @@ public class IoTDBStartCheck {
   private boolean isFirstStart = false;
 
   private final File propertiesFile;
+  private final File oldPropertiesFile;
   private final File tmpPropertiesFile;
 
   private final Properties properties = new Properties();
@@ -138,9 +139,11 @@ public class IoTDBStartCheck {
       }
     }
 
-    propertiesFile =
+    oldPropertiesFile =
         SystemFileFactory.INSTANCE.getFile(
             IoTDBStartCheck.SCHEMA_DIR + File.separator + PROPERTIES_FILE_NAME);
+    propertiesFile = SystemFileFactory.INSTANCE.getFile(
+            config.getSystemDir() + File.separator + PROPERTIES_FILE_NAME);
     tmpPropertiesFile =
         SystemFileFactory.INSTANCE.getFile(
             IoTDBStartCheck.SCHEMA_DIR + File.separator + PROPERTIES_FILE_NAME + ".tmp");
@@ -222,6 +225,18 @@ public class IoTDBStartCheck {
     // in cluster mode, check consensus dir
     if (config.isClusterMode()) {
       DirectoryChecker.getInstance().registerDirectory(new File(config.getConsensusDir()));
+    }
+  }
+
+  /**
+   * The location of system.properties has been adjusted from SHCEMA_DIR to the system directory.
+   * During a restart, it is necessary to check if the file exists in the old location.
+   * If it does, move the file to the new location.
+   * @throws IOException
+   */
+  public void checkOldSystemConfig() throws IOException {
+    if (oldPropertiesFile.exists()) {
+      FileUtils.moveFile(oldPropertiesFile, propertiesFile);
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBStartCheck.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBStartCheck.java
@@ -142,7 +142,8 @@ public class IoTDBStartCheck {
     oldPropertiesFile =
         SystemFileFactory.INSTANCE.getFile(
             IoTDBStartCheck.SCHEMA_DIR + File.separator + PROPERTIES_FILE_NAME);
-    propertiesFile = SystemFileFactory.INSTANCE.getFile(
+    propertiesFile =
+        SystemFileFactory.INSTANCE.getFile(
             config.getSystemDir() + File.separator + PROPERTIES_FILE_NAME);
     tmpPropertiesFile =
         SystemFileFactory.INSTANCE.getFile(
@@ -230,8 +231,9 @@ public class IoTDBStartCheck {
 
   /**
    * The location of system.properties has been adjusted from SHCEMA_DIR to the system directory.
-   * During a restart, it is necessary to check if the file exists in the old location.
-   * If it does, move the file to the new location.
+   * During a restart, it is necessary to check if the file exists in the old location. If it does,
+   * move the file to the new location.
+   *
    * @throws IOException
    */
   public void checkOldSystemConfig() throws IOException {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/client/ConfigNodeInfo.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/client/ConfigNodeInfo.java
@@ -62,7 +62,7 @@ public class ConfigNodeInfo {
     this.onlineConfigNodes = new HashSet<>();
     propertiesFile =
         SystemFileFactory.INSTANCE.getFile(
-            IoTDBDescriptor.getInstance().getConfig().getSchemaDir()
+            IoTDBDescriptor.getInstance().getConfig().getSystemDir()
                 + File.separator
                 + PROPERTIES_FILE_NAME);
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -117,7 +117,7 @@ public class DataNode implements DataNodeMBean {
 
   private static final File SYSTEM_PROPERTIES =
       SystemFileFactory.INSTANCE.getFile(
-          config.getSchemaDir() + File.separator + IoTDBStartCheck.PROPERTIES_FILE_NAME);
+          config.getSystemDir() + File.separator + IoTDBStartCheck.PROPERTIES_FILE_NAME);
 
   /**
    * When joining a cluster or getting configuration this node will retry at most "DEFAULT_RETRY"
@@ -210,6 +210,7 @@ public class DataNode implements DataNodeMBean {
     config.setClusterMode(true);
 
     // Notice: Consider this DataNode as first start if the system.properties file doesn't exist
+    IoTDBStartCheck.getInstance().checkOldSystemConfig();
     boolean isFirstStart = IoTDBStartCheck.getInstance().checkIsFirstStart();
 
     // Set this node


### PR DESCRIPTION
1. For the initial startup, the system.properties file is generated under data/system instead of data/system/schema.
2. During startup, check if there is a system.properties file under data/system/schema. If it exists, move it to data/system.