### PR TITLE
Avoid modFile.exist judgement in QueryContext when there is no actual modFile.

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryContext.java
@@ -32,10 +32,8 @@ import org.apache.iotdb.tsfile.utils.Pair;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /** QueryContext contains the shared information with in a query. */
 public class QueryContext {


### PR DESCRIPTION
## Description

the invoking of `modFile.exists()` is time-consuming and io-consuming operation, and one series scan will lead to once invoking. So we can use an cache to reduce the time of invoking.

In my experiment, 32C64G, 100000 devices * 30 measurements, for queries `select * from root.test.g_0.** order by time desc limit 10 align by device`, it can reduce total time of 2s.

In later, to reduce memory usage, if the resource file has added a variable to represent whether the TsFile has been modified, this variable can be replaced.
