### PR TITLE
add time cost log for datanode start

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBStartCheck.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBStartCheck.java
@@ -408,6 +408,7 @@ public class IoTDBStartCheck {
   }
 
   public void serializeMutableSystemPropertiesIfNecessary() throws IOException {
+    long startTime = System.currentTimeMillis();
     boolean needsSerialize = false;
     for (String param : variableParamValueTable.keySet()) {
       if (!(properties.getProperty(param).equals(getVal(param)))) {
@@ -421,5 +422,9 @@ public class IoTDBStartCheck {
         properties.store(outputStream, SYSTEM_PROPERTIES_STRING);
       }
     }
+    long endTime = System.currentTimeMillis();
+    logger.info(
+        "Serialize mutable system properties successfully, which takes {} ms.",
+        (endTime - startTime));
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/client/ConfigNodeInfo.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/client/ConfigNodeInfo.java
@@ -69,6 +69,7 @@ public class ConfigNodeInfo {
 
   /** Update ConfigNodeList both in memory and system.properties file */
   public void updateConfigNodeList(List<TEndPoint> latestConfigNodes) {
+    long startTime = System.currentTimeMillis();
     // Check whether the config nodes are latest or not
     configNodeInfoReadWriteLock.readLock().lock();
     try {
@@ -86,8 +87,11 @@ public class ConfigNodeInfo {
       onlineConfigNodes.clear();
       onlineConfigNodes.addAll(latestConfigNodes);
       storeConfigNode();
-
-      logger.info("Successfully update ConfigNode: {}.", onlineConfigNodes);
+      long endTime = System.currentTimeMillis();
+      logger.info(
+          "Update ConfigNode Successfully: {}, which takes {} ms.",
+          onlineConfigNodes,
+          (endTime - startTime));
     } catch (IOException e) {
       logger.error("Update ConfigNode failed.", e);
     } finally {
@@ -113,6 +117,7 @@ public class ConfigNodeInfo {
   }
 
   public void loadConfigNodeList() {
+    long startTime = System.currentTimeMillis();
     // properties contain CONFIG_NODE_LIST only when start as Data node
     try {
       configNodeInfoReadWriteLock.writeLock().lock();
@@ -128,6 +133,11 @@ public class ConfigNodeInfo {
         onlineConfigNodes.addAll(
             NodeUrlUtils.parseTEndPointUrls(properties.getProperty(CONFIG_NODE_LIST)));
       }
+      long endTime = System.currentTimeMillis();
+      logger.info(
+          "Load ConfigNode successfully: {}, which takes {} ms.",
+          onlineConfigNodes,
+          (endTime - startTime));
     } catch (BadNodeUrlException e) {
       logger.error("Cannot parse config node list in system.properties");
     } finally {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/TierManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/TierManager.java
@@ -153,12 +153,15 @@ public class TierManager {
   }
 
   public synchronized void resetFolders() {
+    long startTime = System.currentTimeMillis();
     seqTiers.clear();
     unSeqTiers.clear();
     seqDir2TierLevel.clear();
     unSeqDir2TierLevel.clear();
 
     initFolders();
+    long endTime = System.currentTimeMillis();
+    logger.info("The folders is reset successfully, which takes {} ms.", (endTime - startTime));
   }
 
   private void mkDataDirs(List<String> folders) {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/RegisterManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/RegisterManager.java
@@ -48,7 +48,13 @@ public class RegisterManager {
       }
     }
     iServices.add(service);
+    long startTime = System.currentTimeMillis();
     service.start();
+    long endTime = System.currentTimeMillis();
+    logger.info(
+        "The {} service is started successfully, which takes {} ms.",
+        service.getID().getName(),
+        (endTime - startTime));
   }
 
   /** stop all service and clear iService list. */


### PR DESCRIPTION
## Description

This PR supplements the time taken by each module during DataNode startup. When DataNode startup is slow, it helps us quickly locate the module that causes the slow startup.