### PR TITLE
Extend time slice for DriverTasks in higher level queue and double default EXECUTION_TIME_SLICE

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -990,7 +990,7 @@ public class IoTDBConfig {
   private String readConsistencyLevel = "strong";
 
   /** Maximum execution time of a DriverTask */
-  private int driverTaskExecutionTimeSliceInMs = 100;
+  private int driverTaskExecutionTimeSliceInMs = 200;
 
   /** Maximum size of wal buffer used in IoTConsensus. Unit: byte */
   private long throttleThreshold = 50 * 1024 * 1024 * 1024L;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/DriverTaskThread.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/DriverTaskThread.java
@@ -42,23 +42,22 @@ public class DriverTaskThread extends AbstractDriverThread {
   private static final double DRIVER_TASK_EXECUTION_TIME_SLICE_IN_MS =
       IoTDBDescriptor.getInstance().getConfig().getDriverTaskExecutionTimeSliceInMs();
 
-  /** In multi-level feedback queue, levels with lower priority have longer time slices. */
-  private static final Duration[] TIME_SLICE_FOR_EACH_LEVEL;
+  /**
+   * In multi-level feedback queue, levels with lower priority have longer time slices. Currently,
+   * we assign (level + 1) * TimeSliceUnit to each level.
+   */
+  private static final Duration[] TIME_SLICE_FOR_EACH_LEVEL =
+      IntStream.range(0, MultilevelPriorityQueue.getNumOfPriorityLevels())
+          .mapToObj(
+              level ->
+                  new Duration(
+                      (level + 1) * DRIVER_TASK_EXECUTION_TIME_SLICE_IN_MS, TimeUnit.MILLISECONDS))
+          .toArray(Duration[]::new);
 
   // We manage thread pool size directly, so create an unlimited pool
   private static final Executor listeningExecutor =
       IoTDBThreadPoolFactory.newCachedThreadPool(
           ThreadName.DRIVER_TASK_SCHEDULER_NOTIFICATION.getName());
-
-  static {
-    TIME_SLICE_FOR_EACH_LEVEL =
-        IntStream.range(1, MultilevelPriorityQueue.getNumOfPriorityLevels() + 1)
-            .mapToObj(
-                level ->
-                    new Duration(
-                        level * DRIVER_TASK_EXECUTION_TIME_SLICE_IN_MS, TimeUnit.MILLISECONDS))
-            .toArray(Duration[]::new);
-  }
 
   private final Ticker ticker;
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/queue/multilevelqueue/MultilevelPriorityQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/queue/multilevelqueue/MultilevelPriorityQueue.java
@@ -326,6 +326,10 @@ public class MultilevelPriorityQueue extends IndexedBlockingReserveQueue<DriverT
     return LEVEL_THRESHOLD_SECONDS.length - 1;
   }
 
+  public static int getNumOfPriorityLevels() {
+    return LEVEL_THRESHOLD_SECONDS.length;
+  }
+
   // endregion
 
   @TestOnly

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/timer/RuleBasedTimeSliceAllocator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/timer/RuleBasedTimeSliceAllocator.java
@@ -19,8 +19,8 @@
 
 package org.apache.iotdb.db.queryengine.execution.timer;
 
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.queryengine.execution.operator.OperatorContext;
-import org.apache.iotdb.db.queryengine.execution.schedule.DriverTaskThread;
 
 import io.airlift.units.Duration;
 
@@ -33,7 +33,10 @@ import static com.google.common.base.Preconditions.checkState;
 public class RuleBasedTimeSliceAllocator implements ITimeSliceAllocator {
 
   private static final long EXECUTION_TIME_SLICE_IN_MS =
-      DriverTaskThread.EXECUTION_TIME_SLICE.roundTo(TimeUnit.MILLISECONDS);
+      new Duration(
+              IoTDBDescriptor.getInstance().getConfig().getDriverTaskExecutionTimeSliceInMs(),
+              TimeUnit.MILLISECONDS)
+          .roundTo(TimeUnit.MILLISECONDS);
 
   private final Map<OperatorContext, Integer> operatorToWeightMap;
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/DataDriverTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/DataDriverTest.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.commons.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.MeasurementPath;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.queryengine.common.FragmentInstanceId;
 import org.apache.iotdb.db.queryengine.common.PlanFragmentId;
@@ -69,7 +70,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
-import static org.apache.iotdb.db.queryengine.execution.schedule.DriverTaskThread.EXECUTION_TIME_SLICE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -83,6 +83,11 @@ public class DataDriverTest {
 
   private final List<TsFileResource> seqResources = new ArrayList<>();
   private final List<TsFileResource> unSeqResources = new ArrayList<>();
+
+  private static final Duration EXECUTION_TIME_SLICE =
+      new Duration(
+          IoTDBDescriptor.getInstance().getConfig().getDriverTaskExecutionTimeSliceInMs(),
+          TimeUnit.MILLISECONDS);
 
   @Before
   public void setUp() throws MetadataException, IOException, WriteProcessException {

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -400,7 +400,7 @@ cluster_name=defaultCluster
 
 # The max execution time of a DriverTask
 # Datatype: int, Unit: ms
-# driver_task_execution_time_slice_in_ms=100
+# driver_task_execution_time_slice_in_ms=200
 
 # The max capacity of a TsBlock
 # Datatype: int, Unit: byte


### PR DESCRIPTION
This PR does the following two things: 
1. Allocates longer time slices for higher-level tasks in the MultiLevelPriorityQueue. 
3. Changes the default time slice length to 200ms.