### PR TITLE
Check empty target file after sequence InnerSpaceCompactionTask

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/performer/impl/ReadChunkCompactionPerformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/performer/impl/ReadChunkCompactionPerformer.java
@@ -92,6 +92,9 @@ public class ReadChunkCompactionPerformer implements ISeqCompactionPerformer {
         targetResource.updatePlanIndexes(tsFileResource);
       }
       writer.endFile();
+      if (writer.isEmptyTargetFile()) {
+        targetResource.forceMarkDeleted();
+      }
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/AbstractCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/AbstractCompactionTask.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * AbstractCompactionTask is the base class for all compaction task, it carries out the execution of
@@ -372,21 +373,56 @@ public abstract class AbstractCompactionTask {
     return CompactionUtils.isDiskHasSpace();
   }
 
-  protected void validateTsFileResource(
-      List<TsFileResource> targetTsFileList, boolean needValidateOverlap) {
+  protected void validateCompactionResult(
+      List<TsFileResource> sourceSeqFiles,
+      List<TsFileResource> sourceUnseqFiles,
+      List<TsFileResource> targetFiles)
+      throws CompactionValidationFailedException {
+    // skip TsFileResource which is marked as DELETED status
+    List<TsFileResource> validTargetFiles =
+        targetFiles.stream().filter(resource -> !resource.isDeleted()).collect(Collectors.toList());
+    CompactionTaskType taskType = getCompactionTaskType();
+    boolean needToValidateTsFileCorrectness = taskType != CompactionTaskType.INSERTION;
+    boolean needToValidatePartitionSeqSpaceOverlap =
+        getCompactionTaskType() == CompactionTaskType.INNER_UNSEQ;
+
     TsFileValidator validator = TsFileValidator.getInstance();
-    if (!validator.validateTsFiles(targetTsFileList)) {
-      LOGGER.error("Failed to pass compaction validation, target files is {}", targetTsFileList);
+    if (needToValidatePartitionSeqSpaceOverlap) {
+      List<TsFileResource> timePartitionSeqFiles =
+          tsFileManager.getOrCreateSequenceListByTimePartition(timePartition);
+      timePartitionSeqFiles.removeAll(sourceSeqFiles);
+      timePartitionSeqFiles.addAll(validTargetFiles);
+      timePartitionSeqFiles.sort(
+          (f1, f2) -> {
+            int timeDiff =
+                Long.compareUnsigned(
+                    Long.parseLong(f1.getTsFile().getName().split("-")[0]),
+                    Long.parseLong(f2.getTsFile().getName().split("-")[0]));
+            return timeDiff == 0
+                ? Long.compareUnsigned(
+                    Long.parseLong(f1.getTsFile().getName().split("-")[1]),
+                    Long.parseLong(f2.getTsFile().getName().split("-")[1]))
+                : timeDiff;
+          });
+      if (!validator.validateTsFilesIsHasNoOverlap(timePartitionSeqFiles)) {
+        LOGGER.error(
+            "Failed to pass compaction validation, source seq files: {}, source unseq files: {}, target files: {}",
+            sourceSeqFiles,
+            sourceUnseqFiles,
+            targetFiles);
+        throw new CompactionValidationFailedException(
+            "Failed to pass compaction validation, sequence files has overlap, time partition id is "
+                + timePartition);
+      }
+    }
+    if (needToValidateTsFileCorrectness && !validator.validateTsFiles(validTargetFiles)) {
+      LOGGER.error(
+          "Failed to pass compaction validation, source seq files: {}, source unseq files: {}, target files: {}",
+          sourceSeqFiles,
+          sourceUnseqFiles,
+          targetFiles);
       throw new CompactionValidationFailedException(
           "Failed to pass compaction validation, .resources file or tsfile data is wrong");
-    }
-    if (needValidateOverlap
-        && !validator.validateTsFilesIsHasNoOverlap(
-            tsFileManager.getOrCreateSequenceListByTimePartition(timePartition).getArrayList())) {
-      LOGGER.error("Failed to pass compaction validation, target files is {}", targetTsFileList);
-      throw new CompactionValidationFailedException(
-          "Failed to pass compaction validation, sequence files has overlap, time partition id is "
-              + timePartition);
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/AbstractCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/AbstractCompactionTask.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -384,12 +385,12 @@ public abstract class AbstractCompactionTask {
     CompactionTaskType taskType = getCompactionTaskType();
     boolean needToValidateTsFileCorrectness = taskType != CompactionTaskType.INSERTION;
     boolean needToValidatePartitionSeqSpaceOverlap =
-        getCompactionTaskType() == CompactionTaskType.INNER_UNSEQ;
+        getCompactionTaskType() != CompactionTaskType.INNER_UNSEQ;
 
     TsFileValidator validator = TsFileValidator.getInstance();
     if (needToValidatePartitionSeqSpaceOverlap) {
       List<TsFileResource> timePartitionSeqFiles =
-          tsFileManager.getOrCreateSequenceListByTimePartition(timePartition);
+          new ArrayList<>(tsFileManager.getOrCreateSequenceListByTimePartition(timePartition));
       timePartitionSeqFiles.removeAll(sourceSeqFiles);
       timePartitionSeqFiles.addAll(validTargetFiles);
       timePartitionSeqFiles.sort(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
@@ -196,6 +196,9 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
         CompactionUtils.combineModsInCrossCompaction(
             selectedSequenceFiles, selectedUnsequenceFiles, targetTsfileResourceList);
 
+        validateCompactionResult(
+            selectedSequenceFiles, selectedUnsequenceFiles, targetTsfileResourceList);
+
         // update tsfile resource in memory
         tsFileManager.replace(
             selectedSequenceFiles,
@@ -203,9 +206,6 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
             targetTsfileResourceList,
             timePartition,
             true);
-
-        validateCompactionResult(
-            selectedSequenceFiles, selectedUnsequenceFiles, targetTsfileResourceList);
 
         // find empty target files and add log
         for (TsFileResource targetResource : targetTsfileResourceList) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/CrossSpaceCompactionTask.java
@@ -204,6 +204,9 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
             timePartition,
             true);
 
+        validateCompactionResult(
+            selectedSequenceFiles, selectedUnsequenceFiles, targetTsfileResourceList);
+
         // find empty target files and add log
         for (TsFileResource targetResource : targetTsfileResourceList) {
           if (targetResource.isDeleted()) {
@@ -212,8 +215,6 @@ public class CrossSpaceCompactionTask extends AbstractCompactionTask {
             compactionLogger.force();
           }
         }
-
-        validateTsFileResource(targetTsfileResourceList, true);
 
         lockWrite(selectedSequenceFiles);
         lockWrite(selectedUnsequenceFiles);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
@@ -219,6 +219,11 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
               String.format("%s-%s [Compaction] abort", storageGroupName, dataRegionId));
         }
 
+        validateCompactionResult(
+            sequence ? selectedTsFileResourceList : Collections.emptyList(),
+            sequence ? Collections.emptyList() : selectedTsFileResourceList,
+            targetTsFileList);
+
         // replace the old files with new file, the new is in same position as the old
         if (sequence) {
           tsFileManager.replace(
@@ -241,8 +246,6 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
           isTargetTsFileEmpty = true;
           compactionLogger.force();
         }
-
-        validateTsFileResource(targetTsFileList, sequence);
 
         LOGGER.info(
             "{}-{} [Compaction] Compacted target files, try to get the write lock of source files",

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
@@ -225,21 +225,12 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
             targetTsFileList);
 
         // replace the old files with new file, the new is in same position as the old
-        if (sequence) {
-          tsFileManager.replace(
-              selectedTsFileResourceList,
-              Collections.emptyList(),
-              targetTsFileList,
-              timePartition,
-              true);
-        } else {
-          tsFileManager.replace(
-              Collections.emptyList(),
-              selectedTsFileResourceList,
-              targetTsFileList,
-              timePartition,
-              false);
-        }
+        tsFileManager.replace(
+            sequence ? selectedTsFileResourceList : Collections.emptyList(),
+            sequence ? Collections.emptyList() : selectedTsFileResourceList,
+            targetTsFileList,
+            timePartition,
+            sequence);
 
         if (targetTsFileResource.isDeleted()) {
           compactionLogger.logEmptyTargetFile(targetTsFileResource);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/io/CompactionTsFileWriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/io/CompactionTsFileWriter.java
@@ -41,6 +41,7 @@ public class CompactionTsFileWriter extends TsFileIOWriter {
   CompactionType type;
 
   private volatile boolean isWritingAligned = false;
+  private boolean isEmptyTargetFile = true;
 
   public CompactionTsFileWriter(
       File file, boolean enableMemoryControl, long maxMetadataSize, CompactionType type)
@@ -60,6 +61,9 @@ public class CompactionTsFileWriter extends TsFileIOWriter {
   public void writeChunk(IChunkWriter chunkWriter) throws IOException {
     boolean isAligned = chunkWriter instanceof AlignedChunkWriterImpl;
     long beforeOffset = this.getPos();
+    if (!chunkWriter.isEmpty()) {
+      isEmptyTargetFile = false;
+    }
     chunkWriter.writeToFileWriter(this);
     long writtenDataSize = this.getPos() - beforeOffset;
     acquireWrittenDataSizeWithCompactionWriteRateLimiter(writtenDataSize);
@@ -73,6 +77,9 @@ public class CompactionTsFileWriter extends TsFileIOWriter {
   @Override
   public void writeChunk(Chunk chunk, ChunkMetadata chunkMetadata) throws IOException {
     long beforeOffset = this.getPos();
+    if (chunkMetadata.getNumOfPoints() != 0) {
+      isEmptyTargetFile = false;
+    }
     super.writeChunk(chunk, chunkMetadata);
     long writtenDataSize = this.getPos() - beforeOffset;
     acquireWrittenDataSizeWithCompactionWriteRateLimiter(writtenDataSize);
@@ -130,5 +137,9 @@ public class CompactionTsFileWriter extends TsFileIOWriter {
         return;
       }
     }
+  }
+
+  public boolean isEmptyTargetFile() {
+    return isEmptyTargetFile;
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/FastInnerCompactionPerformerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/FastInnerCompactionPerformerTest.java
@@ -949,7 +949,7 @@ public class FastInnerCompactionPerformerTest extends AbstractCompactionTest {
     InnerSpaceCompactionTask task =
         new InnerSpaceCompactionTask(
             0, tsFileManager, unseqResources, false, new FastCompactionPerformer(false), 0);
-    Assert.assertFalse(task.start());
+    Assert.assertTrue(task.start());
     Assert.assertEquals(0, FileReaderManager.getInstance().getClosedFileReaderMap().size());
     Assert.assertEquals(0, FileReaderManager.getInstance().getUnclosedFileReaderMap().size());
     validateSeqFiles(true);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/ReadChunkInnerCompactionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/ReadChunkInnerCompactionTest.java
@@ -378,7 +378,6 @@ public class ReadChunkInnerCompactionTest extends AbstractCompactionTest {
     }
     TsFileResource seqFile3 = createEmptyFileAndResource(true);
     try (CompactionTestFileWriter writer = new CompactionTestFileWriter(seqFile3)) {
-      writer.endChunkGroup();
       writer.endFile();
     }
     seqResources.add(seqFile1);
@@ -442,6 +441,6 @@ public class ReadChunkInnerCompactionTest extends AbstractCompactionTest {
         new InnerSpaceCompactionTask(
             0, tsFileManager, seqResources, true, new ReadChunkCompactionPerformer(), 0);
     Assert.assertTrue(task.start());
-    Assert.assertEquals(0, tsFileManager.getTsFileList(true).size());
+    Assert.assertEquals(1, tsFileManager.getTsFileList(true).size());
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/cross/RewriteCrossSpaceCompactionWithReadPointPerformerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/cross/RewriteCrossSpaceCompactionWithReadPointPerformerTest.java
@@ -458,10 +458,10 @@ public class RewriteCrossSpaceCompactionWithReadPointPerformerTest extends Abstr
     task.start();
 
     for (TsFileResource resource : seqResources) {
-      Assert.assertTrue(resource.getModFile().exists());
+      Assert.assertFalse(resource.getModFile().exists());
     }
     for (TsFileResource resource : unseqResources) {
-      Assert.assertTrue(resource.getModFile().exists());
+      Assert.assertFalse(resource.getModFile().exists());
     }
     for (TsFileResource resource : targetResources) {
       resource.setFile(

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/inner/InnerCompactionEmptyTsFileTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/inner/InnerCompactionEmptyTsFileTest.java
@@ -89,6 +89,6 @@ public class InnerCompactionEmptyTsFileTest extends InnerCompactionTest {
     Future<CompactionTaskSummary> future =
         CompactionTaskManager.getInstance().getCompactionTaskFutureMayBlock(task);
     unseqResources.get(0).readUnlock();
-    Assert.assertFalse(future.get().isSuccess());
+    Assert.assertTrue(future.get().isSuccess());
   }
 }

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/AlignedChunkWriterImpl.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/AlignedChunkWriterImpl.java
@@ -417,6 +417,11 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
   }
 
   @Override
+  public boolean isEmpty() {
+    return timeChunkWriter.getPointNum() + timeChunkWriter.getPageWriter().getPointNumber() == 0;
+  }
+
+  @Override
   public boolean checkIsUnsealedPageOverThreshold(
       long size, long pointNum, boolean returnTrueIfPageEmpty) {
     if ((returnTrueIfPageEmpty && timeChunkWriter.getPageWriter().getPointNumber() == 0)

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ChunkWriterImpl.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ChunkWriterImpl.java
@@ -370,6 +370,11 @@ public class ChunkWriterImpl implements IChunkWriter {
         || statistics.getCount() + pageWriter.getPointNumber() >= pointNum;
   }
 
+  @Override
+  public boolean isEmpty() {
+    return statistics.getCount() + pageWriter.getPointNumber() == 0;
+  }
+
   public TSDataType getDataType() {
     return measurementSchema.getType();
   }

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/IChunkWriter.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/IChunkWriter.java
@@ -52,6 +52,9 @@ public interface IChunkWriter {
    */
   boolean checkIsChunkSizeOverThreshold(long size, long pointNum, boolean returnTrueIfChunkEmpty);
 
+  /** Return true if the chunk writer is empty */
+  boolean isEmpty();
+
   /**
    * used for compaction to check whether the unsealed page is over threshold or not. Return true if
    * there is no unsealed page.


### PR DESCRIPTION
## Description
1. Mark target file as DELETED status if the target file is empty in ReadChunkCompactionPerformer
2. Skip the target file which is marked as DELETED status when validate compaction result