### PR TITLE
Improved stability of Ratis addMemberToGroup and testThresholdSnapshot UT

### DIFF
--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/DiskGuardianTest.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/DiskGuardianTest.java
@@ -93,7 +93,7 @@ public class DiskGuardianTest {
     Assert.assertFalse(hasSnapshot(gid));
     JavaUtils.attemptUntilTrue(
         () -> hasSnapshot(gid),
-        3,
+        12,
         TimeDuration.valueOf(5, TimeUnit.SECONDS),
         "should take snapshot",
         logger);

--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/DiskGuardianTest.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/DiskGuardianTest.java
@@ -88,6 +88,7 @@ public class DiskGuardianTest {
       s.createLocalPeer(gid, members);
     }
 
+    miniCluster.waitUntilActiveLeaderElectedAndReady();
     miniCluster.writeManySerial(0, 10);
     Assert.assertFalse(hasSnapshot(gid));
     JavaUtils.attemptUntilTrue(

--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RecoverReadTest.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RecoverReadTest.java
@@ -175,7 +175,7 @@ public class RecoverReadTest {
     miniCluster.restart();
 
     // wait an active leader to serve linearizable read requests
-    miniCluster.waitUntilActiveLeaderElectedAndReady();
+    miniCluster.waitUntilActiveLeaderElected();
 
     Assert.assertEquals(10, miniCluster.mustRead(0));
   }
@@ -231,7 +231,7 @@ public class RecoverReadTest {
     miniCluster.restart();
 
     // wait until active leader to serve read index requests
-    miniCluster.waitUntilActiveLeaderElectedAndReady();
+    miniCluster.waitUntilActiveLeaderElected();
 
     // query during redo: get exception that ratis is under recovery
     Assert.assertThrows(RatisReadUnavailableException.class, () -> miniCluster.readThrough(0));

--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RecoverReadTest.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RecoverReadTest.java
@@ -175,7 +175,7 @@ public class RecoverReadTest {
     miniCluster.restart();
 
     // wait an active leader to serve linearizable read requests
-    miniCluster.waitUntilActiveLeader();
+    miniCluster.waitUntilActiveLeaderElectedAndReady();
 
     Assert.assertEquals(10, miniCluster.mustRead(0));
   }
@@ -231,7 +231,7 @@ public class RecoverReadTest {
     miniCluster.restart();
 
     // wait until active leader to serve read index requests
-    miniCluster.waitUntilActiveLeader();
+    miniCluster.waitUntilActiveLeaderElectedAndReady();
 
     // query during redo: get exception that ratis is under recovery
     Assert.assertThrows(RatisReadUnavailableException.class, () -> miniCluster.readThrough(0));

--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/TestUtils.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/TestUtils.java
@@ -346,6 +346,15 @@ public class TestUtils {
       return group;
     }
 
+    void waitUntilActiveLeaderElected() throws InterruptedException {
+      JavaUtils.attemptUntilTrue(
+          () -> servers.stream().anyMatch(server -> server.isLeader(gid)),
+          600,
+          TimeDuration.valueOf(100, TimeUnit.MILLISECONDS),
+          "wait leader elected",
+          null);
+    }
+
     void waitUntilActiveLeaderElectedAndReady() throws InterruptedException {
       JavaUtils.attemptUntilTrue(
           () -> servers.stream().anyMatch(server -> server.isLeaderReady(gid)),

--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/TestUtils.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/TestUtils.java
@@ -65,9 +65,11 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class TestUtils {
+
   private static final Logger logger = LoggerFactory.getLogger(TestUtils.class);
 
   public static class TestDataSet implements DataSet {
+
     private int number;
 
     public void setNumber(int number) {
@@ -80,6 +82,7 @@ public class TestUtils {
   }
 
   public static class TestRequest implements IConsensusRequest {
+
     private final int cmd;
 
     public TestRequest(ByteBuffer buffer) {
@@ -113,6 +116,7 @@ public class TestUtils {
   }
 
   public static class IntegerCounter implements IStateMachine, IStateMachine.EventApi {
+
     protected AtomicInteger integer;
     private final Logger logger = LoggerFactory.getLogger(IntegerCounter.class);
     private List<Peer> configuration;
@@ -214,6 +218,7 @@ public class TestUtils {
 
   /** A Mini Raft CLuster Wrapper for Test Env. */
   static class MiniCluster {
+
     private final ConsensusGroupId gid;
     private final int replicas;
     private final List<Peer> peers;
@@ -341,12 +346,12 @@ public class TestUtils {
       return group;
     }
 
-    void waitUntilActiveLeader() throws InterruptedException {
+    void waitUntilActiveLeaderElectedAndReady() throws InterruptedException {
       JavaUtils.attemptUntilTrue(
-          () -> getServer(0).getLeader(gid) != null,
-          100,
+          () -> servers.stream().anyMatch(server -> server.isLeaderReady(gid)),
+          600,
           TimeDuration.valueOf(100, TimeUnit.MILLISECONDS),
-          "wait leader",
+          "wait leader elected and become ready",
           null);
     }
 
@@ -395,7 +400,7 @@ public class TestUtils {
     int mustRead(int serverIndex) throws InterruptedException {
       final ByteBufferConsensusRequest readRequest = TestUtils.TestRequest.getRequest();
 
-      waitUntilActiveLeader();
+      waitUntilActiveLeaderElectedAndReady();
 
       final TimeDuration maxTryDuration = TimeDuration.valueOf(3, TimeUnit.MINUTES);
       final TimeDuration waitDuration = TimeDuration.valueOf(1000, TimeUnit.MILLISECONDS);
@@ -430,6 +435,7 @@ public class TestUtils {
   }
 
   static class MiniClusterFactory {
+
     private final int replicas = 3;
     private ConsensusGroupId gid = new DataRegionId(1);
     private final Function<Integer, File> peerStorageProvider =


### PR DESCRIPTION
For addMemberToGroup UT:
- The previous UT operates the underlying state machine only after the leader is elected, and the state machine may not be fully restored at this time, thus making some subsequent judgments wrong. This PR changes to ensure that the Leader's state machine is not read until the leader is ready (i.e., the state machine is restored) to ensure that the CI environment does not fail

For testThresholdSnapshot UT:
- In CI environment, some threads are scheduled slowly, requiring 3 chances to generate Snapshot may lead to instability, so this PR is changed to 12 times, which is as low as possible in CI environment with weak resource environment