### PR TITLE
Auth online upgrade

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
@@ -232,6 +232,7 @@ public class ConfigRegionStateMachine
     configManager.getProcedureManager().shiftExecutor(true);
     configManager.getRetryFailedTasksThread().startRetryFailedTasksService();
     configManager.getPartitionManager().startRegionCleaner();
+    configManager.checkUserPathPrivilege();
 
     // we do cq recovery async for two reasons:
     // 1. For performance: cq recovery may be time-consuming, we use another thread to do it in

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -1013,6 +1013,10 @@ public class ConfigManager implements IManager {
     }
   }
 
+  public void checkUserPathPrivilege() {
+    permissionManager.checkUserPathPrivilege();
+  }
+
   public TPermissionInfoResp checkUserPrivilegeGrantOpt(
       String username, List<PartialPath> paths, int permission) {
     TSStatus status = confirmLeader();

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/PermissionManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/PermissionManager.java
@@ -122,4 +122,8 @@ public class PermissionManager {
       throws AuthException {
     return authorInfo.checkRoleOfUser(username, rolename);
   }
+
+  public void checkUserPathPrivilege() {
+    authorInfo.checkUserPathPrivilege();
+  }
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/AuthorInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/AuthorInfo.java
@@ -25,6 +25,8 @@ import org.apache.iotdb.commons.auth.authorizer.BasicAuthorizer;
 import org.apache.iotdb.commons.auth.authorizer.IAuthorizer;
 import org.apache.iotdb.commons.auth.authorizer.OpenIdAuthorizer;
 import org.apache.iotdb.commons.auth.entity.PathPrivilege;
+import org.apache.iotdb.commons.auth.entity.PriPrivilegeType;
+import org.apache.iotdb.commons.auth.entity.PrivilegeType;
 import org.apache.iotdb.commons.auth.entity.Role;
 import org.apache.iotdb.commons.auth.entity.User;
 import org.apache.iotdb.commons.conf.CommonConfig;
@@ -58,6 +60,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -179,87 +182,131 @@ public class AuthorInfo implements SnapshotProcessor {
     String password = authorPlan.getPassword();
     String newPassword = authorPlan.getNewPassword();
     Set<Integer> permissions = authorPlan.getPermissions();
+    if (authorType.ordinal() >= ConfigPhysicalPlanType.CreateUserDep.ordinal()
+        && authorType.ordinal() <= ConfigPhysicalPlanType.ListRoleUsersDep.ordinal()) {
+      HashSet<Integer> pricopy = new HashSet<>(permissions);
+      for (int permission : pricopy) {
+        PriPrivilegeType type = PriPrivilegeType.values()[permission];
+        if (type.isAccept()) {
+          for (PrivilegeType item : type.getSubPri()) {
+            pricopy.add(item.ordinal());
+          }
+        }
+      }
+      permissions = pricopy;
+    }
     boolean grantOpt = authorPlan.getGrantOpt();
     List<PartialPath> nodeNameList = authorPlan.getNodeNameList();
     try {
       switch (authorType) {
-        case CreateUserDep:
-        case CreateRoleDep:
-        case DropUserDep:
-        case DropRoleDep:
-        case GrantUserDep:
-        case GrantRoleDep:
-        case GrantRoleToUserDep:
-        case RevokeUserDep:
-        case RevokeRoleDep:
-        case RevokeRoleFromUserDep:
-          // TODO will deal with these authority upgrade soon in the future.
-          throw new AuthException(
-              TSStatusCode.UNSUPPORTED_OPERATION,
-              "unsupport operation: " + authorPlan.getAuthorType());
-        case UpdateUser:
         case UpdateUserDep:
-          authorizer.updateUserPassword(userName, newPassword);
+          authorizer.setUserForPreVersion(true);
+        case UpdateUser:
+          try {
+            authorizer.updateUserPassword(userName, newPassword);
+          } finally {
+            authorizer.setUserForPreVersion(false);
+          }
+          break;
+        case CreateUserDep:
+          AuthUtils.validatePasswordPre(password);
+          AuthUtils.validateUsernamePre(userName);
+          authorizer.createUserWithoutCheck(userName, password);
           break;
         case CreateUser:
           authorizer.createUser(userName, password);
           break;
-        case CreateRole:
+        case CreateRoleDep:
+          AuthUtils.validateRolenamePre(roleName);
           authorizer.createRole(roleName);
           break;
+        case CreateRole:
+          AuthUtils.validateRolename(roleName);
+          authorizer.createRole(roleName);
+          break;
+        case DropUserDep:
         case DropUser:
           authorizer.deleteUser(userName);
           break;
+        case DropRoleDep:
         case DropRole:
           authorizer.deleteRole(roleName);
           break;
+        case GrantRoleDep:
+          authorizer.setRoleForPreVersion(true);
         case GrantRole:
-          for (int permission : permissions) {
-            if (!isPathRelevant(permission)) {
-              authorizer.grantPrivilegeToRole(roleName, null, permission, grantOpt);
-              continue;
+          try {
+            for (int permission : permissions) {
+              if (!isPathRelevant(permission)) {
+                authorizer.grantPrivilegeToRole(roleName, null, permission, grantOpt);
+                continue;
+              }
+              for (PartialPath path : nodeNameList) {
+                authorizer.grantPrivilegeToRole(roleName, path, permission, grantOpt);
+              }
             }
-            for (PartialPath path : nodeNameList) {
-              authorizer.grantPrivilegeToRole(roleName, path, permission, grantOpt);
-            }
+          } finally {
+            authorizer.setRoleForPreVersion(false);
           }
           break;
+        case GrantUserDep:
+          authorizer.setUserForPreVersion(true);
         case GrantUser:
-          for (int permission : permissions) {
-            if (!isPathRelevant(permission)) {
-              authorizer.grantPrivilegeToUser(userName, null, permission, grantOpt);
-              continue;
+          try {
+            for (int permission : permissions) {
+              if (!isPathRelevant(permission)) {
+                authorizer.grantPrivilegeToUser(userName, null, permission, grantOpt);
+                continue;
+              }
+              for (PartialPath path : nodeNameList) {
+                authorizer.grantPrivilegeToUser(userName, path, permission, grantOpt);
+              }
             }
-            for (PartialPath path : nodeNameList) {
-              authorizer.grantPrivilegeToUser(userName, path, permission, grantOpt);
-            }
+          } finally {
+            authorizer.setUserForPreVersion(false);
           }
           break;
+        case GrantRoleToUserDep:
         case GrantRoleToUser:
           authorizer.grantRoleToUser(roleName, userName);
           break;
+        case RevokeUserDep:
+          authorizer.setUserForPreVersion(true);
         case RevokeUser:
-          for (int permission : permissions) {
-            if (!isPathRelevant(permission)) {
-              authorizer.revokePrivilegeFromUser(userName, null, permission);
-              continue;
+          try {
+            for (int permission : permissions) {
+              if (!isPathRelevant(permission)) {
+                authorizer.revokePrivilegeFromUser(userName, null, permission);
+                continue;
+              }
+              for (PartialPath path : nodeNameList) {
+                authorizer.revokePrivilegeFromUser(userName, path, permission);
+              }
             }
-            for (PartialPath path : nodeNameList) {
-              authorizer.revokePrivilegeFromUser(userName, path, permission);
-            }
+          } finally {
+            authorizer.setUserForPreVersion(false);
           }
+
           break;
+        case RevokeRoleDep:
+          authorizer.setRoleForPreVersion(false);
         case RevokeRole:
-          for (int permission : permissions) {
-            if (!isPathRelevant(permission)) {
-              authorizer.revokePrivilegeFromRole(roleName, null, permission);
-              continue;
+          try {
+            for (int permission : permissions) {
+              if (!isPathRelevant(permission)) {
+                authorizer.revokePrivilegeFromRole(roleName, null, permission);
+                continue;
+              }
+              for (PartialPath path : nodeNameList) {
+                authorizer.revokePrivilegeFromRole(roleName, path, permission);
+              }
             }
-            for (PartialPath path : nodeNameList) {
-              authorizer.revokePrivilegeFromRole(roleName, path, permission);
-            }
+          } finally {
+            authorizer.setRoleForPreVersion(false);
           }
+
           break;
+        case RevokeRoleFromUserDep:
         case RevokeRoleFromUser:
           authorizer.revokeRoleFromUser(roleName, userName);
           break;
@@ -575,5 +622,9 @@ public class AuthorInfo implements SnapshotProcessor {
     result.setRoleInfo(tRoleRespMap);
     result.setStatus(new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode()));
     return result;
+  }
+
+  public void checkUserPathPrivilege() {
+    authorizer.checkUserPathPrivilege();
   }
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/AuthorInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/AuthorInfo.java
@@ -182,10 +182,10 @@ public class AuthorInfo implements SnapshotProcessor {
     String password = authorPlan.getPassword();
     String newPassword = authorPlan.getNewPassword();
     Set<Integer> permissions = authorPlan.getPermissions();
-    if (authorType.ordinal() >= ConfigPhysicalPlanType.CreateUserDep.ordinal()
-        && authorType.ordinal() <= ConfigPhysicalPlanType.ListRoleUsersDep.ordinal()) {
-      HashSet<Integer> pricopy = new HashSet<>(permissions);
-      for (int permission : pricopy) {
+    if (authorType.ordinal() >= ConfigPhysicalPlanType.GrantRoleDep.ordinal()
+        && authorType.ordinal() <= ConfigPhysicalPlanType.RevokeRoleFromUserDep.ordinal()) {
+      HashSet<Integer> pricopy = new HashSet<>();
+      for (int permission : permissions) {
         PriPrivilegeType type = PriPrivilegeType.values()[permission];
         if (type.isAccept()) {
           for (PrivilegeType item : type.getSubPri()) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/auth/user/LocalFileUserManagerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/auth/user/LocalFileUserManagerTest.java
@@ -20,6 +20,8 @@ package org.apache.iotdb.db.auth.user;
 
 import org.apache.iotdb.commons.auth.AuthException;
 import org.apache.iotdb.commons.auth.entity.PathPrivilege;
+import org.apache.iotdb.commons.auth.entity.PriPrivilegeType;
+import org.apache.iotdb.commons.auth.entity.Role;
 import org.apache.iotdb.commons.auth.entity.User;
 import org.apache.iotdb.commons.auth.user.LocalFileUserManager;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
@@ -66,13 +68,13 @@ public class LocalFileUserManagerTest {
   public void testIllegalInput() throws AuthException {
     // Password contains space
     try {
-      manager.createUser("username1", "password_ ", false);
+      manager.createUser("username1", "password_ ", true);
     } catch (AuthException e) {
       assertTrue(e.getMessage().contains("cannot contain spaces"));
     }
     // Username contains space
     try {
-      assertFalse(manager.createUser("username 2", "password_", false));
+      assertFalse(manager.createUser("username 2", "password_", true));
     } catch (AuthException e) {
       assertTrue(e.getMessage().contains("cannot contain spaces"));
     }
@@ -105,8 +107,8 @@ public class LocalFileUserManagerTest {
 
     assertFalse(manager.createUser(users[0].getName(), users[0].getPassword(), false));
 
-    Assert.assertThrows(AuthException.class, () -> manager.createUser("too", "short", false));
-    Assert.assertThrows(AuthException.class, () -> manager.createUser("short", "too", false));
+    Assert.assertThrows(AuthException.class, () -> manager.createUser("too", "short", true));
+    Assert.assertThrows(AuthException.class, () -> manager.createUser("short", "too", true));
 
     // delete
     assertTrue(manager.deleteUser("not a user"));
@@ -182,5 +184,51 @@ public class LocalFileUserManagerTest {
     for (int i = 0; i < users.length - 1; i++) {
       assertEquals(users[i].getName(), usernames.get(i + 1));
     }
+  }
+
+  @Test
+  public void testPathCheckForUpgrade() throws AuthException, IllegalPathException {
+    manager.createUser("test", "pwssord", false);
+    manager.setPreVersion(true);
+
+    // turn to root.d.a
+    manager.grantPrivilegeToUser(
+        "test", new PartialPath("root.d.a"), PriPrivilegeType.READ_SCHEMA.ordinal(), false);
+    // turn to root.**
+    manager.grantPrivilegeToUser(
+        "test", new PartialPath("root.d*.a"), PriPrivilegeType.READ_DATA.ordinal(), false);
+    // turn to root.**
+    manager.grantPrivilegeToUser(
+        "test", new PartialPath("root.d*.a"), PriPrivilegeType.READ_SCHEMA.ordinal(), false);
+    // turn to root.**
+    manager.grantPrivilegeToUser(
+        "test", new PartialPath("root.*.a.b"), PriPrivilegeType.READ_SCHEMA.ordinal(), false);
+    // turn to root.ds.a.**
+    manager.grantPrivilegeToUser(
+        "test", new PartialPath("root.ds.a.b*"), PriPrivilegeType.READ_SCHEMA.ordinal(), false);
+    // turn to root.ds.a.b
+    manager.grantPrivilegeToUser(
+        "test", new PartialPath("root.ds.a.b"), PriPrivilegeType.READ_SCHEMA.ordinal(), false);
+    assertFalse(manager.getUser("test").getServiceReady());
+    // after this operation, the user has these privileges:
+    // root.d.a : read_schema
+    // root.** : read_data, read_schema
+    // root.ds.a.** :read_schema
+    // root.ds.a.b : read_schema
+    manager.checkAndRefreshPathPri();
+    Role role = manager.getUser("test");
+    assertTrue(role.getServiceReady());
+    assertEquals(4, role.getPathPrivilegeList().size());
+    manager.revokePrivilegeFromUser(
+        "test", new PartialPath("root.**"), PriPrivilegeType.READ_SCHEMA.ordinal());
+    manager.revokePrivilegeFromUser(
+        "test", new PartialPath("root.**"), PriPrivilegeType.READ_DATA.ordinal());
+    assertEquals(3, role.getPathPrivilegeList().size());
+    assertTrue(
+        role.checkPathPrivilege(
+            new PartialPath("root.ds.a.**"), PriPrivilegeType.READ_SCHEMA.ordinal()));
+    assertFalse(
+        role.checkPathPrivilege(
+            new PartialPath("root.ds.a.**"), PriPrivilegeType.READ_DATA.ordinal()));
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/authorizer/BasicAuthorizer.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/authorizer/BasicAuthorizer.java
@@ -52,6 +52,18 @@ public abstract class BasicAuthorizer implements IAuthorizer, IService {
   IUserManager userManager;
   IRoleManager roleManager;
 
+  /**
+   * This filed only for pre version. When we do a major version upgrade, it can be removed
+   * directly.
+   */
+  // FOR PRE VERSION BEGIN -----
+  public void checkUserPathPrivilege() {
+    userManager.checkAndRefreshPathPri();
+    roleManager.checkAndRefreshPathPri();
+  }
+
+  // FOR PRE VERSION END -----
+
   BasicAuthorizer(IUserManager userManager, IRoleManager roleManager) throws AuthException {
     this.userManager = userManager;
     this.roleManager = roleManager;
@@ -109,14 +121,15 @@ public abstract class BasicAuthorizer implements IAuthorizer, IService {
 
   @Override
   public void createUser(String username, String password) throws AuthException {
-    if (!userManager.createUser(username, password, false)) {
+    if (!userManager.createUser(username, password, true)) {
       throw new AuthException(
           TSStatusCode.USER_ALREADY_EXIST, String.format("User %s already exists", username));
     }
   }
 
-  public void createOpenIdUser(String username, String password) throws AuthException {
-    if (!userManager.createUser(username, password, true)) {
+  @Override
+  public void createUserWithoutCheck(String username, String password) throws AuthException {
+    if (!userManager.createUser(username, password, false)) {
       throw new AuthException(
           TSStatusCode.USER_ALREADY_EXIST, String.format("User %s already exists", username));
     }
@@ -428,5 +441,15 @@ public abstract class BasicAuthorizer implements IAuthorizer, IService {
   public void processLoadSnapshot(File snapshotDir) throws TException, IOException {
     userManager.processLoadSnapshot(snapshotDir);
     roleManager.processLoadSnapshot(snapshotDir);
+  }
+
+  @Override
+  public void setUserForPreVersion(boolean preVersion) {
+    userManager.setPreVersion(preVersion);
+  }
+
+  @Override
+  public void setRoleForPreVersion(boolean preVersion) {
+    roleManager.setPreVersion(preVersion);
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/authorizer/BasicAuthorizer.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/authorizer/BasicAuthorizer.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.service.IService;
 import org.apache.iotdb.commons.service.ServiceType;
 import org.apache.iotdb.commons.utils.AuthUtils;
+import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.apache.thrift.TException;
@@ -451,5 +452,17 @@ public abstract class BasicAuthorizer implements IAuthorizer, IService {
   @Override
   public void setRoleForPreVersion(boolean preVersion) {
     roleManager.setPreVersion(preVersion);
+  }
+
+  @Override
+  @TestOnly
+  public boolean forUserPreVersion() {
+    return this.userManager.preVersion();
+  }
+
+  @Override
+  @TestOnly
+  public boolean forRolePreVersion() {
+    return this.roleManager.preVersion();
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/authorizer/IAuthorizer.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/authorizer/IAuthorizer.java
@@ -266,4 +266,19 @@ public interface IAuthorizer extends SnapshotProcessor {
    * @throws AuthException IOException
    */
   void replaceAllRoles(Map<String, Role> roles) throws AuthException;
+
+  void setUserForPreVersion(boolean preVersion);
+
+  void setRoleForPreVersion(boolean preVersion);
+
+  /**
+   * Create a user with given username and password. New users will only be granted no privileges.
+   *
+   * @param username is not null or empty
+   * @param password is not null or empty
+   * @throws AuthException if the given username or password is illegal or the user already exists.
+   */
+  void createUserWithoutCheck(String username, String password) throws AuthException;
+
+  void checkUserPathPrivilege();
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/authorizer/IAuthorizer.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/authorizer/IAuthorizer.java
@@ -271,6 +271,10 @@ public interface IAuthorizer extends SnapshotProcessor {
 
   void setRoleForPreVersion(boolean preVersion);
 
+  boolean forUserPreVersion();
+
+  boolean forRolePreVersion();
+
   /**
    * Create a user with given username and password. New users will only be granted no privileges.
    *

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/authorizer/OpenIdAuthorizer.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/authorizer/OpenIdAuthorizer.java
@@ -175,7 +175,7 @@ public class OpenIdAuthorizer extends BasicAuthorizer {
     if (!super.listAllUsers().contains(iotdbUsername)) {
       logger.info("User {} logs in for first time, storing it locally!", iotdbUsername);
       // We give the user a random password so that no one could hijack them via local login
-      super.createOpenIdUser(iotdbUsername, UUID.randomUUID().toString());
+      super.createUserWithoutCheck(iotdbUsername, UUID.randomUUID().toString());
     }
     // Always store claims and user
     this.loggedClaims.put(getUsername(claims), claims);

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/entity/PriPrivilegeType.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/entity/PriPrivilegeType.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.commons.auth.entity;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public enum PriPrivilegeType {
+  READ_DATA(true, PrivilegeType.READ_DATA),
+  WRITE_DATA(true, PrivilegeType.WRITE_DATA),
+  READ_SCHEMA(true, PrivilegeType.READ_SCHEMA),
+  WRITE_SCHEMA(true, PrivilegeType.WRITE_SCHEMA),
+  MANAGE_USER(false, PrivilegeType.MANAGE_USER),
+  MANAGE_ROLE(false, PrivilegeType.MANAGE_ROLE),
+  GRANT_PRIVILEGE(false),
+  ALTER_PASSWORD(false),
+  USE_TRIGGER(false, PrivilegeType.USE_TRIGGER),
+  USE_CQ(false, PrivilegeType.USE_CQ),
+  USE_PIPE(false, PrivilegeType.USE_PIPE),
+  MANAGE_DATABASE(false, PrivilegeType.MANAGE_DATABASE),
+  MAINTAIN(false, PrivilegeType.MAINTAIN),
+  READ(true, PrivilegeType.READ_DATA, PrivilegeType.READ_SCHEMA),
+  WRITE(true, PrivilegeType.WRITE_DATA, PrivilegeType.WRITE_SCHEMA),
+  ALL(
+      true,
+      PrivilegeType.READ_SCHEMA,
+      PrivilegeType.READ_DATA,
+      PrivilegeType.WRITE_DATA,
+      PrivilegeType.WRITE_SCHEMA,
+      PrivilegeType.MANAGE_USER,
+      PrivilegeType.MANAGE_ROLE,
+      PrivilegeType.USE_TRIGGER,
+      PrivilegeType.USE_CQ,
+      PrivilegeType.USE_PIPE,
+      PrivilegeType.USE_UDF,
+      PrivilegeType.MANAGE_DATABASE,
+      PrivilegeType.MAINTAIN,
+      PrivilegeType.AUDIT);
+
+  boolean accept = false;
+  private final boolean isPathRelevant;
+  private final List<PrivilegeType> refPri = new ArrayList<>();
+
+  PriPrivilegeType(boolean accept) {
+    this.accept = accept;
+    this.isPathRelevant = false;
+  }
+
+  PriPrivilegeType(boolean isPathRelevant, PrivilegeType... privilegeTypes) {
+    this.accept = true;
+    this.isPathRelevant = isPathRelevant;
+    this.refPri.addAll(Arrays.asList(privilegeTypes));
+  }
+
+  public boolean isAccept() {
+    return this.accept;
+  }
+
+  public boolean isPathRelevant() {
+    return this.isPathRelevant;
+  }
+
+  public Set<PrivilegeType> getSubPri() {
+    Set<PrivilegeType> result = new HashSet<>();
+    for (PrivilegeType peivType : refPri) {
+      result.add(peivType);
+    }
+    return result;
+  }
+}

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/entity/PriPrivilegeType.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/entity/PriPrivilegeType.java
@@ -55,6 +55,7 @@ public enum PriPrivilegeType {
       PrivilegeType.USE_UDF,
       PrivilegeType.MANAGE_DATABASE,
       PrivilegeType.MAINTAIN,
+      PrivilegeType.EXTEND_TEMPLATE,
       PrivilegeType.AUDIT);
 
   boolean accept = false;

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/entity/Role.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/entity/Role.java
@@ -44,6 +44,8 @@ public class Role {
 
   private static final int SYS_PRI_SIZE = PrivilegeType.getSysPriCount();
 
+  private boolean serviceReady = true;
+
   public Role() {
     // empty constructor
   }
@@ -85,6 +87,10 @@ public class Role {
       privs |= 1 << (sysPriTopos(sysGrantOpt) + 16);
     }
     return privs;
+  }
+
+  public boolean getServiceReady() {
+    return serviceReady;
   }
 
   /** -------------- set func ----------------* */
@@ -198,6 +204,10 @@ public class Role {
 
   public void removeSysPrivilege(int privilegeId) {
     sysPrivilegeSet.remove(privilegeId);
+  }
+
+  public void setServiceReady(boolean ready) {
+    serviceReady = ready;
   }
 
   /** ------------ check func ---------------* */

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/role/BasicRoleManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/role/BasicRoleManager.java
@@ -19,8 +19,10 @@
 package org.apache.iotdb.commons.auth.role;
 
 import org.apache.iotdb.commons.auth.AuthException;
+import org.apache.iotdb.commons.auth.entity.PathPrivilege;
 import org.apache.iotdb.commons.auth.entity.Role;
 import org.apache.iotdb.commons.concurrent.HashLock;
+import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.utils.AuthUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
@@ -44,6 +46,8 @@ public abstract class BasicRoleManager implements IRoleManager {
   protected IRoleAccessor accessor;
   protected HashLock lock;
 
+  private boolean preVersion = false;
+
   BasicRoleManager(LocalFileRoleAccessor accessor) {
     this.roleMap = new HashMap<>();
     this.accessor = accessor;
@@ -60,7 +64,6 @@ public abstract class BasicRoleManager implements IRoleManager {
 
   @Override
   public boolean createRole(String rolename) throws AuthException {
-    AuthUtils.validateRolename(rolename);
 
     Role role = getRole(rolename);
     if (role != null) {
@@ -94,7 +97,18 @@ public abstract class BasicRoleManager implements IRoleManager {
             TSStatusCode.ROLE_NOT_EXIST, String.format("No such role %s", rolename));
       }
       if (path != null) {
-        AuthUtils.validatePatternPath(path);
+        if (preVersion) {
+          AuthUtils.validatePath(path);
+          if (role.getServiceReady()) {
+            try {
+              AuthUtils.validatePatternPath(path);
+            } catch (AuthException e) {
+              role.setServiceReady(false);
+            }
+          }
+        } else {
+          AuthUtils.validatePatternPath(path);
+        }
         role.addPathPrivilege(path, privilegeId, grantOpt);
       } else {
         role.getSysPrivilege().add(privilegeId);
@@ -117,15 +131,30 @@ public abstract class BasicRoleManager implements IRoleManager {
         throw new AuthException(
             TSStatusCode.ROLE_NOT_EXIST, String.format("No such role %s", rolename));
       }
-      if (!role.hasPrivilegeToRevoke(path, privilegeId)) {
-        return false;
-      }
-      if (path != null) {
-        AuthUtils.validatePatternPath(path);
-        role.removePathPrivilege(path, privilegeId);
+      if (preVersion) {
+        if (path != null) {
+          if (AuthUtils.hasPrivilege(path, privilegeId, role.getPathPrivilegeList())) {
+            return false;
+          }
+          AuthUtils.validatePath(path);
+          AuthUtils.removePrivilegePre(path, privilegeId, role.getPathPrivilegeList());
+        } else {
+          if (role.getSysPrivilege().contains(privilegeId)) {
+            return false;
+          }
+          role.getSysPrivilege().remove(privilegeId);
+        }
       } else {
-        role.getSysPrivilege().remove(privilegeId);
-        role.getSysPriGrantOpt().remove(privilegeId);
+        if (!role.hasPrivilegeToRevoke(path, privilegeId)) {
+          return false;
+        }
+        if (path != null) {
+          AuthUtils.validatePatternPath(path);
+          role.removePathPrivilege(path, privilegeId);
+        } else {
+          role.getSysPrivilege().remove(privilegeId);
+          role.getSysPriGrantOpt().remove(privilegeId);
+        }
       }
       return true;
     } finally {
@@ -170,5 +199,32 @@ public abstract class BasicRoleManager implements IRoleManager {
         }
       }
     }
+  }
+
+  @Override
+  public void setPreVersion(boolean preVersion) {
+    this.preVersion = preVersion;
+  }
+
+  @Override
+  public void checkAndRefreshPathPri() {
+    roleMap.forEach(
+        (rolename, role) -> {
+          if (!role.getServiceReady()) {
+            for (PathPrivilege pathPri : role.getPathPrivilegeList()) {
+              try {
+                AuthUtils.validatePatternPath(pathPri.getPath());
+              } catch (AuthException e) {
+                PartialPath path = pathPri.getPath();
+                try {
+                  pathPri.setPath(AuthUtils.convertPatternPath(path));
+                } catch (IllegalPathException illegalE) {
+                  //
+                }
+              }
+            }
+          }
+          role.setServiceReady(true);
+        });
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/role/IRoleManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/role/IRoleManager.java
@@ -100,4 +100,8 @@ public interface IRoleManager extends SnapshotProcessor {
    * @throws AuthException
    */
   void replaceAllRoles(Map<String, Role> roles) throws AuthException;
+
+  void setPreVersion(boolean preVersion);
+
+  void checkAndRefreshPathPri();
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/role/IRoleManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/role/IRoleManager.java
@@ -103,5 +103,7 @@ public interface IRoleManager extends SnapshotProcessor {
 
   void setPreVersion(boolean preVersion);
 
+  boolean preVersion();
+
   void checkAndRefreshPathPri();
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/role/LocalFileRoleAccessor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/role/LocalFileRoleAccessor.java
@@ -120,19 +120,7 @@ public class LocalFileRoleAccessor implements IRoleAccessor {
       role.setName(result.getLeft());
       boolean oldVersion = result.getRight();
       if (oldVersion) {
-        // TODO will deal with these authority upgrade soon in the future.
-
-        //        int privilegeNum = dataInputStream.readInt();
-        //        List<PathPrivilege> pathPrivilegeList = new ArrayList<>();
-        //        for (int i = 0; i < privilegeNum; i++) {
-        //          pathPrivilegeList.add(
-        //                  IOUtils.readPathPrivilege(dataInputStream, STRING_ENCODING,
-        // strBufferLocal,true));
-        //        }
-        //        role.setPrivilegeList(pathPrivilegeList);
-        role.setPrivilegeList(new ArrayList<>());
-        role.setSysPrivilegeSet(new HashSet<>());
-        role.setSysPriGrantOpt(new HashSet<>());
+        IOUtils.loadRolePrivilege(role, dataInputStream, STRING_ENCODING, strBufferLocal);
         return role;
       } else {
         role.setSysPrivilegeSet(dataInputStream.readInt());

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/role/LocalFileRoleAccessor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/role/LocalFileRoleAccessor.java
@@ -303,8 +303,15 @@ public class LocalFileRoleAccessor implements IRoleAccessor {
         IOUtils.writeInt(outputStream, privilegeNum, encodingBufferLocal);
         for (int i = 0; i < privilegeNum; i++) {
           PathPrivilege pathPrivilege = role.getPathPrivilegeList().get(i);
-          IOUtils.writePathPrivilege(
-              outputStream, pathPrivilege, STRING_ENCODING, encodingBufferLocal);
+          IOUtils.writeString(
+              outputStream,
+              pathPrivilege.getPath().getFullPath(),
+              STRING_ENCODING,
+              encodingBufferLocal);
+          IOUtils.writeInt(outputStream, pathPrivilege.getPrivileges().size(), encodingBufferLocal);
+          for (Integer item : pathPrivilege.getPrivileges()) {
+            IOUtils.writeInt(outputStream, item, encodingBufferLocal);
+          }
         }
         outputStream.flush();
       } catch (Exception e) {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/user/IUserManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/user/IUserManager.java
@@ -155,5 +155,7 @@ public interface IUserManager extends SnapshotProcessor {
 
   void setPreVersion(boolean perVersion);
 
+  boolean preVersion();
+
   void checkAndRefreshPathPri();
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/user/IUserManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/user/IUserManager.java
@@ -152,4 +152,8 @@ public interface IUserManager extends SnapshotProcessor {
    * @throws AuthException
    */
   void replaceAllUsers(Map<String, User> users) throws AuthException;
+
+  void setPreVersion(boolean perVersion);
+
+  void checkAndRefreshPathPri();
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/user/LocalFileUserAccessor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/user/LocalFileUserAccessor.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
+import java.io.EOFException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -131,40 +132,19 @@ public class LocalFileUserAccessor implements IUserAccessor {
       user.setName(result.getLeft());
       user.setPassword(IOUtils.readString(dataInputStream, STRING_ENCODING, strBufferLocal));
       if (oldVersion) {
-        // TODO will deal with these authority upgrade soon in the future.
-
-        //        int privilegeNum = dataInputStream.readInt();
-        //        List<PathPrivilege> pathPrivilegeList = new ArrayList<>();
-        //        for (int i = 0; i < privilegeNum; i++) {
-        //          pathPrivilegeList.add(
-        //                  IOUtils.readPathPrivilege(dataInputStream, STRING_ENCODING,
-        // strBufferLocal, versionNow));
-        //        }
-        //        user.setPrivilegeList(pathPrivilegeList);
-        //        int roleNum = dataInputStream.readInt();
-        //        List<String> roleList = new ArrayList<>();
-        //        for (int i = 0; i < roleNum; i++) {
-        //          String userName = IOUtils.readString(dataInputStream, STRING_ENCODING,
-        // strBufferLocal);
-        //          roleList.add(userName);
-        //        }
-        //        user.setRoleList(roleList);
-        //        // for online upgrading, profile for v0.9.x/v1 does not contain waterMark
-        //        long userProfileLength = userProfile.length();
-        //        try {
-        //          user.setUseWaterMark(dataInputStream.readInt() != 0);
-        //        } catch (EOFException e1) {
-        //          user.setUseWaterMark(false);
-        //          try (RandomAccessFile file = new RandomAccessFile(userProfile, "rw")) {
-        //            file.seek(userProfileLength);
-        //            file.writeInt(0);
-        //          }
-        //        }
-        user.setRoleList(new ArrayList<>());
-        user.setSysPrivilegeSet(new HashSet<>());
-        user.setPrivilegeList(new ArrayList<>());
-        user.setSysPriGrantOpt(new HashSet<>());
-        user.setUseWaterMark(false);
+        IOUtils.loadRolePrivilege(user, dataInputStream, STRING_ENCODING, strBufferLocal);
+        int roleNum = dataInputStream.readInt();
+        List<String> roleList = new ArrayList<>();
+        for (int i = 0; i < roleNum; i++) {
+          String roleName = IOUtils.readString(dataInputStream, STRING_ENCODING, strBufferLocal);
+          roleList.add(roleName);
+        }
+        user.setRoleList(roleList);
+        try {
+          user.setUseWaterMark(dataInputStream.readInt() != 0);
+        } catch (EOFException e1) {
+          user.setUseWaterMark(false);
+        }
         return user;
       } else {
         user.setSysPrivilegeSet(dataInputStream.readInt());

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/user/LocalFileUserAccessor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/user/LocalFileUserAccessor.java
@@ -435,10 +435,16 @@ public class LocalFileUserAccessor implements IUserAccessor {
         IOUtils.writeInt(outputStream, privilegeNum, encodingBufferLocal);
         for (int i = 0; i < privilegeNum; i++) {
           PathPrivilege pathPrivilege = user.getPathPrivilegeList().get(i);
-          IOUtils.writePathPrivilege(
-              outputStream, pathPrivilege, STRING_ENCODING, encodingBufferLocal);
+          IOUtils.writeString(
+              outputStream,
+              pathPrivilege.getPath().getFullPath(),
+              STRING_ENCODING,
+              encodingBufferLocal);
+          IOUtils.writeInt(outputStream, pathPrivilege.getPrivileges().size(), encodingBufferLocal);
+          for (Integer item : pathPrivilege.getPrivileges()) {
+            IOUtils.writeInt(outputStream, item, encodingBufferLocal);
+          }
         }
-
         int userNum = user.getRoleList().size();
         IOUtils.writeInt(outputStream, userNum, encodingBufferLocal);
         for (int i = 0; i < userNum; i++) {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/AuthUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/AuthUtils.java
@@ -311,7 +311,7 @@ public class AuthUtils {
   public static boolean hasPrivilege(
       PartialPath path, int privilegeId, List<PathPrivilege> privilegeList) {
     for (PathPrivilege pathPrivilege : privilegeList) {
-      if (pathPrivilege.getPath().matchFullPath(path)
+      if (pathPrivilege.getPath().equals(path)
           && pathPrivilege.getPrivileges().contains(privilegeId)) {
         return true;
       }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/AuthUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/AuthUtils.java
@@ -370,7 +370,7 @@ public class AuthUtils {
     Iterator<PathPrivilege> it = privilegeList.iterator();
     while (it.hasNext()) {
       PathPrivilege pathPri = it.next();
-      if (pathPri.getPath().matchFullPath(path)) {
+      if (pathPri.getPath().equals(path)) {
         pathPri.revokePrivilege(privilegeId);
         if (pathPri.getPrivileges().isEmpty()) {
           it.remove();

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/AuthUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/AuthUtils.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.commons.auth.entity.PathPrivilege;
 import org.apache.iotdb.commons.auth.entity.PrivilegeType;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
+import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.path.PathDeserializeUtil;
 import org.apache.iotdb.commons.path.PathPatternUtil;
@@ -60,6 +61,48 @@ public class AuthUtils {
   private AuthUtils() {
     // Empty constructor
   }
+  /**
+   * This filed only for pre version. When we do a major version upgrade, it can be removed
+   * directly.
+   */
+  // FOR PRE VERSION BEGIN -----
+  private static final int MAX_LENGTH_PRE = 64;
+
+  private static final String REX_PATTERN_PRE = "^[-\\w]*$";
+
+  public static void validatePasswordPre(String password) throws AuthException {
+    validateNameOrPasswordPre(password);
+  }
+
+  public static void validateUsernamePre(String username) throws AuthException {
+    validateNameOrPasswordPre(username);
+  }
+
+  public static void validateRolenamePre(String rolename) throws AuthException {
+    validateNameOrPasswordPre(rolename);
+  }
+
+  public static void validateNameOrPasswordPre(String str) throws AuthException {
+    int length = str.length();
+    if (length < MIN_LENGTH) {
+      throw new AuthException(
+          TSStatusCode.ILLEGAL_PARAMETER,
+          "The length of name or password must be greater than or equal to " + MIN_LENGTH);
+    } else if (length > MAX_LENGTH_PRE) {
+      throw new AuthException(
+          TSStatusCode.ILLEGAL_PARAMETER,
+          "The length of name or password must be less than or equal to " + MAX_LENGTH);
+    } else if (str.contains(" ")) {
+      throw new AuthException(
+          TSStatusCode.ILLEGAL_PARAMETER, "The name or password cannot contain spaces");
+    } else if (!str.matches(REX_PATTERN_PRE)) {
+      throw new AuthException(
+          TSStatusCode.ILLEGAL_PARAMETER,
+          "The name or password can only contain letters, numbers, and underscores");
+    }
+  }
+
+  // FOR PRE VERSION DONE ---
 
   /**
    * Validate password
@@ -161,6 +204,20 @@ public class AuthUtils {
     }
   }
 
+  public static PartialPath convertPatternPath(PartialPath path) throws IllegalPathException {
+    String pathStr = new String();
+    int i = 0;
+    for (; i < path.getNodeLength(); i++) {
+      if (!PathPatternUtil.hasWildcard(path.getNodes()[i])) {
+        pathStr = pathStr.concat(path.getNodes()[i] + ".");
+      } else {
+        break;
+      }
+    }
+    pathStr = pathStr.concat("**");
+    return new PartialPath(pathStr);
+  }
+
   /**
    * Encrypt password
    *
@@ -251,6 +308,16 @@ public class AuthUtils {
     return false;
   }
 
+  public static boolean hasPrivilege(
+      PartialPath path, int privilegeId, List<PathPrivilege> privilegeList) {
+    for (PathPrivilege pathPrivilege : privilegeList) {
+      if (pathPrivilege.getPath().matchFullPath(path)
+          && pathPrivilege.getPrivileges().contains(privilegeId)) {
+        return true;
+      }
+    }
+    return false;
+  }
   /**
    * Add privilege
    *
@@ -290,6 +357,20 @@ public class AuthUtils {
     while (it.hasNext()) {
       PathPrivilege pathPri = it.next();
       if (path.matchFullPath(pathPri.getPath())) {
+        pathPri.revokePrivilege(privilegeId);
+        if (pathPri.getPrivileges().isEmpty()) {
+          it.remove();
+        }
+      }
+    }
+  }
+
+  public static void removePrivilegePre(
+      PartialPath path, int privilegeId, List<PathPrivilege> privilegeList) {
+    Iterator<PathPrivilege> it = privilegeList.iterator();
+    while (it.hasNext()) {
+      PathPrivilege pathPri = it.next();
+      if (pathPri.getPath().matchFullPath(path)) {
         pathPri.revokePrivilege(privilegeId);
         if (pathPri.getPrivileges().isEmpty()) {
           it.remove();

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/IOUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/IOUtils.java
@@ -216,19 +216,23 @@ public class IOUtils {
       }
       PathPrivilege pathPriv = new PathPrivilege(ppath);
       int priNum = inputStream.readInt();
+      boolean isPathRelevant = false;
       for (int j = 0; j < priNum; j++) {
         PriPrivilegeType priType = PriPrivilegeType.values()[inputStream.readInt()];
         if (priType.isAccept()) {
           for (PrivilegeType item : priType.getSubPri()) {
             if (item.isPathRelevant()) {
               pathPriv.grantPrivilege(item.ordinal(), false);
+              isPathRelevant = true;
             } else {
               role.getSysPrivilege().add(item.ordinal());
             }
           }
         }
       }
-      pathPrivilegeList.add(pathPriv);
+      if (isPathRelevant) {
+        pathPrivilegeList.add(pathPriv);
+      }
     }
     role.setPrivilegeList(pathPrivilegeList);
   }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/IOUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/IOUtils.java
@@ -18,7 +18,11 @@
  */
 package org.apache.iotdb.commons.utils;
 
+import org.apache.iotdb.commons.auth.AuthException;
 import org.apache.iotdb.commons.auth.entity.PathPrivilege;
+import org.apache.iotdb.commons.auth.entity.PriPrivilegeType;
+import org.apache.iotdb.commons.auth.entity.PrivilegeType;
+import org.apache.iotdb.commons.auth.entity.Role;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.tsfile.utils.Pair;
@@ -28,6 +32,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 
 public class IOUtils {
 
@@ -190,6 +196,41 @@ public class IOUtils {
       pathPrivilege.setAllPrivileges(privileges);
       return pathPrivilege;
     }
+  }
+
+  public static void loadRolePrivilege(
+      Role role, DataInputStream inputStream, String encoding, ThreadLocal<byte[]> strBufferLocal)
+      throws IOException, IllegalPathException {
+    role.setSysPrivilegeSet(0);
+    int pathPriNum = inputStream.readInt();
+    List<PathPrivilege> pathPrivilegeList = new ArrayList<>();
+    for (int i = 0; i < pathPriNum; i++) {
+      String path = IOUtils.readString(inputStream, encoding, strBufferLocal);
+      PartialPath ppath = new PartialPath(path);
+      if (role.getServiceReady()) {
+        try {
+          AuthUtils.validatePatternPath(ppath);
+        } catch (AuthException e) {
+          role.setServiceReady(false);
+        }
+      }
+      PathPrivilege pathPriv = new PathPrivilege(ppath);
+      int priNum = inputStream.readInt();
+      for (int j = 0; j < priNum; j++) {
+        PriPrivilegeType priType = PriPrivilegeType.values()[inputStream.readInt()];
+        if (priType.isAccept()) {
+          for (PrivilegeType item : priType.getSubPri()) {
+            if (item.isPathRelevant()) {
+              pathPriv.grantPrivilege(item.ordinal(), false);
+            } else {
+              role.getSysPrivilege().add(item.ordinal());
+            }
+          }
+        }
+      }
+      pathPrivilegeList.add(pathPriv);
+    }
+    role.setPrivilegeList(pathPrivilegeList);
   }
 
   /**

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/utils/AuthUtilsTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/utils/AuthUtilsTest.java
@@ -186,4 +186,16 @@ public class AuthUtilsTest {
         AuthException.class,
         () -> AuthUtils.validatePatternPath(new PartialPath(new String("*a.data.t1.**.**"))));
   }
+
+  @Test
+  public void authUtilsTest_ConvertPattern() throws IllegalPathException {
+    PartialPath path = AuthUtils.convertPatternPath(new PartialPath("root.*.t1.t2"));
+    Assert.assertTrue(path.equals(new PartialPath("root.**")));
+    path = AuthUtils.convertPatternPath(new PartialPath("root.*t1.t1.t2"));
+    Assert.assertTrue(path.equals(new PartialPath("root.**")));
+    path = AuthUtils.convertPatternPath(new PartialPath("root.*"));
+    Assert.assertTrue(path.equals(new PartialPath("root.**")));
+    path = AuthUtils.convertPatternPath(new PartialPath("root.t2.*.t1.**"));
+    Assert.assertTrue(path.equals(new PartialPath("root.t2.**")));
+  }
 }


### PR DESCRIPTION
In this pr:
1. iotdb can upgrade online from pre version.
a. accept pre version raftlog and act as pre version.
b. load pre version profile and translate privilege into current version type.
c. add a lots of UT to check pre-raftlog and pre-file can be process