### PR TITLE
Storage Engine: fix wal delete thread exception because multi thread safety question

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -143,6 +143,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.Phaser;
@@ -258,7 +259,7 @@ public class DataRegion implements IDataRegionForQuery {
    * different IoTDB instance will have identical data, providing convenience for data comparison
    * across different instances. partition number -> max version number
    */
-  private Map<Long, Long> partitionMaxFileVersions = new HashMap<>();
+  private Map<Long, Long> partitionMaxFileVersions = new ConcurrentHashMap<>();
   /** database info for mem control. */
   private final DataRegionInfo dataRegionInfo = new DataRegionInfo(this);
   /** whether it's ready from recovery. */


### PR DESCRIPTION
## Description

The existing mechanism will have multiple threads modify the `partitionMaxFileVersions` property, which may cause a concurrency problem. This PR will fix an exception raised by a concurrency problem

## Before this PR
Have a probability will throw a ConcurrentModificationException
<img width="1318" alt="image" src="https://github.com/apache/iotdb/assets/34238279/16151f4a-aa3b-47fa-859e-7852d4afce81">

## After this PR
ConcurrentModificationException will not happen again