### PR TITLE
Clear useless query resource ASAP

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/driver/DataDriver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/driver/DataDriver.java
@@ -103,6 +103,7 @@ public class DataDriver extends Driver {
 
       this.init = true;
     } finally {
+      ((DataDriverContext) driverContext).clearSourceOperators();
       QUERY_EXECUTION_METRICS.recordExecutionCost(
           QUERY_RESOURCE_INIT, System.nanoTime() - startTime);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/driver/DataDriverContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/driver/DataDriverContext.java
@@ -31,8 +31,10 @@ import java.util.List;
 
 public class DataDriverContext extends DriverContext {
 
-  private final List<PartialPath> paths;
-  private final List<DataSourceOperator> sourceOperators;
+  // it will be set to null, after being merged into Parent FIContext
+  private List<PartialPath> paths;
+  // it will be set to null, after QueryDataSource being inited
+  private List<DataSourceOperator> sourceOperators;
 
   public DataDriverContext(FragmentInstanceContext fragmentInstanceContext, int pipelineId) {
     super(fragmentInstanceContext, pipelineId);
@@ -58,6 +60,11 @@ public class DataDriverContext extends DriverContext {
     return paths;
   }
 
+  public void clearPaths() {
+    // friendly for gc
+    paths = null;
+  }
+
   public IDataRegionForQuery getDataRegion() {
     return getFragmentInstanceContext().getDataRegion();
   }
@@ -68,6 +75,11 @@ public class DataDriverContext extends DriverContext {
 
   public List<DataSourceOperator> getSourceOperators() {
     return sourceOperators;
+  }
+
+  public void clearSourceOperators() {
+    // friendly for gc
+    sourceOperators = null;
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceContext.java
@@ -61,6 +61,8 @@ public class FragmentInstanceContext extends QueryContext {
 
   private IDataRegionForQuery dataRegion;
   private Filter globalTimeFilter;
+
+  // it will only be used once, after sharedQueryDataSource being inited, it will be set to null
   private List<PartialPath> sourcePaths;
   // Shared by all scan operators in this fragment instance to avoid memory problem
   private QueryDataSource sharedQueryDataSource;
@@ -361,6 +363,8 @@ public class FragmentInstanceContext extends QueryContext {
   public synchronized QueryDataSource getSharedQueryDataSource() throws QueryProcessException {
     if (sharedQueryDataSource == null) {
       initQueryDataSource(sourcePaths);
+      // friendly for gc
+      sourcePaths = null;
     }
     return sharedQueryDataSource;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/QueryExecution.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/QueryExecution.java
@@ -233,6 +233,9 @@ public class QueryExecution implements IQueryExecution {
     PERFORMANCE_OVERVIEW_METRICS.recordPlanCost(System.nanoTime() - startTime);
     schedule();
 
+    // friendly for gc
+    logicalPlan.clearUselessMemory();
+
     // set partial insert error message
     // When some columns in one insert failed, other column will continue executing insertion.
     // The error message should be return to client, therefore we need to set it after the insertion

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LocalExecutionPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LocalExecutionPlanner.java
@@ -171,8 +171,11 @@ public class LocalExecutionPlanner {
     context
         .getPipelineDriverFactories()
         .forEach(
-            pipeline ->
-                sourcePaths.addAll(((DataDriverContext) pipeline.getDriverContext()).getPaths()));
+            pipeline -> {
+              DataDriverContext dataDriverContext = (DataDriverContext) pipeline.getDriverContext();
+              sourcePaths.addAll(dataDriverContext.getPaths());
+              dataDriverContext.clearPaths();
+            });
     return sourcePaths;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/LogicalQueryPlan.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/LogicalQueryPlan.java
@@ -28,7 +28,7 @@ import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNode;
 public class LogicalQueryPlan {
 
   private final MPPQueryContext context;
-  private final PlanNode rootNode;
+  private PlanNode rootNode;
 
   public LogicalQueryPlan(MPPQueryContext context, PlanNode rootNode) {
     this.context = context;
@@ -41,5 +41,9 @@ public class LogicalQueryPlan {
 
   public MPPQueryContext getContext() {
     return context;
+  }
+
+  public void clearUselessMemory() {
+    rootNode = null;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/PlanFragment.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/PlanFragment.java
@@ -196,6 +196,11 @@ public class PlanFragment {
     return root;
   }
 
+  public void clearUselessField() {
+    planNodeTree = null;
+    typeProvider = null;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/FragmentInstanceDispatcherImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/FragmentInstanceDispatcherImpl.java
@@ -131,6 +131,9 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
                 RpcUtils.getStatus(
                     TSStatusCode.INTERNAL_SERVER_ERROR, UNEXPECTED_ERRORS + t.getMessage())));
       } finally {
+        // friendly for gc, clear the plan node tree, for some queries select all devices, it will
+        // release lots of memory
+        instance.getFragment().clearUselessField();
         QUERY_EXECUTION_METRIC_SET.recordExecutionCost(
             DISPATCH_READ, System.nanoTime() - startTime);
       }


### PR DESCRIPTION
In some big query, like select * from root.db.** that query all devices.

1. the query plan will be memory-consuming and actually LogicalPlan and DistributionPlan is useless now after we dispatch all FIs.

2. these queries' Physical Operator Tree will also be very large and we need to set to null as soon as possible. And in most operators (like TopKOperator),  we've already done that, we will set i-th child to null if we detect there will be no data for that child. However, I found that we still save all SourceOperators in DataDriverContext which just used for initializing `QueryDataSource`. So we should set them to null after `QueryDataSource` being initialized.