### PR TITLE
Use faster constructor of PartialPath in Compaction

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/performer/impl/ReadChunkCompactionPerformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/performer/impl/ReadChunkCompactionPerformer.java
@@ -33,6 +33,7 @@ import org.apache.iotdb.db.storageengine.dataregion.compaction.io.CompactionTsFi
 import org.apache.iotdb.db.storageengine.dataregion.compaction.schedule.constant.CompactionType;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.storageengine.rescon.memory.SystemInfo;
+import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.file.metadata.AlignedChunkMetadata;
 import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
 import org.apache.iotdb.tsfile.read.TsFileSequenceReader;
@@ -167,7 +168,8 @@ public class ReadChunkCompactionPerformer implements ISeqCompactionPerformer {
     while (seriesIterator.hasNextSeries()) {
       checkThreadInterrupted();
       // TODO: we can provide a configuration item to enable concurrent between each series
-      PartialPath p = new PartialPath(device, seriesIterator.nextSeries());
+      String pathStr = device + TsFileConstant.PATH_SEPARATOR + seriesIterator.nextSeries();
+      PartialPath p = new PartialPath(pathStr.split("\\."));
       // TODO: seriesIterator needs to be refactor.
       // This statement must be called before next hasNextSeries() called, or it may be trapped in a
       // dead-loop.

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/MultiTsFileDeviceIterator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/MultiTsFileDeviceIterator.java
@@ -28,6 +28,7 @@ import org.apache.iotdb.db.storageengine.dataregion.modification.ModificationFil
 import org.apache.iotdb.db.storageengine.dataregion.read.control.FileReaderManager;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.utils.ModificationUtils;
+import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.file.metadata.AlignedChunkMetadata;
 import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
 import org.apache.iotdb.tsfile.file.metadata.IChunkMetadata;
@@ -546,7 +547,8 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
 
       LinkedList<Pair<TsFileSequenceReader, List<ChunkMetadata>>>
           readerAndChunkMetadataForThisSeries = new LinkedList<>();
-      PartialPath path = new PartialPath(device, currentCompactingSeries);
+      String pathStr = device + TsFileConstant.PATH_SEPARATOR + currentCompactingSeries;
+      PartialPath path = new PartialPath(pathStr.split("\\."));
 
       for (TsFileResource resource : tsFileResourcesSortedByAsc) {
         TsFileSequenceReader reader = readerMap.get(resource);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/AlignedSeriesCompactionExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/AlignedSeriesCompactionExecutor.java
@@ -31,6 +31,7 @@ import org.apache.iotdb.db.storageengine.dataregion.compaction.io.CompactionTsFi
 import org.apache.iotdb.db.storageengine.dataregion.modification.Modification;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.utils.ModificationUtils;
+import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.exception.write.PageException;
 import org.apache.iotdb.tsfile.file.MetaMarker;
 import org.apache.iotdb.tsfile.file.header.ChunkHeader;
@@ -200,16 +201,13 @@ public class AlignedSeriesCompactionExecutor extends SeriesCompactionExecutor {
             .getValueChunkMetadataList()
             .forEach(
                 x -> {
-                  try {
-                    if (x == null) {
-                      valueModifications.add(null);
-                    } else {
-                      valueModifications.add(
-                          getModificationsFromCache(
-                              resource, new PartialPath(deviceId, x.getMeasurementUid())));
-                    }
-                  } catch (IllegalPathException e) {
-                    throw new RuntimeException(e);
+                  if (x == null) {
+                    valueModifications.add(null);
+                  } else {
+                    String pathStr =
+                        deviceId + TsFileConstant.PATH_SEPARATOR + x.getMeasurementUid();
+                    valueModifications.add(
+                        getModificationsFromCache(resource, new PartialPath(pathStr.split("\\."))));
                   }
                 });
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/NonAlignedSeriesCompactionExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/NonAlignedSeriesCompactionExecutor.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.utils.wri
 import org.apache.iotdb.db.storageengine.dataregion.modification.Modification;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.utils.ModificationUtils;
+import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.exception.write.PageException;
 import org.apache.iotdb.tsfile.file.MetaMarker;
 import org.apache.iotdb.tsfile.file.header.ChunkHeader;
@@ -138,11 +139,13 @@ public class NonAlignedSeriesCompactionExecutor extends SeriesCompactionExecutor
 
       if (!iChunkMetadataList.isEmpty()) {
         // modify chunk metadatas
+        String pathStr =
+            deviceId
+                + TsFileConstant.PATH_SEPARATOR
+                + iChunkMetadataList.get(0).getMeasurementUid();
         ModificationUtils.modifyChunkMetaData(
             iChunkMetadataList,
-            getModificationsFromCache(
-                resource,
-                new PartialPath(deviceId, iChunkMetadataList.get(0).getMeasurementUid())));
+            getModificationsFromCache(resource, new PartialPath(pathStr.split("\\."))));
         if (iChunkMetadataList.isEmpty()) {
           // all chunks has been deleted in this file, just remove it
           removeFile(fileElement);


### PR DESCRIPTION
## Description
Use faster constructor of PartialPath in Compaction.
The constructor of PartialPath with device and measurement may cost long time, this pr replace these usage to another constructor.
<img width="1474" alt="截屏2023-11-15 18 30 24" src="https://github.com/apache/iotdb/assets/55970239/7cd08b4e-8990-4756-90b2-8b7b906673e4">
