### PR TITLE
Pipe: introduce pipe_max_allowed_pinned_memtable_count param for realtime hybrid mode

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/PipeRealtimeDataRegionLogExtractor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/PipeRealtimeDataRegionLogExtractor.java
@@ -50,7 +50,7 @@ public class PipeRealtimeDataRegionLogExtractor extends PipeRealtimeDataRegionEx
     } else {
       throw new UnsupportedOperationException(
           String.format(
-              "Unsupported event type %s for hybrid realtime extractor %s",
+              "Unsupported event type %s for log realtime extractor %s",
               eventToExtract.getClass(), this));
     }
   }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -184,6 +184,7 @@ public class CommonConfig {
   private int pipeAirGapReceiverPort = 9780;
 
   private int pipeMaxAllowedPendingTsFileEpochPerDataRegion = 2;
+  private int pipeMaxAllowedPinnedMemTableCount = 50;
 
   private boolean pipeMemoryManagementEnabled = true;
   private long pipeMemoryAllocateRetryIntervalMs = 1000;
@@ -739,6 +740,14 @@ public class CommonConfig {
   public void setPipeMaxAllowedPendingTsFileEpochPerDataRegion(
       int pipeExtractorPendingQueueTsfileLimit) {
     this.pipeMaxAllowedPendingTsFileEpochPerDataRegion = pipeExtractorPendingQueueTsfileLimit;
+  }
+
+  public int getPipeMaxAllowedPinnedMemTableCount() {
+    return pipeMaxAllowedPinnedMemTableCount;
+  }
+
+  public void setPipeMaxAllowedPinnedMemTableCount(int pipeMaxAllowedPinnedMemTableCount) {
+    this.pipeMaxAllowedPinnedMemTableCount = pipeMaxAllowedPinnedMemTableCount;
   }
 
   public boolean getPipeMemoryManagementEnabled() {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -392,6 +392,11 @@ public class CommonDescriptor {
             properties.getProperty(
                 "pipe_max_allowed_pending_tsfile_epoch_per_data_region",
                 String.valueOf(config.getPipeMaxAllowedPendingTsFileEpochPerDataRegion()))));
+    config.setPipeMaxAllowedPinnedMemTableCount(
+        Integer.parseInt(
+            properties.getProperty(
+                "pipe_max_allowed_pinned_memtable_count",
+                String.valueOf(config.getPipeMaxAllowedPinnedMemTableCount()))));
 
     config.setPipeMemoryManagementEnabled(
         Boolean.parseBoolean(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeConfig.java
@@ -161,6 +161,10 @@ public class PipeConfig {
     return COMMON_CONFIG.getPipeMaxAllowedPendingTsFileEpochPerDataRegion();
   }
 
+  public int getPipeMaxAllowedPinnedMemTableCount() {
+    return COMMON_CONFIG.getPipeMaxAllowedPinnedMemTableCount();
+  }
+
   /////////////////////////////// Memory ///////////////////////////////
 
   public boolean getPipeMemoryManagementEnabled() {
@@ -244,6 +248,7 @@ public class PipeConfig {
     LOGGER.info(
         "PipeMaxAllowedPendingTsFileEpochPerDataRegion: {}",
         getPipeMaxAllowedPendingTsFileEpochPerDataRegion());
+    LOGGER.info("PipeMaxAllowedPinnedMemTableCount: {}", getPipeMaxAllowedPinnedMemTableCount());
 
     LOGGER.info("PipeMemoryManagementEnabled: {}", getPipeMemoryManagementEnabled());
     LOGGER.info("PipeMemoryAllocateMaxRetries: {}", getPipeMemoryAllocateMaxRetries());


### PR DESCRIPTION
As title.

In the following 4 cases, we should not extract any more tablet events. all the data represented by the tablet events should be carried by the following tsfile event:

1. The historical extractor has not consumed all the data.
2. HybridExtractor will first try to do extraction in log mode, and then choose log or tsfile mode to continue extracting, but if Wal size > maximum size of wal buffer, the write operation will be throttled, so we should not extract any more tablet events.
3. The number of pinned memtables has reached the dangerous threshold.
4. The number of tsfile events in the pending queue has exceeded the limit.
