### PR TITLE
Pipe: Utilize `parallelStream` for concurrent execution of create, start, stop, and drop pipe tasks to enhance performance

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/PipeDataNodeTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/PipeDataNodeTask.java
@@ -23,7 +23,12 @@ import org.apache.iotdb.common.rpc.thrift.TConsensusGroupId;
 import org.apache.iotdb.commons.pipe.task.PipeTask;
 import org.apache.iotdb.commons.pipe.task.stage.PipeTaskStage;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class PipeDataNodeTask implements PipeTask {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PipeDataNodeTask.class);
 
   protected final String pipeName;
   protected final TConsensusGroupId regionId;
@@ -48,30 +53,50 @@ public class PipeDataNodeTask implements PipeTask {
 
   @Override
   public void create() {
+    final long startTime = System.currentTimeMillis();
     extractorStage.create();
     processorStage.create();
     connectorStage.create();
+    LOGGER.info(
+        "Create pipe DN task {} successfully within {} ms",
+        this,
+        System.currentTimeMillis() - startTime);
   }
 
   @Override
   public void drop() {
+    final long startTime = System.currentTimeMillis();
     extractorStage.drop();
     processorStage.drop();
     connectorStage.drop();
+    LOGGER.info(
+        "Drop pipe DN task {} successfully within {} ms",
+        this,
+        System.currentTimeMillis() - startTime);
   }
 
   @Override
   public void start() {
+    final long startTime = System.currentTimeMillis();
     extractorStage.start();
     processorStage.start();
     connectorStage.start();
+    LOGGER.info(
+        "Start pipe DN task {} successfully within {} ms",
+        this,
+        System.currentTimeMillis() - startTime);
   }
 
   @Override
   public void stop() {
+    final long startTime = System.currentTimeMillis();
     extractorStage.stop();
     processorStage.stop();
     connectorStage.stop();
+    LOGGER.info(
+        "Stop pipe DN task {} successfully within {} ms",
+        this,
+        System.currentTimeMillis() - startTime);
   }
 
   public TConsensusGroupId getRegionId() {
@@ -80,5 +105,10 @@ public class PipeDataNodeTask implements PipeTask {
 
   public String getPipeName() {
     return pipeName;
+  }
+
+  @Override
+  public String toString() {
+    return pipeName + "@" + regionId;
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/PipeTaskAgent.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/PipeTaskAgent.java
@@ -408,11 +408,17 @@ public abstract class PipeTaskAgent {
       dropPipe(pipeName, existedPipeMeta.getStaticMeta().getCreationTime());
     }
 
-    // Create pipe tasks and trigger create() method for each pipe task
+    // Create pipe tasks
     final Map<TConsensusGroupId, PipeTask> pipeTasks = buildPipeTasks(pipeMetaFromCoordinator);
-    for (PipeTask pipeTask : pipeTasks.values()) {
-      pipeTask.create();
-    }
+
+    // Trigger create() method for each pipe task by parallel stream
+    final long startTime = System.currentTimeMillis();
+    pipeTasks.values().parallelStream().forEach(PipeTask::create);
+    LOGGER.info(
+        "Create all pipe tasks on Pipe {} successfully within {} ms",
+        pipeName,
+        System.currentTimeMillis() - startTime);
+
     pipeTaskManager.addPipeTasks(pipeMetaFromCoordinator.getStaticMeta(), pipeTasks);
 
     // No matter the pipe status from coordinator is RUNNING or STOPPED, we always set the status
@@ -444,7 +450,7 @@ public abstract class PipeTaskAgent {
     // dropPipeTaskByConsensusGroup).
     existedPipeMeta.getRuntimeMeta().getStatus().set(PipeStatus.DROPPED);
 
-    // Drop pipe tasks and trigger drop() method for each pipe task
+    // Drop pipe tasks
     final Map<TConsensusGroupId, PipeTask> pipeTasks =
         pipeTaskManager.removePipeTasks(existedPipeMeta.getStaticMeta());
     if (pipeTasks == null) {
@@ -455,9 +461,14 @@ public abstract class PipeTaskAgent {
           creationTime);
       return;
     }
-    for (PipeTask pipeTask : pipeTasks.values()) {
-      pipeTask.drop();
-    }
+
+    // Trigger drop() method for each pipe task by parallel stream
+    final long startTime = System.currentTimeMillis();
+    pipeTasks.values().parallelStream().forEach(PipeTask::drop);
+    LOGGER.info(
+        "Drop all pipe tasks on Pipe {} successfully within {} ms",
+        pipeName,
+        System.currentTimeMillis() - startTime);
 
     // Remove pipe meta from pipe meta keeper
     pipeMetaKeeper.removePipeMeta(pipeName);
@@ -475,7 +486,7 @@ public abstract class PipeTaskAgent {
     // dropPipeTaskByConsensusGroup).
     existedPipeMeta.getRuntimeMeta().getStatus().set(PipeStatus.DROPPED);
 
-    // Drop pipe tasks and trigger drop() method for each pipe task
+    // Drop pipe tasks
     final Map<TConsensusGroupId, PipeTask> pipeTasks =
         pipeTaskManager.removePipeTasks(existedPipeMeta.getStaticMeta());
     if (pipeTasks == null) {
@@ -483,9 +494,14 @@ public abstract class PipeTaskAgent {
           "Pipe {} has already been dropped or has not been created. Skip dropping.", pipeName);
       return;
     }
-    for (PipeTask pipeTask : pipeTasks.values()) {
-      pipeTask.drop();
-    }
+
+    // Trigger drop() method for each pipe task by parallel stream
+    final long startTime = System.currentTimeMillis();
+    pipeTasks.values().parallelStream().forEach(PipeTask::drop);
+    LOGGER.info(
+        "Drop all pipe tasks on Pipe {} successfully within {} ms",
+        pipeName,
+        System.currentTimeMillis() - startTime);
 
     // Remove pipe meta from pipe meta keeper
     pipeMetaKeeper.removePipeMeta(pipeName);
@@ -498,7 +514,7 @@ public abstract class PipeTaskAgent {
       return;
     }
 
-    // Trigger start() method for each pipe task
+    // Get pipe tasks
     final Map<TConsensusGroupId, PipeTask> pipeTasks =
         pipeTaskManager.getPipeTasks(existedPipeMeta.getStaticMeta());
     if (pipeTasks == null) {
@@ -509,9 +525,14 @@ public abstract class PipeTaskAgent {
           creationTime);
       return;
     }
-    for (PipeTask pipeTask : pipeTasks.values()) {
-      pipeTask.start();
-    }
+
+    // Trigger start() method for each pipe task by parallel stream
+    final long startTime = System.currentTimeMillis();
+    pipeTasks.values().parallelStream().forEach(PipeTask::start);
+    LOGGER.info(
+        "Start all pipe tasks on Pipe {} successfully within {} ms",
+        pipeName,
+        System.currentTimeMillis() - startTime);
 
     // Set pipe meta status to RUNNING
     existedPipeMeta.getRuntimeMeta().getStatus().set(PipeStatus.RUNNING);
@@ -530,7 +551,7 @@ public abstract class PipeTaskAgent {
       return;
     }
 
-    // Trigger stop() method for each pipe task
+    // Get pipe tasks
     final Map<TConsensusGroupId, PipeTask> pipeTasks =
         pipeTaskManager.getPipeTasks(existedPipeMeta.getStaticMeta());
     if (pipeTasks == null) {
@@ -541,9 +562,14 @@ public abstract class PipeTaskAgent {
           creationTime);
       return;
     }
-    for (PipeTask pipeTask : pipeTasks.values()) {
-      pipeTask.stop();
-    }
+
+    // Trigger stop() method for each pipe task by parallel stream
+    final long startTime = System.currentTimeMillis();
+    pipeTasks.values().parallelStream().forEach(PipeTask::stop);
+    LOGGER.info(
+        "Stop all pipe tasks on Pipe {} successfully within {} ms",
+        pipeName,
+        System.currentTimeMillis() - startTime);
 
     // Set pipe meta status to STOPPED
     existedPipeMeta.getRuntimeMeta().getStatus().set(PipeStatus.STOPPED);


### PR DESCRIPTION
## Description

Currently, when creating a pipe, if there is historical data in the cluster, the pipe will be automatically started. This involves **serially** extracting historical data in each data region. When dealing with large data, timeouts may occur, leading to pipe creation failure. To address this, we are considering parallelizing the above operations using `parallelStream` (inspired by @SteveYurongSu).

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [x] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
