### PR TITLE
Compaction rate limiter parameter supports negative value

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/schedule/CompactionTaskManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/schedule/CompactionTaskManager.java
@@ -249,7 +249,7 @@ public class CompactionTaskManager implements IService {
   private void setWriteMergeRate(final double throughoutMbPerSec) {
     double throughout = throughoutMbPerSec * 1024.0 * 1024.0;
     // if throughout = 0, disable rate limiting
-    if (throughout == 0) {
+    if (throughout <= 0) {
       throughout = Double.MAX_VALUE;
     }
     if (mergeWriteRateLimiter.getRate() != throughout) {

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -671,6 +671,7 @@ timestamp_precision=ms
 # compaction_submission_interval_in_ms=60000
 
 # The limit of write throughput merge can reach per second
+# values less than or equal to 0 means no limit
 # Datatype: int
 # compaction_write_throughput_mb_per_sec=16
 


### PR DESCRIPTION
## Before

Currently, the parameter compaction_write_throughput_mb_per_sec doesn't support negative value and negative values make RateLimitor throwing exceptions.

## After

Any value less than or equal to 0 means no limit in the compaction_write_throughput_mb_per_sec.