### PR TITLE
Fix reconnect bug for JDBC

### DIFF
--- a/iotdb-client/cli/src/main/java/org/apache/iotdb/cli/AbstractCli.java
+++ b/iotdb-client/cli/src/main/java/org/apache/iotdb/cli/AbstractCli.java
@@ -576,7 +576,7 @@ public abstract class AbstractCli {
         println("Msg: " + SUCCESS_MESSAGE);
       }
     } catch (Exception e) {
-      println("Msg: " + e.getMessage());
+      println("Msg: " + e);
       executeStatus = CODE_ERROR;
     } finally {
       resetArgs();

--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
@@ -222,7 +222,7 @@ public class IoTDBStatement implements Statement {
         try {
           return executeSQL(sql);
         } catch (TException e2) {
-          throw new SQLException(String.format("Fail to execute %s", sql), e2);
+          throw new SQLException(e2);
         }
       } else {
         throw new SQLException(

--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
@@ -736,9 +736,16 @@ public class IoTDBStatement implements Statement {
     }
   }
 
-  private void reInit() {
+  private boolean reInit() throws SQLException {
     this.client = connection.getClient();
     this.sessionId = connection.getSessionId();
+    try {
+      this.stmtId = client.requestStatementId(sessionId);
+      return true;
+    } catch (Exception e) {
+      throw new SQLException(
+          "Cannot get id for statement after reconnecting. please check server status", e);
+    }
   }
 
   private void requestStmtId() throws SQLException {
@@ -759,9 +766,9 @@ public class IoTDBStatement implements Statement {
     }
   }
 
-  private boolean reConnect() {
+  private boolean reConnect() throws SQLException {
     boolean flag = connection.reconnect();
-    reInit();
+    flag = flag && reInit();
     return flag;
   }
 


### PR DESCRIPTION
We need to regenerate a statement id while reconnecting, otherwise we will get the following error msg.
![img_v3_025t_b8d56b2f-9fa8-4b7b-a77c-f2ea8647994g](https://github.com/apache/iotdb/assets/16079446/f8b5835b-4208-42cc-b267-a41ee45278c3)
