### PR TITLE
Optimize memory usage of fetchSchema when inserting data

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/AbstractSchemaRegionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/AbstractSchemaRegionTest.java
@@ -52,10 +52,10 @@ public abstract class AbstractSchemaRegionTest {
   @Parameterized.Parameters(name = "{0}")
   public static List<SchemaRegionTestParams> getTestModes() {
     return Arrays.asList(
-        new SchemaRegionTestParams("MemoryMode", "Memory", -1, true));
-//        new SchemaRegionTestParams("PBTree-FullMemory", "PBTree", 10000, true),
-//        new SchemaRegionTestParams("PBTree-PartialMemory", "PBTree", 3, true),
-//        new SchemaRegionTestParams("PBTree-NonMemory", "PBTree", 0, true));
+        new SchemaRegionTestParams("MemoryMode", "Memory", -1, true),
+        new SchemaRegionTestParams("PBTree-FullMemory", "PBTree", 10000, true),
+        new SchemaRegionTestParams("PBTree-PartialMemory", "PBTree", 3, true),
+        new SchemaRegionTestParams("PBTree-NonMemory", "PBTree", 0, true));
   }
 
   public AbstractSchemaRegionTest(SchemaRegionTestParams testParams) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/AbstractSchemaRegionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/AbstractSchemaRegionTest.java
@@ -52,10 +52,10 @@ public abstract class AbstractSchemaRegionTest {
   @Parameterized.Parameters(name = "{0}")
   public static List<SchemaRegionTestParams> getTestModes() {
     return Arrays.asList(
-        new SchemaRegionTestParams("MemoryMode", "Memory", -1, true),
-        new SchemaRegionTestParams("PBTree-FullMemory", "PBTree", 10000, true),
-        new SchemaRegionTestParams("PBTree-PartialMemory", "PBTree", 3, true),
-        new SchemaRegionTestParams("PBTree-NonMemory", "PBTree", 0, true));
+        new SchemaRegionTestParams("MemoryMode", "Memory", -1, true));
+//        new SchemaRegionTestParams("PBTree-FullMemory", "PBTree", 10000, true),
+//        new SchemaRegionTestParams("PBTree-PartialMemory", "PBTree", 3, true),
+//        new SchemaRegionTestParams("PBTree-NonMemory", "PBTree", 0, true));
   }
 
   public AbstractSchemaRegionTest(SchemaRegionTestParams testParams) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionBasicTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionBasicTest.java
@@ -40,6 +40,7 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -73,7 +74,7 @@ public class SchemaRegionBasicTest extends AbstractSchemaRegionTest {
   }
 
   @Test
