### PR TITLE
[IOTDB-6220] Pipe: Added connector endpoint check logic to avoid self-transmission

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/IoTDBConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/IoTDBConnector.java
@@ -81,6 +81,18 @@ public abstract class IoTDBConnector implements PipeConnector {
   @Override
   public void customize(PipeParameters parameters, PipeConnectorRuntimeConfiguration configuration)
       throws Exception {
+    nodeUrls.clear();
+    nodeUrls.addAll(parseNodeUrls(parameters));
+    LOGGER.info("IoTDBConnector nodeUrls: {}", nodeUrls);
+
+    isTabletBatchModeEnabled =
+        parameters.getBooleanOrDefault(
+            Arrays.asList(CONNECTOR_IOTDB_BATCH_MODE_ENABLE_KEY, SINK_IOTDB_BATCH_MODE_ENABLE_KEY),
+            CONNECTOR_IOTDB_BATCH_MODE_ENABLE_DEFAULT_VALUE);
+    LOGGER.info("IoTDBConnector isTabletBatchModeEnabled: {}", isTabletBatchModeEnabled);
+  }
+
+  protected Set<TEndPoint> parseNodeUrls(PipeParameters parameters) {
     final Set<TEndPoint> givenNodeUrls = new HashSet<>(nodeUrls);
 
     if (parameters.hasAttribute(CONNECTOR_IOTDB_IP_KEY)
@@ -110,14 +122,6 @@ public abstract class IoTDBConnector implements PipeConnector {
               Arrays.asList(parameters.getString(SINK_IOTDB_NODE_URLS_KEY).split(","))));
     }
 
-    nodeUrls.clear();
-    nodeUrls.addAll(givenNodeUrls);
-    LOGGER.info("IoTDBConnector nodeUrls: {}", nodeUrls);
-
-    isTabletBatchModeEnabled =
-        parameters.getBooleanOrDefault(
-            Arrays.asList(CONNECTOR_IOTDB_BATCH_MODE_ENABLE_KEY, SINK_IOTDB_BATCH_MODE_ENABLE_KEY),
-            CONNECTOR_IOTDB_BATCH_MODE_ENABLE_DEFAULT_VALUE);
-    LOGGER.info("IoTDBConnector isTabletBatchModeEnabled: {}", isTabletBatchModeEnabled);
+    return givenNodeUrls;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/airgap/IoTDBAirGapConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/airgap/IoTDBAirGapConnector.java
@@ -89,23 +89,24 @@ public class IoTDBAirGapConnector extends IoTDBConnector {
   @Override
   public void validate(PipeParameterValidator validator) throws Exception {
     super.validate(validator);
-    final IoTDBConfig conf = IoTDBDescriptor.getInstance().getConfig();
-    final PipeConfig pipeConf = PipeConfig.getInstance();
+    final IoTDBConfig ioTDBConfig = IoTDBDescriptor.getInstance().getConfig();
+    final PipeConfig pipeConfig = PipeConfig.getInstance();
     Set<TEndPoint> givenNodeUrls = parseNodeUrls(validator.getParameters());
 
     validator.validate(
         empty ->
-            !(pipeConf.getPipeAirGapReceiverEnabled()
+            !(pipeConfig.getPipeAirGapReceiverEnabled()
                     && (givenNodeUrls.contains(
-                        new TEndPoint(conf.getRpcAddress(), pipeConf.getPipeAirGapReceiverPort())))
+                        new TEndPoint(
+                            ioTDBConfig.getRpcAddress(), pipeConfig.getPipeAirGapReceiverPort())))
                 || givenNodeUrls.contains(
-                    new TEndPoint("127.0.0.1", pipeConf.getPipeAirGapReceiverPort()))
+                    new TEndPoint("127.0.0.1", pipeConfig.getPipeAirGapReceiverPort()))
                 || givenNodeUrls.contains(
-                    new TEndPoint("0.0.0.0", pipeConf.getPipeAirGapReceiverPort()))),
+                    new TEndPoint("0.0.0.0", pipeConfig.getPipeAirGapReceiverPort()))),
         String.format(
             "The pipe destinations %s cannot point to one of the dataNodes' air gap receiver endpoint %s",
             givenNodeUrls,
-            new TEndPoint(conf.getRpcAddress(), pipeConf.getPipeAirGapReceiverPort())));
+            new TEndPoint(ioTDBConfig.getRpcAddress(), pipeConfig.getPipeAirGapReceiverPort())));
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/airgap/IoTDBAirGapConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/airgap/IoTDBAirGapConnector.java
@@ -96,10 +96,14 @@ public class IoTDBAirGapConnector extends IoTDBConnector {
     validator.validate(
         empty ->
             !(pipeConf.getPipeAirGapReceiverEnabled()
-                && givenNodeUrls.contains(
-                    new TEndPoint(conf.getRpcAddress(), pipeConf.getPipeAirGapReceiverPort()))),
+                    && (givenNodeUrls.contains(
+                        new TEndPoint(conf.getRpcAddress(), pipeConf.getPipeAirGapReceiverPort())))
+                || givenNodeUrls.contains(
+                    new TEndPoint("127.0.0.1", pipeConf.getPipeAirGapReceiverPort()))
+                || givenNodeUrls.contains(
+                    new TEndPoint("0.0.0.0", pipeConf.getPipeAirGapReceiverPort()))),
         String.format(
-            "The pipe destinations %s cannot contain one of the dataNodes' air gap receiver endpoint %s",
+            "The pipe destinations %s cannot point to one of the dataNodes' air gap receiver endpoint %s",
             givenNodeUrls,
             new TEndPoint(conf.getRpcAddress(), pipeConf.getPipeAirGapReceiverPort())));
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/airgap/IoTDBAirGapConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/airgap/IoTDBAirGapConnector.java
@@ -104,7 +104,7 @@ public class IoTDBAirGapConnector extends IoTDBConnector {
                 || givenNodeUrls.contains(
                     new TEndPoint("0.0.0.0", pipeConfig.getPipeAirGapReceiverPort()))),
         String.format(
-            "The pipe destinations %s cannot point to one of the dataNodes' air gap receiver endpoint %s",
+            "One of the endpoints %s of the receivers is pointing back to the air gap receiver %s on sender itself",
             givenNodeUrls,
             new TEndPoint(ioTDBConfig.getRpcAddress(), pipeConfig.getPipeAirGapReceiverPort())));
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
@@ -127,7 +127,7 @@ public class IoTDBLegacyPipeConnector implements PipeConnector {
                     || givenNodeUrls.contains(new TEndPoint("127.0.0.1", conf.getRpcPort()))
                     || givenNodeUrls.contains(new TEndPoint("0.0.0.0", conf.getRpcPort()))),
             String.format(
-                "The pipe destinations %s cannot point to one of the dataNodes' thrift receiver endpoint %s",
+                "The pipe destinations %s cannot point to one of the dataNodes' legacy receiver endpoint %s",
                 givenNodeUrls, new TEndPoint(conf.getRpcAddress(), conf.getRpcPort())));
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
@@ -103,7 +103,7 @@ public class IoTDBLegacyPipeConnector implements PipeConnector {
   @Override
   public void validate(PipeParameterValidator validator) throws Exception {
     final PipeParameters parameters = validator.getParameters();
-    final IoTDBConfig conf = IoTDBDescriptor.getInstance().getConfig();
+    final IoTDBConfig ioTDBConfig = IoTDBDescriptor.getInstance().getConfig();
     Set<TEndPoint> givenNodeUrls = parseNodeUrls(validator.getParameters());
 
     validator
@@ -123,12 +123,14 @@ public class IoTDBLegacyPipeConnector implements PipeConnector {
             parameters.hasAttribute(SINK_IOTDB_PORT_KEY))
         .validate(
             empty ->
-                !(givenNodeUrls.contains(new TEndPoint(conf.getRpcAddress(), conf.getRpcPort()))
-                    || givenNodeUrls.contains(new TEndPoint("127.0.0.1", conf.getRpcPort()))
-                    || givenNodeUrls.contains(new TEndPoint("0.0.0.0", conf.getRpcPort()))),
+                !(givenNodeUrls.contains(
+                        new TEndPoint(ioTDBConfig.getRpcAddress(), ioTDBConfig.getRpcPort()))
+                    || givenNodeUrls.contains(new TEndPoint("127.0.0.1", ioTDBConfig.getRpcPort()))
+                    || givenNodeUrls.contains(new TEndPoint("0.0.0.0", ioTDBConfig.getRpcPort()))),
             String.format(
                 "The pipe destinations %s cannot point to one of the dataNodes' legacy receiver endpoint %s",
-                givenNodeUrls, new TEndPoint(conf.getRpcAddress(), conf.getRpcPort())));
+                givenNodeUrls,
+                new TEndPoint(ioTDBConfig.getRpcAddress(), ioTDBConfig.getRpcPort())));
   }
 
   private Set<TEndPoint> parseNodeUrls(PipeParameters parameters) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
