### PR TITLE
Take snapshot for mods using copy instead of hard link

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/snapshot/SnapshotTaker.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/snapshot/SnapshotTaker.java
@@ -203,10 +203,10 @@ public class SnapshotTaker {
 
   private void copyFile(File target, File source) throws IOException {
     if (!target.getParentFile().exists()) {
-      LOGGER.error("Hard link target dir {} doesn't exist", target.getParentFile());
+      LOGGER.error("Copy target dir {} doesn't exist", target.getParentFile());
     }
     if (!source.exists()) {
-      LOGGER.error("Hard link source file {} doesn't exist", source);
+      LOGGER.error("Copy source file {} doesn't exist", source);
     }
     Files.deleteIfExists(target.toPath());
     Files.copy(source.toPath(), target.toPath());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/snapshot/SnapshotTaker.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/snapshot/SnapshotTaker.java
@@ -177,7 +177,7 @@ public class SnapshotTaker {
             new File(snapshotTsFile.getAbsolutePath() + TsFileResource.RESOURCE_SUFFIX),
             new File(tsFile.getAbsolutePath() + TsFileResource.RESOURCE_SUFFIX));
         if (resource.getModFile().exists()) {
-          createHardLink(
+          copyFile(
               new File(snapshotTsFile.getAbsolutePath() + ModificationFile.FILE_SUFFIX),
               new File(tsFile.getAbsolutePath() + ModificationFile.FILE_SUFFIX));
         }
@@ -198,6 +198,18 @@ public class SnapshotTaker {
     }
     Files.deleteIfExists(target.toPath());
     Files.createLink(target.toPath(), source.toPath());
+    snapshotLogger.logFile(source);
+  }
+
+  private void copyFile(File target, File source) throws IOException {
+    if (!target.getParentFile().exists()) {
+      LOGGER.error("Hard link target dir {} doesn't exist", target.getParentFile());
+    }
+    if (!source.exists()) {
+      LOGGER.error("Hard link source file {} doesn't exist", source);
+    }
+    Files.deleteIfExists(target.toPath());
+    Files.copy(source.toPath(), target.toPath());
     snapshotLogger.logFile(source);
   }
 


### PR DESCRIPTION
Currently, a hard link of mods file is created when taking snapshot for data region, but the mods file is not immutable, which means the snapshot could be updated. We need to make sure the snapshot is immutable too, so a copy of mods file should be created instead of hard link.