### PR TITLE
fix insert&delete cases dead data.

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/DataNodeInternalRPCServiceImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/DataNodeInternalRPCServiceImpl.java
@@ -512,11 +512,13 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
   @Override
   public TSStatus invalidateMatchedSchemaCache(TInvalidateMatchedSchemaCacheReq req) {
     DataNodeSchemaCache cache = DataNodeSchemaCache.getInstance();
+    cache.takeDeleteLock();
     cache.takeWriteLock();
     try {
       cache.invalidate(PathPatternTree.deserialize(req.pathPatternTree).getAllPathPatterns());
     } finally {
       cache.releaseWriteLock();
+      cache.releaseDeleteLock();
     }
     return RpcUtils.SUCCESS_STATUS;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/MPPQueryContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/MPPQueryContext.java
@@ -59,6 +59,8 @@ public class MPPQueryContext {
 
   private Filter globalTimeFilter;
 
+  private boolean acquiredLock;
+
   public MPPQueryContext(QueryId queryId) {
     this.queryId = queryId;
     this.endPointBlackList = new LinkedList<>();
@@ -153,6 +155,14 @@ public class MPPQueryContext {
 
   public String getSql() {
     return sql;
+  }
+
+  public boolean getAcquiredLock() {
+    return acquiredLock;
+  }
+
+  public void setAcquiredLock(boolean acuqired) {
+    acquiredLock = acuqired;
   }
 
   public void generateGlobalTimeFilter(Analysis analysis) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/executor/RegionWriteExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/executor/RegionWriteExecutor.java
@@ -305,7 +305,8 @@ public class RegionWriteExecutor {
     @Override
     public RegionExecutionResult visitDeleteData(
         DeleteDataNode node, WritePlanNodeExecutionContext context) {
-      // data deletion should block data insertion, especially when executed for deleting timeseries
+      // data deletion don't need to block data insertion, but there are some creation operation
+      // require write lock on data region.
       context.getRegionWriteValidationRWLock().writeLock().lock();
       try {
         return super.visitDeleteData(node, context);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/Coordinator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/Coordinator.java
@@ -163,7 +163,7 @@ public class Coordinator {
       return execution.getStatus();
     } finally {
       if (queryContext != null && queryContext.getAcquiredLock()) {
-        DataNodeSchemaCache.getInstance().releaseReadLock();
+        DataNodeSchemaCache.getInstance().releaseInsertLock();
       }
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/Coordinator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/Coordinator.java
@@ -35,6 +35,7 @@ import org.apache.iotdb.db.queryengine.common.QueryId;
 import org.apache.iotdb.db.queryengine.common.SessionInfo;
 import org.apache.iotdb.db.queryengine.execution.QueryIdGenerator;
 import org.apache.iotdb.db.queryengine.plan.analyze.IPartitionFetcher;
+import org.apache.iotdb.db.queryengine.plan.analyze.cache.schema.DataNodeSchemaCache;
 import org.apache.iotdb.db.queryengine.plan.analyze.schema.ISchemaFetcher;
 import org.apache.iotdb.db.queryengine.plan.execution.ExecutionResult;
 import org.apache.iotdb.db.queryengine.plan.execution.IQueryExecution;
@@ -132,11 +133,12 @@ public class Coordinator {
       long timeOut) {
     long startTime = System.currentTimeMillis();
     QueryId globalQueryId = queryIdGenerator.createNextQueryId();
+    MPPQueryContext queryContext = null;
     try (SetThreadName queryName = new SetThreadName(globalQueryId.getId())) {
       if (sql != null && sql.length() > 0) {
         LOGGER.debug("[QueryStart] sql: {}", sql);
       }
-      MPPQueryContext queryContext =
+      queryContext =
           new MPPQueryContext(
               sql,
               globalQueryId,
@@ -159,6 +161,10 @@ public class Coordinator {
       }
       execution.start();
       return execution.getStatus();
+    } finally {
+      if (queryContext != null && queryContext.getAcquiredLock()) {
+        DataNodeSchemaCache.getInstance().releaseReadLock();
+      }
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/schema/ClusterSchemaFetcher.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/schema/ClusterSchemaFetcher.java
@@ -52,6 +52,9 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
   private final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
 
   private final Coordinator coordinator = Coordinator.getInstance();
+
+  // DataNodeSchemaCache's rwlock is used to block deletion when we insert the same timeseries
+  // and will be released after coordinator's execute().
   private final DataNodeSchemaCache schemaCache = DataNodeSchemaCache.getInstance();
   private final ITemplateManager templateManager = ClusterTemplateManager.getInstance();
 
@@ -188,7 +191,7 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
         schemaComputationWithAutoCreation.computeMeasurement(index, null);
       }
     } finally {
-      schemaCache.releaseReadLock();
+      context.setAcquiredLock(true);
     }
   }
 
@@ -225,7 +228,7 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
             templateSetInfoList, templateTimeSeriesRequestList, context);
       }
     } finally {
-      schemaCache.releaseReadLock();
+      context.setAcquiredLock(true);
     }
   }
 
@@ -312,7 +315,7 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
 
       return schemaTree;
     } finally {
-      schemaCache.releaseReadLock();
+      context.setAcquiredLock(true);
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/schema/ClusterSchemaFetcher.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/schema/ClusterSchemaFetcher.java
@@ -165,6 +165,8 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
       MPPQueryContext context) {
     // The schema cache R/W and fetch operation must be locked together thus the cache clean
     // operation executed by delete timeseries will be effective.
+    schemaCache.takeInsertLock();
+    context.setAcquiredLock(true);
     schemaCache.takeReadLock();
     try {
       Pair<Template, PartialPath> templateSetInfo =
@@ -191,7 +193,7 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
         schemaComputationWithAutoCreation.computeMeasurement(index, null);
       }
     } finally {
-      context.setAcquiredLock(true);
+      schemaCache.releaseReadLock();
     }
   }
 
@@ -201,6 +203,8 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
       MPPQueryContext context) {
     // The schema cache R/W and fetch operation must be locked together thus the cache clean
     // operation executed by delete timeseries will be effective.
+    schemaCache.takeInsertLock();
+    context.setAcquiredLock(true);
     schemaCache.takeReadLock();
     try {
 
@@ -228,7 +232,7 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
             templateSetInfoList, templateTimeSeriesRequestList, context);
       }
     } finally {
-      context.setAcquiredLock(true);
+      schemaCache.releaseReadLock();
     }
   }
 
@@ -243,6 +247,8 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
       MPPQueryContext context) {
     // The schema cache R/W and fetch operation must be locked together thus the cache clean
     // operation executed by delete timeseries will be effective.
+    schemaCache.takeInsertLock();
+    context.setAcquiredLock(true);
     schemaCache.takeReadLock();
     try {
       ClusterSchemaTree schemaTree = new ClusterSchemaTree();
@@ -315,7 +321,7 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
 
       return schemaTree;
     } finally {
-      context.setAcquiredLock(true);
+      schemaCache.releaseReadLock();
     }
   }
 


### PR DESCRIPTION
In this PR:
1. remove useless write lock on schema cache when execute deletion
2. coordinator will acquire a read lock on schema cache, which will block deletion's cache invalidation.
3. solves the DEAD data problem: these data have no metadata but only data.