### PR TITLE
Pipe: conceal SSL trust store password & improve exception messages for sink connection establishment

### DIFF
--- a/iotdb-api/pipe-api/src/main/java/org/apache/iotdb/pipe/api/exception/PipeConnectionException.java
+++ b/iotdb-api/pipe-api/src/main/java/org/apache/iotdb/pipe/api/exception/PipeConnectionException.java
@@ -21,6 +21,8 @@ package org.apache.iotdb.pipe.api.exception;
 
 public class PipeConnectionException extends PipeException {
 
+  public static String CONNECTION_ERROR_FORMATTER = "Connect to receiver %s:%s error, because: %s";
+
   public PipeConnectionException(String message) {
     super(message);
   }

--- a/iotdb-api/pipe-api/src/main/java/org/apache/iotdb/pipe/api/exception/PipeParameterNotValidException.java
+++ b/iotdb-api/pipe-api/src/main/java/org/apache/iotdb/pipe/api/exception/PipeParameterNotValidException.java
@@ -21,6 +21,9 @@ package org.apache.iotdb.pipe.api.exception;
 
 public class PipeParameterNotValidException extends PipeException {
 
+  public static String PARSE_URL_ERROR_FORMATTER =
+      "Error parsing node urls from target servers %s, because %s";
+
   public PipeParameterNotValidException(String message) {
     super(message);
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
@@ -210,6 +210,14 @@ public class IoTDBLegacyPipeConnector implements PipeConnector {
     useSSL = parameters.getBooleanOrDefault(SINK_IOTDB_SSL_ENABLE_KEY, false);
     trustStore = parameters.getString(SINK_IOTDB_SSL_TRUST_STORE_PATH_KEY);
     trustStorePwd = parameters.getString(SINK_IOTDB_SSL_TRUST_STORE_PWD_KEY);
+
+    // To avoid security issues, we have removed 'sink.ssl.trust-store-pwd' from the pipe metadata
+    // parameters to prevent the leakage of keys in show pipe results or logs.
+    // The `attributeSortedString2SubtaskLifeCycleMap` in PipeConnectorSubtaskManager fully retains
+    // the parameters corresponding to the connector.
+    if (useSSL) {
+      parameters.getAttribute().remove(SINK_IOTDB_SSL_TRUST_STORE_PWD_KEY);
+    }
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
@@ -224,19 +224,18 @@ public class IoTDBLegacyPipeConnector implements PipeConnector {
   public void handshake() throws Exception {
     close();
 
-    client =
-        new IoTDBThriftSyncConnectorClient(
-            new ThriftClientProperty.Builder()
-                .setConnectionTimeoutMs(COMMON_CONFIG.getConnectionTimeoutInMS())
-                .setRpcThriftCompressionEnabled(COMMON_CONFIG.isRpcThriftCompressionEnabled())
-                .build(),
-            ipAddress,
-            port,
-            useSSL,
-            trustStore,
-            trustStorePwd);
-
     try {
+      client =
+          new IoTDBThriftSyncConnectorClient(
+              new ThriftClientProperty.Builder()
+                  .setConnectionTimeoutMs(COMMON_CONFIG.getConnectionTimeoutInMS())
+                  .setRpcThriftCompressionEnabled(COMMON_CONFIG.isRpcThriftCompressionEnabled())
+                  .build(),
+              ipAddress,
+              port,
+              useSSL,
+              trustStore,
+              trustStorePwd);
       final TSyncIdentityInfo identityInfo =
           new TSyncIdentityInfo(
               pipeName, creationTime, syncConnectorVersion, IoTDBConstant.PATH_ROOT);
@@ -252,7 +251,7 @@ public class IoTDBLegacyPipeConnector implements PipeConnector {
     } catch (TException e) {
       throw new PipeConnectionException(
           String.format(
-              "Connect to receiver %s:%s error, because: %s", ipAddress, port, e.getMessage()),
+              PipeConnectionException.CONNECTION_ERROR_FORMATTER, ipAddress, port, e.getMessage()),
           e);
     }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
@@ -210,14 +210,6 @@ public class IoTDBLegacyPipeConnector implements PipeConnector {
     useSSL = parameters.getBooleanOrDefault(SINK_IOTDB_SSL_ENABLE_KEY, false);
     trustStore = parameters.getString(SINK_IOTDB_SSL_TRUST_STORE_PATH_KEY);
     trustStorePwd = parameters.getString(SINK_IOTDB_SSL_TRUST_STORE_PWD_KEY);
-
-    // To avoid security issues, we have removed 'sink.ssl.trust-store-pwd' from the pipe metadata
-    // parameters to prevent the leakage of keys in show pipe results or logs.
-    // The `attributeSortedString2SubtaskLifeCycleMap` in PipeConnectorSubtaskManager fully retains
-    // the parameters corresponding to the connector.
-    if (useSSL) {
-      parameters.getAttribute().remove(SINK_IOTDB_SSL_TRUST_STORE_PWD_KEY);
-    }
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBThriftAsyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBThriftAsyncConnector.java
@@ -68,6 +68,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeConnectorConstant.CONNECTOR_IOTDB_BATCH_MODE_ENABLE_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeConnectorConstant.SINK_IOTDB_BATCH_MODE_ENABLE_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeConnectorConstant.SINK_IOTDB_SSL_ENABLE_KEY;
+import static org.apache.iotdb.commons.pipe.config.constant.PipeConnectorConstant.SINK_IOTDB_SSL_TRUST_STORE_PATH_KEY;
+import static org.apache.iotdb.commons.pipe.config.constant.PipeConnectorConstant.SINK_IOTDB_SSL_TRUST_STORE_PWD_KEY;
 
 public class IoTDBThriftAsyncConnector extends IoTDBConnector {
 
@@ -116,9 +118,11 @@ public class IoTDBThriftAsyncConnector extends IoTDBConnector {
 
     final PipeParameters parameters = validator.getParameters();
     validator.validate(
-        useSSL -> !((boolean) useSSL),
+        args -> !((boolean) args[0] || (boolean) args[1] || (boolean) args[2]),
         "Only 'iotdb-thrift-ssl-sink' supports SSL transmission currently.",
-        parameters.getBooleanOrDefault(SINK_IOTDB_SSL_ENABLE_KEY, false));
+        parameters.getBooleanOrDefault(SINK_IOTDB_SSL_ENABLE_KEY, false),
+        parameters.hasAttribute(SINK_IOTDB_SSL_TRUST_STORE_PATH_KEY),
+        parameters.hasAttribute(SINK_IOTDB_SSL_TRUST_STORE_PWD_KEY));
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBThriftAsyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBThriftAsyncConnector.java
@@ -117,7 +117,7 @@ public class IoTDBThriftAsyncConnector extends IoTDBConnector {
     final PipeParameters parameters = validator.getParameters();
     validator.validate(
         useSSL -> !((boolean) useSSL),
-        "IoTDBThriftAsyncConnector does not support SSL transmission currently",
+        "Only 'iotdb-thrift-ssl-sink' supports SSL transmission currently.",
         parameters.getBooleanOrDefault(SINK_IOTDB_SSL_ENABLE_KEY, false));
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncClientManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncClientManager.java
@@ -80,8 +80,7 @@ public class IoTDBThriftSyncClientManager implements Closeable {
     }
   }
 
-  public void checkClientStatusAndTryReconstructIfNecessary()
-      throws IOException, TTransportException {
+  public void checkClientStatusAndTryReconstructIfNecessary() throws IOException {
     // reconstruct all dead clients
     for (final Map.Entry<TEndPoint, Pair<IoTDBThriftSyncConnectorClient, Boolean>> entry :
         endPoint2ClientAndStatus.entrySet()) {
@@ -104,7 +103,7 @@ public class IoTDBThriftSyncClientManager implements Closeable {
             "All target servers %s are not available.", endPoint2ClientAndStatus.keySet()));
   }
 
-  private void reconstructClient(TEndPoint endPoint) throws TTransportException, IOException {
+  private void reconstructClient(TEndPoint endPoint) throws IOException {
     final Pair<IoTDBThriftSyncConnectorClient, Boolean> clientAndStatus =
         endPoint2ClientAndStatus.get(endPoint);
 
@@ -120,18 +119,28 @@ public class IoTDBThriftSyncClientManager implements Closeable {
       }
     }
 
-    clientAndStatus.setLeft(
-        new IoTDBThriftSyncConnectorClient(
-            new ThriftClientProperty.Builder()
-                .setConnectionTimeoutMs((int) PIPE_CONFIG.getPipeConnectorHandshakeTimeoutMs())
-                .setRpcThriftCompressionEnabled(
-                    PIPE_CONFIG.isPipeConnectorRPCThriftCompressionEnabled())
-                .build(),
-            endPoint.getIp(),
-            endPoint.getPort(),
-            useSSL,
-            trustStorePath,
-            trustStorePwd));
+    try {
+      clientAndStatus.setLeft(
+          new IoTDBThriftSyncConnectorClient(
+              new ThriftClientProperty.Builder()
+                  .setConnectionTimeoutMs((int) PIPE_CONFIG.getPipeConnectorHandshakeTimeoutMs())
+                  .setRpcThriftCompressionEnabled(
+                      PIPE_CONFIG.isPipeConnectorRPCThriftCompressionEnabled())
+                  .build(),
+              endPoint.getIp(),
+              endPoint.getPort(),
+              useSSL,
+              trustStorePath,
+              trustStorePwd));
+    } catch (TTransportException e) {
+      throw new PipeConnectionException(
+          String.format(
+              PipeConnectionException.CONNECTION_ERROR_FORMATTER,
+              endPoint.getIp(),
+              endPoint.getPort(),
+              e.getMessage()),
+          e);
+    }
 
     try {
       final TPipeTransferResp resp =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
@@ -156,6 +156,14 @@ public class IoTDBThriftSyncConnector extends IoTDBConnector {
     final String trustStorePath = parameters.getString(SINK_IOTDB_SSL_TRUST_STORE_PATH_KEY);
     final String trustStorePwd = parameters.getString(SINK_IOTDB_SSL_TRUST_STORE_PWD_KEY);
 
+    // To avoid security issues, we have removed 'sink.ssl.trust-store-pwd' from the pipe metadata
+    // parameters to prevent the leakage of keys in show pipe results or logs.
+    // The `attributeSortedString2SubtaskLifeCycleMap` in PipeConnectorSubtaskManager fully retains
+    // the parameters corresponding to the connector.
+    if (useSSL) {
+      parameters.getAttribute().remove(SINK_IOTDB_SSL_TRUST_STORE_PWD_KEY);
+    }
+
     // leader cache configuration
     final boolean useLeaderCache =
         parameters.getBooleanOrDefault(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
@@ -156,14 +156,6 @@ public class IoTDBThriftSyncConnector extends IoTDBConnector {
     final String trustStorePath = parameters.getString(SINK_IOTDB_SSL_TRUST_STORE_PATH_KEY);
     final String trustStorePwd = parameters.getString(SINK_IOTDB_SSL_TRUST_STORE_PWD_KEY);
 
-    // To avoid security issues, we have removed 'sink.ssl.trust-store-pwd' from the pipe metadata
-    // parameters to prevent the leakage of keys in show pipe results or logs.
-    // The `attributeSortedString2SubtaskLifeCycleMap` in PipeConnectorSubtaskManager fully retains
-    // the parameters corresponding to the connector.
-    if (useSSL) {
-      parameters.getAttribute().remove(SINK_IOTDB_SSL_TRUST_STORE_PWD_KEY);
-    }
-
     // leader cache configuration
     final boolean useLeaderCache =
         parameters.getBooleanOrDefault(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/task/meta/PipeStaticMeta.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/task/meta/PipeStaticMeta.java
@@ -221,11 +221,11 @@ public class PipeStaticMeta {
         + "', creationTime="
         + creationTime
         + ", extractorParameters="
-        + extractorParameters.getAttribute()
+        + extractorParameters
         + ", processorParameters="
-        + processorParameters.getAttribute()
+        + processorParameters
         + ", connectorParameters="
-        + connectorParameters.getAttribute()
+        + connectorParameters
         + "}";
   }
 }


### PR DESCRIPTION
## Description

As title, with more details:

1. Concealing the `ssl.trust-store-pwd` in parameters.
2. Implementing stricter checks for SSL in the case of async connector.
3. Standardizing exceptions thrown during the construction of `IoTDBThriftSyncConnectorClient` as `PipeConnectionException`.
4. Standardizing exceptions thrown during the parsing of node URLs as `PipeParameterNotValidException`.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [x] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
