### PR TITLE
Pipe: automatically start pipe upon creation & allow to start RUNNING pipe & allow to stop STOPPED pipe 

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/IoTDBPipeSwitchStatusIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/IoTDBPipeSwitchStatusIT.java
@@ -83,11 +83,11 @@ public class IoTDBPipeSwitchStatusIT extends AbstractPipeDualIT {
 
       List<TShowPipeInfo> showPipeResult = client.showPipe(new TShowPipeReq()).pipeInfoList;
       Assert.assertTrue(
-          showPipeResult.stream().anyMatch((o) -> o.id.equals("p1") && o.state.equals("STOPPED")));
+          showPipeResult.stream().anyMatch((o) -> o.id.equals("p1") && o.state.equals("RUNNING")));
       Assert.assertTrue(
-          showPipeResult.stream().anyMatch((o) -> o.id.equals("p2") && o.state.equals("STOPPED")));
+          showPipeResult.stream().anyMatch((o) -> o.id.equals("p2") && o.state.equals("RUNNING")));
       Assert.assertTrue(
-          showPipeResult.stream().anyMatch((o) -> o.id.equals("p3") && o.state.equals("STOPPED")));
+          showPipeResult.stream().anyMatch((o) -> o.id.equals("p3") && o.state.equals("RUNNING")));
 
       Assert.assertEquals(
           TSStatusCode.SUCCESS_STATUS.getStatusCode(), client.startPipe("p1").getCode());
@@ -148,9 +148,8 @@ public class IoTDBPipeSwitchStatusIT extends AbstractPipeDualIT {
 
       List<TShowPipeInfo> showPipeResult = client.showPipe(new TShowPipeReq()).pipeInfoList;
       Assert.assertTrue(
-          showPipeResult.stream().anyMatch((o) -> o.id.equals("p1") && o.state.equals("STOPPED")));
+          showPipeResult.stream().anyMatch((o) -> o.id.equals("p1") && o.state.equals("RUNNING")));
 
-      Assert.assertEquals(TSStatusCode.PIPE_ERROR.getStatusCode(), client.stopPipe("p1").getCode());
       status =
           client.createPipe(
               new TCreatePipeReq("p1", connectorAttributes)
@@ -168,10 +167,17 @@ public class IoTDBPipeSwitchStatusIT extends AbstractPipeDualIT {
           showPipeResult.stream().anyMatch((o) -> o.id.equals("p1") && o.state.equals("RUNNING")));
 
       Assert.assertEquals(
-          TSStatusCode.PIPE_ERROR.getStatusCode(), client.startPipe("p1").getCode());
+          TSStatusCode.SUCCESS_STATUS.getStatusCode(), client.stopPipe("p1").getCode());
       showPipeResult = client.showPipe(new TShowPipeReq()).pipeInfoList;
       Assert.assertTrue(
-          showPipeResult.stream().anyMatch((o) -> o.id.equals("p1") && o.state.equals("RUNNING")));
+          showPipeResult.stream().anyMatch((o) -> o.id.equals("p1") && o.state.equals("STOPPED")));
+      Assert.assertEquals(1, showPipeResult.stream().filter((o) -> o.id.equals("p1")).count());
+
+      Assert.assertEquals(
+          TSStatusCode.SUCCESS_STATUS.getStatusCode(), client.stopPipe("p1").getCode());
+      showPipeResult = client.showPipe(new TShowPipeReq()).pipeInfoList;
+      Assert.assertTrue(
+          showPipeResult.stream().anyMatch((o) -> o.id.equals("p1") && o.state.equals("STOPPED")));
       Assert.assertEquals(1, showPipeResult.stream().filter((o) -> o.id.equals("p1")).count());
     }
   }
@@ -262,7 +268,7 @@ public class IoTDBPipeSwitchStatusIT extends AbstractPipeDualIT {
       Assert.assertEquals(TSStatusCode.PIPE_ERROR.getStatusCode(), client.startPipe("*").getCode());
       List<TShowPipeInfo> showPipeResult = client.showPipe(new TShowPipeReq()).pipeInfoList;
       Assert.assertTrue(
-          showPipeResult.stream().anyMatch((o) -> o.id.equals("p1") && o.state.equals("STOPPED")));
+          showPipeResult.stream().anyMatch((o) -> o.id.equals("p1") && o.state.equals("RUNNING")));
 
       Assert.assertEquals(
           TSStatusCode.SUCCESS_STATUS.getStatusCode(), client.startPipe("p1").getCode());

