### PR TITLE
Fix duplicated create logical view in PBTree mode

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/MTreeBelowSGCachedImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/MTreeBelowSGCachedImpl.java
@@ -954,7 +954,7 @@ public class MTreeBelowSGCachedImpl {
         ICachedMNode device = checkAndAutoCreateDeviceNode(devicePath.getTailNode(), deviceParent);
         try {
           String leafName = path.getMeasurement();
-          if (device.hasChild(leafName)) {
+          if (store.hasChild(device, leafName)) {
             ICachedMNode node = device.getChild(leafName);
             if (node.isMeasurement()) {
               if (node.getAsMeasurementMNode().isPreDeleted()) {


### PR DESCRIPTION
## Description

When creating logical view, we should double check node not exists using interface `store.hasChild(parent, childName)` instead of `parent.hasChild(childName)`.