### PR TITLE
PBTree: fix deed lock in ReleaseFlushMonitor and Scheduler

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/CachedMTreeStore.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/CachedMTreeStore.java
@@ -605,15 +605,10 @@ public class CachedMTreeStore implements IMTreeStore<ICachedMNode> {
    * @return should not continue releasing
    */
   public boolean executeMemoryRelease(AtomicLong releaseNodeNum, AtomicLong releaseMemorySize) {
-    lockManager.globalReadLock(true);
-    try {
-      if (regionStatistics.getUnpinnedMemorySize() != 0) {
-        return !memoryManager.evict(releaseNodeNum, releaseMemorySize);
-      } else {
-        return true;
-      }
-    } finally {
-      lockManager.globalReadUnlock();
+    if (regionStatistics.getUnpinnedMemorySize() != 0) {
+      return !memoryManager.evict(releaseNodeNum, releaseMemorySize);
+    } else {
+      return true;
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/flush/Scheduler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/flush/Scheduler.java
@@ -246,7 +246,7 @@ public class Scheduler {
                 LOGGER.debug("It takes {}ms to flush MTree in SchemaRegion {}", time, regionId);
               }
               store.recordFlushMetrics(time, flushNodeNum.get(), flushMemSize.get());
-              lockManager.globalReadLock();
+              lockManager.globalReadUnlock();
               flushingRegionSet.remove(regionId);
             }
           });

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/MonitorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/MonitorTest.java
@@ -23,7 +23,6 @@ import org.apache.iotdb.db.schemaengine.rescon.CachedSchemaRegionStatistics;
 import org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.pbtree.CachedMTreeStore;
 import org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.pbtree.lock.LockManager;
 import org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.pbtree.memory.ReleaseFlushMonitor;
-import org.apache.iotdb.tsfile.utils.Pair;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -78,11 +77,11 @@ public class MonitorTest {
     setRecord(4, Arrays.asList(700L, 800L, 2500L), Arrays.asList(1000L, 1500L, 5000L));
     // free =2100
     setRecord(5, Arrays.asList(0L, 2000L), Arrays.asList(1000L, 3900L));
-    List<Pair<Integer, Long>> regions = releaseFlushMonitor.getRegionsToFlush(5000);
+    List<Integer> regions = releaseFlushMonitor.getRegionsToFlush(5000);
     Assert.assertEquals(3, regions.size());
-    Assert.assertEquals(5, regions.get(0).left.intValue());
-    Assert.assertEquals(2, regions.get(1).left.intValue());
-    Assert.assertEquals(4, regions.get(2).left.intValue());
+    Assert.assertEquals(5, regions.get(0).intValue());
+    Assert.assertEquals(2, regions.get(1).intValue());
+    Assert.assertEquals(4, regions.get(2).intValue());
   }
 
   @Test
@@ -90,9 +89,9 @@ public class MonitorTest {
     mockCachedMTreeStore(2);
     setRecord(1, Arrays.asList(0L, 2000L), Arrays.asList(100L, 7000L));
     setRecord(2, Collections.singletonList(3000L), Collections.singletonList(3500L));
-    List<Pair<Integer, Long>> regions = releaseFlushMonitor.getRegionsToFlush(7000);
+    List<Integer> regions = releaseFlushMonitor.getRegionsToFlush(7000);
     Assert.assertEquals(1, regions.size());
-    Assert.assertEquals(2, regions.get(0).left.intValue());
+    Assert.assertEquals(2, regions.get(0).intValue());
   }
 
   private void setRecord(int regionId, List<Long> startTimes, List<Long> eneTimes) {


### PR DESCRIPTION
## Description

Dead lock happened when:
* Thread A try to flush all, hold Scheduler's synchronized lock, acquire store read lock.
* Thread A try to schedule flush, hold store read lock, acquire Scheduler's synchronized lock.


Solution: Make store all read&write locks are acquired after Scheduler's synchronized lock.