### PR TITLE
Fix tsfile counted twice in TsFileMetrics

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/metrics/file/TsFileMetrics.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/metrics/file/TsFileMetrics.java
@@ -366,7 +366,7 @@ public class TsFileMetrics implements IMetricSet {
             (seq ? SEQUENCE : UNSEQUENCE),
             entry.getKey(),
             innerEntry.getKey(),
-            innerEntry.getValue().getLeft());
+            0);
       }
     }
     for (Map.Entry<String, Map<String, Pair<Long, Gauge>>> entry :
@@ -377,7 +377,7 @@ public class TsFileMetrics implements IMetricSet {
             (seq ? SEQUENCE : UNSEQUENCE),
             entry.getKey(),
             innerEntry.getKey(),
-            innerEntry.getValue().getLeft());
+            0);
       }
     }
     for (Map.Entry<Integer, Pair<Integer, Gauge>> entry :
@@ -386,7 +386,7 @@ public class TsFileMetrics implements IMetricSet {
           seq ? seqLevelTsFileCountMap : unseqLevelTsFileCountMap,
           seq ? SEQUENCE : UNSEQUENCE,
           entry.getKey(),
-          entry.getValue().getLeft());
+          0);
     }
     for (Map.Entry<Integer, Pair<Long, Gauge>> entry :
         (seq ? seqLevelTsFileSizeMap : unseqLevelTsFileSizeMap).entrySet()) {
@@ -394,7 +394,7 @@ public class TsFileMetrics implements IMetricSet {
           seq ? seqLevelTsFileSizeMap : unseqLevelTsFileSizeMap,
           seq ? SEQUENCE : UNSEQUENCE,
           entry.getKey(),
-          entry.getValue().getLeft());
+          0);
     }
   }
 


### PR DESCRIPTION
## Description
![image](https://github.com/apache/iotdb/assets/25913899/1aa76ec8-621a-474b-9eb0-9af0ae6f3433)

In the recovery process of datanode, the updateRemainData method of TsFileMetrics will update the tsfile size and count twice than the real values.

After fixing, the number will be correct.

![nrlm1UN4dZ](https://github.com/apache/iotdb/assets/25913899/3f4377b8-2411-4f93-9bda-0095385c2d1a)



