### PR TITLE
Pipe: fix drop pipe stuck (make connector subtask close faster by early returning)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/EnrichedEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/EnrichedEvent.java
@@ -95,6 +95,7 @@ public abstract class EnrichedEvent implements Event {
         }
       }
       referenceCount.decrementAndGet();
+      referenceCount.compareAndSet(-1, 0);
     }
     return isSuccessful;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/EnrichedEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/EnrichedEvent.java
@@ -27,6 +27,9 @@ import org.apache.iotdb.db.pipe.agent.PipeAgent;
 import org.apache.iotdb.db.pipe.config.constant.PipeExtractorConstant;
 import org.apache.iotdb.pipe.api.event.Event;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -34,6 +37,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  * additional information mainly includes the reference count of the event.
  */
 public abstract class EnrichedEvent implements Event {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(EnrichedEvent.class);
 
   private final AtomicInteger referenceCount;
 
@@ -94,8 +99,10 @@ public abstract class EnrichedEvent implements Event {
           reportProgress();
         }
       }
-      referenceCount.decrementAndGet();
-      referenceCount.compareAndSet(-1, 0);
+      final int newReferenceCount = referenceCount.decrementAndGet();
+      if (newReferenceCount < 0) {
+        LOGGER.warn("reference count is decreased to {}.", newReferenceCount);
+      }
     }
     return isSuccessful;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/connection/PipeEventCollector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/connection/PipeEventCollector.java
