### PR TITLE
PBTree: Fix deadlock of PBTree release and flush

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/CachedMTreeStore.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/CachedMTreeStore.java
@@ -586,7 +586,7 @@ public class CachedMTreeStore implements IMTreeStore<ICachedMNode> {
    * @return should not continue releasing
    */
   public boolean executeMemoryRelease() {
-    lockManager.globalReadLock();
+    lockManager.globalReadLock(true);
     try {
       if (regionStatistics.getUnpinnedMemorySize() != 0) {
         return !memoryManager.evict();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/lock/LockManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/lock/LockManager.java
@@ -102,6 +102,10 @@ public class LockManager {
     readWriteLock.threadReadLock();
   }
 
+  public void globalReadLock(boolean prior) {
+    readWriteLock.threadReadLock(prior);
+  }
+
   public void globalReadUnlock() {
     readWriteLock.threadReadUnlock();
   }


### PR DESCRIPTION
## Description


### Problem

Here's the deadlock description:
flushMonitor + readCnt wait -> 
releaseMonitor+Scheduler#synchronize wait -> 
worker release readWait -> 
snapshot  writeWait -> 
flushMonitor + readCnt


### Solution

Enable the release worker to surpass the write lock waiting thread to directly execute memory release.

Thus the release worker only have to wait for write lock protected execution finished, and the releaseMonitor won't hold the object header lock for long.


