### PR TITLE
Use min(limt, page size) as the init capacity of result block

### DIFF
--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/AlignedPageReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/AlignedPageReader.java
@@ -420,6 +420,16 @@ public class AlignedPageReader implements IPageReader, IAlignedPageReader {
 
   @Override
   public void initTsBlockBuilder(List<TSDataType> dataTypes) {
-    builder = new TsBlockBuilder((int) timePageReader.getStatistics().getCount(), dataTypes);
+    if (paginationController.hasCurLimit()) {
+      builder =
+          new TsBlockBuilder(
+              (int)
+                  Math.min(
+                      paginationController.getCurLimit(),
+                      timePageReader.getStatistics().getCount()),
+              dataTypes);
+    } else {
+      builder = new TsBlockBuilder((int) timePageReader.getStatistics().getCount(), dataTypes);
+    }
   }
 }

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/PageReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/PageReader.java
@@ -181,7 +181,19 @@ public class PageReader implements IPageReader {
 
   @Override
   public TsBlock getAllSatisfiedData() throws IOException {
-    TsBlockBuilder builder = new TsBlockBuilder(Collections.singletonList(dataType));
+    TsBlockBuilder builder;
+    if (paginationController.hasCurLimit()) {
+      builder =
+          new TsBlockBuilder(
+              (int)
+                  Math.min(
+                      paginationController.getCurLimit(), pageHeader.getStatistics().getCount()),
+              Collections.singletonList(dataType));
+    } else {
+      builder =
+          new TsBlockBuilder(
+              (int) pageHeader.getStatistics().getCount(), Collections.singletonList(dataType));
+    }
     TimeColumnBuilder timeBuilder = builder.getTimeColumnBuilder();
     ColumnBuilder valueBuilder = builder.getColumnBuilder(0);
     if (pageSatisfy()) {


### PR DESCRIPTION
In some query cases, of the limit is much less than the count of each page, we should use limit instead of page size as the init capacity of the result block.

![bfc77345-8ab2-4292-86dc-0c171c60c358](https://github.com/apache/iotdb/assets/16079446/783c031d-30c6-4f13-ad3c-640159d357bb)
