### PR TITLE
[IoTDB-6172] Finish canAddTsBlock of SharedTsBlockQueue to ensure that blocked Driver could be correctly finished

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/exchange/SharedTsBlockQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/exchange/SharedTsBlockQueue.java
@@ -269,6 +269,9 @@ public class SharedTsBlockQueue {
     if (!blocked.isDone()) {
       blocked.set(null);
     }
+    if (!canAddTsBlock.isDone()) {
+      canAddTsBlock.set(null);
+    }
     if (blockedOnMemory != null) {
       bufferRetainedSizeInBytes -= localMemoryManager.getQueryPool().tryCancel(blockedOnMemory);
     }
@@ -305,6 +308,9 @@ public class SharedTsBlockQueue {
     if (!blocked.isDone()) {
       blocked.cancel(true);
     }
+    if (!canAddTsBlock.isDone()) {
+      canAddTsBlock.set(null);
+    }
     if (blockedOnMemory != null) {
       bufferRetainedSizeInBytes -= localMemoryManager.getQueryPool().tryCancel(blockedOnMemory);
     }
@@ -329,6 +335,9 @@ public class SharedTsBlockQueue {
     closed = true;
     if (!blocked.isDone()) {
       blocked.setException(t);
+    }
+    if (!canAddTsBlock.isDone()) {
+      canAddTsBlock.set(null);
     }
     if (blockedOnMemory != null) {
       bufferRetainedSizeInBytes -= localMemoryManager.getQueryPool().tryCancel(blockedOnMemory);


### PR DESCRIPTION
The blocked future of LocalSinkChannel is done when its downstream LocalSourceHandle asks it for data. In query with limit clause, it is possible that a Driver is blocked because its ISink is blocked. When the query finishes, we should ensure that the blocked Drivers can be waken and then be finished correctly.