### PR TITLE
[IOTDB-6276] Load IT: Add ConnectionTimeoutMs for IOTDBLoadTsFileIT.testLoadWithMods

### DIFF
--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppDataNodeConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppDataNodeConfig.java
@@ -61,4 +61,10 @@ public class MppDataNodeConfig extends MppBaseConfig implements DataNodeConfig {
     properties.setProperty("enable_rest_service", String.valueOf(enableRestService));
     return this;
   }
+
+  @Override
+  public DataNodeConfig setConnectionTimeoutInMS(int connectionTimeoutInMS) {
+    properties.setProperty("dn_connection_timeout_ms", String.valueOf(connectionTimeoutInMS));
+    return this;
+  }
 }

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/remote/config/RemoteDataNodeConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/remote/config/RemoteDataNodeConfig.java
@@ -32,4 +32,9 @@ public class RemoteDataNodeConfig implements DataNodeConfig {
   public DataNodeConfig setEnableRestService(boolean enableRestService) {
     return this;
   }
+
+  @Override
+  public DataNodeConfig setConnectionTimeoutInMS(int connectionTimeoutInMS) {
+    return this;
+  }
 }

--- a/integration-test/src/main/java/org/apache/iotdb/itbase/env/DataNodeConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/itbase/env/DataNodeConfig.java
@@ -26,4 +26,6 @@ public interface DataNodeConfig {
   DataNodeConfig setMetricReporterType(List<String> metricReporterTypes);
 
   DataNodeConfig setEnableRestService(boolean enableRestService);
+
+  DataNodeConfig setConnectionTimeoutInMS(int connectionTimeoutInMS);
 }

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IOTDBLoadTsFileIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IOTDBLoadTsFileIT.java
@@ -51,6 +51,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.iotdb.db.it.utils.TestUtils.assertNonQueryTestFail;
 import static org.apache.iotdb.db.it.utils.TestUtils.createUser;
@@ -63,6 +64,7 @@ import static org.apache.iotdb.db.it.utils.TestUtils.grantUserSystemPrivileges;
 public class IOTDBLoadTsFileIT {
   private static final Logger LOGGER = LoggerFactory.getLogger(IOTDBLoadTsFileIT.class);
   private static final long PARTITION_INTERVAL = 10 * 1000L;
+  private static final int connectionTimeoutInMS = (int) TimeUnit.SECONDS.toMillis(300);
 
   private File tmpDir;
 
@@ -70,6 +72,10 @@ public class IOTDBLoadTsFileIT {
   public void setUp() throws Exception {
     tmpDir = new File(Files.createTempDirectory("load").toUri());
     EnvFactory.getEnv().getConfig().getCommonConfig().setTimePartitionInterval(PARTITION_INTERVAL);
+    EnvFactory.getEnv()
+        .getConfig()
+        .getDataNodeConfig()
+        .setConnectionTimeoutInMS(connectionTimeoutInMS);
     EnvFactory.getEnv().initClusterEnvironment();
   }
 


### PR DESCRIPTION
Question:
- IOTDBLoadTsFileIT.testLoadWithMods fails to pass the CI, the client displays NPE and the logs show that TsFileWriterManager has been closed.
- The reason is that the Load receiver is unable to persist the file fragments within the Thrift timeout, which causes the Load to advance to the second phase and close the TsFileWriterManager that is persisting at the receiver, resulting in an exception being thrown.

Solution:
- Increase IOTDBLoadTsFileIT.testLoadWithMods to test the Thrift Timeout time and the upper limit of Load file fragment size in the scenario.

问题：
- IOTDBLoadTsFileIT.testLoadWithMods 无法通过 CI，客户端显示 NPE ，日志显示 TsFileWriterManager has been closed.
- 原因在于 Load 接收端无法在 Thrift 超时时间内持久化文件碎片，导致 Load 提前进入第二阶段，关闭了接收端正在进行持久化的 TsFileWriterManager，导致抛出异常

解决方案：
- 调大 IOTDBLoadTsFileIT.testLoadWithMods 测试场景中的 Thrift Timeout 时间以及 Load 文件碎片大小上限

[IOTDBLoadTsFileIT_testLoadWithMods.zip](https://github.com/apache/iotdb/files/13743156/IOTDBLoadTsFileIT_testLoadWithMods.zip)
