### PR TITLE
Fix datanode stuck when meets disk error

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -211,6 +211,7 @@ public class DataNode implements DataNodeMBean {
         SYSTEM_PROPERTIES.deleteOnExit();
       }
       stop();
+      System.exit(-1);
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -423,6 +423,10 @@ public class DataRegion implements IDataRegionForQuery {
     try {
       recoverCompaction();
     } catch (Exception e) {
+      // signal wal recover manager to recover this region's files
+      WALRecoverManager.getInstance()
+          .getAllDataRegionScannedLatch()
+          .countDownWithException(e.getMessage());
       throw new DataRegionException(e);
     }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/utils/listener/AbstractResultListener.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/utils/listener/AbstractResultListener.java
@@ -71,6 +71,8 @@ public abstract class AbstractResultListener {
         } catch (InterruptedException e) {
           logger.warn("Interrupted when waiting for result.", e);
           Thread.currentThread().interrupt();
+          status = Status.FAILURE;
+          break;
         }
       }
     }


### PR DESCRIPTION
## Description

#11172 was trying to fix datanode stuck issue when meets disk error. However, there are still some problems need to fix.

1. When DataRegion compaction recover failed, the CountDownLatch of WALRecoverManager needs to countdown as well.
2. The waitForResult method of AbstractResultListener may have the endless loop, when catches an InterruptedException.  We need to add a break logic to exit the loop.
3. After calling the stop method in DataNode, some threads may still live. Therefore, adding a `System.exit` is a better way to exit the DataNode.

## How to test

See #11172 