### PR TITLE
Enable SchemaRegion Leader Auto Balance

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
@@ -192,7 +192,7 @@ public class ConfigNodeConfig {
   private String leaderDistributionPolicy = ILeaderBalancer.MIN_COST_FLOW_POLICY;
 
   /** Whether to enable auto leader balance for Ratis consensus protocol. */
-  private boolean enableAutoLeaderBalanceForRatisConsensus = false;
+  private boolean enableAutoLeaderBalanceForRatisConsensus = true;
 
   /** Whether to enable auto leader balance for IoTConsensus protocol. */
   private boolean enableAutoLeaderBalanceForIoTConsensus = true;

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -139,7 +139,7 @@ data_replication_factor=1
 # The ConfigNode-leader will balance the leader of Ratis-RegionGroups by leader_distribution_policy if set true.
 # Notice: Default is false because the Ratis is unstable for this function.
 # Datatype: Boolean
-# enable_auto_leader_balance_for_ratis_consensus=false
+# enable_auto_leader_balance_for_ratis_consensus=true
 
 # Whether to enable auto leader balance for IoTConsensus protocol.
 # The ConfigNode-leader will balance the leader of IoTConsensus-RegionGroups by leader_distribution_policy if set true.


### PR DESCRIPTION
The stability of the migration Leader has been significantly improved after Ratis 3.0 was integrated. We plan to turn on automatic balancing of Schema Region Leader in version 1.3.2 to make the load more even in scenarios with more schema regions. We only need to change one of the default parameters.