### PR TITLE
Pipe: Disable batch mode for retry connector in case some events are never retried & Pipe won't collect TsFile without tail magic & Make async connector stop properly when retry count exceeds limit

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/airgap/IoTDBAirGapConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/airgap/IoTDBAirGapConnector.java
@@ -240,6 +240,11 @@ public class IoTDBAirGapConnector extends IoTDBConnector {
       return;
     }
 
+    if (!((PipeTsFileInsertionEvent) tsFileInsertionEvent).waitForTsFileClose()) {
+      LOGGER.warn("Pipe found a temporary TsFile which shouldn't be transferred. Skipping.");
+      return;
+    }
+
     if (((EnrichedEvent) tsFileInsertionEvent).shouldParsePatternOrTime()) {
       try {
         for (final TabletInsertionEvent event : tsFileInsertionEvent.toTabletInsertionEvents()) {
@@ -307,9 +312,7 @@ public class IoTDBAirGapConnector extends IoTDBConnector {
   }
 
   private void doTransfer(Socket socket, PipeTsFileInsertionEvent pipeTsFileInsertionEvent)
-      throws PipeException, InterruptedException, IOException {
-    pipeTsFileInsertionEvent.waitForTsFileClose();
-
+      throws PipeException, IOException {
     final File tsFile = pipeTsFileInsertionEvent.getTsFile();
 
     // 1. Transfer file piece by piece

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/airgap/IoTDBAirGapConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/airgap/IoTDBAirGapConnector.java
@@ -241,7 +241,9 @@ public class IoTDBAirGapConnector extends IoTDBConnector {
     }
 
     if (!((PipeTsFileInsertionEvent) tsFileInsertionEvent).waitForTsFileClose()) {
-      LOGGER.warn("Pipe found a temporary TsFile which shouldn't be transferred. Skipping.");
+      LOGGER.warn(
+          "Pipe skipping temporary TsFile which shouldn't be transferred: {}",
+          ((PipeTsFileInsertionEvent) tsFileInsertionEvent).getTsFile());
       return;
     }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
@@ -207,7 +207,9 @@ public class IoTDBLegacyPipeConnector implements PipeConnector {
     }
 
     if (!((PipeTsFileInsertionEvent) tsFileInsertionEvent).waitForTsFileClose()) {
-      LOGGER.warn("Pipe found a temporary TsFile which shouldn't be transferred. Skipping.");
+      LOGGER.warn(
+          "Pipe skipping temporary TsFile which shouldn't be transferred: {}",
+          ((PipeTsFileInsertionEvent) tsFileInsertionEvent).getTsFile());
       return;
     }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
@@ -206,6 +206,11 @@ public class IoTDBLegacyPipeConnector implements PipeConnector {
           "IoTDBLegacyPipeConnector only support PipeTsFileInsertionEvent.");
     }
 
+    if (!((PipeTsFileInsertionEvent) tsFileInsertionEvent).waitForTsFileClose()) {
+      LOGGER.warn("Pipe found a temporary TsFile which shouldn't be transferred. Skipping.");
+      return;
+    }
+
     try {
       doTransfer((PipeTsFileInsertionEvent) tsFileInsertionEvent);
     } catch (TException e) {
@@ -244,9 +249,7 @@ public class IoTDBLegacyPipeConnector implements PipeConnector {
   }
 
   private void doTransfer(PipeTsFileInsertionEvent pipeTsFileInsertionEvent)
-      throws PipeException, TException, InterruptedException, IOException {
-    pipeTsFileInsertionEvent.waitForTsFileClose();
-
+      throws PipeException, TException, IOException {
     final File tsFile = pipeTsFileInsertionEvent.getTsFile();
     transportSingleFilePieceByPiece(tsFile);
     client.sendPipeData(ByteBuffer.wrap(new TsFilePipeData("", tsFile.getName(), -1).serialize()));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBThriftAsyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBThriftAsyncConnector.java
@@ -300,7 +300,9 @@ public class IoTDBThriftAsyncConnector extends IoTDBConnector {
     final PipeTsFileInsertionEvent pipeTsFileInsertionEvent =
         (PipeTsFileInsertionEvent) tsFileInsertionEvent;
     if (!pipeTsFileInsertionEvent.waitForTsFileClose()) {
-      LOGGER.warn("Pipe found a temporary TsFile which shouldn't be transferred. Skipping.");
+      LOGGER.warn(
+          "Pipe skipping temporary TsFile which shouldn't be transferred: {}",
+          pipeTsFileInsertionEvent.getTsFile());
       return;
     }
 
@@ -352,13 +354,7 @@ public class IoTDBThriftAsyncConnector extends IoTDBConnector {
 
   @Override
   public void transfer(Event event) throws Exception {
-    try {
-      transferQueuedEventsIfNecessary();
-    } catch (Exception e) {
-      LOGGER.warn("caught ex in retry, rethrown.");
-      throw e;
-    }
-    LOGGER.warn("no ex in retry");
+    transferQueuedEventsIfNecessary();
     transferBatchedEventsIfNecessary();
 
     if (!(event instanceof PipeHeartbeatEvent)) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
@@ -232,7 +232,9 @@ public class IoTDBThriftSyncConnector extends IoTDBConnector {
     }
 
     if (!((PipeTsFileInsertionEvent) tsFileInsertionEvent).waitForTsFileClose()) {
-      LOGGER.warn("Pipe found a temporary TsFile which shouldn't be transferred. Skipping.");
+      LOGGER.warn(
+          "Pipe skipping temporary TsFile which shouldn't be transferred: {}",
+          ((PipeTsFileInsertionEvent) tsFileInsertionEvent).getTsFile());
       return;
     }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
@@ -231,6 +231,11 @@ public class IoTDBThriftSyncConnector extends IoTDBConnector {
       return;
     }
 
+    if (!((PipeTsFileInsertionEvent) tsFileInsertionEvent).waitForTsFileClose()) {
+      LOGGER.warn("Pipe found a temporary TsFile which shouldn't be transferred. Skipping.");
+      return;
+    }
+
     if (((EnrichedEvent) tsFileInsertionEvent).shouldParsePatternOrTime()) {
       for (final TabletInsertionEvent event : tsFileInsertionEvent.toTabletInsertionEvents()) {
         transfer(event);
@@ -327,9 +332,7 @@ public class IoTDBThriftSyncConnector extends IoTDBConnector {
 
   private void doTransfer(
       IoTDBThriftSyncConnectorClient client, PipeTsFileInsertionEvent pipeTsFileInsertionEvent)
-      throws PipeException, TException, InterruptedException, IOException {
-    pipeTsFileInsertionEvent.waitForTsFileClose();
-
+      throws PipeException, TException, IOException {
     final File tsFile = pipeTsFileInsertionEvent.getTsFile();
 
     // 1. Transfer file piece by piece

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/EnrichedEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/EnrichedEvent.java
@@ -181,6 +181,8 @@ public abstract class EnrichedEvent implements Event {
   public void reportException(PipeRuntimeException pipeRuntimeException) {
     if (pipeTaskMeta != null) {
       PipeAgent.runtime().report(pipeTaskMeta, pipeRuntimeException);
+    } else {
+      LOGGER.warn("Attempt to report pipe exception to a null PipeTaskMeta.");
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/EnrichedEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/EnrichedEvent.java
@@ -182,7 +182,7 @@ public abstract class EnrichedEvent implements Event {
     if (pipeTaskMeta != null) {
       PipeAgent.runtime().report(pipeTaskMeta, pipeRuntimeException);
     } else {
-      LOGGER.warn("Attempt to report pipe exception to a null PipeTaskMeta.");
+      LOGGER.warn("Attempt to report pipe exception to a null PipeTaskMeta.", pipeRuntimeException);
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/heartbeat/PipeHeartbeatEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/heartbeat/PipeHeartbeatEvent.java
@@ -73,8 +73,12 @@ public class PipeHeartbeatEvent extends EnrichedEvent {
     this.shouldPrintMessage = shouldPrintMessage;
   }
 
-  public PipeHeartbeatEvent(String dataRegionId, long timePublished, boolean shouldPrintMessage) {
-    super(null, null);
+  public PipeHeartbeatEvent(
+      String dataRegionId,
+      long timePublished,
+      boolean shouldPrintMessage,
+      PipeTaskMeta pipeTaskMeta) {
+    super(pipeTaskMeta, null);
     this.dataRegionId = dataRegionId;
     this.timePublished = timePublished;
     this.shouldPrintMessage = shouldPrintMessage;
@@ -103,7 +107,8 @@ public class PipeHeartbeatEvent extends EnrichedEvent {
   @Override
   public EnrichedEvent shallowCopySelfAndBindPipeTaskMetaForProgressReport(
       PipeTaskMeta pipeTaskMeta, String pattern) {
-    return new PipeHeartbeatEvent(dataRegionId, timePublished, shouldPrintMessage);
+    // Should record PipeTaskMeta, for sometimes HeartbeatEvents should report exceptions.
+    return new PipeHeartbeatEvent(dataRegionId, timePublished, shouldPrintMessage, pipeTaskMeta);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/heartbeat/PipeHeartbeatEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/heartbeat/PipeHeartbeatEvent.java
@@ -74,10 +74,10 @@ public class PipeHeartbeatEvent extends EnrichedEvent {
   }
 
   public PipeHeartbeatEvent(
+      PipeTaskMeta pipeTaskMeta,
       String dataRegionId,
       long timePublished,
-      boolean shouldPrintMessage,
-      PipeTaskMeta pipeTaskMeta) {
+      boolean shouldPrintMessage) {
     super(pipeTaskMeta, null);
     this.dataRegionId = dataRegionId;
     this.timePublished = timePublished;
@@ -108,7 +108,7 @@ public class PipeHeartbeatEvent extends EnrichedEvent {
   public EnrichedEvent shallowCopySelfAndBindPipeTaskMetaForProgressReport(
       PipeTaskMeta pipeTaskMeta, String pattern) {
     // Should record PipeTaskMeta, for sometimes HeartbeatEvents should report exceptions.
-    return new PipeHeartbeatEvent(dataRegionId, timePublished, shouldPrintMessage, pipeTaskMeta);
+    return new PipeHeartbeatEvent(pipeTaskMeta, dataRegionId, timePublished, shouldPrintMessage);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
@@ -161,6 +161,12 @@ public class TsFileProcessor {
   private static final String FLUSH_QUERY_WRITE_RELEASE =
       "{}: {} get flushQueryLock write lock released";
 
+  /**
+   * Whether this file keeps TsFile format. If the file violates TsFile format, then it shouldn't be
+   * captured by pipe engine.
+   */
+  private boolean isTsFileFormatValidForPipe = true;
+
   /** close file listener. */
   private final List<CloseFileListener> closeFileListeners = new CopyOnWriteArrayList<>();
 
@@ -1384,6 +1390,7 @@ public class TsFileProcessor {
     // remove this processor from Closing list in DataRegion,
     // mark the TsFileResource closed, no need writer anymore
     writer.close();
+    isTsFileFormatValidForPipe = false; // empty file, no need to be captured by pipe
     for (CloseFileListener closeFileListener : closeFileListeners) {
       closeFileListener.onClosed(this);
     }
@@ -1397,6 +1404,11 @@ public class TsFileProcessor {
         tsFileResource.getTsFile().getAbsoluteFile());
 
     writer = null;
+  }
+
+  /** Only useful after TsFile is closed. */
+  public boolean isTsFileFormatValidForPipe() {
+    return isTsFileFormatValidForPipe;
   }
 
   public boolean isManagedByFlushManager() {


### PR DESCRIPTION
This PR includes:
- Disable batch mode for retry connector in case some events are never retried
- Pipe won't collect TsFile without tail magic
- Make async connector stop properly when retry count exceeds limit (exception will be properly reported by HeartbeatEvents)