### PR TITLE
Fix TsFileResource is deleted cause compaction validation result is not correct

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
@@ -400,6 +400,9 @@ public class TsFileResource {
 
   public DeviceTimeIndex buildDeviceTimeIndex() throws IOException {
     readLock();
+    if (!resourceFileExists()) {
+      return new DeviceTimeIndex();
+    }
     try (InputStream inputStream =
         FSFactoryProducer.getFSFactory().getBufferedInputStream(file.getPath() + RESOURCE_SUFFIX)) {
       ReadWriteIOUtils.readByte(inputStream);


### PR DESCRIPTION
## Description
Fix deleted TsFileResource or borken TsFileResource may cause compaction validation result not correct.
When validate whether the compaction target file is overlapped with sequence files, the resource file may be read by buildDeviceTimeIndex(). However, other sequence files may be deleted by other compaction task. Then the validation method will catch an IOException and directly return a flag which means validate successfully.