### PR TITLE
Add -XX:+PrintStringTableStatistics VM options to print StringTableStatistics after JVM exits

### DIFF
--- a/iotdb-core/confignode/src/assembly/resources/conf/confignode-env.bat
+++ b/iotdb-core/confignode/src/assembly/resources/conf/confignode-env.bat
@@ -122,9 +122,10 @@ set CONFIGNODE_HEAP_OPTS=-Xmx%ON_HEAP_MEMORY% -Xms%ON_HEAP_MEMORY%
 set CONFIGNODE_HEAP_OPTS=%CONFIGNODE_HEAP_OPTS% -XX:MaxDirectMemorySize=%OFF_HEAP_MEMORY%
 set CONFIGNODE_HEAP_OPTS=%CONFIGNODE_HEAP_OPTS% -Djdk.nio.maxCachedBufferSize=%MAX_CACHED_BUFFER_SIZE%
 set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:+CrashOnOutOfMemoryError
+set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:+PrintStringTableStatistics
 
-@REM if you want to dump the heap memory while OOM happening, you can use the following command, remember to replace /tmp/heapdump.hprof with your own file path and the folder where this file is located needs to be created in advance
-@REM IOTDB_JMX_OPTS=%IOTDB_HEAP_OPTS% -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=\tmp\confignode_heapdump.hprof
+@REM if you want to dump the heap memory while OOM happening, you can use the following command, remember to replace /tmp/ with your own file path and the folder where this file is located needs to be created in advance
+@REM IOTDB_JMX_OPTS=%IOTDB_HEAP_OPTS% -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=\tmp\
 
 @REM You can put your env variable here
 @REM set JAVA_HOME=%JAVA_HOME%

--- a/iotdb-core/confignode/src/assembly/resources/conf/confignode-env.sh
+++ b/iotdb-core/confignode/src/assembly/resources/conf/confignode-env.sh
@@ -274,8 +274,9 @@ CONFIGNODE_JMX_OPTS="$CONFIGNODE_JMX_OPTS -Xmx${ON_HEAP_MEMORY}"
 CONFIGNODE_JMX_OPTS="$CONFIGNODE_JMX_OPTS -XX:MaxDirectMemorySize=${OFF_HEAP_MEMORY}"
 CONFIGNODE_JMX_OPTS="$CONFIGNODE_JMX_OPTS -Djdk.nio.maxCachedBufferSize=${MAX_CACHED_BUFFER_SIZE}"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:+CrashOnOutOfMemoryError"
-# if you want to dump the heap memory while OOM happening, you can use the following command, remember to replace /tmp/heapdump.hprof with your own file path and the folder where this file is located needs to be created in advance
-#IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/confignode_heapdump.hprof"
+IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:+PrintStringTableStatistics"
+# if you want to dump the heap memory while OOM happening, you can use the following command, remember to replace /tmp/ with your own file path and the folder where this file is located needs to be created in advance
+#IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/"
 
 echo "ConfigNode on heap memory size = ${ON_HEAP_MEMORY}B, off heap memory size = ${OFF_HEAP_MEMORY}B"
 echo "If you want to change this configuration, please check conf/confignode-env.sh."

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
@@ -36,6 +36,7 @@ import org.apache.iotdb.commons.service.ServiceType;
 import org.apache.iotdb.commons.service.metric.JvmGcMonitorMetrics;
 import org.apache.iotdb.commons.service.metric.MetricService;
 import org.apache.iotdb.commons.service.metric.cpu.CpuUsageMetrics;
+import org.apache.iotdb.commons.utils.StdOutErrRedirect;
 import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.confignode.client.ConfigNodeRequestType;
 import org.apache.iotdb.confignode.client.sync.SyncConfigNodeClientPool;
@@ -111,6 +112,7 @@ public class ConfigNode implements ConfigNodeMBean {
         "{} default charset is: {}",
         ConfigNodeConstant.GLOBAL_NAME,
         Charset.defaultCharset().displayName());
+    StdOutErrRedirect.redirectSystemOutAndErrToLog();
     new ConfigNodeCommandLine().doMain(args);
   }
 

--- a/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.bat
+++ b/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.bat
@@ -121,9 +121,10 @@ set IOTDB_HEAP_OPTS=-Xmx%ON_HEAP_MEMORY% -Xms%ON_HEAP_MEMORY%
 set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:MaxDirectMemorySize=%OFF_HEAP_MEMORY%
 set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -Djdk.nio.maxCachedBufferSize=%MAX_CACHED_BUFFER_SIZE%
 set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:+CrashOnOutOfMemoryError
+set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:+PrintStringTableStatistics
 
