### PR TITLE
Pipe: refined key set of tags for pipe metrics

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/IoTDBDataRegionExtractor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/IoTDBDataRegionExtractor.java
@@ -72,7 +72,10 @@ public class IoTDBDataRegionExtractor implements PipeExtractor {
   private PipeHistoricalDataRegionExtractor historicalExtractor;
   private PipeRealtimeDataRegionExtractor realtimeExtractor;
 
+  // Record these variables to provide corresponding value to tag key of monitoring metrics
   private String taskID;
+  private String pipeName;
+  private long creationTime;
   private int dataRegionId;
 
   public IoTDBDataRegionExtractor() {
@@ -182,8 +185,8 @@ public class IoTDBDataRegionExtractor implements PipeExtractor {
       throws Exception {
     dataRegionId =
         ((PipeTaskExtractorRuntimeEnvironment) configuration.getRuntimeEnvironment()).getRegionId();
-    String pipeName = configuration.getRuntimeEnvironment().getPipeName();
-    long creationTime = configuration.getRuntimeEnvironment().getCreationTime();
+    pipeName = configuration.getRuntimeEnvironment().getPipeName();
+    creationTime = configuration.getRuntimeEnvironment().getCreationTime();
     taskID = pipeName + "_" + dataRegionId + "_" + creationTime;
 
     historicalExtractor.customize(parameters, configuration);
@@ -282,8 +285,22 @@ public class IoTDBDataRegionExtractor implements PipeExtractor {
     PipeExtractorMetrics.getInstance().deregister(taskID);
   }
 
+  //////////////////////////// APIs provided for metric framework ////////////////////////////
+
   public String getTaskID() {
     return taskID;
+  }
+
+  public String getPipeName() {
+    return pipeName;
+  }
+
+  public int getDataRegionId() {
+    return dataRegionId;
+  }
+
+  public long getCreationTime() {
+    return creationTime;
   }
 
   public int getHistoricalTsFileInsertionEventCount() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/metric/PipeConnectorMetrics.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/metric/PipeConnectorMetrics.java
@@ -70,51 +70,79 @@ public class PipeConnectorMetrics implements IMetricSet {
   }
 
   private void createAutoGauge(String taskID) {
+    PipeConnectorSubtask connector = connectorMap.get(taskID);
+    // pending event count
     metricService.createAutoGauge(
         Metric.UNTRANSFERRED_TABLET_COUNT.toString(),
         MetricLevel.IMPORTANT,
-        connectorMap.get(taskID),
+        connector,
         PipeConnectorSubtask::getTabletInsertionEventCount,
         Tag.NAME.toString(),
-        taskID);
+        connector.getAttributeSortedString(),
+        Tag.INDEX.toString(),
+        String.valueOf(connector.getConnectorIndex()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(connector.getCreationTime()));
     metricService.createAutoGauge(
         Metric.UNTRANSFERRED_TSFILE_COUNT.toString(),
         MetricLevel.IMPORTANT,
-        connectorMap.get(taskID),
+        connector,
         PipeConnectorSubtask::getTsFileInsertionEventCount,
         Tag.NAME.toString(),
-        taskID);
+        connector.getAttributeSortedString(),
+        Tag.INDEX.toString(),
+        String.valueOf(connector.getConnectorIndex()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(connector.getCreationTime()));
     metricService.createAutoGauge(
         Metric.UNTRANSFERRED_HEARTBEAT_COUNT.toString(),
         MetricLevel.IMPORTANT,
-        connectorMap.get(taskID),
+        connector,
         PipeConnectorSubtask::getPipeHeartbeatEventCount,
         Tag.NAME.toString(),
-        taskID);
+        connector.getAttributeSortedString(),
+        Tag.INDEX.toString(),
+        String.valueOf(connector.getConnectorIndex()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(connector.getCreationTime()));
   }
 
   private void createRate(String taskID) {
+    PipeConnectorSubtask connector = connectorMap.get(taskID);
+    // transfer event rate
     tabletRateMap.put(
         taskID,
         metricService.getOrCreateRate(
             Metric.PIPE_CONNECTOR_TABLET_TRANSFER.toString(),
             MetricLevel.IMPORTANT,
             Tag.NAME.toString(),
-            taskID));
+            connector.getAttributeSortedString(),
+            Tag.INDEX.toString(),
+            String.valueOf(connector.getConnectorIndex()),
+            Tag.CREATION_TIME.toString(),
+            String.valueOf(connector.getCreationTime())));
     tsFileRateMap.put(
         taskID,
         metricService.getOrCreateRate(
             Metric.PIPE_CONNECTOR_TSFILE_TRANSFER.toString(),
             MetricLevel.IMPORTANT,
             Tag.NAME.toString(),
-            taskID));
+            connector.getAttributeSortedString(),
+            Tag.INDEX.toString(),
+            String.valueOf(connector.getConnectorIndex()),
+            Tag.CREATION_TIME.toString(),
+            String.valueOf(connector.getCreationTime())));
     pipeHeartbeatRateMap.put(
         taskID,
         metricService.getOrCreateRate(
             Metric.PIPE_CONNECTOR_HEARTBEAT_TRANSFER.toString(),
             MetricLevel.IMPORTANT,
             Tag.NAME.toString(),
-            taskID));
+            connector.getAttributeSortedString(),
+            Tag.INDEX.toString(),
+            String.valueOf(connector.getConnectorIndex()),
+            Tag.CREATION_TIME.toString(),
+            String.valueOf(connector.getCreationTime())));
   }
 
   @Override
