### PR TITLE
Pipe: degrade exception to log when executing pipe procedure operations on DN to enhance the availability

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/IoTDBPipeExtractorIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/IoTDBPipeExtractorIT.java
@@ -91,7 +91,7 @@ public class IoTDBPipeExtractorIT {
       Map<String, String> connectorAttributes = new HashMap<>();
 
       extractorAttributes.put("extractor", "iotdb-extractor");
-      extractorAttributes.put("extractor.history.enabled", "true");
+      extractorAttributes.put("extractor.history.enable", "true");
 
       connectorAttributes.put("connector", "iotdb-thrift-connector");
       connectorAttributes.put("connector.batch.enable", "false");
@@ -174,7 +174,7 @@ public class IoTDBPipeExtractorIT {
           String.format(
               "create pipe p1"
                   + " with extractor ("
-                  + "'extractor.history.enabled'='true',"
+                  + "'extractor.history.enable'='true',"
                   + "'extractor.history.start-time'=%s)"
                   + " with connector ("
                   + "'connector'='iotdb-thrift-connector',"
@@ -198,13 +198,13 @@ public class IoTDBPipeExtractorIT {
       List<TShowPipeInfo> showPipeResult = client.showPipe(new TShowPipeReq()).pipeInfoList;
       Assert.assertEquals(0, showPipeResult.size());
 
-      // can not set 'extractor.history.enabled' and 'extractor.realtime.enabled' both to false
+      // can not set 'extractor.history.enable' and 'extractor.realtime.enable' both to false
       String sql =
           String.format(
               "create pipe p1"
                   + " with extractor ("
-                  + "'extractor.history.enabled'='false',"
-                  + "'extractor.realtime.enabled'='false')"
+                  + "'extractor.history.enable'='false',"
+                  + "'extractor.realtime.enable'='false')"
                   + " with connector ("
                   + "'connector'='iotdb-thrift-connector',"
                   + "'connector.ip'='%s',"

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/CreatePipeProcedureV2.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/CreatePipeProcedureV2.java
@@ -146,18 +146,17 @@ public class CreatePipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
   }
 
   @Override
-  protected void executeFromOperateOnDataNodes(ConfigNodeProcedureEnv env)
-      throws PipeException, IOException {
+  protected void executeFromOperateOnDataNodes(ConfigNodeProcedureEnv env) throws IOException {
     final String pipeName = createPipeRequest.getPipeName();
     LOGGER.info("CreatePipeProcedureV2: executeFromOperateOnDataNodes({})", pipeName);
 
     String exceptionMessage =
         parsePushPipeMetaExceptionForPipe(pipeName, pushSinglePipeMetaToDataNodes(pipeName, env));
     if (!exceptionMessage.isEmpty()) {
-      throw new PipeException(
-          String.format(
-              "Failed to create pipe %s, details: %s",
-              createPipeRequest.getPipeName(), exceptionMessage));
+      LOGGER.warn(
+          "Failed to create pipe {}, details: {}, metadata will be synchronized later.",
+          createPipeRequest.getPipeName(),
+          exceptionMessage);
     }
   }
 
@@ -209,10 +208,10 @@ public class CreatePipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
         parsePushPipeMetaExceptionForPipe(
             createPipeRequest.getPipeName(), pushPipeMetaToDataNodes(env));
     if (!exceptionMessage.isEmpty()) {
-      throw new PipeException(
-          String.format(
-              "Failed to rollback create pipe %s, details: %s",
-              createPipeRequest.getPipeName(), exceptionMessage));
+      LOGGER.warn(
+          "Failed to rollback create pipe {}, details: {}, metadata will be synchronized later.",
+          createPipeRequest.getPipeName(),
+          exceptionMessage);
     }
   }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/DropPipeProcedureV2.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/DropPipeProcedureV2.java
@@ -89,14 +89,16 @@ public class DropPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
   }
 
   @Override
-  protected void executeFromOperateOnDataNodes(ConfigNodeProcedureEnv env) throws PipeException {
+  protected void executeFromOperateOnDataNodes(ConfigNodeProcedureEnv env) {
     LOGGER.info("DropPipeProcedureV2: executeFromOperateOnDataNodes({})", pipeName);
 
     String exceptionMessage =
         parsePushPipeMetaExceptionForPipe(pipeName, dropSinglePipeOnDataNodes(pipeName, env));
     if (!exceptionMessage.isEmpty()) {
-      throw new PipeException(
-          String.format("Failed to drop pipe %s, details: %s", pipeName, exceptionMessage));
+      LOGGER.warn(
+          "Failed to drop pipe {}, details: {}, metadata will be synchronized later.",
+          pipeName,
+          exceptionMessage);
     }
   }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/StartPipeProcedureV2.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/StartPipeProcedureV2.java
@@ -93,15 +93,16 @@ public class StartPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
   }
 
   @Override
-  protected void executeFromOperateOnDataNodes(ConfigNodeProcedureEnv env)
-      throws PipeException, IOException {
+  protected void executeFromOperateOnDataNodes(ConfigNodeProcedureEnv env) throws IOException {
     LOGGER.info("StartPipeProcedureV2: executeFromOperateOnDataNodes({})", pipeName);
 
     String exceptionMessage =
         parsePushPipeMetaExceptionForPipe(pipeName, pushSinglePipeMetaToDataNodes(pipeName, env));
     if (!exceptionMessage.isEmpty()) {
-      throw new PipeException(
-          String.format("Failed to start pipe %s, details: %s", pipeName, exceptionMessage));
+      LOGGER.warn(
+          "Failed to start pipe {}, details: {}, metadata will be synchronized later.",
+          pipeName,
+          exceptionMessage);
     }
 
     // Clear exceptions and set isStoppedByRuntimeException to false if the pipe is
@@ -142,17 +143,17 @@ public class StartPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
   }
 
   @Override
-  protected void rollbackFromOperateOnDataNodes(ConfigNodeProcedureEnv env)
-      throws PipeException, IOException {
+  protected void rollbackFromOperateOnDataNodes(ConfigNodeProcedureEnv env) throws IOException {
     LOGGER.info("StartPipeProcedureV2: rollbackFromOperateOnDataNodes({})", pipeName);
 
     // Push all pipe metas to datanode, may be time-consuming
     String exceptionMessage =
         parsePushPipeMetaExceptionForPipe(pipeName, pushPipeMetaToDataNodes(env));
     if (!exceptionMessage.isEmpty()) {
-      throw new PipeException(
-          String.format(
-              "Failed to rollback start pipe %s, details: %s", pipeName, exceptionMessage));
+      LOGGER.warn(
+          "Failed to rollback start pipe {}, details: {}, metadata will be synchronized later.",
+          pipeName,
+          exceptionMessage);
     }
   }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/StartPipeProcedureV2.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/StartPipeProcedureV2.java
@@ -103,6 +103,7 @@ public class StartPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
           "Failed to start pipe {}, details: {}, metadata will be synchronized later.",
           pipeName,
           exceptionMessage);
+      return;
     }
 
     // Clear exceptions and set isStoppedByRuntimeException to false if the pipe is

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/StopPipeProcedureV2.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/StopPipeProcedureV2.java
@@ -93,15 +93,16 @@ public class StopPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
   }
 
   @Override
-  protected void executeFromOperateOnDataNodes(ConfigNodeProcedureEnv env)
-      throws PipeException, IOException {
+  protected void executeFromOperateOnDataNodes(ConfigNodeProcedureEnv env) throws IOException {
     LOGGER.info("StopPipeProcedureV2: executeFromOperateOnDataNodes({})", pipeName);
 
     String exceptionMessage =
         parsePushPipeMetaExceptionForPipe(pipeName, pushSinglePipeMetaToDataNodes(pipeName, env));
     if (!exceptionMessage.isEmpty()) {
-      throw new PipeException(
-          String.format("Failed to stop pipe %s, details: %s", pipeName, exceptionMessage));
+      LOGGER.warn(
+          "Failed to stop pipe {}, details: {}, metadata will be synchronized later.",
+          pipeName,
+          exceptionMessage);
     }
   }
 
@@ -138,17 +139,17 @@ public class StopPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
   }
 
   @Override
-  protected void rollbackFromOperateOnDataNodes(ConfigNodeProcedureEnv env)
-      throws PipeException, IOException {
+  protected void rollbackFromOperateOnDataNodes(ConfigNodeProcedureEnv env) throws IOException {
     LOGGER.info("StopPipeProcedureV2: rollbackFromOperateOnDataNodes({})", pipeName);
 
     // Push all pipe metas to datanode, may be time-consuming
     String exceptionMessage =
         parsePushPipeMetaExceptionForPipe(pipeName, pushPipeMetaToDataNodes(env));
     if (!exceptionMessage.isEmpty()) {
-      throw new PipeException(
-          String.format(
-              "Failed to rollback stop pipe %s, details: %s", pipeName, exceptionMessage));
+      LOGGER.warn(
+          "Failed to rollback stop pipe {}, details: {}, metadata will be synchronized later.",
+          pipeName,
+          exceptionMessage);
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/historical/PipeHistoricalDataRegionTsFileExtractor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/historical/PipeHistoricalDataRegionTsFileExtractor.java
@@ -35,6 +35,7 @@ import org.apache.iotdb.pipe.api.customizer.configuration.PipeExtractorRuntimeCo
 import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameterValidator;
 import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameters;
 import org.apache.iotdb.pipe.api.event.Event;
+import org.apache.iotdb.pipe.api.exception.PipeParameterNotValidException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,7 +93,38 @@ public class PipeHistoricalDataRegionTsFileExtractor implements PipeHistoricalDa
 
   @Override
   public void validate(PipeParameterValidator validator) {
-    // Do nothing
+    PipeParameters parameters = validator.getParameters();
+
+    // User may set the EXTRACTOR_HISTORY_START_TIME and EXTRACTOR_HISTORY_END_TIME without
+    // enabling the historical data extraction, which may affect the realtime data extraction.
+    final boolean isHistoricalExtractorEnabledByUser =
+        parameters.getBooleanOrDefault(
+            Arrays.asList(EXTRACTOR_HISTORY_ENABLE_KEY, SOURCE_HISTORY_ENABLE_KEY),
+            EXTRACTOR_HISTORY_ENABLE_DEFAULT_VALUE);
+
+    try {
+      historicalDataExtractionStartTime =
+          isHistoricalExtractorEnabledByUser
+                  && parameters.hasAnyAttributes(
+                      EXTRACTOR_HISTORY_START_TIME_KEY, SOURCE_HISTORY_START_TIME_KEY)
+              ? DateTimeUtils.convertDatetimeStrToLong(
+                  parameters.getStringByKeys(
+                      EXTRACTOR_HISTORY_START_TIME_KEY, SOURCE_HISTORY_START_TIME_KEY),
+                  ZoneId.systemDefault())
+              : Long.MIN_VALUE;
+      historicalDataExtractionEndTime =
+          isHistoricalExtractorEnabledByUser
+                  && parameters.hasAnyAttributes(
+                      EXTRACTOR_HISTORY_END_TIME_KEY, SOURCE_HISTORY_END_TIME_KEY)
+              ? DateTimeUtils.convertDatetimeStrToLong(
+                  parameters.getStringByKeys(
+                      EXTRACTOR_HISTORY_END_TIME_KEY, SOURCE_HISTORY_END_TIME_KEY),
+                  ZoneId.systemDefault())
+              : Long.MAX_VALUE;
+    } catch (Exception e) {
+      // compatible with the current validation framework
+      throw new PipeParameterNotValidException(e.getMessage());
+    }
   }
 
   @Override
@@ -124,31 +156,6 @@ public class PipeHistoricalDataRegionTsFileExtractor implements PipeHistoricalDa
         isDbNameCoveredByPattern = true;
       }
     }
-
-    // User may set the EXTRACTOR_HISTORY_START_TIME and EXTRACTOR_HISTORY_END_TIME without
-    // enabling the historical data extraction, which may affect the realtime data extraction.
-    final boolean isHistoricalExtractorEnabledByUser =
-        parameters.getBooleanOrDefault(
-            Arrays.asList(EXTRACTOR_HISTORY_ENABLE_KEY, SOURCE_HISTORY_ENABLE_KEY),
-            EXTRACTOR_HISTORY_ENABLE_DEFAULT_VALUE);
-    historicalDataExtractionStartTime =
-        isHistoricalExtractorEnabledByUser
-                && parameters.hasAnyAttributes(
-                    EXTRACTOR_HISTORY_START_TIME_KEY, SOURCE_HISTORY_START_TIME_KEY)
-            ? DateTimeUtils.convertDatetimeStrToLong(
-                parameters.getStringByKeys(
-                    EXTRACTOR_HISTORY_START_TIME_KEY, SOURCE_HISTORY_START_TIME_KEY),
-                ZoneId.systemDefault())
-            : Long.MIN_VALUE;
-    historicalDataExtractionEndTime =
-        isHistoricalExtractorEnabledByUser
-                && parameters.hasAnyAttributes(
-                    EXTRACTOR_HISTORY_END_TIME_KEY, SOURCE_HISTORY_END_TIME_KEY)
-            ? DateTimeUtils.convertDatetimeStrToLong(
-                parameters.getStringByKeys(
-                    EXTRACTOR_HISTORY_END_TIME_KEY, SOURCE_HISTORY_END_TIME_KEY),
-                ZoneId.systemDefault())
-            : Long.MAX_VALUE;
 
     // Enable historical extractor by default
     historicalDataExtractionTimeLowerBound =


### PR DESCRIPTION
## Description

To enhance the availability of Pipe, even if an exception occurs during the `executeFromOperateOnDataNodes` (`rollbackFromOperateOnDataNodes`) phase of procedures like create/start/stop/drop pipe on CN, where pipe metadata on DN is not synchronized with CN, it is considered successful. The pipe metadata will be automatically synchronized within at most one synchronization cycle.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [x] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
