### PR TITLE
Fixed issue where ConfigNode might recover incorrectly under SimpleConsensus

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
@@ -53,10 +53,13 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 /** StateMachine for ConfigRegion. */
 public class ConfigRegionStateMachine implements IStateMachine, IStateMachine.EventApi {
@@ -84,6 +87,8 @@ public class ConfigRegionStateMachine implements IStateMachine, IStateMachine.Ev
   private static final long LOG_FILE_MAX_SIZE =
       CONF.getConfigNodeSimpleConsensusLogSegmentSizeMax();
   private final TEndPoint currentNodeTEndPoint;
+  private static Pattern LOG_INPROGRESS_PATTERN = Pattern.compile("\\d+");
+  private static Pattern LOG_PATTERN = Pattern.compile("(?<=_)(\\d+)$");
 
   public ConfigRegionStateMachine(ConfigManager configManager, ConfigPlanExecutor executor) {
     this.executor = executor;
@@ -323,6 +328,7 @@ public class ConfigRegionStateMachine implements IStateMachine, IStateMachine.Ev
     dir.mkdirs();
     String[] list = new File(CURRENT_FILE_DIR).list();
     if (list != null && list.length != 0) {
+      Arrays.sort(list, new FileComparator());
       for (String logFileName : list) {
         File logFile =
             SystemFileFactory.INSTANCE.getFile(CURRENT_FILE_DIR + File.separator + logFileName);
@@ -393,6 +399,23 @@ public class ConfigRegionStateMachine implements IStateMachine, IStateMachine.Ev
           "Create ConfigNode SimpleConsensusFile failed, filePath: {}",
           simpleLogFile.getAbsolutePath(),
           e);
+    }
+  }
+
+  static class FileComparator implements Comparator<String> {
+    @Override
+    public int compare(String filename1, String filename2) {
+      long id1 = parseEndIndex(filename1);
+      long id2 = parseEndIndex(filename2);
+      return Long.compare(id1, id2);
+    }
+  }
+
+  static long parseEndIndex(String filename) {
+    if (filename.startsWith("log_inprogress_")) {
+      return Long.parseLong(LOG_INPROGRESS_PATTERN.matcher(filename).group());
+    } else {
+      return Long.parseLong(LOG_PATTERN.matcher(filename).group());
     }
   }
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
@@ -59,6 +59,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /** StateMachine for ConfigRegion. */
@@ -413,9 +414,16 @@ public class ConfigRegionStateMachine implements IStateMachine, IStateMachine.Ev
 
   static long parseEndIndex(String filename) {
     if (filename.startsWith("log_inprogress_")) {
-      return Long.parseLong(LOG_INPROGRESS_PATTERN.matcher(filename).group());
+      Matcher matcher = LOG_INPROGRESS_PATTERN.matcher(filename);
+      if (matcher.find()) {
+        return Long.parseLong(matcher.group());
+      }
     } else {
-      return Long.parseLong(LOG_PATTERN.matcher(filename).group());
+      Matcher matcher = LOG_PATTERN.matcher(filename);
+      if (matcher.find()) {
+        return Long.parseLong(matcher.group());
+      }
     }
+    return 0;
   }
 }


### PR DESCRIPTION
## Description

SimpleConsensus logs are restored in the wrong order during startup.