### PR TITLE
add config for inner compaction selector

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -538,6 +538,18 @@ public class IoTDBConfig {
   /** The size of candidate compaction task queue. */
   private int candidateCompactionTaskQueueSize = 50;
 
+  /**
+   * When the size of the mods file corresponding to TsFile exceeds this value, inner compaction
+   * tasks containing mods files are selected first.
+   */
+  private long innerCompactionTaskSelectionModsFileThreshold = 50 * 1024 * 1024L;
+  /**
+   * When disk availability is lower than the sum of (disk_space_warning_threshold +
+   * inner_compaction_task_selection_disk_redundancy), inner compaction tasks containing mods files
+   * are selected first.
+   */
+  private double innerCompactionTaskSelectionDiskRedundancy = 0.05;
+
   /** The size of global compaction estimation file info cahce. */
   private int globalCompactionFileInfoCacheSize = 1000;
 
@@ -3787,5 +3799,24 @@ public class IoTDBConfig {
 
   public void setEnableTsFileValidation(boolean enableTsFileValidation) {
     this.enableTsFileValidation = enableTsFileValidation;
+  }
+
+  public long getInnerCompactionTaskSelectionModsFileThreshold() {
+    return innerCompactionTaskSelectionModsFileThreshold;
+  }
+
+  public void setInnerCompactionTaskSelectionModsFileThreshold(
+      long innerCompactionTaskSelectionModsFileThreshold) {
+    this.innerCompactionTaskSelectionModsFileThreshold =
+        innerCompactionTaskSelectionModsFileThreshold;
+  }
+
+  public double getInnerCompactionTaskSelectionDiskRedundancy() {
+    return innerCompactionTaskSelectionDiskRedundancy;
+  }
+
+  public void setInnerCompactionTaskSelectionDiskRedundancy(
+      double innerCompactionTaskSelectionDiskRedundancy) {
+    this.innerCompactionTaskSelectionDiskRedundancy = innerCompactionTaskSelectionDiskRedundancy;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -691,6 +691,18 @@ public class IoTDBDescriptor {
                 "candidate_compaction_task_queue_size",
                 Integer.toString(conf.getCandidateCompactionTaskQueueSize()))));
 
+    conf.setInnerCompactionTaskSelectionDiskRedundancy(
+        Double.parseDouble(
+            properties.getProperty(
+                "inner_compaction_task_selection_disk_redundancy",
+                Double.toString(conf.getInnerCompactionTaskSelectionDiskRedundancy()))));
+
+    conf.setInnerCompactionTaskSelectionModsFileThreshold(
+        Long.parseLong(
+            properties.getProperty(
+                "inner_compaction_task_selection_mods_file_threshold",
+                Long.toString(conf.getInnerCompactionTaskSelectionModsFileThreshold()))));
+
     conf.setEnablePartialInsert(
         Boolean.parseBoolean(
             properties.getProperty(
@@ -1197,6 +1209,18 @@ public class IoTDBDescriptor {
     conf.setEnableCrossSpaceCompaction(newConfigEnableCrossSpaceCompaction);
     conf.setEnableSeqSpaceCompaction(newConfigEnableSeqSpaceCompaction);
     conf.setEnableUnseqSpaceCompaction(newConfigEnableUnseqSpaceCompaction);
+
+    conf.setInnerCompactionTaskSelectionDiskRedundancy(
+        Double.parseDouble(
+            properties.getProperty(
+                "inner_compaction_task_selection_disk_redundancy",
+                Double.toString(conf.getInnerCompactionTaskSelectionDiskRedundancy()))));
+
+    conf.setInnerCompactionTaskSelectionModsFileThreshold(
+        Long.parseLong(
+            properties.getProperty(
+                "inner_compaction_task_selection_mods_file_threshold",
+                Long.toString(conf.getInnerCompactionTaskSelectionModsFileThreshold()))));
   }
 
   private void loadWALHotModifiedProps(Properties properties) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/impl/SizeTieredCompactionSelector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/impl/SizeTieredCompactionSelector.java
@@ -67,11 +67,6 @@ public class SizeTieredCompactionSelector
   protected boolean sequence;
   protected TsFileManager tsFileManager;
   protected boolean hasNextTimePartition;
-  private static final long MODS_FILE_SIZE_THRESHOLD =
-      config.getInnerCompactionTaskSelectionModsFileThreshold();
-
-  private static final double DISK_REDUNDANCY =
-      config.getInnerCompactionTaskSelectionDiskRedundancy();
 
   public SizeTieredCompactionSelector(
       String storageGroupName,
@@ -201,8 +196,9 @@ public class SizeTieredCompactionSelector
       if (tsFileResource.getStatus() != TsFileResourceStatus.NORMAL) {
         continue;
       }
-      if (modFile.getSize() > MODS_FILE_SIZE_THRESHOLD
-          || !CompactionUtils.isDiskHasSpace(DISK_REDUNDANCY)) {
+      if (modFile.getSize() > config.getInnerCompactionTaskSelectionModsFileThreshold()
+          || !CompactionUtils.isDiskHasSpace(
+              config.getInnerCompactionTaskSelectionDiskRedundancy())) {
         taskList.add(
             createCompactionTask(
                 Collections.singletonList(tsFileResource), CompactionTaskPriorityType.MOD_SETTLE));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/impl/SizeTieredCompactionSelector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/impl/SizeTieredCompactionSelector.java
@@ -67,9 +67,11 @@ public class SizeTieredCompactionSelector
   protected boolean sequence;
   protected TsFileManager tsFileManager;
   protected boolean hasNextTimePartition;
-  private static final long MODS_FILE_SIZE_THRESHOLD = 1024 * 1024 * 50L;
+  private static final long MODS_FILE_SIZE_THRESHOLD =
+      config.getInnerCompactionTaskSelectionModsFileThreshold();
 
-  private static final double DISK_REDUNDANCY = 0.05;
+  private static final double DISK_REDUNDANCY =
+      config.getInnerCompactionTaskSelectionDiskRedundancy();
 
   public SizeTieredCompactionSelector(
       String storageGroupName,

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -680,7 +680,15 @@ timestamp_precision=ms
 # Datatype: int
 # sub_compaction_thread_count=4
 
+# Redundancy value of disk availability, only use for inner compaction.
+# When disk availability is lower than the sum of (disk_space_warning_threshold + inner_compaction_task_selection_disk_redundancy), inner compaction tasks containing mods files are selected first.
+# DataType: double
+# inner_compaction_task_selection_disk_redundancy=0.05
 
+# Mods file size threshold, only use for inner compaction.
+# When the size of the mods file corresponding to TsFile exceeds this value, inner compaction tasks containing mods files are selected first.
+# DataType: long
+# inner_compaction_task_selection_mods_file_threshold=52428800
 
 ####################
 ### Write Ahead Log Configuration


### PR DESCRIPTION
## Description

Two new inner compaction configurations:
1. inner_compaction_task_selection_disk_redundancy
2. inner_compaction_task_selection_mods_file_threshold

When the size of the mods file corresponding to TsFile exceeds **inner_compaction_task_selection_mods_file_threshold** or disk availability is lower than the sum of **(disk_space_warning_threshold + inner_compaction_task_selection_disk_redundancy)**, inner compaction tasks containing mods files are selected first.