### PR TITLE
Using the cumulative execution time of all FIs of a Query as the basis for calculating the level in MultiLevelPriorityQueue of the related DriverTasks

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/DriverScheduler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/DriverScheduler.java
@@ -65,7 +65,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static com.google.common.base.Preconditions.checkState;
 import static org.apache.iotdb.db.queryengine.metric.DriverSchedulerMetricSet.BLOCK_QUEUED_TIME;
 import static org.apache.iotdb.db.queryengine.metric.DriverSchedulerMetricSet.READY_QUEUED_TIME;
 
@@ -87,7 +86,7 @@ public class DriverScheduler implements IDriverScheduler, IService {
   private final IndexedBlockingQueue<DriverTask> timeoutQueue;
   private final Set<DriverTask> blockedTasks;
   private final Map<QueryId, Map<FragmentInstanceId, Set<DriverTask>>> queryMap;
-  /** All FIs of one query dispatched to this Node shares one DriverTaskHandle */
+  /** All FIs of one query dispatched to this Node shares one DriverTaskHandle. */
   private final Map<QueryId, DriverTaskHandle> queryIdToDriverTaskHandleMap;
 
   private final ITaskScheduler scheduler;
@@ -453,6 +452,7 @@ public class DriverScheduler implements IDriverScheduler, IService {
   @Override
   public void abortQuery(QueryId queryId) {
     Map<FragmentInstanceId, Set<DriverTask>> queryRelatedTasks = queryMap.remove(queryId);
+    queryIdToDriverTaskHandleMap.remove(queryId);
     if (queryRelatedTasks != null) {
       for (Set<DriverTask> fragmentRelatedTasks : queryRelatedTasks.values()) {
         if (fragmentRelatedTasks != null) {
@@ -463,8 +463,6 @@ public class DriverScheduler implements IDriverScheduler, IService {
         }
       }
     }
-    DriverTaskHandle taskHandle = queryIdToDriverTaskHandleMap.remove(queryId);
-    checkState(taskHandle == null, "taskHandle must be removed when clearDriverTasks are done.");
   }
 
   private static class InstanceHolder {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/queue/multilevelqueue/DriverTaskHandle.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/queue/multilevelqueue/DriverTaskHandle.java
@@ -27,6 +27,11 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * This class is used to ensure that all the DriverTasks of all the FIs of one query accumulate
+ * scheduling time together, to avoid a single query occupying too much Level0 time due to an excess
+ * of FIs.
+ */
 public class DriverTaskHandle {
 
   private final int driverTaskHandleId;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/queue/multilevelqueue/MultilevelPriorityQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/queue/multilevelqueue/MultilevelPriorityQueue.java
@@ -37,7 +37,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  */
 public class MultilevelPriorityQueue extends IndexedBlockingReserveQueue<DriverTask> {
   /** Scheduled time threshold of TASK in each level. */
-  static final int[] LEVEL_THRESHOLD_SECONDS = {0, 1, 10, 60, 300};
+  static final int[] LEVEL_THRESHOLD_SECONDS = {0, 3, 30, 120, 600};
 
   /** the upper limit one Task can contribute to its level in one scheduled time. */
   static final long LEVEL_CONTRIBUTION_CAP = SECONDS.toNanos(30);


### PR DESCRIPTION
If a query has many FIs, and each FI is divided into a large number of DriverTasks, using the cumulative execution time of FIs as the basis for calculating the level of DriverTasks might result in the current query being allocated more CPU resources than expected.
The insertion and removal of elements in queryIdToDriverTaskHandleMap are consistent with queryMap, so memory leak issues are not expected.