### PR TITLE
[mlnode] Logging module, shut down function and the fixing of a bug about multi process training

### DIFF
--- a/iotdb-core/mlnode/iotdb/mlnode/client.py
+++ b/iotdb-core/mlnode/iotdb/mlnode/client.py
@@ -66,7 +66,7 @@ class DataNodeClient(object):
             try:
                 transport.open()
             except TTransport.TTransportException as e:
-                logger.exception("TTransportException!", exc_info=e)
+                logger.error("TTransportException!", exc_info=e)
                 raise e
 
         protocol = TBinaryProtocol.TBinaryProtocol(transport)
@@ -95,7 +95,7 @@ class DataNodeClient(object):
                 raise RuntimeError(
                     f'Fetched empty data with sql: {query_body}')
         except Exception as e:
-            logger.warn(
+            logger.warning(
                 f'Fail to fetch data with sql: {query_body}')
             raise e
         query_id = resp.queryId
@@ -114,7 +114,7 @@ class DataNodeClient(object):
                                                        resp.tsDataset))
                 has_more_data = resp.hasMoreData
             except Exception as e:
-                logger.warn(
+                logger.warning(
                     f'Fail to fetch more data with query id: {query_id}')
                 raise e
         return data
@@ -135,7 +135,7 @@ class DataNodeClient(object):
             status = self.__client.recordModelMetrics(req)
             verify_success(status, "An error occurs when calling record_model_metrics()")
         except TTransport.TException as e:
-            logger.exception(e.message)
+            logger.error(e.message)
 
 
 class ConfigNodeClient(object):
@@ -163,7 +163,7 @@ class ConfigNodeClient(object):
                 self.__connect(self.__config_leader)
                 return
             except TException:
-                logger.warn("The current node {} may have been down, try next node", self.__config_leader)
+                logger.warning("The current node {} may have been down, try next node", self.__config_leader)
                 self.__config_leader = None
 
         if self.__transport is not None:
@@ -178,7 +178,7 @@ class ConfigNodeClient(object):
                 self.__connect(try_endpoint)
                 return
             except TException:
-                logger.warn("The current node {} may have been down, try next node", try_endpoint)
+                logger.warning("The current node {} may have been down, try next node", try_endpoint)
 
             try_host_num = try_host_num + 1
 
@@ -192,7 +192,7 @@ class ConfigNodeClient(object):
             try:
                 transport.open()
             except TTransport.TTransportException as e:
-                logger.exception("TTransportException!", exc_info=e)
+                logger.error("TTransportException!", exc_info=e)
 
         protocol = TBinaryProtocol.TBinaryProtocol(transport)
         self.__client = IConfigNodeRPCService.Client(protocol)
@@ -237,7 +237,7 @@ class ConfigNodeClient(object):
                     verify_success(status, "An error occurs when calling update_model_state()")
                     return
             except TTransport.TException:
-                logger.warn("Failed to connect to ConfigNode {} from MLNode when executing update_model_info()",
+                logger.warning("Failed to connect to ConfigNode {} from MLNode when executing update_model_info()",
                             self.__config_leader)
                 self.__config_leader = None
             self.__wait_and_reconnect()
@@ -263,7 +263,7 @@ class ConfigNodeClient(object):
                     verify_success(status, "An error occurs when calling update_model_info()")
                     return
             except TTransport.TException:
-                logger.warn("Failed to connect to ConfigNode {} from MLNode when executing update_model_info()",
+                logger.warning("Failed to connect to ConfigNode {} from MLNode when executing update_model_info()",
                             self.__config_leader)
                 self.__config_leader = None
             self.__wait_and_reconnect()

--- a/iotdb-core/mlnode/iotdb/mlnode/config.py
+++ b/iotdb-core/mlnode/iotdb/mlnode/config.py
@@ -156,9 +156,9 @@ class MLNodeDescriptor(object):
             if file_configs.mn_target_data_node is not None:
                 self.__config.set_mn_target_data_node(file_configs.mn_target_data_node)
         except BadNodeUrlError:
-            logger.warn("Cannot load MLNode conf file, use default configuration.")
+            logger.warning("Cannot load MLNode conf file, use default configuration.")
         except Exception as e:
-            logger.warn("Cannot load MLNode conf file, use default configuration. {}".format(e))
+            logger.warning("Cannot load MLNode conf file, use default configuration. {}".format(e))
 
     def get_config(self) -> MLNodeConfig:
         return self.__config

--- a/iotdb-core/mlnode/iotdb/mlnode/handler.py
+++ b/iotdb-core/mlnode/iotdb/mlnode/handler.py
@@ -40,14 +40,16 @@ class MLNodeRPCServiceHandler(IMLNodeRPCService.Iface):
         self.__task_manager = TaskManager(pool_size=descriptor.get_config().get_mn_mn_task_pool_size())
 
     def deleteModel(self, req: TDeleteModelReq):
+        logger.debug(f"delete model {req.modelId}")
         try:
             model_storage.delete_model(req.modelId)
             return get_status(TSStatusCode.SUCCESS_STATUS)
         except Exception as e:
-            logger.warn(e)
+            logger.warning(e)
             return get_status(TSStatusCode.MLNODE_INTERNAL_ERROR, str(e))
 
     def createTrainingTask(self, req: TCreateTrainingTaskReq):
+        logger.debug(f"create training task {req.modelId}")
         task = None
         try:
             # parse options
@@ -70,7 +72,7 @@ class MLNodeRPCServiceHandler(IMLNodeRPCService.Iface):
 
             return get_status(TSStatusCode.SUCCESS_STATUS)
         except Exception as e:
-            logger.warn(e)
+            logger.warning(e)
             return get_status(TSStatusCode.MLNODE_INTERNAL_ERROR, str(e))
         finally:
             if task is not None:
@@ -78,6 +80,7 @@ class MLNodeRPCServiceHandler(IMLNodeRPCService.Iface):
                 self.__task_manager.submit_training_task(task)
 
     def forecast(self, req: TForecastReq):
+        logger.debug(f"forecast {req.modelId}")
         model_path, data, pred_length = parse_forecast_request(req)
         try:
             task = self.__task_manager.create_forecast_task(
@@ -91,5 +94,5 @@ class MLNodeRPCServiceHandler(IMLNodeRPCService.Iface):
             resp = TForecastResp(get_status(TSStatusCode.SUCCESS_STATUS), forecast_result)
             return resp
         except Exception as e:
-            logger.warn(e)
+            logger.warning(e)
             return get_status(TSStatusCode.MLNODE_INTERNAL_ERROR, str(e))

--- a/iotdb-core/mlnode/iotdb/mlnode/log.py
+++ b/iotdb-core/mlnode/iotdb/mlnode/log.py
@@ -41,9 +41,8 @@ class LoggerFilter(logging.Filter):
         pid = os.getpid()
         process_name = multiprocessing.current_process().name
 
-        # 格式化函数调用栈信息
         stack_info = ""
-        frame_info = stack_trace[7]  # 忽略前两个栈帧
+        frame_info = stack_trace[7]
         stack_info += f"File: {frame_info.filename}, Line: {frame_info.lineno}, Function: {frame_info.function}"
 
         return f"PID: {pid} PName: {process_name} Stack Trace:{stack_info}"
@@ -54,10 +53,10 @@ class Logger:
         file_names = ['log_mlnode_debug.log', 'log_mlnode_info.log', 'log_mlnode_warning.log', 'log_mlnode_error.log']
         file_levels = [logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR]
 
-        if not os.path.exists(log_dir):  # 检查目录是否存在，不存在则创建
+        if not os.path.exists(log_dir):
             os.mkdir(log_dir)
             os.chmod(log_dir, 0o777)
-        for file_name in file_names:  # 检查文件是否存在，不存在则创建
+        for file_name in file_names:
             log_path = log_dir + "/" + file_name
             if not os.path.exists(log_path):
                 f = open(log_path, mode='w', encoding='utf-8')

--- a/iotdb-core/mlnode/iotdb/mlnode/log.py
+++ b/iotdb-core/mlnode/iotdb/mlnode/log.py
@@ -49,6 +49,16 @@ class LoggerFilter(logging.Filter):
 
 
 class Logger:
+    """
+    Args:
+        log_dir: log directory
+
+    logger_format: log format of global logger
+    logger: global logger with custom format and level
+    file_handlers: file handlers for different levels
+    console_handler: console handler for stdout
+    __lock: lock for logger
+    """
     def __init__(self, log_dir=LOG_DIR):
         file_names = ['log_mlnode_debug.log', 'log_mlnode_info.log', 'log_mlnode_warning.log', 'log_mlnode_error.log']
         file_levels = [logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR]
@@ -87,34 +97,24 @@ class Logger:
         self.logger.addFilter(LoggerFilter())
         self.__lock = multiprocessing.Lock()
 
-    def debug(self, *args):
+    def debug(self, *args) -> None:
         self.__lock.acquire()
         self.logger.debug(' '.join(map(str, args)))
         self.__lock.release()
 
-    def info(self, *args):
+    def info(self, *args) -> None:
         self.__lock.acquire()
         self.logger.info(' '.join(map(str, args)))
         self.__lock.release()
 
-    def warning(self, *args):
+    def warning(self, *args) -> None:
         self.__lock.acquire()
         self.logger.warning(' '.join(map(str, args)))
         self.__lock.release()
 
-    def warn(self, *args):
-        self.__lock.acquire()
-        self.logger.warning(' '.join(map(str, args)))
-        self.__lock.release()
-
-    def error(self, *args):
+    def error(self, *args) -> None:
         self.__lock.acquire()
         self.logger.error(' '.join(map(str, args)))
-        self.__lock.release()
-
-    def exception(self, *args, exc_info=None):
-        self.__lock.acquire()
-        self.logger.error(' '.join(map(str, args)) + ' ' + str(exc_info))
         self.__lock.release()
 
 

--- a/iotdb-core/mlnode/iotdb/mlnode/log.py
+++ b/iotdb-core/mlnode/iotdb/mlnode/log.py
@@ -17,18 +17,106 @@
 #
 import logging
 import os
-from logging.config import fileConfig
+import random
+import sys
+import multiprocessing
+import inspect
 
-from iotdb.mlnode.constant import (MLNODE_CONF_DIRECTORY_NAME,
-                                   MLNODE_LOG_CONF_FILE_NAME)
+# log directory
+LOG_DIR = "./logs"
+# level fot stdout
+STD_LEVEL = logging.INFO
 
-log_conf_file = os.path.join(os.getcwd(), MLNODE_CONF_DIRECTORY_NAME, MLNODE_LOG_CONF_FILE_NAME)
-if os.path.exists(log_conf_file):
-    fileConfig(log_conf_file)
-else:
-    logging.basicConfig(
-        level=logging.DEBUG,
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-    )
 
-logger = logging.getLogger()
+class LoggerFilter(logging.Filter):
+    def filter(self, record):
+        record.msg = f"{self.custom_log_info()} Message: {record.msg}"
+        return True
+
+    @staticmethod
+    def custom_log_info():
+        frame = inspect.currentframe()
+        stack_trace = inspect.getouterframes(frame)
+
+        pid = os.getpid()
+        process_name = multiprocessing.current_process().name
+
+        # 格式化函数调用栈信息
+        stack_info = ""
+        frame_info = stack_trace[7]  # 忽略前两个栈帧
+        stack_info += f"File: {frame_info.filename}, Line: {frame_info.lineno}, Function: {frame_info.function}"
+
+        return f"PID: {pid} PName: {process_name} Stack Trace:{stack_info}"
+
+
+class Logger:
+    def __init__(self, log_dir=LOG_DIR):
+        file_names = ['log_mlnode_debug.log', 'log_mlnode_info.log', 'log_mlnode_warning.log', 'log_mlnode_error.log']
+        file_levels = [logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR]
+
+        if not os.path.exists(log_dir):  # 检查目录是否存在，不存在则创建
+            os.mkdir(log_dir)
+            os.chmod(log_dir, 0o777)
+        for file_name in file_names:  # 检查文件是否存在，不存在则创建
+            log_path = log_dir + "/" + file_name
+            if not os.path.exists(log_path):
+                f = open(log_path, mode='w', encoding='utf-8')
+                f.close()
+                os.chmod(log_path, 0o777)
+        self.logger_format = logging.Formatter(fmt='%(asctime)s Level: %(levelname)s %('
+                                                   'message)s',
+                                               datefmt='%Y-%m-%d %H:%M:%S')
+
+        self.logger = logging.getLogger(str(random.random()))
+        self.logger.handlers.clear()
+        self.logger.setLevel(logging.DEBUG)
+
+        self.file_handlers = []
+        for l in range(len(file_names)):
+            self.file_handlers.append(logging.FileHandler(log_dir + "/" + file_names[l], mode='a'))
+            self.file_handlers[l].setLevel(file_levels[l])
+            self.file_handlers[l].setFormatter(self.logger_format)
+
+        self.console_handler = logging.StreamHandler(sys.stdout)
+        self.console_handler.setLevel(STD_LEVEL)
+        self.console_handler.setFormatter(self.logger_format)
+
+        self.logger.addHandler(self.console_handler)
+        for filehandler in self.file_handlers:
+            self.logger.addHandler(filehandler)
+
+        self.logger.addFilter(LoggerFilter())
+        self.__lock = multiprocessing.Lock()
+
+    def debug(self, *args):
+        self.__lock.acquire()
+        self.logger.debug(' '.join(map(str, args)))
+        self.__lock.release()
+
+    def info(self, *args):
+        self.__lock.acquire()
+        self.logger.info(' '.join(map(str, args)))
+        self.__lock.release()
+
+    def warning(self, *args):
+        self.__lock.acquire()
+        self.logger.warning(' '.join(map(str, args)))
+        self.__lock.release()
+
+    def warn(self, *args):
+        self.__lock.acquire()
+        self.logger.warning(' '.join(map(str, args)))
+        self.__lock.release()
+
+    def error(self, *args):
+        self.__lock.acquire()
+        self.logger.error(' '.join(map(str, args)))
+        self.__lock.release()
+
+    def exception(self, *args, exc_info=None):
+        self.__lock.acquire()
+        self.logger.error(' '.join(map(str, args)) + ' ' + str(exc_info))
+        self.__lock.release()
+
+
+logger = Logger()

--- a/iotdb-core/mlnode/iotdb/mlnode/process/manager.py
+++ b/iotdb-core/mlnode/iotdb/mlnode/process/manager.py
@@ -49,8 +49,6 @@ class NoDaemonContext(type(multiprocessing.get_context())):
     Process = NoDaemonProcess
 
 
-# We sub-class multiprocessing.pool.Pool instead of multiprocessing.Pool
-# because the latter is only a wrapper function, not a proper class.
 class NestablePool(multiprocessing.pool.Pool):
     def __init__(self, *args, **kwargs):
         kwargs['context'] = NoDaemonContext()
@@ -64,12 +62,6 @@ class NestablePool(multiprocessing.pool.Pool):
         self.processes.append(p)
         print(self.processes)
         super(NestablePool, self).apply_async(func, args=args, kwds=kwds, callback=callback)
-
-    def terminate(self):
-        for p in self._pool:
-            logger.info("terminate process: {}".format(p))
-            p.terminate()
-        super(NestablePool, self).terminate()
 
 
 class TaskManager(object):

--- a/iotdb-core/mlnode/iotdb/mlnode/process/trial.py
+++ b/iotdb-core/mlnode/iotdb/mlnode/process/trial.py
@@ -112,6 +112,7 @@ class ForecastingTrainingTrial(BasicTrial):
         self.metrics_dict = build_metrics(forecast_metric_names)
 
     def train(self, epoch: int) -> float:
+        logger.debug(f'Starting trial training, trial id: {self.trial_id}, epoch: {epoch}')
         self.model.train()
         train_loss = []
         epoch_time = time.time()
@@ -153,6 +154,7 @@ class ForecastingTrainingTrial(BasicTrial):
         return train_loss
 
     def vali(self, epoch: int) -> Tuple[float, Dict]:
+        logger.debug(f'Starting trial vali, trial id: {self.trial_id}, epoch: {epoch}')
         self.model.eval()
         val_loss = []
         metrics_value_dict = {name: [] for name in forecast_metric_names}
@@ -197,6 +199,7 @@ class ForecastingTrainingTrial(BasicTrial):
         """
         Start training with the specified parameters, save the best model and report metrics to the db.
         """
+        logger.info(f'Starting trial, trial id: {self.trial_id}')
         try:
             best_loss = np.inf
             best_metrics_dict = None
@@ -220,5 +223,5 @@ class ForecastingTrainingTrial(BasicTrial):
             self.configNode_client.update_model_info(self.model_id, self.trial_id, model_info)
             return best_loss
         except Exception as e:
-            logger.warn(e)
+            logger.warning(e)
             raise e

--- a/iotdb-core/mlnode/iotdb/mlnode/script.py
+++ b/iotdb-core/mlnode/iotdb/mlnode/script.py
@@ -15,22 +15,48 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+import os
+import platform
 import sys
 
+from iotdb.mlnode.config import descriptor
 from iotdb.mlnode.log import logger
 from iotdb.mlnode.service import MLNode
 
+server: MLNode = None
+
 
 def main():
+    global server
     arguments = sys.argv
     if len(arguments) == 1:
         logger.info("Command line argument must be specified.")
         return
-
     argument = sys.argv[1]
     # TODO(lmh): support more commands
     if argument == 'start':
         server = MLNode()
         server.start()
+    elif argument == 'stop':
+        port = descriptor.get_config().get_mn_rpc_port()
+        if platform.system() == "Windows":
+            cmd = f"netstat -ano | findstr {port}"
+            result = os.popen(cmd).read().strip().split()
+            if result:
+                pid = result[-1]
+                # 终止指定进程ID的进程
+                os.system(f"taskkill /F /PID {pid}")
+                logger.info(f"Terminated process with PID {pid} that was using port {port}")
+            else:
+                logger.info(f"No process found using port {port}")
+        else:
+            cmd = f"lsof -i:{port} -t"
+            pid = os.popen(cmd).read().strip()
+            if pid:
+                # 终止指定进程ID的进程
+                os.system(f"kill -9 {pid}")
+                logger.info(f"Terminated process with PID {pid} that was using port {port}")
+            else:
+                logger.info(f"No process found using port {port}")
     else:
         logger.info("Unknown argument: {}.".format(argument))

--- a/iotdb-core/mlnode/iotdb/mlnode/script.py
+++ b/iotdb-core/mlnode/iotdb/mlnode/script.py
@@ -33,7 +33,6 @@ def main():
         logger.info("Command line argument must be specified.")
         return
     argument = sys.argv[1]
-    # TODO(lmh): support more commands
     if argument == 'start':
         server = MLNode()
         server.start()
@@ -44,7 +43,6 @@ def main():
             result = os.popen(cmd).read().strip().split()
             if result:
                 pid = result[-1]
-                # 终止指定进程ID的进程
                 os.system(f"taskkill /F /PID {pid}")
                 logger.info(f"Terminated process with PID {pid} that was using port {port}")
             else:
@@ -53,7 +51,6 @@ def main():
             cmd = f"lsof -i:{port} -t"
             pid = os.popen(cmd).read().strip()
             if pid:
-                # 终止指定进程ID的进程
                 os.system(f"kill -9 {pid}")
                 logger.info(f"Terminated process with PID {pid} that was using port {port}")
             else:

--- a/iotdb-core/mlnode/iotdb/mlnode/script.py
+++ b/iotdb-core/mlnode/iotdb/mlnode/script.py
@@ -42,7 +42,7 @@ def main():
             cmd = f"netstat -ano | findstr {port}"
             result = os.popen(cmd).read().strip().split()
             if result:
-                pid = result[-1]
+                pid = result[4]
                 os.system(f"taskkill /F /PID {pid}")
                 logger.info(f"Terminated process with PID {pid} that was using port {port}")
             else:
@@ -56,4 +56,4 @@ def main():
             else:
                 logger.info(f"No process found using port {port}")
     else:
-        logger.info("Unknown argument: {}.".format(argument))
+        logger.warning("Unknown argument: {}.".format(argument))

--- a/iotdb-core/mlnode/iotdb/mlnode/service.py
+++ b/iotdb-core/mlnode/iotdb/mlnode/service.py
@@ -56,3 +56,4 @@ class MLNode(object):
         time.sleep(0.1)
         logger.info('IoTDB-MLNode has successfully started.')
 
+

--- a/iotdb-core/mlnode/iotdb/mlnode/service.py
+++ b/iotdb-core/mlnode/iotdb/mlnode/service.py
@@ -50,6 +50,7 @@ class MLNode(object):
         self.__rpc_service = RPCService()
 
     def start(self) -> None:
+        logger.info('IoTDB-MLNode is starting...')
         self.__rpc_service.start()
 
         # sleep 100ms for waiting the rpc server start.

--- a/iotdb-core/mlnode/iotdb/mlnode/storage.py
+++ b/iotdb-core/mlnode/iotdb/mlnode/storage.py
@@ -51,6 +51,7 @@ class ModelStorage(object):
                    model_id: str,
                    trial_id: str) -> str:
         model_dir_path = os.path.join(self.__model_dir, f'{model_id}')
+        logger.debug(f"save model {model_config} to {model_dir_path}")
         self.lock.acquire()
         if not os.path.exists(model_dir_path):
             os.makedirs(model_dir_path)
@@ -76,6 +77,7 @@ class ModelStorage(object):
             jit_model: a ScriptModule contains model architecture and parameters, which can be deployed cross-platform
             model_config: a dict contains model attributes
         """
+        logger.debug(f"load model from {file_path}")
         file_path = os.path.join(self.__model_dir, file_path)
         if file_path in self.__model_cache:
             return self.__model_cache[file_path]
@@ -90,6 +92,7 @@ class ModelStorage(object):
                 return jit_model, model_config
 
     def delete_model(self, model_id: str) -> None:
+        logger.debug(f"delete model {model_id}")
         model_dir_path = os.path.join(self.__model_dir, f'{model_id}')
         if os.path.exists(model_dir_path):
             for file_name in os.listdir(model_dir_path):
@@ -97,6 +100,7 @@ class ModelStorage(object):
             shutil.rmtree(model_dir_path)
 
     def delete_trial(self, model_id: str, trial_id: str) -> None:
+        logger.debug(f"delete trial {trial_id} of model {model_id}")
         model_file_path = os.path.join(self.__model_dir, f'{model_id}', f'{trial_id}.pt')
         self.__remove_from_cache(model_file_path)
         if os.path.exists(model_file_path):

--- a/iotdb-core/mlnode/iotdb/mlnode/util.py
+++ b/iotdb-core/mlnode/iotdb/mlnode/util.py
@@ -57,7 +57,7 @@ def get_status(status_code: TSStatusCode, message: str = None) -> TSStatus:
 
 def verify_success(status: TSStatus, err_msg: str) -> None:
     if status.code != TSStatusCode.SUCCESS_STATUS.get_status_code():
-        logger.warn(err_msg + ", error status is ", status)
+        logger.warning(err_msg + ", error status is ", status)
         raise RuntimeError(str(status.code) + ": " + status.message)
 
 


### PR DESCRIPTION
### Description
Logging module, shut down function and the fixing of a bug about multi process training
We have developed new functions for the mlnode module of IoTDB, which mainly includes the following three parts:

### Content
#### Logging module
Developed a logging module for mlnode, supporting standard function calls and localized log information for multi-process security

#### Shut down function
Completed the addition of the mlnode shutdown function, and implemented the direct shutdown of the mlnode main process based on the port number on the Linux system

#### Bug fixing
Fixed the issue involved in related work, which is that the original process pool does not support creating nums_ Issues with worker subprocesses

### Usage
#### Logging module
We provide 5 levels of functions including debug, info, warn, error, and the module can localize logs according to the log level. In subsequent development, we only need to use a form similar to calling the Python standard logging module to use it.

#### Stop function
Since our start function is designed in the form of pip package, our stop function is developed in a similar form. If user start the mlnode in a terminal, we can stop the node in another one with the command "mlnode stop".