### PR TITLE
Fix aligned device modification not matched in MultiTsFileDeviceIterator

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/MultiTsFileDeviceIterator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/MultiTsFileDeviceIterator.java
@@ -400,12 +400,10 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
     }
 
     for (Modification modification : modifications) {
-      if (modification.getDevice().equals(currentDevice.left)) {
-        for (int i = 0; i < valueChunkMetadataList.size(); ++i) {
-          PartialPath path = valueSeriesPaths.get(i);
-          if (path != null && modification.getPath().matchFullPath(path)) {
-            modificationForCurDevice.get(i).add(modification);
-          }
+      for (int i = 0; i < valueChunkMetadataList.size(); ++i) {
+        PartialPath path = valueSeriesPaths.get(i);
+        if (path != null && modification.getPath().matchFullPath(path)) {
+          modificationForCurDevice.get(i).add(modification);
         }
       }
     }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/ReadChunkInnerCompactionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/ReadChunkInnerCompactionTest.java
@@ -435,7 +435,7 @@ public class ReadChunkInnerCompactionTest extends AbstractCompactionTest {
     }
     seqFile1
         .getModFile()
-        .write(new Deletion(new PartialPath("root.testsg.d1.**"), Long.MAX_VALUE, Long.MAX_VALUE));
+        .write(new Deletion(new PartialPath("root.testsg.d1.s1"), Long.MAX_VALUE, Long.MAX_VALUE));
     seqFile1.getModFile().close();
     TsFileResource seqFile2 = createEmptyFileAndResource(true);
     try (CompactionTestFileWriter writer = new CompactionTestFileWriter(seqFile2)) {
@@ -515,6 +515,113 @@ public class ReadChunkInnerCompactionTest extends AbstractCompactionTest {
     seqFile3
         .getModFile()
         .write(new Deletion(new PartialPath("root.testsg.d1.**"), Long.MAX_VALUE, Long.MAX_VALUE));
+    seqFile3.getModFile().close();
+    seqResources.add(seqFile1);
+    seqResources.add(seqFile2);
+    seqResources.add(seqFile3);
+    InnerSpaceCompactionTask task =
+        new InnerSpaceCompactionTask(
+            0, tsFileManager, seqResources, true, new ReadChunkCompactionPerformer(), 0);
+    Assert.assertTrue(task.start());
+    Assert.assertEquals(0, tsFileManager.getTsFileList(true).size());
+  }
+
+  @Test
+  public void testReadChunkPerformerWithEmptyTargetFile5()
+      throws IOException, IllegalPathException {
+    TsFileResource seqFile1 = createEmptyFileAndResource(true);
+    try (CompactionTestFileWriter writer = new CompactionTestFileWriter(seqFile1)) {
+      writer.startChunkGroup("d1");
+      writer.generateSimpleNonAlignedSeriesToCurrentDevice(
+          "s1", new TimeRange[] {new TimeRange(1, 2)}, TSEncoding.PLAIN, CompressionType.LZ4);
+      writer.endChunkGroup();
+      writer.endFile();
+    }
+    seqFile1
+        .getModFile()
+        .write(new Deletion(new PartialPath("root.**"), Long.MAX_VALUE, Long.MAX_VALUE));
+    seqFile1.getModFile().close();
+    TsFileResource seqFile2 = createEmptyFileAndResource(true);
+    try (CompactionTestFileWriter writer = new CompactionTestFileWriter(seqFile2)) {
+      writer.startChunkGroup("d1");
+      writer.generateSimpleNonAlignedSeriesToCurrentDevice(
+          "s1", new TimeRange[] {new TimeRange(5, 6)}, TSEncoding.PLAIN, CompressionType.LZ4);
+      writer.endChunkGroup();
+      writer.endFile();
+    }
+    seqFile2
+        .getModFile()
+        .write(new Deletion(new PartialPath("root.**"), Long.MAX_VALUE, Long.MAX_VALUE));
+    seqFile2.getModFile().close();
+    TsFileResource seqFile3 = createEmptyFileAndResource(true);
+    try (CompactionTestFileWriter writer = new CompactionTestFileWriter(seqFile3)) {
+      writer.startChunkGroup("d1");
+      writer.generateSimpleNonAlignedSeriesToCurrentDevice(
+          "s1", new TimeRange[] {new TimeRange(10, 20)}, TSEncoding.PLAIN, CompressionType.LZ4);
+      writer.endChunkGroup();
+      writer.endFile();
+    }
+    seqFile3
+        .getModFile()
+        .write(new Deletion(new PartialPath("root.testsg.**"), Long.MAX_VALUE, Long.MAX_VALUE));
+    seqFile3.getModFile().close();
+    seqResources.add(seqFile1);
+    seqResources.add(seqFile2);
+    seqResources.add(seqFile3);
+    InnerSpaceCompactionTask task =
+        new InnerSpaceCompactionTask(
+            0, tsFileManager, seqResources, true, new ReadChunkCompactionPerformer(), 0);
+    Assert.assertTrue(task.start());
+    Assert.assertEquals(0, tsFileManager.getTsFileList(true).size());
+  }
+
+  @Test
+  public void testReadChunkPerformerWithEmptyTargetFile6()
+      throws IOException, IllegalPathException {
+    TsFileResource seqFile1 = createEmptyFileAndResource(true);
+    try (CompactionTestFileWriter writer = new CompactionTestFileWriter(seqFile1)) {
+      writer.startChunkGroup("d1");
+      writer.generateSimpleAlignedSeriesToCurrentDevice(
+          Arrays.asList("s1"),
+          new TimeRange[] {new TimeRange(1, 2)},
+          TSEncoding.PLAIN,
+          CompressionType.LZ4);
+      writer.endChunkGroup();
+      writer.endFile();
+    }
+    seqFile1
+        .getModFile()
+        .write(new Deletion(new PartialPath("root.**"), Long.MAX_VALUE, Long.MAX_VALUE));
+    seqFile1.getModFile().close();
+    TsFileResource seqFile2 = createEmptyFileAndResource(true);
+    try (CompactionTestFileWriter writer = new CompactionTestFileWriter(seqFile2)) {
+      writer.startChunkGroup("d1");
+      writer.generateSimpleAlignedSeriesToCurrentDevice(
+          Arrays.asList("s1"),
+          new TimeRange[] {new TimeRange(5, 6)},
+          TSEncoding.PLAIN,
+          CompressionType.LZ4);
+      writer.endChunkGroup();
+      writer.endFile();
+    }
+    seqFile2
+        .getModFile()
+        .write(new Deletion(new PartialPath("root.**"), Long.MAX_VALUE, Long.MAX_VALUE));
+    seqFile2.getModFile().close();
+    TsFileResource seqFile3 = createEmptyFileAndResource(true);
+    try (CompactionTestFileWriter writer = new CompactionTestFileWriter(seqFile3)) {
+      writer.startChunkGroup("d1");
+      writer.generateSimpleAlignedSeriesToCurrentDevice(
+          Arrays.asList("s1"),
+          new TimeRange[] {new TimeRange(10, 20)},
+          TSEncoding.PLAIN,
+          CompressionType.LZ4);
+      writer.endChunkGroup();
+      writer.endFile();
+    }
+    seqFile3
+        .getModFile()
+        .write(new Deletion(new PartialPath("root.testsg.**"), Long.MAX_VALUE, Long.MAX_VALUE));
     seqFile3.getModFile().close();
     seqResources.add(seqFile1);
     seqResources.add(seqFile2);


### PR DESCRIPTION
## Description
Fix aligned device modification not matched in MultiTsFileDeviceIterator
## Reappear
1. delete all data of db with modification
2. trigger an inner space compaction with ReadChunkCompactionPerformer
3. execute a query with the deleted datas