### PR TITLE
[IOTDB-6259] Bump ratis version to 3.0.0

### DIFF
--- a/iotdb-core/consensus/pom.xml
+++ b/iotdb-core/consensus/pom.xml
@@ -42,6 +42,10 @@
             <version>1.3.1-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>metrics-interface</artifactId>
             <version>1.3.1-SNAPSHOT</version>
@@ -127,11 +131,6 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.iotdb</groupId>
-            <artifactId>metrics-interface</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <build>

--- a/iotdb-core/consensus/pom.xml
+++ b/iotdb-core/consensus/pom.xml
@@ -118,14 +118,6 @@
             <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-jmx</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>tsfile</artifactId>
             <version>1.3.1-SNAPSHOT</version>
@@ -135,6 +127,11 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.iotdb</groupId>
+            <artifactId>metrics-interface</artifactId>
+            <version>1.3.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <build>

--- a/iotdb-core/consensus/pom.xml
+++ b/iotdb-core/consensus/pom.xml
@@ -42,10 +42,6 @@
             <version>1.3.1-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>metrics-interface</artifactId>
             <version>1.3.1-SNAPSHOT</version>

--- a/iotdb-core/consensus/pom.xml
+++ b/iotdb-core/consensus/pom.xml
@@ -87,7 +87,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ratis</groupId>
-            <artifactId>ratis-metrics</artifactId>
+            <artifactId>ratis-metrics-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.ratis</groupId>

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/metrics/CounterProxy.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/metrics/CounterProxy.java
@@ -21,8 +21,10 @@ package org.apache.iotdb.consensus.ratis.metrics;
 
 import org.apache.iotdb.metrics.type.Counter;
 
