### PR TITLE
add file validate when rename file, avoid rename error because file is not exist

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -3046,7 +3046,10 @@ public class DataRegion implements IDataRegionForQuery {
 
   private void renameAndHandleError(String originFileName, String newFileName) {
     try {
-      Files.move(Paths.get(originFileName), Paths.get(newFileName));
+      File originFile = new File(originFileName);
+      if (originFile.exists()) {
+        Files.move(originFile.toPath(), Paths.get(newFileName));
+      }
     } catch (IOException e) {
       logger.error("Failed to rename {} to {},", originFileName, newFileName, e);
     }


### PR DESCRIPTION
## Description

rename the file only when it exists. Otherwise, the file is not renamed.

## How to test

1. start a 1C1D cluster
2. execute `insert into root.a1.d1 (time,s4) values (14,"123f111aa");`
3. execute `delete timeseries root.a1.d1.**`
4. execute `flush`
5. observe for any of the following errors
<img width="1281" alt="image" src="https://github.com/apache/iotdb/assets/34238279/27914a94-6f96-4fbf-80dd-f508528c3574">


