### PR TITLE
Add stopwatch for AbstractConsumeAllOperator

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/AbstractConsumeAllOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/AbstractConsumeAllOperator.java
@@ -178,9 +178,7 @@ public abstract class AbstractConsumeAllOperator extends AbstractOperator
         child.close();
       }
     }
-
     // friendly for gc
-    children.clear();
     inputTsBlocks = null;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/AbstractConsumeAllOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/AbstractConsumeAllOperator.java
@@ -28,6 +28,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static com.google.common.util.concurrent.Futures.successfulAsList;
 
@@ -37,10 +38,16 @@ public abstract class AbstractConsumeAllOperator extends AbstractOperator
   protected final List<Operator> children;
   protected final int inputOperatorsCount;
   /** TsBlock from child operator. Only one cache now. */
-  protected final TsBlock[] inputTsBlocks;
+  protected TsBlock[] inputTsBlocks;
 
   protected final boolean[] canCallNext;
   protected int readyChildIndex;
+
+  /** Index of the child that is currently fetching input */
+  protected int currentChildIndex = 0;
+
+  /** Indicate whether we found an empty child input in one loop */
+  protected boolean hasEmptyChild = false;
 
   protected AbstractConsumeAllOperator(OperatorContext operatorContext, List<Operator> children) {
     this.operatorContext = operatorContext;
@@ -84,41 +91,83 @@ public abstract class AbstractConsumeAllOperator extends AbstractOperator
    * @throws Exception errors happened while getting tsblock from children
    */
   protected boolean prepareInput() throws Exception {
-    boolean allReady = true;
-    for (int i = 0; i < inputOperatorsCount; i++) {
-      if (!isEmpty(i) || children.get(i) == null) {
+
+    // start stopwatch
+    long maxRuntime = operatorContext.getMaxRunTime().roundTo(TimeUnit.NANOSECONDS);
+    long start = System.nanoTime();
+
+    while (System.nanoTime() - start < maxRuntime && currentChildIndex < inputOperatorsCount) {
+      if (canSkipCurrentChild(currentChildIndex)) {
+        currentChildIndex++;
         continue;
       }
-      if (canCallNext[i] && children.get(i).hasNextWithTimer()) {
-        inputTsBlocks[i] = getNextTsBlock(i);
-        canCallNext[i] = false;
-        // child operator has next but return an empty TsBlock which means that it may not
-        // finish calculation in given time slice.
-        // In such case, TimeJoinOperator can't go on calculating, so we just return null.
-        // We can also use the while loop here to continuously call the hasNext() and next()
-        // methods of the child operator until its hasNext() returns false or the next() gets
-        // the data that is not empty, but this will cause the execution time of the while loop
-        // to be uncontrollable and may exceed all allocated time slice
-        if (isEmpty(i)) {
-          allReady = false;
+      if (canCallNext[currentChildIndex]) {
+        if (children.get(currentChildIndex).hasNextWithTimer()) {
+          inputTsBlocks[currentChildIndex] = getNextTsBlock(currentChildIndex);
+          canCallNext[currentChildIndex] = false;
+          // child operator has next but return an empty TsBlock which means that it may not
+          // finish calculation in given time slice.
+          // In such case, TimeJoinOperator can't go on calculating, so we just return null.
+          // We can also use the while loop here to continuously call the hasNext() and next()
+          // methods of the child operator until its hasNext() returns false or the next() gets
+          // the data that is not empty, but this will cause the execution time of the while loop
+          // to be uncontrollable and may exceed all allocated time slice
+          if (isEmpty(currentChildIndex)) {
+            hasEmptyChild = true;
+          } else {
+            processCurrentInputTsBlock(currentChildIndex);
+          }
+        } else {
+          handleFinishedChild(currentChildIndex);
         }
       } else {
-        allReady = false;
-        if (canCallNext[i]) {
-          // canCallNext[i] == true means children.get(i).hasNext == false
-          // we can close the finished children
-          children.get(i).close();
-          children.set(i, null);
-        }
+        hasEmptyChild = true;
+      }
+      currentChildIndex++;
+    }
+
+    if (currentChildIndex == inputOperatorsCount) {
+      // start a new loop
+      currentChildIndex = 0;
+      if (!hasEmptyChild) {
+        return true;
+      } else {
+        hasEmptyChild = false;
       }
     }
-    return allReady;
+    return false;
   }
 
   /** If the tsBlock is null or has no more data in the tsBlock, return true; else return false. */
   protected boolean isEmpty(int index) {
     return inputTsBlocks[index] == null || inputTsBlocks[index].isEmpty();
   }
+
+  // region helper function used in prepareInput, the subclass can have its own implementation
+
+  /**
+   * @param currentChildIndex the index of the child
+   * @return true if we can skip the currentChild in prepareInput
+   */
+  protected boolean canSkipCurrentChild(int currentChildIndex) {
+    return !isEmpty(currentChildIndex) || children.get(currentChildIndex) == null;
+  }
+
+  /** @param currentInputIndex index of the input TsBlock */
+  protected void processCurrentInputTsBlock(int currentInputIndex) {
+    // do nothing here, the subclass have its own implementation
+  }
+
+  /**
+   * @param currentChildIndex the index of the child
+   * @throws Exception Potential Exception thrown by Operator.close()
+   */
+  protected void handleFinishedChild(int currentChildIndex) throws Exception {
+    children.get(currentChildIndex).close();
+    children.set(currentChildIndex, null);
+  }
+
+  // endregion
 
   @Override
   public void close() throws Exception {
@@ -127,6 +176,9 @@ public abstract class AbstractConsumeAllOperator extends AbstractOperator
         child.close();
       }
     }
+    children.clear();
+    // friendly for gc
+    inputTsBlocks = null;
   }
 
   protected TsBlock getNextTsBlock(int childIndex) throws Exception {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/MergeSortOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/MergeSortOperator.java
@@ -216,40 +216,36 @@ public class MergeSortOperator extends AbstractConsumeAllOperator {
     return currentRetainedSize - minChildReturnSize;
   }
 
+  // region helper function used in prepareInput
+
   /**
-   * Try to cache one result of each child.
-   *
-   * @return true if results of all children are ready or have no more TsBlocks. Return false if
-   *     some children is blocked or return null.
+   * @param currentChildIndex the index of the child
+   * @return true if we can skip the currentChild in prepareInput
    */
   @Override
-  protected boolean prepareInput() throws Exception {
-    boolean allReady = true;
-    for (int i = 0; i < inputOperatorsCount; i++) {
-      if (needCallNext(i)) {
-        continue;
-      }
-      if (canCallNext[i]) {
-        if (children.get(i).hasNextWithTimer()) {
-          inputTsBlocks[i] = getNextTsBlock(i);
-          canCallNext[i] = false;
-          if (isEmpty(i)) {
-            allReady = false;
-          } else {
-            mergeSortHeap.push(new MergeSortKey(inputTsBlocks[i], 0, i));
-          }
-        } else {
-          noMoreTsBlocks[i] = true;
-          inputTsBlocks[i] = null;
-        }
-      } else {
-        allReady = false;
-      }
-    }
-    return allReady;
+  protected boolean canSkipCurrentChild(int currentChildIndex) {
+    return noMoreTsBlocks[currentChildIndex]
+        || !isEmpty(currentChildIndex)
+        || children.get(currentChildIndex) == null;
   }
 
-  private boolean needCallNext(int i) {
-    return noMoreTsBlocks[i] || !isEmpty(i) || children.get(i) == null;
+  /** @param currentInputIndex index of the input TsBlock */
+  @Override
+  protected void processCurrentInputTsBlock(int currentInputIndex) {
+    mergeSortHeap.push(new MergeSortKey(inputTsBlocks[currentInputIndex], 0, currentInputIndex));
   }
+
+  /**
+   * @param currentChildIndex the index of the child
+   * @throws Exception Potential Exception thrown by Operator.close()
+   */
+  @Override
+  protected void handleFinishedChild(int currentChildIndex) throws Exception {
+    noMoreTsBlocks[currentChildIndex] = true;
+    inputTsBlocks[currentChildIndex] = null;
+    children.get(currentChildIndex).close();
+    children.set(currentChildIndex, null);
+  }
+
+  // endregion
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/join/RowBasedTimeJoinOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/join/RowBasedTimeJoinOperator.java
@@ -276,45 +276,38 @@ public class RowBasedTimeJoinOperator extends AbstractConsumeAllOperator {
     timeSelector.add(inputTsBlocks[index].getTimeByIndex(inputIndex[index]));
   }
 
+  // region helper function used in prepareInput
+
   /**
-   * Try to cache one result of each child.
-   *
-   * @return true if results of all children are ready or have no more TsBlocks. Return false if
-   *     some children is blocked or return null.
+   * @param currentChildIndex the index of the child
+   * @return true if we can skip the currentChild in prepareInput
    */
   @Override
-  protected boolean prepareInput() throws Exception {
-    boolean allReady = true;
-    for (int i = 0; i < inputOperatorsCount; i++) {
-      if (needCallNext(i)) {
-        continue;
-      }
-      if (canCallNext[i]) {
-        if (children.get(i).hasNextWithTimer()) {
-          inputTsBlocks[i] = getNextTsBlock(i);
-          canCallNext[i] = false;
-          if (isEmpty(i)) {
-            allReady = false;
-          } else {
-            updateTimeSelector(i);
-          }
-        } else {
-          noMoreTsBlocks[i] = true;
-          inputTsBlocks[i] = null;
-          children.get(i).close();
-          children.set(i, null);
-        }
-
-      } else {
-        allReady = false;
-      }
-    }
-    return allReady;
+  protected boolean canSkipCurrentChild(int currentChildIndex) {
+    return noMoreTsBlocks[currentChildIndex]
+        || !isEmpty(currentChildIndex)
+        || children.get(currentChildIndex) == null;
   }
 
-  private boolean needCallNext(int i) {
-    return noMoreTsBlocks[i] || !isEmpty(i) || children.get(i) == null;
+  /** @param currentInputIndex index of the input TsBlock */
+  @Override
+  protected void processCurrentInputTsBlock(int currentInputIndex) {
+    updateTimeSelector(currentInputIndex);
   }
+
+  /**
+   * @param currentChildIndex the index of the child
+   * @throws Exception Potential Exception thrown by Operator.close()
+   */
+  @Override
+  protected void handleFinishedChild(int currentChildIndex) throws Exception {
+    noMoreTsBlocks[currentChildIndex] = true;
+    inputTsBlocks[currentChildIndex] = null;
+    children.get(currentChildIndex).close();
+    children.set(currentChildIndex, null);
+  }
+
+  // endregion
 
   @TestOnly
   public List<Operator> getChildren() {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/DataDriverTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/DataDriverTest.java
@@ -164,6 +164,7 @@ public class DataDriverTest {
                   new SingleColumnMerger(new InputLocation(0, 0), new AscTimeComparator()),
                   new SingleColumnMerger(new InputLocation(1, 0), new AscTimeComparator())),
               new AscTimeComparator());
+      timeJoinOperator.getOperatorContext().setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       LimitOperator limitOperator =
           new LimitOperator(driverContext.getOperatorContexts().get(3), 250, timeJoinOperator);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/AlignedSeriesScanOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/AlignedSeriesScanOperatorTest.java
@@ -398,6 +398,7 @@ public class AlignedSeriesScanOperatorTest {
                   new SingleColumnMerger(new InputLocation(6, 0), new AscTimeComparator()),
                   new SingleColumnMerger(new InputLocation(7, 0), new AscTimeComparator())),
               new AscTimeComparator());
+      timeJoinOperator.getOperatorContext().setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
       int count = 0;
       while (timeJoinOperator.isBlocked().isDone() && timeJoinOperator.hasNext()) {
         TsBlock tsBlock = timeJoinOperator.next();
@@ -688,6 +689,7 @@ public class AlignedSeriesScanOperatorTest {
                   new SingleColumnMerger(new InputLocation(6, 0), new DescTimeComparator()),
                   new SingleColumnMerger(new InputLocation(7, 0), new DescTimeComparator())),
               new DescTimeComparator());
+      timeJoinOperator.getOperatorContext().setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       int count = 499;
       while (timeJoinOperator.isBlocked().isDone() && timeJoinOperator.hasNext()) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/HorizontallyConcatOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/HorizontallyConcatOperatorTest.java
@@ -182,6 +182,9 @@ public class HorizontallyConcatOperatorTest {
                   TSDataType.INT64,
                   TSDataType.DOUBLE,
                   TSDataType.INT32));
+      horizontallyConcatOperator
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       int count = 0;
       while (horizontallyConcatOperator.isBlocked().isDone()

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/LimitOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/LimitOperatorTest.java
@@ -149,9 +149,11 @@ public class LimitOperatorTest {
                   new SingleColumnMerger(new InputLocation(0, 0), new AscTimeComparator()),
                   new SingleColumnMerger(new InputLocation(1, 0), new AscTimeComparator())),
               new AscTimeComparator());
+      timeJoinOperator.getOperatorContext().setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       LimitOperator limitOperator =
           new LimitOperator(driverContext.getOperatorContexts().get(3), 250, timeJoinOperator);
+
       int count = 0;
       while (limitOperator.isBlocked().isDone() && limitOperator.hasNext()) {
         TsBlock tsBlock = limitOperator.next();

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/MergeSortOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/MergeSortOperatorTest.java
@@ -284,6 +284,9 @@ public class MergeSortOperatorTest {
                           ? new AscTimeComparator()
                           : new DescTimeComparator())),
               timeOrdering == Ordering.ASC ? new AscTimeComparator() : new DescTimeComparator());
+      timeJoinOperator1
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
       SingleDeviceViewOperator singleDeviceViewOperator2 =
           new SingleDeviceViewOperator(
               driverContext.getOperatorContexts().get(7),
@@ -310,6 +313,10 @@ public class MergeSortOperatorTest {
                           ? new AscTimeComparator()
                           : new DescTimeComparator())),
               timeOrdering == Ordering.ASC ? new AscTimeComparator() : new DescTimeComparator());
+      timeJoinOperator2
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
+
       SingleDeviceViewOperator singleDeviceViewOperator3 =
           new SingleDeviceViewOperator(
               driverContext.getOperatorContexts().get(9),
@@ -720,6 +727,9 @@ public class MergeSortOperatorTest {
                           ? new AscTimeComparator()
                           : new DescTimeComparator())),
               timeOrdering == Ordering.ASC ? new AscTimeComparator() : new DescTimeComparator());
+      timeJoinOperator1
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       RowBasedTimeJoinOperator timeJoinOperator2 =
           new RowBasedTimeJoinOperator(
@@ -739,6 +749,9 @@ public class MergeSortOperatorTest {
                           ? new AscTimeComparator()
                           : new DescTimeComparator())),
               timeOrdering == Ordering.ASC ? new AscTimeComparator() : new DescTimeComparator());
+      timeJoinOperator2
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       RowBasedTimeJoinOperator timeJoinOperator3 =
           new RowBasedTimeJoinOperator(
@@ -758,6 +771,10 @@ public class MergeSortOperatorTest {
                           ? new AscTimeComparator()
                           : new DescTimeComparator())),
               timeOrdering == Ordering.ASC ? new AscTimeComparator() : new DescTimeComparator());
+      timeJoinOperator3
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
+
       SingleDeviceViewOperator singleDeviceViewOperator1 =
           new SingleDeviceViewOperator(
               driverContext.getOperatorContexts().get(10),
@@ -1190,6 +1207,9 @@ public class MergeSortOperatorTest {
                           ? new AscTimeComparator()
                           : new DescTimeComparator())),
               timeOrdering == Ordering.ASC ? new AscTimeComparator() : new DescTimeComparator());
