### PR TITLE
[IOTDB-5706] Data inconsistency between IoT protocol replications

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataRegionStateMachine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataRegionStateMachine.java
@@ -243,18 +243,18 @@ public class DataRegionStateMachine extends BaseStateMachine {
   protected TSStatus write(PlanNode planNode) {
     // To ensure the Data inconsistency between multiple replications, we add retry in write
     // operation.
-    TSStatus result = null;
+    TSStatus result;
     int retryTime = 0;
-    while (retryTime < MAX_WRITE_RETRY_TIMES) {
+    while (true) {
       result = planNode.accept(new DataExecutionVisitor(), region);
       if (needRetry(result.getCode())) {
         retryTime++;
         logger.debug(
             "write operation failed because {}, retryTime: {}.", result.getCode(), retryTime);
-        if (retryTime == MAX_WRITE_RETRY_TIMES) {
+        if (retryTime % MAX_WRITE_RETRY_TIMES == 0) {
           logger.error(
               "write operation still failed after {} retry times, because {}.",
-              MAX_WRITE_RETRY_TIMES,
+              retryTime,
               result.getCode());
         }
         try {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataRegionStateMachine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataRegionStateMachine.java
@@ -65,8 +65,6 @@ public class DataRegionStateMachine extends BaseStateMachine {
 
   protected DataRegion region;
 
-  private static final int MAX_WRITE_RETRY_TIMES = 5;
-
   private static final long WRITE_RETRY_WAIT_TIME_IN_MS = 1000;
 
   public DataRegionStateMachine(DataRegion region) {
@@ -251,7 +249,7 @@ public class DataRegionStateMachine extends BaseStateMachine {
         retryTime++;
         logger.debug(
             "write operation failed because {}, retryTime: {}.", result.getCode(), retryTime);
-        if (retryTime % MAX_WRITE_RETRY_TIMES == 0) {
+        if (retryTime % 5 == 0) {
           logger.error(
               "write operation still failed after {} retry times, because {}.",
               retryTime,


### PR DESCRIPTION
## Description

In previous [pr](https://github.com/apache/iotdb/pull/11748), we added retry in DataRegionStateMachine write operations to fix the atomicity problem.

In this pr, we change to infinite retry to completely solve the inconsistency problem caused by system reject.

Please see [jira](https://issues.apache.org/jira/browse/IOTDB-5706) for details.