@@ -134,39 +162,67 @@ public class PipeConnectorMetrics implements IMetricSet {
   }
 
   private void removeAutoGauge(String taskID) {
+    PipeConnectorSubtask connector = connectorMap.get(taskID);
+    // pending event count
     metricService.remove(
         MetricType.AUTO_GAUGE,
         Metric.UNTRANSFERRED_TABLET_COUNT.toString(),
         Tag.NAME.toString(),
-        taskID);
+        connector.getAttributeSortedString(),
+        Tag.INDEX.toString(),
+        String.valueOf(connector.getConnectorIndex()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(connector.getCreationTime()));
     metricService.remove(
         MetricType.AUTO_GAUGE,
         Metric.UNTRANSFERRED_TSFILE_COUNT.toString(),
         Tag.NAME.toString(),
-        taskID);
+        connector.getAttributeSortedString(),
+        Tag.INDEX.toString(),
+        String.valueOf(connector.getConnectorIndex()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(connector.getCreationTime()));
     metricService.remove(
         MetricType.AUTO_GAUGE,
         Metric.UNTRANSFERRED_HEARTBEAT_COUNT.toString(),
         Tag.NAME.toString(),
-        taskID);
+        connector.getAttributeSortedString(),
+        Tag.INDEX.toString(),
+        String.valueOf(connector.getConnectorIndex()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(connector.getCreationTime()));
   }
 
   private void removeRate(String taskID) {
+    PipeConnectorSubtask connector = connectorMap.get(taskID);
+    // transfer event rate
     metricService.remove(
         MetricType.RATE,
         Metric.PIPE_CONNECTOR_TABLET_TRANSFER.toString(),
         Tag.NAME.toString(),
-        taskID);
+        connector.getAttributeSortedString(),
+        Tag.INDEX.toString(),
+        String.valueOf(connector.getConnectorIndex()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(connector.getCreationTime()));
     metricService.remove(
         MetricType.RATE,
         Metric.PIPE_CONNECTOR_TSFILE_TRANSFER.toString(),
         Tag.NAME.toString(),
-        taskID);
+        connector.getAttributeSortedString(),
+        Tag.INDEX.toString(),
+        String.valueOf(connector.getConnectorIndex()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(connector.getCreationTime()));
     metricService.remove(
         MetricType.RATE,
         Metric.PIPE_CONNECTOR_HEARTBEAT_TRANSFER.toString(),
         Tag.NAME.toString(),
-        taskID);
+        connector.getAttributeSortedString(),
+        Tag.INDEX.toString(),
+        String.valueOf(connector.getConnectorIndex()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(connector.getCreationTime()));
     tabletRateMap.remove(taskID);
     tsFileRateMap.remove(taskID);
     pipeHeartbeatRateMap.remove(taskID);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/metric/PipeExtractorMetrics.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/metric/PipeExtractorMetrics.java
@@ -75,69 +75,106 @@ public class PipeExtractorMetrics implements IMetricSet {
   }
 
   private void createAutoGauge(String taskID) {
+    IoTDBDataRegionExtractor extractor = extractorMap.get(taskID);
     // pending event count
     metricService.createAutoGauge(
         Metric.UNPROCESSED_HISTORICAL_TSFILE_COUNT.toString(),
         MetricLevel.IMPORTANT,
-        extractorMap.get(taskID),
+        extractor,
         IoTDBDataRegionExtractor::getHistoricalTsFileInsertionEventCount,
         Tag.NAME.toString(),
-        taskID);
+        extractor.getPipeName(),
+        Tag.REGION.toString(),
+        String.valueOf(extractor.getDataRegionId()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(extractor.getCreationTime()));
     metricService.createAutoGauge(
         Metric.UNPROCESSED_REALTIME_TSFILE_COUNT.toString(),
         MetricLevel.IMPORTANT,
-        extractorMap.get(taskID),
+        extractor,
         IoTDBDataRegionExtractor::getRealtimeTsFileInsertionEventCount,
         Tag.NAME.toString(),
-        taskID);
+        extractor.getPipeName(),
+        Tag.REGION.toString(),
+        String.valueOf(extractor.getDataRegionId()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(extractor.getCreationTime()));
     metricService.createAutoGauge(
         Metric.UNPROCESSED_TABLET_COUNT.toString(),
         MetricLevel.IMPORTANT,
-        extractorMap.get(taskID),
+        extractor,
         IoTDBDataRegionExtractor::getTabletInsertionEventCount,
         Tag.NAME.toString(),
-        taskID);
+        extractor.getPipeName(),
+        Tag.REGION.toString(),
+        String.valueOf(extractor.getDataRegionId()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(extractor.getCreationTime()));
     metricService.createAutoGauge(
         Metric.UNPROCESSED_HEARTBEAT_COUNT.toString(),
         MetricLevel.IMPORTANT,
-        extractorMap.get(taskID),
+        extractor,
         IoTDBDataRegionExtractor::getPipeHeartbeatEventCount,
         Tag.NAME.toString(),
-        taskID);
+        extractor.getPipeName(),
+        Tag.REGION.toString(),
+        String.valueOf(extractor.getDataRegionId()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(extractor.getCreationTime()));
   }
 
   private void createRate(String taskID) {
+    IoTDBDataRegionExtractor extractor = extractorMap.get(taskID);
+    // supply event rate
     tabletRateMap.put(
         taskID,
         metricService.getOrCreateRate(
             Metric.PIPE_EXTRACTOR_TABLET_SUPPLY.toString(),
             MetricLevel.IMPORTANT,
             Tag.NAME.toString(),
-            taskID));
+            extractor.getPipeName(),
+            Tag.REGION.toString(),
+            String.valueOf(extractor.getDataRegionId()),
+            Tag.CREATION_TIME.toString(),
+            String.valueOf(extractor.getCreationTime())));
     tsFileRateMap.put(
         taskID,
         metricService.getOrCreateRate(
             Metric.PIPE_EXTRACTOR_TSFILE_SUPPLY.toString(),
             MetricLevel.IMPORTANT,
             Tag.NAME.toString(),
-            taskID));
+            extractor.getPipeName(),
+            Tag.REGION.toString(),
+            String.valueOf(extractor.getDataRegionId()),
+            Tag.CREATION_TIME.toString(),
+            String.valueOf(extractor.getCreationTime())));
     pipeHeartbeatRateMap.put(
         taskID,
         metricService.getOrCreateRate(
             Metric.PIPE_EXTRACTOR_HEARTBEAT_SUPPLY.toString(),
             MetricLevel.IMPORTANT,
             Tag.NAME.toString(),
-            taskID));
+            extractor.getPipeName(),
+            Tag.REGION.toString(),
+            String.valueOf(extractor.getDataRegionId()),
+            Tag.CREATION_TIME.toString(),
+            String.valueOf(extractor.getCreationTime())));
   }
 
   private void createGauge(String taskID) {
+    IoTDBDataRegionExtractor extractor = extractorMap.get(taskID);
+    // tsfile epoch state
     recentProcessedTsFileEpochStateMap.put(
         taskID,
         metricService.getOrCreateGauge(
             Metric.PIPE_EXTRACTOR_TSFILE_EPOCH_STATE.toString(),
             MetricLevel.IMPORTANT,
             Tag.NAME.toString(),
-            taskID));
+            extractor.getPipeName(),
+            Tag.REGION.toString(),
+            String.valueOf(extractor.getDataRegionId()),
+            Tag.CREATION_TIME.toString(),
+            String.valueOf(extractor.getCreationTime())));
   }
 
   @Override
