### PR TITLE
[IOTDB-6165] Pipe: cache device metadata in TsFile reader to avoid redundant IO

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/TsFileInsertionDataContainer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/TsFileInsertionDataContainer.java
@@ -90,7 +90,7 @@ public class TsFileInsertionDataContainer implements AutoCloseable {
     this.sourceEvent = sourceEvent;
 
     try {
-      tsFileSequenceReader = new TsFileSequenceReader(tsFile.getAbsolutePath());
+      tsFileSequenceReader = new TsFileSequenceReader(tsFile.getAbsolutePath(), true, true);
       tsFileReader = new TsFileReader(tsFileSequenceReader);
 
       deviceMeasurementsMapIterator = filterDeviceMeasurementsMapByPattern().entrySet().iterator();


### PR DESCRIPTION
device metadata is deserialized from the file twice in the constructor of TsFileDataContainer, causing an IO overhead.
before:
![image](https://github.com/apache/iotdb/assets/55695098/9a14897b-56bd-416e-9a1e-7888cadd1c03)
after:
<img width="1058" alt="image" src="https://github.com/apache/iotdb/assets/55695098/b043c074-734d-4c51-845a-a682ffa3cb70">
