### PR TITLE
Add logs in compaction recovery

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/recover/CompactionRecoverManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/recover/CompactionRecoverManager.java
@@ -59,12 +59,12 @@ public class CompactionRecoverManager {
   }
 
   public void recoverInnerSpaceCompaction(boolean isSequence) {
-    logger.info("recovering inner compaction");
+    logger.info("{} [Compaction][Recover] recovering inner compaction", logicalStorageGroupName);
     recoverCompaction(true, isSequence);
   }
 
   public void recoverCrossSpaceCompaction() {
-    logger.info("recovering cross compaction");
+    logger.info("{} [Compaction][Recover] recovering cross compaction", logicalStorageGroupName);
     recoverCompaction(false, true);
   }
 
@@ -79,6 +79,10 @@ public class CompactionRecoverManager {
     for (String dir : dirs) {
       File storageGroupDir =
           new File(dir + File.separator + logicalStorageGroupName + File.separator + dataRegionId);
+      logger.info(
+          "{} [Compaction][Recover] recover compaction in data region dir {}",
+          logicalStorageGroupName,
+          storageGroupDir.getAbsolutePath());
       if (!storageGroupDir.exists()) {
         return;
       }
@@ -91,6 +95,10 @@ public class CompactionRecoverManager {
             || !Pattern.compile("\\d*").matcher(timePartitionDir.getName()).matches()) {
           continue;
         }
+        logger.info(
+            "{} [Compaction][Recover] recover compaction in time partition dir {}",
+            logicalStorageGroupName,
+            timePartitionDir.getAbsolutePath());
         // recover temporary files generated during compacted
         recoverCompaction(isInnerSpace, timePartitionDir);
 
@@ -129,7 +137,8 @@ public class CompactionRecoverManager {
     File[] compactionLogs =
         CompactionLogger.findCompactionLogs(isInnerSpace, timePartitionDir.getPath());
     for (File compactionLog : compactionLogs) {
-      logger.info("Calling compaction recover task.");
+      logger.info(
+          "{} [Compaction][Recover] calling compaction recover task.", logicalStorageGroupName);
       new CompactionRecoverTask(
               logicalStorageGroupName, dataRegionId, tsFileManager, compactionLog, isInnerSpace)
           .doCompaction();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/recover/CompactionRecoverManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/recover/CompactionRecoverManager.java
@@ -59,7 +59,10 @@ public class CompactionRecoverManager {
   }
 
   public void recoverInnerSpaceCompaction(boolean isSequence) {
-    logger.info("{} [Compaction][Recover] recovering inner compaction", logicalStorageGroupName);
+    logger.info(
+        "{} [Compaction][Recover] recovering {} inner compaction",
+        logicalStorageGroupName,
+        isSequence ? "sequence" : "unsequence");
     recoverCompaction(true, isSequence);
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/recover/CompactionRecoverManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/recover/CompactionRecoverManager.java
@@ -142,7 +142,7 @@ public class CompactionRecoverManager {
         CompactionLogger.findCompactionLogs(isInnerSpace, timePartitionDir.getPath());
     for (File compactionLog : compactionLogs) {
       logger.info(
-              "{} [Compaction][Recover] calling compaction recover task.", logicalStorageGroupName);
+          "{} [Compaction][Recover] calling compaction recover task.", logicalStorageGroupName);
       if (!isInnerSpace
           && compactionLog
               .getAbsolutePath()


### PR DESCRIPTION
Add logs of the data region directory and time partition directory in compaction recovery to find out whether each directory is scanned correctly.