### PR TITLE
[IOTDB-6164] Fix create illegal path through rest api bug

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/rest/v1/handler/StatementConstructionHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/rest/v1/handler/StatementConstructionHandler.java
@@ -17,7 +17,8 @@
 
 package org.apache.iotdb.db.protocol.rest.v1.handler;
 
-import org.apache.iotdb.commons.exception.IllegalPathException;
+import org.apache.iotdb.commons.exception.MetadataException;
+import org.apache.iotdb.commons.utils.PathUtils;
 import org.apache.iotdb.db.exception.WriteProcessRejectException;
 import org.apache.iotdb.db.protocol.rest.utils.InsertRowDataUtils;
 import org.apache.iotdb.db.protocol.rest.v1.model.InsertRecordsRequest;
@@ -42,14 +43,16 @@ public class StatementConstructionHandler {
 
   public static InsertTabletStatement constructInsertTabletStatement(
       InsertTabletRequest insertTabletRequest)
-      throws IllegalPathException, WriteProcessRejectException {
+      throws MetadataException, WriteProcessRejectException {
     TimestampPrecisionUtils.checkTimestampPrecision(
         insertTabletRequest.getTimestamps().get(insertTabletRequest.getTimestamps().size() - 1));
     // construct insert statement
     InsertTabletStatement insertStatement = new InsertTabletStatement();
     insertStatement.setDevicePath(
         DataNodeDevicePathCache.getInstance().getPartialPath(insertTabletRequest.getDeviceId()));
-    insertStatement.setMeasurements(insertTabletRequest.getMeasurements().toArray(new String[0]));
+    insertStatement.setMeasurements(
+        PathUtils.checkIsLegalSingleMeasurementsAndUpdate(insertTabletRequest.getMeasurements())
+            .toArray(new String[0]));
     List<List<Object>> rawData = insertTabletRequest.getValues();
     List<String> rawDataType = insertTabletRequest.getDataTypes();
 
@@ -176,7 +179,7 @@ public class StatementConstructionHandler {
 
   public static InsertRowsStatement createInsertRowsStatement(
       InsertRecordsRequest insertRecordsRequest)
-      throws IllegalPathException, IoTDBConnectionException {
+      throws MetadataException, IoTDBConnectionException {
 
     // construct insert statement
     InsertRowsStatement insertStatement = new InsertRowsStatement();
@@ -206,7 +209,9 @@ public class StatementConstructionHandler {
           DataNodeDevicePathCache.getInstance()
               .getPartialPath(insertRecordsRequest.getDeviceIds().get(i)));
       statement.setMeasurements(
-          insertRecordsRequest.getMeasurementsList().get(i).toArray(new String[0]));
+          PathUtils.checkIsLegalSingleMeasurementsAndUpdate(
+                  insertRecordsRequest.getMeasurementsList().get(i))
+              .toArray(new String[0]));
       TimestampPrecisionUtils.checkTimestampPrecision(insertRecordsRequest.getTimestamps().get(i));
       statement.setTime(insertRecordsRequest.getTimestamps().get(i));
       statement.setDataTypes(dataTypesList.get(i).toArray(new TSDataType[0]));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/rest/v2/handler/StatementConstructionHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/rest/v2/handler/StatementConstructionHandler.java
@@ -17,7 +17,8 @@
 
 package org.apache.iotdb.db.protocol.rest.v2.handler;
 
-import org.apache.iotdb.commons.exception.IllegalPathException;
+import org.apache.iotdb.commons.exception.MetadataException;
+import org.apache.iotdb.commons.utils.PathUtils;
 import org.apache.iotdb.db.exception.WriteProcessRejectException;
 import org.apache.iotdb.db.protocol.rest.utils.InsertRowDataUtils;
 import org.apache.iotdb.db.protocol.rest.v2.model.InsertRecordsRequest;
@@ -42,14 +43,17 @@ public class StatementConstructionHandler {
 
   public static InsertTabletStatement constructInsertTabletStatement(
       InsertTabletRequest insertTabletRequest)
-      throws IllegalPathException, WriteProcessRejectException {
+      throws MetadataException, WriteProcessRejectException {
     TimestampPrecisionUtils.checkTimestampPrecision(
         insertTabletRequest.getTimestamps().get(insertTabletRequest.getTimestamps().size() - 1));
     // construct insert statement
     InsertTabletStatement insertStatement = new InsertTabletStatement();
     insertStatement.setDevicePath(
         DataNodeDevicePathCache.getInstance().getPartialPath(insertTabletRequest.getDevice()));
-    insertStatement.setMeasurements(insertTabletRequest.getMeasurements().toArray(new String[0]));
+    // check whether measurement is legal according to syntax convention
+    insertStatement.setMeasurements(
+        PathUtils.checkIsLegalSingleMeasurementsAndUpdate(insertTabletRequest.getMeasurements())
+            .toArray(new String[0]));
     List<List<Object>> rawData = insertTabletRequest.getValues();
     List<String> rawDataType = insertTabletRequest.getDataTypes();
 
@@ -176,7 +180,7 @@ public class StatementConstructionHandler {
 
   public static InsertRowsStatement createInsertRowsStatement(
       InsertRecordsRequest insertRecordsRequest)
-      throws IllegalPathException, IoTDBConnectionException {
+      throws MetadataException, IoTDBConnectionException {
 
     // construct insert statement
     InsertRowsStatement insertStatement = new InsertRowsStatement();
@@ -206,7 +210,9 @@ public class StatementConstructionHandler {
           DataNodeDevicePathCache.getInstance()
               .getPartialPath(insertRecordsRequest.getDevices().get(i)));
       statement.setMeasurements(
-          insertRecordsRequest.getMeasurementsList().get(i).toArray(new String[0]));
+          PathUtils.checkIsLegalSingleMeasurementsAndUpdate(
+                  insertRecordsRequest.getMeasurementsList().get(i))
+              .toArray(new String[0]));
       TimestampPrecisionUtils.checkTimestampPrecision(insertRecordsRequest.getTimestamps().get(i));
       statement.setTime(insertRecordsRequest.getTimestamps().get(i));
       statement.setDataTypes(dataTypesList.get(i).toArray(new TSDataType[0]));


### PR DESCRIPTION
After this pr, we  will get error msg while using illegal path
<img width="1827" alt="image" src="https://github.com/apache/iotdb/assets/16079446/83b634c7-6175-4bbb-b324-dda8680802d3">
And we must use \`\` to include the path to be successful.
<img width="1870" alt="image" src="https://github.com/apache/iotdb/assets/16079446/2982dcef-d9c1-43a7-a497-07bcf02d3716">
