### PR TITLE
IT: revert some changes in restart IT to make the error log clear when failed to restart

### DIFF
--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/env/AbstractEnv.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/env/AbstractEnv.java
@@ -280,7 +280,7 @@ public abstract class AbstractEnv implements BaseEnv {
     testJDBCConnection();
   }
   /**
-   * Returns whether the all nodes' status all match the provided predicate. check nodes with RPC.
+   * check whether all nodes' status match the provided predicate with RPC
    * after retryCount times, if the status of all nodes still not match the predicate, throw
    * AssertionError.
    *

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/env/AbstractEnv.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/env/AbstractEnv.java
@@ -264,29 +264,29 @@ public abstract class AbstractEnv implements BaseEnv {
     return result;
   }
 
-  public boolean checkClusterStatusWithoutUnknown() {
-    return checkClusterStatus(
-            nodeStatusMap -> nodeStatusMap.values().stream().noneMatch("Unknown"::equals))
-        && testJDBCConnection();
+  public void checkClusterStatusWithoutUnknown() {
+    checkClusterStatus(
+        nodeStatusMap -> nodeStatusMap.values().stream().noneMatch("Unknown"::equals));
+    testJDBCConnection();
   }
 
-  public boolean checkClusterStatusOneUnknownOtherRunning() {
-    return checkClusterStatus(
-            nodeStatus -> {
-              Map<String, Integer> count = countNodeStatus(nodeStatus);
-              return count.getOrDefault("Unknown", 0) == 1
-                  && count.getOrDefault("Running", 0) == nodeStatus.size() - 1;
-            })
-        && testJDBCConnection();
+  public void checkClusterStatusOneUnknownOtherRunning() {
+    checkClusterStatus(
+        nodeStatus -> {
+          Map<String, Integer> count = countNodeStatus(nodeStatus);
+          return count.getOrDefault("Unknown", 0) == 1
+              && count.getOrDefault("Running", 0) == nodeStatus.size() - 1;
+        });
+    testJDBCConnection();
   }
   /**
-   * Returns whether the all nodes' status all match the provided predicate. check nodes with RPC
+   * Returns whether the all nodes' status all match the provided predicate. check nodes with RPC.
+   * after retryCount times, if the status of all nodes still not match the predicate, throw
+   * AssertionError.
    *
    * @param statusCheck the predicate to test the status of nodes
-   * @return {@code true} if all nodes' status of the cluster match the provided predicate,
-   *     otherwise {@code false}
    */
