### PR TITLE
Adjust series_partition_slot_num to series_slot_num in the response message

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -1089,7 +1089,7 @@ public class ConfigManager implements IManager {
     }
 
     if (clusterParameters.getSeriesPartitionSlotNum() != CONF.getSeriesSlotNum()) {
-      return errorStatus.setMessage(errorPrefix + "series_partition_slot_num" + errorSuffix);
+      return errorStatus.setMessage(errorPrefix + "series_slot_num" + errorSuffix);
     }
     if (!clusterParameters
         .getSeriesPartitionExecutorClass()


### PR DESCRIPTION
The series_partition_slot_num parameter has been replaced by series_slot_num, and the error message needs to be updated