+      timeJoinOperator1
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       RowBasedTimeJoinOperator timeJoinOperator2 =
           new RowBasedTimeJoinOperator(
@@ -1209,6 +1229,9 @@ public class MergeSortOperatorTest {
                           ? new AscTimeComparator()
                           : new DescTimeComparator())),
               timeOrdering == Ordering.ASC ? new AscTimeComparator() : new DescTimeComparator());
+      timeJoinOperator2
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       RowBasedTimeJoinOperator timeJoinOperator3 =
           new RowBasedTimeJoinOperator(
@@ -1228,6 +1251,9 @@ public class MergeSortOperatorTest {
                           ? new AscTimeComparator()
                           : new DescTimeComparator())),
               timeOrdering == Ordering.ASC ? new AscTimeComparator() : new DescTimeComparator());
+      timeJoinOperator3
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       List<String> devices = new ArrayList<>(Arrays.asList(DEVICE0, DEVICE1, DEVICE2, DEVICE3));
       if (deviceOrdering == Ordering.DESC) Collections.reverse(devices);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OffsetOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OffsetOperatorTest.java
@@ -152,6 +152,7 @@ public class OffsetOperatorTest {
                   new SingleColumnMerger(new InputLocation(0, 0), new AscTimeComparator()),
                   new SingleColumnMerger(new InputLocation(1, 0), new AscTimeComparator())),
               new AscTimeComparator());
