### PR TITLE
Fix deadlock when delete timeseries after loading data.

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IOTDBLoadTsFileIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IOTDBLoadTsFileIT.java
@@ -220,6 +220,15 @@ public class IOTDBLoadTsFileIT {
         }
       }
     }
+
+    // try delete after loading. Expect no deadlock
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute(
+          String.format(
+              "delete timeseries %s.%s",
+              SchemaConfig.DEVICE_0, SchemaConfig.MEASUREMENT_00.getMeasurementId()));
+    }
   }
 
   @Test

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/MPPQueryContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/MPPQueryContext.java
@@ -59,7 +59,7 @@ public class MPPQueryContext {
 
   private Filter globalTimeFilter;
 
-  private boolean acquiredLock;
+  private int acquiredLockNum;
 
   public MPPQueryContext(QueryId queryId) {
     this.queryId = queryId;
@@ -157,12 +157,12 @@ public class MPPQueryContext {
     return sql;
   }
 
-  public boolean getAcquiredLock() {
-    return acquiredLock;
+  public int getAcquiredLockNum() {
+    return acquiredLockNum;
   }
 
-  public void setAcquiredLock(boolean acuqired) {
-    acquiredLock = acuqired;
+  public void addAcquiredLockNum() {
+    acquiredLockNum++;
   }
 
   public void generateGlobalTimeFilter(Analysis analysis) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/Coordinator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/Coordinator.java
@@ -162,8 +162,9 @@ public class Coordinator {
       execution.start();
       return execution.getStatus();
     } finally {
-      if (queryContext != null && queryContext.getAcquiredLock()) {
-        DataNodeSchemaCache.getInstance().releaseInsertLock();
+      int lockNums = queryContext.getAcquiredLockNum();
+      if (queryContext != null && lockNums > 0) {
+        for (int i = 0; i < lockNums; i++) DataNodeSchemaCache.getInstance().releaseInsertLock();
       }
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/schema/ClusterSchemaFetcher.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/schema/ClusterSchemaFetcher.java
@@ -166,7 +166,7 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
     // The schema cache R/W and fetch operation must be locked together thus the cache clean
     // operation executed by delete timeseries will be effective.
     schemaCache.takeInsertLock();
-    context.setAcquiredLock(true);
+    context.addAcquiredLockNum();
     schemaCache.takeReadLock();
     try {
       Pair<Template, PartialPath> templateSetInfo =
@@ -204,7 +204,7 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
     // The schema cache R/W and fetch operation must be locked together thus the cache clean
     // operation executed by delete timeseries will be effective.
     schemaCache.takeInsertLock();
-    context.setAcquiredLock(true);
+    context.addAcquiredLockNum();
     schemaCache.takeReadLock();
     try {
 
@@ -248,7 +248,7 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
     // The schema cache R/W and fetch operation must be locked together thus the cache clean
     // operation executed by delete timeseries will be effective.
     schemaCache.takeInsertLock();
-    context.setAcquiredLock(true);
+    context.addAcquiredLockNum();
     schemaCache.takeReadLock();
     try {
       ClusterSchemaTree schemaTree = new ClusterSchemaTree();


### PR DESCRIPTION
IOTDB will acquire serval readlocks when loading data. But because of pr:https://github.com/apache/iotdb/pull/11773, It will cause deadlock when delete data after loading tsfile.