### PR TITLE
Thrift zero-copy optimization for TElasticFramedTransport

### DIFF
--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
@@ -20,7 +20,7 @@
 package org.apache.iotdb.jdbc;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
-import org.apache.iotdb.rpc.RpcTransportFactory;
+import org.apache.iotdb.rpc.DeepCopyRpcTransportFactory;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
@@ -465,12 +465,12 @@ public class IoTDBConnection implements Connection {
   }
 
   private void openTransport() throws TTransportException {
-    RpcTransportFactory.setDefaultBufferCapacity(params.getThriftDefaultBufferSize());
-    RpcTransportFactory.setThriftMaxFrameSize(params.getThriftMaxFrameSize());
+    DeepCopyRpcTransportFactory.setDefaultBufferCapacity(params.getThriftDefaultBufferSize());
+    DeepCopyRpcTransportFactory.setThriftMaxFrameSize(params.getThriftMaxFrameSize());
 
     if (params.isUseSSL()) {
       transport =
-          RpcTransportFactory.INSTANCE.getTransport(
+          DeepCopyRpcTransportFactory.INSTANCE.getTransport(
               params.getHost(),
               params.getPort(),
               getNetworkTimeout(),
@@ -478,7 +478,7 @@ public class IoTDBConnection implements Connection {
               params.getTrustStorePwd());
     } else {
       transport =
-          RpcTransportFactory.INSTANCE.getTransport(
+          DeepCopyRpcTransportFactory.INSTANCE.getTransport(
               params.getHost(), params.getPort(), getNetworkTimeout());
     }
     if (!transport.isOpen()) {

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/BaseRpcTransportFactory.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/BaseRpcTransportFactory.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.rpc;
+
+import org.apache.thrift.transport.TMemoryInputTransport;
+import org.apache.thrift.transport.TSSLTransportFactory;
+import org.apache.thrift.transport.TSocket;
+import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
+import org.apache.thrift.transport.TTransportFactory;
+
+@SuppressWarnings("java:S1135") // ignore todos
+public class BaseRpcTransportFactory extends TTransportFactory {
+
+  // TODO: make it a config
+  public static boolean USE_SNAPPY = false;
+
+  protected static int thriftDefaultBufferSize = RpcUtils.THRIFT_DEFAULT_BUF_CAPACITY;
+  protected static int thriftMaxFrameSize = RpcUtils.THRIFT_FRAME_MAX_SIZE;
+
+  protected final TTransportFactory inner;
+
+  protected BaseRpcTransportFactory(TTransportFactory inner) {
+    this.inner = inner;
+  }
+
+  @Override
+  public TTransport getTransport(TTransport trans) throws TTransportException {
+    updateConfigurationForAsyncServerIfNecessary(trans);
+    return inner.getTransport(trans);
+  }
+
+  /**
+   * The Thrift AsyncServer uses TMemoryInputTransport (<a
+   * href="https://github.com/apache/thrift/blob/master/lib/java/src/main/java/org/apache/thrift/server/AbstractNonblockingServer.java#L291">...</a>),
+   * which employs the default configuration and performs size checks during the read and write
+   * processes. This behavior is not in line with our expectations of manually adjusting certain
+   * parameters. Therefore, special handling is required for it in this function.
+   *
+   * @param trans TTransport
+   */
+  private void updateConfigurationForAsyncServerIfNecessary(TTransport trans) {
+    if (trans instanceof TMemoryInputTransport) {
+      trans
+          .getConfiguration()
+          .setRecursionLimit(TConfigurationConst.defaultTConfiguration.getRecursionLimit());
+      trans
+          .getConfiguration()
+          .setMaxMessageSize(TConfigurationConst.defaultTConfiguration.getMaxMessageSize());
+      trans
+          .getConfiguration()
+          .setMaxFrameSize(TConfigurationConst.defaultTConfiguration.getMaxFrameSize());
+    }
+  }
+
+  public TTransport getTransportWithNoTimeout(String ip, int port) throws TTransportException {
+    return inner.getTransport(new TSocket(TConfigurationConst.defaultTConfiguration, ip, port));
+  }
+
+  public TTransport getTransport(
+      String ip, int port, int timeout, String trustStore, String trustStorePwd)
+      throws TTransportException {
+    TSSLTransportFactory.TSSLTransportParameters params =
+        new TSSLTransportFactory.TSSLTransportParameters();
+    params.setTrustStore(trustStore, trustStorePwd);
+    TTransport transport = TSSLTransportFactory.getClientSocket(ip, port, timeout, params);
+    return inner.getTransport(transport);
+  }
+
+  public TTransport getTransport(String ip, int port, int timeout) throws TTransportException {
+    return inner.getTransport(
+        new TSocket(TConfigurationConst.defaultTConfiguration, ip, port, timeout));
+  }
+
+  public static boolean isUseSnappy() {
+    return USE_SNAPPY;
+  }
+
+  public static void setUseSnappy(boolean useSnappy) {
+    USE_SNAPPY = useSnappy;
+  }
+
+  public static void setDefaultBufferCapacity(int thriftDefaultBufferSize) {
+    BaseRpcTransportFactory.thriftDefaultBufferSize = thriftDefaultBufferSize;
+  }
+
+  public static void setThriftMaxFrameSize(int thriftMaxFrameSize) {
+    BaseRpcTransportFactory.thriftMaxFrameSize = thriftMaxFrameSize;
+  }
+}

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/DeepCopyRpcTransportFactory.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/DeepCopyRpcTransportFactory.java
@@ -21,26 +21,26 @@ package org.apache.iotdb.rpc;
 
 import org.apache.thrift.transport.TTransportFactory;
 
-public class RpcTransportFactory extends BaseRpcTransportFactory {
+public class DeepCopyRpcTransportFactory extends BaseRpcTransportFactory {
 
-  public static RpcTransportFactory INSTANCE;
+  public static DeepCopyRpcTransportFactory INSTANCE;
 
   static {
     reInit();
   }
 
-  private RpcTransportFactory(TTransportFactory inner) {
+  private DeepCopyRpcTransportFactory(TTransportFactory inner) {
     super(inner);
   }
 
   public static void reInit() {
     INSTANCE =
         USE_SNAPPY
-            ? new RpcTransportFactory(
+            ? new DeepCopyRpcTransportFactory(
                 new TimeoutChangeableTSnappyFramedTransport.Factory(
-                    thriftDefaultBufferSize, thriftMaxFrameSize, false))
-            : new RpcTransportFactory(
+                    thriftDefaultBufferSize, thriftMaxFrameSize, true))
+            : new DeepCopyRpcTransportFactory(
                 new TElasticFramedTransport.Factory(
-                    thriftDefaultBufferSize, thriftMaxFrameSize, false));
+                    thriftDefaultBufferSize, thriftMaxFrameSize, true));
   }
 }

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TCompressedElasticFramedTransport.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TCompressedElasticFramedTransport.java
@@ -31,8 +31,11 @@ public abstract class TCompressedElasticFramedTransport extends TElasticFramedTr
   private AutoScalingBufferReadTransport readCompressBuffer;
 
   protected TCompressedElasticFramedTransport(
-      TTransport underlying, int thriftDefaultBufferSize, int thriftMaxFrameSize) {
-    super(underlying, thriftDefaultBufferSize, thriftMaxFrameSize);
+      TTransport underlying,
+      int thriftDefaultBufferSize,
+      int thriftMaxFrameSize,
+      boolean copyBinary) {
+    super(underlying, thriftDefaultBufferSize, thriftMaxFrameSize, copyBinary);
     writeCompressBuffer = new AutoScalingBufferWriteTransport(thriftDefaultBufferSize);
     readCompressBuffer = new AutoScalingBufferReadTransport(thriftDefaultBufferSize);
   }

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TElasticFramedTransport.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TElasticFramedTransport.java
@@ -46,30 +46,38 @@ public class TElasticFramedTransport extends TTransport {
      */
     protected final int thriftDefaultBufferSize;
 
+    /**
+     * When copyBinary flag is true, the transport will copy the binary data from the underlying.
+     * This is a protection for the underlying buffer to be reused by the caller protocol.
+     */
+    protected final boolean copyBinary;
+
     public Factory() {
-      this(RpcUtils.THRIFT_DEFAULT_BUF_CAPACITY, RpcUtils.THRIFT_FRAME_MAX_SIZE);
+      this(RpcUtils.THRIFT_DEFAULT_BUF_CAPACITY, RpcUtils.THRIFT_FRAME_MAX_SIZE, true);
     }
 
-    public Factory(int thriftDefaultBufferSize, int thriftMaxFrameSize) {
+    public Factory(int thriftDefaultBufferSize, int thriftMaxFrameSize, boolean copyBinary) {
       this.thriftDefaultBufferSize = thriftDefaultBufferSize;
       this.thriftMaxFrameSize = thriftMaxFrameSize;
+      this.copyBinary = copyBinary;
     }
 
     @Override
     public TTransport getTransport(TTransport trans) {
-      return new TElasticFramedTransport(trans, thriftDefaultBufferSize, thriftMaxFrameSize);
+      return new TElasticFramedTransport(
+          trans, thriftDefaultBufferSize, thriftMaxFrameSize, copyBinary);
     }
   }
 
-  public TElasticFramedTransport(TTransport underlying) {
-    this(underlying, RpcUtils.THRIFT_DEFAULT_BUF_CAPACITY, RpcUtils.THRIFT_FRAME_MAX_SIZE);
-  }
-
   public TElasticFramedTransport(
-      TTransport underlying, int thriftDefaultBufferSize, int thriftMaxFrameSize) {
+      TTransport underlying,
+      int thriftDefaultBufferSize,
+      int thriftMaxFrameSize,
+      boolean copyBinary) {
     this.underlying = underlying;
     this.thriftDefaultBufferSize = thriftDefaultBufferSize;
     this.thriftMaxFrameSize = thriftMaxFrameSize;
+    this.copyBinary = copyBinary;
     readBuffer = new AutoScalingBufferReadTransport(thriftDefaultBufferSize);
     writeBuffer = new AutoScalingBufferWriteTransport(thriftDefaultBufferSize);
   }
@@ -81,6 +89,7 @@ public class TElasticFramedTransport extends TTransport {
   protected AutoScalingBufferReadTransport readBuffer;
   protected AutoScalingBufferWriteTransport writeBuffer;
   protected final byte[] i32buf = new byte[4];
+  private final boolean copyBinary;
 
   @Override
   public boolean isOpen() {
@@ -168,6 +177,8 @@ public class TElasticFramedTransport extends TTransport {
 
   @Override
   public int getBytesRemainingInBuffer() {
+    // return -1 can make the caller protocol to copy binary data from the underlying transport.
+    if (copyBinary) return -1;
     return readBuffer.getBytesRemainingInBuffer();
   }
 

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TElasticFramedTransport.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TElasticFramedTransport.java
@@ -165,4 +165,24 @@ public class TElasticFramedTransport extends TTransport {
   public TTransport getSocket() {
     return underlying;
   }
+
+  @Override
+  public int getBytesRemainingInBuffer() {
+    return readBuffer.getBytesRemainingInBuffer();
+  }
+
+  @Override
+  public byte[] getBuffer() {
+    return readBuffer.getBuffer();
+  }
+
+  @Override
+  public int getBufferPosition() {
+    return readBuffer.getBufferPosition();
+  }
+
+  @Override
+  public void consumeBuffer(int len) {
+    readBuffer.consumeBuffer(len);
+  }
 }

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TSnappyElasticFramedTransport.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TSnappyElasticFramedTransport.java
@@ -29,30 +29,34 @@ public class TSnappyElasticFramedTransport extends TCompressedElasticFramedTrans
   public static class Factory extends TElasticFramedTransport.Factory {
 
     public Factory() {
-      this(RpcUtils.THRIFT_DEFAULT_BUF_CAPACITY, RpcUtils.THRIFT_FRAME_MAX_SIZE);
+      this(RpcUtils.THRIFT_DEFAULT_BUF_CAPACITY, RpcUtils.THRIFT_FRAME_MAX_SIZE, true);
     }
 
-    public Factory(int thriftDefaultBufferSize) {
-      this(thriftDefaultBufferSize, RpcUtils.THRIFT_FRAME_MAX_SIZE);
+    public Factory(int thriftDefaultBufferSize, boolean copyBinary) {
+      this(thriftDefaultBufferSize, RpcUtils.THRIFT_FRAME_MAX_SIZE, copyBinary);
     }
 
-    public Factory(int thriftDefaultBufferSize, int thriftMaxFrameSize) {
-      super(thriftDefaultBufferSize, thriftMaxFrameSize);
+    public Factory(int thriftDefaultBufferSize, int thriftMaxFrameSize, boolean copyBinary) {
+      super(thriftDefaultBufferSize, thriftMaxFrameSize, copyBinary);
     }
 
     @Override
     public TTransport getTransport(TTransport trans) {
-      return new TSnappyElasticFramedTransport(trans, thriftDefaultBufferSize, thriftMaxFrameSize);
+      return new TSnappyElasticFramedTransport(
+          trans, thriftDefaultBufferSize, thriftMaxFrameSize, copyBinary);
     }
   }
 
   public TSnappyElasticFramedTransport(TTransport underlying) {
-    this(underlying, RpcUtils.THRIFT_DEFAULT_BUF_CAPACITY, RpcUtils.THRIFT_FRAME_MAX_SIZE);
+    this(underlying, RpcUtils.THRIFT_DEFAULT_BUF_CAPACITY, RpcUtils.THRIFT_FRAME_MAX_SIZE, true);
   }
 
   public TSnappyElasticFramedTransport(
-      TTransport underlying, int thriftDefaultBufferSize, int thriftMaxFrameSize) {
-    super(underlying, thriftDefaultBufferSize, thriftMaxFrameSize);
+      TTransport underlying,
+      int thriftDefaultBufferSize,
+      int thriftMaxFrameSize,
+      boolean copyBinary) {
+    super(underlying, thriftDefaultBufferSize, thriftMaxFrameSize, copyBinary);
   }
 
   @Override

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TimeoutChangeableTFastFramedTransport.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TimeoutChangeableTFastFramedTransport.java
@@ -31,8 +31,8 @@ public class TimeoutChangeableTFastFramedTransport extends TElasticFramedTranspo
   private final TSocket underlyingSocket;
 
   public TimeoutChangeableTFastFramedTransport(
-      TSocket underlying, int thriftDefaultBufferSize, int thriftMaxFrameSize) {
-    super(underlying, thriftDefaultBufferSize, thriftMaxFrameSize);
+      TSocket underlying, int thriftDefaultBufferSize, int thriftMaxFrameSize, boolean copyBinary) {
+    super(underlying, thriftDefaultBufferSize, thriftMaxFrameSize, copyBinary);
     this.underlyingSocket = underlying;
   }
 
@@ -56,19 +56,22 @@ public class TimeoutChangeableTFastFramedTransport extends TElasticFramedTranspo
 
     private final int thriftDefaultBufferSize;
     protected final int thriftMaxFrameSize;
+    protected final boolean copyBinary;
 
-    public Factory(int thriftDefaultBufferSize, int thriftMaxFrameSize) {
+    public Factory(int thriftDefaultBufferSize, int thriftMaxFrameSize, boolean copyBinary) {
       this.thriftDefaultBufferSize = thriftDefaultBufferSize;
       this.thriftMaxFrameSize = thriftMaxFrameSize;
+      this.copyBinary = copyBinary;
     }
 
     @Override
     public TTransport getTransport(TTransport trans) {
       if (trans instanceof TSocket) {
         return new TimeoutChangeableTFastFramedTransport(
-            (TSocket) trans, thriftDefaultBufferSize, thriftMaxFrameSize);
+            (TSocket) trans, thriftDefaultBufferSize, thriftMaxFrameSize, copyBinary);
       } else {
-        return new TElasticFramedTransport(trans, thriftDefaultBufferSize, thriftMaxFrameSize);
+        return new TElasticFramedTransport(
+            trans, thriftDefaultBufferSize, thriftMaxFrameSize, true);
       }
     }
   }

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TimeoutChangeableTFastFramedTransport.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TimeoutChangeableTFastFramedTransport.java
@@ -71,7 +71,7 @@ public class TimeoutChangeableTFastFramedTransport extends TElasticFramedTranspo
             (TSocket) trans, thriftDefaultBufferSize, thriftMaxFrameSize, copyBinary);
       } else {
         return new TElasticFramedTransport(
-            trans, thriftDefaultBufferSize, thriftMaxFrameSize, true);
+            trans, thriftDefaultBufferSize, thriftMaxFrameSize, copyBinary);
       }
     }
   }

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TimeoutChangeableTSnappyFramedTransport.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TimeoutChangeableTSnappyFramedTransport.java
@@ -31,8 +31,8 @@ public class TimeoutChangeableTSnappyFramedTransport extends TSnappyElasticFrame
   private final TSocket underlyingSocket;
 
   public TimeoutChangeableTSnappyFramedTransport(
-      TSocket underlying, int thriftDefaultBufferSize, int thriftMaxFrameSize) {
-    super(underlying, thriftDefaultBufferSize, thriftMaxFrameSize);
+      TSocket underlying, int thriftDefaultBufferSize, int thriftMaxFrameSize, boolean copyBinary) {
+    super(underlying, thriftDefaultBufferSize, thriftMaxFrameSize, copyBinary);
     this.underlyingSocket = underlying;
   }
 
@@ -56,20 +56,22 @@ public class TimeoutChangeableTSnappyFramedTransport extends TSnappyElasticFrame
 
     private final int thriftDefaultBufferSize;
     protected final int thriftMaxFrameSize;
+    protected final boolean copyBinary;
 
-    public Factory(int thriftDefaultBufferSize, int thriftMaxFrameSize) {
+    public Factory(int thriftDefaultBufferSize, int thriftMaxFrameSize, boolean copyBinary) {
       this.thriftDefaultBufferSize = thriftDefaultBufferSize;
       this.thriftMaxFrameSize = thriftMaxFrameSize;
+      this.copyBinary = copyBinary;
     }
 
     @Override
     public TTransport getTransport(TTransport trans) {
       if (trans instanceof TSocket) {
         return new TimeoutChangeableTSnappyFramedTransport(
-            (TSocket) trans, thriftDefaultBufferSize, thriftMaxFrameSize);
+            (TSocket) trans, thriftDefaultBufferSize, thriftMaxFrameSize, copyBinary);
       } else {
         return new TSnappyElasticFramedTransport(
-            trans, thriftDefaultBufferSize, thriftMaxFrameSize);
+            trans, thriftDefaultBufferSize, thriftMaxFrameSize, copyBinary);
       }
     }
   }

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/ZeroCopyRpcTransportFactory.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/ZeroCopyRpcTransportFactory.java
@@ -21,25 +21,25 @@ package org.apache.iotdb.rpc;
 
 import org.apache.thrift.transport.TTransportFactory;
 
-public class RpcTransportFactory extends BaseRpcTransportFactory {
+public class ZeroCopyRpcTransportFactory extends BaseRpcTransportFactory {
 
-  public static RpcTransportFactory INSTANCE;
+  public static ZeroCopyRpcTransportFactory INSTANCE;
 
   static {
     reInit();
   }
 
-  private RpcTransportFactory(TTransportFactory inner) {
+  private ZeroCopyRpcTransportFactory(TTransportFactory inner) {
     super(inner);
   }
 
   public static void reInit() {
     INSTANCE =
         USE_SNAPPY
-            ? new RpcTransportFactory(
+            ? new ZeroCopyRpcTransportFactory(
                 new TimeoutChangeableTSnappyFramedTransport.Factory(
                     thriftDefaultBufferSize, thriftMaxFrameSize, false))
-            : new RpcTransportFactory(
+            : new ZeroCopyRpcTransportFactory(
                 new TElasticFramedTransport.Factory(
                     thriftDefaultBufferSize, thriftMaxFrameSize, false));
   }

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -74,6 +74,7 @@ import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.ByteBuffer;
 import java.security.SecureRandom;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -417,6 +418,17 @@ public class SessionConnection {
     }
 
     RpcUtils.verifySuccess(execResp.getStatus());
+
+    if (execResp.queryResult != null) {
+      for (int i = 0; i < execResp.queryResult.size(); i++) {
+        ByteBuffer oldBuffer = execResp.queryResult.get(i);
+        ByteBuffer newBuffer = ByteBuffer.allocate(oldBuffer.remaining());
+        oldBuffer.get(newBuffer.array());
+        newBuffer.flip();
+        execResp.queryResult.set(i, newBuffer);
+      }
+    }
+
     return new SessionDataSet(
         sql,
         execResp.getColumns(),

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -422,10 +422,9 @@ public class SessionConnection {
     if (execResp.queryResult != null) {
       for (int i = 0; i < execResp.queryResult.size(); i++) {
         ByteBuffer oldBuffer = execResp.queryResult.get(i);
-        ByteBuffer newBuffer = ByteBuffer.allocate(oldBuffer.remaining());
-        oldBuffer.get(newBuffer.array());
-        newBuffer.flip();
-        execResp.queryResult.set(i, newBuffer);
+        byte[] bytes = new byte[oldBuffer.remaining()];
+        oldBuffer.get(bytes);
+        execResp.queryResult.set(i, ByteBuffer.wrap(bytes));
       }
     }
 

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/ThriftConnection.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/ThriftConnection.java
@@ -21,8 +21,8 @@ package org.apache.iotdb.session;
 
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.isession.SessionDataSet;
+import org.apache.iotdb.rpc.DeepCopyRpcTransportFactory;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
-import org.apache.iotdb.rpc.RpcTransportFactory;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
@@ -80,12 +80,12 @@ public class ThriftConnection {
       ZoneId zoneId,
       String version)
       throws IoTDBConnectionException {
-    RpcTransportFactory.setDefaultBufferCapacity(thriftDefaultBufferSize);
-    RpcTransportFactory.setThriftMaxFrameSize(thriftMaxFrameSize);
+    DeepCopyRpcTransportFactory.setDefaultBufferCapacity(thriftDefaultBufferSize);
+    DeepCopyRpcTransportFactory.setThriftMaxFrameSize(thriftMaxFrameSize);
     try {
       if (useSSL) {
         transport =
-            RpcTransportFactory.INSTANCE.getTransport(
+            DeepCopyRpcTransportFactory.INSTANCE.getTransport(
                 endPoint.getIp(),
                 endPoint.getPort(),
                 connectionTimeoutInMs,
@@ -93,7 +93,7 @@ public class ThriftConnection {
                 trustStorePwd);
       } else {
         transport =
-            RpcTransportFactory.INSTANCE.getTransport(
+            DeepCopyRpcTransportFactory.INSTANCE.getTransport(
                 // as there is a try-catch already, we do not need to use TSocket.wrap
                 endPoint.getIp(), endPoint.getPort(), connectionTimeoutInMs);
       }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCService.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCService.java
@@ -29,6 +29,7 @@ import org.apache.iotdb.commons.service.metric.MetricService;
 import org.apache.iotdb.confignode.conf.ConfigNodeConfig;
 import org.apache.iotdb.confignode.conf.ConfigNodeDescriptor;
 import org.apache.iotdb.confignode.rpc.thrift.IConfigNodeRPCService;
+import org.apache.iotdb.rpc.DeepCopyRpcTransportFactory;
 
 /** ConfigNodeRPCServer exposes the interface that interacts with the DataNode */
 public class ConfigNodeRPCService extends ThriftService implements ConfigNodeRPCServiceMBean {
@@ -69,7 +70,8 @@ public class ConfigNodeRPCService extends ThriftService implements ConfigNodeRPC
               configConf.getCnRpcMaxConcurrentClientNum(),
               configConf.getThriftServerAwaitTimeForStopService(),
               new ConfigNodeRPCServiceHandler(),
-              commonConfig.isRpcThriftCompressionEnabled());
+              commonConfig.isRpcThriftCompressionEnabled(),
+              DeepCopyRpcTransportFactory.INSTANCE);
     } catch (RPCServiceException e) {
       throw new IllegalAccessException(e.getMessage());
     }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/client/SyncIoTConsensusServiceClient.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/client/SyncIoTConsensusServiceClient.java
@@ -26,7 +26,7 @@ import org.apache.iotdb.commons.client.factory.ThriftClientFactory;
 import org.apache.iotdb.commons.client.property.ThriftClientProperty;
 import org.apache.iotdb.commons.client.sync.SyncThriftClientWithErrorHandler;
 import org.apache.iotdb.consensus.iot.thrift.IoTConsensusIService;
-import org.apache.iotdb.rpc.RpcTransportFactory;
+import org.apache.iotdb.rpc.DeepCopyRpcTransportFactory;
 import org.apache.iotdb.rpc.TConfigurationConst;
 
 import org.apache.commons.pool2.PooledObject;
@@ -50,7 +50,7 @@ public class SyncIoTConsensusServiceClient extends IoTConsensusIService.Client
         property
             .getProtocolFactory()
             .getProtocol(
-                RpcTransportFactory.INSTANCE.getTransport(
+                DeepCopyRpcTransportFactory.INSTANCE.getTransport(
                     new TSocket(
                         TConfigurationConst.defaultTConfiguration,
                         endpoint.getIp(),

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/service/IoTConsensusRPCService.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/service/IoTConsensusRPCService.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.commons.service.ThriftService;
 import org.apache.iotdb.commons.service.ThriftServiceThread;
 import org.apache.iotdb.consensus.config.IoTConsensusConfig;
 import org.apache.iotdb.consensus.iot.thrift.IoTConsensusIService;
+import org.apache.iotdb.rpc.RpcTransportFactory;
 
 import org.apache.thrift.TBaseAsyncProcessor;
 import org.slf4j.Logger;
@@ -85,7 +86,8 @@ public class IoTConsensusRPCService extends ThriftService implements IoTConsensu
               config.getRpc().isRpcThriftCompressionEnabled(),
               config.getRpc().getConnectionTimeoutInMs(),
               config.getRpc().getThriftMaxFrameSize(),
-              ThriftServiceThread.ServerType.SELECTOR);
+              ThriftServiceThread.ServerType.SELECTOR,
+              RpcTransportFactory.INSTANCE);
     } catch (RPCServiceException e) {
       throw new IllegalAccessException(e.getMessage());
     }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/service/IoTConsensusRPCService.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/service/IoTConsensusRPCService.java
@@ -27,7 +27,7 @@ import org.apache.iotdb.commons.service.ThriftService;
 import org.apache.iotdb.commons.service.ThriftServiceThread;
 import org.apache.iotdb.consensus.config.IoTConsensusConfig;
 import org.apache.iotdb.consensus.iot.thrift.IoTConsensusIService;
-import org.apache.iotdb.rpc.RpcTransportFactory;
+import org.apache.iotdb.rpc.ZeroCopyRpcTransportFactory;
 
 import org.apache.thrift.TBaseAsyncProcessor;
 import org.slf4j.Logger;
@@ -87,7 +87,7 @@ public class IoTConsensusRPCService extends ThriftService implements IoTConsensu
               config.getRpc().getConnectionTimeoutInMs(),
               config.getRpc().getThriftMaxFrameSize(),
               ThriftServiceThread.ServerType.SELECTOR,
-              RpcTransportFactory.INSTANCE);
+              ZeroCopyRpcTransportFactory.INSTANCE);
     } catch (RPCServiceException e) {
       throw new IllegalAccessException(e.getMessage());
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -41,6 +41,7 @@ import org.apache.iotdb.db.storageengine.dataregion.tsfile.timeindex.TimeIndexLe
 import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALMode;
 import org.apache.iotdb.db.utils.datastructure.TVListSortAlgorithm;
 import org.apache.iotdb.metrics.metricsets.system.SystemMetrics;
+import org.apache.iotdb.rpc.BaseRpcTransportFactory;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.ZeroCopyRpcTransportFactory;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
@@ -2506,7 +2507,7 @@ public class IoTDBConfig {
 
   public void setThriftMaxFrameSize(int thriftMaxFrameSize) {
     this.thriftMaxFrameSize = thriftMaxFrameSize;
-    ZeroCopyRpcTransportFactory.setThriftMaxFrameSize(this.thriftMaxFrameSize);
+    BaseRpcTransportFactory.setThriftMaxFrameSize(this.thriftMaxFrameSize);
   }
 
   public int getThriftDefaultBufferSize() {
@@ -2515,7 +2516,7 @@ public class IoTDBConfig {
 
   public void setThriftDefaultBufferSize(int thriftDefaultBufferSize) {
     this.thriftDefaultBufferSize = thriftDefaultBufferSize;
-    ZeroCopyRpcTransportFactory.setDefaultBufferCapacity(this.thriftDefaultBufferSize);
+    BaseRpcTransportFactory.setDefaultBufferCapacity(this.thriftDefaultBufferSize);
   }
 
   public int getCheckPeriodWhenInsertBlocked() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -41,8 +41,8 @@ import org.apache.iotdb.db.storageengine.dataregion.tsfile.timeindex.TimeIndexLe
 import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALMode;
 import org.apache.iotdb.db.utils.datastructure.TVListSortAlgorithm;
 import org.apache.iotdb.metrics.metricsets.system.SystemMetrics;
-import org.apache.iotdb.rpc.RpcTransportFactory;
 import org.apache.iotdb.rpc.RpcUtils;
+import org.apache.iotdb.rpc.ZeroCopyRpcTransportFactory;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -2506,7 +2506,7 @@ public class IoTDBConfig {
 
   public void setThriftMaxFrameSize(int thriftMaxFrameSize) {
     this.thriftMaxFrameSize = thriftMaxFrameSize;
-    RpcTransportFactory.setThriftMaxFrameSize(this.thriftMaxFrameSize);
+    ZeroCopyRpcTransportFactory.setThriftMaxFrameSize(this.thriftMaxFrameSize);
   }
 
   public int getThriftDefaultBufferSize() {
@@ -2515,7 +2515,7 @@ public class IoTDBConfig {
 
   public void setThriftDefaultBufferSize(int thriftDefaultBufferSize) {
     this.thriftDefaultBufferSize = thriftDefaultBufferSize;
-    RpcTransportFactory.setDefaultBufferCapacity(this.thriftDefaultBufferSize);
+    ZeroCopyRpcTransportFactory.setDefaultBufferCapacity(this.thriftDefaultBufferSize);
   }
 
   public int getCheckPeriodWhenInsertBlocked() {
@@ -2596,7 +2596,7 @@ public class IoTDBConfig {
 
   public void setRpcAdvancedCompressionEnable(boolean rpcAdvancedCompressionEnable) {
     this.rpcAdvancedCompressionEnable = rpcAdvancedCompressionEnable;
-    RpcTransportFactory.setUseSnappy(this.rpcAdvancedCompressionEnable);
+    ZeroCopyRpcTransportFactory.setUseSnappy(this.rpcAdvancedCompressionEnable);
   }
 
   public int getMlogBufferSize() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -53,6 +53,7 @@ import org.apache.iotdb.metrics.reporter.iotdb.IoTDBInternalMemoryReporter;
 import org.apache.iotdb.metrics.reporter.iotdb.IoTDBInternalReporter;
 import org.apache.iotdb.metrics.utils.InternalReporterType;
 import org.apache.iotdb.metrics.utils.NodeType;
+import org.apache.iotdb.rpc.DeepCopyRpcTransportFactory;
 import org.apache.iotdb.rpc.ZeroCopyRpcTransportFactory;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -970,6 +971,7 @@ public class IoTDBDescriptor {
 
     // make RPCTransportFactory taking effect.
     ZeroCopyRpcTransportFactory.reInit();
+    DeepCopyRpcTransportFactory.reInit();
 
     // UDF
     loadUDFProps(properties);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -53,7 +53,7 @@ import org.apache.iotdb.metrics.reporter.iotdb.IoTDBInternalMemoryReporter;
 import org.apache.iotdb.metrics.reporter.iotdb.IoTDBInternalReporter;
 import org.apache.iotdb.metrics.utils.InternalReporterType;
 import org.apache.iotdb.metrics.utils.NodeType;
-import org.apache.iotdb.rpc.RpcTransportFactory;
+import org.apache.iotdb.rpc.ZeroCopyRpcTransportFactory;
 import org.apache.iotdb.tsfile.common.conf.TSFileDescriptor;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
@@ -969,7 +969,7 @@ public class IoTDBDescriptor {
     loadTsFileProps(properties);
 
     // make RPCTransportFactory taking effect.
-    RpcTransportFactory.reInit();
+    ZeroCopyRpcTransportFactory.reInit();
 
     // UDF
     loadUDFProps(properties);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/legacy/IoTDBLegacyPipeReceiverAgent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/legacy/IoTDBLegacyPipeReceiverAgent.java
@@ -180,7 +180,7 @@ public class IoTDBLegacyPipeReceiverAgent {
     // step2. deserialize PipeData
     PipeData pipeData;
     try {
-      int length = buff.capacity();
+      int length = buff.remaining();
       byte[] byteArray = new byte[length];
       buff.get(byteArray);
       pipeData = PipeData.createPipeData(byteArray);
@@ -288,7 +288,7 @@ public class IoTDBLegacyPipeReceiverAgent {
 
     // step3. append file
     try (RandomAccessFile randomAccessFile = new RandomAccessFile(file, "rw")) {
-      int length = buff.capacity();
+      int length = buff.remaining();
       randomAccessFile.seek(startIndex);
       byte[] byteArray = new byte[length];
       buff.get(byteArray);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/client/ConfigNodeClient.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/client/ConfigNodeClient.java
@@ -129,7 +129,7 @@ import org.apache.iotdb.confignode.rpc.thrift.TThrottleQuotaResp;
 import org.apache.iotdb.confignode.rpc.thrift.TUnsetSchemaTemplateReq;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
-import org.apache.iotdb.rpc.RpcTransportFactory;
+import org.apache.iotdb.rpc.DeepCopyRpcTransportFactory;
 import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.apache.commons.pool2.PooledObject;
@@ -195,7 +195,7 @@ public class ConfigNodeClient implements IConfigNodeRPCService.Iface, ThriftClie
   public void connect(TEndPoint endpoint) throws TException {
     try {
       transport =
-          RpcTransportFactory.INSTANCE.getTransport(
+          DeepCopyRpcTransportFactory.INSTANCE.getTransport(
               // As there is a try-catch already, we do not need to use TSocket.wrap
               endpoint.getIp(), endpoint.getPort(), property.getConnectionTimeoutMs());
       if (!transport.isOpen()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/exchange/MPPDataExchangeService.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/exchange/MPPDataExchangeService.java
@@ -35,6 +35,7 @@ import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.queryengine.execution.memory.LocalMemoryManager;
 import org.apache.iotdb.mpp.rpc.thrift.MPPDataExchangeService.Processor;
+import org.apache.iotdb.rpc.DeepCopyRpcTransportFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,7 +98,8 @@ public class MPPDataExchangeService extends ThriftService implements MPPDataExch
               config.getRpcMaxConcurrentClientNum(),
               config.getThriftServerAwaitTimeForStopService(),
               new MPPDataExchangeServiceThriftHandler(),
-              config.isRpcThriftCompressionEnable());
+              config.isRpcThriftCompressionEnable(),
+              DeepCopyRpcTransportFactory.INSTANCE);
     } catch (RPCServiceException e) {
       throw new IllegalAccessException(e.getMessage());
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/DataNodeInternalRPCService.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/DataNodeInternalRPCService.java
@@ -31,6 +31,7 @@ import org.apache.iotdb.db.protocol.thrift.handler.InternalServiceThriftHandler;
 import org.apache.iotdb.db.protocol.thrift.impl.DataNodeInternalRPCServiceImpl;
 import org.apache.iotdb.db.service.metrics.DataNodeInternalRPCServiceMetrics;
 import org.apache.iotdb.mpp.rpc.thrift.IDataNodeRPCService.Processor;
+import org.apache.iotdb.rpc.DeepCopyRpcTransportFactory;
 
 public class DataNodeInternalRPCService extends ThriftService
     implements DataNodeInternalRPCServiceMBean {
@@ -67,7 +68,8 @@ public class DataNodeInternalRPCService extends ThriftService
               config.getRpcMaxConcurrentClientNum(),
               config.getThriftServerAwaitTimeForStopService(),
               new InternalServiceThriftHandler(),
-              config.isRpcThriftCompressionEnable());
+              config.isRpcThriftCompressionEnable(),
+              DeepCopyRpcTransportFactory.INSTANCE);
     } catch (RPCServiceException e) {
       throw new IllegalAccessException(e.getMessage());
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/RPCService.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/RPCService.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.db.protocol.thrift.ProcessorWithMetrics;
 import org.apache.iotdb.db.protocol.thrift.handler.RPCServiceThriftHandler;
 import org.apache.iotdb.db.protocol.thrift.impl.IClientRPCServiceWithHandler;
 import org.apache.iotdb.db.service.metrics.RPCServiceMetrics;
+import org.apache.iotdb.rpc.RpcTransportFactory;
 
 import java.lang.reflect.InvocationTargetException;
 
@@ -73,7 +74,8 @@ public class RPCService extends ThriftService implements RPCServiceMBean {
                 IoTDBDescriptor.getInstance().getConfig().isRpcThriftCompressionEnable(),
                 config.getKeyStorePath(),
                 config.getKeyStorePwd(),
-                config.getConnectionTimeoutInMS());
+                config.getConnectionTimeoutInMS(),
+                RpcTransportFactory.INSTANCE);
       } else {
         thriftServiceThread =
             new ThriftServiceThread(
@@ -85,9 +87,9 @@ public class RPCService extends ThriftService implements RPCServiceMBean {
                 config.getRpcMaxConcurrentClientNum(),
                 config.getThriftServerAwaitTimeForStopService(),
                 new RPCServiceThriftHandler(impl),
-                IoTDBDescriptor.getInstance().getConfig().isRpcThriftCompressionEnable());
+                IoTDBDescriptor.getInstance().getConfig().isRpcThriftCompressionEnable(),
+                RpcTransportFactory.INSTANCE);
       }
-
     } catch (RPCServiceException e) {
       throw new IllegalAccessException(e.getMessage());
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/RPCService.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/RPCService.java
@@ -30,7 +30,7 @@ import org.apache.iotdb.db.protocol.thrift.ProcessorWithMetrics;
 import org.apache.iotdb.db.protocol.thrift.handler.RPCServiceThriftHandler;
 import org.apache.iotdb.db.protocol.thrift.impl.IClientRPCServiceWithHandler;
 import org.apache.iotdb.db.service.metrics.RPCServiceMetrics;
-import org.apache.iotdb.rpc.RpcTransportFactory;
+import org.apache.iotdb.rpc.ZeroCopyRpcTransportFactory;
 
 import java.lang.reflect.InvocationTargetException;
 
@@ -75,7 +75,7 @@ public class RPCService extends ThriftService implements RPCServiceMBean {
                 config.getKeyStorePath(),
                 config.getKeyStorePwd(),
                 config.getConnectionTimeoutInMS(),
-                RpcTransportFactory.INSTANCE);
+                ZeroCopyRpcTransportFactory.INSTANCE);
       } else {
         thriftServiceThread =
             new ThriftServiceThread(
@@ -88,7 +88,7 @@ public class RPCService extends ThriftService implements RPCServiceMBean {
                 config.getThriftServerAwaitTimeForStopService(),
                 new RPCServiceThriftHandler(impl),
                 IoTDBDescriptor.getInstance().getConfig().isRpcThriftCompressionEnable(),
-                RpcTransportFactory.INSTANCE);
+                ZeroCopyRpcTransportFactory.INSTANCE);
       }
     } catch (RPCServiceException e) {
       throw new IllegalAccessException(e.getMessage());

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/sync/SyncConfigNodeIServiceClient.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/sync/SyncConfigNodeIServiceClient.java
@@ -25,7 +25,7 @@ import org.apache.iotdb.commons.client.ThriftClient;
 import org.apache.iotdb.commons.client.factory.ThriftClientFactory;
 import org.apache.iotdb.commons.client.property.ThriftClientProperty;
 import org.apache.iotdb.confignode.rpc.thrift.IConfigNodeRPCService;
-import org.apache.iotdb.rpc.RpcTransportFactory;
+import org.apache.iotdb.rpc.DeepCopyRpcTransportFactory;
 import org.apache.iotdb.rpc.TConfigurationConst;
 import org.apache.iotdb.rpc.TimeoutChangeableTransport;
 
@@ -52,7 +52,7 @@ public class SyncConfigNodeIServiceClient extends IConfigNodeRPCService.Client
         property
             .getProtocolFactory()
             .getProtocol(
-                RpcTransportFactory.INSTANCE.getTransport(
+                DeepCopyRpcTransportFactory.INSTANCE.getTransport(
                     new TSocket(
                         TConfigurationConst.defaultTConfiguration,
                         endPoint.getIp(),

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/sync/SyncDataNodeInternalServiceClient.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/sync/SyncDataNodeInternalServiceClient.java
@@ -26,7 +26,7 @@ import org.apache.iotdb.commons.client.factory.ThriftClientFactory;
 import org.apache.iotdb.commons.client.property.ThriftClientProperty;
 import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.mpp.rpc.thrift.IDataNodeRPCService;
-import org.apache.iotdb.rpc.RpcTransportFactory;
+import org.apache.iotdb.rpc.DeepCopyRpcTransportFactory;
 import org.apache.iotdb.rpc.TConfigurationConst;
 import org.apache.iotdb.rpc.TimeoutChangeableTransport;
 
@@ -53,7 +53,7 @@ public class SyncDataNodeInternalServiceClient extends IDataNodeRPCService.Clien
         property
             .getProtocolFactory()
             .getProtocol(
-                RpcTransportFactory.INSTANCE.getTransport(
+                DeepCopyRpcTransportFactory.INSTANCE.getTransport(
                     new TSocket(
                         TConfigurationConst.defaultTConfiguration,
                         endpoint.getIp(),

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/sync/SyncDataNodeMPPDataExchangeServiceClient.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/sync/SyncDataNodeMPPDataExchangeServiceClient.java
@@ -25,7 +25,7 @@ import org.apache.iotdb.commons.client.ThriftClient;
 import org.apache.iotdb.commons.client.factory.ThriftClientFactory;
 import org.apache.iotdb.commons.client.property.ThriftClientProperty;
 import org.apache.iotdb.mpp.rpc.thrift.MPPDataExchangeService;
-import org.apache.iotdb.rpc.RpcTransportFactory;
+import org.apache.iotdb.rpc.DeepCopyRpcTransportFactory;
 import org.apache.iotdb.rpc.TConfigurationConst;
 import org.apache.iotdb.rpc.TimeoutChangeableTransport;
 
@@ -52,7 +52,7 @@ public class SyncDataNodeMPPDataExchangeServiceClient extends MPPDataExchangeSer
         property
             .getProtocolFactory()
             .getProtocol(
-                RpcTransportFactory.INSTANCE.getTransport(
+                DeepCopyRpcTransportFactory.INSTANCE.getTransport(
                     new TSocket(
                         TConfigurationConst.defaultTConfiguration,
                         endpoint.getIp(),

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/connector/client/IoTDBSyncClient.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/connector/client/IoTDBSyncClient.java
@@ -21,7 +21,7 @@ package org.apache.iotdb.commons.pipe.connector.client;
 
 import org.apache.iotdb.commons.client.ThriftClient;
 import org.apache.iotdb.commons.client.property.ThriftClientProperty;
-import org.apache.iotdb.rpc.RpcTransportFactory;
+import org.apache.iotdb.rpc.DeepCopyRpcTransportFactory;
 import org.apache.iotdb.rpc.TimeoutChangeableTransport;
 import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
 
@@ -44,13 +44,13 @@ public class IoTDBSyncClient extends IClientRPCService.Client
             .getProtocolFactory()
             .getProtocol(
                 useSSL
-                    ? RpcTransportFactory.INSTANCE.getTransport(
+                    ? DeepCopyRpcTransportFactory.INSTANCE.getTransport(
                         ipAddress,
                         port,
                         property.getConnectionTimeoutMs(),
                         trustStore,
                         trustStorePwd)
-                    : RpcTransportFactory.INSTANCE.getTransport(
+                    : DeepCopyRpcTransportFactory.INSTANCE.getTransport(
                         ipAddress, port, property.getConnectionTimeoutMs())));
     TTransport transport = getInputProtocol().getTransport();
     if (!transport.isOpen()) {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/AbstractThriftServiceThread.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/AbstractThriftServiceThread.java
@@ -62,6 +62,8 @@ public abstract class AbstractThriftServiceThread extends Thread {
 
   private TProtocolFactory protocolFactory;
 
+  private TTransportFactory transportFactory;
+
   // currently, we can reuse the ProtocolFactory instance.
   private static TCompactProtocol.Factory compactProtocolFactory = new TCompactProtocol.Factory();
   private static TBinaryProtocol.Factory binaryProtocolFactory = new TBinaryProtocol.Factory();
@@ -70,7 +72,9 @@ public abstract class AbstractThriftServiceThread extends Thread {
     protocolFactory = getProtocolFactory(compress);
   }
 
-  public abstract TTransportFactory getTTransportFactory();
+  public TTransportFactory getTTransportFactory() {
+    return transportFactory;
+  }
 
   public static TProtocolFactory getProtocolFactory(boolean compress) {
     if (compress) {
@@ -116,7 +120,9 @@ public abstract class AbstractThriftServiceThread extends Thread {
       boolean compress,
       int connectionTimeoutInMS,
       int maxReadBufferBytes,
-      ServerType serverType) {
+      ServerType serverType,
+      TTransportFactory transportFactory) {
+    this.transportFactory = transportFactory;
     initProtocolFactory(compress);
     this.serviceName = serviceName;
     try {
@@ -168,7 +174,9 @@ public abstract class AbstractThriftServiceThread extends Thread {
       boolean compress,
       String keyStorePath,
       String keyStorePwd,
-      int clientTimeout) {
+      int clientTimeout,
+      TTransportFactory transportFactory) {
+    this.transportFactory = transportFactory;
     initProtocolFactory(compress);
     this.serviceName = serviceName;
 
@@ -200,7 +208,9 @@ public abstract class AbstractThriftServiceThread extends Thread {
       int maxWorkerThreads,
       int timeoutSecond,
       TServerEventHandler serverEventHandler,
-      boolean compress) {
+      boolean compress,
+      TTransportFactory transportFactory) {
+    this.transportFactory = transportFactory;
     initProtocolFactory(compress);
     this.serviceName = serviceName;
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/ThriftServiceThread.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/ThriftServiceThread.java
@@ -19,8 +19,6 @@
 
 package org.apache.iotdb.commons.service;
 
-import org.apache.iotdb.rpc.RpcTransportFactory;
-
 import org.apache.thrift.TBaseAsyncProcessor;
 import org.apache.thrift.TProcessor;
 import org.apache.thrift.server.TServerEventHandler;
@@ -44,7 +42,8 @@ public class ThriftServiceThread extends AbstractThriftServiceThread {
       boolean compress,
       int connectionTimeoutInMS,
       int maxReadBufferBytes,
-      ServerType serverType) {
+      ServerType serverType,
+      TTransportFactory transportFactory) {
     super(
         processor,
         serviceName,
@@ -59,7 +58,8 @@ public class ThriftServiceThread extends AbstractThriftServiceThread {
         compress,
         connectionTimeoutInMS,
         maxReadBufferBytes,
-        serverType);
+        serverType,
+        transportFactory);
   }
 
   /** for synced ThriftServiceThread */
@@ -76,7 +76,8 @@ public class ThriftServiceThread extends AbstractThriftServiceThread {
       boolean compress,
       String keyStorePath,
       String keyStorePwd,
-      int clientTimeout) {
+      int clientTimeout,
+      TTransportFactory transportFactory) {
     super(
         processor,
         serviceName,
@@ -89,7 +90,8 @@ public class ThriftServiceThread extends AbstractThriftServiceThread {
         compress,
         keyStorePath,
         keyStorePwd,
-        clientTimeout);
+        clientTimeout,
+        transportFactory);
   }
 
   public ThriftServiceThread(
@@ -101,7 +103,8 @@ public class ThriftServiceThread extends AbstractThriftServiceThread {
       int maxWorkerThreads,
       int timeoutSecond,
       TServerEventHandler serverEventHandler,
-      boolean compress) {
+      boolean compress,
+      TTransportFactory transportFactory) {
     super(
         processor,
         serviceName,
@@ -111,11 +114,7 @@ public class ThriftServiceThread extends AbstractThriftServiceThread {
         maxWorkerThreads,
         timeoutSecond,
         serverEventHandler,
-        compress);
-  }
-
-  @Override
-  public TTransportFactory getTTransportFactory() {
-    return RpcTransportFactory.INSTANCE;
+        compress,
+        transportFactory);
   }
 }

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/client/mock/MockInternalRPCService.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/client/mock/MockInternalRPCService.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.commons.service.ServiceType;
 import org.apache.iotdb.commons.service.ThriftService;
 import org.apache.iotdb.commons.service.ThriftServiceThread;
 import org.apache.iotdb.mpp.rpc.thrift.IDataNodeRPCService;
+import org.apache.iotdb.rpc.DeepCopyRpcTransportFactory;
 
 import org.apache.thrift.server.TServerEventHandler;
 
@@ -69,7 +70,8 @@ public class MockInternalRPCService extends ThriftService implements MockInterna
               65535,
               60,
               mock(TServerEventHandler.class),
-              false);
+              false,
+              DeepCopyRpcTransportFactory.INSTANCE);
     } catch (RPCServiceException e) {
       throw new IllegalAccessException(e.getMessage());
     }


### PR DESCRIPTION
Previously, these methods of TElasticFramedTransport are not override implemented.
TBinaryProtocol will allocate new byte array and copy from frame buffer. After this pr, TBinaryProtocol can wrap the byte buffer with the reference of frame buffer segment, which eliminates the cost of memory allocation and memory copying. 

<img width="820" alt="image" src="https://github.com/apache/iotdb/assets/50790061/47e32c3c-454e-4c1e-af74-06724be1069f">

We use benchmark to evaluate this optimization (Insert Tablet with text value type):
* Before
<img width="1242" alt="image" src="https://github.com/apache/iotdb/assets/50790061/04eac1f2-e0f7-4a6e-9303-009dd336d178">
* After
<img width="1216" alt="image" src="https://github.com/apache/iotdb/assets/50790061/0f20346b-896f-4a65-a7ae-091041c2f238">



