### PR TITLE
Validate flushed tsfile without holding closeQueryLock

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -124,6 +124,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -153,6 +154,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import static org.apache.iotdb.commons.conf.IoTDBConstant.FILE_NAME_SEPARATOR;
 import static org.apache.iotdb.db.queryengine.metric.QueryResourceMetricSet.SEQUENCE_TSFILE;
 import static org.apache.iotdb.db.queryengine.metric.QueryResourceMetricSet.UNSEQUENCE_TSFILE;
+import static org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource.BROKEN_SUFFIX;
+import static org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource.RESOURCE_SUFFIX;
 import static org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource.TEMP_SUFFIX;
 import static org.apache.iotdb.tsfile.common.constant.TsFileConstant.TSFILE_SUFFIX;
 
@@ -2093,7 +2096,10 @@ public class DataRegion implements IDataRegionForQuery {
     try {
       tsFileProcessor.close();
       if (tsFileNotValid) {
-        tsFileProcessor.getTsFileResource().remove();
+        String tsFilePath = tsFileProcessor.getTsFileResource().getTsFile().getAbsolutePath();
+        renameAndHandleError(tsFilePath, tsFilePath + BROKEN_SUFFIX);
+        renameAndHandleError(
+            tsFilePath + RESOURCE_SUFFIX, tsFilePath + RESOURCE_SUFFIX + BROKEN_SUFFIX);
         tsFileManager.remove(tsFileProcessor.getTsFileResource(), tsFileProcessor.isSequence());
       } else {
         tsFileResourceManager.registerSealedTsFileResource(tsFileProcessor.getTsFileResource());
@@ -2487,10 +2493,8 @@ public class DataRegion implements IDataRegionForQuery {
               tsFileToLoad.getAbsolutePath(), targetFile.getAbsolutePath(), e.getMessage()));
     }
 
-    File resourceFileToLoad =
-        fsFactory.getFile(tsFileToLoad.getAbsolutePath() + TsFileResource.RESOURCE_SUFFIX);
-    File targetResourceFile =
-        fsFactory.getFile(targetFile.getAbsolutePath() + TsFileResource.RESOURCE_SUFFIX);
+    File resourceFileToLoad = fsFactory.getFile(tsFileToLoad.getAbsolutePath() + RESOURCE_SUFFIX);
+    File targetResourceFile = fsFactory.getFile(targetFile.getAbsolutePath() + RESOURCE_SUFFIX);
     try {
       if (deleteOriginFile) {
         FileUtils.moveFile(resourceFileToLoad, targetResourceFile);
@@ -3038,6 +3042,14 @@ public class DataRegion implements IDataRegionForQuery {
 
   public long getMemCost() {
     return dataRegionInfo.getMemCost();
+  }
+
+  private void renameAndHandleError(String originFileName, String newFileName) {
+    try {
+      Files.move(Paths.get(originFileName), Paths.get(newFileName));
+    } catch (IOException e) {
+      logger.error("Failed to rename {} to {},", originFileName, newFileName, e);
+    }
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
@@ -87,6 +87,7 @@ public class TsFileResource {
 
   public static final String RESOURCE_SUFFIX = ".resource";
   public static final String TEMP_SUFFIX = ".temp";
+  public static final String BROKEN_SUFFIX = ".broken";
 
   /** version number */
   public static final byte VERSION_NUMBER = 1;


### PR DESCRIPTION
## Description

### Fixed issue
(describe what the issue is and what the impact if we don't fix it)

### Reason
(explain how the issue is created in previous change)

### How to fix it
(explain the changes in this PR and describe how to fix the issue)


Validate flushed TsFile without holding closeQueryLock.
Before this fix, the validation of writing will be performed when holding the write lock of 'closeQueryLock' if TsFile correctness validation is enabled, which block other threads to close TsFile or query.
