### PR TITLE
[ISSUE-11199] Pipe: fix NPE when casting from null values in InsertRowNode deserialization

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/IoTDBPipeDataSyncIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/IoTDBPipeDataSyncIT.java
@@ -129,4 +129,66 @@ public class IoTDBPipeDataSyncIT {
       }
     }
   }
+
+  @Test
+  public void testInsertNull() throws Exception {
+    DataNodeWrapper receiverDataNode = receiverEnv.getDataNodeWrapper(0);
+
+    String receiverIp = receiverDataNode.getIp();
+    int receiverPort = receiverDataNode.getPort();
+
+    try (SyncConfigNodeIServiceClient client =
+        (SyncConfigNodeIServiceClient) senderEnv.getLeaderConfigNodeConnection()) {
+      Map<String, String> extractorAttributes = new HashMap<>();
+      Map<String, String> processorAttributes = new HashMap<>();
+      Map<String, String> connectorAttributes = new HashMap<>();
+
+      connectorAttributes.put("connector", "iotdb-thrift-connector");
+      connectorAttributes.put("connector.ip", receiverIp);
+      connectorAttributes.put("connector.port", Integer.toString(receiverPort));
+
+      TSStatus status =
+          client.createPipe(
+              new TCreatePipeReq("testPipe", connectorAttributes)
+                  .setExtractorAttributes(extractorAttributes)
+                  .setProcessorAttributes(processorAttributes));
+
+      Assert.assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), status.getCode());
+
+      Assert.assertEquals(
+          TSStatusCode.SUCCESS_STATUS.getStatusCode(), client.startPipe("testPipe").getCode());
+
+      try (Connection connection = receiverEnv.getConnection();
+          Statement statement = connection.createStatement()) {
+        statement.execute("create aligned timeseries root.sg.d1(s0 float, s1 float)");
+      } catch (SQLException e) {
+        e.printStackTrace();
+        fail(e.getMessage());
+      }
+
+      try (Connection connection = senderEnv.getConnection();
+          Statement statement = connection.createStatement()) {
+        statement.execute("create aligned timeseries root.sg.d1(s0 float, s1 float)");
+        statement.execute("insert into root.sg.d1(time, s0, s1) values (3, null, 25.34)");
+      } catch (SQLException e) {
+        e.printStackTrace();
+        fail(e.getMessage());
+      }
+
+      try (Connection connection = receiverEnv.getConnection();
+          Statement statement = connection.createStatement()) {
+        await()
+            .atMost(600, TimeUnit.SECONDS)
+            .untilAsserted(
+                () ->
+                    TestUtils.assertResultSetEqual(
+                        statement.executeQuery("select * from root.**"),
+                        "Time,root.sg.d1.s0,root.sg.d1.s1,",
+                        Collections.singleton("3,null,25.34,")));
+      } catch (Exception e) {
+        e.printStackTrace();
+        fail(e.getMessage());
+      }
+    }
+  }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/CommonUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/CommonUtils.java
@@ -38,6 +38,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 @SuppressWarnings("java:S106") // for console outputs
 public class CommonUtils {
@@ -110,6 +111,9 @@ public class CommonUtils {
   }
 
   public static boolean checkCanCastType(TSDataType src, TSDataType dest) {
+    if (Objects.isNull(src)) {
+      return true;
+    }
     switch (src) {
       case INT32:
         if (dest == TSDataType.INT64 || dest == TSDataType.FLOAT || dest == TSDataType.DOUBLE) {
@@ -128,6 +132,9 @@ public class CommonUtils {
   }
 
   public static Object castValue(TSDataType srcDataType, TSDataType destDataType, Object value) {
+    if (Objects.isNull(value)) {
+      return null;
+    }
     switch (srcDataType) {
       case INT32:
         if (destDataType == TSDataType.INT64) {


### PR DESCRIPTION
## Description

Fix https://github.com/apache/iotdb/issues/11199, allow casting from null when deserializing InsertRowNode.

---

For this insert statement:

```sql
insert into root.sg.d1(time, s0, s1) values (3, null, 25.34);
```

The source-side pipe stream processing engine will convert it into the following RPC sent to the target-side:

```
TPipeTransferReq(version:1, type:6, body:[0, 0, 0, 0, 0, 0, 0, 1, 0, 14, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 10, 114, 111, 111, 116, 46, 115, 103, 46, 100, 49, 0, 0, 0, 2, 1, 0, 0, 0, 2, 115, 48, 3, 8, 7, 0, 0, 0, 0, 0, 0, 0, 2, 115, 49, 3, 8, 7, 0, 0, 0, 0, -2, 3, 65, -54, -72, 82, 0, 1, 0, 0, 0, 1, 49, 0, 0, 0, 0, 0, 0, 0, 0])
```

The focus here is on the deserialization logic of its `body`.

The deserialization logic is in `org.apache.iotdb.db.pipe.connector.payload.evolvable.request.PipeTransferTabletBatchReq#fromTPipeTransferReq`.

| binary                                                     | explanation            | remark        |
| ---------------------------------------------------------- | ---------------------- | ------------- |
| 0, 0, 0, 0                                                 | binary reqs size       |               |
| 0, 0, 0, 1                                                 | insert node reqs size  |               |
| 0, 14                                                      | plan node type         | InsertRowNode |
| 0, 0, 0, 0, 0, 0, 0, 3                                     | time                   |               |
| 0, 0, 0, 10, 114, 111, 111, 116, 46, 115, 103, 46, 100, 49 | device path            | `root.sg.d1`  |
| 0, 0, 0, 2                                                 | measurement size       |               |
| 1                                                          | has schema             |               |
| 0, 0, 0, 2, 115, 48                                        | first measurement      | `s0`          |
| 3                                                          | measurement type       | float         |
| 8                                                          | measurement encoding   | gorilla       |
| 7                                                          | measurement compressor | lz4           |
| 0, 0, 0, 0                                                 | measurement props size |               |
| 0, 0, 0, 2, 115, 49                                        | second measurement     | `s1`          |
| 3                                                          | measurement type       | float         |
| 8                                                          | measurement encoding   | gorilla       |
| 7                                                          | measurement compressor | lz4           |
| 0, 0, 0, 0                                                 | measurement props size |               |
| -2                                                         | first value type       | **null**      |
| 3                                                          | second value type      | float         |
| 65, -54, -72, 82                                           | second value           | 25.34         |
| 0                                                          | is need infer type     | false         |
| 1                                                          | is aligned             | true          |
| 0, 0, 0, 1, 49                                             | plan node id           | `1`           |
| 0, 0, 0, 0                                                 | child count            |               |
| 0, 0, 0, 0                                                 | tablet reqs size       |               |

So, it can be observed that after deserialization, the `InsertRowStatement` object has `dataTypes` member with values of `[null, TSDataType.FLOAT]`. This leads to a NullPointerException in `org.apache.iotdb.db.utils.CommonUtils#checkCanCastType`. Similarly, the `values` member has values of `[null, 25.34]`, also leads to NPE in `org.apache.iotdb.db.utils.CommonUtils#castValue`.

One natural idea is to check in `checkCanCastType` and `castValue` whether the source type or source value is null. If so, allow further deserialization (i.e., pass type checking or return a null value).

Since the utility methods `checkCanCastType` and `castValue` appear to be used only by `InsertRowStatement` and `InsertTabletStatement`, the logic changes resulting from the above modification are manageable.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [x] added integration tests.
- [x] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
