### PR TITLE
Pipe: Ignore ConcurrentModificationException caused by PipeWALResourceManager#ttlCheck() & PipeTsFileResourceManager#ttlCheck()

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/tsfile/PipeTsFileResourceManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/tsfile/PipeTsFileResourceManager.java
@@ -315,6 +315,11 @@ public class PipeTsFileResourceManager {
   }
 
   public int getLinkedTsfileCount() {
-    return hardlinkOrCopiedFileToPipeTsFileResourceMap.size();
+    lock.lock();
+    try {
+      return hardlinkOrCopiedFileToPipeTsFileResourceMap.size();
+    } finally {
+      lock.unlock();
+    }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/tsfile/PipeTsFileResourceManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/tsfile/PipeTsFileResourceManager.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -71,6 +72,9 @@ public class PipeTsFileResourceManager {
               entry.getKey(),
               entry.getValue().getReferenceCount());
         }
+      } catch (ConcurrentModificationException e) {
+        LOGGER.info(
+            "Concurrent modification issues happened, skipping the file in this round of ttl check");
       } catch (IOException e) {
         LOGGER.warn("failed to close PipeTsFileResource when checking TTL: ", e);
       } finally {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/wal/PipeWALResourceManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/wal/PipeWALResourceManager.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
@@ -75,6 +76,9 @@ public abstract class PipeWALResourceManager {
               entry.getKey(),
               entry.getValue().getReferenceCount());
         }
+      } catch (ConcurrentModificationException e) {
+        LOGGER.info(
+            "Concurrent modification issues happened, skipping the WAL in this round of ttl check");
       } finally {
         lock.unlock();
       }


### PR DESCRIPTION
<img width="1154" alt="d80329d9d7eaa76b135748d2f9d7ee6" src="https://github.com/apache/iotdb/assets/55695098/235f41da-9c58-4d67-addd-43787194ab42">
