### PR TITLE
PBTree: Prevent Concurrent Read With Stale Page

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/BTreePageManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/BTreePageManager.java
@@ -344,8 +344,8 @@ public class BTreePageManager extends PageManager {
           tarPage.getAsSegmentedPage().deleteSegment(getSegIndex(delSegAddr));
           if (tarPage.getAsSegmentedPage().validSegments() == 0) {
             tarPage.getAsSegmentedPage().purgeSegments();
-            cxt.indexBuckets.sortIntoBucket(tarPage, (short) -1);
           }
+          cxt.indexBuckets.sortIntoBucket(tarPage, (short) -1);
         }
 
         if (tarPage.getAsInternalPage() != null) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/BTreePageManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/BTreePageManager.java
@@ -396,9 +396,9 @@ public class BTreePageManager extends PageManager {
    * Since transplant and replacement may invalidate page instance held by a blocked read-thread,
    * the read-thread need to validate its page object once it obtained the lock.
    *
-   * @param initPage page instance held before lock
-   * @param parent flush node which contains latest segment address
-   * @param cxt update context if necessary
+   * @param initPage page instance with read lock held
+   * @param parent MTree node to read children, containing latest segment address
+   * @param cxt update context if page/segment modified
    * @return validated page
    */
   private ISchemaPage validatePage(ISchemaPage initPage, ICachedMNode parent, SchemaPageContext cxt)

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/BTreePageManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/BTreePageManager.java
@@ -392,6 +392,60 @@ public class BTreePageManager extends PageManager {
     }
   }
 
