### PR TITLE
Fix update and recovery of LastFlushTimeMap

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/HashLastFlushTimeMap.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/HashLastFlushTimeMap.java
@@ -192,7 +192,7 @@ public class HashLastFlushTimeMap implements ILastFlushTimeMap {
     for (Map.Entry<String, Long> entry : updateMap.entrySet()) {
       partitionLatestFlushedTimeForEachDevice
           .computeIfAbsent(partitionId, id -> new HashMap<>())
-          .put(entry.getKey(), entry.getValue());
+          .merge(entry.getKey(), entry.getValue(), Math::max);
       updateNewlyFlushedPartitionLatestFlushedTimeForEachDevice(
           partitionId, entry.getKey(), entry.getValue());
       if (globalLatestFlushedTimeForEachDevice.getOrDefault(entry.getKey(), Long.MIN_VALUE)

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileManager.java
@@ -115,7 +115,11 @@ public class TsFileManager {
       List<TsFileResource> seqTsFileResourceList =
           sequenceFiles.computeIfAbsent(partitionId, l -> new TsFileResourceList());
       for (int i = seqTsFileResourceList.size() - 1; i >= 0; i--) {
-        Set<String> deviceSet = seqTsFileResourceList.get(i).getDevices();
+        TsFileResource seqResource = seqTsFileResourceList.get(i);
+        if (seqResource.isClosed()) {
+          continue;
+        }
+        Set<String> deviceSet = seqResource.getDevices();
         if (deviceSet.contains(devicePath)) {
           lastFlushTime = seqTsFileResourceList.get(i).getEndTime(devicePath);
           break;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileManager.java
@@ -116,7 +116,7 @@ public class TsFileManager {
           sequenceFiles.computeIfAbsent(partitionId, l -> new TsFileResourceList());
       for (int i = seqTsFileResourceList.size() - 1; i >= 0; i--) {
         TsFileResource seqResource = seqTsFileResourceList.get(i);
-        if (seqResource.isClosed()) {
+        if (!seqResource.isClosed()) {
           continue;
         }
         Set<String> deviceSet = seqResource.getDevices();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/memory/TimePartitionManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/memory/TimePartitionManager.java
@@ -116,6 +116,12 @@ public class TimePartitionManager {
             StorageEngine.getInstance().getDataRegion(timePartitionInfo.dataRegionId);
         if (dataRegion != null) {
           dataRegion.releaseFlushTimeMap(timePartitionInfo.partitionId);
+          logger.info(
+              "[{}]evict LastFlushTimeMap of old TimePartitionInfo-{}, mem size is {}, remaining mem cost is {}",
+              timePartitionInfo.dataRegionId,
+              timePartitionInfo.partitionId,
+              timePartitionInfo.memSize,
+              memCost);
         }
         timePartitionInfoMap
             .get(timePartitionInfo.dataRegionId)


### PR DESCRIPTION
## Description
1. When a sequence tsfile is flushed, the LastFlushTimeMap will update with the end time of the devices of the tsfile. The method `updateLatestFlushTime` is called here and put the value to LastFlushTimeMap, which is correct in normal cases. However, if the lastFlushTime is modified by `load`, the end time of unsequence space may larger than the sequence space, and the LastFlushTime may be set to a smaller value.
2. When recover the LastFlushTime of a device, TsFileManager will search the sequence files in reverse order and find the last sequence file who contains the device. If the LastFlushTimeMap of a time partition is evicted by FlushCallback of another  tsfile and there is a unclosed tsfile in the evicted time partition, the next write of the time partition will recover the LastFlushTime from the unclosed TsFileResource and the result of recovered LastFlushTime is Long.MIN_VALUE. Then, the data of the insertion will enter sequence space through it is unsequence data. 

To reappear problem1：
1. execute this sql
<img width="462" alt="截屏2023-11-15 10 54 01" src="https://github.com/apache/iotdb/assets/55970239/5d05c243-903a-4bb0-8f15-d6d0ab46f753">

2. load a tsfile with time range 10 - 11
<img width="632" alt="截屏2023-11-15 10 49 58" src="https://github.com/apache/iotdb/assets/55970239/bbe2c0e3-ee52-439f-88c9-e68469b7a8ea">

3. execute these sqls.
<img width="562" alt="截屏2023-11-15 10 54 21" src="https://github.com/apache/iotdb/assets/55970239/8d3f4c94-fb20-4962-8ddb-d7aad16b35cc">


3. There are two files in sequence space.

To reappear problem2, set the timePartitionInfoMemoryThreshold to very small and the avgSeriesPointNumberThreshold to 2, and execute these sql.
<img width="444" alt="截屏2023-11-14 18 08 14" src="https://github.com/apache/iotdb/assets/55970239/4dd69776-1cf8-4bbc-8b47-b6a56f56428a">
