### PR TITLE
Fix insertRecords may cause sequence data overlapped

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -894,8 +894,18 @@ public class DataRegion implements IDataRegionForQuery {
                   > lastFlushTimeMap.getFlushedTime(
                       timePartitionId, insertRowNode.getDevicePath().getFullPath());
 
+      Map<TsFileProcessor, Boolean> tsFileProcessorMapForFlushing = new HashMap<>();
+
       // insert to sequence or unSequence file
-      insertToTsFileProcessor(insertRowNode, isSequence, timePartitionId);
+      insertToTsFileProcessor(
+          insertRowNode, isSequence, timePartitionId, tsFileProcessorMapForFlushing);
+
+      // check memtable size and may asyncTryToFlush the work memtable
+      for (Map.Entry<TsFileProcessor, Boolean> entry : tsFileProcessorMapForFlushing.entrySet()) {
+        if (entry.getKey().shouldFlush()) {
+          fileFlushPolicy.apply(this, entry.getKey(), entry.getValue());
+        }
+      }
     } finally {
       writeUnlock();
     }
@@ -1110,7 +1120,10 @@ public class DataRegion implements IDataRegionForQuery {
   }
 
   private void insertToTsFileProcessor(
-      InsertRowNode insertRowNode, boolean sequence, long timePartitionId)
+      InsertRowNode insertRowNode,
+      boolean sequence,
+      long timePartitionId,
+      Map<TsFileProcessor, Boolean> tsFileProcessorMapForFlushing)
       throws WriteProcessException {
     if (insertRowNode.allMeasurementFailed()) {
       return;
@@ -1126,10 +1139,7 @@ public class DataRegion implements IDataRegionForQuery {
     PERFORMANCE_OVERVIEW_METRICS.recordScheduleWalCost(costsForMetrics[2]);
     PERFORMANCE_OVERVIEW_METRICS.recordScheduleMemTableCost(costsForMetrics[3]);
 
-    // check memtable size and may asyncTryToFlush the work memtable
-    if (tsFileProcessor.shouldFlush()) {
-      fileFlushPolicy.apply(this, tsFileProcessor, sequence);
-    }
+    tsFileProcessorMapForFlushing.put(tsFileProcessor, sequence);
 
     if (CommonDescriptor.getInstance().getConfig().isLastCacheEnable()) {
       if ((config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)
@@ -1174,7 +1184,7 @@ public class DataRegion implements IDataRegionForQuery {
       InsertRowsNode insertRowsNode, boolean[] areSequence, long[] timePartitionIds) {
     List<InsertRowNode> executedInsertRowNodeList = new ArrayList<>();
     long[] costsForMetrics = new long[4];
-    Map<TsFileProcessor, Boolean> tsFileProcessorMap = new HashMap<>();
+    Map<TsFileProcessor, Boolean> tsFileProcessorMapForFlushing = new HashMap<>();
     for (int i = 0; i < areSequence.length; i++) {
       InsertRowNode insertRowNode = insertRowsNode.getInsertRowNodeList().get(i);
       if (insertRowNode.allMeasurementFailed()) {
@@ -1185,7 +1195,7 @@ public class DataRegion implements IDataRegionForQuery {
       if (tsFileProcessor == null) {
         continue;
       }
-      tsFileProcessorMap.put(tsFileProcessor, areSequence[i]);
+      tsFileProcessorMapForFlushing.put(tsFileProcessor, areSequence[i]);
       try {
         tsFileProcessor.insert(insertRowNode, costsForMetrics);
       } catch (WriteProcessException e) {
@@ -1195,7 +1205,7 @@ public class DataRegion implements IDataRegionForQuery {
     }
 
     // check memtable size and may asyncTryToFlush the work memtable
-    for (Map.Entry<TsFileProcessor, Boolean> entry : tsFileProcessorMap.entrySet()) {
+    for (Map.Entry<TsFileProcessor, Boolean> entry : tsFileProcessorMapForFlushing.entrySet()) {
       if (entry.getKey().shouldFlush()) {
         fileFlushPolicy.apply(this, entry.getKey(), entry.getValue());
       }
@@ -3061,6 +3071,7 @@ public class DataRegion implements IDataRegionForQuery {
       if (deleted) {
         return;
       }
+      Map<TsFileProcessor, Boolean> tsFileProcessorMapForFlushing = new HashMap<>();
       for (int i = 0; i < insertRowsOfOneDeviceNode.getInsertRowNodeList().size(); i++) {
         InsertRowNode insertRowNode = insertRowsOfOneDeviceNode.getInsertRowNodeList().get(i);
         if (!isAlive(insertRowNode.getTime())) {
@@ -3103,11 +3114,18 @@ public class DataRegion implements IDataRegionForQuery {
 
         // insert to sequence or unSequence file
         try {
-          insertToTsFileProcessor(insertRowNode, isSequence, timePartitionId);
+          insertToTsFileProcessor(
+              insertRowNode, isSequence, timePartitionId, tsFileProcessorMapForFlushing);
         } catch (WriteProcessException e) {
           insertRowsOfOneDeviceNode
               .getResults()
               .put(i, RpcUtils.getStatus(e.getErrorCode(), e.getMessage()));
+        }
+      }
+      // check memtable size and may asyncTryToFlush the work memtable
+      for (Map.Entry<TsFileProcessor, Boolean> entry : tsFileProcessorMapForFlushing.entrySet()) {
+        if (entry.getKey().shouldFlush()) {
+          fileFlushPolicy.apply(this, entry.getKey(), entry.getValue());
         }
       }
     } finally {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/DataRegionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/DataRegionTest.java
@@ -31,10 +31,13 @@ import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.DataRegionException;
 import org.apache.iotdb.db.exception.WriteProcessException;
+import org.apache.iotdb.db.exception.WriteProcessRejectException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.queryengine.common.QueryId;
 import org.apache.iotdb.db.queryengine.execution.fragment.QueryContext;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertRowNode;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertRowsNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertTabletNode;
 import org.apache.iotdb.db.storageengine.StorageEngine;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.performer.ICompactionPerformer;
@@ -857,6 +860,41 @@ public class DataRegionTest {
 
     config.setEnableSeparateData(defaultEnableDiscard);
     COMMON_CONFIG.setTimePartitionInterval(defaultTimePartition);
+  }
+
+  @Test
+  public void testInsertUnSequenceRows()
+      throws IllegalPathException, WriteProcessRejectException, QueryProcessException,
+          DataRegionException {
+    int defaultAvgSeriesPointNumberThreshold = config.getAvgSeriesPointNumberThreshold();
+    config.setAvgSeriesPointNumberThreshold(2);
+    DataRegion dataRegion1 = new DummyDataRegion(systemDir, "root.Rows");
+    long[] time = new long[] {3, 4, 1, 2};
+    List<Integer> indexList = new ArrayList<>();
+    List<InsertRowNode> nodes = new ArrayList<>();
+    for (int i = 0; i < 4; i++) {
+      TSRecord record = new TSRecord(time[i], "root.Rows");
+      record.addTuple(DataPoint.getDataPoint(TSDataType.INT32, measurementId, String.valueOf(i)));
+      nodes.add(buildInsertRowNodeByTSRecord(record));
+      indexList.add(i);
+    }
+    InsertRowsNode insertRowsNode = new InsertRowsNode(new PlanNodeId(""), indexList, nodes);
+    dataRegion1.insert(insertRowsNode);
+    dataRegion1.syncCloseAllWorkingTsFileProcessors();
+    QueryDataSource queryDataSource =
+        dataRegion1.query(
+            Collections.singletonList(new PartialPath("root.Rows", measurementId)),
+            "root.Rows",
+            context,
+            null,
+            null);
+    Assert.assertEquals(1, queryDataSource.getSeqResources().size());
+    Assert.assertEquals(0, queryDataSource.getUnseqResources().size());
+    for (TsFileResource resource : queryDataSource.getSeqResources()) {
+      Assert.assertTrue(resource.isClosed());
+    }
+    dataRegion1.syncDeleteDataFiles();
+    config.setAvgSeriesPointNumberThreshold(defaultAvgSeriesPointNumberThreshold);
   }
 
   @Test


### PR DESCRIPTION
## Description

https://jira.infra.timecho.com:8443/browse/TIMECHODB-534

When the DataRegion executes the batch insert interface, we should always apply flush when the whole insertNode executed. Otherwise, some parts of sequence data may overlap.

## How to Reproduce

Set `avg_series_point_number_threshold = 2`, then execute the following code.

```
private static void insertRecords() throws IoTDBConnectionException, StatementExecutionException {
  String deviceId = ROOT_SG1_D1;
  List<String> measurements = new ArrayList<>();
  measurements.add("s1");
  measurements.add("s2");
  measurements.add("s3");
  List<String> deviceIds = new ArrayList<>();
  List<List<String>> measurementsList = new ArrayList<>();
  List<List<Object>> valuesList = new ArrayList<>();
  List<Long> timestamps = new ArrayList<>();
  List<List<TSDataType>> typesList = new ArrayList<>();
  long[] t = new long[] {3, 4, 1, 2};

  for (int time = 0; time < 4; time++) {
    List<Object> values = new ArrayList<>();
    List<TSDataType> types = new ArrayList<>();
    values.add(1L);
    values.add(2L);
    values.add(3L);
    types.add(TSDataType.INT64);
    types.add(TSDataType.INT64);
    types.add(TSDataType.INT64);

    deviceIds.add(deviceId);
    measurementsList.add(measurements);
    valuesList.add(values);
    typesList.add(types);
    timestamps.add(t[time]);
  }

  session.insertRecords(deviceIds, timestamps, measurementsList, typesList, valuesList);
}
```

You will see the TsFile resources of sequence data overlapped.
![r5CSOhecLt](https://github.com/apache/iotdb/assets/25913899/387faf4f-4da5-4f89-be89-0ed52a9c94c3)
