### PR TITLE
Added getRegionId api for partitionManager

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
@@ -1388,6 +1388,13 @@ public class PartitionManager {
     partitionInfo.getDataRegionIds(databases, dataRegionIds);
   }
 
+  /**
+   * Get the {@link TConsensusGroupType} of the given integer regionId.
+   *
+   * @param regionId The specified integer regionId
+   * @return {@link Optional#of(Object tConsensusGroupType)} of the given integer regionId, or
+   *     {@link Optional#empty()} if the integer regionId does not match any of the regionGroups.
+   */
   public Optional<TConsensusGroupType> getRegionType(int regionId) {
     return partitionInfo.getRegionType(regionId);
   }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
@@ -1392,6 +1392,10 @@ public class PartitionManager {
     partitionInfo.getDataRegionIds(databases, dataRegionIds);
   }
 
+  public Optional<TConsensusGroupType> getRegionType(int regionId) {
+    return partitionInfo.getRegionType(regionId);
+  }
+
   /**
    * Get the last DataAllotTable of the specified Database.
    *

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
@@ -30,8 +30,6 @@ import org.apache.iotdb.commons.cluster.RegionRoleType;
 import org.apache.iotdb.commons.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.commons.concurrent.ThreadName;
 import org.apache.iotdb.commons.concurrent.threadpool.ScheduledExecutorUtil;
-import org.apache.iotdb.commons.conf.CommonConfig;
-import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.partition.DataPartitionTable;
 import org.apache.iotdb.commons.partition.SchemaPartitionTable;
 import org.apache.iotdb.commons.partition.executor.SeriesPartitionExecutor;
@@ -124,8 +122,6 @@ public class PartitionManager {
       CONF.getSchemaRegionGroupExtensionPolicy();
   private static final RegionGroupExtensionPolicy DATA_REGION_GROUP_EXTENSION_POLICY =
       CONF.getDataRegionGroupExtensionPolicy();
-
-  private static final CommonConfig COMMON_CONFIG = CommonDescriptor.getInstance().getConfig();
 
   private final IManager configManager;
   private final PartitionInfo partitionInfo;

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/DatabasePartitionTable.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/DatabasePartitionTable.java
@@ -49,13 +49,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class DatabasePartitionTable {
   private static final Logger LOGGER = LoggerFactory.getLogger(DatabasePartitionTable.class);
@@ -594,10 +594,11 @@ public class DatabasePartitionTable {
     return dataRegionIds;
   }
 
-  public Stream<TConsensusGroupType> getRegionType(int regionId) {
+  public Optional<TConsensusGroupType> getRegionType(int regionId) {
     return regionGroupMap.keySet().stream()
         .filter(tConsensusGroupId -> tConsensusGroupId.getId() == regionId)
-        .map(TConsensusGroupId::getType);
+        .map(TConsensusGroupId::getType)
+        .findFirst();
   }
 
   /**

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/DatabasePartitionTable.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/DatabasePartitionTable.java
@@ -55,6 +55,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class DatabasePartitionTable {
   private static final Logger LOGGER = LoggerFactory.getLogger(DatabasePartitionTable.class);
@@ -591,6 +592,12 @@ public class DatabasePartitionTable {
       }
     }
     return dataRegionIds;
+  }
+
+  public Stream<TConsensusGroupType> getRegionType(int regionId) {
+    return regionGroupMap.keySet().stream()
+        .filter(tConsensusGroupId -> tConsensusGroupId.getId() == regionId)
+        .map(TConsensusGroupId::getType);
   }
 
   /**

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
@@ -1094,6 +1094,19 @@ public class PartitionInfo implements SnapshotProcessor {
     }
   }
 
+  public Optional<TConsensusGroupType> getRegionType(int regionId) {
+    if (databasePartitionTables.values().stream()
+        .flatMap(databasePartitionTable -> databasePartitionTable.getDataRegionIds().stream())
+        .anyMatch(o -> o == regionId)) {
+      return Optional.of(TConsensusGroupType.DataRegion);
+    } else if (databasePartitionTables.values().stream()
+        .flatMap(databasePartitionTable -> databasePartitionTable.getSchemaRegionIds().stream())
+        .anyMatch(o -> o == regionId)) {
+      return Optional.of(TConsensusGroupType.SchemaRegion);
+    }
+    return Optional.empty();
+  }
+
   public void clear() {
     nextRegionGroupId.set(-1);
     databasePartitionTables.clear();

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
@@ -1096,8 +1096,10 @@ public class PartitionInfo implements SnapshotProcessor {
 
   public Optional<TConsensusGroupType> getRegionType(int regionId) {
     return databasePartitionTables.values().stream()
-        .flatMap(databasePartitionTable -> databasePartitionTable.getRegionType(regionId))
-        .findAny();
+        .map(databasePartitionTable -> databasePartitionTable.getRegionType(regionId))
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .findFirst();
   }
 
   public void clear() {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
@@ -1095,16 +1095,9 @@ public class PartitionInfo implements SnapshotProcessor {
   }
 
   public Optional<TConsensusGroupType> getRegionType(int regionId) {
-    if (databasePartitionTables.values().stream()
-        .flatMap(databasePartitionTable -> databasePartitionTable.getDataRegionIds().stream())
-        .anyMatch(o -> o == regionId)) {
-      return Optional.of(TConsensusGroupType.DataRegion);
-    } else if (databasePartitionTables.values().stream()
-        .flatMap(databasePartitionTable -> databasePartitionTable.getSchemaRegionIds().stream())
-        .anyMatch(o -> o == regionId)) {
-      return Optional.of(TConsensusGroupType.SchemaRegion);
-    }
-    return Optional.empty();
+    return databasePartitionTables.values().stream()
+        .flatMap(databasePartitionTable -> databasePartitionTable.getRegionType(regionId))
+        .findAny();
   }
 
   public void clear() {

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/PartitionInfoTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/PartitionInfoTest.java
@@ -45,9 +45,9 @@ import org.apache.iotdb.confignode.rpc.thrift.TShowRegionReq;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.thrift.TException;
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
@@ -81,16 +81,16 @@ public class PartitionInfoTest {
     }
   }
 
-  @BeforeClass
-  public static void setup() {
+  @Before
+  public void setup() {
     partitionInfo = new PartitionInfo();
     if (!snapshotDir.exists()) {
       snapshotDir.mkdirs();
     }
   }
 
-  @AfterClass
-  public static void cleanup() throws IOException {
+  @After
+  public void cleanup() throws IOException {
     partitionInfo.clear();
     if (snapshotDir.exists()) {
       FileUtils.deleteDirectory(snapshotDir);

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/PartitionInfoTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/PartitionInfoTest.java
@@ -176,13 +176,9 @@ public class PartitionInfoTest {
     // Create a DataRegion
     createRegionGroupsPlan = new CreateRegionGroupsPlan();
     TConsensusGroupId dataRegionId =
-        generateTConsensusGroupId(
-            testFlag.SchemaPartition.getFlag(), TConsensusGroupType.DataRegion);
+        generateTConsensusGroupId(testFlag.DataPartition.getFlag(), TConsensusGroupType.DataRegion);
     TRegionReplicaSet dataRegionReplicaSet =
-        generateTRegionReplicaSet(
-            testFlag.DataPartition.getFlag(),
-            generateTConsensusGroupId(
-                testFlag.DataPartition.getFlag(), TConsensusGroupType.DataRegion));
+        generateTRegionReplicaSet(testFlag.DataPartition.getFlag(), dataRegionId);
     createRegionGroupsPlan.addRegionGroup("root.test", dataRegionReplicaSet);
     partitionInfo.createRegionGroups(createRegionGroupsPlan);
 

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/PartitionInfoTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/PartitionInfoTest.java
@@ -57,6 +57,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.apache.iotdb.db.utils.constant.TestConstant.BASE_OUTPUT_PATH;
 
@@ -152,6 +153,49 @@ public class PartitionInfoTest {
   }
 
   @Test
+  public void testGetRegionType() {
+
+    partitionInfo.generateNextRegionGroupId();
+
+    // Set StorageGroup
+    partitionInfo.createDatabase(
+        new DatabaseSchemaPlan(
+            ConfigPhysicalPlanType.CreateDatabase, new TDatabaseSchema("root.test")));
+
+    // Create a SchemaRegion
+    CreateRegionGroupsPlan createRegionGroupsPlan = new CreateRegionGroupsPlan();
+    TConsensusGroupId schemaRegionId =
+        generateTConsensusGroupId(
+            testFlag.SchemaPartition.getFlag(), TConsensusGroupType.SchemaRegion);
+
+    TRegionReplicaSet schemaRegionReplicaSet =
+        generateTRegionReplicaSet(testFlag.SchemaPartition.getFlag(), schemaRegionId);
+    createRegionGroupsPlan.addRegionGroup("root.test", schemaRegionReplicaSet);
+    partitionInfo.createRegionGroups(createRegionGroupsPlan);
+
+    // Create a DataRegion
+    createRegionGroupsPlan = new CreateRegionGroupsPlan();
+    TConsensusGroupId dataRegionId =
+        generateTConsensusGroupId(
+            testFlag.SchemaPartition.getFlag(), TConsensusGroupType.DataRegion);
+    TRegionReplicaSet dataRegionReplicaSet =
+        generateTRegionReplicaSet(
+            testFlag.DataPartition.getFlag(),
+            generateTConsensusGroupId(
+                testFlag.DataPartition.getFlag(), TConsensusGroupType.DataRegion));
+    createRegionGroupsPlan.addRegionGroup("root.test", dataRegionReplicaSet);
+    partitionInfo.createRegionGroups(createRegionGroupsPlan);
+
+    Assert.assertEquals(
+        Optional.of(TConsensusGroupType.SchemaRegion),
+        partitionInfo.getRegionType(schemaRegionId.getId()));
+    Assert.assertEquals(
+        Optional.of(TConsensusGroupType.DataRegion),
+        partitionInfo.getRegionType(dataRegionId.getId()));
+    Assert.assertEquals(Optional.empty(), partitionInfo.getRegionType(-1));
+  }
+
+  @Test
   public void testShowRegion() {
     for (int i = 0; i < 2; i++) {
       partitionInfo.generateNextRegionGroupId();
@@ -187,43 +231,43 @@ public class PartitionInfoTest {
     regionReq.setShowRegionReq(showRegionReq);
     RegionInfoListResp regionInfoList1 =
         (RegionInfoListResp) partitionInfo.getRegionInfoList(regionReq);
-    Assert.assertEquals(regionInfoList1.getRegionInfoList().size(), 20);
+    Assert.assertEquals(20, regionInfoList1.getRegionInfoList().size());
     regionInfoList1
         .getRegionInfoList()
-        .forEach((regionInfo) -> Assert.assertEquals(regionInfo.getClientRpcIp(), "127.0.0.1"));
+        .forEach((regionInfo) -> Assert.assertEquals("127.0.0.1", regionInfo.getClientRpcIp()));
 
     showRegionReq.setConsensusGroupType(TConsensusGroupType.SchemaRegion);
     RegionInfoListResp regionInfoList2 =
         (RegionInfoListResp) partitionInfo.getRegionInfoList(regionReq);
-    Assert.assertEquals(regionInfoList2.getRegionInfoList().size(), 10);
+    Assert.assertEquals(10, regionInfoList2.getRegionInfoList().size());
     regionInfoList2
         .getRegionInfoList()
         .forEach(
             (regionInfo) ->
                 Assert.assertEquals(
-                    regionInfo.getConsensusGroupId().getType(), TConsensusGroupType.SchemaRegion));
+                    TConsensusGroupType.SchemaRegion, regionInfo.getConsensusGroupId().getType()));
 
     showRegionReq.setConsensusGroupType(TConsensusGroupType.DataRegion);
     RegionInfoListResp regionInfoList3 =
         (RegionInfoListResp) partitionInfo.getRegionInfoList(regionReq);
-    Assert.assertEquals(regionInfoList3.getRegionInfoList().size(), 10);
+    Assert.assertEquals(10, regionInfoList3.getRegionInfoList().size());
     regionInfoList3
         .getRegionInfoList()
         .forEach(
             (regionInfo) ->
                 Assert.assertEquals(
-                    regionInfo.getConsensusGroupId().getType(), TConsensusGroupType.DataRegion));
+                    TConsensusGroupType.DataRegion, regionInfo.getConsensusGroupId().getType()));
     showRegionReq.setConsensusGroupType(null);
     showRegionReq.setDatabases(Collections.singletonList("root.test1"));
     RegionInfoListResp regionInfoList4 =
         (RegionInfoListResp) partitionInfo.getRegionInfoList(regionReq);
-    Assert.assertEquals(regionInfoList4.getRegionInfoList().size(), 10);
+    Assert.assertEquals(10, regionInfoList4.getRegionInfoList().size());
     regionInfoList4
         .getRegionInfoList()
         .forEach(
             (regionInfo) -> {
-              Assert.assertEquals(regionInfo.getClientRpcIp(), "127.0.0.1");
-              Assert.assertEquals(regionInfo.getDatabase(), "root.test1");
+              Assert.assertEquals("127.0.0.1", regionInfo.getClientRpcIp());
+              Assert.assertEquals("root.test1", regionInfo.getDatabase());
             });
   }
 


### PR DESCRIPTION
## Description
Added getRegionId api for partitionManager for pipe.
This PR can return the TConsensusGroupId for a given integer, Optional.empty() if it doesn't match any of the existing IDs.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
