### PR TITLE
[IOTDB-6178] Add fsync for schemaregion, CQInfo, ModelInfo

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/ModelInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/ModelInfo.java
@@ -251,6 +251,7 @@ public class ModelInfo implements SnapshotProcessor {
     acquireModelTableReadLock();
     try (FileOutputStream fileOutputStream = new FileOutputStream(snapshotFile)) {
       modelTable.serialize(fileOutputStream);
+      fileOutputStream.getFD().sync();
       return true;
     } finally {
       releaseModelTableReadLock();

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/cq/CQInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/cq/CQInfo.java
@@ -226,6 +226,7 @@ public class CQInfo implements SnapshotProcessor {
     try (FileOutputStream fileOutputStream = new FileOutputStream(snapshotFile)) {
 
       serialize(fileOutputStream);
+      fileOutputStream.getFD().sync();
       return true;
     } finally {
       lock.readLock().unlock();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/mem/snapshot/MemMTreeSnapshotUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/mem/snapshot/MemMTreeSnapshotUtil.java
@@ -81,9 +81,14 @@ public class MemMTreeSnapshotUtil {
     File snapshot = SystemFileFactory.INSTANCE.getFile(snapshotDir, SchemaConstant.MTREE_SNAPSHOT);
 
     try {
-      try (BufferedOutputStream outputStream =
-          new BufferedOutputStream(new FileOutputStream(snapshotTmp))) {
+      FileOutputStream fileOutputStream = new FileOutputStream(snapshotTmp);
+      BufferedOutputStream outputStream = new BufferedOutputStream(fileOutputStream);
+      try {
         serializeTo(store, outputStream);
+      } finally {
+        outputStream.flush();
+        fileOutputStream.getFD().sync();
+        outputStream.close();
       }
       if (snapshot.exists() && !FileUtils.deleteFileIfExist(snapshot)) {
         logger.error(


### PR DESCRIPTION
more details can be seen in https://issues.apache.org/jira/browse/IOTDB-6178.

the solutions can be found in https://apache-iotdb.feishu.cn/docx/L6XNd0HBbo57xFx1DQ0cjkNenhg

In this pr, I add fsync for schemaregion, CQInfo, ModelInfo.