### PR TITLE
Optimize dispatch log printing in the Readonly scenario

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/FragmentInstanceDispatcherImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/FragmentInstanceDispatcherImpl.java
@@ -389,10 +389,13 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
         RegionWriteExecutor writeExecutor = new RegionWriteExecutor();
         RegionExecutionResult writeResult = writeExecutor.execute(groupId, planNode);
         if (!writeResult.isAccepted()) {
-          logger.warn(
-              "write locally failed. TSStatus: {}, message: {}",
-              writeResult.getStatus(),
-              writeResult.getMessage());
+          // DO NOT LOG READ_ONLY ERROR
+          if (writeResult.getStatus().getCode() != TSStatusCode.SYSTEM_READ_ONLY.getStatusCode()) {
+            logger.warn(
+                "write locally failed. TSStatus: {}, message: {}",
+                writeResult.getStatus(),
+                writeResult.getMessage());
+          }
           if (writeResult.getStatus() == null) {
             throw new FragmentInstanceDispatchException(
                 RpcUtils.getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR, writeResult.getMessage()));


### PR DESCRIPTION
![img_v3_0271_49528a2e-3aa0-46ca-997f-188533d28a2g](https://github.com/apache/iotdb/assets/32640567/72ad226d-4bbb-42da-b893-75e0521d2320)
