### PR TITLE
Use bash instead of sh in integration test.

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/cli/it/StartClientScriptIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/cli/it/StartClientScriptIT.java
@@ -119,7 +119,7 @@ public class StartClientScriptIT extends AbstractScript {
     };
     ProcessBuilder builder =
         new ProcessBuilder(
-            "sh",
+            "bash",
             sbinPath + File.separator + "start-cli.sh",
             "-h",
             ip,
@@ -135,7 +135,7 @@ public class StartClientScriptIT extends AbstractScript {
     final String[] output2 = {"Msg: The statement is executed successfully."};
     ProcessBuilder builder2 =
         new ProcessBuilder(
-            "sh",
+            "bash",
             sbinPath + File.separator + "start-cli.sh",
             "-h",
             ip,

--- a/integration-test/src/test/java/org/apache/iotdb/tools/ExportCsvTestIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/tools/ExportCsvTestIT.java
@@ -135,7 +135,7 @@ public class ExportCsvTestIT extends AbstractScript {
     // -h 127.0.0.1 -p 6667 -u root -pw root -td ./ -q "select * from root.**"
     ProcessBuilder builder =
         new ProcessBuilder(
-            "sh",
+            "bash",
             toolsPath + File.separator + "export-csv.sh",
             "-h",
             ip,
@@ -158,7 +158,7 @@ public class ExportCsvTestIT extends AbstractScript {
     // -h 127.0.0.1 -p 6667 -u root -pw root -td ./ -q "select * from root.**"
     ProcessBuilder builder1 =
         new ProcessBuilder(
-            "sh",
+            "bash",
             toolsPath + File.separator + "export-tsfile.sh",
             "-h",
             ip,

--- a/integration-test/src/test/java/org/apache/iotdb/tools/ExportTsFileTestIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/tools/ExportTsFileTestIT.java
@@ -135,7 +135,7 @@ public class ExportTsFileTestIT extends AbstractScript {
     // -h 127.0.0.1 -p 6667 -u root -pw root -td ./ -q "select * from root.**"
     ProcessBuilder builder =
         new ProcessBuilder(
-            "sh",
+            "bash",
             toolsPath + File.separator + "export-tsfile.sh",
             "-h",
             ip,
@@ -158,7 +158,7 @@ public class ExportTsFileTestIT extends AbstractScript {
     // -h 127.0.0.1 -p 6667 -u root -pw root -td ./ -q "select * from root.**"
     ProcessBuilder builder1 =
         new ProcessBuilder(
-            "sh",
+            "bash",
             toolsPath + File.separator + "export-tsfile.sh",
             "-h",
             ip,

--- a/iotdb-client/cli/src/test/java/org/apache/iotdb/tool/integration/ExportCsvTestIT.java
+++ b/iotdb-client/cli/src/test/java/org/apache/iotdb/tool/integration/ExportCsvTestIT.java
@@ -89,7 +89,7 @@ public class ExportCsvTestIT extends AbstractScript {
     String dir = getCliPath();
     ProcessBuilder builder =
         new ProcessBuilder(
-            "sh",
+            "bash",
             dir + File.separator + "tools" + File.separator + "export-csv.sh",
             "-h",
             "127.0.0.1",

--- a/iotdb-client/cli/src/test/java/org/apache/iotdb/tool/integration/ImportCsvTestIT.java
+++ b/iotdb-client/cli/src/test/java/org/apache/iotdb/tool/integration/ImportCsvTestIT.java
@@ -89,7 +89,7 @@ public class ImportCsvTestIT extends AbstractScript {
     String dir = getCliPath();
     ProcessBuilder builder =
         new ProcessBuilder(
-            "sh",
+            "bash",
             dir + File.separator + "tools" + File.separator + "import-csv.sh",
             "-h",
             "127.0.0.1",


### PR DESCRIPTION
## Description

Some CI environment is ubuntu, but `sh` in ubuntu is indeed `dash` which is incompatible from `bash`.

So change `sh` to `bash` in integration-test.
