### PR TITLE
[IOTDB-6264] Load: Optimized Validation Messages with 'write_data' Permissions When Loading TsFiles Without schema Creation

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IOTDBLoadTsFileIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IOTDBLoadTsFileIT.java
@@ -338,7 +338,7 @@ public class IOTDBLoadTsFileIT {
 
     assertNonQueryTestFail(
         String.format("load \"%s\" sgLevel=2", tmpDir.getAbsolutePath()),
-        "Auto create or verify schema error when executing statement LoadTsFileStatement",
+        "No permissions for this operation, please add privilege MANAGE_DATABASE",
         "test",
         "test123");
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/LoadTsfileAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/LoadTsfileAnalyzer.java
@@ -27,7 +27,6 @@ import org.apache.iotdb.commons.client.exception.ClientManagerException;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.consensus.ConfigRegionId;
 import org.apache.iotdb.commons.exception.IllegalPathException;
-import org.apache.iotdb.commons.exception.IoTDBException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.schema.SchemaConstant;
 import org.apache.iotdb.commons.service.metric.PerformanceOverviewMetrics;
@@ -157,11 +156,7 @@ public class LoadTsfileAnalyzer {
         throw new SemanticException(
             String.format("TsFile %s is empty or incomplete.", tsFile.getPath()));
       } catch (AuthException e) {
-        schemaAutoCreatorAndVerifier.clear();
-        Analysis analysis = new Analysis();
-        analysis.setFinishQueryAfterAnalyze(true);
-        analysis.setFailStatus(RpcUtils.getStatus(e.getCode(), e.getMessage()));
-        return analysis;
+        return createFailAnalysisForAuthException(e);
       } catch (Exception e) {
         schemaAutoCreatorAndVerifier.clear();
         LOGGER.warn("Parse file {} to resource error.", tsFile.getPath(), e);
@@ -171,8 +166,12 @@ public class LoadTsfileAnalyzer {
       }
     }
 
-    schemaAutoCreatorAndVerifier.flush();
-    schemaAutoCreatorAndVerifier.clear();
+    try {
+      schemaAutoCreatorAndVerifier.flush();
+      schemaAutoCreatorAndVerifier.clear();
+    } catch (AuthException e) {
+      return createFailAnalysisForAuthException(e);
+    }
 
     LOGGER.info("Load - Analysis Stage: all tsfiles have been analyzed.");
 
@@ -237,6 +236,14 @@ public class LoadTsfileAnalyzer {
         .flatMap(List::stream)
         .mapToLong(t -> t.getStatistics().getCount())
         .sum();
+  }
+
+  private Analysis createFailAnalysisForAuthException(AuthException e) {
+    schemaAutoCreatorAndVerifier.clear();
+    Analysis analysis = new Analysis();
+    analysis.setFinishQueryAfterAnalyze(true);
+    analysis.setFailStatus(RpcUtils.getStatus(e.getCode(), e.getMessage()));
+    return analysis;
   }
 
   private final class SchemaAutoCreatorAndVerifier {
@@ -315,7 +322,8 @@ public class LoadTsfileAnalyzer {
      * This can only be invoked after all timeseries in the current tsfile have been processed.
      * Otherwise, the isAligned status may be wrong.
      */
-    public void flushAndClearDeviceIsAlignedCacheIfNecessary() throws SemanticException {
+    public void flushAndClearDeviceIsAlignedCacheIfNecessary()
+        throws SemanticException, AuthException {
       // avoid OOM when loading a tsfile with too many timeseries
       // or loading too many tsfiles at the same time
       if (tsfileDevice2IsAligned.size() > 10000) {
@@ -324,13 +332,13 @@ public class LoadTsfileAnalyzer {
       }
     }
 
-    public void flush() {
+    public void flush() throws AuthException {
       doAutoCreateAndVerify();
 
       currentBatchDevice2TimeseriesSchemas.clear();
     }
 
-    private void doAutoCreateAndVerify() throws SemanticException {
+    private void doAutoCreateAndVerify() throws SemanticException, AuthException {
       if (currentBatchDevice2TimeseriesSchemas.isEmpty()) {
         return;
       }
@@ -351,6 +359,8 @@ public class LoadTsfileAnalyzer {
         if (loadTsFileStatement.isVerifySchema()) {
           verifySchema(schemaTree);
         }
+      } catch (AuthException e) {
+        throw e;
       } catch (Exception e) {
         LOGGER.warn("Auto create or verify schema error.", e);
         throw new SemanticException(
@@ -377,7 +387,7 @@ public class LoadTsfileAnalyzer {
     }
 
     private void autoCreateDatabase()
-        throws VerifyMetadataException, LoadFileException, IllegalPathException {
+        throws VerifyMetadataException, LoadFileException, IllegalPathException, AuthException {
       final int databasePrefixNodesLength = loadTsFileStatement.getDatabaseLevel() + 1;
       final Set<PartialPath> databasesNeededToBeSet = new HashSet<>();
 
@@ -433,12 +443,13 @@ public class LoadTsfileAnalyzer {
       }
     }
 
-    private void executeSetDatabaseStatement(Statement statement) throws LoadFileException {
+    private void executeSetDatabaseStatement(Statement statement)
+        throws LoadFileException, AuthException {
       // 1.check Authority
       TSStatus status =
           AuthorityChecker.checkAuthority(statement, context.getSession().getUserName());
       if (status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
-        throw new RuntimeException(new IoTDBException(status.getMessage(), status.getCode()));
+        throw new AuthException(TSStatusCode.representOf(status.getCode()), status.getMessage());
       }
 
       // 2.execute setDatabase statement


### PR DESCRIPTION
## Description
As titile.

## Testing Performed
IoTDB> create user user01 'pass1234';
IoTDB> GRANT WRITE_DATA ON root.** TO USER user01; 

<img width="1117" alt="image" src="https://github.com/apache/iotdb/assets/42286868/24ca849a-1485-4602-9d7d-362b38cbd35f">