+  /**
+   * Since transplant and replacement may invalidate page instance held by a blocked read-thread,
+   * the read-thread need to validate its page object once it obtained the lock.
+   *
+   * @param initPage page instance held before lock
+   * @param parent flush node which contains latest segment address
+   * @param cxt update context if necessary
+   * @return validated page
+   */
+  private ISchemaPage validatePage(ISchemaPage initPage, ICachedMNode parent, SchemaPageContext cxt)
+      throws IOException, MetadataException {
+    boolean safeFlag = false;
+    // check like crabbing
+    ISchemaPage crabPage;
+    while (!safeFlag) {
+      SchemaPageContext doubleCheckContext = new SchemaPageContext();
+      if (getPageIndex(getNodeAddress(parent)) != initPage.getPageIndex()) {
+        // transplanted, release the stale and check the new
+        long addrB4Lock = getNodeAddress(parent);
+        int piB4Lock = getPageIndex(addrB4Lock);
+
+        crabPage = getPageInstance(piB4Lock, doubleCheckContext);
+        crabPage.getLock().readLock().lock();
+
+        initPage.decrementAndGetRefCnt();
+        initPage.getLock().readLock().unlock();
+
+        // UNNECESSARY to TRACE lock since the very page will be unlocked at end of read
+        cxt.referredPages.remove(initPage.getPageIndex());
+        cxt.referredPages.put(crabPage.getPageIndex(), crabPage);
+        initPage = crabPage;
+        continue;
+      }
+
+      crabPage = getPageInstance(initPage.getPageIndex(), doubleCheckContext);
+      if (crabPage != initPage) {
+        // replaced, the lock and ref count should be the same
+        if (crabPage.getLock() != initPage.getLock()
+            || crabPage.getRefCnt() != initPage.getRefCnt()) {
+          crabPage.decrementAndGetRefCnt();
+          initPage.decrementAndGetRefCnt();
+          initPage.getLock().readLock().unlock();
+          throw new MetadataException(
+              "Page[%d] replacement error: Different ref count or lock object.");
+        }
+        // update context is enough, ref and lock is left for main read process
+        cxt.referredPages.put(initPage.getPageIndex(), crabPage);
+        initPage = crabPage;
+      }
+      safeFlag = true;
+    }
+    return initPage;
+  }
+
   @Override
   public ICachedMNode getChildNode(ICachedMNode parent, String childName)
       throws MetadataException, IOException {
@@ -406,7 +460,9 @@ public class BTreePageManager extends PageManager {
 
     // a single read lock on initial page is sufficient to mutex write, no need to trace it
     int initIndex = getPageIndex(getNodeAddress(parent));
-    getPageInstance(initIndex, cxt).getLock().readLock().lock();
+    ISchemaPage initPage = getPageInstance(initIndex, cxt);
+    initPage.getLock().readLock().lock();
+    initPage = validatePage(initPage, parent, cxt);
     try {
       long actualSegAddr = getTargetSegmentAddress(getNodeAddress(parent), childName, cxt);
       ICachedMNode child =
@@ -429,7 +485,7 @@ public class BTreePageManager extends PageManager {
       }
       return child;
     } finally {
-      getPageInstance(initIndex, cxt).getLock().readLock().unlock();
+      initPage.getLock().readLock().unlock();
       releaseReferent(cxt);
       threadContexts.remove(Thread.currentThread().getId(), cxt);
     }
@@ -460,8 +516,10 @@ public class BTreePageManager extends PageManager {
     int pageIdx = getPageIndex(getNodeAddress(parent));
 
     short segId = getSegIndex(getNodeAddress(parent));
-    ISchemaPage page = getPageInstance(pageIdx, cxt);
+    ISchemaPage page = getPageInstance(pageIdx, cxt), pageHeldLock;
     page.getLock().readLock().lock();
+    page = validatePage(page, parent, cxt);
+    pageHeldLock = page;
 
     try {
       while (page.getAsSegmentedPage() == null) {
@@ -512,7 +570,7 @@ public class BTreePageManager extends PageManager {
       };
     } finally {
       // safety of iterator should be guaranteed by upper layer
-      getPageInstance(pageIdx, cxt).getLock().readLock().unlock();
+      pageHeldLock.getLock().readLock().unlock();
       releaseReferent(cxt);
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/BTreePageManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/BTreePageManager.java
@@ -441,6 +441,8 @@ public class BTreePageManager extends PageManager {
         cxt.referredPages.put(initPage.getPageIndex(), crabPage);
         initPage = crabPage;
       }
+      // same page shall only be referred once
+      crabPage.decrementAndGetRefCnt();
       safeFlag = true;
     }
     return initPage;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/PageManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/PageManager.java
@@ -298,14 +298,14 @@ public abstract class PageManager implements IPageManager {
         return;
       }
 
-      if (minPageIndex > 0) {
+      if (minPageIndex >= 0) {
         page = getPageInstance(minPageIndex, cxt);
         page.getLock().writeLock().lock();
         cxt.traceLock(page);
         cxt.indexBuckets.sortIntoBucket(page, (short) -1);
       }
 
-      if (minPageIndex != maxPageIndex && maxPageIndex > 0) {
+      if (minPageIndex != maxPageIndex && maxPageIndex >= 0) {
         page = getPageInstance(maxPageIndex, cxt);
         page.getLock().writeLock().lock();
         cxt.traceLock(page);
@@ -398,6 +398,7 @@ public abstract class PageManager implements IPageManager {
               newPage.transplantSegment(curPage.getAsSegmentedPage(), actSegId, newSegSize);
           newPage.write(SchemaFile.getSegIndex(curSegAddr), entry.getKey(), childBuffer);
           curPage.getAsSegmentedPage().deleteSegment(actSegId);
+          cxt.indexBuckets.sortIntoBucket(curPage, (short) -1);
 
           // entrant lock guarantees thread-safe
           SchemaFile.setNodeAddress(node, curSegAddr);
@@ -511,6 +512,7 @@ public abstract class PageManager implements IPageManager {
           // assign new segment address
           curSegAddr = newPage.transplantSegment(curPage.getAsSegmentedPage(), actSegId, newSegSiz);
           curPage.getAsSegmentedPage().deleteSegment(actSegId);
+          cxt.indexBuckets.sortIntoBucket(curPage, (short) -1);
 
           newPage.update(SchemaFile.getSegIndex(curSegAddr), entry.getKey(), childBuffer);
           SchemaFile.setNodeAddress(node, curSegAddr);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/PageManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/PageManager.java
@@ -236,7 +236,7 @@ public abstract class PageManager implements IPageManager {
   /** Context only tracks write locks, and so it shall be released. */
   protected void releaseLocks(SchemaPageContext cxt) {
     for (int i : cxt.lockTraces) {
-      pageInstCache.get(i).getLock().writeLock().unlock();
+      cxt.referredPages.get(i).getLock().writeLock().unlock();
     }
   }
 
@@ -788,8 +788,7 @@ public abstract class PageManager implements IPageManager {
         cxt.traceLock(targetPage);
 
         // transfer the page from pageIndexBuckets to cxt.buckets thus not be accessed by other
-        // WRITE
-        // thread
+        //  WRITE thread
         cxt.indexBuckets.sortIntoBucket(targetPage, size);
         return targetPage.getAsSegmentedPage();
       }
@@ -1020,11 +1019,11 @@ public abstract class PageManager implements IPageManager {
       interleavedFlushCnt = 0;
     }
 
-    public void markDirty(ISchemaPage page) {
+    protected void markDirty(ISchemaPage page) {
       markDirty(page, false);
     }
 
-    private void markDirty(ISchemaPage page, boolean forceReplace) {
+    protected void markDirty(ISchemaPage page, boolean forceReplace) {
       if (!page.isDirtyPage()) {
         dirtyCnt++;
       }
@@ -1041,7 +1040,7 @@ public abstract class PageManager implements IPageManager {
       }
     }
 
-    private void traceLock(ISchemaPage page) {
+    protected void traceLock(ISchemaPage page) {
       refer(page);
       lockTraces.add(page.getPageIndex());
     }


### PR DESCRIPTION
## Description

As the page lock is a field within page instance, any read thread blocked by the lock had already held the instance. If the executing writing thread transplanted the target segment or replaced the page instance, the read thread may proceed with a stale page. Although this issue has not occured yet, it is possible to take place in further test and should be fixed as this revision did.


### Content1 ...

### Content2 ...

### Content3 ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
