### PR TITLE
Avoid reading file when recover last flush time from FileTimeIndex

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileManager.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.storageengine.dataregion.tsfile;
 
 import org.apache.iotdb.commons.utils.TimePartitionUtils;
+import org.apache.iotdb.db.storageengine.dataregion.tsfile.timeindex.ITimeIndex;
 import org.apache.iotdb.db.storageengine.rescon.memory.TsFileResourceManager;
 
 import java.io.IOException;
@@ -119,10 +120,14 @@ public class TsFileManager {
         if (!seqResource.isClosed()) {
           continue;
         }
-        Set<String> deviceSet = seqResource.getDevices();
-        if (deviceSet.contains(devicePath)) {
-          lastFlushTime = seqTsFileResourceList.get(i).getEndTime(devicePath);
-          break;
+        if (seqResource.getTimeIndexType() == ITimeIndex.DEVICE_TIME_INDEX_TYPE) {
+          Set<String> deviceSet = seqResource.getDevices();
+          if (deviceSet.contains(devicePath)) {
+            lastFlushTime = Math.max(lastFlushTime, seqResource.getEndTime(devicePath));
+            break;
+          }
+        } else {
+          lastFlushTime = Math.max(lastFlushTime, seqResource.getEndTime(devicePath));
         }
       }
       List<TsFileResource> unseqTsFileResourceList =

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/LastFlushTimeMapTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/LastFlushTimeMapTest.java
@@ -139,6 +139,8 @@ public class LastFlushTimeMapTest {
     }
     Assert.assertEquals(
         10000, dataRegion.getLastFlushTimeMap().getFlushedTime(0, "root.vehicle.d0"));
+    Assert.assertEquals(
+        10000, dataRegion.getLastFlushTimeMap().getFlushedTime(0, "root.vehicle.d1"));
   }
 
   @Test


### PR DESCRIPTION
## Description
A machine with 32G memory, 5 million devices, while writing data from 10 time partitions at the same time, the write speed is very slow, CPU sampling found that it takes more time to recover the last flush time from TimeIndex.

![image](https://github.com/apache/iotdb/assets/25913899/f9edf514-1742-4009-8e10-e89119b2df7e)

## Test result
1c1d
8GB DataNode 
write_memory_proportion=1000000000:1
flush_proportion=0.01
chunk_timeseriesmeta_free_memory_proportion=2:200:400:100:400:400:1:100

BenchMark
DB_SWITCH=IoTDB-110-SESSION_BY_RECORDS
LOOP=50
DEVICE_NUMBER=20000
SENSOR_NUMBER=1
VECTOR=false
INSERT_DATATYPE_PROPORTION=0:0:1:0:0:0
BATCH_SIZE_PER_WRITE=1

**Before throughput(point/s) = 8799.88**

**After throughput(point/s) = 19597.55**