### PR TITLE
[IOTDB-6262] Pipe: fix NPE while deserializing WAL (caused by non-atomic WAL rename operation during pipe read)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
@@ -930,7 +930,7 @@ public class WALNode implements IWALNode {
   }
 
   /** Get the .wal file starts with the specified version id */
-  public File getWALFile(long versionId) {
+  public File getWALFile(long versionId) throws FileNotFoundException {
     return WALFileUtils.getWALFile(logDirectory, versionId);
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/utils/WALFileUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/utils/WALFileUtils.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.storageengine.dataregion.wal.utils;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.regex.Matcher;
@@ -73,12 +74,15 @@ public class WALFileUtils {
   }
 
   /** Get the .wal file starts with the specified version id in the directory. */
-  public static File getWALFile(File dir, long versionId) {
+  public static File getWALFile(File dir, long versionId) throws FileNotFoundException {
     String filePrefix = WAL_FILE_PREFIX + versionId + FILE_NAME_SEPARATOR;
     File[] files =
         dir.listFiles((d, name) -> walFilenameFilter(d, name) && name.startsWith(filePrefix));
     if (files == null || files.length != 1) {
-      return null;
+      throw new FileNotFoundException(
+          String.format(
+              "Fail to get wal file by versionId=%s and files=%s.",
+              versionId, Arrays.toString(files)));
     }
     return files[0];
   }


### PR DESCRIPTION
Problem:
- Due to the concurrent execution of the renaming of the wal file and the reading of the wal file by the pipe, the pipe may not be able to fetch the wal file when it reads the wal file, resulting in an NPE.
 
Solution:
1. change Files.renameTo in wal code to Files.move for better atomicity and visibility.
2. add logging when wal fetches a file
3. add logging when pipe fetches a wal value to print the memtable id and wal file version id that it failed to fetch.

问题：
- 由于wal 文件的重命名和 pipe 读取 wal 文件存在并发执行的情况，导致 pipe 读取 wal 文件时可能无法获取 wal 文件，导致 NPE

解决方案：
1. 将 wal 代码中的 Files.renameTo 改成原子性和可见性更好的 Files.move
2. 增加 wal 获取文件时的日志
3. 增加 pipe 获取 wal 值时的日志，打印未能获取的 memtable id 和 wal file version id

![image](https://github.com/apache/iotdb/assets/87161145/5e1b79f7-449d-43ce-b41b-fc033bd4af9a)
