### PR TITLE
[IOTDB-6250] Pipe: Fix topological sort with null ProgressIndex 

### DIFF
--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/ProgressIndex.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/ProgressIndex.java
@@ -124,10 +124,8 @@ public abstract class ProgressIndex {
    */
   public abstract TotalOrderSumTuple getTotalOrderSumTuple();
 
-  public final int topologicalCompareTo(ProgressIndex progressIndex) {
-    return progressIndex == null
-        ? 1
-        : getTotalOrderSumTuple().compareTo(progressIndex.getTotalOrderSumTuple());
+  public final int topologicalCompareTo(@Nonnull ProgressIndex progressIndex) {
+    return getTotalOrderSumTuple().compareTo(progressIndex.getTotalOrderSumTuple());
   }
 
   /**


### PR DESCRIPTION
Problem:
ProgressIndex cann't compare with null, modify args in ProgressIndex#topologicalCompareTo to nonnull.

问题：
ProgressIndex 不能和 null 比，修改  ProgressIndex#topologicalCompareTo 的入参为 nonnull