### PR TITLE
Return when leader election waiting is interrupted

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/LoadCache.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/LoadCache.java
@@ -559,8 +559,8 @@ public class LoadCache {
       try {
         TimeUnit.MILLISECONDS.sleep(HEARTBEAT_INTERVAL);
       } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
         LOGGER.warn("Interrupt when wait for leader election", e);
+        return;
       }
     }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/LoadCache.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/LoadCache.java
@@ -559,6 +559,7 @@ public class LoadCache {
       try {
         TimeUnit.MILLISECONDS.sleep(HEARTBEAT_INTERVAL);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         LOGGER.warn("Interrupt when wait for leader election", e);
         return;
       }


### PR DESCRIPTION
There is no need to pay more time when leader election was interrupted. Since all the information just stored in memory. The ConfigNode will re-calculate them when restart.