### PR TITLE
Add Interface to extend TsFileResource

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResourceBlockType.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResourceBlockType.java
@@ -19,9 +19,10 @@
 
 package org.apache.iotdb.db.storageengine.dataregion.tsfile;
 
+import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
+
 import java.io.IOException;
 import java.io.OutputStream;
-import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 
 public enum TsFileResourceBlockType {
   EMPTY_BLOCK((byte) 0),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResourceBlockType.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResourceBlockType.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.storageengine.dataregion.tsfile;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
+
+public enum TsFileResourceBlockType {
+  EMPTY_BLOCK((byte) 0),
+  PROGRESS_INDEX((byte) 1),
+  ;
+
+  private final byte type;
+
+  TsFileResourceBlockType(byte type) {
+    this.type = type;
+  }
+
+  public void serialize(OutputStream outputStream) throws IOException {
+    ReadWriteIOUtils.write(type, outputStream);
+  }
+
+  public static TsFileResourceBlockType deserialize(byte type) {
+    switch (type) {
+      case 0:
+        return EMPTY_BLOCK;
+      case 1:
+        return PROGRESS_INDEX;
+      default:
+        throw new IllegalArgumentException("Invalid input: " + type);
+    }
+  }
+}


### PR DESCRIPTION
## Description

Currently, TsFileResource serializes the PROGRESS INDEX information to TsFileResource files. When serializes the PROGRESS INDEX information, firstly write a byte 1 or 0 to represent whether contains the progress index, then write the content.

Now, we can extend the usage of the PROGRESS INDEX to store more information. We can introduce the  TsFileResourceBlockType to represent the block type of TsFileResource File and use more types bytes 2,3... to record the extended file block.

## Design
https://apache-iotdb.feishu.cn/docx/VIpmddFQFoa3yKxX9MhcvZ6cnXg
