### PR TITLE
Return WRITE_PROCESS_ERROR when catching BatchProcessException in writing process

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataExecutionVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataExecutionVisitor.java
@@ -84,7 +84,7 @@ public class DataExecutionVisitor extends PlanVisitor<TSStatus, DataRegion> {
           node.getTimes()[0],
           node.getMeasurements(),
           e.getFailingStatus());
-      return StatusUtils.getStatus(TSStatusCode.representOf(e.getErrorCode()));
+      return new TSStatus(TSStatusCode.WRITE_PROCESS_ERROR.getStatusCode());
     }
   }
 
@@ -197,7 +197,7 @@ public class DataExecutionVisitor extends PlanVisitor<TSStatus, DataRegion> {
       return StatusUtils.OK;
     } catch (IOException e) {
       LOGGER.error("Error in executing plan node: {}", node, e);
-      return StatusUtils.EXECUTE_STATEMENT_ERROR;
+      return new TSStatus(TSStatusCode.WRITE_PROCESS_ERROR.getStatusCode());
     }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -2826,7 +2826,7 @@ public class DataRegion implements IDataRegionForQuery {
       } catch (WriteProcessException | BatchProcessException e) {
         insertMultiTabletsNode
             .getResults()
-            .put(i, RpcUtils.getStatus(e.getErrorCode(), e.getMessage()));
+            .put(i, new TSStatus(TSStatusCode.WRITE_PROCESS_ERROR.getStatusCode()));
       }
     }
 


### PR DESCRIPTION
## Description
Before this change, some write operations will return `QUERY_PROCESS_ERROR` when catching BatchProcessException. The status seems wired for write operations. And especially in IoTConsensus, it won't trigger operation retry when the response code is `QUERY_PROCESS_ERROR`.

Thus, to fix this issue, we will return WRITE_PROCESS_ERROR if write operation catches BatchProcessException