### PR TITLE
Fix query data with authority return unexpected result

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBAuthIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBAuthIT.java
@@ -42,7 +42,9 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -1114,5 +1116,56 @@ public class IoTDBAuthIT {
     resultSet = adminStmt.executeQuery("LIST PRIVILEGES OF USER user1");
     ans = ",root.t1.**,READ_DATA,false,\n" + ",root.t1.**,READ_SCHEMA,false,\n";
     validateResultSet(resultSet, ans);
+  }
+
+  @Test
+  public void testQueryTemplate() throws SQLException {
+    // 1. revoke from user/role
+    Connection adminCon = EnvFactory.getEnv().getConnection();
+    Statement adminStmt = adminCon.createStatement();
+    adminStmt.execute("CREATE USER user1 'password'");
+    adminStmt.execute("GRANT READ_DATA ON root.sg.d1.** TO USER user1 with grant option;");
+    adminStmt.execute("GRANT READ_DATA ON root.sg.aligned_template.temperature TO USER user1;");
+    adminStmt.execute("CREATE DATABASE root.sg;");
+    adminStmt.execute(
+        "create device template t1 aligned (temperature FLOAT encoding=Gorilla, status BOOLEAN encoding=PLAIN);");
+    adminStmt.execute("set device template t1 to root.sg.aligned_template;");
+    adminStmt.execute("insert into root.sg.d1(time,s1,s2) values(1,1,1)");
+    adminStmt.execute("insert into root.sg.d2(time,s1,s2) values(1,1,1)");
+    adminStmt.execute(
+        "insert into root.sg.aligned_template(time,temperature,status) values(1,20,true)");
+    try (ResultSet resultSet = adminStmt.executeQuery("select * from root.**;")) {
+      Set<String> standards =
+          new HashSet<>(
+              Arrays.asList(
+                  "Time",
+                  "root.sg.aligned_template.temperature",
+                  "root.sg.aligned_template.status",
+                  "root.sg.d2.s1",
+                  "root.sg.d2.s2",
+                  "root.sg.d1.s1",
+                  "root.sg.d1.s2"));
+      ResultSetMetaData metaData = resultSet.getMetaData();
+      for (int i = 1; i < metaData.getColumnCount() + 1; i++) {
+        Assert.assertTrue(standards.remove(metaData.getColumnName(i)));
+      }
+      Assert.assertTrue(standards.isEmpty());
+    }
+    Connection user1Con = EnvFactory.getEnv().getConnection("user1", "password");
+    Statement user1Stmt = user1Con.createStatement();
+    try (ResultSet resultSet = user1Stmt.executeQuery("select * from root.**;")) {
+      Set<String> standards =
+          new HashSet<>(
+              Arrays.asList(
+                  "Time",
+                  "root.sg.aligned_template.temperature",
+                  "root.sg.d1.s1",
+                  "root.sg.d1.s2"));
+      ResultSetMetaData metaData = resultSet.getMetaData();
+      for (int i = 1; i < metaData.getColumnCount() + 1; i++) {
+        Assert.assertTrue(standards.remove(metaData.getColumnName(i)));
+      }
+      Assert.assertTrue(standards.isEmpty());
+    }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/schematree/ClusterSchemaTree.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/schematree/ClusterSchemaTree.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.queryengine.common.schematree;
 
 import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.path.PathPatternTree;
 import org.apache.iotdb.commons.schema.view.LogicalViewSchema;
 import org.apache.iotdb.commons.utils.PathUtils;
 import org.apache.iotdb.commons.utils.TestOnly;
@@ -73,6 +74,8 @@ public class ClusterSchemaTree implements ISchemaTree {
 
   private Map<Integer, Template> templateMap = new HashMap<>();
 
+  private PathPatternTree authorityScope;
+
   public ClusterSchemaTree() {
     root = new SchemaInternalNode(PATH_ROOT);
   }
@@ -97,7 +100,7 @@ public class ClusterSchemaTree implements ISchemaTree {
       PartialPath pathPattern, int slimit, int soffset, boolean isPrefixMatch) {
     try (SchemaTreeVisitorWithLimitOffsetWrapper<MeasurementPath> visitor =
         SchemaTreeVisitorFactory.createSchemaTreeMeasurementVisitor(
-            root, pathPattern, isPrefixMatch, slimit, soffset)) {
+            root, pathPattern, isPrefixMatch, slimit, soffset, authorityScope)) {
       visitor.setTemplateMap(templateMap);
       return new Pair<>(visitor.getAllResult(), visitor.getNextOffset());
     }
@@ -534,5 +537,10 @@ public class ClusterSchemaTree implements ISchemaTree {
   @Override
   public boolean isEmpty() {
     return root.getChildren() == null || root.getChildren().isEmpty();
+  }
+
+  @Override
+  public void setAuthorityScope(PathPatternTree scope) {
+    this.authorityScope = scope;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/schematree/ISchemaTree.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/schematree/ISchemaTree.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.queryengine.common.schematree;
 
 import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.path.PathPatternTree;
 import org.apache.iotdb.db.schemaengine.template.Template;
 import org.apache.iotdb.tsfile.utils.Pair;
 
@@ -98,4 +99,6 @@ public interface ISchemaTree {
    * @return whether there's view in this schema tree
    */
   boolean hasLogicalViewMeasurement();
+
+  void setAuthorityScope(PathPatternTree scope);
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/schematree/visitor/SchemaTreeVisitorFactory.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/schematree/visitor/SchemaTreeVisitorFactory.java
@@ -51,6 +51,11 @@ public class SchemaTreeVisitorFactory {
         new SchemaTreeMeasurementVisitor(root, pathPattern, isPrefixMatch), slimit, soffset);
   }
 
+  public static SchemaTreeMeasurementVisitor createSchemaTreeMeasurementVisitor(
+      SchemaNode root, PartialPath pathPattern, PathPatternTree scope) {
+    return new SchemaTreeMeasurementVisitor(root, pathPattern, false, scope);
+  }
+
   public static SchemaTreeVisitorWithLimitOffsetWrapper<MeasurementPath>
       createSchemaTreeMeasurementVisitor(
           SchemaNode root,

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/traverser/Traverser.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/traverser/Traverser.java
@@ -231,7 +231,6 @@ public abstract class Traverser<R, N extends IMNode<N>> extends AbstractTreeVisi
 
   @Override
   protected Iterator<N> getChildrenIterator(N parent) throws MetadataException {
-    IMNodeIterator<N> currentChildrenIterator;
     if (parent.isAboveDatabase()) {
       return new MNodeIterator<>(parent.getChildren().values().iterator());
     } else {


### PR DESCRIPTION
## Description

```
create aligned timeseries root.sg.d1(s1 float encoding=rle, s2 int64 encoding=rle);
create timeseries root.sg.d2.s1 with datatype=float,encoding=rle;
create timeseries root.sg.d2.s2 with datatype=int64,encoding=rle;
create device template t1 aligned (temperature FLOAT encoding=Gorilla, status BOOLEAN encoding=PLAIN);
set device template t1 to root.sg.aligned_template;
show paths set device template t1;
create timeseries using device template on root.sg.aligned_template;

insert into root.sg.d1(time,s1,s2) values(1,1,1),(2,2,2),(3,3,3),(4,4,4),(5,5,5),(6,6,6),(7,7,7),(8,8,8),(9,9,9),(10,10,10);
insert into root.sg.d2(time,s1,s2) values(1,1,1),(2,2,2),(3,3,3),(4,null,4),(6,6,null);
insert into root.sg.aligned_template(time,temperature,status) values(1,20,false),(2,22.1,true),(3,18,false);
```

<img width="479" alt="image" src="https://github.com/apache/iotdb/assets/43774645/44549735-af7f-4e9b-86c7-766770736372">


<img width="700" alt="image" src="https://github.com/apache/iotdb/assets/43774645/ec53de8c-635c-4d3f-9a09-a3992cd9da82">
