### PR TITLE
PBTree: Enable pre-allocation for Internal/Device child node

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/PageManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/PageManager.java
@@ -324,19 +324,14 @@ public abstract class PageManager implements IPageManager {
       if (!child.isMeasurement()) {
         alias = null;
 
-        if (getNodeAddress(child) >= 0) {
-          // new child with a valid segment address, weird
-          throw new MetadataException(
-              String.format(
-                  "A child [%s] in newChildBuffer shall not have segmentAddress.",
-                  child.getFullPath()));
-        }
-
-        // pre-allocate except that child is a device node using template
-        if (!(child.isDevice() && child.getAsDeviceMNode().isUseTemplate())) {
+        // TODO optimization if many device only using template but has no child
+        if (getNodeAddress(child) < 0) {
           short estSegSize = estimateSegmentSize(child);
           long glbIndex = preAllocateSegment(estSegSize, cxt);
           SchemaFile.setNodeAddress(child, glbIndex);
+        } else {
+          // new child with a valid segment address could be maliciously modified
+          throw new MetadataException("A child in newChildBuffer shall not have segmentAddress.");
         }
       } else {
         alias =


### PR DESCRIPTION
## Description

[Previously](https://github.com/apache/iotdb/pull/11467) this mechanism was disabled for more efficient when there are many devices using template with no descendents. The modification would throw exception if nested device and its parental device are both using template, which means a device using template does have a descendent.

The optimization should be considered in further development.