### PR TITLE
optimize wal snapshot or flush threshold

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/WALManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/WALManager.java
@@ -199,7 +199,7 @@ public class WALManager implements IService {
   }
 
   public long getThrottleThreshold() {
-    return (long) (config.getThrottleThreshold() * 0.8);
+    return (long) (config.getThrottleThreshold() * 0.6);
   }
 
   public long getTotalDiskUsage() {


### PR DESCRIPTION
## Description

Adjust the memTable snapshot or flush threshold. Change from iot_consensus_throttle_threshold_in_byte * 0.8 to iot_consensus_throttle_threshold_in_byte * 0.6. when wal disk usage small than iot_consensus_throttle_threshold_in_byte * 0.6, will snapshot or flush oldest memTable util greater than it.