-@REM if you want to dump the heap memory while OOM happening, you can use the following command, remember to replace /tmp/heapdump.hprof with your own file path and the folder where this file is located needs to be created in advance
-@REM IOTDB_JMX_OPTS=%IOTDB_HEAP_OPTS% -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=\tmp\datanode_heapdump.hprof
+@REM if you want to dump the heap memory while OOM happening, you can use the following command, remember to replace /tmp/ with your own file path and the folder where this file is located needs to be created in advance
+@REM IOTDB_JMX_OPTS=%IOTDB_HEAP_OPTS% -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=\tmp\
 
 @REM You can put your env variable here
 @REM set JAVA_HOME=%JAVA_HOME%

--- a/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.sh
+++ b/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.sh
@@ -269,8 +269,9 @@ IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xmx${ON_HEAP_MEMORY}"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:MaxDirectMemorySize=${OFF_HEAP_MEMORY}"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Djdk.nio.maxCachedBufferSize=${MAX_CACHED_BUFFER_SIZE}"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:+CrashOnOutOfMemoryError"
-# if you want to dump the heap memory while OOM happening, you can use the following command, remember to replace /tmp/heapdump.hprof with your own file path and the folder where this file is located needs to be created in advance
-#IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/datanode_heapdump.hprof"
+IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:+PrintStringTableStatistics"
+# if you want to dump the heap memory while OOM happening, you can use the following command, remember to replace /tmp/ with your own file path and the folder where this file is located needs to be created in advance
+#IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/"
 
 
 echo "DataNode on heap memory size = ${ON_HEAP_MEMORY}B, off heap memory size = ${OFF_HEAP_MEMORY}B"

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -44,6 +44,7 @@ import org.apache.iotdb.commons.udf.UDFInformation;
 import org.apache.iotdb.commons.udf.service.UDFClassLoaderManager;
 import org.apache.iotdb.commons.udf.service.UDFExecutableManager;
 import org.apache.iotdb.commons.udf.service.UDFManagementService;
+import org.apache.iotdb.commons.utils.StdOutErrRedirect;
 import org.apache.iotdb.confignode.rpc.thrift.TDataNodeRegisterReq;
 import org.apache.iotdb.confignode.rpc.thrift.TDataNodeRegisterResp;
 import org.apache.iotdb.confignode.rpc.thrift.TDataNodeRestartReq;
@@ -165,6 +166,7 @@ public class DataNode implements DataNodeMBean {
   public static void main(String[] args) {
     logger.info("IoTDB-DataNode environment variables: {}", IoTDBConfig.getEnvironmentVariables());
     logger.info("IoTDB-DataNode default charset is: {}", Charset.defaultCharset().displayName());
+    StdOutErrRedirect.redirectSystemOutAndErrToLog();
     new DataNodeServerCommandLine().doMain(args);
   }
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/StdOutErrRedirect.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/StdOutErrRedirect.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.commons.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+public class StdOutErrRedirect {
+  private static final Logger LOGGER = LoggerFactory.getLogger(StdOutErrRedirect.class);
+
+  private StdOutErrRedirect() {}
+
+  public static void redirectSystemOutAndErrToLog() {
+    System.setOut(new PrintStream(new InfoLoggerStream(LOGGER)));
+    System.setErr(new PrintStream(new ErrorLoggerStream(LOGGER)));
+  }
+
+  private static class InfoLoggerStream extends OutputStream {
+
+    private final Logger logger;
+
+    public InfoLoggerStream(Logger logger) {
+      super();
+      this.logger = logger;
+    }
+
+    @Override
+    public void write(int b) {
+      String string = String.valueOf((char) b);
+      if (!string.trim().isEmpty()) logger.info(string);
+    }
+
+    @Override
+    public void write(byte[] b) {
+      String string = new String(b);
+      if (!string.trim().isEmpty()) {
+        logger.info(string);
+      }
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) {
+      String string = new String(b, off, len);
+      if (!string.trim().isEmpty()) logger.info(string);
+    }
+  }
+
+  private static class ErrorLoggerStream extends OutputStream {
+
+    private final Logger logger;
+
+    public ErrorLoggerStream(Logger logger) {
+      super();
+      this.logger = logger;
+    }
+
+    @Override
+    public void write(int b) {
+      String string = String.valueOf((char) b);
+      if (!string.trim().isEmpty()) logger.error(string);
+    }
+
+    @Override
+    public void write(byte[] b) {
+      String string = new String(b);
+      if (!string.trim().isEmpty()) {
+        logger.error(string);
+      }
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) {
+      String string = new String(b, off, len);
+      if (!string.trim().isEmpty()) logger.error(string);
+    }
+  }
+}


### PR DESCRIPTION
I do two things in this pr:
1. add -XX:+PrintStringTableStatistics VM options to print StringTableStatistics after JVM exits
2. change the HeapDumpPath from file path to folder, because if IoTDB has already OOM last time and dumped a file. Next time if the file still exists, it won't dump any more, but if we only put it as a folder, JVM will generate the filename using pid.