### PR TITLE
[IOTDB-6227] Remove unused retry policy in IStateMachine

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
@@ -59,8 +59,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /** StateMachine for ConfigRegion. */
-public class ConfigRegionStateMachine
-    implements IStateMachine, IStateMachine.EventApi, IStateMachine.RetryPolicy {
+public class ConfigRegionStateMachine implements IStateMachine, IStateMachine.EventApi {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ConfigRegionStateMachine.class);
 

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/IStateMachine.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/IStateMachine.java
@@ -112,38 +112,6 @@ public interface IStateMachine {
     return Utils.listAllRegularFilesRecursively(latestSnapshotRootDir);
   }
 
-  /**
-   * To guarantee the statemachine replication property, when {@link #write(IConsensusRequest)}
-   * failed in this statemachine, Upper consensus implementation like RatisConsensus may choose to
-   * retry the operation until it succeed.
-   */
-  interface RetryPolicy {
-    /** whether we should retry according to the last write result. */
-    default boolean shouldRetry(TSStatus writeResult) {
-      return false;
-    }
-
-    /**
-     * Use the latest write result to update final write result.
-     *
-     * @param previousResult previous write result
-     * @param retryResult latest write result
-     * @return the aggregated result upon current retry
-     */
-    default TSStatus updateResult(TSStatus previousResult, TSStatus retryResult) {
-      return retryResult;
-    }
-
-    /**
-     * sleep time before the next retry.
-     *
-     * @return time in millis
-     */
-    default long getSleepTime() {
-      return 100;
-    }
-  }
-
   /** An optional API for event notifications. */
   interface EventApi {
     /**

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ApplicationStateMachineProxy.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ApplicationStateMachineProxy.java
@@ -65,7 +65,6 @@ public class ApplicationStateMachineProxy extends BaseStateMachine {
   private static final PerformanceOverviewMetrics PERFORMANCE_OVERVIEW_METRICS =
       PerformanceOverviewMetrics.getInstance();
   private final IStateMachine applicationStateMachine;
-  private final IStateMachine.RetryPolicy retryPolicy;
   private final SnapshotStorage snapshotStorage;
   private final RaftGroupId groupId;
   private final ConsensusGroupId consensusGroupId;
@@ -84,10 +83,6 @@ public class ApplicationStateMachineProxy extends BaseStateMachine {
     this.canStaleRead = canStaleRead;
     this.groupId = id;
     this.consensusGroupId = Utils.fromRaftGroupIdToConsensusGroupId(id);
-    retryPolicy =
-        applicationStateMachine instanceof IStateMachine.RetryPolicy
-            ? (IStateMachine.RetryPolicy) applicationStateMachine
-            : new IStateMachine.RetryPolicy() {};
     snapshotStorage = new SnapshotStorage(applicationStateMachine, groupId);
     consensusGroupType = Utils.getConsensusGroupTypeFromPrefix(groupId.toString());
     applicationStateMachine.start();
@@ -134,7 +129,7 @@ public class ApplicationStateMachineProxy extends BaseStateMachine {
     RaftProtos.LogEntryProto log = trx.getLogEntry();
     updateLastAppliedTermIndex(log.getTerm(), log.getIndex());
 
-    IConsensusRequest applicationRequest;
+    final IConsensusRequest applicationRequest;
 
     // if this server is leader
     // it will first try to obtain applicationRequest from transaction context
@@ -148,37 +143,16 @@ public class ApplicationStateMachineProxy extends BaseStateMachine {
           new ByteBufferConsensusRequest(
               log.getStateMachineLogEntry().getLogData().asReadOnlyByteBuffer());
     }
+    final IConsensusRequest deserializedRequest =
+        applicationStateMachine.deserializeRequest(applicationRequest);
 
-    Message ret = null;
+    Message ret;
     waitUntilSystemAllowApply();
-    TSStatus finalStatus = null;
-    boolean shouldRetry = false;
-    boolean firstTry = true;
     do {
       try {
-        if (!firstTry) {
-          Thread.sleep(retryPolicy.getSleepTime());
-        }
-        IConsensusRequest deserializedRequest =
-            applicationStateMachine.deserializeRequest(applicationRequest);
-
-        TSStatus result = applicationStateMachine.write(deserializedRequest);
-
-        if (firstTry) {
-          finalStatus = result;
-          firstTry = false;
-        } else {
-          finalStatus = retryPolicy.updateResult(finalStatus, result);
-        }
-
-        shouldRetry = retryPolicy.shouldRetry(finalStatus);
-        if (!shouldRetry) {
-          ret = new ResponseMessage(finalStatus);
-          break;
-        }
-      } catch (InterruptedException i) {
-        logger.warn("{} interrupted when retry sleep", this);
-        Thread.currentThread().interrupt();
+        final TSStatus result = applicationStateMachine.write(deserializedRequest);
+        ret = new ResponseMessage(result);
+        break;
       } catch (Throwable rte) {
         logger.error("application statemachine throws a runtime exception: ", rte);
         ret =
@@ -187,12 +161,12 @@ public class ApplicationStateMachineProxy extends BaseStateMachine {
                     .setMessage("internal error. statemachine throws a runtime exception: " + rte));
         if (Utils.stallApply()) {
           waitUntilSystemAllowApply();
-          shouldRetry = true;
         } else {
           break;
         }
       }
-    } while (shouldRetry);
+    } while (Utils.stallApply());
+
     if (isLeader) {
       // only record time cost for data region in Performance Overview Dashboard
       if (consensusGroupType == TConsensusGroupType.DataRegion) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/BaseStateMachine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/BaseStateMachine.java
@@ -29,8 +29,7 @@ import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class BaseStateMachine
-    implements IStateMachine, IStateMachine.EventApi, IStateMachine.RetryPolicy {
+public abstract class BaseStateMachine implements IStateMachine, IStateMachine.EventApi {
 
   private static final Logger logger = LoggerFactory.getLogger(BaseStateMachine.class);
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataRegionStateMachine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataRegionStateMachine.java
@@ -266,24 +266,6 @@ public class DataRegionStateMachine extends BaseStateMachine {
   }
 
   @Override
-  public boolean shouldRetry(TSStatus writeResult) {
-    // TODO implement this
-    return super.shouldRetry(writeResult);
-  }
-
-  @Override
-  public TSStatus updateResult(TSStatus previousResult, TSStatus retryResult) {
-    // TODO implement this
-    return super.updateResult(previousResult, retryResult);
-  }
-
-  @Override
-  public long getSleepTime() {
-    // TODO implement this
-    return super.getSleepTime();
-  }
-
-  @Override
   public File getSnapshotRoot() {
     String snapshotDir =
         IoTDBDescriptor.getInstance().getConfig().getRatisDataRegionSnapshotDir()

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/schemaregion/SchemaRegionStateMachine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/schemaregion/SchemaRegionStateMachine.java
@@ -97,22 +97,4 @@ public class SchemaRegionStateMachine extends BaseStateMachine {
         fragmentInstance.getId());
     return QUERY_INSTANCE_MANAGER.execSchemaQueryFragmentInstance(fragmentInstance, schemaRegion);
   }
-
-  @Override
-  public boolean shouldRetry(TSStatus writeResult) {
-    // TODO implement this
-    return super.shouldRetry(writeResult);
-  }
-
-  @Override
-  public TSStatus updateResult(TSStatus previousResult, TSStatus retryResult) {
-    // TODO implement this
-    return super.updateResult(previousResult, retryResult);
-  }
-
-  @Override
-  public long getSleepTime() {
-    // TODO implement this
-    return super.getSleepTime();
-  }
 }


### PR DESCRIPTION
The retry policy is never used in IStateMachine, yet it brings complexity in Ratis write while may incur poerformance penalties. We should remove it.
see https://issues.apache.org/jira/browse/IOTDB-6227