### PR TITLE
Add missing synchronized on abort of SourceHandle

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/exchange/source/SourceHandle.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/exchange/source/SourceHandle.java
@@ -359,7 +359,7 @@ public class SourceHandle implements ISourceHandle {
   }
 
   @Override
-  public void abort(Throwable t) {
+  public synchronized void abort(Throwable t) {
     try (SetThreadName sourceHandleName = new SetThreadName(threadName)) {
       if (aborted || closed) {
         return;


### PR DESCRIPTION
This pr adds missing synchronized on abort of SourceHandle. If we do not hold the lock before aborting the SourceHandle, there may be concurrent issues.