### PR TITLE
[IOTDB-6246] Pipe: Validator validates the range of values for optional parameters improperly

### DIFF
--- a/iotdb-api/pipe-api/src/main/java/org/apache/iotdb/pipe/api/customizer/parameter/PipeParameterValidator.java
+++ b/iotdb-api/pipe-api/src/main/java/org/apache/iotdb/pipe/api/customizer/parameter/PipeParameterValidator.java
@@ -68,10 +68,6 @@ public class PipeParameterValidator {
       }
     }
 
-    if (canBeOptional) {
-      return this;
-    }
-
     throw new PipeAttributeNotProvidedException(
         String.format("%s should be one of %s", key, Arrays.toString(optionalValues)));
   }


### PR DESCRIPTION
Problem:
validator passes when validating an optional parameter, even if the parameter entered by the user is not in the specified range

问题：
validator 在验证一个可选参数时，即使用户输入的参数不在指定范围内，也会通过验证