### PR TITLE
Show regionId supports SQL queries by time range.

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/partition/IoTDBPartitionGetterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/partition/IoTDBPartitionGetterIT.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.common.rpc.thrift.TConsensusGroupId;
 import org.apache.iotdb.common.rpc.thrift.TConsensusGroupType;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.common.rpc.thrift.TSeriesPartitionSlot;
+import org.apache.iotdb.common.rpc.thrift.TTimePartitionSlot;
 import org.apache.iotdb.commons.client.sync.SyncConfigNodeIServiceClient;
 import org.apache.iotdb.commons.schema.SchemaConstant;
 import org.apache.iotdb.confignode.it.utils.ConfigNodeTestUtils;
@@ -359,16 +360,18 @@ public class IoTDBPartitionGetterIT {
       // Get RegionIds of specified database and timestamp
       getRegionIdReq = new TGetRegionIdReq(TConsensusGroupType.DataRegion);
       getRegionIdReq.setDatabase(sg0);
-      getRegionIdReq.setTimeStamp(0);
+      getRegionIdReq.setStartTimeSlot(new TTimePartitionSlot(0));
+      getRegionIdReq.setEndTimeSlot(new TTimePartitionSlot(0));
       getRegionIdResp = client.getRegionId(getRegionIdReq);
       Assert.assertEquals(
           TSStatusCode.SUCCESS_STATUS.getStatusCode(), getRegionIdResp.status.getCode());
 
-      //           Get RegionId with wrong PartitionSlot
+      //   Get schema RegionIds with specified database and timestamp will ignore timestamp and
+      // return success.
       getRegionIdReq.setType(TConsensusGroupType.SchemaRegion);
       getRegionIdResp = client.getRegionId(getRegionIdReq);
       Assert.assertEquals(
-          TSStatusCode.ILLEGAL_PARAMETER.getStatusCode(), getRegionIdResp.status.getCode());
+          TSStatusCode.SUCCESS_STATUS.getStatusCode(), getRegionIdResp.status.getCode());
 
       // Get all RegionIds within database
       for (int i = 0; i < storageGroupNum; i++) {
@@ -383,7 +386,8 @@ public class IoTDBPartitionGetterIT {
         for (long j = 0; j < testTimePartitionSlotsNum; j++) {
           TGetRegionIdReq subReq = new TGetRegionIdReq(TConsensusGroupType.DataRegion);
           subReq.setDatabase(curSg);
-          subReq.setTimeStamp(j * testTimePartitionInterval);
+          subReq.setStartTimeSlot(new TTimePartitionSlot(j * testTimePartitionInterval));
+          subReq.setEndTimeSlot(new TTimePartitionSlot(j * testTimePartitionInterval));
           TGetRegionIdResp subResp = client.getRegionId(subReq);
           Assert.assertEquals(
               TSStatusCode.SUCCESS_STATUS.getStatusCode(), subResp.getStatus().getCode());

--- a/iotdb-core/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IoTDBSqlParser.g4
+++ b/iotdb-core/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IoTDBSqlParser.g4
@@ -479,8 +479,7 @@ showConfigNodes
 getRegionId
     : SHOW (DATA|SCHEMA) REGIONID WHERE (DATABASE operator_eq database=prefixPath
         |DEVICE operator_eq device=prefixPath)
-        (operator_and firstExpression = expression )?
-        (operator_and secondExpression = expression )?
+        (operator_and timeRangeExpression = expression )?
     ;
 
 // ---- Get Time Slot List

--- a/iotdb-core/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IoTDBSqlParser.g4
+++ b/iotdb-core/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IoTDBSqlParser.g4
@@ -479,7 +479,8 @@ showConfigNodes
 getRegionId
     : SHOW (DATA|SCHEMA) REGIONID WHERE (DATABASE operator_eq database=prefixPath
         |DEVICE operator_eq device=prefixPath)
-        (operator_and (TIMESTAMP|TIME) operator_eq time = timeValue)?
+        (operator_and (TIMESTAMP|TIME) (OPERATOR_GT | OPERATOR_GTE | OPERATOR_SEQ | OPERATOR_DEQ) firstTime = timeValue)?
+        (operator_and (TIMESTAMP|TIME) (OPERATOR_LT | OPERATOR_LTE) secondTime = timeValue)?
     ;
 
 // ---- Get Time Slot List

--- a/iotdb-core/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IoTDBSqlParser.g4
+++ b/iotdb-core/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IoTDBSqlParser.g4
@@ -479,8 +479,8 @@ showConfigNodes
 getRegionId
     : SHOW (DATA|SCHEMA) REGIONID WHERE (DATABASE operator_eq database=prefixPath
         |DEVICE operator_eq device=prefixPath)
-        (operator_and (TIMESTAMP|TIME) (OPERATOR_GT | OPERATOR_GTE | OPERATOR_SEQ | OPERATOR_DEQ) firstTime = timeValue)?
-        (operator_and (TIMESTAMP|TIME) (OPERATOR_LT | OPERATOR_LTE) secondTime = timeValue)?
+        (operator_and firstExpression = expression )?
+        (operator_and secondExpression = expression )?
     ;
 
 // ---- Get Time Slot List

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/read/region/GetRegionIdPlan.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/read/region/GetRegionIdPlan.java
@@ -38,7 +38,9 @@ public class GetRegionIdPlan extends ConfigPhysicalPlan {
 
   private TConsensusGroupType partitionType;
 
-  private TTimePartitionSlot timeSlotId;
+  private TTimePartitionSlot startTimeSlotId;
+
+  private TTimePartitionSlot endTimeSlotId;
 
   private TSeriesPartitionSlot seriesSlotId;
 
@@ -51,7 +53,8 @@ public class GetRegionIdPlan extends ConfigPhysicalPlan {
     this.partitionType = partitionType;
     this.database = "";
     this.seriesSlotId = new TSeriesPartitionSlot(-1);
-    this.timeSlotId = new TTimePartitionSlot(-1);
+    this.startTimeSlotId = new TTimePartitionSlot(-1);
+    this.endTimeSlotId = new TTimePartitionSlot(-1);
   }
 
   public String getDatabase() {
@@ -70,12 +73,20 @@ public class GetRegionIdPlan extends ConfigPhysicalPlan {
     return seriesSlotId;
   }
 
-  public void setTimeSlotId(TTimePartitionSlot timeSlotId) {
-    this.timeSlotId = timeSlotId;
+  public TTimePartitionSlot getStartTimeSlotId() {
+    return startTimeSlotId;
   }
 
-  public TTimePartitionSlot getTimeSlotId() {
-    return timeSlotId;
+  public void setStartTimeSlotId(TTimePartitionSlot startTimeSlotId) {
+    this.startTimeSlotId = startTimeSlotId;
+  }
+
+  public TTimePartitionSlot getEndTimeSlotId() {
+    return endTimeSlotId;
+  }
+
+  public void setEndTimeSlotId(TTimePartitionSlot endTimeSlotId) {
+    this.endTimeSlotId = endTimeSlotId;
   }
 
   public TConsensusGroupType getPartitionType() {
@@ -88,7 +99,8 @@ public class GetRegionIdPlan extends ConfigPhysicalPlan {
     stream.writeInt(partitionType.ordinal());
     ReadWriteIOUtils.write(database, stream);
     ThriftCommonsSerDeUtils.serializeTSeriesPartitionSlot(seriesSlotId, stream);
-    ThriftCommonsSerDeUtils.serializeTTimePartitionSlot(timeSlotId, stream);
+    ThriftCommonsSerDeUtils.serializeTTimePartitionSlot(startTimeSlotId, stream);
+    ThriftCommonsSerDeUtils.serializeTTimePartitionSlot(endTimeSlotId, stream);
   }
 
   @Override
@@ -96,7 +108,8 @@ public class GetRegionIdPlan extends ConfigPhysicalPlan {
     this.partitionType = TConsensusGroupType.findByValue(buffer.getInt());
     this.database = ReadWriteIOUtils.readString(buffer);
     this.seriesSlotId = ThriftCommonsSerDeUtils.deserializeTSeriesPartitionSlot(buffer);
-    this.timeSlotId = ThriftCommonsSerDeUtils.deserializeTTimePartitionSlot(buffer);
+    this.startTimeSlotId = ThriftCommonsSerDeUtils.deserializeTTimePartitionSlot(buffer);
+    this.endTimeSlotId = ThriftCommonsSerDeUtils.deserializeTTimePartitionSlot(buffer);
   }
 
   @Override
@@ -111,7 +124,8 @@ public class GetRegionIdPlan extends ConfigPhysicalPlan {
     return database.equals(that.database)
         && partitionType.equals(that.partitionType)
         && seriesSlotId.equals(that.seriesSlotId)
-        && timeSlotId.equals(that.timeSlotId);
+        && startTimeSlotId.equals(that.startTimeSlotId)
+        && endTimeSlotId.equals(that.endTimeSlotId);
   }
 
   @Override
@@ -120,7 +134,8 @@ public class GetRegionIdPlan extends ConfigPhysicalPlan {
     hashcode = hashcode * 31 + Objects.hash(partitionType.ordinal());
     hashcode = hashcode * 31 + Objects.hash(database);
     hashcode = hashcode * 31 + seriesSlotId.hashCode();
-    hashcode = hashcode * 31 + timeSlotId.hashCode();
+    hashcode = hashcode * 31 + startTimeSlotId.hashCode();
+    hashcode = hashcode * 31 + endTimeSlotId.hashCode();
     return hashcode;
   }
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
@@ -34,7 +34,6 @@ import org.apache.iotdb.commons.partition.DataPartitionTable;
 import org.apache.iotdb.commons.partition.SchemaPartitionTable;
 import org.apache.iotdb.commons.partition.executor.SeriesPartitionExecutor;
 import org.apache.iotdb.commons.path.PartialPath;
-import org.apache.iotdb.commons.utils.TimePartitionUtils;
 import org.apache.iotdb.confignode.client.DataNodeRequestType;
 import org.apache.iotdb.confignode.client.async.AsyncDataNodeClientPool;
 import org.apache.iotdb.confignode.client.async.handlers.AsyncClientHandler;
@@ -1033,8 +1032,9 @@ public class PartitionManager {
       return new GetRegionIdResp(RpcUtils.SUCCESS_STATUS, new ArrayList<>());
     }
 
-    if (req.isSetTimeStamp()) {
-      plan.setTimeSlotId(TimePartitionUtils.getTimePartitionSlot(req.getTimeStamp()));
+    if (req.isSetStartTimeSlot()) {
+      plan.setStartTimeSlotId(req.getStartTimeSlot());
+      plan.setEndTimeSlotId(req.getEndTimeSlot());
     }
     try {
       return (GetRegionIdResp) getConsensusManager().read(plan);

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
@@ -1031,11 +1031,8 @@ public class PartitionManager {
       // Return empty result if Database not specified
       return new GetRegionIdResp(RpcUtils.SUCCESS_STATUS, new ArrayList<>());
     }
-
-    if (req.isSetStartTimeSlot()) {
-      plan.setStartTimeSlotId(req.getStartTimeSlot());
-      plan.setEndTimeSlotId(req.getEndTimeSlot());
-    }
+    plan.setStartTimeSlotId(req.getStartTimeSlot());
+    plan.setEndTimeSlotId(req.getEndTimeSlot());
     try {
       return (GetRegionIdResp) getConsensusManager().read(plan);
     } catch (ConsensusException e) {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
@@ -1031,8 +1031,17 @@ public class PartitionManager {
       // Return empty result if Database not specified
       return new GetRegionIdResp(RpcUtils.SUCCESS_STATUS, new ArrayList<>());
     }
-    plan.setStartTimeSlotId(req.getStartTimeSlot());
-    plan.setEndTimeSlotId(req.getEndTimeSlot());
+    if (req.isSetStartTimeSlot()) {
+      plan.setStartTimeSlotId(req.getStartTimeSlot());
+    } else {
+      plan.setStartTimeSlotId(new TTimePartitionSlot(0));
+    }
+    if (req.isSetEndTimeSlot()) {
+      plan.setEndTimeSlotId(req.getEndTimeSlot());
+    } else {
+      plan.setEndTimeSlotId(new TTimePartitionSlot(Long.MAX_VALUE));
+    }
+
     try {
       return (GetRegionIdResp) getConsensusManager().read(plan);
     } catch (ConsensusException e) {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/DatabasePartitionTable.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/DatabasePartitionTable.java
@@ -479,9 +479,12 @@ public class DatabasePartitionTable {
   }
 
   public List<TConsensusGroupId> getRegionId(
-      TConsensusGroupType type, TSeriesPartitionSlot seriesSlotId, TTimePartitionSlot timeSlotId) {
+      TConsensusGroupType type,
+      TSeriesPartitionSlot seriesSlotId,
+      TTimePartitionSlot startTimeSlotId,
+      TTimePartitionSlot endTimeSlotId) {
     if (type == TConsensusGroupType.DataRegion) {
-      return dataPartitionTable.getRegionId(seriesSlotId, timeSlotId);
+      return dataPartitionTable.getRegionId(seriesSlotId, startTimeSlotId, endTimeSlotId);
     } else if (type == TConsensusGroupType.SchemaRegion) {
       return schemaPartitionTable.getRegionId(seriesSlotId);
     } else {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
@@ -979,7 +979,11 @@ public class PartitionInfo implements SnapshotProcessor {
     return new GetRegionIdResp(
         new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode()),
         databasePartitionTable
-            .getRegionId(plan.getPartitionType(), plan.getSeriesSlotId(), plan.getTimeSlotId())
+            .getRegionId(
+                plan.getPartitionType(),
+                plan.getSeriesSlotId(),
+                plan.getStartTimeSlotId(),
+                plan.getEndTimeSlotId())
             .stream()
             .distinct()
             .sorted(Comparator.comparing(TConsensusGroupId::getId))

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
@@ -974,7 +974,6 @@ public class PartitionInfo implements SnapshotProcessor {
       return new GetRegionIdResp(
           new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode()), new ArrayList<>());
     }
-
     DatabasePartitionTable databasePartitionTable = databasePartitionTables.get(plan.getDatabase());
     return new GetRegionIdResp(
         new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode()),

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
@@ -20,7 +20,6 @@
 package org.apache.iotdb.confignode.service.thrift;
 
 import org.apache.iotdb.common.rpc.thrift.TConfigNodeLocation;
-import org.apache.iotdb.common.rpc.thrift.TConsensusGroupType;
 import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
 import org.apache.iotdb.common.rpc.thrift.TFlushReq;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
@@ -955,11 +955,6 @@ public class ConfigNodeRPCServiceProcessor implements IConfigNodeRPCService.Ifac
 
   @Override
   public TGetRegionIdResp getRegionId(TGetRegionIdReq req) {
-    if (req.isSetStartTimeSlot() && req.getType() != TConsensusGroupType.DataRegion) {
-      TSStatus status = new TSStatus(TSStatusCode.ILLEGAL_PARAMETER.getStatusCode());
-      status.setMessage("Only data region can set time");
-      return new TGetRegionIdResp(status);
-    }
     return configManager.getRegionId(req);
   }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
@@ -955,7 +955,7 @@ public class ConfigNodeRPCServiceProcessor implements IConfigNodeRPCService.Ifac
 
   @Override
   public TGetRegionIdResp getRegionId(TGetRegionIdReq req) {
-    if (req.isSetTimeStamp() && req.getType() != TConsensusGroupType.DataRegion) {
+    if (req.isSetStartTimeSlot() && req.getType() != TConsensusGroupType.DataRegion) {
       TSStatus status = new TSStatus(TSStatusCode.ILLEGAL_PARAMETER.getStatusCode());
       status.setMessage("Only data region can set time");
       return new TGetRegionIdResp(status);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/executor/ClusterConfigTaskExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/executor/ClusterConfigTaskExecutor.java
@@ -1919,12 +1919,10 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
       } else {
         tGetRegionIdReq.setDatabase(getRegionIdStatement.getDatabase());
       }
-      if (getRegionIdStatement.getStartTimeStamp() >= 0) {
-        tGetRegionIdReq.setStartTimeSlot(
-            TimePartitionUtils.getTimePartitionSlot(getRegionIdStatement.getStartTimeStamp()));
-        tGetRegionIdReq.setEndTimeSlot(
-            TimePartitionUtils.getTimePartitionSlot(getRegionIdStatement.getEndTimeStamp()));
-      }
+      tGetRegionIdReq.setStartTimeSlot(
+          TimePartitionUtils.getTimePartitionSlot(getRegionIdStatement.getStartTimeStamp()));
+      tGetRegionIdReq.setEndTimeSlot(
+          TimePartitionUtils.getTimePartitionSlot(getRegionIdStatement.getEndTimeStamp()));
       resp = configNodeClient.getRegionId(tGetRegionIdReq);
       if (resp.getStatus().getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         future.setException(new IoTDBException(resp.getStatus().message, resp.getStatus().code));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/executor/ClusterConfigTaskExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/executor/ClusterConfigTaskExecutor.java
@@ -45,6 +45,7 @@ import org.apache.iotdb.commons.schema.view.viewExpression.ViewExpression;
 import org.apache.iotdb.commons.trigger.service.TriggerExecutableManager;
 import org.apache.iotdb.commons.udf.service.UDFClassLoader;
 import org.apache.iotdb.commons.udf.service.UDFExecutableManager;
+import org.apache.iotdb.commons.utils.TimePartitionUtils;
 import org.apache.iotdb.confignode.rpc.thrift.TAlterLogicalViewReq;
 import org.apache.iotdb.confignode.rpc.thrift.TAlterSchemaTemplateReq;
 import org.apache.iotdb.confignode.rpc.thrift.TCountDatabaseResp;
@@ -1918,8 +1919,11 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
       } else {
         tGetRegionIdReq.setDatabase(getRegionIdStatement.getDatabase());
       }
-      if (getRegionIdStatement.getTimeStamp() >= 0) {
-        tGetRegionIdReq.setTimeStamp(getRegionIdStatement.getTimeStamp());
+      if (getRegionIdStatement.getStartTimeStamp() >= 0) {
+        tGetRegionIdReq.setStartTimeSlot(
+            TimePartitionUtils.getTimePartitionSlot(getRegionIdStatement.getStartTimeStamp()));
+        tGetRegionIdReq.setEndTimeSlot(
+            TimePartitionUtils.getTimePartitionSlot(getRegionIdStatement.getEndTimeStamp()));
       }
       resp = configNodeClient.getRegionId(tGetRegionIdReq);
       if (resp.getStatus().getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/parser/ASTVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/parser/ASTVisitor.java
@@ -223,7 +223,6 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import javafx.util.Pair;
 
 import static org.apache.iotdb.commons.schema.SchemaConstant.ALL_RESULT_NODES;
 import static org.apache.iotdb.db.queryengine.plan.optimization.LimitOffsetPushDown.canPushDownLimitOffsetToGroupByTime;
@@ -3671,38 +3670,17 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
       getRegionIdStatement.setDevice(ctx.device.getText());
     }
     long startTime = -1;
-    long endTime = -1;
-    if (ctx.firstTime != null) {
-      long timestamp = parseTimeValue(ctx.firstTime, CommonDateTimeUtils.currentTime());
-      if (timestamp < 0) {
-        throw new SemanticException("time must be greater than or equal to 0");
+    long endTime = Long.MAX_VALUE;
+
+    if (ctx.firstExpression != null) {
+      Expression firstExpression = parseExpression(ctx.firstExpression, true);
+      switch(firstExpression.getExpressionType()){
+        case: ExpressionType.EQUAL_TO
       }
-      if (ctx.OPERATOR_DEQ() != null || ctx.OPERATOR_SEQ() != null) {
-        startTime = timestamp;
-        endTime = timestamp;
-      }
-      if (ctx.OPERATOR_GT() != null) {
-        startTime = timestamp+1;
-        endTime = Long.MAX_VALUE;
-      }
-      if (ctx.OPERATOR_GTE() != null) {
-        startTime = timestamp;
-        endTime = Long.MAX_VALUE;
-      }
-    }
-    if (ctx.secondTime != null) {
-      long timestamp = parseTimeValue(ctx.secondTime, CommonDateTimeUtils.currentTime());
-      if(timestamp < 0) {
-        throw new SemanticException("time must be greater than or equal to 0");
-      }
-      if (ctx.OPERATOR_LTE() != null) {
-          startTime = Math.max(startTime, 0);
-          endTime = Math.min(endTime, timestamp);
-      }
-      if(ctx.OPERATOR_LT() != null) {
-        startTime = Math.max(startTime, 0);
-        endTime = Math.min(endTime, timestamp-1);
-      }
+      ExpressionType tmpType = firstExpression.getExpressionType();
+      List<Expression> result = firstExpression.getExpressions();
+      System.out.println("1");
+
     }
     getRegionIdStatement.setStartTimeStamp(startTime);
     getRegionIdStatement.setEndTimeStamp(endTime);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/metadata/GetRegionIdStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/metadata/GetRegionIdStatement.java
@@ -49,7 +49,25 @@ public class GetRegionIdStatement extends Statement implements IConfigStatement 
 
   private String device;
   private final TConsensusGroupType partitionType;
-  private long timeStamp = -1;
+  private long startTimeStamp;
+
+  private long endTimeStamp;
+
+  public long getEndTimeStamp() {
+    return endTimeStamp;
+  }
+
+  public void setEndTimeStamp(long endTimeStamp) {
+    this.endTimeStamp = endTimeStamp;
+  }
+
+  public long getStartTimeStamp() {
+    return startTimeStamp;
+  }
+
+  public void setStartTimeStamp(long startTimeStamp) {
+    this.startTimeStamp = startTimeStamp;
+  }
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GetRegionIdStatement.class);
 
@@ -70,20 +88,12 @@ public class GetRegionIdStatement extends Statement implements IConfigStatement 
     return device;
   }
 
-  public long getTimeStamp() {
-    return timeStamp;
-  }
-
   public void setDatabase(String database) {
     this.database = database;
   }
 
   public void setDevice(String device) {
     this.device = device;
-  }
-
-  public void setTimeStamp(long timeStamp) {
-    this.timeStamp = timeStamp;
   }
 
   @Override

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/partition/DataPartitionTable.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/partition/DataPartitionTable.java
@@ -186,24 +186,26 @@ public class DataPartitionTable {
    * Query a timePartition's corresponding dataRegionIds
    *
    * @param seriesSlotId SeriesPartitionSlot
-   * @param timeSlotId TimePartitionSlot
-   * @return the timePartition's corresponding dataRegionIds, if seriesSlotId==-1, then return all
-   *     seriesPartitionTable's dataRegionIds; if timeSlotId == -1, then return all the seriesSlot's
-   *     dataRegionIds.
+   * @param startTimeSlotId startTimePartitionSlot
+   * @param endTimeSlotId endTimePartitionSlot
+   * @return the timePartition' s corresponding dataRegionIds, if seriesSlotId==-1, then return all
+   *     seriesPartitionTable's dataRegionIds;
    */
   public List<TConsensusGroupId> getRegionId(
-      TSeriesPartitionSlot seriesSlotId, TTimePartitionSlot timeSlotId) {
+      TSeriesPartitionSlot seriesSlotId,
+      TTimePartitionSlot startTimeSlotId,
+      TTimePartitionSlot endTimeSlotId) {
     if (seriesSlotId.getSlotId() == -1) {
       List<TConsensusGroupId> regionIds = new ArrayList<>();
       dataPartitionMap.forEach(
           (seriesPartitionSlot, seriesPartitionTable) ->
-              regionIds.addAll(seriesPartitionTable.getRegionId(timeSlotId)));
+              regionIds.addAll(seriesPartitionTable.getRegionId(startTimeSlotId, endTimeSlotId)));
       return regionIds;
     } else if (!dataPartitionMap.containsKey(seriesSlotId)) {
       return new ArrayList<>();
     } else {
       SeriesPartitionTable seriesPartitionTable = dataPartitionMap.get(seriesSlotId);
-      return seriesPartitionTable.getRegionId(timeSlotId);
+      return seriesPartitionTable.getRegionId(startTimeSlotId, endTimeSlotId);
     }
   }
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/partition/SeriesPartitionTable.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/partition/SeriesPartitionTable.java
@@ -150,25 +150,18 @@ public class SeriesPartitionTable {
    *
    * @param startTimeSlotId start Time partition's timeSlotId
    * @param endTimeSlotId end Time partition's timeSlotId
-   * @return the timePartition's corresponding dataRegionIds. if startTimeSlotId == -1, then return
-   *     all the seriesSlot's dataRegionIds. else return the dataRegions which timeslotIds are in
-   *     the time range [startTimeSlotId, endTimeSlotId].
+   * @return the timePartition's corresponding dataRegionIds. return the dataRegions which
+   *     timeslotIds are in the time range [startTimeSlotId, endTimeSlotId].
    */
   List<TConsensusGroupId> getRegionId(
       TTimePartitionSlot startTimeSlotId, TTimePartitionSlot endTimeSlotId) {
-    if (startTimeSlotId.getStartTime() != -1) {
-      return seriesPartitionMap.entrySet().stream()
-          .filter(
-              entry ->
-                  entry.getKey().getStartTime() >= startTimeSlotId.getStartTime()
-                      && entry.getKey().getStartTime() <= endTimeSlotId.getStartTime())
-          .flatMap(entry -> entry.getValue().stream())
-          .collect(Collectors.toList());
-    } else {
-      return seriesPartitionMap.values().stream()
-          .flatMap(List::stream)
-          .collect(Collectors.toList());
-    }
+    return seriesPartitionMap.entrySet().stream()
+        .filter(
+            entry ->
+                entry.getKey().getStartTime() >= startTimeSlotId.getStartTime()
+                    && entry.getKey().getStartTime() <= endTimeSlotId.getStartTime())
+        .flatMap(entry -> entry.getValue().stream())
+        .collect(Collectors.toList());
   }
 
   List<TTimePartitionSlot> getTimeSlotList(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/partition/SeriesPartitionTable.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/partition/SeriesPartitionTable.java
@@ -148,15 +148,22 @@ public class SeriesPartitionTable {
   /**
    * Query a timePartition's corresponding dataRegionIds.
    *
-   * @param timeSlotId Time partition's timeSlotId
-   * @return the timePartition's corresponding dataRegionIds
+   * @param startTimeSlotId start Time partition's timeSlotId
+   * @param endTimeSlotId end Time partition's timeSlotId
+   * @return the timePartition's corresponding dataRegionIds. if startTimeSlotId == -1, then return
+   *     all the seriesSlot's dataRegionIds. else return the dataRegions which timeslotIds are in
+   *     the time range [startTimeSlotId, endTimeSlotId].
    */
-  List<TConsensusGroupId> getRegionId(TTimePartitionSlot timeSlotId) {
-    if (timeSlotId.getStartTime() != -1) {
-      if (!seriesPartitionMap.containsKey(timeSlotId)) {
-        return new ArrayList<>();
-      }
-      return seriesPartitionMap.get(timeSlotId);
+  List<TConsensusGroupId> getRegionId(
+      TTimePartitionSlot startTimeSlotId, TTimePartitionSlot endTimeSlotId) {
+    if (startTimeSlotId.getStartTime() != -1) {
+      return seriesPartitionMap.entrySet().stream()
+          .filter(
+              entry ->
+                  entry.getKey().getStartTime() >= startTimeSlotId.getStartTime()
+                      && entry.getKey().getStartTime() <= endTimeSlotId.getStartTime())
+          .flatMap(entry -> entry.getValue().stream())
+          .collect(Collectors.toList());
     } else {
       return seriesPartitionMap.values().stream()
           .flatMap(List::stream)

--- a/iotdb-protocol/thrift-confignode/src/main/thrift/confignode.thrift
+++ b/iotdb-protocol/thrift-confignode/src/main/thrift/confignode.thrift
@@ -251,7 +251,8 @@ struct TGetRegionIdReq {
     1: required common.TConsensusGroupType type
     2: optional string database
     3: optional string device
-    4: optional i64 timeStamp
+    4: optional common.TTimePartitionSlot startTimeSlot
+    5: optional common.TTimePartitionSlot endTimeSlot
 }
 
 struct TGetRegionIdResp {


### PR DESCRIPTION
In https://github.com/apache/iotdb/pull/9665, I improved the SQL query for displaying regionId. However, it didn't support SQL queries based on a time range. Now, it supports SQL queries based on a time range.
sql with range time example
![image](https://github.com/apache/iotdb/assets/38746920/f4f15707-c90b-48e5-ae63-6133c5fe6a3c)
![image](https://github.com/apache/iotdb/assets/38746920/7aae5189-f85c-48a7-a4c9-e53a14447d58)
![image](https://github.com/apache/iotdb/assets/38746920/e3e53b3a-8199-4d84-85bd-2487c8547665)
you can see more information in https://apache-iotdb.feishu.cn/docx/NnzTdj3RcoSJyjxDSFxc01PJnvY#doxcnXfK9CBQk8fnRF5GpLiiuyh
