### PR TITLE
[IOTDB-6275] Disable limit/offset push down in ORDER BY

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/orderBy/IoTDBOrderByIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/orderBy/IoTDBOrderByIT.java
@@ -251,20 +251,6 @@ public class IoTDBOrderByIT {
   }
 
   @Test
-  public void orderByTest17() {
-    String sql = "select num,bigNum,floatNum,str,bool from root.sg.d order by str desc, str asc";
-    int[] ans = {3, 2, 5, 12, 0, 9, 13, 8, 4, 7, 1, 10, 6, 11, 14};
-    testNormalOrderBy(sql, Arrays.reverse(ans));
-  }
-
-  @Test
-  public void orderByTest18() {
-    String sql = "select num,bigNum,floatNum,str,bool from root.sg.d order by str, str";
-    int[] ans = {3, 2, 5, 12, 0, 9, 13, 8, 4, 7, 1, 10, 6, 11, 14};
-    testNormalOrderBy(sql, ans);
-  }
-
-  @Test
   public void orderByTest15() {
     String sql = "select num+bigNum,floatNum from root.sg.d order by str";
     int[] ans = {3, 2, 5, 12, 0, 9, 13, 8, 4, 7, 1, 10, 6, 11, 14};
@@ -387,6 +373,46 @@ public class IoTDBOrderByIT {
               actualNum,
               0.001);
 
+          i++;
+        }
+        assertEquals(i, ans.length);
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail();
+    }
+  }
+
+  @Test
+  public void orderByTest17() {
+    String sql = "select num,bigNum,floatNum,str,bool from root.sg.d order by str desc, str asc";
+    int[] ans = {3, 2, 5, 12, 0, 9, 13, 8, 4, 7, 1, 10, 6, 11, 14};
+    testNormalOrderBy(sql, Arrays.reverse(ans));
+  }
+
+  @Test
+  public void orderByTest18() {
+    String sql = "select num,bigNum,floatNum,str,bool from root.sg.d order by str, str";
+    int[] ans = {3, 2, 5, 12, 0, 9, 13, 8, 4, 7, 1, 10, 6, 11, 14};
+    testNormalOrderBy(sql, ans);
+  }
+
+  // limit cannot be pushed down in ORDER BY
+  @Test
+  public void orderByTest19() {
+    String sql = "select num from root.sg.d order by num limit 5";
+    int[] ans = {2, 1, 0, 7, 8};
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      try (ResultSet resultSet = statement.executeQuery(sql)) {
+        ResultSetMetaData metaData = resultSet.getMetaData();
+        checkHeader(metaData, new String[] {"Time", "root.sg.d.num"});
+        int i = 0;
+        while (resultSet.next()) {
+          String actualTime = resultSet.getString(1);
+          String actualNum = resultSet.getString(2);
+          assertEquals(res[ans[i]][0], actualTime);
+          assertEquals(res[ans[i]][1], actualNum);
           i++;
         }
         assertEquals(i, ans.length);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/optimization/LimitOffsetPushDown.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/optimization/LimitOffsetPushDown.java
@@ -33,6 +33,7 @@ import org.apache.iotdb.db.queryengine.plan.planner.plan.node.process.LimitNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.process.MultiChildProcessNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.process.OffsetNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.process.SingleChildProcessNode;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.process.SortNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.process.TransformNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.source.AlignedSeriesScanNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.source.SeriesScanNode;
@@ -140,6 +141,13 @@ public class LimitOffsetPushDown implements PlanOptimizer {
       // Value filtering push-down occurs during the logical planning phase. If there is still a
       // FilterNode here, it means that there are read filter conditions that cannot be pushed
       // down.
+      context.setEnablePushDown(false);
+      return node;
+    }
+
+    @Override
+    public PlanNode visitSort(SortNode node, RewriterContext context) {
+      // Limit/Offset in ORDER BY focus the sorted result, so it should not be pushed down.
       context.setEnablePushDown(false);
       return node;
     }


### PR DESCRIPTION
We cannot push limit down to scan if we have order by clause. 
Limit/Offset only works on the sorted results.