### PR TITLE
[IOTDB-6302] Enhance the support of ISO_LOCAL_DATE_TIME timestamp format

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/DateTimeUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/DateTimeUtils.java
@@ -97,9 +97,7 @@ public class DateTimeUtils {
             .appendLiteral(':')
             .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
             .optionalStart()
-            .appendLiteral('.')
-            .appendValue(ChronoField.MILLI_OF_SECOND, 3)
-            .optionalEnd()
+            .appendFraction(ChronoField.MILLI_OF_SECOND, 0, 3, true)
             .toFormatter();
   }
 
@@ -115,9 +113,7 @@ public class DateTimeUtils {
             .appendLiteral(':')
             .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
             .optionalStart()
-            .appendLiteral('.')
-            .appendValue(ChronoField.MICRO_OF_SECOND, 6)
-            .optionalEnd()
+            .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true)
             .toFormatter();
   }
 
@@ -133,8 +129,7 @@ public class DateTimeUtils {
             .appendLiteral(':')
             .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
             .optionalStart()
-            .appendLiteral('.')
-            .appendValue(ChronoField.NANO_OF_SECOND, 9)
+            .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
             .optionalEnd()
             .toFormatter();
   }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/DateTimeUtilsTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/DateTimeUtilsTest.java
@@ -50,6 +50,7 @@ public class DateTimeUtilsTest {
     }
     testConvertDatetimeStrToLongWithoutMS(zoneOffset, zoneId, timestamp - 689 + delta);
     testConvertDatetimeStrToLongWithMS(zoneOffset, zoneId, timestamp + delta);
+    testConvertDatetimeStrToLongWithMS2(zoneOffset, zoneId, timestamp - 9 + delta);
   }
 
   @Test
@@ -59,6 +60,7 @@ public class DateTimeUtilsTest {
     delta = 8 * 3600000;
     testConvertDatetimeStrToLongWithoutMS(zoneOffset, zoneId, timestamp - 689 + delta);
     testConvertDatetimeStrToLongWithMS(zoneOffset, zoneId, timestamp + delta);
+    testConvertDatetimeStrToLongWithMS2(zoneOffset, zoneId, timestamp - 9 + delta);
   }
 
   @Test
@@ -212,6 +214,45 @@ public class DateTimeUtilsTest {
           "2019-01-02T15:13:27.689" + zoneOffset,
           "2019/01/02T15:13:27.689" + zoneOffset,
           "2019.01.02T15:13:27.689" + zoneOffset,
+        };
+    for (String str : timeFormatWithoutMs) {
+      assertEquals(res, DateTimeUtils.convertDatetimeStrToLong(str, zoneOffset, 0, "ms"));
+    }
+
+    for (String str : timeFormatWithoutMs) {
+      assertEquals(res, DateTimeUtils.convertDatetimeStrToLong(str, zoneId));
+    }
+  }
+
+  public void testConvertDatetimeStrToLongWithMS2(ZoneOffset zoneOffset, ZoneId zoneId, long res) {
+    String[] timeFormatWithoutMs =
+        new String[] {
+          "2019-01-02 15:13:27.680",
+          "2019/01/02 15:13:27.680",
+          "2019.01.02 15:13:27.680",
+          "2019-01-02T15:13:27.680",
+          "2019-01-02T15:13:27.680",
+          "2019/01/02T15:13:27.680",
+          "2019.01.02T15:13:27.680",
+          "2019-01-02 15:13:27.680" + zoneOffset,
+          "2019/01/02 15:13:27.680" + zoneOffset,
+          "2019.01.02 15:13:27.680" + zoneOffset,
+          "2019-01-02T15:13:27.680" + zoneOffset,
+          "2019/01/02T15:13:27.680" + zoneOffset,
+          "2019.01.02T15:13:27.680" + zoneOffset,
+          "2019-01-02 15:13:27.68",
+          "2019/01/02 15:13:27.68",
+          "2019.01.02 15:13:27.68",
+          "2019-01-02T15:13:27.68",
+          "2019-01-02T15:13:27.68",
+          "2019/01/02T15:13:27.68",
+          "2019.01.02T15:13:27.68",
+          "2019-01-02 15:13:27.68" + zoneOffset,
+          "2019/01/02 15:13:27.68" + zoneOffset,
+          "2019.01.02 15:13:27.68" + zoneOffset,
+          "2019-01-02T15:13:27.68" + zoneOffset,
+          "2019/01/02T15:13:27.68" + zoneOffset,
+          "2019.01.02T15:13:27.68" + zoneOffset,
         };
     for (String str : timeFormatWithoutMs) {
       assertEquals(res, DateTimeUtils.convertDatetimeStrToLong(str, zoneOffset, 0, "ms"));


### PR DESCRIPTION
## Description

IoTDB doesn't support timestamp format like `2024-02-22T16:36:34.67`, which should be equivalent to `2024-02-22T16:36:34.670`.


![image](https://github.com/apache/iotdb/assets/25913899/44cba219-f87b-431f-9d31-54de0d8915de)


After referred the code of JDK below, we can simply support it.

<img width="842" alt="image" src="https://github.com/apache/iotdb/assets/25913899/af1bb9ec-3983-471e-a612-c50021ff9407">

<img width="604" alt="image" src="https://github.com/apache/iotdb/assets/25913899/2784f046-c85a-4d60-a967-d16dba3ecada">