@@ -158,56 +195,93 @@ public class PipeExtractorMetrics implements IMetricSet {
   }
 
   private void removeAutoGauge(String taskID) {
+    IoTDBDataRegionExtractor extractor = extractorMap.get(taskID);
     // pending event count
     metricService.remove(
         MetricType.AUTO_GAUGE,
         Metric.UNPROCESSED_HISTORICAL_TSFILE_COUNT.toString(),
         Tag.NAME.toString(),
-        taskID);
+        extractor.getPipeName(),
+        Tag.REGION.toString(),
+        String.valueOf(extractor.getDataRegionId()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(extractor.getCreationTime()));
     metricService.remove(
         MetricType.AUTO_GAUGE,
         Metric.UNPROCESSED_REALTIME_TSFILE_COUNT.toString(),
         Tag.NAME.toString(),
-        taskID);
+        extractor.getPipeName(),
+        Tag.REGION.toString(),
+        String.valueOf(extractor.getDataRegionId()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(extractor.getCreationTime()));
     metricService.remove(
         MetricType.AUTO_GAUGE,
         Metric.UNPROCESSED_TABLET_COUNT.toString(),
         Tag.NAME.toString(),
-        taskID);
+        extractor.getPipeName(),
+        Tag.REGION.toString(),
+        String.valueOf(extractor.getDataRegionId()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(extractor.getCreationTime()));
     metricService.remove(
         MetricType.AUTO_GAUGE,
         Metric.UNPROCESSED_HEARTBEAT_COUNT.toString(),
         Tag.NAME.toString(),
-        taskID);
+        extractor.getPipeName(),
+        Tag.REGION.toString(),
+        String.valueOf(extractor.getDataRegionId()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(extractor.getCreationTime()));
   }
 
   private void removeRate(String taskID) {
+    IoTDBDataRegionExtractor extractor = extractorMap.get(taskID);
+    // supply event rate
     metricService.remove(
         MetricType.RATE,
         Metric.PIPE_EXTRACTOR_TABLET_SUPPLY.toString(),
         Tag.NAME.toString(),
-        taskID);
+        extractor.getPipeName(),
+        Tag.REGION.toString(),
+        String.valueOf(extractor.getDataRegionId()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(extractor.getCreationTime()));
     metricService.remove(
         MetricType.RATE,
         Metric.PIPE_EXTRACTOR_TSFILE_SUPPLY.toString(),
         Tag.NAME.toString(),
-        taskID);
+        extractor.getPipeName(),
+        Tag.REGION.toString(),
+        String.valueOf(extractor.getDataRegionId()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(extractor.getCreationTime()));
     metricService.remove(
         MetricType.RATE,
         Metric.PIPE_EXTRACTOR_HEARTBEAT_SUPPLY.toString(),
         Tag.NAME.toString(),
-        taskID);
+        extractor.getPipeName(),
+        Tag.REGION.toString(),
+        String.valueOf(extractor.getDataRegionId()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(extractor.getCreationTime()));
     tabletRateMap.remove(taskID);
     tsFileRateMap.remove(taskID);
     pipeHeartbeatRateMap.remove(taskID);
   }
 
   private void removeGauge(String taskID) {
+    IoTDBDataRegionExtractor extractor = extractorMap.get(taskID);
+    // tsfile epoch state
     metricService.remove(
         MetricType.GAUGE,
         Metric.PIPE_EXTRACTOR_TSFILE_EPOCH_STATE.toString(),
         Tag.NAME.toString(),
-        taskID);
+        extractor.getPipeName(),
+        Tag.REGION.toString(),
+        String.valueOf(extractor.getDataRegionId()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(extractor.getCreationTime()));
   }
 
   //////////////////////////// register & deregister (pipe integration) ////////////////////////////

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/metric/PipeProcessorMetrics.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/metric/PipeProcessorMetrics.java
@@ -70,51 +70,79 @@ public class PipeProcessorMetrics implements IMetricSet {
   }
 
   private void createAutoGauge(String taskID) {
+    PipeProcessorSubtask processor = processorMap.get(taskID);
+    // pending event count
     metricService.createAutoGauge(
         Metric.BUFFERED_TABLET_COUNT.toString(),
         MetricLevel.IMPORTANT,
-        processorMap.get(taskID),
+        processor,
         PipeProcessorSubtask::getTabletInsertionEventCount,
         Tag.NAME.toString(),
-        taskID);
+        processor.getPipeName(),
+        Tag.REGION.toString(),
+        String.valueOf(processor.getDataRegionId()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(processor.getCreationTime()));
     metricService.createAutoGauge(
         Metric.BUFFERED_TSFILE_COUNT.toString(),
         MetricLevel.IMPORTANT,
-        processorMap.get(taskID),
+        processor,
         PipeProcessorSubtask::getTsFileInsertionEventCount,
         Tag.NAME.toString(),
-        taskID);
+        processor.getPipeName(),
+        Tag.REGION.toString(),
+        String.valueOf(processor.getDataRegionId()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(processor.getCreationTime()));
     metricService.createAutoGauge(
         Metric.BUFFERED_HEARTBEAT_COUNT.toString(),
         MetricLevel.IMPORTANT,
-        processorMap.get(taskID),
+        processor,
         PipeProcessorSubtask::getPipeHeartbeatEventCount,
         Tag.NAME.toString(),
-        taskID);
+        processor.getPipeName(),
+        Tag.REGION.toString(),
+        String.valueOf(processor.getDataRegionId()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(processor.getCreationTime()));
   }
 
   private void createRate(String taskID) {
+    PipeProcessorSubtask processor = processorMap.get(taskID);
+    // process event rate
     tabletRateMap.put(
         taskID,
         metricService.getOrCreateRate(
             Metric.PIPE_PROCESSOR_TABLET_PROCESS.toString(),
             MetricLevel.IMPORTANT,
             Tag.NAME.toString(),
-            taskID));
+            processor.getPipeName(),
+            Tag.REGION.toString(),
+            String.valueOf(processor.getDataRegionId()),
+            Tag.CREATION_TIME.toString(),
+            String.valueOf(processor.getCreationTime())));
     tsFileRateMap.put(
         taskID,
         metricService.getOrCreateRate(
             Metric.PIPE_PROCESSOR_TSFILE_PROCESS.toString(),
             MetricLevel.IMPORTANT,
             Tag.NAME.toString(),
-            taskID));
+            processor.getPipeName(),
+            Tag.REGION.toString(),
+            String.valueOf(processor.getDataRegionId()),
+            Tag.CREATION_TIME.toString(),
+            String.valueOf(processor.getCreationTime())));
     pipeHeartbeatRateMap.put(
         taskID,
         metricService.getOrCreateRate(
             Metric.PIPE_PROCESSOR_HEARTBEAT_PROCESS.toString(),
             MetricLevel.IMPORTANT,
             Tag.NAME.toString(),
-            taskID));
+            processor.getPipeName(),
+            Tag.REGION.toString(),
+            String.valueOf(processor.getDataRegionId()),
+            Tag.CREATION_TIME.toString(),
+            String.valueOf(processor.getCreationTime())));
   }
 
   @Override
