### PR TITLE
[IOTDB-6185] Fix show cluster null status bug

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -446,8 +446,18 @@ public class ConfigManager implements IManager {
               .map(TDataNodeConfiguration::getLocation)
               .sorted(Comparator.comparingInt(TDataNodeLocation::getDataNodeId))
               .collect(Collectors.toList());
-      Map<Integer, String> nodeStatus = getLoadManager().getNodeStatusWithReason();
       Map<Integer, TNodeVersionInfo> nodeVersionInfo = getNodeManager().getNodeVersionInfo();
+      Map<Integer, String> nodeStatus = getLoadManager().getNodeStatusWithReason();
+      for (TConfigNodeLocation configNodeLocation : configNodeLocations) {
+        if (!nodeStatus.containsKey(configNodeLocation.getConfigNodeId())) {
+          nodeStatus.put(configNodeLocation.getConfigNodeId(), NodeStatus.Unknown.toString());
+        }
+      }
+      for (TDataNodeLocation dataNodeLocation : dataNodeInfoLocations) {
+        if (!nodeStatus.containsKey(dataNodeLocation.getDataNodeId())) {
+          nodeStatus.put(dataNodeLocation.getDataNodeId(), NodeStatus.Unknown.toString());
+        }
+      }
       return new TShowClusterResp(
           status, configNodeLocations, dataNodeInfoLocations, nodeStatus, nodeVersionInfo);
     } else {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/node/NodeManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/node/NodeManager.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.common.rpc.thrift.TFlushReq;
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.cluster.NodeStatus;
+import org.apache.iotdb.commons.cluster.NodeType;
 import org.apache.iotdb.commons.cluster.RegionRoleType;
 import org.apache.iotdb.commons.conf.CommonConfig;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
@@ -55,6 +56,7 @@ import org.apache.iotdb.confignode.manager.UDFManager;
 import org.apache.iotdb.confignode.manager.consensus.ConsensusManager;
 import org.apache.iotdb.confignode.manager.load.LoadManager;
 import org.apache.iotdb.confignode.manager.load.cache.node.ConfigNodeHeartbeatCache;
+import org.apache.iotdb.confignode.manager.load.cache.node.NodeHeartbeatSample;
 import org.apache.iotdb.confignode.manager.partition.PartitionManager;
 import org.apache.iotdb.confignode.manager.partition.PartitionMetrics;
 import org.apache.iotdb.confignode.manager.pipe.PipeManager;
@@ -261,6 +263,13 @@ public class NodeManager {
     } catch (ConsensusException e) {
       LOGGER.warn(CONSENSUS_WRITE_ERROR, e);
     }
+
+    // Init HeartbeatCache
+    getLoadManager()
+        .forceUpdateNodeCache(
+            NodeType.DataNode,
+            dataNodeId,
+            NodeHeartbeatSample.generateDefaultSample(NodeStatus.Unknown));
 
     // update datanode's versionInfo
     UpdateVersionInfoPlan updateVersionInfoPlan =

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/node/AddConfigNodeProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/node/AddConfigNodeProcedure.java
@@ -20,8 +20,11 @@
 package org.apache.iotdb.confignode.procedure.impl.node;
 
 import org.apache.iotdb.common.rpc.thrift.TConfigNodeLocation;
+import org.apache.iotdb.commons.cluster.NodeStatus;
+import org.apache.iotdb.commons.cluster.NodeType;
 import org.apache.iotdb.commons.exception.runtime.ThriftSerDeException;
 import org.apache.iotdb.commons.utils.ThriftConfigNodeSerDeUtils;
+import org.apache.iotdb.confignode.manager.load.cache.node.NodeHeartbeatSample;
 import org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv;
 import org.apache.iotdb.confignode.procedure.exception.ProcedureException;
 import org.apache.iotdb.confignode.procedure.state.AddConfigNodeState;
@@ -83,6 +86,12 @@ public class AddConfigNodeProcedure extends AbstractNodeProcedure<AddConfigNodeS
           env.notifyRegisterSuccess(tConfigNodeLocation);
           env.applyConfigNode(tConfigNodeLocation, versionInfo);
           env.broadCastTheLatestConfigNodeGroup();
+          env.getConfigManager()
+              .getLoadManager()
+              .forceUpdateNodeCache(
+                  NodeType.ConfigNode,
+                  tConfigNodeLocation.getConfigNodeId(),
+                  NodeHeartbeatSample.generateDefaultSample(NodeStatus.Unknown));
           LOG.info("The ConfigNode: {} is successfully added to the cluster", tConfigNodeLocation);
           return Flow.NO_MORE_STATE;
       }


### PR DESCRIPTION
Some Node's status might be `null` if the ConfigNode can't send heartbeat request to them. Therefore, the ConfigNode will initiate all Node's status to `Unknown` and make sure all Node's status are either exist or set to `Unknown` by default.