### PR TITLE
flink-iotdb-connector: IoTDBSink throws NPE

### DIFF
--- a/iotdb-connector/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/IoTDBSink.java
+++ b/iotdb-connector/flink-iotdb-connector/src/main/java/org/apache/iotdb/flink/IoTDBSink.java
@@ -57,7 +57,7 @@ public class IoTDBSink<IN> extends RichSinkFunction<IN> {
 
   private int batchSize = 0;
   private int flushIntervalMs = 3000;
-  private transient List<Event> batchList;
+  private List<Event> batchList;
   private int sessionPoolSize = 2;
 
   public IoTDBSink(IoTDBSinkOptions options, IoTSerializationSchema<IN> schema) {


### PR DESCRIPTION
![image](https://github.com/apache/iotdb/assets/21176290/dd52e991-bdb1-4011-a093-201903ed929b)
