### PR TITLE
Fix the data scan ordering when executing last query

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/Analysis.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/Analysis.java
@@ -210,8 +210,7 @@ public class Analysis {
   // timeseries, otherwise it will be null
   private Ordering timeseriesOrderingForLastQuery = null;
 
-  // Used to store view expression in last query which is non-writable
-  private Set<Expression> lastQueryNonWritableViewExpressions;
+  // Key: non-writable view expression, Value: corresponding source expressions
   private Map<Expression, List<Expression>> lastQueryNonWritableViewSourceExpressionMap;
 
   private Set<Expression> lastQueryBaseExpressions;
@@ -741,15 +740,6 @@ public class Analysis {
 
   public void setLastQueryBaseExpressions(Set<Expression> lastQueryBaseExpressions) {
     this.lastQueryBaseExpressions = lastQueryBaseExpressions;
-  }
-
-  public Set<Expression> getLastQueryNonWritableViewExpressions() {
-    return this.lastQueryNonWritableViewExpressions;
-  }
-
-  public void setLastQueryNonWritableViewExpression(
-      Set<Expression> lastQueryNonWritableViewExpression) {
-    this.lastQueryNonWritableViewExpressions = lastQueryNonWritableViewExpression;
   }
 
   public Map<Expression, List<Expression>> getLastQueryNonWritableViewSourceExpressionMap() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
@@ -497,7 +497,6 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       Analysis analysis, List<Expression> selectExpressions, ISchemaTree schemaTree) {
     Set<Expression> sourceExpressions = new LinkedHashSet<>();
     Set<Expression> lastQueryBaseExpressions = new LinkedHashSet<>();
-    Set<Expression> lastQueryNonWritableViewExpressions = null;
     Map<Expression, List<Expression>> lastQueryNonWritableViewSourceExpressionMap = null;
 
     for (Expression selectExpression : selectExpressions) {
@@ -507,13 +506,11 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
           lastQueryBaseExpressions.add(lastQuerySourceExpression);
           sourceExpressions.add(lastQuerySourceExpression);
         } else {
-          if (lastQueryNonWritableViewExpressions == null) {
-            lastQueryNonWritableViewExpressions = new LinkedHashSet<>();
+          if (lastQueryNonWritableViewSourceExpressionMap == null) {
             lastQueryNonWritableViewSourceExpressionMap = new HashMap<>();
           }
           List<Expression> sourceExpressionsOfNonWritableView =
               searchSourceExpressions(lastQuerySourceExpression);
-          lastQueryNonWritableViewExpressions.add(lastQuerySourceExpression);
           lastQueryNonWritableViewSourceExpressionMap.put(
               lastQuerySourceExpression, sourceExpressionsOfNonWritableView);
           sourceExpressions.addAll(sourceExpressionsOfNonWritableView);
@@ -523,7 +520,6 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
 
     analysis.setSourceExpressions(sourceExpressions);
     analysis.setLastQueryBaseExpressions(lastQueryBaseExpressions);
-    analysis.setLastQueryNonWritableViewExpression(lastQueryNonWritableViewExpressions);
     analysis.setLastQueryNonWritableViewSourceExpressionMap(
         lastQueryNonWritableViewSourceExpressionMap);
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LogicalPlanVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LogicalPlanVisitor.java
@@ -104,7 +104,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import static org.apache.iotdb.db.queryengine.plan.statement.component.Ordering.ASC;
 import static org.apache.iotdb.db.utils.constant.SqlConstant.COUNT_TIME;
 
 /**
@@ -135,7 +134,6 @@ public class LogicalPlanVisitor extends StatementVisitor<PlanNode, MPPQueryConte
               .planLast(
                   analysis,
                   analysis.getTimeseriesOrderingForLastQuery(),
-                  queryStatement.getResultTimeOrder(),
                   queryStatement.getSelectComponent().getZoneId())
               .planOffset(queryStatement.getRowOffset())
               .planLimit(queryStatement.getRowLimit());
@@ -617,13 +615,14 @@ public class LogicalPlanVisitor extends StatementVisitor<PlanNode, MPPQueryConte
                 analysis.getRelatedTemplateInfo(),
                 showTimeSeriesStatement.getAuthorityScope())
             .planSchemaQueryMerge(showTimeSeriesStatement.isOrderByHeat());
+
     // show latest timeseries
     if (showTimeSeriesStatement.isOrderByHeat()
         && null != analysis.getDataPartitionInfo()
         && 0 != analysis.getDataPartitionInfo().getDataPartitionMap().size()) {
       PlanNode lastPlanNode =
           new LogicalPlanBuilder(analysis, context)
-              .planLast(analysis, null, ASC, ZoneId.systemDefault())
+              .planLast(analysis, null, ZoneId.systemDefault())
               .getRoot();
       planBuilder = planBuilder.planSchemaQueryOrderByHeat(lastPlanNode);
     }


### PR DESCRIPTION
## Description

1. always using "Ordering.DESC" resultTimeOrder when executing last query for non-base view.
2. remove redundant variable `lastQueryNonWriteViewExpressions`, just using `lastQueryNonWritableViewSourceExpressionMap` is enough.

