### PR TITLE
Fix aligned timeseries query error after delete some data in memtable

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBAlignedSeriesQueryWithDeletionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBAlignedSeriesQueryWithDeletionIT.java
@@ -126,4 +126,32 @@ public class IoTDBAlignedSeriesQueryWithDeletionIT {
       fail(e.getMessage());
     }
   }
+
+  @Test
+  public void selectPartialDeletedColumns() {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute(
+          "insert into root.sg1.factory0.d1.group1(time, s_lat, s_son)"
+              + " aligned values (10,3.3,4.4),(20,13.3,14.4),(30,23.3,24.4),(40,43.3,44.4);");
+      statement.execute(
+          "insert into root.sg1.factory0.d1.group1(time, s_lat, s_son, s_boolean)"
+              + " aligned values (10,3.3,4.4, true),(20,13.3,14.4, false),(30,23.3,24.4, true),(40,43.3,44.4, true);");
+      ResultSet resultSet = statement.executeQuery("select * from root.sg1.factory0.d1.group1;");
+      int cnt = 0;
+      while (resultSet.next()) {
+        cnt++;
+      }
+      assertEquals(4, cnt);
+      statement.execute("delete from root.sg1.factory0.d1.group1.* where time < 30;");
+      resultSet = statement.executeQuery("select * from root.sg1.factory0.d1.group1;");
+      cnt = 0;
+      while (resultSet.next()) {
+        cnt++;
+      }
+      assertEquals(2, cnt);
+    } catch (SQLException e) {
+      fail(e.getMessage());
+    }
+  }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AlignedWritableMemChunk.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AlignedWritableMemChunk.java
@@ -349,7 +349,7 @@ public class AlignedWritableMemChunk implements IWritableMemChunk {
       int nextRowIndex = sortedRowIndex + 1;
       while (nextRowIndex < list.rowCount()
           && rowBitMap != null
-          && rowBitMap.isMarked(nextRowIndex)) {
+          && rowBitMap.isMarked(list.getValueIndex(nextRowIndex))) {
         nextRowIndex++;
       }
       if (nextRowIndex != list.rowCount() && time == list.getTime(nextRowIndex)) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
@@ -915,11 +915,13 @@ public abstract class AlignedTVList extends TVList {
     // time column
     for (int sortedRowIndex = 0; sortedRowIndex < rowCount; sortedRowIndex++) {
       // skip empty row
-      if (rowBitMap != null && rowBitMap.isMarked(sortedRowIndex)) {
+      if (rowBitMap != null && rowBitMap.isMarked(getValueIndex(sortedRowIndex))) {
         continue;
       }
       int nextRowIndex = sortedRowIndex + 1;
-      while (nextRowIndex < rowCount && rowBitMap != null && rowBitMap.isMarked(nextRowIndex)) {
+      while (nextRowIndex < rowCount
+          && rowBitMap != null
+          && rowBitMap.isMarked(getValueIndex(nextRowIndex))) {
         nextRowIndex++;
       }
       if (nextRowIndex == rowCount || getTime(sortedRowIndex) != getTime(nextRowIndex)) {


### PR DESCRIPTION
## Description

Execute the following sqls
```
insert into root.sg1.factory0.d1.group1(time, s_lat, s_son) aligned values (10,3.3,4.4),(20,13.3,14.4),(30,23.3,24.4),(40,43.3,44.4);
insert into root.sg1.factory0.d1.group1(time, s_lat, s_son, s_boolean) aligned values (10,3.3,4.4, true),(20,13.3,14.4, false),(30,23.3,24.4, true),(40,43.3,44.4, true);
select * from root.sg1.factory0.d1.group1;
delete from root.sg1.factory0.d1.group1.* where time < 30;
select * from root.sg1.factory0.d1.group1;
```

The following error will appear.
```
Msg: org.apache.iotdb.jdbc.IoTDBSQLException: 301: Declared positions (2) does not match column 0's number of entries (3)
```

The reason of this bug is when we use rowBitMap to get the information of whether the row is all null, we alway need to getValueIndex method first. 