### PR TITLE
Pipe: Changed the property files' "extractor" and "connector" related parameters to their "source" and "sink" counterparts

### DIFF
--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -956,16 +956,16 @@ timestamp_precision=ms
 # pipe_subtask_executor_max_thread_num=5
 
 # The connection timeout (in milliseconds) for the thrift client.
-# pipe_connector_timeout_ms=900000
+# pipe_sink_timeout_ms=900000
 
-# The maximum number of selectors that can be used in the async connector.
-# pipe_async_connector_selector_number=1
+# The maximum number of selectors that can be used in the async sink.
+# pipe_async_sink_selector_number=1
 
-# The core number of clients that can be used in the async connector.
-# pipe_async_connector_core_client_number=8
+# The core number of clients that can be used in the async sink.
+# pipe_async_sink_core_client_number=8
 
-# The maximum number of clients that can be used in the async connector.
-# pipe_async_connector_max_client_number=16
+# The maximum number of clients that can be used in the async sink.
+# pipe_async_sink_max_client_number=16
 
 # Whether to enable receiving pipe data through air gap.
 # The receiver can only return 0 or 1 in tcp mode to indicate whether the data is received successfully.

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -958,14 +958,14 @@ timestamp_precision=ms
 # The connection timeout (in milliseconds) for the thrift client.
 # pipe_sink_timeout_ms=900000
 
-# The maximum number of selectors that can be used in the async sink.
-# pipe_async_sink_selector_number=1
+# The maximum number of selectors that can be used in the sink.
+# pipe_sink_selector_number=1
 
-# The core number of clients that can be used in the async sink.
-# pipe_async_sink_core_client_number=8
+# The core number of clients that can be used in the sink.
+# pipe_sink_core_client_number=8
 