-  public boolean checkClusterStatus(Predicate<Map<Integer, String>> statusCheck) {
+  public void checkClusterStatus(Predicate<Map<Integer, String>> statusCheck) {
     logger.info("Testing cluster environment...");
     TShowClusterResp showClusterResp;
     Exception lastException = null;
@@ -316,7 +316,7 @@ public abstract class AbstractEnv implements BaseEnv {
 
         if (flag) {
           logger.info("The cluster is now ready for testing!");
-          return true;
+          return;
         }
       } catch (Exception e) {
         lastException = e;
@@ -330,12 +330,12 @@ public abstract class AbstractEnv implements BaseEnv {
     }
     if (lastException != null) {
       logger.error(
-          "exception in testWorking of ClusterID, message: {}",
+          "exception in test Cluster with RPC, message: {}",
           lastException.getMessage(),
           lastException);
     }
-    logger.info("checkNodeHeartbeat failed after {} retries", retryCount);
-    return false;
+    throw new AssertionError(
+        String.format("After %d times retry, the cluster can't work!", retryCount));
   }
 
   @Override
@@ -488,7 +488,9 @@ public abstract class AbstractEnv implements BaseEnv {
   // because it is hard to add retry and handle exception when getting jdbc connections in
   // getWriteConnectionWithSpecifiedDataNode and getReadConnections.
   // so use this function to add retry when cluster is ready.
-  protected boolean testJDBCConnection() {
+  // after retryCount times, if the jdbc can't connect, throw
+  // AssertionError.
+  protected void testJDBCConnection() {
     logger.info("Testing JDBC connection...");
     List<String> endpoints =
         dataNodeWrapperList.stream()
@@ -526,10 +528,10 @@ public abstract class AbstractEnv implements BaseEnv {
     try {
       testDelegate.requestAll();
     } catch (Exception e) {
-      logger.error("Failed to connect to DataNode", e);
-      return false;
+      logger.error("exception in test Cluster with RPC, message: {}", e.getMessage(), e);
+      throw new AssertionError(
+          String.format("After %d times retry, the cluster can't work!", retryCount));
     }
-    return true;
   }
 
   private String getParam(Constant.Version version, int timeout) {

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/env/AbstractEnv.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/env/AbstractEnv.java
@@ -280,9 +280,8 @@ public abstract class AbstractEnv implements BaseEnv {
     testJDBCConnection();
   }
   /**
-   * check whether all nodes' status match the provided predicate with RPC
-   * after retryCount times, if the status of all nodes still not match the predicate, throw
-   * AssertionError.
+   * check whether all nodes' status match the provided predicate with RPC. after retryCount times,
+   * if the status of all nodes still not match the predicate, throw AssertionError.
    *
    * @param statusCheck the predicate to test the status of nodes
    */

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/cluster/IoTDBClusterRestartIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/cluster/IoTDBClusterRestartIT.java
@@ -104,7 +104,7 @@ public class IoTDBClusterRestartIT {
     EnvFactory.getEnv().startAllConfigNodes();
     logger.info("Restarting all DataNodes...");
     EnvFactory.getEnv().startAllDataNodes();
-    Assert.assertTrue(((AbstractEnv) EnvFactory.getEnv()).checkClusterStatusWithoutUnknown());
+    ((AbstractEnv) EnvFactory.getEnv()).checkClusterStatusWithoutUnknown();
   }
 
   @Test
@@ -228,8 +228,7 @@ public class IoTDBClusterRestartIT {
     }
     EnvFactory.getEnv().startAllDataNodes();
     logger.info("Restarted");
-    Assert.assertTrue(
-        ((AbstractEnv) EnvFactory.getEnv()).checkClusterStatusOneUnknownOtherRunning());
+    ((AbstractEnv) EnvFactory.getEnv()).checkClusterStatusOneUnknownOtherRunning();
     logger.info("Working without Seed-ConfigNode");
   }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBRecoverIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBRecoverIT.java
@@ -109,7 +109,7 @@ public class IoTDBRecoverIT {
     EnvFactory.getEnv().startAllDataNodes();
     logger.info("All DataNodes are started");
     // check cluster whether restart
-    Assert.assertTrue(((AbstractEnv) EnvFactory.getEnv()).checkClusterStatusWithoutUnknown());
+    ((AbstractEnv) EnvFactory.getEnv()).checkClusterStatusWithoutUnknown();
     String[] retArray = new String[] {"0,2", "0,4", "0,3"};
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
@@ -200,7 +200,7 @@ public class IoTDBRecoverIT {
     EnvFactory.getEnv().startAllDataNodes();
     logger.info("All DataNodes are started");
     // wait for cluster to start and check
-    Assert.assertTrue(((AbstractEnv) EnvFactory.getEnv()).checkClusterStatusWithoutUnknown());
+    ((AbstractEnv) EnvFactory.getEnv()).checkClusterStatusWithoutUnknown();
     // count test
     String[] retArray = new String[] {"0,2001,2001,2001,2001", "0,7500,7500,7500,7500"};
     try (Connection connection = EnvFactory.getEnv().getConnection();

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBRecoverUnclosedIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBRecoverUnclosedIT.java
@@ -26,7 +26,6 @@ import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -149,7 +148,7 @@ public class IoTDBRecoverUnclosedIT {
     EnvFactory.getEnv().startAllDataNodes();
     logger.info("All DataNodes are started");
     // wait for cluster to start and check
-    Assert.assertTrue(((AbstractEnv) EnvFactory.getEnv()).checkClusterStatusWithoutUnknown());
+    ((AbstractEnv) EnvFactory.getEnv()).checkClusterStatusWithoutUnknown();
 
     // test count,
     try (Connection connection = EnvFactory.getEnv().getConnection();

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/utils/TestUtils.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/utils/TestUtils.java
@@ -631,12 +631,12 @@ public class TestUtils {
     }
   }
 
-  public static boolean restartCluster(BaseEnv env) {
+  public static void restartCluster(BaseEnv env) {
     env.shutdownAllDataNodes();
     env.shutdownAllConfigNodes();
     env.startAllConfigNodes();
     env.startAllDataNodes();
-    return ((AbstractEnv) env).checkClusterStatusWithoutUnknown();
+    ((AbstractEnv) env).checkClusterStatusWithoutUnknown();
   }
 
   public static void assertDataOnEnv(

--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/IoTDBPipeClusterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/IoTDBPipeClusterIT.java
@@ -237,7 +237,7 @@ public class IoTDBPipeClusterIT extends AbstractPipeDualIT {
           }
           try {
             senderEnv.startDataNode(i);
-            Assert.assertTrue(((AbstractEnv) senderEnv).checkClusterStatusWithoutUnknown());
+            ((AbstractEnv) senderEnv).checkClusterStatusWithoutUnknown();
           } catch (Exception e) {
             e.printStackTrace();
             return;
@@ -261,8 +261,8 @@ public class IoTDBPipeClusterIT extends AbstractPipeDualIT {
           "count(root.db.d1.s1),",
           Collections.singleton("2,"));
     }
-    Assert.assertTrue(TestUtils.restartCluster(senderEnv));
-    Assert.assertTrue(TestUtils.restartCluster(receiverEnv));
+    TestUtils.restartCluster(senderEnv);
+    TestUtils.restartCluster(receiverEnv);
 
     try (SyncConfigNodeIServiceClient client =
         (SyncConfigNodeIServiceClient) senderEnv.getLeaderConfigNodeConnection()) {
@@ -357,8 +357,8 @@ public class IoTDBPipeClusterIT extends AbstractPipeDualIT {
           Collections.singleton("2,"));
     }
 
-    Assert.assertTrue(TestUtils.restartCluster(senderEnv));
-    Assert.assertTrue(TestUtils.restartCluster(receiverEnv));
+    TestUtils.restartCluster(senderEnv);
+    TestUtils.restartCluster(receiverEnv);
 
     try (SyncConfigNodeIServiceClient client =
         (SyncConfigNodeIServiceClient) senderEnv.getLeaderConfigNodeConnection()) {
@@ -626,7 +626,7 @@ public class IoTDBPipeClusterIT extends AbstractPipeDualIT {
         senderEnv.startDataNode(senderEnv.getDataNodeWrapperList().size() - 1);
         senderEnv.shutdownDataNode(senderEnv.getDataNodeWrapperList().size() - 1);
         senderEnv.getDataNodeWrapperList().remove(senderEnv.getDataNodeWrapperList().size() - 1);
-        Assert.assertTrue(((AbstractEnv) senderEnv).checkClusterStatusWithoutUnknown());
+        ((AbstractEnv) senderEnv).checkClusterStatusWithoutUnknown();
       } catch (Exception e) {
         e.printStackTrace();
         return;
@@ -684,7 +684,7 @@ public class IoTDBPipeClusterIT extends AbstractPipeDualIT {
       return;
     }
 
-    Assert.assertTrue(TestUtils.restartCluster(senderEnv));
+    TestUtils.restartCluster(senderEnv);
     TestUtils.assertDataOnEnv(
         receiverEnv,
         "select count(*) from root.**",

--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/IoTDBPipeLifeCycleIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/IoTDBPipeLifeCycleIT.java
@@ -427,8 +427,8 @@ public class IoTDBPipeLifeCycleIT extends AbstractPipeDualIT {
           receiverEnv, "select * from root.**", "Time,root.db.d1.s1,", expectedResSet);
     }
 
-    Assert.assertTrue(TestUtils.restartCluster(senderEnv));
-    Assert.assertTrue(TestUtils.restartCluster(receiverEnv));
+    TestUtils.restartCluster(senderEnv);
+    TestUtils.restartCluster(receiverEnv);
 
     try (SyncConfigNodeIServiceClient ignored =
         (SyncConfigNodeIServiceClient) senderEnv.getLeaderConfigNodeConnection()) {
@@ -491,7 +491,7 @@ public class IoTDBPipeLifeCycleIT extends AbstractPipeDualIT {
               });
       t.start();
 
-      Assert.assertTrue(TestUtils.restartCluster(receiverEnv));
+      TestUtils.restartCluster(receiverEnv);
       t.join();
 
       TestUtils.assertDataOnEnv(
@@ -664,8 +664,8 @@ public class IoTDBPipeLifeCycleIT extends AbstractPipeDualIT {
     TestUtils.assertDataOnEnv(
         receiverEnv, "select * from root.**", "Time,root.db.d1.s1,", expectedResSet);
 
-    Assert.assertTrue(TestUtils.restartCluster(senderEnv));
-    Assert.assertTrue(TestUtils.restartCluster(receiverEnv));
+    TestUtils.restartCluster(senderEnv);
+    TestUtils.restartCluster(receiverEnv);
 
     for (int i = 400; i < 500; ++i) {
       if (!TestUtils.tryExecuteNonQueryWithRetry(


### PR DESCRIPTION
in https://github.com/apache/iotdb/pull/12022.
I catch exceptions during the restart cluster check process, then return a boolean value to indicate the result of the restart. This approach makes the error log unclear when there is a problem.
now revert it