### PR TITLE
Fix the error when last query non-writble view with same sensors

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
@@ -475,7 +475,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
           }
           List<Expression> sourceExpressionsOfNonWritableView =
               searchSourceExpressions(lastQuerySourceExpression);
-          lastQueryNonWritableViewSourceExpressionMap.put(
+          lastQueryNonWritableViewSourceExpressionMap.putIfAbsent(
               lastQuerySourceExpression, sourceExpressionsOfNonWritableView);
           sourceExpressions.addAll(sourceExpressionsOfNonWritableView);
         }


### PR DESCRIPTION
## Description

see [TIMECHODB-467]

Before fix, the sqls below will throw npe.
`create timeseries root.db.t1.s1 with dataType=BOOLEAN;
create timeseries root.db.t1.s2 with dataType=INT32;
create timeseries root.db.t1.s3 with dataType=INT64;
create timeseries root.db.t1.s4 with dataType=FLOAT;
create timeseries root.db.t1.s5 with dataType=DOUBLE;
create timeseries root.db.t1.s6 with dataType=TEXT;

create aligned timeseries root.db.t2(s11 boolean encoding=PLAIN compressor=lz4,s12 INT32 encoding=TS_2DIFF compressor=SNAPPY,s13 INT64 encoding=GORILLA compressor=LZ4,s14 FLOAT encoding=RLE compressor=SNAPPY,s15 DOUBLE encoding=GORILLA compressor=LZ4,s16 TEXT encoding=DICTIONARY compressor=SNAPPY);

insert into root.db.t1(time,s1,s2,s3,s4,s5,s6) values(1,true,1,1,1.2,1.3,'hi');
insert into root.db.t2(time,s11,s12,s13,s14,s15,s16) values(1,false,2,2,2.2,2.3,',lily');

create view root.db.v1(c1,c2,c3,c4,c5,c6) as select s1&&s11,s2+s12,s3+s13,cast(s4+s14 as float),cast(s15-s5 as int32),concat(s6,s16) from root.db.t1,root.db.t2;

select last c2,c2 from root.db.v1;`