@@ -134,39 +162,67 @@ public class PipeProcessorMetrics implements IMetricSet {
   }
 
   private void removeAutoGauge(String taskID) {
+    PipeProcessorSubtask processor = processorMap.get(taskID);
+    // pending event count
     metricService.remove(
         MetricType.AUTO_GAUGE,
         Metric.BUFFERED_TABLET_COUNT.toString(),
         Tag.NAME.toString(),
-        taskID);
+        processor.getPipeName(),
+        Tag.REGION.toString(),
+        String.valueOf(processor.getDataRegionId()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(processor.getCreationTime()));
     metricService.remove(
         MetricType.AUTO_GAUGE,
         Metric.BUFFERED_TSFILE_COUNT.toString(),
         Tag.NAME.toString(),
-        taskID);
+        processor.getPipeName(),
+        Tag.REGION.toString(),
+        String.valueOf(processor.getDataRegionId()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(processor.getCreationTime()));
     metricService.remove(
         MetricType.AUTO_GAUGE,
         Metric.BUFFERED_HEARTBEAT_COUNT.toString(),
         Tag.NAME.toString(),
-        taskID);
+        processor.getPipeName(),
+        Tag.REGION.toString(),
+        String.valueOf(processor.getDataRegionId()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(processor.getCreationTime()));
   }
 
   private void removeRate(String taskID) {
+    PipeProcessorSubtask processor = processorMap.get(taskID);
+    // process event rate
     metricService.remove(
         MetricType.RATE,
         Metric.PIPE_PROCESSOR_TABLET_PROCESS.toString(),
         Tag.NAME.toString(),
-        taskID);
+        processor.getPipeName(),
+        Tag.REGION.toString(),
+        String.valueOf(processor.getDataRegionId()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(processor.getCreationTime()));
     metricService.remove(
         MetricType.RATE,
         Metric.PIPE_PROCESSOR_TSFILE_PROCESS.toString(),
         Tag.NAME.toString(),
-        taskID);
+        processor.getPipeName(),
+        Tag.REGION.toString(),
+        String.valueOf(processor.getDataRegionId()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(processor.getCreationTime()));
     metricService.remove(
         MetricType.RATE,
         Metric.PIPE_PROCESSOR_HEARTBEAT_PROCESS.toString(),
         Tag.NAME.toString(),
-        taskID);
+        processor.getPipeName(),
+        Tag.REGION.toString(),
+        String.valueOf(processor.getDataRegionId()),
+        Tag.CREATION_TIME.toString(),
+        String.valueOf(processor.getCreationTime()));
     tabletRateMap.remove(taskID);
     tsFileRateMap.remove(taskID);
     pipeHeartbeatRateMap.remove(taskID);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/stage/PipeTaskProcessorStage.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/stage/PipeTaskProcessorStage.java
