### PR TITLE
Fix ConcurrentModificationException when evict time partition info

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -3398,7 +3398,12 @@ public class DataRegion implements IDataRegionForQuery {
   }
 
   public void releaseFlushTimeMap(long timePartitionId) {
-    lastFlushTimeMap.removePartition(timePartitionId);
+    writeLock("releaseFlushTimeMap");
+    try {
+      lastFlushTimeMap.removePartition(timePartitionId);
+    } finally {
+      writeUnlock();
+    }
   }
 
   public long getMemCost() {


### PR DESCRIPTION
## Description

When concurrently insert data of multiple time partitions, there may be a error appeared. 
![img_v3_0270_15e18945-c5d0-47d9-9bf5-447bc5bf62eg](https://github.com/apache/iotdb/assets/25913899/96b384b6-3b84-4e37-bd3d-8d1e6e8cfeb6)

The reason of this bug is when call releaseFlushTimeMap by the client thread of another dataRegion, a writeLock should be get first.

