### PR TITLE
Improve the high availability of IoTDB

### DIFF
--- a/example/session/src/main/java/org/apache/iotdb/SessionExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/SessionExample.java
@@ -348,9 +348,9 @@ public class SessionExample {
     types.add(TSDataType.FLOAT);
     types.add(TSDataType.FLOAT);
     List<Object> values = new ArrayList<>();
-    values.add(2.0f);
-    values.add(2.0f);
-    values.add(2.0f);
+    values.add(4.0f);
+    values.add(4.0f);
+    values.add(4.0f);
 
     List<List<String>> measurementsList = new ArrayList<>();
     measurementsList.add(measurements);
@@ -363,9 +363,9 @@ public class SessionExample {
     valuesList.add(values);
 
     List<Long> timestamps = new ArrayList<>();
-    timestamps.add(2L);
-    timestamps.add(2L);
-    timestamps.add(2L);
+    timestamps.add(4L);
+    timestamps.add(4L);
+    timestamps.add(4L);
 
     List<List<TSDataType>> typesList = new ArrayList<>();
     typesList.add(types);

--- a/example/session/src/main/java/org/apache/iotdb/SessionExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/SessionExample.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.isession.template.Template;
 import org.apache.iotdb.isession.util.Version;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.StatementExecutionException;
+import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.session.Session;
 import org.apache.iotdb.session.template.MeasurementNode;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
@@ -77,48 +78,48 @@ public class SessionExample {
     // set session fetchSize
     session.setFetchSize(10000);
 
-    //    try {
-    //      session.createDatabase("root.sg1");
-    //    } catch (StatementExecutionException e) {
-    //      if (e.getStatusCode() != TSStatusCode.DATABASE_ALREADY_EXISTS.getStatusCode()) {
-    //        throw e;
-    //      }
-    //    }
+    try {
+      session.createDatabase("root.sg1");
+    } catch (StatementExecutionException e) {
+      if (e.getStatusCode() != TSStatusCode.DATABASE_ALREADY_EXISTS.getStatusCode()) {
+        throw e;
+      }
+    }
 
     //     createTemplate();
-    //    createTimeseries();
-    //    createMultiTimeseries();
-    //    insertRecord();
-    //    insertTablet();
+    createTimeseries();
+    createMultiTimeseries();
+    insertRecord();
+    insertTablet();
     //    insertTabletWithNullValues();
     //    insertTablets();
-    insertRecords();
+    //    insertRecords();
     //    insertText();
     //    selectInto();
     //    createAndDropContinuousQueries();
     //    nonQuery();
-    //    query();
+    query();
     //    queryWithTimeout();
-    //    rawDataQuery();
-    //    lastDataQuery();
-    //    aggregationQuery();
-    //    groupByQuery();
+    rawDataQuery();
+    lastDataQuery();
+    aggregationQuery();
+    groupByQuery();
     //    queryByIterator();
     //    deleteData();
     //    deleteTimeseries();
     //    setTimeout();
 
-    //    sessionEnableRedirect = new Session(LOCAL_HOST, 6667, "root", "root");
-    //    sessionEnableRedirect.setEnableQueryRedirection(true);
-    //    sessionEnableRedirect.open(false);
+    sessionEnableRedirect = new Session(LOCAL_HOST, 6667, "root", "root");
+    sessionEnableRedirect.setEnableQueryRedirection(true);
+    sessionEnableRedirect.open(false);
 
     // set session fetchSize
-    //    sessionEnableRedirect.setFetchSize(10000);
+    sessionEnableRedirect.setFetchSize(10000);
 
-    //    fastLastDataQueryForOneDevice();
-    //    insertRecord4Redirect();
-    //    query4Redirect();
-    //    sessionEnableRedirect.close();
+    fastLastDataQueryForOneDevice();
+    insertRecord4Redirect();
+    query4Redirect();
+    sessionEnableRedirect.close();
     session.close();
   }
 
@@ -335,42 +336,41 @@ public class SessionExample {
   }
 
   private static void insertRecords() throws IoTDBConnectionException, StatementExecutionException {
+    String deviceId = ROOT_SG1_D1;
     List<String> measurements = new ArrayList<>();
     measurements.add("s1");
     measurements.add("s2");
     measurements.add("s3");
     List<String> deviceIds = new ArrayList<>();
-    deviceIds.add("root.db.d1");
-    deviceIds.add("root.db.d2");
-    deviceIds.add("root.db.d3");
-    List<TSDataType> types = new ArrayList<>();
-    types.add(TSDataType.FLOAT);
-    types.add(TSDataType.FLOAT);
-    types.add(TSDataType.FLOAT);
-    List<Object> values = new ArrayList<>();
-    values.add(4.0f);
-    values.add(4.0f);
-    values.add(4.0f);
-
     List<List<String>> measurementsList = new ArrayList<>();
-    measurementsList.add(measurements);
-    measurementsList.add(measurements);
-    measurementsList.add(measurements);
-
     List<List<Object>> valuesList = new ArrayList<>();
-    valuesList.add(values);
-    valuesList.add(values);
-    valuesList.add(values);
-
     List<Long> timestamps = new ArrayList<>();
-    timestamps.add(4L);
-    timestamps.add(4L);
-    timestamps.add(4L);
-
     List<List<TSDataType>> typesList = new ArrayList<>();
-    typesList.add(types);
-    typesList.add(types);
-    typesList.add(types);
+
+    for (long time = 0; time < 500; time++) {
+      List<Object> values = new ArrayList<>();
+      List<TSDataType> types = new ArrayList<>();
+      values.add(1L);
+      values.add(2L);
+      values.add(3L);
+      types.add(TSDataType.INT64);
+      types.add(TSDataType.INT64);
+      types.add(TSDataType.INT64);
+
+      deviceIds.add(deviceId);
+      measurementsList.add(measurements);
+      valuesList.add(values);
+      typesList.add(types);
+      timestamps.add(time);
+      if (time != 0 && time % 100 == 0) {
+        session.insertRecords(deviceIds, timestamps, measurementsList, typesList, valuesList);
+        deviceIds.clear();
+        measurementsList.clear();
+        valuesList.clear();
+        typesList.clear();
+        timestamps.clear();
+      }
+    }
 
     session.insertRecords(deviceIds, timestamps, measurementsList, typesList, valuesList);
   }

--- a/example/session/src/main/java/org/apache/iotdb/SessionExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/SessionExample.java
@@ -26,7 +26,6 @@ import org.apache.iotdb.isession.template.Template;
 import org.apache.iotdb.isession.util.Version;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.StatementExecutionException;
-import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.session.Session;
 import org.apache.iotdb.session.template.MeasurementNode;
 import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
@@ -78,48 +77,48 @@ public class SessionExample {
     // set session fetchSize
     session.setFetchSize(10000);
 
-    try {
-      session.createDatabase("root.sg1");
-    } catch (StatementExecutionException e) {
-      if (e.getStatusCode() != TSStatusCode.DATABASE_ALREADY_EXISTS.getStatusCode()) {
-        throw e;
-      }
-    }
+    //    try {
+    //      session.createDatabase("root.sg1");
+    //    } catch (StatementExecutionException e) {
+    //      if (e.getStatusCode() != TSStatusCode.DATABASE_ALREADY_EXISTS.getStatusCode()) {
+    //        throw e;
+    //      }
+    //    }
 
     //     createTemplate();
-    createTimeseries();
-    createMultiTimeseries();
-    insertRecord();
-    insertTablet();
+    //    createTimeseries();
+    //    createMultiTimeseries();
+    //    insertRecord();
+    //    insertTablet();
     //    insertTabletWithNullValues();
     //    insertTablets();
-    //    insertRecords();
+    insertRecords();
     //    insertText();
     //    selectInto();
     //    createAndDropContinuousQueries();
     //    nonQuery();
-    query();
+    //    query();
     //    queryWithTimeout();
-    rawDataQuery();
-    lastDataQuery();
-    aggregationQuery();
-    groupByQuery();
+    //    rawDataQuery();
+    //    lastDataQuery();
+    //    aggregationQuery();
+    //    groupByQuery();
     //    queryByIterator();
     //    deleteData();
     //    deleteTimeseries();
     //    setTimeout();
 
-    sessionEnableRedirect = new Session(LOCAL_HOST, 6667, "root", "root");
-    sessionEnableRedirect.setEnableQueryRedirection(true);
-    sessionEnableRedirect.open(false);
+    //    sessionEnableRedirect = new Session(LOCAL_HOST, 6667, "root", "root");
+    //    sessionEnableRedirect.setEnableQueryRedirection(true);
+    //    sessionEnableRedirect.open(false);
 
     // set session fetchSize
-    sessionEnableRedirect.setFetchSize(10000);
+    //    sessionEnableRedirect.setFetchSize(10000);
 
-    fastLastDataQueryForOneDevice();
-    insertRecord4Redirect();
-    query4Redirect();
-    sessionEnableRedirect.close();
+    //    fastLastDataQueryForOneDevice();
+    //    insertRecord4Redirect();
+    //    query4Redirect();
+    //    sessionEnableRedirect.close();
     session.close();
   }
 
@@ -336,41 +335,42 @@ public class SessionExample {
   }
 
   private static void insertRecords() throws IoTDBConnectionException, StatementExecutionException {
-    String deviceId = ROOT_SG1_D1;
     List<String> measurements = new ArrayList<>();
     measurements.add("s1");
     measurements.add("s2");
     measurements.add("s3");
     List<String> deviceIds = new ArrayList<>();
+    deviceIds.add("root.db.d1");
+    deviceIds.add("root.db.d2");
+    deviceIds.add("root.db.d3");
+    List<TSDataType> types = new ArrayList<>();
+    types.add(TSDataType.FLOAT);
+    types.add(TSDataType.FLOAT);
+    types.add(TSDataType.FLOAT);
+    List<Object> values = new ArrayList<>();
+    values.add(2.0f);
+    values.add(2.0f);
+    values.add(2.0f);
+
     List<List<String>> measurementsList = new ArrayList<>();
+    measurementsList.add(measurements);
+    measurementsList.add(measurements);
+    measurementsList.add(measurements);
+
     List<List<Object>> valuesList = new ArrayList<>();
+    valuesList.add(values);
+    valuesList.add(values);
+    valuesList.add(values);
+
     List<Long> timestamps = new ArrayList<>();
+    timestamps.add(2L);
+    timestamps.add(2L);
+    timestamps.add(2L);
+
     List<List<TSDataType>> typesList = new ArrayList<>();
-
-    for (long time = 0; time < 500; time++) {
-      List<Object> values = new ArrayList<>();
-      List<TSDataType> types = new ArrayList<>();
-      values.add(1L);
-      values.add(2L);
-      values.add(3L);
-      types.add(TSDataType.INT64);
-      types.add(TSDataType.INT64);
-      types.add(TSDataType.INT64);
-
-      deviceIds.add(deviceId);
-      measurementsList.add(measurements);
-      valuesList.add(values);
-      typesList.add(types);
-      timestamps.add(time);
-      if (time != 0 && time % 100 == 0) {
-        session.insertRecords(deviceIds, timestamps, measurementsList, typesList, valuesList);
-        deviceIds.clear();
-        measurementsList.clear();
-        valuesList.clear();
-        typesList.clear();
-        timestamps.clear();
-      }
-    }
+    typesList.add(types);
+    typesList.add(types);
+    typesList.add(types);
 
     session.insertRecords(deviceIds, timestamps, measurementsList, typesList, valuesList);
   }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/client/AsyncIoTConsensusServiceClient.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/client/AsyncIoTConsensusServiceClient.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.commons.client.property.ThriftClientProperty;
 import org.apache.iotdb.consensus.iot.thrift.IoTConsensusIService;
 import org.apache.iotdb.rpc.TNonblockingSocketWrapper;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.apache.thrift.async.TAsyncClientManager;
@@ -110,7 +111,10 @@ public class AsyncIoTConsensusServiceClient extends IoTConsensusIService.AsyncCl
       checkReady();
       return true;
     } catch (Exception e) {
-      logger.info("Unexpected exception occurs in {} :", this, e);
+      logger.info(
+          "Unexpected exception occurs in {}, error msg is {}",
+          this,
+          ExceptionUtils.getRootCause(e).toString());
       return false;
     }
   }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/client/DispatchLogHandler.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/client/DispatchLogHandler.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.consensus.iot.logdispatcher.LogDispatcherThreadMetrics;
 import org.apache.iotdb.consensus.iot.thrift.TSyncLogEntriesRes;
 import org.apache.iotdb.rpc.TSStatusCode;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.thrift.async.AsyncMethodCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,12 +78,14 @@ public class DispatchLogHandler implements AsyncMethodCallback<TSyncLogEntriesRe
 
   @Override
   public void onError(Exception exception) {
-    logger.warn(
-        "Can not send {} to peer for {} times {} because {}",
-        batch,
-        thread.getPeer(),
-        ++retryCount,
-        exception);
+    if (logger.isWarnEnabled()) {
+      logger.warn(
+          "Can not send {} to peer for {} times {} because {}",
+          batch,
+          thread.getPeer(),
+          ++retryCount,
+          ExceptionUtils.getRootCause(exception).toString());
+    }
     sleepCorrespondingTimeAndRetryAsynchronous();
   }
 

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/client/DispatchLogHandler.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/client/DispatchLogHandler.java
@@ -78,12 +78,13 @@ public class DispatchLogHandler implements AsyncMethodCallback<TSyncLogEntriesRe
 
   @Override
   public void onError(Exception exception) {
+    ++retryCount;
     if (logger.isWarnEnabled()) {
       logger.warn(
           "Can not send {} to peer for {} times {} because {}",
           batch,
           thread.getPeer(),
-          ++retryCount,
+          retryCount,
           ExceptionUtils.getRootCause(exception).toString());
     }
     sleepCorrespondingTimeAndRetryAsynchronous();

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/client/DispatchLogHandler.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/client/DispatchLogHandler.java
@@ -69,7 +69,7 @@ public class DispatchLogHandler implements AsyncMethodCallback<TSyncLogEntriesRe
     logDispatcherThreadMetrics.recordSyncLogTimePerRequest(System.nanoTime() - createTime);
   }
 
