### PR TITLE
Reduce stack message of known compaction exceptions in log

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/exception/CompactionFileCountExceededException.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/exception/CompactionFileCountExceededException.java
@@ -23,4 +23,9 @@ public class CompactionFileCountExceededException extends Exception {
   public CompactionFileCountExceededException(String message) {
     super(message);
   }
+
+  @Override
+  public Throwable fillInStackTrace() {
+    return this;
+  }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/exception/CompactionLastTimeCheckFailedException.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/exception/CompactionLastTimeCheckFailedException.java
@@ -31,4 +31,9 @@ public class CompactionLastTimeCheckFailedException extends RuntimeException {
             + ", which should be later than the last time "
             + lastTimestamp);
   }
+
+  @Override
+  public Throwable fillInStackTrace() {
+    return this;
+  }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/exception/CompactionMemoryNotEnoughException.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/exception/CompactionMemoryNotEnoughException.java
@@ -24,4 +24,9 @@ public class CompactionMemoryNotEnoughException extends Exception {
   public CompactionMemoryNotEnoughException(String message) {
     super(message);
   }
+
+  @Override
+  public Throwable fillInStackTrace() {
+    return this;
+  }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/exception/CompactionValidationFailedException.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/exception/CompactionValidationFailedException.java
@@ -23,4 +23,9 @@ public class CompactionValidationFailedException extends RuntimeException {
   public CompactionValidationFailedException(String msg) {
     super(msg);
   }
+
+  @Override
+  public Throwable fillInStackTrace() {
+    return this;
+  }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/performer/impl/FastCompactionPerformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/performer/impl/FastCompactionPerformer.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.WriteProcessException;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.exception.CompactionLastTimeCheckFailedException;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.exception.IllegalCompactionTaskSummaryException;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.performer.ICrossCompactionPerformer;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.performer.ISeqCompactionPerformer;
@@ -242,6 +243,9 @@ public class FastCompactionPerformer
         futures.get(i).get();
         subTaskSummary.increase(taskSummaryList.get(i));
       } catch (ExecutionException e) {
+        if (e.getCause() instanceof CompactionLastTimeCheckFailedException) {
+          throw (CompactionLastTimeCheckFailedException) e.getCause();
+        }
         throw new IOException("[Compaction] SubCompactionTask meet errors ", e);
       }
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/AbstractCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/AbstractCompactionTask.java
@@ -135,7 +135,8 @@ public abstract class AbstractCompactionTask {
   public void handleTaskCleanup() {}
 
   protected void printLogWhenException(Logger logger, Exception e) {
-    if (e instanceof CompactionLastTimeCheckFailedException) {
+    if (e instanceof CompactionLastTimeCheckFailedException
+        || e instanceof CompactionValidationFailedException) {
       logger.error(
           "{}-{} [Compaction] Meet errors {}: {}.",
           getCompactionTaskType(),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/AbstractCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/AbstractCompactionTask.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.service.metrics.CompactionMetrics;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.constant.CompactionTaskType;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.exception.CompactionLastTimeCheckFailedException;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.exception.CompactionValidationFailedException;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.exception.FileCannotTransitToCompactingException;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.performer.ICompactionPerformer;
@@ -134,7 +135,14 @@ public abstract class AbstractCompactionTask {
   public void handleTaskCleanup() {}
 
   protected void printLogWhenException(Logger logger, Exception e) {
-    if (e instanceof InterruptedException) {
+    if (e instanceof CompactionLastTimeCheckFailedException) {
+      logger.error(
+          "{}-{} [Compaction] Meet errors {}: {}.",
+          getCompactionTaskType(),
+          storageGroupName,
+          dataRegionId,
+          e.getMessage());
+    } else if (e instanceof InterruptedException) {
       logger.warn("{}-{} [Compaction] Compaction interrupted", storageGroupName, dataRegionId);
       Thread.currentThread().interrupt();
     } else {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/schedule/CompactionWorker.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/schedule/CompactionWorker.java
@@ -106,7 +106,7 @@ public class CompactionWorker implements Runnable {
     } catch (FileCannotTransitToCompactingException
         | CompactionMemoryNotEnoughException
         | CompactionFileCountExceededException e) {
-      LOGGER.info("CompactionTask {} cannot be executed. Reason: {}", task, e);
+      LOGGER.info("CompactionTask {} cannot be executed. Reason: {}", task, e.getMessage());
     } catch (InterruptedException e) {
       LOGGER.warn("InterruptedException occurred when preparing compaction task. {}", task, e);
       Thread.currentThread().interrupt();


### PR DESCRIPTION
## Description
1. Reduce stack message of known compaction exceptions in log (CompactionMemoryNotEnoughException, CompactionFileCountExceedException, CompactionValidationFailedException, CompactionLastTimeCheckFailedException and FileCannotTransitToCompactingException).
2. Avoid trace stack for known compaction exceptions by reimplement 'fillInStackTrace' method.
