### PR TITLE
Manipulate series of Audit and IoTDB reporter as super user

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/audit/AuditLogger.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/audit/AuditLogger.java
@@ -21,12 +21,14 @@ package org.apache.iotdb.db.audit;
 
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.IllegalPathException;
+import org.apache.iotdb.db.auth.AuthorityChecker;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.protocol.session.ClientSession;
 import org.apache.iotdb.db.protocol.session.IClientSession;
 import org.apache.iotdb.db.protocol.session.SessionManager;
+import org.apache.iotdb.db.queryengine.common.SessionInfo;
 import org.apache.iotdb.db.queryengine.plan.Coordinator;
 import org.apache.iotdb.db.queryengine.plan.analyze.ClusterPartitionFetcher;
 import org.apache.iotdb.db.queryengine.plan.analyze.cache.schema.DataNodeDevicePathCache;
@@ -43,6 +45,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.validation.constraints.NotNull;
 
+import java.time.ZoneId;
 import java.util.List;
 
 import static org.apache.iotdb.db.pipe.receiver.legacy.loader.ILoader.SCHEMA_FETCHER;
@@ -59,6 +62,8 @@ public class AuditLogger {
   private static final Coordinator COORDINATOR = Coordinator.getInstance();
   private static final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
   private static final List<AuditLogStorage> auditLogStorageList = config.getAuditLogStorage();
+  private static final SessionInfo sessionInfo =
+      new SessionInfo(0, AuthorityChecker.SUPER_USER, ZoneId.systemDefault().getId());
 
   private static final List<AuditLogOperation> auditLogOperationList =
       config.getAuditLogOperation();
@@ -108,7 +113,7 @@ public class AuditLogger {
           COORDINATOR.execute(
               generateInsertStatement(log, address, username),
               SESSION_MANAGER.requestQueryId(),
-              SESSION_MANAGER.getSessionInfo(SESSION_MANAGER.getCurrSession()),
+              sessionInfo,
               "",
               ClusterPartitionFetcher.getInstance(),
               SCHEMA_FETCHER);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/metrics/IoTDBInternalLocalReporter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/metrics/IoTDBInternalLocalReporter.java
@@ -29,6 +29,7 @@ import org.apache.iotdb.commons.schema.SchemaConstant;
 import org.apache.iotdb.confignode.rpc.thrift.TDatabaseSchema;
 import org.apache.iotdb.confignode.rpc.thrift.TGetDatabaseReq;
 import org.apache.iotdb.confignode.rpc.thrift.TShowDatabaseResp;
+import org.apache.iotdb.db.auth.AuthorityChecker;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.protocol.client.ConfigNodeClient;
 import org.apache.iotdb.db.protocol.client.ConfigNodeClientManager;
@@ -81,7 +82,7 @@ public class IoTDBInternalLocalReporter extends IoTDBInternalReporter {
   public IoTDBInternalLocalReporter() {
     partitionFetcher = ClusterPartitionFetcher.getInstance();
     schemaFetcher = ClusterSchemaFetcher.getInstance();
-    sessionInfo = new SessionInfo(0, "root", ZoneId.systemDefault().getId());
+    sessionInfo = new SessionInfo(0, AuthorityChecker.SUPER_USER, ZoneId.systemDefault().getId());
 
     IClientManager<ConfigRegionId, ConfigNodeClient> configNodeClientManager =
         ConfigNodeClientManager.getInstance();


### PR DESCRIPTION
Fix reason: 
1. If we manipulate series of audit as a common user, it will be rejected because of no permission;
![img_v2_6cfc5ffa-4008-4f2d-858e-ae6ddc0aa34g](https://github.com/apache/iotdb/assets/60659567/df15c01a-225f-4d8a-a2ac-7feec43bcdf0)
2. We need to get the name of super user from Config.

Fix verify:
<img width="1269" alt="image" src="https://github.com/apache/iotdb/assets/60659567/ffe5c281-fe93-4555-be21-98685d9ff8ea">
<img width="1269" alt="image" src="https://github.com/apache/iotdb/assets/60659567/e29c71ec-4749-44f6-9083-45d9f25f8244">
