### PR TITLE
try fix SessionPoolTest UT

### DIFF
--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -160,7 +160,7 @@ public class Session implements ISession {
   protected Version version;
 
   // default enable
-  private boolean enableAutoFetch = true;
+  protected boolean enableAutoFetch = true;
 
   private static final String REDIRECT_TWICE = "redirect twice";
 

--- a/iotdb-client/session/src/test/java/org/apache/iotdb/session/SessionCacheLeaderTest.java
+++ b/iotdb-client/session/src/test/java/org/apache/iotdb/session/SessionCacheLeaderTest.java
@@ -973,6 +973,7 @@ public class SessionCacheLeaderTest {
           SessionConfig.DEFAULT_MAX_FRAME_SIZE,
           enableRedirection,
           SessionConfig.DEFAULT_VERSION);
+      this.enableAutoFetch = false;
     }
 
     @Override

--- a/iotdb-client/session/src/test/java/org/apache/iotdb/session/SessionConnectionTest.java
+++ b/iotdb-client/session/src/test/java/org/apache/iotdb/session/SessionConnectionTest.java
@@ -86,7 +86,13 @@ public class SessionConnectionTest {
     sessionConnection = new SessionConnection();
     Whitebox.setInternalState(sessionConnection, "transport", transport);
     Whitebox.setInternalState(sessionConnection, "client", client);
-    session = new Session(Arrays.asList("127.0.0.1:12"), "root", "root");
+    session =
+        new Session.Builder()
+            .nodeUrls(Collections.singletonList("127.0.0.1:12"))
+            .username("root")
+            .password("root")
+            .enableAutoFetch(false)
+            .build();
     Whitebox.setInternalState(sessionConnection, "session", session);
     Mockito.when(transport.isOpen()).thenReturn(true);
     TSStatus tsStatus = new TSStatus(TSStatusCode.REDIRECTION_RECOMMEND.getStatusCode());
@@ -151,7 +157,14 @@ public class SessionConnectionTest {
 
   @Test(expected = NumberFormatException.class)
   public void testBuildSessionConnection() throws IoTDBConnectionException {
-    session = new Session("local", 12, "root", "root");
+    session =
+        new Session.Builder()
+            .host("local")
+            .port(12)
+            .username("root")
+            .password("root")
+            .enableAutoFetch(false)
+            .build();
     SessionConnection sessionConnection1 =
         new SessionConnection(
             session,
@@ -161,7 +174,14 @@ public class SessionConnectionTest {
 
   @Test(expected = IoTDBConnectionException.class)
   public void testBuildSessionConnection2() throws IoTDBConnectionException {
-    session = new Session("local", 12, "root", "root");
+    session =
+        new Session.Builder()
+            .host("local")
+            .port(12)
+            .username("root")
+            .password("root")
+            .enableAutoFetch(false)
+            .build();
     SessionConnection sessionConnection1 =
         new SessionConnection(
             session,

--- a/iotdb-client/session/src/test/java/org/apache/iotdb/session/SessionTest.java
+++ b/iotdb-client/session/src/test/java/org/apache/iotdb/session/SessionTest.java
@@ -67,7 +67,14 @@ public class SessionTest {
   @Before
   public void setUp() throws IoTDBConnectionException, StatementExecutionException {
     MockitoAnnotations.initMocks(this);
-    session = new Session("host", 11, "user", "pwd");
+    session =
+        new Session.Builder()
+            .host("host")
+            .port(11)
+            .username("user")
+            .password("pwd")
+            .enableAutoFetch(false)
+            .build();
     Whitebox.setInternalState(session, "defaultSessionConnection", sessionConnection);
     TSQueryTemplateResp resp = new TSQueryTemplateResp();
     resp.setMeasurements(Arrays.asList("root.sg1.d1.s1"));

--- a/iotdb-client/session/src/test/java/org/apache/iotdb/session/pool/SessionPoolExceptionTest.java
+++ b/iotdb-client/session/src/test/java/org/apache/iotdb/session/pool/SessionPoolExceptionTest.java
@@ -69,7 +69,14 @@ public class SessionPoolExceptionTest {
   public void setUp() {
     MockitoAnnotations.initMocks(this);
 
-    sessionPool = new SessionPool(Arrays.asList("host:11"), "user", "password", 10);
+    sessionPool =
+        new SessionPool.Builder()
+            .nodeUrls(Collections.singletonList("host:11"))
+            .user("user")
+            .password("password")
+            .maxSize(10)
+            .enableAutoFetch(false)
+            .build();
     ConcurrentLinkedDeque<ISession> queue = new ConcurrentLinkedDeque<>();
     queue.add(session);
     Whitebox.setInternalState(sessionPool, "queue", queue);

--- a/iotdb-client/session/src/test/java/org/apache/iotdb/session/pool/SessionPoolTest.java
+++ b/iotdb-client/session/src/test/java/org/apache/iotdb/session/pool/SessionPoolTest.java
@@ -183,11 +183,20 @@ public class SessionPoolTest {
     TSStatus closeResp = successStatus;
     Mockito.when(client.closeOperation(any(TSCloseOperationReq.class))).thenReturn(closeResp);
 
-    sessionPool = new SessionPool("host", 11, "user", "password", 5);
+    sessionPool =
+        new SessionPool.Builder()
+            .host("host")
+            .port(11)
+            .user("user")
+            .password("password")
+            .maxSize(5)
+            .enableAutoFetch(false)
+            .build();
+
     ConcurrentLinkedDeque<ISession> queue = new ConcurrentLinkedDeque<>();
     queue.add(session);
 
-    // 设置 SessionPool 对象的内部状态
+    // set SessionPool's internal field state
     Whitebox.setInternalState(sessionPool, "queue", queue);
   }
 


### PR DESCRIPTION
In Session & SessionPool UT, we should set `enableAutoFetch` to `false` to avoid NPE in close.
![image](https://github.com/apache/iotdb/assets/16079446/9de2e4ff-1794-459d-94b2-5a869cae33d1)