@@ -96,6 +96,9 @@ public class PipeTaskProcessorStage extends PipeTaskStage {
     this.pipeProcessorSubtask =
         new PipeProcessorSubtask(
             taskId,
+            creationTime,
+            pipeName,
+            dataRegionId.getId(),
             pipeExtractorInputEventSupplier,
             pipeProcessor,
             pipeConnectorOutputEventCollector);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/PipeSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/PipeSubtask.java
@@ -46,6 +46,9 @@ public abstract class PipeSubtask
   // Used for identifying the subtask
   protected final String taskID;
 
+  // Record these variables to provide corresponding value to tag key of monitoring metrics
+  protected long creationTime;
+
   // For thread pool to execute subtasks
   protected ListeningExecutorService subtaskWorkerThreadPoolExecutor;
 
@@ -59,9 +62,10 @@ public abstract class PipeSubtask
   protected final AtomicInteger retryCount = new AtomicInteger(0);
   protected Event lastEvent;
 
-  protected PipeSubtask(String taskID) {
+  protected PipeSubtask(String taskID, long creationTime) {
     super();
     this.taskID = taskID;
+    this.creationTime = creationTime;
   }
 
   public abstract void bindExecutors(
@@ -235,6 +239,10 @@ public abstract class PipeSubtask
 
   public String getTaskID() {
     return taskID;
+  }
+
+  public long getCreationTime() {
+    return creationTime;
   }
 
   public int getRetryCount() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/connector/PipeConnectorSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/connector/PipeConnectorSubtask.java
@@ -59,23 +59,20 @@ public class PipeConnectorSubtask extends PipeSubtask {
   protected final DecoratingLock callbackDecoratingLock = new DecoratingLock();
   protected ExecutorService subtaskCallbackListeningExecutor;
 
-  public Integer getTsFileInsertionEventCount() {
-    return inputPendingQueue.getTsFileInsertionEventCount();
-  }
-
-  public Integer getTabletInsertionEventCount() {
-    return inputPendingQueue.getTabletInsertionEventCount();
-  }
-
-  public Integer getPipeHeartbeatEventCount() {
-    return inputPendingQueue.getPipeHeartbeatEventCount();
-  }
+  // Record these variables to provide corresponding value to tag key of monitoring metrics
+  private final String attributeSortedString;
+  private final int connectorIndex;
 
   public PipeConnectorSubtask(
       String taskID,
+      long creationTime,
+      String attributeSortedString,
+      int connectorIndex,
       BoundedBlockingPendingQueue<Event> inputPendingQueue,
       PipeConnector outputPipeConnector) {
-    super(taskID);
+    super(taskID, creationTime);
+    this.attributeSortedString = attributeSortedString;
+    this.connectorIndex = connectorIndex;
     this.inputPendingQueue = inputPendingQueue;
     this.outputPipeConnector = outputPipeConnector;
     PipeConnectorMetrics.getInstance().register(this);
@@ -291,5 +288,27 @@ public class PipeConnectorSubtask extends PipeSubtask {
       // Should be called after outputPipeConnector.close()
       super.close();
     }
+  }
+
+  //////////////////////////// APIs provided for metric framework ////////////////////////////
+
+  public String getAttributeSortedString() {
+    return attributeSortedString;
+  }
+
+  public int getConnectorIndex() {
+    return connectorIndex;
+  }
+
+  public Integer getTsFileInsertionEventCount() {
+    return inputPendingQueue.getTsFileInsertionEventCount();
+  }
+
+  public Integer getTabletInsertionEventCount() {
+    return inputPendingQueue.getTabletInsertionEventCount();
+  }
+
+  public Integer getPipeHeartbeatEventCount() {
+    return inputPendingQueue.getPipeHeartbeatEventCount();
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/connector/PipeConnectorSubtaskManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/connector/PipeConnectorSubtaskManager.java
@@ -86,7 +86,7 @@ public class PipeConnectorSubtaskManager {
           new BoundedBlockingPendingQueue<>(
               PipeConfig.getInstance().getPipeConnectorPendingQueueSize());
 
-      for (int i = 0; i < connectorNum; i++) {
+      for (int connectorIndex = 0; connectorIndex < connectorNum; connectorIndex++) {
         final PipeConnector pipeConnector =
             CONNECTOR_CONSTRUCTORS
                 .getOrDefault(
@@ -110,7 +110,13 @@ public class PipeConnectorSubtaskManager {
         final PipeConnectorSubtask pipeConnectorSubtask =
             new PipeConnectorSubtask(
                 String.format(
-                    "%s_%s_%s", attributeSortedString, pipeRuntimeEnvironment.getCreationTime(), i),
+                    "%s_%s_%s",
+                    attributeSortedString,
+                    pipeRuntimeEnvironment.getCreationTime(),
+                    connectorIndex),
+                pipeRuntimeEnvironment.getCreationTime(),
+                attributeSortedString,
+                connectorIndex,
                 pendingQueue,
                 pipeConnector);
         final PipeConnectorSubtaskLifeCycle pipeConnectorSubtaskLifeCycle =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/processor/PipeProcessorSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/processor/PipeProcessorSubtask.java
@@ -49,12 +49,21 @@ public class PipeProcessorSubtask extends PipeSubtask {
   private final PipeProcessor pipeProcessor;
   private final PipeEventCollector outputEventCollector;
 
+  // Record these variables to provide corresponding value to tag key of monitoring metrics
+  private final String pipeName;
+  private final int dataRegionId;
+
   public PipeProcessorSubtask(
       String taskID,
+      long creationTime,
+      String pipeName,
+      int dataRegionId,
       EventSupplier inputEventSupplier,
       PipeProcessor pipeProcessor,
       PipeEventCollector outputEventCollector) {
-    super(taskID);
+    super(taskID, creationTime);
+    this.pipeName = pipeName;
+    this.dataRegionId = dataRegionId;
     this.inputEventSupplier = inputEventSupplier;
     this.pipeProcessor = pipeProcessor;
     this.outputEventCollector = outputEventCollector;
@@ -178,6 +187,16 @@ public class PipeProcessorSubtask extends PipeSubtask {
   @Override
   public int hashCode() {
     return taskID.hashCode();
+  }
+
+  //////////////////////////// APIs provided for metric framework ////////////////////////////
+
+  public String getPipeName() {
+    return pipeName;
+  }
+
+  public int getDataRegionId() {
+    return dataRegionId;
   }
 
   public int getTabletInsertionEventCount() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/utils/WALInsertNodeCache.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/utils/WALInsertNodeCache.java
@@ -171,7 +171,7 @@ public class WALInsertNodeCache {
   }
 
   public double getCacheHitRate() {
-    return Objects.nonNull(lruCache) ? lruCache.stats().hitRate() : 0;
+    return Objects.nonNull(lruCache) ? 1 - lruCache.stats().missRate() : 0;
   }
 
   /////////////////////////// MemTable ///////////////////////////

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/utils/WALInsertNodeCache.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/utils/WALInsertNodeCache.java
@@ -83,6 +83,7 @@ public class WALInsertNodeCache {
             .weigher(
                 (Weigher<WALEntryPosition, Pair<ByteBuffer, InsertNode>>)
                     (position, pair) -> position.getSize())
+            .recordStats()
             .build(new WALInsertNodeCacheLoader());
     PipeWALInsertNodeCacheMetrics.getInstance().register(this, dataRegionId);
   }
@@ -171,7 +172,7 @@ public class WALInsertNodeCache {
   }
 
   public double getCacheHitRate() {
-    return Objects.nonNull(lruCache) ? 1 - lruCache.stats().missRate() : 0;
+    return Objects.nonNull(lruCache) ? lruCache.stats().hitRate() : 0;
   }
 
   /////////////////////////// MemTable ///////////////////////////

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/execution/PipeConnectorSubtaskExecutorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/execution/PipeConnectorSubtaskExecutorTest.java
@@ -39,6 +39,9 @@ public class PipeConnectorSubtaskExecutorTest extends PipeSubtaskExecutorTest {
         Mockito.spy(
             new PipeConnectorSubtask(
                 "PipeConnectorSubtaskExecutorTest",
+                System.currentTimeMillis(),
+                "TestAttributeSortedString",
+                0,
                 mock(BoundedBlockingPendingQueue.class),
                 mock(PipeConnector.class)));
   }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/execution/PipeProcessorSubtaskExecutorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/execution/PipeProcessorSubtaskExecutorTest.java
@@ -40,6 +40,9 @@ public class PipeProcessorSubtaskExecutorTest extends PipeSubtaskExecutorTest {
         Mockito.spy(
             new PipeProcessorSubtask(
                 "PipeProcessorSubtaskExecutorTest",
+                System.currentTimeMillis(),
+                "TestPipe",
+                0,
                 mock(EventSupplier.class),
                 mock(PipeProcessor.class),
                 mock(PipeEventCollector.class)));

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/metric/enums/Tag.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/metric/enums/Tag.java
@@ -28,7 +28,9 @@ public enum Tag {
   FROM("from"),
   STAGE("stage"),
   OPERATION("operation"),
-  INTERFACE("interface");
+  INTERFACE("interface"),
+  CREATION_TIME("creation_time"),
+  INDEX("index");
 
   final String value;
 


### PR DESCRIPTION
## Description

To provide more detailed legend information to Grafana and enable aggregation by pipe name or data region, this PR modifies some of the tag key sets for pipe metrics:

- before: `{name (TaskID)}`
- after this PR: `{Name (PipeName / AttributeSortedString), CreationTime, Index, DataRegion}`

Additionally, it fixes the issue where the hit rate in PipeWALInsertNodeCacheMetrics is always `1.0`.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [x] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
