### PR TITLE
Fix partition interval may be not set correctly

### DIFF
--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -402,10 +402,10 @@ public class CommonDescriptor {
   }
 
   public void loadGlobalConfig(TGlobalConfig globalConfig) {
+    config.setTimestampPrecision(globalConfig.timestampPrecision);
     config.setTimePartitionInterval(
         CommonDateTimeUtils.convertMilliTimeWithPrecision(
             globalConfig.timePartitionInterval, config.getTimestampPrecision()));
-    config.setTimestampPrecision(globalConfig.timestampPrecision);
     config.setSchemaEngineMode(globalConfig.schemaEngineMode);
     config.setTagAttributeTotalSize(globalConfig.tagAttributeTotalSize);
     config.setDiskSpaceWarningThreshold(globalConfig.getDiskSpaceWarningThreshold());


### PR DESCRIPTION
Performance: If the CN and DN use different common config files, and the `time_precision` config are not same between two files, DN will set the wrong partitionInterval.