### PR TITLE
Fix insertion compaction replace keyword bug

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InsertionCrossSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InsertionCrossSpaceCompactionTask.java
@@ -195,7 +195,9 @@ public class InsertionCrossSpaceCompactionTask extends AbstractCompactionTask {
 
   public File generateTargetFile() throws IOException {
     String path = unseqFileToInsert.getTsFile().getParentFile().getPath();
-    path = path.replace("unsequence", "sequence");
+    int pos = path.lastIndexOf("unsequence");
+    path = path.substring(0, pos) + "sequence" + path.substring(pos + "unsequence".length());
+
     TsFileNameGenerator.TsFileName tsFileName =
         TsFileNameGenerator.getTsFileName(unseqFileToInsert.getTsFile().getName());
     tsFileName.setTime(timestamp);


### PR DESCRIPTION
## Description
Fix insertion compaction replace keyword bug.
If the data directory of IoTDB contains the keyword 'unsequence', this will cause the target file of InsertionCompaction to appear in the wrong dir.
<img width="1422" alt="截屏2023-11-11 17 49 05" src="https://github.com/apache/iotdb/assets/55970239/b4f60866-ee16-4e42-a608-7d9cc946b24e">
The dir 'test-load-unsequence' is replaced to 'test-load-sequence' in target compaction file.