### PR TITLE
Fix explain error when align by device + template

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/memory/StatementMemorySourceVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/memory/StatementMemorySourceVisitor.java
@@ -71,7 +71,8 @@ public class StatementMemorySourceVisitor
     return (context.getAnalysis().getSourceExpressions() == null
             || context.getAnalysis().getSourceExpressions().isEmpty())
         && (context.getAnalysis().getDeviceToSourceExpressions() == null
-            || context.getAnalysis().getDeviceToSourceExpressions().isEmpty());
+            || context.getAnalysis().getDeviceToSourceExpressions().isEmpty())
+        && context.getAnalysis().getDeviceTemplate() == null;
   }
 
   @Override

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/analyze/FakeSchemaFetcherImpl.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/analyze/FakeSchemaFetcherImpl.java
@@ -44,11 +44,9 @@ import java.util.Map;
 public class FakeSchemaFetcherImpl implements ISchemaFetcher {
 
   private final ClusterSchemaTree schemaTree = new ClusterSchemaTree(generateSchemaTree());
-  private MPPQueryContext context;
 
   @Override
   public ClusterSchemaTree fetchSchema(PathPatternTree patternTree, MPPQueryContext context) {
-    this.context = context;
     schemaTree.setDatabases(Collections.singleton("root.sg"));
     return schemaTree;
   }
@@ -77,7 +75,7 @@ public class FakeSchemaFetcherImpl implements ISchemaFetcher {
    * Generate the following tree: root.sg.d1.s1, root.sg.d1.s2(status) root.sg.d2.s1,
    * root.sg.d2.s2(status) root.sg.d2.a.s1, root.sg.d2.a.s2(status)
    *
-   * @return the root node of the generated schemTree
+   * @return the root node of the generated schemaTree
    */
   private SchemaNode generateSchemaTree() {
     SchemaNode root = new SchemaInternalNode("root");


### PR DESCRIPTION
## Description


Before fix, the explain result of below sql list is empty.


`CREATE database root.sg2;
CREATE schema template t2 aligned (s1 FLOAT encoding=RLE, s2 BOOLEAN encoding=PLAIN compression=SNAPPY, s3 INT32);
SET SCHEMA TEMPLATE t2 to root.sg2;
INSERT INTO root.sg2.d1(timestamp,s1,s2,s3) values(1,1.1,false,1), (2,2.2,false,2);
INSERT INTO root.sg2.d2(timestamp,s1,s2,s3) values(1,11.1,false,11), (2,22.2,false,22);
INSERT INTO root.sg2.d3(timestamp,s1,s2,s3) values(1,111.1,true,null), (4,444.4,true,44);
INSERT INTO root.sg2.d4(timestamp,s1,s2,s3) values(1,1111.1,true,1111), (5,5555.5,false,5555);
SELECT * FROM root.sg2.** ALIGN BY DEVICE;`