### PR TITLE
Fix bad tsfile being recoverd from wal

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/file/TsFilePlanRedoer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/file/TsFilePlanRedoer.java
@@ -78,12 +78,9 @@ public class TsFilePlanRedoer {
     if (!node.hasValidMeasurements()) {
       return;
     }
+    String deviceId = node.getDevicePath().getFullPath();
     if (tsFileResource != null) {
-      String deviceId =
-          node.isAligned()
-              ? node.getDevicePath().getDevicePath().getFullPath()
-              : node.getDevicePath().getFullPath();
-      // orders of insert node is guaranteed by storage storageengine, just check time in the file
+      // orders of insert node is guaranteed by storage engine, just check time in the file
       // the last chunk group may contain the same data with the logs, ignore such logs in seq file
       long lastEndTime = tsFileResource.getEndTime(deviceId);
       long minTimeInNode;
@@ -97,7 +94,7 @@ public class TsFilePlanRedoer {
       }
     }
 
-    node.setDeviceID(DeviceIDFactory.getInstance().getDeviceID(node.getDevicePath()));
+    node.setDeviceID(DeviceIDFactory.getInstance().getDeviceID(deviceId));
 
     if (node instanceof InsertRowNode) {
       if (node.isAligned()) {

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/file/header/ChunkGroupHeader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/file/header/ChunkGroupHeader.java
@@ -73,6 +73,9 @@ public class ChunkGroupHeader {
     }
 
     String deviceID = ReadWriteIOUtils.readVarIntString(inputStream);
+    if (deviceID == null || deviceID.isEmpty()) {
+      throw new IOException("DeviceId is empty");
+    }
     return new ChunkGroupHeader(deviceID);
   }
 

--- a/iotdb-core/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TsFileSequenceReaderTest.java
+++ b/iotdb-core/tsfile/src/test/java/org/apache/iotdb/tsfile/read/TsFileSequenceReaderTest.java
@@ -125,7 +125,7 @@ public class TsFileSequenceReaderTest {
       List<ChunkMetadata> metadataList = chunkMetadataMap.get("s" + id);
       int numOfPoints = 0;
       for (ChunkMetadata metadata : metadataList) {
-        numOfPoints += metadata.getNumOfPoints();
+        numOfPoints += (int) metadata.getNumOfPoints();
       }
       Assert.assertEquals(res[i], numOfPoints);
     }
@@ -167,9 +167,10 @@ public class TsFileSequenceReaderTest {
     }
 
     // read tsfile with selfCheck method
-    TsFileSequenceReader reader = new TsFileSequenceReader(FILE_PATH);
-    Assert.assertEquals(
-        TsFileCheckStatus.COMPLETE_FILE,
-        reader.selfCheck(new HashMap<>(), new ArrayList<>(), false));
+    try (TsFileSequenceReader reader = new TsFileSequenceReader(FILE_PATH)) {
+      Assert.assertEquals(
+          TsFileCheckStatus.COMPLETE_FILE,
+          reader.selfCheck(new HashMap<>(), new ArrayList<>(), false));
+    }
   }
 }

--- a/iotdb-core/tsfile/src/test/java/org/apache/iotdb/tsfile/write/writer/RestorableTsFileIOWriterTest.java
+++ b/iotdb-core/tsfile/src/test/java/org/apache/iotdb/tsfile/write/writer/RestorableTsFileIOWriterTest.java
@@ -253,6 +253,43 @@ public class RestorableTsFileIOWriterTest {
     writer = new TsFileWriter(rWriter);
     writer.close();
     assertNotEquals(TsFileIOWriter.MAGIC_STRING_BYTES.length, rWriter.getTruncatedSize());
+    assertEquals(89, rWriter.getTruncatedSize());
+    rWriter.close();
+
+    TsFileSequenceReader reader = new TsFileSequenceReader(FILE_NAME);
+    List<ChunkMetadata> chunkMetadataList = reader.getChunkMetadataList(new Path("d1", "s1", true));
+    assertNotNull(chunkMetadataList);
+    chunkMetadataList = reader.getChunkMetadataList(new Path("d1", "s2", true));
+    assertNotNull(chunkMetadataList);
+    reader.close();
+  }
+
+  @Test
+  public void testAChunkGroupEndWithALotOfZeroBytes() throws Exception {
+    TsFileWriter writer = new TsFileWriter(file);
+    writer.registerTimeseries(
+        new Path("d1"), new MeasurementSchema("s1", TSDataType.FLOAT, TSEncoding.RLE));
+    writer.registerTimeseries(
+        new Path("d1"), new MeasurementSchema("s2", TSDataType.FLOAT, TSEncoding.RLE));
+    writer.write(
+        new TSRecord(1, "d1")
+            .addTuple(new FloatDataPoint("s1", 5))
+            .addTuple(new FloatDataPoint("s2", 4)));
+    writer.write(
+        new TSRecord(2, "d1")
+            .addTuple(new FloatDataPoint("s1", 5))
+            .addTuple(new FloatDataPoint("s2", 4)));
+    writer.flushAllChunkGroups();
+    // write 10 Zero bytes
+    for (int i = 0; i < 10; i++) {
+      writer.getIOWriter().writeChunkGroupMarkerForTest();
+    }
+    writer.getIOWriter().close();
+    RestorableTsFileIOWriter rWriter = new RestorableTsFileIOWriter(file);
+    writer = new TsFileWriter(rWriter);
+    writer.close();
+    assertNotEquals(TsFileIOWriter.MAGIC_STRING_BYTES.length, rWriter.getTruncatedSize());
+    assertEquals(89, rWriter.getTruncatedSize());
     rWriter.close();
 
     TsFileSequenceReader reader = new TsFileSequenceReader(FILE_NAME);


### PR DESCRIPTION
## Description

After OS system shutdown and restart IoTDB service, there is a broken TsFile cannot be compacted.

![image](https://github.com/apache/iotdb/assets/25913899/beb2ff28-3c15-4404-9e84-c0290078b4f9)

It caused by this 0-level TsFile contains two chunk groups with same device id. And there are several issues to fix. 

1. Before restart IoTDB, this TsFile ended with a lot of zero bytes. However the current selfcheck logic will treated these zero bytes as correct chunk group, which cause the truncate position is not correct.
2. In TsFilePlanRedoer, there is a wrong logic of filter the InsertPlan from wal. Some InsertPlans which should be filtered are inserted into the recovering memtable. Therefore, the TsFile will contains two chunk groups with same device id.
3. in UnsealedTsFileRecoverPerformer, there is an outdated redundant logic should be removed. 

## How to test

1. Add `System.exit(-1);` at the end of syncFlushMemTable method of MemtableFlushTask. 
2. Modify configs, set DataRegionPolicy as CUSTOM and DataRegionNumPerDB to 1
3. Start IoTDB, execute the following sql, then the dataNode will shutdown because of step 1
```sql
insert into root.sg.d1(time,s1,s2) aligned values(1,2,3)
insert into root.sg.d2(time,s1,s2) aligned values(1,2,3)
flush
```
4. Edit the TsFile, delete some bytes from the end.
5. Remove the line added in step 1, restart IoTDB, then execute `select * from root.**`. Before fixing, the query will be stuck.

