### PR TITLE
Fix insertRecordsOfOneDevice causes data out of order

### DIFF
--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppCommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppCommonConfig.java
@@ -121,6 +121,15 @@ public class MppCommonConfig extends MppBaseConfig implements CommonConfig {
   }
 
   @Override
+  public CommonConfig setMaxInnerCompactionCandidateFileNum(
+      int maxInnerCompactionCandidateFileNum) {
+    setProperty(
+        "max_inner_compaction_candidate_file_num",
+        String.valueOf(maxInnerCompactionCandidateFileNum));
+    return this;
+  }
+
+  @Override
   public CommonConfig setAutoCreateSchemaEnabled(boolean enableAutoCreateSchema) {
     setProperty("enable_auto_create_schema", String.valueOf(enableAutoCreateSchema));
     return this;

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppSharedCommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppSharedCommonConfig.java
@@ -118,6 +118,14 @@ public class MppSharedCommonConfig implements CommonConfig {
   }
 
   @Override
+  public CommonConfig setMaxInnerCompactionCandidateFileNum(
+      int maxInnerCompactionCandidateFileNum) {
+    cnConfig.setMaxInnerCompactionCandidateFileNum(maxInnerCompactionCandidateFileNum);
+    dnConfig.setMaxInnerCompactionCandidateFileNum(maxInnerCompactionCandidateFileNum);
+    return this;
+  }
+
+  @Override
   public CommonConfig setAutoCreateSchemaEnabled(boolean enableAutoCreateSchema) {
     cnConfig.setAutoCreateSchemaEnabled(enableAutoCreateSchema);
     dnConfig.setAutoCreateSchemaEnabled(enableAutoCreateSchema);

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/remote/config/RemoteCommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/remote/config/RemoteCommonConfig.java
@@ -85,6 +85,12 @@ public class RemoteCommonConfig implements CommonConfig {
   }
 
   @Override
+  public CommonConfig setMaxInnerCompactionCandidateFileNum(
+      int maxInnerCompactionCandidateFileNum) {
+    return this;
+  }
+
+  @Override
   public CommonConfig setAutoCreateSchemaEnabled(boolean enableAutoCreateSchema) {
     return this;
   }

--- a/integration-test/src/main/java/org/apache/iotdb/itbase/env/CommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/itbase/env/CommonConfig.java
@@ -48,6 +48,8 @@ public interface CommonConfig {
 
   CommonConfig setEnableCrossSpaceCompaction(boolean enableCrossSpaceCompaction);
 
+  CommonConfig setMaxInnerCompactionCandidateFileNum(int maxInnerCompactionCandidateFileNum);
+
   CommonConfig setAutoCreateSchemaEnabled(boolean enableAutoCreateSchema);
 
   CommonConfig setEnableLastCache(boolean lastCacheEnable);

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBInsertMultiRowIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBInsertMultiRowIT.java
@@ -158,7 +158,6 @@ public class IoTDBInsertMultiRowIT {
       st2.execute(
           "INSERT INTO root.t1.d1(timestamp, s1) VALUES (6, 10),(7,12),(8,14),(9,160),(10,null),(11,58)");
     } catch (SQLException e) {
-      e.printStackTrace();
       fail();
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
@@ -2107,7 +2107,20 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       // construct insert statement
       InsertRowsOfOneDeviceStatement insertRowsOfOneDeviceStatement =
           new InsertRowsOfOneDeviceStatement();
+      if (!checkSorted(timeArray)) {
+        Integer[] index = new Integer[timeArray.length];
+        for (int i = 0; i < index.length; i++) {
+          index[i] = i;
+        }
+        Arrays.sort(index, Comparator.comparingLong(o -> timeArray[o]));
+        Arrays.sort(timeArray, 0, timeArray.length);
+        insertStatement.setValuesList(
+            Arrays.stream(index)
+                .map(insertStatement.getValuesList()::get)
+                .collect(Collectors.toList()));
+      }
       List<InsertRowStatement> insertRowStatementList = new ArrayList<>();
+
       for (int i = 0; i < timeArray.length; i++) {
         InsertRowStatement statement = new InsertRowStatement();
         statement.setDevicePath(devicePath);
@@ -2127,6 +2140,15 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       insertRowsOfOneDeviceStatement.setInsertRowStatementList(insertRowStatementList);
       return insertRowsOfOneDeviceStatement.accept(this, context);
     }
+  }
+
+  private boolean checkSorted(long[] times) {
+    for (int i = 1; i < times.length; i++) {
+      if (times[i] < times[i - 1]) {
+        return false;
+      }
+    }
+    return true;
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertNode.java
@@ -133,6 +133,10 @@ public abstract class InsertNode extends WritePlanNode implements ComparableCons
     return measurements;
   }
 
+  public void setMeasurements(String[] measurements) {
+    this.measurements = measurements;
+  }
+
   public TSDataType[] getDataTypes() {
     return dataTypes;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertRowsOfOneDeviceNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertRowsOfOneDeviceNode.java
@@ -20,6 +20,7 @@ package org.apache.iotdb.db.queryengine.plan.planner.plan.node.write;
 
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
+import org.apache.iotdb.common.rpc.thrift.TTimePartitionSlot;
 import org.apache.iotdb.commons.consensus.index.ProgressIndex;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
@@ -146,24 +147,28 @@ public class InsertRowsOfOneDeviceNode extends InsertNode {
   public List<WritePlanNode> splitByPartition(Analysis analysis) {
     List<WritePlanNode> result = new ArrayList<>();
 
-    Map<TRegionReplicaSet, List<InsertRowNode>> splitMap = new HashMap<>();
-    Map<TRegionReplicaSet, List<Integer>> splitMapForIndex = new HashMap<>();
+    Map<TRegionReplicaSet, Map<TTimePartitionSlot, List<InsertRowNode>>> splitMap = new HashMap<>();
+    Map<TRegionReplicaSet, Map<TTimePartitionSlot, List<Integer>>> splitMapForIndex =
+        new HashMap<>();
 
     for (int i = 0; i < insertRowNodeList.size(); i++) {
       InsertRowNode insertRowNode = insertRowNodeList.get(i);
+      TTimePartitionSlot timePartitionSlot =
+          TimePartitionUtils.getTimePartitionSlot(insertRowNode.getTime());
       TRegionReplicaSet dataRegionReplicaSet =
           analysis
               .getDataPartitionInfo()
-              .getDataRegionReplicaSetForWriting(
-                  devicePath.getFullPath(),
-                  TimePartitionUtils.getTimePartitionSlot(insertRowNode.getTime()));
-      List<InsertRowNode> tmpMap =
-          splitMap.computeIfAbsent(dataRegionReplicaSet, k -> new ArrayList<>());
-      List<Integer> tmpIndexMap =
-          splitMapForIndex.computeIfAbsent(dataRegionReplicaSet, k -> new ArrayList<>());
-
-      tmpMap.add(insertRowNode);
-      tmpIndexMap.add(insertRowNodeIndexList.get(i));
+              .getDataRegionReplicaSetForWriting(devicePath.getFullPath(), timePartitionSlot);
+      Map<TTimePartitionSlot, List<InsertRowNode>> tmpMap =
+          splitMap.computeIfAbsent(dataRegionReplicaSet, k -> new HashMap<>());
+      Map<TTimePartitionSlot, List<Integer>> tmpIndexMap =
+          splitMapForIndex.computeIfAbsent(dataRegionReplicaSet, k -> new HashMap<>());
+      List<InsertRowNode> tmpList =
+          tmpMap.computeIfAbsent(timePartitionSlot, k -> new ArrayList<>());
+      List<Integer> tmpIndexList =
+          tmpIndexMap.computeIfAbsent(timePartitionSlot, k -> new ArrayList<>());
+      tmpList.add(insertRowNode);
+      tmpIndexList.add(insertRowNodeIndexList.get(i));
 
       if (i == insertRowNodeList.size() - 1) {
         analysis.setRedirectNodeList(
@@ -172,12 +177,17 @@ public class InsertRowsOfOneDeviceNode extends InsertNode {
       }
     }
 
-    for (Map.Entry<TRegionReplicaSet, List<InsertRowNode>> entry : splitMap.entrySet()) {
-      InsertRowsOfOneDeviceNode reducedNode = new InsertRowsOfOneDeviceNode(this.getPlanNodeId());
-      reducedNode.setInsertRowNodeList(entry.getValue());
-      reducedNode.setInsertRowNodeIndexList(splitMapForIndex.get(entry.getKey()));
-      reducedNode.setDataRegionReplicaSet(entry.getKey());
-      result.add(reducedNode);
+    for (Map.Entry<TRegionReplicaSet, Map<TTimePartitionSlot, List<InsertRowNode>>> entry1 :
+        splitMap.entrySet()) {
+      for (Map.Entry<TTimePartitionSlot, List<InsertRowNode>> entry :
+          entry1.getValue().entrySet()) {
+        InsertRowsOfOneDeviceNode reducedNode = new InsertRowsOfOneDeviceNode(this.getPlanNodeId());
+        reducedNode.setInsertRowNodeList(entry.getValue());
+        reducedNode.setInsertRowNodeIndexList(
+            splitMapForIndex.get(entry1.getKey()).get(entry.getKey()));
+        reducedNode.setDataRegionReplicaSet(entry1.getKey());
+        result.add(reducedNode);
+      }
     }
     return result;
   }


### PR DESCRIPTION
## Description

When an insertRecordsOfOneDevice write request contains data from two time partitions 0 and 1, assuming that the first data is sequential data from a 0 partition, the initial value of isSequence is false. The isSequence is set to true after the code block of line 2794 is entered and the first data is written to the sequential space of the 0 partition. If the second data is an out-of-order data in the 1 partition, isSequence is still true, and the out-of-order data in the 2794 line is not entered into the out-of-order judgment, and the out-of-order data will be written into the order space of the 1 partition. This causes timestamp overlaps between sequential space files in the 1 partition.

![image](https://github.com/apache/iotdb/assets/25913899/875f1a79-ef98-4d6b-a828-6565dbae9ffe)

To fix it, when doing insertRecordsOfOneDeviceNode split, the different time of the same DataRegion partition data split into different sub insertRecordsOfOneDeviceNode, So that the same insertRecordsOfOneDeviceNode DataRegion to not appear across time partition, so as to avoid this situation.


## How to test
1. Change`time_partition_interval=100`, `max_inner_compaction_candidate_file_num=2`
2. execute the following sql
```sql
insert into root.sg1.d1(time,s1) values(150,1)
flush
insert into root.sg1.d1(time,s1) values(1,1),(104,2)
flush
```
3. execute query `select * from root.**`