@@ -128,7 +128,7 @@ public class IoTDBLegacyPipeConnector implements PipeConnector {
                     || givenNodeUrls.contains(new TEndPoint("127.0.0.1", ioTDBConfig.getRpcPort()))
                     || givenNodeUrls.contains(new TEndPoint("0.0.0.0", ioTDBConfig.getRpcPort()))),
             String.format(
-                "The pipe destinations %s cannot point to one of the dataNodes' legacy receiver endpoint %s",
+                "One of the endpoints %s of the receivers is pointing back to the legacy receiver on sender %s itself",
                 givenNodeUrls,
                 new TEndPoint(ioTDBConfig.getRpcAddress(), ioTDBConfig.getRpcPort())));
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.pipe.connector.protocol.legacy;
 
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.client.property.ThriftClientProperty;
 import org.apache.iotdb.commons.conf.CommonConfig;
@@ -26,6 +27,8 @@ import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.pipe.PipeRuntimeCriticalException;
 import org.apache.iotdb.commons.pipe.config.PipeConfig;
+import org.apache.iotdb.db.conf.IoTDBConfig;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.pipe.connector.payload.legacy.TsFilePipeData;
 import org.apache.iotdb.db.pipe.connector.protocol.thrift.sync.IoTDBThriftSyncConnectorClient;
 import org.apache.iotdb.db.pipe.event.common.heartbeat.PipeHeartbeatEvent;
