### PR TITLE
Support high available while meeting timeout exception

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/AsyncSendPlanNodeHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/AsyncSendPlanNodeHandler.java
@@ -100,7 +100,6 @@ public class AsyncSendPlanNodeHandler implements AsyncMethodCallback<TSendBatchP
     Throwable rootCause = ExceptionUtils.getRootCause(e);
     // 1. connection broken it means that the remote node may go offline
     // 2. or the method call is time out
-    // 3. or the target node is ReadOnly
     return isConnectionBroken(rootCause) || (e instanceof TimeoutException);
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/AsyncSendPlanNodeHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/AsyncSendPlanNodeHandler.java
@@ -31,6 +31,7 @@ import org.apache.thrift.async.AsyncMethodCallback;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.apache.iotdb.commons.client.ThriftClient.isConnectionBroken;
@@ -97,9 +98,10 @@ public class AsyncSendPlanNodeHandler implements AsyncMethodCallback<TSendBatchP
 
   private boolean needRetry(Exception e) {
     Throwable rootCause = ExceptionUtils.getRootCause(e);
-    // if the exception is SocketException and its error message is Broken pipe, it means that the
-    // remote node may go offline
-    return isConnectionBroken(rootCause);
+    // 1. connection broken it means that the remote node may go offline
+    // 2. or the method call is time out
+    // 3. or the target node is ReadOnly
+    return isConnectionBroken(rootCause) || (e instanceof TimeoutException);
   }
 
   private boolean needRetry(TSendSinglePlanNodeResp resp) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
@@ -55,6 +55,9 @@ public class IoTDBShutdownHook extends Thread {
 
   @Override
   public void run() {
+    // stop external rpc service firstly.
+    RPCService.getInstance().stop();
+
     // close rocksdb if possible to avoid lose data
     if (SchemaEngineMode.valueOf(CommonDescriptor.getInstance().getConfig().getSchemaEngineMode())
         .equals(SchemaEngineMode.Rocksdb_based)) {


### PR DESCRIPTION
1. If TimeoutException happened while sending write FI, we need to retry sending this FI to another follower.
![img_v3_0256_2972aaeb-f965-4b30-b33c-921c0970a45g](https://github.com/apache/iotdb/assets/16079446/9ff8ef4d-1ee9-4060-b91a-1d837fb20316)
![b676fdc9-7f45-444d-b0f8-9a7199632833](https://github.com/apache/iotdb/assets/16079446/a7427cb9-c808-4576-9fa5-44c960dbc7bc)

2. We need to stop rpc service firstly in shut down hook, because we don't want to receive more client requests which will also be refused in the later process.
