### PR TITLE
PBTreeSketchTool support view

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/RecordUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/RecordUtils.java
@@ -62,6 +62,7 @@ public class RecordUtils {
   private static final short ALIAS_OFFSET = 19;
   private static final short SEG_ADDRESS_OFFSET = 3;
   private static final short SCHEMA_OFFSET = 11;
+  private static final short VIEW_OFFSET = 12;
   private static final short INTERNAL_BITFLAG_OFFSET = 15;
 
   private static final byte INTERNAL_TYPE = 0;
@@ -310,7 +311,14 @@ public class RecordUtils {
     return res;
   }
 
-  public static boolean getAlignment(ByteBuffer recBuf) {
+  /** return as: [dataType, encoding, compression, preDelete] */
+  public static ViewExpression getViewExpression(ByteBuffer recBuf) {
+    int oriPos = recBuf.position();
+    recBuf.position(oriPos + VIEW_OFFSET);
+    return ViewExpression.deserialize(recBuf);
+  }
+
+  public static Boolean getAlignment(ByteBuffer recBuf) {
     int oriPos = recBuf.position();
     recBuf.position(oriPos + INTERNAL_BITFLAG_OFFSET);
     byte flag = ReadWriteIOUtils.readByte(recBuf);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/WrappedSegment.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/WrappedSegment.java
@@ -833,7 +833,7 @@ public class WrappedSegment implements ISegment<ByteBuffer, ICachedMNode> {
             String.format(
                 "(%s, %s, %s),",
                 pair.left,
-                    isAligned==null?"null":(RecordUtils.getAlignment(bufferR) ? "aligned" : "not_aligned"),
+                isAligned == null ? "null" : isAligned ? "aligned" : "not_aligned",
                 RecordUtils.getRecordSegAddr(bufferR) == -1
                     ? -1
                     : Long.toHexString(RecordUtils.getRecordSegAddr(bufferR))));
@@ -847,19 +847,16 @@ public class WrappedSegment implements ISegment<ByteBuffer, ICachedMNode> {
                 TSEncoding.values()[schemaBytes[1]],
                 CompressionType.deserialize(schemaBytes[2]),
                 RecordUtils.getRecordAlias(bufferR)));
-      } else if(RecordUtils.getRecordType(bufferR) == 5){
+      } else if (RecordUtils.getRecordType(bufferR) == 5) {
         int oriPos = bufferR.position();
         bufferR.position(oriPos + 3);
         long of = ReadWriteIOUtils.readLong(bufferR);
         boolean pred = ReadWriteIOUtils.readBool(bufferR);
-        ViewExpression viewExpression =  ViewExpression.deserialize(bufferR);
+        ViewExpression viewExpression = ViewExpression.deserialize(bufferR);
         // view
         builder.append(
-                String.format(
-                        "view(%s, %s, %s, %s),",
-                        pair.left,
-                        of,pred, viewExpression.toString()));
-      }else {
+            String.format("view(%s, %s, %s, %s),", pair.left, of, pred, viewExpression.toString()));
+      } else {
         throw new BufferUnderflowException();
       }
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/WrappedSegment.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/WrappedSegment.java
@@ -19,6 +19,7 @@
 package org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.pbtree.schemafile;
 
 import org.apache.iotdb.commons.exception.MetadataException;
+import org.apache.iotdb.commons.schema.view.viewExpression.ViewExpression;
 import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.db.exception.metadata.schemafile.ColossalRecordException;
 import org.apache.iotdb.db.exception.metadata.schemafile.RecordDuplicatedException;
