### PR TITLE
Optimize python client insert records values serialization

### DIFF
--- a/iotdb-client/client-py/iotdb/utils/IoTDBConstants.py
+++ b/iotdb-client/client-py/iotdb/utils/IoTDBConstants.py
@@ -16,12 +16,12 @@
 # under the License.
 #
 
-from enum import unique, IntEnum
+from enum import Enum, unique
 import numpy as np
 
 
 @unique
-class TSDataType(IntEnum):
+class TSDataType(Enum):
     BOOLEAN = 0
     INT32 = 1
     INT64 = 2
@@ -49,7 +49,7 @@ class TSDataType(IntEnum):
 
 
 @unique
-class TSEncoding(IntEnum):
+class TSEncoding(Enum):
     PLAIN = 0
     DICTIONARY = 1
     RLE = 2
@@ -74,7 +74,7 @@ class TSEncoding(IntEnum):
 
 
 @unique
-class Compressor(IntEnum):
+class Compressor(Enum):
     UNCOMPRESSED = 0
     SNAPPY = 1
     GZIP = 2

--- a/iotdb-client/client-py/iotdb/utils/IoTDBConstants.py
+++ b/iotdb-client/client-py/iotdb/utils/IoTDBConstants.py
@@ -16,12 +16,12 @@
 # under the License.
 #
 
-from enum import Enum, unique
+from enum import unique, IntEnum
 import numpy as np
 
 
 @unique
-class TSDataType(Enum):
+class TSDataType(IntEnum):
     BOOLEAN = 0
     INT32 = 1
     INT64 = 2
@@ -49,7 +49,7 @@ class TSDataType(Enum):
 
 
 @unique
-class TSEncoding(Enum):
+class TSEncoding(IntEnum):
     PLAIN = 0
     DICTIONARY = 1
     RLE = 2
@@ -74,7 +74,7 @@ class TSEncoding(Enum):
 
 
 @unique
-class Compressor(Enum):
+class Compressor(IntEnum):
     UNCOMPRESSED = 0
     SNAPPY = 1
     GZIP = 2


### PR DESCRIPTION
## Description

This PR is optimizing the insert records values serialization of Python Client. The Enum.value method in Python is not fast enough, we should try to avoid using it too much...

## How to test

You can run the following code.

```Python
from datetime import datetime
import numpy as np

from iotdb.Session import Session
from iotdb.utils.IoTDBConstants import TSDataType, TSEncoding, Compressor
from iotdb.utils.NumpyTablet import NumpyTablet

# creating session connection.
ip = "127.0.0.1"
port_ = "6667"
username_ = "root"
password_ = "root"
session = Session(ip, port_, username_, password_, fetch_size=1024, zone_id="UTC+8", enable_redirection=False)

session.open(False)

device = "root.sg.d"
measurements_ = []
ts_path_lst_ = []
values_ = []
for i in range(440):
    measurement = "s" + str(i)
    measurements_.append(measurement)
    ts_path_lst_.append(device + "." + measurement)
    values_.append(1.1 * i)

data_type_lst_ = [TSDataType.FLOAT for _ in range(440)]
encoding_lst_ = [TSEncoding.GORILLA for _ in range(440)]
compressor_lst_ = [Compressor.LZ4 for _ in range(440)]
startTime = int(datetime.now().timestamp() * 1000)
for i in range(10000):
    session.test_insert_record(device, 1692761800000 + i, measurements_, data_type_lst_, values_)
print("InsertRecord 10000 rows cost: " + str(int(datetime.now().timestamp() * 1000) - startTime) + "ms")
session.close()
exit(0)
```
### Result
Before this PR: InsertRecord 10000 rows cost: **9396ms**

After: InsertRecord 10000 rows cost: **5163ms**