### PR TITLE
PBTree: Fix deadlock when segment deleted

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/BTreePageManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/BTreePageManager.java
@@ -344,8 +344,8 @@ public class BTreePageManager extends PageManager {
           tarPage.getAsSegmentedPage().deleteSegment(getSegIndex(delSegAddr));
           if (tarPage.getAsSegmentedPage().validSegments() == 0) {
             tarPage.getAsSegmentedPage().purgeSegments();
-            cxt.indexBuckets.sortIntoBucket(tarPage, (short) -1);
           }
+          cxt.indexBuckets.sortIntoBucket(tarPage, (short) -1);
         }
 
         if (tarPage.getAsInternalPage() != null) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/PageManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/PageManager.java
@@ -298,14 +298,14 @@ public abstract class PageManager implements IPageManager {
         return;
       }
 
-      if (minPageIndex > 0) {
+      if (minPageIndex >= 0) {
         page = getPageInstance(minPageIndex, cxt);
         page.getLock().writeLock().lock();
         cxt.traceLock(page);
         cxt.indexBuckets.sortIntoBucket(page, (short) -1);
       }
 
-      if (minPageIndex != maxPageIndex && maxPageIndex > 0) {
+      if (minPageIndex != maxPageIndex && maxPageIndex >= 0) {
         page = getPageInstance(maxPageIndex, cxt);
         page.getLock().writeLock().lock();
         cxt.traceLock(page);
@@ -398,6 +398,7 @@ public abstract class PageManager implements IPageManager {
               newPage.transplantSegment(curPage.getAsSegmentedPage(), actSegId, newSegSize);
           newPage.write(SchemaFile.getSegIndex(curSegAddr), entry.getKey(), childBuffer);
           curPage.getAsSegmentedPage().deleteSegment(actSegId);
+          cxt.indexBuckets.sortIntoBucket(curPage, (short) -1);
 
           // entrant lock guarantees thread-safe
           SchemaFile.setNodeAddress(node, curSegAddr);
@@ -511,6 +512,7 @@ public abstract class PageManager implements IPageManager {
           // assign new segment address
           curSegAddr = newPage.transplantSegment(curPage.getAsSegmentedPage(), actSegId, newSegSiz);
           curPage.getAsSegmentedPage().deleteSegment(actSegId);
+          cxt.indexBuckets.sortIntoBucket(curPage, (short) -1);
 
           newPage.update(SchemaFile.getSegIndex(curSegAddr), entry.getKey(), childBuffer);
           SchemaFile.setNodeAddress(node, curSegAddr);


### PR DESCRIPTION
## Description
Previously, there was a deadlock issue caused by a reentrant write lock that would only unlock once, leading to a situation where any read thread attempting to access the page would be blocked.

This reentrant lock scenario, although rare, occurred recurrently on the test server. If one page has just allocated (more precisely, pre-allocated) last few bytes, it will be removed from local(context) index buckets but not added back. Right now a segment of this page was transplanted into another page, the previous implementation failed to update spare space variation of this page in the local index buckets, which are designed for quick retrieval based on specified spare space. However, this page might have been previously marked in the global index bucket, with a spare space before allocation. And then it could be retrieved by the previous bucket entry, creating a reentrant lock situation.

This revised version marks spare space variation of segment transplatation in local index buckets, eliminating the deadlock issue.


<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