+      timeJoinOperator.getOperatorContext().setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       OffsetOperator offsetOperator =
           new OffsetOperator(driverContext.getOperatorContexts().get(3), 100, timeJoinOperator);
@@ -257,6 +258,7 @@ public class OffsetOperatorTest {
                   new SingleColumnMerger(new InputLocation(0, 0), new AscTimeComparator()),
                   new SingleColumnMerger(new InputLocation(1, 0), new AscTimeComparator())),
               new AscTimeComparator());
+      timeJoinOperator.getOperatorContext().setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       OffsetOperator offsetOperator =
           new OffsetOperator(driverContext.getOperatorContexts().get(3), 0, timeJoinOperator);
@@ -359,6 +361,7 @@ public class OffsetOperatorTest {
                   new SingleColumnMerger(new InputLocation(0, 0), new AscTimeComparator()),
                   new SingleColumnMerger(new InputLocation(1, 0), new AscTimeComparator())),
               new AscTimeComparator());
+      timeJoinOperator.getOperatorContext().setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       OffsetOperator offsetOperator =
           new OffsetOperator(driverContext.getOperatorContexts().get(3), 500, timeJoinOperator);
@@ -445,6 +448,7 @@ public class OffsetOperatorTest {
                   new SingleColumnMerger(new InputLocation(0, 0), new AscTimeComparator()),
                   new SingleColumnMerger(new InputLocation(1, 0), new AscTimeComparator())),
               new AscTimeComparator());
