### PR TITLE
Fix query with authority returning wrong columns

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/schematree/ISchemaTree.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/schematree/ISchemaTree.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.queryengine.common.schematree;
 import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.path.PathPatternTree;
+import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.db.schemaengine.template.Template;
 import org.apache.iotdb.tsfile.utils.Pair;
 
@@ -36,12 +37,27 @@ public interface ISchemaTree {
    * @param isPrefixMatch if true, the path pattern is used to match prefix path
    * @return Left: all measurement paths; Right: remaining series offset
    */
+  @TestOnly
   Pair<List<MeasurementPath>, Integer> searchMeasurementPaths(
       PartialPath pathPattern, int slimit, int soffset, boolean isPrefixMatch);
 
+  /**
+   * Return all measurement paths for given path pattern.
+   *
+   * @param pathPattern can be a pattern or a full path of timeseries.
+   * @return Left: all measurement paths; Right: remaining series offset
+   */
   Pair<List<MeasurementPath>, Integer> searchMeasurementPaths(PartialPath pathPattern);
 
-  Pair<List<MeasurementPath>, Integer> searchMeasurementPaths(PartialPath pathPattern, boolean ignoreAuthority);
+  /**
+   * Return all measurement paths for given path pattern.
+   *
+   * @param pathPattern can be a pattern or a full path of timeseries.
+   * @param scope only the tree nodes in the scope can be accessed.
+   * @return Left: all measurement paths; Right: remaining series offset
+   */
+  Pair<List<MeasurementPath>, Integer> searchMeasurementPaths(
+      PartialPath pathPattern, PathPatternTree scope);
 
   /**
    * Get all device matching the path pattern.
@@ -101,10 +117,4 @@ public interface ISchemaTree {
    * @return whether there's view in this schema tree
    */
   boolean hasLogicalViewMeasurement();
-
-  /**
-   * Set the authority scope of this schema tree. After the authority scope is set, only the tree nodes in the scope can be accessed if not specify to ignore.
-   * @param scope the authority scope
-   */
-  void setAuthorityScope(PathPatternTree scope);
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/schematree/ISchemaTree.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/schematree/ISchemaTree.java
@@ -41,6 +41,8 @@ public interface ISchemaTree {
 
   Pair<List<MeasurementPath>, Integer> searchMeasurementPaths(PartialPath pathPattern);
 
+  Pair<List<MeasurementPath>, Integer> searchMeasurementPaths(PartialPath pathPattern, boolean ignoreAuthority);
+
   /**
    * Get all device matching the path pattern.
    *
@@ -100,5 +102,9 @@ public interface ISchemaTree {
    */
   boolean hasLogicalViewMeasurement();
 
+  /**
+   * Set the authority scope of this schema tree. After the authority scope is set, only the tree nodes in the scope can be accessed if not specify to ignore.
+   * @param scope the authority scope
+   */
   void setAuthorityScope(PathPatternTree scope);
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
@@ -491,6 +491,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     try {
       for (MeasurementPath measurementPath :
           originSchemaTree.searchMeasurementPaths(ALL_MATCH_PATTERN).left) {
+        // all logical view measurement paths should be included in the authority scope
         if (measurementPath.getMeasurementSchema().isLogicalView()) {
           useLogicalView = true;
           LogicalViewSchema logicalViewSchema =
@@ -2925,6 +2926,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     deleteDataStatement.getPathList().forEach(patternTree::appendPathPattern);
 
     ISchemaTree schemaTree = schemaFetcher.fetchSchema(patternTree, context);
+    // There is no need to set authority scope for schema tree because if invalid delete statements have been filtered out.
     Set<String> deduplicatedDevicePaths = new HashSet<>();
 
     if (schemaTree.hasLogicalViewMeasurement()) {
@@ -2935,7 +2937,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       LogicalViewSchema logicalViewSchema;
       PartialPath sourcePathOfAliasSeries;
       for (MeasurementPath measurementPath :
-          schemaTree.searchMeasurementPaths(ALL_MATCH_PATTERN).left) {
+          schemaTree.searchMeasurementPaths(ALL_MATCH_PATTERN, true).left) {
         measurementSchema = measurementPath.getMeasurementSchema();
         if (measurementSchema.isLogicalView()) {
           logicalViewSchema = (LogicalViewSchema) measurementSchema;
@@ -3257,7 +3259,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     // search each path, make sure they all exist.
     int numOfExistPaths = 0;
     for (PartialPath path : pathList) {
-      Pair<List<MeasurementPath>, Integer> pathPair = schemaTree.searchMeasurementPaths(path);
+      Pair<List<MeasurementPath>, Integer> pathPair = schemaTree.searchMeasurementPaths(path, true);
       numOfExistPaths += !pathPair.left.isEmpty() ? 1 : 0;
     }
     return new Pair<>(schemaTree, numOfExistPaths);
@@ -3274,7 +3276,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     List<PartialPath> result = new ArrayList<>();
     for (PartialPath path : pathList) {
       Pair<List<MeasurementPath>, Integer> measurementPathList =
-          schemaTree.searchMeasurementPaths(path);
+          schemaTree.searchMeasurementPaths(path, true);
       if (measurementPathList.left.isEmpty()) {
         return new Pair<>(result, path);
       }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/ExpressionAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/ExpressionAnalyzer.java
@@ -402,8 +402,8 @@ public class ExpressionAnalyzer {
    *     expressions
    */
   public static List<Expression> bindSchemaForExpression(
-      Expression expression, ISchemaTree schemaTree) {
-    return new BindSchemaForExpressionVisitor().process(expression, schemaTree);
+      Expression expression, ISchemaTree schemaTree, PathPatternTree authorityScope) {
+    return new BindSchemaForExpressionVisitor(authorityScope).process(expression, schemaTree);
   }
 
   /**
@@ -416,8 +416,12 @@ public class ExpressionAnalyzer {
    * @return the expression list with full path and after binding schema
    */
   public static List<Expression> bindSchemaForPredicate(
-      Expression predicate, List<PartialPath> prefixPaths, ISchemaTree schemaTree, boolean isRoot) {
-    return new BindSchemaForPredicateVisitor()
+      Expression predicate,
+      List<PartialPath> prefixPaths,
+      ISchemaTree schemaTree,
+      boolean isRoot,
+      PathPatternTree authorityScope) {
+    return new BindSchemaForPredicateVisitor(authorityScope)
         .process(
             predicate, new BindSchemaForPredicateVisitor.Context(prefixPaths, schemaTree, isRoot));
   }
@@ -437,8 +441,11 @@ public class ExpressionAnalyzer {
    * @return expression list with full path and after binding schema
    */
   public static List<Expression> concatDeviceAndBindSchemaForExpression(
-      Expression expression, PartialPath devicePath, ISchemaTree schemaTree) {
-    return new ConcatDeviceAndBindSchemaForExpressionVisitor()
+      Expression expression,
+      PartialPath devicePath,
+      ISchemaTree schemaTree,
+      PathPatternTree authorityScope) {
+    return new ConcatDeviceAndBindSchemaForExpressionVisitor(authorityScope)
         .process(
             expression,
             new ConcatDeviceAndBindSchemaForExpressionVisitor.Context(devicePath, schemaTree));
@@ -451,8 +458,12 @@ public class ExpressionAnalyzer {
    * @return the expression list with full path and after binding schema
    */
   public static List<Expression> concatDeviceAndBindSchemaForPredicate(
-      Expression predicate, PartialPath devicePath, ISchemaTree schemaTree, boolean isWhere) {
-    return new ConcatDeviceAndBindSchemaForPredicateVisitor()
+      Expression predicate,
+      PartialPath devicePath,
+      ISchemaTree schemaTree,
+      boolean isWhere,
+      PathPatternTree authorityScope) {
+    return new ConcatDeviceAndBindSchemaForPredicateVisitor(authorityScope)
         .process(
             predicate,
             new ConcatDeviceAndBindSchemaForPredicateVisitor.Context(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/visitor/CompleteMeasurementSchemaVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/visitor/CompleteMeasurementSchemaVisitor.java
@@ -93,7 +93,7 @@ public class CompleteMeasurementSchemaVisitor extends ExpressionVisitor<Expressi
     try {
       path.getMeasurementSchema();
     } catch (Exception notAMeasurementPath) {
-      List<MeasurementPath> actualPaths = schemaTree.searchMeasurementPaths(path, true).left;
+      List<MeasurementPath> actualPaths = schemaTree.searchMeasurementPaths(path).left;
       if (actualPaths.size() != 1) {
         throw new SemanticException(new BrokenViewException(path.getFullPath(), actualPaths));
       }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/visitor/CompleteMeasurementSchemaVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/visitor/CompleteMeasurementSchemaVisitor.java
@@ -93,7 +93,7 @@ public class CompleteMeasurementSchemaVisitor extends ExpressionVisitor<Expressi
     try {
       path.getMeasurementSchema();
     } catch (Exception notAMeasurementPath) {
-      List<MeasurementPath> actualPaths = schemaTree.searchMeasurementPaths(path).left;
+      List<MeasurementPath> actualPaths = schemaTree.searchMeasurementPaths(path, true).left;
       if (actualPaths.size() != 1) {
         throw new SemanticException(new BrokenViewException(path.getFullPath(), actualPaths));
       }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/visitor/cartesian/BindSchemaForExpressionVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/visitor/cartesian/BindSchemaForExpressionVisitor.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.queryengine.plan.expression.visitor.cartesian;
 
 import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.path.PathPatternTree;
 import org.apache.iotdb.commons.schema.view.LogicalViewSchema;
 import org.apache.iotdb.commons.schema.view.viewExpression.ViewExpression;
 import org.apache.iotdb.db.queryengine.common.schematree.ISchemaTree;
@@ -46,6 +47,12 @@ import static org.apache.iotdb.db.utils.TypeInferenceUtils.bindTypeForAggregatio
 import static org.apache.iotdb.db.utils.constant.SqlConstant.COUNT_TIME;
 
 public class BindSchemaForExpressionVisitor extends CartesianProductVisitor<ISchemaTree> {
+
+  private final PathPatternTree authorityScope;
+
+  public BindSchemaForExpressionVisitor(PathPatternTree authorityScope) {
+    this.authorityScope = authorityScope;
+  }
 
   @Override
   public List<Expression> visitFunctionExpression(
@@ -104,7 +111,7 @@ public class BindSchemaForExpressionVisitor extends CartesianProductVisitor<ISch
       TimeSeriesOperand timeSeriesOperand, ISchemaTree schemaTree) {
     PartialPath timeSeriesOperandPath = timeSeriesOperand.getPath();
     List<MeasurementPath> actualPaths =
-        schemaTree.searchMeasurementPaths(timeSeriesOperandPath).left;
+        schemaTree.searchMeasurementPaths(timeSeriesOperandPath, authorityScope).left;
     // process logical view
     List<MeasurementPath> nonViewActualPaths = new ArrayList<>();
     List<MeasurementPath> viewPaths = new ArrayList<>();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/visitor/cartesian/BindSchemaForPredicateVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/visitor/cartesian/BindSchemaForPredicateVisitor.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.queryengine.plan.expression.visitor.cartesian;
 
 import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.path.PathPatternTree;
 import org.apache.iotdb.db.queryengine.common.schematree.ISchemaTree;
 import org.apache.iotdb.db.queryengine.plan.expression.Expression;
 import org.apache.iotdb.db.queryengine.plan.expression.ExpressionType;
@@ -48,6 +49,12 @@ import static org.apache.iotdb.db.utils.constant.SqlConstant.COUNT_TIME;
 
 public class BindSchemaForPredicateVisitor
     extends CartesianProductVisitor<BindSchemaForPredicateVisitor.Context> {
+
+  private final PathPatternTree authorityScope;
+
+  public BindSchemaForPredicateVisitor(PathPatternTree authorityScope) {
+    this.authorityScope = authorityScope;
+  }
 
   @Override
   public List<Expression> visitBinaryExpression(
@@ -119,7 +126,7 @@ public class BindSchemaForPredicateVisitor
     List<MeasurementPath> viewPathList = new ArrayList<>();
     for (PartialPath concatPath : concatPaths) {
       List<MeasurementPath> actualPaths =
-          context.getSchemaTree().searchMeasurementPaths(concatPath).left;
+          context.getSchemaTree().searchMeasurementPaths(concatPath, authorityScope).left;
       if (actualPaths.isEmpty()) {
         return Collections.singletonList(new NullOperand());
       }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/visitor/cartesian/ConcatDeviceAndBindSchemaForExpressionVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/visitor/cartesian/ConcatDeviceAndBindSchemaForExpressionVisitor.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.queryengine.plan.expression.visitor.cartesian;
 
 import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.path.PathPatternTree;
 import org.apache.iotdb.db.exception.sql.SemanticException;
 import org.apache.iotdb.db.queryengine.common.schematree.ISchemaTree;
 import org.apache.iotdb.db.queryengine.plan.analyze.ExpressionUtils;
@@ -45,6 +46,12 @@ import static org.apache.iotdb.db.utils.constant.SqlConstant.COUNT_TIME;
 
 public class ConcatDeviceAndBindSchemaForExpressionVisitor
     extends CartesianProductVisitor<ConcatDeviceAndBindSchemaForExpressionVisitor.Context> {
+
+  private final PathPatternTree authorityScope;
+
+  public ConcatDeviceAndBindSchemaForExpressionVisitor(PathPatternTree authorityScope) {
+    this.authorityScope = authorityScope;
+  }
 
   @Override
   public List<Expression> visitFunctionExpression(
@@ -93,7 +100,7 @@ public class ConcatDeviceAndBindSchemaForExpressionVisitor
     PartialPath concatPath = context.getDevicePath().concatPath(measurement);
 
     List<MeasurementPath> actualPaths =
-        context.getSchemaTree().searchMeasurementPaths(concatPath).left;
+        context.getSchemaTree().searchMeasurementPaths(concatPath, authorityScope).left;
     if (actualPaths.isEmpty()) {
       return Collections.emptyList();
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/visitor/cartesian/ConcatDeviceAndBindSchemaForPredicateVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/visitor/cartesian/ConcatDeviceAndBindSchemaForPredicateVisitor.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.queryengine.plan.expression.visitor.cartesian;
 
 import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.path.PathPatternTree;
 import org.apache.iotdb.db.exception.sql.SemanticException;
 import org.apache.iotdb.db.queryengine.common.schematree.ISchemaTree;
 import org.apache.iotdb.db.queryengine.plan.expression.Expression;
@@ -41,6 +42,13 @@ import static org.apache.iotdb.db.queryengine.plan.expression.visitor.cartesian.
 
 public class ConcatDeviceAndBindSchemaForPredicateVisitor
     extends CartesianProductVisitor<ConcatDeviceAndBindSchemaForPredicateVisitor.Context> {
+
+  private final PathPatternTree authorityScope;
+
+  public ConcatDeviceAndBindSchemaForPredicateVisitor(PathPatternTree authorityScope) {
+    this.authorityScope = authorityScope;
+  }
+
   @Override
   public List<Expression> visitFunctionExpression(FunctionExpression predicate, Context context) {
     if (predicate.isBuiltInAggregationFunctionExpression() && context.isWhere()) {
@@ -63,7 +71,7 @@ public class ConcatDeviceAndBindSchemaForPredicateVisitor
     List<MeasurementPath> nonViewPathList = new ArrayList<>();
     List<MeasurementPath> viewPathList = new ArrayList<>();
     List<MeasurementPath> actualPaths =
-        context.getSchemaTree().searchMeasurementPaths(concatPath).left;
+        context.getSchemaTree().searchMeasurementPaths(concatPath, authorityScope).left;
     if (actualPaths.isEmpty()) {
       return Collections.singletonList(new NullOperand());
     }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/analyze/ExpressionAnalyzerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/analyze/ExpressionAnalyzerTest.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.queryengine.plan.analyze;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.path.PathPatternTree;
+import org.apache.iotdb.commons.schema.SchemaConstant;
 import org.apache.iotdb.db.queryengine.common.schematree.ISchemaTree;
 
 import org.junit.Test;
@@ -55,7 +56,8 @@ public class ExpressionAnalyzerTest {
             and(gt(timeSeries("s1"), intValue("1")), gt(timeSeries("s2"), intValue("1"))),
             prefixPaths,
             fakeSchemaTree,
-            true));
+            true,
+            SchemaConstant.ALL_MATCH_SCOPE));
 
     assertEquals(
         Arrays.asList(
@@ -79,6 +81,7 @@ public class ExpressionAnalyzerTest {
             count(and(gt(timeSeries("s1"), intValue("1")), gt(timeSeries("s2"), intValue("1")))),
             prefixPaths,
             fakeSchemaTree,
-            true));
+            true,
+            SchemaConstant.ALL_MATCH_SCOPE));
   }
 }


### PR DESCRIPTION
## Description

This PR fix some query bugs with authority:

1. Query view series without origin time series read authority.
2. Query pure template series with partitial authority.

For implementation, I removed the `authorityScope` field from the `ClusterSchemaTree` for better maintenance. This could lead to redundant data when `ClusterSchemaTree` uses templates.

To work around this, the query engine filters again acccording to the authorityScope in the `QueryStatement` when FE parses the `Expression` and `Predicate`.

