### PR TITLE
Refactor CachedMTreeStore.updateMNode interface usage and implementation in PBTree

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/schema/ConfigMTreeStore.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/schema/ConfigMTreeStore.java
@@ -35,6 +35,7 @@ import org.apache.iotdb.db.schemaengine.template.Template;
 
 import java.io.File;
 import java.util.Map;
+import java.util.function.Consumer;
 
 /** This is a memory-based implementation of IMTreeStore. All MNodes are stored in memory. */
 public class ConfigMTreeStore implements IMTreeStore<IConfigMNode> {
@@ -98,7 +99,7 @@ public class ConfigMTreeStore implements IMTreeStore<IConfigMNode> {
   }
 
   @Override
-  public void updateMNode(IConfigMNode node) {}
+  public void updateMNode(IConfigMNode node, Consumer<IConfigMNode> consumer) {}
 
   @Override
   public IDeviceMNode<IConfigMNode> setToEntity(IConfigMNode node) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/impl/SchemaRegionPBTreeImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/impl/SchemaRegionPBTreeImpl.java
@@ -626,8 +626,9 @@ public class SchemaRegionPBTreeImpl implements ISchemaRegion {
           writeToMLog(plan);
         }
         if (offset != -1) {
-          leafMNode.setOffset(offset);
-          mtree.updateMNode(leafMNode.getAsMNode());
+          long finalOffset = offset;
+          mtree.updateMNode(
+              leafMNode.getAsMNode(), o -> o.getAsMeasurementMNode().setOffset(finalOffset));
         }
 
       } finally {
@@ -738,8 +739,10 @@ public class SchemaRegionPBTreeImpl implements ISchemaRegion {
         tagOffsets = plan.getTagOffsets();
         for (int i = 0; i < measurements.size(); i++) {
           if (tagOffsets.get(i) != -1) {
-            measurementMNodeList.get(i).setOffset(tagOffsets.get(i));
-            mtree.updateMNode(measurementMNodeList.get(i).getAsMNode());
+            final long offset = tagOffsets.get(i);
+            mtree.updateMNode(
+                measurementMNodeList.get(i).getAsMNode(),
+                o -> o.getAsMeasurementMNode().setOffset(offset));
           }
         }
       } finally {
@@ -1009,8 +1012,8 @@ public class SchemaRegionPBTreeImpl implements ISchemaRegion {
   private void changeOffset(PartialPath path, long offset) throws MetadataException {
     IMeasurementMNode<ICachedMNode> measurementMNode = mtree.getMeasurementMNode(path);
     try {
-      measurementMNode.setOffset(offset);
-      mtree.updateMNode(measurementMNode.getAsMNode());
+      mtree.updateMNode(
+          measurementMNode.getAsMNode(), o -> o.getAsMeasurementMNode().setOffset(offset));
 
       if (isRecovering) {
         try {
@@ -1054,8 +1057,7 @@ public class SchemaRegionPBTreeImpl implements ISchemaRegion {
       if (leafMNode.getOffset() < 0) {
         long offset = tagManager.writeTagFile(tagsMap, attributesMap);
         writeToMLog(SchemaRegionWritePlanFactory.getChangeTagOffsetPlan(fullPath, offset));
-        leafMNode.setOffset(offset);
-        mtree.updateMNode(leafMNode.getAsMNode());
+        mtree.updateMNode(leafMNode.getAsMNode(), o -> o.getAsMeasurementMNode().setOffset(offset));
         // update inverted Index map
         if (tagsMap != null && !tagsMap.isEmpty()) {
           tagManager.addIndex(tagsMap, leafMNode);
@@ -1094,14 +1096,13 @@ public class SchemaRegionPBTreeImpl implements ISchemaRegion {
       if (leafMNode.getOffset() < 0) {
         long offset = tagManager.writeTagFile(Collections.emptyMap(), attributesMap);
         writeToMLog(SchemaRegionWritePlanFactory.getChangeTagOffsetPlan(fullPath, offset));
-        leafMNode.setOffset(offset);
-        mtree.updateMNode(leafMNode.getAsMNode());
+        mtree.updateMNode(leafMNode.getAsMNode(), o -> o.getAsMeasurementMNode().setOffset(offset));
         return;
       }
 
       tagManager.addAttributes(attributesMap, fullPath, leafMNode);
     } finally {
-      mtree.updateMNode(leafMNode.getAsMNode());
+      mtree.unPinMNode(leafMNode.getAsMNode());
     }
   }
 
@@ -1121,8 +1122,7 @@ public class SchemaRegionPBTreeImpl implements ISchemaRegion {
       if (leafMNode.getOffset() < 0) {
         long offset = tagManager.writeTagFile(tagsMap, Collections.emptyMap());
         writeToMLog(SchemaRegionWritePlanFactory.getChangeTagOffsetPlan(fullPath, offset));
-        leafMNode.setOffset(offset);
-        mtree.updateMNode(leafMNode.getAsMNode());
+        mtree.updateMNode(leafMNode.getAsMNode(), o -> o.getAsMeasurementMNode().setOffset(offset));
         // update inverted Index map
         tagManager.addIndex(tagsMap, leafMNode);
         mtree.pinMNode(leafMNode.getAsMNode());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/IMTreeStore.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/IMTreeStore.java
@@ -28,6 +28,7 @@ import org.apache.iotdb.db.schemaengine.template.Template;
 
 import java.io.File;
 import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  * This interface defines the basic access methods of an MTreeStore.
@@ -73,7 +74,7 @@ public interface IMTreeStore<N extends IMNode<N>> {
 
   void deleteChild(N parent, String childName) throws MetadataException;
 
-  void updateMNode(N node) throws MetadataException;
+  void updateMNode(N node, Consumer<N> consumer) throws MetadataException;
 
   IDeviceMNode<N> setToEntity(N node) throws MetadataException;
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/mem/MemMTreeStore.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/mem/MemMTreeStore.java
@@ -135,7 +135,7 @@ public class MemMTreeStore implements IMTreeStore<IMemMNode> {
   }
 
   @Override
-  public void updateMNode(IMemMNode node) {}
+  public void updateMNode(IMemMNode node, Consumer<IMemMNode> consumer) {}
 
   @Override
   public IDeviceMNode<IMemMNode> setToEntity(IMemMNode node) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/ReentrantReadOnlyCachedMTreeStore.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/ReentrantReadOnlyCachedMTreeStore.java
@@ -29,6 +29,7 @@ import org.apache.iotdb.db.schemaengine.template.Template;
 
 import java.io.File;
 import java.util.Map;
+import java.util.function.Consumer;
 
 public class ReentrantReadOnlyCachedMTreeStore implements IMTreeStore<ICachedMNode> {
   private final CachedMTreeStore store;
@@ -82,8 +83,8 @@ public class ReentrantReadOnlyCachedMTreeStore implements IMTreeStore<ICachedMNo
   }
 
   @Override
-  public void updateMNode(ICachedMNode node) {
-    store.updateMNode(node, false);
+  public void updateMNode(ICachedMNode node, Consumer<ICachedMNode> consumer) {
+    store.updateMNode(node, consumer, false);
   }
 
   @Override


### PR DESCRIPTION
## Description


### Motivation
In the original implementation, the attribute modification is not protected by the read lock, therefore a node already in buffer may experience redundant flush while the updated info may already be synced to disk.

Here's a simple example. 

MNode A is already in buffer since it may be newly added to MTree or recently updated. 

Thread A tries to modify some attribute in it while the flush thread starts a flush process and take the write lock in advance. 

In this case, the modified info will be synced to disk by this flush process, but thread A may still invoke the updateMNode method to add the node to buffer after this flush. 

The result is a node with nothing new will experience another flush process.

### Modification

Refactor the updateMNode method to require the invokers to pass the specific update process as a consumer, which will be protected by read lock.



