### PR TITLE
[IOTDB-6245] Load: Adjust forceCloseWriterManager execution delay in LoadTsFileManager to 15mins to avoid OOM & clear all data structures after use to help GC

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/LoadTsfileAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/LoadTsfileAnalyzer.java
@@ -154,6 +154,7 @@ public class LoadTsfileAnalyzer {
               i + 1, tsfileNum, String.format("%.3f", (i + 1) * 100.00 / tsfileNum));
         }
       } catch (IllegalArgumentException e) {
+        schemaAutoCreatorAndVerifier.clear();
         LOGGER.warn(
             String.format(
                 "Parse file %s to resource error, this TsFile maybe empty.", tsFile.getPath()),
@@ -161,11 +162,13 @@ public class LoadTsfileAnalyzer {
         throw new SemanticException(
             String.format("TsFile %s is empty or incomplete.", tsFile.getPath()));
       } catch (AuthException e) {
+        schemaAutoCreatorAndVerifier.clear();
         Analysis analysis = new Analysis();
         analysis.setFinishQueryAfterAnalyze(true);
         analysis.setFailStatus(RpcUtils.getStatus(e.getCode(), e.getMessage()));
         return analysis;
       } catch (Exception e) {
+        schemaAutoCreatorAndVerifier.clear();
         LOGGER.warn(String.format("Parse file %s to resource error.", tsFile.getPath()), e);
         throw new SemanticException(
             String.format(
@@ -661,6 +664,7 @@ public class LoadTsfileAnalyzer {
     public void clear() {
       tsfileDevice2IsAligned.clear();
       currentBatchDevice2TimeseriesSchemas.clear();
+      currentBatchTimeseriesCount = 0;
       alreadySetDatabases.clear();
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/LoadTsfileAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/LoadTsfileAnalyzer.java
@@ -174,6 +174,8 @@ public class LoadTsfileAnalyzer {
     }
 
     schemaAutoCreatorAndVerifier.flush();
+    schemaAutoCreatorAndVerifier.clear();
+
     LOGGER.info("Load - Analysis Stage: all tsfiles have been analyzed.");
 
     // data partition will be queried in the scheduler
@@ -654,6 +656,12 @@ public class LoadTsfileAnalyzer {
           }
         }
       }
+    }
+
+    public void clear() {
+      tsfileDevice2IsAligned.clear();
+      currentBatchDevice2TimeseriesSchemas.clear();
+      alreadySetDatabases.clear();
     }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/load/LoadTsFileScheduler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/load/LoadTsFileScheduler.java
@@ -92,7 +92,7 @@ import java.util.stream.IntStream;
  */
 public class LoadTsFileScheduler implements IScheduler {
   private static final Logger logger = LoggerFactory.getLogger(LoadTsFileScheduler.class);
-  public static final long LOAD_TASK_MAX_TIME_IN_SECOND = 5184000L; // one day
+  public static final long LOAD_TASK_MAX_TIME_IN_SECOND = 900L; // 15min
   private static final long MAX_MEMORY_SIZE;
   private static final int TRANSMIT_LIMIT;
 
@@ -456,6 +456,8 @@ public class LoadTsFileScheduler implements IScheduler {
           }
         }
       }
+
+      replicaSet2Piece.clear();
 
       return true;
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/load/LoadTsFileScheduler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/load/LoadTsFileScheduler.java
@@ -457,8 +457,6 @@ public class LoadTsFileScheduler implements IScheduler {
         }
       }
 
-      replicaSet2Piece.clear();
-
       return true;
     }
 
@@ -509,6 +507,8 @@ public class LoadTsFileScheduler implements IScheduler {
           return false;
         }
       }
+
+      replicaSet2Piece.clear();
       return true;
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/load/LoadTsFileScheduler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/load/LoadTsFileScheduler.java
@@ -203,8 +203,8 @@ public class LoadTsFileScheduler implements IScheduler {
   }
 
   private boolean firstPhase(LoadSingleTsFileNode node) {
+    final TsFileDataManager tsFileDataManager = new TsFileDataManager(this, node);
     try {
-      TsFileDataManager tsFileDataManager = new TsFileDataManager(this, node);
       new TsFileSplitter(
               node.getTsFileResource().getTsFile(), tsFileDataManager::addOrSendTsFileData)
           .splitTsFileByDataPartition();
@@ -225,6 +225,8 @@ public class LoadTsFileScheduler implements IScheduler {
       logger.warn(
           String.format("Parse or send TsFile %s error.", node.getTsFileResource().getTsFile()), e);
       return false;
+    } finally {
+      tsFileDataManager.clear();
     }
     return true;
   }
@@ -507,9 +509,11 @@ public class LoadTsFileScheduler implements IScheduler {
           return false;
         }
       }
-
-      replicaSet2Piece.clear();
       return true;
+    }
+
+    private void clear() {
+      replicaSet2Piece.clear();
     }
   }
 


### PR DESCRIPTION
## Description

1. Adjust forceCloseWriterManager execution delay in LoadTsFileManager to 15mins to avoid OOM 
2. Clear all data structures after use to help GC