### PR TITLE
Fix empty tsfile resource didn't remove

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -2054,14 +2054,8 @@ public class DataRegion implements IDataRegionForQuery {
     try {
       tsFileProcessor.close();
       if (tsFileProcessor.isEmpty() || tsFileProcessor.getTsFileResource().isEmpty()) {
-        try {
-          fsFactory.deleteIfExists(tsFileProcessor.getTsFileResource().getTsFile());
-          tsFileManager.remove(tsFileProcessor.getTsFileResource(), tsFileProcessor.isSequence());
-        } catch (IOException e) {
-          logger.error(
-              "Remove empty file {} error",
-              tsFileProcessor.getTsFileResource().getTsFile().getAbsolutePath());
-        }
+        tsFileProcessor.getTsFileResource().remove();
+        tsFileManager.remove(tsFileProcessor.getTsFileResource(), tsFileProcessor.isSequence());
       } else {
         tsFileResourceManager.registerSealedTsFileResource(tsFileProcessor.getTsFileResource());
       }


### PR DESCRIPTION
## Description

#11404 fixed an error that the TsFileResource endTime is not correct when insert empty tablet and flush. However, after the empty TsFile deleted, the Resource file didn't removed.

This Pr is fixing this issue.