### PR TITLE
Add disk space log in cluster heartbeat

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/DataNodeInternalRPCServiceImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/DataNodeInternalRPCServiceImpl.java
@@ -1242,6 +1242,7 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
   }
 
   private void sampleDiskLoad(TLoadSample loadSample) {
+    final double byteToGb = 1024 * 1024 * 1024;
     double availableDisk =
         MetricService.getInstance()
             .getAutoGauge(
@@ -1258,6 +1259,7 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
                 Tag.NAME.toString(),
                 SYSTEM)
             .getValue();
+    LOGGER.info("[Heartbeat] disk space: {}, {}", availableDisk, totalDisk);
 
     if (availableDisk != 0 && totalDisk != 0) {
       double freeDiskRatio = availableDisk / totalDisk;
@@ -1266,7 +1268,12 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
       // Reset NodeStatus if necessary
       if (freeDiskRatio < commonConfig.getDiskSpaceWarningThreshold()) {
         LOGGER.warn(
-            "The remaining disk usage ratio:{} is less than disk_spec_warning_threshold:{}, set system to readonly!",
+            "The available disk space is : {}GB, "
+                + "the total disk space is : {}GB, "
+                + "and the remaining disk usage ratio: {} is "
+                + "less than disk_spec_warning_threshold: {}, set system to readonly!",
+            availableDisk / byteToGb,
+            totalDisk / byteToGb,
             freeDiskRatio,
             commonConfig.getDiskSpaceWarningThreshold());
         commonConfig.setNodeStatus(NodeStatus.ReadOnly);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/DataNodeInternalRPCServiceImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/DataNodeInternalRPCServiceImpl.java
@@ -203,6 +203,7 @@ import org.apache.iotdb.trigger.api.enums.TriggerEvent;
 import org.apache.iotdb.tsfile.exception.NotImplementedException;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.read.common.block.TsBlock;
+import org.apache.iotdb.tsfile.utils.RamUsageEstimator;
 import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
 import org.apache.iotdb.tsfile.write.record.Tablet;
 
@@ -1242,7 +1243,6 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
   }
 
   private void sampleDiskLoad(TLoadSample loadSample) {
-    final double byteToGb = 1024 * 1024 * 1024;
     double availableDisk =
         MetricService.getInstance()
             .getAutoGauge(
@@ -1267,12 +1267,12 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
       // Reset NodeStatus if necessary
       if (freeDiskRatio < commonConfig.getDiskSpaceWarningThreshold()) {
         LOGGER.warn(
-            "The available disk space is : {}GB, "
-                + "the total disk space is : {}GB, "
+            "The available disk space is : {}, "
+                + "the total disk space is : {}, "
                 + "and the remaining disk usage ratio: {} is "
                 + "less than disk_spec_warning_threshold: {}, set system to readonly!",
-            availableDisk / byteToGb,
-            totalDisk / byteToGb,
+            RamUsageEstimator.humanReadableUnits((long) availableDisk),
+            RamUsageEstimator.humanReadableUnits((long) totalDisk),
             freeDiskRatio,
             commonConfig.getDiskSpaceWarningThreshold());
         commonConfig.setNodeStatus(NodeStatus.ReadOnly);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/DataNodeInternalRPCServiceImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/DataNodeInternalRPCServiceImpl.java
@@ -1259,7 +1259,6 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
                 Tag.NAME.toString(),
                 SYSTEM)
             .getValue();
-    LOGGER.info("[Heartbeat] disk space: {}, {}", availableDisk, totalDisk);
 
     if (availableDisk != 0 && totalDisk != 0) {
       double freeDiskRatio = availableDisk / totalDisk;


### PR DESCRIPTION
The heartbeat process now will print the available disk space and the total disk space when the remaining disk space is less than the disk space warning threshold.