### PR TITLE
[IOTDB-6160] Correct the target paths verify logic in Select Into

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/SelectIntoUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/SelectIntoUtils.java
@@ -26,8 +26,8 @@ import org.apache.iotdb.db.exception.sql.SemanticException;
 import org.apache.iotdb.db.queryengine.common.schematree.ISchemaTree;
 import org.apache.iotdb.db.queryengine.plan.expression.Expression;
 import org.apache.iotdb.db.queryengine.plan.expression.leaf.TimeSeriesOperand;
+import org.apache.iotdb.db.queryengine.plan.parser.ASTVisitor;
 import org.apache.iotdb.db.utils.TypeInferenceUtils;
-import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.utils.Pair;
 
@@ -107,13 +107,7 @@ public class SelectIntoUtils {
       resNode = matcher.replaceFirst(sourceNodes[index]);
       matcher = LEVELED_PATH_TEMPLATE_PATTERN.matcher(resNode);
     }
-    if (!TsFileConstant.NODE_NAME_PATTERN.matcher(resNode).matches()) {
-      throw new SemanticException(
-          String.format(
-              "Parsed node name %s is illegal, unquoted node name can only consist of digits, characters and underscore, or start or end with wildcard",
-              resNode));
-    }
-    return resNode;
+    return ASTVisitor.parseNodeString(resNode);
   }
 
   public static boolean checkIsAllRawSeriesQuery(List<Expression> expressions) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/parser/ASTVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/parser/ASTVisitor.java
@@ -2033,7 +2033,7 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
     return parseNodeStringInIntoPath(ctx.getText());
   }
 
