### PR TITLE
Add last time check for inner space compaction task

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/exception/CompactionLastTimeCheckFailedException.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/exception/CompactionLastTimeCheckFailedException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.storageengine.dataregion.compaction.execute.exception;
+
+public class CompactionLastTimeCheckFailedException extends RuntimeException {
+
+  public CompactionLastTimeCheckFailedException(
+      String path, long currentTimestamp, long lastTimestamp) {
+    super(
+        "Timestamp of the current point of "
+            + path
+            + " is "
+            + currentTimestamp
+            + ", which should be later than the last time "
+            + lastTimestamp);
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/writer/AbstractCompactionWriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/writer/AbstractCompactionWriter.java
@@ -19,7 +19,9 @@
 
 package org.apache.iotdb.db.storageengine.dataregion.compaction.execute.utils.writer;
 
+import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.exception.CompactionLastTimeCheckFailedException;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.io.CompactionTsFileWriter;
 import org.apache.iotdb.tsfile.access.Column;
 import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
@@ -304,5 +306,14 @@ public abstract class AbstractCompactionWriter implements AutoCloseable {
 
   protected long getChunkSize(Chunk chunk) {
     return (long) chunk.getHeader().getSerializedSize() + chunk.getHeader().getDataSize();
+  }
+
+  protected void checkPreviousTimestamp(long currentWritingTimestamp, int subTaskId) {
+    if (currentWritingTimestamp <= lastTime[subTaskId]) {
+      throw new CompactionLastTimeCheckFailedException(
+          deviceId + IoTDBConstant.PATH_SEPARATOR + measurementId[subTaskId],
+          currentWritingTimestamp,
+          lastTime[subTaskId]);
+    }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/writer/AbstractCrossCompactionWriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/writer/AbstractCrossCompactionWriter.java
@@ -19,7 +19,6 @@
 
 package org.apache.iotdb.db.storageengine.dataregion.compaction.execute.utils.writer;
 
-import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.utils.CompactionUtils;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.io.CompactionTsFileWriter;
@@ -188,15 +187,7 @@ public abstract class AbstractCrossCompactionWriter extends AbstractCompactionWr
    */
   protected void checkTimeAndMayFlushChunkToCurrentFile(long timestamp, int subTaskId)
       throws IOException {
-    if (timestamp <= lastTime[subTaskId]) {
-      throw new RuntimeException(
-          "Timestamp of the current point of "
-              + (deviceId + IoTDBConstant.PATH_SEPARATOR + measurementId[subTaskId])
-              + " is "
-              + timestamp
-              + ", which should be later than the last time "
-              + lastTime[subTaskId]);
-    }
+    checkPreviousTimestamp(timestamp, subTaskId);
 
     int fileIndex = seqFileIndexArray[subTaskId];
     boolean hasFlushedCurrentChunk = false;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/writer/AbstractInnerCompactionWriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/writer/AbstractInnerCompactionWriter.java
@@ -81,10 +81,12 @@ public abstract class AbstractInnerCompactionWriter extends AbstractCompactionWr
 
   @Override
   public void write(TimeValuePair timeValuePair, int subTaskId) throws IOException {
+    checkPreviousTimestamp(timeValuePair.getTimestamp(), subTaskId);
     writeDataPoint(timeValuePair.getTimestamp(), timeValuePair.getValue(), chunkWriters[subTaskId]);
     chunkPointNumArray[subTaskId]++;
     checkChunkSizeAndMayOpenANewChunk(fileWriter, chunkWriters[subTaskId], subTaskId);
     isEmptyFile = false;
+    lastTime[subTaskId] = timeValuePair.getTimestamp();
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/writer/FastInnerCompactionWriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/writer/FastInnerCompactionWriter.java
@@ -54,6 +54,7 @@ public class FastInnerCompactionWriter extends AbstractInnerCompactionWriter {
   @Override
   public boolean flushNonAlignedChunk(Chunk chunk, ChunkMetadata chunkMetadata, int subTaskId)
       throws IOException {
+    checkPreviousTimestamp(chunkMetadata.getStartTime(), subTaskId);
     if (chunkPointNumArray[subTaskId] != 0
         && chunkWriters[subTaskId].checkIsChunkSizeOverThreshold(
             targetChunkSize, targetChunkPointNum, false)) {
@@ -87,6 +88,7 @@ public class FastInnerCompactionWriter extends AbstractInnerCompactionWriter {
       List<IChunkMetadata> valueChunkMetadatas,
       int subTaskId)
       throws IOException {
+    checkPreviousTimestamp(timeChunkMetadata.getStartTime(), subTaskId);
     if (chunkPointNumArray[subTaskId] != 0
         && chunkWriters[subTaskId].checkIsChunkSizeOverThreshold(
             targetChunkSize, targetChunkPointNum, false)) {
@@ -122,6 +124,7 @@ public class FastInnerCompactionWriter extends AbstractInnerCompactionWriter {
       List<PageHeader> valuePageHeaders,
       int subTaskId)
       throws IOException, PageException {
+    checkPreviousTimestamp(timePageHeader.getStartTime(), subTaskId);
     boolean isUnsealedPageOverThreshold =
         chunkWriters[subTaskId].checkIsUnsealedPageOverThreshold(
             pageSizeLowerBoundInCompaction, pagePointNumLowerBoundInCompaction, true);
@@ -157,6 +160,7 @@ public class FastInnerCompactionWriter extends AbstractInnerCompactionWriter {
    */
   public boolean flushNonAlignedPage(
       ByteBuffer compressedPageData, PageHeader pageHeader, int subTaskId) throws PageException {
+    checkPreviousTimestamp(pageHeader.getStartTime(), subTaskId);
     boolean isUnsealedPageOverThreshold =
         chunkWriters[subTaskId].checkIsUnsealedPageOverThreshold(
             pageSizeLowerBoundInCompaction, pagePointNumLowerBoundInCompaction, true);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/CompactionOverlapCheckTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/CompactionOverlapCheckTest.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.storageengine.dataregion.compaction;
+
+import org.apache.iotdb.commons.exception.MetadataException;
+import org.apache.iotdb.db.exception.StorageEngineException;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.performer.impl.FastCompactionPerformer;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.performer.impl.ReadChunkCompactionPerformer;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.task.CrossSpaceCompactionTask;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.task.InnerSpaceCompactionTask;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.utils.CompactionTestFileWriter;
+import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
+import org.apache.iotdb.tsfile.exception.write.WriteProcessException;
+import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.iotdb.tsfile.read.common.TimeRange;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class CompactionOverlapCheckTest extends AbstractCompactionTest {
+
+  @Before
+  public void setUp()
+      throws IOException, WriteProcessException, MetadataException, InterruptedException {
+    super.setUp();
+  }
+
+  @After
+  public void tearDown() throws IOException, StorageEngineException {
+    super.tearDown();
+  }
+
+  @Test
+  public void
+      testOverlapFilesInnerSequenceSpaceCompactionWithReadChunkCompactionPerformerWithNonAlignedSeries()
+          throws IOException {
+    prepareOverlapSequenceFilesWithNonAlignedSeries();
+    InnerSpaceCompactionTask task =
+        new InnerSpaceCompactionTask(
+            0, tsFileManager, seqResources, true, new ReadChunkCompactionPerformer(), 0);
+    Assert.assertFalse(task.start());
+  }
+
+  @Test
+  public void
+      testOverlapFilesInnerSequenceSpaceCompactionWithReadChunkCompactionPerformerWithAlignedSeries()
+          throws IOException {
+    prepareOverlapSequenceFilesWithAlignedSeries();
+    InnerSpaceCompactionTask task =
+        new InnerSpaceCompactionTask(
+            0, tsFileManager, seqResources, true, new ReadChunkCompactionPerformer(), 0);
+    Assert.assertFalse(task.start());
+  }
+
+  @Test
+  public void
+      testOverlapFilesInnerSequenceSpaceCompactionWithFastCompactionPerformerWithNonAlignedSeries()
+          throws IOException {
+    prepareOverlapSequenceFilesWithNonAlignedSeries();
+    InnerSpaceCompactionTask task =
+        new InnerSpaceCompactionTask(
+            0, tsFileManager, seqResources, true, new FastCompactionPerformer(false), 0);
+    Assert.assertFalse(task.start());
+  }
+
+  @Test
+  public void
+      testOverlapFilesInnerSequenceSpaceCompactionWithFastCompactionPerformerWithAlignedSeries()
+          throws IOException {
+    prepareOverlapSequenceFilesWithAlignedSeries();
+    InnerSpaceCompactionTask task =
+        new InnerSpaceCompactionTask(
+            0, tsFileManager, seqResources, true, new FastCompactionPerformer(false), 0);
+    Assert.assertFalse(task.start());
+  }
+
+  @Test
+  public void
+      testOverlapFilesInnerUnSequenceSpaceCompactionWithFastCompactionPerformerWithNonAlignedSeries()
+          throws IOException {
+    prepareInsideChunkOverlapUnSequenceFilesWithNonAlignedSeries();
+    InnerSpaceCompactionTask task =
+        new InnerSpaceCompactionTask(
+            0, tsFileManager, unseqResources, false, new FastCompactionPerformer(false), 0);
+    Assert.assertFalse(task.start());
+  }
+
+  @Test
+  public void
+      testOverlapFilesInnerUnSequenceSpaceCompactionWithFastCompactionPerformerWithAlignedSeries()
+          throws IOException {
+    prepareInsideChunkOverlapUnSequenceFilesWithAlignedSeries();
+    InnerSpaceCompactionTask task =
+        new InnerSpaceCompactionTask(
+            0, tsFileManager, unseqResources, false, new FastCompactionPerformer(false), 0);
+    Assert.assertFalse(task.start());
+  }
+
+  @Test
+  public void testOverlapFilesCrossSpaceCompactionWithFastCompactionPerformerWithNonAlignedSeries()
+      throws IOException {
+    prepareOverlapSequenceFilesWithNonAlignedSeries();
+    prepareInsideChunkOverlapUnSequenceFilesWithNonAlignedSeries();
+    CrossSpaceCompactionTask task =
+        new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            seqResources,
+            unseqResources,
+            new FastCompactionPerformer(true),
+            0,
+            0);
+    Assert.assertFalse(task.start());
+  }
+
+  @Test
+  public void testOverlapFilesCrossSpaceCompactionWithFastCompactionPerformerWithAlignedSeries()
+      throws IOException {
+    prepareOverlapSequenceFilesWithAlignedSeries();
+    prepareInsideChunkOverlapUnSequenceFilesWithAlignedSeries();
+    CrossSpaceCompactionTask task =
+        new CrossSpaceCompactionTask(
+            0,
+            tsFileManager,
+            seqResources,
+            unseqResources,
+            new FastCompactionPerformer(true),
+            0,
+            0);
+    Assert.assertFalse(task.start());
+  }
+
+  private void prepareOverlapSequenceFilesWithNonAlignedSeries() throws IOException {
+    TsFileResource seqResource1 = createEmptyFileAndResource(true);
+    try (CompactionTestFileWriter writer = new CompactionTestFileWriter(seqResource1)) {
+      writer.startChunkGroup("d1");
+      writer.generateSimpleNonAlignedSeriesToCurrentDevice(
+          "s1",
+          new TimeRange[][][] {
+            new TimeRange[][] {new TimeRange[] {new TimeRange(10, 12), new TimeRange(3, 12)}}
+          },
+          TSEncoding.PLAIN,
+          CompressionType.LZ4);
+      writer.endChunkGroup();
+      writer.endFile();
+    }
+    TsFileResource seqResource2 = createEmptyFileAndResource(true);
+    try (CompactionTestFileWriter writer = new CompactionTestFileWriter(seqResource2)) {
+      writer.startChunkGroup("d1");
+      writer.generateSimpleNonAlignedSeriesToCurrentDevice(
+          "s1", new TimeRange[] {new TimeRange(1, 9)}, TSEncoding.PLAIN, CompressionType.LZ4);
+      writer.endChunkGroup();
+      writer.endFile();
+    }
+    seqResources.add(seqResource1);
+    seqResources.add(seqResource2);
+    tsFileManager.addAll(seqResources, true);
+  }
+
+  private void prepareOverlapSequenceFilesWithAlignedSeries() throws IOException {
+    TsFileResource seqResource1 = createEmptyFileAndResource(true);
+    try (CompactionTestFileWriter writer = new CompactionTestFileWriter(seqResource1)) {
+      writer.startChunkGroup("d1");
+      writer.generateSimpleAlignedSeriesToCurrentDevice(
+          Arrays.asList("s1", "s2"),
+          new TimeRange[][][] {
+            new TimeRange[][] {new TimeRange[] {new TimeRange(10, 12), new TimeRange(3, 12)}}
+          },
+          TSEncoding.PLAIN,
+          CompressionType.LZ4);
+      writer.endChunkGroup();
+      writer.endFile();
+    }
+    TsFileResource seqResource2 = createEmptyFileAndResource(true);
+    try (CompactionTestFileWriter writer = new CompactionTestFileWriter(seqResource2)) {
+      writer.startChunkGroup("d1");
+      writer.generateSimpleAlignedSeriesToCurrentDevice(
+          Arrays.asList("s1", "s2"),
+          new TimeRange[] {new TimeRange(1, 9)},
+          TSEncoding.PLAIN,
+          CompressionType.LZ4);
+      writer.endChunkGroup();
+      writer.endFile();
+    }
+    seqResources.add(seqResource1);
+    seqResources.add(seqResource2);
+    tsFileManager.addAll(seqResources, true);
+  }
+
+  private void prepareInsideChunkOverlapUnSequenceFilesWithNonAlignedSeries() throws IOException {
+    TsFileResource unseqResource1 = createEmptyFileAndResource(true);
+    try (CompactionTestFileWriter writer = new CompactionTestFileWriter(unseqResource1)) {
+      writer.startChunkGroup("d1");
+      writer.generateSimpleNonAlignedSeriesToCurrentDevice(
+          "s1",
+          new TimeRange[][][] {
+            new TimeRange[][] {new TimeRange[] {new TimeRange(10, 12), new TimeRange(3, 12)}}
+          },
+          TSEncoding.PLAIN,
+          CompressionType.LZ4);
+      writer.endChunkGroup();
+      writer.endFile();
+    }
+    TsFileResource unseqResource2 = createEmptyFileAndResource(true);
+    try (CompactionTestFileWriter writer = new CompactionTestFileWriter(unseqResource2)) {
+      writer.startChunkGroup("d1");
+      writer.generateSimpleNonAlignedSeriesToCurrentDevice(
+          "s1", new TimeRange[] {new TimeRange(35, 40)}, TSEncoding.PLAIN, CompressionType.LZ4);
+      writer.endChunkGroup();
+      writer.endFile();
+    }
+    unseqResources.add(unseqResource1);
+    unseqResources.add(unseqResource2);
+    tsFileManager.addAll(unseqResources, false);
+  }
+
+  private void prepareInsideChunkOverlapUnSequenceFilesWithAlignedSeries() throws IOException {
+    TsFileResource unseqResource1 = createEmptyFileAndResource(true);
+    try (CompactionTestFileWriter writer = new CompactionTestFileWriter(unseqResource1)) {
+      writer.startChunkGroup("d1");
+      writer.generateSimpleAlignedSeriesToCurrentDevice(
+          Arrays.asList("s1", "s2"),
+          new TimeRange[][][] {
+            new TimeRange[][] {new TimeRange[] {new TimeRange(10, 12), new TimeRange(3, 12)}}
+          },
+          TSEncoding.PLAIN,
+          CompressionType.LZ4);
+      writer.endChunkGroup();
+      writer.endFile();
+    }
+    TsFileResource unseqResource2 = createEmptyFileAndResource(true);
+    try (CompactionTestFileWriter writer = new CompactionTestFileWriter(unseqResource2)) {
+      writer.startChunkGroup("d1");
+      writer.generateSimpleAlignedSeriesToCurrentDevice(
+          Arrays.asList("s1", "s2"),
+          new TimeRange[] {new TimeRange(35, 40)},
+          TSEncoding.PLAIN,
+          CompressionType.LZ4);
+      writer.endChunkGroup();
+      writer.endFile();
+    }
+    unseqResources.add(unseqResource1);
+    unseqResources.add(unseqResource2);
+    tsFileManager.addAll(unseqResources, false);
+  }
+}


### PR DESCRIPTION
## Description
Add last time check for inner space compaction task. 
When the source file has overlap data, compaction task will throw a CompactionLastTimeCheckFailedException.