### PR TITLE
Clear status in InsertNodes to fix consensus endless retry

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataExecutionVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataExecutionVisitor.java
@@ -129,9 +129,11 @@ public class DataExecutionVisitor extends PlanVisitor<TSStatus, DataRegion> {
             failedEntry.getValue());
         // return WRITE_PROCESS_REJECT directly for the consensus retry logic
         if (failedEntry.getValue().getCode() == TSStatusCode.WRITE_PROCESS_REJECT.getStatusCode()) {
+          node.clearResults();
           return failedEntry.getValue();
         }
       }
+      node.clearResults();
       return firstStatus;
     }
   }
@@ -158,9 +160,11 @@ public class DataExecutionVisitor extends PlanVisitor<TSStatus, DataRegion> {
             failedEntry.getValue());
         // return WRITE_PROCESS_REJECT directly for the consensus retry logic
         if (failedEntry.getValue().getCode() == TSStatusCode.WRITE_PROCESS_REJECT.getStatusCode()) {
+          node.clearResults();
           return failedEntry.getValue();
         }
       }
+      node.clearResults();
       return firstStatus;
     }
   }
@@ -193,9 +197,11 @@ public class DataExecutionVisitor extends PlanVisitor<TSStatus, DataRegion> {
             failedEntry.getValue());
         // return WRITE_PROCESS_REJECT directly for the consensus retry logic
         if (failedEntry.getValue().getCode() == TSStatusCode.WRITE_PROCESS_REJECT.getStatusCode()) {
+          node.clearResults();
           return failedEntry.getValue();
         }
       }
+      node.clearResults();
       return firstStatus;
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataExecutionVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataExecutionVisitor.java
@@ -133,7 +133,6 @@ public class DataExecutionVisitor extends PlanVisitor<TSStatus, DataRegion> {
           return failedEntry.getValue();
         }
       }
-      node.clearResults();
       return firstStatus;
     }
   }
@@ -164,7 +163,6 @@ public class DataExecutionVisitor extends PlanVisitor<TSStatus, DataRegion> {
           return failedEntry.getValue();
         }
       }
-      node.clearResults();
       return firstStatus;
     }
   }
@@ -201,7 +199,6 @@ public class DataExecutionVisitor extends PlanVisitor<TSStatus, DataRegion> {
           return failedEntry.getValue();
         }
       }
-      node.clearResults();
       return firstStatus;
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertMultiTabletsNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertMultiTabletsNode.java
@@ -159,6 +159,10 @@ public class InsertMultiTabletsNode extends InsertNode {
     return results;
   }
 
+  public void clearResults() {
+    results.clear();
+  }
+
   public TSStatus[] getFailingStatus() {
     return StatusUtils.getFailingStatus(results, insertTabletNodeList.size());
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertRowsNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertRowsNode.java
@@ -107,6 +107,10 @@ public class InsertRowsNode extends InsertNode {
     return results;
   }
 
+  public void clearResults() {
+    results.clear();
+  }
+
   public TSStatus[] getFailingStatus() {
     return StatusUtils.getFailingStatus(results, insertRowNodeList.size());
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertRowsOfOneDeviceNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertRowsOfOneDeviceNode.java
@@ -86,6 +86,10 @@ public class InsertRowsOfOneDeviceNode extends InsertNode {
     return results;
   }
 
+  public void clearResults() {
+    results.clear();
+  }
+
   @Override
   public void setSearchIndex(long index) {
     searchIndex = index;


### PR DESCRIPTION
When an InsertTabletsNode contains the system reject status, the consensus will retry it endlessly. 