-  private String parseNodeString(String nodeName) {
+  public static String parseNodeString(String nodeName) {
     if (nodeName.equals(IoTDBConstant.ONE_LEVEL_PATH_WILDCARD)
         || nodeName.equals(IoTDBConstant.MULTI_LEVEL_PATH_WILDCARD)) {
       return nodeName;
@@ -2046,19 +2046,20 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
     return nodeName;
   }
 
-  private String parseNodeStringInIntoPath(String nodeName) {
+  private static String parseNodeStringInIntoPath(String nodeName) {
     if (nodeName.equals(IoTDBConstant.DOUBLE_COLONS)) {
       return nodeName;
     }
     if (nodeName.startsWith(TsFileConstant.BACK_QUOTE_STRING)
         && nodeName.endsWith(TsFileConstant.BACK_QUOTE_STRING)) {
-      return PathUtils.removeBackQuotesIfNecessary(nodeName);
+      // needn't remove back_quotes here, we will remove them after placeholders applied
+      return nodeName;
     }
     checkNodeNameInIntoPath(nodeName);
     return nodeName;
   }
 
-  private void checkNodeName(String src) {
+  private static void checkNodeName(String src) {
     // node name could start with * and end with *
     if (!TsFileConstant.NODE_NAME_PATTERN.matcher(src).matches()) {
       throw new SemanticException(
@@ -2068,7 +2069,7 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
     }
   }
 
-  private void checkNodeNameInIntoPath(String src) {
+  private static void checkNodeNameInIntoPath(String src) {
     // ${} are allowed
     if (!TsFileConstant.NODE_NAME_IN_INTO_PATH_PATTERN.matcher(src).matches()) {
       throw new SemanticException(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/component/IntoComponent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/component/IntoComponent.java
@@ -43,6 +43,8 @@ public class IntoComponent extends StatementNode {
       "select into: target paths in into clause should be different.";
   public static final String DEVICE_ALIGNMENT_INCONSISTENT_ERROR_MSG =
       "select into: alignment property must be the same for the same device.";
+  public static final String ILLEGAL_NODE_NAME_ERROR_MSG =
+      "is illegal, unquoted node name can only consist of digits, characters and underscore, or start or end with wildcard";
 
   private final List<IntoItem> intoItems;
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeFailTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeFailTest.java
@@ -34,6 +34,7 @@ import static org.apache.iotdb.db.queryengine.plan.statement.component.IntoCompo
 import static org.apache.iotdb.db.queryengine.plan.statement.component.IntoComponent.DEVICE_NUM_MISMATCH_ERROR_MSG;
 import static org.apache.iotdb.db.queryengine.plan.statement.component.IntoComponent.DUPLICATE_TARGET_PATH_ERROR_MSG;
 import static org.apache.iotdb.db.queryengine.plan.statement.component.IntoComponent.FORBID_PLACEHOLDER_ERROR_MSG;
+import static org.apache.iotdb.db.queryengine.plan.statement.component.IntoComponent.ILLEGAL_NODE_NAME_ERROR_MSG;
 import static org.apache.iotdb.db.queryengine.plan.statement.component.IntoComponent.PATH_NUM_MISMATCH_ERROR_MSG;
 import static org.apache.iotdb.db.queryengine.plan.statement.component.IntoComponent.PLACEHOLDER_MISMATCH_ERROR_MSG;
 import static org.apache.iotdb.db.queryengine.plan.statement.crud.QueryStatement.COUNT_TIME_CAN_ONLY_EXIST_ALONE;
@@ -154,6 +155,10 @@ public class AnalyzeFailTest {
     assertAnalyzeSemanticException(
         "select s1, s2 into ::(s1_1, s2_2), root.backup_sg.::(s1, s2) from root.sg.* align by device;",
         PLACEHOLDER_MISMATCH_ERROR_MSG);
+    assertAnalyzeSemanticException(
+        "select s1 into root.sg_bk.${2}_$abc(s1) from root.sg.d1;", ILLEGAL_NODE_NAME_ERROR_MSG);
+    assertAnalyzeSemanticException(
+        "select s1 into root.sg_bk.d01(${3}_$abc) from root.sg.d1;", ILLEGAL_NODE_NAME_ERROR_MSG);
   }
 
   @Test

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeTest.java
@@ -678,7 +678,11 @@ public class AnalyzeTest {
             "select s1, s2 into root.sg_copy.::(::) from root.sg.*;",
             "select s1, s2 into root.sg_copy.d1_copy(${2}_${3}), root.sg_copy.d1_copy(${2}_${3}), root.sg_copy.d2_copy(${2}_${3}), root.sg_copy.d2_copy(${2}_${3}) from root.sg.d1, root.sg.d2;",
             "select d1.s1, d1.s2, d2.s1, d2.s2 into ::(s1_1, s2_2), root.sg.d2_2(s3_3), root.backup_${1}.::(s4) from root.sg",
-            "select s1, s2 into root.sg_bk.new_d1(::) from root.sg.d1;");
+            "select s1, s2 into root.sg_bk.new_d1(::) from root.sg.d1;",
+            "select s1 into root.sg_bk.${2}(s1) from root.sg.d1;",
+            "select s1 into root.sg_bk.`${test`(s1) from root.sg.d1;",
+            "select s1 into root.sg_bk.`${2}${test`(s1) from root.sg.d1;");
+
     List<List<Pair<String, PartialPath>>> results =
         Arrays.asList(
             Arrays.asList(
@@ -738,7 +742,13 @@ public class AnalyzeTest {
                 new Pair("root.sg.d2.s2", new PartialPath("root.backup_sg.d2.s4"))),
             Arrays.asList(
                 new Pair("root.sg.d1.s1", new PartialPath("root.sg_bk.new_d1.s1")),
-                new Pair("root.sg.d1.s2", new PartialPath("root.sg_bk.new_d1.s2"))));
+                new Pair("root.sg.d1.s2", new PartialPath("root.sg_bk.new_d1.s2"))),
+            Collections.singletonList(
+                new Pair("root.sg.d1.s1", new PartialPath("root.sg_bk.d1.s1"))),
+            Collections.singletonList(
+                new Pair("root.sg.d1.s1", new PartialPath("root.sg_bk.`${test`.s1"))),
+            Collections.singletonList(
+                new Pair("root.sg.d1.s1", new PartialPath("root.sg_bk.`d1${test`.s1"))));
 
     for (int i = 0; i < sqls.size(); i++) {
       Analysis analysis = analyzeSQL(sqls.get(i));


### PR DESCRIPTION
correct the wrong fix logic in https://github.com/apache/iotdb/pull/10060

logic now: When generate statement, don't remove back_quotes any more; 
after placeholders applied, we will remove back_quotes if necessary or check if the node name is legal.