### PR TITLE
Make timeout error msg more readable

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/DriverScheduler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/DriverScheduler.java
@@ -50,6 +50,7 @@ import org.apache.iotdb.mpp.rpc.thrift.TFragmentInstanceId;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -576,6 +577,7 @@ public class DriverScheduler implements IDriverScheduler, IService {
           task.unlock();
         }
         clearDriverTask(task);
+        String abortCause = task.getAbortCause();
         QueryId queryId = task.getDriverTaskId().getQueryId();
         Map<FragmentInstanceId, Set<DriverTask>> queryRelatedTasks = queryMap.remove(queryId);
         if (queryRelatedTasks != null) {
@@ -586,7 +588,10 @@ public class DriverScheduler implements IDriverScheduler, IService {
                   if (task.equals(otherTask)) {
                     continue;
                   }
-                  otherTask.setAbortCause(DriverTaskAbortedException.BY_QUERY_CASCADING_ABORTED);
+                  otherTask.setAbortCause(
+                      StringUtils.isEmpty(abortCause)
+                          ? DriverTaskAbortedException.BY_QUERY_CASCADING_ABORTED
+                          : abortCause);
                   clearDriverTask(otherTask);
                 }
               }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/FixedRateFragInsStateTracker.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/FixedRateFragInsStateTracker.java
@@ -124,7 +124,9 @@ public class FixedRateFragInsStateTracker extends AbstractFragInsStateTracker {
                   instance.getId(), k -> new InstanceStateMetrics(instance.isRoot()));
           if (needPrintState(
               metrics.lastState, instanceInfo.getState(), metrics.durationToLastPrintInMS)) {
-            logger.debug("[PrintFIState] state is {}", instanceInfo.getState());
+            if (logger.isDebugEnabled()) {
+              logger.debug("[PrintFIState] state is {}", instanceInfo.getState());
+            }
             metrics.reset(instanceInfo.getState());
           } else {
             metrics.addDuration(STATE_FETCH_INTERVAL_IN_MS);
@@ -144,7 +146,9 @@ public class FixedRateFragInsStateTracker extends AbstractFragInsStateTracker {
       if (instanceInfo.getFailureInfoList() == null
           || instanceInfo.getFailureInfoList().isEmpty()) {
         stateMachine.transitionToFailed(
-            new RuntimeException(String.format("FragmentInstance[%s] is failed.", instanceId)));
+            new RuntimeException(
+                String.format(
+                    "FragmentInstance[%s] is failed. %s", instanceId, instanceInfo.getMessage())));
       } else {
         stateMachine.transitionToFailed(instanceInfo.getFailureInfoList().get(0).toException());
       }


### PR DESCRIPTION
Previously, we use BY_QUERY_CASCADING_ABORTED to abort other FI in same query which may cause users got a error msg that is not timeout.