### PR TITLE
Fix concurrent bug in QueryContext

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryContext.java
@@ -32,11 +32,11 @@ import org.apache.iotdb.tsfile.file.metadata.IChunkMetadata;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 /** QueryContext contains the shared information with in a query. */
 public class QueryContext {
@@ -49,7 +49,7 @@ public class QueryContext {
    * Modifications, and we do not want it to create multiple copies within a query.
    */
   private final Map<String, PatternTreeMap<Modification, ModsSerializer>> fileModCache =
-      new HashMap<>();
+      new ConcurrentHashMap<>();
 
   protected long queryId;
 
@@ -62,7 +62,7 @@ public class QueryContext {
 
   private volatile boolean isInterrupted = false;
 
-  private final Set<TsFileID> nonExistentModFiles = new HashSet<>();
+  private final Set<TsFileID> nonExistentModFiles = new CopyOnWriteArraySet<>();
 
   public QueryContext() {}
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryContext.java
@@ -95,14 +95,16 @@ public class QueryContext {
     }
 
     PatternTreeMap<Modification, ModsSerializer> allModifications =
-        fileModCache.get(modFile.getFilePath());
-    if (allModifications == null) {
-      allModifications = PatternTreeMapFactory.getModsPatternTreeMap();
-      for (Modification modification : modFile.getModificationsIter()) {
-        allModifications.append(modification.getPath(), modification);
-      }
-      fileModCache.put(modFile.getFilePath(), allModifications);
-    }
+        fileModCache.computeIfAbsent(
+            modFile.getFilePath(),
+            k -> {
+              PatternTreeMap<Modification, ModsSerializer> modifications =
+                  PatternTreeMapFactory.getModsPatternTreeMap();
+              for (Modification modification : modFile.getModificationsIter()) {
+                modifications.append(modification.getPath(), modification);
+              }
+              return modifications;
+            });
     return ModificationFile.sortAndMerge(allModifications.getOverlapped(path));
   }
 


### PR DESCRIPTION
## Description

Fix concurrent bug in QueryContext, use ConcurrentHashMap and CopyOnWriteArraySet instead of HashMap and HashSet. 