### PR TITLE
Fix estimating compaction memory without acquire read lock

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBRepairDataIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBRepairDataIT.java
@@ -44,6 +44,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.iotdb.db.utils.constant.TestConstant.TIMESTAMP_STR;
 import static org.junit.Assert.assertNotNull;
@@ -81,6 +82,7 @@ public class IoTDBRepairDataIT {
         if (sorted) {
           return;
         }
+        Thread.sleep(TimeUnit.SECONDS.toMillis(1));
       }
       Assert.fail();
     } catch (Exception e) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/AbstractCompactionEstimator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/AbstractCompactionEstimator.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.storageengine.dataregion.flush.CompressionRatio;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
+import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResourceStatus;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.timeindex.DeviceTimeIndex;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.timeindex.FileTimeIndex;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.timeindex.ITimeIndex;
@@ -62,6 +63,15 @@ public abstract class AbstractCompactionEstimator {
   protected abstract long calculatingMetadataMemoryCost(CompactionTaskInfo taskInfo);
 
   protected abstract long calculatingDataMemoryCost(CompactionTaskInfo taskInfo) throws IOException;
+
+  protected boolean isAllSourceFileExist(List<TsFileResource> resources) {
+    for (TsFileResource resource : resources) {
+      if (resource.getStatus() == TsFileResourceStatus.DELETED) {
+        return false;
+      }
+    }
+    return true;
+  }
 
   protected CompactionTaskInfo calculatingCompactionTaskInfo(List<TsFileResource> resources)
       throws IOException {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/AbstractCrossSpaceEstimator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/AbstractCrossSpaceEstimator.java
@@ -45,6 +45,9 @@ public abstract class AbstractCrossSpaceEstimator extends AbstractCompactionEsti
 
     long cost = 0;
     try {
+      if (!isAllSourceFileExist(resources)) {
+        return -1L;
+      }
       CompactionTaskInfo taskInfo = calculatingCompactionTaskInfo(resources);
       cost += calculatingMetadataMemoryCost(taskInfo);
       cost += calculatingDataMemoryCost(taskInfo);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/AbstractInnerSpaceEstimator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/AbstractInnerSpaceEstimator.java
@@ -34,9 +34,22 @@ public abstract class AbstractInnerSpaceEstimator extends AbstractCompactionEsti
     if (!config.isEnableCompactionMemControl()) {
       return 0;
     }
-    CompactionTaskInfo taskInfo = calculatingCompactionTaskInfo(resources);
-    long cost = calculatingMetadataMemoryCost(taskInfo);
-    cost += calculatingDataMemoryCost(taskInfo);
+
+    if (!CompactionEstimateUtils.addReadLock(resources)) {
+      return -1L;
+    }
+    long cost = 0;
+    try {
+      if (!isAllSourceFileExist(resources)) {
+        return -1L;
+      }
+
+      CompactionTaskInfo taskInfo = calculatingCompactionTaskInfo(resources);
+      cost = calculatingMetadataMemoryCost(taskInfo);
+      cost += calculatingDataMemoryCost(taskInfo);
+    } finally {
+      CompactionEstimateUtils.releaseReadLock(resources);
+    }
     return cost;
   }
 }


### PR DESCRIPTION
## Description
1. Fix estimating compaction memory without acquire read lock. This PR acquire the lock of compaction source files and check whether the status is DELETED.
2. Fix RepairDataIT