### PR TITLE
Fix lose data when recover data dir onto a new iotdb

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/WALRecoverManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/WALRecoverManager.java
@@ -48,6 +48,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
+import static org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALFileUtils.getTsFileRelativePath;
+
 /** First set allVsgScannedLatch, then call recover method. */
 public class WALRecoverManager {
   private static final Logger logger = LoggerFactory.getLogger(WALRecoverManager.class);
@@ -187,8 +189,10 @@ public class WALRecoverManager {
       return null;
     } else {
       try {
-        String canonicalPath = recoverPerformer.getTsFileResource().getTsFile().getCanonicalPath();
-        absolutePath2RecoverPerformer.put(canonicalPath, recoverPerformer);
+        String tsFileRelativePath =
+            getTsFileRelativePath(
+                recoverPerformer.getTsFileResource().getTsFile().getCanonicalPath());
+        absolutePath2RecoverPerformer.put(tsFileRelativePath, recoverPerformer);
       } catch (IOException e) {
         logger.error(
             "Fail to add recover performer for file {}",
@@ -201,8 +205,7 @@ public class WALRecoverManager {
 
   UnsealedTsFileRecoverPerformer removeRecoverPerformer(File file) {
     try {
-      String canonicalPath = file.getCanonicalPath();
-      return absolutePath2RecoverPerformer.remove(canonicalPath);
+      return absolutePath2RecoverPerformer.remove(getTsFileRelativePath(file.getCanonicalPath()));
     } catch (IOException e) {
       logger.error("Fail to remove recover performer for file {}", file, e);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/utils/WALFileUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/utils/WALFileUtils.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.storageengine.dataregion.wal.utils;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.regex.Matcher;
@@ -167,5 +168,18 @@ public class WALFileUtils {
   /** Get .wal filename. */
   public static String getLogFileName(long versionId, long startSearchIndex, WALFileStatus status) {
     return String.format(WAL_FILE_NAME_FORMAT, versionId, startSearchIndex, status.getCode());
+  }
+
+  /**
+   * get tsFile relative path from sequence or unsequence dir. <br>
+   * eg: <br>
+   * input: <br>
+   * /iotdb/absolute/path/data/datanode/data/sequence/root.db/1/2818/1704354353829-1-0-0.tsfile
+   * output: <br>
+   * sequence/root.db/1/2818/1704354353829-1-0-0.tsfile
+   */
+  public static String getTsFileRelativePath(String absolutePath) {
+    Path path = new File(absolutePath).toPath();
+    return path.subpath(path.getNameCount() - 5, path.getNameCount()).toString();
   }
 }


### PR DESCRIPTION
## Description

If the iotdb contains unflushed data, suddenly outages (for example, kill -9). After an outage, the data directory is copied to the iotdb of another directory, and data is lost after startup.  This PR solves the problem of lost data.

## How to test

1. Start an iotdb and write one piece of data,` insert into root.test.d1 (s1) values (1) `.
2. Run the kill -9 command to stop the ConfigNode and DataNode processes.
3. Copy the 'data' directory into a new iotdb and start it (the new iotdb will not be the same as the previous path).
4. Verify that data exists, `select * from root.test.**`

## Before this PR
The data is missing. It can't be found.

## After this PR
The data is recovered and can be found.