### PR TITLE
[DRAFT] test jdk 21

### DIFF
--- a/.github/workflows/cluster-it-1c1d.yml
+++ b/.github/workflows/cluster-it-1c1d.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:
-          distribution: liberica
+          distribution: corretto
           java-version: ${{ matrix.java }}
       - name: Cache Maven packages
         uses: actions/cache@v3

--- a/.github/workflows/cluster-it-1c1d.yml
+++ b/.github/workflows/cluster-it-1c1d.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       max-parallel: 20
       matrix:
-        java: [11]
+        java: [21]
         os: [ ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -34,14 +34,14 @@ jobs:
       fail-fast: false
       max-parallel: 20
       matrix:
-        java: [ 8, 11, 17 ]
+        java: [ 8, 11, 21 ]
         os: [ ubuntu-latest, windows-latest ]
         it_task: [ 'others', 'datanode' ]
         include:
-          - java: 17
+          - java: 21
             os: macos-latest
             it_task: 'datanode'
-          - java: 17
+          - java: 21
             os: macos-latest
             it_task: 'others'
     runs-on: ${{ matrix.os }}

--- a/pom.xml
+++ b/pom.xml
@@ -1405,6 +1405,15 @@
                 <argLine>--add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</argLine>
             </properties>
         </profile>
+        <profile>
+            <id>.java-21-and-above</id>
+            <activation>
+                <jdk>[21,)</jdk>
+            </activation>
+            <properties>
+                <spotless.skip>true</spotless.skip>
+            </properties>
+        </profile>
         <!-- Little helper profile that will disable running the cmake tests when the maven tests are being skipped -->
         <profile>
             <id>.skipTests</id>

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
         <enforcer.skip>true</enforcer.skip>
         <!-- Updating the plugin would require us to update the java-format version -->
         <!--spotless.version>2.39.0</spotless.version-->
-        <spotless.version>2.27.1</spotless.version>
+        <spotless.version>2.30.0</spotless.version>
         <!-- Override this to `true`, if you want to disable spotless -->
         <spotless.skip>false</spotless.skip>
         <httpclient.version>4.5.14</httpclient.version>
@@ -782,10 +782,6 @@
                             <importOrder>
                                 <order>org.apache.iotdb,,javax,java,\#</order>
                             </importOrder>
-                            <palantirJavaFormat>
-                                <!-- TODO https://github.com/diffplug/spotless/issues/1774 -->
-                                <version>2.35.0</version>
-                            </palantirJavaFormat>
                             <removeUnusedImports/>
                         </java>
                         <lineEndings>UNIX</lineEndings>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.assembly.version>3.6.0</maven.assembly.version>
         <scala.library.version>2.12</scala.library.version>
-        <scala.version>2.12.10</scala.version>
+        <scala.version>2.12.18</scala.version>
         <hadoop2.version>2.10.1</hadoop2.version>
         <hive2.version>2.3.6</hive2.version>
         <junit.version>4.13.2</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -782,6 +782,10 @@
                             <importOrder>
                                 <order>org.apache.iotdb,,javax,java,\#</order>
                             </importOrder>
+                            <palantirJavaFormat>
+                                <!-- TODO https://github.com/diffplug/spotless/issues/1774 -->
+                                <version>2.35.0</version>
+                            </palantirJavaFormat>
                             <removeUnusedImports/>
                         </java>
                         <lineEndings>UNIX</lineEndings>


### PR DESCRIPTION
There are two issues about supporting JDK 21.
1. Scala version 2.12.10 doesn't support JDK 21, should be upgraded to 2.12.18.
2. The current version of spotless plugin we are using cannot run with JDK 21. Therefore I disabled the spotless check for JDK 21.