### PR TITLE
[IOTDB-6183] Optimize the timeout retry logic of IoTConsensus sending RPCS

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/client/IoTConsensusClientPool.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/client/IoTConsensusClientPool.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.commons.client.ClientManagerMetrics;
 import org.apache.iotdb.commons.client.IClientPoolFactory;
 import org.apache.iotdb.commons.client.property.ClientPoolProperty;
 import org.apache.iotdb.commons.client.property.ThriftClientProperty;
+import org.apache.iotdb.commons.client.property.ThriftClientProperty.DefaultProperty;
 import org.apache.iotdb.commons.concurrent.ThreadName;
 import org.apache.iotdb.consensus.config.IoTConsensusConfig;
 
@@ -54,7 +55,10 @@ public class IoTConsensusClientPool {
               new SyncIoTConsensusServiceClient.Factory(
                   manager,
                   new ThriftClientProperty.Builder()
-                      .setConnectionTimeoutMs(config.getRpc().getConnectionTimeoutInMs())
+                      // We never let it time out, because the logic behind a timeout is also to
+                      // retry, which might actually worsen the situation. For example, resulting in
+                      // a significant increase in the number of file handles.
+                      .setConnectionTimeoutMs(DefaultProperty.CONNECTION_NEVER_TIMEOUT_MS)
                       .setRpcThriftCompressionEnabled(
                           config.getRpc().isRpcThriftCompressionEnabled())
                       .setPrintLogWhenEncounterException(
@@ -88,7 +92,10 @@ public class IoTConsensusClientPool {
               new AsyncIoTConsensusServiceClient.Factory(
                   manager,
                   new ThriftClientProperty.Builder()
-                      .setConnectionTimeoutMs(config.getRpc().getConnectionTimeoutInMs())
+                      // We never let it time out, because the logic behind a timeout is also to
+                      // retry, which might actually worsen the situation. For example, resulting in
+                      // a significant increase in the number of file handles.
+                      .setConnectionTimeoutMs(DefaultProperty.CONNECTION_NEVER_TIMEOUT_MS)
                       .setRpcThriftCompressionEnabled(
                           config.getRpc().isRpcThriftCompressionEnabled())
                       .setSelectorNumOfAsyncClientManager(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/property/ThriftClientProperty.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/property/ThriftClientProperty.java
@@ -108,12 +108,13 @@ public class ThriftClientProperty {
     }
   }
 
-  private static class DefaultProperty {
+  public static class DefaultProperty {
 
     private DefaultProperty() {}
 
     public static final boolean RPC_THRIFT_COMPRESSED_ENABLED = false;
     public static final int CONNECTION_TIMEOUT_MS = (int) TimeUnit.SECONDS.toMillis(20);
+    public static final int CONNECTION_NEVER_TIMEOUT_MS = 0;
     public static final int SELECTOR_NUM_OF_ASYNC_CLIENT_MANAGER = 1;
     public static final boolean PRINT_LOG_WHEN_ENCOUNTER_EXCEPTION = true;
   }


### PR DESCRIPTION
see [jira6183](https://issues.apache.org/jira/browse/IOTDB-6183)