-/** A Proxy class using IoTDB Counter to replace the dropwizard Counter. */
-public class CounterProxy extends com.codahale.metrics.Counter {
+import org.apache.ratis.metrics.LongCounter;
+
+/** CounterProxy will route Ratis' internal counter metrics to our IoTDB {@link Counter} */
+public class CounterProxy implements LongCounter {
 
   /** IoTDB Counter. */
   private final Counter counter;

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/metrics/CounterProxy.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/metrics/CounterProxy.java
@@ -20,7 +20,6 @@
 package org.apache.iotdb.consensus.ratis.metrics;
 
 import org.apache.iotdb.metrics.type.Counter;
-
 import org.apache.ratis.metrics.LongCounter;
 
 /** CounterProxy will route Ratis' internal counter metrics to our IoTDB {@link Counter} */
@@ -55,6 +54,6 @@ public class CounterProxy implements LongCounter {
 
   @Override
   public long getCount() {
-    return counter.count();
+    return counter.getCount();
   }
 }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/metrics/CounterProxy.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/metrics/CounterProxy.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.consensus.ratis.metrics;
 
 import org.apache.iotdb.metrics.type.Counter;
+
 import org.apache.ratis.metrics.LongCounter;
 
 /** CounterProxy will route Ratis' internal counter metrics to our IoTDB {@link Counter} */

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/metrics/CounterProxy.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/metrics/CounterProxy.java
@@ -55,6 +55,6 @@ public class CounterProxy implements LongCounter {
 
   @Override
   public long getCount() {
-    return counter.getCount();
+    return counter.count();
   }
 }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/metrics/GaugeProxy.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/metrics/GaugeProxy.java
@@ -19,27 +19,21 @@
 
 package org.apache.iotdb.consensus.ratis.metrics;
 
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.MetricRegistry;
+import java.util.function.Supplier;
 
 /** AutoGauge supplier holder class. */
-public class GaugeProxy implements Gauge {
+public class GaugeProxy<T> {
 
-  private final Gauge gauge;
+  private final Supplier<T> gaugeSupplier;
 
-  public GaugeProxy(MetricRegistry.MetricSupplier<Gauge> metricSupplier) {
-    this.gauge = metricSupplier.newMetric();
+  public GaugeProxy(Supplier<Supplier<T>> supplier) {
+    this.gaugeSupplier = supplier.get();
   }
 
-  @Override
-  public Object getValue() {
-    return gauge.getValue();
-  }
-
-  double getValueAsDouble() {
-    Object value = getValue();
-    if (value instanceof Number) {
-      return ((Number) value).doubleValue();
+  double getDoubleValue() {
+    Object latestValue = gaugeSupplier.get();
+    if (latestValue instanceof Number) {
+      return ((Number) latestValue).doubleValue();
     }
     return 0.0;
   }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/metrics/IoTDBMetricRegistry.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/metrics/IoTDBMetricRegistry.java
@@ -24,25 +24,17 @@ import org.apache.iotdb.metrics.AbstractMetricService;
 import org.apache.iotdb.metrics.utils.MetricLevel;
 import org.apache.iotdb.metrics.utils.MetricType;
 
-import com.codahale.metrics.ConsoleReporter;
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.Histogram;
-import com.codahale.metrics.Meter;
-import com.codahale.metrics.Metric;
-import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.MetricSet;
-import com.codahale.metrics.Timer;
-import com.codahale.metrics.jmx.JmxReporter;
+import org.apache.ratis.metrics.LongCounter;
 import org.apache.ratis.metrics.MetricRegistryInfo;
 import org.apache.ratis.metrics.RatisMetricRegistry;
+import org.apache.ratis.metrics.Timekeeper;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.SortedMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
 public class IoTDBMetricRegistry implements RatisMetricRegistry {
 
@@ -52,7 +44,7 @@ public class IoTDBMetricRegistry implements RatisMetricRegistry {
   private final Map<String, String> metricNameCache = new ConcurrentHashMap<>();
   private final Map<String, CounterProxy> counterCache = new ConcurrentHashMap<>();
   private final Map<String, TimerProxy> timerCache = new ConcurrentHashMap<>();
-  private final Map<String, GaugeProxy> gaugeCache = new ConcurrentHashMap<>();
+  private final Map<String, Boolean> gaugeCache = new ConcurrentHashMap<>();
   /** Time taken to flush log. */
   public static final String RAFT_LOG_FLUSH_TIME = "flushTime";
   /** Size of SegmentedRaftLogCache::closedSegments in bytes. */
@@ -75,12 +67,6 @@ public class IoTDBMetricRegistry implements RatisMetricRegistry {
   public static final String FOLLOWER_APPEND_ENTRIES_LATENCY = "follower_append_entry_latency";
   /** Time taken to process write requests from client. */
   public static final String RAFT_CLIENT_WRITE_REQUEST = "clientWriteRequest";
-
-  private static final String METHOD_NOT_USED_EXCEPTION_MESSAGE =
-      "This method is not used in IoTDB project";
-
-  private static final String METER_NOT_USED_EXCEPTION_MESSAGE =
-      "Meter is not used in Ratis Metrics";
 
   private static final List<String> RATIS_METRICS = new ArrayList<>();
 
@@ -120,7 +106,7 @@ public class IoTDBMetricRegistry implements RatisMetricRegistry {
   }
 
   @Override
-  public Timer timer(String name) {
+  public Timekeeper timer(String name) {
     final String fullName = getMetricName(name);
     return timerCache.computeIfAbsent(
         fullName,
@@ -128,7 +114,7 @@ public class IoTDBMetricRegistry implements RatisMetricRegistry {
   }
 
   @Override
-  public Counter counter(String name) {
+  public LongCounter counter(String name) {
     final String fullName = getMetricName(name);
     return counterCache.computeIfAbsent(
         fullName,
@@ -161,91 +147,20 @@ public class IoTDBMetricRegistry implements RatisMetricRegistry {
   }
 
   @Override
-  public Gauge gauge(String name, MetricRegistry.MetricSupplier<Gauge> metricSupplier) {
-    final String fullName = getMetricName(name);
-    return gaugeCache.computeIfAbsent(
+  public <T> void gauge(String fullName, Supplier<Supplier<T>> supplier) {
+    gaugeCache.computeIfAbsent(
         fullName,
-        gaugeName -> {
-          final GaugeProxy gauge = new GaugeProxy(metricSupplier);
+        name -> {
+          final GaugeProxy<T> gauge = new GaugeProxy<>(supplier);
           metricService.createAutoGauge(
-              gaugeName, getMetricLevel(fullName), gauge, GaugeProxy::getValueAsDouble);
-          return gauge;
+              name, getMetricLevel(name), gauge, GaugeProxy::getDoubleValue);
+          return true;
         });
-  }
-
-  @Override
-  public Timer timer(String name, MetricRegistry.MetricSupplier<Timer> metricSupplier) {
-    throw new UnsupportedOperationException(METHOD_NOT_USED_EXCEPTION_MESSAGE);
-  }
-
-  @Override
-  public SortedMap<String, Gauge> getGauges(MetricFilter metricFilter) {
-    throw new UnsupportedOperationException(METHOD_NOT_USED_EXCEPTION_MESSAGE);
-  }
-
-  @Override
-  public Counter counter(String name, MetricRegistry.MetricSupplier<Counter> metricSupplier) {
-    throw new UnsupportedOperationException(METHOD_NOT_USED_EXCEPTION_MESSAGE);
-  }
-
-  @Override
-  public Histogram histogram(String name) {
-    throw new UnsupportedOperationException("Histogram is not used in Ratis Metrics");
-  }
-
-  @Override
-  public Meter meter(String name) {
-    throw new UnsupportedOperationException(METER_NOT_USED_EXCEPTION_MESSAGE);
-  }
-
-  @Override
-  public Meter meter(String name, MetricRegistry.MetricSupplier<Meter> metricSupplier) {
-    throw new UnsupportedOperationException(METER_NOT_USED_EXCEPTION_MESSAGE);
-  }
-
-  @Override
-  public Metric get(String name) {
-    throw new UnsupportedOperationException(METER_NOT_USED_EXCEPTION_MESSAGE);
-  }
-
-  @Override
-  public <T extends Metric> T register(String name, T t) throws IllegalArgumentException {
-    throw new UnsupportedOperationException("register is not used in Ratis Metrics");
-  }
-
-  @Override
-  public MetricRegistry getDropWizardMetricRegistry() {
-    throw new UnsupportedOperationException(METHOD_NOT_USED_EXCEPTION_MESSAGE);
   }
 
   @Override
   public MetricRegistryInfo getMetricRegistryInfo() {
     return info;
-  }
-
-  @Override
-  public void registerAll(String s, MetricSet metricSet) {
-    throw new UnsupportedOperationException("registerAll is not used in Ratis Metrics");
-  }
-
-  @Override
-  public void setJmxReporter(JmxReporter jmxReporter) {
-    throw new UnsupportedOperationException("JmxReporter is not used in Ratis Metrics");
-  }
-
-  @Override
-  public JmxReporter getJmxReporter() {
-    throw new UnsupportedOperationException("JmxReporter is not used in Ratis Metrics");
-  }
-
-  @Override
-  public void setConsoleReporter(ConsoleReporter consoleReporter) {
-    throw new UnsupportedOperationException("ConsoleReporter is not used in Ratis Metrics");
-  }
-
-  @Override
-  public ConsoleReporter getConsoleReporter() {
-    throw new UnsupportedOperationException("ConsoleReporter is not used in Ratis Metrics");
   }
 
   void removeAll() {

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/metrics/IoTDBMetricRegistry.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/metrics/IoTDBMetricRegistry.java
@@ -24,7 +24,6 @@ import org.apache.iotdb.metrics.AbstractMetricService;
 import org.apache.iotdb.metrics.utils.MetricLevel;
 import org.apache.iotdb.metrics.utils.MetricType;
 
-import com.codahale.metrics.MetricRegistry;
 import org.apache.ratis.metrics.LongCounter;
 import org.apache.ratis.metrics.MetricRegistryInfo;
 import org.apache.ratis.metrics.RatisMetricRegistry;
@@ -85,15 +84,14 @@ public class IoTDBMetricRegistry implements RatisMetricRegistry {
   IoTDBMetricRegistry(MetricRegistryInfo info, AbstractMetricService service) {
     this.info = info;
     this.metricService = service;
-    prefix =
-        MetricRegistry.name(
-            Utils.getConsensusGroupTypeFromPrefix(info.getPrefix()).toString(),
-            info.getApplicationName(),
-            info.getMetricsComponentName());
+    this.prefix =
+        Utils.getConsensusGroupTypeFromPrefix(info.getPrefix()).toString()
+            + info.getApplicationName()
+            + info.getMetricsComponentName();
   }
 
   private String getMetricName(String name) {
-    return metricNameCache.computeIfAbsent(name, n -> MetricRegistry.name(prefix, n));
+    return metricNameCache.computeIfAbsent(name, n -> this.prefix + n);
   }
 
   public MetricLevel getMetricLevel(String name) {

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/metrics/MetricRegistryManager.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/metrics/MetricRegistryManager.java
@@ -36,7 +36,7 @@ import java.util.function.Consumer;
 public class MetricRegistryManager extends MetricRegistries {
   /** Using RefCountingMap here because of potential duplicate MetricRegistryInfos. */
   private final RefCountingMap<MetricRegistryInfo, RatisMetricRegistry> registries;
-  /** TODO: enable ratis metrics after verifying its correctness and efficiency. */
+
   private final AbstractMetricService service = MetricService.getInstance();
 
   public MetricRegistryManager() {

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/metrics/RatisMetricsManager.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/metrics/RatisMetricsManager.java
@@ -30,12 +30,12 @@ import java.util.function.BiConsumer;
 
 public class RatisMetricsManager {
 
-  static class TimeKeeper implements AutoCloseable {
+  public static class TimeReporter implements AutoCloseable {
     private final long startMoment;
     private final TConsensusGroupType groupType;
     private final BiConsumer<Long, TConsensusGroupType> reporter;
 
-    private TimeKeeper(
+    private TimeReporter(
         BiConsumer<Long, TConsensusGroupType> reporter, TConsensusGroupType groupType) {
       this.reporter = reporter;
       this.groupType = groupType;
@@ -55,16 +55,16 @@ public class RatisMetricsManager {
 
   private final MetricService metricService = MetricService.getInstance();
 
-  public TimeKeeper startWriteLocallyTimer(TConsensusGroupType consensusGroupType) {
-    return new TimeKeeper(this::recordWriteLocallyCost, consensusGroupType);
+  public TimeReporter startWriteLocallyTimer(TConsensusGroupType consensusGroupType) {
+    return new TimeReporter(this::recordWriteLocallyCost, consensusGroupType);
   }
 
-  public TimeKeeper startWriteRemotelyTimer(TConsensusGroupType consensusGroupType) {
-    return new TimeKeeper(this::recordWriteRemotelyCost, consensusGroupType);
+  public TimeReporter startWriteRemotelyTimer(TConsensusGroupType consensusGroupType) {
+    return new TimeReporter(this::recordWriteRemotelyCost, consensusGroupType);
   }
 
-  public TimeKeeper startReadTimer(TConsensusGroupType consensusGroupType) {
-    return new TimeKeeper(this::recordReadRequestCost, consensusGroupType);
+  public TimeReporter startReadTimer(TConsensusGroupType consensusGroupType) {
+    return new TimeReporter(this::recordReadRequestCost, consensusGroupType);
   }
 
   /** Record the time cost in write locally stage. */
@@ -112,6 +112,10 @@ public class RatisMetricsManager {
         MetricLevel.IMPORTANT,
         Tag.STAGE.toString(),
         RatisMetricSet.WRITE_STATE_MACHINE);
+  }
+
+  private RatisMetricsManager() {
+    // empty constructor
   }
 
   public static RatisMetricsManager getInstance() {

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/metrics/TimerProxy.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/metrics/TimerProxy.java
@@ -21,23 +21,39 @@ package org.apache.iotdb.consensus.ratis.metrics;
 
 import org.apache.iotdb.metrics.type.Timer;
 
+import org.apache.ratis.metrics.Timekeeper;
+
 import java.util.concurrent.TimeUnit;
 
-public class TimerProxy extends com.codahale.metrics.Timer {
+/** TimerProxy will route Ratis' internal timer metrics to our IoTDB {@link Timer} */
+public class TimerProxy implements Timekeeper {
+
+  private static class TimerContext implements Timekeeper.Context {
+
+    private final Timer reporter;
+    private final long startTime;
+
+    TimerContext(Timer reporter) {
+      this.reporter = reporter;
+      this.startTime = System.nanoTime();
+    }
+
+    @Override
+    public long stop() {
+      final long elapsed = System.nanoTime() - startTime;
+      reporter.update(elapsed, TimeUnit.NANOSECONDS);
+      return elapsed;
+    }
+  }
+
   private final Timer timer;
 
   TimerProxy(Timer timer) {
     this.timer = timer;
   }
 
-  /** time() method is used as a user time clock. Will reuse the dropwizard implementation. */
   @Override
   public Context time() {
-    return super.time();
-  }
-
-  @Override
-  public void update(long duration, TimeUnit unit) {
-    timer.update(duration, unit);
+    return new TimerContext(timer);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -143,14 +143,14 @@
         <osgi.version>7.0.0</osgi.version>
         <pax-jdbc-common.version>1.5.6</pax-jdbc-common.version>
         <powermock.version>2.0.9</powermock.version>
-        <ratis-thirdparty-misc.version>1.0.4</ratis-thirdparty-misc.version>
+        <ratis-thirdparty-misc.version>1.0.5</ratis-thirdparty-misc.version>
         <!--
       This is an unreleased version of a custom branch. The 8-character part after the version number
       This is an unreleased version of a custom branch. The 8-character part after the version number
       is for ensuring the SNAPSHOT will stay available. We should however have the Ratis folks do a
       new release soon, as releasing with this version is more than sub-ideal.
     -->
-        <ratis.version>2.5.2-0f5f95d-SNAPSHOT</ratis.version>
+        <ratis.version>3.0.0</ratis.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <reactor-netty.version>1.1.13</reactor-netty.version>
         <reactor.version>3.5.10</reactor.version>
@@ -828,7 +828,7 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.ratis</groupId>
-                <artifactId>ratis-metrics</artifactId>
+                <artifactId>ratis-metrics-api</artifactId>
                 <version>${ratis.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Bump ratis version to 3.0.0 and change the metrics implementation.

The metrics can be correctly created and referred. see
<img width="1710" alt="image" src="https://github.com/apache/iotdb/assets/48054931/cc75bdf5-ee3b-421d-8686-ac40370d1d33">
