### PR TITLE
upgrade compression ratio file name format and solve the problem of high compression ratio caused by repeated data writing

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/flush/CompressionRatio.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/flush/CompressionRatio.java
@@ -152,11 +152,7 @@ public class CompressionRatio {
           "After restoring from compression ratio file, total memory size = {}, total disk size = {}",
           totalMemorySize,
           totalDiskSize);
-      for (int i = 0; i < ratioFiles.length; i++) {
-        if (i != maxRatioIndex) {
-          Files.delete(ratioFiles[i].toPath());
-        }
-      }
+      deleteRedundantFilesByIndex(ratioFiles, maxRatioIndex);
     } else { // If there is no new file, try to restore from the old version file
       File[] ratioFilesBeforeV121 =
           directory.listFiles((dir, name) -> name.startsWith(FILE_PREFIX_BEFORE_V121));
@@ -172,11 +168,15 @@ public class CompressionRatio {
             maxRatioIndex = i;
           }
         }
-        for (int i = 0; i < ratioFilesBeforeV121.length; i++) {
-          if (i != maxRatioIndex) {
-            Files.delete(ratioFilesBeforeV121[i].toPath());
-          }
-        }
+        deleteRedundantFilesByIndex(ratioFilesBeforeV121, maxRatioIndex);
+      }
+    }
+  }
+
+  public static void deleteRedundantFilesByIndex(File[] files, int index) throws IOException {
+    for (int i = 0; i < files.length; i++) {
+      if (i != index) {
+        Files.delete(files[i].toPath());
       }
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
@@ -1329,7 +1329,7 @@ public class TsFileProcessor {
       String dataRegionId = dataRegionInfo.getDataRegion().getDataRegionId();
       WritingMetrics.getInstance()
           .recordTsFileCompressionRatioOfFlushingMemTable(dataRegionId, compressionRatio);
-      CompressionRatio.getInstance().updateRatio(compressionRatio);
+      CompressionRatio.getInstance().updateRatio(totalMemTableSize, writer.getPos());
     } catch (IOException e) {
       logger.error(
           "{}: {} update compression ratio failed",

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/WritableMemChunk.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/WritableMemChunk.java
@@ -333,11 +333,10 @@ public class WritableMemChunk implements IWritableMemChunk {
 
       // skip duplicated data
       if ((sortedRowIndex + 1 < list.rowCount() && (time == list.getTime(sortedRowIndex + 1)))) {
-        boolean isTextDataType = tsDataType == TSDataType.TEXT;
         long recordSize =
             MemUtils.getRecordSize(
                 tsDataType,
-                isTextDataType ? list.getBinary(sortedRowIndex) : null,
+                tsDataType == TSDataType.TEXT ? list.getBinary(sortedRowIndex) : null,
                 CONFIG.isEnableMemControl());
         CompressionRatio.decreaseDuplicatedMemorySize(recordSize);
         continue;

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/flush/CompressionRatioTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/flush/CompressionRatioTest.java
@@ -62,7 +62,7 @@ public class CompressionRatioTest {
     long totalMemorySize = 10;
     long totalDiskSize = 5;
 
-    for (int i = 0; i < 5; i ++) {
+    for (int i = 0; i < 5; i++) {
       this.compressionRatio.updateRatio(10, 5);
       if (!new File(
               directory,


### PR DESCRIPTION
## Description
This PR has three optimizations:
1. The naming format of the compression Ratio file is changed from `Ratio-compressRatio-flushCount`to `ratio-totalMemoryDataSize-totalDiskDataSize`
2. The rule for calculating the compression ratio from the `sum(memTableSize/flushSize) / count(flushTimes)` to ` totalMemoryDataSize / totalDiskDataSize `
3. Add the `memTableSize` deduplication logic. If no deduplication is performed, the compression ratio calculated is very large, resulting in inaccurate estimation of the combined memory. Therefore, in flush encode, if data is duplicated, the size of the duplicate is removed from `memTableSize`.

## Snapshot
<img width="1294" alt="image" src="https://github.com/apache/iotdb/assets/34238279/d3e3e858-52fa-4930-aeb4-8fdfa94bd4e5">
