### PR TITLE
Load: skipping instead of throwing exceptions when loading empty tsfiles

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/LoadTsfileAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/LoadTsfileAnalyzer.java
@@ -110,10 +110,7 @@ public class LoadTsfileAnalyzer {
         if (LOGGER.isWarnEnabled()) {
           LOGGER.warn(String.format("TsFile %s is empty.", tsFile.getPath()));
         }
-        throw new SemanticException(
-            String.format(
-                "TsFile %s is empty, please check it be flushed to disk correctly.",
-                tsFile.getPath()));
+        continue;
       }
 
       try {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/LoadTsfileAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/LoadTsfileAnalyzer.java
@@ -110,6 +110,11 @@ public class LoadTsfileAnalyzer {
         if (LOGGER.isWarnEnabled()) {
           LOGGER.warn(String.format("TsFile %s is empty.", tsFile.getPath()));
         }
+        if (LOGGER.isInfoEnabled()) {
+          LOGGER.info(
+              "Load - Analysis Stage: {}/{} tsfiles have been analyzed, progress: {}%",
+              i + 1, tsfileNum, String.format("%.3f", (i + 1) * 100.00 / tsfileNum));
+        }
         continue;
       }
 


### PR DESCRIPTION
When the loaded TsFile is empty, continue to load the next