### PR TITLE
Fix fetch nested device with template will miss some devices

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/schematree/ClusterSchemaTree.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/schematree/ClusterSchemaTree.java
@@ -277,7 +277,7 @@ public class ClusterSchemaTree implements ISchemaTree {
     String[] nodes = devicePath.getNodes();
     SchemaNode cur = root;
     SchemaNode child;
-    for (int i = 1; i < nodes.length-1; i++) {
+    for (int i = 1; i < nodes.length - 1; i++) {
       child = cur.getChild(nodes[i]);
       if (child == null) {
         child = new SchemaInternalNode(nodes[i]);
@@ -287,15 +287,15 @@ public class ClusterSchemaTree implements ISchemaTree {
     }
     String deviceName = nodes[nodes.length - 1];
     child = cur.getChild(deviceName);
-    if(child==null){
+    if (child == null) {
       SchemaEntityNode entityNode = new SchemaEntityNode(deviceName);
       entityNode.setAligned(isAligned);
       entityNode.setTemplateId(templateId);
       cur.addChild(deviceName, entityNode);
-    }else if(child.isEntity()){
+    } else if (child.isEntity()) {
       child.getAsEntityNode().setTemplateId(templateId);
       child.getAsEntityNode().setAligned(isAligned);
-    }else {
+    } else {
       SchemaEntityNode entityNode = new SchemaEntityNode(deviceName);
       entityNode.setAligned(isAligned);
       entityNode.setTemplateId(templateId);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/schematree/ClusterSchemaTree.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/schematree/ClusterSchemaTree.java
@@ -277,20 +277,29 @@ public class ClusterSchemaTree implements ISchemaTree {
     String[] nodes = devicePath.getNodes();
     SchemaNode cur = root;
     SchemaNode child;
-    for (int i = 1; i < nodes.length; i++) {
+    for (int i = 1; i < nodes.length-1; i++) {
       child = cur.getChild(nodes[i]);
       if (child == null) {
-        if (i == nodes.length - 1) {
-          SchemaEntityNode entityNode = new SchemaEntityNode(nodes[i]);
-          entityNode.setAligned(isAligned);
-          entityNode.setTemplateId(templateId);
-          child = entityNode;
-        } else {
-          child = new SchemaInternalNode(nodes[i]);
-        }
+        child = new SchemaInternalNode(nodes[i]);
         cur.addChild(nodes[i], child);
       }
       cur = child;
+    }
+    String deviceName = nodes[nodes.length - 1];
+    child = cur.getChild(deviceName);
+    if(child==null){
+      SchemaEntityNode entityNode = new SchemaEntityNode(deviceName);
+      entityNode.setAligned(isAligned);
+      entityNode.setTemplateId(templateId);
+      cur.addChild(deviceName, entityNode);
+    }else if(child.isEntity()){
+      child.getAsEntityNode().setTemplateId(templateId);
+      child.getAsEntityNode().setAligned(isAligned);
+    }else {
+      SchemaEntityNode entityNode = new SchemaEntityNode(deviceName);
+      entityNode.setAligned(isAligned);
+      entityNode.setTemplateId(templateId);
+      cur.replaceChild(deviceName, entityNode);
     }
     templateMap.putIfAbsent(templateId, template);
   }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionTemplateTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionTemplateTest.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.path.PathPatternTree;
 import org.apache.iotdb.db.queryengine.common.schematree.ClusterSchemaTree;
+import org.apache.iotdb.db.queryengine.common.schematree.DeviceSchemaInfo;
 import org.apache.iotdb.db.schemaengine.schemaregion.ISchemaRegion;
 import org.apache.iotdb.db.schemaengine.schemaregion.read.resp.info.ISchemaInfo;
 import org.apache.iotdb.db.schemaengine.schemaregion.read.resp.info.ITimeSeriesSchemaInfo;
@@ -54,6 +55,35 @@ public class SchemaRegionTemplateTest extends AbstractSchemaRegionTest {
   public SchemaRegionTemplateTest(SchemaRegionTestParams testParams) {
     super(testParams);
   }
+
+
+  @Test
+  public void testFetchNestedTemplateDevice() throws Exception {
+    ISchemaRegion schemaRegion = getSchemaRegion("root.sg", 0);
+    int templateId = 1;
+    Template template =
+            new Template(
+                    "t1",
+                    Arrays.asList("s1", "s2"),
+                    Arrays.asList(TSDataType.DOUBLE, TSDataType.INT32),
+                    Arrays.asList(TSEncoding.RLE, TSEncoding.RLE),
+                    Arrays.asList(CompressionType.SNAPPY, CompressionType.SNAPPY));
+    template.setId(templateId);
+    schemaRegion.activateSchemaTemplate(
+            SchemaRegionWritePlanFactory.getActivateTemplateInClusterPlan(
+                    new PartialPath("root.sg.d1"), 2, templateId),
+            template);
+    schemaRegion.activateSchemaTemplate(
+            SchemaRegionWritePlanFactory.getActivateTemplateInClusterPlan(
+                    new PartialPath("root.sg.d1.GPS"), 3, templateId),
+            template);
+    ClusterSchemaTree schemaTree = schemaRegion.fetchSchema(ALL_MATCH_SCOPE, Collections.singletonMap(templateId, template), true);
+    Assert.assertEquals(2,schemaTree.getAllDevices().size());
+    for(DeviceSchemaInfo deviceSchemaInfo:schemaTree.getAllDevices()){
+      Assert.assertEquals(templateId, deviceSchemaInfo.getTemplateId());
+    }
+  }
+
 
   /** Test {@link ISchemaRegion#activateSchemaTemplate}. */
   @Test

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionTemplateTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionTemplateTest.java
@@ -56,34 +56,34 @@ public class SchemaRegionTemplateTest extends AbstractSchemaRegionTest {
     super(testParams);
   }
 
-
   @Test
   public void testFetchNestedTemplateDevice() throws Exception {
     ISchemaRegion schemaRegion = getSchemaRegion("root.sg", 0);
     int templateId = 1;
     Template template =
-            new Template(
-                    "t1",
-                    Arrays.asList("s1", "s2"),
-                    Arrays.asList(TSDataType.DOUBLE, TSDataType.INT32),
-                    Arrays.asList(TSEncoding.RLE, TSEncoding.RLE),
-                    Arrays.asList(CompressionType.SNAPPY, CompressionType.SNAPPY));
+        new Template(
+            "t1",
+            Arrays.asList("s1", "s2"),
+            Arrays.asList(TSDataType.DOUBLE, TSDataType.INT32),
+            Arrays.asList(TSEncoding.RLE, TSEncoding.RLE),
+            Arrays.asList(CompressionType.SNAPPY, CompressionType.SNAPPY));
     template.setId(templateId);
     schemaRegion.activateSchemaTemplate(
-            SchemaRegionWritePlanFactory.getActivateTemplateInClusterPlan(
-                    new PartialPath("root.sg.d1"), 2, templateId),
-            template);
+        SchemaRegionWritePlanFactory.getActivateTemplateInClusterPlan(
+            new PartialPath("root.sg.d1"), 2, templateId),
+        template);
     schemaRegion.activateSchemaTemplate(
-            SchemaRegionWritePlanFactory.getActivateTemplateInClusterPlan(
-                    new PartialPath("root.sg.d1.GPS"), 3, templateId),
-            template);
-    ClusterSchemaTree schemaTree = schemaRegion.fetchSchema(ALL_MATCH_SCOPE, Collections.singletonMap(templateId, template), true);
-    Assert.assertEquals(2,schemaTree.getAllDevices().size());
-    for(DeviceSchemaInfo deviceSchemaInfo:schemaTree.getAllDevices()){
+        SchemaRegionWritePlanFactory.getActivateTemplateInClusterPlan(
+            new PartialPath("root.sg.d1.GPS"), 3, templateId),
+        template);
+    ClusterSchemaTree schemaTree =
+        schemaRegion.fetchSchema(
+            ALL_MATCH_SCOPE, Collections.singletonMap(templateId, template), true);
+    Assert.assertEquals(2, schemaTree.getAllDevices().size());
+    for (DeviceSchemaInfo deviceSchemaInfo : schemaTree.getAllDevices()) {
       Assert.assertEquals(templateId, deviceSchemaInfo.getTemplateId());
     }
   }
-
 
   /** Test {@link ISchemaRegion#activateSchemaTemplate}. */
   @Test


### PR DESCRIPTION
## Description


### Reproduce
```
--1. CREATE TEMPLATE
create device template t1 (temperature FLOAT encoding=RLE, status BOOLEAN encoding=PLAIN compression=SNAPPY);
show schema templates;
show device templates;
create database root.sg1;

--2. SET TEMPLATE
set device template t1 to root.sg1.d1;
show paths set schema template t1;
show paths set device template t1;

--3. ACTIVATE TEMPLATE
create timeseries of device template on root.sg1.d1;
show paths using device template t1;
show devices root.sg1.**;
show timeseries;
show timeseries root.sg1.**;

--4. INSERT DATA
insert into root.sg1.d1(time, temperature, status) values(1, 1, 1);
insert into root.sg1.d1(time, temperature, status) values(2, 2, 0), (3, 3, 1);
select * from root.sg1.d1;

--5. QUERY
insert into root.sg1.d1.GPS(time, latitude, longitude) values(1, 1, 1);
show timeseries root.sg1.d1.**;
select * from root.sg1.**;
```
<img width="936" alt="image" src="https://github.com/apache/iotdb/assets/43774645/ddd6ad3f-3e95-44b7-a047-183dbb2f99fa">


### After fix
<img width="1461" alt="image" src="https://github.com/apache/iotdb/assets/43774645/97ed6376-4adf-4413-a29e-ec717f8abe7f">

