### PR TITLE
Pipe: Make error message reported by pipe parameter check clearer

### DIFF
--- a/iotdb-api/pipe-api/src/main/java/org/apache/iotdb/pipe/api/customizer/parameter/PipeParameterValidator.java
+++ b/iotdb-api/pipe-api/src/main/java/org/apache/iotdb/pipe/api/customizer/parameter/PipeParameterValidator.java
@@ -56,7 +56,7 @@ public class PipeParameterValidator {
       throws PipeAttributeNotProvidedException {
     if (!parameters.hasAttribute(key)) {
       if (!canBeOptional) {
-        throw new PipeAttributeNotProvidedException(String.format("%s should be set.", key));
+        throw new PipeParameterNotValidException(String.format("Parameter %s should be set.", key));
       }
       return this;
     }
@@ -68,8 +68,8 @@ public class PipeParameterValidator {
       }
     }
 
-    throw new PipeAttributeNotProvidedException(
-        String.format("%s should be one of %s", key, Arrays.toString(optionalValues)));
+    throw new PipeParameterNotValidException(
+        String.format("The value of %s should be one of %s", key, Arrays.toString(optionalValues)));
   }
 
   /**


### PR DESCRIPTION
## Description

As title.

Example:

```sql
create pipe extractor_realtime_1 
with extractor ('extractor'='iotdb-extractor', 'extractor.pattern'='root.aligned','extractor.history.enable'='false','extractor.realtime.enable'='0') 
with connector ('connector'='iotdb-thrift-connector', 'connector.ip'='127.0.0.1', 'connector.port'='6667');
```

* Before fix:
![image](https://github.com/apache/iotdb/assets/30497621/af37a346-ce97-4315-9998-76185e168364)

* After fix:
![image](https://github.com/apache/iotdb/assets/30497621/af74068d-e968-4547-82c4-318311a6270f)
