### PR TITLE
[IOTDB-6239] Revert updation of CreateRegionGroupsPlan

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/write/region/CreateRegionGroupsPlan.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/write/region/CreateRegionGroupsPlan.java
@@ -22,7 +22,6 @@ package org.apache.iotdb.confignode.consensus.request.write.region;
 import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.commons.utils.BasicStructureSerDeUtil;
-import org.apache.iotdb.commons.utils.CommonDateTimeUtils;
 import org.apache.iotdb.commons.utils.ThriftCommonsSerDeUtils;
 import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlan;
 import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlanType;
@@ -43,7 +42,6 @@ import java.util.stream.Collectors;
 /** Create regions for specified Databases. */
 public class CreateRegionGroupsPlan extends ConfigPhysicalPlan {
 
-  protected long createTime;
   // Map<Database, List<TRegionReplicaSet>>
   protected final Map<String, List<TRegionReplicaSet>> regionGroupMap;
 
@@ -59,14 +57,6 @@ public class CreateRegionGroupsPlan extends ConfigPhysicalPlan {
 
   public Map<String, List<TRegionReplicaSet>> getRegionGroupMap() {
     return regionGroupMap;
-  }
-
-  public long getCreateTime() {
-    return createTime;
-  }
-
-  public void setCreateTime(long createTime) {
-    this.createTime = createTime;
   }
 
   public void addRegionGroup(String database, TRegionReplicaSet regionReplicaSet) {
@@ -114,8 +104,6 @@ public class CreateRegionGroupsPlan extends ConfigPhysicalPlan {
           regionReplicaSet ->
               ThriftCommonsSerDeUtils.serializeTRegionReplicaSet(regionReplicaSet, stream));
     }
-
-    stream.writeLong(createTime);
   }
 
   @Override
@@ -132,13 +120,6 @@ public class CreateRegionGroupsPlan extends ConfigPhysicalPlan {
         regionGroupMap.get(database).add(regionReplicaSet);
       }
     }
-
-    if (buffer.hasRemaining()) {
-      // For compatibility
-      createTime = buffer.getLong();
-    } else {
-      createTime = CommonDateTimeUtils.currentTime();
-    }
   }
 
   @Override
@@ -153,11 +134,11 @@ public class CreateRegionGroupsPlan extends ConfigPhysicalPlan {
       return false;
     }
     CreateRegionGroupsPlan that = (CreateRegionGroupsPlan) o;
-    return createTime == that.createTime && Objects.equals(regionGroupMap, that.regionGroupMap);
+    return Objects.equals(regionGroupMap, that.regionGroupMap);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), createTime, regionGroupMap);
+    return Objects.hash(super.hashCode(), regionGroupMap);
   }
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/DatabasePartitionTable.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/DatabasePartitionTable.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.common.rpc.thrift.TSeriesPartitionSlot;
 import org.apache.iotdb.common.rpc.thrift.TTimePartitionSlot;
 import org.apache.iotdb.commons.partition.DataPartitionTable;
 import org.apache.iotdb.commons.partition.SchemaPartitionTable;
+import org.apache.iotdb.commons.utils.CommonDateTimeUtils;
 import org.apache.iotdb.confignode.consensus.request.read.region.GetRegionInfoListPlan;
 import org.apache.iotdb.confignode.rpc.thrift.TRegionInfo;
 import org.apache.iotdb.confignode.rpc.thrift.TShowRegionReq;
