### PR TITLE
[RatisConsensus] Fix Precondition failure on consensus read

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -388,6 +388,9 @@ class RatisConsensus implements IConsensus {
                     // connect to the peer)
                     // We can still retry in case it's a temporary network partition.
                     return RaftClientReply.newBuilder()
+                        .setClientId(localFakeId)
+                        .setServerId(server.getId())
+                        .setGroupId(request.getRaftGroupId())
                         .setException(
                             new ReadIndexException(
                                 "internal GRPC connection error:", ioe.getCause()))


### PR DESCRIPTION
<img width="1338" alt="image" src="https://github.com/apache/iotdb/assets/48054931/5b2bc6b6-99be-40f6-a634-7bb77903f3ff">
Ratis required clientId serverId and groupId when constructing reply messge.