### PR TITLE
Fix the issue that compaction scheduler is not started when DataRegion created

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/StorageEngine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/StorageEngine.java
@@ -218,18 +218,9 @@ public class StorageEngine implements IService {
               checkResults(futures, "StorageEngine failed to recover.");
               setAllSgReady(true);
               ttlMapForRecover.clear();
-              initCompactionSchedule();
             },
             ThreadName.STORAGE_ENGINE_RECOVER_TRIGGER.getName());
     recoverEndTrigger.start();
-  }
-
-  private void initCompactionSchedule() {
-    for (DataRegion dataRegion : dataRegionMap.values()) {
-      if (dataRegion != null) {
-        dataRegion.initCompactionSchedule();
-      }
-    }
   }
 
   private void asyncRecover(List<Future<Void>> futures) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -583,6 +583,8 @@ public class DataRegion implements IDataRegionForQuery {
       throw new DataRegionException(e);
     }
 
+    initCompactionSchedule();
+
     if (StorageEngine.getInstance().isAllSgReady()) {
       logger.info("The data region {}[{}] is created successfully", databaseName, dataRegionId);
     } else {


### PR DESCRIPTION
## Description
Before this change, a newly created DataRegion won't start compaction because the init logic is moved from DataRegion to StorageEngine, which made the init logic only run when recoving

This PR fix this issue.

<img width="786" alt="image" src="https://github.com/apache/iotdb/assets/18027703/5613189f-8686-448b-9c56-acea5d3fc518">
