### PR TITLE
Add a param to switch whether to enable data separation or not

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -824,7 +824,11 @@ public class IoTDBConfig {
   /** the interval to log recover progress of each vsg when starting iotdb */
   private long recoveryLogIntervalInMs = 5_000L;
 
-  private boolean enableDiscardOutOfOrderData = false;
+  /**
+   * Separate sequence and unsequence data or not. If it is false, then all data will be written
+   * into unsequence data dir.
+   */
+  private boolean enableSeparateData = true;
 
   /** the method to transform device path to device id, can be 'Plain' or 'SHA256' */
   private String deviceIDTransformationMethod = "Plain";
@@ -1387,12 +1391,12 @@ public class IoTDBConfig {
     this.rpcPort = rpcPort;
   }
 
-  public boolean isEnableDiscardOutOfOrderData() {
-    return enableDiscardOutOfOrderData;
+  public boolean isEnableSeparateData() {
+    return enableSeparateData;
   }
 
-  public void setEnableDiscardOutOfOrderData(boolean enableDiscardOutOfOrderData) {
-    this.enableDiscardOutOfOrderData = enableDiscardOutOfOrderData;
+  public void setEnableSeparateData(boolean enableSeparateData) {
+    this.enableSeparateData = enableSeparateData;
   }
 
   public String getSystemDir() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -822,11 +822,10 @@ public class IoTDBDescriptor {
             properties.getProperty(
                 "recovery_log_interval_in_ms", String.valueOf(conf.getRecoveryLogIntervalInMs()))));
 
-    conf.setEnableDiscardOutOfOrderData(
+    conf.setEnableSeparateData(
         Boolean.parseBoolean(
             properties.getProperty(
-                "enable_discard_out_of_order_data",
-                Boolean.toString(conf.isEnableDiscardOutOfOrderData()))));
+                "enable_separate_data", Boolean.toString(conf.isEnableSeparateData()))));
 
     conf.setWindowEvaluationThreadCount(
         Integer.parseInt(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/ILastFlushTimeMap.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/ILastFlushTimeMap.java
@@ -24,35 +24,26 @@ import java.util.Map;
 /** This interface manages last time and flush time for sequence and unsequence determination */
 public interface ILastFlushTimeMap {
 
-  // region set
-  void setMultiDeviceFlushedTime(long timePartitionId, Map<String, Long> flushedTimeMap);
-
-  void setOneDeviceFlushedTime(long timePartitionId, String path, long time);
-
-  void setMultiDeviceGlobalFlushedTime(Map<String, Long> globalFlushedTimeMap);
-
-  void setOneDeviceGlobalFlushedTime(String path, long time);
-  // endregion
-
   // region update
+  /** Update partitionLatestFlushedTimeForEachDevice. */
+  void updateOneDeviceFlushedTime(long timePartitionId, String path, long time);
 
-  void updateFlushedTime(long timePartitionId, String path, long time);
+  void updateMultiDeviceFlushedTime(long timePartitionId, Map<String, Long> flushedTimeMap);
 
-  void updateGlobalFlushedTime(String path, long time);
+  /** Update globalLatestFlushedTimeForEachDevice. */
+  void updateOneDeviceGlobalFlushedTime(String path, long time);
 
-  void updateNewlyFlushedPartitionLatestFlushedTimeForEachDevice(
-      long partitionId, String deviceId, long time);
+  void updateMultiDeviceGlobalFlushedTime(Map<String, Long> globalFlushedTimeMap);
+
+  /**
+   * Update both partitionLatestFlushedTimeForEachDevice and globalLatestFlushedTimeForEachDevice.
+   */
+  void updateLatestFlushTime(long partitionId, Map<String, Long> updateMap);
   // endregion
 
   // region ensure
   boolean checkAndCreateFlushedTimePartition(long timePartitionId);
 
-  // endregion
-
-  // region support upgrade methods
-  void applyNewlyFlushedTimeToFlushedTime();
-
-  void updateLatestFlushTime(long partitionId, Map<String, Long> updateMap);
   // endregion
 
   // region read

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/DataRegionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/DataRegionTest.java
@@ -541,10 +541,10 @@ public class DataRegionTest {
   }
 
   @Test
-  public void testEnableDiscardOutOfOrderDataForInsertRowPlan()
+  public void testDisableSeparateDataForInsertRowPlan()
       throws WriteProcessException, QueryProcessException, IllegalPathException, IOException {
     boolean defaultValue = config.isEnableSeparateData();
-    config.setEnableSeparateData(true);
+    config.setEnableSeparateData(false);
 
     for (int j = 21; j <= 30; j++) {
       TSRecord record = new TSRecord(j, deviceId);
@@ -573,8 +573,8 @@ public class DataRegionTest {
             deviceId,
             context,
             null);
-    Assert.assertEquals(10, queryDataSource.getSeqResources().size());
-    Assert.assertEquals(0, queryDataSource.getUnseqResources().size());
+    Assert.assertEquals(0, queryDataSource.getSeqResources().size());
+    Assert.assertEquals(20, queryDataSource.getUnseqResources().size());
     for (TsFileResource resource : queryDataSource.getSeqResources()) {
       Assert.assertTrue(resource.isClosed());
     }
@@ -586,11 +586,11 @@ public class DataRegionTest {
   }
 
   @Test
-  public void testEnableDiscardOutOfOrderDataForInsertTablet1()
+  public void testDisableSeparateDataForInsertTablet1()
       throws QueryProcessException, IllegalPathException, IOException, WriteProcessException {
     boolean defaultEnableDiscard = config.isEnableSeparateData();
     long defaultTimePartition = COMMON_CONFIG.getTimePartitionInterval();
-    config.setEnableSeparateData(true);
+    config.setEnableSeparateData(false);
     COMMON_CONFIG.setTimePartitionInterval(100000);
 
     String[] measurements = new String[2];
@@ -663,8 +663,8 @@ public class DataRegionTest {
             context,
             null);
 
-    Assert.assertEquals(2, queryDataSource.getSeqResources().size());
-    Assert.assertEquals(0, queryDataSource.getUnseqResources().size());
+    Assert.assertEquals(0, queryDataSource.getSeqResources().size());
+    Assert.assertEquals(2, queryDataSource.getUnseqResources().size());
     for (TsFileResource resource : queryDataSource.getSeqResources()) {
       Assert.assertTrue(resource.isClosed());
     }
@@ -674,11 +674,11 @@ public class DataRegionTest {
   }
 
   @Test
-  public void testEnableDiscardOutOfOrderDataForInsertTablet2()
+  public void testDisableSeparateDataForInsertTablet2()
       throws QueryProcessException, IllegalPathException, IOException, WriteProcessException {
     boolean defaultEnableDiscard = config.isEnableSeparateData();
     long defaultTimePartition = COMMON_CONFIG.getTimePartitionInterval();
-    config.setEnableSeparateData(true);
+    config.setEnableSeparateData(false);
     COMMON_CONFIG.setTimePartitionInterval(1200000);
 
     String[] measurements = new String[2];
@@ -751,8 +751,8 @@ public class DataRegionTest {
             context,
             null);
 
-    Assert.assertEquals(2, queryDataSource.getSeqResources().size());
-    Assert.assertEquals(0, queryDataSource.getUnseqResources().size());
+    Assert.assertEquals(0, queryDataSource.getSeqResources().size());
+    Assert.assertEquals(2, queryDataSource.getUnseqResources().size());
     for (TsFileResource resource : queryDataSource.getSeqResources()) {
       Assert.assertTrue(resource.isClosed());
     }
@@ -762,11 +762,11 @@ public class DataRegionTest {
   }
 
   @Test
-  public void testEnableDiscardOutOfOrderDataForInsertTablet3()
+  public void testDisableSeparateDataForInsertTablet3()
       throws QueryProcessException, IllegalPathException, IOException, WriteProcessException {
     boolean defaultEnableDiscard = config.isEnableSeparateData();
     long defaultTimePartition = COMMON_CONFIG.getTimePartitionInterval();
-    config.setEnableSeparateData(true);
+    config.setEnableSeparateData(false);
     COMMON_CONFIG.setTimePartitionInterval(1000000);
 
     String[] measurements = new String[2];
@@ -839,8 +839,8 @@ public class DataRegionTest {
             context,
             null);
 
-    Assert.assertEquals(2, queryDataSource.getSeqResources().size());
-    Assert.assertEquals(0, queryDataSource.getUnseqResources().size());
+    Assert.assertEquals(0, queryDataSource.getSeqResources().size());
+    Assert.assertEquals(2, queryDataSource.getUnseqResources().size());
     for (TsFileResource resource : queryDataSource.getSeqResources()) {
       Assert.assertTrue(resource.isClosed());
     }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/DataRegionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/DataRegionTest.java
@@ -543,8 +543,8 @@ public class DataRegionTest {
   @Test
   public void testEnableDiscardOutOfOrderDataForInsertRowPlan()
       throws WriteProcessException, QueryProcessException, IllegalPathException, IOException {
-    boolean defaultValue = config.isEnableDiscardOutOfOrderData();
-    config.setEnableDiscardOutOfOrderData(true);
+    boolean defaultValue = config.isEnableSeparateData();
+    config.setEnableSeparateData(true);
 
     for (int j = 21; j <= 30; j++) {
       TSRecord record = new TSRecord(j, deviceId);
@@ -582,15 +582,15 @@ public class DataRegionTest {
       Assert.assertTrue(resource.isClosed());
     }
 
-    config.setEnableDiscardOutOfOrderData(defaultValue);
+    config.setEnableSeparateData(defaultValue);
   }
 
   @Test
   public void testEnableDiscardOutOfOrderDataForInsertTablet1()
       throws QueryProcessException, IllegalPathException, IOException, WriteProcessException {
-    boolean defaultEnableDiscard = config.isEnableDiscardOutOfOrderData();
+    boolean defaultEnableDiscard = config.isEnableSeparateData();
     long defaultTimePartition = COMMON_CONFIG.getTimePartitionInterval();
-    config.setEnableDiscardOutOfOrderData(true);
+    config.setEnableSeparateData(true);
     COMMON_CONFIG.setTimePartitionInterval(100000);
 
     String[] measurements = new String[2];
@@ -669,16 +669,16 @@ public class DataRegionTest {
       Assert.assertTrue(resource.isClosed());
     }
 
-    config.setEnableDiscardOutOfOrderData(defaultEnableDiscard);
+    config.setEnableSeparateData(defaultEnableDiscard);
     COMMON_CONFIG.setTimePartitionInterval(defaultTimePartition);
   }
 
   @Test
   public void testEnableDiscardOutOfOrderDataForInsertTablet2()
       throws QueryProcessException, IllegalPathException, IOException, WriteProcessException {
-    boolean defaultEnableDiscard = config.isEnableDiscardOutOfOrderData();
+    boolean defaultEnableDiscard = config.isEnableSeparateData();
     long defaultTimePartition = COMMON_CONFIG.getTimePartitionInterval();
-    config.setEnableDiscardOutOfOrderData(true);
+    config.setEnableSeparateData(true);
     COMMON_CONFIG.setTimePartitionInterval(1200000);
 
     String[] measurements = new String[2];
@@ -757,16 +757,16 @@ public class DataRegionTest {
       Assert.assertTrue(resource.isClosed());
     }
 
-    config.setEnableDiscardOutOfOrderData(defaultEnableDiscard);
+    config.setEnableSeparateData(defaultEnableDiscard);
     COMMON_CONFIG.setTimePartitionInterval(defaultTimePartition);
   }
 
   @Test
   public void testEnableDiscardOutOfOrderDataForInsertTablet3()
       throws QueryProcessException, IllegalPathException, IOException, WriteProcessException {
-    boolean defaultEnableDiscard = config.isEnableDiscardOutOfOrderData();
+    boolean defaultEnableDiscard = config.isEnableSeparateData();
     long defaultTimePartition = COMMON_CONFIG.getTimePartitionInterval();
-    config.setEnableDiscardOutOfOrderData(true);
+    config.setEnableSeparateData(true);
     COMMON_CONFIG.setTimePartitionInterval(1000000);
 
     String[] measurements = new String[2];
@@ -845,7 +845,7 @@ public class DataRegionTest {
       Assert.assertTrue(resource.isClosed());
     }
 
-    config.setEnableDiscardOutOfOrderData(defaultEnableDiscard);
+    config.setEnableSeparateData(defaultEnableDiscard);
     COMMON_CONFIG.setTimePartitionInterval(defaultTimePartition);
   }
 

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -467,10 +467,10 @@ timestamp_precision=ms
 # Datatype: int
 # max_waiting_time_when_insert_blocked=10000
 
-# Add a switch to drop ouf-of-order data
-# Out-of-order data will impact the aggregation query a lot. Users may not care about discarding some out-of-order data.
+# Add a switch to enable separate sequence and unsequence data.
+# If it is true, then data will be separated into seq and unseq data dir. If it is false, then all data will be written into unseq data dir.
 # Datatype: boolean
-# enable_discard_out_of_order_data=false
+# enable_separate_data=true
 
 # What will the system do when unrecoverable error occurs.
 # Datatype: String


### PR DESCRIPTION
Add `enable_separate_data` param to switch whether to enable data separation or not. The default is true, which means the data is separated into sequence and unsequence data dir. If it is false, all data will be written to the unsequence data dir.

Our system maintains two data structures in the `HashLastFlushTimeMap` class, one is `partitionLatestFlushedTimeForEachDevice` and the other is `globalLatestFlushedTimeForEachDevice`. The former is used to separate seq and unseq data in each partition, and the latter is used for last cache queries.
1. When the `enable_separate_data` parameter is false, `partitionLatestFlushedTimeForEachDevice` is no longer maintained in the memory. There is no need to judge the order of data, and the data is written directly to the unseq data directory. In the writing scenario of massive devices, it can save a lot of memory and greatly improve the writing performance, avoiding disk IO to obtain `deviceLastFlushTime` after resource degrades, which consumes a lot of CPU.
2. When the `enable_last_cache` parameter is false, `globalLatestFlushedTimeForEachDevice` is no longer maintained in the memory, which can save a lot of memory in the scenario of writing massive devices.