### PR TITLE
Pipe: Set pipe_sink_selector_number to pipe_sink_core_client_number to improve the performance of concurrent file transfers

### DIFF
--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -959,7 +959,8 @@ timestamp_precision=ms
 # pipe_sink_timeout_ms=900000
 
 # The maximum number of selectors that can be used in the sink.
-# pipe_sink_selector_number=1
+# Recommend to set this value to less than or equal to pipe_sink_max_client_number.
+# pipe_sink_selector_number=8
 
 # The core number of clients that can be used in the sink.
 # pipe_sink_core_client_number=8

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -171,7 +171,7 @@ public class CommonConfig {
   private int pipeConnectorPendingQueueSize = 256;
   private boolean pipeConnectorRPCThriftCompressionEnabled = false;
 
-  private int pipeAsyncConnectorSelectorNumber = 1;
+  private int pipeAsyncConnectorSelectorNumber = 8;
   private int pipeAsyncConnectorCoreClientNumber = 8;
   private int pipeAsyncConnectorMaxClientNumber = 16;
 


### PR DESCRIPTION
As title.