### PR TITLE
Enhance IoTConsensus retry judgement to all writenodes in a batch

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/client/DispatchLogHandler.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/client/DispatchLogHandler.java
@@ -54,7 +54,7 @@ public class DispatchLogHandler implements AsyncMethodCallback<TSyncLogEntriesRe
 
   @Override
   public void onComplete(TSyncLogEntriesRes response) {
-    if (response.getStatuses().size() == 1 && needRetry(response.getStatuses().get(0).getCode())) {
+    if (response.getStatuses().stream().anyMatch(status -> needRetry(status.getCode()))) {
       logger.warn(
           "Can not send {} to peer {} for {} times because {}",
           batch,


### PR DESCRIPTION
Currently, iotconsensus only determines the first one when deciding whether to retry, which is inaccurate. 
In fact, if any request in a batch fails, we will retry the whole batch