### PR TITLE
[IOTDB-6220] Pipe: Changed the sink loopback detection logic to support hostName and IPv6 specification.

### DIFF
--- a/iotdb-api/pipe-api/src/main/java/org/apache/iotdb/pipe/api/customizer/parameter/PipeParameterValidator.java
+++ b/iotdb-api/pipe-api/src/main/java/org/apache/iotdb/pipe/api/customizer/parameter/PipeParameterValidator.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.pipe.api.customizer.parameter;
 import org.apache.iotdb.pipe.api.exception.PipeAttributeNotProvidedException;
 import org.apache.iotdb.pipe.api.exception.PipeParameterNotValidException;
 
+import java.net.UnknownHostException;
 import java.util.Arrays;
 
 public class PipeParameterValidator {
@@ -121,6 +122,6 @@ public class PipeParameterValidator {
 
   public interface MultipleObjectsValidationRule {
 
-    boolean validate(Object... args);
+    boolean validate(Object... args) throws UnknownHostException;
   }
 }

--- a/iotdb-api/pipe-api/src/main/java/org/apache/iotdb/pipe/api/customizer/parameter/PipeParameterValidator.java
+++ b/iotdb-api/pipe-api/src/main/java/org/apache/iotdb/pipe/api/customizer/parameter/PipeParameterValidator.java
@@ -22,7 +22,6 @@ package org.apache.iotdb.pipe.api.customizer.parameter;
 import org.apache.iotdb.pipe.api.exception.PipeAttributeNotProvidedException;
 import org.apache.iotdb.pipe.api.exception.PipeParameterNotValidException;
 
-import java.net.UnknownHostException;
 import java.util.Arrays;
 
 public class PipeParameterValidator {
@@ -122,6 +121,6 @@ public class PipeParameterValidator {
 
   public interface MultipleObjectsValidationRule {
 
-    boolean validate(Object... args) throws UnknownHostException;
+    boolean validate(Object... args);
   }
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
@@ -41,6 +41,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.Collections;
 import java.util.Properties;
 
 public class ConfigNodeDescriptor {
@@ -890,10 +892,17 @@ public class ConfigNodeDescriptor {
    * @return True if the seed_config_node points to itself
    */
   public boolean isSeedConfigNode() {
-    return (conf.getInternalAddress().equals(conf.getSeedConfigNode().getIp())
-            || (NodeUrlUtils.isLocalAddress(conf.getInternalAddress())
-                && NodeUrlUtils.isLocalAddress(conf.getSeedConfigNode().getIp())))
-        && conf.getInternalPort() == conf.getSeedConfigNode().getPort();
+    try {
+      return (conf.getInternalAddress().equals(conf.getSeedConfigNode().getIp())
+              || (NodeUrlUtils.containsLocalAddress(
+                      Collections.singletonList(conf.getInternalAddress()))
+                  && NodeUrlUtils.containsLocalAddress(
+                      Collections.singletonList(conf.getSeedConfigNode().getIp()))))
+          && conf.getInternalPort() == conf.getSeedConfigNode().getPort();
+    } catch (UnknownHostException e) {
+      LOGGER.warn("Unknown host when checking seed configNode IP {}", conf.getInternalAddress(), e);
+      return false;
+    }
   }
 
   public static ConfigNodeDescriptor getInstance() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
@@ -61,6 +61,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -125,42 +126,47 @@ public class IoTDBLegacyPipeConnector implements PipeConnector {
             parameters.hasAttribute(SINK_IOTDB_PORT_KEY))
         .validate(
             empty -> {
-              // Ensure the sink doesn't point to the legacy receiver on DataNode itself
+              try {
+                // Ensure the sink doesn't point to the legacy receiver on DataNode itself
 
-              // Check internal and external, IPv4 and IPv6 network addresses
-              HashSet<String> selfAddresses =
-                  Arrays.stream(InetAddress.getAllByName(InetAddress.getLocalHost().getHostName()))
-                      .map(InetAddress::getHostAddress)
-                      .collect(Collectors.toCollection(HashSet::new));
-              // Check IPv4 and IPv6 loopback address 127.0.0.1 and 0.0.0.0.0.0.0.1
-              selfAddresses.addAll(
-                  Arrays.stream(InetAddress.getAllByName("localhost"))
-                      .map(InetAddress::getHostAddress)
-                      .collect(Collectors.toCollection(HashSet::new)));
-              // Check general address 0.0.0.0
-              selfAddresses.add("0.0.0.0");
-
-              for (TEndPoint endPoint : givenNodeUrls) {
-                if (endPoint.getPort() != ioTDBConfig.getRpcPort()) {
-                  continue;
-                }
-
-                // The specified receiver addresses, Effective for ip and host name
-                HashSet<String> receiverAddresses =
-                    Arrays.stream(InetAddress.getAllByName(endPoint.getIp()))
+                // Check internal and external, IPv4 and IPv6 network addresses
+                HashSet<String> selfAddresses =
+                    Arrays.stream(
+                            InetAddress.getAllByName(InetAddress.getLocalHost().getHostName()))
                         .map(InetAddress::getHostAddress)
                         .collect(Collectors.toCollection(HashSet::new));
-                receiverAddresses.retainAll(selfAddresses);
+                // Check IPv4 and IPv6 loopback address 127.0.0.1 and 0.0.0.0.0.0.0.1
+                selfAddresses.addAll(
+                    Arrays.stream(InetAddress.getAllByName("localhost"))
+                        .map(InetAddress::getHostAddress)
+                        .collect(Collectors.toCollection(HashSet::new)));
+                // Check general address 0.0.0.0
+                selfAddresses.add("0.0.0.0");
 
-                if (!receiverAddresses.isEmpty()) {
-                  return false;
+                for (TEndPoint endPoint : givenNodeUrls) {
+                  if (endPoint.getPort() != ioTDBConfig.getRpcPort()) {
+                    continue;
+                  }
+
+                  // The specified receiver addresses, Effective for ip and host name
+                  HashSet<String> receiverAddresses =
+                      Arrays.stream(InetAddress.getAllByName(endPoint.getIp()))
+                          .map(InetAddress::getHostAddress)
+                          .collect(Collectors.toCollection(HashSet::new));
+                  receiverAddresses.retainAll(selfAddresses);
+
+                  if (!receiverAddresses.isEmpty()) {
+                    return false;
+                  }
                 }
+              } catch (UnknownHostException e) {
+                LOGGER.warn("Unknown host when checking pipe sink IP.", e);
+                return false;
               }
-
               return true;
             },
             String.format(
-                "One of the endpoints %s of the receivers is pointing back to the legacy receiver on sender %s itself",
+                "One of the endpoints %s of the receivers is pointing back to the legacy receiver %s on sender itself, or unknown host when checking pipe sink IP.",
                 givenNodeUrls,
                 new TEndPoint(ioTDBConfig.getRpcAddress(), ioTDBConfig.getRpcPort())));
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.pipe.PipeRuntimeCriticalException;
 import org.apache.iotdb.commons.pipe.config.PipeConfig;
+import org.apache.iotdb.commons.utils.NodeUrlUtils;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.pipe.connector.payload.legacy.TsFilePipeData;
@@ -60,7 +61,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -128,42 +128,15 @@ public class IoTDBLegacyPipeConnector implements PipeConnector {
             empty -> {
               try {
                 // Ensure the sink doesn't point to the legacy receiver on DataNode itself
-
-                // Check internal and external, IPv4 and IPv6 network addresses
-                HashSet<String> selfAddresses =
-                    Arrays.stream(
-                            InetAddress.getAllByName(InetAddress.getLocalHost().getHostName()))
-                        .map(InetAddress::getHostAddress)
-                        .collect(Collectors.toCollection(HashSet::new));
-                // Check IPv4 and IPv6 loopback address 127.0.0.1 and 0.0.0.0.0.0.0.1
-                selfAddresses.addAll(
-                    Arrays.stream(InetAddress.getAllByName("localhost"))
-                        .map(InetAddress::getHostAddress)
-                        .collect(Collectors.toCollection(HashSet::new)));
-                // Check general address 0.0.0.0
-                selfAddresses.add("0.0.0.0");
-
-                for (TEndPoint endPoint : givenNodeUrls) {
-                  if (endPoint.getPort() != ioTDBConfig.getRpcPort()) {
-                    continue;
-                  }
-
-                  // The specified receiver addresses, Effective for ip and host name
-                  HashSet<String> receiverAddresses =
-                      Arrays.stream(InetAddress.getAllByName(endPoint.getIp()))
-                          .map(InetAddress::getHostAddress)
-                          .collect(Collectors.toCollection(HashSet::new));
-                  receiverAddresses.retainAll(selfAddresses);
-
-                  if (!receiverAddresses.isEmpty()) {
-                    return false;
-                  }
-                }
+                return !NodeUrlUtils.containsLocalAddress(
+                    givenNodeUrls.stream()
+                        .filter(tEndPoint -> tEndPoint.getPort() == ioTDBConfig.getRpcPort())
+                        .map(TEndPoint::getIp)
+                        .collect(Collectors.toList()));
               } catch (UnknownHostException e) {
                 LOGGER.warn("Unknown host when checking pipe sink IP.", e);
                 return false;
               }
-              return true;
             },
             String.format(
                 "One of the endpoints %s of the receivers is pointing back to the legacy receiver %s on sender itself, or unknown host when checking pipe sink IP.",

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
@@ -60,6 +60,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -92,42 +93,47 @@ public class IoTDBThriftSyncConnector extends IoTDBConnector {
 
     validator.validate(
         empty -> {
-          // Ensure the sink doesn't point to the thrift receiver on DataNode itself
+          try {
+            // Ensure the sink doesn't point to the thrift receiver on DataNode itself
 
-          // Check internal and external, IPv4 and IPv6 network addresses
-          HashSet<String> selfAddresses =
-              Arrays.stream(InetAddress.getAllByName(InetAddress.getLocalHost().getHostName()))
-                  .map(InetAddress::getHostAddress)
-                  .collect(Collectors.toCollection(HashSet::new));
-          // Check IPv4 and IPv6 loopback address 127.0.0.1 and 0.0.0.0.0.0.0.1
-          selfAddresses.addAll(
-              Arrays.stream(InetAddress.getAllByName("localhost"))
-                  .map(InetAddress::getHostAddress)
-                  .collect(Collectors.toCollection(HashSet::new)));
-          // Check general address 0.0.0.0
-          selfAddresses.add("0.0.0.0");
-
-          for (TEndPoint endPoint : givenNodeUrls) {
-            if (endPoint.getPort() != ioTDBConfig.getRpcPort()) {
-              continue;
-            }
-
-            // The specified receiver addresses, Effective for ip and host name
-            HashSet<String> receiverAddresses =
-                Arrays.stream(InetAddress.getAllByName(endPoint.getIp()))
+            // Check internal and external, IPv4 and IPv6 network addresses
+            HashSet<String> selfAddresses =
+                Arrays.stream(InetAddress.getAllByName(InetAddress.getLocalHost().getHostName()))
                     .map(InetAddress::getHostAddress)
                     .collect(Collectors.toCollection(HashSet::new));
-            receiverAddresses.retainAll(selfAddresses);
+            // Check IPv4 and IPv6 loopback address 127.0.0.1 and 0.0.0.0.0.0.0.1
+            selfAddresses.addAll(
+                Arrays.stream(InetAddress.getAllByName("localhost"))
+                    .map(InetAddress::getHostAddress)
+                    .collect(Collectors.toCollection(HashSet::new)));
+            // Check general address 0.0.0.0
+            selfAddresses.add("0.0.0.0");
 
-            if (!receiverAddresses.isEmpty()) {
-              return false;
+            for (TEndPoint endPoint : givenNodeUrls) {
+              if (endPoint.getPort() != ioTDBConfig.getRpcPort()) {
+                continue;
+              }
+
+              // The specified receiver addresses, Effective for ip and host name
+              HashSet<String> receiverAddresses =
+                  Arrays.stream(InetAddress.getAllByName(endPoint.getIp()))
+                      .map(InetAddress::getHostAddress)
+                      .collect(Collectors.toCollection(HashSet::new));
+              receiverAddresses.retainAll(selfAddresses);
+
+              if (!receiverAddresses.isEmpty()) {
+                return false;
+              }
             }
-          }
 
-          return true;
+            return true;
+          } catch (UnknownHostException e) {
+            LOGGER.warn("Unknown host when checking pipe sink IP.", e);
+            return false;
+          }
         },
         String.format(
-            "One of the endpoints %s of the receivers is pointing back to the thrift receiver %s on sender itself",
+            "One of the endpoints %s of the receivers is pointing back to the thrift receiver %s on sender itself, or unknown host when checking pipe sink IP.",
             givenNodeUrls, new TEndPoint(ioTDBConfig.getRpcAddress(), ioTDBConfig.getRpcPort())));
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.commons.client.property.ThriftClientProperty;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.pipe.config.PipeConfig;
+import org.apache.iotdb.commons.utils.NodeUrlUtils;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.pipe.connector.payload.evolvable.builder.IoTDBThriftSyncPipeTransferBatchReqBuilder;
@@ -59,11 +60,9 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -95,38 +94,11 @@ public class IoTDBThriftSyncConnector extends IoTDBConnector {
         empty -> {
           try {
             // Ensure the sink doesn't point to the thrift receiver on DataNode itself
-
-            // Check internal and external, IPv4 and IPv6 network addresses
-            HashSet<String> selfAddresses =
-                Arrays.stream(InetAddress.getAllByName(InetAddress.getLocalHost().getHostName()))
-                    .map(InetAddress::getHostAddress)
-                    .collect(Collectors.toCollection(HashSet::new));
-            // Check IPv4 and IPv6 loopback address 127.0.0.1 and 0.0.0.0.0.0.0.1
-            selfAddresses.addAll(
-                Arrays.stream(InetAddress.getAllByName("localhost"))
-                    .map(InetAddress::getHostAddress)
-                    .collect(Collectors.toCollection(HashSet::new)));
-            // Check general address 0.0.0.0
-            selfAddresses.add("0.0.0.0");
-
-            for (TEndPoint endPoint : givenNodeUrls) {
-              if (endPoint.getPort() != ioTDBConfig.getRpcPort()) {
-                continue;
-              }
-
-              // The specified receiver addresses, Effective for ip and host name
-              HashSet<String> receiverAddresses =
-                  Arrays.stream(InetAddress.getAllByName(endPoint.getIp()))
-                      .map(InetAddress::getHostAddress)
-                      .collect(Collectors.toCollection(HashSet::new));
-              receiverAddresses.retainAll(selfAddresses);
-
-              if (!receiverAddresses.isEmpty()) {
-                return false;
-              }
-            }
-
-            return true;
+            return !NodeUrlUtils.containsLocalAddress(
+                givenNodeUrls.stream()
+                    .filter(tEndPoint -> tEndPoint.getPort() == ioTDBConfig.getRpcPort())
+                    .map(TEndPoint::getIp)
+                    .collect(Collectors.toList()));
           } catch (UnknownHostException e) {
             LOGGER.warn("Unknown host when checking pipe sink IP.", e);
             return false;

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/NodeUrlUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/NodeUrlUtils.java
@@ -40,6 +40,8 @@ public class NodeUrlUtils {
 
   private static final Logger logger = LoggerFactory.getLogger(NodeUrlUtils.class);
 
+  public static final String WILD_CARD_ADDRESS = "0.0.0.0";
+  public static final String LOOPBACK_HOST_NAME = "localhost";
   /**
    * Convert TEndPoint to TEndPointUrl
    *
@@ -213,7 +215,7 @@ public class NodeUrlUtils {
         continue;
       }
       // Unify address or hostName, converting them to addresses
-      HashSet<String> translatedAddresses =
+      Set<String> translatedAddresses =
           Arrays.stream(InetAddress.getAllByName(addressOrHostName))
               .map(InetAddress::getHostAddress)
               .collect(Collectors.toCollection(HashSet::new));
@@ -243,11 +245,11 @@ public class NodeUrlUtils {
             .collect(Collectors.toCollection(HashSet::new));
     // Check IPv4 and IPv6 loopback addresses 127.0.0.1 and 0.0.0.0.0.0.0.1
     selfAddresses.addAll(
-        Arrays.stream(InetAddress.getAllByName("localhost"))
+        Arrays.stream(InetAddress.getAllByName(LOOPBACK_HOST_NAME))
             .map(InetAddress::getHostAddress)
             .collect(Collectors.toCollection(HashSet::new)));
     // Check general address 0.0.0.0
-    selfAddresses.add("0.0.0.0");
+    selfAddresses.add(WILD_CARD_ADDRESS);
 
     return selfAddresses;
   }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/NodeUrlUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/NodeUrlUtils.java
@@ -26,10 +26,15 @@ import org.apache.iotdb.commons.exception.BadNodeUrlException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
 
 public class NodeUrlUtils {
 
@@ -188,10 +193,62 @@ public class NodeUrlUtils {
     return parseTConfigNodeUrls(Arrays.asList(configNodeUrls.split(";")));
   }
 
-  public static boolean isLocalAddress(String ip) {
-    if (ip == null) {
+  /**
+   * Detect whether the given addresses or host names(may contain both) point to the node itself.
+   *
+   * @param addressesOrHostNames List of the addresses or host name to check
+   * @return true if one of the given strings point to the node itself
+   * @throws UnknownHostException Throw when unable to parse the given addresses or host names
+   */
+  public static boolean containsLocalAddress(List<String> addressesOrHostNames)
+      throws UnknownHostException {
+    if (addressesOrHostNames == null) {
       return false;
     }
-    return ip.equals("0.0.0.0") || ip.equals("127.0.0.1") || ip.equals("localhost");
+
+    Set<String> selfAddresses = getAllLocalAddresses();
+
+    for (String addressOrHostName : addressesOrHostNames) {
+      if (addressOrHostName == null) {
+        continue;
+      }
+      // Unify address or hostName, converting them to addresses
+      HashSet<String> translatedAddresses =
+          Arrays.stream(InetAddress.getAllByName(addressOrHostName))
+              .map(InetAddress::getHostAddress)
+              .collect(Collectors.toCollection(HashSet::new));
+      translatedAddresses.retainAll(selfAddresses);
+
+      if (!translatedAddresses.isEmpty()) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Return all the internal, external, IPv4, IPv6 and loopback addresses(without hostname) of the
+   * node
+   *
+   * @return the local addresses set
+   * @throws UnknownHostException Throw when unable to self addresses or host names (Normally not
+   *     thrown)
+   */
+  public static Set<String> getAllLocalAddresses() throws UnknownHostException {
+    // Check internal and external, IPv4 and IPv6 network addresses
+    Set<String> selfAddresses =
+        Arrays.stream(InetAddress.getAllByName(InetAddress.getLocalHost().getHostName()))
+            .map(InetAddress::getHostAddress)
+            .collect(Collectors.toCollection(HashSet::new));
+    // Check IPv4 and IPv6 loopback addresses 127.0.0.1 and 0.0.0.0.0.0.0.1
+    selfAddresses.addAll(
+        Arrays.stream(InetAddress.getAllByName("localhost"))
+            .map(InetAddress::getHostAddress)
+            .collect(Collectors.toCollection(HashSet::new)));
+    // Check general address 0.0.0.0
+    selfAddresses.add("0.0.0.0");
+
+    return selfAddresses;
   }
 }


### PR DESCRIPTION
## [IOTDB-6220](https://issues.apache.org/jira/browse/IOTDB-6220)
Added hostName and IPv6 addresses detection of IoTDB pipe sink, and seed configNode pointing to itself.

Now the following IPs or host names pointing to the receiver on sender itself is not allowed:
1. Loopback addresses or hosts
    - "localhost"
    - "LOCALHOST"
    - "127.0.0.1"
    - "0.0.0.0.0.0.0.1"
2. General address
    - "0.0.0.0"
3. All the sender's IPv4 and IPv6 addresses
    - "192.168.100.56"
    - "10.255.1.70"
    - "fd37:634f:c2bf:421a:a63a:22aa:a80e:f5b6"
5. The senders host name
    - "DESKTOP-LOUNTUK"

### Test images
![img_v3_024p_8e6311f4-f747-44fb-a86e-b8e98b05dfag](https://github.com/apache/iotdb/assets/87789683/4d38f8fc-60a5-4b1d-83fc-dbc6b4de2a97)
![img_v3_024p_ecf8312c-f32b-49dd-9ae6-b81543d5f8cg](https://github.com/apache/iotdb/assets/87789683/853b14b0-d41c-49a4-909b-f4d306c88d2a)

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
