### PR TITLE
Fix the path of TsFileResource in unit test

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/LastFlushTimeMapTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/LastFlushTimeMapTest.java
@@ -143,43 +143,65 @@ public class LastFlushTimeMapTest {
 
   @Test
   public void testRecoverDeviceLastFlushedTimeWhenLargestTimestampInUnSeqSpace() {
+    String seqDirPath =
+        TestConstant.BASE_OUTPUT_PATH
+            + "data"
+            + File.separator
+            + "sequence"
+            + File.separator
+            + "root.testsg"
+            + File.separator
+            + "0"
+            + File.separator
+            + "0";
+    String unseqDirPath =
+        TestConstant.BASE_OUTPUT_PATH
+            + "data"
+            + File.separator
+            + "unsequence"
+            + File.separator
+            + "root.testsg"
+            + File.separator
+            + "0"
+            + File.separator
+            + "0";
     String device = "root.testsg.d1";
-    File seqResourceFile1 = new File("1-1-0-0.tsfile.resource");
+    File seqResourceFile1 = new File(seqDirPath + File.separator + "1-1-0-0.tsfile.resource");
     TsFileResource seqResource1 = new TsFileResource();
     seqResource1.setFile(seqResourceFile1);
     seqResource1.setTimeIndex(new DeviceTimeIndex());
     seqResource1.updateStartTime(device, 10);
     seqResource1.updateEndTime(device, 20);
 
-    File seqResourceFile2 = new File("2-2-0-0.tsfile.resource");
+    File seqResourceFile2 = new File(seqDirPath + File.separator + "2-2-0-0.tsfile.resource");
     TsFileResource seqResource2 = new TsFileResource();
     seqResource2.setTimeIndex(new DeviceTimeIndex());
     seqResource2.setFile(seqResourceFile2);
     seqResource2.updateStartTime(device, 30);
     seqResource2.updateEndTime(device, 40);
 
-    File seqResourceFile3 = new File("3-3-0-0.tsfile.resource");
+    File seqResourceFile3 = new File(seqDirPath + File.separator + "3-3-0-0.tsfile.resource");
     TsFileResource seqResource3 = new TsFileResource();
     seqResource3.setTimeIndex(new DeviceTimeIndex());
     seqResource3.setFile(seqResourceFile3);
     seqResource3.updateStartTime(device, 50);
     seqResource3.updateEndTime(device, 60);
 
-    File unseqResourceFile1 = new File("4-4-0-0.tsfile.resource");
+    File unseqResourceFile1 = new File(unseqDirPath + File.separator + "4-4-0-0.tsfile.resource");
     TsFileResource unseqResource1 = new TsFileResource();
     unseqResource1.setTimeIndex(new DeviceTimeIndex());
     unseqResource1.setFile(unseqResourceFile1);
     unseqResource1.updateStartTime(device, 1);
     unseqResource1.updateEndTime(device, 100);
 
-    File unseqResourceFile2 = new File("5-5-0-0.tsfile.resource");
+    File unseqResourceFile2 = new File(unseqDirPath + File.separator + "5-5-0-0.tsfile.resource");
     TsFileResource unseqResource2 = new TsFileResource();
     unseqResource2.setTimeIndex(new DeviceTimeIndex());
     unseqResource2.setFile(unseqResourceFile2);
     unseqResource2.updateStartTime(device, 1);
     unseqResource2.updateEndTime(device, 10);
 
-    File unseqResourceFile3 = new File("6-6-0-0.tsfile.resource");
+    File unseqResourceFile3 = new File(unseqDirPath + File.separator + "6-6-0-0.tsfile.resource");
     TsFileResource unseqResource3 = new TsFileResource();
     unseqResource3.setTimeIndex(new DeviceTimeIndex());
     unseqResource3.setFile(unseqResourceFile3);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/AbstractCompactionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/AbstractCompactionTest.java
@@ -154,7 +154,7 @@ public class AbstractCompactionTest {
               + File.separator
               + "0");
 
-  protected static Map<Long, Pair<File, File>> registeredTimePartitionDirs = new HashMap<>();
+  protected Map<Long, Pair<File, File>> registeredTimePartitionDirs = new HashMap<>();
 
   private int fileVersion = 0;
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/AbstractCompactionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/AbstractCompactionTest.java
@@ -672,6 +672,9 @@ public class AbstractCompactionTest {
 
   protected TsFileResource createEmptyFileAndResourceWithName(
       String fileName, long timePartition, boolean isSeq) {
+    if (!registeredTimePartitionDirs.containsKey(timePartition)) {
+      createTimePartitionDirIfNotExist(timePartition);
+    }
     String filePath;
     if (isSeq) {
       filePath =

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/cross/InsertionCrossSpaceCompactionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/cross/InsertionCrossSpaceCompactionTest.java
@@ -419,11 +419,13 @@ public class InsertionCrossSpaceCompactionTest extends AbstractCompactionTest {
         generateSingleNonAlignedSeriesFileWithDevices(
             "3-3-0-0.tsfile", new String[] {"d1"}, new TimeRange[] {new TimeRange(6, 9)}, false);
     unseqResource2.setStatusForTest(TsFileResourceStatus.NORMAL);
+    createTimePartitionDirIfNotExist(2808L);
     TsFileResource unseqResource3 =
-        generateSingleNonAlignedSeriesFileWithDevices(
+        generateSingleNonAlignedSeriesFileWithDevicesWithTimePartition(
             "4-4-0-0.tsfile",
             new String[] {"d1"},
             new TimeRange[] {new TimeRange(1698301490306L, 1698301490406L)},
+            2808L,
             false);
     unseqResource3.setStatusForTest(TsFileResourceStatus.NORMAL);
     unseqResources.add(unseqResource1);
@@ -458,6 +460,24 @@ public class InsertionCrossSpaceCompactionTest extends AbstractCompactionTest {
   public TsFileResource generateSingleNonAlignedSeriesFileWithDevices(
       String fileName, String[] devices, TimeRange[] timeRanges, boolean seq) throws IOException {
     TsFileResource seqResource1 = createEmptyFileAndResourceWithName(fileName, seq, 0);
+    CompactionTestFileWriter writer1 = new CompactionTestFileWriter(seqResource1);
+    for (int i = 0; i < devices.length; i++) {
+      String device = devices[i];
+      TimeRange timeRange = timeRanges[i];
+      writer1.startChunkGroup(device);
+      writer1.generateSimpleNonAlignedSeriesToCurrentDevice(
+          "s1", new TimeRange[] {timeRange}, TSEncoding.PLAIN, CompressionType.LZ4);
+      writer1.endChunkGroup();
+    }
+    writer1.endFile();
+    writer1.close();
+    return seqResource1;
+  }
+
+  public TsFileResource generateSingleNonAlignedSeriesFileWithDevicesWithTimePartition(
+      String fileName, String[] devices, TimeRange[] timeRanges, long timePartition, boolean seq)
+      throws IOException {
+    TsFileResource seqResource1 = createEmptyFileAndResourceWithName(fileName, timePartition, seq);
     CompactionTestFileWriter writer1 = new CompactionTestFileWriter(seqResource1);
     for (int i = 0; i < devices.length; i++) {
       String device = devices[i];


### PR DESCRIPTION
## Description
Before this change, some unit tests use a simple path which only contains the file name as the path of TsFileResoruce. Another in process PR will analyze TsFileResource path to decode `DataRegion`, `Database` and so on. It needs a whole path and will throw exception when using simple path in UTs.

This PR fix it and replace the simple path with a whole path when creating TsFileResource
