### PR TITLE
[IOTDB-6206] Metric Core: Shrink ringBuffer length to optimize histogram and timer's record performance

### DIFF
--- a/iotdb-core/metrics/core/src/main/java/org/apache/iotdb/metrics/core/IoTDBMetricManager.java
+++ b/iotdb-core/metrics/core/src/main/java/org/apache/iotdb/metrics/core/IoTDBMetricManager.java
@@ -67,6 +67,7 @@ public class IoTDBMetricManager extends AbstractMetricManager {
     DistributionStatisticConfig distributionStatisticConfig =
         DistributionStatisticConfig.builder()
             .percentiles(0.5, 0.99)
+            .bufferLength(2)
             .build()
             .merge(defaultHistogramConfig);
 
@@ -106,7 +107,7 @@ public class IoTDBMetricManager extends AbstractMetricManager {
   }
 
   @Override
-  public Timer createTimer(MetricInfo metricInfo) {
+  public Timer createTimer() {
     // set pauseDetector
     PauseDetector pauseDetector = new NoPauseDetector();
 

--- a/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/AbstractMetricManager.java
+++ b/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/AbstractMetricManager.java
@@ -283,7 +283,7 @@ public abstract class AbstractMetricManager {
         metrics.computeIfAbsent(
             metricInfo,
             key -> {
-              Timer timer = createTimer(metricInfo);
+              Timer timer = createTimer();
               nameToMetaInfo.put(name, metricInfo.getMetaInfo());
               notifyReporterOnAdd(timer, metricInfo);
               return timer;
@@ -296,10 +296,8 @@ public abstract class AbstractMetricManager {
 
   /**
    * Create timer according to metric framework.
-   *
-   * @param metricInfo the metricInfo of metric
    */
-  protected abstract Timer createTimer(MetricInfo metricInfo);
+  protected abstract Timer createTimer();
 
   // endregion
 

--- a/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/AbstractMetricManager.java
+++ b/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/AbstractMetricManager.java
@@ -294,9 +294,7 @@ public abstract class AbstractMetricManager {
     throw new IllegalArgumentException(metricInfo + ALREADY_EXISTS);
   }
 
-  /**
-   * Create timer according to metric framework.
-   */
+  /** Create timer according to metric framework. */
   protected abstract Timer createTimer();
 
   // endregion

--- a/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/impl/DoNothingMetricManager.java
+++ b/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/impl/DoNothingMetricManager.java
@@ -67,7 +67,7 @@ public class DoNothingMetricManager extends AbstractMetricManager {
   }
 
   @Override
-  public Timer createTimer(MetricInfo metricInfo) {
+  public Timer createTimer() {
     return DO_NOTHING_TIMER;
   }
 


### PR DESCRIPTION
[IOTDB-6206](https://issues.apache.org/jira/projects/IOTDB/issues/IOTDB-6206?filter=allissues)
1. Reduce the length of micrometer's internal histogram ringBuffer to optimize writing efficiency
2. Reduce some duplicate parameter