### PR TITLE
[RatisConsensus] Enable Leader Transfer UT

### DIFF
--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RatisConsensusTest.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RatisConsensusTest.java
@@ -24,16 +24,20 @@ import org.apache.iotdb.consensus.IStateMachine;
 import org.apache.iotdb.consensus.common.ConsensusGroup;
 import org.apache.iotdb.consensus.common.Peer;
 import org.apache.iotdb.consensus.config.RatisConfig;
+import org.apache.iotdb.consensus.exception.ConsensusException;
 import org.apache.iotdb.consensus.exception.ConsensusGroupAlreadyExistException;
 import org.apache.iotdb.consensus.exception.ConsensusGroupNotExistException;
 import org.apache.iotdb.consensus.exception.PeerAlreadyInConsensusGroupException;
 import org.apache.iotdb.consensus.exception.PeerNotInConsensusGroupException;
 
+import org.apache.iotdb.consensus.ratis.utils.Retriable;
 import org.apache.ratis.util.TimeDuration;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
@@ -41,7 +45,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+
 public class RatisConsensusTest {
+  private final static Logger logger = LoggerFactory.getLogger(RatisConsensusTest.class);
 
   private ConsensusGroupId gid;
   private List<Peer> peers;
@@ -207,7 +213,7 @@ public class RatisConsensusTest {
     doConsensus(0, 10, 210);
   }
 
-  // FIXME: Turn on the test when it is stable
+  @Test
   public void transferLeader() throws Exception {
     servers.get(0).createLocalPeer(group.getGroupId(), group.getPeers());
     servers.get(1).createLocalPeer(group.getGroupId(), group.getPeers());
@@ -215,14 +221,42 @@ public class RatisConsensusTest {
 
     doConsensus(0, 10, 10);
 
-    int leaderIndex = servers.get(0).getLeader(group.getGroupId()).getNodeId() - 1;
+    final int oldLeader = servers.get(0).getLeader(group.getGroupId()).getNodeId();
+    final int newLeader = (oldLeader + 1) % miniCluster.getServers().size();
+    logger.debug("old leader is {} and new leader is {}", oldLeader, newLeader);
 
-    servers.get(0).transferLeader(group.getGroupId(), peers.get((leaderIndex + 1) % 3));
+    try {
+      servers.get(0).transferLeader(group.getGroupId(), peers.get(newLeader));
+    } catch (ConsensusException e) {
+      logger.error("Failed to transfer snapshot:", e);
+      Assert.fail();
+    }
 
-    Peer newLeader = servers.get(0).getLeader(group.getGroupId());
-    Assert.assertNotNull(newLeader);
+    // After the transferLeader request, the new peer will start leader election, need to wait here
+    miniCluster.waitUntilActiveLeaderElectedAndReady();
 
-    Assert.assertEquals((leaderIndex + 1) % 3, newLeader.getNodeId() - 1);
+    final Peer newLeaderPeer = servers.get(0).getLeader(group.getGroupId());
+    Assert.assertNotNull(newLeaderPeer);
+    Assert.assertEquals(newLeader, newLeaderPeer.getNodeId());
+  }
+
+  @Test
+  public void transferLeaderFailed() throws Exception {
+    servers.get(0).createLocalPeer(group.getGroupId(), group.getPeers());
+    servers.get(1).createLocalPeer(group.getGroupId(), group.getPeers());
+    servers.get(2).createLocalPeer(group.getGroupId(), group.getPeers());
+
+    doConsensus(0, 10, 10);
+
+    final int leader = servers.get(0).getLeader(gid).getNodeId();
+    final int f1 = (leader + 1) % 3;
+    servers.get(f1).stop();
+    doConsensus(leader, 10, 20);
+
+    // transfer will fail since the server 2 is down
+    Assert.assertThrows(ConsensusException.class, () -> {
+      servers.get(leader).transferLeader(gid, peers.get(f1));
+    });
   }
 
   @Test

--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RatisConsensusTest.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/RatisConsensusTest.java
@@ -30,7 +30,6 @@ import org.apache.iotdb.consensus.exception.ConsensusGroupNotExistException;
 import org.apache.iotdb.consensus.exception.PeerAlreadyInConsensusGroupException;
 import org.apache.iotdb.consensus.exception.PeerNotInConsensusGroupException;
 
-import org.apache.iotdb.consensus.ratis.utils.Retriable;
 import org.apache.ratis.util.TimeDuration;
 import org.junit.After;
 import org.junit.Assert;
@@ -45,9 +44,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-
 public class RatisConsensusTest {
-  private final static Logger logger = LoggerFactory.getLogger(RatisConsensusTest.class);
+  private static final Logger logger = LoggerFactory.getLogger(RatisConsensusTest.class);
 
   private ConsensusGroupId gid;
   private List<Peer> peers;
@@ -254,9 +252,11 @@ public class RatisConsensusTest {
     doConsensus(leader, 10, 20);
 
     // transfer will fail since the server 2 is down
-    Assert.assertThrows(ConsensusException.class, () -> {
-      servers.get(leader).transferLeader(gid, peers.get(f1));
-    });
+    Assert.assertThrows(
+        ConsensusException.class,
+        () -> {
+          servers.get(leader).transferLeader(gid, peers.get(f1));
+        });
   }
 
   @Test


### PR DESCRIPTION
Enable Leader Transfer UT for preparation on load balancing.

100x tests passed locally.

<img width="1482" alt="image" src="https://github.com/apache/iotdb/assets/48054931/4f4cb6d4-c17f-4f5d-a232-9a01fa00bac3">
<img width="1669" alt="image" src="https://github.com/apache/iotdb/assets/48054931/ae5d3de7-8c01-4710-800e-1cf587f40115">

