### PR TITLE
Add java doc for SessionDataSet.next() method and HeapDump configuration in datanode-env

### DIFF
--- a/iotdb-client/isession/src/main/java/org/apache/iotdb/isession/SessionDataSet.java
+++ b/iotdb-client/isession/src/main/java/org/apache/iotdb/isession/SessionDataSet.java
@@ -211,6 +211,15 @@ public class SessionDataSet implements AutoCloseable {
     return new RowRecord(ioTDBRpcDataSet.time, outFields);
   }
 
+  /**
+   * Iterate ResultSet using this method isn't very efficient, because it will use RowRecord to
+   * represent a row which contains much object creation and converting overhead If you just want to
+   * get each value of each column row by row, you can use SessionDataSet.iterator() to get
+   * DataIterator, and use DataIterator.getXXX() function to get current row's specified column
+   * value.
+   *
+   * @return One complete row saved in RowRecord
+   */
   public RowRecord next() throws StatementExecutionException, IoTDBConnectionException {
     if (!ioTDBRpcDataSet.hasCachedRecord && !hasNext()) {
       return null;

--- a/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.bat
+++ b/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.bat
@@ -120,6 +120,9 @@ set IOTDB_HEAP_OPTS=-Xmx%ON_HEAP_MEMORY% -Xms%ON_HEAP_MEMORY%
 set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:MaxDirectMemorySize=%OFF_HEAP_MEMORY%
 set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -Djdk.nio.maxCachedBufferSize=%MAX_CACHED_BUFFER_SIZE%
 
+@REM if you want to dump the heap memory while OOM happening, you can use the following command, remember to replace /tmp/heapdump.hprof with your own file path and the folder where this file is located needs to be created in advance
+@REM IOTDB_JMX_OPTS=%IOTDB_HEAP_OPTS% -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=\tmp\heapdump.hprof
+
 @REM You can put your env variable here
 @REM set JAVA_HOME=%JAVA_HOME%
 

--- a/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.sh
+++ b/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.sh
@@ -269,6 +269,9 @@ IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xms${ON_HEAP_MEMORY}"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xmx${ON_HEAP_MEMORY}"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:MaxDirectMemorySize=${OFF_HEAP_MEMORY}"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Djdk.nio.maxCachedBufferSize=${MAX_CACHED_BUFFER_SIZE}"
+# if you want to dump the heap memory while OOM happening, you can use the following command, remember to replace /tmp/heapdump.hprof with your own file path and the folder where this file is located needs to be created in advance
+#IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/heapdump.hprof"
+
 
 echo "DataNode on heap memory size = ${ON_HEAP_MEMORY}B, off heap memory size = ${OFF_HEAP_MEMORY}B"
 echo "If you want to change this configuration, please check conf/datanode-env.sh."


### PR DESCRIPTION
In this pr, we do two user-friendly changes:

1. add java doc for SessionDataSet.next(), and recommend users to use SessionDataSet.DataIterator to iterate their result set if possible
2. add HeapDump configuration in datanode-env to let DBA can quickly add `-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=`.