### PR TITLE
Improve BinaryStatistics deserialization

### DIFF
--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/statistics/BinaryStatistics.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/statistics/BinaryStatistics.java
@@ -42,8 +42,10 @@ public class BinaryStatistics extends Statistics<Binary> {
       ClassLayout.parseClass(BinaryStatistics.class).instanceSize()
           + 2 * ClassLayout.parseClass(Binary.class).instanceSize();
 
-  private Binary firstValue = new Binary("", TSFileConfig.STRING_CHARSET);
-  private Binary lastValue = new Binary("", TSFileConfig.STRING_CHARSET);
+  private static final Binary EMPTY_VALUE = new Binary("", TSFileConfig.STRING_CHARSET);
+
+  private Binary firstValue = EMPTY_VALUE;
+  private Binary lastValue = EMPTY_VALUE;
 
   @Override
   public TSDataType getType() {


### PR DESCRIPTION
the first value and last value initialization process in BinaryStatistics is time consuming, and there is no need for us to do it.
<img width="1919" alt="image" src="https://github.com/apache/iotdb/assets/16079446/31c9f16b-f7a6-4317-b5dd-ce0a217b175f">
