### PR TITLE
Print Exception only when encountering unexpected TSStatus

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/executor/RegionWriteExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/executor/RegionWriteExecutor.java
@@ -574,7 +574,11 @@ public class RegionWriteExecutor {
                           ((MeasurementAlreadyExistException) metadataException)
                               .getMeasurementPath())));
             } else {
-              LOGGER.warn(METADATA_ERROR_MSG, metadataException);
+              int errorCode = metadataException.getErrorCode();
+              if (errorCode != TSStatusCode.PATH_ALREADY_EXIST.getStatusCode()
+                  || errorCode != TSStatusCode.ALIAS_ALREADY_EXIST.getStatusCode()) {
+                LOGGER.warn(METADATA_ERROR_MSG, metadataException);
+              }
               failingStatus.add(
                   RpcUtils.getStatus(
                       metadataException.getErrorCode(), metadataException.getMessage()));


### PR DESCRIPTION
PATH_ALREADY_EXIST and ALIAS_ALREADY_EXIST is what we expect, we should never print it as Exception