-  private boolean needRetry(int statusCode) {
+  public static boolean needRetry(int statusCode) {
     return statusCode == TSStatusCode.INTERNAL_SERVER_ERROR.getStatusCode()
         || statusCode == TSStatusCode.SYSTEM_READ_ONLY.getStatusCode()
         || statusCode == TSStatusCode.WRITE_PROCESS_REJECT.getStatusCode();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/exception/metadata/SeriesOverflowException.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/exception/metadata/SeriesOverflowException.java
@@ -28,10 +28,7 @@ public class SeriesOverflowException extends MetadataException {
   public SeriesOverflowException(long memoryUsage, long seriesNum) {
     super(
         String.format(
-            "There are too many timeseries in memory. "
-                + "Current memory usage is %s and series num is %s. "
-                + "Please increase MAX_HEAP_SIZE in datanode-env.sh/bat, "
-                + "restart and create timeseries again.",
+            "Too many timeseries in memory without device template(current memory: %s, series num: %s). To optimize memory, DEVICE TEMPLATE is more recommended when devices have same time series.",
             memoryUsage, seriesNum),
         TSStatusCode.SERIES_OVERFLOW.getStatusCode());
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/FragmentInstance.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/FragmentInstance.java
@@ -74,6 +74,9 @@ public class FragmentInstance implements IConsensusRequest {
 
   private boolean isHighestPriority;
 
+  // indicate which index we are retrying
+  private transient int nextRetryIndex = 0;
+
   // We can add some more params for a specific FragmentInstance
   // So that we can make different FragmentInstance owns different data range.
 
@@ -268,6 +271,14 @@ public class FragmentInstance implements IConsensusRequest {
   }
 
   public TDataNodeLocation getHostDataNode() {
+    return hostDataNode;
+  }
+
+  public TDataNodeLocation getNextRetriedHostDataNode() {
+    nextRetryIndex =
+        (nextRetryIndex + 1) % executorType.getRegionReplicaSet().getDataNodeLocations().size();
+    this.hostDataNode =
+        executorType.getRegionReplicaSet().getDataNodeLocations().get(nextRetryIndex);
     return hostDataNode;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/AsyncPlanNodeSender.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/AsyncPlanNodeSender.java
@@ -194,8 +194,8 @@ public class AsyncPlanNodeSender {
 
   /**
    * This class is used to aggregate PlanNode of the same datanode into one rpc. In order to ensure
-   * the one-to-one correspondence between r esponse and request, the corresponding index needs to
-   * be recorded.
+   * the one-to-one correspondence between response and request, the corresponding index needs to be
+   * recorded.
    */
   static class BatchRequestWithIndex {
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/AsyncPlanNodeSender.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/AsyncPlanNodeSender.java
@@ -35,14 +35,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
-
-import static com.google.common.util.concurrent.Futures.immediateFuture;
 
 public class AsyncPlanNodeSender {
 
@@ -53,8 +51,11 @@ public class AsyncPlanNodeSender {
 
   private final Map<TEndPoint, BatchRequestWithIndex> batchRequests;
   private final Map<Integer, TSendSinglePlanNodeResp> instanceId2RespMap;
+
+  private final List<Integer> needRetryInstanceIndex;
+
   private final AtomicLong pendingNumber;
-  private final long startSendTime;
+  private long startSendTime;
 
   public AsyncPlanNodeSender(
       IClientManager<TEndPoint, AsyncDataNodeInternalServiceClient>
@@ -77,6 +78,7 @@ public class AsyncPlanNodeSender {
                   instances.get(i).getRegionReplicaSet().getRegionId()));
     }
     this.instanceId2RespMap = new ConcurrentHashMap<>(instances.size() + 1, 1);
+    this.needRetryInstanceIndex = Collections.synchronizedList(new ArrayList<>());
     this.pendingNumber = new AtomicLong(batchRequests.keySet().size());
   }
 
@@ -84,7 +86,11 @@ public class AsyncPlanNodeSender {
     for (Map.Entry<TEndPoint, BatchRequestWithIndex> entry : batchRequests.entrySet()) {
       AsyncSendPlanNodeHandler handler =
           new AsyncSendPlanNodeHandler(
-              entry.getValue().getIndexes(), pendingNumber, instanceId2RespMap, startSendTime);
+              entry.getValue().getIndexes(),
+              pendingNumber,
+              instanceId2RespMap,
+              needRetryInstanceIndex,
+              startSendTime);
       try {
         AsyncDataNodeInternalServiceClient client =
             asyncInternalServiceClientManager.borrowClient(entry.getKey());
@@ -135,32 +141,61 @@ public class AsyncPlanNodeSender {
     return failureStatusList;
   }
 
-  public Future<FragInstanceDispatchResult> getResult() {
-    for (Map.Entry<Integer, TSendSinglePlanNodeResp> entry : instanceId2RespMap.entrySet()) {
-      if (!entry.getValue().accepted) {
-        logger.warn(
-            "dispatch write failed. status: {}, code: {}, message: {}, node {}",
-            entry.getValue().status,
-            TSStatusCode.representOf(entry.getValue().status.code),
-            entry.getValue().message,
-            instances.get(entry.getKey()).getHostDataNode().getInternalEndPoint());
-        if (entry.getValue().getStatus() == null) {
-          return immediateFuture(
-              new FragInstanceDispatchResult(
-                  RpcUtils.getStatus(
-                      TSStatusCode.WRITE_PROCESS_ERROR, entry.getValue().getMessage())));
-        } else {
-          return immediateFuture(new FragInstanceDispatchResult(entry.getValue().getStatus()));
-        }
-      }
+  public boolean needRetry() {
+    // retried FI list is not empty and data region replica number is greater than 1
+    return !needRetryInstanceIndex.isEmpty()
+        && instances.get(0).getRegionReplicaSet().dataNodeLocations.size() > 1;
+  }
+
+  /**
+   * This function should be called after all last batch responses were received. This function will
+   * do the cleaning work and caller won't need to do the cleaning work outside this function. We
+   * will retry all failed FIs in last batch whose id were all saved in needRetryInstanceIds, if
+   * there are still failed FIs this time, they will be also saved in needRetryInstanceIds.
+   *
+   * <p>It's a sync function which means that once this function returned, the results of this retry
+   * have been received, and you don't need to call waitUntilCompleted.
+   */
+  public void retry() throws InterruptedException {
+    // 1. rebuild the batchRequests using remaining failed FIs, change the replica for each failed
+    // FI in this step
+    batchRequests.clear();
+    for (int fragmentInstanceIndex : needRetryInstanceIndex) {
+      this.batchRequests
+          .computeIfAbsent(
+              instances
+                  .get(fragmentInstanceIndex)
+                  .getNextRetriedHostDataNode()
+                  .getInternalEndPoint(),
+              x -> new BatchRequestWithIndex())
+          .addSinglePlanNodeReq(
+              fragmentInstanceIndex,
+              new TSendSinglePlanNodeReq(
+                  new TPlanNode(
+                      instances
+                          .get(fragmentInstanceIndex)
+                          .getFragment()
+                          .getPlanNodeTree()
+                          .serializeToByteBuffer()),
+                  instances.get(fragmentInstanceIndex).getRegionReplicaSet().getRegionId()));
     }
-    return immediateFuture(new FragInstanceDispatchResult(true));
+
+    // 2. reset the pendingNumber, needRetryInstanceIds and startSendTime
+    needRetryInstanceIndex.clear();
+    pendingNumber.set(batchRequests.keySet().size());
+    startSendTime = System.nanoTime();
+
+    // 3. call sendAll() to retry
+    sendAll();
+
+    // 4. call waitUntilCompleted() to wait for the responses
+    waitUntilCompleted();
   }
 
   /**
    * This class is used to aggregate PlanNode of the same datanode into one rpc. In order to ensure
-   * the one-to-one correspondence between response and request, the corresponding index needs to be
-   * recorded.
+   * the one-to-one correspondence between r esponse and request, the corresponding index needs to
+   * be recorded.
    */
   static class BatchRequestWithIndex {
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/AsyncSendPlanNodeHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/AsyncSendPlanNodeHandler.java
@@ -103,6 +103,6 @@ public class AsyncSendPlanNodeHandler implements AsyncMethodCallback<TSendBatchP
   }
 
   private boolean needRetry(TSendSinglePlanNodeResp resp) {
-    return DispatchLogHandler.needRetry(resp.status.code);
+    return !resp.accepted && DispatchLogHandler.needRetry(resp.status.code);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/FragmentInstanceDispatcherImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/FragmentInstanceDispatcherImpl.java
@@ -48,6 +48,7 @@ import org.apache.iotdb.mpp.rpc.thrift.TSendSinglePlanNodeResp;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -339,7 +340,10 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
                   String.format("unknown read type [%s]", instance.getType())));
       }
     } catch (ClientManagerException | TException e) {
-      logger.warn("can't connect to node {}", endPoint, e);
+      logger.warn(
+          "can't connect to node {}, error msg is {}.",
+          endPoint,
+          ExceptionUtils.getRootCause(e).toString());
       TSStatus status = new TSStatus();
       status.setCode(TSStatusCode.DISPATCH_ERROR.getStatusCode());
       status.setMessage("can't connect to node " + endPoint);

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/ThriftClient.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/ThriftClient.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.net.ConnectException;
 import java.net.SocketException;
 
 /**
@@ -109,6 +110,8 @@ public interface ThriftClient {
             && (cause.getMessage().contains("Socket is closed by peer")
                 || cause.getMessage().contains("Read call frame size failed")))
         || (cause instanceof IOException
-            && cause.getMessage().contains("Connection reset by peer"));
+            && (cause.getMessage().contains("Connection reset by peer")
+                || cause.getMessage().contains("Broken pipe")))
+        || (cause instanceof ConnectException && cause.getMessage().contains("Connection refused"));
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/ThriftClient.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/ThriftClient.java
@@ -25,6 +25,7 @@ import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.SocketException;
 
@@ -102,9 +103,11 @@ public interface ThriftClient {
    * @param cause Throwable
    * @return true/false
    */
-  public static boolean isConnectionBroken(Throwable cause) {
+  static boolean isConnectionBroken(Throwable cause) {
     return (cause instanceof SocketException && cause.getMessage().contains("Broken pipe"))
         || (cause instanceof TTransportException
-            && cause.getMessage().contains("Socket is closed by peer"));
+            && cause.getMessage().contains("Socket is closed by peer"))
+        || (cause instanceof IOException
+            && cause.getMessage().contains("Connection reset by peer"));
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/ThriftClient.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/ThriftClient.java
@@ -89,8 +89,8 @@ public interface ThriftClient {
         if (o.printLogWhenEncounterException()) {
           logger.info(
               "Broken pipe error happened in sending RPC,"
-                  + " we need to clear all previous cached connection",
-              t);
+                  + " we need to clear all previous cached connection, error msg is {}",
+              rootCause.toString());
         }
         o.invalidateAll();
       }
@@ -106,7 +106,8 @@ public interface ThriftClient {
   static boolean isConnectionBroken(Throwable cause) {
     return (cause instanceof SocketException && cause.getMessage().contains("Broken pipe"))
         || (cause instanceof TTransportException
-            && cause.getMessage().contains("Socket is closed by peer"))
+            && (cause.getMessage().contains("Socket is closed by peer")
+                || cause.getMessage().contains("Read call frame size failed")))
         || (cause instanceof IOException
             && cause.getMessage().contains("Connection reset by peer"));
   }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/ThriftClient.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/ThriftClient.java
@@ -102,7 +102,7 @@ public interface ThriftClient {
    * @param cause Throwable
    * @return true/false
    */
-  static boolean isConnectionBroken(Throwable cause) {
+  public static boolean isConnectionBroken(Throwable cause) {
     return (cause instanceof SocketException && cause.getMessage().contains("Broken pipe"))
         || (cause instanceof TTransportException
             && cause.getMessage().contains("Socket is closed by peer"));

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncConfigNodeIServiceClient.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncConfigNodeIServiceClient.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.commons.client.property.ThriftClientProperty;
 import org.apache.iotdb.confignode.rpc.thrift.IConfigNodeRPCService;
 import org.apache.iotdb.rpc.TNonblockingSocketWrapper;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.apache.thrift.async.TAsyncClientManager;
@@ -110,7 +111,10 @@ public class AsyncConfigNodeIServiceClient extends IConfigNodeRPCService.AsyncCl
       return true;
     } catch (Exception e) {
       if (printLogWhenEncounterException) {
-        logger.error("Unexpected exception occurs in {} : {}", this, e.getMessage());
+        logger.error(
+            "Unexpected exception occurs in {}, error msg is {}",
+            this,
+            ExceptionUtils.getRootCause(e).toString());
       }
       return false;
     }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncDataNodeInternalServiceClient.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncDataNodeInternalServiceClient.java
@@ -28,6 +28,7 @@ import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.mpp.rpc.thrift.IDataNodeRPCService;
 import org.apache.iotdb.rpc.TNonblockingSocketWrapper;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.apache.thrift.async.TAsyncClientManager;
@@ -123,7 +124,10 @@ public class AsyncDataNodeInternalServiceClient extends IDataNodeRPCService.Asyn
       return true;
     } catch (Exception e) {
       if (printLogWhenEncounterException) {
-        logger.error("Unexpected exception occurs in {} : {}", this, e.getMessage());
+        logger.error(
+            "Unexpected exception occurs in {}, error msg is {}",
+            this,
+            ExceptionUtils.getRootCause(e).toString());
       }
       return false;
     }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncDataNodeMPPDataExchangeServiceClient.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncDataNodeMPPDataExchangeServiceClient.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.commons.client.property.ThriftClientProperty;
 import org.apache.iotdb.mpp.rpc.thrift.MPPDataExchangeService;
 import org.apache.iotdb.rpc.TNonblockingSocketWrapper;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.apache.thrift.async.TAsyncClientManager;
@@ -111,7 +112,10 @@ public class AsyncDataNodeMPPDataExchangeServiceClient extends MPPDataExchangeSe
       return true;
     } catch (Exception e) {
       if (printLogWhenEncounterException) {
-        logger.error("Unexpected exception occurs in {} : {}", this, e.getMessage());
+        logger.error(
+            "Unexpected exception occurs in {}, error msg is {}",
+            this,
+            ExceptionUtils.getRootCause(e).toString());
       }
       return false;
     }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncPipeDataTransferServiceClient.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncPipeDataTransferServiceClient.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.commons.client.property.ThriftClientProperty;
 import org.apache.iotdb.rpc.TNonblockingSocketWrapper;
 import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.apache.thrift.async.TAsyncClientManager;
@@ -127,7 +128,10 @@ public class AsyncPipeDataTransferServiceClient extends IClientRPCService.AsyncC
       return true;
     } catch (Exception e) {
       if (printLogWhenEncounterException) {
-        LOGGER.error("Unexpected exception occurs in {} : {}", this, e.getMessage());
+        LOGGER.error(
+            "Unexpected exception occurs in {}, error msg is {}",
+            this,
+            ExceptionUtils.getRootCause(e).toString());
       }
       return false;
     }


### PR DESCRIPTION
For 3C3D 2 replicas or 3 replicas dataregion, if we kill one datanode, client should keep inserting data successfully without any error.
However, currently, there is no retry logic in dispatch for write, so if the leader of one DataRegionGroup is down, the dispatch phase will fail and will return a 302 status code to Session, and meet this kind of StatusCode, Session won't retry this write request, it will throw this exception to the upper layer. You will get the error msg like the following:

<img width="1920" alt="image" src="https://github.com/apache/iotdb/assets/16079446/c0987905-5816-4daa-a664-0503c0edac12">

more details about this improvement can be found in this feishu doc(https://timechor.feishu.cn/docx/WuVJdNpGOowEGIxvaOlcwt9mngg)

In this pr, we add retry logic in `AsyncPlanNodeSender` which will try other replica to do the write dispatch.

I also simplify the error msg while connection is down, only print the root cause class name and its msg instead of the full call stack.

