### PR TITLE
Add SLEEP_BOUND for the DriverTaskTimeoutSentinelThread

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/DriverScheduler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/DriverScheduler.java
@@ -263,7 +263,7 @@ public class DriverScheduler implements IDriverScheduler, IService {
     for (DriverTask task : submittedTasks) {
       registerTaskToQueryMap(queryId, task);
     }
-    timeoutQueue.push(submittedTasks.get(submittedTasks.size() - 1));
+    scheduler.enforceTimeLimit(submittedTasks.get(submittedTasks.size() - 1));
     for (DriverTask task : submittedTasks) {
       submitTaskToReadyQueue(task);
     }
@@ -551,6 +551,11 @@ public class DriverScheduler implements IDriverScheduler, IService {
       // tasks) which will try to get the lock of SynchronizedSet.
       // Thread B locks the SynchronizedSet first and then tries to lock the task.
       clearDriverTask(task);
+    }
+
+    @Override
+    public void enforceTimeLimit(DriverTask task) {
+      timeoutQueue.push(task);
     }
 
     @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/DriverTaskTimeoutSentinelThread.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/DriverTaskTimeoutSentinelThread.java
@@ -55,12 +55,14 @@ public class DriverTaskTimeoutSentinelThread extends AbstractDriverThread {
       task.unlock();
     }
 
-    // If this task is not timeout, we can wait it to timeout.
+    // If this task has not reached the time limit, we can wait for some time.
     // SlEEP_BOUND ensures that DriverTaskTimeoutSentinelThread won't sleep for too long when the
     // waitTime of the task is long.
     long waitTime = Math.min(task.getDDL() - System.currentTimeMillis(), SLEEP_BOUND);
-    if (waitTime > 0L) {
+    while (waitTime > 0L) {
+      long startSleep = System.currentTimeMillis();
       Thread.sleep(waitTime);
+      waitTime -= (System.currentTimeMillis() - startSleep);
     }
 
     task.lock();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/DriverTaskTimeoutSentinelThread.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/DriverTaskTimeoutSentinelThread.java
@@ -70,9 +70,8 @@ public class DriverTaskTimeoutSentinelThread extends AbstractDriverThread {
       if (task.isEndState()) {
         return;
       }
-      waitTime = task.getDDL() - System.currentTimeMillis();
       // if the Task still has not reached the time limit, re-push the task in the TimeoutQueue.
-      if (waitTime > 0L) {
+      if (task.getDDL() - System.currentTimeMillis() > 0L) {
         scheduler.enforceTimeLimit(task);
         return;
       }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/DriverTaskTimeoutSentinelThread.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/DriverTaskTimeoutSentinelThread.java
@@ -51,24 +51,16 @@ public class DriverTaskTimeoutSentinelThread extends AbstractDriverThread {
       if (task.isEndState()) {
         return;
       }
-      long waitTime = task.getDDL() - System.currentTimeMillis();
-      // if the waitTime is more than SLEEP_BOUND, re-push the task in the TimeoutQueue. SlEEP_BOUND
-      // ensures that DriverTaskTimeoutSentinelThread won't sleep for too long when the waitTime
-      // of the current task is long.
-      if (waitTime > SLEEP_BOUND) {
-        scheduler.enforceTimeLimit(task);
-        return;
-      }
     } finally {
       task.unlock();
     }
 
     // If this task is not timeout, we can wait it to timeout.
-    long waitTime = task.getDDL() - System.currentTimeMillis();
-    while (waitTime > 0L) {
-      // After this time, the task must be timeout.
+    // SlEEP_BOUND ensures that DriverTaskTimeoutSentinelThread won't sleep for too long when the
+    // waitTime of the task is long.
+    long waitTime = Math.min(task.getDDL() - System.currentTimeMillis(), SLEEP_BOUND);
+    if (waitTime > 0L) {
       Thread.sleep(waitTime);
-      waitTime = task.getDDL() - System.currentTimeMillis();
     }
 
     task.lock();
@@ -76,6 +68,12 @@ public class DriverTaskTimeoutSentinelThread extends AbstractDriverThread {
       // If this task is already in an end state, it means that the resource releasing will be
       // handled by other threads, we don't care anymore.
       if (task.isEndState()) {
+        return;
+      }
+      waitTime = task.getDDL() - System.currentTimeMillis();
+      // if the Task still has not reached the time limit, re-push the task in the TimeoutQueue.
+      if (waitTime > 0L) {
+        scheduler.enforceTimeLimit(task);
         return;
       }
     } finally {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/ITaskScheduler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/ITaskScheduler.java
@@ -70,4 +70,12 @@ public interface ITaskScheduler {
    * @param task the task to be switched.
    */
   void toAborted(DriverTask task);
+
+  /**
+   * Add a time watch for the task. The task will be aborted if it can not be finished in the given
+   * amount of time.
+   *
+   * @param task the target task.
+   */
+  void enforceTimeLimit(DriverTask task);
 }


### PR DESCRIPTION
Before this PR, if the ddl of a DriverTask selected by the SentinelThread is very long(e.g. Integer.MAX_VALUE), the SentinelThread will sleep forever and the timeout mechanism for the query will become ineffective.
In this PR, I add a SLEEP_BOUND for the SentinelThread to ensure that it won't sleep for too long. SLEEP_BOUND is just an empirical value rather than a calculated one.
We re-push the task into the timeout queue within the lock, so the status of the task will not be changed until we finish the re-push. If the task is finished after we re-push it into the timeout queue, the task will be removed from the timeout queue either in the process of finishing/aborting a DriverTask, or when it is selected by the SentinelThread again.