### PR TITLE
Pipe: result of show pipes statement is incorrect when it contains back quoted pipe names

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/IoTDBPipeSyntaxIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/IoTDBPipeSyntaxIT.java
@@ -58,6 +58,7 @@ public class IoTDBPipeSyntaxIT extends AbstractPipeDualIT {
         (SyncConfigNodeIServiceClient) senderEnv.getLeaderConfigNodeConnection()) {
 
       List<String> validPipeNames = Arrays.asList("Pipe_1", "null", "`33`", "`root`", "中文", "with");
+      List<String> exceptedPipeNames = Arrays.asList("Pipe_1", "null", "33", "root", "中文", "with");
       for (String pipeName : validPipeNames) {
         try (Connection connection = senderEnv.getConnection();
             Statement statement = connection.createStatement()) {
@@ -77,7 +78,7 @@ public class IoTDBPipeSyntaxIT extends AbstractPipeDualIT {
       }
 
       List<TShowPipeInfo> showPipeResult = client.showPipe(new TShowPipeReq()).pipeInfoList;
-      for (String pipeName : validPipeNames) {
+      for (String pipeName : exceptedPipeNames) {
         Assert.assertTrue(
             showPipeResult.stream()
                 .anyMatch((o) -> o.id.equals(pipeName) && o.state.equals("RUNNING")));

--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/IoTDBPipeSyntaxIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/IoTDBPipeSyntaxIT.java
@@ -58,7 +58,7 @@ public class IoTDBPipeSyntaxIT extends AbstractPipeDualIT {
         (SyncConfigNodeIServiceClient) senderEnv.getLeaderConfigNodeConnection()) {
 
       List<String> validPipeNames = Arrays.asList("Pipe_1", "null", "`33`", "`root`", "中文", "with");
-      List<String> exceptedPipeNames = Arrays.asList("Pipe_1", "null", "33", "root", "中文", "with");
+      List<String> expectedPipeNames = Arrays.asList("Pipe_1", "null", "33", "root", "中文", "with");
       for (String pipeName : validPipeNames) {
         try (Connection connection = senderEnv.getConnection();
             Statement statement = connection.createStatement()) {
@@ -78,7 +78,7 @@ public class IoTDBPipeSyntaxIT extends AbstractPipeDualIT {
       }
 
       List<TShowPipeInfo> showPipeResult = client.showPipe(new TShowPipeReq()).pipeInfoList;
-      for (String pipeName : exceptedPipeNames) {
+      for (String pipeName : expectedPipeNames) {
         Assert.assertTrue(
             showPipeResult.stream()
                 .anyMatch((o) -> o.id.equals(pipeName) && o.state.equals("RUNNING")));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/executor/ClusterConfigTaskExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/executor/ClusterConfigTaskExecutor.java
@@ -202,7 +202,6 @@ import org.apache.iotdb.udf.api.UDTF;
 
 import com.google.common.util.concurrent.SettableFuture;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
@@ -1670,7 +1669,7 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
     try (ConfigNodeClient configNodeClient =
         CONFIG_NODE_CLIENT_MANAGER.borrowClient(ConfigNodeInfo.CONFIG_REGION_ID)) {
       TShowPipeReq tShowPipeReq = new TShowPipeReq();
-      if (!StringUtils.isEmpty(showPipesStatement.getPipeName())) {
+      if (showPipesStatement.getPipeName() != null) {
         tShowPipeReq.setPipeName(showPipesStatement.getPipeName());
       }
       if (showPipesStatement.getWhereClause()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/parser/ASTVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/parser/ASTVisitor.java
@@ -907,7 +907,7 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
   @Override
   public Statement visitCreatePipePlugin(IoTDBSqlParser.CreatePipePluginContext ctx) {
     return new CreatePipePluginStatement(
-        ctx.pluginName.getText(),
+        parseIdentifier(ctx.pluginName.getText()),
         parseStringLiteral(ctx.className.getText()),
         parseAndValidateURI(ctx.uriClause()));
   }
@@ -915,7 +915,7 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
   // Drop PipePlugin =====================================================================
   @Override
   public Statement visitDropPipePlugin(IoTDBSqlParser.DropPipePluginContext ctx) {
-    return new DropPipePluginStatement(ctx.pluginName.getText());
+    return new DropPipePluginStatement(parseIdentifier(ctx.pluginName.getText()));
   }
 
   // Show PipePlugins =====================================================================
@@ -3577,7 +3577,7 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
         new CreatePipeStatement(StatementType.CREATE_PIPE);
 
     if (ctx.pipeName != null) {
-      createPipeStatement.setPipeName(ctx.pipeName.getText());
+      createPipeStatement.setPipeName(parseIdentifier(ctx.pipeName.getText()));
     } else {
       throw new SemanticException(
           "Not support for this sql in CREATEPIPE, please enter pipe name.");
@@ -3640,7 +3640,7 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
     final DropPipeStatement dropPipeStatement = new DropPipeStatement(StatementType.DROP_PIPE);
 
     if (ctx.pipeName != null) {
-      dropPipeStatement.setPipeName(ctx.pipeName.getText());
+      dropPipeStatement.setPipeName(parseIdentifier(ctx.pipeName.getText()));
     } else {
       throw new SemanticException("Not support for this sql in DROP PIPE, please enter pipename.");
     }
@@ -3653,7 +3653,7 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
     final StartPipeStatement startPipeStatement = new StartPipeStatement(StatementType.START_PIPE);
 
     if (ctx.pipeName != null) {
-      startPipeStatement.setPipeName(ctx.pipeName.getText());
+      startPipeStatement.setPipeName(parseIdentifier(ctx.pipeName.getText()));
     } else {
       throw new SemanticException("Not support for this sql in START PIPE, please enter pipename.");
     }
@@ -3666,7 +3666,7 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
     final StopPipeStatement stopPipeStatement = new StopPipeStatement(StatementType.STOP_PIPE);
 
     if (ctx.pipeName != null) {
-      stopPipeStatement.setPipeName(ctx.pipeName.getText());
+      stopPipeStatement.setPipeName(parseIdentifier(ctx.pipeName.getText()));
     } else {
       throw new SemanticException("Not support for this sql in STOP PIPE, please enter pipename.");
     }


### PR DESCRIPTION
1. Filter back quote in pipe name, but it's still necessary to and back quote if there is illegal character in pipe name.
2. Fix bug:  result of pipe's query statement contains back quote is incorrect.