### PR TITLE
Pipe: fix constructor of `PipeTsFileInsertionEvent` & filter out empty events on sender side

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/IoTDBPipeExtractorIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/IoTDBPipeExtractorIT.java
@@ -741,12 +741,34 @@ public class IoTDBPipeExtractorIT extends AbstractPipeDualIT {
           "count(root.db.d1.at1),count(root.db.d3.at1),",
           Collections.singleton("3,3,"));
 
+      // flush realtime data - test PipeTsFileInsertionEvent
+      if (!TestUtils.tryExecuteNonQueriesWithRetry(senderEnv, Collections.singletonList("flush"))) {
+        return;
+      }
+
+      TestUtils.assertDataOnEnv(
+          receiverEnv,
+          "select count(*) from root.**",
+          "count(root.db.d1.at1),count(root.db.d3.at1),",
+          Collections.singleton("3,3,"));
+
       // insert realtime data that does not overlap with time range
       if (!TestUtils.tryExecuteNonQueriesWithRetry(
           senderEnv,
           Collections.singletonList(
               "insert into root.db.d4 (time, at1)"
                   + " values (6000, 6), (7000, 7), (8000, 8), (9000, 9), (10000, 10)"))) {
+        return;
+      }
+
+      TestUtils.assertDataOnEnv(
+          receiverEnv,
+          "select count(*) from root.**",
+          "count(root.db.d1.at1),count(root.db.d3.at1),",
+          Collections.singleton("3,3,"));
+
+      // flush realtime data - test PipeTsFileInsertionEvent
+      if (!TestUtils.tryExecuteNonQueriesWithRetry(senderEnv, Collections.singletonList("flush"))) {
         return;
       }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/airgap/IoTDBAirGapConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/airgap/IoTDBAirGapConnector.java