@@ -59,6 +62,8 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.apache.iotdb.db.pipe.config.constant.PipeConnectorConstant.CONNECTOR_IOTDB_IP_KEY;
 import static org.apache.iotdb.db.pipe.config.constant.PipeConnectorConstant.CONNECTOR_IOTDB_PASSWORD_DEFAULT_VALUE;
@@ -98,19 +103,53 @@ public class IoTDBLegacyPipeConnector implements PipeConnector {
   @Override
   public void validate(PipeParameterValidator validator) throws Exception {
     final PipeParameters parameters = validator.getParameters();
-    validator.validate(
-        args ->
-            ((boolean) args[0] && (boolean) args[1]) || ((boolean) args[2] && (boolean) args[3]),
-        String.format(
-            "Either %s:%s or %s:%s must be specified",
-            CONNECTOR_IOTDB_IP_KEY,
-            CONNECTOR_IOTDB_PORT_KEY,
-            SINK_IOTDB_IP_KEY,
-            SINK_IOTDB_PORT_KEY),
-        parameters.hasAttribute(CONNECTOR_IOTDB_IP_KEY),
-        parameters.hasAttribute(CONNECTOR_IOTDB_PORT_KEY),
-        parameters.hasAttribute(SINK_IOTDB_IP_KEY),
-        parameters.hasAttribute(SINK_IOTDB_PORT_KEY));
+    final IoTDBConfig conf = IoTDBDescriptor.getInstance().getConfig();
+    Set<TEndPoint> givenNodeUrls = parseNodeUrls(validator.getParameters());
+
+    validator
+        .validate(
+            args ->
+                ((boolean) args[0] && (boolean) args[1])
+                    || ((boolean) args[2] && (boolean) args[3]),
+            String.format(
+                "Either %s:%s or %s:%s must be specified",
+                CONNECTOR_IOTDB_IP_KEY,
+                CONNECTOR_IOTDB_PORT_KEY,
+                SINK_IOTDB_IP_KEY,
+                SINK_IOTDB_PORT_KEY),
+            parameters.hasAttribute(CONNECTOR_IOTDB_IP_KEY),
+            parameters.hasAttribute(CONNECTOR_IOTDB_PORT_KEY),
+            parameters.hasAttribute(SINK_IOTDB_IP_KEY),
+            parameters.hasAttribute(SINK_IOTDB_PORT_KEY))
+        .validate(
+            empty ->
+                !(givenNodeUrls.contains(new TEndPoint(conf.getRpcAddress(), conf.getRpcPort()))
+                    || givenNodeUrls.contains(new TEndPoint("127.0.0.1", conf.getRpcPort()))
+                    || givenNodeUrls.contains(new TEndPoint("0.0.0.0", conf.getRpcPort()))),
+            String.format(
+                "The pipe destinations %s cannot point to one of the dataNodes' thrift receiver endpoint %s",
+                givenNodeUrls, new TEndPoint(conf.getRpcAddress(), conf.getRpcPort())));
+  }
+
+  private Set<TEndPoint> parseNodeUrls(PipeParameters parameters) {
+    final Set<TEndPoint> givenNodeUrls = new HashSet<>();
+
+    if (parameters.hasAttribute(CONNECTOR_IOTDB_IP_KEY)
+        && parameters.hasAttribute(CONNECTOR_IOTDB_PORT_KEY)) {
+      givenNodeUrls.add(
+          new TEndPoint(
+              parameters.getString(CONNECTOR_IOTDB_IP_KEY),
+              parameters.getInt(CONNECTOR_IOTDB_PORT_KEY)));
+    }
+
+    if (parameters.hasAttribute(SINK_IOTDB_IP_KEY)
+        && parameters.hasAttribute(SINK_IOTDB_PORT_KEY)) {
+      givenNodeUrls.add(
+          new TEndPoint(
+              parameters.getString(SINK_IOTDB_IP_KEY), parameters.getInt(SINK_IOTDB_PORT_KEY)));
+    }
+
+    return givenNodeUrls;
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
@@ -84,17 +84,18 @@ public class IoTDBThriftSyncConnector extends IoTDBConnector {
   @Override
   public void validate(PipeParameterValidator validator) throws Exception {
     super.validate(validator);
-    final IoTDBConfig conf = IoTDBDescriptor.getInstance().getConfig();
+    final IoTDBConfig ioTDBConfig = IoTDBDescriptor.getInstance().getConfig();
     Set<TEndPoint> givenNodeUrls = parseNodeUrls(validator.getParameters());
 
     validator.validate(
         empty ->
-            !(givenNodeUrls.contains(new TEndPoint(conf.getRpcAddress(), conf.getRpcPort()))
-                || givenNodeUrls.contains(new TEndPoint("127.0.0.1", conf.getRpcPort()))
-                || givenNodeUrls.contains(new TEndPoint("0.0.0.0", conf.getRpcPort()))),
+            !(givenNodeUrls.contains(
+                    new TEndPoint(ioTDBConfig.getRpcAddress(), ioTDBConfig.getRpcPort()))
+                || givenNodeUrls.contains(new TEndPoint("127.0.0.1", ioTDBConfig.getRpcPort()))
+                || givenNodeUrls.contains(new TEndPoint("0.0.0.0", ioTDBConfig.getRpcPort()))),
         String.format(
             "The pipe destinations %s cannot point to one of the dataNodes' thrift receiver endpoint %s",
-            givenNodeUrls, new TEndPoint(conf.getRpcAddress(), conf.getRpcPort())));
+            givenNodeUrls, new TEndPoint(ioTDBConfig.getRpcAddress(), ioTDBConfig.getRpcPort())));
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
@@ -88,9 +88,12 @@ public class IoTDBThriftSyncConnector extends IoTDBConnector {
     Set<TEndPoint> givenNodeUrls = parseNodeUrls(validator.getParameters());
 
     validator.validate(
-        empty -> givenNodeUrls.contains(new TEndPoint(conf.getRpcAddress(), conf.getRpcPort())),
+        empty ->
+            !(givenNodeUrls.contains(new TEndPoint(conf.getRpcAddress(), conf.getRpcPort()))
+                || givenNodeUrls.contains(new TEndPoint("127.0.0.1", conf.getRpcPort()))
+                || givenNodeUrls.contains(new TEndPoint("0.0.0.0", conf.getRpcPort()))),
         String.format(
-            "The pipe destinations %s cannot contain one of the dataNodes' thrift receiver endpoint %s",
+            "The pipe destinations %s cannot point to one of the dataNodes' thrift receiver endpoint %s",
             givenNodeUrls, new TEndPoint(conf.getRpcAddress(), conf.getRpcPort())));
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.pipe.connector.protocol.thrift.sync;
 
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.commons.client.property.ThriftClientProperty;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.pipe.config.PipeConfig;
@@ -50,7 +51,6 @@ import org.apache.iotdb.pipe.api.exception.PipeConnectionException;
 import org.apache.iotdb.pipe.api.exception.PipeException;
 import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.service.rpc.thrift.TPipeTransferResp;
-import org.apache.iotdb.session.util.SessionUtils;
 
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
@@ -61,8 +61,8 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 public class IoTDBThriftSyncConnector extends IoTDBConnector {
 
@@ -85,19 +85,13 @@ public class IoTDBThriftSyncConnector extends IoTDBConnector {
   public void validate(PipeParameterValidator validator) throws Exception {
     super.validate(validator);
     final IoTDBConfig conf = IoTDBDescriptor.getInstance().getConfig();
+    Set<TEndPoint> givenNodeUrls = parseNodeUrls(validator.getParameters());
 
     validator.validate(
-        arg ->
-            !parseNodeUrls(((PipeParameters) arg))
-                .containsAll(
-                    SessionUtils.parseSeedNodeUrls(
-                        Collections.singletonList(conf.getRpcAddress() + conf.getRpcPort()))),
+        empty -> givenNodeUrls.contains(new TEndPoint(conf.getRpcAddress(), conf.getRpcPort())),
         String.format(
             "The pipe destinations %s cannot contain one of the dataNodes' thrift receiver endpoint %s",
-            parseNodeUrls(validator.getParameters()),
-            SessionUtils.parseSeedNodeUrls(
-                Collections.singletonList(conf.getRpcAddress() + conf.getRpcPort()))),
-        validator.getParameters());
+            givenNodeUrls, new TEndPoint(conf.getRpcAddress(), conf.getRpcPort())));
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
@@ -94,7 +94,7 @@ public class IoTDBThriftSyncConnector extends IoTDBConnector {
                 || givenNodeUrls.contains(new TEndPoint("127.0.0.1", ioTDBConfig.getRpcPort()))
                 || givenNodeUrls.contains(new TEndPoint("0.0.0.0", ioTDBConfig.getRpcPort()))),
         String.format(
-            "The pipe destinations %s cannot point to one of the dataNodes' thrift receiver endpoint %s",
+            "One of the endpoints %s of the receivers is pointing back to the thrift receiver %s on sender itself",
             givenNodeUrls, new TEndPoint(ioTDBConfig.getRpcAddress(), ioTDBConfig.getRpcPort())));
   }
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/connector/PipeConnectorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/connector/PipeConnectorTest.java
@@ -37,8 +37,7 @@ public class PipeConnectorTest {
 
   @Test(expected = PipeConnectionException.class)
   public void testIoTDBLegacyPipeConnector() {
-    IoTDBLegacyPipeConnector connector = new IoTDBLegacyPipeConnector();
-    try {
+    try (IoTDBLegacyPipeConnector connector = new IoTDBLegacyPipeConnector()) {
       connector.validate(
           new PipeParameterValidator(
               new PipeParameters(
@@ -58,8 +57,7 @@ public class PipeConnectorTest {
 
   @Test(expected = PipeConnectionException.class)
   public void testIoTDBThriftSyncConnector() {
-    IoTDBThriftSyncConnector connector = new IoTDBThriftSyncConnector();
-    try {
+    try (IoTDBThriftSyncConnector connector = new IoTDBThriftSyncConnector()) {
       connector.validate(
           new PipeParameterValidator(
               new PipeParameters(
@@ -79,8 +77,7 @@ public class PipeConnectorTest {
 
   @Test(expected = PipeConnectionException.class)
   public void testIoTDBThriftAsyncConnector() {
-    IoTDBThriftAsyncConnector connector = new IoTDBThriftAsyncConnector();
-    try {
+    try (IoTDBThriftAsyncConnector connector = new IoTDBThriftAsyncConnector()) {
       connector.validate(
           new PipeParameterValidator(
               new PipeParameters(

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/connector/PipeConnectorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/connector/PipeConnectorTest.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.db.pipe.connector.protocol.thrift.async.IoTDBThriftAsync
 import org.apache.iotdb.db.pipe.connector.protocol.thrift.sync.IoTDBThriftSyncConnector;
 import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameterValidator;
 import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameters;
+import org.apache.iotdb.pipe.api.exception.PipeConnectionException;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -75,7 +76,7 @@ public class PipeConnectorTest {
     }
   }
 
-  @Test
+  @Test(expected = PipeConnectionException.class)
   public void testIoTDBThriftAsyncConnector() {
     IoTDBThriftAsyncConnector connector = new IoTDBThriftAsyncConnector();
     try {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/connector/PipeConnectorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/connector/PipeConnectorTest.java
@@ -26,7 +26,7 @@ import org.apache.iotdb.db.pipe.connector.protocol.thrift.async.IoTDBThriftAsync
 import org.apache.iotdb.db.pipe.connector.protocol.thrift.sync.IoTDBThriftSyncConnector;
 import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameterValidator;
 import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameters;
-import org.apache.iotdb.pipe.api.exception.PipeConnectionException;
+import org.apache.iotdb.pipe.api.exception.PipeParameterNotValidException;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -35,8 +35,8 @@ import java.util.HashMap;
 
 public class PipeConnectorTest {
 
-  @Test(expected = PipeConnectionException.class)
-  public void testIoTDBLegacyPipeConnector() {
+  @Test(expected = PipeParameterNotValidException.class)
+  public void testIoTDBLegacyPipeConnectorToSelf() throws Exception {
     try (IoTDBLegacyPipeConnector connector = new IoTDBLegacyPipeConnector()) {
       connector.validate(
           new PipeParameterValidator(
@@ -50,13 +50,31 @@ public class PipeConnectorTest {
                       put(PipeConnectorConstant.CONNECTOR_IOTDB_PORT_KEY, "6667");
                     }
                   })));
+    }
+  }
+
+  @Test
+  public void testIoTDBLegacyPipeConnectorToOthers() {
+    try (IoTDBLegacyPipeConnector connector = new IoTDBLegacyPipeConnector()) {
+      connector.validate(
+          new PipeParameterValidator(
+              new PipeParameters(
+                  new HashMap<String, String>() {
+                    {
+                      put(
+                          PipeConnectorConstant.CONNECTOR_KEY,
+                          BuiltinPipePlugin.IOTDB_LEGACY_PIPE_CONNECTOR.getPipePluginName());
+                      put(PipeConnectorConstant.CONNECTOR_IOTDB_IP_KEY, "127.0.0.1");
+                      put(PipeConnectorConstant.CONNECTOR_IOTDB_PORT_KEY, "6668");
+                    }
+                  })));
     } catch (Exception e) {
       Assert.fail();
     }
   }
 
-  @Test(expected = PipeConnectionException.class)
-  public void testIoTDBThriftSyncConnector() {
+  @Test(expected = PipeParameterNotValidException.class)
+  public void testIoTDBThriftSyncConnectorToSelf() throws Exception {
     try (IoTDBThriftSyncConnector connector = new IoTDBThriftSyncConnector()) {
       connector.validate(
           new PipeParameterValidator(
@@ -70,13 +88,31 @@ public class PipeConnectorTest {
                       put(PipeConnectorConstant.CONNECTOR_IOTDB_PORT_KEY, "6667");
                     }
                   })));
+    }
+  }
+
+  @Test
+  public void testIoTDBThriftSyncConnectorToOthers() {
+    try (IoTDBThriftSyncConnector connector = new IoTDBThriftSyncConnector()) {
+      connector.validate(
+          new PipeParameterValidator(
+              new PipeParameters(
+                  new HashMap<String, String>() {
+                    {
+                      put(
+                          PipeConnectorConstant.CONNECTOR_KEY,
+                          BuiltinPipePlugin.IOTDB_THRIFT_SYNC_CONNECTOR.getPipePluginName());
+                      put(PipeConnectorConstant.CONNECTOR_IOTDB_IP_KEY, "127.0.0.1");
+                      put(PipeConnectorConstant.CONNECTOR_IOTDB_PORT_KEY, "6668");
+                    }
+                  })));
     } catch (Exception e) {
       Assert.fail();
     }
   }
 
-  @Test(expected = PipeConnectionException.class)
-  public void testIoTDBThriftAsyncConnector() {
+  @Test(expected = PipeParameterNotValidException.class)
+  public void testIoTDBThriftAsyncConnectorToSelf() throws Exception {
     try (IoTDBThriftAsyncConnector connector = new IoTDBThriftAsyncConnector()) {
       connector.validate(
           new PipeParameterValidator(
@@ -87,6 +123,23 @@ public class PipeConnectorTest {
                           PipeConnectorConstant.CONNECTOR_KEY,
                           BuiltinPipePlugin.IOTDB_THRIFT_ASYNC_CONNECTOR.getPipePluginName());
                       put(PipeConnectorConstant.CONNECTOR_IOTDB_NODE_URLS_KEY, "127.0.0.1:6667");
+                    }
+                  })));
+    }
+  }
+
+  @Test
+  public void testIoTDBThriftAsyncConnectorToOthers() {
+    try (IoTDBThriftAsyncConnector connector = new IoTDBThriftAsyncConnector()) {
+      connector.validate(
+          new PipeParameterValidator(
+              new PipeParameters(
+                  new HashMap<String, String>() {
+                    {
+                      put(
+                          PipeConnectorConstant.CONNECTOR_KEY,
+                          BuiltinPipePlugin.IOTDB_THRIFT_ASYNC_CONNECTOR.getPipePluginName());
+                      put(PipeConnectorConstant.CONNECTOR_IOTDB_NODE_URLS_KEY, "127.0.0.1:6668");
                     }
                   })));
     } catch (Exception e) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/connector/PipeConnectorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/connector/PipeConnectorTest.java
@@ -34,7 +34,8 @@ import org.junit.Test;
 import java.util.HashMap;
 
 public class PipeConnectorTest {
-  @Test
+
+  @Test(expected = PipeConnectionException.class)
   public void testIoTDBLegacyPipeConnector() {
     IoTDBLegacyPipeConnector connector = new IoTDBLegacyPipeConnector();
     try {
@@ -55,7 +56,7 @@ public class PipeConnectorTest {
     }
   }
 
-  @Test
+  @Test(expected = PipeConnectionException.class)
   public void testIoTDBThriftSyncConnector() {
     IoTDBThriftSyncConnector connector = new IoTDBThriftSyncConnector();
     try {


### PR DESCRIPTION
## IOTDB-6220
As the title said.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
