### PR TITLE
Cache LZ4Factory to avoid performance problem with LZ4Factory

### DIFF
--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/compress/ICompressor.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/compress/ICompressor.java
@@ -198,12 +198,20 @@ public interface ICompressor extends Serializable {
   }
 
   class IOTDBLZ4Compressor implements ICompressor {
-    private LZ4Compressor compressor;
+    /**
+     * This instance should be cached to avoid performance problem. See:
+     * https://github.com/lz4/lz4-java/issues/152 and https://github.com/apache/spark/pull/24905
+     */
+    private static final LZ4Factory factory = LZ4Factory.fastestInstance();
+
+    private static final LZ4Compressor compressor = factory.fastCompressor();
+
+    public static LZ4Factory getFactory() {
+      return factory;
+    }
 
     public IOTDBLZ4Compressor() {
       super();
-      LZ4Factory factory = LZ4Factory.fastestInstance();
-      compressor = factory.fastCompressor();
     }
 
     @Override

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/compress/IUnCompressor.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/compress/IUnCompressor.java
@@ -24,7 +24,6 @@ import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 
 import com.github.luben.zstd.Zstd;
 import net.jpountz.lz4.LZ4Compressor;
-import net.jpountz.lz4.LZ4Factory;
 import net.jpountz.lz4.LZ4SafeDecompressor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -201,12 +200,10 @@ public interface IUnCompressor {
         "tsfile-compression LZ4UnCompressor: errors occurs when uncompress input byte";
 
     private static final int MAX_COMPRESS_RATIO = 255;
-    private LZ4SafeDecompressor decompressor;
+    private static final LZ4SafeDecompressor decompressor =
+        ICompressor.IOTDBLZ4Compressor.getFactory().safeDecompressor();
 
-    public LZ4UnCompressor() {
-      LZ4Factory factory = LZ4Factory.fastestInstance();
-      decompressor = factory.safeDecompressor();
-    }
+    public LZ4UnCompressor() {}
 
     @Override
     public int getUncompressedLength(byte[] array, int offset, int length) {


### PR DESCRIPTION
## Description
This pr cache the instance of LZ4Factory to avoid performance problem. 
<img width="709" alt="截屏2023-12-13 18 22 36" src="https://github.com/apache/iotdb/assets/55970239/34072c75-04f2-470b-92ec-67a19febf296">
