### PR TITLE
[IOTDB-6238] Fix delete timeSeries / deactivate template procedure rollback logic

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/DeactivateTemplateProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/DeactivateTemplateProcedure.java
@@ -108,11 +108,11 @@ public class DeactivateTemplateProcedure
             return Flow.NO_MORE_STATE;
           }
         case CLEAN_DATANODE_SCHEMA_CACHE:
-          LOGGER.info("Invalidate cache of template timeseries {}", requestMessage);
+          LOGGER.info("Invalidate cache of template timeSeries {}", requestMessage);
           invalidateCache(env);
           break;
         case DELETE_DATA:
-          LOGGER.info("Delete data of template timeseries {}", requestMessage);
+          LOGGER.info("Delete data of template timeSeries {}", requestMessage);
           deleteData(env);
           break;
         case DEACTIVATE_TEMPLATE:
@@ -120,19 +120,17 @@ public class DeactivateTemplateProcedure
           deactivateTemplate(env);
           return Flow.NO_MORE_STATE;
         default:
-          setFailure(new ProcedureException("Unrecognized state " + state.toString()));
+          setFailure(new ProcedureException("Unrecognized state " + state));
           return Flow.NO_MORE_STATE;
       }
       return Flow.HAS_MORE_STATE;
     } finally {
       LOGGER.info(
-          String.format(
-              "DeactivateTemplate-[%s] costs %sms",
-              state.toString(), (System.currentTimeMillis() - startTime)));
+          "DeactivateTemplate-[{}] costs {}ms", state, (System.currentTimeMillis() - startTime));
     }
   }
 
-  // return the total num of timeseries in schema black list
+  // return the total num of timeSeries in schema black list
   private long constructBlackList(ConfigNodeProcedureEnv env) {
     Map<TConsensusGroupId, TRegionReplicaSet> targetSchemaRegionGroup =
         env.getConfigManager().getRelatedSchemaRegionGroup(timeSeriesPatternTree);
@@ -203,7 +201,7 @@ public class DeactivateTemplateProcedure
         // all dataNodes must clear the related schema cache
         if (status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
           LOGGER.error(
-              "Failed to invalidate schema cache of template timeseries {}", requestMessage);
+              "Failed to invalidate schema cache of template timeSeries {}", requestMessage);
           setFailure(
               new ProcedureException(new MetadataException("Invalidate schema cache failed")));
           return;
@@ -218,7 +216,7 @@ public class DeactivateTemplateProcedure
     Map<TConsensusGroupId, TRegionReplicaSet> relatedDataRegionGroup =
         env.getConfigManager().getRelatedDataRegionGroup(timeSeriesPatternTree);
 
-    // target timeseries has no data or no target timeseres, return directly
+    // target timeSeries has no data or no target timeSeries, return directly
     if (!relatedDataRegionGroup.isEmpty() && !timeSeriesPatternTree.isEmpty()) {
       DeactivateTemplateRegionTaskExecutor<TDeleteDataForDeleteSchemaReq> deleteDataTask =
           new DeactivateTemplateRegionTaskExecutor<>(
@@ -251,17 +249,19 @@ public class DeactivateTemplateProcedure
   protected void rollbackState(
       ConfigNodeProcedureEnv env, DeactivateTemplateState deactivateTemplateState)
       throws IOException, InterruptedException, ProcedureException {
-    DeactivateTemplateRegionTaskExecutor<TRollbackSchemaBlackListWithTemplateReq>
-        rollbackStateTask =
-            new DeactivateTemplateRegionTaskExecutor<>(
-                "roll back schema black list",
-                env,
-                env.getConfigManager().getRelatedSchemaRegionGroup(timeSeriesPatternTree),
-                DataNodeRequestType.ROLLBACK_SCHEMA_BLACK_LIST_WITH_TEMPLATE,
-                ((dataNodeLocation, consensusGroupIdList) ->
-                    new TRollbackSchemaBlackListWithTemplateReq(
-                        consensusGroupIdList, dataNodeRequest)));
-    rollbackStateTask.execute();
+    if (deactivateTemplateState == DeactivateTemplateState.CONSTRUCT_BLACK_LIST) {
+      DeactivateTemplateRegionTaskExecutor<TRollbackSchemaBlackListWithTemplateReq>
+          rollbackStateTask =
+              new DeactivateTemplateRegionTaskExecutor<>(
+                  "roll back schema black list",
+                  env,
+                  env.getConfigManager().getRelatedSchemaRegionGroup(timeSeriesPatternTree),
+                  DataNodeRequestType.ROLLBACK_SCHEMA_BLACK_LIST_WITH_TEMPLATE,
+                  ((dataNodeLocation, consensusGroupIdList) ->
+                      new TRollbackSchemaBlackListWithTemplateReq(
+                          consensusGroupIdList, dataNodeRequest)));
+      rollbackStateTask.execute();
+    }
   }
 
   @Override

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/UnsetTemplateProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/UnsetTemplateProcedure.java
@@ -124,15 +124,12 @@ public class UnsetTemplateProcedure
           unsetTemplate(env);
           return Flow.NO_MORE_STATE;
         default:
-          setFailure(new ProcedureException("Unrecognized state " + state.toString()));
+          setFailure(new ProcedureException("Unrecognized state " + state));
           return Flow.NO_MORE_STATE;
       }
       return Flow.HAS_MORE_STATE;
     } finally {
-      LOGGER.info(
-          String.format(
-              "UnsetTemplate-[%s] costs %sms",
-              state.toString(), (System.currentTimeMillis() - startTime)));
+      LOGGER.info("UnsetTemplate-[{}] costs {}ms", state, (System.currentTimeMillis() - startTime));
     }
   }
 
@@ -280,7 +277,7 @@ public class UnsetTemplateProcedure
       return;
     }
     alreadyRollback = true;
-    ProcedureException rollbackException = null;
+    ProcedureException rollbackException;
     try {
       executeRollbackInvalidateCache(env);
       TSStatus status =


### PR DESCRIPTION
## [IOTDB-6238](https://issues.apache.org/jira/browse/IOTDB-6238)
Previously, delete timeSeries / deactivate template procedure will execute the same rollback logic each state, however only the first state requires that. This PR fixed this and did some refactor to improve the coding style.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
