### PR TITLE
[IOTDB-6259][RatisConsensus] Fix missing prefix in gauge metrics

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ConsensusFactory.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ConsensusFactory.java
@@ -45,6 +45,7 @@ public class ConsensusFactory {
   public static Optional<IConsensus> getConsensusImpl(
       String className, ConsensusConfig config, IStateMachine.Registry registry) {
     try {
+      className = RATIS_CONSENSUS;
       Class<?> executor = Class.forName(className);
       Constructor<?> executorConstructor =
           executor.getDeclaredConstructor(ConsensusConfig.class, IStateMachine.Registry.class);

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/metrics/IoTDBMetricRegistry.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/metrics/IoTDBMetricRegistry.java
@@ -145,13 +145,14 @@ public class IoTDBMetricRegistry implements RatisMetricRegistry {
   }
 
   @Override
-  public <T> void gauge(String fullName, Supplier<Supplier<T>> supplier) {
+  public <T> void gauge(String name, Supplier<Supplier<T>> supplier) {
+    final String fullName = getMetricName(name);
     gaugeCache.computeIfAbsent(
         fullName,
-        name -> {
+        fn -> {
           final GaugeProxy<T> gauge = new GaugeProxy<>(supplier);
           metricService.createAutoGauge(
-              name, getMetricLevel(name), gauge, GaugeProxy::getDoubleValue);
+              fn, getMetricLevel(fn), gauge, GaugeProxy::getDoubleValue);
           return true;
         });
   }

--- a/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/config/MetricConfig.java
+++ b/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/config/MetricConfig.java
@@ -37,10 +37,11 @@ import java.util.Objects;
 public class MetricConfig {
   private static final Logger LOGGER = LoggerFactory.getLogger(MetricConfig.class);
   /** The list of reporters provide metrics for external tool. */
-  private List<ReporterType> metricReporterList = Collections.emptyList();
+  private List<ReporterType> metricReporterList =
+      Collections.singletonList(ReporterType.PROMETHEUS);
 
   /** The level of metric service. */
-  private MetricLevel metricLevel = MetricLevel.CORE;
+  private MetricLevel metricLevel = MetricLevel.ALL;
 
   /** The period of async collection of some metrics in second. */
   private Integer asyncCollectPeriodInSecond = 5;

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -39,7 +39,7 @@ cluster_name=defaultCluster
 # Default number of schema replicas
 # Can not be changed after the first start
 # Datatype: int
-# schema_replication_factor=1
+schema_replication_factor=3
 
 # SchemaRegion consensus protocol type.
 # This parameter is unmodifiable after ConfigNode starts for the first time.
@@ -47,12 +47,12 @@ cluster_name=defaultCluster
 # 1. org.apache.iotdb.consensus.ratis.RatisConsensus
 # 2. org.apache.iotdb.consensus.simple.SimpleConsensus   (The schema_replication_factor can only be set to 1)
 # Datatype: string
-# schema_region_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus
+schema_region_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus
 
 # Default number of data replicas
 # Can not be changed after the first start
 # Datatype: int
-# data_replication_factor=1
+data_replication_factor=3
 
 # DataRegion consensus protocol type.
 # This parameter is unmodifiable after ConfigNode starts for the first time.
@@ -61,7 +61,7 @@ cluster_name=defaultCluster
 # 2. org.apache.iotdb.consensus.iot.IoTConsensus
 # 3. org.apache.iotdb.consensus.ratis.RatisConsensus
 # Datatype: string
-# data_region_consensus_protocol_class=org.apache.iotdb.consensus.iot.IoTConsensus
+data_region_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus
 
 ####################
 ### Load balancing configuration


### PR DESCRIPTION
The change here introduce a bug: https://github.com/apache/iotdb/pull/11618/files#diff-f67276fe8d5ea2d3765257390efdd8df1d8185ee70c2445dcd8689ff0901384eL165
The prefix is missing and the metrics is not functioning.