### PR TITLE
Fix aggregation error when inserting negative timestamp

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBInsertWithQueryIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBInsertWithQueryIT.java
@@ -37,6 +37,7 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.iotdb.db.it.utils.TestUtils.resultSetEqualTest;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
@@ -159,6 +160,8 @@ public class IoTDBInsertWithQueryIT {
 
     // select
     selectAndCount(2001);
+
+    negativeTimestampAggregationTest();
   }
 
   @Test
@@ -479,5 +482,25 @@ public class IoTDBInsertWithQueryIT {
       e.printStackTrace();
       fail(e.getMessage());
     }
+  }
+
+  private void negativeTimestampAggregationTest() {
+    String[] expectedHeader = new String[] {"count(root.fans.d0.s0)"};
+    String[] retArray = new String[] {"2001,"};
+    resultSetEqualTest("SELECT count(s0) FROM root.fans.d0;", expectedHeader, retArray);
+
+    expectedHeader = new String[] {"count(root.fans.d0.s0)"};
+    retArray = new String[] {"1999,"};
+    resultSetEqualTest(
+        "SELECT count(s0) FROM root.fans.d0 WHERE time<-1;", expectedHeader, retArray);
+
+    expectedHeader = new String[] {"min_time(root.fans.d0.s0)"};
+    retArray = new String[] {"-2000,"};
+    resultSetEqualTest("SELECT min_time(s0) FROM root.fans.d0;", expectedHeader, retArray);
+
+    expectedHeader = new String[] {"max_time(root.fans.d0.s0)"};
+    retArray = new String[] {"-2,"};
+    resultSetEqualTest(
+        "SELECT max_time(s0) FROM root.fans.d0 WHERE time<-1;", expectedHeader, retArray);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/timerangeiterator/SingleTimeWindowIterator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/timerangeiterator/SingleTimeWindowIterator.java
@@ -69,7 +69,8 @@ public class SingleTimeWindowIterator implements ITimeRangeIterator {
 
   @Override
   public long currentOutputTime() {
-    return curTimeRange.getMin();
+    // display time as 0 in aggregation result
+    return curTimeRange.getMin() == Long.MIN_VALUE ? 0 : curTimeRange.getMin();
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/AggregationUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/AggregationUtil.java
@@ -68,7 +68,7 @@ public class AggregationUtil {
       boolean ascending,
       boolean outputPartialTimeWindow) {
     if (groupByTimeParameter == null) {
-      return new SingleTimeWindowIterator(0, Long.MAX_VALUE);
+      return new SingleTimeWindowIterator(Long.MIN_VALUE, Long.MAX_VALUE);
     } else {
       return TimeRangeIteratorFactory.getTimeRangeIterator(
           groupByTimeParameter.getStartTime(),


### PR DESCRIPTION
## Description

Before fix, the result of select count(*) from root.** is always 0, now it will be the right value.

See details in TIMECHODB-434.
