### PR TITLE
Fix UT DataRegion.testMerge

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/DataRegionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/DataRegionTest.java
@@ -898,8 +898,14 @@ public class DataRegionTest {
         IoTDBDescriptor.getInstance().getConfig().isEnableSeqSpaceCompaction();
     boolean originEnableUnseqSpaceCompaction =
         IoTDBDescriptor.getInstance().getConfig().isEnableUnseqSpaceCompaction();
+    boolean originEnableCrossSpaceCompaction =
+        IoTDBDescriptor.getInstance().getConfig().isEnableCrossSpaceCompaction();
+    boolean originEnableInsertionCompaction =
+        IoTDBDescriptor.getInstance().getConfig().isEnableInsertionCrossSpaceCompaction();
     IoTDBDescriptor.getInstance().getConfig().setEnableSeqSpaceCompaction(true);
     IoTDBDescriptor.getInstance().getConfig().setEnableUnseqSpaceCompaction(true);
+    IoTDBDescriptor.getInstance().getConfig().setEnableCrossSpaceCompaction(false);
+    IoTDBDescriptor.getInstance().getConfig().setEnableInsertionCrossSpaceCompaction(false);
     long finishedCompactionTaskNumWhenTestStart =
         CompactionTaskManager.getInstance().getFinishedTaskNum();
     for (int j = 21; j <= 30; j++) {
@@ -955,6 +961,12 @@ public class DataRegionTest {
     IoTDBDescriptor.getInstance()
         .getConfig()
         .setEnableSeqSpaceCompaction(originEnableSeqSpaceCompaction);
+    IoTDBDescriptor.getInstance()
+        .getConfig()
+        .setEnableCrossSpaceCompaction(originEnableCrossSpaceCompaction);
+    IoTDBDescriptor.getInstance()
+        .getConfig()
+        .setEnableInsertionCrossSpaceCompaction(originEnableInsertionCompaction);
     IoTDBDescriptor.getInstance()
         .getConfig()
         .setEnableUnseqSpaceCompaction(originEnableUnseqSpaceCompaction);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/DataRegionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/DataRegionTest.java
@@ -936,7 +936,7 @@ public class DataRegionTest {
         break;
       }
     } while (CompactionTaskManager.getInstance().getFinishedTaskNum()
-        == finishedCompactionTaskNumWhenTestStart);
+        <= finishedCompactionTaskNumWhenTestStart + 1);
 
     QueryDataSource queryDataSource =
         dataRegion.query(


### PR DESCRIPTION
## Description
Fix UT DataRegion.testMerge. This UT test manually triggered merge, which may cause concurrent issue.
If the unsequence inner space compaction task is finised before sequence space compaction task, the test may failed.
