### PR TITLE
fix datanode can't stop because wal thread.

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
@@ -71,7 +71,7 @@ public class IoTDBShutdownHook extends Thread {
     if (!IoTDBDescriptor.getInstance().getConfig().isClusterMode()) {
       StorageEngine.getInstance().syncCloseAllProcessor();
     }
-    WALManager.getInstance().deleteOutdatedWALFiles();
+    WALManager.getInstance().deleteOutdatedFilesInWALNodes();
 
     // We did this work because the RatisConsensus recovery mechanism is different from other
     // consensus algorithms, which will replace the underlying storage engine based on its

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/StorageEngine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/StorageEngine.java
@@ -552,7 +552,7 @@ public class StorageEngine implements IService {
   public void operateFlush(TFlushReq req) {
     if (req.storageGroups == null) {
       StorageEngine.getInstance().syncCloseAllProcessor();
-      WALManager.getInstance().deleteOutdatedWALFiles();
+      WALManager.getInstance().deleteOutdatedFilesInWALNodes();
     } else {
       for (String storageGroup : req.storageGroups) {
         if (req.isSeq == null) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/WALManagerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/WALManagerTest.java
@@ -98,7 +98,7 @@ public class WALManagerTest {
       }
     }
 
-    walManager.deleteOutdatedWALFiles();
+    walManager.deleteOutdatedFilesInWALNodes();
 
     for (String walDir : walDirs) {
       File walDirFile = new File(walDir);


### PR DESCRIPTION
## Description

1. Fixed DataNode not stopping because Wal thread could not exit, after this PR, delete outdated will only execute once.
2. When IoTDBShutDownHook and Flush delete WAL expired files, the asynchronous thread is changed to the synchronous thread, which is more convenient when checking logs