### PR TITLE
PBTree: Prevent SchemaFile deadlock when check read page

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/BTreePageManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/BTreePageManager.java
@@ -406,45 +406,44 @@ public class BTreePageManager extends PageManager {
     boolean safeFlag = false;
     // check like crabbing
     ISchemaPage crabPage;
-    while (!safeFlag) {
-      SchemaPageContext doubleCheckContext = new SchemaPageContext();
-      if (getPageIndex(getNodeAddress(parent)) != initPage.getPageIndex()) {
-        // transplanted, release the stale and check the new
-        long addrB4Lock = getNodeAddress(parent);
-        int piB4Lock = getPageIndex(addrB4Lock);
+    SchemaPageContext doubleCheckContext;
+    while (getPageIndex(getNodeAddress(parent)) != initPage.getPageIndex()) {
+      // transplanted, release the stale and obtain/lock the new
+      doubleCheckContext = new SchemaPageContext();
+      long addrB4Lock = getNodeAddress(parent);
+      int piB4Lock = getPageIndex(addrB4Lock);
 
-        crabPage = getPageInstance(piB4Lock, doubleCheckContext);
-        crabPage.getLock().readLock().lock();
+      initPage.decrementAndGetRefCnt();
+      initPage.getLock().readLock().unlock();
 
+      crabPage = getPageInstance(piB4Lock, doubleCheckContext);
+      crabPage.getLock().readLock().lock();
+
+      // UNNECESSARY to TRACE lock since the very page will be unlocked at end of read
+      cxt.referredPages.remove(initPage.getPageIndex());
+      cxt.referredPages.put(crabPage.getPageIndex(), crabPage);
+      initPage = crabPage;
+    }
+
+    // a fresh context to read-through from global cache
+    doubleCheckContext = new SchemaPageContext();
+    crabPage = getPageInstance(initPage.getPageIndex(), doubleCheckContext);
+    if (crabPage != initPage) {
+      // replaced, the lock and ref count should be the same
+      if (crabPage.getLock() != initPage.getLock()
+          || crabPage.getRefCnt() != initPage.getRefCnt()) {
+        crabPage.decrementAndGetRefCnt();
         initPage.decrementAndGetRefCnt();
         initPage.getLock().readLock().unlock();
-
-        // UNNECESSARY to TRACE lock since the very page will be unlocked at end of read
-        cxt.referredPages.remove(initPage.getPageIndex());
-        cxt.referredPages.put(crabPage.getPageIndex(), crabPage);
-        initPage = crabPage;
-        continue;
+        throw new MetadataException(
+            "Page[%d] replacement error: Different ref count or lock object.");
       }
-
-      crabPage = getPageInstance(initPage.getPageIndex(), doubleCheckContext);
-      if (crabPage != initPage) {
-        // replaced, the lock and ref count should be the same
-        if (crabPage.getLock() != initPage.getLock()
-            || crabPage.getRefCnt() != initPage.getRefCnt()) {
-          crabPage.decrementAndGetRefCnt();
-          initPage.decrementAndGetRefCnt();
-          initPage.getLock().readLock().unlock();
-          throw new MetadataException(
-              "Page[%d] replacement error: Different ref count or lock object.");
-        }
-        // update context is enough, ref and lock is left for main read process
-        cxt.referredPages.put(initPage.getPageIndex(), crabPage);
-        initPage = crabPage;
-      }
-      // same page shall only be referred once
-      crabPage.decrementAndGetRefCnt();
-      safeFlag = true;
+      // update context is enough, ref and lock is left for main read process
+      cxt.referredPages.put(initPage.getPageIndex(), crabPage);
+      initPage = crabPage;
     }
+    // same page shall only be referred once
+    crabPage.decrementAndGetRefCnt();
     return initPage;
   }
 


### PR DESCRIPTION
## Description

previously when check read page whether stale, a page read lock is held and another is being obtained, which may lead to a deadlock.
Now the reading thread will unlock the stale page before obtain the latest one.

### Content1 ...

### Content2 ...

### Content3 ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
