### PR TITLE
Fix the issue where ConfigNode reports 'ConsensusGroupAlreadyExist' error during startup in some scenarios

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -426,11 +426,11 @@ class RatisConsensus implements IConsensus {
   public void createLocalPeer(ConsensusGroupId groupId, List<Peer> peers)
       throws ConsensusException {
     RaftGroup group = buildRaftGroup(groupId, peers);
-    RaftGroup clientGroup =
-        group.getPeers().isEmpty() ? RaftGroup.valueOf(group.getGroupId(), myself) : group;
-    try (RatisClient client = getRaftClient(clientGroup)) {
+    try {
       RaftClientReply reply =
-          client.getRaftClient().getGroupManagementApi(myself.getId()).add(group, true);
+          server.groupManagement(
+              GroupManagementRequest.newAdd(
+                  localFakeId, myself.getId(), localFakeCallId.incrementAndGet(), group, true));
       if (!reply.isSuccess()) {
         throw new RatisRequestFailedException(reply.getException());
       }


### PR DESCRIPTION
![img_v3_0277_e93e2168-74f4-4e9c-a2fc-8ffb2325c43g](https://github.com/apache/iotdb/assets/32640567/d9c8f837-54f7-489d-a8a2-9966d7b544fc)

In some operating systems, creating a consensus group takes longer than the default ratis client timeout of 10 seconds, so the current method of using RaftClient to create a consensus group locally will trigger a retry, resulting in a log error.

This PR solves the problem by changing RPC to LPC