### PR TITLE
TopKNode will use IdentityNode but not ShuffleSinkNode

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/TopKOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/TopKOperator.java
@@ -80,7 +80,7 @@ public class TopKOperator implements ProcessOperator {
   // the data of every childOperator is in order
   private final boolean childrenDataInOrder;
 
-  public static int operatorBatchUpperBound = 100000;
+  public static final int OPERATOR_BATCH_UPPER_BOUND = 100000;
 
   public TopKOperator(
       OperatorContext operatorContext,
@@ -101,9 +101,9 @@ public class TopKOperator implements ProcessOperator {
     initResultTsBlock();
 
     deviceBatchStep =
-        operatorBatchUpperBound % topValue == 0
-            ? operatorBatchUpperBound / topValue
-            : operatorBatchUpperBound / topValue + 1;
+        OPERATOR_BATCH_UPPER_BOUND % topValue == 0
+            ? OPERATOR_BATCH_UPPER_BOUND / topValue
+            : OPERATOR_BATCH_UPPER_BOUND / topValue + 1;
     canCallNext = new boolean[deviceOperators.size()];
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/DistributionPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/DistributionPlanner.java
@@ -51,6 +51,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.apache.iotdb.db.queryengine.plan.planner.plan.node.process.TopKNode.LIMIT_USE_TOP_K_FOR_ALIGN_BY_DEVICE;
+
 public class DistributionPlanner {
   private final Analysis analysis;
   private final MPPQueryContext context;
@@ -155,10 +157,21 @@ public class DistributionPlanner {
   private boolean needShuffleSinkNode(
       QueryStatement queryStatement, NodeGroupContext nodeGroupContext) {
     OrderByComponent orderByComponent = queryStatement.getOrderByComponent();
-    return nodeGroupContext.isAlignByDevice()
-        && orderByComponent != null
-        && (!orderByComponent.getSortItemList().isEmpty()
-            && (orderByComponent.isBasedOnTime() && !queryStatement.hasOrderByExpression()));
+
+    if (nodeGroupContext.isAlignByDevice() && orderByComponent != null) {
+
+      // TopKNode will use IdentityNode but not ShuffleSinkNode
+      if (queryStatement.hasLimit()
+          && !queryStatement.isOrderByBasedOnDevice()
+          && queryStatement.getRowLimit() <= LIMIT_USE_TOP_K_FOR_ALIGN_BY_DEVICE) {
+        return false;
+      }
+
+      return !orderByComponent.getSortItemList().isEmpty()
+          && (orderByComponent.isBasedOnTime() && !queryStatement.hasOrderByExpression());
+    }
+
+    return false;
   }
 
   public PlanNode optimize(PlanNode rootWithExchange) {


### PR DESCRIPTION
## Description

ShuffleSinkNode set dop as 1, which is unexpected for TopKNode.

![image](https://github.com/apache/iotdb/assets/6756545/3cc4bdf3-f2af-46e6-b56d-469f41f7779b)

