### PR TITLE
[IOTDB-1476]IoTDB support IPv6

### DIFF
--- a/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/UtilsTest.java
+++ b/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/UtilsTest.java
@@ -70,7 +70,7 @@ public class UtilsTest {
     String userName = "test";
     String userPwd = "test";
     String host1 =
-        "AD80::E32B::CR25::B3WE::DG4G::DWTF,AD80::E32B::CR25::B3WE::DG4G:DWTF::CGDE,AD80::E32B::CR25::B3WE::DG4G::DWTF";
+        "AD80:E32B:CR25:B3WE:DG4G:DWTF,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE,AD80:E32B:CR25:B3WE:DG4G:DWTF";
     int port = 6667;
     Properties properties = new Properties();
     properties.setProperty(Config.AUTH_USER, userName);

--- a/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/UtilsTest.java
+++ b/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/UtilsTest.java
@@ -70,7 +70,7 @@ public class UtilsTest {
     String userName = "test";
     String userPwd = "test";
     String host1 =
-        "AD80:E32B:CR25:B3WE:DG4G:DWTF:EEWE:BBBE,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:EEWE:BBBE,AD80:E32B:CR25:B3WE:DG4G:DWTF:EEWE:BBBE";
+        "AD80:E32B:CA25:B3AE:DA4A:DAAF:EEAE:BBBE,AD80:E32B:CA25:B3AE:DAAA:DAAF:CADE:EEAE:BBBE,AD80:E32B:CA25:B3AE:DA4A:DAAF:EEAE:BBBE";
     int port = 6667;
     Properties properties = new Properties();
     properties.setProperty(Config.AUTH_USER, userName);

--- a/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/UtilsTest.java
+++ b/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/UtilsTest.java
@@ -65,6 +65,31 @@ public class UtilsTest {
     assertEquals(params.getPassword(), userPwd);
   }
 
+  @Test
+  public void testParseIPV6URL() throws IoTDBURLException {
+    String userName = "test";
+    String userPwd = "test";
+    String host1 =
+        "AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE";
+    int port = 6667;
+    Properties properties = new Properties();
+    properties.setProperty(Config.AUTH_USER, userName);
+    properties.setProperty(Config.AUTH_PASSWORD, userPwd);
+    IoTDBConnectionParams params =
+        Utils.parseUrl(String.format(Config.IOTDB_URL_PREFIX + "%s:%s/", host1, port), properties);
+    assertEquals(host1, params.getHost());
+    assertEquals(port, params.getPort());
+    assertEquals(userName, params.getUsername());
+    assertEquals(userPwd, params.getPassword());
+
+    params =
+        Utils.parseUrl(String.format(Config.IOTDB_URL_PREFIX + "%s:%s", host1, port), properties);
+    assertEquals(params.getHost(), host1);
+    assertEquals(params.getPort(), port);
+    assertEquals(params.getUsername(), userName);
+    assertEquals(params.getPassword(), userPwd);
+  }
+
   @Test(expected = IoTDBURLException.class)
   public void testParseWrongUrl1() throws IoTDBURLException {
     Properties properties = new Properties();

--- a/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/UtilsTest.java
+++ b/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/UtilsTest.java
@@ -70,7 +70,7 @@ public class UtilsTest {
     String userName = "test";
     String userPwd = "test";
     String host1 =
-        "AD80:E32B:CR25:B3WE:DG4G:DWTF,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE,AD80:E32B:CR25:B3WE:DG4G:DWTF";
+        "AD80:E32B:CR25:B3WE:DG4G:DWTF:EEWE:BBBE,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:EEWE:BBBE,AD80:E32B:CR25:B3WE:DG4G:DWTF:EEWE:BBBE";
     int port = 6667;
     Properties properties = new Properties();
     properties.setProperty(Config.AUTH_USER, userName);

--- a/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/UtilsTest.java
+++ b/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/UtilsTest.java
@@ -70,7 +70,7 @@ public class UtilsTest {
     String userName = "test";
     String userPwd = "test";
     String host1 =
-        "AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE";
+        "AD80::E32B::CR25::B3WE::DG4G::DWTF,AD80::E32B::CR25::B3WE::DG4G:DWTF::CGDE,AD80::E32B::CR25::B3WE::DG4G::DWTF";
     int port = 6667;
     Properties properties = new Properties();
     properties.setProperty(Config.AUTH_USER, userName);

--- a/iotdb-client/service-rpc/pom.xml
+++ b/iotdb-client/service-rpc/pom.xml
@@ -71,10 +71,6 @@
             <artifactId>snappy-java</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/iotdb-client/service-rpc/pom.xml
+++ b/iotdb-client/service-rpc/pom.xml
@@ -71,6 +71,10 @@
             <artifactId>snappy-java</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/UrlUtils.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/UrlUtils.java
@@ -40,18 +40,17 @@ public class UrlUtils {
    * @return TEndPoint null if parse error
    */
   public static TEndPoint parseTEndPointIpv4AndIpv6Url(String endPointUrl) {
+    TEndPoint endPoint = new TEndPoint();
     InetSocketAddress address = getSocketAddress(endPointUrl);
-    if (address == null) {
-      logger.warn("Bad url: {}", endPointUrl);
-      return null;
+    if (address != null) {
+      endPoint.setIp(address.getHostString());
+      endPoint.setPort(address.getPort());
     }
-    String ip = address.getHostString();
-    int port = address.getPort();
-    return new TEndPoint(ip, port);
+    return endPoint;
   }
 
   /**
-   * generate address from url, support ipv4 and ipv6
+   * Generate address from url, support ipv4 and ipv6
    *
    * @param url example:D80:0000:0000:0000:ABAA:0000:00C2:0002:22227
    * @return socket address

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/UrlUtils.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/UrlUtils.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.rpc;
+
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+
+/** The UrlUtils */
+public class UrlUtils {
+  private static final Logger logger = LoggerFactory.getLogger(UrlUtils.class);
+  public static final String COLON = ":";
+
+  private UrlUtils() {}
+
+  /**
+   * Parse TEndPoint from a given TEndPointUrl
+   *
+   * @param endPointUrl ip:port
+   * @return TEndPoint null if parse error
+   */
+  public static TEndPoint parseTEndPointIpv4AndIpv6Url(String endPointUrl) {
+    InetSocketAddress address = getSocketAddress(endPointUrl);
+    if (address == null) {
+      logger.warn("Bad url: {}", endPointUrl);
+      return null;
+    }
+    String ip = address.getHostString();
+    int port = address.getPort();
+    return new TEndPoint(ip, port);
+  }
+
+  /**
+   * generate address from url, support ipv4 and ipv6
+   *
+   * @param url example:D80:0000:0000:0000:ABAA:0000:00C2:0002:22227
+   * @return socket address
+   */
+  private static InetSocketAddress getSocketAddress(String url) {
+    String ip = null;
+    String port = null;
+    InetSocketAddress address = null;
+    if (url.contains(COLON)) {
+      int i;
+      if (url.contains("%")) {
+        i = url.lastIndexOf("%");
+        url = url.trim();
+      } else {
+        i = url.lastIndexOf(COLON);
+      }
+      port = url.substring(url.lastIndexOf(COLON) + 1);
+      ip = url.substring(0, i);
+
+      try {
+        address = new InetSocketAddress(ip, Integer.parseInt(port));
+      } catch (NumberFormatException e) {
+        logger.warn("Bad url: {}", url);
+      }
+    } else {
+      logger.warn("Bad url: {}", url);
+    }
+
+    return address;
+  }
+}

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/UrlUtils.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/UrlUtils.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 /** The UrlUtils */
 public class UrlUtils {
   private static final String POINT_COLON = ":";
+  private static final String ABB_COLON = "[";
 
   private UrlUtils() {}
 
@@ -36,9 +37,12 @@ public class UrlUtils {
   public static TEndPoint parseTEndPointIpv4AndIpv6Url(String endPointUrl) {
     TEndPoint endPoint = new TEndPoint();
     if (endPointUrl.contains(POINT_COLON)) {
-      int i = endPointUrl.lastIndexOf(POINT_COLON);
+      int point_position = endPointUrl.lastIndexOf(POINT_COLON);
       String port = endPointUrl.substring(endPointUrl.lastIndexOf(POINT_COLON) + 1);
-      String ip = endPointUrl.substring(0, i);
+      String ip = endPointUrl.substring(0, point_position);
+      if (ip.contains(ABB_COLON)) {
+        ip = ip.substring(1, ip.length() - 1);
+      }
       endPoint.setIp(ip);
       endPoint.setPort(Integer.parseInt(port));
     }

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/UrlUtils.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/UrlUtils.java
@@ -21,64 +21,27 @@ package org.apache.iotdb.rpc;
 
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.net.InetSocketAddress;
-
 /** The UrlUtils */
 public class UrlUtils {
-  private static final Logger logger = LoggerFactory.getLogger(UrlUtils.class);
-  public static final String COLON = ":";
+  private static final String POINT_COLON = ":";
 
   private UrlUtils() {}
 
   /**
-   * Parse TEndPoint from a given TEndPointUrl
+   * Parse TEndPoint from a given TEndPointUrl example:D80:0000:0000:0000:ABAA:0000:00C2:0002:22227
    *
    * @param endPointUrl ip:port
    * @return TEndPoint null if parse error
    */
   public static TEndPoint parseTEndPointIpv4AndIpv6Url(String endPointUrl) {
     TEndPoint endPoint = new TEndPoint();
-    InetSocketAddress address = getSocketAddress(endPointUrl);
-    if (address != null) {
-      endPoint.setIp(address.getHostString());
-      endPoint.setPort(address.getPort());
+    if (endPointUrl.contains(POINT_COLON)) {
+      int i = endPointUrl.lastIndexOf(POINT_COLON);
+      String port = endPointUrl.substring(endPointUrl.lastIndexOf(POINT_COLON) + 1);
+      String ip = endPointUrl.substring(0, i);
+      endPoint.setIp(ip);
+      endPoint.setPort(Integer.parseInt(port));
     }
     return endPoint;
-  }
-
-  /**
-   * Generate address from url, support ipv4 and ipv6
-   *
-   * @param url example:D80:0000:0000:0000:ABAA:0000:00C2:0002:22227
-   * @return socket address
-   */
-  private static InetSocketAddress getSocketAddress(String url) {
-    String ip = null;
-    String port = null;
-    InetSocketAddress address = null;
-    if (url.contains(COLON)) {
-      int i;
-      if (url.contains("%")) {
-        i = url.lastIndexOf("%");
-        url = url.trim();
-      } else {
-        i = url.lastIndexOf(COLON);
-      }
-      port = url.substring(url.lastIndexOf(COLON) + 1);
-      ip = url.substring(0, i);
-
-      try {
-        address = new InetSocketAddress(ip, Integer.parseInt(port));
-      } catch (NumberFormatException e) {
-        logger.warn("Bad url: {}", url);
-      }
-    } else {
-      logger.warn("Bad url: {}", url);
-    }
-
-    return address;
   }
 }

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/UrlUtils.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/UrlUtils.java
@@ -29,7 +29,8 @@ public class UrlUtils {
   private UrlUtils() {}
 
   /**
-   * Parse TEndPoint from a given TEndPointUrl example:D80:0000:0000:0000:ABAA:0000:00C2:0002:22227
+   * Parse TEndPoint from a given TEndPointUrl
+   * example:[D80:0000:0000:0000:ABAA:0000:00C2:0002]:22227
    *
    * @param endPointUrl ip:port
    * @return TEndPoint null if parse error

--- a/iotdb-client/service-rpc/src/test/java/org/apache/iotdb/rpc/UrlUtilsTest.java
+++ b/iotdb-client/service-rpc/src/test/java/org/apache/iotdb/rpc/UrlUtilsTest.java
@@ -29,25 +29,25 @@ public class UrlUtilsTest {
 
   @Test
   public void testParseIPV6URL() {
-    String hostAndPoint = "D80:0000:0000:0000:ABAA:00BB:EEAA:BBRR:22227";
+    String hostAndPoint = "D80:0000:0000:0000:ABAA:00BB:EEAA:BBDD:22227";
     TEndPoint endPoint = UrlUtils.parseTEndPointIpv4AndIpv6Url(hostAndPoint);
-    assertEquals(endPoint.getIp(), "D80:0000:0000:0000:ABAA:00BB:EEAA:BBRR");
+    assertEquals(endPoint.getIp(), "D80:0000:0000:0000:ABAA:00BB:EEAA:BBDD");
     assertEquals(endPoint.getPort(), 22227);
   }
 
   @Test
-  public void testParseIPV6PercentURL() {
-    String hostAndPoint = "D80:0000:GETW:SSEE:0000:0000:ABAA:0000%14:22227";
+  public void testParseIPV6URL_2() {
+    String hostAndPoint = "[D80:0000:0000:0000:ABAA:00BB:EEAA:BBDD]:22227";
     TEndPoint endPoint = UrlUtils.parseTEndPointIpv4AndIpv6Url(hostAndPoint);
-    assertEquals(endPoint.getIp(), "D80:0000:GETW:SSEE:0000:0000:ABAA:0000%14");
+    assertEquals(endPoint.getIp(), "D80:0000:0000:0000:ABAA:00BB:EEAA:BBDD");
     assertEquals(endPoint.getPort(), 22227);
   }
 
   @Test
   public void testParseIPV6AbbURL() {
-    String hostAndPoint = "[D80:ABAA:0]:22227";
+    String hostAndPoint = "[D80::ABAA:0]:22227";
     TEndPoint endPoint = UrlUtils.parseTEndPointIpv4AndIpv6Url(hostAndPoint);
-    assertEquals(endPoint.getIp(), "D80:ABAA:0");
+    assertEquals(endPoint.getIp(), "D80::ABAA:0");
     assertEquals(endPoint.getPort(), 22227);
   }
 

--- a/iotdb-client/service-rpc/src/test/java/org/apache/iotdb/rpc/UrlUtilsTest.java
+++ b/iotdb-client/service-rpc/src/test/java/org/apache/iotdb/rpc/UrlUtilsTest.java
@@ -29,17 +29,25 @@ public class UrlUtilsTest {
 
   @Test
   public void testParseIPV6URL() {
-    String hostAndPoint = "D80::0000::0000::0000::ABAA::0000:22227";
+    String hostAndPoint = "D80:0000:0000:0000:ABAA:0000:22227";
     TEndPoint endPoint = UrlUtils.parseTEndPointIpv4AndIpv6Url(hostAndPoint);
-    assertEquals(endPoint.getIp(), "D80::0000::0000::0000::ABAA::0000");
+    assertEquals(endPoint.getIp(), "D80:0000:0000:0000:ABAA:0000");
     assertEquals(endPoint.getPort(), 22227);
   }
 
   @Test
   public void testParseIPV6PercentURL() {
-    String hostAndPoint = "D80::0000::0000::0000::ABAA::0000%14:22227";
+    String hostAndPoint = "D80:0000:0000:0000:ABAA:0000%14:22227";
     TEndPoint endPoint = UrlUtils.parseTEndPointIpv4AndIpv6Url(hostAndPoint);
-    assertEquals(endPoint.getIp(), "D80::0000::0000::0000::ABAA::0000%14");
+    assertEquals(endPoint.getIp(), "D80:0000:0000:0000:ABAA:0000%14");
+    assertEquals(endPoint.getPort(), 22227);
+  }
+
+  @Test
+  public void testParseIPV6AbbURL() {
+    String hostAndPoint = "[D80:ABAA:0]:22227";
+    TEndPoint endPoint = UrlUtils.parseTEndPointIpv4AndIpv6Url(hostAndPoint);
+    assertEquals(endPoint.getIp(), "D80:ABAA:0");
     assertEquals(endPoint.getPort(), 22227);
   }
 

--- a/iotdb-client/service-rpc/src/test/java/org/apache/iotdb/rpc/UrlUtilsTest.java
+++ b/iotdb-client/service-rpc/src/test/java/org/apache/iotdb/rpc/UrlUtilsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.rpc;
+
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class UrlUtilsTest {
+
+  @Test
+  public void testParseIPV6URL() {
+    String hostAndPoint = "D80:0000:0000:0000:ABAA:0000:00C2:0002:22227";
+    TEndPoint endPoint = UrlUtils.parseTEndPointIpv4AndIpv6Url(hostAndPoint);
+    assertEquals(endPoint.getIp(), "d80:0:0:0:abaa:0:c2:2");
+    assertEquals(endPoint.getPort(), 22227);
+  }
+
+  @Test
+  public void testParseIPV4URL() {
+    String hostAndPoint = "192.0.0.1:22227";
+    TEndPoint endPoint = UrlUtils.parseTEndPointIpv4AndIpv6Url(hostAndPoint);
+    assertEquals(endPoint.getIp(), "192.0.0.1");
+    assertEquals(endPoint.getPort(), 22227);
+  }
+}

--- a/iotdb-client/service-rpc/src/test/java/org/apache/iotdb/rpc/UrlUtilsTest.java
+++ b/iotdb-client/service-rpc/src/test/java/org/apache/iotdb/rpc/UrlUtilsTest.java
@@ -29,17 +29,17 @@ public class UrlUtilsTest {
 
   @Test
   public void testParseIPV6URL() {
-    String hostAndPoint = "D80:0000:0000:0000:ABAA:0000:22227";
+    String hostAndPoint = "D80:0000:0000:0000:ABAA:00BB:EEAA:BBRR:22227";
     TEndPoint endPoint = UrlUtils.parseTEndPointIpv4AndIpv6Url(hostAndPoint);
-    assertEquals(endPoint.getIp(), "D80:0000:0000:0000:ABAA:0000");
+    assertEquals(endPoint.getIp(), "D80:0000:0000:0000:ABAA:00BB:EEAA:BBRR");
     assertEquals(endPoint.getPort(), 22227);
   }
 
   @Test
   public void testParseIPV6PercentURL() {
-    String hostAndPoint = "D80:0000:0000:0000:ABAA:0000%14:22227";
+    String hostAndPoint = "D80:0000:GETW:SSEE:0000:0000:ABAA:0000%14:22227";
     TEndPoint endPoint = UrlUtils.parseTEndPointIpv4AndIpv6Url(hostAndPoint);
-    assertEquals(endPoint.getIp(), "D80:0000:0000:0000:ABAA:0000%14");
+    assertEquals(endPoint.getIp(), "D80:0000:GETW:SSEE:0000:0000:ABAA:0000%14");
     assertEquals(endPoint.getPort(), 22227);
   }
 

--- a/iotdb-client/service-rpc/src/test/java/org/apache/iotdb/rpc/UrlUtilsTest.java
+++ b/iotdb-client/service-rpc/src/test/java/org/apache/iotdb/rpc/UrlUtilsTest.java
@@ -29,9 +29,17 @@ public class UrlUtilsTest {
 
   @Test
   public void testParseIPV6URL() {
-    String hostAndPoint = "D80:0000:0000:0000:ABAA:0000:00C2:0002:22227";
+    String hostAndPoint = "D80::0000::0000::0000::ABAA::0000:22227";
     TEndPoint endPoint = UrlUtils.parseTEndPointIpv4AndIpv6Url(hostAndPoint);
-    assertEquals(endPoint.getIp(), "d80:0:0:0:abaa:0:c2:2");
+    assertEquals(endPoint.getIp(), "D80::0000::0000::0000::ABAA::0000");
+    assertEquals(endPoint.getPort(), 22227);
+  }
+
+  @Test
+  public void testParseIPV6PercentURL() {
+    String hostAndPoint = "D80::0000::0000::0000::ABAA::0000%14:22227";
+    TEndPoint endPoint = UrlUtils.parseTEndPointIpv4AndIpv6Url(hostAndPoint);
+    assertEquals(endPoint.getIp(), "D80::0000::0000::0000::ABAA::0000%14");
     assertEquals(endPoint.getPort(), 22227);
   }
 

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/util/SessionUtils.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/util/SessionUtils.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.session.util;
 
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
+import org.apache.iotdb.rpc.UrlUtils;
 import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 import org.apache.iotdb.tsfile.enums.TSDataType;
 import org.apache.iotdb.tsfile.exception.UnSupportedDataTypeException;
@@ -254,25 +255,10 @@ public class SessionUtils {
     }
     List<TEndPoint> endPointsList = new ArrayList<>();
     for (String nodeUrl : nodeUrls) {
-      TEndPoint endPoint = parseNodeUrl(nodeUrl);
+      TEndPoint endPoint = UrlUtils.parseTEndPointIpv4AndIpv6Url(nodeUrl);
       endPointsList.add(endPoint);
     }
     return endPointsList;
-  }
-
-  private static TEndPoint parseNodeUrl(String nodeUrl) {
-    TEndPoint endPoint = new TEndPoint();
-    String[] split = nodeUrl.split(":");
-    if (split.length != 2) {
-      throw new NumberFormatException("NodeUrl Incorrect format");
-    }
-    String ip = split[0];
-    try {
-      int rpcPort = Integer.parseInt(split[1]);
-      return endPoint.setIp(ip).setPort(rpcPort);
-    } catch (Exception e) {
-      throw new NumberFormatException("NodeUrl Incorrect format");
-    }
   }
 
   private SessionUtils() {}

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/NodeUrlUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/NodeUrlUtils.java
@@ -35,7 +35,6 @@ import java.util.StringJoiner;
 public class NodeUrlUtils {
 
   private static final Logger logger = LoggerFactory.getLogger(NodeUrlUtils.class);
-  public static final String COLON = ":";
 
   /**
    * Convert TEndPoint to TEndPointUrl

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/NodeUrlUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/NodeUrlUtils.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.commons.utils;
 import org.apache.iotdb.common.rpc.thrift.TConfigNodeLocation;
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.commons.exception.BadNodeUrlException;
+import org.apache.iotdb.rpc.UrlUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +35,7 @@ import java.util.StringJoiner;
 public class NodeUrlUtils {
 
   private static final Logger logger = LoggerFactory.getLogger(NodeUrlUtils.class);
+  public static final String COLON = ":";
 
   /**
    * Convert TEndPoint to TEndPointUrl
@@ -70,21 +72,7 @@ public class NodeUrlUtils {
    * @throws BadNodeUrlException Throw when unable to parse
    */
   public static TEndPoint parseTEndPointUrl(String endPointUrl) throws BadNodeUrlException {
-    String[] split = endPointUrl.split(":");
-    if (split.length != 2) {
-      logger.warn("Illegal endpoint url format: {}", endPointUrl);
-      throw new BadNodeUrlException(String.format("Bad endpoint url: %s", endPointUrl));
-    }
-    String ip = split[0];
-    TEndPoint result;
-    try {
-      int port = Integer.parseInt(split[1]);
-      result = new TEndPoint(ip, port);
-    } catch (NumberFormatException e) {
-      logger.warn("Illegal endpoint url format: {}", endPointUrl);
-      throw new BadNodeUrlException(String.format("Bad node url: %s", endPointUrl));
-    }
-    return result;
+    return UrlUtils.parseTEndPointIpv4AndIpv6Url(endPointUrl);
   }
 
   /**
@@ -98,7 +86,7 @@ public class NodeUrlUtils {
       throws BadNodeUrlException {
     List<TEndPoint> result = new ArrayList<>();
     for (String url : endPointUrls) {
-      result.add(parseTEndPointUrl(url));
+      result.add(UrlUtils.parseTEndPointIpv4AndIpv6Url(url));
     }
     return result;
   }
@@ -157,7 +145,9 @@ public class NodeUrlUtils {
       throw new BadNodeUrlException(String.format("Bad node url: %s", configNodeUrl));
     }
     return new TConfigNodeLocation(
-        Integer.parseInt(split[0]), parseTEndPointUrl(split[1]), parseTEndPointUrl(split[2]));
+        Integer.parseInt(split[0]),
+        UrlUtils.parseTEndPointIpv4AndIpv6Url(split[1]),
+        UrlUtils.parseTEndPointIpv4AndIpv6Url(split[2]));
   }
 
   /**

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/utils/NodeUrlUtilsTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/utils/NodeUrlUtilsTest.java
@@ -78,18 +78,18 @@ public class NodeUrlUtilsTest {
         Arrays.asList(
             new TConfigNodeLocation(
                 0,
-                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:ABFD", 22277),
-                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:ABFD", 22278)),
+                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CDDE:ABFD", 22277),
+                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CDDE:ABFD", 22278)),
             new TConfigNodeLocation(
                 1,
-                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:ABFD", 22279),
-                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:ABFD", 22280)),
+                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CDDE:ABFD", 22279),
+                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CDDE:ABFD", 22280)),
             new TConfigNodeLocation(
                 2,
-                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:ABFD", 22281),
-                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:ABFD", 22282)));
+                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CDDE:ABFD", 22281),
+                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CDDE:ABFD", 22282)));
     final String configNodeUrls =
-        "0,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:ABFD:22277,[AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:ABFD]:22278;1,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:ABFD:22279,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:ABFD:22280;2,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:ABFD:22281,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:ABFD:22282";
+        "0,AD80:E32B:CR25:B3WE:DG4G:DWTF:CDDE:ABFD:22277,[AD80:E32B:CR25:B3WE:DG4G:DWTF:CDDE:ABFD]:22278;1,AD80:E32B:CR25:B3WE:DG4G:DWTF:CDDE:ABFD:22279,AD80:E32B:CR25:B3WE:DG4G:DWTF:CDDE:ABFD:22280;2,AD80:E32B:CR25:B3WE:DG4G:DWTF:CDDE:ABFD:22281,AD80:E32B:CR25:B3WE:DG4G:DWTF:CDDE:ABFD:22282";
     Assert.assertEquals(configNodeLocations, NodeUrlUtils.parseTConfigNodeUrls(configNodeUrls));
   }
 }

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/utils/NodeUrlUtilsTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/utils/NodeUrlUtilsTest.java
@@ -65,12 +65,10 @@ public class NodeUrlUtilsTest {
     final List<TEndPoint> endPoints =
         Arrays.asList(
             new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:2345", 6667),
-            new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:2345", 6668),
-            new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:2345", 6669));
+            new TEndPoint("0:0:0:0:0:FFFF:129.144.52.38", 6668),
+            new TEndPoint("::13.1.68.3", 6669));
     final String endPointUrls =
-        "AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:2345:6667,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:2345:6668,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:2345:6669";
-
-    Assert.assertEquals(endPointUrls, NodeUrlUtils.convertTEndPointUrls(endPoints));
+        "AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:2345:6667,[0:0:0:0:0:FFFF:129.144.52.38]:6668,[::13.1.68.3]:6669";
     Assert.assertEquals(endPoints, NodeUrlUtils.parseTEndPointUrls(endPointUrls));
   }
 
@@ -80,20 +78,18 @@ public class NodeUrlUtilsTest {
         Arrays.asList(
             new TConfigNodeLocation(
                 0,
-                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE", 22277),
-                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE", 22278)),
+                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:ABFD", 22277),
+                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:ABFD", 22278)),
             new TConfigNodeLocation(
                 1,
-                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE", 22279),
-                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE", 22280)),
+                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:ABFD", 22279),
+                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:ABFD", 22280)),
             new TConfigNodeLocation(
                 2,
-                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE", 22281),
-                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE", 22282)));
+                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:ABFD", 22281),
+                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:ABFD", 22282)));
     final String configNodeUrls =
-        "0,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:22277,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:22278;1,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:22279,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:22280;2,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:22281,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:22282";
-
-    Assert.assertEquals(configNodeUrls, NodeUrlUtils.convertTConfigNodeUrls(configNodeLocations));
+        "0,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:ABFD:22277,[AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:ABFD]:22278;1,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:ABFD:22279,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:ABFD:22280;2,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:ABFD:22281,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:ABFD:22282";
     Assert.assertEquals(configNodeLocations, NodeUrlUtils.parseTConfigNodeUrls(configNodeUrls));
   }
 }

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/utils/NodeUrlUtilsTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/utils/NodeUrlUtilsTest.java
@@ -64,11 +64,11 @@ public class NodeUrlUtilsTest {
   public void parseAndConvertTEndPointUrlsIPV4AndIPV6Test() throws BadNodeUrlException {
     final List<TEndPoint> endPoints =
         Arrays.asList(
-            new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:2345", 6667),
+            new TEndPoint("AD80:E32B:CA25:B3AE:DC4C:DAAF:CCDE:2345", 6667),
             new TEndPoint("0:0:0:0:0:FFFF:129.144.52.38", 6668),
             new TEndPoint("::13.1.68.3", 6669));
     final String endPointUrls =
-        "AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:2345:6667,[0:0:0:0:0:FFFF:129.144.52.38]:6668,[::13.1.68.3]:6669";
+        "AD80:E32B:CA25:B3AE:DC4C:DAAF:CCDE:2345:6667,[0:0:0:0:0:FFFF:129.144.52.38]:6668,[::13.1.68.3]:6669";
     Assert.assertEquals(endPoints, NodeUrlUtils.parseTEndPointUrls(endPointUrls));
   }
 
@@ -78,18 +78,18 @@ public class NodeUrlUtilsTest {
         Arrays.asList(
             new TConfigNodeLocation(
                 0,
-                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CDDE:ABFD", 22277),
-                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CDDE:ABFD", 22278)),
+                new TEndPoint("AD80:E32B:CA25:B3AE:DC4C:DAAF:CDDE:ABFD", 22277),
+                new TEndPoint("AD80:E32B:CA25:B3AE:DC4C:DAAF:CDDE:ABFD", 22278)),
             new TConfigNodeLocation(
                 1,
-                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CDDE:ABFD", 22279),
-                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CDDE:ABFD", 22280)),
+                new TEndPoint("AD80:E32B:CA25:B3AE:DC4C:DAAF:CDDE:ABFD", 22279),
+                new TEndPoint("AD80:E32B:CA25:B3AE:DC4C:DAAF:CDDE:ABFD", 22280)),
             new TConfigNodeLocation(
                 2,
-                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CDDE:ABFD", 22281),
-                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CDDE:ABFD", 22282)));
+                new TEndPoint("AD80:E32B:CA25:B3AE:DC4C:DAAF:CDDE:ABFD", 22281),
+                new TEndPoint("AD80:E32B:CA25:B3AE:DC4C:DAAF:CDDE:ABFD", 22282)));
     final String configNodeUrls =
-        "0,AD80:E32B:CR25:B3WE:DG4G:DWTF:CDDE:ABFD:22277,[AD80:E32B:CR25:B3WE:DG4G:DWTF:CDDE:ABFD]:22278;1,AD80:E32B:CR25:B3WE:DG4G:DWTF:CDDE:ABFD:22279,AD80:E32B:CR25:B3WE:DG4G:DWTF:CDDE:ABFD:22280;2,AD80:E32B:CR25:B3WE:DG4G:DWTF:CDDE:ABFD:22281,AD80:E32B:CR25:B3WE:DG4G:DWTF:CDDE:ABFD:22282";
+        "0,AD80:E32B:CA25:B3AE:DC4C:DAAF:CDDE:ABFD:22277,[AD80:E32B:CA25:B3AE:DC4C:DAAF:CDDE:ABFD]:22278;1,AD80:E32B:CA25:B3AE:DC4C:DAAF:CDDE:ABFD:22279,AD80:E32B:CA25:B3AE:DC4C:DAAF:CDDE:ABFD:22280;2,AD80:E32B:CA25:B3AE:DC4C:DAAF:CDDE:ABFD:22281,AD80:E32B:CA25:B3AE:DC4C:DAAF:CDDE:ABFD:22282";
     Assert.assertEquals(configNodeLocations, NodeUrlUtils.parseTConfigNodeUrls(configNodeUrls));
   }
 }

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/utils/NodeUrlUtilsTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/utils/NodeUrlUtilsTest.java
@@ -59,4 +59,41 @@ public class NodeUrlUtilsTest {
     Assert.assertEquals(configNodeUrls, NodeUrlUtils.convertTConfigNodeUrls(configNodeLocations));
     Assert.assertEquals(configNodeLocations, NodeUrlUtils.parseTConfigNodeUrls(configNodeUrls));
   }
+
+  @Test
+  public void parseAndConvertTEndPointUrlsIPV4AndIPV6Test() throws BadNodeUrlException {
+    final List<TEndPoint> endPoints =
+        Arrays.asList(
+            new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:2345", 6667),
+            new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:2345", 6668),
+            new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:2345", 6669));
+    final String endPointUrls =
+        "AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:2345:6667,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:2345:6668,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:2345:6669";
+
+    Assert.assertEquals(endPointUrls, NodeUrlUtils.convertTEndPointUrls(endPoints));
+    Assert.assertEquals(endPoints, NodeUrlUtils.parseTEndPointUrls(endPointUrls));
+  }
+
+  @Test
+  public void parseAndConvertTConfigNodeUrlsIPV4AndIPV6Test() throws BadNodeUrlException {
+    final List<TConfigNodeLocation> configNodeLocations =
+        Arrays.asList(
+            new TConfigNodeLocation(
+                0,
+                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE", 22277),
+                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE", 22278)),
+            new TConfigNodeLocation(
+                1,
+                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE", 22279),
+                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE", 22280)),
+            new TConfigNodeLocation(
+                2,
+                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE", 22281),
+                new TEndPoint("AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE", 22282)));
+    final String configNodeUrls =
+        "0,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:22277,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:22278;1,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:22279,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:22280;2,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:22281,AD80:E32B:CR25:B3WE:DG4G:DWTF:CGDE:22282";
+
+    Assert.assertEquals(configNodeUrls, NodeUrlUtils.convertTConfigNodeUrls(configNodeLocations));
+    Assert.assertEquals(configNodeLocations, NodeUrlUtils.parseTConfigNodeUrls(configNodeUrls));
+  }
 }


### PR DESCRIPTION
IPv6 is used to parse the IP address and port number in the URL.
this function , we has been tested in ipv6 server。
![image](https://github.com/apache/iotdb/assets/66939405/d30a392d-fcfb-410e-ab68-909409a983a1)