@@ -26,12 +26,15 @@ import org.apache.iotdb.pipe.api.event.Event;
 
 import java.util.Deque;
 import java.util.LinkedList;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class PipeEventCollector implements EventCollector, AutoCloseable {
 
   private final BoundedBlockingPendingQueue<Event> pendingQueue;
 
   private final Deque<Event> bufferQueue;
+
+  private final AtomicBoolean isClosed = new AtomicBoolean(false);
 
   public PipeEventCollector(BoundedBlockingPendingQueue<Event> pendingQueue) {
     this.pendingQueue = pendingQueue;
@@ -48,7 +51,7 @@ public class PipeEventCollector implements EventCollector, AutoCloseable {
       ((PipeHeartbeatEvent) event).recordConnectorQueueSize(pendingQueue);
     }
 
-    while (!bufferQueue.isEmpty()) {
+    while (!isClosed.get() && !bufferQueue.isEmpty()) {
       final Event bufferedEvent = bufferQueue.peek();
       // Try to put already buffered events into pending queue, if pending queue is full, wait for
       // pending queue to be available with timeout.
@@ -77,7 +80,7 @@ public class PipeEventCollector implements EventCollector, AutoCloseable {
    * @return true if there are still buffered events after this operation, false otherwise.
    */
   public synchronized boolean tryCollectBufferedEvents() {
-    while (!bufferQueue.isEmpty()) {
+    while (!isClosed.get() && !bufferQueue.isEmpty()) {
       final Event bufferedEvent = bufferQueue.peek();
       if (pendingQueue.waitedOffer(bufferedEvent)) {
         bufferQueue.poll();
@@ -88,7 +91,12 @@ public class PipeEventCollector implements EventCollector, AutoCloseable {
     return false;
   }
 
-  public synchronized void close() {
+  public void close() {
+    isClosed.set(true);
+    doClose();
+  }
+
+  private synchronized void doClose() {
     bufferQueue.forEach(
         event -> {
           if (event instanceof EnrichedEvent) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/PipeSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/PipeSubtask.java
@@ -113,6 +113,12 @@ public abstract class PipeSubtask
 
   @Override
   public void onFailure(@NotNull Throwable throwable) {
+    if (isClosed.get()) {
+      LOGGER.info("onFailure in pipe subtask, ignored because pipe is dropped.");
+      releaseLastEvent(false);
+      return;
+    }
+
     if (retryCount.get() == 0) {
       LOGGER.warn(
           "Failed to execute subtask {}({}), because of {}. Will retry for {} times.",

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/connector/PipeConnectorSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/connector/PipeConnectorSubtask.java
@@ -53,7 +53,6 @@ public class PipeConnectorSubtask extends PipeSubtask {
   // For input and output
   private final BoundedBlockingPendingQueue<Event> inputPendingQueue;
   private final PipeConnector outputPipeConnector;
-  // The lock will be held if subtask is transferring
 
   // For thread pool to execute callbacks
   protected final DecoratingLock callbackDecoratingLock = new DecoratingLock();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/connector/PipeConnectorSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/connector/PipeConnectorSubtask.java
@@ -244,8 +244,6 @@ public class PipeConnectorSubtask extends PipeSubtask {
   @Override
   public void close() {
     isClosed.set(true);
-    // If tryLock() fails, the connector subtask should be transferring now and will call doClose()
-    // after transfer complete. doClose() will be called at least once.
     try {
       outputPipeConnector.close();
     } catch (Exception e) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/connector/PipeConnectorSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/connector/PipeConnectorSubtask.java
@@ -125,6 +125,7 @@ public class PipeConnectorSubtask extends PipeSubtask {
       if (!isClosed.get()) {
         throw e;
       } else {
+        LOGGER.info("PipeConnectionException in pipe transfer, ignored because pipe is dropped.");
         releaseLastEvent(false);
       }
     } catch (Exception e) {
@@ -135,6 +136,7 @@ public class PipeConnectorSubtask extends PipeSubtask {
                 + "according to the pipe-api description.",
             e);
       } else {
+        LOGGER.info("Exception in pipe transfer, ignored because pipe is dropped.");
         releaseLastEvent(false);
       }
     }
@@ -145,6 +147,8 @@ public class PipeConnectorSubtask extends PipeSubtask {
   @Override
   public void onFailure(@NotNull Throwable throwable) {
     if (isClosed.get()) {
+      LOGGER.info("onFailure in pipe transfer, ignored because pipe is dropped.");
+      releaseLastEvent(false);
       return;
     }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/connector/PipeConnectorSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/connector/PipeConnectorSubtask.java
@@ -93,6 +93,7 @@ public class PipeConnectorSubtask extends PipeSubtask {
     if (isClosed.get()) {
       return false;
     }
+
     final Event event = lastEvent != null ? lastEvent : inputPendingQueue.waitedPoll();
     // Record this event for retrying on connection failure or other exceptions
     setLastEvent(event);
@@ -142,6 +143,7 @@ public class PipeConnectorSubtask extends PipeSubtask {
     if (isClosed.get()) {
       return;
     }
+
     // Retry to connect to the target system if the connection is broken
     if (throwable instanceof PipeConnectionException) {
       LOGGER.warn(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/connector/PipeConnectorSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/connector/PipeConnectorSubtask.java
@@ -124,6 +124,8 @@ public class PipeConnectorSubtask extends PipeSubtask {
     } catch (PipeConnectionException e) {
       if (!isClosed.get()) {
         throw e;
+      } else {
+        releaseLastEvent(false);
       }
     } catch (Exception e) {
       if (!isClosed.get()) {
@@ -132,6 +134,8 @@ public class PipeConnectorSubtask extends PipeSubtask {
                 + "whether the implementation of PipeConnector is correct "
                 + "according to the pipe-api description.",
             e);
+      } else {
+        releaseLastEvent(false);
       }
     }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/processor/PipeProcessorSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/processor/PipeProcessorSubtask.java
@@ -119,6 +119,7 @@ public class PipeProcessorSubtask extends PipeSubtask {
                 + "according to the pipe-api description.",
             e);
       } else {
+        LOGGER.info("Exception in pipe event processing, ignored because pipe is dropped.");
         releaseLastEvent(false);
       }
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/processor/PipeProcessorSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/processor/PipeProcessorSubtask.java
@@ -84,6 +84,7 @@ public class PipeProcessorSubtask extends PipeSubtask {
     if (isClosed.get()) {
       return false;
     }
+
     final Event event = lastEvent != null ? lastEvent : inputEventSupplier.supply();
     // Record the last event for retry when exception occurs
     setLastEvent(event);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/processor/PipeProcessorSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/processor/PipeProcessorSubtask.java
@@ -118,6 +118,8 @@ public class PipeProcessorSubtask extends PipeSubtask {
                 + "whether the implementation of PipeProcessor is correct "
                 + "according to the pipe-api description.",
             e);
+      } else {
+        releaseLastEvent(false);
       }
     }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/processor/PipeProcessorSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/processor/PipeProcessorSubtask.java
@@ -35,7 +35,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class PipeProcessorSubtask extends PipeSubtask {
@@ -49,8 +48,6 @@ public class PipeProcessorSubtask extends PipeSubtask {
   private final PipeProcessor pipeProcessor;
   private final PipeEventCollector outputEventCollector;
 
-  private final AtomicBoolean isClosed;
-
   public PipeProcessorSubtask(
       String taskID,
       EventSupplier inputEventSupplier,
@@ -60,7 +57,6 @@ public class PipeProcessorSubtask extends PipeSubtask {
     this.inputEventSupplier = inputEventSupplier;
     this.pipeProcessor = pipeProcessor;
     this.outputEventCollector = outputEventCollector;
-    isClosed = new AtomicBoolean(false);
   }
 
   @Override
@@ -84,10 +80,13 @@ public class PipeProcessorSubtask extends PipeSubtask {
   }
 
   @Override
-  protected synchronized boolean executeOnce() throws Exception {
+  protected boolean executeOnce() throws Exception {
+    if (isClosed.get()) {
+      return false;
+    }
     final Event event = lastEvent != null ? lastEvent : inputEventSupplier.supply();
     // Record the last event for retry when exception occurs
-    lastEvent = event;
+    setLastEvent(event);
     if (event == null) {
       // Though there is no event to process, there may still be some buffered events
       // in the outputEventCollector. Return true if there are still buffered events,
@@ -112,11 +111,13 @@ public class PipeProcessorSubtask extends PipeSubtask {
 
       releaseLastEvent(true);
     } catch (Exception e) {
-      throw new PipeException(
-          "Error occurred during executing PipeProcessor#process, perhaps need to check "
-              + "whether the implementation of PipeProcessor is correct "
-              + "according to the pipe-api description.",
-          e);
+      if (!isClosed.get()) {
+        throw new PipeException(
+            "Error occurred during executing PipeProcessor#process, perhaps need to check "
+                + "whether the implementation of PipeProcessor is correct "
+                + "according to the pipe-api description.",
+            e);
+      }
     }
 
     return true;
@@ -130,10 +131,7 @@ public class PipeProcessorSubtask extends PipeSubtask {
   }
 
   @Override
-  // synchronized for pipeProcessor.close() and releaseLastEvent() in super.close().
-  // make sure that the lastEvent will not be updated after pipeProcessor.close() to avoid
-  // resource leak because of the lastEvent is not released.
-  public synchronized void close() {
+  public void close() {
     try {
       isClosed.set(true);
 


### PR DESCRIPTION
If we drop a pipe when it is transferring a large TsFile, the "drop pipe" statement will stuck for a while, until the TsFile is fully transferred or the query times out. This PR will make connector subtask close faster by early returning.