@@ -827,11 +828,12 @@ public class WrappedSegment implements ISegment<ByteBuffer, ICachedMNode> {
     for (Pair<String, Short> pair : keyAddressList) {
       bufferR.position(pair.right + pair.left.getBytes().length + 4);
       if (RecordUtils.getRecordType(bufferR) == 0 || RecordUtils.getRecordType(bufferR) == 1) {
+        Boolean isAligned = RecordUtils.getAlignment(bufferR);
         builder.append(
             String.format(
                 "(%s, %s, %s),",
                 pair.left,
-                RecordUtils.getAlignment(bufferR) ? "aligned" : "not_aligned",
+                    isAligned==null?"null":(RecordUtils.getAlignment(bufferR) ? "aligned" : "not_aligned"),
                 RecordUtils.getRecordSegAddr(bufferR) == -1
                     ? -1
                     : Long.toHexString(RecordUtils.getRecordSegAddr(bufferR))));
@@ -845,7 +847,19 @@ public class WrappedSegment implements ISegment<ByteBuffer, ICachedMNode> {
                 TSEncoding.values()[schemaBytes[1]],
                 CompressionType.deserialize(schemaBytes[2]),
                 RecordUtils.getRecordAlias(bufferR)));
-      } else {
+      } else if(RecordUtils.getRecordType(bufferR) == 5){
+        int oriPos = bufferR.position();
+        bufferR.position(oriPos + 3);
+        long of = ReadWriteIOUtils.readLong(bufferR);
+        boolean pred = ReadWriteIOUtils.readBool(bufferR);
+        ViewExpression viewExpression =  ViewExpression.deserialize(bufferR);
+        // view
+        builder.append(
+                String.format(
+                        "view(%s, %s, %s, %s),",
+                        pair.left,
+                        of,pred, viewExpression.toString()));
+      }else {
         throw new BufferUnderflowException();
       }
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/schema/PBTreeFileSketchTool.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/schema/PBTreeFileSketchTool.java
@@ -92,8 +92,6 @@ public class PBTreeFileSketchTool {
   }
 
   public static void main(String[] args) {
-    args = new String[] {"-f", "/Users/chenyanze/Downloads/pbtree.pst", "-o", "sketch_1.txt"};
-//    args = new String[] {"-f", "/Users/chenyanze/Downloads/pbtree1.pst", "-o", "sketch_2.txt"};
     Options options = createOptions();
     HelpFormatter hf = new HelpFormatter();
     hf.setOptionComparator(null);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/schema/PBTreeFileSketchTool.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/schema/PBTreeFileSketchTool.java
@@ -92,6 +92,8 @@ public class PBTreeFileSketchTool {
   }
 
   public static void main(String[] args) {
+    args = new String[] {"-f", "/Users/chenyanze/Downloads/pbtree.pst", "-o", "sketch_1.txt"};
+//    args = new String[] {"-f", "/Users/chenyanze/Downloads/pbtree1.pst", "-o", "sketch_2.txt"};
     Options options = createOptions();
     HelpFormatter hf = new HelpFormatter();
     hf.setOptionComparator(null);
@@ -119,7 +121,7 @@ public class PBTreeFileSketchTool {
       parseBasicParams(commandLine);
       sketchFile(inputFile, outputFile);
     } catch (Exception e) {
-      logger.error("Encounter an error, because: {} ", e.getMessage());
+      logger.error("Encounter an error, because: {} ", e.getMessage(), e);
     }
   }
 


### PR DESCRIPTION
## Description

PBTreeSketchTool support view

E.g
```
=============================
== PBTree File Sketch Tool ==
=============================
== Notice: 
==  Internal/Entity presents as (name, is_aligned, child_segment_address)
==  Measurement presents as (name, data_type, encoding, compressor, alias_if_exist)
=============================
Belong to StorageGroup: [NOT SPECIFIED], segment of SG:0, total pages:2
---------------------
page_id:0, total_seg:1, spare_from:16382, spare_size:0
seg_id:0, offset:32, address:0, next_seg:-1, [length: 16350, total_records: 1, spare_size:16295,(datatest, null, 10000),]

---------------------
page_id:1, total_seg:2, spare_from:218, spare_size:16162
seg_id:0, offset:32, address:10000, next_seg:-1, [length: 79, total_records: 1, spare_size:0,(0000765110de42ae8a84eaf2a8fd042f, null, 10001),]
seg_id:1, offset:111, address:10001, next_seg:-1, [length: 107, total_records: 1, spare_size:0,view(data, -1, false, root.db.datatest.0000765110de42ae8a84eaf2a8fd042f.data),]

```