### PR TITLE
flink-sql-iotdb-connector: add property `cdc.mode` in cdc connector

### DIFF
--- a/iotdb-connector/flink-sql-iotdb-connector/src/main/java/org/apache/iotdb/flink/sql/common/Options.java
+++ b/iotdb-connector/flink-sql-iotdb-connector/src/main/java/org/apache/iotdb/flink/sql/common/Options.java
@@ -49,9 +49,16 @@ public class Options {
       ConfigOptions.key("sql").stringType().noDefaultValue();
   public static final ConfigOption<String> PATTERN =
       ConfigOptions.key("cdc.pattern").stringType().noDefaultValue();
+  public static final ConfigOption<CDCMode> CDC_MODE =
+      ConfigOptions.key("cdc.mode").enumType(CDCMode.class).defaultValue(CDCMode.ALL);
 
   public enum Mode {
     CDC,
     BOUNDED
+  }
+
+  public enum CDCMode {
+    REALTIME,
+    ALL
   }
 }

--- a/iotdb-connector/flink-sql-iotdb-connector/src/main/java/org/apache/iotdb/flink/sql/factory/IoTDBDynamicTableFactory.java
+++ b/iotdb-connector/flink-sql-iotdb-connector/src/main/java/org/apache/iotdb/flink/sql/factory/IoTDBDynamicTableFactory.java
@@ -94,6 +94,7 @@ public class IoTDBDynamicTableFactory
     optionalOptions.add(Options.CDC_PORT);
     optionalOptions.add(Options.SQL);
     optionalOptions.add(Options.PATTERN);
+    optionalOptions.add(Options.CDC_MODE);
 
     return optionalOptions;
   }


### PR DESCRIPTION
Currently, only full data can be consumed, not only real-time data. A new property `cdc.mode` can resolve this problem.