### PR TITLE
PBTree: Fix NPE during concurrent creating and iterating schema

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/flush/PBTreeFlushExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/flush/PBTreeFlushExecutor.java
@@ -79,7 +79,7 @@ public class PBTreeFlushExecutor {
         processFlushDatabase(databaseMNode);
       } catch (Exception e) {
         exceptions.add(e);
-        logger.error(e.getMessage());
+        logger.error(e.getMessage(), e);
       }
     }
     while (subtreeRoots.hasNext() && checkRemainToFlush()) {
@@ -87,7 +87,7 @@ public class PBTreeFlushExecutor {
         processFlushNonDatabase(subtreeRoots.next());
       } catch (Exception e) {
         exceptions.add(e);
-        logger.error(e.getMessage());
+        logger.error(e.getMessage(), e);
       }
     }
     if (!exceptions.isEmpty()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/flush/PBTreeFlushExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/flush/PBTreeFlushExecutor.java
@@ -79,7 +79,7 @@ public class PBTreeFlushExecutor {
         processFlushDatabase(databaseMNode);
       } catch (Exception e) {
         exceptions.add(e);
-        logger.error(e.getMessage(), e);
+        logger.warn(e.getMessage(), e);
       }
     }
     while (subtreeRoots.hasNext() && checkRemainToFlush()) {
@@ -87,7 +87,7 @@ public class PBTreeFlushExecutor {
         processFlushNonDatabase(subtreeRoots.next());
       } catch (Exception e) {
         exceptions.add(e);
-        logger.error(e.getMessage(), e);
+        logger.warn(e.getMessage(), e);
       }
     }
     if (!exceptions.isEmpty()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/BTreePageManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/BTreePageManager.java
@@ -479,11 +479,15 @@ public class BTreePageManager extends PageManager {
           try {
             ISchemaPage nPage;
             while (children.isEmpty() && nextSeg >= 0) {
+              boolean hasThisPage = cxt.referredPages.containsKey(getPageIndex(nextSeg));
               nPage = getPageInstance(getPageIndex(nextSeg), cxt);
               children = nPage.getAsSegmentedPage().getChildren(getSegIndex(nextSeg));
               nextSeg = nPage.getAsSegmentedPage().getNextSegAddress(getSegIndex(nextSeg));
               // children iteration need not pin page, consistency is guaranteed by upper layer
-              nPage.decrementAndGetRefCnt();
+              if (!hasThisPage) {
+                cxt.referredPages.remove(nPage.getPageIndex());
+                nPage.decrementAndGetRefCnt();
+              }
             }
           } catch (MetadataException | IOException e) {
             logger.error(e.getMessage());


### PR DESCRIPTION
## Description

1. Add stack trace logic during exception processing
2. Add page referent check and release logic during iterating B+ Tree pages to avoid wrong page eviction and deadlock.