@@ -251,7 +251,7 @@ public class IoTDBAirGapConnector extends IoTDBConnector {
     } else {
       // ignore raw tablet event with zero rows
       if (tabletInsertionEvent instanceof PipeRawTabletInsertionEvent) {
-        if (((PipeRawTabletInsertionEvent) tabletInsertionEvent).isParsedOrEmptyAfterParsing()) {
+        if (((PipeRawTabletInsertionEvent) tabletInsertionEvent).hasNoNeedParsingAndIsEmpty()) {
           return;
         }
       }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/airgap/IoTDBAirGapConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/airgap/IoTDBAirGapConnector.java
@@ -60,7 +60,10 @@ import java.io.RandomAccessFile;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.zip.CRC32;
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/airgap/IoTDBAirGapConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/airgap/IoTDBAirGapConnector.java
@@ -227,11 +227,6 @@ public class IoTDBAirGapConnector extends IoTDBConnector {
 
   @Override
   public void transfer(TabletInsertionEvent tabletInsertionEvent) throws Exception {
-    // ignore event with zero rows
-    if (Objects.isNull(tabletInsertionEvent)) {
-      return;
-    }
-
     // PipeProcessor can change the type of TabletInsertionEvent
     if (!(tabletInsertionEvent instanceof PipeInsertNodeTabletInsertionEvent)
         && !(tabletInsertionEvent instanceof PipeRawTabletInsertionEvent)) {
@@ -241,6 +236,13 @@ public class IoTDBAirGapConnector extends IoTDBConnector {
               + "Ignore {}.",
           tabletInsertionEvent);
       return;
+    }
+
+    // ignore raw tablet event with zero rows
+    if (tabletInsertionEvent instanceof PipeRawTabletInsertionEvent) {
+      if (((PipeRawTabletInsertionEvent) tabletInsertionEvent).isEmpty()) {
+        return;
+      }
     }
 
     if (((EnrichedEvent) tabletInsertionEvent).shouldParsePatternOrTime()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/airgap/IoTDBAirGapConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/airgap/IoTDBAirGapConnector.java
@@ -60,10 +60,7 @@ import java.io.RandomAccessFile;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.zip.CRC32;
 
@@ -227,6 +224,11 @@ public class IoTDBAirGapConnector extends IoTDBConnector {
 
   @Override
   public void transfer(TabletInsertionEvent tabletInsertionEvent) throws Exception {
+    // ignore event with zero rows
+    if (Objects.isNull(tabletInsertionEvent)) {
+      return;
+    }
+
     // PipeProcessor can change the type of TabletInsertionEvent
     if (!(tabletInsertionEvent instanceof PipeInsertNodeTabletInsertionEvent)
         && !(tabletInsertionEvent instanceof PipeRawTabletInsertionEvent)) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/airgap/IoTDBAirGapConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/airgap/IoTDBAirGapConnector.java
@@ -238,13 +238,6 @@ public class IoTDBAirGapConnector extends IoTDBConnector {
       return;
     }
 
-    // ignore raw tablet event with zero rows
-    if (tabletInsertionEvent instanceof PipeRawTabletInsertionEvent) {
-      if (((PipeRawTabletInsertionEvent) tabletInsertionEvent).isEmpty()) {
-        return;
-      }
-    }
-
     if (((EnrichedEvent) tabletInsertionEvent).shouldParsePatternOrTime()) {
       if (tabletInsertionEvent instanceof PipeInsertNodeTabletInsertionEvent) {
         transfer(
@@ -255,6 +248,13 @@ public class IoTDBAirGapConnector extends IoTDBConnector {
             ((PipeRawTabletInsertionEvent) tabletInsertionEvent).parseEventWithPatternOrTime());
       }
       return;
+    } else {
+      // ignore raw tablet event with zero rows
+      if (tabletInsertionEvent instanceof PipeRawTabletInsertionEvent) {
+        if (((PipeRawTabletInsertionEvent) tabletInsertionEvent).isParsedOrEmptyAfterParsing()) {
+          return;
+        }
+      }
     }
 
     final int socketIndex = nextSocketIndex();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBThriftAsyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBThriftAsyncConnector.java
@@ -53,6 +53,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Objects;
 import java.util.concurrent.PriorityBlockingQueue;
 
 import static org.apache.iotdb.commons.pipe.config.constant.PipeConnectorConstant.CONNECTOR_IOTDB_BATCH_MODE_ENABLE_KEY;
@@ -140,6 +141,11 @@ public class IoTDBThriftAsyncConnector extends IoTDBConnector {
   @Override
   public void transfer(TabletInsertionEvent tabletInsertionEvent) throws Exception {
     transferQueuedEventsIfNecessary();
+
+    // ignore event with zero rows
+    if (Objects.isNull(tabletInsertionEvent)) {
+      return;
+    }
 
     if (!(tabletInsertionEvent instanceof PipeInsertNodeTabletInsertionEvent)
         && !(tabletInsertionEvent instanceof PipeRawTabletInsertionEvent)) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBThriftAsyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBThriftAsyncConnector.java
@@ -53,7 +53,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.Objects;
 import java.util.concurrent.PriorityBlockingQueue;
 
 import static org.apache.iotdb.commons.pipe.config.constant.PipeConnectorConstant.CONNECTOR_IOTDB_BATCH_MODE_ENABLE_KEY;
@@ -142,11 +141,6 @@ public class IoTDBThriftAsyncConnector extends IoTDBConnector {
   public void transfer(TabletInsertionEvent tabletInsertionEvent) throws Exception {
     transferQueuedEventsIfNecessary();
 
-    // ignore event with zero rows
-    if (Objects.isNull(tabletInsertionEvent)) {
-      return;
-    }
-
     if (!(tabletInsertionEvent instanceof PipeInsertNodeTabletInsertionEvent)
         && !(tabletInsertionEvent instanceof PipeRawTabletInsertionEvent)) {
       LOGGER.warn(
@@ -154,6 +148,13 @@ public class IoTDBThriftAsyncConnector extends IoTDBConnector {
               + "Current event: {}.",
           tabletInsertionEvent);
       return;
+    }
+
+    // ignore raw tablet event with zero rows
+    if (tabletInsertionEvent instanceof PipeRawTabletInsertionEvent) {
+      if (((PipeRawTabletInsertionEvent) tabletInsertionEvent).isEmpty()) {
+        return;
+      }
     }
 
     if (((EnrichedEvent) tabletInsertionEvent).shouldParsePatternOrTime()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBThriftAsyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBThriftAsyncConnector.java
@@ -150,13 +150,6 @@ public class IoTDBThriftAsyncConnector extends IoTDBConnector {
       return;
     }
 
-    // ignore raw tablet event with zero rows
-    if (tabletInsertionEvent instanceof PipeRawTabletInsertionEvent) {
-      if (((PipeRawTabletInsertionEvent) tabletInsertionEvent).isEmpty()) {
-        return;
-      }
-    }
-
     if (((EnrichedEvent) tabletInsertionEvent).shouldParsePatternOrTime()) {
       if (tabletInsertionEvent instanceof PipeInsertNodeTabletInsertionEvent) {
         transfer(
@@ -167,6 +160,13 @@ public class IoTDBThriftAsyncConnector extends IoTDBConnector {
             ((PipeRawTabletInsertionEvent) tabletInsertionEvent).parseEventWithPatternOrTime());
       }
       return;
+    } else {
+      // ignore raw tablet event with zero rows
+      if (tabletInsertionEvent instanceof PipeRawTabletInsertionEvent) {
+        if (((PipeRawTabletInsertionEvent) tabletInsertionEvent).isParsedOrEmptyAfterParsing()) {
+          return;
+        }
+      }
     }
 
     if (isTabletBatchModeEnabled) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBThriftAsyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBThriftAsyncConnector.java
@@ -163,7 +163,7 @@ public class IoTDBThriftAsyncConnector extends IoTDBConnector {
     } else {
       // ignore raw tablet event with zero rows
       if (tabletInsertionEvent instanceof PipeRawTabletInsertionEvent) {
-        if (((PipeRawTabletInsertionEvent) tabletInsertionEvent).isParsedOrEmptyAfterParsing()) {
+        if (((PipeRawTabletInsertionEvent) tabletInsertionEvent).hasNoNeedParsingAndIsEmpty()) {
           return;
         }
       }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
@@ -197,13 +197,6 @@ public class IoTDBThriftSyncConnector extends IoTDBConnector {
       return;
     }
 
-    // ignore raw tablet event with zero rows
-    if (tabletInsertionEvent instanceof PipeRawTabletInsertionEvent) {
-      if (((PipeRawTabletInsertionEvent) tabletInsertionEvent).isEmpty()) {
-        return;
-      }
-    }
-
     if (((EnrichedEvent) tabletInsertionEvent).shouldParsePatternOrTime()) {
       if (tabletInsertionEvent instanceof PipeInsertNodeTabletInsertionEvent) {
         transfer(
@@ -214,6 +207,13 @@ public class IoTDBThriftSyncConnector extends IoTDBConnector {
             ((PipeRawTabletInsertionEvent) tabletInsertionEvent).parseEventWithPatternOrTime());
       }
       return;
+    } else {
+      // ignore raw tablet event with zero rows
+      if (tabletInsertionEvent instanceof PipeRawTabletInsertionEvent) {
+        if (((PipeRawTabletInsertionEvent) tabletInsertionEvent).isParsedOrEmptyAfterParsing()) {
+          return;
+        }
+      }
     }
 
     try {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
@@ -210,7 +210,7 @@ public class IoTDBThriftSyncConnector extends IoTDBConnector {
     } else {
       // ignore raw tablet event with zero rows
       if (tabletInsertionEvent instanceof PipeRawTabletInsertionEvent) {
-        if (((PipeRawTabletInsertionEvent) tabletInsertionEvent).isParsedOrEmptyAfterParsing()) {
+        if (((PipeRawTabletInsertionEvent) tabletInsertionEvent).hasNoNeedParsingAndIsEmpty()) {
           return;
         }
       }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
@@ -63,7 +63,6 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.net.UnknownHostException;
 import java.util.Arrays;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -187,11 +186,6 @@ public class IoTDBThriftSyncConnector extends IoTDBConnector {
 
   @Override
   public void transfer(TabletInsertionEvent tabletInsertionEvent) throws Exception {
-    // ignore event with zero rows
-    if (Objects.isNull(tabletInsertionEvent)) {
-      return;
-    }
-
     // PipeProcessor can change the type of TabletInsertionEvent
     if (!(tabletInsertionEvent instanceof PipeInsertNodeTabletInsertionEvent)
         && !(tabletInsertionEvent instanceof PipeRawTabletInsertionEvent)) {
@@ -201,6 +195,13 @@ public class IoTDBThriftSyncConnector extends IoTDBConnector {
               + "Ignore {}.",
           tabletInsertionEvent);
       return;
+    }
+
+    // ignore raw tablet event with zero rows
+    if (tabletInsertionEvent instanceof PipeRawTabletInsertionEvent) {
+      if (((PipeRawTabletInsertionEvent) tabletInsertionEvent).isEmpty()) {
+        return;
+      }
     }
 
     if (((EnrichedEvent) tabletInsertionEvent).shouldParsePatternOrTime()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/sync/IoTDBThriftSyncConnector.java
@@ -63,6 +63,7 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.net.UnknownHostException;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -186,6 +187,11 @@ public class IoTDBThriftSyncConnector extends IoTDBConnector {
 
   @Override
   public void transfer(TabletInsertionEvent tabletInsertionEvent) throws Exception {
+    // ignore event with zero rows
+    if (Objects.isNull(tabletInsertionEvent)) {
+      return;
+    }
+
     // PipeProcessor can change the type of TabletInsertionEvent
     if (!(tabletInsertionEvent instanceof PipeInsertNodeTabletInsertionEvent)
         && !(tabletInsertionEvent instanceof PipeRawTabletInsertionEvent)) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/writeback/WriteBackConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/writeback/WriteBackConnector.java
@@ -92,13 +92,6 @@ public class WriteBackConnector implements PipeConnector {
       return;
     }
 
-    // ignore raw tablet event with zero rows
-    if (tabletInsertionEvent instanceof PipeRawTabletInsertionEvent) {
-      if (((PipeRawTabletInsertionEvent) tabletInsertionEvent).isEmpty()) {
-        return;
-      }
-    }
-
     if (((EnrichedEvent) tabletInsertionEvent).shouldParsePatternOrTime()) {
       if (tabletInsertionEvent instanceof PipeInsertNodeTabletInsertionEvent) {
         transfer(
@@ -109,6 +102,13 @@ public class WriteBackConnector implements PipeConnector {
             ((PipeRawTabletInsertionEvent) tabletInsertionEvent).parseEventWithPatternOrTime());
       }
       return;
+    } else {
+      // ignore raw tablet event with zero rows
+      if (tabletInsertionEvent instanceof PipeRawTabletInsertionEvent) {
+        if (((PipeRawTabletInsertionEvent) tabletInsertionEvent).isParsedOrEmptyAfterParsing()) {
+          return;
+        }
+      }
     }
 
     if (tabletInsertionEvent instanceof PipeInsertNodeTabletInsertionEvent) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/writeback/WriteBackConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/writeback/WriteBackConnector.java
@@ -105,7 +105,7 @@ public class WriteBackConnector implements PipeConnector {
     } else {
       // ignore raw tablet event with zero rows
       if (tabletInsertionEvent instanceof PipeRawTabletInsertionEvent) {
-        if (((PipeRawTabletInsertionEvent) tabletInsertionEvent).isParsedOrEmptyAfterParsing()) {
+        if (((PipeRawTabletInsertionEvent) tabletInsertionEvent).hasNoNeedParsingAndIsEmpty()) {
           return;
         }
       }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/writeback/WriteBackConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/writeback/WriteBackConnector.java
@@ -81,11 +81,6 @@ public class WriteBackConnector implements PipeConnector {
 
   @Override
   public void transfer(TabletInsertionEvent tabletInsertionEvent) throws Exception {
-    // ignore event with zero rows
-    if (Objects.isNull(tabletInsertionEvent)) {
-      return;
-    }
-
     // PipeProcessor can change the type of TabletInsertionEvent
     if (!(tabletInsertionEvent instanceof PipeInsertNodeTabletInsertionEvent)
         && !(tabletInsertionEvent instanceof PipeRawTabletInsertionEvent)) {
@@ -95,6 +90,13 @@ public class WriteBackConnector implements PipeConnector {
               + "Ignore {}.",
           tabletInsertionEvent);
       return;
+    }
+
+    // ignore raw tablet event with zero rows
+    if (tabletInsertionEvent instanceof PipeRawTabletInsertionEvent) {
+      if (((PipeRawTabletInsertionEvent) tabletInsertionEvent).isEmpty()) {
+        return;
+      }
     }
 
     if (((EnrichedEvent) tabletInsertionEvent).shouldParsePatternOrTime()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/writeback/WriteBackConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/writeback/WriteBackConnector.java
@@ -81,6 +81,11 @@ public class WriteBackConnector implements PipeConnector {
 
   @Override
   public void transfer(TabletInsertionEvent tabletInsertionEvent) throws Exception {
+    // ignore event with zero rows
+    if (Objects.isNull(tabletInsertionEvent)) {
+      return;
+    }
+
     // PipeProcessor can change the type of TabletInsertionEvent
     if (!(tabletInsertionEvent instanceof PipeInsertNodeTabletInsertionEvent)
         && !(tabletInsertionEvent instanceof PipeRawTabletInsertionEvent)) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/heartbeat/PipeHeartbeatEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/heartbeat/PipeHeartbeatEvent.java
@@ -109,6 +109,7 @@ public class PipeHeartbeatEvent extends EnrichedEvent {
   public EnrichedEvent shallowCopySelfAndBindPipeTaskMetaForProgressReport(
       String pipeName, PipeTaskMeta pipeTaskMeta, String pattern, long startTime, long endTime) {
     // Should record PipeTaskMeta, for sometimes HeartbeatEvents should report exceptions.
+    // Here we ignore parameters `pattern`, `startTime`, and `endTime`.
     return new PipeHeartbeatEvent(
         pipeName, pipeTaskMeta, dataRegionId, timePublished, shouldPrintMessage);
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeInsertNodeTabletInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeInsertNodeTabletInsertionEvent.java
@@ -238,7 +238,7 @@ public class PipeInsertNodeTabletInsertionEvent extends EnrichedEvent
     }
   }
 
-  /////////////////////////// parsePattern ///////////////////////////
+  /////////////////////////// parsePatternOrTime ///////////////////////////
 
   public TabletInsertionEvent parseEventWithPatternOrTime() {
     return new PipeRawTabletInsertionEvent(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeInsertNodeTabletInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeInsertNodeTabletInsertionEvent.java
@@ -241,8 +241,13 @@ public class PipeInsertNodeTabletInsertionEvent extends EnrichedEvent
   /////////////////////////// parsePattern ///////////////////////////
 
   public TabletInsertionEvent parseEventWithPatternOrTime() {
-    return new PipeRawTabletInsertionEvent(
-        convertToTablet(), isAligned, pipeName, pipeTaskMeta, this, true);
+    Tablet tablet = convertToTablet();
+    if (tablet.rowSize == 0) {
+      // Returning null here to indicate to the caller to ignore this event when parsing during
+      // transfer.
+      return null;
+    }
+    return new PipeRawTabletInsertionEvent(tablet, isAligned, pipeName, pipeTaskMeta, this, true);
   }
 
   /////////////////////////// Object ///////////////////////////

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeInsertNodeTabletInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeInsertNodeTabletInsertionEvent.java
@@ -241,13 +241,8 @@ public class PipeInsertNodeTabletInsertionEvent extends EnrichedEvent
   /////////////////////////// parsePattern ///////////////////////////
 
   public TabletInsertionEvent parseEventWithPatternOrTime() {
-    Tablet tablet = convertToTablet();
-    if (tablet.rowSize == 0) {
-      // Returning null here to indicate to the caller to ignore this event when parsing during
-      // transfer.
-      return null;
-    }
-    return new PipeRawTabletInsertionEvent(tablet, isAligned, pipeName, pipeTaskMeta, this, true);
+    return new PipeRawTabletInsertionEvent(
+        convertToTablet(), isAligned, pipeName, pipeTaskMeta, this, true);
   }
 
   /////////////////////////// Object ///////////////////////////

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEvent.java
@@ -205,7 +205,7 @@ public class PipeRawTabletInsertionEvent extends EnrichedEvent implements Tablet
         convertToTablet(), isAligned, pipeName, pipeTaskMeta, this, needToReport);
   }
 
-  public boolean isParsedOrEmptyAfterParsing() {
+  public boolean hasNoNeedParsingAndIsEmpty() {
     return !shouldParsePatternOrTime() && tablet.rowSize == 0;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEvent.java
@@ -198,17 +198,14 @@ public class PipeRawTabletInsertionEvent extends EnrichedEvent implements Tablet
     return dataContainer.convertToTablet();
   }
 
-  /////////////////////////// parsePattern ///////////////////////////
+  /////////////////////////// parsePatternOrTime ///////////////////////////
 
   public TabletInsertionEvent parseEventWithPatternOrTime() {
     return new PipeRawTabletInsertionEvent(
         convertToTablet(), isAligned, pipeName, pipeTaskMeta, this, needToReport);
   }
 
-  public boolean isEmpty() {
-    if (shouldParsePatternOrTime()) {
-      return false;
-    }
-    return tablet.rowSize == 0;
+  public boolean isParsedOrEmptyAfterParsing() {
+    return !shouldParsePatternOrTime() && tablet.rowSize == 0;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEvent.java
@@ -201,13 +201,11 @@ public class PipeRawTabletInsertionEvent extends EnrichedEvent implements Tablet
   /////////////////////////// parsePattern ///////////////////////////
 
   public TabletInsertionEvent parseEventWithPatternOrTime() {
-    Tablet tablet = convertToTablet();
-    if (tablet.rowSize == 0) {
-      // Returning null here to indicate to the caller to ignore this event when parsing during
-      // transfer.
-      return null;
-    }
     return new PipeRawTabletInsertionEvent(
-        tablet, isAligned, pipeName, pipeTaskMeta, this, needToReport);
+        convertToTablet(), isAligned, pipeName, pipeTaskMeta, this, needToReport);
+  }
+
+  public boolean isEmpty() {
+    return tablet.rowSize == 0;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEvent.java
@@ -201,7 +201,13 @@ public class PipeRawTabletInsertionEvent extends EnrichedEvent implements Tablet
   /////////////////////////// parsePattern ///////////////////////////
 
   public TabletInsertionEvent parseEventWithPatternOrTime() {
+    Tablet tablet = convertToTablet();
+    if (tablet.rowSize == 0) {
+      // Returning null here to indicate to the caller to ignore this event when parsing during
+      // transfer.
+      return null;
+    }
     return new PipeRawTabletInsertionEvent(
-        convertToTablet(), isAligned, pipeName, pipeTaskMeta, this, needToReport);
+        tablet, isAligned, pipeName, pipeTaskMeta, this, needToReport);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEvent.java
@@ -206,6 +206,9 @@ public class PipeRawTabletInsertionEvent extends EnrichedEvent implements Tablet
   }
 
   public boolean isEmpty() {
+    if (shouldParsePatternOrTime()) {
+      return false;
+    }
     return tablet.rowSize == 0;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/TabletInsertionDataContainer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/TabletInsertionDataContainer.java
@@ -167,8 +167,8 @@ public class TabletInsertionDataContainer {
     }
 
     rowCount = rowIndexList.size();
-    if (rowCount == 0) {
-      LOGGER.info(
+    if (rowCount == 0 && LOGGER.isDebugEnabled()) {
+      LOGGER.debug(
           "InsertRowNode({}) is parsed to zero rows according to the pattern({}) and time range [{}, {}], the corresponding source event({}) will be ignored.",
           insertRowNode,
           pattern,
@@ -238,8 +238,8 @@ public class TabletInsertionDataContainer {
     }
 
     rowCount = timestampColumn.length;
-    if (rowCount == 0) {
-      LOGGER.info(
+    if (rowCount == 0 && LOGGER.isDebugEnabled()) {
+      LOGGER.debug(
           "InsertTabletNode({}) is parsed to zero rows according to the pattern({}) and time range [{}, {}], the corresponding source event({}) will be ignored.",
           insertTabletNode,
           pattern,
@@ -315,8 +315,8 @@ public class TabletInsertionDataContainer {
     }
 
     rowCount = tablet.rowSize;
-    if (rowCount == 0) {
-      LOGGER.info(
+    if (rowCount == 0 && LOGGER.isDebugEnabled()) {
+      LOGGER.debug(
           "Tablet({}) is parsed to zero rows according to the pattern({}) and time range [{}, {}], the corresponding source event({}) will be ignored.",
           tablet,
           pattern,

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEvent.java
@@ -166,14 +166,7 @@ public class PipeTsFileInsertionEvent extends EnrichedEvent implements TsFileIns
   public PipeTsFileInsertionEvent shallowCopySelfAndBindPipeTaskMetaForProgressReport(
       String pipeName, PipeTaskMeta pipeTaskMeta, String pattern, long startTime, long endTime) {
     return new PipeTsFileInsertionEvent(
-        resource,
-        isLoaded,
-        isGeneratedByPipe,
-        pipeName,
-        pipeTaskMeta,
-        pattern,
-        this.startTime,
-        this.endTime);
+        resource, isLoaded, isGeneratedByPipe, pipeName, pipeTaskMeta, pattern, startTime, endTime);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/historical/PipeHistoricalDataRegionTsFileExtractor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/historical/PipeHistoricalDataRegionTsFileExtractor.java
@@ -86,8 +86,8 @@ public class PipeHistoricalDataRegionTsFileExtractor implements PipeHistoricalDa
 
   private boolean isHistoricalExtractorEnabled = false;
 
-  private long historicalDataExtractionStartTime; // Event time
-  private long historicalDataExtractionEndTime; // Event time
+  private long historicalDataExtractionStartTime = Long.MIN_VALUE; // Event time
+  private long historicalDataExtractionEndTime = Long.MAX_VALUE; // Event time
 
   private long historicalDataExtractionTimeLowerBound; // Arrival time
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/PipeRealtimeDataRegionExtractor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/PipeRealtimeDataRegionExtractor.java
@@ -136,6 +136,13 @@ public abstract class PipeRealtimeDataRegionExtractor implements PipeExtractor {
     dataRegionId = String.valueOf(environment.getRegionId());
     pipeTaskMeta = environment.getPipeTaskMeta();
 
+    // Metrics related to TsFileEpoch are managed in PipeExtractorMetrics. These metrics are
+    // indexed by the taskID of IoTDBDataRegionExtractor. To avoid PipeRealtimeDataRegionExtractor
+    // holding a reference to IoTDBDataRegionExtractor, the taskID should be constructed to
+    // match that of IoTDBDataRegionExtractor.
+    long creationTime = environment.getCreationTime();
+    taskID = pipeName + "_" + dataRegionId + "_" + creationTime;
+
     pattern =
         parameters.getStringOrDefault(
             Arrays.asList(EXTRACTOR_PATTERN_KEY, SOURCE_PATTERN_KEY),
@@ -179,13 +186,6 @@ public abstract class PipeRealtimeDataRegionExtractor implements PipeExtractor {
                 PipeExtractorConstant.EXTRACTOR_FORWARDING_PIPE_REQUESTS_KEY,
                 PipeExtractorConstant.SOURCE_FORWARDING_PIPE_REQUESTS_KEY),
             PipeExtractorConstant.EXTRACTOR_FORWARDING_PIPE_REQUESTS_DEFAULT_VALUE);
-
-    // Metrics related to TsFileEpoch are managed in PipeExtractorMetrics. These metrics are
-    // indexed by the taskID of IoTDBDataRegionExtractor. To avoid PipeRealtimeDataRegionExtractor
-    // holding a reference to IoTDBDataRegionExtractor, the taskID should be constructed to
-    // match that of IoTDBDataRegionExtractor.
-    long creationTime = configuration.getRuntimeEnvironment().getCreationTime();
-    taskID = pipeName + "_" + dataRegionId + "_" + creationTime;
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/PipeRealtimeDataRegionExtractor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/realtime/PipeRealtimeDataRegionExtractor.java
@@ -70,8 +70,8 @@ public abstract class PipeRealtimeDataRegionExtractor implements PipeExtractor {
   protected String pattern;
   private boolean isDbNameCoveredByPattern = false;
 
-  protected long realtimeDataExtractionStartTime; // Event time
-  protected long realtimeDataExtractionEndTime; // Event time
+  protected long realtimeDataExtractionStartTime = Long.MIN_VALUE; // Event time
+  protected long realtimeDataExtractionEndTime = Long.MAX_VALUE; // Event time
 
   private final AtomicBoolean enableSkippingTimeParseByTimePartition = new AtomicBoolean(false);
   private boolean disableSkippingTimeParse = false;

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/extractor/PipeRealtimeExtractTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/extractor/PipeRealtimeExtractTest.java
@@ -34,6 +34,7 @@ import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertRowNode;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALEntryHandler;
+import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameterValidator;
 import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameters;
 import org.apache.iotdb.pipe.api.event.Event;
 import org.apache.iotdb.pipe.api.event.dml.insertion.TabletInsertionEvent;
@@ -104,57 +105,68 @@ public class PipeRealtimeExtractTest {
   public void testRealtimeExtractProcess() {
     // set up realtime extractor
 
-    try (PipeRealtimeDataRegionLogExtractor extractor1 = new PipeRealtimeDataRegionLogExtractor();
-        PipeRealtimeDataRegionHybridExtractor extractor2 =
+    try (PipeRealtimeDataRegionLogExtractor extractor0 = new PipeRealtimeDataRegionLogExtractor();
+        PipeRealtimeDataRegionHybridExtractor extractor1 =
             new PipeRealtimeDataRegionHybridExtractor();
-        PipeRealtimeDataRegionTsFileExtractor extractor3 =
+        PipeRealtimeDataRegionTsFileExtractor extractor2 =
             new PipeRealtimeDataRegionTsFileExtractor();
-        PipeRealtimeDataRegionHybridExtractor extractor4 =
+        PipeRealtimeDataRegionHybridExtractor extractor3 =
             new PipeRealtimeDataRegionHybridExtractor()) {
 
-      extractor1.customize(
+      PipeParameters parameters0 =
           new PipeParameters(
               new HashMap<String, String>() {
                 {
                   put(PipeExtractorConstant.EXTRACTOR_PATTERN_KEY, pattern1);
                 }
-              }),
-          new PipeTaskRuntimeConfiguration(
-              new PipeTaskExtractorRuntimeEnvironment(
-                  "1", 1, Integer.parseInt(dataRegion1), null)));
-      extractor2.customize(
+              });
+      PipeParameters parameters1 =
           new PipeParameters(
               new HashMap<String, String>() {
                 {
                   put(PipeExtractorConstant.EXTRACTOR_PATTERN_KEY, pattern2);
                 }
-              }),
-          new PipeTaskRuntimeConfiguration(
-              new PipeTaskExtractorRuntimeEnvironment(
-                  "1", 1, Integer.parseInt(dataRegion1), null)));
-      extractor3.customize(
+              });
+      PipeParameters parameters2 =
           new PipeParameters(
               new HashMap<String, String>() {
                 {
                   put(PipeExtractorConstant.EXTRACTOR_PATTERN_KEY, pattern1);
                 }
-              }),
-          new PipeTaskRuntimeConfiguration(
-              new PipeTaskExtractorRuntimeEnvironment(
-                  "1", 1, Integer.parseInt(dataRegion2), null)));
-      extractor4.customize(
+              });
+      PipeParameters parameters3 =
           new PipeParameters(
               new HashMap<String, String>() {
                 {
                   put(PipeExtractorConstant.EXTRACTOR_PATTERN_KEY, pattern2);
                 }
-              }),
+              });
+
+      PipeTaskRuntimeConfiguration configuration0 =
           new PipeTaskRuntimeConfiguration(
-              new PipeTaskExtractorRuntimeEnvironment(
-                  "1", 1, Integer.parseInt(dataRegion2), null)));
+              new PipeTaskExtractorRuntimeEnvironment("1", 1, Integer.parseInt(dataRegion1), null));
+      PipeTaskRuntimeConfiguration configuration1 =
+          new PipeTaskRuntimeConfiguration(
+              new PipeTaskExtractorRuntimeEnvironment("1", 1, Integer.parseInt(dataRegion1), null));
+      PipeTaskRuntimeConfiguration configuration2 =
+          new PipeTaskRuntimeConfiguration(
+              new PipeTaskExtractorRuntimeEnvironment("1", 1, Integer.parseInt(dataRegion2), null));
+      PipeTaskRuntimeConfiguration configuration3 =
+          new PipeTaskRuntimeConfiguration(
+              new PipeTaskExtractorRuntimeEnvironment("1", 1, Integer.parseInt(dataRegion2), null));
+
+      // Some parameters of extractor are validated and initialized during the validation process.
+      extractor0.validate(new PipeParameterValidator(parameters0));
+      extractor0.customize(parameters0, configuration0);
+      extractor1.validate(new PipeParameterValidator(parameters1));
+      extractor1.customize(parameters1, configuration1);
+      extractor2.validate(new PipeParameterValidator(parameters2));
+      extractor2.customize(parameters2, configuration2);
+      extractor3.validate(new PipeParameterValidator(parameters3));
+      extractor3.customize(parameters3, configuration3);
 
       PipeRealtimeDataRegionExtractor[] extractors =
-          new PipeRealtimeDataRegionExtractor[] {extractor1, extractor2, extractor3, extractor4};
+          new PipeRealtimeDataRegionExtractor[] {extractor0, extractor1, extractor2, extractor3};
 
       // start extractor 0, 1
       extractors[0].start();


### PR DESCRIPTION
## Description

This PR is a fix and optimization for https://github.com/apache/iotdb/pull/11757, including the following:
1. Fixing the constructor of `PipeTsFileInsertionEvent` that caused issues with incorrect initialization of event time, and enhancing related integration tests.
2. Filtering out empty events on the sender side to reduce data traffic, while lowering the log level for parsing empty events to debug.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [x] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
