### PR TITLE
Pipe: add status message for procedure execution timed out

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
@@ -927,7 +927,9 @@ public class ProcedureManager {
           executor.getResultOrProcedure(procedureId);
       if (!finishedProcedure.isFinished()) {
         // the procedure is still executing
-        statusList.add(RpcUtils.getStatus(TSStatusCode.OVERLAP_WITH_EXISTING_TASK));
+        statusList.add(
+            RpcUtils.getStatus(
+                TSStatusCode.OVERLAP_WITH_EXISTING_TASK, "Procedure execution timed out."));
         isSucceed = false;
         continue;
       }


### PR DESCRIPTION
## Description

Before https://github.com/apache/iotdb/pull/11222, there might be an error like the following when creating or dropping a pipe:

```text
2023-09-25 23:27:42,705 [pool-32-IoTDB-MPP-Coordinator-Executor-19] WARN  o.a.i.d.q.p.e.c.ConfigExecution:126 - Failures happened during running ConfigExecution. 
org.apache.iotdb.commons.exception.IoTDBException: null
```

The reason for the error message being **null** is that the DataNode (DN) did not correctly set the status message after the procedure timeout. This PR fixes this issue.

**TBD:** I find the status code `TSStatusCode.OVERLAP_WITH_EXISTING_TASK` here to be somewhat unreasonable, although it doesn't affect the logic of the **PIPE** caller because of:

```java
return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(statusList.get(0).getMessage());
```

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [x] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
