### PR TITLE
Pipe: fix potential NPE risk when reflecting `pipeReceiverFileDirs`

### DIFF
--- a/iotdb-core/datanode/pom.xml
+++ b/iotdb-core/datanode/pom.xml
@@ -328,7 +328,7 @@
         <dependency>
             <groupId>org.apache.ratis</groupId>
             <artifactId>ratis-thirdparty-misc</artifactId>
-            <scope>test</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.nimbusds</groupId>

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -1080,8 +1080,8 @@ public class IoTDBConfig {
   private double maxMemoryRatioForQueue = 0.6;
 
   /** Pipe related */
-  /** initialized as null, updated based on the latest `systemDir` during querying */
-  private String[] pipeReceiverFileDirs = null;
+  /** initialized as empty, updated based on the latest `systemDir` during querying */
+  private String[] pipeReceiverFileDirs = new String[0];
 
   /** Resource control */
   private boolean quotaEnable = false;
@@ -3715,7 +3715,7 @@ public class IoTDBConfig {
   }
 
   public String[] getPipeReceiverFileDirs() {
-    return Objects.isNull(this.pipeReceiverFileDirs)
+    return (Objects.isNull(this.pipeReceiverFileDirs) || this.pipeReceiverFileDirs.length == 0)
         ? new String[] {systemDir + File.separator + "pipe" + File.separator + "receiver"}
         : this.pipeReceiverFileDirs;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -71,6 +71,7 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.ServiceLoader;
@@ -1987,11 +1988,14 @@ public class IoTDBDescriptor {
     conf.setPipeLibDir(properties.getProperty("pipe_lib_dir", conf.getPipeLibDir()));
 
     conf.setPipeReceiverFileDirs(
-        properties
-            .getProperty(
-                "pipe_receiver_file_dirs", String.join(",", conf.getPipeReceiverFileDirs()))
-            .trim()
-            .split(","));
+        Arrays.stream(
+                properties
+                    .getProperty(
+                        "pipe_receiver_file_dirs", String.join(",", conf.getPipeReceiverFileDirs()))
+                    .trim()
+                    .split(","))
+            .filter(dir -> !dir.isEmpty())
+            .toArray(String[]::new));
   }
 
   private void loadCQProps(Properties properties) {


### PR DESCRIPTION
## Description

As title, avoid initializing `pipeReceiverFileDirs` as null.

Also changes `ratis-thirdparty-misc` dependency scope from **test** to **runtime**, prevents errors during DN startup (by IDEA):

```
2023-10-18 19:20:35,234 [main] ERROR o.a.i.c.ConsensusFactory:58 - Couldn't Construct IConsensus class: org.apache.iotdb.consensus.ratis.RatisConsensus 
java.lang.reflect.InvocationTargetException: null
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
        at org.apache.iotdb.consensus.ConsensusFactory.getConsensusImpl(ConsensusFactory.java:52)
        at org.apache.iotdb.db.consensus.SchemaRegionConsensusImpl$SchemaRegionConsensusImplHolder.<clinit>(SchemaRegionConsensusImpl.java:57)
        at org.apache.iotdb.db.consensus.SchemaRegionConsensusImpl.getInstance(SchemaRegionConsensusImpl.java:50)
        at org.apache.iotdb.db.service.DataNode.active(DataNode.java:494)
        at org.apache.iotdb.db.service.DataNode.doAddNode(DataNode.java:185)
        at org.apache.iotdb.db.service.DataNodeServerCommandLine.run(DataNodeServerCommandLine.java:81)
        at org.apache.iotdb.commons.ServerCommandLine.doMain(ServerCommandLine.java:58)
        at org.apache.iotdb.db.service.DataNode.main(DataNode.java:159)
Caused by: java.lang.NoClassDefFoundError: org/apache/ratis/thirdparty/com/google/protobuf/ByteString
        at org.apache.ratis.protocol.RaftId.toByteString(RaftId.java:52)
        at org.apache.ratis.protocol.RaftId.<clinit>(RaftId.java:32)
        at org.apache.iotdb.consensus.ratis.RatisConsensus.<init>(RatisConsensus.java:120)
        ... 12 common frames omitted
Caused by: java.lang.ClassNotFoundException: org.apache.ratis.thirdparty.com.google.protobuf.ByteString
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:527)
        ... 15 common frames omitted
2023-10-18 19:20:35,236 [main] ERROR o.a.i.c.c.IoTDBDefaultThreadExceptionHandler:31 - Exception in thread main-1 
java.lang.ExceptionInInitializerError: null
        at org.apache.iotdb.db.consensus.SchemaRegionConsensusImpl.getInstance(SchemaRegionConsensusImpl.java:50)
        at org.apache.iotdb.db.service.DataNode.active(DataNode.java:494)
        at org.apache.iotdb.db.service.DataNode.doAddNode(DataNode.java:185)
        at org.apache.iotdb.db.service.DataNodeServerCommandLine.run(DataNodeServerCommandLine.java:81)
        at org.apache.iotdb.commons.ServerCommandLine.doMain(ServerCommandLine.java:58)
        at org.apache.iotdb.db.service.DataNode.main(DataNode.java:159)
Caused by: java.lang.IllegalArgumentException: Construct consensusImpl failed, Please check your consensus className org.apache.iotdb.consensus.ratis.RatisConsensus
        at org.apache.iotdb.db.consensus.SchemaRegionConsensusImpl$SchemaRegionConsensusImplHolder.lambda$static$1(SchemaRegionConsensusImpl.java:155)
        at java.base/java.util.Optional.orElseThrow(Optional.java:408)
        at org.apache.iotdb.db.consensus.SchemaRegionConsensusImpl$SchemaRegionConsensusImplHolder.<clinit>(SchemaRegionConsensusImpl.java:152)
        ... 6 common frames omitted
```

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [x] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
