### PR TITLE
add entry.

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlan.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlan.java
@@ -257,6 +257,23 @@ public abstract class ConfigPhysicalPlan implements IConsensusRequest {
         case DeleteDatabase:
           plan = new DeleteDatabasePlan();
           break;
+        case ListUserDep:
+        case ListRoleDep:
+        case ListUserPrivilegeDep:
+        case ListRolePrivilegeDep:
+        case ListUserRolesDep:
+        case ListRoleUsersDep:
+        case CreateUserDep:
+        case CreateRoleDep:
+        case DropUserDep:
+        case DropRoleDep:
+        case GrantRoleDep:
+        case GrantUserDep:
+        case GrantRoleToUserDep:
+        case RevokeUserDep:
+        case RevokeRoleDep:
+        case RevokeRoleFromUserDep:
+        case UpdateUserDep:
         case ListUser:
         case ListRole:
         case ListUserPrivilege:


### PR DESCRIPTION
```bash
#!/bin/bash

iotdb_source_path="/Users/oushu/dev/iotdb"
iotdb_install_path="/tmp/iotdb"
iotdb_branch="rel/1.2"
iotdb_current_branch="sl_fix_upgrade_1.2"

echo "iotdb source path : $iotdb_source_path"
echo "iotdb install path : $iotdb_install_path"
echo "iotdb source branch : $iotdb_branch"

echo "----- check source path git status"
cd  "$iotdb_source_path"
output=$(git status  --porcelain)
if [ -n "$output" ]; then
    echo "error, you have unsaved git files."
    exit 1
fi
echo " git status ok"

echo "----- complie pre version iotdb"
git checkout "$iotdb_branch"
mvn clean package -pl distribution  -am -DskipTests  -T 20 > complie_pre.txt

echo "----- install into $iotdb_install_path"
cp -rf distribution/target/apache-iotdb-1.2.0-SNAPSHOT-all-bin/apache-iotdb-1.2.0-SNAPSHOT-all-bin "$iotdb_install_path"

echo "----- start pre version iotdb"
cd ${iotdb_install_path}/sbin
sh start-standalone.sh
echo "----- iotdb standalone started."

echo "----- generate sql to execute"
# go to the dir of gen.py
python3 gen.py
cp -rf $iotdb_install_path/data /tmp/data


cd ${iotdb_install_path}/sbin
sh start-cli.sh -e "list privileges user test1user"
sh stop-standalone.sh

echo "----- complie current code"
cd  "$iotdb_source_path"
git checkout "$iotdb_current_branch"
mvn clean package -pl distribution  -am -DskipTests  -T 20 > compile_cur.txt

echo "----- install into $iotdb_install_path"
mv  ${iotdb_install_path} /tmp/iot_bak
cp -rf distribution/target/apache-iotdb-1.3.0-SNAPSHOT-all-bin/apache-iotdb-1.3.0-SNAPSHOT-all-bin ${iotdb_install_path}
cp -rf /tmp/data ${iotdb_install_path}


echo "----- start current version iotdb"
cd ${iotdb_install_path}/sbin
sh start-standalone.sh
echo "----- iotdb standalone started."

sh start-cli.sh -e "list privileges of user test1user"
```

```python
from iotdb.Session import Session
import threading

turn = 1000;
# creating session connection.
ip = "127.0.0.1"
port_ = "6667"
username_ = "root"
password_ = "root"
# or make this operation a func and run it prepallelly.
session = Session(ip, port_, username_, password_, fetch_size=1024, zone_id="UTC+8", enable_redirection=True)
session.open(False)

prePriv = [
    "CREATE_DATABASE",
    "INSERT_TIMESERIES",
    "INSERT_TIMESERIES",
    "READ_TIMESERIES",
    "CREATE_TIMESERIES",
    "DELETE_TIMESERIES",
    "CREATE_USER",
    "DELETE_USER",
    "MODIFY_PASSWORD",
    "LIST_USER",
    "GRANT_USER_PRIVILEGE",
    "REVOKE_USER_PRIVILEGE",
    "GRANT_USER_ROLE",
    "REVOKE_USER_ROLE",
    "CREATE_ROLE",
    "DELETE_ROLE",
    "LIST_ROLE",
    "GRANT_ROLE_PRIVILEGE",
    "REVOKE_ROLE_PRIVILEGE",
    "CREATE_FUNCTION",
    "DROP_FUNCTION",
    "CREATE_TRIGGER",
    "DROP_TRIGGER",
    "START_TRIGGER",
    "STOP_TRIGGER",
    "CREATE_CONTINUOUS_QUERY",
    "DROP_CONTINUOUS_QUERY",
    "ALL",
    "DELETE_DATABASE",
    "ALTER_TIMESERIES",
    "UPDATE_TEMPLATE",
    "READ_TEMPLATE",
    "APPLY_TEMPLATE",
    "READ_TEMPLATE_APPLICATION",
    "SHOW_CONTINUOUS_QUERIES",
    "CREATE_PIPEPLUGIN",
    "DROP_PIPEPLUGIN",
    "SHOW_PIPEPLUGINS",
    "CREATE_PIPE",
    "START_PIPE",
    "STOP_PIPE",
    "DROP_PIPE",
    "SHOW_PIPES",
    "CREATE_VIEW",
    "ALTER_VIEW",
    "RENAME_VIEW",
    "DELETE_VIEW",
]

priPathIndex = [0,1,2,3,4,5,21,22,23,24,28,29,32,43,46]
basicPath = "root.d1.t2"
rootPath = "root.**"
errPath = "root.t1.*.t2"

grant_base_sql = "grant {} {} privileges {} {} {}"
revoke_base_sql = "revoke {} {} privileges {} {} {}"
## after this operation, there will be 5000 * 4 logs in db.
for i in range(1):
    print(i)
    withoutpath = False
    priv = prePriv[i % prePriv.__len__()]
    if ((i % prePriv.__len__()) not in priPathIndex):
        path = rootPath
        withoutpath = True
    else :
        path = basicPath
    if (i % 3 == 0):
        path = errPath
    if (withoutpath):
        verb = ""
        path = ""
        reverb = ""
        gverb =""
    else :
        gverb = "on"
        reverb = "on"
    # grant to user
    grant_sql1 = str.format(grant_base_sql,"user","test1user", priv, gverb, path)
    print(grant_sql1)
    session.execute_non_query_statement(grant_sql1)
    ## grant to role 
    grant_sql2 = str.format(grant_base_sql,"role","test1role", priv, gverb, path)
    print(grant_sql2)
    session.execute_non_query_statement(grant_sql2)
    ## revoke user
    revoke_sql1 = str.format(revoke_base_sql,"user","test1user", priv, reverb, path)
    print(revoke_sql1)
    session.execute_non_query_statement(revoke_sql1)
    ## revoke role
    revoke_sql2 = str.format(revoke_base_sql,"role","test1role", priv, reverb, path)
    print(revoke_sql2)
    session.execute_non_query_statement(revoke_sql2)

# now user and role will dont have privilege

for index,priv in enumerate(prePriv):
    if (index in priPathIndex):
        sql = str.format(grant_base_sql, "user", "test1user", priv,"on" ,errPath)
    else :
        sql = str.format(grant_base_sql, "user", "test1user", priv, "", "")
    if (priv == "ALL" or priv == "INSERT_TIMESERIES"):
        continue
    print(sql)
    session.execute_non_query_statement(sql)
```