### PR TITLE
[IOTDB-6190] Increase the threshold for Ratis to shut itself down if it detects that a process is stuck

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/consensus/ConsensusManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/consensus/ConsensusManager.java
@@ -158,6 +158,10 @@ public class ConsensusManager {
                                           TimeDuration.valueOf(
                                               CONF.getConfigNodeRatisRequestTimeoutMs(),
                                               TimeUnit.MILLISECONDS))
+                                      .setSlownessTimeout(
+                                          TimeDuration.valueOf(
+                                              CONF.getConfigNodeRatisRequestTimeoutMs() * 6,
+                                              TimeUnit.MILLISECONDS))
                                       .setFirstElectionTimeoutMin(
                                           TimeDuration.valueOf(
                                               CONF.getRatisFirstElectionTimeoutMinMs(),

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/config/RatisConfig.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/config/RatisConfig.java
@@ -267,13 +267,7 @@ public class RatisConfig {
       private TimeDuration timeoutMax = TimeDuration.valueOf(4, TimeUnit.SECONDS);
       private TimeDuration requestTimeout = TimeDuration.valueOf(20, TimeUnit.SECONDS);
       private TimeDuration sleepTime = TimeDuration.valueOf(1, TimeUnit.SECONDS);
-      /**
-       * TODO: After introducing version 3.0 of Ratis, we plan to reduce the value of this parameter
-       * because a new parameter will be introduced later. For more details, please refer to `<a
-       * href="https://lists.apache.org/thread/vxd97lpllqtdb8cdbt3nxvg1kv6kjfss">email</a>`. It is
-       * set to 100 years instead of Long.MAX_VALUE to avoid potential overflows when shifting time.
-       */
-      private TimeDuration slownessTimeout = TimeDuration.valueOf(100 * 365L, TimeUnit.DAYS);
+      private TimeDuration slownessTimeout = TimeDuration.valueOf(120, TimeUnit.SECONDS);
 
       private TimeDuration firstElectionTimeoutMin =
           TimeDuration.valueOf(50, TimeUnit.MILLISECONDS);
@@ -1145,13 +1139,19 @@ public class RatisConfig {
   public static class Utils {
 
     private final int sleepDeviationThresholdMs;
+    private final int closeThresholdMs;
 
-    private Utils(int sleepDeviationThresholdMs) {
+    private Utils(int sleepDeviationThresholdMs, int closeThresholdMs) {
       this.sleepDeviationThresholdMs = sleepDeviationThresholdMs;
+      this.closeThresholdMs = closeThresholdMs;
     }
 
     public int getSleepDeviationThresholdMs() {
       return sleepDeviationThresholdMs;
+    }
+
+    public int getCloseThresholdMs() {
+      return closeThresholdMs;
     }
 
     public static Utils.Builder newBuilder() {
@@ -1161,13 +1161,18 @@ public class RatisConfig {
     public static class Builder {
 
       private int sleepDeviationThresholdMs = 4 * 1000;
+      private int closeThresholdMs = Integer.MAX_VALUE;
 
       public Utils build() {
-        return new Utils(sleepDeviationThresholdMs);
+        return new Utils(sleepDeviationThresholdMs, closeThresholdMs);
       }
 
       public void setSleepDeviationThresholdMs(int sleepDeviationThresholdMs) {
         this.sleepDeviationThresholdMs = sleepDeviationThresholdMs;
+      }
+
+      public void setCloseThresholdMs(int closeThresholdMs) {
+        this.closeThresholdMs = closeThresholdMs;
       }
     }
   }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/utils/Utils.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/utils/Utils.java
@@ -327,6 +327,7 @@ public class Utils {
 
     RaftServerConfigKeys.setSleepDeviationThreshold(
         properties, config.getUtils().getSleepDeviationThresholdMs());
+    RaftServerConfigKeys.setCloseThreshold(properties, config.getUtils().getCloseThresholdMs());
 
     final TimeDuration clientMaxRetryGap = getMaxRetrySleepTime(config.getClient());
     RaftServerConfigKeys.RetryCache.setExpiryTime(properties, clientMaxRetryGap);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/DataRegionConsensusImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/DataRegionConsensusImpl.java
@@ -144,6 +144,10 @@ public class DataRegionConsensusImpl {
                                         TimeDuration.valueOf(
                                             CONF.getDataRatisConsensusRequestTimeoutMs(),
                                             TimeUnit.MILLISECONDS))
+                                    .setSlownessTimeout(
+                                        TimeDuration.valueOf(
+                                            CONF.getDataRatisConsensusRequestTimeoutMs() * 6,
+                                            TimeUnit.MILLISECONDS))
                                     .setFirstElectionTimeoutMin(
                                         TimeDuration.valueOf(
                                             CONF.getRatisFirstElectionTimeoutMinMs(),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/SchemaRegionConsensusImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/SchemaRegionConsensusImpl.java
@@ -105,6 +105,10 @@ public class SchemaRegionConsensusImpl {
                                         TimeDuration.valueOf(
                                             CONF.getSchemaRatisConsensusRequestTimeoutMs(),
                                             TimeUnit.MILLISECONDS))
+                                    .setSlownessTimeout(
+                                        TimeDuration.valueOf(
+                                            CONF.getSchemaRatisConsensusRequestTimeoutMs() * 6,
+                                            TimeUnit.MILLISECONDS))
                                     .setFirstElectionTimeoutMin(
                                         TimeDuration.valueOf(
                                             CONF.getRatisFirstElectionTimeoutMinMs(),


### PR DESCRIPTION
After Ratis was updated to version 3.0, the way this parameter is set has changed, and the previous [PR](https://github.com/apache/iotdb/pull/11416/files) is no longer valid and needs to be modified