### PR TITLE
Fix PointPriorityReader calculation of aligned series null value num

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/reader/PointPriorityReader.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/reader/PointPriorityReader.java
@@ -88,8 +88,8 @@ public class PointPriorityReader {
     pointElementsWithSameTimestamp.add(pointQueue.poll());
 
     TsPrimitiveType[] currentValues = currentPoint.getValue().getVector();
-    int nullValueNum = currentValues.length;
     while (!pointQueue.isEmpty()) {
+      int nullValueNum = currentValues.length;
       if (pointQueue.peek().timestamp > lastTime) {
         // the smallest time of all pages is later than the last time, then break the loop
         break;


### PR DESCRIPTION
## Description
Fix PointPriorityReader calculation of aligned series null value num.
The decreasing of null value num may repeated in some cases, which cause some series lost point.
If the result of null value num is negative, point won't lost through the calculation of this field is wrong.
![image](https://github.com/apache/iotdb/assets/55970239/d3db90d9-c3bb-4613-a2be-00b3ebb46a5f)
If the result equals 0, the loop break directly and some point may not merged into current time value pair.
![image](https://github.com/apache/iotdb/assets/55970239/a42120d9-76cf-48a1-abd9-339e6947eb1f)
