### PR TITLE
Add log for NotEnoughDataNodeException

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/exception/NotEnoughDataNodeException.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/exception/NotEnoughDataNodeException.java
@@ -29,7 +29,8 @@ public class NotEnoughDataNodeException extends ConfigNodeException {
       List<TDataNodeConfiguration> dataNodeConfigurations, int replicationFactor) {
     super(
         String.format(
-            "DataNode is not enough, please register more. Current DataNodes: %s, replicationFactor: %d",
+            "DataNode is not enough, please register more. "
+                + "Current DataNodes: %s, replicationFactor: %d",
             dataNodeConfigurations, replicationFactor));
   }
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/exception/NotEnoughDataNodeException.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/exception/NotEnoughDataNodeException.java
@@ -19,9 +19,17 @@
 
 package org.apache.iotdb.confignode.exception;
 
+import org.apache.iotdb.common.rpc.thrift.TDataNodeConfiguration;
+
+import java.util.List;
+
 public class NotEnoughDataNodeException extends ConfigNodeException {
 
-  public NotEnoughDataNodeException() {
-    super("DataNode is not enough, please register more.");
+  public NotEnoughDataNodeException(
+      List<TDataNodeConfiguration> dataNodeConfigurations, int replicationFactor) {
+    super(
+        String.format(
+            "DataNode is not enough, please register more. Current DataNodes: %s, replicationFactor: %d",
+            dataNodeConfigurations, replicationFactor));
   }
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/RegionBalancer.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/RegionBalancer.java
@@ -84,7 +84,7 @@ public class RegionBalancer {
       int replicationFactor =
           getClusterSchemaManager().getReplicationFactor(database, consensusGroupType);
       if (availableDataNodes.size() < replicationFactor) {
-        throw new NotEnoughDataNodeException();
+        throw new NotEnoughDataNodeException(availableDataNodes, replicationFactor);
       }
     }
 


### PR DESCRIPTION
Add log for NotEnoughDataNodeException. Therefore when the cluster DataNode is not enough, we can compare the detailed information between registered DataNodes and the replicationFactor.