### PR TITLE
Fix UT testLargeFileInLowerLevel timeout

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/CompactionSchedulerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/CompactionSchedulerTest.java
@@ -101,6 +101,7 @@ public class CompactionSchedulerTest {
         .getConfig()
         .setInnerUnseqCompactionPerformer(InnerUnseqCompactionPerformer.READ_POINT);
     IoTDBDescriptor.getInstance().getConfig().setMinCrossCompactionUnseqFileLevel(0);
+    IoTDBDescriptor.getInstance().getConfig().setEnableCompactionMemControl(false);
     CompactionTaskManager.getInstance().start();
     while (CompactionTaskManager.getInstance().getExecutingTaskCount() > 0) {
       try {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/utils/CompactionConfigRestorer.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/utils/CompactionConfigRestorer.java
@@ -58,6 +58,9 @@ public class CompactionConfigRestorer {
   private int oldMinCrossCompactionUnseqLevel =
       IoTDBDescriptor.getInstance().getConfig().getMinCrossCompactionUnseqFileLevel();
 
+  private boolean oldEnableCompactionMemControl =
+      IoTDBDescriptor.getInstance().getConfig().isEnableCompactionMemControl();
+
   public CompactionConfigRestorer() {}
 
   public void restoreCompactionConfig() {
@@ -83,5 +86,6 @@ public class CompactionConfigRestorer {
     config.setInnerSeqCompactionPerformer(oldInnerSeqPerformer);
     config.setInnerUnseqCompactionPerformer(oldInnerUnseqPerformer);
     config.setMinCrossCompactionUnseqFileLevel(oldMinCrossCompactionUnseqLevel);
+    config.setEnableCompactionMemControl(oldEnableCompactionMemControl);
   }
 }


### PR DESCRIPTION
## Description

![image](https://github.com/apache/iotdb/assets/25913899/8fa122f3-679b-47ed-b2be-5cfad6ae110d)

This UT is testing large file merging, which requires a large amount of memory, and the CI environment has a small memory. As a result, the file merging is limited due to the merging memory control, and the merging cannot be completed.

To fix it, we need setEnableCompactionMemControl= false for this UT.