### PR TITLE
Disable spotless for JDK 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2581,7 +2581,7 @@
                 <argLine>--add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</argLine>
             </properties>
         </profile>
-        <!--Current version of spotless cannot support JDK21-->
+        <!-- Current version of spotless cannot support JDK21 -->
         <profile>
             <id>.java-21-and-above</id>
             <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -2581,6 +2581,16 @@
                 <argLine>--add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</argLine>
             </properties>
         </profile>
+        <!--Current version of spotless cannot support JDK21-->
+        <profile>
+            <id>.java-21-and-above</id>
+            <activation>
+                <jdk>[21,)</jdk>
+            </activation>
+            <properties>
+                <spotless.skip>true</spotless.skip>
+            </properties>
+        </profile>
         <!-- Little helper profile that will disable running the cmake tests when the maven tests are being skipped -->
         <profile>
             <id>.skipTests</id>


### PR DESCRIPTION
## Description

The current version of spotless plugin we are using cannot run with JDK 21. Therefore I disabled the spotless check for JDK 21. 

After this fixing, we can run `mvn clean package -pl distribution -am -DskipTests` with JDK21 directly.  
![20d10792-c604-4cbc-9b6b-5b3867bb460d](https://github.com/apache/iotdb/assets/25913899/a125fd7f-1c20-4539-b846-595a22420efe)
