### PR TITLE
Load: Trigger last flush time map & tsfile resource degrading after successful load

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/load/LoadTsFileManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/load/LoadTsFileManager.java
@@ -59,7 +59,7 @@ import java.util.concurrent.PriorityBlockingQueue;
 /**
  * {@link LoadTsFileManager} is used for dealing with {@link LoadTsFilePieceNode} and {@link
  * LoadCommand}. This class turn the content of a piece of loading TsFile into a new TsFile. When
- * DataNode finish transfer pieces, this class will flush all TsFile and laod them into IoTDB, or
+ * DataNode finish transfer pieces, this class will flush all TsFile and load them into IoTDB, or
  * delete all.
  */
 public class LoadTsFileManager {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -2596,7 +2596,7 @@ public class DataRegion implements IDataRegionForQuery {
       // update last cache
       resetLastCacheWhenLoadingTsFile();
 
-      // help last flush map degrade
+      // update last flush time & help last flush time map degrade
       if (config.isEnableSeparateData()) {
         final DataRegionId dataRegionId = new DataRegionId(Integer.parseInt(this.dataRegionId));
         final long timePartitionId = newTsFileResource.getTimePartition();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -2593,10 +2593,40 @@ public class DataRegion implements IDataRegionForQuery {
               false,
               newTsFileResource.getTsFile().getName());
 
-      resetLastCacheWhenLoadingTsFile(); // update last cache
-      updateLastFlushTime(newTsFileResource); // update last flush time
-      long partitionNum = newTsFileResource.getTimePartition();
-      updatePartitionFileVersion(partitionNum, newTsFileResource.getVersion());
+      // update last cache
+      resetLastCacheWhenLoadingTsFile();
+
+      // help last flush map degrade
+      if (config.isEnableSeparateData()) {
+        final DataRegionId dataRegionId = new DataRegionId(Integer.parseInt(this.dataRegionId));
+        final long timePartitionId = newTsFileResource.getTimePartition();
+        if (!lastFlushTimeMap.checkAndCreateFlushedTimePartition(timePartitionId)) {
+          TimePartitionManager.getInstance()
+              .registerTimePartitionInfo(
+                  new TimePartitionInfo(
+                      dataRegionId,
+                      timePartitionId,
+                      false,
+                      Long.MAX_VALUE,
+                      lastFlushTimeMap.getMemSize(timePartitionId)));
+        }
+        updateLastFlushTime(newTsFileResource);
+        TimePartitionManager.getInstance()
+            .updateAfterFlushing(
+                dataRegionId,
+                timePartitionId,
+                System.currentTimeMillis(),
+                lastFlushTimeMap.getMemSize(timePartitionId),
+                false);
+      }
+
+      // update partition version
+      updatePartitionFileVersion(
+          newTsFileResource.getTimePartition(), newTsFileResource.getVersion());
+
+      // help tsfile resource degrade
+      TsFileResourceManager.getInstance().registerSealedTsFileResource(newTsFileResource);
+
       logger.info("TsFile {} is successfully loaded in unsequence list.", newFileName);
     } catch (DiskSpaceInsufficientException e) {
       logger.error(


### PR DESCRIPTION
## Description

After loading about 1_200_000 files into the storage engine, the system threw OOM exception.

After careful check, it was found that the current load tsfile operation does not trigger the last flush time map & tsfile resource degrading.

![img_v3_027l_1a6ddaed-b927-49f5-a7bb-8274715e9f4g](https://github.com/apache/iotdb/assets/30497621/cb079acc-882a-41a7-b44c-f4ed967ff306)

![img_v3_027o_b8422e4d-ea51-424d-b01f-4e3cfecec0eg](https://github.com/apache/iotdb/assets/30497621/1d48a31d-18f9-44d9-b802-58bc2973dc64)

![image](https://github.com/apache/iotdb/assets/30497621/2c1b085a-8067-4243-b214-8ec6610b1367)

