### PR TITLE
Fixed Ratis server RPC timeout parameter setting invalidation bug

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/utils/Utils.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/utils/Utils.java
@@ -241,6 +241,7 @@ public class Utils {
     RaftServerConfigKeys.Rpc.setTimeoutMin(properties, config.getRpc().getTimeoutMin());
     RaftServerConfigKeys.Rpc.setTimeoutMax(properties, config.getRpc().getTimeoutMax());
     RaftServerConfigKeys.Rpc.setSleepTime(properties, config.getRpc().getSleepTime());
+    RaftServerConfigKeys.Rpc.setRequestTimeout(properties, config.getRpc().getRequestTimeout());
     RaftClientConfigKeys.Rpc.setRequestTimeout(properties, config.getRpc().getRequestTimeout());
 
     RaftServerConfigKeys.LeaderElection.setLeaderStepDownWaitTime(


### PR DESCRIPTION
Phenomenon：
- Our Ratis RPC timeout parameter is only applied to the Client, not to the Server. 
- This results in the following RPC timeout still being 3s, which we actually set to 10s in the parameter
![img_v2_c21a223f-119b-4262-8fae-b9cad8f44bcg](https://github.com/apache/iotdb/assets/32640567/649587ea-6131-4e47-9a2d-507d0d6bd063)

Solution：
- Set the corresponding parameters when starting the Ratis Server

