### PR TITLE
Added fsync operation when persisting files

### DIFF
--- a/iotdb-connector/hadoop/src/main/java/org/apache/iotdb/hadoop/fileSystem/HDFSOutput.java
+++ b/iotdb-connector/hadoop/src/main/java/org/apache/iotdb/hadoop/fileSystem/HDFSOutput.java
@@ -101,4 +101,9 @@ public class HDFSOutput implements TsFileOutput {
       fsDataOutputStream = fs.append(path);
     }
   }
+
+  @Override
+  public void force() throws IOException {
+    // do nothing
+  }
 }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -59,7 +59,6 @@ import org.apache.iotdb.consensus.iot.thrift.TWaitSyncLogCompleteReq;
 import org.apache.iotdb.consensus.iot.thrift.TWaitSyncLogCompleteRes;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
-import org.apache.iotdb.tsfile.utils.PublicBAOS;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.thrift.TException;
@@ -68,6 +67,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.DataOutputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
@@ -593,12 +593,8 @@ public class IoTConsensusServerImpl {
   }
 
   public void persistConfiguration() {
-    try (PublicBAOS publicBAOS = new PublicBAOS();
-        DataOutputStream outputStream = new DataOutputStream(publicBAOS)) {
-      serializeConfigurationTo(outputStream);
-      Files.write(
-          Paths.get(new File(storageDir, CONFIGURATION_FILE_NAME).getAbsolutePath()),
-          publicBAOS.getBuf());
+    try {
+      serializeConfigurationAndFsyncToDisk(CONFIGURATION_FILE_NAME);
     } catch (IOException e) {
       // TODO: (xingtanzjr) need to handle the IOException because the IoTConsensus won't
       // work expectedly
@@ -608,15 +604,13 @@ public class IoTConsensusServerImpl {
   }
 
   public void persistConfigurationUpdate() throws ConsensusGroupModifyPeerException {
-    try (PublicBAOS publicBAOS = new PublicBAOS();
-        DataOutputStream outputStream = new DataOutputStream(publicBAOS)) {
-      serializeConfigurationTo(outputStream);
+    try {
+      serializeConfigurationAndFsyncToDisk(CONFIGURATION_TMP_FILE_NAME);
       Path tmpConfigurationPath =
           Paths.get(new File(storageDir, CONFIGURATION_TMP_FILE_NAME).getAbsolutePath());
       Path configurationPath =
           Paths.get(new File(storageDir, CONFIGURATION_FILE_NAME).getAbsolutePath());
-      Files.write(tmpConfigurationPath, publicBAOS.getBuf());
-      Files.delete(configurationPath);
+      Files.deleteIfExists(configurationPath);
       Files.move(tmpConfigurationPath, configurationPath);
     } catch (IOException e) {
       throw new ConsensusGroupModifyPeerException(
@@ -817,6 +811,20 @@ public class IoTConsensusServerImpl {
 
   public String getConsensusGroupId() {
     return consensusGroupId;
+  }
+
+  private void serializeConfigurationAndFsyncToDisk(String configurationFileName)
+      throws IOException {
+    FileOutputStream fileOutputStream =
+        new FileOutputStream(new File(storageDir, configurationFileName));
+    DataOutputStream outputStream = new DataOutputStream(fileOutputStream);
+    try {
+      serializeConfigurationTo(outputStream);
+    } finally {
+      fileOutputStream.flush();
+      fileOutputStream.getFD().sync();
+      outputStream.close();
+    }
   }
 
   /**

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBStartCheck.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBStartCheck.java
@@ -373,8 +373,8 @@ public class IoTDBStartCheck {
     }
 
     reloadProperties();
-
-    try (FileOutputStream tmpFOS = new FileOutputStream(tmpPropertiesFile.toString())) {
+    FileOutputStream tmpFOS = new FileOutputStream(tmpPropertiesFile.toString());
+    try {
       properties.setProperty(IoTDBConstant.CLUSTER_NAME, clusterName);
       properties.setProperty(DATA_NODE_ID, String.valueOf(dataNodeId));
       properties.store(tmpFOS, SYSTEM_PROPERTIES_STRING);
@@ -382,6 +382,10 @@ public class IoTDBStartCheck {
       if (propertiesFile.exists()) {
         Files.delete(propertiesFile.toPath());
       }
+    } finally {
+      tmpFOS.flush();
+      tmpFOS.getFD().sync();
+      tmpFOS.close();
     }
     // rename system.properties.tmp to system.properties
     FileUtils.moveFile(tmpPropertiesFile, propertiesFile);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
@@ -152,6 +152,7 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
         compactionLogger.logFiles(selectedSequenceFiles, CompactionLogger.STR_SOURCE_FILES);
         compactionLogger.logFiles(selectedUnsequenceFiles, CompactionLogger.STR_SOURCE_FILES);
         compactionLogger.logFiles(targetTsfileResourceList, CompactionLogger.STR_TARGET_FILES);
+        compactionLogger.force();
 
         performer.setSourceFiles(selectedSequenceFiles, selectedUnsequenceFiles);
         performer.setTargetFiles(targetTsfileResourceList);
@@ -177,6 +178,7 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
         for (TsFileResource targetResource : targetTsfileResourceList) {
           if (targetResource.isDeleted()) {
             compactionLogger.logFile(targetResource, CompactionLogger.STR_DELETED_TARGET_FILES);
+            compactionLogger.force();
           }
         }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
@@ -179,7 +179,7 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
         targetTsFileList = new ArrayList<>(Collections.singletonList(targetTsFileResource));
         compactionLogger.logFiles(selectedTsFileResourceList, CompactionLogger.STR_SOURCE_FILES);
         compactionLogger.logFiles(targetTsFileList, CompactionLogger.STR_TARGET_FILES);
-
+        compactionLogger.force();
         LOGGER.info(
             "{}-{} [Compaction] compaction with {}",
             storageGroupName,
@@ -231,6 +231,7 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
 
         if (targetTsFileResource.isDeleted()) {
           compactionLogger.logFile(targetTsFileResource, CompactionLogger.STR_DELETED_TARGET_FILES);
+          compactionLogger.force();
         }
 
         CompactionValidator validator = CompactionValidator.getInstance();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/log/CompactionLogger.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/log/CompactionLogger.java
@@ -21,9 +21,8 @@ package org.apache.iotdb.db.storageengine.dataregion.compaction.execute.utils.lo
 
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.List;
 
@@ -48,10 +47,10 @@ public class CompactionLogger implements AutoCloseable {
   public static final String UNSEQUENCE_NAME_FROM_OLD = "unsequence";
   public static final String STR_MERGE_START_FROM_OLD = "merge start";
 
-  private BufferedWriter logStream;
+  private FileOutputStream logStream;
 
   public CompactionLogger(File logFile) throws IOException {
-    logStream = new BufferedWriter(new FileWriter(logFile, true));
+    logStream = new FileOutputStream(logFile, true);
   }
 
   @Override
@@ -61,24 +60,17 @@ public class CompactionLogger implements AutoCloseable {
 
   public void logFiles(List<TsFileResource> tsFiles, String flag) throws IOException {
     for (TsFileResource tsFileResource : tsFiles) {
-      logStream.write(
-          flag
-              + TsFileIdentifier.INFO_SEPARATOR
-              + TsFileIdentifier.getFileIdentifierFromFilePath(
-                      tsFileResource.getTsFile().getAbsolutePath())
-                  .toString());
-      logStream.newLine();
+      logFile(tsFileResource, flag);
     }
-    logStream.flush();
   }
 
   public void logFile(TsFileResource tsFile, String flag) throws IOException {
-    logStream.write(
+    String log =
         flag
             + TsFileIdentifier.INFO_SEPARATOR
-            + TsFileIdentifier.getFileIdentifierFromFilePath(tsFile.getTsFile().getAbsolutePath())
-                .toString());
-    logStream.newLine();
+            + TsFileIdentifier.getFileIdentifierFromFilePath(tsFile.getTsFile().getAbsolutePath());
+    logStream.write(log.getBytes());
+    logStream.write(System.lineSeparator().getBytes());
     logStream.flush();
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/log/CompactionLogger.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/log/CompactionLogger.java
@@ -55,8 +55,6 @@ public class CompactionLogger implements AutoCloseable {
 
   @Override
   public void close() throws IOException {
-    logStream.flush();
-    logStream.getFD().sync();
     logStream.close();
   }
 
@@ -85,5 +83,15 @@ public class CompactionLogger implements AutoCloseable {
     } else {
       return new File[0];
     }
+  }
+
+  /**
+   * call system fsync function, make sure data flush to disk
+   *
+   * @throws IOException
+   */
+  public void force() throws IOException {
+    logStream.flush();
+    logStream.getFD().sync();
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/log/CompactionLogger.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/log/CompactionLogger.java
@@ -55,6 +55,8 @@ public class CompactionLogger implements AutoCloseable {
 
   @Override
   public void close() throws IOException {
+    logStream.flush();
+    logStream.getFD().sync();
     logStream.close();
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
@@ -1244,6 +1244,11 @@ public class TsFileProcessor {
 
     // for sync flush
     syncReleaseFlushedMemTable(memTableToFlush);
+    try {
+      writer.getTsFileOutput().force();
+    } catch (IOException e) {
+      logger.error("fsync memTable data to disk error,", e);
+    }
 
     // call flushed listener after memtable is released safely
     for (FlushListener flushListener : flushListeners) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/modification/io/ModificationWriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/modification/io/ModificationWriter.java
@@ -43,4 +43,7 @@ public interface ModificationWriter {
 
   /** Release resources like streams. */
   void close() throws IOException;
+
+  /** Make sure that the data in the buffer is flushed to disk */
+  void force() throws IOException;
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/snapshot/SnapshotLogger.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/snapshot/SnapshotLogger.java
@@ -35,6 +35,7 @@ public class SnapshotLogger implements AutoCloseable {
 
   private File logFile;
   private BufferedOutputStream os;
+  private FileOutputStream fos;
 
   public SnapshotLogger(File logFile) throws IOException {
     this.logFile = logFile;
@@ -44,11 +45,14 @@ public class SnapshotLogger implements AutoCloseable {
     if (!this.logFile.createNewFile()) {
       throw new IOException("Cannot create file " + logFile.getAbsolutePath());
     }
-    os = new BufferedOutputStream(new FileOutputStream(logFile));
+    fos = new FileOutputStream(logFile);
+    os = new BufferedOutputStream(fos);
   }
 
   @Override
   public void close() throws Exception {
+    fos.flush();
+    fos.getFD().sync();
     os.close();
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
@@ -52,10 +52,11 @@ import org.apache.iotdb.tsfile.write.writer.TsFileIOWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -230,42 +231,50 @@ public class TsFileResource {
   }
 
   public synchronized void serialize() throws IOException {
-    try (OutputStream outputStream =
-        fsFactory.getBufferedOutputStream(file + RESOURCE_SUFFIX + TEMP_SUFFIX)) {
-      ReadWriteIOUtils.write(VERSION_NUMBER, outputStream);
-      timeIndex.serialize(outputStream);
-
-      ReadWriteIOUtils.write(maxPlanIndex, outputStream);
-      ReadWriteIOUtils.write(minPlanIndex, outputStream);
-
-      if (modFile != null && modFile.exists()) {
-        String modFileName = new File(modFile.getFilePath()).getName();
-        ReadWriteIOUtils.write(modFileName, outputStream);
-      } else {
-        // make the first "inputStream.available() > 0" in deserialize() happy.
-        //
-        // if modFile not exist, write null (-1). the first "inputStream.available() > 0" in
-        // deserialize() and deserializeFromOldFile() detect -1 and deserialize modFileName as null
-        // and skip the modFile deserialize.
-        //
-        // this make sure the first and the second "inputStream.available() > 0" in deserialize()
-        // will always be called... which is a bit ugly but allows the following variable
-        // maxProgressIndex to be deserialized correctly.
-        ReadWriteIOUtils.write((String) null, outputStream);
-      }
-
-      if (maxProgressIndex != null) {
-        ReadWriteIOUtils.write(true, outputStream);
-        maxProgressIndex.serialize(outputStream);
-      } else {
-        ReadWriteIOUtils.write(false, outputStream);
-      }
+    FileOutputStream fileOutputStream = new FileOutputStream(file + RESOURCE_SUFFIX + TEMP_SUFFIX);
+    BufferedOutputStream outputStream = new BufferedOutputStream(fileOutputStream);
+    try {
+      serializeTo(outputStream);
+    } finally {
+      outputStream.flush();
+      fileOutputStream.getFD().sync();
+      outputStream.close();
     }
-
     File src = fsFactory.getFile(file + RESOURCE_SUFFIX + TEMP_SUFFIX);
     File dest = fsFactory.getFile(file + RESOURCE_SUFFIX);
     fsFactory.deleteIfExists(dest);
     fsFactory.moveFile(src, dest);
+  }
+
+  private void serializeTo(BufferedOutputStream outputStream) throws IOException {
+    ReadWriteIOUtils.write(VERSION_NUMBER, outputStream);
+    timeIndex.serialize(outputStream);
+
+    ReadWriteIOUtils.write(maxPlanIndex, outputStream);
+    ReadWriteIOUtils.write(minPlanIndex, outputStream);
+
+    if (modFile != null && modFile.exists()) {
+      String modFileName = new File(modFile.getFilePath()).getName();
+      ReadWriteIOUtils.write(modFileName, outputStream);
+    } else {
+      // make the first "inputStream.available() > 0" in deserialize() happy.
+      //
+      // if modFile not exist, write null (-1). the first "inputStream.available() > 0" in
+      // deserialize() and deserializeFromOldFile() detect -1 and deserialize modFileName as null
+      // and skip the modFile deserialize.
+      //
+      // this make sure the first and the second "inputStream.available() > 0" in deserialize()
+      // will always be called... which is a bit ugly but allows the following variable
+      // maxProgressIndex to be deserialized correctly.
+      ReadWriteIOUtils.write((String) null, outputStream);
+    }
+
+    if (maxProgressIndex != null) {
+      ReadWriteIOUtils.write(true, outputStream);
+      maxProgressIndex.serialize(outputStream);
+    } else {
+      ReadWriteIOUtils.write(false, outputStream);
+    }
   }
 
   /** deserialize from disk */

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/LocalTsFileOutput.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/LocalTsFileOutput.java
@@ -77,6 +77,7 @@ public class LocalTsFileOutput extends OutputStream implements TsFileOutput {
 
   @Override
   public void close() throws IOException {
+    force();
     bufferedStream.close();
     outputStream.close();
   }
@@ -96,5 +97,11 @@ public class LocalTsFileOutput extends OutputStream implements TsFileOutput {
     bufferedStream.flush();
     outputStream.getChannel().truncate(size);
     position = outputStream.getChannel().position();
+  }
+
+  @Override
+  public void force() throws IOException {
+    bufferedStream.flush();
+    outputStream.getFD().sync();
   }
 }

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/LocalTsFileOutput.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/LocalTsFileOutput.java
@@ -77,7 +77,6 @@ public class LocalTsFileOutput extends OutputStream implements TsFileOutput {
 
   @Override
   public void close() throws IOException {
-    force();
     bufferedStream.close();
     outputStream.close();
   }
@@ -101,7 +100,7 @@ public class LocalTsFileOutput extends OutputStream implements TsFileOutput {
 
   @Override
   public void force() throws IOException {
-    bufferedStream.flush();
+    flush();
     outputStream.getFD().sync();
   }
 }

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
@@ -736,4 +736,8 @@ public class TsFileIOWriter implements AutoCloseable {
   public void flush() throws IOException {
     out.flush();
   }
+
+  public TsFileOutput getTsFileOutput() {
+    return this.out;
+  }
 }

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileIOWriter.java
@@ -333,8 +333,11 @@ public class TsFileIOWriter implements AutoCloseable {
     // write magic string
     out.write(MAGIC_STRING_BYTES);
 
+    // flush page cache data to disk
+    out.force();
     // close file
     out.close();
+
     if (resourceLogger.isDebugEnabled() && file != null) {
       resourceLogger.debug("{} writer is closed.", file.getName());
     }

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileOutput.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/TsFileOutput.java
@@ -88,4 +88,7 @@ public interface TsFileOutput {
    * @param size size The new size, a non-negative byte count
    */
   void truncate(long size) throws IOException;
+
+  /** Make sure that the data in the buffer is flushed to disk */
+  void force() throws IOException;
 }

--- a/iotdb-core/tsfile/src/test/java/org/apache/iotdb/tsfile/write/writer/TestTsFileOutput.java
+++ b/iotdb-core/tsfile/src/test/java/org/apache/iotdb/tsfile/write/writer/TestTsFileOutput.java
@@ -67,4 +67,9 @@ public class TestTsFileOutput implements TsFileOutput {
   public void truncate(long size) {
     publicBAOS.truncate((int) size);
   }
+
+  @Override
+  public void force() {
+    // do nothing
+  }
 }


### PR DESCRIPTION
## Description

The following operations have added fsync operations:
1. flush the endFile() operation to ensure that data in `tsfile` and `.resource` files is flushed to disks
2. The `configuration.dat` file is persisted and updated when the consensus group is started
3. Update`DataNodeId` and `ClusterName` for System.properties
4. Update the `snapshot.log` file