### PR TITLE
[IOTDB-6204] Pipe: Changed the default settings and add manual configuration logic for opc-ua-connector key directory 

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -116,33 +116,39 @@ public class IoTDBDescriptor {
     return conf;
   }
 
+  public String getConfDir() {
+    // Check if a config-directory was specified first.
+    String confString = System.getProperty(IoTDBConstant.IOTDB_CONF, null);
+    // If it wasn't, check if a home directory was provided (This usually contains a config)
+    if (confString == null) {
+      confString = System.getProperty(IoTDBConstant.IOTDB_HOME, null);
+      if (confString != null) {
+        confString = confString + File.separatorChar + "conf";
+      }
+    }
+    return confString;
+  }
+
   /**
    * get props url location
    *
    * @return url object if location exit, otherwise null.
    */
   public URL getPropsUrl(String configFileName) {
-    // Check if a config-directory was specified first.
-    String urlString = System.getProperty(IoTDBConstant.IOTDB_CONF, null);
-    // If it wasn't, check if a home directory was provided (This usually contains a config)
+    String urlString = getConfDir();
     if (urlString == null) {
-      urlString = System.getProperty(IoTDBConstant.IOTDB_HOME, null);
-      if (urlString != null) {
-        urlString = urlString + File.separatorChar + "conf" + File.separatorChar + configFileName;
-      } else {
-        // If this too wasn't provided, try to find a default config in the root of the classpath.
-        URL uri = IoTDBConfig.class.getResource("/" + configFileName);
-        if (uri != null) {
-          return uri;
-        }
-        logger.warn(
-            "Cannot find IOTDB_HOME or IOTDB_CONF environment variable when loading "
-                + "config file {}, use default configuration",
-            configFileName);
-        // update all data seriesPath
-        conf.updatePath();
-        return null;
+      // If urlString wasn't provided, try to find a default config in the root of the classpath.
+      URL uri = IoTDBConfig.class.getResource("/" + configFileName);
+      if (uri != null) {
+        return uri;
       }
+      logger.warn(
+          "Cannot find IOTDB_HOME or IOTDB_CONF environment variable when loading "
+              + "config file {}, use default configuration",
+          configFileName);
+      // update all data seriesPath
+      conf.updatePath();
+      return null;
     }
     // If a config location was provided, but it doesn't end with a properties file,
     // append the default location.

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/config/constant/PipeConnectorConstant.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/config/constant/PipeConnectorConstant.java
@@ -19,8 +19,8 @@
 
 package org.apache.iotdb.db.pipe.config.constant;
 
-import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.pipe.config.PipeConfig;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
 
 import java.io.File;
 
@@ -74,20 +74,10 @@ public class PipeConnectorConstant {
   public static final int CONNECTOR_OPC_UA_HTTPS_BIND_PORT_DEFAULT_VALUE = 8443;
 
   public static final String CONNECTOR_OPC_UA_SECURITY_DIR_KEY = "connector.opcua.security.dir";
-  public static final String CONNECTOR_OPC_UA_SECURITY_DIR_DEFAULT_VALUE;
-
-  static {
-    // Check if a config-directory was specified first.
-    String urlString = System.getProperty(IoTDBConstant.IOTDB_CONF, null);
-    // If it wasn't, check if a home directory was provided (This usually contains a config)
-    if (urlString == null) {
-      urlString = System.getProperty(IoTDBConstant.IOTDB_HOME, null);
-      if (urlString != null) {
-        urlString = urlString + File.separatorChar + "conf";
-      }
-    }
-    CONNECTOR_OPC_UA_SECURITY_DIR_DEFAULT_VALUE = urlString + File.separatorChar + "opc_security";
-  }
+  public static final String CONNECTOR_OPC_UA_SECURITY_DIR_DEFAULT_VALUE =
+      IoTDBDescriptor.getInstance().getConfDir() != null
+          ? IoTDBDescriptor.getInstance().getConfDir() + File.separatorChar + "opc_security"
+          : null;
 
   private PipeConnectorConstant() {
     throw new IllegalStateException("Utility class");

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/config/constant/PipeConnectorConstant.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/config/constant/PipeConnectorConstant.java
@@ -77,7 +77,7 @@ public class PipeConnectorConstant {
   public static final String CONNECTOR_OPC_UA_SECURITY_DIR_DEFAULT_VALUE =
       IoTDBDescriptor.getInstance().getConfDir() != null
           ? IoTDBDescriptor.getInstance().getConfDir() + File.separatorChar + "opc_security"
-          : null;
+          : System.getProperty("user.home") + File.separatorChar + "iotdb_opc_security";
 
   private PipeConnectorConstant() {
     throw new IllegalStateException("Utility class");

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/config/constant/PipeConnectorConstant.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/config/constant/PipeConnectorConstant.java
@@ -19,7 +19,10 @@
 
 package org.apache.iotdb.db.pipe.config.constant;
 
+import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.pipe.config.PipeConfig;
+
+import java.io.File;
 
 import static org.apache.iotdb.commons.conf.IoTDBConstant.MB;
 
@@ -69,6 +72,22 @@ public class PipeConnectorConstant {
 
   public static final String CONNECTOR_OPC_UA_HTTPS_BIND_PORT_KEY = "connector.opcua.https.port";
   public static final int CONNECTOR_OPC_UA_HTTPS_BIND_PORT_DEFAULT_VALUE = 8443;
+
+  public static final String CONNECTOR_OPC_UA_SECURITY_DIR_KEY = "connector.opcua.security.dir";
+  public static final String CONNECTOR_OPC_UA_SECURITY_DIR_DEFAULT_VALUE;
+
+  static {
+    // Check if a config-directory was specified first.
+    String urlString = System.getProperty(IoTDBConstant.IOTDB_CONF, null);
+    // If it wasn't, check if a home directory was provided (This usually contains a config)
+    if (urlString == null) {
+      urlString = System.getProperty(IoTDBConstant.IOTDB_HOME, null);
+      if (urlString != null) {
+        urlString = urlString + File.separatorChar + "conf";
+      }
+    }
+    CONNECTOR_OPC_UA_SECURITY_DIR_DEFAULT_VALUE = urlString + File.separatorChar + "opc_security";
+  }
 
   private PipeConnectorConstant() {
     throw new IllegalStateException("Utility class");

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/opcua/OpcUaConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/opcua/OpcUaConnector.java
@@ -56,6 +56,8 @@ import static org.apache.iotdb.db.pipe.config.constant.PipeConnectorConstant.CON
 import static org.apache.iotdb.db.pipe.config.constant.PipeConnectorConstant.CONNECTOR_IOTDB_USER_KEY;
 import static org.apache.iotdb.db.pipe.config.constant.PipeConnectorConstant.CONNECTOR_OPC_UA_HTTPS_BIND_PORT_DEFAULT_VALUE;
 import static org.apache.iotdb.db.pipe.config.constant.PipeConnectorConstant.CONNECTOR_OPC_UA_HTTPS_BIND_PORT_KEY;
+import static org.apache.iotdb.db.pipe.config.constant.PipeConnectorConstant.CONNECTOR_OPC_UA_SECURITY_DIR_DEFAULT_VALUE;
+import static org.apache.iotdb.db.pipe.config.constant.PipeConnectorConstant.CONNECTOR_OPC_UA_SECURITY_DIR_KEY;
 import static org.apache.iotdb.db.pipe.config.constant.PipeConnectorConstant.CONNECTOR_OPC_UA_TCP_BIND_PORT_DEFAULT_VALUE;
 import static org.apache.iotdb.db.pipe.config.constant.PipeConnectorConstant.CONNECTOR_OPC_UA_TCP_BIND_PORT_KEY;
 
@@ -94,6 +96,9 @@ public class OpcUaConnector implements PipeConnector {
     String password =
         parameters.getStringOrDefault(
             CONNECTOR_IOTDB_PASSWORD_KEY, CONNECTOR_IOTDB_PASSWORD_DEFAULT_VALUE);
+    String securityDir =
+        parameters.getStringOrDefault(
+            CONNECTOR_OPC_UA_SECURITY_DIR_KEY, CONNECTOR_OPC_UA_SECURITY_DIR_DEFAULT_VALUE);
 
     synchronized (SERVER_KEY_TO_REFERENCE_COUNT_AND_SERVER_MAP) {
       serverKey = httpsBindPort + ":" + tcpBindPort;
@@ -110,6 +115,7 @@ public class OpcUaConnector implements PipeConnector {
                               .setHttpsBindPort(httpsBindPort)
                               .setUser(user)
                               .setPassword(password)
+                              .setSecurityDir(securityDir)
                               .build();
                       newServer.startup();
                       return new Pair<>(new AtomicInteger(0), newServer);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/opcua/OpcUaServerBuilder.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/opcua/OpcUaServerBuilder.java
@@ -78,12 +78,14 @@ public class OpcUaServerBuilder {
   private int httpsBindPort;
   private String user;
   private String password;
+  private Path securityDir;
 
   public OpcUaServerBuilder() {
     tcpBindPort = PipeConnectorConstant.CONNECTOR_OPC_UA_TCP_BIND_PORT_DEFAULT_VALUE;
     httpsBindPort = PipeConnectorConstant.CONNECTOR_OPC_UA_HTTPS_BIND_PORT_DEFAULT_VALUE;
     user = PipeConnectorConstant.CONNECTOR_IOTDB_USER_DEFAULT_VALUE;
     password = PipeConnectorConstant.CONNECTOR_IOTDB_PASSWORD_DEFAULT_VALUE;
+    securityDir = Paths.get(PipeConnectorConstant.CONNECTOR_OPC_UA_SECURITY_DIR_DEFAULT_VALUE);
   }
 
   public OpcUaServerBuilder setTcpBindPort(int tcpBindPort) {
@@ -106,22 +108,26 @@ public class OpcUaServerBuilder {
     return this;
   }
 
+  public OpcUaServerBuilder setSecurityDir(String securityDir) {
+    this.securityDir = Paths.get(securityDir);
+    return this;
+  }
+
   public OpcUaServer build() throws Exception {
-    Path securityTempDir = Paths.get(System.getProperty("java.io.tmpdir"), "iotdb", "security");
-    Files.createDirectories(securityTempDir);
-    if (!Files.exists(securityTempDir)) {
-      throw new PipeException("Unable to create security temp dir: " + securityTempDir);
+    Files.createDirectories(securityDir);
+    if (!Files.exists(securityDir)) {
+      throw new PipeException("Unable to create security dir: " + securityDir);
     }
 
-    File pkiDir = securityTempDir.resolve("pki").toFile();
+    File pkiDir = securityDir.resolve("pki").toFile();
 
     LoggerFactory.getLogger(OpcUaServerBuilder.class)
-        .info("Security dir: {}", securityTempDir.toAbsolutePath());
+        .info("Security dir: {}", securityDir.toAbsolutePath());
     LoggerFactory.getLogger(OpcUaServerBuilder.class)
         .info("Security pki dir: {}", pkiDir.getAbsolutePath());
 
     OpcUaKeyStoreLoader loader =
-        new OpcUaKeyStoreLoader().load(securityTempDir, password.toCharArray());
+        new OpcUaKeyStoreLoader().load(securityDir, password.toCharArray());
 
     DefaultCertificateManager certificateManager =
         new DefaultCertificateManager(loader.getServerKeyPair(), loader.getServerCertificate());


### PR DESCRIPTION
## IOTDB-6204
The previous opc-ua-connector key directory setting "java.io.tmpdir" is not capable of keeping certificates in a long run, thus the key directory is now configurable and resides in "%IOTDB-CONF%/opc-security" directory by default.
"IOTDB-CONF" is because the directory may ususally be manually accessed by users.
The outcome:
![image](https://github.com/apache/iotdb/assets/87789683/ae901a12-a39b-43ef-a17b-296a4dc02d1b)

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
