### PR TITLE
Accelerate the process of PlanNode to Operator

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/AbstractDataSourceOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/AbstractDataSourceOperator.java
@@ -20,13 +20,23 @@
 package org.apache.iotdb.db.queryengine.execution.operator.source;
 
 import org.apache.iotdb.db.storageengine.dataregion.read.QueryDataSource;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
+
+import java.util.List;
 
 public abstract class AbstractDataSourceOperator extends AbstractSourceOperator
     implements DataSourceOperator {
   protected SeriesScanUtil seriesScanUtil;
 
+  // Using for building result tsBlock
+  protected TsBlockBuilder resultTsBlockBuilder;
+
   @Override
   public void initQueryDataSource(QueryDataSource dataSource) {
     seriesScanUtil.initQueryDataSource(dataSource);
+    resultTsBlockBuilder = new TsBlockBuilder(getResultDataTypes());
   }
+
+  protected abstract List<TSDataType> getResultDataTypes();
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/AbstractSeriesAggregationScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/AbstractSeriesAggregationScanOperator.java
@@ -29,7 +29,6 @@ import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.statistics.Statistics;
 import org.apache.iotdb.tsfile.read.common.TimeRange;
 import org.apache.iotdb.tsfile.read.common.block.TsBlock;
-import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilder;
 import org.apache.iotdb.tsfile.utils.Pair;
 
 import java.io.IOException;
@@ -59,9 +58,6 @@ public abstract class AbstractSeriesAggregationScanOperator extends AbstractData
   // But in facing of statistics, it will invoke another method processStatistics()
   protected final List<Aggregator> aggregators;
 
-  // Using for building result tsBlock
-  protected final TsBlockBuilder resultTsBlockBuilder;
-
   protected boolean finished = false;
 
   private final long cachedRawDataSize;
@@ -88,12 +84,6 @@ public abstract class AbstractSeriesAggregationScanOperator extends AbstractData
     this.subSensorSize = subSensorSize;
     this.aggregators = aggregators;
     this.timeRangeIterator = timeRangeIterator;
-
-    List<TSDataType> dataTypes = new ArrayList<>();
-    for (Aggregator aggregator : aggregators) {
-      dataTypes.addAll(Arrays.asList(aggregator.getOutputType()));
-    }
-    this.resultTsBlockBuilder = new TsBlockBuilder(dataTypes);
 
     this.cachedRawDataSize =
         (1L + subSensorSize) * TSFileDescriptor.getInstance().getConfig().getPageSizeInByte();
@@ -388,5 +378,14 @@ public abstract class AbstractSeriesAggregationScanOperator extends AbstractData
     return !seriesScanUtil.isPageOverlapped()
         && currentPageStatistics.containedByTimeFilter(seriesScanUtil.getGlobalTimeFilter())
         && !seriesScanUtil.currentPageModified();
+  }
+
+  @Override
+  protected List<TSDataType> getResultDataTypes() {
+    List<TSDataType> dataTypes = new ArrayList<>();
+    for (Aggregator aggregator : aggregators) {
+      dataTypes.addAll(Arrays.asList(aggregator.getOutputType()));
+    }
+    return dataTypes;
   }
 }


### PR DESCRIPTION
The process of PlanNode to Operator is a single-thread and blocking oepration in scheduling, so we should not put too much heavy work in it, we should try our best to let it simple and fast, so some heavy and unnecessary work should be delayed into the DriverTask which will be executed in seperated query worker thread and is async.

<img width="1736" alt="image" src="https://github.com/apache/iotdb/assets/16079446/97b377c7-5761-4c43-8c1b-507223536cc1">
