### PR TITLE
Optimize merge selection process and increase disk space availability logic

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/AbstractCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/AbstractCompactionTask.java
@@ -218,6 +218,10 @@ public abstract class AbstractCompactionTask {
     return innerSeqTask;
   }
 
+  public CompactionTaskType getCompactionTaskType() {
+    return compactionTaskType;
+  }
+
   public boolean isDiskSpaceCheckPassed() {
     if (compactionTaskType == CompactionTaskType.MOD_SETTLE) {
       return true;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/AbstractCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/AbstractCompactionTask.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.storageengine.dataregion.compaction.execute.task;
 
 import org.apache.iotdb.db.service.metrics.CompactionMetrics;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.performer.ICompactionPerformer;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.utils.CompactionUtils;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.schedule.CompactionTaskManager;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileManager;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
@@ -215,5 +216,12 @@ public abstract class AbstractCompactionTask {
 
   public boolean isInnerSeqTask() {
     return innerSeqTask;
+  }
+
+  public boolean isDiskSpaceCheckPassed() {
+    if (compactionTaskType == CompactionTaskType.MOD_SETTLE) {
+      return true;
+    }
+    return CompactionUtils.isDiskHasSpace();
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/AbstractCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/AbstractCompactionTask.java
@@ -19,16 +19,12 @@
 
 package org.apache.iotdb.db.storageengine.dataregion.compaction.execute.task;
 
-import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.db.service.metrics.CompactionMetrics;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.performer.ICompactionPerformer;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.schedule.CompactionTaskManager;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileManager;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResourceStatus;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -41,10 +37,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  * finished. The future returns the {@link CompactionTaskSummary} of this task execution.
  */
 public abstract class AbstractCompactionTask {
-  @SuppressWarnings("squid:S1068")
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(IoTDBConstant.COMPACTION_LOGGER_NAME);
-
   protected String dataRegionId;
   protected String storageGroupName;
   protected long timePartition;
@@ -59,6 +51,8 @@ public abstract class AbstractCompactionTask {
 
   protected long memoryCost = 0L;
 
+  protected CompactionTaskType compactionTaskType;
+
   protected AbstractCompactionTask(
       String storageGroupName,
       String dataRegionId,
@@ -66,12 +60,31 @@ public abstract class AbstractCompactionTask {
       TsFileManager tsFileManager,
       AtomicInteger currentTaskNum,
       long serialId) {
+    this(
+        storageGroupName,
+        dataRegionId,
+        timePartition,
+        tsFileManager,
+        currentTaskNum,
+        serialId,
+        CompactionTaskType.NORMAL);
+  }
+
+  protected AbstractCompactionTask(
+      String storageGroupName,
+      String dataRegionId,
+      long timePartition,
+      TsFileManager tsFileManager,
+      AtomicInteger currentTaskNum,
+      long serialId,
+      CompactionTaskType compactionTaskType) {
     this.storageGroupName = storageGroupName;
     this.dataRegionId = dataRegionId;
     this.timePartition = timePartition;
     this.tsFileManager = tsFileManager;
     this.currentTaskNum = currentTaskNum;
     this.serialId = serialId;
+    this.compactionTaskType = compactionTaskType;
   }
 
   protected abstract List<TsFileResource> getAllSourceTsFiles();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CompactionTaskType.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CompactionTaskType.java
@@ -16,14 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iotdb.db.storageengine.dataregion.compaction.selector;
 
-import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.task.InnerSpaceCompactionTask;
-import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
+package org.apache.iotdb.db.storageengine.dataregion.compaction.execute.task;
 
-import java.util.List;
+public enum CompactionTaskType {
+  /** default compaction task type */
+  NORMAL,
 
-public interface IInnerUnseqSpaceSelector extends ICompactionSelector {
-  @Override
-  List<InnerSpaceCompactionTask> selectInnerSpaceTask(List<TsFileResource> resources);
+  /**
+   * in either of the following situations: 1. the TsFile has .mods file whose size exceeds 50 MB.
+   * 2. the TsFile has .mods file and the disk availability rate is lower than the
+   * disk_space_warning_threshold.
+   */
+  MOD_SETTLE
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
@@ -366,7 +366,7 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
       resetCompactionCandidateStatusForAllSourceFiles();
       return false;
     }
-    if (compactionTaskType == CompactionTaskType.NORMAL && CompactionUtils.isDiskHaveSpace()) {
+    if (compactionTaskType == CompactionTaskType.NORMAL && !CompactionUtils.isDiskHaveSpace()) {
       LOGGER.debug(
           "cross task start check failed because disk free ratio is less than disk_space_warning_threshold");
       return false;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
@@ -366,6 +366,11 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
       resetCompactionCandidateStatusForAllSourceFiles();
       return false;
     }
+    if (compactionTaskType == CompactionTaskType.NORMAL && CompactionUtils.isDiskHaveSpace()) {
+      LOGGER.debug(
+          "cross task start check failed because disk free ratio is less than disk_space_warning_threshold");
+      return false;
+    }
     try {
       SystemInfo.getInstance().addCompactionMemoryCost(memoryCost, 60);
       SystemInfo.getInstance()

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
@@ -366,9 +366,9 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
       resetCompactionCandidateStatusForAllSourceFiles();
       return false;
     }
-    if (compactionTaskType == CompactionTaskType.NORMAL && !CompactionUtils.isDiskHaveSpace()) {
+    if (!isDiskSpaceCheckPassed()) {
       LOGGER.debug(
-          "cross task start check failed because disk free ratio is less than disk_space_warning_threshold");
+          "cross compaction task start check failed because disk free ratio is less than disk_space_warning_threshold");
       return false;
     }
     try {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
@@ -476,9 +476,9 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
       resetCompactionCandidateStatusForAllSourceFiles();
       return false;
     }
-    if (compactionTaskType == CompactionTaskType.NORMAL && !CompactionUtils.isDiskHaveSpace()) {
+    if (!isDiskSpaceCheckPassed()) {
       LOGGER.debug(
-          "inner task start check failed because disk free ratio is less than disk_space_warning_threshold");
+          "inner compaction task start check failed because disk free ratio is less than disk_space_warning_threshold");
       return false;
     }
     try {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
@@ -88,13 +88,34 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
       ICompactionPerformer performer,
       AtomicInteger currentTaskNum,
       long serialId) {
+    this(
+        timePartition,
+        tsFileManager,
+        selectedTsFileResourceList,
+        sequence,
+        performer,
+        currentTaskNum,
+        serialId,
+        CompactionTaskType.NORMAL);
+  }
+
+  public InnerSpaceCompactionTask(
+      long timePartition,
+      TsFileManager tsFileManager,
+      List<TsFileResource> selectedTsFileResourceList,
+      boolean sequence,
+      ICompactionPerformer performer,
+      AtomicInteger currentTaskNum,
+      long serialId,
+      CompactionTaskType compactionTaskType) {
     super(
         tsFileManager.getStorageGroupName(),
         tsFileManager.getDataRegionId(),
         timePartition,
         tsFileManager,
         currentTaskNum,
-        serialId);
+        serialId,
+        compactionTaskType);
     this.selectedTsFileResourceList = selectedTsFileResourceList;
     this.sequence = sequence;
     this.performer = performer;
@@ -453,6 +474,11 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
   public boolean checkValidAndSetMerging() {
     if (!tsFileManager.isAllowCompaction()) {
       resetCompactionCandidateStatusForAllSourceFiles();
+      return false;
+    }
+    if (compactionTaskType == CompactionTaskType.NORMAL && CompactionUtils.isDiskHaveSpace()) {
+      LOGGER.debug(
+          "inner task start check failed because disk free ratio is less than disk_space_warning_threshold");
       return false;
     }
     try {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
@@ -476,7 +476,7 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
       resetCompactionCandidateStatusForAllSourceFiles();
       return false;
     }
-    if (compactionTaskType == CompactionTaskType.NORMAL && CompactionUtils.isDiskHaveSpace()) {
+    if (compactionTaskType == CompactionTaskType.NORMAL && !CompactionUtils.isDiskHaveSpace()) {
       LOGGER.debug(
           "inner task start check failed because disk free ratio is less than disk_space_warning_threshold");
       return false;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/CompactionUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/CompactionUtils.java
@@ -474,6 +474,10 @@ public class CompactionUtils {
   }
 
   public static boolean isDiskHasSpace() {
+    return isDiskHasSpace(0d);
+  }
+
+  public static boolean isDiskHasSpace(double redundancy) {
     double freeDisk =
         MetricService.getInstance()
             .getAutoGauge(
@@ -493,7 +497,7 @@ public class CompactionUtils {
 
     if (freeDisk != 0 && totalDisk != 0) {
       return freeDisk / totalDisk
-          > CommonDescriptor.getInstance().getConfig().getDiskSpaceWarningThreshold();
+          > CommonDescriptor.getInstance().getConfig().getDiskSpaceWarningThreshold() + redundancy;
     }
     return true;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/CompactionUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/CompactionUtils.java
@@ -19,13 +19,18 @@
 
 package org.apache.iotdb.db.storageengine.dataregion.compaction.execute.utils;
 
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
+import org.apache.iotdb.commons.service.metric.MetricService;
+import org.apache.iotdb.commons.service.metric.enums.Tag;
 import org.apache.iotdb.db.service.metrics.FileMetrics;
 import org.apache.iotdb.db.storageengine.dataregion.modification.Modification;
 import org.apache.iotdb.db.storageengine.dataregion.modification.ModificationFile;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileManager;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.timeindex.DeviceTimeIndex;
+import org.apache.iotdb.metrics.utils.MetricLevel;
+import org.apache.iotdb.metrics.utils.SystemMetric;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
@@ -69,6 +74,7 @@ import java.util.Set;
 public class CompactionUtils {
   private static final Logger logger =
       LoggerFactory.getLogger(IoTDBConstant.COMPACTION_LOGGER_NAME);
+  private static final String SYSTEM = "system";
 
   private CompactionUtils() {}
 
@@ -465,5 +471,30 @@ public class CompactionUtils {
       fileSizes = Arrays.copyOfRange(fileSizes, 0, removeSuccessFileNum);
       FileMetrics.getInstance().deleteFile(fileSizes, seq, fileNames);
     }
+  }
+
+  public static boolean isDiskHaveSpace() {
+    double freeDisk =
+        MetricService.getInstance()
+            .getAutoGauge(
+                SystemMetric.SYS_DISK_FREE_SPACE.toString(),
+                MetricLevel.CORE,
+                Tag.NAME.toString(),
+                SYSTEM)
+            .value();
+    double totalDisk =
+        MetricService.getInstance()
+            .getAutoGauge(
+                SystemMetric.SYS_DISK_TOTAL_SPACE.toString(),
+                MetricLevel.CORE,
+                Tag.NAME.toString(),
+                SYSTEM)
+            .value();
+
+    if (freeDisk != 0 && totalDisk != 0) {
+      return freeDisk / totalDisk
+          > CommonDescriptor.getInstance().getConfig().getDiskSpaceWarningThreshold();
+    }
+    return true;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/CompactionUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/CompactionUtils.java
@@ -473,7 +473,7 @@ public class CompactionUtils {
     }
   }
 
-  public static boolean isDiskHaveSpace() {
+  public static boolean isDiskHasSpace() {
     double freeDisk =
         MetricService.getInstance()
             .getAutoGauge(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/schedule/CompactionScheduler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/schedule/CompactionScheduler.java
@@ -22,14 +22,12 @@ package org.apache.iotdb.db.storageengine.dataregion.compaction.schedule;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
-import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.performer.ICompactionPerformer;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.task.CrossSpaceCompactionTask;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.task.InnerSpaceCompactionTask;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.selector.ICompactionSelector;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.selector.ICrossSpaceSelector;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.selector.utils.CrossCompactionTaskResource;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileManager;
-import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,7 +100,7 @@ public class CompactionScheduler {
               .getInnerUnsequenceCompactionSelector()
               .createInstance(storageGroupName, dataRegionId, timePartition, tsFileManager);
     }
-    List<List<TsFileResource>> taskList =
+    List<InnerSpaceCompactionTask> innerSpaceTaskList =
         innerSpaceCompactionSelector.selectInnerSpaceTask(
             sequence
                 ? tsFileManager.getOrCreateSequenceListByTimePartition(timePartition)
@@ -110,27 +108,8 @@ public class CompactionScheduler {
     // the name of this variable is trySubmitCount, because the task submitted to the queue could be
     // evicted due to the low priority of the task
     int trySubmitCount = 0;
-    for (List<TsFileResource> task : taskList) {
-      ICompactionPerformer performer =
-          sequence
-              ? IoTDBDescriptor.getInstance()
-                  .getConfig()
-                  .getInnerSeqCompactionPerformer()
-                  .createInstance()
-              : IoTDBDescriptor.getInstance()
-                  .getConfig()
-                  .getInnerUnseqCompactionPerformer()
-                  .createInstance();
-      if (CompactionTaskManager.getInstance()
-          .addTaskToWaitingQueue(
-              new InnerSpaceCompactionTask(
-                  timePartition,
-                  tsFileManager,
-                  task,
-                  sequence,
-                  performer,
-                  CompactionTaskManager.currentTaskNum,
-                  tsFileManager.getNextCompactionTaskId()))) {
+    for (InnerSpaceCompactionTask task : innerSpaceTaskList) {
+      if (CompactionTaskManager.getInstance().addTaskToWaitingQueue(task)) {
         trySubmitCount++;
       }
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/schedule/comparator/DefaultCompactionTaskComparatorImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/schedule/comparator/DefaultCompactionTaskComparatorImpl.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.storageengine.dataregion.compaction.schedule.compara
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.task.AbstractCompactionTask;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.task.CompactionTaskType;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.task.CrossSpaceCompactionTask;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.task.InnerSpaceCompactionTask;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.schedule.constant.CompactionPriority;
@@ -63,6 +64,12 @@ public class DefaultCompactionTaskComparatorImpl implements ICompactionTaskCompa
 
   public int compareInnerSpaceCompactionTask(
       InnerSpaceCompactionTask o1, InnerSpaceCompactionTask o2) {
+
+    // if compactionTaskType of o1 and o2 are different
+    // we prefer to execute task type with MOD_SETTLE
+    if (o1.getCompactionTaskType() != o2.getCompactionTaskType()) {
+      return o1.getCompactionTaskType() == CompactionTaskType.MOD_SETTLE ? -1 : 1;
+    }
 
     // if max mods file size of o1 and o2 are different
     // we prefer to execute task with greater mods file

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/ICompactionSelector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/ICompactionSelector.java
@@ -19,6 +19,7 @@
 package org.apache.iotdb.db.storageengine.dataregion.compaction.selector;
 
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.performer.constant.CrossCompactionPerformer;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.task.InnerSpaceCompactionTask;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.schedule.CompactionTaskManager;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.selector.estimator.AbstractCompactionEstimator;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.selector.estimator.FastCrossSpaceCompactionEstimator;
@@ -39,7 +40,7 @@ public interface ICompactionSelector {
    * It takes the list of tsfile in a time partition as input, and returns a list of list. Each list in
    * the returned list is the source files of one compaction tasks.
    */
-  default List<List<TsFileResource>> selectInnerSpaceTask(List<TsFileResource> resources) {
+  default List<InnerSpaceCompactionTask> selectInnerSpaceTask(List<TsFileResource> resources) {
     throw new RuntimeException("This kind of selector cannot be used to select inner space task");
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/IInnerSeqSpaceSelector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/IInnerSeqSpaceSelector.java
@@ -18,11 +18,12 @@
  */
 package org.apache.iotdb.db.storageengine.dataregion.compaction.selector;
 
+import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.task.InnerSpaceCompactionTask;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 
 import java.util.List;
 
 public interface IInnerSeqSpaceSelector extends ICompactionSelector {
   @Override
-  List<List<TsFileResource>> selectInnerSpaceTask(List<TsFileResource> resources);
+  List<InnerSpaceCompactionTask> selectInnerSpaceTask(List<TsFileResource> resources);
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/impl/SizeTieredCompactionSelector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/impl/SizeTieredCompactionSelector.java
@@ -22,6 +22,10 @@ package org.apache.iotdb.db.storageengine.dataregion.compaction.selector.impl;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.performer.ICompactionPerformer;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.task.CompactionTaskType;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.task.InnerSpaceCompactionTask;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.utils.CompactionUtils;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.schedule.CompactionTaskManager;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.schedule.comparator.ICompactionTaskComparator;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.selector.IInnerSeqSpaceSelector;
@@ -31,7 +35,6 @@ import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileManager;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResourceStatus;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.generator.TsFileNameGenerator;
-import org.apache.iotdb.tsfile.utils.Pair;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,11 +42,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Objects;
-import java.util.PriorityQueue;
 
 /**
  * SizeTieredCompactionSelector selects files to be compacted based on the size of files. The
@@ -96,19 +95,19 @@ public class SizeTieredCompactionSelector
    * @throws IOException if the name of tsfile is incorrect
    */
   @SuppressWarnings({"squid:S3776", "squid:S135"})
-  private List<Pair<List<TsFileResource>, Long>> selectSingleLevel(int level) throws IOException {
+  private List<List<TsFileResource>> selectSingleLevel(int level) throws IOException {
     List<TsFileResource> selectedFileList = new ArrayList<>();
     long selectedFileSize = 0L;
     long targetCompactionFileSize = config.getTargetCompactionFileSize();
 
-    List<Pair<List<TsFileResource>, Long>> taskList = new ArrayList<>();
+    List<List<TsFileResource>> taskList = new ArrayList<>();
     for (TsFileResource currentFile : tsFileResources) {
       TsFileNameGenerator.TsFileName currentName =
           TsFileNameGenerator.getTsFileName(currentFile.getTsFile().getName());
       if (currentName.getInnerCompactionCnt() != level) {
         // meet files of another level
         if (selectedFileList.size() > 1) {
-          taskList.add(new Pair<>(new ArrayList<>(selectedFileList), selectedFileSize));
+          taskList.add(new ArrayList<>(selectedFileList));
         }
         selectedFileList = new ArrayList<>();
         selectedFileSize = 0L;
@@ -132,7 +131,7 @@ public class SizeTieredCompactionSelector
           || selectedFileList.size() >= config.getFileLimitPerInnerTask()) {
         // submit the task
         if (selectedFileList.size() > 1) {
-          taskList.add(new Pair<>(new ArrayList<>(selectedFileList), selectedFileSize));
+          taskList.add(new ArrayList<>(selectedFileList));
         }
         selectedFileList = new ArrayList<>();
         selectedFileSize = 0L;
@@ -142,7 +141,7 @@ public class SizeTieredCompactionSelector
     // if next time partition exists
     // submit a merge task even it does not meet the requirement for file num or file size
     if (hasNextTimePartition && selectedFileList.size() > 1) {
-      taskList.add(new Pair<>(new ArrayList<>(selectedFileList), selectedFileSize));
+      taskList.add(new ArrayList<>(selectedFileList));
     }
     return taskList;
   }
@@ -159,36 +158,54 @@ public class SizeTieredCompactionSelector
    * @return Returns whether the file was found and submits the merge task
    */
   @Override
-  public List<List<TsFileResource>> selectInnerSpaceTask(List<TsFileResource> tsFileResources) {
+  public List<InnerSpaceCompactionTask> selectInnerSpaceTask(List<TsFileResource> tsFileResources) {
     this.tsFileResources = tsFileResources;
-    PriorityQueue<Pair<List<TsFileResource>, Long>> taskPriorityQueue =
-        new PriorityQueue<>(new SizeTieredCompactionTaskComparator());
+    List<InnerSpaceCompactionTask> innerSpaceTaskList = new ArrayList<>();
     try {
-      // preferentially select files based on mods file size
-      taskPriorityQueue.addAll(selectMaxModsFileTask());
-
-      // if a suitable file is not selected in the first step, select the file at the tsfile level
-      if (taskPriorityQueue.isEmpty()) {
-        taskPriorityQueue.addAll(selectLevelTask());
+      CompactionTaskType taskType = CompactionTaskType.MOD_SETTLE;
+      // 1. preferentially select files based on mod file
+      List<List<TsFileResource>> selectedTsFileList = selectTsFileBaseOnModFile();
+      if (selectedTsFileList.isEmpty()) {
+        // 2. if a suitable file is not selected in the first step, select the file at the tsFile
+        // level
+        selectedTsFileList = selectTsFileBaseOnLevel();
+        taskType = CompactionTaskType.NORMAL;
       }
 
-      List<List<TsFileResource>> taskList = new LinkedList<>();
-      while (!taskPriorityQueue.isEmpty()) {
-        List<TsFileResource> resources = taskPriorityQueue.poll().left;
-        taskList.add(resources);
+      // 3. added to the task queue based on the selected TsFile, performer, and task type.
+      for (List<TsFileResource> selectedTsFileResourceList : selectedTsFileList) {
+        ICompactionPerformer performer =
+            sequence
+                ? IoTDBDescriptor.getInstance()
+                    .getConfig()
+                    .getInnerSeqCompactionPerformer()
+                    .createInstance()
+                : IoTDBDescriptor.getInstance()
+                    .getConfig()
+                    .getInnerUnseqCompactionPerformer()
+                    .createInstance();
+        innerSpaceTaskList.add(
+            new InnerSpaceCompactionTask(
+                timePartition,
+                tsFileManager,
+                selectedTsFileResourceList,
+                sequence,
+                performer,
+                CompactionTaskManager.currentTaskNum,
+                tsFileManager.getNextCompactionTaskId(),
+                taskType));
       }
-      return taskList;
     } catch (Exception e) {
       LOGGER.error("Exception occurs while selecting files", e);
     }
-    return Collections.emptyList();
+    return innerSpaceTaskList;
   }
 
-  private List<Pair<List<TsFileResource>, Long>> selectLevelTask() throws IOException {
-    List<Pair<List<TsFileResource>, Long>> taskList = new ArrayList<>();
+  private List<List<TsFileResource>> selectTsFileBaseOnLevel() throws IOException {
+    List<List<TsFileResource>> taskList = new ArrayList<>();
     int maxLevel = searchMaxFileLevel();
     for (int currentLevel = 0; currentLevel <= maxLevel; currentLevel++) {
-      List<Pair<List<TsFileResource>, Long>> singleLevelTask = selectSingleLevel(currentLevel);
+      List<List<TsFileResource>> singleLevelTask = selectSingleLevel(currentLevel);
       if (!singleLevelTask.isEmpty()) {
         taskList.addAll(singleLevelTask);
         break;
@@ -197,13 +214,15 @@ public class SizeTieredCompactionSelector
     return taskList;
   }
 
-  private List<Pair<List<TsFileResource>, Long>> selectMaxModsFileTask() {
-    List<Pair<List<TsFileResource>, Long>> taskList = new ArrayList<>();
+  private List<List<TsFileResource>> selectTsFileBaseOnModFile() {
+    List<List<TsFileResource>> taskList = new ArrayList<>();
     for (TsFileResource tsFileResource : tsFileResources) {
       ModificationFile modFile = tsFileResource.getModFile();
-      if (!Objects.isNull(modFile) && modFile.getSize() > MODS_FILE_SIZE_THRESHOLD) {
-        taskList.add(
-            new Pair<>(Collections.singletonList(tsFileResource), tsFileResource.getTsFileSize()));
+      if (!modFile.exists()) {
+        continue;
+      }
+      if (modFile.getSize() > MODS_FILE_SIZE_THRESHOLD || !CompactionUtils.isDiskHaveSpace()) {
+        taskList.add(Collections.singletonList(tsFileResource));
         LOGGER.debug("select tsfile {},the mod file size is {}", tsFileResource, modFile.getSize());
       }
     }
@@ -220,29 +239,5 @@ public class SizeTieredCompactionSelector
       }
     }
     return maxLevel;
-  }
-
-  private class SizeTieredCompactionTaskComparator
-      implements Comparator<Pair<List<TsFileResource>, Long>> {
-
-    @Override
-    public int compare(Pair<List<TsFileResource>, Long> o1, Pair<List<TsFileResource>, Long> o2) {
-      TsFileResource resourceOfO1 = o1.left.get(0);
-      TsFileResource resourceOfO2 = o2.left.get(0);
-      try {
-        TsFileNameGenerator.TsFileName fileNameOfO1 =
-            TsFileNameGenerator.getTsFileName(resourceOfO1.getTsFile().getName());
-        TsFileNameGenerator.TsFileName fileNameOfO2 =
-            TsFileNameGenerator.getTsFileName(resourceOfO2.getTsFile().getName());
-        if (fileNameOfO1.getInnerCompactionCnt() != fileNameOfO2.getInnerCompactionCnt()) {
-          // the higher the inner compaction count, the higher the priority is
-          return fileNameOfO2.getInnerCompactionCnt() - fileNameOfO1.getInnerCompactionCnt();
-        }
-        // the larger the version number, the higher the priority is
-        return (int) (fileNameOfO2.getVersion() - fileNameOfO1.getVersion());
-      } catch (IOException e) {
-        return 0;
-      }
-    }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/impl/SizeTieredCompactionSelector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/impl/SizeTieredCompactionSelector.java
@@ -69,6 +69,8 @@ public class SizeTieredCompactionSelector
   protected boolean hasNextTimePartition;
   private static final long MODS_FILE_SIZE_THRESHOLD = 1024 * 1024 * 50L;
 
+  private static final double DISK_REDUNDANCY = 0.05;
+
   public SizeTieredCompactionSelector(
       String storageGroupName,
       String dataRegionId,
@@ -194,7 +196,8 @@ public class SizeTieredCompactionSelector
       if (Objects.isNull(modFile) || !modFile.exists()) {
         continue;
       }
-      if (modFile.getSize() > MODS_FILE_SIZE_THRESHOLD || !CompactionUtils.isDiskHasSpace()) {
+      if (modFile.getSize() > MODS_FILE_SIZE_THRESHOLD
+          || !CompactionUtils.isDiskHasSpace(DISK_REDUNDANCY)) {
         taskList.add(
             createCompactionTask(
                 Collections.singletonList(tsFileResource), CompactionTaskType.MOD_SETTLE));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/impl/SizeTieredCompactionSelector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/impl/SizeTieredCompactionSelector.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * SizeTieredCompactionSelector selects files to be compacted based on the size of files. The
@@ -218,10 +219,10 @@ public class SizeTieredCompactionSelector
     List<List<TsFileResource>> taskList = new ArrayList<>();
     for (TsFileResource tsFileResource : tsFileResources) {
       ModificationFile modFile = tsFileResource.getModFile();
-      if (!modFile.exists()) {
+      if (Objects.isNull(modFile) || !modFile.exists()) {
         continue;
       }
-      if (modFile.getSize() > MODS_FILE_SIZE_THRESHOLD || !CompactionUtils.isDiskHaveSpace()) {
+      if (modFile.getSize() > MODS_FILE_SIZE_THRESHOLD || !CompactionUtils.isDiskHasSpace()) {
         taskList.add(Collections.singletonList(tsFileResource));
         LOGGER.debug("select tsfile {},the mod file size is {}", tsFileResource, modFile.getSize());
       }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/cross/CrossSpaceCompactionWithFastPerformerValidationTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/cross/CrossSpaceCompactionWithFastPerformerValidationTest.java
@@ -2307,7 +2307,7 @@ public class CrossSpaceCompactionWithFastPerformerValidationTest extends Abstrac
 
     // target file of first compaction task can be selected to participate in another inner
     // compaction task
-    List<List<TsFileResource>> innerPairs = innerSelector.selectInnerSpaceTask(targetResources);
+    List<InnerSpaceCompactionTask> innerPairs = innerSelector.selectInnerSpaceTask(targetResources);
     Assert.assertEquals(1, innerPairs.size());
   }
 
@@ -2347,20 +2347,11 @@ public class CrossSpaceCompactionWithFastPerformerValidationTest extends Abstrac
         readSourceFiles(timeseriesPaths, Collections.emptyList());
 
     // inner seq space compact
-    List<List<TsFileResource>> taskResources =
+    List<InnerSpaceCompactionTask> taskResources =
         new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
             .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
-    for (List<TsFileResource> taskResource : taskResources) {
-      Assert.assertTrue(
-          new InnerSpaceCompactionTask(
-                  0,
-                  tsFileManager,
-                  taskResource,
-                  true,
-                  new FastCompactionPerformer(false),
-                  new AtomicInteger(0),
-                  0L)
-              .start());
+    for (InnerSpaceCompactionTask task : taskResources) {
+      Assert.assertTrue(task.start());
     }
 
     // select cross compaction
@@ -2429,20 +2420,11 @@ public class CrossSpaceCompactionWithFastPerformerValidationTest extends Abstrac
         readSourceFiles(timeseriesPaths, Collections.emptyList());
 
     // inner seq space compact
-    List<List<TsFileResource>> taskResources =
+    List<InnerSpaceCompactionTask> taskResources =
         new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
             .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
-    for (List<TsFileResource> taskResource : taskResources) {
-      Assert.assertTrue(
-          new InnerSpaceCompactionTask(
-                  0,
-                  tsFileManager,
-                  taskResource,
-                  true,
-                  new FastCompactionPerformer(false),
-                  new AtomicInteger(0),
-                  0L)
-              .start());
+    for (InnerSpaceCompactionTask task : taskResources) {
+      Assert.assertTrue(task.start());
     }
 
     // select cross compaction
@@ -2511,20 +2493,11 @@ public class CrossSpaceCompactionWithFastPerformerValidationTest extends Abstrac
         readSourceFiles(timeseriesPaths, Collections.emptyList());
 
     // inner seq space compact
-    List<List<TsFileResource>> taskResources =
+    List<InnerSpaceCompactionTask> innerSpaceCompactionTasks =
         new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
             .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
-    for (List<TsFileResource> taskResource : taskResources) {
-      Assert.assertTrue(
-          new InnerSpaceCompactionTask(
-                  0,
-                  tsFileManager,
-                  taskResource,
-                  true,
-                  new FastCompactionPerformer(false),
-                  new AtomicInteger(0),
-                  0L)
-              .start());
+    for (InnerSpaceCompactionTask task : innerSpaceCompactionTasks) {
+      Assert.assertTrue(task.start());
     }
 
     // select cross compaction
@@ -2594,20 +2567,11 @@ public class CrossSpaceCompactionWithFastPerformerValidationTest extends Abstrac
         readSourceFiles(timeseriesPaths, Collections.emptyList());
 
     // inner seq space compact
-    List<List<TsFileResource>> taskResources =
+    List<InnerSpaceCompactionTask> innerSpaceCompactionTasks =
         new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
             .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
-    for (List<TsFileResource> taskResource : taskResources) {
-      Assert.assertTrue(
-          new InnerSpaceCompactionTask(
-                  0,
-                  tsFileManager,
-                  taskResource,
-                  true,
-                  new FastCompactionPerformer(false),
-                  new AtomicInteger(0),
-                  0L)
-              .start());
+    for (InnerSpaceCompactionTask task : innerSpaceCompactionTasks) {
+      Assert.assertTrue(task.start());
     }
 
     // select cross compaction
@@ -2684,20 +2648,11 @@ public class CrossSpaceCompactionWithFastPerformerValidationTest extends Abstrac
         readSourceFiles(timeseriesPaths, Collections.emptyList());
 
     // inner seq space compact
-    List<List<TsFileResource>> taskResources =
+    List<InnerSpaceCompactionTask> innerSpaceCompactionTasks =
         new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
             .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
-    for (List<TsFileResource> taskResource : taskResources) {
-      Assert.assertTrue(
-          new InnerSpaceCompactionTask(
-                  0,
-                  tsFileManager,
-                  taskResource,
-                  true,
-                  new FastCompactionPerformer(false),
-                  new AtomicInteger(0),
-                  0L)
-              .start());
+    for (InnerSpaceCompactionTask task : innerSpaceCompactionTasks) {
+      Assert.assertTrue(task.start());
     }
 
     // select cross compaction
@@ -2772,20 +2727,11 @@ public class CrossSpaceCompactionWithFastPerformerValidationTest extends Abstrac
         readSourceFiles(timeseriesPaths, Collections.emptyList());
 
     // inner seq space compact
-    List<List<TsFileResource>> taskResources =
+    List<InnerSpaceCompactionTask> innerSpaceCompactionTasks =
         new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
             .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
-    for (List<TsFileResource> taskResource : taskResources) {
-      Assert.assertTrue(
-          new InnerSpaceCompactionTask(
-                  0,
-                  tsFileManager,
-                  taskResource,
-                  true,
-                  new FastCompactionPerformer(false),
-                  new AtomicInteger(0),
-                  0L)
-              .start());
+    for (InnerSpaceCompactionTask task : innerSpaceCompactionTasks) {
+      Assert.assertTrue(task.start());
     }
 
     // select cross compaction
@@ -2861,20 +2807,11 @@ public class CrossSpaceCompactionWithFastPerformerValidationTest extends Abstrac
         readSourceFiles(timeseriesPaths, Collections.emptyList());
 
     // inner seq space compact
-    List<List<TsFileResource>> taskResources =
+    List<InnerSpaceCompactionTask> innerSpaceCompactionTasks =
         new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
             .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
-    for (List<TsFileResource> taskResource : taskResources) {
-      Assert.assertTrue(
-          new InnerSpaceCompactionTask(
-                  0,
-                  tsFileManager,
-                  taskResource,
-                  true,
-                  new FastCompactionPerformer(false),
-                  new AtomicInteger(0),
-                  0L)
-              .start());
+    for (InnerSpaceCompactionTask task : innerSpaceCompactionTasks) {
+      Assert.assertTrue(task.start());
     }
 
     // select cross compaction
@@ -2951,20 +2888,11 @@ public class CrossSpaceCompactionWithFastPerformerValidationTest extends Abstrac
         readSourceFiles(timeseriesPaths, Collections.emptyList());
 
     // inner seq space compact
-    List<List<TsFileResource>> taskResources =
+    List<InnerSpaceCompactionTask> innerSpaceCompactionTasks =
         new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
             .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
-    for (List<TsFileResource> taskResource : taskResources) {
-      Assert.assertTrue(
-          new InnerSpaceCompactionTask(
-                  0,
-                  tsFileManager,
-                  taskResource,
-                  true,
-                  new FastCompactionPerformer(false),
-                  new AtomicInteger(0),
-                  0L)
-              .start());
+    for (InnerSpaceCompactionTask task : innerSpaceCompactionTasks) {
+      Assert.assertTrue(task.start());
     }
 
     // select cross compaction

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/cross/CrossSpaceCompactionWithReadPointPerformerValidationTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/cross/CrossSpaceCompactionWithReadPointPerformerValidationTest.java
@@ -2199,19 +2199,11 @@ public class CrossSpaceCompactionWithReadPointPerformerValidationTest
         readSourceFiles(timeseriesPaths, Collections.emptyList());
 
     // inner seq space compact
-    List<List<TsFileResource>> taskResources =
+    List<InnerSpaceCompactionTask> innerSpaceCompactionTasks =
         new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
             .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
-    for (List<TsFileResource> taskResource : taskResources) {
-      new InnerSpaceCompactionTask(
-              0,
-              tsFileManager,
-              taskResource,
-              true,
-              new ReadPointCompactionPerformer(),
-              new AtomicInteger(0),
-              0L)
-          .start();
+    for (InnerSpaceCompactionTask task : innerSpaceCompactionTasks) {
+      task.start();
     }
 
     // select cross compaction
@@ -2280,19 +2272,11 @@ public class CrossSpaceCompactionWithReadPointPerformerValidationTest
         readSourceFiles(timeseriesPaths, Collections.emptyList());
 
     // inner seq space compact
-    List<List<TsFileResource>> taskResources =
+    List<InnerSpaceCompactionTask> innerSpaceCompactionTasks =
         new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
             .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
-    for (List<TsFileResource> taskResource : taskResources) {
-      new InnerSpaceCompactionTask(
-              0,
-              tsFileManager,
-              taskResource,
-              true,
-              new ReadPointCompactionPerformer(),
-              new AtomicInteger(0),
-              0L)
-          .start();
+    for (InnerSpaceCompactionTask task : innerSpaceCompactionTasks) {
+      task.start();
     }
 
     // select cross compaction
@@ -2362,19 +2346,11 @@ public class CrossSpaceCompactionWithReadPointPerformerValidationTest
         readSourceFiles(timeseriesPaths, Collections.emptyList());
 
     // inner seq space compact
-    List<List<TsFileResource>> taskResources =
+    List<InnerSpaceCompactionTask> innerSpaceCompactionTasks =
         new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
             .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
-    for (List<TsFileResource> taskResource : taskResources) {
-      new InnerSpaceCompactionTask(
-              0,
-              tsFileManager,
-              taskResource,
-              true,
-              new ReadPointCompactionPerformer(),
-              new AtomicInteger(0),
-              0L)
-          .start();
+    for (InnerSpaceCompactionTask task : innerSpaceCompactionTasks) {
+      task.start();
     }
 
     // select cross compaction
@@ -2445,19 +2421,11 @@ public class CrossSpaceCompactionWithReadPointPerformerValidationTest
         readSourceFiles(timeseriesPaths, Collections.emptyList());
 
     // inner seq space compact
-    List<List<TsFileResource>> taskResources =
+    List<InnerSpaceCompactionTask> innerSpaceCompactionTasks =
         new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
             .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
-    for (List<TsFileResource> taskResource : taskResources) {
-      new InnerSpaceCompactionTask(
-              0,
-              tsFileManager,
-              taskResource,
-              true,
-              new ReadPointCompactionPerformer(),
-              new AtomicInteger(0),
-              0L)
-          .start();
+    for (InnerSpaceCompactionTask task : innerSpaceCompactionTasks) {
+      task.start();
     }
 
     // select cross compaction
@@ -2534,19 +2502,11 @@ public class CrossSpaceCompactionWithReadPointPerformerValidationTest
         readSourceFiles(timeseriesPaths, Collections.emptyList());
 
     // inner seq space compact
-    List<List<TsFileResource>> taskResources =
+    List<InnerSpaceCompactionTask> innerSpaceCompactionTasks =
         new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
             .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
-    for (List<TsFileResource> taskResource : taskResources) {
-      new InnerSpaceCompactionTask(
-              0,
-              tsFileManager,
-              taskResource,
-              true,
-              new ReadPointCompactionPerformer(),
-              new AtomicInteger(0),
-              0L)
-          .start();
+    for (InnerSpaceCompactionTask task : innerSpaceCompactionTasks) {
+      task.start();
     }
 
     // select cross compaction
@@ -2622,19 +2582,11 @@ public class CrossSpaceCompactionWithReadPointPerformerValidationTest
         readSourceFiles(timeseriesPaths, Collections.emptyList());
 
     // inner seq space compact
-    List<List<TsFileResource>> taskResources =
+    List<InnerSpaceCompactionTask> innerSpaceCompactionTasks =
         new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
             .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
-    for (List<TsFileResource> taskResource : taskResources) {
-      new InnerSpaceCompactionTask(
-              0,
-              tsFileManager,
-              taskResource,
-              true,
-              new ReadPointCompactionPerformer(),
-              new AtomicInteger(0),
-              0L)
-          .start();
+    for (InnerSpaceCompactionTask task : innerSpaceCompactionTasks) {
+      task.start();
     }
 
     // select cross compaction
@@ -2711,19 +2663,11 @@ public class CrossSpaceCompactionWithReadPointPerformerValidationTest
         readSourceFiles(timeseriesPaths, Collections.emptyList());
 
     // inner seq space compact
-    List<List<TsFileResource>> taskResources =
+    List<InnerSpaceCompactionTask> innerSpaceCompactionTasks =
         new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
             .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
-    for (List<TsFileResource> taskResource : taskResources) {
-      new InnerSpaceCompactionTask(
-              0,
-              tsFileManager,
-              taskResource,
-              true,
-              new ReadPointCompactionPerformer(),
-              new AtomicInteger(0),
-              0L)
-          .start();
+    for (InnerSpaceCompactionTask task : innerSpaceCompactionTasks) {
+      task.start();
     }
 
     // select cross compaction
@@ -2801,19 +2745,11 @@ public class CrossSpaceCompactionWithReadPointPerformerValidationTest
         readSourceFiles(timeseriesPaths, Collections.emptyList());
 
     // inner seq space compact
-    List<List<TsFileResource>> taskResources =
+    List<InnerSpaceCompactionTask> innerSpaceCompactionTasks =
         new SizeTieredCompactionSelector(COMPACTION_TEST_SG, "0", 0, true, tsFileManager)
             .selectInnerSpaceTask(tsFileManager.getOrCreateSequenceListByTimePartition(0));
-    for (List<TsFileResource> taskResource : taskResources) {
-      new InnerSpaceCompactionTask(
-              0,
-              tsFileManager,
-              taskResource,
-              true,
-              new ReadChunkCompactionPerformer(),
-              new AtomicInteger(0),
-              0L)
-          .start();
+    for (InnerSpaceCompactionTask task : innerSpaceCompactionTasks) {
+      task.start();
     }
 
     // select cross compaction

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/inner/InnerSpaceCompactionSelectorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/inner/InnerSpaceCompactionSelectorTest.java
@@ -85,11 +85,14 @@ public class InnerSpaceCompactionSelectorTest extends AbstractCompactionTest {
                     new SizeTieredCompactionSelector("", "", 0, true, tsFileManager);
                 List<TsFileResource> resources =
                     tsFileManager.getOrCreateSequenceListByTimePartition(0);
-                List<List<TsFileResource>> taskResource = selector.selectInnerSpaceTask(resources);
-                if (taskResource.size() != 2) {
+                List<InnerSpaceCompactionTask> innerSpaceCompactionTasks =
+                    selector.selectInnerSpaceTask(resources);
+                if (innerSpaceCompactionTasks.size() != 2) {
                   throw new RuntimeException("task num is not 2");
                 }
-                if (taskResource.get(0).size() != 2 || taskResource.get(1).size() != 2) {
+                if (innerSpaceCompactionTasks.get(0).getSelectedTsFileResourceList().size() != 2
+                    || innerSpaceCompactionTasks.get(1).getSelectedTsFileResourceList().size()
+                        != 2) {
                   throw new RuntimeException("selected file num is not 2");
                 }
               } catch (Exception e) {
@@ -147,18 +150,20 @@ public class InnerSpaceCompactionSelectorTest extends AbstractCompactionTest {
                 // copy candidate source file list
                 List<TsFileResource> resources =
                     tsFileManager.getOrCreateSequenceListByTimePartition(0);
-                List<List<TsFileResource>> taskResource = selector.selectInnerSpaceTask(resources);
+                List<InnerSpaceCompactionTask> innerSpaceCompactionTasks =
+                    selector.selectInnerSpaceTask(resources);
 
                 // the other thread holds write lock and delete files successfully before setting
                 // status to COMPACTION_CANDIDATE
                 cd1.countDown();
                 cd2.await();
 
-                if (taskResource.size() != 3) {
+                if (innerSpaceCompactionTasks.size() != 3) {
                   throw new RuntimeException("task num is not 3");
                 }
-                for (int idx = 0; idx < taskResource.size(); idx++) {
-                  List<TsFileResource> task = taskResource.get(idx);
+                for (int idx = 0; idx < innerSpaceCompactionTasks.size(); idx++) {
+                  List<TsFileResource> task =
+                      innerSpaceCompactionTasks.get(idx).getSelectedTsFileResourceList();
                   if (task.size() != 2) {
                     throw new RuntimeException("selected file num is not 2");
                   }
@@ -252,13 +257,14 @@ public class InnerSpaceCompactionSelectorTest extends AbstractCompactionTest {
                 // copy candidate source file list
                 List<TsFileResource> resources =
                     tsFileManager.getOrCreateSequenceListByTimePartition(0);
-                List<List<TsFileResource>> taskResource = selector.selectInnerSpaceTask(resources);
+                List<InnerSpaceCompactionTask> taskResource =
+                    selector.selectInnerSpaceTask(resources);
 
                 if (taskResource.size() != 3) {
                   throw new RuntimeException("task num is not 3");
                 }
                 for (int idx = 0; idx < taskResource.size(); idx++) {
-                  List<TsFileResource> task = taskResource.get(idx);
+                  List<TsFileResource> task = taskResource.get(idx).getSelectedTsFileResourceList();
                   if (task.size() != 2) {
                     throw new RuntimeException("selected file num is not 2");
                   }
@@ -366,11 +372,14 @@ public class InnerSpaceCompactionSelectorTest extends AbstractCompactionTest {
                     new SizeTieredCompactionSelector("", "", 0, true, tsFileManager);
                 List<TsFileResource> resources =
                     tsFileManager.getOrCreateSequenceListByTimePartition(0);
-                List<List<TsFileResource>> taskResource = selector.selectInnerSpaceTask(resources);
-                if (taskResource.size() != 2) {
+                List<InnerSpaceCompactionTask> innerSpaceCompactionTasks =
+                    selector.selectInnerSpaceTask(resources);
+                if (innerSpaceCompactionTasks.size() != 2) {
                   throw new RuntimeException("task num is not 2");
                 }
-                if (taskResource.get(0).size() != 2 || taskResource.get(1).size() != 2) {
+                if (innerSpaceCompactionTasks.get(0).getSelectedTsFileResourceList().size() != 2
+                    || innerSpaceCompactionTasks.get(1).getSelectedTsFileResourceList().size()
+                        != 2) {
                   throw new RuntimeException("selected file num is not 2");
                 }
               } catch (Exception e) {
@@ -432,18 +441,20 @@ public class InnerSpaceCompactionSelectorTest extends AbstractCompactionTest {
                 // copy candidate source file list
                 List<TsFileResource> resources =
                     tsFileManager.getOrCreateSequenceListByTimePartition(0);
-                List<List<TsFileResource>> taskResource = selector.selectInnerSpaceTask(resources);
+                List<InnerSpaceCompactionTask> innerSpaceCompactionTasks =
+                    selector.selectInnerSpaceTask(resources);
 
                 // the other thread holds write lock and delete files successfully before setting
                 // status to COMPACTION_CANDIDATE
                 cd1.countDown();
                 cd2.await();
 
-                if (taskResource.size() != 3) {
+                if (innerSpaceCompactionTasks.size() != 3) {
                   throw new RuntimeException("task num is not 3");
                 }
-                for (int idx = 0; idx < taskResource.size(); idx++) {
-                  List<TsFileResource> task = taskResource.get(idx);
+                for (int idx = 0; idx < innerSpaceCompactionTasks.size(); idx++) {
+                  List<TsFileResource> task =
+                      innerSpaceCompactionTasks.get(idx).getSelectedTsFileResourceList();
                   if (task.size() != 2) {
                     throw new RuntimeException("selected file num is not 2");
                   }
@@ -540,13 +551,15 @@ public class InnerSpaceCompactionSelectorTest extends AbstractCompactionTest {
                 // copy candidate source file list
                 List<TsFileResource> resources =
                     tsFileManager.getOrCreateSequenceListByTimePartition(0);
-                List<List<TsFileResource>> taskResource = selector.selectInnerSpaceTask(resources);
+                List<InnerSpaceCompactionTask> innerSpaceCompactionTasks =
+                    selector.selectInnerSpaceTask(resources);
 
-                if (taskResource.size() != 3) {
+                if (innerSpaceCompactionTasks.size() != 3) {
                   throw new RuntimeException("task num is not 3");
                 }
-                for (int idx = 0; idx < taskResource.size(); idx++) {
-                  List<TsFileResource> task = taskResource.get(idx);
+                for (int idx = 0; idx < innerSpaceCompactionTasks.size(); idx++) {
+                  List<TsFileResource> task =
+                      innerSpaceCompactionTasks.get(idx).getSelectedTsFileResourceList();
                   if (task.size() != 2) {
                     throw new RuntimeException("selected file num is not 2");
                   }
@@ -652,8 +665,9 @@ public class InnerSpaceCompactionSelectorTest extends AbstractCompactionTest {
         new SizeTieredCompactionSelector("", "", 0, true, tsFileManager);
     // copy candidate source file list
     List<TsFileResource> resources = tsFileManager.getOrCreateSequenceListByTimePartition(0);
-    List<List<TsFileResource>> taskResource = selector.selectInnerSpaceTask(resources);
-    Assert.assertEquals(1, taskResource.size());
+    List<InnerSpaceCompactionTask> innerSpaceCompactionTasks =
+        selector.selectInnerSpaceTask(resources);
+    Assert.assertEquals(1, innerSpaceCompactionTasks.size());
     modFile.remove();
   }
 }


### PR DESCRIPTION
## Description
This PR mainly has the following upgrades:
1. Added the selection criteria for merging tasks in the space. When the availability of disk space is insufficient, TsFile containing mods file is preferentially selected.
2. Compaction adds the CompactionTaskType attribute to a task and compacts the task to `NORMAL` and `MOD_SETTLE`. `NORMAL` is the default value. When the disk size of the mod file exceeds 50M or the disk space availability is insufficient, the mods file sorting task is preferred. In this case, the task type is `MOD_SETTLE`. When a task is executed, the system determines the disk space availability. If the task type is `NORMAL` and the disk space availability is insufficient, the task is discarded from the priority queue to avoid unexpected errors.
3. Optimized the return value of the `selectInnerSpaceTask()` method. The previous return value was not convenient to wrap the CompactionTask object, so we made the logic of this method more pure, the purpose is to return a list of tasks that can be executed, which can be put directly into the task queue or directly executed.
4. Remove the priority queue in the in-space selection step. The `CompactionTaskManager` priority queue already contains all the priority decisions, so the priority queue in the selection stage is meaningless.