### PR TITLE
[IOTDB-6265] Construct SessionPool using empty nodeUrls should throw exception

### DIFF
--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -373,6 +373,9 @@ public class Session implements ISession {
       int thriftMaxFrameSize,
       boolean enableRedirection,
       Version version) {
+    if (nodeUrls.isEmpty()) {
+      throw new IllegalArgumentException("nodeUrls shouldn't be empty.");
+    }
     this.nodeUrls = nodeUrls;
     this.username = username;
     this.password = password;
@@ -385,7 +388,10 @@ public class Session implements ISession {
   }
 
   public Session(Builder builder) {
-    if (builder.nodeUrls != null && builder.nodeUrls.size() > 0) {
+    if (builder.nodeUrls != null) {
+      if (builder.nodeUrls.isEmpty()) {
+        throw new IllegalArgumentException("nodeUrls shouldn't be empty.");
+      }
       this.nodeUrls = builder.nodeUrls;
       this.enableQueryRedirection = true;
     } else {

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
@@ -418,6 +418,9 @@ public class SessionPool implements ISessionPool {
     this.maxSize = maxSize;
     this.host = null;
     this.port = -1;
+    if (nodeUrls.isEmpty()) {
+      throw new IllegalArgumentException("nodeUrls shouldn't be empty.");
+    }
     this.nodeUrls = nodeUrls;
     this.user = user;
     this.password = password;
@@ -452,7 +455,10 @@ public class SessionPool implements ISessionPool {
     this.version = builder.version;
     this.thriftDefaultBufferSize = builder.thriftDefaultBufferSize;
     this.thriftMaxFrameSize = builder.thriftMaxFrameSize;
-    if (builder.nodeUrls != null && builder.nodeUrls.size() > 0) {
+    if (builder.nodeUrls != null) {
+      if (builder.nodeUrls.isEmpty()) {
+        throw new IllegalArgumentException("nodeUrls shouldn't be empty.");
+      }
       this.nodeUrls = builder.nodeUrls;
       this.host = null;
       this.port = -1;

--- a/iotdb-client/session/src/test/java/org/apache/iotdb/session/SessionTest.java
+++ b/iotdb-client/session/src/test/java/org/apache/iotdb/session/SessionTest.java
@@ -49,11 +49,13 @@ import java.io.IOException;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 
 public class SessionTest {
@@ -1179,5 +1181,15 @@ public class SessionTest {
   public void testGetBackupConfiguration()
       throws IoTDBConnectionException, StatementExecutionException {
     session.getBackupConfiguration();
+  }
+
+  @Test
+  public void testEmptyNodeUrls() {
+    try {
+      ISession failedSession = new Session(Collections.emptyList(), "root", "root");
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("nodeUrls shouldn't be empty.", e.getMessage());
+    }
   }
 }

--- a/iotdb-client/session/src/test/java/org/apache/iotdb/session/pool/SessionPoolExceptionTest.java
+++ b/iotdb-client/session/src/test/java/org/apache/iotdb/session/pool/SessionPoolExceptionTest.java
@@ -43,6 +43,7 @@ import org.powermock.reflect.Whitebox;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -50,6 +51,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -261,6 +263,16 @@ public class SessionPoolExceptionTest {
       sessionPool.insertRecords(deviceIds, timeList, measurementsList, typesList, valuesList);
     } catch (IoTDBConnectionException e) {
       assertTrue(e instanceof IoTDBConnectionException);
+    }
+  }
+
+  @Test
+  public void testEmptyNodeUrls() {
+    try {
+      ISessionPool failedSession = new SessionPool(Collections.emptyList(), "root", "root", 1);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("nodeUrls shouldn't be empty.", e.getMessage());
     }
   }
 }


### PR DESCRIPTION
while we use an empty nodeUrls to construct SessionPool, we will succeed(using localhost and 6667 as default host and port) which is not we want. We expect it throw exception to tell us that nodeUrls shouldn't be empty.

```java
SessionPool sessionPool = new SessionPool(Collections.emptyList(), "root", "root", 3);
```