### PR TITLE
Pipe: add flag for memtable to avoid retransmission of tsfile generated by forwarded insertion

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/flush/NotifyFlushMemTable.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/flush/NotifyFlushMemTable.java
@@ -36,4 +36,11 @@ public class NotifyFlushMemTable extends AbstractMemTable {
   public boolean isSignalMemTable() {
     return true;
   }
+
+  @Override
+  public boolean isTotallyGeneratedByPipe() {
+    // Even though the `isTotallyGeneratedByPipe` for the corresponding memory table of this
+    // `NotifyFlushMemTable` might be true, we still return false to ensure data integrity.
+    return false;
+  }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AbstractMemTable.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AbstractMemTable.java
@@ -720,6 +720,6 @@ public abstract class AbstractMemTable implements IMemTable {
 
   @Override
   public boolean isTotallyGeneratedByPipe() {
-    return isTotallyGeneratedByPipe.get();
+    return this.isTotallyGeneratedByPipe.get();
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AbstractMemTable.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AbstractMemTable.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
@@ -101,6 +102,8 @@ public abstract class AbstractMemTable implements IMemTable {
   private String dataRegionId;
 
   private static final String METRIC_POINT_IN = Metric.POINTS_IN.toString();
+
+  private final AtomicBoolean isTotallyGeneratedByPipe = new AtomicBoolean(true);
 
   protected AbstractMemTable() {
     this.database = null;
@@ -708,5 +711,15 @@ public abstract class AbstractMemTable implements IMemTable {
   public void setDatabaseAndDataRegionId(String database, String dataRegionId) {
     this.database = database;
     this.dataRegionId = dataRegionId;
+  }
+
+  @Override
+  public void markAsNotGeneratedByPipe() {
+    this.isTotallyGeneratedByPipe.set(false);
+  }
+
+  @Override
+  public boolean isTotallyGeneratedByPipe() {
+    return isTotallyGeneratedByPipe.get();
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/IMemTable.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/IMemTable.java
@@ -179,4 +179,8 @@ public interface IMemTable extends WALEntryValue {
   String getDataRegionId();
 
   void setDatabaseAndDataRegionId(String database, String dataRegionId);
+
+  void markAsNotGeneratedByPipe();
+
+  boolean isTotallyGeneratedByPipe();
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
@@ -286,6 +286,9 @@ public class TsFileProcessor {
     startTime = System.nanoTime();
 
     PipeAgent.runtime().assignSimpleProgressIndexIfNeeded(insertRowNode);
+    if (!insertRowNode.isGeneratedByPipe()) {
+      workMemTable.markAsNotGeneratedByPipe();
+    }
     PipeInsertionDataNodeListener.getInstance()
         .listenToInsertNode(
             dataRegionInfo.getDataRegion().getDataRegionId(),
@@ -397,6 +400,9 @@ public class TsFileProcessor {
     startTime = System.nanoTime();
 
     PipeAgent.runtime().assignSimpleProgressIndexIfNeeded(insertTabletNode);
+    if (!insertTabletNode.isGeneratedByPipe()) {
+      workMemTable.markAsNotGeneratedByPipe();
+    }
     PipeInsertionDataNodeListener.getInstance()
         .listenToInsertNode(
             dataRegionInfo.getDataRegion().getDataRegionId(),
@@ -908,7 +914,10 @@ public class TsFileProcessor {
       try {
         PipeInsertionDataNodeListener.getInstance()
             .listenToTsFile(
-                dataRegionInfo.getDataRegion().getDataRegionId(), tsFileResource, false, false);
+                dataRegionInfo.getDataRegion().getDataRegionId(),
+                tsFileResource,
+                false,
+                workMemTable.isTotallyGeneratedByPipe());
 
         // When invoke closing TsFile after insert data to memTable, we shouldn't flush until invoke
         // flushing memTable in System module.

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
@@ -917,7 +917,7 @@ public class TsFileProcessor {
                 dataRegionInfo.getDataRegion().getDataRegionId(),
                 tsFileResource,
                 false,
-                workMemTable.isTotallyGeneratedByPipe());
+                tmpMemTable.isTotallyGeneratedByPipe());
 
         // When invoke closing TsFile after insert data to memTable, we shouldn't flush until invoke
         // flushing memTable in System module.


### PR DESCRIPTION
## Description

As title.

---

**Regeneration:**

During disk flushing, it is now impossible to determine whether the content of a tsfile is forwarded through a pipe or contains data written by a regular client. Therefore, for data synchronized from A to B in log mode, if B establishes a bidirectional connection to A in file mode, there may be an issue with B rewriting part of the data written by A.

```sql
create pipe a2b with source ('realtime.mode'='log') with sink ('node-urls'='127.0.0.1:6668', 'forwarding-pipe-requests'='false');
create pipe b2a with source ('realtime.mode'='file') with sink ('node-urls'='127.0.0.1:6667', 'forwarding-pipe-requests'='false');
```

---

**Solution:**

Add an flag for memtable to determine whether the generated tsfile contains content written non-pipe forwarded; only forward tsfiles that contain non-pipe forwarded writes.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [x] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
