### PR TITLE
Accelerate datanode recovery

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
@@ -68,7 +68,12 @@ public class IoTDBShutdownHook extends Thread {
     WALManager.getInstance().waitAllWALFlushed();
 
     // flush data to Tsfile and remove WAL log files
-    StorageEngine.getInstance().syncCloseAllProcessor();
+    if (!IoTDBDescriptor.getInstance()
+        .getConfig()
+        .getDataRegionConsensusProtocolClass()
+        .equals(ConsensusFactory.RATIS_CONSENSUS)) {
+      StorageEngine.getInstance().syncCloseAllProcessor();
+    }
     WALManager.getInstance().deleteOutdatedWALFiles();
 
     // We did this work because the RatisConsensus recovery mechanism is different from other

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
@@ -68,9 +68,7 @@ public class IoTDBShutdownHook extends Thread {
     WALManager.getInstance().waitAllWALFlushed();
 
     // flush data to Tsfile and remove WAL log files
-    if (!IoTDBDescriptor.getInstance().getConfig().isClusterMode()) {
-      StorageEngine.getInstance().syncCloseAllProcessor();
-    }
+    StorageEngine.getInstance().syncCloseAllProcessor();
     WALManager.getInstance().deleteOutdatedWALFiles();
 
     // We did this work because the RatisConsensus recovery mechanism is different from other

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/StorageEngine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/StorageEngine.java
@@ -296,6 +296,11 @@ public class StorageEngine implements IService {
     }
 
     recover();
+    for (DataRegion dataRegion : dataRegionMap.values()) {
+      if (dataRegion != null) {
+        dataRegion.initCompaction();
+      }
+    }
 
     ttlCheckThread =
         IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor(ThreadName.TTL_CHECK.getName());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -564,17 +564,6 @@ public class DataRegion implements IDataRegionForQuery {
     } else {
       logger.info("The data region {}[{}] is recovered successfully", databaseName, dataRegionId);
     }
-
-    while (!StorageEngine.getInstance().isAllSgReady()) {
-      try {
-        TimeUnit.MILLISECONDS.sleep(1000);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        return;
-      }
-    }
-    // recover and start timed compaction thread
-    initCompaction();
   }
 
   private void updateLastFlushTime(TsFileResource resource, boolean isSeq) {
@@ -591,7 +580,7 @@ public class DataRegion implements IDataRegionForQuery {
     }
   }
 
-  private void initCompaction() {
+  public void initCompaction() {
     if (!config.isEnableSeqSpaceCompaction()
         && !config.isEnableUnseqSpaceCompaction()
         && !config.isEnableCrossSpaceCompaction()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -559,14 +559,22 @@ public class DataRegion implements IDataRegionForQuery {
       throw new DataRegionException(e);
     }
 
-    // recover and start timed compaction thread
-    initCompaction();
-
     if (StorageEngine.getInstance().isAllSgReady()) {
       logger.info("The data region {}[{}] is created successfully", databaseName, dataRegionId);
     } else {
       logger.info("The data region {}[{}] is recovered successfully", databaseName, dataRegionId);
     }
+
+    while (!StorageEngine.getInstance().isAllSgReady()) {
+      try {
+        TimeUnit.MILLISECONDS.sleep(1000);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return;
+      }
+    }
+    // recover and start timed compaction thread
+    initCompaction();
   }
 
   private void updateLastFlushTime(TsFileResource resource, boolean isSeq) {


### PR DESCRIPTION
## Description

This PR is optimizing two points.

1. #5800 added a strategy. When execute stop scripts, the data in memory will flush to disk. However, this strategy was skipped.
2. Compaction threads may take too much CPU resource, which caused recovery being slow. We can start compaction after all data region recovered.