### PR TITLE
fix empty resource recovered from wal

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -724,6 +724,10 @@ public class DataRegion implements IDataRegionForQuery {
       TsFileResource tsFileResource = recoverPerformer.getTsFileResource();
       boolean isSeq = recoverPerformer.isSequence();
       if (!recoverPerformer.canWrite()) {
+        if (!TsFileValidator.getInstance().validateTsFile(tsFileResource)) {
+          tsFileResource.remove();
+          return;
+        }
         // cannot write, just close it
         try {
           tsFileResource.close();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -724,15 +724,15 @@ public class DataRegion implements IDataRegionForQuery {
       TsFileResource tsFileResource = recoverPerformer.getTsFileResource();
       boolean isSeq = recoverPerformer.isSequence();
       if (!recoverPerformer.canWrite()) {
-        if (!TsFileValidator.getInstance().validateTsFile(tsFileResource)) {
-          tsFileResource.remove();
-          return;
-        }
         // cannot write, just close it
         try {
           tsFileResource.close();
         } catch (IOException e) {
           logger.error("Fail to close TsFile {} when recovering", tsFileResource.getTsFile(), e);
+        }
+        if (!TsFileValidator.getInstance().validateTsFile(tsFileResource)) {
+          tsFileResource.remove();
+          return;
         }
         updateLastFlushTime(tsFileResource, isSeq);
         tsFileResourceManager.registerSealedTsFileResource(tsFileResource);


### PR DESCRIPTION
## Description

#11404 fixed when inserting empty Tablet and flush, some empty TsFileResource generated. However, after inserting empty Tablet, killing and restarting DataNode, the empty TsFileResource will still be generated.

To fix it, we need to add the deletion logic of #11404 to the position where resource recovered from WAL. 


## How to reproduce

1. start 1C1D iotdb and execute the following code.
```java

  public static void main(String[] args)
      throws IoTDBConnectionException, StatementExecutionException {
    session =
        new Session.Builder()
            .host(LOCAL_HOST)
            .port(6667)
            .username("root")
            .password("root")
            .version(Version.V_1_0)
            .build();
    session.open(false);
    insertTablet();
    session.close();
  }


  private static void insertTablet() throws IoTDBConnectionException, StatementExecutionException {
    // The schema of measurements of one device
    // only measurementId and data type in MeasurementSchema take effects in Tablet
    List<MeasurementSchema> schemaList = new ArrayList<>();
    schemaList.add(new MeasurementSchema("s1", TSDataType.INT64));
    schemaList.add(new MeasurementSchema("s2", TSDataType.INT64));
    schemaList.add(new MeasurementSchema("s3", TSDataType.INT64));

    Tablet tablet = new Tablet(ROOT_SG1_D1, schemaList, 100);

    // Method 1 to add tablet data
    long timestamp = System.currentTimeMillis();

    for (long row = 0; row < 100; row++) {
      int rowIndex = tablet.rowSize++;
      tablet.addTimestamp(rowIndex, timestamp);
      for (int s = 0; s < 3; s++) {
        tablet.addValue(schemaList.get(s).getMeasurementId(), rowIndex, null);
      }
      if (tablet.rowSize == tablet.getMaxRowNumber()) {
        session.insertTablet(tablet, true);
        tablet.reset();
      }
      timestamp++;
    }

    if (tablet.rowSize != 0) {
      session.insertTablet(tablet);
      tablet.reset();
    }
  }
```
2. kill datanode by `kill -9 <pid>`
3. restart datanode, then print the TsFileResource. You will see the TsFileResource doesn't contains any devices.