### PR TITLE
Support_NewTemplateFilteringSyntax_IsNull_IsNotNull

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBRestServiceIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBRestServiceIT.java
@@ -1366,7 +1366,7 @@ public class IoTDBRestServiceIT {
     List<Object> values4 =
         new ArrayList<Object>() {
           {
-            add("null");
+            add(null);
           }
         };
     Assert.assertEquals(columnNames, columnNamesResult);
@@ -2017,7 +2017,7 @@ public class IoTDBRestServiceIT {
     List<Object> values4 =
         new ArrayList<Object>() {
           {
-            add("null");
+            add(null);
           }
         };
     Assert.assertEquals(columnNames, columnNamesResult);

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBMetadataFetchIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBMetadataFetchIT.java
@@ -281,8 +281,8 @@ public class IoTDBMetadataFetchIT extends AbstractSchemaIT {
 
       String[] sqls =
           new String[] {
-            "show devices root.** where template != null",
-            "show devices root.sg2.** with database where template = t2",
+            "show devices root.** where template is not null",
+            "show devices root.sg2.** with database where template = 't2'",
           };
       Set<String>[] standards =
           new Set[] {

--- a/iotdb-core/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IoTDBSqlParser.g4
+++ b/iotdb-core/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IoTDBSqlParser.g4
@@ -214,7 +214,8 @@ devicesWhereClause
     ;
 
 templateEqualExpression
-    : TEMPLATE (OPERATOR_SEQ | OPERATOR_NEQ)  templateName=identifier
+    : TEMPLATE (OPERATOR_SEQ | OPERATOR_NEQ)  templateName=STRING_LITERAL
+    | TEMPLATE operator_is operator_not? null_literal
     ;
 
 deviceContainsExpression

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/source/DeviceSchemaSource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/source/DeviceSchemaSource.java
@@ -38,7 +38,6 @@ import org.apache.iotdb.tsfile.utils.Binary;
 
 import java.util.List;
 
-import static org.apache.iotdb.commons.conf.IoTDBConstant.STRING_NULL;
 import static org.apache.iotdb.commons.schema.SchemaConstant.ALL_MATCH_PATTERN;
 
 public class DeviceSchemaSource implements ISchemaSource<IDeviceSchemaInfo> {
@@ -98,28 +97,38 @@ public class DeviceSchemaSource implements ISchemaSource<IDeviceSchemaInfo> {
     builder
         .getColumnBuilder(0)
         .writeBinary(new Binary(device.getFullPath(), TSFileConfig.STRING_CHARSET));
-
-    String templateName = STRING_NULL;
     int templateId = device.getTemplateId();
-    if (templateId != -1) {
-      templateName = ClusterTemplateManager.getInstance().getTemplate(templateId).getName();
-    }
-
     if (hasSgCol) {
       builder.getColumnBuilder(1).writeBinary(new Binary(database, TSFileConfig.STRING_CHARSET));
       builder
           .getColumnBuilder(2)
           .writeBinary(new Binary(String.valueOf(device.isAligned()), TSFileConfig.STRING_CHARSET));
-      builder
-          .getColumnBuilder(3)
-          .writeBinary(new Binary(String.valueOf(templateName), TSFileConfig.STRING_CHARSET));
+      if (templateId != -1) {
+        builder
+            .getColumnBuilder(3)
+            .writeBinary(
+                new Binary(
+                    String.valueOf(
+                        ClusterTemplateManager.getInstance().getTemplate(templateId).getName()),
+                    TSFileConfig.STRING_CHARSET));
+      } else {
+        builder.getColumnBuilder(3).appendNull();
+      }
     } else {
       builder
           .getColumnBuilder(1)
           .writeBinary(new Binary(String.valueOf(device.isAligned()), TSFileConfig.STRING_CHARSET));
-      builder
-          .getColumnBuilder(2)
-          .writeBinary(new Binary(String.valueOf(templateName), TSFileConfig.STRING_CHARSET));
+      if (templateId != -1) {
+        builder
+            .getColumnBuilder(2)
+            .writeBinary(
+                new Binary(
+                    String.valueOf(
+                        ClusterTemplateManager.getInstance().getTemplate(templateId).getName()),
+                    TSFileConfig.STRING_CHARSET));
+      } else {
+        builder.getColumnBuilder(2).appendNull();
+      }
     }
     builder.declarePosition();
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/parser/ASTVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/parser/ASTVisitor.java
@@ -713,13 +713,19 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
       return SchemaFilterFactory.createPathContainsFilter(
           parseStringLiteral(ctx.deviceContainsExpression().value.getText()));
     } else {
-      if (ctx.templateEqualExpression().OPERATOR_SEQ() != null) {
-        return SchemaFilterFactory.createTemplateNameFilter(
-            parseIdentifier(ctx.templateEqualExpression().templateName.getText()), true);
+      String templateName = null;
+      boolean isEqual = true;
+      if (ctx.templateEqualExpression().operator_is() != null) {
+        if (ctx.templateEqualExpression().operator_not() != null) {
+          isEqual = false;
+        }
       } else {
-        return SchemaFilterFactory.createTemplateNameFilter(
-            parseIdentifier(ctx.templateEqualExpression().templateName.getText()), false);
+        templateName = parseStringLiteral(ctx.templateEqualExpression().templateName.getText());
+        if (ctx.templateEqualExpression().OPERATOR_NEQ() != null) {
+          isEqual = false;
+        }
       }
+      return SchemaFilterFactory.createTemplateNameFilter(templateName, isEqual);
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/read/resp/info/impl/ShowDevicesResult.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/read/resp/info/impl/ShowDevicesResult.java
@@ -26,11 +26,6 @@ public class ShowDevicesResult extends ShowSchemaResult implements IDeviceSchema
   private Boolean isAligned;
   private int templateId;
 
-  public ShowDevicesResult(String name, Boolean isAligned) {
-    super(name);
-    this.isAligned = isAligned;
-  }
-
   public ShowDevicesResult(String name, Boolean isAligned, int templateId) {
     super(name);
     this.isAligned = isAligned;
@@ -54,6 +49,8 @@ public class ShowDevicesResult extends ShowSchemaResult implements IDeviceSchema
         + ", isAligned = "
         + isAligned
         + '\''
+        + ", templateId = "
+        + templateId
         + "}";
   }
 
@@ -66,11 +63,13 @@ public class ShowDevicesResult extends ShowSchemaResult implements IDeviceSchema
       return false;
     }
     ShowDevicesResult result = (ShowDevicesResult) o;
-    return Objects.equals(path, result.path) && isAligned == result.isAligned;
+    return Objects.equals(path, result.path)
+        && isAligned == result.isAligned
+        && templateId == result.templateId;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(path, isAligned);
+    return Objects.hash(path, isAligned, templateId);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/utils/filter/DeviceFilterVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/utils/filter/DeviceFilterVisitor.java
@@ -26,8 +26,6 @@ import org.apache.iotdb.commons.schema.filter.impl.TemplateFilter;
 import org.apache.iotdb.db.schemaengine.schemaregion.read.resp.info.IDeviceSchemaInfo;
 import org.apache.iotdb.db.schemaengine.template.ClusterTemplateManager;
 
-import static org.apache.iotdb.commons.conf.IoTDBConstant.STRING_NULL;
-
 public class DeviceFilterVisitor extends SchemaFilterVisitor<IDeviceSchemaInfo> {
   @Override
   public boolean visitNode(SchemaFilter filter, IDeviceSchemaInfo info) {
@@ -45,17 +43,18 @@ public class DeviceFilterVisitor extends SchemaFilterVisitor<IDeviceSchemaInfo> 
 
   @Override
   public boolean visitTemplateFilter(TemplateFilter templateFilter, IDeviceSchemaInfo info) {
-    if (templateFilter.getTemplateName() == null) {
-      return true;
-    }
-    String templateName = STRING_NULL;
     boolean equalAns;
-    int TemplateId = info.getTemplateId();
-    if (TemplateId != -1) {
-      templateName = ClusterTemplateManager.getInstance().getTemplate(TemplateId).getName();
-      equalAns = templateName.equals(templateFilter.getTemplateName());
+    int templateId = info.getTemplateId();
+    String filterTemplateName = templateFilter.getTemplateName();
+    if (templateId != -1) {
+      equalAns =
+          filterTemplateName != null
+              && ClusterTemplateManager.getInstance()
+                  .getTemplate(templateId)
+                  .getName()
+                  .equals(filterTemplateName);
     } else {
-      equalAns = templateName.equalsIgnoreCase(templateFilter.getTemplateName());
+      equalAns = filterTemplateName == null;
     }
 
     if (templateFilter.isEqual()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/utils/filter/DeviceFilterVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/utils/filter/DeviceFilterVisitor.java
@@ -48,19 +48,15 @@ public class DeviceFilterVisitor extends SchemaFilterVisitor<IDeviceSchemaInfo> 
     String filterTemplateName = templateFilter.getTemplateName();
     if (templateId != -1) {
       equalAns =
-          filterTemplateName != null
-              && ClusterTemplateManager.getInstance()
-                  .getTemplate(templateId)
-                  .getName()
-                  .equals(filterTemplateName);
+          ClusterTemplateManager.getInstance()
+              .getTemplate(templateId)
+              .getName()
+              .equals(filterTemplateName);
+      return templateFilter.isEqual() == equalAns;
+    } else if (filterTemplateName == null) {
+      return templateFilter.isEqual();
     } else {
-      equalAns = filterTemplateName == null;
-    }
-
-    if (templateFilter.isEqual()) {
-      return equalAns;
-    } else {
-      return !equalAns;
+      return false;
     }
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/schema/SchemaQueryScanOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/schema/SchemaQueryScanOperatorTest.java
@@ -57,9 +57,7 @@ import java.util.concurrent.ExecutorService;
 
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
 import static org.apache.iotdb.db.queryengine.execution.operator.schema.SchemaOperatorTestUtil.EXCEPTION_MESSAGE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class SchemaQueryScanOperatorTest {
   private static final String META_SCAN_OPERATOR_TEST_SG = "root.MetaScanOperatorTest";
@@ -128,7 +126,7 @@ public class SchemaQueryScanOperatorTest {
                 assertEquals("false", tsBlock.getColumn(j).getBinary(i).toString());
                 break;
               case 3:
-                assertEquals("null", tsBlock.getColumn(j).getBinary(i).toString());
+                assertNull(tsBlock.getColumn(j).getBinary(i));
                 break;
               default:
                 break;

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/schema/SchemaQueryScanOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/schema/SchemaQueryScanOperatorTest.java
@@ -57,7 +57,10 @@ import java.util.concurrent.ExecutorService;
 
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
 import static org.apache.iotdb.db.queryengine.execution.operator.schema.SchemaOperatorTestUtil.EXCEPTION_MESSAGE;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class SchemaQueryScanOperatorTest {
   private static final String META_SCAN_OPERATOR_TEST_SG = "root.MetaScanOperatorTest";

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/IoTDBConstant.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/IoTDBConstant.java
@@ -336,5 +336,4 @@ public class IoTDBConstant {
   public static final String TIER_SEPARATOR = ";";
 
   public static final String OBJECT_STORAGE_DIR = "object_storage";
-  public static final String STRING_NULL = "null";
 }


### PR DESCRIPTION
This modification is based on the work in https://github.com/apache/iotdb/pull/11681.

The main improvements of this work are:
- Implemented new syntax for null checking in template filtering.
- Supported distinguishing between the template name 'null' and the null value.
- Fixed the scenario where using the string 'null' as a return result led to an empty null value.

The expected outcomes of this implementation are as follows:
```
// Query to display activated template columns effect
IoTDB > show devices

// Execution result
+-----------------+-------------+-------------+
|          devices|    isAligned|     template|
+-----------------+-------------+-------------+
|root.ln.wf01.wt01|        false|           t1|
|root.ln.wf01.wt02|        false|           t2|
|root.ll.wf02.wt02|        false|         null|
+-----------------+-------------+-------------+

// Query to filter by template column equals condition
IoTDB > show devices where template = 't1'

// Execution result
+-----------------+-------------+-------------+
|       devices   |  isAligned  |  template   |
+-----------------+-------------+-------------+
|root.ln.wf01.wt01|    false    |     t1      |
+-----------------+-------------+-------------+

// Query to filter by template column equals null condition
IoTDB > show devices where template is null

// Execution result
+-----------------+-------------+-------------+
|       devices   |  isAligned  |  template   |
+-----------------+-------------+-------------+
|root.ll.wf02.wt02|    false    |    null     |
+-----------------+-------------+-------------+

// Query to filter by template column not equals condition
IoTDB > show devices where template != 't1'

// Execution result
+-----------------+-------------+-------------+
|          devices|    isAligned|     template|
+-----------------+-------------+-------------+
|root.ln.wf01.wt02|        false|           t2|
+-----------------+-------------+-------------+

// Query to filter by template column not equals null condition
IoTDB > show devices where template is not null

// Execution result
+-----------------+-------------+-------------+
|          devices|    isAligned|     template|
+-----------------+-------------+-------------+
|root.ln.wf01.wt01|        false|           t1|
|root.ln.wf01.wt02|        false|           t2|
+-----------------+-------------+-------------+
```

Implementation Details:
- Implemented new syntax for null checking in template filtering:
    - G4 Grammar for Statement Generation: Added new syntax in G4 under deviceswhereclause for templateEqualExpression, enabling queries for null values using 'is null' and 'is not null'.
    - Implementation of TemplateFilter Logic: Based on G4 modifications, corresponding changes were made in ASTVisitor's visitshowdevice, distinguishing four cases for 'is null' and 'is not null'. The previously implemented createTemplateFilter function was called with a null templateName for subsequent evaluations.
    - Execution by Operator: In SchemaCountOperator, trygetnext uses schemaReader's getDeviceReader in schema creation. DeviceFilterVisitor handles TemplateFilter visits. The logic checks if the stored template name is not empty. If the filter's template name is not empty and doesn't match the stored template name, it's considered a match. Similarly, when the stored template name is empty and the filter's template name is also empty, it's considered a match.

- Supported distinguishing between the template name 'null' and the null value:
    - G4 Grammar for Statement Generation: Modified G4 under deviceswhereclause for templateEqualExpression, changing the objects for 'template =' or 'template !=' from identifier to STRING_LITERAL.
    - Implementation of TemplateFilter Logic: Following the G4 changes, the parsing function for identifier in ASTVisitor's visitshowdevice needed modification to parse StringLiteral instead.

- Fixed the scenario where using the string 'null' as a return result led to an empty null value:
    - Execution by Operator: In the final trygetnext function, setColumns was used to set the results obtained from schemaReader to the respective columns. For displaying null values, the previous method of writing into a static NULL string variable via writeBinary was replaced with appendNull()."