### PR TITLE
Add the ability for ClientManager to periodically clean up idle objects

### DIFF
--- a/iotdb-core/confignode/src/assembly/resources/conf/iotdb-confignode.properties
+++ b/iotdb-core/confignode/src/assembly/resources/conf/iotdb-confignode.properties
@@ -105,11 +105,6 @@ cn_seed_config_node=127.0.0.1:10710
 # Datatype: int
 # cn_selector_thread_nums_of_client_manager=1
 
-# The maximum number of clients that can be idle for a node in a clientManager.
-# When the number of idle clients on a node exceeds this number, newly returned clients will be released
-# Datatype: int
-# cn_core_client_count_for_each_node_in_client_manager=200
-
 # The maximum number of clients that can be allocated for a node in a clientManager.
 # when the number of the client to a single node exceeds this number, the thread for applying for a client will be blocked
 # for a while, then ClientManager will throw ClientManagerException if there are no clients after the block time.

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
@@ -126,12 +126,6 @@ public class ConfigNodeConfig {
   private int thriftServerAwaitTimeForStopService = 60;
 
   /**
-   * The maximum number of clients that can be idle for a node in a clientManager. When the number
-   * of idle clients on a node exceeds this number, newly returned clients will be released.
-   */
-  private int coreClientNumForEachNode = DefaultProperty.CORE_CLIENT_NUM_FOR_EACH_NODE;
-
-  /**
    * The maximum number of clients that can be allocated for a node in a clientManager. When the
    * number of the client to a single node exceeds this number, the thread for applying for a client
    * will be blocked for a while, then ClientManager will throw ClientManagerException if there are
@@ -449,15 +443,6 @@ public class ConfigNodeConfig {
 
   public void setCnThriftDefaultBufferSize(int thriftDefaultBufferSize) {
     this.thriftDefaultBufferSize = thriftDefaultBufferSize;
-  }
-
-  public int getCoreClientNumForEachNode() {
-    return coreClientNumForEachNode;
-  }
-
-  public ConfigNodeConfig setCoreClientNumForEachNode(int coreClientNumForEachNode) {
-    this.coreClientNumForEachNode = coreClientNumForEachNode;
-    return this;
   }
 
   public int getMaxClientNumForEachNode() {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
@@ -316,14 +316,6 @@ public class ConfigNodeDescriptor {
                     "cn_thrift_max_frame_size", String.valueOf(conf.getCnThriftMaxFrameSize()))
                 .trim()));
 
-    conf.setCoreClientNumForEachNode(
-        Integer.parseInt(
-            properties
-                .getProperty(
-                    "cn_core_client_count_for_each_node_in_client_manager",
-                    String.valueOf(conf.getCoreClientNumForEachNode()))
-                .trim()));
-
     conf.setMaxClientNumForEachNode(
         Integer.parseInt(
             properties

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/consensus/ConsensusManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/consensus/ConsensusManager.java
@@ -181,8 +181,6 @@ public class ConsensusManager {
                                           CONF.getConfigNodeRatisInitialSleepTimeMs())
                                       .setClientRetryMaxSleepTimeMs(
                                           CONF.getConfigNodeRatisMaxSleepTimeMs())
-                                      .setCoreClientNumForEachNode(
-                                          CONF.getCoreClientNumForEachNode())
                                       .setMaxClientNumForEachNode(CONF.getMaxClientNumForEachNode())
                                       .build())
                               .setImpl(

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/config/IoTConsensusConfig.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/config/IoTConsensusConfig.java
@@ -80,7 +80,6 @@ public class IoTConsensusConfig {
 
     private final boolean printLogWhenThriftClientEncounterException;
     private final int thriftMaxFrameSize;
-    private final int coreClientNumForEachNode;
     private final int maxClientNumForEachNode;
 
     private RPC(
@@ -93,7 +92,6 @@ public class IoTConsensusConfig {
         int connectionTimeoutInMs,
         boolean printLogWhenThriftClientEncounterException,
         int thriftMaxFrameSize,
-        int coreClientNumForEachNode,
         int maxClientNumForEachNode) {
       this.rpcSelectorThreadNum = rpcSelectorThreadNum;
       this.rpcMinConcurrentClientNum = rpcMinConcurrentClientNum;
@@ -104,7 +102,6 @@ public class IoTConsensusConfig {
       this.connectionTimeoutInMs = connectionTimeoutInMs;
       this.printLogWhenThriftClientEncounterException = printLogWhenThriftClientEncounterException;
       this.thriftMaxFrameSize = thriftMaxFrameSize;
-      this.coreClientNumForEachNode = coreClientNumForEachNode;
       this.maxClientNumForEachNode = maxClientNumForEachNode;
     }
 
@@ -144,10 +141,6 @@ public class IoTConsensusConfig {
       return thriftMaxFrameSize;
     }
 
-    public int getCoreClientNumForEachNode() {
-      return coreClientNumForEachNode;
-    }
-
     public int getMaxClientNumForEachNode() {
       return maxClientNumForEachNode;
     }
@@ -168,9 +161,6 @@ public class IoTConsensusConfig {
 
       private boolean printLogWhenThriftClientEncounterException = true;
       private int thriftMaxFrameSize = 536870912;
-
-      private int coreClientNumForEachNode = DefaultProperty.CORE_CLIENT_NUM_FOR_EACH_NODE;
-
       private int maxClientNumForEachNode = DefaultProperty.MAX_CLIENT_NUM_FOR_EACH_NODE;
 
       public RPC.Builder setRpcSelectorThreadNum(int rpcSelectorThreadNum) {
@@ -221,11 +211,6 @@ public class IoTConsensusConfig {
         return this;
       }
 
-      public RPC.Builder setCoreClientNumForEachNode(int coreClientNumForEachNode) {
-        this.coreClientNumForEachNode = coreClientNumForEachNode;
-        return this;
-      }
-
       public Builder setMaxClientNumForEachNode(int maxClientNumForEachNode) {
         this.maxClientNumForEachNode = maxClientNumForEachNode;
         return this;
@@ -242,7 +227,6 @@ public class IoTConsensusConfig {
             connectionTimeoutInMs,
             printLogWhenThriftClientEncounterException,
             thriftMaxFrameSize,
-            coreClientNumForEachNode,
             maxClientNumForEachNode);
       }
     }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/config/RatisConfig.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/config/RatisConfig.java
@@ -821,7 +821,6 @@ public class RatisConfig {
     private final int clientMaxRetryAttempt;
     private final long clientRetryInitialSleepTimeMs;
     private final long clientRetryMaxSleepTimeMs;
-    private final int coreClientNumForEachNode;
     private final int maxClientNumForEachNode;
 
     public Client(
@@ -829,13 +828,11 @@ public class RatisConfig {
         int clientMaxRetryAttempt,
         long clientRetryInitialSleepTimeMs,
         long clientRetryMaxSleepTimeMs,
-        int coreClientNumForEachNode,
         int maxClientNumForEachNode) {
       this.clientRequestTimeoutMillis = clientRequestTimeoutMillis;
       this.clientMaxRetryAttempt = clientMaxRetryAttempt;
       this.clientRetryInitialSleepTimeMs = clientRetryInitialSleepTimeMs;
       this.clientRetryMaxSleepTimeMs = clientRetryMaxSleepTimeMs;
-      this.coreClientNumForEachNode = coreClientNumForEachNode;
       this.maxClientNumForEachNode = maxClientNumForEachNode;
     }
 
@@ -855,10 +852,6 @@ public class RatisConfig {
       return clientRetryMaxSleepTimeMs;
     }
 
-    public int getCoreClientNumForEachNode() {
-      return coreClientNumForEachNode;
-    }
-
     public int getMaxClientNumForEachNode() {
       return maxClientNumForEachNode;
     }
@@ -873,9 +866,6 @@ public class RatisConfig {
       private int clientMaxRetryAttempt = 10;
       private long clientRetryInitialSleepTimeMs = 100;
       private long clientRetryMaxSleepTimeMs = 10000;
-
-      private int coreClientNumForEachNode = DefaultProperty.CORE_CLIENT_NUM_FOR_EACH_NODE;
-
       private int maxClientNumForEachNode = DefaultProperty.MAX_CLIENT_NUM_FOR_EACH_NODE;
 
       public Client build() {
@@ -884,7 +874,6 @@ public class RatisConfig {
             clientMaxRetryAttempt,
             clientRetryInitialSleepTimeMs,
             clientRetryMaxSleepTimeMs,
-            coreClientNumForEachNode,
             maxClientNumForEachNode);
       }
 
@@ -905,11 +894,6 @@ public class RatisConfig {
 
       public Builder setClientRetryMaxSleepTimeMs(long clientRetryMaxSleepTimeMs) {
         this.clientRetryMaxSleepTimeMs = clientRetryMaxSleepTimeMs;
-        return this;
-      }
-
-      public Builder setCoreClientNumForEachNode(int coreClientNumForEachNode) {
-        this.coreClientNumForEachNode = coreClientNumForEachNode;
         return this;
       }
 

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/client/IoTConsensusClientPool.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/client/IoTConsensusClientPool.java
@@ -65,7 +65,6 @@ public class IoTConsensusClientPool {
                           config.getRpc().isPrintLogWhenThriftClientEncounterException())
                       .build()),
               new ClientPoolProperty.Builder<SyncIoTConsensusServiceClient>()
-                  .setCoreClientNumForEachNode(config.getRpc().getCoreClientNumForEachNode())
                   .setMaxClientNumForEachNode(config.getRpc().getMaxClientNumForEachNode())
                   .build()
                   .getConfig());
@@ -105,7 +104,6 @@ public class IoTConsensusClientPool {
                       .build(),
                   ThreadName.ASYNC_DATANODE_IOT_CONSENSUS_CLIENT_POOL.getName()),
               new ClientPoolProperty.Builder<AsyncIoTConsensusServiceClient>()
-                  .setCoreClientNumForEachNode(config.getRpc().getCoreClientNumForEachNode())
                   .setMaxClientNumForEachNode(config.getRpc().getMaxClientNumForEachNode())
                   .build()
                   .getConfig());

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -796,7 +796,6 @@ class RatisConsensus implements IConsensus {
           new GenericKeyedObjectPool<>(
               new RatisClient.Factory(manager, properties, clientRpc, config.getClient()),
               new ClientPoolProperty.Builder<RatisClient>()
-                  .setCoreClientNumForEachNode(config.getClient().getCoreClientNumForEachNode())
                   .setMaxClientNumForEachNode(config.getClient().getMaxClientNumForEachNode())
                   .build()
                   .getConfig());

--- a/iotdb-core/datanode/src/assembly/resources/conf/iotdb-datanode.properties
+++ b/iotdb-core/datanode/src/assembly/resources/conf/iotdb-datanode.properties
@@ -132,11 +132,6 @@ dn_seed_config_node=127.0.0.1:10710
 # Datatype: int
 # dn_selector_thread_count_of_client_manager=1
 
-# The maximum number of clients that can be idle for a node in a clientManager.
-# When the number of idle clients on a node exceeds this number, newly returned clients will be released
-# Datatype: int
-# dn_core_client_count_for_each_node_in_client_manager=200
-
 # The maximum number of clients that can be allocated for a node in a clientManager.
 # When the number of the client to a single node exceeds this number, the thread for applying for a client will be blocked
 # for a while, then ClientManager will throw ClientManagerException if there are no clients after the block time.

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -933,12 +933,6 @@ public class IoTDBConfig {
           : 1;
 
   /**
-   * The maximum number of clients that can be idle for a node in a clientManager. When the number
-   * of idle clients on a node exceeds this number, newly returned clients will be released
-   */
-  private int coreClientNumForEachNode = DefaultProperty.CORE_CLIENT_NUM_FOR_EACH_NODE;
-
-  /**
    * The maximum number of clients that can be allocated for a node in a clientManager. When the
    * number of the client to a single node exceeds this number, the thread for applying for a client
    * will be blocked for a while, then ClientManager will throw ClientManagerException if there are
@@ -3041,14 +3035,6 @@ public class IoTDBConfig {
 
   public void setMaxClientNumForEachNode(int maxClientNumForEachNode) {
     this.maxClientNumForEachNode = maxClientNumForEachNode;
-  }
-
-  public int getCoreClientNumForEachNode() {
-    return coreClientNumForEachNode;
-  }
-
-  public void setCoreClientNumForEachNode(int coreClientNumForEachNode) {
-    this.coreClientNumForEachNode = coreClientNumForEachNode;
   }
 
   public int getSelectorNumOfClientManager() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -241,21 +241,6 @@ public class IoTDBDescriptor {
                     "dn_connection_timeout_ms", String.valueOf(conf.getConnectionTimeoutInMS()))
                 .trim()));
 
-    if (properties.getProperty("dn_core_connection_for_internal_service", null) != null) {
-      conf.setCoreClientNumForEachNode(
-          Integer.parseInt(
-              properties.getProperty("dn_core_connection_for_internal_service").trim()));
-      LOGGER.warn(
-          "The parameter dn_core_connection_for_internal_service is out of date. Please rename it to dn_core_client_count_for_each_node_in_client_manager.");
-    }
-    conf.setCoreClientNumForEachNode(
-        Integer.parseInt(
-            properties
-                .getProperty(
-                    "dn_core_client_count_for_each_node_in_client_manager",
-                    String.valueOf(conf.getCoreClientNumForEachNode()))
-                .trim()));
-
     if (properties.getProperty("dn_max_connection_for_internal_service", null) != null) {
       conf.setMaxClientNumForEachNode(
           Integer.parseInt(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/DataRegionConsensusImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/DataRegionConsensusImpl.java
@@ -86,7 +86,6 @@ public class DataRegionConsensusImpl {
                                     .setThriftServerAwaitTimeForStopService(
                                         CONF.getThriftServerAwaitTimeForStopService())
                                     .setThriftMaxFrameSize(CONF.getThriftMaxFrameSize())
-                                    .setCoreClientNumForEachNode(CONF.getCoreClientNumForEachNode())
                                     .setMaxClientNumForEachNode(CONF.getMaxClientNumForEachNode())
                                     .build())
                             .setReplication(
@@ -167,7 +166,6 @@ public class DataRegionConsensusImpl {
                                         CONF.getDataRatisConsensusInitialSleepTimeMs())
                                     .setClientRetryMaxSleepTimeMs(
                                         CONF.getDataRatisConsensusMaxSleepTimeMs())
-                                    .setCoreClientNumForEachNode(CONF.getCoreClientNumForEachNode())
                                     .setMaxClientNumForEachNode(CONF.getMaxClientNumForEachNode())
                                     .build())
                             .setImpl(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/SchemaRegionConsensusImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/SchemaRegionConsensusImpl.java
@@ -128,7 +128,6 @@ public class SchemaRegionConsensusImpl {
                                         CONF.getDataRatisConsensusInitialSleepTimeMs())
                                     .setClientRetryMaxSleepTimeMs(
                                         CONF.getDataRatisConsensusMaxSleepTimeMs())
-                                    .setCoreClientNumForEachNode(CONF.getCoreClientNumForEachNode())
                                     .setMaxClientNumForEachNode(CONF.getMaxClientNumForEachNode())
                                     .build())
                             .setImpl(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/client/DataNodeClientPoolFactory.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/client/DataNodeClientPoolFactory.java
@@ -54,7 +54,6 @@ public class DataNodeClientPoolFactory {
                       .setRpcThriftCompressionEnabled(conf.isRpcThriftCompressionEnable())
                       .build()),
               new ClientPoolProperty.Builder<ConfigNodeClient>()
-                  .setCoreClientNumForEachNode(conf.getCoreClientNumForEachNode())
                   .setMaxClientNumForEachNode(conf.getMaxClientNumForEachNode())
                   .build()
                   .getConfig());
@@ -83,7 +82,6 @@ public class DataNodeClientPoolFactory {
                               : 1)
                       .build()),
               new ClientPoolProperty.Builder<ConfigNodeClient>()
-                  .setCoreClientNumForEachNode(conf.getCoreClientNumForEachNode())
                   .setMaxClientNumForEachNode(conf.getMaxClientNumForEachNode())
                   .build()
                   .getConfig());

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -955,9 +955,6 @@ data_replication_factor=1
 # Recommend to set this value to less than or equal to pipe_sink_max_client_number.
 # pipe_sink_selector_number=8
 
-# The core number of clients that can be used in the sink.
-# pipe_sink_core_client_number=8
-
 # The maximum number of clients that can be used in the sink.
 # pipe_sink_max_client_number=16
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/ClientPoolFactory.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/ClientPoolFactory.java
@@ -57,8 +57,6 @@ public class ClientPoolFactory {
                       .setRpcThriftCompressionEnabled(conf.isRpcThriftCompressionEnabled())
                       .build()),
               new ClientPoolProperty.Builder<SyncConfigNodeIServiceClient>()
-                  .setCoreClientNumForEachNode(conf.getCoreClientNumForEachNode())
-                  .setMaxClientNumForEachNode(conf.getMaxClientNumForEachNode())
                   .build()
                   .getConfig());
       ClientManagerMetrics.getInstance()
@@ -84,8 +82,6 @@ public class ClientPoolFactory {
                       .build(),
                   ThreadName.ASYNC_CONFIGNODE_CLIENT_POOL.getName()),
               new ClientPoolProperty.Builder<AsyncConfigNodeIServiceClient>()
-                  .setCoreClientNumForEachNode(conf.getCoreClientNumForEachNode())
-                  .setMaxClientNumForEachNode(conf.getMaxClientNumForEachNode())
                   .build()
                   .getConfig());
       ClientManagerMetrics.getInstance()
@@ -109,8 +105,6 @@ public class ClientPoolFactory {
                       .setRpcThriftCompressionEnabled(conf.isRpcThriftCompressionEnabled())
                       .build()),
               new ClientPoolProperty.Builder<SyncDataNodeInternalServiceClient>()
-                  .setCoreClientNumForEachNode(conf.getCoreClientNumForEachNode())
-                  .setMaxClientNumForEachNode(conf.getMaxClientNumForEachNode())
                   .build()
                   .getConfig());
       ClientManagerMetrics.getInstance()
@@ -136,8 +130,6 @@ public class ClientPoolFactory {
                       .build(),
                   ThreadName.ASYNC_DATANODE_CLIENT_POOL.getName()),
               new ClientPoolProperty.Builder<AsyncDataNodeInternalServiceClient>()
-                  .setCoreClientNumForEachNode(conf.getCoreClientNumForEachNode())
-                  .setMaxClientNumForEachNode(conf.getMaxClientNumForEachNode())
                   .build()
                   .getConfig());
       ClientManagerMetrics.getInstance()
@@ -165,8 +157,6 @@ public class ClientPoolFactory {
                       .build(),
                   ThreadName.ASYNC_CONFIGNODE_HEARTBEAT_CLIENT_POOL.getName()),
               new ClientPoolProperty.Builder<AsyncConfigNodeIServiceClient>()
-                  .setCoreClientNumForEachNode(conf.getCoreClientNumForEachNode())
-                  .setMaxClientNumForEachNode(conf.getMaxClientNumForEachNode())
                   .build()
                   .getConfig());
       ClientManagerMetrics.getInstance()
@@ -192,8 +182,6 @@ public class ClientPoolFactory {
                       .build(),
                   ThreadName.ASYNC_DATANODE_HEARTBEAT_CLIENT_POOL.getName()),
               new ClientPoolProperty.Builder<AsyncDataNodeInternalServiceClient>()
-                  .setCoreClientNumForEachNode(conf.getCoreClientNumForEachNode())
-                  .setMaxClientNumForEachNode(conf.getMaxClientNumForEachNode())
                   .build()
                   .getConfig());
       ClientManagerMetrics.getInstance()
@@ -217,8 +205,6 @@ public class ClientPoolFactory {
                       .setRpcThriftCompressionEnabled(conf.isRpcThriftCompressionEnabled())
                       .build()),
               new ClientPoolProperty.Builder<SyncDataNodeMPPDataExchangeServiceClient>()
-                  .setCoreClientNumForEachNode(conf.getCoreClientNumForEachNode())
-                  .setMaxClientNumForEachNode(conf.getMaxClientNumForEachNode())
                   .build()
                   .getConfig());
       ClientManagerMetrics.getInstance()
@@ -244,8 +230,6 @@ public class ClientPoolFactory {
                       .build(),
                   ThreadName.ASYNC_DATANODE_MPP_DATA_EXCHANGE_CLIENT_POOL.getName()),
               new ClientPoolProperty.Builder<AsyncDataNodeMPPDataExchangeServiceClient>()
-                  .setCoreClientNumForEachNode(conf.getCoreClientNumForEachNode())
-                  .setMaxClientNumForEachNode(conf.getMaxClientNumForEachNode())
                   .build()
                   .getConfig());
       ClientManagerMetrics.getInstance()
@@ -273,7 +257,6 @@ public class ClientPoolFactory {
                       .build(),
                   ThreadName.PIPE_ASYNC_CONNECTOR_CLIENT_POOL.getName()),
               new ClientPoolProperty.Builder<AsyncPipeDataTransferServiceClient>()
-                  .setCoreClientNumForEachNode(conf.getPipeAsyncConnectorCoreClientNumber())
                   .setMaxClientNumForEachNode(conf.getPipeAsyncConnectorMaxClientNumber())
                   .build()
                   .getConfig());

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/ClientPoolFactory.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/ClientPoolFactory.java
@@ -56,9 +56,7 @@ public class ClientPoolFactory {
                       .setConnectionTimeoutMs(conf.getConnectionTimeoutInMS())
                       .setRpcThriftCompressionEnabled(conf.isRpcThriftCompressionEnabled())
                       .build()),
-              new ClientPoolProperty.Builder<SyncConfigNodeIServiceClient>()
-                  .build()
-                  .getConfig());
+              new ClientPoolProperty.Builder<SyncConfigNodeIServiceClient>().build().getConfig());
       ClientManagerMetrics.getInstance()
           .registerClientManager(this.getClass().getSimpleName(), clientPool);
       return clientPool;
@@ -81,9 +79,7 @@ public class ClientPoolFactory {
                       .setSelectorNumOfAsyncClientManager(conf.getSelectorNumOfClientManager())
                       .build(),
                   ThreadName.ASYNC_CONFIGNODE_CLIENT_POOL.getName()),
-              new ClientPoolProperty.Builder<AsyncConfigNodeIServiceClient>()
-                  .build()
-                  .getConfig());
+              new ClientPoolProperty.Builder<AsyncConfigNodeIServiceClient>().build().getConfig());
       ClientManagerMetrics.getInstance()
           .registerClientManager(this.getClass().getSimpleName(), clientPool);
       return clientPool;
@@ -156,9 +152,7 @@ public class ClientPoolFactory {
                       .setPrintLogWhenEncounterException(false)
                       .build(),
                   ThreadName.ASYNC_CONFIGNODE_HEARTBEAT_CLIENT_POOL.getName()),
-              new ClientPoolProperty.Builder<AsyncConfigNodeIServiceClient>()
-                  .build()
-                  .getConfig());
+              new ClientPoolProperty.Builder<AsyncConfigNodeIServiceClient>().build().getConfig());
       ClientManagerMetrics.getInstance()
           .registerClientManager(this.getClass().getSimpleName(), clientPool);
       return clientPool;

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/property/ClientPoolProperty.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/property/ClientPoolProperty.java
@@ -59,8 +59,8 @@ public class ClientPoolProperty<V> {
 
     /**
      * the duration to sleep between runs of the idle object evictor thread. When non-positive, no
-     * idle object evictor thread will be run, which means clients that are idle for more than {@code
-     * maxIdleTimeForClient} will never be cleaned up.
+     * idle object evictor thread will be run, which means clients that are idle for more than
+     * {@code maxIdleTimeForClient} will never be cleaned up.
      */
     private long timeBetweenEvictionRuns = DefaultProperty.TIME_BETWEEN_EVICTION_RUNS_MS;
 
@@ -103,7 +103,7 @@ public class ClientPoolProperty<V> {
 
     public static final long WAIT_CLIENT_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(10);
     public static final long MIN_IDLE_TIME_FOR_CLIENT_MS = TimeUnit.MINUTES.toMillis(1);
-    public static final long TIME_BETWEEN_EVICTION_RUNS_MS = TimeUnit.SECONDS.toMillis(30);
+    public static final long TIME_BETWEEN_EVICTION_RUNS_MS = TimeUnit.MINUTES.toMillis(1);
     public static final int MAX_CLIENT_NUM_FOR_EACH_NODE = 300;
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/property/ClientPoolProperty.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/property/ClientPoolProperty.java
@@ -60,7 +60,7 @@ public class ClientPoolProperty<V> {
     /**
      * the duration to sleep between runs of the idle object evictor thread. When non-positive, no
      * idle object evictor thread will be run, which means clients that are idle for more than
-     * {@code maxIdleTimeForClient} will never be cleaned up.
+     * {@code minIdleTimeForClient} will never be cleaned up.
      */
     private long timeBetweenEvictionRuns = DefaultProperty.TIME_BETWEEN_EVICTION_RUNS_MS;
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/property/ClientPoolProperty.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/property/ClientPoolProperty.java
@@ -45,13 +45,24 @@ public class ClientPoolProperty<V> {
      */
     private long waitClientTimeoutMs = DefaultProperty.WAIT_CLIENT_TIMEOUT_MS;
 
-    /** the maximum number of clients that can be allocated for a node. */
-    private int maxClientNumForEachNode = DefaultProperty.MAX_CLIENT_NUM_FOR_EACH_NODE;
     /**
-     * the maximum number of clients that can be idle for a node. When the number of idle clients on
-     * a node exceeds this number, newly returned clients will be released.
+     * the maximum number of clients that can be allocated for a node. When some clients are idle
+     * for more than {@code maxIdleTimeForClient}, they will be cleaned up.
      */
-    private int coreClientNumForEachNode = DefaultProperty.CORE_CLIENT_NUM_FOR_EACH_NODE;
+    private int maxClientNumForEachNode = DefaultProperty.MAX_CLIENT_NUM_FOR_EACH_NODE;
+
+    /**
+     * the minimum amount of time a client may sit idle in the pool before it is eligible for
+     * eviction by the idle object evictor.
+     */
+    private long minIdleTimeForClient = DefaultProperty.MIN_IDLE_TIME_FOR_CLIENT_MS;
+
+    /**
+     * the duration to sleep between runs of the idle object evictor thread. When non-positive, no
+     * idle object evictor thread will be run, which means clients that are idle for more than {@code
+     * maxIdleTimeForClient} will never be cleaned up.
+     */
+    private long timeBetweenEvictionRuns = DefaultProperty.TIME_BETWEEN_EVICTION_RUNS_MS;
 
     public Builder<V> setWaitClientTimeoutMs(long waitClientTimeoutMs) {
       this.waitClientTimeoutMs = waitClientTimeoutMs;
@@ -63,15 +74,22 @@ public class ClientPoolProperty<V> {
       return this;
     }
 
-    public Builder<V> setCoreClientNumForEachNode(int coreClientNumForEachNode) {
-      this.coreClientNumForEachNode = coreClientNumForEachNode;
+    public Builder<V> setMinIdleTimeForClient(long minIdleTimeForClient) {
+      this.minIdleTimeForClient = minIdleTimeForClient;
+      return this;
+    }
+
+    public Builder<V> setTimeBetweenEvictionRuns(long timeBetweenEvictionRuns) {
+      this.timeBetweenEvictionRuns = timeBetweenEvictionRuns;
       return this;
     }
 
     public ClientPoolProperty<V> build() {
       GenericKeyedObjectPoolConfig<V> poolConfig = new GenericKeyedObjectPoolConfig<>();
       poolConfig.setMaxTotalPerKey(maxClientNumForEachNode);
-      poolConfig.setMaxIdlePerKey(coreClientNumForEachNode);
+      poolConfig.setMaxIdlePerKey(maxClientNumForEachNode);
+      poolConfig.setTimeBetweenEvictionRuns(Duration.ofMillis(timeBetweenEvictionRuns));
+      poolConfig.setMinEvictableIdleTime(Duration.ofMillis(minIdleTimeForClient));
       poolConfig.setMaxWait(Duration.ofMillis(waitClientTimeoutMs));
       poolConfig.setTestOnReturn(true);
       poolConfig.setTestOnBorrow(true);
@@ -84,7 +102,8 @@ public class ClientPoolProperty<V> {
     private DefaultProperty() {}
 
     public static final long WAIT_CLIENT_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(10);
+    public static final long MIN_IDLE_TIME_FOR_CLIENT_MS = TimeUnit.MINUTES.toMillis(1);
+    public static final long TIME_BETWEEN_EVICTION_RUNS_MS = TimeUnit.SECONDS.toMillis(30);
     public static final int MAX_CLIENT_NUM_FOR_EACH_NODE = 300;
-    public static final int CORE_CLIENT_NUM_FOR_EACH_NODE = 200;
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -107,8 +107,6 @@ public class CommonConfig {
 
   /** Whether to use thrift compression. */
   private boolean isRpcThriftCompressionEnabled = false;
-
-  private int coreClientNumForEachNode = DefaultProperty.CORE_CLIENT_NUM_FOR_EACH_NODE;
   private int maxClientNumForEachNode = DefaultProperty.MAX_CLIENT_NUM_FOR_EACH_NODE;
 
   /** What will the system do when unrecoverable error occurs. */
@@ -172,7 +170,6 @@ public class CommonConfig {
   private boolean pipeConnectorRPCThriftCompressionEnabled = false;
 
   private int pipeAsyncConnectorSelectorNumber = 8;
-  private int pipeAsyncConnectorCoreClientNumber = 8;
   private int pipeAsyncConnectorMaxClientNumber = 16;
 
   private boolean isSeperatedPipeHeartbeatEnabled = true;
@@ -379,14 +376,6 @@ public class CommonConfig {
 
   public void setMaxClientNumForEachNode(int maxClientNumForEachNode) {
     this.maxClientNumForEachNode = maxClientNumForEachNode;
-  }
-
-  public int getCoreClientNumForEachNode() {
-    return coreClientNumForEachNode;
-  }
-
-  public void setCoreClientNumForEachNode(int coreClientNumForEachNode) {
-    this.coreClientNumForEachNode = coreClientNumForEachNode;
   }
 
   HandleSystemErrorStrategy getHandleSystemErrorStrategy() {
@@ -602,14 +591,6 @@ public class CommonConfig {
 
   public void setPipeAsyncConnectorSelectorNumber(int pipeAsyncConnectorSelectorNumber) {
     this.pipeAsyncConnectorSelectorNumber = pipeAsyncConnectorSelectorNumber;
-  }
-
-  public int getPipeAsyncConnectorCoreClientNumber() {
-    return pipeAsyncConnectorCoreClientNumber;
-  }
-
-  public void setPipeAsyncConnectorCoreClientNumber(int pipeAsyncConnectorCoreClientNumber) {
-    this.pipeAsyncConnectorCoreClientNumber = pipeAsyncConnectorCoreClientNumber;
   }
 
   public int getPipeAsyncConnectorMaxClientNumber() {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -107,6 +107,7 @@ public class CommonConfig {
 
   /** Whether to use thrift compression. */
   private boolean isRpcThriftCompressionEnabled = false;
+
   private int maxClientNumForEachNode = DefaultProperty.MAX_CLIENT_NUM_FOR_EACH_NODE;
 
   /** What will the system do when unrecoverable error occurs. */

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -134,14 +134,6 @@ public class CommonDescriptor {
                     String.valueOf(config.getSelectorNumOfClientManager()))
                 .trim()));
 
-    config.setCoreClientNumForEachNode(
-        Integer.parseInt(
-            properties
-                .getProperty(
-                    "cn_core_client_count_for_each_node_in_client_manager",
-                    String.valueOf(config.getCoreClientNumForEachNode()))
-                .trim()));
-
     config.setMaxClientNumForEachNode(
         Integer.parseInt(
             properties
@@ -171,14 +163,6 @@ public class CommonDescriptor {
                 .getProperty(
                     "dn_selector_thread_nums_of_client_manager",
                     String.valueOf(config.getSelectorNumOfClientManager()))
-                .trim()));
-
-    config.setCoreClientNumForEachNode(
-        Integer.parseInt(
-            properties
-                .getProperty(
-                    "dn_core_client_count_for_each_node_in_client_manager",
-                    String.valueOf(config.getCoreClientNumForEachNode()))
                 .trim()));
 
     config.setMaxClientNumForEachNode(
@@ -384,13 +368,6 @@ public class CommonDescriptor {
                     properties.getProperty(
                         "pipe_async_connector_selector_number",
                         String.valueOf(config.getPipeAsyncConnectorSelectorNumber())))));
-    config.setPipeAsyncConnectorCoreClientNumber(
-        Integer.parseInt(
-            Optional.ofNullable(properties.getProperty("pipe_sink_core_client_number"))
-                .orElse(
-                    properties.getProperty(
-                        "pipe_async_connector_core_client_number",
-                        String.valueOf(config.getPipeAsyncConnectorCoreClientNumber())))));
     config.setPipeAsyncConnectorMaxClientNumber(
         Integer.parseInt(
             Optional.ofNullable(properties.getProperty("pipe_sink_max_client_number"))

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeConfig.java
@@ -119,10 +119,6 @@ public class PipeConfig {
     return COMMON_CONFIG.getPipeAsyncConnectorSelectorNumber();
   }
 
-  public int getPipeAsyncConnectorCoreClientNumber() {
-    return COMMON_CONFIG.getPipeAsyncConnectorCoreClientNumber();
-  }
-
   public int getPipeAsyncConnectorMaxClientNumber() {
     return COMMON_CONFIG.getPipeAsyncConnectorMaxClientNumber();
   }
@@ -247,7 +243,6 @@ public class PipeConfig {
         isPipeConnectorRPCThriftCompressionEnabled());
 
     LOGGER.info("PipeAsyncConnectorSelectorNumber: {}", getPipeAsyncConnectorSelectorNumber());
-    LOGGER.info("PipeAsyncConnectorCoreClientNumber: {}", getPipeAsyncConnectorCoreClientNumber());
     LOGGER.info("PipeAsyncConnectorMaxClientNumber: {}", getPipeAsyncConnectorMaxClientNumber());
 
     LOGGER.info("SeperatedPipeHeartbeatEnabled: {}", isSeperatedPipeHeartbeatEnabled());

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/client/ClientManagerTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/client/ClientManagerTest.java
@@ -259,8 +259,8 @@ public class ClientManagerTest {
         long current = System.currentTimeMillis();
         // for each idle client, its theoretical max idle time is `minIdleDuration` +
         // `evictionRunsDuration`. Taking into account the difference in thread scheduling rates of
-        // different machines, here we multiply by 3
-        if ((current - start) > (minIdleDuration + evictionRunsDuration) * 3) {
+        // different machines, here we multiply by 6
+        if ((current - start) > (minIdleDuration + evictionRunsDuration) * 6) {
           Assert.fail("Evict invalid client failed");
         }
       }

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/client/ClientManagerTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/client/ClientManagerTest.java
@@ -258,8 +258,9 @@ public class ClientManagerTest {
         // test eviction
         long current = System.currentTimeMillis();
         // for each idle client, its theoretical max idle time is `minIdleDuration` +
-        // `evictionRunsDuration`
-        if ((current - start) > (minIdleDuration + evictionRunsDuration)) {
+        // `evictionRunsDuration`. Taking into account the difference in thread scheduling rates of
+        // different machines, here we multiply by 3
+        if ((current - start) > (minIdleDuration + evictionRunsDuration) * 3) {
           Assert.fail("Evict invalid client failed");
         }
       }

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/client/ClientManagerTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/client/ClientManagerTest.java
@@ -265,6 +265,7 @@ public class ClientManagerTest {
         }
       }
     }
+    Thread.sleep(minIdleDuration + evictionRunsDuration);
     // since the two clients are idle for more than 10s, which exceeds `minIdleDuration`, they
     // should be destroyed.
     Assert.assertEquals(0, syncClusterManager.getPool().getNumActive(endPoint));


### PR DESCRIPTION
sub task of https://github.com/apache/iotdb/issues/11949

1. Add eviction thread to evict clients that are idle more than 1 minute.
2. Merge `core_client_num` and `max_client_num` params, only remain `max_client_num`
3. Add eviction UT

Detailed docs: https://timechor.feishu.cn/docx/GJYjd1vuYoxQr8xNJejcC7Q6nTc