### PR TITLE
Fix TsFileResource endTime error when insert empty tablet and flush

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -2053,7 +2053,7 @@ public class DataRegion implements IDataRegionForQuery {
     closeQueryLock.writeLock().lock();
     try {
       tsFileProcessor.close();
-      if (tsFileProcessor.isEmpty()) {
+      if (tsFileProcessor.isEmpty() || tsFileProcessor.getTsFileResource().isEmpty()) {
         try {
           fsFactory.deleteIfExists(tsFileProcessor.getTsFileResource().getTsFile());
           tsFileManager.remove(tsFileProcessor.getTsFileResource(), tsFileProcessor.isSequence());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AbstractMemTable.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AbstractMemTable.java
@@ -660,7 +660,11 @@ public abstract class AbstractMemTable implements IMemTable {
   public Map<String, Long> getMaxTime() {
     Map<String, Long> latestTimeForEachDevice = new HashMap<>();
     for (Entry<IDeviceID, IWritableMemChunkGroup> entry : memTableMap.entrySet()) {
-      latestTimeForEachDevice.put(entry.getKey().toStringID(), entry.getValue().getMaxTime());
+      // When insert null values in to IWritableMemChunkGroup, the maxTime will not be updated.
+      // In this scenario, the maxTime will be Long.MIN_VALUE. We shouldn't return this device.
+      if (entry.getValue().getMaxTime() != Long.MIN_VALUE) {
+        latestTimeForEachDevice.put(entry.getKey().toStringID(), entry.getValue().getMaxTime());
+      }
     }
     return latestTimeForEachDevice;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AbstractMemTable.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AbstractMemTable.java
@@ -662,8 +662,9 @@ public abstract class AbstractMemTable implements IMemTable {
     for (Entry<IDeviceID, IWritableMemChunkGroup> entry : memTableMap.entrySet()) {
       // When insert null values in to IWritableMemChunkGroup, the maxTime will not be updated.
       // In this scenario, the maxTime will be Long.MIN_VALUE. We shouldn't return this device.
-      if (entry.getValue().getMaxTime() != Long.MIN_VALUE) {
-        latestTimeForEachDevice.put(entry.getKey().toStringID(), entry.getValue().getMaxTime());
+      long maxTime = entry.getValue().getMaxTime();
+      if (maxTime != Long.MIN_VALUE) {
+        latestTimeForEachDevice.put(entry.getKey().toStringID(), maxTime);
       }
     }
     return latestTimeForEachDevice;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
@@ -1167,6 +1167,10 @@ public class TsFileResource {
     return maxProgressIndex == null ? MinimumProgressIndex.INSTANCE : maxProgressIndex;
   }
 
+  public boolean isEmpty() {
+    return getDevices().isEmpty();
+  }
+
   public String getDatabaseName() {
     return file.getParentFile().getParentFile().getParentFile().getName();
   }


### PR DESCRIPTION
## Description

When data is written using the insertTablet() interface and both values are null, exactly the data written is flushed. An empty TsFile file will be generated, the space cannot be deleted, and the generated resource file will be incorrect, and the endTime of the device will be Long.MIN_VALUE. This in turn affects query and merge mechanisms.

Based on this, this PR has the following two optimizations:
1. In the flush process, it is added that if the resource file is empty, the generated TsFile and.resource file are deleted
2. Enhance the judgment logic when there is no valid data in MemTable. If there is no valid data, delete the related empty Device data from the resource.

## How to test
Execute the following code.

```java
  public static void main(String[] args)
      throws IoTDBConnectionException, StatementExecutionException {
    session =
        new Session.Builder()
            .host(LOCAL_HOST)
            .port(6667)
            .username("root")
            .password("root")
            .version(Version.V_1_0)
            .build();
    session.open(false);
    insertTablet();
    session.executeNonQueryStatement("flush");
    session.close();
  }


  private static void insertTablet() throws IoTDBConnectionException, StatementExecutionException {
    // The schema of measurements of one device
    // only measurementId and data type in MeasurementSchema take effects in Tablet
    List<MeasurementSchema> schemaList = new ArrayList<>();
    schemaList.add(new MeasurementSchema("s1", TSDataType.INT64));
    schemaList.add(new MeasurementSchema("s2", TSDataType.INT64));
    schemaList.add(new MeasurementSchema("s3", TSDataType.INT64));

    Tablet tablet = new Tablet(ROOT_SG1_D1, schemaList, 100);

    // Method 1 to add tablet data
    long timestamp = System.currentTimeMillis();

    for (long row = 0; row < 100; row++) {
      int rowIndex = tablet.rowSize++;
      tablet.addTimestamp(rowIndex, timestamp);
      for (int s = 0; s < 3; s++) {
        tablet.addValue(schemaList.get(s).getMeasurementId(), rowIndex, null);
      }
      if (tablet.rowSize == tablet.getMaxRowNumber()) {
        session.insertTablet(tablet, true);
        tablet.reset();
      }
      timestamp++;
    }

    if (tablet.rowSize != 0) {
      session.insertTablet(tablet);
      tablet.reset();
    }
  }

```

Then print the TsFileResource file, you will see the endTime is Long.MIN_VALUE.