--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/IoTDBPipeSyntaxIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/IoTDBPipeSyntaxIT.java
@@ -80,7 +80,7 @@ public class IoTDBPipeSyntaxIT extends AbstractPipeDualIT {
       for (String pipeName : validPipeNames) {
         Assert.assertTrue(
             showPipeResult.stream()
-                .anyMatch((o) -> o.id.equals(pipeName) && o.state.equals("STOPPED")));
+                .anyMatch((o) -> o.id.equals(pipeName) && o.state.equals("RUNNING")));
       }
 
       for (String pipeName : validPipeNames) {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipeTaskInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipeTaskInfo.java
@@ -158,16 +158,18 @@ public class PipeTaskInfo implements SnapshotProcessor {
     throw new PipeException(exceptionMessage);
   }
 
-  public void checkBeforeStartPipe(String pipeName) throws PipeException {
+  /** @return true if the pipe status is RUNNING before starting the pipe */
+  public boolean checkBeforeStartPipe(String pipeName) throws PipeException {
     acquireReadLock();
     try {
-      checkBeforeStartPipeInternal(pipeName);
+      return checkBeforeStartPipeInternal(pipeName);
     } finally {
       releaseReadLock();
     }
   }
 
-  private void checkBeforeStartPipeInternal(String pipeName) throws PipeException {
+  /** @return true if the pipe status is RUNNING before starting the pipe */
+  private boolean checkBeforeStartPipeInternal(String pipeName) throws PipeException {
     if (!isPipeExisted(pipeName)) {
       final String exceptionMessage =
           String.format("Failed to start pipe %s, the pipe does not exist", pipeName);
@@ -179,8 +181,8 @@ public class PipeTaskInfo implements SnapshotProcessor {
     if (pipeStatus == PipeStatus.RUNNING) {
       final String exceptionMessage =
           String.format("Failed to start pipe %s, the pipe is already running", pipeName);
-      LOGGER.info(exceptionMessage);
-      throw new PipeException(exceptionMessage);
+      LOGGER.warn(exceptionMessage);
+      return true;
     }
     if (pipeStatus == PipeStatus.DROPPED) {
       final String exceptionMessage =
@@ -188,18 +190,22 @@ public class PipeTaskInfo implements SnapshotProcessor {
       LOGGER.info(exceptionMessage);
       throw new PipeException(exceptionMessage);
     }
+
+    return false;
   }
 
-  public void checkBeforeStopPipe(String pipeName) throws PipeException {
+  /** @return true if the pipe status is STOPPED before stopping the pipe */
+  public boolean checkBeforeStopPipe(String pipeName) throws PipeException {
     acquireReadLock();
     try {
-      checkBeforeStopPipeInternal(pipeName);
+      return checkBeforeStopPipeInternal(pipeName);
     } finally {
       releaseReadLock();
     }
   }
 
-  private void checkBeforeStopPipeInternal(String pipeName) throws PipeException {
+  /** @return true if the pipe status is STOPPED before stopping the pipe */
+  private boolean checkBeforeStopPipeInternal(String pipeName) throws PipeException {
     if (!isPipeExisted(pipeName)) {
       final String exceptionMessage =
           String.format("Failed to stop pipe %s, the pipe does not exist", pipeName);
@@ -211,8 +217,8 @@ public class PipeTaskInfo implements SnapshotProcessor {
     if (pipeStatus == PipeStatus.STOPPED) {
       final String exceptionMessage =
           String.format("Failed to stop pipe %s, the pipe is already stop", pipeName);
-      LOGGER.info(exceptionMessage);
-      throw new PipeException(exceptionMessage);
+      LOGGER.warn(exceptionMessage);
+      return true;
     }
     if (pipeStatus == PipeStatus.DROPPED) {
       final String exceptionMessage =
@@ -220,6 +226,8 @@ public class PipeTaskInfo implements SnapshotProcessor {
       LOGGER.info(exceptionMessage);
       throw new PipeException(exceptionMessage);
     }
+
+    return false;
   }
 
   public void checkBeforeDropPipe(String pipeName) {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/CreatePipeProcedureV2.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/CreatePipeProcedureV2.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.consensus.index.impl.MinimumProgressIndex;
 import org.apache.iotdb.commons.pipe.task.meta.PipeRuntimeMeta;
 import org.apache.iotdb.commons.pipe.task.meta.PipeStaticMeta;
+import org.apache.iotdb.commons.pipe.task.meta.PipeStatus;
 import org.apache.iotdb.commons.pipe.task.meta.PipeTaskMeta;
 import org.apache.iotdb.commons.schema.SchemaConstant;
 import org.apache.iotdb.confignode.consensus.request.write.pipe.task.CreatePipePlanV2;
@@ -120,6 +121,7 @@ public class CreatePipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
               }
             });
     pipeRuntimeMeta = new PipeRuntimeMeta(consensusGroupIdToTaskMetaMap);
+    pipeRuntimeMeta.getStatus().set(PipeStatus.RUNNING);
   }
 
   @Override

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/StartPipeProcedureV2.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/StartPipeProcedureV2.java
@@ -84,7 +84,7 @@ public class StartPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
     LOGGER.info("StartPipeProcedureV2: executeFromWriteConfigNodeConsensus({})", pipeName);
 
     if (canSkipSubsequentStages) {
-      LOGGER.info("Pipe status is RUNNING, skip executeFromWriteConfigNodeConsensus({})", pipeName);
+      LOGGER.warn("Pipe status is RUNNING, skip executeFromWriteConfigNodeConsensus({})", pipeName);
       return;
     }
 
@@ -109,7 +109,7 @@ public class StartPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
     LOGGER.info("StartPipeProcedureV2: executeFromOperateOnDataNodes({})", pipeName);
 
     if (canSkipSubsequentStages) {
-      LOGGER.info("Pipe status is RUNNING, skip executeFromOperateOnDataNodes({})", pipeName);
+      LOGGER.warn("Pipe status is RUNNING, skip executeFromOperateOnDataNodes({})", pipeName);
       return;
     }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/StartPipeProcedureV2.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/StartPipeProcedureV2.java
@@ -44,6 +44,12 @@ public class StartPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
 
   private String pipeName;
 
+  // This variable is used to record whether the pipe status is RUNNING and to determine whether to
+  // skip this procedure.
+  //
+  // Pure in-memory object, not involved in snapshot serialization and deserialization.
+  private boolean canSkipSubsequentStages;
+
   public StartPipeProcedureV2() {
     super();
   }
@@ -51,6 +57,7 @@ public class StartPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
   public StartPipeProcedureV2(String pipeName) throws PipeException {
     super();
     this.pipeName = pipeName;
+    this.canSkipSubsequentStages = false;
   }
 
   @Override
@@ -62,7 +69,7 @@ public class StartPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
   protected void executeFromValidateTask(ConfigNodeProcedureEnv env) throws PipeException {
     LOGGER.info("StartPipeProcedureV2: executeFromValidateTask({})", pipeName);
 
-    pipeTaskInfo.get().checkBeforeStartPipe(pipeName);
+    canSkipSubsequentStages = pipeTaskInfo.get().checkBeforeStartPipe(pipeName);
   }
 
   @Override
@@ -75,6 +82,11 @@ public class StartPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
   protected void executeFromWriteConfigNodeConsensus(ConfigNodeProcedureEnv env)
       throws PipeException {
     LOGGER.info("StartPipeProcedureV2: executeFromWriteConfigNodeConsensus({})", pipeName);
+
+    if (canSkipSubsequentStages) {
+      LOGGER.info("Pipe status is RUNNING, skip executeFromWriteConfigNodeConsensus({})", pipeName);
+      return;
+    }
 
     TSStatus response;
     try {
@@ -95,6 +107,11 @@ public class StartPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
   @Override
   protected void executeFromOperateOnDataNodes(ConfigNodeProcedureEnv env) throws IOException {
     LOGGER.info("StartPipeProcedureV2: executeFromOperateOnDataNodes({})", pipeName);
+
+    if (canSkipSubsequentStages) {
+      LOGGER.info("Pipe status is RUNNING, skip executeFromOperateOnDataNodes({})", pipeName);
+      return;
+    }
 
     String exceptionMessage =
         parsePushPipeMetaExceptionForPipe(pipeName, pushSinglePipeMetaToDataNodes(pipeName, env));

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/StopPipeProcedureV2.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/StopPipeProcedureV2.java
@@ -44,6 +44,12 @@ public class StopPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
 
   private String pipeName;
 
+  // This variable is used to record whether the pipe status is STOPPED and to determine whether to
+  // skip this procedure.
+  //
+  // Pure in-memory object, not involved in snapshot serialization and deserialization.
+  private boolean canSkipSubsequentStages;
+
   public StopPipeProcedureV2() {
     super();
   }
@@ -51,6 +57,7 @@ public class StopPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
   public StopPipeProcedureV2(String pipeName) throws PipeException {
     super();
     this.pipeName = pipeName;
+    this.canSkipSubsequentStages = false;
   }
 
   @Override
@@ -62,7 +69,7 @@ public class StopPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
   protected void executeFromValidateTask(ConfigNodeProcedureEnv env) throws PipeException {
     LOGGER.info("StopPipeProcedureV2: executeFromValidateTask({})", pipeName);
 
-    pipeTaskInfo.get().checkBeforeStopPipe(pipeName);
+    canSkipSubsequentStages = pipeTaskInfo.get().checkBeforeStopPipe(pipeName);
   }
 
   @Override
@@ -75,6 +82,11 @@ public class StopPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
   protected void executeFromWriteConfigNodeConsensus(ConfigNodeProcedureEnv env)
       throws PipeException {
     LOGGER.info("StopPipeProcedureV2: executeFromWriteConfigNodeConsensus({})", pipeName);
+
+    if (canSkipSubsequentStages) {
+      LOGGER.info("Pipe status is STOPPED, skip executeFromWriteConfigNodeConsensus({})", pipeName);
+      return;
+    }
 
     TSStatus response;
     try {
@@ -95,6 +107,11 @@ public class StopPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
   @Override
   protected void executeFromOperateOnDataNodes(ConfigNodeProcedureEnv env) throws IOException {
     LOGGER.info("StopPipeProcedureV2: executeFromOperateOnDataNodes({})", pipeName);
+
+    if (canSkipSubsequentStages) {
+      LOGGER.info("Pipe status is STOPPED, skip executeFromOperateOnDataNodes({})", pipeName);
+      return;
+    }
 
     String exceptionMessage =
         parsePushPipeMetaExceptionForPipe(pipeName, pushSinglePipeMetaToDataNodes(pipeName, env));

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/StopPipeProcedureV2.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/StopPipeProcedureV2.java
@@ -84,7 +84,7 @@ public class StopPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
     LOGGER.info("StopPipeProcedureV2: executeFromWriteConfigNodeConsensus({})", pipeName);
 
     if (canSkipSubsequentStages) {
-      LOGGER.info("Pipe status is STOPPED, skip executeFromWriteConfigNodeConsensus({})", pipeName);
+      LOGGER.warn("Pipe status is STOPPED, skip executeFromWriteConfigNodeConsensus({})", pipeName);
       return;
     }
 
@@ -109,7 +109,7 @@ public class StopPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
     LOGGER.info("StopPipeProcedureV2: executeFromOperateOnDataNodes({})", pipeName);
 
     if (canSkipSubsequentStages) {
-      LOGGER.info("Pipe status is STOPPED, skip executeFromOperateOnDataNodes({})", pipeName);
+      LOGGER.warn("Pipe status is STOPPED, skip executeFromOperateOnDataNodes({})", pipeName);
       return;
     }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/PipeTaskAgent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/PipeTaskAgent.java
@@ -66,9 +66,9 @@ import java.util.stream.Collectors;
  * State transition diagram of a pipe task:
  *
  * <p><code>
- * |----------------|                     |---------| --> start pipe --> |---------|                   |---------|
- * | initial status | --> create pipe --> | STOPPED |                    | RUNNING | --> drop pipe --> | DROPPED |
- * |----------------|                     |---------| <-- stop  pipe <-- |---------|                   |---------|
+ * |----------------|                     |---------| --> stop  pipe --> |---------|                   |---------|
+ * | initial status | --> create pipe --> | RUNNING |                    | STOPPED | --> drop pipe --> | DROPPED |
+ * |----------------|                     |---------| <-- start pipe <-- |---------|                   |---------|
  *                                             |                                                            |
  *                                             | ----------------------> drop pipe -----------------------> |
  * </code>


### PR DESCRIPTION
## Description

As title, set the pipe status to `RUNNING` in create pipe procedure, so that users do not need to manually start the pipe after creating it.

**TODO:**

- [ ] This may lead to some IT failures.
- [x] Some comments need to be modified accordingly.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [x] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
