### PR TITLE
Skip loading Chunk without matched ChunkMetadata

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/load/TsFileSplitter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/load/TsFileSplitter.java
@@ -113,6 +113,12 @@ public class TsFileSplitter {
                 ((header.getChunkType() & TsFileConstant.TIME_COLUMN_MASK)
                     == TsFileConstant.TIME_COLUMN_MASK);
             IChunkMetadata chunkMetadata = offset2ChunkMetadata.get(chunkOffset - Byte.BYTES);
+            // When loading TsFile with Chunk in data zone but no matched ChunkMetadata
+            // at the end of file, this Chunk needs to be skipped.
+            if (chunkMetadata == null) {
+              reader.readChunk(-1, header.getDataSize());
+              break;
+            }
             TTimePartitionSlot timePartitionSlot =
                 TimePartitionUtils.getTimePartitionSlot(chunkMetadata.getStartTime());
             ChunkData chunkData =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/load/TsFileSplitter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/load/TsFileSplitter.java
@@ -235,6 +235,12 @@ public class TsFileSplitter {
             chunkOffset = reader.position();
             chunkMetadata = offset2ChunkMetadata.get(chunkOffset - Byte.BYTES);
             header = reader.readChunkHeader(marker);
+            // When loading TsFile with Chunk in data zone but no matched ChunkMetadata
+            // at the end of file, this Chunk needs to be skipped.
+            if (chunkMetadata == null) {
+              reader.readChunk(-1, header.getDataSize());
+              break;
+            }
             if (header.getDataSize() == 0) {
               handleEmptyValueChunk(
                   header, pageIndex2ChunkData, chunkMetadata, isTimeChunkNeedDecode);


### PR DESCRIPTION
## Description

When loading TsFile with Chunk in data zone but no matched ChunkMetadata at the end of file, this Chunk needs to be skipped.

https://apache-iotdb.feishu.cn/docx/XMOHdnEwXoDp3Zx8w8ScBlcBnhe