### PR TITLE
Fix wal delete npe when calculating effective info ration

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
@@ -324,11 +324,14 @@ public class WALNode implements IWALNode {
     private void updateEffectiveInfoRationAndUpdateMetric() {
       // calculate effective information ratio
       long costOfActiveMemTables = checkpointManager.getTotalCostOfActiveMemTables();
+      MemTableInfo oldestUnpinnedMemTableInfo = checkpointManager.getOldestUnpinnedMemTableInfo();
       long totalCost =
-          (getCurrentWALFileVersion()
-                  - checkpointManager.getOldestUnpinnedMemTableInfo().getFirstFileVersionId()
-                  + 1)
-              * config.getWalFileSizeThresholdInByte();
+          oldestUnpinnedMemTableInfo == null
+              ? costOfActiveMemTables
+              : (getCurrentWALFileVersion()
+                      - oldestUnpinnedMemTableInfo.getFirstFileVersionId()
+                      + 1)
+                  * config.getWalFileSizeThresholdInByte();
       if (totalCost == 0) {
         return;
       }


### PR DESCRIPTION
![img_v3_027d_f243e3d2-2948-4b6f-8bcd-c20f060fc4cg](https://github.com/apache/iotdb/assets/43991780/f0f57091-dd15-4683-b98d-5663f9cb348d)

NPE occurs because CheckpointManager.getOldestUnpinnedMemTableInfo() may return null.