### PR TITLE
[IOTDB-6187] IoTConsense WAL Interval Reading Strategy Optimization

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
@@ -611,7 +611,7 @@ public class WALNode implements IWALNode {
     /** true means filesToSearch and currentFileIndex are outdated, call updateFilesToSearch */
     private boolean needUpdatingFilesToSearch = true;
     /** batch store insert nodes */
-    private final List<IndexedConsensusRequest> insertNodes = new LinkedList<>();
+    private final LinkedList<IndexedConsensusRequest> insertNodes = new LinkedList<>();
     /** iterator of insertNodes */
     private ListIterator<IndexedConsensusRequest> itr = null;
 
@@ -837,7 +837,7 @@ public class WALNode implements IWALNode {
       if (itr != null
           && itr.hasNext()
           && insertNodes.get(itr.nextIndex()).getSearchIndex() <= targetIndex
-          && targetIndex <= insertNodes.get(insertNodes.size() - 1).getSearchIndex()) {
+          && targetIndex <= insertNodes.getLast().getSearchIndex()) {
         while (itr.hasNext()) {
           IndexedConsensusRequest request = itr.next();
           if (targetIndex == request.getSearchIndex()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
@@ -64,9 +64,9 @@ import java.io.FileNotFoundException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -613,7 +613,7 @@ public class WALNode implements IWALNode {
     /** batch store insert nodes */
     private final List<IndexedConsensusRequest> insertNodes = new LinkedList<>();
     /** iterator of insertNodes */
-    private Iterator<IndexedConsensusRequest> itr = null;
+    private ListIterator<IndexedConsensusRequest> itr = null;
 
     public PlanNodeIterator(long startIndex) {
       this.nextSearchIndex = startIndex;
@@ -775,7 +775,7 @@ public class WALNode implements IWALNode {
 
       // update iterator
       if (!insertNodes.isEmpty()) {
-        itr = insertNodes.iterator();
+        itr = insertNodes.listIterator();
         return true;
       }
       return false;
@@ -832,6 +832,13 @@ public class WALNode implements IWALNode {
             nextSearchIndex,
             targetIndex,
             targetIndex);
+      }
+      if (itr != null && itr.hasNext()) {
+        IndexedConsensusRequest request = itr.next();
+        itr.previous();
+        if (targetIndex == request.getSearchIndex()) {
+          return;
+        }
       }
       reset();
       nextSearchIndex = targetIndex;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
@@ -834,6 +834,9 @@ public class WALNode implements IWALNode {
             targetIndex);
       }
       while (itr != null && itr.hasNext()) {
+        if (insertNodes.get(insertNodes.size() - 1).getSearchIndex() < targetIndex) {
+          break;
+        }
         IndexedConsensusRequest request = itr.next();
         if (targetIndex == request.getSearchIndex()) {
           itr.previous();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
@@ -833,17 +833,21 @@ public class WALNode implements IWALNode {
             targetIndex,
             targetIndex);
       }
-      while (itr != null && itr.hasNext()) {
-        if (insertNodes.get(insertNodes.size() - 1).getSearchIndex() < targetIndex) {
-          break;
-        }
-        IndexedConsensusRequest request = itr.next();
-        if (targetIndex == request.getSearchIndex()) {
-          itr.previous();
-          nextSearchIndex = targetIndex;
-          return;
+
+      if (itr != null
+          && itr.hasNext()
+          && insertNodes.get(itr.nextIndex()).getSearchIndex() <= targetIndex
+          && targetIndex <= insertNodes.get(insertNodes.size() - 1).getSearchIndex()) {
+        while (itr.hasNext()) {
+          IndexedConsensusRequest request = itr.next();
+          if (targetIndex == request.getSearchIndex()) {
+            itr.previous();
+            nextSearchIndex = targetIndex;
+            return;
+          }
         }
       }
+
       reset();
       nextSearchIndex = targetIndex;
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
@@ -833,10 +833,11 @@ public class WALNode implements IWALNode {
             targetIndex,
             targetIndex);
       }
-      if (itr != null && itr.hasNext()) {
+      while (itr != null && itr.hasNext()) {
         IndexedConsensusRequest request = itr.next();
-        itr.previous();
         if (targetIndex == request.getSearchIndex()) {
+          itr.previous();
+          nextSearchIndex = targetIndex;
           return;
         }
       }


### PR DESCRIPTION
#### Description

IoTConsensus WAL always resets the insertNodes when WAL skip to a new targetIndex. But in most writting process, targetIndex is sequentially increasing, which means we may use the previous insertNodes as a cache and doesn't need to reset it everytime.