### PR TITLE
Implement iterative volatile node process during pbtree flush

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/CachedMTreeStore.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/CachedMTreeStore.java
@@ -49,7 +49,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
@@ -557,8 +556,12 @@ public class CachedMTreeStore implements IMTreeStore<ICachedMNode> {
           return;
         }
       }
-      List<ICachedMNode> nodesToPersist = cacheManager.collectVolatileMNodes();
-      for (ICachedMNode volatileNode : nodesToPersist) {
+      Iterator<ICachedMNode> nodesToPersist = cacheManager.collectVolatileMNodes();
+      boolean hasNodeToPersist = nodesToPersist.hasNext();
+
+      ICachedMNode volatileNode;
+      while (nodesToPersist.hasNext()) {
+        volatileNode = nodesToPersist.next();
         try {
           file.writeMNode(volatileNode);
         } catch (MetadataException | IOException e) {
@@ -570,7 +573,8 @@ public class CachedMTreeStore implements IMTreeStore<ICachedMNode> {
         }
         cacheManager.updateCacheStatusAfterPersist(volatileNode);
       }
-      if (updatedStorageGroupMNode != null || !nodesToPersist.isEmpty()) {
+
+      if (updatedStorageGroupMNode != null || hasNodeToPersist) {
         flushCallback.run();
       }
     } catch (Throwable e) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/CachedMTreeStore.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/CachedMTreeStore.java
@@ -21,7 +21,6 @@ package org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.pbtree;
 
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
-import org.apache.iotdb.commons.schema.node.role.IDatabaseMNode;
 import org.apache.iotdb.commons.schema.node.role.IDeviceMNode;
 import org.apache.iotdb.commons.schema.node.role.IMeasurementMNode;
 import org.apache.iotdb.commons.schema.node.utils.IMNodeFactory;
@@ -547,7 +546,8 @@ public class CachedMTreeStore implements IMTreeStore<ICachedMNode> {
 
   /** Sync all volatile nodes to PBTree and execute memory release after flush. */
   public void flushVolatileNodes() {
-    PBTreeFlushExecutor flushExecutor = new PBTreeFlushExecutor(schemaRegionId, this, cacheManager, file, flushCallback);
+    PBTreeFlushExecutor flushExecutor =
+        new PBTreeFlushExecutor(schemaRegionId, this, cacheManager, file, flushCallback);
     flushExecutor.flushVolatileNodes();
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/CacheManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/CacheManager.java
@@ -308,6 +308,7 @@ public abstract class CacheManager implements ICacheManager {
 
     private void tryGetNext() {
       ICachedMNode node;
+      ICachedMNode tmp;
       CacheEntry cacheEntry;
       while (bufferedNodeIterator.hasNext()) {
         node = bufferedNodeIterator.next();
@@ -321,6 +322,13 @@ public abstract class CacheManager implements ICacheManager {
 
         if (node.isMeasurement() || !getCachedMNodeContainer(node).hasChildrenInBuffer()) {
           addToNodeCache(cacheEntry, node);
+          tmp = node.getParent();
+          while (!tmp.isDatabase()
+              && !isInNodeCache(getCacheEntry(tmp))
+              && !getCachedMNodeContainer(tmp).hasChildrenInBuffer()) {
+            addToNodeCache(getCacheEntry(tmp), tmp);
+            tmp = tmp.getParent();
+          }
         } else {
           // nodes with volatile children should be treated as root of volatile subtree and return
           // for flush

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/CacheManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/CacheManager.java
@@ -700,7 +700,7 @@ public abstract class CacheManager implements ICacheManager {
         if (nextNode == null) {
           tryGetNext();
           if (nextNode == null && hasNew) {
-            synchronized (this){
+            synchronized (this) {
               hasNew = false;
               mapIndex = 0;
             }
@@ -734,7 +734,7 @@ public abstract class CacheManager implements ICacheManager {
         while (!currentIterator.hasNext()) {
           currentIterator = null;
 
-          synchronized (this){
+          synchronized (this) {
             mapIndex++;
           }
 
@@ -749,8 +749,8 @@ public abstract class CacheManager implements ICacheManager {
 
       private void checkHasNew(int index) {
         if (mapIndex >= index) {
-          synchronized (this){
-            if (mapIndex >= index){
+          synchronized (this) {
+            if (mapIndex >= index) {
               hasNew = true;
             }
           }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/CacheManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/CacheManager.java
@@ -365,6 +365,8 @@ public abstract class CacheManager implements ICacheManager {
           getCachedMNodeContainer(node).getChildrenBufferIterator();
       if (childrenBufferIterator.hasNext()) {
         nextMNode = node;
+        // after written to disk, the children will be moved to container.cache,
+        // thus they should be stored temporarily for rest iteration
         List<ICachedMNode> bufferedChildren = new ArrayList<>();
         while (childrenBufferIterator.hasNext()) {
           bufferedChildren.add(childrenBufferIterator.next());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/CacheManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/CacheManager.java
@@ -275,7 +275,7 @@ public abstract class CacheManager implements ICacheManager {
             return;
           } else if (!node.isDatabase()) {
             // the volatile subtree of this node has been deleted, thus there's no need to flush it
-            // add the node and its ancestors to buffer
+            // add the node and its ancestors to cache
             // if there's flush failure, such node and ancestors will be removed from cache again by
             // #updateCacheStatusAfterFlushFailure
             ICachedMNode tmp = node;
@@ -343,7 +343,7 @@ public abstract class CacheManager implements ICacheManager {
 
         if (node.isMeasurement() || !getCachedMNodeContainer(node).hasChildrenInBuffer()) {
           // there's no volatile subtree under this node, thus there's no need to flush it
-          // add the node and its ancestors to buffer
+          // add the node and its ancestors to cache
           // if there's flush failure, such node and ancestors will be removed from cache again by
           // #updateCacheStatusAfterFlushFailure
           addToNodeCache(cacheEntry, node);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/ICacheManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/ICacheManager.java
@@ -23,7 +23,7 @@ import org.apache.iotdb.db.exception.metadata.cache.MNodeNotCachedException;
 import org.apache.iotdb.db.exception.metadata.cache.MNodeNotPinnedException;
 import org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.pbtree.mnode.ICachedMNode;
 
-import java.util.List;
+import java.util.Iterator;
 
 public interface ICacheManager {
 
@@ -41,7 +41,7 @@ public interface ICacheManager {
 
   IDatabaseMNode<ICachedMNode> collectUpdatedStorageGroupMNodes();
 
-  List<ICachedMNode> collectVolatileMNodes();
+  Iterator<ICachedMNode> collectVolatileMNodes();
 
   void remove(ICachedMNode node);
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/ICacheManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/cache/ICacheManager.java
@@ -37,11 +37,13 @@ public interface ICacheManager {
 
   void updateCacheStatusAfterUpdate(ICachedMNode node);
 
-  void updateCacheStatusAfterPersist(ICachedMNode node);
-
   IDatabaseMNode<ICachedMNode> collectUpdatedStorageGroupMNodes();
 
-  Iterator<ICachedMNode> collectVolatileMNodes();
+  Iterator<ICachedMNode> collectVolatileSubtrees();
+
+  Iterator<ICachedMNode> updateCacheStatusAndRetrieveSubtreeAfterPersist(ICachedMNode subtreeRoot);
+
+  void updateCacheStatusAfterFlushFailure(ICachedMNode subtreeRoot);
 
   void remove(ICachedMNode node);
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/flush/PBTreeFlushExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/flush/PBTreeFlushExecutor.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.pbtree.flush;
+
+import org.apache.iotdb.commons.exception.MetadataException;
+import org.apache.iotdb.commons.schema.node.role.IDatabaseMNode;
+import org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.pbtree.CachedMTreeStore;
+import org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.pbtree.cache.ICacheManager;
+import org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.pbtree.mnode.ICachedMNode;
+import org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.pbtree.schemafile.ISchemaFile;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+public class PBTreeFlushExecutor {
+
+  private static final Logger logger = LoggerFactory.getLogger(PBTreeFlushExecutor.class);
+
+  private final int schemaRegionId;
+
+  private final CachedMTreeStore store;
+
+  private final ICacheManager cacheManager;
+
+  private final ISchemaFile file;
+
+  private final Runnable flushCallback;
+
+  public PBTreeFlushExecutor(
+      int schemaRegionId,
+      CachedMTreeStore store,
+      ICacheManager cacheManager,
+      ISchemaFile file,
+      Runnable flushCallback) {
+    this.schemaRegionId = schemaRegionId;
+    this.store = store;
+    this.cacheManager = cacheManager;
+    this.file = file;
+    this.flushCallback = flushCallback;
+  }
+
+  public void flushVolatileNodes() {
+    try {
+      if (flushVolatileDBNode() || flushVolatileSubtree()) {
+        flushCallback.run();
+      }
+    } catch (MetadataException | IOException e) {
+      logger.warn(
+          "Exception occurred during MTree flush, current SchemaRegionId is {}", schemaRegionId, e);
+    } catch (Throwable e) {
+      logger.error(
+          "Error occurred during MTree flush, current SchemaRegionId is {}", schemaRegionId, e);
+      e.printStackTrace();
+    }
+  }
+
+  private boolean flushVolatileDBNode() throws IOException {
+    IDatabaseMNode<ICachedMNode> updatedStorageGroupMNode =
+        cacheManager.collectUpdatedStorageGroupMNodes();
+    if (updatedStorageGroupMNode == null) {
+      return false;
+    }
+
+    try {
+      file.updateDatabaseNode(updatedStorageGroupMNode);
+      return true;
+    } catch (IOException e) {
+      logger.warn(
+          "IOException occurred during updating StorageGroupMNode {}",
+          updatedStorageGroupMNode.getFullPath(),
+          e);
+      throw e;
+    }
+  }
+
+  private boolean flushVolatileSubtree() throws MetadataException, IOException {
+    long startTime = System.currentTimeMillis();
+    Iterator<ICachedMNode> nodesToPersist = cacheManager.collectVolatileMNodes();
+    boolean hasNodesToPersist = nodesToPersist.hasNext();
+
+    ICachedMNode volatileNode;
+    while (nodesToPersist.hasNext()) {
+      volatileNode = nodesToPersist.next();
+      try {
+        file.writeMNode(volatileNode);
+      } catch (MetadataException | IOException e) {
+        logger.warn(
+            "Error occurred during MTree flush, current node is {}", volatileNode.getFullPath(), e);
+        throw e;
+      }
+      cacheManager.updateCacheStatusAfterPersist(volatileNode);
+    }
+    logger.info(
+        "It takes {}ms to flush MTree in SchemaRegion {}",
+        (System.currentTimeMillis() - startTime),
+        schemaRegionId);
+    return hasNodesToPersist;
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/mnode/container/CachedMNodeContainer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/mnode/container/CachedMNodeContainer.java
@@ -264,6 +264,11 @@ public class CachedMNodeContainer implements ICachedMNodeContainer {
   }
 
   @Override
+  public boolean hasChildrenInBuffer() {
+    return !isEmpty(updatedChildBuffer) || !isEmpty(newChildBuffer);
+  }
+
+  @Override
   public Iterator<ICachedMNode> getChildrenIterator() {
     return new CachedMNodeContainerIterator();
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/mnode/container/ICachedMNodeContainer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/mnode/container/ICachedMNodeContainer.java
@@ -40,6 +40,8 @@ public interface ICachedMNodeContainer extends IMNodeContainer<ICachedMNode> {
 
   boolean hasChildInBuffer(String name);
 
+  boolean hasChildrenInBuffer();
+
   Iterator<ICachedMNode> getChildrenIterator();
 
   Iterator<ICachedMNode> getChildrenBufferIterator();


### PR DESCRIPTION
## Description


### Motivation

The original flush implementation will collect all volatile node into a list for flush. Such mechanism will bring extra space and time costs, like duplicate reference storage and list scan.

### Modification

Implement an iterative process for volatile flush. Now the Cachemanager will return a iterator, used to iteratively visit volatile subtree in memory, and the CachedMTreeStore will use it to write nodes into file. 

