### PR TITLE
Fix Compaction Schedule didn't start

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/StorageEngine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/StorageEngine.java
@@ -658,8 +658,8 @@ public class StorageEngine implements IService {
         region.deleteFolder(systemDir);
         if (config.isClusterMode()
             && config
-            .getDataRegionConsensusProtocolClass()
-            .equals(ConsensusFactory.IOT_CONSENSUS)) {
+                .getDataRegionConsensusProtocolClass()
+                .equals(ConsensusFactory.IOT_CONSENSUS)) {
           // delete wal
           WALManager.getInstance()
               .deleteWALNode(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -600,7 +600,7 @@ public class DataRegion implements IDataRegionForQuery {
     lastFlushTimeMap.setMultiDeviceGlobalFlushedTime(endTimeMap);
   }
 
-  public void initCompaction() {
+  public void initCompactionSchedule() {
     if (!config.isEnableSeqSpaceCompaction()
         && !config.isEnableUnseqSpaceCompaction()
         && !config.isEnableCrossSpaceCompaction()


### PR DESCRIPTION
## Description

#11421 tried to start the CompactionSchedule of each data region after all data regions recovered. However, the previous implement didn't make sure all data region recovered before init Compaction Schedule. Besides, some recovering data regions may not init Compaction Schedule.

This PR is moving the initCompactionSchedule to the recoverEndTrigger Thread where we can know the recover status of all data regions.