### PR TITLE
Fixed Ratis query not retrying when DataNode restarts

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/exception/RatisReadUnavailableException.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/exception/RatisReadUnavailableException.java
@@ -22,7 +22,7 @@ package org.apache.iotdb.consensus.exception;
 /** RaftServer is unable to serve linearizable read requests. */
 public class RatisReadUnavailableException extends ConsensusException {
 
-  public static final String RATIS_READ_UNAVAILABLE =
+  private static final String RATIS_READ_UNAVAILABLE =
       "Raft Server cannot serve read requests now (leader is unknown or under recovery). "
           + "Please try read later: ";
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/DataNodeInternalRPCServiceImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/DataNodeInternalRPCServiceImpl.java
@@ -308,7 +308,7 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
     TSendFragmentInstanceResp resp = new TSendFragmentInstanceResp();
     resp.setAccepted(executionResult.isAccepted());
     resp.setMessage(executionResult.getMessage());
-    // TODO
+    resp.setNeedRetry(executionResult.isNeedRetry());
     return resp;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/executor/RegionExecutionResult.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/executor/RegionExecutionResult.java
@@ -28,6 +28,7 @@ public class RegionExecutionResult {
   private String message;
 
   private TSStatus status;
+  private boolean needRetry;
 
   public boolean isAccepted() {
     return accepted;
@@ -51,5 +52,13 @@ public class RegionExecutionResult {
 
   public void setStatus(TSStatus status) {
     this.status = status;
+  }
+
+  public boolean isNeedRetry() {
+    return needRetry;
+  }
+
+  public void setNeedRetry(boolean needRetry) {
+    this.needRetry = needRetry;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/executor/RegionReadExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/executor/RegionReadExecutor.java
@@ -24,7 +24,6 @@ import org.apache.iotdb.commons.consensus.DataRegionId;
 import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.consensus.IConsensus;
 import org.apache.iotdb.consensus.common.DataSet;
-import org.apache.iotdb.consensus.exception.ConsensusException;
 import org.apache.iotdb.db.consensus.DataRegionConsensusImpl;
 import org.apache.iotdb.db.consensus.SchemaRegionConsensusImpl;
 import org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceInfo;
@@ -92,7 +91,7 @@ public class RegionReadExecutor {
         resp.setMessage(info.getMessage());
       }
       return resp;
-    } catch (ConsensusException e) {
+    } catch (Throwable e) {
       LOGGER.error("Execute FragmentInstance in ConsensusGroup {} failed.", groupId, e);
       resp.setMessage(String.format(ERROR_MSG_FORMAT, e.getMessage()));
       Throwable t = e.getCause();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/executor/RegionReadExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/executor/RegionReadExecutor.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.commons.consensus.DataRegionId;
 import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.consensus.IConsensus;
 import org.apache.iotdb.consensus.common.DataSet;
+import org.apache.iotdb.consensus.exception.ConsensusException;
 import org.apache.iotdb.db.consensus.DataRegionConsensusImpl;
 import org.apache.iotdb.db.consensus.SchemaRegionConsensusImpl;
 import org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceInfo;
@@ -32,6 +33,10 @@ import org.apache.iotdb.db.queryengine.plan.planner.plan.FragmentInstance;
 import org.apache.iotdb.db.storageengine.dataregion.VirtualDataRegion;
 import org.apache.iotdb.db.utils.SetThreadName;
 
+import org.apache.ratis.protocol.exceptions.NotLeaderException;
+import org.apache.ratis.protocol.exceptions.ReadException;
+import org.apache.ratis.protocol.exceptions.ReadIndexException;
+import org.apache.ratis.protocol.exceptions.ServerNotReadyException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,14 +74,14 @@ public class RegionReadExecutor {
   public RegionExecutionResult execute(
       ConsensusGroupId groupId, FragmentInstance fragmentInstance) {
     // execute fragment instance in state machine
-    DataSet readResponse;
+    RegionExecutionResult resp = new RegionExecutionResult();
     try (SetThreadName threadName = new SetThreadName(fragmentInstance.getId().getFullId())) {
+      DataSet readResponse;
       if (groupId instanceof DataRegionId) {
         readResponse = dataRegionConsensus.read(groupId, fragmentInstance);
       } else {
         readResponse = schemaRegionConsensus.read(groupId, fragmentInstance);
       }
-      RegionExecutionResult resp = new RegionExecutionResult();
       if (readResponse == null) {
         LOGGER.error(RESPONSE_NULL_ERROR_MSG);
         resp.setAccepted(false);
@@ -87,11 +92,16 @@ public class RegionReadExecutor {
         resp.setMessage(info.getMessage());
       }
       return resp;
-    } catch (Throwable t) {
-      LOGGER.error("Execute FragmentInstance in ConsensusGroup {} failed.", groupId, t);
-      RegionExecutionResult resp = new RegionExecutionResult();
-      resp.setAccepted(false);
-      resp.setMessage(String.format(ERROR_MSG_FORMAT, t.getMessage()));
+    } catch (ConsensusException e) {
+      LOGGER.error("Execute FragmentInstance in ConsensusGroup {} failed.", groupId, e);
+      resp.setMessage(String.format(ERROR_MSG_FORMAT, e.getMessage()));
+      Throwable t = e.getCause();
+      if (t instanceof ReadException
+          || t instanceof ReadIndexException
+          || t instanceof NotLeaderException
+          || t instanceof ServerNotReadyException) {
+        resp.setNeedRetry(true);
+      }
       return resp;
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/FragmentInstanceDispatcherImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/FragmentInstanceDispatcherImpl.java
@@ -301,8 +301,8 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
               client.sendFragmentInstance(sendFragmentInstanceReq);
           if (!sendFragmentInstanceResp.accepted) {
             logger.warn(sendFragmentInstanceResp.message);
-            if (sendFragmentInstanceResp.message.contains(
-                RatisReadUnavailableException.RATIS_READ_UNAVAILABLE)) {
+            if (sendFragmentInstanceResp.isSetNeedRetry()
+                && sendFragmentInstanceResp.isNeedRetry()) {
               throw new RatisReadUnavailableException(sendFragmentInstanceResp.message);
             } else {
               throw new FragmentInstanceDispatchException(

--- a/iotdb-protocol/thrift-datanode/src/main/thrift/datanode.thrift
+++ b/iotdb-protocol/thrift-datanode/src/main/thrift/datanode.thrift
@@ -116,6 +116,7 @@ struct TSendFragmentInstanceReq {
 struct TSendFragmentInstanceResp {
   1: required bool accepted
   2: optional string message
+  3: optional bool needRetry
 }
 
 struct TSendSinglePlanNodeReq {


### PR DESCRIPTION
![img_v3_027m_4aefc1d2-8b82-464c-aaf9-20fb04a502cg](https://github.com/apache/iotdb/assets/32640567/e7eb09b1-4ef9-4834-9b4f-29b96be54840)
<img width="1043" alt="image" src="https://github.com/apache/iotdb/assets/32640567/401fceb0-2f78-4a73-915f-2c88e76684a1">


Retry the request for ServerNotReadyException