### PR TITLE
[IOTDB-6299] Fix bug in merging overlapped data process caused by filter & offset push down

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBAlignedSeriesQueryIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBAlignedSeriesQueryIT.java
@@ -1015,6 +1015,54 @@ public class IoTDBAlignedSeriesQueryIT {
   }
 
   @Test
+  public void selectAllAlignedWithLimitOffsetTest() {
+
+    String[] retArray =
+            new String[] {
+                    "14,14.0,14,14,null,null",
+                    "15,15.0,15,15,null,null",
+                    "16,16.0,16,16,null,null",
+                    "17,17.0,17,17,null,null",
+                    "18,18.0,18,18,null,null",
+            };
+
+    String[] columnNames = {
+            "root.sg1.d1.s1", "root.sg1.d1.s2", "root.sg1.d1.s3", "root.sg1.d1.s4", "root.sg1.d1.s5"
+    };
+
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+         Statement statement = connection.createStatement()) {
+
+      try (ResultSet resultSet =
+                   statement.executeQuery(
+                           "select * from root.sg1.d1 where time >= 9 and time <= 33 offset 5 limit 5")) {
+        ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+        Map<String, Integer> map = new HashMap<>();
+        for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
+          map.put(resultSetMetaData.getColumnName(i), i);
+        }
+        assertEquals(columnNames.length + 1, resultSetMetaData.getColumnCount());
+        int cnt = 0;
+        while (resultSet.next()) {
+          StringBuilder builder = new StringBuilder();
+          builder.append(resultSet.getString(1));
+          for (String columnName : columnNames) {
+            int index = map.get(columnName);
+            builder.append(",").append(resultSet.getString(index));
+          }
+          assertEquals(retArray[cnt], builder.toString());
+          cnt++;
+        }
+        assertEquals(retArray.length, cnt);
+      }
+
+    } catch (SQLException e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
   public void selectSomeAlignedWithValueFilterTest1() {
 
     String[] retArray =

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBAlignedSeriesQueryIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBAlignedSeriesQueryIT.java
@@ -1018,24 +1018,24 @@ public class IoTDBAlignedSeriesQueryIT {
   public void selectAllAlignedWithLimitOffsetTest() {
 
     String[] retArray =
-            new String[] {
-                    "14,14.0,14,14,null,null",
-                    "15,15.0,15,15,null,null",
-                    "16,16.0,16,16,null,null",
-                    "17,17.0,17,17,null,null",
-                    "18,18.0,18,18,null,null",
-            };
+        new String[] {
+          "14,14.0,14,14,null,null",
+          "15,15.0,15,15,null,null",
+          "16,16.0,16,16,null,null",
+          "17,17.0,17,17,null,null",
+          "18,18.0,18,18,null,null",
+        };
 
     String[] columnNames = {
-            "root.sg1.d1.s1", "root.sg1.d1.s2", "root.sg1.d1.s3", "root.sg1.d1.s4", "root.sg1.d1.s5"
+      "root.sg1.d1.s1", "root.sg1.d1.s2", "root.sg1.d1.s3", "root.sg1.d1.s4", "root.sg1.d1.s5"
     };
 
     try (Connection connection = EnvFactory.getEnv().getConnection();
-         Statement statement = connection.createStatement()) {
+        Statement statement = connection.createStatement()) {
 
       try (ResultSet resultSet =
-                   statement.executeQuery(
-                           "select * from root.sg1.d1 where time >= 9 and time <= 33 offset 5 limit 5")) {
+          statement.executeQuery(
+              "select * from root.sg1.d1 where time >= 9 and time <= 33 offset 5 limit 5")) {
         ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
         Map<String, Integer> map = new HashMap<>();
         for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/series/AlignedSeriesScanPredicatePushDownTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/series/AlignedSeriesScanPredicatePushDownTest.java
@@ -216,7 +216,12 @@ public class AlignedSeriesScanPredicatePushDownTest extends AbstractAlignedSerie
     Assert.assertTrue(seriesScanUtil.hasNextPage());
     Assert.assertFalse(seriesScanUtil.canUseCurrentPageStatistics());
     tsBlock = seriesScanUtil.nextPage();
-    Assert.assertNull(tsBlock);
+    Assert.assertTrue(tsBlock == null || tsBlock.isEmpty());
+
+    Assert.assertTrue(seriesScanUtil.hasNextPage());
+    Assert.assertFalse(seriesScanUtil.canUseCurrentPageStatistics());
+    tsBlock = seriesScanUtil.nextPage();
+    Assert.assertTrue(tsBlock == null || tsBlock.isEmpty());
 
     Assert.assertFalse(seriesScanUtil.hasNextPage());
     Assert.assertFalse(seriesScanUtil.hasNextChunk());

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/series/SeriesScanLimitOffsetPushDownTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/series/SeriesScanLimitOffsetPushDownTest.java
@@ -215,6 +215,11 @@ public class SeriesScanLimitOffsetPushDownTest extends AbstractSeriesScanTest {
     TsBlock tsBlock = seriesScanUtil.nextPage();
     Assert.assertTrue(tsBlock == null || tsBlock.isEmpty());
 
+    Assert.assertTrue(seriesScanUtil.hasNextPage());
+
+    tsBlock = seriesScanUtil.nextPage();
+    Assert.assertTrue(tsBlock == null || tsBlock.isEmpty());
+
     Assert.assertFalse(seriesScanUtil.hasNextPage());
 
     Assert.assertTrue(seriesScanUtil.hasNextChunk());

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/TsBlockUtil.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/TsBlockUtil.java
@@ -21,6 +21,8 @@ package org.apache.iotdb.tsfile.read.common.block;
 
 import org.apache.iotdb.tsfile.read.common.TimeRange;
 import org.apache.iotdb.tsfile.read.common.block.column.TimeColumn;
+import org.apache.iotdb.tsfile.read.filter.basic.Filter;
+import org.apache.iotdb.tsfile.read.reader.series.PaginationController;
 
 public class TsBlockUtil {
 
@@ -64,5 +66,58 @@ public class TsBlockUtil {
       }
     }
     return left;
+  }
+
+  public static TsBlock applyFilterAndLimitOffsetToTsBlock(
+      TsBlock unFilteredBlock,
+      TsBlockBuilder builder,
+      Filter pushDownFilter,
+      PaginationController paginationController) {
+    boolean[] keepCurrentRow = pushDownFilter.satisfyTsBlock(unFilteredBlock);
+
+    // construct time column
+    int readEndIndex =
+        buildTimeColumnWithPagination(
+            unFilteredBlock, builder, keepCurrentRow, paginationController);
+
+    // construct value columns
+    for (int i = 0; i < builder.getValueColumnBuilders().length; i++) {
+      for (int rowIndex = 0; rowIndex < readEndIndex; rowIndex++) {
+        if (keepCurrentRow[rowIndex]) {
+          if (unFilteredBlock.getValueColumns()[i].isNull(rowIndex)) {
+            builder.getColumnBuilder(i).appendNull();
+          } else {
+            builder
+                .getColumnBuilder(i)
+                .writeObject(unFilteredBlock.getValueColumns()[i].getObject(rowIndex));
+          }
+        }
+      }
+    }
+    return builder.build();
+  }
+
+  private static int buildTimeColumnWithPagination(
+      TsBlock unFilteredBlock,
+      TsBlockBuilder builder,
+      boolean[] keepCurrentRow,
+      PaginationController paginationController) {
+    int readEndIndex = unFilteredBlock.getPositionCount();
+    for (int rowIndex = 0; rowIndex < readEndIndex; rowIndex++) {
+      if (keepCurrentRow[rowIndex]) {
+        if (paginationController.hasCurOffset()) {
+          paginationController.consumeOffset();
+          keepCurrentRow[rowIndex] = false;
+        } else if (paginationController.hasCurLimit()) {
+          builder.getTimeColumnBuilder().writeLong(unFilteredBlock.getTimeByIndex(rowIndex));
+          builder.declarePosition();
+          paginationController.consumeLimit();
+        } else {
+          readEndIndex = rowIndex;
+          break;
+        }
+      }
+    }
+    return readEndIndex;
   }
 }


### PR DESCRIPTION
**[Reproduction Method]**

- **Config:**
maxNumberOfPointsInPage = 2
maxTsBlockLineNumber = 3

- **Insert:**
    ```SQL
    CREATE DATABASE root.sg1;
    create aligned timeseries root.sg1.d1(s1 FLOAT encoding=RLE, s2 INT32 encoding=Gorilla compression=SNAPPY, s3 INT64, s4 BOOLEAN, s5 TEXT);
    insert into root.sg1.d1(time, s1, s2, s3, s4, s5) aligned values(9, 9.0, 9, 9, FALSE, 'aligned_test9');
    insert into root.sg1.d1(time, s2, s3, s4, s5) aligned values(10, 10, 10, TRUE, 'aligned_test10');
    flush;
    insert into root.sg1.d1(time, s1, s2, s3) aligned values(11, 11.0, 11, 11);
    insert into root.sg1.d1(time, s1, s2, s3) aligned values(12, 12.0, 12, 12);
    insert into root.sg1.d1(time, s1, s2, s3) aligned values(13, 13.0, 13, 13);
    insert into root.sg1.d1(time, s1, s2, s3) aligned values(14, 14.0, 14, 14);
    insert into root.sg1.d1(time, s1, s2, s3) aligned values(15, 15.0, 15, 15);
    insert into root.sg1.d1(time, s1, s2, s3) aligned values(16, 16.0, 16, 16);
    insert into root.sg1.d1(time, s1, s2, s3) aligned values(17, 17.0, 17, 17);
    insert into root.sg1.d1(time, s1, s2, s3) aligned values(18, 18.0, 18, 18);
    insert into root.sg1.d1(time, s1, s2, s3) aligned values(19, 19.0, 19, 19);
    insert into root.sg1.d1(time, s1, s2, s3) aligned values(20, 20.0, 20, 20);
    flush;
    insert into root.sg1.d1(time, s1, s2, s3, s4, s5) aligned values(13, 130000.0, 130000, 130000, TRUE, 'aligned_unseq_test13');
    flush;
    ```

- **Query:**
    ```SQL
    select * from root.sg1.d1 where time >= 9 and time <= 33 offset 5 limit 5
    ```

    - Before:

    ![image](https://github.com/apache/iotdb/assets/36565497/c4cb5cb3-a39a-4475-ae4a-2453332182d2)

    - After:

    ![image](https://github.com/apache/iotdb/assets/36565497/a46188c7-7d51-4828-937c-3b4d0986b88c)
