### PR TITLE
Simplify NodeBuffer iterator logic

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/memory/ReleaseFlushMonitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/memory/ReleaseFlushMonitor.java
@@ -227,8 +227,22 @@ public class ReleaseFlushMonitor {
 
   @TestOnly
   public void forceFlushAndRelease() {
-    scheduler.forceFlushAll();
-    scheduler.scheduleRelease(true);
+    boolean needFlush = false;
+    while (true) {
+      needFlush = false;
+      for (CachedMTreeStore store : regionToStoreMap.values()) {
+        if (store.getRegionStatistics().getBufferNodeNum() > 0) {
+          needFlush = true;
+          break;
+        }
+      }
+      if (needFlush) {
+        scheduler.forceFlushAll();
+        scheduler.scheduleRelease(true);
+      } else {
+        break;
+      }
+    }
   }
 
   public void clear() {


### PR DESCRIPTION
## Description

Since the ReleaseFlushMonitor takes the responsibility of rounded flush until all volatile nodes being flushed, there's no need to implement complex modification-sensitive iterator in NodeBuffer. Remove related logic.