### PR TITLE
Modify compaction schedule for insertion compaction

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -2147,7 +2147,7 @@ public class DataRegion implements IDataRegionForQuery {
       trySubmitCount += executeInsertionCompaction(timePartitions);
       summary.incrementSubmitTaskNum(CompactionTaskType.INSERTION, trySubmitCount);
     }
-    if (summary.getSubmitInsertionCrossSpaceCompactionTaskNum() > 0) {
+    if (summary.getSubmitInsertionCrossSpaceCompactionTaskNum() == 0) {
       // the name of this variable is trySubmitCount, because the task submitted to the queue could
       // be
       // evicted due to the low priority of the task

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -2147,19 +2147,25 @@ public class DataRegion implements IDataRegionForQuery {
       trySubmitCount += executeInsertionCompaction(timePartitions);
       summary.incrementSubmitTaskNum(CompactionTaskType.INSERTION, trySubmitCount);
     }
-    // the name of this variable is trySubmitCount, because the task submitted to the queue could be
-    // evicted due to the low priority of the task
-    try {
-      for (long timePartition : timePartitions) {
-        trySubmitCount +=
-            CompactionScheduler.scheduleCompaction(tsFileManager, timePartition, summary);
+    if (summary.getSubmitInsertionCrossSpaceCompactionTaskNum() > 0) {
+      // the name of this variable is trySubmitCount, because the task submitted to the queue could
+      // be
+      // evicted due to the low priority of the task
+      try {
+        for (long timePartition : timePartitions) {
+          trySubmitCount +=
+              CompactionScheduler.scheduleCompaction(tsFileManager, timePartition, summary);
+        }
+      } catch (Throwable e) {
+        logger.error("Meet error in compaction schedule.", e);
       }
-    } catch (Throwable e) {
-      logger.error("Meet error in compaction schedule.", e);
     }
     if (summary.hasSubmitTask()) {
       logger.info(
-          "[CompactionScheduler][{}] selected sequence InnerSpaceCompactionTask num is {}, selected unsequence InnerSpaceCompactionTask num is {}, selected CrossSpaceCompactionTask num is {}, selected InsertionCrossSpaceCompactionTask num is {}",
+          "[CompactionScheduler][{}] selected sequence InnerSpaceCompactionTask num is {},"
+              + " selected unsequence InnerSpaceCompactionTask num is {},"
+              + " selected CrossSpaceCompactionTask num is {},"
+              + " selected InsertionCrossSpaceCompactionTask num is {}",
           dataRegionId,
           summary.getSubmitSeqInnerSpaceCompactionTaskNum(),
           summary.getSubmitUnseqInnerSpaceCompactionTaskNum(),


### PR DESCRIPTION
## Description
Modify compaction schedule policy for insertion compaction. Skip the selection of other compaction task if any insertion compaction task num is submitted. 
## Test by load 65G sequence TsFile 
Before this PR:
<img width="1152" alt="截屏2023-11-20 14 09 39" src="https://github.com/apache/iotdb/assets/55970239/6ebd6f4e-ccff-4919-bd5d-cfc2d8ba9d31">

<img width="1311" alt="截屏2023-11-20 14 07 28" src="https://github.com/apache/iotdb/assets/55970239/ef589b23-64bf-419e-af2b-d1dd3d26c3c3">

After this PR:
All files loaded into unsequence space are moved to sequence space directly.
<img width="1355" alt="截屏2023-11-20 14 07 45" src="https://github.com/apache/iotdb/assets/55970239/08de2d1b-e25e-4c51-8003-62670c970f33">
<img width="999" alt="截屏2023-11-20 14 09 07" src="https://github.com/apache/iotdb/assets/55970239/92471eb9-71a3-4866-a829-0fd7b0cac4ae">
