### PR TITLE
PBTree: Fix NPE in SchemaFile conccurency control

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/flush/PBTreeFlushExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/flush/PBTreeFlushExecutor.java
@@ -79,6 +79,7 @@ public class PBTreeFlushExecutor {
         processFlushDatabase(databaseMNode);
       } catch (Exception e) {
         exceptions.add(e);
+        logger.error(e.getMessage());
       }
     }
     while (subtreeRoots.hasNext() && checkRemainToFlush()) {
@@ -86,6 +87,7 @@ public class PBTreeFlushExecutor {
         processFlushNonDatabase(subtreeRoots.next());
       } catch (Exception e) {
         exceptions.add(e);
+        logger.error(e.getMessage());
       }
     }
     if (!exceptions.isEmpty()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/flush/Scheduler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/flush/Scheduler.java
@@ -176,6 +176,7 @@ public class Scheduler {
     AtomicInteger remainToFlush = new AtomicInteger(BATCH_FLUSH_SUBTREE);
     for (int regionId : regionIds) {
       if (flushingRegionSet.contains(regionId)) {
+        regionToStore.get(regionId).getLockManager().globalReadUnlock();
         continue;
       }
       flushingRegionSet.add(regionId);
@@ -187,7 +188,6 @@ public class Scheduler {
             LockManager lockManager = store.getLockManager();
             long startTime = System.currentTimeMillis();
             try {
-              lockManager.globalReadLock();
               if (file == null) {
                 // store has been closed
                 return;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/flush/Scheduler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/flush/Scheduler.java
@@ -28,6 +28,7 @@ import org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.pbtree.lock.Lock
 import org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.pbtree.memcontrol.IReleaseFlushStrategy;
 import org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.pbtree.memory.IMemoryManager;
 import org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.pbtree.schemafile.ISchemaFile;
+import org.apache.iotdb.tsfile.utils.Pair;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -172,11 +173,13 @@ public class Scheduler {
    * @param regionIds determine the MTreeStore to select subtrees, the head of the list is the first
    *     MTreeStore to select subtrees
    */
-  public synchronized void scheduleFlush(List<Integer> regionIds) {
+  public synchronized void scheduleFlush(List<Pair<Integer, Long>> regionIds) {
     AtomicInteger remainToFlush = new AtomicInteger(BATCH_FLUSH_SUBTREE);
-    for (int regionId : regionIds) {
-      if (flushingRegionSet.contains(regionId)) {
-        regionToStore.get(regionId).getLockManager().globalReadUnlock();
+    boolean hasBreak = false;
+    for (Pair<Integer, Long> pair : regionIds) {
+      int regionId = pair.getLeft();
+      if (hasBreak || flushingRegionSet.contains(regionId)) {
+        regionToStore.get(regionId).getLockManager().globalStampedReadUnlock(pair.getRight());
         continue;
       }
       flushingRegionSet.add(regionId);
@@ -201,6 +204,8 @@ public class Scheduler {
                   regionId,
                   e.getMessage(),
                   e);
+            } catch (Throwable e) {
+              LOGGER.error("Error occurred during PBTree flush", e);
             } finally {
               long time = System.currentTimeMillis() - startTime;
               if (time > 10_000) {
@@ -208,12 +213,12 @@ public class Scheduler {
               } else {
                 LOGGER.debug("It takes {}ms to flush MTree in SchemaRegion {}", time, regionId);
               }
-              lockManager.globalReadUnlock();
+              lockManager.globalStampedReadUnlock(pair.getRight());
               flushingRegionSet.remove(regionId);
             }
           });
       if (remainToFlush.get() <= 0) {
-        break;
+        hasBreak = true;
       }
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/memory/ReleaseFlushMonitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/memory/ReleaseFlushMonitor.java
@@ -28,6 +28,7 @@ import org.apache.iotdb.db.schemaengine.rescon.CachedSchemaEngineStatistics;
 import org.apache.iotdb.db.schemaengine.rescon.ISchemaEngineStatistics;
 import org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.pbtree.CachedMTreeStore;
 import org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.pbtree.flush.Scheduler;
+import org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.pbtree.lock.LockManager;
 import org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.pbtree.memcontrol.IReleaseFlushStrategy;
 import org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.pbtree.memcontrol.ReleaseFlushStrategyNumBasedImpl;
 import org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.pbtree.memcontrol.ReleaseFlushStrategySizeBasedImpl;
@@ -193,32 +194,53 @@ public class ReleaseFlushMonitor {
     List<Pair<Integer, Long>> regionAndFreeTimeList = new ArrayList<>();
     for (Map.Entry<Integer, RecordList> entry : regionToTraverserTime.entrySet()) {
       int regionId = entry.getKey();
-      long traverserEndTime = windowsStartTime;
-      long traverserFreeTime = 0;
-      RecordList recordList = entry.getValue();
-      Iterator<RecordNode> iterator = recordList.iterator();
-      while (iterator.hasNext()) {
-        RecordNode recordNode = iterator.next();
-        if (recordNode.startTime > windowsEndTime) {
-          break;
-        }
-        if (recordNode.startTime > traverserEndTime) {
-          traverserFreeTime += (recordNode.startTime - traverserEndTime);
-          traverserEndTime = recordNode.endTime;
-        } else if (recordNode.endTime > traverserEndTime) {
-          traverserEndTime = recordNode.endTime;
-        }
-        if (recordNode.endTime < windowsStartTime) {
-          iterator.remove();
-        } else if (recordNode.endTime >= windowsEndTime) {
-          break;
-        }
+      CachedMTreeStore store = regionToStoreMap.get(regionId);
+      if (store == null) {
+        // already been removed
+        continue;
       }
-      if (traverserEndTime < windowsEndTime) {
-        traverserFreeTime += (windowsEndTime - traverserEndTime);
-      }
-      if (traverserFreeTime > FREE_FLUSH_PROPORTION * MONITOR_INETRVAL_MILLISECONDS) {
-        regionAndFreeTimeList.add(new Pair<>(regionId, traverserFreeTime));
+
+      LockManager lockManager = store.getLockManager();
+      lockManager.globalReadLock();
+      boolean needReleaseLock = true;
+      try {
+        if (!regionToStoreMap.containsKey(regionId)) {
+          // already been removed
+          continue;
+        }
+
+        long traverserEndTime = windowsStartTime;
+        long traverserFreeTime = 0;
+        RecordList recordList = entry.getValue();
+        Iterator<RecordNode> iterator = recordList.iterator();
+        while (iterator.hasNext()) {
+          RecordNode recordNode = iterator.next();
+          if (recordNode.startTime > windowsEndTime) {
+            break;
+          }
+          if (recordNode.startTime > traverserEndTime) {
+            traverserFreeTime += (recordNode.startTime - traverserEndTime);
+            traverserEndTime = recordNode.endTime;
+          } else if (recordNode.endTime > traverserEndTime) {
+            traverserEndTime = recordNode.endTime;
+          }
+          if (recordNode.endTime < windowsStartTime) {
+            iterator.remove();
+          } else if (recordNode.endTime >= windowsEndTime) {
+            break;
+          }
+        }
+        if (traverserEndTime < windowsEndTime) {
+          traverserFreeTime += (windowsEndTime - traverserEndTime);
+        }
+        if (traverserFreeTime > FREE_FLUSH_PROPORTION * MONITOR_INETRVAL_MILLISECONDS) {
+          regionAndFreeTimeList.add(new Pair<>(regionId, traverserFreeTime));
+          needReleaseLock = false;
+        }
+      } finally {
+        if (needReleaseLock) {
+          lockManager.globalReadUnlock();
+        }
       }
     }
     regionAndFreeTimeList.sort(Comparator.comparing((Pair<Integer, Long> o) -> o.right).reversed());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/BTreePageManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/BTreePageManager.java
@@ -92,8 +92,6 @@ public class BTreePageManager extends PageManager {
    * In this implementation, subordinate index builds on alias.
    *
    * @param parNode node needs to build subordinate index.
-   * @throws MetadataException
-   * @throws IOException
    */
   @Override
   protected void buildSubIndex(ICachedMNode parNode, SchemaPageContext cxt)

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/PageManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/PageManager.java
@@ -89,7 +89,7 @@ public abstract class PageManager implements IPageManager {
   private final FileChannel channel;
 
   // handle timeout interruption during reading
-  private File pmtFile;
+  private final File pmtFile;
   private FileChannel readChannel;
 
   private final AtomicInteger logCounter;
@@ -160,8 +160,7 @@ public abstract class PageManager implements IPageManager {
     if (!res.isEmpty()) {
       try (FileOutputStream outputStream = new FileOutputStream(logPath, true)) {
         outputStream.write(new byte[] {SchemaFileConfig.SF_COMMIT_MARK});
-        long length = outputStream.getChannel().size();
-        return length;
+        return outputStream.getChannel().size();
       }
     }
     return 0L;
@@ -227,14 +226,14 @@ public abstract class PageManager implements IPageManager {
   }
 
   /** Context only tracks write locks, and so it shall be released. */
-  protected void releaseLocks(SchemaPageContext cxt) throws IOException, MetadataException {
+  protected void releaseLocks(SchemaPageContext cxt) {
     for (int i : cxt.lockTraces) {
       pageInstCache.get(i).getLock().writeLock().unlock();
     }
   }
 
   /** release referents and evict likely useless page if necessary */
-  protected void releaseReferent(SchemaPageContext cxt) throws IOException, MetadataException {
+  protected void releaseReferent(SchemaPageContext cxt) {
     for (ISchemaPage p : cxt.referredPages.values()) {
       p.getRefCnt().decrementAndGet();
     }
@@ -243,7 +242,10 @@ public abstract class PageManager implements IPageManager {
       cacheLock.lock();
       try {
         for (ISchemaPage p : cxt.referredPages.values()) {
-          if (p.getRefCnt().get() == 0) {
+          // unnecessary to evict the page object in context by 2 case:
+          //  1. it is held by another thread, e.g., RefCnt != 0
+          //  2. it had already been evicted, e.g., pageCache.get(id) != page
+          if (p.getRefCnt().get() == 0 && pageInstCache.get(p.getPageIndex()) == p) {
             pageInstCache.remove(p.getPageIndex());
           }
         }
@@ -402,7 +404,7 @@ public abstract class PageManager implements IPageManager {
 
   private void writeUpdatedChildren(ICachedMNode node, SchemaPageContext cxt)
       throws MetadataException, IOException {
-    boolean removeOldSubEntry = false, insertNewSubEntry = false;
+    boolean removeOldSubEntry, insertNewSubEntry;
     int subIndex;
     long curSegAddr = getNodeAddress(node);
     long actualAddress; // actual segment to write record
@@ -528,11 +530,7 @@ public abstract class PageManager implements IPageManager {
       ISchemaPage curPage, String key, ByteBuffer childBuffer, SchemaPageContext cxt)
       throws MetadataException, IOException;
 
-  /**
-   * Same as {@linkplain #multiPageInsertOverflowOperation}
-   *
-   * @return the top internal page
-   */
+  /** Same as {@linkplain #multiPageInsertOverflowOperation} */
   protected abstract void multiPageUpdateOverflowOperation(
       ISchemaPage curPage, String key, ByteBuffer childBuffer, SchemaPageContext cxt)
       throws MetadataException, IOException;
@@ -659,7 +657,7 @@ public abstract class PageManager implements IPageManager {
     // can be reclaimed since the page only referred by pageInstCache
     cxt.referredPages.remove(cxt.lastLeafPage.getPageIndex());
     // alleviate eviction pressure
-    pageInstCache.remove(cxt.lastLeafPage);
+    pageInstCache.remove(cxt.lastLeafPage.getPageIndex());
 
     cxt.lastLeafPage = page.getAsSegmentedPage();
   }
@@ -842,12 +840,7 @@ public abstract class PageManager implements IPageManager {
         + SchemaFileConfig.FILE_HEADER_SIZE;
   }
 
-  /**
-   * Estimate segment size for pre-allocate
-   *
-   * @param node
-   * @return
-   */
+  /** Estimate segment size for pre-allocate */
   private static short estimateSegmentSize(ICachedMNode node) {
     int childNum = node.getChildren().size();
     if (childNum < SchemaFileConfig.SEG_SIZE_METRIC[0]) {
@@ -891,7 +884,6 @@ public abstract class PageManager implements IPageManager {
    * @param expSize expected size calculated from next new record
    * @param batchSize size of children within one #writeNewChildren(ICachedMNode)
    * @return estimated size
-   * @throws MetadataException
    */
   private static short reEstimateSegSize(int expSize, int batchSize) throws MetadataException {
     if (batchSize < SchemaFileConfig.SEG_SIZE_METRIC[0]) {
@@ -1069,7 +1061,7 @@ public abstract class PageManager implements IPageManager {
 
     public PageIndexSortBuckets(short[] borders, Map<Integer, ISchemaPage> container) {
       bounds = Arrays.copyOf(borders, borders.length);
-      buckets = new LinkedList[borders.length];
+      buckets = (LinkedList<Integer>[]) new LinkedList[borders.length];
       pageContainer = container;
       for (int i = 0; i < borders.length; i++) {
         buckets[i] = new LinkedList<>();

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/MonitorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/MonitorTest.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.metadata.mtree.schemafile;
 
 import org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.pbtree.memory.ReleaseFlushMonitor;
+import org.apache.iotdb.tsfile.utils.Pair;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -58,20 +59,20 @@ public class MonitorTest {
     setRecord(4, Arrays.asList(700L, 800L, 2500L), Arrays.asList(1000L, 1500L, 5000L));
     // free =2100
     setRecord(5, Arrays.asList(0L, 2000L), Arrays.asList(1000L, 3900L));
-    List<Integer> regions = releaseFlushMonitor.getRegionsToFlush(5000);
+    List<Pair<Integer, Long>> regions = releaseFlushMonitor.getRegionsToFlush(5000);
     Assert.assertEquals(3, regions.size());
-    Assert.assertEquals(5, regions.get(0).intValue());
-    Assert.assertEquals(2, regions.get(1).intValue());
-    Assert.assertEquals(4, regions.get(2).intValue());
+    Assert.assertEquals(5, regions.get(0).left.intValue());
+    Assert.assertEquals(2, regions.get(1).left.intValue());
+    Assert.assertEquals(4, regions.get(2).left.intValue());
   }
 
   @Test
   public void testGetRegionsToFlush2() {
     setRecord(1, Arrays.asList(0L, 2000L), Arrays.asList(100L, 7000L));
     setRecord(2, Collections.singletonList(3000L), Collections.singletonList(3500L));
-    List<Integer> regions = releaseFlushMonitor.getRegionsToFlush(7000);
+    List<Pair<Integer, Long>> regions = releaseFlushMonitor.getRegionsToFlush(7000);
     Assert.assertEquals(1, regions.size());
-    Assert.assertEquals(2, regions.get(0).intValue());
+    Assert.assertEquals(2, regions.get(0).left.intValue());
   }
 
   private void setRecord(int regionId, List<Long> startTimes, List<Long> eneTimes) {


### PR DESCRIPTION
## Description
Previously, a NPE could occur due to eviction checks and executions being performed on different objects. 

If two threads, T1 and T2, concurrently decrement the reference count of the same page, one would be blocked by an exclusive lock before entering eviction process. Suppose T1 acquires the lock and completes the eviction. Before T2 can obtain the lock, another thread T3 might acquire it and attempt to read the evicted page. This action triggers a disk read and creates a new page object, even while T2 still holds a page object with the same page index. Eventually, when T2 proceeds with eviction, it finds the reference count of its page to be zero and evicts the page with same page index which is actually held by T3. This erroneous eviction could subsequently lead to an NPE when T3 finishes all taks and attempts to evict the same page from the cache.

Currently, the eviction process for any page object is governed by two criteria: firstly, the object's reference count must be zero; secondly, the page to be evicted from cache must have an objectID matching the objectID of the page that resides in the context of the evicting thread.
 
This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
