### PR TITLE
Fix query return unexpected result with authority

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/schematree/ClusterSchemaTree.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/schematree/ClusterSchemaTree.java
@@ -459,6 +459,7 @@ public class ClusterSchemaTree implements ISchemaTree {
     Deque<SchemaNode> stack = new ArrayDeque<>();
     SchemaNode child;
     boolean hasLogicalView = false;
+    boolean hasNormalTimeSeries = false;
     Map<Integer, Template> templateMap = new HashMap<>();
 
     while (inputStream.available() > 0) {
@@ -469,6 +470,7 @@ public class ClusterSchemaTree implements ISchemaTree {
         if (measurementNode.isLogicalView()) {
           hasLogicalView = true;
         }
+        hasNormalTimeSeries = true;
       } else {
         SchemaInternalNode internalNode;
         if (nodeType == SCHEMA_ENTITY_NODE) {
@@ -501,6 +503,7 @@ public class ClusterSchemaTree implements ISchemaTree {
     ClusterSchemaTree result = new ClusterSchemaTree(stack.poll());
     result.templateMap = templateMap;
     result.hasLogicalMeasurementPath = hasLogicalView;
+    result.hasNormalTimeSeries = hasNormalTimeSeries;
     return result;
   }
 
@@ -546,10 +549,5 @@ public class ClusterSchemaTree implements ISchemaTree {
   @Override
   public boolean isEmpty() {
     return root.getChildren() == null || root.getChildren().isEmpty();
-  }
-
-  @Override
-  public void setAuthorityScope(PathPatternTree scope) {
-    this.authorityScope = scope;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/schematree/ISchemaTree.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/schematree/ISchemaTree.java
@@ -21,7 +21,7 @@ package org.apache.iotdb.db.queryengine.common.schematree;
 
 import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.commons.path.PartialPath;
-import org.apache.iotdb.commons.path.PathPatternTree;
+import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.db.schemaengine.template.Template;
 import org.apache.iotdb.tsfile.utils.Pair;
 
@@ -36,9 +36,16 @@ public interface ISchemaTree {
    * @param isPrefixMatch if true, the path pattern is used to match prefix path
    * @return Left: all measurement paths; Right: remaining series offset
    */
+  @TestOnly
   Pair<List<MeasurementPath>, Integer> searchMeasurementPaths(
       PartialPath pathPattern, int slimit, int soffset, boolean isPrefixMatch);
 
+  /**
+   * Return all measurement paths for given path pattern.
+   *
+   * @param pathPattern can be a pattern or a full path of timeseries.
+   * @return Left: all measurement paths; Right: remaining series offset
+   */
   Pair<List<MeasurementPath>, Integer> searchMeasurementPaths(PartialPath pathPattern);
 
   /**
@@ -99,6 +106,4 @@ public interface ISchemaTree {
    * @return whether there's view in this schema tree
    */
   boolean hasLogicalViewMeasurement();
-
-  void setAuthorityScope(PathPatternTree scope);
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/SchemaFetchScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/SchemaFetchScanOperator.java
@@ -49,6 +49,7 @@ public class SchemaFetchScanOperator implements SourceOperator {
 
   private final ISchemaRegion schemaRegion;
   private final boolean withTags;
+  private final boolean withTemplate;
   private boolean isFinished = false;
 
   private static final int DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES =
@@ -60,13 +61,15 @@ public class SchemaFetchScanOperator implements SourceOperator {
       PathPatternTree patternTree,
       Map<Integer, Template> templateMap,
       ISchemaRegion schemaRegion,
-      boolean withTags) {
+      boolean withTags,
+      boolean withTemplate) {
     this.sourceId = planNodeId;
     this.operatorContext = context;
     this.patternTree = patternTree;
     this.schemaRegion = schemaRegion;
     this.templateMap = templateMap;
     this.withTags = withTags;
+    this.withTemplate = withTemplate;
   }
 
   @Override
@@ -103,7 +106,8 @@ public class SchemaFetchScanOperator implements SourceOperator {
   }
 
   private TsBlock fetchSchema() throws MetadataException {
-    ClusterSchemaTree schemaTree = schemaRegion.fetchSchema(patternTree, templateMap, withTags);
+    ClusterSchemaTree schemaTree =
+        schemaRegion.fetchSchema(patternTree, templateMap, withTags, withTemplate);
 
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     try {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
@@ -363,13 +363,21 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     ISchemaTree schemaTree;
     try {
       logger.debug("[StartFetchSchema]");
+      PathPatternTree authorizedPatternTree = queryStatement.getAuthorityScope();
+      // If the authority scope of query statement contains full path, we should fetch schema
+      // without template. Otherwise, the result ISchemaTree may contain template series that is
+      // not authorized to access.
+      boolean allWildcardLeaf =
+          !authorizedPatternTree.isContainFullPath() && authorizedPatternTree.isContainWildcard();
       if (queryStatement.isGroupByTag()) {
         schemaTree =
-            schemaFetcher.fetchSchemaWithTags(concatPathRewriter.getPatternTree(), context);
+            schemaFetcher.fetchSchemaWithTags(
+                concatPathRewriter.getPatternTree(), allWildcardLeaf, context);
       } else {
-        schemaTree = schemaFetcher.fetchSchema(concatPathRewriter.getPatternTree(), context);
+        schemaTree =
+            schemaFetcher.fetchSchema(
+                concatPathRewriter.getPatternTree(), allWildcardLeaf, context);
       }
-      schemaTree.setAuthorityScope(queryStatement.getAuthorityScope());
 
       // make sure paths in logical view is fetched
       updateSchemaTreeByViews(analysis, schemaTree);
@@ -514,7 +522,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     }
 
     if (needToReFetch) {
-      ISchemaTree viewSchemaTree = this.schemaFetcher.fetchSchema(patternTree, null);
+      ISchemaTree viewSchemaTree = this.schemaFetcher.fetchSchema(patternTree, true, null);
       originSchemaTree.mergeSchemaTree(viewSchemaTree);
       Set<String> allDatabases = viewSchemaTree.getDatabases();
       allDatabases.addAll(originSchemaTree.getDatabases());
@@ -1983,7 +1991,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
 
     // fetch schema of target paths
     long startTime = System.nanoTime();
-    ISchemaTree targetSchemaTree = schemaFetcher.fetchSchema(targetPathTree, null);
+    ISchemaTree targetSchemaTree = schemaFetcher.fetchSchema(targetPathTree, true, null);
     QueryPlanCostMetricSet.getInstance()
         .recordPlanCost(SCHEMA_FETCHER, System.nanoTime() - startTime);
     deviceViewIntoPathDescriptor.bindType(targetSchemaTree);
@@ -2051,7 +2059,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
 
     // fetch schema of target paths
     long startTime = System.nanoTime();
-    ISchemaTree targetSchemaTree = schemaFetcher.fetchSchema(targetPathTree, null);
+    ISchemaTree targetSchemaTree = schemaFetcher.fetchSchema(targetPathTree, true, null);
     updateSchemaTreeByViews(analysis, targetSchemaTree);
     QueryPlanCostMetricSet.getInstance()
         .recordPlanCost(SCHEMA_FETCHER, System.nanoTime() - startTime);
@@ -2691,7 +2699,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       patternTree.constructTree();
       // request schema fetch API
       logger.debug("[StartFetchSchema]");
-      ISchemaTree schemaTree = schemaFetcher.fetchSchema(patternTree, context);
+      ISchemaTree schemaTree = schemaFetcher.fetchSchema(patternTree, true, context);
       updateSchemaTreeByViews(analysis, schemaTree);
       logger.debug("[EndFetchSchema]]");
 
@@ -2924,7 +2932,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     PathPatternTree patternTree = new PathPatternTree();
     deleteDataStatement.getPathList().forEach(patternTree::appendPathPattern);
 
-    ISchemaTree schemaTree = schemaFetcher.fetchSchema(patternTree, context);
+    ISchemaTree schemaTree = schemaFetcher.fetchSchema(patternTree, true, context);
     Set<String> deduplicatedDevicePaths = new HashSet<>();
 
     if (schemaTree.hasLogicalViewMeasurement()) {
@@ -3251,7 +3259,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       for (PartialPath path : pathList) {
         pathPatternTree.appendPathPattern(path);
       }
-      schemaTree = this.schemaFetcher.fetchSchema(pathPatternTree, context);
+      schemaTree = this.schemaFetcher.fetchSchema(pathPatternTree, true, context);
     }
 
     // search each path, make sure they all exist.

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/schema/ClusterSchemaFetchExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/schema/ClusterSchemaFetchExecutor.java
@@ -96,14 +96,17 @@ class ClusterSchemaFetchExecutor {
    * cache the result.
    */
   ClusterSchemaTree fetchSchemaOfFuzzyMatch(
-      PathPatternTree patternTree, boolean withTags, MPPQueryContext context) {
+      PathPatternTree patternTree,
+      boolean withTags,
+      boolean withTemplate,
+      MPPQueryContext context) {
     Map<Integer, Template> templateMap = new HashMap<>();
     List<PartialPath> pathPatternList = patternTree.getAllPathPatterns();
     for (PartialPath pattern : pathPatternList) {
       templateMap.putAll(templateManager.checkAllRelatedTemplate(pattern));
     }
     return executeSchemaFetchQuery(
-        new SchemaFetchStatement(patternTree, templateMap, withTags), context);
+        new SchemaFetchStatement(patternTree, templateMap, withTags, withTemplate), context);
   }
 
   /**
@@ -115,10 +118,14 @@ class ClusterSchemaFetchExecutor {
    * @return fetched schema
    */
   ClusterSchemaTree fetchSchemaOfPreciseMatchOrPreciseDeviceUsingTemplate(
-      List<PartialPath> fullPathList, PathPatternTree rawPatternTree, MPPQueryContext context) {
+      List<PartialPath> fullPathList,
+      PathPatternTree rawPatternTree,
+      boolean withTemplate,
+      MPPQueryContext context) {
     ClusterSchemaTree schemaTree =
         executeSchemaFetchQuery(
-            new SchemaFetchStatement(rawPatternTree, analyzeTemplate(fullPathList), false),
+            new SchemaFetchStatement(
+                rawPatternTree, analyzeTemplate(fullPathList), false, withTemplate),
             context);
     if (!schemaTree.isEmpty()) {
       schemaCacheUpdater.accept(schemaTree);
@@ -182,7 +189,7 @@ class ClusterSchemaFetchExecutor {
     ClusterSchemaTree schemaTree =
         executeSchemaFetchQuery(
             new SchemaFetchStatement(
-                patternTree, analyzeTemplate(patternTree.getAllPathPatterns()), false),
+                patternTree, analyzeTemplate(patternTree.getAllPathPatterns()), false, true),
             context);
     if (!schemaTree.isEmpty()) {
       schemaCacheUpdater.accept(schemaTree);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/schema/ClusterSchemaFetcher.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/schema/ClusterSchemaFetcher.java
@@ -78,7 +78,8 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
   private ClusterSchemaFetcher() {}
 
   @Override
-  public ClusterSchemaTree fetchSchema(PathPatternTree patternTree, MPPQueryContext context) {
+  public ClusterSchemaTree fetchSchema(
+      PathPatternTree patternTree, boolean withTemplate, MPPQueryContext context) {
     patternTree.constructTree();
     List<PartialPath> pathPatternList = patternTree.getAllPathPatterns();
     List<PartialPath> explicitPathList = new ArrayList<>();
@@ -95,7 +96,8 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
     }
 
     if (explicitPathList.size() + explicitDevicePatternCount < pathPatternList.size()) {
-      return clusterSchemaFetchExecutor.fetchSchemaOfFuzzyMatch(patternTree, false, context);
+      return clusterSchemaFetchExecutor.fetchSchemaOfFuzzyMatch(
+          patternTree, false, withTemplate, context);
     }
 
     // The schema cache R/W and fetch operation must be locked together thus the cache clean
@@ -139,7 +141,7 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
       }
 
       return clusterSchemaFetchExecutor.fetchSchemaOfPreciseMatchOrPreciseDeviceUsingTemplate(
-          pathPatternList, patternTree, context);
+          pathPatternList, patternTree, withTemplate, context);
 
     } finally {
       schemaCache.releaseReadLock();
@@ -148,9 +150,10 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
 
   @Override
   public ClusterSchemaTree fetchSchemaWithTags(
-      PathPatternTree patternTree, MPPQueryContext context) {
+      PathPatternTree patternTree, boolean withTemplate, MPPQueryContext context) {
     patternTree.constructTree();
-    return clusterSchemaFetchExecutor.fetchSchemaOfFuzzyMatch(patternTree, true, context);
+    return clusterSchemaFetchExecutor.fetchSchemaOfFuzzyMatch(
+        patternTree, true, withTemplate, context);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/schema/ISchemaFetcher.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/schema/ISchemaFetcher.java
@@ -43,7 +43,8 @@ public interface ISchemaFetcher {
    * @param patternTree used for matching the timeseries
    * @return the matched timeseries schema organized as tree structure logically
    */
-  ISchemaTree fetchSchema(PathPatternTree patternTree, MPPQueryContext context);
+  ISchemaTree fetchSchema(
+      PathPatternTree patternTree, boolean withTemplate, MPPQueryContext context);
 
   /**
    * Fetch all the schema with tags of existing timeseries matched by the given patternTree
@@ -51,7 +52,8 @@ public interface ISchemaFetcher {
    * @param patternTree used for matching the timeseries
    * @return the matched timeseries schema organized as tree structure logically
    */
-  ISchemaTree fetchSchemaWithTags(PathPatternTree patternTree, MPPQueryContext context);
+  ISchemaTree fetchSchemaWithTags(
+      PathPatternTree patternTree, boolean withTemplate, MPPQueryContext context);
 
   /**
    * Fetch and compute the schema of target timeseries, with device and measurement defined in given

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/executor/ClusterConfigTaskExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/executor/ClusterConfigTaskExecutor.java
@@ -1757,7 +1757,8 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
     PathPatternTree patternTree = new PathPatternTree();
     patternTree.appendFullPath(oldName);
     patternTree.constructTree();
-    ISchemaTree schemaTree = ClusterSchemaFetcher.getInstance().fetchSchema(patternTree, null);
+    ISchemaTree schemaTree =
+        ClusterSchemaFetcher.getInstance().fetchSchema(patternTree, true, null);
     List<MeasurementPath> measurementPathList = schemaTree.searchMeasurementPaths(oldName).left;
     if (measurementPathList.isEmpty()) {
       future.setException(new PathNotExistException(oldName.getFullPath()));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LogicalPlanBuilder.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LogicalPlanBuilder.java
@@ -1339,7 +1339,8 @@ public class LogicalPlanBuilder {
       List<String> storageGroupList,
       PathPatternTree patternTree,
       Map<Integer, Template> templateMap,
-      boolean withTags) {
+      boolean withTags,
+      boolean withTemplate) {
     PartialPath storageGroupPath;
     for (String storageGroup : storageGroupList) {
       try {
@@ -1357,7 +1358,8 @@ public class LogicalPlanBuilder {
                 storageGroupPath,
                 overlappedPatternTree,
                 templateMap,
-                withTags));
+                withTags,
+                withTemplate));
       } catch (IllegalPathException e) {
         // definitely won't happen
         throw new RuntimeException(e);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LogicalPlanVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LogicalPlanVisitor.java
@@ -841,7 +841,8 @@ public class LogicalPlanVisitor extends StatementVisitor<PlanNode, MPPQueryConte
             storageGroupList,
             schemaFetchStatement.getPatternTree(),
             schemaFetchStatement.getTemplateMap(),
-            schemaFetchStatement.isWithTags())
+            schemaFetchStatement.isWithTags(),
+            schemaFetchStatement.isWithTemplate())
         .getRoot();
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/OperatorTreeGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/OperatorTreeGenerator.java
@@ -2075,7 +2075,8 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
         node.getPatternTree(),
         node.getTemplateMap(),
         ((SchemaDriverContext) (context.getDriverContext())).getSchemaRegion(),
-        node.isWithTags());
+        node.isWithTags(),
+        node.isWithTemplate());
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/metedata/read/SchemaFetchScanNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/metedata/read/SchemaFetchScanNode.java
@@ -49,6 +49,7 @@ public class SchemaFetchScanNode extends SourceNode {
   private final PathPatternTree patternTree;
   private final Map<Integer, Template> templateMap;
   private final boolean withTags;
+  private final boolean withTemplate;
   private TRegionReplicaSet schemaRegionReplicaSet;
 
   public SchemaFetchScanNode(
@@ -56,13 +57,15 @@ public class SchemaFetchScanNode extends SourceNode {
       PartialPath storageGroup,
       PathPatternTree patternTree,
       Map<Integer, Template> templateMap,
-      boolean withTags) {
+      boolean withTags,
+      boolean withTemplate) {
     super(id);
     this.storageGroup = storageGroup;
     this.patternTree = patternTree;
     this.patternTree.constructTree();
     this.templateMap = templateMap;
     this.withTags = withTags;
+    this.withTemplate = withTemplate;
   }
 
   public PartialPath getStorageGroup() {
@@ -88,7 +91,7 @@ public class SchemaFetchScanNode extends SourceNode {
   @Override
   public PlanNode clone() {
     return new SchemaFetchScanNode(
-        getPlanNodeId(), storageGroup, patternTree, templateMap, withTags);
+        getPlanNodeId(), storageGroup, patternTree, templateMap, withTags, withTemplate);
   }
 
   @Override
@@ -121,6 +124,7 @@ public class SchemaFetchScanNode extends SourceNode {
       template.serialize(byteBuffer);
     }
     ReadWriteIOUtils.write(withTags, byteBuffer);
+    ReadWriteIOUtils.write(withTemplate, byteBuffer);
   }
 
   @Override
@@ -133,6 +137,7 @@ public class SchemaFetchScanNode extends SourceNode {
       template.serialize(stream);
     }
     ReadWriteIOUtils.write(withTags, stream);
+    ReadWriteIOUtils.write(withTemplate, stream);
   }
 
   public static SchemaFetchScanNode deserialize(ByteBuffer byteBuffer) {
@@ -148,8 +153,10 @@ public class SchemaFetchScanNode extends SourceNode {
       templateMap.put(template.getId(), template);
     }
     boolean withTags = ReadWriteIOUtils.readBool(byteBuffer);
+    boolean withTemplate = ReadWriteIOUtils.readBool(byteBuffer);
     PlanNodeId planNodeId = PlanNodeId.deserialize(byteBuffer);
-    return new SchemaFetchScanNode(planNodeId, storageGroup, patternTree, templateMap, withTags);
+    return new SchemaFetchScanNode(
+        planNodeId, storageGroup, patternTree, templateMap, withTags, withTemplate);
   }
 
   @Override
@@ -175,5 +182,9 @@ public class SchemaFetchScanNode extends SourceNode {
 
   public boolean isWithTags() {
     return withTags;
+  }
+
+  public boolean isWithTemplate() {
+    return withTemplate;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/internal/SchemaFetchStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/internal/SchemaFetchStatement.java
@@ -34,13 +34,18 @@ public class SchemaFetchStatement extends Statement {
   private final PathPatternTree patternTree;
   private final Map<Integer, Template> templateMap;
   private final boolean withTags;
+  private final boolean withTemplate;
 
   public SchemaFetchStatement(
-      PathPatternTree patternTree, Map<Integer, Template> templateMap, boolean withTags) {
+      PathPatternTree patternTree,
+      Map<Integer, Template> templateMap,
+      boolean withTags,
+      boolean withTemplate) {
     super();
     this.patternTree = patternTree;
     this.templateMap = templateMap;
     this.withTags = withTags;
+    this.withTemplate = withTemplate;
     setType(StatementType.FETCH_SCHEMA);
   }
 
@@ -64,5 +69,9 @@ public class SchemaFetchStatement extends Statement {
 
   public boolean isWithTags() {
     return withTags;
+  }
+
+  public boolean isWithTemplate() {
+    return withTemplate;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/ISchemaRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/ISchemaRegion.java
@@ -196,7 +196,10 @@ public interface ISchemaRegion {
   MeasurementPath fetchMeasurementPath(PartialPath fullPath) throws MetadataException;
 
   ClusterSchemaTree fetchSchema(
-      PathPatternTree patternTree, Map<Integer, Template> templateMap, boolean withTags)
+      PathPatternTree patternTree,
+      Map<Integer, Template> templateMap,
+      boolean withTags,
+      boolean withTemplate)
       throws MetadataException;
 
   // endregion

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/impl/SchemaRegionMemoryImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/impl/SchemaRegionMemoryImpl.java
@@ -918,16 +918,19 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
 
   @Override
   public ClusterSchemaTree fetchSchema(
-      PathPatternTree patternTree, Map<Integer, Template> templateMap, boolean withTags)
+      PathPatternTree patternTree,
+      Map<Integer, Template> templateMap,
+      boolean withTags,
+      boolean withTemplate)
       throws MetadataException {
     if (patternTree.isContainWildcard()) {
       ClusterSchemaTree schemaTree = new ClusterSchemaTree();
       for (PartialPath path : patternTree.getAllPathPatterns()) {
-        schemaTree.mergeSchemaTree(mtree.fetchSchema(path, templateMap, withTags));
+        schemaTree.mergeSchemaTree(mtree.fetchSchema(path, templateMap, withTags, withTemplate));
       }
       return schemaTree;
     } else {
-      return mtree.fetchSchemaWithoutWildcard(patternTree, templateMap, withTags);
+      return mtree.fetchSchemaWithoutWildcard(patternTree, templateMap, withTags, withTemplate);
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/impl/SchemaRegionPBTreeImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/impl/SchemaRegionPBTreeImpl.java
@@ -990,16 +990,19 @@ public class SchemaRegionPBTreeImpl implements ISchemaRegion {
 
   @Override
   public ClusterSchemaTree fetchSchema(
-      PathPatternTree patternTree, Map<Integer, Template> templateMap, boolean withTags)
+      PathPatternTree patternTree,
+      Map<Integer, Template> templateMap,
+      boolean withTags,
+      boolean withTemplate)
       throws MetadataException {
     if (patternTree.isContainWildcard()) {
       ClusterSchemaTree schemaTree = new ClusterSchemaTree();
       for (PartialPath path : patternTree.getAllPathPatterns()) {
-        schemaTree.mergeSchemaTree(mtree.fetchSchema(path, templateMap, withTags));
+        schemaTree.mergeSchemaTree(mtree.fetchSchema(path, templateMap, withTags, withTemplate));
       }
       return schemaTree;
     } else {
-      return mtree.fetchSchemaWithoutWildcard(patternTree, templateMap, withTags);
+      return mtree.fetchSchemaWithoutWildcard(patternTree, templateMap, withTags, withTemplate);
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/mem/MTreeBelowSGMemoryImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/mem/MTreeBelowSGMemoryImpl.java
@@ -698,7 +698,10 @@ public class MTreeBelowSGMemoryImpl {
 
   // region Interfaces and Implementation for metadata info Query
   public ClusterSchemaTree fetchSchema(
-      PartialPath pathPattern, Map<Integer, Template> templateMap, boolean withTags)
+      PartialPath pathPattern,
+      Map<Integer, Template> templateMap,
+      boolean withTags,
+      boolean withTemplate)
       throws MetadataException {
     ClusterSchemaTree schemaTree = new ClusterSchemaTree();
     try (MeasurementCollector<Void, IMemMNode> collector =
@@ -707,7 +710,7 @@ public class MTreeBelowSGMemoryImpl {
           protected Void collectMeasurement(IMeasurementMNode<IMemMNode> node) {
             IDeviceMNode<IMemMNode> deviceMNode = getParentOfNextMatchedNode().getAsDeviceMNode();
             int templateId = deviceMNode.getSchemaTemplateIdWithState();
-            if (templateId >= 0) {
+            if (withTemplate && templateId >= 0) {
               schemaTree.appendTemplateDevice(
                   deviceMNode.getPartialPath(), deviceMNode.isAligned(), templateId, null);
               skipTemplateChildren(deviceMNode);
@@ -733,7 +736,10 @@ public class MTreeBelowSGMemoryImpl {
   }
 
   public ClusterSchemaTree fetchSchemaWithoutWildcard(
-      PathPatternTree patternTree, Map<Integer, Template> templateMap, boolean withTags)
+      PathPatternTree patternTree,
+      Map<Integer, Template> templateMap,
+      boolean withTags,
+      boolean withTemplate)
       throws MetadataException {
     ClusterSchemaTree schemaTree = new ClusterSchemaTree();
     try (MeasurementCollector<Void, IMemMNode> collector =
@@ -742,7 +748,7 @@ public class MTreeBelowSGMemoryImpl {
           protected Void collectMeasurement(IMeasurementMNode<IMemMNode> node) {
             IDeviceMNode<IMemMNode> deviceMNode = getParentOfNextMatchedNode().getAsDeviceMNode();
             int templateId = deviceMNode.getSchemaTemplateIdWithState();
-            if (templateId >= 0) {
+            if (withTemplate && templateId >= 0) {
               schemaTree.appendTemplateDevice(
                   deviceMNode.getPartialPath(), deviceMNode.isAligned(), templateId, null);
               skipTemplateChildren(deviceMNode);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/MTreeBelowSGCachedImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/MTreeBelowSGCachedImpl.java
@@ -812,7 +812,10 @@ public class MTreeBelowSGCachedImpl {
 
   // region Interfaces and Implementation for metadata info Query
   public ClusterSchemaTree fetchSchema(
-      PartialPath pathPattern, Map<Integer, Template> templateMap, boolean withTags)
+      PartialPath pathPattern,
+      Map<Integer, Template> templateMap,
+      boolean withTags,
+      boolean withTemplate)
       throws MetadataException {
     ClusterSchemaTree schemaTree = new ClusterSchemaTree();
     try (MeasurementCollector<Void, ICachedMNode> collector =
@@ -822,7 +825,7 @@ public class MTreeBelowSGCachedImpl {
             IDeviceMNode<ICachedMNode> deviceMNode =
                 getParentOfNextMatchedNode().getAsDeviceMNode();
             int templateId = deviceMNode.getSchemaTemplateIdWithState();
-            if (templateId >= 0) {
+            if (withTemplate && templateId >= 0) {
               schemaTree.appendTemplateDevice(
                   deviceMNode.getPartialPath(), deviceMNode.isAligned(), templateId, null);
               skipTemplateChildren(deviceMNode);
@@ -848,7 +851,10 @@ public class MTreeBelowSGCachedImpl {
   }
 
   public ClusterSchemaTree fetchSchemaWithoutWildcard(
-      PathPatternTree patternTree, Map<Integer, Template> templateMap, boolean withTags)
+      PathPatternTree patternTree,
+      Map<Integer, Template> templateMap,
+      boolean withTags,
+      boolean withTemplate)
       throws MetadataException {
     ClusterSchemaTree schemaTree = new ClusterSchemaTree();
     try (MeasurementCollector<Void, ICachedMNode> collector =
@@ -858,7 +864,7 @@ public class MTreeBelowSGCachedImpl {
             IDeviceMNode<ICachedMNode> deviceMNode =
                 getParentOfNextMatchedNode().getAsDeviceMNode();
             int templateId = deviceMNode.getSchemaTemplateIdWithState();
-            if (templateId >= 0) {
+            if (withTemplate && templateId >= 0) {
               schemaTree.appendTemplateDevice(
                   deviceMNode.getPartialPath(), deviceMNode.isAligned(), templateId, null);
               skipTemplateChildren(deviceMNode);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/read/resp/reader/impl/TimeseriesReaderWithViewFetch.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/read/resp/reader/impl/TimeseriesReaderWithViewFetch.java
@@ -240,7 +240,8 @@ public class TimeseriesReaderWithViewFetch implements ISchemaReader<ITimeSeriesS
     // clear cachedViewList, all cached view will be added in the last step
     cachedViewList.clear();
 
-    ISchemaTree schemaTree = ClusterSchemaFetcher.getInstance().fetchSchema(patternTree, null);
+    ISchemaTree schemaTree =
+        ClusterSchemaFetcher.getInstance().fetchSchema(patternTree, true, null);
     // process each view expression and get data type
     TransformToExpressionVisitor transformToExpressionVisitor = new TransformToExpressionVisitor();
     CompleteMeasurementSchemaVisitor completeMeasurementSchemaVisitor =

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionBasicTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionBasicTest.java
@@ -102,11 +102,11 @@ public class SchemaRegionBasicTest extends AbstractSchemaRegionTest {
       }
     }
     patternTree.constructTree();
-    schemaRegion.fetchSchema(patternTree, Collections.EMPTY_MAP, false);
+    schemaRegion.fetchSchema(patternTree, Collections.EMPTY_MAP, false, true);
     long startTime;
     startTime = System.currentTimeMillis();
     for (int i = 0; i < 10; i++) {
-      schemaRegion.fetchSchema(patternTree, Collections.EMPTY_MAP, false);
+      schemaRegion.fetchSchema(patternTree, Collections.EMPTY_MAP, false, true);
     }
     System.out.println("cost time: " + (System.currentTimeMillis() - startTime));
   }
@@ -151,7 +151,8 @@ public class SchemaRegionBasicTest extends AbstractSchemaRegionTest {
     patternTree.appendPathPattern(new PartialPath("root.sg.wf01.wt01.*"));
     patternTree.constructTree();
     ;
-    ClusterSchemaTree schemas = schemaRegion.fetchSchema(patternTree, Collections.EMPTY_MAP, true);
+    ClusterSchemaTree schemas =
+        schemaRegion.fetchSchema(patternTree, Collections.EMPTY_MAP, true, true);
     List<MeasurementPath> measurementPaths =
         schemas.searchMeasurementPaths(new PartialPath("root.sg.wf01.wt01.*")).left;
     Assert.assertEquals(measurementPaths.size(), 2);
@@ -180,7 +181,7 @@ public class SchemaRegionBasicTest extends AbstractSchemaRegionTest {
     patternTree = new PathPatternTree();
     patternTree.appendPathPattern(new PartialPath("root.sg.wf01.wt01.temp"));
     patternTree.constructTree();
-    schemas = schemaRegion.fetchSchema(patternTree, Collections.EMPTY_MAP, false);
+    schemas = schemaRegion.fetchSchema(patternTree, Collections.EMPTY_MAP, false, true);
     measurementPaths =
         schemas.searchMeasurementPaths(new PartialPath("root.sg.wf01.wt01.temp")).left;
     Assert.assertEquals(measurementPaths.size(), 1);
@@ -366,7 +367,7 @@ public class SchemaRegionBasicTest extends AbstractSchemaRegionTest {
     schemaRegion.deleteTimeseriesInBlackList(patternTree);
     List<MeasurementPath> schemas =
         schemaRegion
-            .fetchSchema(ALL_MATCH_SCOPE, Collections.EMPTY_MAP, false)
+            .fetchSchema(ALL_MATCH_SCOPE, Collections.EMPTY_MAP, false, true)
             .searchMeasurementPaths(ALL_MATCH_PATTERN)
             .left;
     Assert.assertEquals(1, schemas.size());

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionTemplateTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionTemplateTest.java
@@ -78,7 +78,7 @@ public class SchemaRegionTemplateTest extends AbstractSchemaRegionTest {
         template);
     ClusterSchemaTree schemaTree =
         schemaRegion.fetchSchema(
-            ALL_MATCH_SCOPE, Collections.singletonMap(templateId, template), true);
+            ALL_MATCH_SCOPE, Collections.singletonMap(templateId, template), true, true);
     Assert.assertEquals(2, schemaTree.getAllDevices().size());
     for (DeviceSchemaInfo deviceSchemaInfo : schemaTree.getAllDevices()) {
       Assert.assertEquals(templateId, deviceSchemaInfo.getTemplateId());
@@ -212,7 +212,8 @@ public class SchemaRegionTemplateTest extends AbstractSchemaRegionTest {
             "root.sg.wf02.s2");
 
     // check fetch schema
-    ClusterSchemaTree schemaTree = schemaRegion.fetchSchema(ALL_MATCH_SCOPE, templateMap, true);
+    ClusterSchemaTree schemaTree =
+        schemaRegion.fetchSchema(ALL_MATCH_SCOPE, templateMap, true, true);
     schemaTree.setTemplateMap(templateMap);
     List<MeasurementPath> schemas = schemaTree.searchMeasurementPaths(ALL_MATCH_PATTERN).left;
     Assert.assertEquals(expectedTimeseries.size(), schemas.size());
@@ -258,7 +259,7 @@ public class SchemaRegionTemplateTest extends AbstractSchemaRegionTest {
 
     ClusterSchemaTree schemaTree =
         schemaRegion.fetchSchema(
-            patternTree, Collections.singletonMap(templateId, template), false);
+            patternTree, Collections.singletonMap(templateId, template), false, true);
     schemaTree.setTemplateMap(Collections.singletonMap(templateId, template));
     Assert.assertEquals(
         1, schemaTree.searchMeasurementPaths(new PartialPath("root.db.d1.s1")).left.size());
@@ -266,7 +267,7 @@ public class SchemaRegionTemplateTest extends AbstractSchemaRegionTest {
     patternTree.appendFullPath(new PartialPath("root.db.d1.s3"));
     schemaTree =
         schemaRegion.fetchSchema(
-            patternTree, Collections.singletonMap(templateId, template), false);
+            patternTree, Collections.singletonMap(templateId, template), false, true);
     schemaTree.setTemplateMap(Collections.singletonMap(templateId, template));
     Assert.assertEquals(
         0, schemaTree.searchMeasurementPaths(new PartialPath("root.db.d1.s3")).left.size());

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OperatorMemoryTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OperatorMemoryTest.java
@@ -830,7 +830,13 @@ public class OperatorMemoryTest {
 
       SchemaFetchScanOperator operator =
           new SchemaFetchScanOperator(
-              planNodeId, driverContext.getOperatorContexts().get(0), null, null, null, false);
+              planNodeId,
+              driverContext.getOperatorContexts().get(0),
+              null,
+              null,
+              null,
+              false,
+              false);
 
       assertEquals(DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES, operator.calculateMaxPeekMemory());
       assertEquals(DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES, operator.calculateMaxReturnSize());

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/schema/SchemaFetchScanOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/schema/SchemaFetchScanOperatorTest.java
@@ -60,7 +60,7 @@ public class SchemaFetchScanOperatorTest {
 
     SchemaFetchScanOperator schemaFetchScanOperator =
         new SchemaFetchScanOperator(
-            null, null, patternTree, Collections.emptyMap(), schemaRegion, false);
+            null, null, patternTree, Collections.emptyMap(), schemaRegion, false, true);
 
     Assert.assertTrue(schemaFetchScanOperator.hasNext());
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/schema/SchemaFetchScanOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/schema/SchemaFetchScanOperatorTest.java
@@ -151,7 +151,7 @@ public class SchemaFetchScanOperatorTest {
     patternTree.appendPathPattern(new PartialPath("root.**.status"));
     patternTree.appendPathPattern(new PartialPath("root.**.s1"));
     patternTree.constructTree();
-    Mockito.when(schemaRegion.fetchSchema(patternTree, Collections.emptyMap(), false))
+    Mockito.when(schemaRegion.fetchSchema(patternTree, Collections.emptyMap(), false, true))
         .thenReturn(clusterSchemaTree);
 
     return schemaRegion;

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/analyze/ExpressionAnalyzerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/analyze/ExpressionAnalyzerTest.java
@@ -42,7 +42,7 @@ public class ExpressionAnalyzerTest {
   @Test
   public void testRemoveWildcardInFilter() throws IllegalPathException {
     ISchemaTree fakeSchemaTree =
-        new FakeSchemaFetcherImpl().fetchSchema(new PathPatternTree(), null);
+        new FakeSchemaFetcherImpl().fetchSchema(new PathPatternTree(), true, null);
     List<PartialPath> prefixPaths = Arrays.asList(path("root.sg.d1"), path("root.sg.d2"));
 
     assertEquals(

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/analyze/FakeSchemaFetcherImpl.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/analyze/FakeSchemaFetcherImpl.java
@@ -46,14 +46,16 @@ public class FakeSchemaFetcherImpl implements ISchemaFetcher {
   private final ClusterSchemaTree schemaTree = new ClusterSchemaTree(generateSchemaTree());
 
   @Override
-  public ClusterSchemaTree fetchSchema(PathPatternTree patternTree, MPPQueryContext context) {
+  public ClusterSchemaTree fetchSchema(
+      PathPatternTree patternTree, boolean withTemplate, MPPQueryContext context) {
     schemaTree.setDatabases(Collections.singleton("root.sg"));
     return schemaTree;
   }
 
   @Override
-  public ISchemaTree fetchSchemaWithTags(PathPatternTree patternTree, MPPQueryContext context) {
-    return fetchSchema(patternTree, context);
+  public ISchemaTree fetchSchemaWithTags(
+      PathPatternTree patternTree, boolean withTemplate, MPPQueryContext context) {
+    return fetchSchema(patternTree, withTemplate, context);
   }
 
   @Override

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/plan/distribution/Util.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/plan/distribution/Util.java
@@ -300,12 +300,14 @@ public class Util {
   private static ISchemaFetcher getFakeSchemaFetcher() {
     return new ISchemaFetcher() {
       @Override
-      public ISchemaTree fetchSchema(PathPatternTree patternTree, MPPQueryContext context) {
+      public ISchemaTree fetchSchema(
+          PathPatternTree patternTree, boolean withTemplate, MPPQueryContext context) {
         return ANALYSIS.getSchemaTree();
       }
 
       @Override
-      public ISchemaTree fetchSchemaWithTags(PathPatternTree patternTree, MPPQueryContext context) {
+      public ISchemaTree fetchSchemaWithTags(
+          PathPatternTree patternTree, boolean withTemplate, MPPQueryContext context) {
         return ANALYSIS.getSchemaTree();
       }
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/plan/distribution/Util2.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/plan/distribution/Util2.java
@@ -194,12 +194,14 @@ public class Util2 {
   private static ISchemaFetcher getFakeSchemaFetcher() {
     return new ISchemaFetcher() {
       @Override
-      public ISchemaTree fetchSchema(PathPatternTree patternTree, MPPQueryContext context) {
+      public ISchemaTree fetchSchema(
+          PathPatternTree patternTree, boolean withTemplate, MPPQueryContext context) {
         return ANALYSIS.getSchemaTree();
       }
 
       @Override
-      public ISchemaTree fetchSchemaWithTags(PathPatternTree patternTree, MPPQueryContext context) {
+      public ISchemaTree fetchSchemaWithTags(
+          PathPatternTree patternTree, boolean withTemplate, MPPQueryContext context) {
         return ANALYSIS.getSchemaTree();
       }
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/plan/node/metadata/read/SchemaFetchMergeNodeTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/plan/node/metadata/read/SchemaFetchMergeNodeTest.java
@@ -48,6 +48,7 @@ public class SchemaFetchMergeNodeTest {
             new PartialPath("root.sg"),
             patternTree,
             Collections.emptyMap(),
+            true,
             true);
     schemaFetchMergeNode.addChild(schemaFetchScanNode);
     ByteBuffer byteBuffer = ByteBuffer.allocate(1024 * 1024);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/plan/node/metadata/read/SchemaFetchScanNodeTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/plan/node/metadata/read/SchemaFetchScanNodeTest.java
@@ -44,6 +44,7 @@ public class SchemaFetchScanNodeTest {
             new PartialPath("root.sg"),
             patternTree,
             Collections.emptyMap(),
+            true,
             true);
     ByteBuffer byteBuffer = ByteBuffer.allocate(1024 * 1024);
     schemaFetchScanNode.serialize(byteBuffer);
@@ -53,5 +54,6 @@ public class SchemaFetchScanNodeTest {
     Assert.assertEquals(
         "root.sg.**.*", recoveredNode.getPatternTree().getAllPathPatterns().get(0).getFullPath());
     Assert.assertTrue(recoveredNode.isWithTags());
+    Assert.assertTrue(recoveredNode.isWithTemplate());
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTree.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTree.java
@@ -46,6 +46,7 @@ public class PathPatternTree {
   // set the default value to TRUE to ensure correctness
   private boolean useWildcard = true;
   private boolean containWildcard = false;
+  private boolean containFullPath = false;
 
   public PathPatternTree(boolean useWildcard) {
     this();
@@ -59,6 +60,10 @@ public class PathPatternTree {
 
   public boolean isContainWildcard() {
     return containWildcard;
+  }
+
+  public boolean isContainFullPath() {
+    return containFullPath;
   }
 
   public PathPatternNode<Void, VoidSerializer> getRoot() {
@@ -148,6 +153,9 @@ public class PathPatternTree {
   private void processNodeName(String nodeName) {
     if (!containWildcard) {
       containWildcard = PathPatternUtil.hasWildcard(nodeName);
+    }
+    if (!containFullPath) {
+      containFullPath = !PathPatternUtil.hasWildcard(nodeName);
     }
   }
 


### PR DESCRIPTION
## Description

This PR fix some query bugs with authority:

1. Query pure template series with partitial authority.
<img width="962" alt="image" src="https://github.com/apache/iotdb/assets/43774645/baef6ef2-f862-400d-8b4c-32d776f187e3">
<img width="678" alt="image" src="https://github.com/apache/iotdb/assets/43774645/d3b076cf-0842-4556-8580-3dbea0369a8d">

2. Query view series without origin time series read authority.
<img width="966" alt="image" src="https://github.com/apache/iotdb/assets/43774645/d28178e2-27b9-4cd6-97ef-d05574fed82d">
<img width="798" alt="image" src="https://github.com/apache/iotdb/assets/43774645/f80d017c-84b8-4366-9e1a-677e42e2affc">


For implementation, I removed the authorityScope field from the ClusterSchemaTree for better maintenance. To avoid redundant measurement when ClusterSchemaTree uses templates, the query engine will determine whether to fetch schema with template by `authorityScope`.
```java
// If the authority scope of query statement contains full path, we should fetch schema
// without template. Otherwise, the result ISchemaTree may contain template series that is
// not authorized to access.
boolean allWildcardLeaf = !authorizedPatternTree.isContainFullPath() && authorizedPatternTree.isContainWildcard();
```
If allWildcardLeaf is true, the result ClusterSchemaTree must not contain redundant measurement.