@@ -90,12 +91,13 @@ public class DatabasePartitionTable {
    * Cache allocation result of new RegionGroups.
    *
    * @param replicaSets List<TRegionReplicaSet>
-   * @param createTime The creation time of RegionGroups
    */
-  public void createRegionGroups(List<TRegionReplicaSet> replicaSets, long createTime) {
+  public void createRegionGroups(List<TRegionReplicaSet> replicaSets) {
     replicaSets.forEach(
         replicaSet ->
-            regionGroupMap.put(replicaSet.getRegionId(), new RegionGroup(createTime, replicaSet)));
+            regionGroupMap.put(
+                replicaSet.getRegionId(),
+                new RegionGroup(CommonDateTimeUtils.currentTime(), replicaSet)));
   }
 
   /** @return Deep copy of all Regions' RegionReplicaSet within one StorageGroup */

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
@@ -165,9 +165,7 @@ public class PartitionInfo implements SnapshotProcessor {
     plan.getRegionGroupMap()
         .forEach(
             (database, regionReplicaSets) -> {
-              databasePartitionTables
-                  .get(database)
-                  .createRegionGroups(regionReplicaSets, plan.getCreateTime());
+              databasePartitionTables.get(database).createRegionGroups(regionReplicaSets);
               regionReplicaSets.forEach(
                   regionReplicaSet ->
                       maxRegionId.set(

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/statemachine/CreateRegionGroupsProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/statemachine/CreateRegionGroupsProcedure.java
@@ -23,7 +23,6 @@ import org.apache.iotdb.common.rpc.thrift.TConsensusGroupId;
 import org.apache.iotdb.common.rpc.thrift.TConsensusGroupType;
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.commons.cluster.RegionStatus;
-import org.apache.iotdb.commons.utils.CommonDateTimeUtils;
 import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.commons.utils.ThriftCommonsSerDeUtils;
 import org.apache.iotdb.confignode.consensus.request.write.region.CreateRegionGroupsPlan;
@@ -91,7 +90,6 @@ public class CreateRegionGroupsProcedure
         break;
       case SHUNT_REGION_REPLICAS:
         persistPlan = new CreateRegionGroupsPlan();
-        persistPlan.setCreateTime(CommonDateTimeUtils.currentTime());
         OfferRegionMaintainTasksPlan offerPlan = new OfferRegionMaintainTasksPlan();
         // Filter those RegionGroups that created successfully
         createRegionGroupsPlan

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlanSerDeTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlanSerDeTest.java
@@ -51,7 +51,6 @@ import org.apache.iotdb.commons.sync.PipeStatus;
 import org.apache.iotdb.commons.sync.TsFilePipeInfo;
 import org.apache.iotdb.commons.trigger.TriggerInformation;
 import org.apache.iotdb.commons.udf.UDFInformation;
-import org.apache.iotdb.commons.utils.CommonDateTimeUtils;
 import org.apache.iotdb.confignode.consensus.request.auth.AuthorPlan;
 import org.apache.iotdb.confignode.consensus.request.read.database.CountDatabasePlan;
 import org.apache.iotdb.confignode.consensus.request.read.database.GetDatabasePlan;
@@ -347,7 +346,6 @@ public class ConfigPhysicalPlanSerDeTest {
     dataNodeLocation.setSchemaRegionConsensusEndPoint(new TEndPoint("0.0.0.0", 10750));
 
     CreateRegionGroupsPlan req0 = new CreateRegionGroupsPlan();
-    req0.setCreateTime(CommonDateTimeUtils.currentTime());
     TRegionReplicaSet dataRegionSet = new TRegionReplicaSet();
     dataRegionSet.setRegionId(new TConsensusGroupId(TConsensusGroupType.DataRegion, 0));
     dataRegionSet.setDataNodeLocations(Collections.singletonList(dataNodeLocation));
@@ -867,11 +865,9 @@ public class ConfigPhysicalPlanSerDeTest {
     failedRegions.put(dataRegionGroupId, dataRegionSet);
     failedRegions.put(schemaRegionGroupId, schemaRegionSet);
     CreateRegionGroupsPlan createRegionGroupsPlan = new CreateRegionGroupsPlan();
-    createRegionGroupsPlan.setCreateTime(CommonDateTimeUtils.currentTime());
     createRegionGroupsPlan.addRegionGroup("root.sg0", dataRegionSet);
     createRegionGroupsPlan.addRegionGroup("root.sg1", schemaRegionSet);
     CreateRegionGroupsPlan persistPlan = new CreateRegionGroupsPlan();
-    persistPlan.setCreateTime(CommonDateTimeUtils.currentTime());
     persistPlan.addRegionGroup("root.sg0", dataRegionSet);
     persistPlan.addRegionGroup("root.sg1", schemaRegionSet);
     CreateRegionGroupsProcedure procedure0 =

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/PartitionInfoTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/PartitionInfoTest.java
@@ -29,7 +29,6 @@ import org.apache.iotdb.common.rpc.thrift.TTimePartitionSlot;
 import org.apache.iotdb.commons.partition.DataPartitionTable;
 import org.apache.iotdb.commons.partition.SchemaPartitionTable;
 import org.apache.iotdb.commons.partition.SeriesPartitionTable;
-import org.apache.iotdb.commons.utils.CommonDateTimeUtils;
 import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlanType;
 import org.apache.iotdb.confignode.consensus.request.read.region.GetRegionInfoListPlan;
 import org.apache.iotdb.confignode.consensus.request.write.database.DatabaseSchemaPlan;
@@ -109,8 +108,6 @@ public class PartitionInfoTest {
 
     // Create a SchemaRegion
     CreateRegionGroupsPlan createRegionGroupsReq = new CreateRegionGroupsPlan();
-    createRegionGroupsReq.setCreateTime(CommonDateTimeUtils.currentTime());
-
     TRegionReplicaSet schemaRegionReplicaSet =
         generateTRegionReplicaSet(
             testFlag.SchemaPartition.getFlag(),
@@ -166,7 +163,6 @@ public class PartitionInfoTest {
 
       // Create a SchemaRegion
       CreateRegionGroupsPlan createRegionGroupsPlan = new CreateRegionGroupsPlan();
-      createRegionGroupsPlan.setCreateTime(CommonDateTimeUtils.currentTime());
       TRegionReplicaSet schemaRegionReplicaSet =
           generateTRegionReplicaSet(
               testFlag.SchemaPartition.getFlag(),
@@ -177,7 +173,6 @@ public class PartitionInfoTest {
 
       // Create a DataRegion
       createRegionGroupsPlan = new CreateRegionGroupsPlan();
-      createRegionGroupsPlan.setCreateTime(CommonDateTimeUtils.currentTime());
       TRegionReplicaSet dataRegionReplicaSet =
           generateTRegionReplicaSet(
               testFlag.DataPartition.getFlag(),

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/CreateRegionGroupsProcedureTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/CreateRegionGroupsProcedureTest.java
@@ -24,7 +24,6 @@ import org.apache.iotdb.common.rpc.thrift.TConsensusGroupType;
 import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
-import org.apache.iotdb.commons.utils.CommonDateTimeUtils;
 import org.apache.iotdb.confignode.consensus.request.write.region.CreateRegionGroupsPlan;
 import org.apache.iotdb.confignode.procedure.impl.statemachine.CreateRegionGroupsProcedure;
 import org.apache.iotdb.confignode.procedure.store.ProcedureFactory;
@@ -92,12 +91,10 @@ public class CreateRegionGroupsProcedureTest {
     assertEquals(failedRegions0, failedRegions1);
 
     CreateRegionGroupsPlan createRegionGroupsPlan = new CreateRegionGroupsPlan();
-    createRegionGroupsPlan.setCreateTime(CommonDateTimeUtils.currentTime());
     createRegionGroupsPlan.addRegionGroup("root.sg0", dataRegionSet);
     createRegionGroupsPlan.addRegionGroup("root.sg1", schemaRegionSet);
 
     CreateRegionGroupsPlan persistPlan = new CreateRegionGroupsPlan();
-    persistPlan.setCreateTime(CommonDateTimeUtils.currentTime());
     persistPlan.addRegionGroup("root.sg0", dataRegionSet);
     persistPlan.addRegionGroup("root.sg1", schemaRegionSet);
 


### PR DESCRIPTION
**Jira:** https://issues.apache.org/jira/browse/IOTDB-6239

This PR reverts the updation of CreateRegionGroupsPlan in https://github.com/apache/iotdb/pull/11481. Because it's too expensive to supporting the compability in the current serialization framework.

The compability problem can be resolved by importing thrift-idl framework, which might be implemented at v1.4.0