### PR TITLE
Fix the failure of metric module

### DIFF
--- a/iotdb-core/datanode/pom.xml
+++ b/iotdb-core/datanode/pom.xml
@@ -280,18 +280,16 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- These two dependencies are needed at runtime -->
+        <!-- These two dependencies are needed at runtime, so please not set test scope -->
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>dropwizard-metrics</artifactId>
             <version>1.3.0-SNAPSHOT</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>micrometer-metrics</artifactId>
             <version>1.3.0-SNAPSHOT</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/AbstractMetricService.java
+++ b/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/AbstractMetricService.java
@@ -132,7 +132,7 @@ public abstract class AbstractMetricService {
 
     // if no more implementations, we use nothingManager.
     if (size == 0 || metricManager == null) {
-      LOGGER.debug("No MetricManager available, defaulting to DoNothingMetricManager");
+      LOGGER.info("No MetricManager available, defaulting to DoNothingMetricManager");
       metricManager = new DoNothingMetricManager();
     } else if (size > 1) {
       LOGGER.info(


### PR DESCRIPTION
Fix the failure of metric module. Because we use SPI in metric module, so we shouldn't set metric related dependency's scope as test which may lead to failure