+      timeJoinOperator.getOperatorContext().setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       OffsetOperator offsetOperator =
           new OffsetOperator(

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/SingleDeviceViewOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/SingleDeviceViewOperatorTest.java
@@ -155,6 +155,8 @@ public class SingleDeviceViewOperatorTest {
                   new SingleColumnMerger(new InputLocation(0, 0), new AscTimeComparator()),
                   new SingleColumnMerger(new InputLocation(1, 0), new AscTimeComparator())),
               new AscTimeComparator());
+      timeJoinOperator.getOperatorContext().setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
+
       SingleDeviceViewOperator singleDeviceViewOperator =
           new SingleDeviceViewOperator(
               driverContext.getOperatorContexts().get(3),

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/SortOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/SortOperatorTest.java
@@ -180,6 +180,9 @@ public class SortOperatorTest {
                           ? new AscTimeComparator()
                           : new DescTimeComparator())),
               timeOrdering == Ordering.ASC ? new AscTimeComparator() : new DescTimeComparator());
+      timeJoinOperator1
+          .getOperatorContext()
+          .setMaxRunTime(new Duration(500, TimeUnit.MILLISECONDS));
 
       if (!getSortOperator) return timeJoinOperator1;
 


### PR DESCRIPTION
Related issue: https://jira.infra.timecho.com:8443/browse/TIMECHODB-342
Related doc: https://apache-iotdb.feishu.cn/docx/DQhWdXTeooCouHxeMCTcG3J7n4T
In a nutshell, some of the Operators fail to limit execution time in one Next() and these Operators may occupy the Query-Worker Thread for too long.
This PR aims to add stopwatch for AbstractConsumeAllOperator and its subclasses so that their execution time can be bounded.
The test result is listed in the above related doc.