### PR TITLE
fix(cli-windows): Ensure that any user defined CLASSPATH variables ar…

### DIFF
--- a/iotdb-client/cli/src/assembly/resources/sbin/start-cli.bat
+++ b/iotdb-client/cli/src/assembly/resources/sbin/start-cli.bat
@@ -22,6 +22,8 @@
 @REM You can put your env variable here
 @REM set JAVA_HOME=%JAVA_HOME%
 
+set PATH="%JAVA_HOME%\bin\";%PATH%
+
 if "%OS%" == "Windows_NT" setlocal
 
 pushd %~dp0..
@@ -36,10 +38,18 @@ if NOT DEFINED JAVA_HOME goto :err
 set JAVA_OPTS=-ea^
  -DIOTDB_HOME="%IOTDB_HOME%"
 
-REM For each jar in the IOTDB_HOME lib directory call append to build the CLASSPATH variable.
-if EXIST %IOTDB_HOME%\lib (set CLASSPATH=%CLASSPATH%;"%IOTDB_HOME%\lib\*") else set CLASSPATH=%CLASSPATH%;"%IOTDB_HOME%\..\lib\*"
+@REM ***** CLASSPATH library setting *****
+@REM Ensure that any user defined CLASSPATH variables are not used on startup
+if EXIST %IOTDB_HOME%\lib (set CLASSPATH="%IOTDB_HOME%\lib\*") else set CLASSPATH="%IOTDB_HOME%\..\lib\*"
+goto okClasspath
+
+:append
+set CLASSPATH=%CLASSPATH%;%1
+
+goto :eof
 
 REM -----------------------------------------------------------------------------
+:okClasspath
 set PARAMETERS=%*
 
 @REM if "%PARAMETERS%" == "" set PARAMETERS=-h 127.0.0.1 -p 6667 -u root -pw root
@@ -58,7 +68,7 @@ echo %PARAMETERS% | findstr /c:"-h ">nul && (set PARAMETERS=%PARAMETERS%) || (se
 
 echo %PARAMETERS%
 
-"%JAVA_HOME%\bin\java" %JAVA_OPTS% -cp %CLASSPATH% %MAIN_CLASS% %PARAMETERS%
+java %JAVA_OPTS% -cp %CLASSPATH% %MAIN_CLASS% %PARAMETERS%
 set ret_code=%ERRORLEVEL%
 goto finally
 


### PR DESCRIPTION
Ensure that any user defined CLASSPATH variables are not used on startup
like start-confignode.bat and start-datanode.bat