### PR TITLE
Change partial aggregation symbols for variance and standard deviation aggregators.

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/AggregationUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/AggregationUtil.java
@@ -56,6 +56,8 @@ public class AggregationUtil {
 
   private static final int INVALID_END_TIME = -1;
 
+  private static final String PARTIAL_SUFFIX = "_partial";
+
   private AggregationUtil() {
     // Forbidding instantiation
   }
@@ -253,5 +255,9 @@ public class AggregationUtil {
       default:
         throw new UnsupportedOperationException("Unknown data type " + tsDataType);
     }
+  }
+
+  public static String addPartialSuffix(String aggregationName) {
+    return aggregationName + PARTIAL_SUFFIX;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LogicalPlanBuilder.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LogicalPlanBuilder.java
@@ -697,29 +697,27 @@ public class LogicalPlanBuilder {
 
   public static void updateTypeProviderByPartialAggregation(
       AggregationDescriptor aggregationDescriptor, TypeProvider typeProvider) {
-    List<TAggregationType> splitAggregations =
+    List<String> partialAggregationsNames =
         SchemaUtils.splitPartialAggregation(aggregationDescriptor.getAggregationType());
     String inputExpressionStr =
         aggregationDescriptor.getInputExpressions().get(0).getExpressionString();
-    for (TAggregationType aggregation : splitAggregations) {
-      String functionName = aggregation.toString().toLowerCase();
-      TSDataType aggregationType = SchemaUtils.getAggregationType(functionName);
+    for (String partialAggregationName : partialAggregationsNames) {
+      TSDataType aggregationType = SchemaUtils.getAggregationType(partialAggregationName);
       typeProvider.setType(
-          String.format("%s(%s)", functionName, inputExpressionStr),
-          aggregationType == null ? typeProvider.getType(inputExpressionStr) : aggregationType);
+          String.format("%s(%s)", partialAggregationName, inputExpressionStr),
+          aggregationType == null ? TSDataType.TEXT : aggregationType);
     }
   }
 
   public static void updateTypeProviderByPartialAggregation(
       CrossSeriesAggregationDescriptor aggregationDescriptor, TypeProvider typeProvider) {
-    List<TAggregationType> splitAggregations =
-        SchemaUtils.splitPartialAggregation(aggregationDescriptor.getAggregationType());
+    List<String> partialAggregationsNames =
+            SchemaUtils.splitPartialAggregation(aggregationDescriptor.getAggregationType());
     PartialPath path = ((TimeSeriesOperand) aggregationDescriptor.getOutputExpression()).getPath();
-    for (TAggregationType aggregationType : splitAggregations) {
-      String functionName = aggregationType.toString().toLowerCase();
+    for (String partialAggregationName : partialAggregationsNames) {
       typeProvider.setType(
-          String.format("%s(%s)", functionName, path.getFullPath()),
-          SchemaUtils.getSeriesTypeByPath(path, functionName));
+          String.format("%s(%s)", partialAggregationName, path.getFullPath()),
+          SchemaUtils.getSeriesTypeByPath(path, partialAggregationName));
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LogicalPlanBuilder.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LogicalPlanBuilder.java
@@ -19,7 +19,6 @@
 
 package org.apache.iotdb.db.queryengine.plan.planner;
 
-import org.apache.iotdb.common.rpc.thrift.TAggregationType;
 import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
 import org.apache.iotdb.common.rpc.thrift.TSchemaNode;
 import org.apache.iotdb.commons.exception.IllegalPathException;
@@ -712,7 +711,7 @@ public class LogicalPlanBuilder {
   public static void updateTypeProviderByPartialAggregation(
       CrossSeriesAggregationDescriptor aggregationDescriptor, TypeProvider typeProvider) {
     List<String> partialAggregationsNames =
-            SchemaUtils.splitPartialAggregation(aggregationDescriptor.getAggregationType());
+        SchemaUtils.splitPartialAggregation(aggregationDescriptor.getAggregationType());
     PartialPath path = ((TimeSeriesOperand) aggregationDescriptor.getOutputExpression()).getPath();
     for (String partialAggregationName : partialAggregationsNames) {
       typeProvider.setType(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/parameter/AggregationDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/parameter/AggregationDescriptor.java
@@ -146,22 +146,22 @@ public class AggregationDescriptor {
           outputAggregationNames.add(SqlConstant.MIN_TIME);
           break;
         case STDDEV:
-          outputAggregationNames.add(SqlConstant.STDDEV);
+          outputAggregationNames.add(SqlConstant.STDDEV + "_partial");
           break;
         case STDDEV_POP:
-          outputAggregationNames.add(SqlConstant.STDDEV_POP);
+          outputAggregationNames.add(SqlConstant.STDDEV_POP + "_partial");
           break;
         case STDDEV_SAMP:
-          outputAggregationNames.add(SqlConstant.STDDEV_SAMP);
+          outputAggregationNames.add(SqlConstant.STDDEV_SAMP + "_partial");
           break;
         case VARIANCE:
-          outputAggregationNames.add(SqlConstant.VARIANCE);
+          outputAggregationNames.add(SqlConstant.VARIANCE + "_partial");
           break;
         case VAR_POP:
-          outputAggregationNames.add(SqlConstant.VAR_POP);
+          outputAggregationNames.add(SqlConstant.VAR_POP + "_partial");
           break;
         case VAR_SAMP:
-          outputAggregationNames.add(SqlConstant.VAR_SAMP);
+          outputAggregationNames.add(SqlConstant.VAR_SAMP + "_partial");
           break;
         default:
           outputAggregationNames.add(aggregationFuncName);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/parameter/AggregationDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/parameter/AggregationDescriptor.java
@@ -35,6 +35,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.apache.iotdb.db.queryengine.execution.operator.AggregationUtil.addPartialSuffix;
+
 public class AggregationDescriptor {
 
   // aggregation function type
@@ -146,22 +148,22 @@ public class AggregationDescriptor {
           outputAggregationNames.add(SqlConstant.MIN_TIME);
           break;
         case STDDEV:
-          outputAggregationNames.add(SqlConstant.STDDEV + "_partial");
+          outputAggregationNames.add(addPartialSuffix(SqlConstant.STDDEV));
           break;
         case STDDEV_POP:
-          outputAggregationNames.add(SqlConstant.STDDEV_POP + "_partial");
+          outputAggregationNames.add(addPartialSuffix(SqlConstant.STDDEV_POP));
           break;
         case STDDEV_SAMP:
-          outputAggregationNames.add(SqlConstant.STDDEV_SAMP + "_partial");
+          outputAggregationNames.add(addPartialSuffix(SqlConstant.STDDEV_SAMP));
           break;
         case VARIANCE:
-          outputAggregationNames.add(SqlConstant.VARIANCE + "_partial");
+          outputAggregationNames.add(addPartialSuffix(SqlConstant.VARIANCE));
           break;
         case VAR_POP:
-          outputAggregationNames.add(SqlConstant.VAR_POP + "_partial");
+          outputAggregationNames.add(addPartialSuffix(SqlConstant.VAR_POP));
           break;
         case VAR_SAMP:
-          outputAggregationNames.add(SqlConstant.VAR_SAMP + "_partial");
+          outputAggregationNames.add(addPartialSuffix(SqlConstant.VAR_SAMP));
           break;
         default:
           outputAggregationNames.add(aggregationFuncName);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/SchemaUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/SchemaUtils.java
@@ -137,7 +137,7 @@ public class SchemaUtils {
       case SqlConstant.MAX_VALUE:
       case SqlConstant.MODE:
       default:
-        return null;
+        return TSDataType.TEXT;
     }
   }
 
@@ -184,28 +184,28 @@ public class SchemaUtils {
     }
   }
 
-  public static List<TAggregationType> splitPartialAggregation(TAggregationType aggregationType) {
+  public static List<String> splitPartialAggregation(TAggregationType aggregationType) {
     switch (aggregationType) {
       case FIRST_VALUE:
-        return Collections.singletonList(TAggregationType.MIN_TIME);
+        return Collections.singletonList(SqlConstant.MIN_TIME);
       case LAST_VALUE:
-        return Collections.singletonList(TAggregationType.MAX_TIME);
+        return Collections.singletonList(SqlConstant.MAX_TIME);
       case STDDEV:
-        return Collections.singletonList(TAggregationType.STDDEV);
+        return Collections.singletonList(SqlConstant.STDDEV + "_partial");
       case STDDEV_POP:
-        return Collections.singletonList(TAggregationType.STDDEV_POP);
+        return Collections.singletonList(SqlConstant.STDDEV_POP + "_partial");
       case STDDEV_SAMP:
-        return Collections.singletonList(TAggregationType.STDDEV_SAMP);
+        return Collections.singletonList(SqlConstant.STDDEV_SAMP + "_partial");
       case VARIANCE:
-        return Collections.singletonList(TAggregationType.VARIANCE);
+        return Collections.singletonList(SqlConstant.VARIANCE + "_partial");
       case VAR_POP:
-        return Collections.singletonList(TAggregationType.VAR_POP);
+        return Collections.singletonList(SqlConstant.VAR_POP + "_partial");
       case VAR_SAMP:
-        return Collections.singletonList(TAggregationType.VAR_SAMP);
+        return Collections.singletonList(SqlConstant.VAR_SAMP + "_partial");
       case AVG:
-        return Arrays.asList(TAggregationType.COUNT, TAggregationType.SUM);
+        return Arrays.asList(SqlConstant.COUNT, SqlConstant.SUM);
       case TIME_DURATION:
-        return Arrays.asList(TAggregationType.MAX_TIME, TAggregationType.MIN_TIME);
+        return Arrays.asList(SqlConstant.MAX_TIME, SqlConstant.MIN_TIME);
       case SUM:
       case MIN_VALUE:
       case MAX_VALUE:


### PR DESCRIPTION
## Description
IoTDB uses `TypeProvider` class to **identify type by given symbol**. And aggregators have two output types, one for partial output, another for final output.

In current variance and standard deviation aggregators, **the two types are different**. The partial output type is `TEXT` while the final output type is depend on user's input, which can be `INT`, `FLOAT` and so on.

However, current implementation outputs **same symbols** for both partial and final aggregators for variance and standard deviation. And this may cause some unexpected behavior like the final output type can be overrided by partial output type. 

This PR adds `_partial` suffix to partial output symbol in order to distinguish from final output symbol. Notice **there is no need to add new integration tests** for this scenario, since #11581 already add `GROUP BY LEVEL` in specific test file, which  
has covered this problem.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test IoTDB cluster.
