### PR TITLE
Fix some problems of FastCompactionPerformer

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/writer/AbstractInnerCompactionWriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/writer/AbstractInnerCompactionWriter.java
@@ -51,13 +51,15 @@ public abstract class AbstractInnerCompactionWriter extends AbstractCompactionWr
                 / IoTDBDescriptor.getInstance().getConfig().getCompactionThreadCount()
                 * IoTDBDescriptor.getInstance().getConfig().getChunkMetadataSizeProportion());
     boolean enableMemoryControl = IoTDBDescriptor.getInstance().getConfig().isEnableMemControl();
+    this.targetResource = targetFileResource;
     this.fileWriter =
         new CompactionTsFileWriter(
             targetFileResource.getTsFile(),
             enableMemoryControl,
             sizeForFileWriter,
-            CompactionType.INNER_UNSEQ_COMPACTION);
-    this.targetResource = targetFileResource;
+            targetResource.isSeq()
+                ? CompactionType.INNER_SEQ_COMPACTION
+                : CompactionType.INNER_UNSEQ_COMPACTION);
     isEmptyFile = true;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/writer/FastInnerCompactionWriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/writer/FastInnerCompactionWriter.java
@@ -125,10 +125,6 @@ public class FastInnerCompactionWriter extends AbstractInnerCompactionWriter {
     boolean isUnsealedPageOverThreshold =
         chunkWriters[subTaskId].checkIsUnsealedPageOverThreshold(
             pageSizeLowerBoundInCompaction, pagePointNumLowerBoundInCompaction, true);
-    if (isUnsealedPageOverThreshold) {
-      // seal page
-      chunkWriters[subTaskId].sealCurrentPage();
-    }
     if (!isUnsealedPageOverThreshold
         || !checkIsAlignedPageLargeEnough(timePageHeader, valuePageHeaders)) {
       // there is unsealed page or current page is not large enough , then deserialize the page
@@ -160,10 +156,6 @@ public class FastInnerCompactionWriter extends AbstractInnerCompactionWriter {
     boolean isUnsealedPageOverThreshold =
         chunkWriters[subTaskId].checkIsUnsealedPageOverThreshold(
             pageSizeLowerBoundInCompaction, pagePointNumLowerBoundInCompaction, true);
-    if (isUnsealedPageOverThreshold) {
-      // seal page
-      chunkWriters[subTaskId].sealCurrentPage();
-    }
     if (!isUnsealedPageOverThreshold || !checkIsPageLargeEnough(pageHeader)) {
       // there is unsealed page or current page is not large enough , then deserialize the page
       return false;


### PR DESCRIPTION
## Description
1. skip seal page if the next page cannot be flushed directly.
2. Fix the compaction metric if FastCompactionPerformer is used for sequence InnerSpaceCompaction
