### PR TITLE
Enhance the robustness of Ratis linearizable reads for node offline scenarios

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/exception/RatisReadUnavailableException.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/exception/RatisReadUnavailableException.java
@@ -22,10 +22,15 @@ package org.apache.iotdb.consensus.exception;
 /** RaftServer is unable to serve linearizable read requests. */
 public class RatisReadUnavailableException extends ConsensusException {
 
+  public static final String RATIS_READ_UNAVAILABLE =
+      "Raft Server cannot serve read requests now (leader is unknown or under recovery). "
+          + "Please try read later: ";
+
   public RatisReadUnavailableException(Throwable cause) {
-    super(
-        "Raft Server cannot serve read requests now (leader is unknown or under recovery). "
-            + "Please try read later: ",
-        cause);
+    super(RATIS_READ_UNAVAILABLE, cause);
+  }
+
+  public RatisReadUnavailableException(String cause) {
+    super(cause);
   }
 }


### PR DESCRIPTION
Currently, when a node goes offline, Ratis linearizable read requests that are blocked on the offline node will get a not leader error. We need to add retry logic in the dispatch and consensus layer for this case.

<img width="1034" alt="image" src="https://github.com/apache/iotdb/assets/32640567/a56b7f20-6a19-4e1d-8de4-fe41a6bb73e5">

