### PR TITLE
Fix inner compaction select task base on mod file

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/impl/SizeTieredCompactionSelector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/impl/SizeTieredCompactionSelector.java
@@ -196,6 +196,9 @@ public class SizeTieredCompactionSelector
       if (Objects.isNull(modFile) || !modFile.exists()) {
         continue;
       }
+      if (tsFileResource.getStatus() != TsFileResourceStatus.NORMAL) {
+        continue;
+      }
       if (modFile.getSize() > MODS_FILE_SIZE_THRESHOLD
           || !CompactionUtils.isDiskHasSpace(DISK_REDUNDANCY)) {
         taskList.add(


### PR DESCRIPTION
## Description
Fix a bug that the TsFileResource whose status is not NORMAL may be selected by selectTaskBaseOnModFile.
Though a tsfile with a mods file whose size is larger than 50M has been selected into a CompactionTask (or other status: COMPACTING, DELETED), it may selected as  candidate of another compaction task by 'selectTaskBaseOnModFile'.
