### PR TITLE
Pipe: preliminary SSL support for pipe connector (sink) sync client

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/config/constant/PipeConnectorConstant.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/config/constant/PipeConnectorConstant.java
@@ -38,6 +38,10 @@ public class PipeConnectorConstant {
   public static final String CONNECTOR_IOTDB_NODE_URLS_KEY = "connector.node-urls";
   public static final String SINK_IOTDB_NODE_URLS_KEY = "sink.node-urls";
 
+  public static final String SINK_IOTDB_SSL_ENABLE_KEY = "sink.ssl.enable";
+  public static final String SINK_IOTDB_SSL_TRUST_STORE_PATH_KEY = "sink.ssl.trust-store-path";
+  public static final String SINK_IOTDB_SSL_TRUST_STORE_PWD_KEY = "sink.ssl.trust-store-pwd";
+
   public static final String CONNECTOR_IOTDB_PARALLEL_TASKS_KEY = "connector.parallel.tasks";
   public static final String SINK_IOTDB_PARALLEL_TASKS_KEY = "sink.parallel.tasks";
   public static final int CONNECTOR_IOTDB_PARALLEL_TASKS_DEFAULT_VALUE =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
@@ -141,7 +141,7 @@ public class IoTDBLegacyPipeConnector implements PipeConnector {
         .validate(
             args -> !((boolean) args[0]) || ((boolean) args[1] && (boolean) args[2]),
             String.format(
-                "When %s is specified, %s and %s must be specified",
+                "When %s is specified to true, %s and %s must be specified",
                 SINK_IOTDB_SSL_ENABLE_KEY,
                 SINK_IOTDB_SSL_TRUST_STORE_PATH_KEY,
                 SINK_IOTDB_SSL_TRUST_STORE_PWD_KEY),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBThriftAsyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBThriftAsyncConnector.java
@@ -73,6 +73,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.iotdb.db.pipe.config.constant.PipeConnectorConstant.CONNECTOR_IOTDB_BATCH_MODE_ENABLE_KEY;
 import static org.apache.iotdb.db.pipe.config.constant.PipeConnectorConstant.SINK_IOTDB_BATCH_MODE_ENABLE_KEY;
+import static org.apache.iotdb.db.pipe.config.constant.PipeConnectorConstant.SINK_IOTDB_SSL_ENABLE_KEY;
 
 public class IoTDBThriftAsyncConnector extends IoTDBConnector {
 
@@ -116,6 +117,12 @@ public class IoTDBThriftAsyncConnector extends IoTDBConnector {
   public void validate(PipeParameterValidator validator) throws Exception {
     super.validate(validator);
     retryConnector.validate(validator);
+
+    final PipeParameters parameters = validator.getParameters();
+    validator.validate(
+        useSSL -> !((boolean) useSSL),
+        "IoTDBThriftAsyncConnector does not support SSL transmission currently",
+        parameters.getBooleanOrDefault(SINK_IOTDB_SSL_ENABLE_KEY, false));
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
@@ -111,7 +111,7 @@ public class IoTDBThriftSyncConnector extends IoTDBConnector {
         .validate(
             args -> !((boolean) args[0]) || ((boolean) args[1] && (boolean) args[2]),
             String.format(
-                "When %s is specified, %s and %s must be specified",
+                "When %s is specified to true, %s and %s must be specified",
                 SINK_IOTDB_SSL_ENABLE_KEY,
                 SINK_IOTDB_SSL_TRUST_STORE_PATH_KEY,
                 SINK_IOTDB_SSL_TRUST_STORE_PWD_KEY),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnectorClient.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnectorClient.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.commons.pipe.config.PipeConfig;
 import org.apache.iotdb.rpc.RpcTransportFactory;
 import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
 
+import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 
 public class IoTDBThriftSyncConnectorClient extends IClientRPCService.Client
@@ -53,7 +54,10 @@ public class IoTDBThriftSyncConnectorClient extends IClientRPCService.Client
                         ipAddress,
                         port,
                         (int) PipeConfig.getInstance().getPipeConnectorTimeoutMs())));
-    getInputProtocol().getTransport().open();
+    TTransport transport = getInputProtocol().getTransport();
+    if (!transport.isOpen()) {
+      transport.open();
+    }
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnectorClient.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnectorClient.java
@@ -23,27 +23,36 @@ import org.apache.iotdb.commons.client.ThriftClient;
 import org.apache.iotdb.commons.client.property.ThriftClientProperty;
 import org.apache.iotdb.commons.pipe.config.PipeConfig;
 import org.apache.iotdb.rpc.RpcTransportFactory;
-import org.apache.iotdb.rpc.TConfigurationConst;
 import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
 
-import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransportException;
 
 public class IoTDBThriftSyncConnectorClient extends IClientRPCService.Client
     implements ThriftClient, AutoCloseable {
 
-  public IoTDBThriftSyncConnectorClient(ThriftClientProperty property, String ipAddress, int port)
+  public IoTDBThriftSyncConnectorClient(
+      ThriftClientProperty property,
+      String ipAddress,
+      int port,
+      boolean useSSL,
+      String trustStore,
+      String trustStorePwd)
       throws TTransportException {
     super(
         property
             .getProtocolFactory()
             .getProtocol(
-                RpcTransportFactory.INSTANCE.getTransport(
-                    new TSocket(
-                        TConfigurationConst.defaultTConfiguration,
+                useSSL
+                    ? RpcTransportFactory.INSTANCE.getTransport(
                         ipAddress,
                         port,
-                        (int) PipeConfig.getInstance().getPipeConnectorTimeoutMs()))));
+                        (int) PipeConfig.getInstance().getPipeConnectorTimeoutMs(),
+                        trustStore,
+                        trustStorePwd)
+                    : RpcTransportFactory.INSTANCE.getTransport(
+                        ipAddress,
+                        port,
+                        (int) PipeConfig.getInstance().getPipeConnectorTimeoutMs())));
     getInputProtocol().getTransport().open();
   }
 


### PR DESCRIPTION
## Description

THIS PR is a follow-up in Pipe for https://github.com/apache/iotdb/pull/11218.

When using iotdb-thrift-sync-connector and iotdb-legacy-pipe-connector, now can configure the sender-side SSL related settings in parameters.

| Key                      | Value                                                        | Value Range       | Required or Optional with Default |
| ------------------------ | ------------------------------------------------------------ | ----------------- | --------------------------------- |
| sink.ssl.enable          | Whether the data service of one of the DN in the target IoTDB supports SSL. | Boolean: true, false | Optional: Default is false         |
| sink.ssl.trust-store-path | The path to the certificate of the Trust Store required for SSL when connecting to the data service of one of the DN in the target IoTDB. | String            | Optional: Required if sink.ssl.enable is true |
| sink.ssl.trust-store-pwd  | The password for the certificate of the Trust Store required for SSL when connecting to the data service of one of the DN in the target IoTDB. | String            | Optional: Required if sink.ssl.enable is true |

For example:

```sql
create pipe a2b
with connector (
    'connector'='iotdb-thrift-sync-connector',
    'sink.ip'='127.0.0.1',
    'sink.port'='6668',
    'sink.ssl.enable'='true',
    'sink.ssl.trust-store-path'='/home/vgalaxy/.truststore',
    'sink.ssl.trust-store-pwd'='123456',
);
```

If the Pipe receiver is configured with SSL, but the sender is not, the sender will throw an error.

```text
2023-11-02 20:54:53,300 [pool-30-IoTDB-DataNodeInternalRPC-Processor-2] WARN  o.a.i.d.p.a.t.PipeTaskAgent:216 - Failed to handle pipe meta changes for a2b 
org.apache.iotdb.pipe.api.exception.PipeException: Failed to construct PipeConnector, because of All target servers [TEndPoint(ip:127.0.0.1, port:6668)] are not available.
        at org.apache.iotdb.db.pipe.task.subtask.connector.PipeConnectorSubtaskManager.register(PipeConnectorSubtaskManager.java:105)
        at org.apache.iotdb.db.pipe.task.stage.PipeTaskConnectorStage.<init>(PipeTaskConnectorStage.java:42)
        at org.apache.iotdb.db.pipe.task.PipeTaskBuilder.build(PipeTaskBuilder.java:58)
        at org.apache.iotdb.db.pipe.agent.task.PipeTaskAgent.createPipeTask(PipeTaskAgent.java:827)
        at org.apache.iotdb.db.pipe.agent.task.PipeTaskAgent.executeSinglePipeRuntimeMetaChanges(PipeTaskAgent.java:301)
        at org.apache.iotdb.db.pipe.agent.task.PipeTaskAgent.executeSinglePipeMetaChanges(PipeTaskAgent.java:275)
        at org.apache.iotdb.db.pipe.agent.task.PipeTaskAgent.handlePipeMetaChangesInternal(PipeTaskAgent.java:210)
        at org.apache.iotdb.db.pipe.agent.task.PipeTaskAgent.handlePipeMetaChanges(PipeTaskAgent.java:191)
        at org.apache.iotdb.db.protocol.thrift.impl.DataNodeInternalRPCServiceImpl.pushPipeMeta(DataNodeInternalRPCServiceImpl.java:943)
        at org.apache.iotdb.mpp.rpc.thrift.IDataNodeRPCService$Processor$pushPipeMeta.getResult(IDataNodeRPCService.java:5746)
        at org.apache.iotdb.mpp.rpc.thrift.IDataNodeRPCService$Processor$pushPipeMeta.getResult(IDataNodeRPCService.java:5726)
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38)
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:38)
        at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:248)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: org.apache.iotdb.pipe.api.exception.PipeConnectionException: All target servers [TEndPoint(ip:127.0.0.1, port:6668)] are not available.
        at org.apache.iotdb.db.pipe.connector.protocol.thrift.sync.IoTDBThriftSyncConnector.handshake(IoTDBThriftSyncConnector.java:211)
        at org.apache.iotdb.db.pipe.task.subtask.connector.PipeConnectorSubtaskManager.register(PipeConnectorSubtaskManager.java:102)
        ... 16 common frames omitted
```

**Known limitations:**

1. For all `nodeUrls` (`sink.ip:sink.port` ∪ `sink.node-urls`), their SSL configuration is shared.
2. Due to the fact that Thrift does not natively support SSL for async clients, it's not ready to configure SSL in iotdb-thrift-async-connector (iotdb-thrift-connector). Doing so will result in an error.

```text
2023-11-02 20:43:32,837 [pool-30-IoTDB-DataNodeInternalRPC-Processor-2] WARN  o.a.i.d.p.a.t.PipeTaskAgent:216 - Failed to handle pipe meta changes for a2b 
org.apache.iotdb.pipe.api.exception.PipeException: Failed to construct PipeConnector, because of IoTDBThriftAsyncConnector does not support SSL transmission currently
        at org.apache.iotdb.db.pipe.task.subtask.connector.PipeConnectorSubtaskManager.register(PipeConnectorSubtaskManager.java:105)
        at org.apache.iotdb.db.pipe.task.stage.PipeTaskConnectorStage.<init>(PipeTaskConnectorStage.java:42)
        at org.apache.iotdb.db.pipe.task.PipeTaskBuilder.build(PipeTaskBuilder.java:58)
        at org.apache.iotdb.db.pipe.agent.task.PipeTaskAgent.createPipeTask(PipeTaskAgent.java:827)
        at org.apache.iotdb.db.pipe.agent.task.PipeTaskAgent.executeSinglePipeRuntimeMetaChanges(PipeTaskAgent.java:301)
        at org.apache.iotdb.db.pipe.agent.task.PipeTaskAgent.executeSinglePipeMetaChanges(PipeTaskAgent.java:275)
        at org.apache.iotdb.db.pipe.agent.task.PipeTaskAgent.handlePipeMetaChangesInternal(PipeTaskAgent.java:210)
        at org.apache.iotdb.db.pipe.agent.task.PipeTaskAgent.handlePipeMetaChanges(PipeTaskAgent.java:191)
        at org.apache.iotdb.db.protocol.thrift.impl.DataNodeInternalRPCServiceImpl.pushPipeMeta(DataNodeInternalRPCServiceImpl.java:943)
        at org.apache.iotdb.mpp.rpc.thrift.IDataNodeRPCService$Processor$pushPipeMeta.getResult(IDataNodeRPCService.java:5746)
        at org.apache.iotdb.mpp.rpc.thrift.IDataNodeRPCService$Processor$pushPipeMeta.getResult(IDataNodeRPCService.java:5726)
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38)
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:38)
        at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:248)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: org.apache.iotdb.pipe.api.exception.PipeParameterNotValidException: IoTDBThriftAsyncConnector does not support SSL transmission currently
        at org.apache.iotdb.pipe.api.customizer.parameter.PipeParameterValidator.validate(PipeParameterValidator.java:93)
        at org.apache.iotdb.db.pipe.connector.protocol.thrift.async.IoTDBThriftAsyncConnector.validate(IoTDBThriftAsyncConnector.java:122)
        at org.apache.iotdb.db.pipe.task.subtask.connector.PipeConnectorSubtaskManager.register(PipeConnectorSubtaskManager.java:99)
        ... 16 common frames omitted
```

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [x] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
