### PR TITLE
fix the parameter is null causing lsof error

### DIFF
--- a/iotdb-core/node-commons/src/assembly/resources/sbin/iotdb-common.sh
+++ b/iotdb-core/node-commons/src/assembly/resources/sbin/iotdb-common.sh
@@ -156,11 +156,6 @@ checkDataNodePortUsages () {
     echo "Warning: If you do not use sudo, the checking may not detect all the occupied ports."
   fi
   occupied=false
-  dn_rpc_port=6667
-  dn_internal_port=10730
-  dn_mpp_data_exchange_port=10740
-  dn_schema_region_consensus_port=10750
-  dn_data_region_consensus_port=10760
   if [ -f "$IOTDB_CONF/iotdb-datanode.properties" ]; then
     dn_rpc_port=$(sed '/^dn_rpc_port=/!d;s/.*=//' "${IOTDB_CONF}"/iotdb-datanode.properties)
     dn_internal_port=$(sed '/^dn_internal_port=/!d;s/.*=//' "${IOTDB_CONF}"/iotdb-datanode.properties)
@@ -175,8 +170,12 @@ checkDataNodePortUsages () {
     dn_data_region_consensus_port=$(sed '/^dn_data_region_consensus_port=/!d;s/.*=//' "${IOTDB_CONF}"/iotdb-datanode.properties)
   else
     echo "Warning: cannot find iotdb-datanode.properties, check the default configuration"
-
   fi
+  dn_rpc_port=${dn_rpc_port:-6667}
+  dn_internal_port=${dn_internal_port:-10730}
+  dn_mpp_data_exchange_port=${dn_mpp_data_exchange_port:-10740}
+  dn_schema_region_consensus_port=${dn_schema_region_consensus_port:-10750}
+  dn_data_region_consensus_port=${dn_data_region_consensus_port:-10760}
   if type lsof >/dev/null 2>&1; then
     PID=$(lsof -t -i:"${dn_rpc_port}" -sTCP:LISTEN)
     if [ -n "$PID" ]; then
@@ -245,8 +244,6 @@ checkConfigNodePortUsages () {
     echo "Warning: If you do not use sudo, the checking may not detect all the occupied ports."
   fi
   occupied=false
-  cn_internal_port=10710
-  cn_consensus_port=10720
   if [ -f "$CONFIGNODE_CONF/iotdb-confignode.properties" ]; then
     cn_internal_port=$(sed '/^cn_internal_port=/!d;s/.*=//' "${CONFIGNODE_CONF}"/iotdb-confignode.properties)
     cn_consensus_port=$(sed '/^cn_consensus_port=/!d;s/.*=//' "${CONFIGNODE_CONF}"/iotdb-confignode.properties)
@@ -256,6 +253,8 @@ checkConfigNodePortUsages () {
   else
     echo "Cannot find iotdb-confignode.properties, check the default configuration"
   fi
+  cn_internal_port=${cn_internal_port:-10710}
+  cn_consensus_port=${cn_consensus_port:-10720}
   if type lsof >/dev/null 2>&1; then
     PID=$(lsof -t -i:"${cn_internal_port}" -sTCP:LISTEN)
     if [ -n "$PID" ]; then


### PR DESCRIPTION
see https://jira.infra.timecho.com:8443/browse/TIMECHODB-441?filter=10506

![image](https://github.com/apache/iotdb/assets/7812383/2f4ca847-35e1-4e09-9601-26afdb2eca96)


Solution:
When the parameter cannot be found in the configuration file, use the default value