### PR TITLE
Increase retry timeout for ratis retry mechanism

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/consensus/ConsensusManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/consensus/ConsensusManager.java
@@ -186,6 +186,9 @@ public class ConsensusManager {
                                       .setRaftLogSizeMaxThreshold(CONF.getConfigNodeRatisLogMax())
                                       .setForceSnapshotInterval(
                                           CONF.getConfigNodeRatisPeriodicSnapshotInterval())
+                                      .setRetryTimesMax(10)
+                                      .setRetryWaitMillis(
+                                          COMMON_CONF.getConnectionTimeoutInMS() / 10)
                                       .build())
                               .setRead(
                                   RatisConfig.Read.newBuilder()

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/DataRegionConsensusImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/DataRegionConsensusImpl.java
@@ -171,6 +171,8 @@ public class DataRegionConsensusImpl {
                                     .setRaftLogSizeMaxThreshold(CONF.getDataRatisLogMax())
                                     .setForceSnapshotInterval(
                                         CONF.getDataRatisPeriodicSnapshotInterval())
+                                    .setRetryTimesMax(10)
+                                    .setRetryWaitMillis(CONF.getConnectionTimeoutInMS() / 10)
                                     .build())
                             .setLeaderLogAppender(
                                 RatisConfig.LeaderLogAppender.newBuilder()

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/SchemaRegionConsensusImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/SchemaRegionConsensusImpl.java
@@ -132,6 +132,8 @@ public class SchemaRegionConsensusImpl {
                                     .setRaftLogSizeMaxThreshold(CONF.getSchemaRatisLogMax())
                                     .setForceSnapshotInterval(
                                         CONF.getSchemaRatisPeriodicSnapshotInterval())
+                                    .setRetryTimesMax(10)
+                                    .setRetryWaitMillis(CONF.getConnectionTimeoutInMS() / 10)
                                     .build())
                             .setLeaderLogAppender(
                                 RatisConfig.LeaderLogAppender.newBuilder()


### PR DESCRIPTION
Previous we only retry 3 times, waiting 500ms each.
We should align this parameter with connection timeout.