### PR TITLE
Fix fail to read memTable ids from the wal file

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/IoTDBShutdownHook.java
@@ -78,7 +78,7 @@ public class IoTDBShutdownHook extends Thread {
         .equals(ConsensusFactory.RATIS_CONSENSUS)) {
       StorageEngine.getInstance().syncCloseAllProcessor();
     }
-    WALManager.getInstance().deleteOutdatedFilesInWALNodes();
+    WALManager.getInstance().syncDeleteOutdatedFilesInWALNodes();
 
     // We did this work because the RatisConsensus recovery mechanism is different from other
     // consensus algorithms, which will replace the underlying storage engine based on its

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/StorageEngine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/StorageEngine.java
@@ -631,7 +631,7 @@ public class StorageEngine implements IService {
   public void operateFlush(TFlushReq req) {
     if (req.storageGroups == null) {
       StorageEngine.getInstance().syncCloseAllProcessor();
-      WALManager.getInstance().deleteOutdatedFilesInWALNodes();
+      WALManager.getInstance().syncDeleteOutdatedFilesInWALNodes();
     } else {
       for (String storageGroup : req.storageGroups) {
         if (req.isSeq == null) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/buffer/WALBuffer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/buffer/WALBuffer.java
@@ -723,8 +723,12 @@ public class WALBuffer extends AbstractWALBuffer {
                     file, FileChannel.open(file.toPath(), StandardOpenOption.READ))
                 .getMemTablesId();
           } catch (IOException e) {
-            logger.error("Fail to read memTable ids from the wal file {}.", id);
-            return new HashSet<>();
+            logger.warn(
+                "Fail to read memTable ids from the wal file {} of wal node {}.",
+                id,
+                identifier,
+                e);
+            return Collections.emptySet();
           }
         });
   }


### PR DESCRIPTION
## Description

When the walDeleteThread and a flush command delete the outdated wal file concurrently, the following error may appear.
![img_v3_028l_e1c4b5ec-c709-4536-91f7-c206f2ab805g](https://github.com/apache/iotdb/assets/25913899/2858ac97-f49c-4581-bb27-7b22d5b96c64)

To fix it, the flush command thread should submit the wal delete task to walDeleteThread instead of executing it by itself. 