-# The maximum number of clients that can be used in the async sink.
-# pipe_async_sink_max_client_number=16
+# The maximum number of clients that can be used in the sink.
+# pipe_sink_max_client_number=16
 
 # Whether to enable receiving pipe data through air gap.
 # The receiver can only return 0 or 1 in tcp mode to indicate whether the data is received successfully.

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -311,15 +311,15 @@ public class CommonDescriptor {
                     properties.getProperty(
                         "pipe_extractor_assigner_disruptor_ring_buffer_entry_size_in_bytes",
                         String.valueOf(
-                            config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
+                            config
+                                .getPipeExtractorAssignerDisruptorRingBufferEntrySizeInBytes())))));
     config.setPipeExtractorMatcherCacheSize(
         Integer.parseInt(
             Optional.ofNullable(properties.getProperty("pipe_source_matcher_cache_size"))
                 .orElse(
                     properties.getProperty(
                         "pipe_extractor_matcher_cache_size",
-                        String.valueOf(
-                            config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
+                        String.valueOf(config.getPipeExtractorMatcherCacheSize())))));
 
     config.setPipeConnectorHandshakeTimeoutMs(
         Long.parseLong(
@@ -327,48 +327,42 @@ public class CommonDescriptor {
                 .orElse(
                     properties.getProperty(
                         "pipe_connector_handshake_timeout_ms",
-                        String.valueOf(
-                            config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
+                        String.valueOf(config.getPipeConnectorHandshakeTimeoutMs())))));
     config.setPipeConnectorTransferTimeoutMs(
         Long.parseLong(
             Optional.ofNullable(properties.getProperty("pipe_sink_timeout_ms"))
                 .orElse(
                     properties.getProperty(
                         "pipe_connector_timeout_ms",
-                        String.valueOf(
-                            config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
+                        String.valueOf(config.getPipeConnectorTransferTimeoutMs())))));
     config.setPipeConnectorReadFileBufferSize(
         Integer.parseInt(
             Optional.ofNullable(properties.getProperty("pipe_sink_read_file_buffer_size"))
                 .orElse(
                     properties.getProperty(
                         "pipe_connector_read_file_buffer_size",
-                        String.valueOf(
-                            config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
+                        String.valueOf(config.getPipeConnectorReadFileBufferSize())))));
     config.setPipeConnectorRetryIntervalMs(
         Long.parseLong(
             Optional.ofNullable(properties.getProperty("pipe_sink_retry_interval_ms"))
                 .orElse(
                     properties.getProperty(
                         "pipe_connector_retry_interval_ms",
-                        String.valueOf(
-                            config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
+                        String.valueOf(config.getPipeConnectorRetryIntervalMs())))));
     config.setPipeConnectorPendingQueueSize(
         Integer.parseInt(
             Optional.ofNullable(properties.getProperty("pipe_sink_pending_queue_size"))
                 .orElse(
                     properties.getProperty(
                         "pipe_connector_pending_queue_size",
-                        String.valueOf(
-                            config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
+                        String.valueOf(config.getPipeConnectorPendingQueueSize())))));
     config.setPipeConnectorRPCThriftCompressionEnabled(
         Boolean.parseBoolean(
             Optional.ofNullable(properties.getProperty("pipe_sink_rpc_thrift_compression_enabled"))
                 .orElse(
                     properties.getProperty(
                         "pipe_connector_rpc_thrift_compression_enabled",
-                        String.valueOf(
-                            config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
+                        String.valueOf(config.isPipeConnectorRPCThriftCompressionEnabled())))));
 
     config.setPipeAsyncConnectorSelectorNumber(
         Integer.parseInt(
@@ -376,24 +370,21 @@ public class CommonDescriptor {
                 .orElse(
                     properties.getProperty(
                         "pipe_async_connector_selector_number",
-                        String.valueOf(
-                            config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
+                        String.valueOf(config.getPipeAsyncConnectorSelectorNumber())))));
     config.setPipeAsyncConnectorCoreClientNumber(
         Integer.parseInt(
             Optional.ofNullable(properties.getProperty("pipe_sink_core_client_number"))
                 .orElse(
                     properties.getProperty(
                         "pipe_async_connector_core_client_number",
-                        String.valueOf(
-                            config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
+                        String.valueOf(config.getPipeAsyncConnectorCoreClientNumber())))));
     config.setPipeAsyncConnectorMaxClientNumber(
         Integer.parseInt(
             Optional.ofNullable(properties.getProperty("pipe_sink_max_client_number"))
                 .orElse(
                     properties.getProperty(
                         "pipe_async_connector_max_client_number",
-                        String.valueOf(
-                            config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
+                        String.valueOf(config.getPipeAsyncConnectorMaxClientNumber())))));
 
     config.setSeperatedPipeHeartbeatEnabled(
         Boolean.parseBoolean(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -372,19 +372,28 @@ public class CommonDescriptor {
 
     config.setPipeAsyncConnectorSelectorNumber(
         Integer.parseInt(
-            properties.getProperty(
-                "pipe_async_connector_selector_number",
-                String.valueOf(config.getPipeAsyncConnectorSelectorNumber()))));
+            Optional.ofNullable(properties.getProperty("pipe_async_connector_selector_number"))
+                .orElse(
+                    properties.getProperty(
+                        "pipe_sink_selector_number",
+                        String.valueOf(
+                            config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
     config.setPipeAsyncConnectorCoreClientNumber(
         Integer.parseInt(
-            properties.getProperty(
-                "pipe_async_connector_core_client_number",
-                String.valueOf(config.getPipeAsyncConnectorCoreClientNumber()))));
+            Optional.ofNullable(properties.getProperty("pipe_async_connector_core_client_number"))
+                .orElse(
+                    properties.getProperty(
+                        "pipe_sink_core_client_number",
+                        String.valueOf(
+                            config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
     config.setPipeAsyncConnectorMaxClientNumber(
         Integer.parseInt(
-            properties.getProperty(
-                "pipe_async_connector_max_client_number",
-                String.valueOf(config.getPipeAsyncConnectorMaxClientNumber()))));
+            Optional.ofNullable(properties.getProperty("pipe_async_connector_max_client_number"))
+                .orElse(
+                    properties.getProperty(
+                        "pipe_sink_max_client_number",
+                        String.valueOf(
+                            config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
 
     config.setSeperatedPipeHeartbeatEnabled(
         Boolean.parseBoolean(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -299,7 +299,7 @@ public class CommonDescriptor {
                     properties.getProperty("pipe_source_assigner_disruptor_ring_buffer_size"))
                 .orElse(
                     properties.getProperty(
-                        "pipe_source_extractor_disruptor_ring_buffer_size",
+                        "pipe_extractor_assigner_disruptor_ring_buffer_size",
                         String.valueOf(
                             config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
     config.setPipeExtractorAssignerDisruptorRingBufferEntrySizeInBytes( // 1MB

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.commons.utils.CommonDateTimeUtils;
 import org.apache.iotdb.confignode.rpc.thrift.TGlobalConfig;
 
 import java.io.File;
+import java.util.Optional;
 import java.util.Properties;
 
 public class CommonDescriptor {
@@ -294,51 +295,80 @@ public class CommonDescriptor {
 
     config.setPipeExtractorAssignerDisruptorRingBufferSize(
         Integer.parseInt(
-            properties.getProperty(
-                "pipe_extractor_assigner_disruptor_ring_buffer_size",
-                String.valueOf(config.getPipeExtractorAssignerDisruptorRingBufferSize()))));
+            Optional.ofNullable(
+                    properties.getProperty("pipe_source_assigner_disruptor_ring_buffer_size"))
+                .orElse(
+                    properties.getProperty(
+                        "pipe_source_extractor_disruptor_ring_buffer_size",
+                        String.valueOf(
+                            config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
     config.setPipeExtractorAssignerDisruptorRingBufferEntrySizeInBytes( // 1MB
         Integer.parseInt(
-            properties.getProperty(
-                "pipe_extractor_assigner_disruptor_ring_buffer_entry_size_in_bytes",
-                String.valueOf(
-                    config.getPipeExtractorAssignerDisruptorRingBufferEntrySizeInBytes()))));
+            Optional.ofNullable(
+                    properties.getProperty(
+                        "pipe_source_assigner_disruptor_ring_buffer_entry_size_in_bytes"))
+                .orElse(
+                    properties.getProperty(
+                        "pipe_extractor_assigner_disruptor_ring_buffer_entry_size_in_bytes",
+                        String.valueOf(
+                            config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
     config.setPipeExtractorMatcherCacheSize(
         Integer.parseInt(
-            properties.getProperty(
-                "pipe_extractor_matcher_cache_size",
-                String.valueOf(config.getPipeExtractorMatcherCacheSize()))));
+            Optional.ofNullable(properties.getProperty("pipe_source_matcher_cache_size"))
+                .orElse(
+                    properties.getProperty(
+                        "pipe_extractor_matcher_cache_size",
+                        String.valueOf(
+                            config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
 
     config.setPipeConnectorHandshakeTimeoutMs(
         Long.parseLong(
-            properties.getProperty(
-                "pipe_connector_handshake_timeout_ms",
-                String.valueOf(config.getPipeConnectorHandshakeTimeoutMs()))));
+            Optional.ofNullable(properties.getProperty("pipe_sink_handshake_timeout_ms"))
+                .orElse(
+                    properties.getProperty(
+                        "pipe_connector_handshake_timeout_ms",
+                        String.valueOf(
+                            config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
     config.setPipeConnectorTransferTimeoutMs(
         Long.parseLong(
-            properties.getProperty(
-                "pipe_connector_timeout_ms",
-                String.valueOf(config.getPipeConnectorTransferTimeoutMs()))));
+            Optional.ofNullable(properties.getProperty("pipe_sink_timeout_ms"))
+                .orElse(
+                    properties.getProperty(
+                        "pipe_connector_timeout_ms",
+                        String.valueOf(
+                            config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
     config.setPipeConnectorReadFileBufferSize(
         Integer.parseInt(
-            properties.getProperty(
-                "pipe_connector_read_file_buffer_size",
-                String.valueOf(config.getPipeConnectorReadFileBufferSize()))));
+            Optional.ofNullable(properties.getProperty("pipe_sink_read_file_buffer_size"))
+                .orElse(
+                    properties.getProperty(
+                        "pipe_connector_read_file_buffer_size",
+                        String.valueOf(
+                            config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
     config.setPipeConnectorRetryIntervalMs(
         Long.parseLong(
-            properties.getProperty(
-                "pipe_connector_retry_interval_ms",
-                String.valueOf(config.getPipeConnectorRetryIntervalMs()))));
+            Optional.ofNullable(properties.getProperty("pipe_sink_retry_interval_ms"))
+                .orElse(
+                    properties.getProperty(
+                        "pipe_connector_retry_interval_ms",
+                        String.valueOf(
+                            config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
     config.setPipeConnectorPendingQueueSize(
         Integer.parseInt(
-            properties.getProperty(
-                "pipe_connector_pending_queue_size",
-                String.valueOf(config.getPipeConnectorPendingQueueSize()))));
+            Optional.ofNullable(properties.getProperty("pipe_sink_pending_queue_size"))
+                .orElse(
+                    properties.getProperty(
+                        "pipe_connector_pending_queue_size",
+                        String.valueOf(
+                            config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
     config.setPipeConnectorRPCThriftCompressionEnabled(
         Boolean.parseBoolean(
-            properties.getProperty(
-                "pipe_connector_rpc_thrift_compression_enabled",
-                String.valueOf(config.isPipeConnectorRPCThriftCompressionEnabled()))));
+            Optional.ofNullable(properties.getProperty("pipe_sink_rpc_thrift_compression_enabled"))
+                .orElse(
+                    properties.getProperty(
+                        "pipe_connector_rpc_thrift_compression_enabled",
+                        String.valueOf(
+                            config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
 
     config.setPipeAsyncConnectorSelectorNumber(
         Integer.parseInt(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -372,26 +372,26 @@ public class CommonDescriptor {
 
     config.setPipeAsyncConnectorSelectorNumber(
         Integer.parseInt(
-            Optional.ofNullable(properties.getProperty("pipe_async_connector_selector_number"))
+            Optional.ofNullable(properties.getProperty("pipe_sink_selector_number"))
                 .orElse(
                     properties.getProperty(
-                        "pipe_sink_selector_number",
+                        "pipe_async_connector_selector_number",
                         String.valueOf(
                             config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
     config.setPipeAsyncConnectorCoreClientNumber(
         Integer.parseInt(
-            Optional.ofNullable(properties.getProperty("pipe_async_connector_core_client_number"))
+            Optional.ofNullable(properties.getProperty("pipe_sink_core_client_number"))
                 .orElse(
                     properties.getProperty(
-                        "pipe_sink_core_client_number",
+                        "pipe_async_connector_core_client_number",
                         String.valueOf(
                             config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
     config.setPipeAsyncConnectorMaxClientNumber(
         Integer.parseInt(
-            Optional.ofNullable(properties.getProperty("pipe_async_connector_max_client_number"))
+            Optional.ofNullable(properties.getProperty("pipe_sink_max_client_number"))
                 .orElse(
                     properties.getProperty(
-                        "pipe_sink_max_client_number",
+                        "pipe_async_connector_max_client_number",
                         String.valueOf(
                             config.getPipeExtractorAssignerDisruptorRingBufferSize())))));
 


### PR DESCRIPTION
## Description

Old:

```
# The connection timeout (in milliseconds) for the thrift client.
# pipe_connector_timeout_ms=900000

# The maximum number of selectors that can be used in the async connector.
# pipe_async_connector_selector_number=1

# The core number of clients that can be used in the async connector.
# pipe_async_connector_core_client_number=8

# The maximum number of clients that can be used in the async connector.
# pipe_async_connector_max_client_number=16
```

New:
```
# The connection timeout (in milliseconds) for the thrift client.
# pipe_sink_timeout_ms=900000

# The maximum number of selectors that can be used in the sink.
# pipe_sink_selector_number=1

# The core number of clients that can be used in the sink.
# pipe_sink_core_client_number=8

# The maximum number of clients that can be used in the sink.
# pipe_sink_max_client_number=16
```

Old parameters can also be parsed and applied.