### PR TITLE
Pipe: add stream & batch options for source.realtime.mode & remove some pipe plugins from show pipe plugins' dataset & make pipe-api compatible with the v1.2.x releases

### DIFF
--- a/iotdb-api/pipe-api/src/main/java/org/apache/iotdb/pipe/api/customizer/parameter/PipeParameterValidator.java
+++ b/iotdb-api/pipe-api/src/main/java/org/apache/iotdb/pipe/api/customizer/parameter/PipeParameterValidator.java
@@ -61,7 +61,7 @@ public class PipeParameterValidator {
       return this;
     }
 
-    final String actualValue = parameters.getString(key);
+    final String actualValue = parameters.getStringByKeys(key);
     for (String optionalValue : optionalValues) {
       if (actualValue.equals(optionalValue)) {
         return this;

--- a/iotdb-api/pipe-api/src/main/java/org/apache/iotdb/pipe/api/customizer/parameter/PipeParameters.java
+++ b/iotdb-api/pipe-api/src/main/java/org/apache/iotdb/pipe/api/customizer/parameter/PipeParameters.java
@@ -61,7 +61,36 @@ public class PipeParameters {
     return false;
   }
 
-  public String getString(String... keys) {
+  public String getString(String key) {
+    return attributes.get(key);
+  }
+
+  public Boolean getBoolean(String key) {
+    String value = attributes.get(key);
+    return value == null ? null : Boolean.parseBoolean(value);
+  }
+
+  public Integer getInt(String key) {
+    String value = attributes.get(key);
+    return value == null ? null : Integer.parseInt(value);
+  }
+
+  public Long getLong(String key) {
+    String value = attributes.get(key);
+    return value == null ? null : Long.parseLong(value);
+  }
+
+  public Float getFloat(String key) {
+    String value = attributes.get(key);
+    return value == null ? null : Float.parseFloat(value);
+  }
+
+  public Double getDouble(String key) {
+    String value = attributes.get(key);
+    return value == null ? null : Double.parseDouble(value);
+  }
+
+  public String getStringByKeys(String... keys) {
     for (final String key : keys) {
       final String value = attributes.get(key);
       if (value != null) {
@@ -71,7 +100,7 @@ public class PipeParameters {
     return null;
   }
 
-  public Boolean getBoolean(String... keys) {
+  public Boolean getBooleanByKeys(String... keys) {
     for (final String key : keys) {
       final String value = attributes.get(key);
       if (value != null) {
@@ -81,7 +110,7 @@ public class PipeParameters {
     return null;
   }
 
-  public Integer getInt(String... keys) {
+  public Integer getIntByKeys(String... keys) {
     for (final String key : keys) {
       final String value = attributes.get(key);
       if (value != null) {
@@ -91,7 +120,7 @@ public class PipeParameters {
     return null;
   }
 
-  public Long getLong(String... keys) {
+  public Long getLongByKeys(String... keys) {
     for (final String key : keys) {
       final String value = attributes.get(key);
       if (value != null) {
@@ -101,7 +130,7 @@ public class PipeParameters {
     return null;
   }
 
-  public Float getFloat(String... keys) {
+  public Float getFloatByKeys(String... keys) {
     for (final String key : keys) {
       final String value = attributes.get(key);
       if (value != null) {
@@ -111,7 +140,7 @@ public class PipeParameters {
     return null;
   }
 
-  public Double getDouble(String... keys) {
+  public Double getDoubleByKeys(String... keys) {
     for (final String key : keys) {
       final String value = attributes.get(key);
       if (value != null) {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipePluginInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipePluginInfo.java
@@ -161,7 +161,7 @@ public class PipePluginInfo implements SnapshotProcessor {
       throw new PipeException(exceptionMessage);
     }
     final String connectorPluginName =
-        connectorParameters.getString(
+        connectorParameters.getStringByKeys(
             PipeConnectorConstant.CONNECTOR_KEY, PipeConnectorConstant.SINK_KEY);
     if (!pipePluginMetaKeeper.containsPipePlugin(connectorPluginName)) {
       final String exceptionMessage =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/plugin/PipePluginAgent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/plugin/PipePluginAgent.java
@@ -226,7 +226,7 @@ public class PipePluginAgent {
     }
     return (PipeConnector)
         reflect(
-            connectorParameters.getString(
+            connectorParameters.getStringByKeys(
                 PipeConnectorConstant.CONNECTOR_KEY, PipeConnectorConstant.SINK_KEY));
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/config/constant/PipeExtractorConstant.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/config/constant/PipeExtractorConstant.java
@@ -53,6 +53,8 @@ public class PipeExtractorConstant {
   public static final String EXTRACTOR_REALTIME_MODE_FILE_VALUE = "file";
   public static final String EXTRACTOR_REALTIME_MODE_LOG_VALUE = "log";
   public static final String EXTRACTOR_REALTIME_MODE_FORCED_LOG_VALUE = "forced-log";
+  public static final String EXTRACTOR_REALTIME_MODE_STREAM_MODE_VALUE = "stream";
+  public static final String EXTRACTOR_REALTIME_MODE_BATCH_MODE_VALUE = "batch";
 
   private PipeExtractorConstant() {
     throw new IllegalStateException("Utility class");

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/IoTDBConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/IoTDBConnector.java
@@ -99,27 +99,28 @@ public abstract class IoTDBConnector implements PipeConnector {
         && parameters.hasAttribute(CONNECTOR_IOTDB_PORT_KEY)) {
       givenNodeUrls.add(
           new TEndPoint(
-              parameters.getString(CONNECTOR_IOTDB_IP_KEY),
-              parameters.getInt(CONNECTOR_IOTDB_PORT_KEY)));
+              parameters.getStringByKeys(CONNECTOR_IOTDB_IP_KEY),
+              parameters.getIntByKeys(CONNECTOR_IOTDB_PORT_KEY)));
     }
 
     if (parameters.hasAttribute(SINK_IOTDB_IP_KEY)
         && parameters.hasAttribute(SINK_IOTDB_PORT_KEY)) {
       givenNodeUrls.add(
           new TEndPoint(
-              parameters.getString(SINK_IOTDB_IP_KEY), parameters.getInt(SINK_IOTDB_PORT_KEY)));
+              parameters.getStringByKeys(SINK_IOTDB_IP_KEY),
+              parameters.getIntByKeys(SINK_IOTDB_PORT_KEY)));
     }
 
     if (parameters.hasAttribute(CONNECTOR_IOTDB_NODE_URLS_KEY)) {
       givenNodeUrls.addAll(
           SessionUtils.parseSeedNodeUrls(
-              Arrays.asList(parameters.getString(CONNECTOR_IOTDB_NODE_URLS_KEY).split(","))));
+              Arrays.asList(parameters.getStringByKeys(CONNECTOR_IOTDB_NODE_URLS_KEY).split(","))));
     }
 
     if (parameters.hasAttribute(SINK_IOTDB_NODE_URLS_KEY)) {
       givenNodeUrls.addAll(
           SessionUtils.parseSeedNodeUrls(
-              Arrays.asList(parameters.getString(SINK_IOTDB_NODE_URLS_KEY).split(","))));
+              Arrays.asList(parameters.getStringByKeys(SINK_IOTDB_NODE_URLS_KEY).split(","))));
     }
 
     return givenNodeUrls;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
@@ -140,15 +140,16 @@ public class IoTDBLegacyPipeConnector implements PipeConnector {
         && parameters.hasAttribute(CONNECTOR_IOTDB_PORT_KEY)) {
       givenNodeUrls.add(
           new TEndPoint(
-              parameters.getString(CONNECTOR_IOTDB_IP_KEY),
-              parameters.getInt(CONNECTOR_IOTDB_PORT_KEY)));
+              parameters.getStringByKeys(CONNECTOR_IOTDB_IP_KEY),
+              parameters.getIntByKeys(CONNECTOR_IOTDB_PORT_KEY)));
     }
 
     if (parameters.hasAttribute(SINK_IOTDB_IP_KEY)
         && parameters.hasAttribute(SINK_IOTDB_PORT_KEY)) {
       givenNodeUrls.add(
           new TEndPoint(
-              parameters.getString(SINK_IOTDB_IP_KEY), parameters.getInt(SINK_IOTDB_PORT_KEY)));
+              parameters.getStringByKeys(SINK_IOTDB_IP_KEY),
+              parameters.getIntByKeys(SINK_IOTDB_PORT_KEY)));
     }
 
     return givenNodeUrls;
@@ -157,8 +158,8 @@ public class IoTDBLegacyPipeConnector implements PipeConnector {
   @Override
   public void customize(PipeParameters parameters, PipeConnectorRuntimeConfiguration configuration)
       throws Exception {
-    ipAddress = parameters.getString(CONNECTOR_IOTDB_IP_KEY, SINK_IOTDB_IP_KEY);
-    port = parameters.getInt(CONNECTOR_IOTDB_PORT_KEY, SINK_IOTDB_PORT_KEY);
+    ipAddress = parameters.getStringByKeys(CONNECTOR_IOTDB_IP_KEY, SINK_IOTDB_IP_KEY);
+    port = parameters.getIntByKeys(CONNECTOR_IOTDB_PORT_KEY, SINK_IOTDB_PORT_KEY);
 
     user =
         parameters.getStringOrDefault(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/IoTDBDataRegionExtractor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/IoTDBDataRegionExtractor.java
@@ -154,7 +154,7 @@ public class IoTDBDataRegionExtractor implements PipeExtractor {
       return;
     }
 
-    switch (parameters.getString(EXTRACTOR_REALTIME_MODE_KEY, SOURCE_REALTIME_MODE_KEY)) {
+    switch (parameters.getStringByKeys(EXTRACTOR_REALTIME_MODE_KEY, SOURCE_REALTIME_MODE_KEY)) {
       case EXTRACTOR_REALTIME_MODE_FILE_VALUE:
       case EXTRACTOR_REALTIME_MODE_BATCH_MODE_VALUE:
         realtimeExtractor = new PipeRealtimeDataRegionTsFileExtractor();
@@ -172,7 +172,7 @@ public class IoTDBDataRegionExtractor implements PipeExtractor {
         if (LOGGER.isWarnEnabled()) {
           LOGGER.warn(
               "Unsupported extractor realtime mode: {}, create a hybrid extractor.",
-              parameters.getString(EXTRACTOR_REALTIME_MODE_KEY, SOURCE_REALTIME_MODE_KEY));
+              parameters.getStringByKeys(EXTRACTOR_REALTIME_MODE_KEY, SOURCE_REALTIME_MODE_KEY));
         }
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/IoTDBDataRegionExtractor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/IoTDBDataRegionExtractor.java
@@ -52,11 +52,13 @@ import static org.apache.iotdb.db.pipe.config.constant.PipeExtractorConstant.EXT
 import static org.apache.iotdb.db.pipe.config.constant.PipeExtractorConstant.EXTRACTOR_HISTORY_ENABLE_KEY;
 import static org.apache.iotdb.db.pipe.config.constant.PipeExtractorConstant.EXTRACTOR_REALTIME_ENABLE_DEFAULT_VALUE;
 import static org.apache.iotdb.db.pipe.config.constant.PipeExtractorConstant.EXTRACTOR_REALTIME_ENABLE_KEY;
+import static org.apache.iotdb.db.pipe.config.constant.PipeExtractorConstant.EXTRACTOR_REALTIME_MODE_BATCH_MODE_VALUE;
 import static org.apache.iotdb.db.pipe.config.constant.PipeExtractorConstant.EXTRACTOR_REALTIME_MODE_FILE_VALUE;
 import static org.apache.iotdb.db.pipe.config.constant.PipeExtractorConstant.EXTRACTOR_REALTIME_MODE_FORCED_LOG_VALUE;
 import static org.apache.iotdb.db.pipe.config.constant.PipeExtractorConstant.EXTRACTOR_REALTIME_MODE_HYBRID_VALUE;
 import static org.apache.iotdb.db.pipe.config.constant.PipeExtractorConstant.EXTRACTOR_REALTIME_MODE_KEY;
 import static org.apache.iotdb.db.pipe.config.constant.PipeExtractorConstant.EXTRACTOR_REALTIME_MODE_LOG_VALUE;
+import static org.apache.iotdb.db.pipe.config.constant.PipeExtractorConstant.EXTRACTOR_REALTIME_MODE_STREAM_MODE_VALUE;
 import static org.apache.iotdb.db.pipe.config.constant.PipeExtractorConstant.SOURCE_HISTORY_ENABLE_KEY;
 import static org.apache.iotdb.db.pipe.config.constant.PipeExtractorConstant.SOURCE_REALTIME_ENABLE_KEY;
 import static org.apache.iotdb.db.pipe.config.constant.PipeExtractorConstant.SOURCE_REALTIME_MODE_KEY;
@@ -117,7 +119,9 @@ public class IoTDBDataRegionExtractor implements PipeExtractor {
           EXTRACTOR_REALTIME_MODE_FILE_VALUE,
           EXTRACTOR_REALTIME_MODE_HYBRID_VALUE,
           EXTRACTOR_REALTIME_MODE_LOG_VALUE,
-          EXTRACTOR_REALTIME_MODE_FORCED_LOG_VALUE);
+          EXTRACTOR_REALTIME_MODE_FORCED_LOG_VALUE,
+          EXTRACTOR_REALTIME_MODE_STREAM_MODE_VALUE,
+          EXTRACTOR_REALTIME_MODE_BATCH_MODE_VALUE);
     }
 
     constructHistoricalExtractor();
@@ -152,10 +156,12 @@ public class IoTDBDataRegionExtractor implements PipeExtractor {
 
     switch (parameters.getString(EXTRACTOR_REALTIME_MODE_KEY, SOURCE_REALTIME_MODE_KEY)) {
       case EXTRACTOR_REALTIME_MODE_FILE_VALUE:
+      case EXTRACTOR_REALTIME_MODE_BATCH_MODE_VALUE:
         realtimeExtractor = new PipeRealtimeDataRegionTsFileExtractor();
         break;
       case EXTRACTOR_REALTIME_MODE_HYBRID_VALUE:
       case EXTRACTOR_REALTIME_MODE_LOG_VALUE:
+      case EXTRACTOR_REALTIME_MODE_STREAM_MODE_VALUE:
         realtimeExtractor = new PipeRealtimeDataRegionHybridExtractor();
         break;
       case EXTRACTOR_REALTIME_MODE_FORCED_LOG_VALUE:

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/historical/PipeHistoricalDataRegionTsFileExtractor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/historical/PipeHistoricalDataRegionTsFileExtractor.java
@@ -132,7 +132,7 @@ public class PipeHistoricalDataRegionTsFileExtractor implements PipeHistoricalDa
                 && parameters.hasAnyAttributes(
                     EXTRACTOR_HISTORY_START_TIME_KEY, SOURCE_HISTORY_START_TIME_KEY)
             ? DateTimeUtils.convertDatetimeStrToLong(
-                parameters.getString(
+                parameters.getStringByKeys(
                     EXTRACTOR_HISTORY_START_TIME_KEY, SOURCE_HISTORY_START_TIME_KEY),
                 ZoneId.systemDefault())
             : Long.MIN_VALUE;
@@ -141,7 +141,8 @@ public class PipeHistoricalDataRegionTsFileExtractor implements PipeHistoricalDa
                 && parameters.hasAnyAttributes(
                     EXTRACTOR_HISTORY_END_TIME_KEY, SOURCE_HISTORY_END_TIME_KEY)
             ? DateTimeUtils.convertDatetimeStrToLong(
-                parameters.getString(EXTRACTOR_HISTORY_END_TIME_KEY, SOURCE_HISTORY_END_TIME_KEY),
+                parameters.getStringByKeys(
+                    EXTRACTOR_HISTORY_END_TIME_KEY, SOURCE_HISTORY_END_TIME_KEY),
                 ZoneId.systemDefault())
             : Long.MAX_VALUE;
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/metadata/ShowPipePluginsTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/metadata/ShowPipePluginsTask.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.queryengine.plan.execution.config.metadata;
 
+import org.apache.iotdb.commons.pipe.plugin.builtin.BuiltinPipePlugin;
 import org.apache.iotdb.commons.pipe.plugin.meta.PipePluginMeta;
 import org.apache.iotdb.db.queryengine.common.header.ColumnHeader;
 import org.apache.iotdb.db.queryengine.common.header.ColumnHeaderConstant;
@@ -70,6 +71,11 @@ public class ShowPipePluginsTask implements IConfigTask {
             .collect(Collectors.toList());
     final TsBlockBuilder builder = new TsBlockBuilder(outputDataTypes);
     for (final PipePluginMeta pipePluginMeta : pipePluginMetaList) {
+      // some pipe plugins are not for user's direct use
+      if (BuiltinPipePlugin.SHOW_PIPE_PLUGINS_BLACKLIST.contains(pipePluginMeta.getPluginName())) {
+        continue;
+      }
+
       builder.getTimeColumnBuilder().writeLong(0L);
       builder.getColumnBuilder(0).writeBinary(BytesUtils.valueOf(pipePluginMeta.getPluginName()));
       builder

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/builtin/BuiltinPipePlugin.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/builtin/BuiltinPipePlugin.java
@@ -30,6 +30,9 @@ import org.apache.iotdb.commons.pipe.plugin.builtin.connector.WebSocketConnector
 import org.apache.iotdb.commons.pipe.plugin.builtin.extractor.IoTDBExtractor;
 import org.apache.iotdb.commons.pipe.plugin.builtin.processor.DoNothingProcessor;
 
+import java.util.HashSet;
+import java.util.Set;
+
 public enum BuiltinPipePlugin {
 
   // extractors
@@ -80,5 +83,25 @@ public enum BuiltinPipePlugin {
 
   public String getClassName() {
     return className;
+  }
+
+  public static final Set<String> SHOW_PIPE_PLUGINS_BLACKLIST = new HashSet<>();
+
+  static {
+    SHOW_PIPE_PLUGINS_BLACKLIST.add(IOTDB_EXTRACTOR.getPipePluginName());
+
+    SHOW_PIPE_PLUGINS_BLACKLIST.add(DO_NOTHING_CONNECTOR.getPipePluginName());
+    SHOW_PIPE_PLUGINS_BLACKLIST.add(IOTDB_THRIFT_CONNECTOR.getPipePluginName());
+    SHOW_PIPE_PLUGINS_BLACKLIST.add(IOTDB_THRIFT_SYNC_CONNECTOR.getPipePluginName());
+    SHOW_PIPE_PLUGINS_BLACKLIST.add(IOTDB_THRIFT_ASYNC_CONNECTOR.getPipePluginName());
+    SHOW_PIPE_PLUGINS_BLACKLIST.add(IOTDB_LEGACY_PIPE_CONNECTOR.getPipePluginName());
+    SHOW_PIPE_PLUGINS_BLACKLIST.add(IOTDB_AIR_GAP_CONNECTOR.getPipePluginName());
+    SHOW_PIPE_PLUGINS_BLACKLIST.add(WEBSOCKET_CONNECTOR.getPipePluginName());
+    SHOW_PIPE_PLUGINS_BLACKLIST.add(OPC_UA_CONNECTOR.getPipePluginName());
+
+    SHOW_PIPE_PLUGINS_BLACKLIST.add(IOTDB_THRIFT_SYNC_SINK.getPipePluginName());
+    SHOW_PIPE_PLUGINS_BLACKLIST.add(IOTDB_THRIFT_ASYNC_SINK.getPipePluginName());
+    SHOW_PIPE_PLUGINS_BLACKLIST.add(IOTDB_LEGACY_PIPE_SINK.getPipePluginName());
+    SHOW_PIPE_PLUGINS_BLACKLIST.add(WEBSOCKET_SINK.getPipePluginName());
   }
 }


### PR DESCRIPTION
As title, this PR includes 3 changes:

* Pipe: add stream & batch options for source.realtime.mode
  * 'stream' mode is equals to 'hybrid' mode
  * 'batch' mode is equals to 'file' mode

* Pipe: remove some pipe plugins from show pipe plugins' dataset
  * some pipe plugins are not for public use

* Pipe: Make pipe-api compatible with the v1.2.x releases
  * add methods (getString, getBoolean, getInt, getLong, getFloat, getDouble) for compatibility