### PR TITLE
[IOTDB-5706] Data inconsistency between IoT protocol replications

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/client/DispatchLogHandler.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/client/DispatchLogHandler.java
@@ -84,7 +84,8 @@ public class DispatchLogHandler implements AsyncMethodCallback<TSyncLogEntriesRe
   public static boolean needRetry(int statusCode) {
     return statusCode == TSStatusCode.INTERNAL_SERVER_ERROR.getStatusCode()
         || statusCode == TSStatusCode.SYSTEM_READ_ONLY.getStatusCode()
-        || statusCode == TSStatusCode.WRITE_PROCESS_REJECT.getStatusCode();
+        || statusCode == TSStatusCode.WRITE_PROCESS_REJECT.getStatusCode()
+        || statusCode == TSStatusCode.WRITE_PROCESS_ERROR.getStatusCode();
   }
 
   @Override


### PR DESCRIPTION
## Description
The status code returned for handling BatchProcessException is `WRITE_PROCESS_ERROR`, but this status code was not included in the retry judgment of IoT, so the batch that caused BatchProcessException did not retry, resulting in inconsistent data between IoT replications.

To fix the problem, we add the status code `WRITE_PROCESS_ERROR` in IoT Retry judgment.

Besides, the atomicity issue of storage engine write operations can also lead to data inconsistency, which will be fixed in subsequent work.