### PR TITLE
Fix compaction UTs and add concurrency control when schedule compaction

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -2158,12 +2158,15 @@ public class DataRegion implements IDataRegionForQuery {
       // be
       // evicted due to the low priority of the task
       try {
+        CompactionScheduler.lockCompactionSelection();
         for (long timePartition : timePartitions) {
           trySubmitCount +=
               CompactionScheduler.scheduleCompaction(tsFileManager, timePartition, summary);
         }
       } catch (Throwable e) {
         logger.error("Meet error in compaction schedule.", e);
+      } finally {
+        CompactionScheduler.unlockCompactionSelection();
       }
     }
     if (summary.hasSubmitTask()) {
@@ -2185,6 +2188,7 @@ public class DataRegion implements IDataRegionForQuery {
   protected int executeInsertionCompaction(List<Long> timePartitions) {
     int trySubmitCount = 0;
     try {
+      CompactionScheduler.lockCompactionSelection();
       while (true) {
         int currentSubmitCount = 0;
         Phaser insertionTaskPhaser = new Phaser(1);
@@ -2202,6 +2206,8 @@ public class DataRegion implements IDataRegionForQuery {
       }
     } catch (Throwable e) {
       logger.error("Meet error in compaction schedule.", e);
+    } finally {
+      CompactionScheduler.unlockCompactionSelection();
     }
     return trySubmitCount;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -2157,8 +2157,8 @@ public class DataRegion implements IDataRegionForQuery {
       // the name of this variable is trySubmitCount, because the task submitted to the queue could
       // be
       // evicted due to the low priority of the task
+      CompactionScheduler.lockCompactionSelection();
       try {
-        CompactionScheduler.lockCompactionSelection();
         for (long timePartition : timePartitions) {
           trySubmitCount +=
               CompactionScheduler.scheduleCompaction(tsFileManager, timePartition, summary);
@@ -2187,8 +2187,8 @@ public class DataRegion implements IDataRegionForQuery {
 
   protected int executeInsertionCompaction(List<Long> timePartitions) {
     int trySubmitCount = 0;
+    CompactionScheduler.lockCompactionSelection();
     try {
-      CompactionScheduler.lockCompactionSelection();
       while (true) {
         int currentSubmitCount = 0;
         Phaser insertionTaskPhaser = new Phaser(1);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/schedule/CompactionScheduler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/schedule/CompactionScheduler.java
@@ -40,6 +40,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.concurrent.Phaser;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 /**
@@ -58,6 +60,17 @@ public class CompactionScheduler {
   private static IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
 
   private CompactionScheduler() {}
+
+  /** avoid timed compaction schedule conflict with manually triggered schedule */
+  private static final Lock compactionTaskSelectionLock = new ReentrantLock();
+
+  public static void lockCompactionSelection() {
+    compactionTaskSelectionLock.lock();
+  }
+
+  public static void unlockCompactionSelection() {
+    compactionTaskSelectionLock.unlock();
+  }
 
   /**
    * Select compaction task and submit them to CompactionTaskManager.

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/settle/SettleRequestHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/settle/SettleRequestHandler.java
@@ -29,6 +29,7 @@ import org.apache.iotdb.db.storageengine.dataregion.DataRegion;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.performer.ICompactionPerformer;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.task.AbstractCompactionTask;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.task.InnerSpaceCompactionTask;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.schedule.CompactionScheduler;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.schedule.CompactionTaskManager;
 import org.apache.iotdb.db.storageengine.dataregion.modification.ModificationFile;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileManager;
@@ -73,16 +74,21 @@ public class SettleRequestHandler {
   public TSStatus handleSettleRequest(TSettleReq req) {
     List<String> paths = req.getPaths();
 
-    SettleRequestContext context = new SettleRequestContext(paths);
-    TSStatus validationResult = context.validate();
-    if (validationResult.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
-      return validationResult;
+    try {
+      CompactionScheduler.lockCompactionSelection();
+      SettleRequestContext context = new SettleRequestContext(paths);
+      TSStatus validationResult = context.validate();
+      if (validationResult.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+        return validationResult;
+      }
+      if (testMode) {
+        return RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS);
+      }
+      List<TsFileResource> selectedTsFileResources = context.getTsFileResourcesByFileNames();
+      return context.submitCompactionTask(selectedTsFileResources);
+    } finally {
+      CompactionScheduler.unlockCompactionSelection();
     }
-    if (testMode) {
-      return RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS);
-    }
-    List<TsFileResource> selectedTsFileResources = context.getTsFileResourcesByFileNames();
-    return context.submitCompactionTask(selectedTsFileResources);
   }
 
   private static class SettleRequestContext {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/settle/SettleRequestHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/settle/SettleRequestHandler.java
@@ -74,8 +74,8 @@ public class SettleRequestHandler {
   public TSStatus handleSettleRequest(TSettleReq req) {
     List<String> paths = req.getPaths();
 
+    CompactionScheduler.lockCompactionSelection();
     try {
-      CompactionScheduler.lockCompactionSelection();
       SettleRequestContext context = new SettleRequestContext(paths);
       TSStatus validationResult = context.validate();
       if (validationResult.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/CompactionSchedulerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/CompactionSchedulerTest.java
@@ -1816,7 +1816,7 @@ public class CompactionSchedulerTest {
         }
         Thread.sleep(100);
         sleepTime += 100;
-        if (sleepTime >= 400_000) {
+        if (sleepTime >= 200_000) {
           fail();
         }
       }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/CompactionSchedulerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/CompactionSchedulerTest.java
@@ -1796,7 +1796,7 @@ public class CompactionSchedulerTest {
         CompactionScheduler.scheduleCompaction(tsFileManager, 0);
         Thread.sleep(100);
         sleepTime += 100;
-        if (sleepTime >= 20_000) {
+        if (sleepTime >= 40_000) {
           fail();
         }
       }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/CompactionSchedulerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/CompactionSchedulerTest.java
@@ -37,6 +37,7 @@ import org.apache.iotdb.db.storageengine.dataregion.compaction.utils.CompactionC
 import org.apache.iotdb.db.storageengine.dataregion.compaction.utils.CompactionFileGeneratorUtils;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileManager;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
+import org.apache.iotdb.db.storageengine.dataregion.tsfile.generator.TsFileNameGenerator;
 import org.apache.iotdb.db.storageengine.rescon.memory.SystemInfo;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.db.utils.constant.TestConstant;
@@ -1792,18 +1793,36 @@ public class CompactionSchedulerTest {
       CompactionScheduler.scheduleCompaction(tsFileManager, 0);
       Thread.sleep(100);
       long sleepTime = 0;
-      while (tsFileManager.getTsFileList(true).size() > 3) {
+      while (tsFileManager.getTsFileList(true).size() >= 2) {
         CompactionScheduler.scheduleCompaction(tsFileManager, 0);
+        tsFileManager.readLock();
+        List<TsFileResource> resources = tsFileManager.getTsFileList(true);
+        int previousFileLevel =
+            TsFileNameGenerator.getTsFileName(resources.get(0).getTsFile().getName())
+                .getInnerCompactionCnt();
+        boolean canMerge = false;
+        for (int i = 1; i < resources.size(); i++) {
+          int currentFileLevel =
+              TsFileNameGenerator.getTsFileName(resources.get(i).getTsFile().getName())
+                  .getInnerCompactionCnt();
+          if (currentFileLevel == previousFileLevel) {
+            canMerge = true;
+            break;
+          }
+        }
+        tsFileManager.readUnlock();
+        if (!canMerge) {
+          break;
+        }
         Thread.sleep(100);
         sleepTime += 100;
-        if (sleepTime >= 40_000) {
+        if (sleepTime >= 400_000) {
           fail();
         }
       }
 
       stopCompactionTaskManager();
       tsFileManager.setAllowCompaction(false);
-      assertEquals(3, tsFileManager.getTsFileList(true).size());
     } finally {
       IoTDBDescriptor.getInstance()
           .getConfig()


### PR DESCRIPTION
## Description
1. Fix UT CompactionSchdulerTest.testLargeFileInLowerLevel
2. Add concurrency control when schedule compaction to avoid conflict from timed compaction schdule and manually triggeered compaction schdule
