### PR TITLE
[IOTDB-6284] Load: The Second Phase Merged into the Consensus Layer

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IOTDBLoadTsFileIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IOTDBLoadTsFileIT.java
@@ -48,6 +48,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -692,6 +693,36 @@ public class IOTDBLoadTsFileIT {
       statement.execute(String.format("load \"%s\"", tmpDir.getAbsolutePath()));
     } catch (IoTDBSQLException e) {
       Assert.assertTrue(e.getMessage().contains("Current system timestamp precision is ms"));
+    }
+  }
+
+  @Test
+  public void testLoadLocally() throws Exception {
+    registerSchema();
+
+    long writtenPoint1 = 0;
+    // device 0, device 1, sg 0
+    try (TsFileGenerator generator = new TsFileGenerator(new File(tmpDir, "1-0-0-0.tsfile"))) {
+      generator.registerTimeseries(
+          SchemaConfig.DEVICE_0, Collections.singletonList(SchemaConfig.MEASUREMENT_00));
+      generator.generateData(SchemaConfig.DEVICE_0, 1, PARTITION_INTERVAL / 10_000, false);
+      writtenPoint1 = generator.getTotalNumber();
+    }
+
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+
+      statement.execute(String.format("load \"%s\" sglevel=2", tmpDir.getAbsolutePath()));
+
+      try (ResultSet resultSet =
+          statement.executeQuery("select count(*) from root.** group by level=1,2")) {
+        if (resultSet.next()) {
+          long sg1Count = resultSet.getLong("count(root.sg.test_0.*.*)");
+          Assert.assertEquals(writtenPoint1, sg1Count);
+        } else {
+          Assert.fail("This ResultSet is empty.");
+        }
+      }
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -171,9 +171,6 @@ public class IoTDBConfig {
   /** The proportion of write memory for compaction */
   private double compactionProportion = 0.2;
 
-  /** The proportion of write memory for loading TsFile */
-  private double loadTsFileProportion = 0.125;
-
   /**
    * If memory cost of data region increased more than proportion of {@linkplain
    * IoTDBConfig#getAllocateMemoryForStorageEngine()}*{@linkplain
@@ -1095,6 +1092,8 @@ public class IoTDBConfig {
   private double maxMemoryRatioForQueue = 0.6;
 
   /** Load related */
+  private double maxAllocateMemoryRatioForLoad = 0.8;
+
   private int loadTsFileAnalyzeSchemaBatchFlushTimeSeriesNumber = 4096;
 
   private long loadTsFileAnalyzeSchemaMemorySizeInBytes =
@@ -3279,10 +3278,6 @@ public class IoTDBConfig {
     return compactionProportion;
   }
 
-  public double getLoadTsFileProportion() {
-    return loadTsFileProportion;
-  }
-
   public static String getEnvironmentVariables() {
     return "\n\t"
         + IoTDBConstant.IOTDB_HOME
@@ -3735,6 +3730,14 @@ public class IoTDBConfig {
 
   public int getModeMapSizeThreshold() {
     return modeMapSizeThreshold;
+  }
+
+  public double getMaxAllocateMemoryRatioForLoad() {
+    return maxAllocateMemoryRatioForLoad;
+  }
+
+  public void setMaxAllocateMemoryRatioForLoad(double maxAllocateMemoryRatioForLoad) {
+    this.maxAllocateMemoryRatioForLoad = maxAllocateMemoryRatioForLoad;
   }
 
   public int getLoadTsFileAnalyzeSchemaBatchFlushTimeSeriesNumber() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -893,6 +893,11 @@ public class IoTDBDescriptor {
       conf.setIntoOperationExecutionThreadCount(2);
     }
 
+    conf.setMaxAllocateMemoryRatioForLoad(
+        Double.parseDouble(
+            properties.getProperty(
+                "max_allocate_memory_ratio_for_load",
+                String.valueOf(conf.getMaxAllocateMemoryRatioForLoad()))));
     conf.setLoadTsFileAnalyzeSchemaBatchFlushTimeSeriesNumber(
         Integer.parseInt(
             properties.getProperty(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataExecutionVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataExecutionVisitor.java
@@ -244,7 +244,11 @@ public class DataExecutionVisitor extends PlanVisitor<TSStatus, DataRegion> {
 
   @Override
   public TSStatus visitLoadTsFileCommand(LoadTsFileCommandNode node, DataRegion context) {
-    LOGGER.info("Receive load command node {}, data region {}", node, context);
+    LOGGER.info(
+        "Receive load command node {}, data region {}-{}",
+        node,
+        context.getDatabaseName(),
+        context.getDataRegionId());
     return StorageEngine.getInstance().executeLoadCommand(context, node);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataExecutionVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataExecutionVisitor.java
@@ -28,6 +28,7 @@ import org.apache.iotdb.db.exception.WriteProcessRejectException;
 import org.apache.iotdb.db.exception.query.OutOfTTLException;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanVisitor;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.load.LoadTsFileCommandNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.pipe.PipeEnrichedDeleteDataNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.pipe.PipeEnrichedInsertNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.DeleteDataNode;
@@ -36,6 +37,7 @@ import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertRowNod
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertRowsNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertRowsOfOneDeviceNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertTabletNode;
+import org.apache.iotdb.db.storageengine.StorageEngine;
 import org.apache.iotdb.db.storageengine.dataregion.DataRegion;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
@@ -238,5 +240,11 @@ public class DataExecutionVisitor extends PlanVisitor<TSStatus, DataRegion> {
   public TSStatus visitPipeEnrichedDeleteData(PipeEnrichedDeleteDataNode node, DataRegion context) {
     node.getDeleteDataNode().markAsGeneratedByPipe();
     return visitDeleteData((DeleteDataNode) node.getDeleteDataNode(), context);
+  }
+
+  @Override
+  public TSStatus visitLoadTsFileCommand(LoadTsFileCommandNode node, DataRegion context) {
+    LOGGER.info("Receive load command node {}, data region {}", node, context);
+    return StorageEngine.getInstance().executeLoadCommand(context, node);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/runtime/PipeRuntimeAgent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/runtime/PipeRuntimeAgent.java
@@ -103,14 +103,13 @@ public class PipeRuntimeAgent implements IService {
     simpleConsensusProgressIndexAssigner.assignIfNeeded(insertNode);
   }
 
-  ////////////////////// Recover ProgressIndex Assigner //////////////////////
+  ////////////////////// Load ProgressIndex Assigner //////////////////////
 
-  public void assignProgressIndexForTsFileLoad(TsFileResource tsFileResource) {
-    tsFileResource.setProgressIndex(
-        new RecoverProgressIndex(
-            DATA_NODE_ID,
-            simpleConsensusProgressIndexAssigner.getSimpleProgressIndexForTsFileRecovery()));
+  public void assignProgressIndexForTsFileLoadIfNeeded(TsFileResource tsFileResource) {
+    simpleConsensusProgressIndexAssigner.assignIfNeeded(tsFileResource);
   }
+
+  ////////////////////// Recover ProgressIndex Assigner //////////////////////
 
   public void assignProgressIndexForTsFileRecovery(TsFileResource tsFileResource) {
     tsFileResource.updateProgressIndex(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/progress/assigner/SimpleConsensusProgressIndexAssigner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/progress/assigner/SimpleConsensusProgressIndexAssigner.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.commons.file.SystemFileFactory;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertNode;
+import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -104,6 +105,15 @@ public class SimpleConsensusProgressIndexAssigner {
     }
 
     insertNode.setProgressIndex(
+        new SimpleProgressIndex(rebootTimes, insertionRequestId.getAndIncrement()));
+  }
+
+  public void assignIfNeeded(TsFileResource resource) {
+    if (!isSimpleConsensusEnable) {
+      return;
+    }
+
+    resource.updateProgressIndex(
         new SimpleProgressIndex(rebootTimes, insertionRequestId.getAndIncrement()));
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/PlanNodeType.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/PlanNodeType.java
@@ -19,6 +19,7 @@
 package org.apache.iotdb.db.queryengine.plan.planner.plan.node;
 
 import org.apache.iotdb.db.queryengine.plan.analyze.TypeProvider;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.load.LoadTsFileCommandNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.load.LoadTsFilePieceNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.metedata.read.CountSchemaMergeNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.metedata.read.DevicesCountNode;
@@ -200,7 +201,8 @@ public enum PlanNodeType {
   PIPE_ENRICHED_DELETE_SCHEMA((short) 86),
 
   INNER_TIME_JOIN((short) 87),
-  LEFT_OUTER_TIME_JOIN((short) 88);
+  LEFT_OUTER_TIME_JOIN((short) 88),
+  LOAD_TSFILE_COMMAND((short) 89);
 
   public static final int BYTES = Short.BYTES;
 
@@ -425,6 +427,8 @@ public enum PlanNodeType {
         return InnerTimeJoinNode.deserialize(buffer);
       case 88:
         return LeftOuterTimeJoinNode.deserialize(buffer);
+      case 89:
+        return LoadTsFileCommandNode.deserialize(buffer);
       default:
         throw new IllegalArgumentException("Invalid node type: " + nodeType);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/PlanVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/PlanVisitor.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.queryengine.plan.planner.plan.node;
 
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.load.LoadTsFileCommandNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.metedata.read.CountSchemaMergeNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.metedata.read.DevicesCountNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.metedata.read.DevicesSchemaScanNode;
@@ -486,6 +487,14 @@ public abstract class PlanVisitor<R, C> {
   }
 
   public R visitPipeEnrichedConfigSchema(PipeEnrichedConfigSchemaNode node, C context) {
+    return visitPlan(node, context);
+  }
+
+  /////////////////////////////////////////////////////////////////////////////////////////////////
+  // Load Node
+  /////////////////////////////////////////////////////////////////////////////////////////////////
+
+  public R visitLoadTsFileCommand(LoadTsFileCommandNode node, C context) {
     return visitPlan(node, context);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/load/LoadSingleTsFileNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/load/LoadSingleTsFileNode.java
@@ -25,7 +25,6 @@ import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.common.rpc.thrift.TTimePartitionSlot;
 import org.apache.iotdb.commons.utils.TimePartitionUtils;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
-import org.apache.iotdb.db.pipe.agent.PipeAgent;
 import org.apache.iotdb.db.queryengine.plan.analyze.Analysis;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
@@ -99,12 +98,9 @@ public class LoadSingleTsFileNode extends WritePlanNode {
       needDecodeTsFile = !isDispatchedToLocal(new HashSet<>(partitionFetcher.apply(slotList)));
     }
 
-    PipeAgent.runtime().assignProgressIndexForTsFileLoad(resource);
-
-    // we serialize the resource file even if the tsfile does not need to be decoded
-    // or the resource file is already existed because we need to serialize the
-    // progress index of the tsfile
-    resource.serialize();
+    if (!needDecodeTsFile && !resource.resourceFileExists()) {
+      resource.serialize();
+    }
 
     return needDecodeTsFile;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/load/LoadTsFileCommandNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/load/LoadTsFileCommandNode.java
@@ -135,12 +135,12 @@ public class LoadTsFileCommandNode extends WritePlanNode {
     InputStream stream = new ByteArrayInputStream(buffer.array());
     try {
       ReadWriteIOUtils.readShort(stream); // read PlanNodeType
-      final int commandIndex = ReadWriteIOUtils.read(buffer);
+      final int commandIndex = ReadWriteIOUtils.readInt(stream);
       final String uuid = ReadWriteIOUtils.readString(stream);
       final boolean isGeneratedByPipe = ReadWriteIOUtils.readBool(stream);
       return new LoadTsFileCommandNode(
           PlanNodeId.deserialize(stream),
-          LoadTsFileScheduler.LoadCommand.values()[commandIndex],
+          LoadCommand.values()[commandIndex],
           uuid,
           isGeneratedByPipe);
     } catch (IOException e) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/load/LoadTsFileScheduler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/load/LoadTsFileScheduler.java
@@ -35,7 +35,6 @@ import org.apache.iotdb.commons.partition.StorageExecutor;
 import org.apache.iotdb.commons.service.metric.MetricService;
 import org.apache.iotdb.commons.service.metric.enums.Metric;
 import org.apache.iotdb.commons.service.metric.enums.Tag;
-import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.LoadReadOnlyException;
 import org.apache.iotdb.db.exception.mpp.FragmentInstanceDispatchException;
@@ -96,20 +95,10 @@ import java.util.stream.IntStream;
 public class LoadTsFileScheduler implements IScheduler {
   private static final Logger LOGGER = LoggerFactory.getLogger(LoadTsFileScheduler.class);
   public static final long LOAD_TASK_MAX_TIME_IN_SECOND = 900L; // 15min
-  private static final long SINGLE_SCHEDULER_MAX_MEMORY_SIZE;
-  private static final int TRANSMIT_LIMIT;
-
-  static {
-    IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
-    SINGLE_SCHEDULER_MAX_MEMORY_SIZE =
-        Math.min(
-            config.getThriftMaxFrameSize() >> 2,
-            (long)
-                (config.getAllocateMemoryForStorageEngine()
-                    * config.getLoadTsFileProportion())); // TODO: change it to query engine
-    TRANSMIT_LIMIT =
-        CommonDescriptor.getInstance().getConfig().getTTimePartitionSlotTransmitLimit();
-  }
+  private static final long SINGLE_SCHEDULER_MAX_MEMORY_SIZE =
+      IoTDBDescriptor.getInstance().getConfig().getThriftMaxFrameSize() >> 2;
+  private static final int TRANSMIT_LIMIT =
+      CommonDescriptor.getInstance().getConfig().getTTimePartitionSlotTransmitLimit();
 
   private final MPPQueryContext queryContext;
   private final QueryStateMachine stateMachine;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/load/LoadTsFileScheduler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/load/LoadTsFileScheduler.java
@@ -365,16 +365,7 @@ public class LoadTsFileScheduler implements IScheduler {
     }
 
     try {
-      FragmentInstance instance =
-          new FragmentInstance(
-              new PlanFragment(fragmentId, node),
-              fragmentId.genFragmentInstanceId(),
-              null,
-              queryContext.getQueryType(),
-              queryContext.getTimeOut(),
-              queryContext.getSession());
-      instance.setExecutorAndHost(new StorageExecutor(node.getLocalRegionReplicaSet()));
-      dispatcher.dispatchLocally(instance);
+      dispatcher.dispatchLocally(createFragmentInstance(node, node.getLocalRegionReplicaSet()));
     } catch (FragmentInstanceDispatchException e) {
       LOGGER.warn(
           String.format(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/StorageEngine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/StorageEngine.java
@@ -841,15 +841,13 @@ public class StorageEngine implements IService {
   public TSStatus executeLoadCommand(DataRegion dataRegion, LoadTsFileCommandNode commandNode) {
     TSStatus status = new TSStatus();
     try {
-      if (getLoadTsFileManager().executeOnDataRegion(dataRegion, commandNode)) {
-        status = RpcUtils.SUCCESS_STATUS;
-      } else {
-        status.setCode(TSStatusCode.LOAD_FILE_ERROR.getStatusCode());
-        status.setMessage(
-            String.format(
-                "No load TsFile uuid %s recorded for executing load command %s.",
-                commandNode.getUuid(), commandNode));
+      if (!getLoadTsFileManager().executeOnDataRegion(dataRegion, commandNode)) {
+        LOGGER.info(
+            "No load TsFile uuid {} recorded for executing load command {}.",
+            commandNode.getUuid(),
+            commandNode);
       }
+      status = RpcUtils.SUCCESS_STATUS;
     } catch (IOException | LoadFileException e) {
       LOGGER.error("Execute load command {} error.", commandNode, e);
       status.setCode(TSStatusCode.LOAD_FILE_ERROR.getStatusCode());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/utils/TsFileResourceUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/utils/TsFileResourceUtils.java
@@ -19,7 +19,6 @@
 
 package org.apache.iotdb.db.storageengine.dataregion.utils;
 
-import org.apache.iotdb.db.pipe.agent.PipeAgent;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResourceStatus;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.timeindex.DeviceTimeIndex;
@@ -422,7 +421,6 @@ public class TsFileResourceUtils {
       }
     }
     resource.setStatus(TsFileResourceStatus.NORMAL);
-    PipeAgent.runtime().assignProgressIndexForTsFileLoad(resource);
     return resource;
   }
 }

--- a/iotdb-protocol/thrift-datanode/src/main/thrift/datanode.thrift
+++ b/iotdb-protocol/thrift-datanode/src/main/thrift/datanode.thrift
@@ -323,6 +323,8 @@ struct TLoadCommandReq{
     1: required i32 commandType
     2: required string uuid
     3: optional bool isGeneratedByPipe
+    4: optional string nodeId
+    5: optional list<common.TConsensusGroupId> consensusGroupIds
 }
 
 struct TLoadResp{


### PR DESCRIPTION
Problems:
The Load TsFile process uses a two-phase transaction commit to ensure consistency. Currently, during the second stage of the validation process, commands are sent directly to each DataNode through the Thrift framework, which does not ensure that the loaded TsFile is organized within the DataRegionGroup. This does not ensure that the loaded TsFiles are organized within the DataRegionGroup, nor can they be correctly identified as progress by the Pipe system.

Solution:
Phase 2 instructions will be wrapped into a consensus layer request and routed through the consensus layer to the target DataRegion to execute the instructions.

问题：
Load TsFile 过程中使用了两阶段事务提交的方式保证一致性。目前在第二阶段确认的过程中直接通过 Thrift 框架发送指令到各个 DataNode 上，这无法保证加载的 TsFile 在 DataRegionGroup 内的有序性。也无法被 Pipe 系统正确地标识成进度

解决方案：
会将第二阶段指令包装成共识层请求，通过共识层路由至目标 DataRegion 再执行指令