### PR TITLE
Optimizing the Binary comparison method in CompareBinaryColumnTransformer

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceContext.java
@@ -417,6 +417,7 @@ public class FragmentInstanceContext extends QueryContext {
         allDriversClosed.await();
         break;
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         LOGGER.warn(
             "Interrupted when await on allDriversClosed, FragmentInstance Id is {}", this.getId());
       }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/binary/CompareBinaryColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/binary/CompareBinaryColumnTransformer.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.queryengine.transformation.dag.column.binary;
 
 import org.apache.iotdb.db.queryengine.transformation.dag.column.ColumnTransformer;
+import org.apache.iotdb.db.queryengine.transformation.dag.util.TransformUtils;
 import org.apache.iotdb.tsfile.read.common.block.column.Column;
 import org.apache.iotdb.tsfile.read.common.block.column.ColumnBuilder;
 import org.apache.iotdb.tsfile.read.common.block.column.RunLengthEncodedColumn;
@@ -50,10 +51,9 @@ public abstract class CompareBinaryColumnTransformer extends BinaryColumnTransfo
         if (TypeEnum.BINARY.equals(leftTransformer.getType().getTypeEnum())) {
           flag =
               transform(
-                  leftTransformer
-                      .getType()
-                      .getBinary(leftColumn, i)
-                      .compareTo(rightTransformer.getType().getBinary(rightColumn, i)));
+                  TransformUtils.compare(
+                      leftTransformer.getType().getBinary(leftColumn, i),
+                      rightTransformer.getType().getBinary(rightColumn, i)));
         } else if (TypeEnum.BOOLEAN.equals(leftTransformer.getType().getTypeEnum())) {
           flag =
               transform(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/binary/CompareBinaryColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/binary/CompareBinaryColumnTransformer.java
@@ -36,7 +36,8 @@ public abstract class CompareBinaryColumnTransformer extends BinaryColumnTransfo
   @Override
   protected void doTransform(
       Column leftColumn, Column rightColumn, ColumnBuilder builder, int positionCount) {
-    // if either column is all null, append nullCount
+    // if either column is all null, append nullCount. For now, a RunLengthEncodeColumn with
+    // mayHaveNull == true is all null
     if ((leftColumn.mayHaveNull() && leftColumn instanceof RunLengthEncodedColumn)
         || (rightColumn.mayHaveNull() && rightColumn instanceof RunLengthEncodedColumn)) {
       builder.appendNull(positionCount);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/ternary/BetweenColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/ternary/BetweenColumnTransformer.java
@@ -21,7 +21,6 @@ package org.apache.iotdb.db.queryengine.transformation.dag.column.ternary;
 
 import org.apache.iotdb.db.queryengine.transformation.dag.column.ColumnTransformer;
 import org.apache.iotdb.db.queryengine.transformation.dag.util.TransformUtils;
-import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 import org.apache.iotdb.tsfile.read.common.block.column.Column;
 import org.apache.iotdb.tsfile.read.common.block.column.ColumnBuilder;
 import org.apache.iotdb.tsfile.read.common.type.BinaryType;
@@ -53,24 +52,12 @@ public class BetweenColumnTransformer extends CompareTernaryColumnTransformer {
         if (firstColumnTransformer.getType() instanceof BinaryType) {
           flag =
               ((TransformUtils.compare(
-                              firstColumnTransformer
-                                  .getType()
-                                  .getBinary(firstColumn, i)
-                                  .getStringValue(TSFileConfig.STRING_CHARSET),
-                              secondColumnTransformer
-                                  .getType()
-                                  .getBinary(secondColumn, i)
-                                  .getStringValue(TSFileConfig.STRING_CHARSET))
+                              firstColumnTransformer.getType().getBinary(firstColumn, i),
+                              secondColumnTransformer.getType().getBinary(secondColumn, i))
                           >= 0)
                       && (TransformUtils.compare(
-                              firstColumnTransformer
-                                  .getType()
-                                  .getBinary(firstColumn, i)
-                                  .getStringValue(TSFileConfig.STRING_CHARSET),
-                              thirdColumnTransformer
-                                  .getType()
-                                  .getBinary(thirdColumn, i)
-                                  .getStringValue(TSFileConfig.STRING_CHARSET))
+                              firstColumnTransformer.getType().getBinary(firstColumn, i),
+                              thirdColumnTransformer.getType().getBinary(thirdColumn, i))
                           <= 0))
                   ^ isNotBetween;
         } else {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/binary/CompareEqualToTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/binary/CompareEqualToTransformer.java
@@ -21,7 +21,6 @@ package org.apache.iotdb.db.queryengine.transformation.dag.transformer.binary;
 
 import org.apache.iotdb.db.queryengine.transformation.api.LayerPointReader;
 import org.apache.iotdb.db.queryengine.transformation.dag.util.TransformUtils;
-import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 
 public class CompareEqualToTransformer extends CompareBinaryTransformer {
 
@@ -42,9 +41,7 @@ public class CompareEqualToTransformer extends CompareBinaryTransformer {
   @Override
   protected Evaluator constructTextEvaluator() {
     return () ->
-        TransformUtils.compare(
-                leftPointReader.currentBinary().getStringValue(TSFileConfig.STRING_CHARSET),
-                rightPointReader.currentBinary().getStringValue(TSFileConfig.STRING_CHARSET))
+        TransformUtils.compare(leftPointReader.currentBinary(), rightPointReader.currentBinary())
             == 0;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/binary/CompareGreaterEqualTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/binary/CompareGreaterEqualTransformer.java
@@ -21,7 +21,6 @@ package org.apache.iotdb.db.queryengine.transformation.dag.transformer.binary;
 
 import org.apache.iotdb.db.queryengine.transformation.api.LayerPointReader;
 import org.apache.iotdb.db.queryengine.transformation.dag.util.TransformUtils;
-import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 
 public class CompareGreaterEqualTransformer extends CompareBinaryTransformer {
 
@@ -42,9 +41,7 @@ public class CompareGreaterEqualTransformer extends CompareBinaryTransformer {
   @Override
   protected Evaluator constructTextEvaluator() {
     return () ->
-        TransformUtils.compare(
-                leftPointReader.currentBinary().getStringValue(TSFileConfig.STRING_CHARSET),
-                rightPointReader.currentBinary().getStringValue(TSFileConfig.STRING_CHARSET))
+        TransformUtils.compare(leftPointReader.currentBinary(), rightPointReader.currentBinary())
             >= 0;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/binary/CompareGreaterThanTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/binary/CompareGreaterThanTransformer.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.queryengine.transformation.dag.transformer.binary;
 
 import org.apache.iotdb.db.queryengine.transformation.api.LayerPointReader;
+import org.apache.iotdb.db.queryengine.transformation.dag.util.TransformUtils;
 
 public class CompareGreaterThanTransformer extends CompareBinaryTransformer {
 
@@ -39,6 +40,8 @@ public class CompareGreaterThanTransformer extends CompareBinaryTransformer {
 
   @Override
   protected Evaluator constructTextEvaluator() {
-    return () -> leftPointReader.currentBinary().compareTo(rightPointReader.currentBinary()) > 0;
+    return () ->
+        TransformUtils.compare(leftPointReader.currentBinary(), rightPointReader.currentBinary())
+            > 0;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/binary/CompareGreaterThanTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/binary/CompareGreaterThanTransformer.java
@@ -20,8 +20,6 @@
 package org.apache.iotdb.db.queryengine.transformation.dag.transformer.binary;
 
 import org.apache.iotdb.db.queryengine.transformation.api.LayerPointReader;
-import org.apache.iotdb.db.queryengine.transformation.dag.util.TransformUtils;
-import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 
 public class CompareGreaterThanTransformer extends CompareBinaryTransformer {
 
@@ -41,10 +39,6 @@ public class CompareGreaterThanTransformer extends CompareBinaryTransformer {
 
   @Override
   protected Evaluator constructTextEvaluator() {
-    return () ->
-        TransformUtils.compare(
-                leftPointReader.currentBinary().getStringValue(TSFileConfig.STRING_CHARSET),
-                rightPointReader.currentBinary().getStringValue(TSFileConfig.STRING_CHARSET))
-            > 0;
+    return () -> leftPointReader.currentBinary().compareTo(rightPointReader.currentBinary()) > 0;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/binary/CompareLessEqualTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/binary/CompareLessEqualTransformer.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.queryengine.transformation.dag.transformer.binary;
 
 import org.apache.iotdb.db.queryengine.transformation.api.LayerPointReader;
+import org.apache.iotdb.db.queryengine.transformation.dag.util.TransformUtils;
 
 public class CompareLessEqualTransformer extends CompareBinaryTransformer {
 
@@ -39,6 +40,8 @@ public class CompareLessEqualTransformer extends CompareBinaryTransformer {
 
   @Override
   protected Evaluator constructTextEvaluator() {
-    return () -> leftPointReader.currentBinary().compareTo(rightPointReader.currentBinary()) <= 0;
+    return () ->
+        TransformUtils.compare(leftPointReader.currentBinary(), rightPointReader.currentBinary())
+            <= 0;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/binary/CompareLessEqualTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/binary/CompareLessEqualTransformer.java
@@ -20,8 +20,6 @@
 package org.apache.iotdb.db.queryengine.transformation.dag.transformer.binary;
 
 import org.apache.iotdb.db.queryengine.transformation.api.LayerPointReader;
-import org.apache.iotdb.db.queryengine.transformation.dag.util.TransformUtils;
-import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 
 public class CompareLessEqualTransformer extends CompareBinaryTransformer {
 
@@ -41,10 +39,6 @@ public class CompareLessEqualTransformer extends CompareBinaryTransformer {
 
   @Override
   protected Evaluator constructTextEvaluator() {
-    return () ->
-        TransformUtils.compare(
-                leftPointReader.currentBinary().getStringValue(TSFileConfig.STRING_CHARSET),
-                rightPointReader.currentBinary().getStringValue(TSFileConfig.STRING_CHARSET))
-            <= 0;
+    return () -> leftPointReader.currentBinary().compareTo(rightPointReader.currentBinary()) <= 0;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/binary/CompareLessThanTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/binary/CompareLessThanTransformer.java
@@ -21,7 +21,6 @@ package org.apache.iotdb.db.queryengine.transformation.dag.transformer.binary;
 
 import org.apache.iotdb.db.queryengine.transformation.api.LayerPointReader;
 import org.apache.iotdb.db.queryengine.transformation.dag.util.TransformUtils;
-import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 
 public class CompareLessThanTransformer extends CompareBinaryTransformer {
 
@@ -42,9 +41,7 @@ public class CompareLessThanTransformer extends CompareBinaryTransformer {
   @Override
   protected Evaluator constructTextEvaluator() {
     return () ->
-        TransformUtils.compare(
-                leftPointReader.currentBinary().getStringValue(TSFileConfig.STRING_CHARSET),
-                rightPointReader.currentBinary().getStringValue(TSFileConfig.STRING_CHARSET))
+        TransformUtils.compare(leftPointReader.currentBinary(), rightPointReader.currentBinary())
             < 0;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/binary/CompareNonEqualTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/binary/CompareNonEqualTransformer.java
@@ -21,7 +21,6 @@ package org.apache.iotdb.db.queryengine.transformation.dag.transformer.binary;
 
 import org.apache.iotdb.db.queryengine.transformation.api.LayerPointReader;
 import org.apache.iotdb.db.queryengine.transformation.dag.util.TransformUtils;
-import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 import org.apache.iotdb.tsfile.exception.write.UnSupportedDataTypeException;
 
 public class CompareNonEqualTransformer extends CompareBinaryTransformer {
@@ -44,9 +43,7 @@ public class CompareNonEqualTransformer extends CompareBinaryTransformer {
   @Override
   protected Evaluator constructTextEvaluator() {
     return () ->
-        TransformUtils.compare(
-                leftPointReader.currentBinary().getStringValue(TSFileConfig.STRING_CHARSET),
-                rightPointReader.currentBinary().getStringValue(TSFileConfig.STRING_CHARSET))
+        TransformUtils.compare(leftPointReader.currentBinary(), rightPointReader.currentBinary())
             != 0;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/ternary/BetweenTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/ternary/BetweenTransformer.java
@@ -23,7 +23,6 @@ package org.apache.iotdb.db.queryengine.transformation.dag.transformer.ternary;
 
 import org.apache.iotdb.db.queryengine.transformation.api.LayerPointReader;
 import org.apache.iotdb.db.queryengine.transformation.dag.util.TransformUtils;
-import org.apache.iotdb.tsfile.common.conf.TSFileConfig;
 
 public class BetweenTransformer extends CompareTernaryTransformer {
 
@@ -57,20 +56,10 @@ public class BetweenTransformer extends CompareTernaryTransformer {
   protected Evaluator constructTextEvaluator() {
     return () ->
         ((TransformUtils.compare(
-                        firstPointReader
-                            .currentBinary()
-                            .getStringValue(TSFileConfig.STRING_CHARSET),
-                        secondPointReader
-                            .currentBinary()
-                            .getStringValue(TSFileConfig.STRING_CHARSET))
+                        firstPointReader.currentBinary(), secondPointReader.currentBinary())
                     >= 0)
                 && (TransformUtils.compare(
-                        firstPointReader
-                            .currentBinary()
-                            .getStringValue(TSFileConfig.STRING_CHARSET),
-                        thirdPointReader
-                            .currentBinary()
-                            .getStringValue(TSFileConfig.STRING_CHARSET))
+                        firstPointReader.currentBinary(), thirdPointReader.currentBinary())
                     <= 0))
             ^ isNotBetween;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/util/TransformUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/util/TransformUtils.java
@@ -35,8 +35,6 @@ import org.apache.iotdb.tsfile.read.common.block.column.IntColumn;
 import org.apache.iotdb.tsfile.read.common.block.column.LongColumn;
 import org.apache.iotdb.tsfile.utils.Binary;
 
-import org.apache.commons.lang3.Validate;
-
 import java.io.IOException;
 import java.util.Objects;
 import java.util.Optional;
@@ -47,28 +45,16 @@ public class TransformUtils {
     throw new IllegalStateException("TransformUtils should not be instantiated.");
   }
 
-  public static int compare(CharSequence cs1, CharSequence cs2) {
-    if (Objects.requireNonNull(cs1) == Objects.requireNonNull(cs2)) {
+  public static int compare(Binary first, Binary second) {
+    if (Objects.requireNonNull(first) == Objects.requireNonNull(second)) {
       return 0;
     }
 
-    if (cs1.getClass() == cs2.getClass() && cs1 instanceof Comparable) {
-      return ((Comparable<Object>) cs1).compareTo(cs2);
-    }
-
-    for (int i = 0, len = Math.min(cs1.length(), cs2.length()); i < len; i++) {
-      char a = cs1.charAt(i);
-      char b = cs2.charAt(i);
-      if (a != b) {
-        return a - b;
-      }
-    }
-
-    return cs1.length() - cs2.length();
+    return first.compareTo(second);
   }
 
   public static Column transformConstantOperandToColumn(ConstantOperand constantOperand) {
-    Validate.notNull(constantOperand);
+    Objects.requireNonNull(constantOperand);
 
     try {
       Object value =
@@ -169,7 +155,8 @@ public class TransformUtils {
         }
         break;
       default:
-        throw new RuntimeException("The data type of the state window strategy is not valid.");
+        throw new UnsupportedOperationException(
+            "The data type of the state window strategy is not valid.");
     }
     return res;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/util/TransformUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/util/TransformUtils.java
@@ -80,21 +80,17 @@ public class TransformUtils {
 
       switch (constantOperand.getDataType()) {
         case INT32:
-          return new IntColumn(1, Optional.of(new boolean[] {false}), new int[] {(int) value});
+          return new IntColumn(1, Optional.empty(), new int[] {(int) value});
         case INT64:
-          return new LongColumn(1, Optional.of(new boolean[] {false}), new long[] {(long) value});
+          return new LongColumn(1, Optional.empty(), new long[] {(long) value});
         case FLOAT:
-          return new FloatColumn(
-              1, Optional.of(new boolean[] {false}), new float[] {(float) value});
+          return new FloatColumn(1, Optional.empty(), new float[] {(float) value});
         case DOUBLE:
-          return new DoubleColumn(
-              1, Optional.of(new boolean[] {false}), new double[] {(double) value});
+          return new DoubleColumn(1, Optional.empty(), new double[] {(double) value});
         case TEXT:
-          return new BinaryColumn(
-              1, Optional.of(new boolean[] {false}), new Binary[] {(Binary) value});
+          return new BinaryColumn(1, Optional.empty(), new Binary[] {(Binary) value});
         case BOOLEAN:
-          return new BooleanColumn(
-              1, Optional.of(new boolean[] {false}), new boolean[] {(boolean) value});
+          return new BooleanColumn(1, Optional.empty(), new boolean[] {(boolean) value});
         default:
           throw new UnSupportedDataTypeException(
               "Unsupported type: " + constantOperand.getDataType());


### PR DESCRIPTION
Related doc: https://apache-iotdb.feishu.cn/docx/VjxMd1BdHotEeIxHzsxc382Jnec
Simply put, this PR avoids unnecessary creation of String objects when comparing Binary types, and ceases computation when encountering an entirely empty column.
Before this PR, doTransform occupied 18.6% of the execution time：
<img width="1203" alt="截屏2023-11-28 15 59 22" src="https://github.com/apache/iotdb/assets/108499334/a0c36687-22b1-4414-b2f1-84885495c31f">
After this PR, doTransform occupied 13.1% of the execution time：
<img width="1217" alt="截屏2023-11-28 16 00 43" src="https://github.com/apache/iotdb/assets/108499334/8232097d-07e9-4901-b38e-5da1a2edac92">
