### PR TITLE
Fix index out of bounds exception in seq inner compaction

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/MultiTsFileDeviceIterator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/MultiTsFileDeviceIterator.java
@@ -373,6 +373,10 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
   private void applyModificationForAlignedChunkMetadataList(
       TsFileResource tsFileResource, List<AlignedChunkMetadata> alignedChunkMetadataList)
       throws IllegalPathException {
+    if (alignedChunkMetadataList.isEmpty()) {
+      // all the value chunks is empty chunk
+      return;
+    }
     ModificationFile modificationFile = ModificationFile.getNormalMods(tsFileResource);
     if (!modificationFile.exists()) {
       return;

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/AlignedTimeSeriesMetadata.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/AlignedTimeSeriesMetadata.java
@@ -155,6 +155,7 @@ public class AlignedTimeSeriesMetadata implements ITimeSeriesMetadata {
     return getAlignedChunkMetadata(timeChunkMetadata, valueChunkMetadataList);
   }
 
+  /** Notice: if all the value chunks is empty chunk, then return empty list. */
   private List<AlignedChunkMetadata> getAlignedChunkMetadata(
       List<IChunkMetadata> timeChunkMetadata, List<List<IChunkMetadata>> valueChunkMetadataList) {
     List<AlignedChunkMetadata> res = new ArrayList<>();

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReader.java
@@ -2078,7 +2078,8 @@ public class TsFileSequenceReader implements AutoCloseable {
   }
 
   /**
-   * Get AlignedChunkMetadata of sensors under one device
+   * Get AlignedChunkMetadata of sensors under one device. Notice: if all the value chunks is empty
+   * chunk, then return empty list.
    *
    * @param device device name
    */


### PR DESCRIPTION
Fix indexOutOfBounds exception with all empty value chunk of one aligned device in seq inner compaction.

![image-2024-01-15-09-53-42-596](https://github.com/apache/iotdb/assets/45144903/059a2964-56e8-4da3-9478-4f8221767270)