-  //  @Ignore
+  @Ignore
   public void testFetchSchemaPerfomance() throws Exception {
     System.out.println(testParams.getTestModeName());
     int deviceNum = 1000;

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionBasicTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionBasicTest.java
@@ -40,6 +40,7 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -70,6 +71,45 @@ public class SchemaRegionBasicTest extends AbstractSchemaRegionTest {
 
   public SchemaRegionBasicTest(SchemaRegionTestParams testParams) {
     super(testParams);
+  }
+
+  @Test
+  @Ignore
+  public void testFetchSchemaPerfomance() throws Exception {
+    System.out.println(testParams.getTestModeName());
+    int deviceNum = 1000;
+    int measurementNum = 40;
+    ISchemaRegion schemaRegion = getSchemaRegion("root.sg", 0);
+    for (int i = 0; i < deviceNum; i++) {
+      for (int j = 0; j < measurementNum; j++) {
+        schemaRegion.createTimeseries(
+                SchemaRegionWritePlanFactory.getCreateTimeSeriesPlan(
+                        new PartialPath("root.sg.d" + i + ".s" + j),
+                        TSDataType.BOOLEAN,
+                        TSEncoding.PLAIN,
+                        CompressionType.SNAPPY,
+                        null,
+                        null,
+                        null,
+                        null),
+                -1);
+      }
+    }
+    PathPatternTree patternTree = new PathPatternTree();
+    for (int i = 0; i < deviceNum; i++) {
+      for (int j = 0; j < measurementNum; j++) {
+        patternTree.appendFullPath(new PartialPath("root.sg.d" + i + ".s" + j));
+      }
+    }
+    patternTree.constructTree();
+    schemaRegion.fetchSchema(patternTree, Collections.EMPTY_MAP, false);
+    long startTime;
+    startTime = System.currentTimeMillis();
+    for (int i = 0; i < 10; i++) {
+      schemaRegion.fetchSchema(patternTree, Collections.EMPTY_MAP, false);
+    }
+    System.out.println(
+            "cost time: " + (System.currentTimeMillis() - startTime));
   }
 
   @Test

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionBasicTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionBasicTest.java
@@ -40,7 +40,6 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -74,7 +73,7 @@ public class SchemaRegionBasicTest extends AbstractSchemaRegionTest {
   }
 
   @Test
-  @Ignore
+  //  @Ignore
   public void testFetchSchemaPerfomance() throws Exception {
     System.out.println(testParams.getTestModeName());
     int deviceNum = 1000;
@@ -83,16 +82,16 @@ public class SchemaRegionBasicTest extends AbstractSchemaRegionTest {
     for (int i = 0; i < deviceNum; i++) {
       for (int j = 0; j < measurementNum; j++) {
         schemaRegion.createTimeseries(
-                SchemaRegionWritePlanFactory.getCreateTimeSeriesPlan(
-                        new PartialPath("root.sg.d" + i + ".s" + j),
-                        TSDataType.BOOLEAN,
-                        TSEncoding.PLAIN,
-                        CompressionType.SNAPPY,
-                        null,
-                        null,
-                        null,
-                        null),
-                -1);
+            SchemaRegionWritePlanFactory.getCreateTimeSeriesPlan(
+                new PartialPath("root.sg.d" + i + ".s" + j),
+                TSDataType.BOOLEAN,
+                TSEncoding.PLAIN,
+                CompressionType.SNAPPY,
+                null,
+                null,
+                null,
+                null),
+            -1);
       }
     }
     PathPatternTree patternTree = new PathPatternTree();
@@ -108,8 +107,7 @@ public class SchemaRegionBasicTest extends AbstractSchemaRegionTest {
     for (int i = 0; i < 10; i++) {
       schemaRegion.fetchSchema(patternTree, Collections.EMPTY_MAP, false);
     }
-    System.out.println(
-            "cost time: " + (System.currentTimeMillis() - startTime));
+    System.out.println("cost time: " + (System.currentTimeMillis() - startTime));
   }
 
   @Test

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/path/fa/dfa/graph/DFAGraph.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/path/fa/dfa/graph/DFAGraph.java
@@ -41,10 +41,10 @@ public class DFAGraph {
   private final List<IFAState> dfaStateList = new ArrayList<>();
 
   // [stateIndex][transitionIndex]
-  private Map<Integer,Map<Integer, IFAState>> dfaTransitionTable = new HashMap<>();
+  private Map<Integer, Map<Integer, IFAState>> dfaTransitionTable = new HashMap<>();
 
   public DFAGraph(NFAGraph nfaGraph, Collection<IFATransition> transitions, int patternNodesCount) {
-//    dfaTransitionTable = new IFAState[patternNodesCount * 2][transitions.size()];
+    //    dfaTransitionTable = new IFAState[patternNodesCount * 2][transitions.size()];
     int closureSize = nfaGraph.getStateSize();
     // init start state
     int index = 0;
@@ -77,9 +77,7 @@ public class DFAGraph {
             dfaStateList.add(newState);
             closureStateMap.put(nextClosure, newState);
             updateDfaTransitionTable(
-                closureStateMap.get(curClosure).getIndex(),
-                transition.getIndex(),
-                newState);
+                closureStateMap.get(curClosure).getIndex(), transition.getIndex(), newState);
             closureStack.push(nextClosure);
           }
         }
@@ -91,20 +89,21 @@ public class DFAGraph {
       PathPatternTree patternTree,
       Map<String, IFATransition> transitionMap,
       int patternNodesCount) {
-//    dfaTransitionTable = new IFAState[patternNodesCount * 2][transitionMap.size()];
+    //    dfaTransitionTable = new IFAState[patternNodesCount * 2][transitionMap.size()];
     // init start state
     IFAState curState = new DFAState(0);
     dfaStateList.add(curState);
     init(patternTree.getRoot(), transitionMap, curState, new AtomicInteger(0));
   }
 
-//  private void ensureCapacity() {
-//    if (dfaStateList.size() > dfaTransitionTable.length) {
-//      IFAState[][] tmp = new IFAState[dfaTransitionTable.length * 2][dfaTransitionTable[0].length];
-//      System.arraycopy(dfaTransitionTable, 0, tmp, 0, dfaTransitionTable.length);
-//      dfaTransitionTable = tmp;
-//    }
-//  }
+  //  private void ensureCapacity() {
+  //    if (dfaStateList.size() > dfaTransitionTable.length) {
+  //      IFAState[][] tmp = new IFAState[dfaTransitionTable.length *
+  // 2][dfaTransitionTable[0].length];
+  //      System.arraycopy(dfaTransitionTable, 0, tmp, 0, dfaTransitionTable.length);
+  //      dfaTransitionTable = tmp;
+  //    }
+  //  }
 
   private void init(
       PathPatternNode<Void, PathPatternNode.VoidSerializer> node,
@@ -115,23 +114,19 @@ public class DFAGraph {
     int stateIndex = curState.getIndex();
     int transitionIndex = transition.getIndex();
     DFAState newState = (DFAState) getFromDfaTransitionTable(stateIndex, transitionIndex);
-    if(newState == null){
+    if (newState == null) {
       newState = new DFAState(stateIndexGenerator.incrementAndGet());
       dfaStateList.add(newState);
       updateDfaTransitionTable(stateIndex, transitionIndex, newState);
-//      ensureCapacity();
-//      dfaTransitionTable[stateIndex][transitionIndex] = newState;
+      //      ensureCapacity();
+      //      dfaTransitionTable[stateIndex][transitionIndex] = newState;
     }
     if (node.isPathPattern()) {
       newState.setFinal(true);
     }
     for (PathPatternNode<Void, PathPatternNode.VoidSerializer> child :
         node.getChildren().values()) {
-      init(
-          child,
-          transitionMap,
-              newState,
-          stateIndexGenerator);
+      init(child, transitionMap, newState, stateIndexGenerator);
     }
   }
 
@@ -153,7 +148,7 @@ public class DFAGraph {
       stringBuilder = new StringBuilder();
       stringBuilder.append(String.format("|%-15d|", i));
       for (IFATransition transition : transitionMap.values()) {
-        IFAState tmp = getFromDfaTransitionTable(i,transition.getIndex());
+        IFAState tmp = getFromDfaTransitionTable(i, transition.getIndex());
         stringBuilder.append(String.format("%-15s|", tmp == null ? "" : tmp.getIndex()));
       }
       stringBuilder.append(String.format("%-15s|", dfaStateList.get(i).isFinal()));
@@ -187,7 +182,7 @@ public class DFAGraph {
       IFAState state, Collection<IFATransition> transitions) {
     Map<String, IFATransition> res = new HashMap<>();
     for (IFATransition transition : transitions) {
-      if (getFromDfaTransitionTable(state.getIndex(),transition.getIndex()) != null) {
+      if (getFromDfaTransitionTable(state.getIndex(), transition.getIndex()) != null) {
         res.put(transition.getAcceptEvent(), transition);
       }
     }
@@ -198,7 +193,7 @@ public class DFAGraph {
       IFAState state, Collection<IFATransition> transitionList) {
     List<IFATransition> res = new ArrayList<>();
     for (IFATransition transition : transitionList) {
-      if (getFromDfaTransitionTable(state.getIndex(),transition.getIndex()) != null) {
+      if (getFromDfaTransitionTable(state.getIndex(), transition.getIndex()) != null) {
         res.add(transition);
       }
     }
@@ -206,7 +201,7 @@ public class DFAGraph {
   }
 
   public IFAState getNextState(IFAState currentState, IFATransition transition) {
-    return getFromDfaTransitionTable(currentState.getIndex(),transition.getIndex());
+    return getFromDfaTransitionTable(currentState.getIndex(), transition.getIndex());
   }
 
   public IFAState getInitialState() {
@@ -222,18 +217,21 @@ public class DFAGraph {
   }
 
   private void updateDfaTransitionTable(int stateIndex, int transitionIndex, IFAState newState) {
-    dfaTransitionTable.compute(stateIndex, (k, v) -> {
-      if (v == null) {
-        v = new HashMap<>();
-      }
-      v.put(transitionIndex, newState);
-      return v;
-    });
+    dfaTransitionTable.compute(
+        stateIndex,
+        (k, v) -> {
+          if (v == null) {
+            v = new HashMap<>();
+          }
+          v.put(transitionIndex, newState);
+          return v;
+        });
   }
+
   private IFAState getFromDfaTransitionTable(int stateIndex, int transitionIndex) {
-    if(dfaTransitionTable.containsKey(stateIndex)){
+    if (dfaTransitionTable.containsKey(stateIndex)) {
       return dfaTransitionTable.get(stateIndex).get(transitionIndex);
-    }else {
+    } else {
       return null;
     }
   }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/path/fa/dfa/graph/DFAGraph.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/path/fa/dfa/graph/DFAGraph.java
@@ -41,10 +41,9 @@ public class DFAGraph {
   private final List<IFAState> dfaStateList = new ArrayList<>();
 
   // [stateIndex][transitionIndex]
-  private Map<Integer, Map<Integer, IFAState>> dfaTransitionTable = new HashMap<>();
+  private final Map<Integer, Map<Integer, IFAState>> dfaTransitionTable = new HashMap<>();
 
-  public DFAGraph(NFAGraph nfaGraph, Collection<IFATransition> transitions, int patternNodesCount) {
-    //    dfaTransitionTable = new IFAState[patternNodesCount * 2][transitions.size()];
+  public DFAGraph(NFAGraph nfaGraph, Collection<IFATransition> transitions) {
     int closureSize = nfaGraph.getStateSize();
     // init start state
     int index = 0;
@@ -85,25 +84,12 @@ public class DFAGraph {
     }
   }
 
-  public DFAGraph(
-      PathPatternTree patternTree,
-      Map<String, IFATransition> transitionMap,
-      int patternNodesCount) {
-    //    dfaTransitionTable = new IFAState[patternNodesCount * 2][transitionMap.size()];
+  public DFAGraph(PathPatternTree patternTree, Map<String, IFATransition> transitionMap) {
     // init start state
     IFAState curState = new DFAState(0);
     dfaStateList.add(curState);
     init(patternTree.getRoot(), transitionMap, curState, new AtomicInteger(0));
   }
-
-  //  private void ensureCapacity() {
-  //    if (dfaStateList.size() > dfaTransitionTable.length) {
-  //      IFAState[][] tmp = new IFAState[dfaTransitionTable.length *
-  // 2][dfaTransitionTable[0].length];
-  //      System.arraycopy(dfaTransitionTable, 0, tmp, 0, dfaTransitionTable.length);
-  //      dfaTransitionTable = tmp;
-  //    }
-  //  }
 
   private void init(
       PathPatternNode<Void, PathPatternNode.VoidSerializer> node,
@@ -118,8 +104,6 @@ public class DFAGraph {
       newState = new DFAState(stateIndexGenerator.incrementAndGet());
       dfaStateList.add(newState);
       updateDfaTransitionTable(stateIndex, transitionIndex, newState);
-      //      ensureCapacity();
-      //      dfaTransitionTable[stateIndex][transitionIndex] = newState;
     }
     if (node.isPathPattern()) {
       newState.setFinal(true);

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/path/fa/dfa/graph/DFAGraph.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/path/fa/dfa/graph/DFAGraph.java
@@ -39,11 +39,12 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class DFAGraph {
   private final List<IFAState> dfaStateList = new ArrayList<>();
+
   // [stateIndex][transitionIndex]
-  private IFAState[][] dfaTransitionTable;
+  private Map<Integer,Map<Integer, IFAState>> dfaTransitionTable = new HashMap<>();
 
   public DFAGraph(NFAGraph nfaGraph, Collection<IFATransition> transitions, int patternNodesCount) {
-    dfaTransitionTable = new IFAState[patternNodesCount * 2][transitions.size()];
+//    dfaTransitionTable = new IFAState[patternNodesCount * 2][transitions.size()];
     int closureSize = nfaGraph.getStateSize();
     // init start state
     int index = 0;
@@ -66,16 +67,19 @@ public class DFAGraph {
         if (!isEmpty) {
           if (closureStateMap.containsKey(nextClosure)) {
             // closure already exist
-            dfaTransitionTable[closureStateMap.get(curClosure).getIndex()][transition.getIndex()] =
-                closureStateMap.get(nextClosure);
+            updateDfaTransitionTable(
+                closureStateMap.get(curClosure).getIndex(),
+                transition.getIndex(),
+                closureStateMap.get(nextClosure));
           } else {
             // new closure
             DFAState newState = new DFAState(++index, nextClosure.isFinal());
             dfaStateList.add(newState);
             closureStateMap.put(nextClosure, newState);
-            ensureCapacity();
-            dfaTransitionTable[closureStateMap.get(curClosure).getIndex()][transition.getIndex()] =
-                newState;
+            updateDfaTransitionTable(
+                closureStateMap.get(curClosure).getIndex(),
+                transition.getIndex(),
+                newState);
             closureStack.push(nextClosure);
           }
         }
@@ -87,20 +91,20 @@ public class DFAGraph {
       PathPatternTree patternTree,
       Map<String, IFATransition> transitionMap,
       int patternNodesCount) {
-    dfaTransitionTable = new IFAState[patternNodesCount * 2][transitionMap.size()];
+//    dfaTransitionTable = new IFAState[patternNodesCount * 2][transitionMap.size()];
     // init start state
     IFAState curState = new DFAState(0);
     dfaStateList.add(curState);
     init(patternTree.getRoot(), transitionMap, curState, new AtomicInteger(0));
   }
 
-  private void ensureCapacity() {
-    if (dfaStateList.size() > dfaTransitionTable.length) {
-      IFAState[][] tmp = new IFAState[dfaTransitionTable.length * 2][dfaTransitionTable[0].length];
-      System.arraycopy(dfaTransitionTable, 0, tmp, 0, dfaTransitionTable.length);
-      dfaTransitionTable = tmp;
-    }
-  }
+//  private void ensureCapacity() {
+//    if (dfaStateList.size() > dfaTransitionTable.length) {
+//      IFAState[][] tmp = new IFAState[dfaTransitionTable.length * 2][dfaTransitionTable[0].length];
+//      System.arraycopy(dfaTransitionTable, 0, tmp, 0, dfaTransitionTable.length);
+//      dfaTransitionTable = tmp;
+//    }
+//  }
 
   private void init(
       PathPatternNode<Void, PathPatternNode.VoidSerializer> node,
@@ -110,21 +114,23 @@ public class DFAGraph {
     IFATransition transition = transitionMap.get(node.getName());
     int stateIndex = curState.getIndex();
     int transitionIndex = transition.getIndex();
-    if (dfaTransitionTable[stateIndex][transitionIndex] == null) {
-      DFAState newState = new DFAState(stateIndexGenerator.incrementAndGet());
+    DFAState newState = (DFAState) getFromDfaTransitionTable(stateIndex, transitionIndex);
+    if(newState == null){
+      newState = new DFAState(stateIndexGenerator.incrementAndGet());
       dfaStateList.add(newState);
-      ensureCapacity();
-      dfaTransitionTable[stateIndex][transitionIndex] = newState;
+      updateDfaTransitionTable(stateIndex, transitionIndex, newState);
+//      ensureCapacity();
+//      dfaTransitionTable[stateIndex][transitionIndex] = newState;
     }
     if (node.isPathPattern()) {
-      ((DFAState) dfaTransitionTable[stateIndex][transitionIndex]).setFinal(true);
+      newState.setFinal(true);
     }
     for (PathPatternNode<Void, PathPatternNode.VoidSerializer> child :
         node.getChildren().values()) {
       init(
           child,
           transitionMap,
-          dfaTransitionTable[stateIndex][transitionIndex],
+              newState,
           stateIndexGenerator);
     }
   }
@@ -147,7 +153,7 @@ public class DFAGraph {
       stringBuilder = new StringBuilder();
       stringBuilder.append(String.format("|%-15d|", i));
       for (IFATransition transition : transitionMap.values()) {
-        IFAState tmp = dfaTransitionTable[i][transition.getIndex()];
+        IFAState tmp = getFromDfaTransitionTable(i,transition.getIndex());
         stringBuilder.append(String.format("%-15s|", tmp == null ? "" : tmp.getIndex()));
       }
       stringBuilder.append(String.format("%-15s|", dfaStateList.get(i).isFinal()));
@@ -181,7 +187,7 @@ public class DFAGraph {
       IFAState state, Collection<IFATransition> transitions) {
     Map<String, IFATransition> res = new HashMap<>();
     for (IFATransition transition : transitions) {
-      if (dfaTransitionTable[state.getIndex()][transition.getIndex()] != null) {
+      if (getFromDfaTransitionTable(state.getIndex(),transition.getIndex()) != null) {
         res.put(transition.getAcceptEvent(), transition);
       }
     }
@@ -192,7 +198,7 @@ public class DFAGraph {
       IFAState state, Collection<IFATransition> transitionList) {
     List<IFATransition> res = new ArrayList<>();
     for (IFATransition transition : transitionList) {
-      if (dfaTransitionTable[state.getIndex()][transition.getIndex()] != null) {
+      if (getFromDfaTransitionTable(state.getIndex(),transition.getIndex()) != null) {
         res.add(transition);
       }
     }
@@ -200,7 +206,7 @@ public class DFAGraph {
   }
 
   public IFAState getNextState(IFAState currentState, IFATransition transition) {
-    return dfaTransitionTable[currentState.getIndex()][transition.getIndex()];
+    return getFromDfaTransitionTable(currentState.getIndex(),transition.getIndex());
   }
 
   public IFAState getInitialState() {
@@ -213,5 +219,22 @@ public class DFAGraph {
 
   public IFAState getState(int index) {
     return dfaStateList.get(index);
+  }
+
+  private void updateDfaTransitionTable(int stateIndex, int transitionIndex, IFAState newState) {
+    dfaTransitionTable.compute(stateIndex, (k, v) -> {
+      if (v == null) {
+        v = new HashMap<>();
+      }
+      v.put(transitionIndex, newState);
+      return v;
+    });
+  }
+  private IFAState getFromDfaTransitionTable(int stateIndex, int transitionIndex) {
+    if(dfaTransitionTable.containsKey(stateIndex)){
+      return dfaTransitionTable.get(stateIndex).get(transitionIndex);
+    }else {
+      return null;
+    }
   }
 }

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/path/PatternDFATest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/path/PatternDFATest.java
@@ -51,10 +51,8 @@ public class PatternDFATest {
     PartialPath pathPattern = new PartialPath("root.**.d.s1");
     // 1. build transition
     boolean wildcard = false;
-    int cnt = 0;
     AtomicInteger transitionIndex = new AtomicInteger();
     for (String node : pathPattern.getNodes()) {
-      cnt++;
       if (IoTDBConstant.ONE_LEVEL_PATH_WILDCARD.equals(node)
           || IoTDBConstant.MULTI_LEVEL_PATH_WILDCARD.equals(node)) {
         wildcard = true;
@@ -73,7 +71,7 @@ public class PatternDFATest {
     NFAGraph nfaGraph = new NFAGraph(pathPattern, false, transitionMap);
     nfaGraph.print(transitionMap);
     // 3. NFA to DFA
-    DFAGraph dfaGraph = new DFAGraph(nfaGraph, transitionMap.values(), cnt);
+    DFAGraph dfaGraph = new DFAGraph(nfaGraph, transitionMap.values());
     dfaGraph.print(transitionMap);
   }
 
@@ -95,11 +93,9 @@ public class PatternDFATest {
     patternTree.constructTree();
     // 1. build transition
     boolean wildcard = false;
-    int cnt = 0;
     AtomicInteger transitionIndex = new AtomicInteger();
     for (PartialPath pathPattern : patternTree.getAllPathPatterns()) {
       for (String node : pathPattern.getNodes()) {
-        cnt++;
         if (IoTDBConstant.ONE_LEVEL_PATH_WILDCARD.equals(node)
             || IoTDBConstant.MULTI_LEVEL_PATH_WILDCARD.equals(node)) {
           wildcard = true;
@@ -119,7 +115,7 @@ public class PatternDFATest {
     NFAGraph nfaGraph = new NFAGraph(patternTree, transitionMap);
     nfaGraph.print(transitionMap);
     // 3. NFA to DFA
-    DFAGraph dfaGraph = new DFAGraph(nfaGraph, transitionMap.values(), cnt);
+    DFAGraph dfaGraph = new DFAGraph(nfaGraph, transitionMap.values());
     dfaGraph.print(transitionMap);
   }
 
@@ -146,7 +142,7 @@ public class PatternDFATest {
     }
     patternTree.constructTree();
     //     build DFA directly
-    DFAGraph dfaGraph = new DFAGraph(patternTree, transitionMap, 18);
+    DFAGraph dfaGraph = new DFAGraph(patternTree, transitionMap);
     dfaGraph.print(transitionMap);
   }
 


### PR DESCRIPTION
## Description

Use HashMap instead of 2D arrays to avoid space occupation in sparse matrices. Experiments with `testFetchSchemaPerfomance` demonstrate that performance is not affected, but there is a significant reduction in memory usage.

Before：
<img width="1227" alt="image" src="https://github.com/apache/iotdb/assets/43774645/e1d4d396-392c-4181-8fa3-dddeb612e318">


After：
<img width="1175" alt="image" src="https://github.com/apache/iotdb/assets/43774645/ec2e2741-9f0b-4306-9ffe-3ff2160e37c6">
