### PR TITLE
Split configuration and add resetPeerList for region migration

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/IConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/IConsensus.java
@@ -143,6 +143,19 @@ public interface IConsensus {
    */
   void removeRemotePeer(ConsensusGroupId groupId, Peer peer) throws ConsensusException;
 
+  /**
+   * Reset the peer list of the corresponding consensus group. Currently only used in the automatic
+   * cleanup of region migration as a rollback for {@link #addRemotePeer(ConsensusGroupId, Peer)},
+   * so it will only be less but not more.
+   *
+   * @param groupId the consensus group
+   * @param peers the new peer list
+   * @return reset result
+   * @throws ConsensusException when resetPeerList doesn't success with other reasons
+   * @throws ConsensusGroupNotExistException when the specified consensus group doesn't exist
+   */
+  TSStatus resetPeerList(ConsensusGroupId groupId, List<Peer> peers) throws ConsensusException;
+
   // management API
 
   /**

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensus.java
@@ -392,6 +392,33 @@ public class IoTConsensus implements IConsensus {
     return new ArrayList<>(stateMachineMap.keySet());
   }
 
+  public TSStatus resetPeerList(ConsensusGroupId groupId, List<Peer> peers)
+      throws ConsensusException {
+    IoTConsensusServerImpl impl =
+        Optional.ofNullable(stateMachineMap.get(groupId))
+            .orElseThrow(() -> new ConsensusGroupNotExistException(groupId));
+    if (impl.isReadOnly()) {
+      return StatusUtils.getStatus(TSStatusCode.SYSTEM_READ_ONLY);
+    } else if (!impl.isActive()) {
+      return RpcUtils.getStatus(
+          TSStatusCode.WRITE_PROCESS_REJECT,
+          "peer is inactive and not ready to receive reset configuration request.");
+    } else {
+      for (Peer peer : impl.getConfiguration()) {
+        if (!peers.contains(peer)) {
+          try {
+            removeRemotePeer(groupId, peer);
+          } catch (ConsensusException e) {
+            logger.error("Failed to remove peer {} from group {}", peer, groupId, e);
+            return RpcUtils.getStatus(TSStatusCode.INTERNAL_SERVER_ERROR, e.getMessage());
+          }
+        }
+      }
+      impl.resetConfiguration(peers);
+      return RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS);
+    }
+  }
+
   public IoTConsensusServerImpl getImpl(ConsensusGroupId groupId) {
     return stateMachineMap.get(groupId);
   }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -680,6 +680,11 @@ public class IoTConsensusServerImpl {
     return tmpConfiguration;
   }
 
+  public void resetConfiguration(List<Peer> newConfiguration) {
+    configuration.clear();
+    configuration.addAll(newConfiguration);
+  }
+
   public IndexedConsensusRequest buildIndexedConsensusRequestForLocalRequest(
       IConsensusRequest request) {
     if (request instanceof ComparableConsensusRequest) {

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -666,13 +666,13 @@ public class IoTConsensusServerImpl {
       throws IOException {
     ByteBuffer buffer;
     List<Peer> tmpConfiguration = new ArrayList<>();
-    File[] files =
+    Path[] files =
         Files.walk(dirPath)
             .filter(Files::isRegularFile)
             .filter(filePath -> filePath.getFileName().toString().contains(configurationFileName))
-            .toArray(File[]::new);
-    for (File file : files) {
-      buffer = ByteBuffer.wrap(Files.readAllBytes(file.toPath()));
+            .toArray(Path[]::new);
+    for (Path file : files) {
+      buffer = ByteBuffer.wrap(Files.readAllBytes(file));
       tmpConfiguration.add(Peer.deserialize(buffer));
     }
     return tmpConfiguration;

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -51,6 +51,7 @@ import org.apache.iotdb.consensus.ratis.metrics.RatisMetricsManager;
 import org.apache.iotdb.consensus.ratis.utils.Retriable;
 import org.apache.iotdb.consensus.ratis.utils.RetryPolicy;
 import org.apache.iotdb.consensus.ratis.utils.Utils;
+import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.apache.commons.pool2.KeyedObjectPool;
@@ -535,6 +536,42 @@ class RatisConsensus implements IConsensus {
             .collect(Collectors.toList());
 
     sendReconfiguration(RaftGroup.valueOf(raftGroupId, newConfig));
+  }
+
+  @Override
+  public TSStatus resetPeerList(ConsensusGroupId groupId, List<Peer> peers)
+      throws ConsensusException {
+    RaftGroupId raftGroupId = Utils.fromConsensusGroupIdToRaftGroupId(groupId);
+    RaftGroup group = getGroupInfo(raftGroupId);
+
+    // pre-conditions: group exists and myself in this group
+    if (group == null || !group.getPeers().contains(myself)) {
+      throw new ConsensusGroupNotExistException(groupId);
+    }
+
+    TSStatus writeResult = RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS);
+    for (Peer peer : peers) {
+      RaftPeer peerToRemove = Utils.fromPeerAndPriorityToRaftPeer(peer, DEFAULT_PRIORITY);
+      // pre-condition: peer is a member of groupId
+      if (!group.getPeers().contains(peerToRemove)) {
+        throw new PeerAlreadyInConsensusGroupException(groupId, peer);
+      }
+      // update group peer information
+      List<RaftPeer> newConfig =
+          group.getPeers().stream()
+              .filter(raftPeer -> !raftPeer.equals(peerToRemove))
+              .collect(Collectors.toList());
+      RaftClientReply reply = sendReconfiguration(RaftGroup.valueOf(raftGroupId, newConfig));
+      if (!reply.isSuccess()) {
+        throw new RatisRequestFailedException(reply.getException());
+      }
+      try {
+        writeResult = Utils.deserializeFrom(reply.getMessage().getContent().asReadOnlyByteBuffer());
+      } catch (Exception e) {
+        throw new RatisRequestFailedException(e);
+      }
+    }
+    return writeResult;
   }
 
   /** NOTICE: transferLeader *does not guarantee* the leader be transferred to newLeader. */

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/simple/SimpleConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/simple/SimpleConsensus.java
@@ -241,6 +241,12 @@ class SimpleConsensus implements IConsensus {
     return new ArrayList<>(stateMachineMap.keySet());
   }
 
+  @Override
+  public TSStatus resetPeerList(ConsensusGroupId groupId, List<Peer> peers)
+      throws ConsensusException {
+    throw new ConsensusException("SimpleConsensus does not support reset peer list");
+  }
+
   private String buildPeerDir(ConsensusGroupId groupId) {
     return storageDir + File.separator + groupId.getType().getValue() + "_" + groupId.getId();
   }


### PR DESCRIPTION
## Description

Split configuration and add resetPeerList for region migration, see [feishu-doc](https://apache-iotdb.feishu.cn/docx/MC8gdgTgOoG9eYx9MIpcrtB9n4e) for details.
