### PR TITLE
Optimize ConfigNode ConsensusManager init logic

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
@@ -243,11 +243,9 @@ public class ConfigRegionStateMachine implements IStateMachine, IStateMachine.Ev
     // Add Metric after leader ready
     configManager.addMetrics();
 
-    // we do cq recovery async for two reasons:
-    // 1. For performance: cq recovery may be time-consuming, we use another thread to do it in
+    // we do cq recovery async for performance:
+    // cq recovery may be time-consuming, we use another thread to do it in
     // make notifyLeaderChanged not blocked by it
-    // 2. For correctness: in cq recovery processing, it will use ConsensusManager which may be
-    // initialized after notifyLeaderChanged finished
     threadPool.submit(() -> configManager.getCQManager().startCQScheduler());
 
     threadPool.submit(

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ClusterManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ClusterManager.java
@@ -27,7 +27,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 public class ClusterManager {
 
@@ -72,15 +71,6 @@ public class ClusterManager {
   private void generateClusterId() {
     String clusterId = String.valueOf(UUID.randomUUID());
     UpdateClusterIdPlan updateClusterIdPlan = new UpdateClusterIdPlan(clusterId);
-    while (configManager.getConsensusManager() == null) {
-      try {
-        LOGGER.info("consensus layer is not ready, sleep 100ms...");
-        TimeUnit.MILLISECONDS.sleep(100);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        LOGGER.warn("Unexpected interruption during waiting for consensus layer ready.");
-      }
-    }
     try {
       configManager.getConsensusManager().write(updateClusterIdPlan);
     } catch (ConsensusException e) {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -311,6 +311,7 @@ public class ConfigManager implements IManager {
 
   public void initConsensusManager() throws IOException {
     this.consensusManager.set(new ConsensusManager(this, this.stateMachine));
+    this.consensusManager.get().start();
   }
 
   public void close() throws IOException {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/cq/CQManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/cq/CQManager.java
@@ -43,7 +43,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -134,16 +133,6 @@ public class CQManager {
 
       // 3. get all CQs
       List<CQInfo.CQEntry> allCQs = null;
-      // wait for consensus layer ready
-      while (configManager.getConsensusManager() == null) {
-        try {
-          LOGGER.info("consensus layer is not ready, sleep 1s...");
-          TimeUnit.SECONDS.sleep(1);
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-          LOGGER.warn("Unexpected interruption during waiting for consensus layer ready.");
-        }
-      }
       // keep fetching until we get all CQEntries if this node is still leader
       while (needFetch(allCQs)) {
         try {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/coordinator/runtime/PipeMetaSyncer.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/coordinator/runtime/PipeMetaSyncer.java
@@ -70,16 +70,6 @@ public class PipeMetaSyncer {
   }
 
   public synchronized void start() {
-    while (configManager.getConsensusManager() == null) {
-      try {
-        LOGGER.info("Consensus layer is not ready, sleep 1s...");
-        TimeUnit.SECONDS.sleep(1);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        LOGGER.warn("Unexpected interruption during waiting for consensus layer ready.");
-      }
-    }
-
     if (metaSyncFuture == null) {
       metaSyncFuture =
           ScheduledExecutorUtil.safelyScheduleWithFixedDelay(


### PR DESCRIPTION
By splitting the creation and launch of consensusManager, we avoid some redundant code.

We can now ensure that consensusManager.get () is never null when notifyLeaderReady is invoked