### PR TITLE
Fix update time index after compact aligned series

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/performer/impl/ReadChunkCompactionPerformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/performer/impl/ReadChunkCompactionPerformer.java
@@ -139,6 +139,7 @@ public class ReadChunkCompactionPerformer implements ISeqCompactionPerformer {
         targetResource.updateEndTime(device, chunkMetadata.getEndTime());
       }
     }
+    writer.checkMetadataSizeAndMayFlush();
     writer.endChunkGroup();
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/readchunk/ReadChunkAlignedSeriesCompactionExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/readchunk/ReadChunkAlignedSeriesCompactionExecutor.java
@@ -177,7 +177,6 @@ public class ReadChunkAlignedSeriesCompactionExecutor {
     if (!chunkWriter.isEmpty()) {
       flushCurrentChunkWriter();
     }
-    writer.checkMetadataSizeAndMayFlush();
   }
 
   private void compactWithAlignedChunk(


### PR DESCRIPTION
## Description
Fix a bug of new read chunk aligned series compaction executor. When chunk metadata in memory is too much, the device time index of compaction target file may lost some device.