### PR TITLE
Fix distributed plan of GroupLevelNode

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/SourceRewriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/SourceRewriter.java
@@ -1210,15 +1210,13 @@ public class SourceRewriter extends SimplePlanNodeRewriter<DistributionPlanConte
       Map<TRegionReplicaSet, List<SeriesAggregationSourceNode>> sourceGroup,
       DistributionPlanContext context) {
     GroupByLevelNode newRoot = (GroupByLevelNode) root.clone();
-    final boolean[] addParent = {false};
     sourceGroup.forEach(
         (dataRegion, sourceNodes) -> {
           if (sourceNodes.size() == 1) {
             newRoot.addChild(sourceNodes.get(0));
           } else {
-            if (!addParent[0]) {
+            if (sourceGroup.size() == 1) {
               sourceNodes.forEach(newRoot::addChild);
-              addParent[0] = true;
             } else {
               GroupByLevelNode parentOfGroup = (GroupByLevelNode) root.clone();
               parentOfGroup.setPlanNodeId(context.queryContext.getQueryId().genPlanNodeId());
@@ -1348,15 +1346,13 @@ public class SourceRewriter extends SimplePlanNodeRewriter<DistributionPlanConte
       Map<TRegionReplicaSet, List<SeriesAggregationSourceNode>> sourceGroup,
       DistributionPlanContext context) {
     GroupByTagNode newRoot = (GroupByTagNode) root.clone();
-    final boolean[] addParent = {false};
     sourceGroup.forEach(
         (dataRegion, sourceNodes) -> {
           if (sourceNodes.size() == 1) {
             newRoot.addChild(sourceNodes.get(0));
           } else {
-            if (!addParent[0]) {
+            if (sourceGroup.size() == 1) {
               sourceNodes.forEach(newRoot::addChild);
-              addParent[0] = true;
             } else {
               HorizontallyConcatNode horizontallyConcatNode =
                   new HorizontallyConcatNode(context.queryContext.getQueryId().genPlanNodeId());

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/AggregationDistributionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/AggregationDistributionTest.java
@@ -362,7 +362,17 @@ public class AggregationDistributionTest {
         f -> verifyAggregationStep(expectedStep, f.getFragment().getPlanNodeTree()));
 
     Map<String, List<String>> expectedDescriptorValue = new HashMap<>();
-    expectedDescriptorValue.put(groupedPath, Arrays.asList(groupedPath, d3s1Path, d4s1Path));
+    expectedDescriptorValue.put(groupedPath, Collections.singletonList(groupedPath));
+    assertTrue(
+        fragmentInstances
+                .get(0)
+                .getFragment()
+                .getPlanNodeTree()
+                .getChildren()
+                .get(0)
+                .getChildren()
+                .get(0)
+            instanceof GroupByLevelNode);
     verifyGroupByLevelDescriptor(
         expectedDescriptorValue,
         (GroupByLevelNode)
@@ -518,8 +528,8 @@ public class AggregationDistributionTest {
         f -> verifyAggregationStep(expectedStep, f.getFragment().getPlanNodeTree()));
 
     Map<String, List<String>> expectedDescriptorValue = new HashMap<>();
-    expectedDescriptorValue.put(groupedPathS1, Arrays.asList(groupedPathS1, d1s1Path));
-    expectedDescriptorValue.put(groupedPathS2, Arrays.asList(groupedPathS2, d1s2Path));
+    expectedDescriptorValue.put(groupedPathS1, Collections.singletonList(groupedPathS1));
+    expectedDescriptorValue.put(groupedPathS2, Collections.singletonList(groupedPathS2));
     verifyGroupByLevelDescriptor(
         expectedDescriptorValue,
         (GroupByLevelNode)
@@ -583,10 +593,30 @@ public class AggregationDistributionTest {
     List<FragmentInstance> fragmentInstances = plan.getInstances();
     fragmentInstances.forEach(
         f -> verifyAggregationStep(expectedStep, f.getFragment().getPlanNodeTree()));
+    assertTrue(
+        fragmentInstances
+                .get(0)
+                .getFragment()
+                .getPlanNodeTree()
+                .getChildren()
+                .get(0)
+                .getChildren()
+                .get(0)
+            instanceof GroupByLevelNode);
+    assertTrue(
+        fragmentInstances
+                .get(0)
+                .getFragment()
+                .getPlanNodeTree()
+                .getChildren()
+                .get(2)
+                .getChildren()
+                .get(0)
+            instanceof GroupByLevelNode);
 
     Map<String, List<String>> expectedDescriptorValue = new HashMap<>();
-    expectedDescriptorValue.put(groupedPathS1, Arrays.asList(groupedPathS1, d1s1Path, d2s1Path));
-    expectedDescriptorValue.put(groupedPathS2, Arrays.asList(groupedPathS2, d1s2Path));
+    expectedDescriptorValue.put(groupedPathS1, Arrays.asList(groupedPathS1, d2s1Path));
+    expectedDescriptorValue.put(groupedPathS2, Collections.singletonList(groupedPathS2));
     verifyGroupByLevelDescriptor(
         expectedDescriptorValue,
         (GroupByLevelNode)

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/AggregationDistributionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/AggregationDistributionTest.java
@@ -604,14 +604,7 @@ public class AggregationDistributionTest {
                 .get(0)
             instanceof GroupByLevelNode);
     assertTrue(
-        fragmentInstances
-                .get(0)
-                .getFragment()
-                .getPlanNodeTree()
-                .getChildren()
-                .get(2)
-                .getChildren()
-                .get(0)
+        fragmentInstances.get(2).getFragment().getPlanNodeTree().getChildren().get(0)
             instanceof GroupByLevelNode);
 
     Map<String, List<String>> expectedDescriptorValue = new HashMap<>();


### PR DESCRIPTION
This PR fixes a potential issue with the distributed plan of GroupLevelNode. When the first group of children of GroupByLevel Node is not selected as the primary FI, it could lead to an excessive number of ExchangeNodes when there are a large number of Nodes. This PR adds a GroupByLevelNode for every group of children whose count is greater than one.