### PR TITLE
PBTree: Fix conccurency control with alias read

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/ISchemaPage.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/ISchemaPage.java
@@ -126,6 +126,10 @@ public interface ISchemaPage {
 
   AtomicInteger getRefCnt();
 
+  int incrementAndGetRefCnt();
+
+  int decrementAndGetRefCnt();
+
   ReadWriteLock getLock();
 
   void syncPageBuffer();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/SchemaPage.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/SchemaPage.java
@@ -79,7 +79,7 @@ public abstract class SchemaPage implements ISchemaPage {
 
   @Override
   public int incrementAndGetRefCnt() {
-    return refCnt.decrementAndGet();
+    return refCnt.incrementAndGet();
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/SchemaPage.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/SchemaPage.java
@@ -78,6 +78,16 @@ public abstract class SchemaPage implements ISchemaPage {
   }
 
   @Override
+  public int incrementAndGetRefCnt() {
+    return refCnt.decrementAndGet();
+  }
+
+  @Override
+  public int decrementAndGetRefCnt() {
+    return refCnt.decrementAndGet();
+  }
+
+  @Override
   public ReadWriteLock getLock() {
     return lock;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/BTreePageManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/BTreePageManager.java
@@ -389,7 +389,6 @@ public class BTreePageManager extends PageManager {
   @Override
   public ICachedMNode getChildNode(ICachedMNode parent, String childName)
       throws MetadataException, IOException {
-    // TODO unnecessary context var
     SchemaPageContext cxt = new SchemaPageContext();
 
     if (getNodeAddress(parent) < 0) {
@@ -419,7 +418,7 @@ public class BTreePageManager extends PageManager {
         }
 
         // try read with sub-index
-        return getChildWithAlias(parent, childName);
+        return getChildWithAlias(parent, childName, cxt);
       }
       return child;
     } finally {
@@ -428,11 +427,8 @@ public class BTreePageManager extends PageManager {
     }
   }
 
-  private ICachedMNode getChildWithAlias(ICachedMNode par, String alias)
+  private ICachedMNode getChildWithAlias(ICachedMNode par, String alias, SchemaPageContext cxt)
       throws IOException, MetadataException {
-    // TODO unnecessary context var
-    SchemaPageContext cxt = new SchemaPageContext();
-
     long srtAddr = getNodeAddress(par);
     ISchemaPage page = getPageInstance(getPageIndex(srtAddr), cxt);
 
@@ -487,7 +483,7 @@ public class BTreePageManager extends PageManager {
               children = nPage.getAsSegmentedPage().getChildren(getSegIndex(nextSeg));
               nextSeg = nPage.getAsSegmentedPage().getNextSegAddress(getSegIndex(nextSeg));
               // children iteration need not pin page, consistency is guaranteed by upper layer
-              nPage.getRefCnt().decrementAndGet();
+              nPage.decrementAndGetRefCnt();
             }
           } catch (MetadataException | IOException e) {
             logger.error(e.getMessage());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/PageManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/PageManager.java
@@ -235,7 +235,7 @@ public abstract class PageManager implements IPageManager {
   /** release referents and evict likely useless page if necessary */
   protected void releaseReferent(SchemaPageContext cxt) {
     for (ISchemaPage p : cxt.referredPages.values()) {
-      p.getRefCnt().decrementAndGet();
+      p.decrementAndGetRefCnt();
     }
 
     if (pageInstCache.size() > SchemaFileConfig.PAGE_CACHE_SIZE) {
@@ -652,7 +652,7 @@ public abstract class PageManager implements IPageManager {
       cxt.lastLeafPage.getLock().writeLock().unlock();
       cxt.lockTraces.remove(cxt.lastLeafPage.getPageIndex());
     }
-    cxt.lastLeafPage.getRefCnt().decrementAndGet();
+    cxt.lastLeafPage.decrementAndGetRefCnt();
 
     // can be reclaimed since the page only referred by pageInstCache
     cxt.referredPages.remove(cxt.lastLeafPage.getPageIndex());
@@ -1024,7 +1024,7 @@ public abstract class PageManager implements IPageManager {
     // referred pages will not be evicted until operation finished
     private void refer(ISchemaPage page) {
       if (!referredPages.containsKey(page.getPageIndex())) {
-        page.getRefCnt().incrementAndGet();
+        page.incrementAndGetRefCnt();
         referredPages.put(page.getPageIndex(), page);
       }
     }


### PR DESCRIPTION
## Description

Fix conccurency control when try to read alias, or read miss.

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
