### PR TITLE
Fix bug: parent procedure should not execute before sub-procedure finished

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/procedure/IoTDBProcedureIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/procedure/IoTDBProcedureIT.java
@@ -157,6 +157,7 @@ public class IoTDBProcedureIT {
     boolean check1 = false;
     try {
       Awaitility.await()
+          .pollDelay(1, TimeUnit.SECONDS)
           .atMost(10, TimeUnit.SECONDS)
           .until(
               () -> {
@@ -177,13 +178,13 @@ public class IoTDBProcedureIT {
         (SyncConfigNodeIServiceClient) EnvFactory.getEnv().getLeaderConfigNodeConnection();
 
     Awaitility.await()
+        .pollDelay(1, TimeUnit.SECONDS)
         .atMost(10, TimeUnit.SECONDS)
         .until(
             () -> {
               try {
                 newLeaderClient.showDatabase(req);
               } catch (Exception e) {
-                Thread.sleep(1000);
                 return false;
               }
               return true;

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -46,7 +46,6 @@ import org.apache.iotdb.commons.service.metric.MetricService;
 import org.apache.iotdb.commons.utils.AuthUtils;
 import org.apache.iotdb.commons.utils.PathUtils;
 import org.apache.iotdb.commons.utils.StatusUtils;
-import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.confignode.conf.ConfigNodeConfig;
 import org.apache.iotdb.confignode.conf.ConfigNodeDescriptor;
 import org.apache.iotdb.confignode.conf.SystemPropertiesUtils;
@@ -616,12 +615,6 @@ public class ConfigManager implements IManager {
     } else {
       return status;
     }
-  }
-
-  @TestOnly
-  @Override
-  public TSStatus createManyDatabases() {
-    return getProcedureManager().createManyDatabases();
   }
 
   private List<TSeriesPartitionSlot> calculateRelatedSlot(PartialPath path, PartialPath database) {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/IManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/IManager.java
@@ -27,7 +27,6 @@ import org.apache.iotdb.common.rpc.thrift.TSetSpaceQuotaReq;
 import org.apache.iotdb.commons.cluster.NodeStatus;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.path.PathPatternTree;
-import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.confignode.consensus.request.auth.AuthorPlan;
 import org.apache.iotdb.confignode.consensus.request.read.database.CountDatabasePlan;
 import org.apache.iotdb.confignode.consensus.request.read.database.GetDatabasePlan;
@@ -326,14 +325,6 @@ public interface IManager {
    * @return status
    */
   TSStatus deleteDatabases(TDeleteDatabasesReq tDeleteReq);
-
-  /**
-   * Create many databases.
-   *
-   * @return status
-   */
-  @TestOnly
-  TSStatus createManyDatabases();
 
   /**
    * Get SchemaPartition.

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
@@ -51,7 +51,6 @@ import org.apache.iotdb.confignode.procedure.Procedure;
 import org.apache.iotdb.confignode.procedure.ProcedureExecutor;
 import org.apache.iotdb.confignode.procedure.ProcedureMetrics;
 import org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv;
-import org.apache.iotdb.confignode.procedure.impl.CreateManyDatabasesProcedure;
 import org.apache.iotdb.confignode.procedure.impl.cq.CreateCQProcedure;
 import org.apache.iotdb.confignode.procedure.impl.node.AddConfigNodeProcedure;
 import org.apache.iotdb.confignode.procedure.impl.node.RemoveConfigNodeProcedure;
@@ -76,6 +75,8 @@ import org.apache.iotdb.confignode.procedure.impl.schema.DeleteTimeSeriesProcedu
 import org.apache.iotdb.confignode.procedure.impl.schema.SetTemplateProcedure;
 import org.apache.iotdb.confignode.procedure.impl.schema.UnsetTemplateProcedure;
 import org.apache.iotdb.confignode.procedure.impl.sync.AuthOperationProcedure;
+import org.apache.iotdb.confignode.procedure.impl.testonly.CreateManyDatabasesProcedure;
+import org.apache.iotdb.confignode.procedure.impl.testonly.MakeChildProcedure;
 import org.apache.iotdb.confignode.procedure.impl.trigger.CreateTriggerProcedure;
 import org.apache.iotdb.confignode.procedure.impl.trigger.DropTriggerProcedure;
 import org.apache.iotdb.confignode.procedure.scheduler.ProcedureScheduler;
@@ -176,6 +177,12 @@ public class ProcedureManager {
   @TestOnly
   public TSStatus createManyDatabases() {
     this.executor.submitProcedure(new CreateManyDatabasesProcedure());
+    return StatusUtils.OK;
+  }
+
+  @TestOnly
+  public TSStatus testSubProcedure() {
+    this.executor.submitProcedure(new MakeChildProcedure());
     return StatusUtils.OK;
   }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
@@ -75,8 +75,8 @@ import org.apache.iotdb.confignode.procedure.impl.schema.DeleteTimeSeriesProcedu
 import org.apache.iotdb.confignode.procedure.impl.schema.SetTemplateProcedure;
 import org.apache.iotdb.confignode.procedure.impl.schema.UnsetTemplateProcedure;
 import org.apache.iotdb.confignode.procedure.impl.sync.AuthOperationProcedure;
+import org.apache.iotdb.confignode.procedure.impl.testonly.AddNeverFinishSubProcedureProcedure;
 import org.apache.iotdb.confignode.procedure.impl.testonly.CreateManyDatabasesProcedure;
-import org.apache.iotdb.confignode.procedure.impl.testonly.MakeChildProcedure;
 import org.apache.iotdb.confignode.procedure.impl.trigger.CreateTriggerProcedure;
 import org.apache.iotdb.confignode.procedure.impl.trigger.DropTriggerProcedure;
 import org.apache.iotdb.confignode.procedure.scheduler.ProcedureScheduler;
@@ -182,7 +182,7 @@ public class ProcedureManager {
 
   @TestOnly
   public TSStatus testSubProcedure() {
-    this.executor.submitProcedure(new MakeChildProcedure());
+    this.executor.submitProcedure(new AddNeverFinishSubProcedureProcedure());
     return StatusUtils.OK;
   }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/testonly/AddNeverFinishSubProcedureProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/testonly/AddNeverFinishSubProcedureProcedure.java
@@ -24,7 +24,7 @@ import org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv;
 import org.apache.iotdb.confignode.procedure.exception.ProcedureException;
 import org.apache.iotdb.confignode.procedure.exception.ProcedureSuspendedException;
 import org.apache.iotdb.confignode.procedure.exception.ProcedureYieldException;
-import org.apache.iotdb.confignode.procedure.impl.statemachine.StateMachineProcedure;
+import org.apache.iotdb.confignode.procedure.impl.StateMachineProcedure;
 import org.apache.iotdb.confignode.procedure.store.ProcedureType;
 
 import java.io.DataOutputStream;

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/testonly/AddNeverFinishSubProcedureProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/testonly/AddNeverFinishSubProcedureProcedure.java
@@ -31,8 +31,8 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 
 @TestOnly
-public class MakeChildProcedure extends StateMachineProcedure<ConfigNodeProcedureEnv, Integer> {
-  public static final String A = "root.start";
+public class AddNeverFinishSubProcedureProcedure
+    extends StateMachineProcedure<ConfigNodeProcedureEnv, Integer> {
   public static final String FAIL_DATABASE_NAME = "root.fail";
 
   @Override
@@ -40,7 +40,6 @@ public class MakeChildProcedure extends StateMachineProcedure<ConfigNodeProcedur
       throws ProcedureSuspendedException, ProcedureYieldException, InterruptedException {
     if (state == 0) {
       // the sub procedure will never finish, so the father procedure should never be called again
-      ProcedureTestUtils.createDatabase(env.getConfigManager(), A);
       addChildProcedure(new NeverFinishProcedure());
       setNextState(1);
       return Flow.HAS_MORE_STATE;
@@ -73,7 +72,7 @@ public class MakeChildProcedure extends StateMachineProcedure<ConfigNodeProcedur
 
   @Override
   public void serialize(DataOutputStream stream) throws IOException {
-    stream.writeShort(ProcedureType.MAKE_CHILD_PROCEDURE.getTypeCode());
+    stream.writeShort(ProcedureType.ADD_NEVER_FINISH_SUB_PROCEDURE_PROCEDURE.getTypeCode());
     super.serialize(stream);
   }
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/testonly/CreateManyDatabasesProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/testonly/CreateManyDatabasesProcedure.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv;
 import org.apache.iotdb.confignode.procedure.exception.ProcedureException;
+import org.apache.iotdb.confignode.procedure.impl.StateMachineProcedure;
 import org.apache.iotdb.confignode.procedure.store.ProcedureType;
 import org.apache.iotdb.rpc.TSStatusCode;
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/testonly/CreateManyDatabasesProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/testonly/CreateManyDatabasesProcedure.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iotdb.confignode.procedure.impl;
+package org.apache.iotdb.confignode.procedure.impl.testonly;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.utils.TestOnly;
@@ -71,11 +71,7 @@ public class CreateManyDatabasesProcedure
 
   private void createDatabase(ConfigNodeProcedureEnv env, int id) throws ProcedureException {
     String databaseName = DATABASE_NAME_PREFIX + id;
-    TDatabaseSchema databaseSchema = new TDatabaseSchema(databaseName);
-    TSStatus status =
-        env.getConfigManager()
-            .setDatabase(
-                new DatabaseSchemaPlan(ConfigPhysicalPlanType.CreateDatabase, databaseSchema));
+    TSStatus status = ProcedureTestUtils.createDatabase(env.getConfigManager(), databaseName);
     if (TSStatusCode.DATABASE_ALREADY_EXISTS.getStatusCode() == status.getCode()) {
       // First mistakes are forgivable, but a second signals a problem.
       if (!createFailedOnce) {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/testonly/CreateManyDatabasesProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/testonly/CreateManyDatabasesProcedure.java
@@ -21,12 +21,9 @@ package org.apache.iotdb.confignode.procedure.impl.testonly;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.utils.TestOnly;
-import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlanType;
-import org.apache.iotdb.confignode.consensus.request.write.database.DatabaseSchemaPlan;
 import org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv;
 import org.apache.iotdb.confignode.procedure.exception.ProcedureException;
 import org.apache.iotdb.confignode.procedure.store.ProcedureType;
-import org.apache.iotdb.confignode.rpc.thrift.TDatabaseSchema;
 import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.slf4j.Logger;

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/testonly/MakeChildProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/testonly/MakeChildProcedure.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.confignode.procedure.impl.testonly;
+
+import org.apache.iotdb.commons.utils.TestOnly;
+import org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv;
+import org.apache.iotdb.confignode.procedure.exception.ProcedureException;
+import org.apache.iotdb.confignode.procedure.exception.ProcedureSuspendedException;
+import org.apache.iotdb.confignode.procedure.exception.ProcedureYieldException;
+import org.apache.iotdb.confignode.procedure.impl.statemachine.StateMachineProcedure;
+import org.apache.iotdb.confignode.procedure.store.ProcedureType;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+@TestOnly
+public class MakeChildProcedure extends StateMachineProcedure<ConfigNodeProcedureEnv, Integer> {
+  public static final String A = "root.start";
+  public static final String FAIL_DATABASE_NAME = "root.fail";
+
+  @Override
+  protected Flow executeFromState(ConfigNodeProcedureEnv env, Integer state)
+      throws ProcedureSuspendedException, ProcedureYieldException, InterruptedException {
+    if (state == 0) {
+      // the sub procedure will never finish, so the father procedure should never be called again
+      ProcedureTestUtils.createDatabase(env.getConfigManager(), A);
+      addChildProcedure(new NeverFinishProcedure());
+      setNextState(1);
+      return Flow.HAS_MORE_STATE;
+    }
+    if (state == 1) {
+      // test fail
+      ProcedureTestUtils.createDatabase(env.getConfigManager(), FAIL_DATABASE_NAME);
+    }
+    return Flow.NO_MORE_STATE;
+  }
+
+  @Override
+  protected void rollbackState(ConfigNodeProcedureEnv configNodeProcedureEnv, Integer integer)
+      throws IOException, InterruptedException, ProcedureException {}
+
+  @Override
+  protected Integer getState(int stateId) {
+    return stateId;
+  }
+
+  @Override
+  protected int getStateId(Integer integer) {
+    return integer;
+  }
+
+  @Override
+  protected Integer getInitialState() {
+    return 0;
+  }
+
+  @Override
+  public void serialize(DataOutputStream stream) throws IOException {
+    stream.writeShort(ProcedureType.MAKE_CHILD_PROCEDURE.getTypeCode());
+    super.serialize(stream);
+  }
+}

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/testonly/NeverFinishProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/testonly/NeverFinishProcedure.java
@@ -24,7 +24,7 @@ import org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv;
 import org.apache.iotdb.confignode.procedure.exception.ProcedureException;
 import org.apache.iotdb.confignode.procedure.exception.ProcedureSuspendedException;
 import org.apache.iotdb.confignode.procedure.exception.ProcedureYieldException;
-import org.apache.iotdb.confignode.procedure.impl.statemachine.StateMachineProcedure;
+import org.apache.iotdb.confignode.procedure.impl.StateMachineProcedure;
 import org.apache.iotdb.confignode.procedure.store.ProcedureType;
 
 import java.io.DataOutputStream;

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/testonly/NeverFinishProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/testonly/NeverFinishProcedure.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.confignode.procedure.impl.testonly;
+
+import org.apache.iotdb.commons.utils.TestOnly;
+import org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv;
+import org.apache.iotdb.confignode.procedure.exception.ProcedureException;
+import org.apache.iotdb.confignode.procedure.exception.ProcedureSuspendedException;
+import org.apache.iotdb.confignode.procedure.exception.ProcedureYieldException;
+import org.apache.iotdb.confignode.procedure.impl.statemachine.StateMachineProcedure;
+import org.apache.iotdb.confignode.procedure.store.ProcedureType;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/** This procedure will never finish. */
+@TestOnly
+public class NeverFinishProcedure extends StateMachineProcedure<ConfigNodeProcedureEnv, Integer> {
+  @Override
+  protected Flow executeFromState(ConfigNodeProcedureEnv env, Integer state)
+      throws ProcedureSuspendedException, ProcedureYieldException, InterruptedException {
+    setNextState(state + 1);
+    //    ProcedureTestUtils.createDatabase(env.getConfigManager(), String.valueOf(state));
+    return Flow.HAS_MORE_STATE;
+  }
+
+  @Override
+  protected void rollbackState(ConfigNodeProcedureEnv configNodeProcedureEnv, Integer state)
+      throws IOException, InterruptedException, ProcedureException {}
+
+  @Override
+  protected Integer getState(int stateId) {
+    return stateId;
+  }
+
+  @Override
+  protected int getStateId(Integer integer) {
+    return integer;
+  }
+
+  @Override
+  protected Integer getInitialState() {
+    return 0;
+  }
+
+  @Override
+  public void serialize(DataOutputStream stream) throws IOException {
+    stream.writeShort(ProcedureType.NEVER_FINISH_PROCEDURE.getTypeCode());
+    super.serialize(stream);
+  }
+}

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/testonly/NeverFinishProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/testonly/NeverFinishProcedure.java
@@ -37,7 +37,7 @@ public class NeverFinishProcedure extends StateMachineProcedure<ConfigNodeProced
   protected Flow executeFromState(ConfigNodeProcedureEnv env, Integer state)
       throws ProcedureSuspendedException, ProcedureYieldException, InterruptedException {
     setNextState(state + 1);
-    //    ProcedureTestUtils.createDatabase(env.getConfigManager(), String.valueOf(state));
+    Thread.sleep(1000);
     return Flow.HAS_MORE_STATE;
   }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/testonly/ProcedureTestUtils.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/testonly/ProcedureTestUtils.java
@@ -15,20 +15,20 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
  */
 
-package org.apache.iotdb.commons.utils;
+package org.apache.iotdb.confignode.procedure.impl.testonly;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import org.apache.iotdb.common.rpc.thrift.TSStatus;
+import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlanType;
+import org.apache.iotdb.confignode.consensus.request.write.database.DatabaseSchemaPlan;
+import org.apache.iotdb.confignode.manager.ConfigManager;
+import org.apache.iotdb.confignode.rpc.thrift.TDatabaseSchema;
 
-/**
- * TestOnly implies that the class or method should only be used in the tests, otherwise its
- * functionality is not guaranteed and may interfere with the normal code.
- */
-@Target({ElementType.FIELD, ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE})
-@Retention(RetentionPolicy.SOURCE)
-public @interface TestOnly {}
+public class ProcedureTestUtils {
+  public static TSStatus createDatabase(ConfigManager configManager, String name) {
+    TDatabaseSchema databaseSchema = new TDatabaseSchema(name);
+    return configManager.setDatabase(
+        new DatabaseSchemaPlan(ConfigPhysicalPlanType.CreateDatabase, databaseSchema));
+  }
+}

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/store/ProcedureFactory.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/store/ProcedureFactory.java
@@ -20,7 +20,6 @@
 package org.apache.iotdb.confignode.procedure.store;
 
 import org.apache.iotdb.confignode.procedure.Procedure;
-import org.apache.iotdb.confignode.procedure.impl.CreateManyDatabasesProcedure;
 import org.apache.iotdb.confignode.procedure.impl.cq.CreateCQProcedure;
 import org.apache.iotdb.confignode.procedure.impl.node.AddConfigNodeProcedure;
 import org.apache.iotdb.confignode.procedure.impl.node.RemoveConfigNodeProcedure;
@@ -49,6 +48,9 @@ import org.apache.iotdb.confignode.procedure.impl.sync.CreatePipeProcedure;
 import org.apache.iotdb.confignode.procedure.impl.sync.DropPipeProcedure;
 import org.apache.iotdb.confignode.procedure.impl.sync.StartPipeProcedure;
 import org.apache.iotdb.confignode.procedure.impl.sync.StopPipeProcedure;
+import org.apache.iotdb.confignode.procedure.impl.testonly.CreateManyDatabasesProcedure;
+import org.apache.iotdb.confignode.procedure.impl.testonly.MakeChildProcedure;
+import org.apache.iotdb.confignode.procedure.impl.testonly.NeverFinishProcedure;
 import org.apache.iotdb.confignode.procedure.impl.trigger.CreateTriggerProcedure;
 import org.apache.iotdb.confignode.procedure.impl.trigger.DropTriggerProcedure;
 import org.apache.iotdb.confignode.service.ConfigNode;
@@ -199,6 +201,12 @@ public class ProcedureFactory implements IProcedureFactory {
       case CREATE_MANY_DATABASES_PROCEDURE:
         procedure = new CreateManyDatabasesProcedure();
         break;
+      case NEVER_FINISH_PROCEDURE:
+        procedure = new NeverFinishProcedure();
+        break;
+      case MAKE_CHILD_PROCEDURE:
+        procedure = new MakeChildProcedure();
+        break;
       default:
         LOGGER.error("Unknown Procedure type: {}", typeCode);
         throw new IOException("Unknown Procedure type: " + typeCode);
@@ -270,6 +278,10 @@ public class ProcedureFactory implements IProcedureFactory {
       return ProcedureType.AUTH_OPERATE_PROCEDURE;
     } else if (procedure instanceof CreateManyDatabasesProcedure) {
       return ProcedureType.CREATE_MANY_DATABASES_PROCEDURE;
+    } else if (procedure instanceof NeverFinishProcedure) {
+      return ProcedureType.NEVER_FINISH_PROCEDURE;
+    } else if (procedure instanceof MakeChildProcedure) {
+      return ProcedureType.MAKE_CHILD_PROCEDURE;
     }
     throw new UnsupportedOperationException(
         "Procedure type " + procedure.getClass() + " is not supported");

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/store/ProcedureFactory.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/store/ProcedureFactory.java
@@ -48,8 +48,8 @@ import org.apache.iotdb.confignode.procedure.impl.sync.CreatePipeProcedure;
 import org.apache.iotdb.confignode.procedure.impl.sync.DropPipeProcedure;
 import org.apache.iotdb.confignode.procedure.impl.sync.StartPipeProcedure;
 import org.apache.iotdb.confignode.procedure.impl.sync.StopPipeProcedure;
+import org.apache.iotdb.confignode.procedure.impl.testonly.AddNeverFinishSubProcedureProcedure;
 import org.apache.iotdb.confignode.procedure.impl.testonly.CreateManyDatabasesProcedure;
-import org.apache.iotdb.confignode.procedure.impl.testonly.MakeChildProcedure;
 import org.apache.iotdb.confignode.procedure.impl.testonly.NeverFinishProcedure;
 import org.apache.iotdb.confignode.procedure.impl.trigger.CreateTriggerProcedure;
 import org.apache.iotdb.confignode.procedure.impl.trigger.DropTriggerProcedure;
@@ -204,8 +204,8 @@ public class ProcedureFactory implements IProcedureFactory {
       case NEVER_FINISH_PROCEDURE:
         procedure = new NeverFinishProcedure();
         break;
-      case MAKE_CHILD_PROCEDURE:
-        procedure = new MakeChildProcedure();
+      case ADD_NEVER_FINISH_SUB_PROCEDURE_PROCEDURE:
+        procedure = new AddNeverFinishSubProcedureProcedure();
         break;
       default:
         LOGGER.error("Unknown Procedure type: {}", typeCode);
@@ -280,8 +280,8 @@ public class ProcedureFactory implements IProcedureFactory {
       return ProcedureType.CREATE_MANY_DATABASES_PROCEDURE;
     } else if (procedure instanceof NeverFinishProcedure) {
       return ProcedureType.NEVER_FINISH_PROCEDURE;
-    } else if (procedure instanceof MakeChildProcedure) {
-      return ProcedureType.MAKE_CHILD_PROCEDURE;
+    } else if (procedure instanceof AddNeverFinishSubProcedureProcedure) {
+      return ProcedureType.ADD_NEVER_FINISH_SUB_PROCEDURE_PROCEDURE;
     }
     throw new UnsupportedOperationException(
         "Procedure type " + procedure.getClass() + " is not supported");

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/store/ProcedureType.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/store/ProcedureType.java
@@ -101,9 +101,7 @@ public enum ProcedureType {
   @TestOnly
   NEVER_FINISH_PROCEDURE((short) 66600),
   @TestOnly
-  MAKE_CHILD_PROCEDURE((short) 66601),
-
-    ;
+  ADD_NEVER_FINISH_SUB_PROCEDURE_PROCEDURE((short) 66601);
 
   private final short typeCode;
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/store/ProcedureType.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/store/ProcedureType.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iotdb.confignode.procedure.store;
 
+import org.apache.iotdb.commons.utils.TestOnly;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -34,6 +36,7 @@ public enum ProcedureType {
   DELETE_DATABASE_PROCEDURE((short) 200),
   REGION_MIGRATE_PROCEDURE((short) 201),
   CREATE_REGION_GROUPS((short) 202),
+  @TestOnly
   CREATE_MANY_DATABASES_PROCEDURE((short) 203),
 
   /** Timeseries */
@@ -93,7 +96,14 @@ public enum ProcedureType {
   PIPE_ENRICHED_CREATE_TRIGGER_PROCEDURE((short) 1408),
   PIPE_ENRICHED_DROP_TRIGGER_PROCEDURE((short) 1409),
   PIPE_ENRICHED_AUTH_OPERATE_PROCEDURE((short) 1410),
-  ;
+
+  /** Other */
+  @TestOnly
+  NEVER_FINISH_PROCEDURE((short) 66600),
+  @TestOnly
+  MAKE_CHILD_PROCEDURE((short) 66601),
+
+    ;
 
   private final short typeCode;
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
@@ -155,6 +155,7 @@ import org.apache.iotdb.confignode.rpc.thrift.TShowThrottleReq;
 import org.apache.iotdb.confignode.rpc.thrift.TShowVariablesResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSpaceQuotaResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSystemConfigurationResp;
+import org.apache.iotdb.confignode.rpc.thrift.TTestOperation;
 import org.apache.iotdb.confignode.rpc.thrift.TThrottleQuotaResp;
 import org.apache.iotdb.confignode.rpc.thrift.TUnsetSchemaTemplateReq;
 import org.apache.iotdb.confignode.service.ConfigNode;
@@ -483,8 +484,17 @@ public class ConfigNodeRPCServiceProcessor implements IConfigNodeRPCService.Ifac
   }
 
   @Override
-  public TSStatus createManyDatabases() throws TException {
-    return configManager.createManyDatabases();
+  public TSStatus callSpecialProcedure(TTestOperation operation) throws TException {
+    switch (operation) {
+      case TEST_PROCEDURE_RECOVER:
+        return configManager.getProcedureManager().createManyDatabases();
+      case TEST_SUB_PROCEDURE:
+        return configManager.getProcedureManager().testSubProcedure();
+      default:
+        String msg = String.format("operation %s is not supported", operation);
+        LOGGER.error(msg);
+        throw new UnsupportedOperationException(msg);
+    }
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/client/ConfigNodeClient.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/client/ConfigNodeClient.java
@@ -124,6 +124,7 @@ import org.apache.iotdb.confignode.rpc.thrift.TShowThrottleReq;
 import org.apache.iotdb.confignode.rpc.thrift.TShowVariablesResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSpaceQuotaResp;
 import org.apache.iotdb.confignode.rpc.thrift.TSystemConfigurationResp;
+import org.apache.iotdb.confignode.rpc.thrift.TTestOperation;
 import org.apache.iotdb.confignode.rpc.thrift.TThrottleQuotaResp;
 import org.apache.iotdb.confignode.rpc.thrift.TUnsetSchemaTemplateReq;
 import org.apache.iotdb.db.conf.IoTDBConfig;
@@ -464,9 +465,9 @@ public class ConfigNodeClient implements IConfigNodeRPCService.Iface, ThriftClie
   }
 
   @Override
-  public TSStatus createManyDatabases() throws TException {
+  public TSStatus callSpecialProcedure(TTestOperation operation) throws TException {
     return executeRemoteCallWithRetry(
-        () -> client.createManyDatabases(), status -> !updateConfigNodeLeader(status));
+        () -> client.callSpecialProcedure(operation), status -> !updateConfigNodeLeader(status));
   }
 
   @Override

--- a/iotdb-protocol/thrift-confignode/src/main/thrift/confignode.thrift
+++ b/iotdb-protocol/thrift-confignode/src/main/thrift/confignode.thrift
@@ -836,6 +836,13 @@ enum TActivationControl {
   ALL_LICENSE_FILE_DELETED
 }
 
+// ====================================================
+// Test only
+// ====================================================
+enum TTestOperation {
+  TEST_PROCEDURE_RECOVER,
+  TEST_SUB_PROCEDURE,
+}
 
 service IConfigNodeRPCService {
 
@@ -969,7 +976,7 @@ service IConfigNodeRPCService {
   TDatabaseSchemaResp getMatchedDatabaseSchemas(TGetDatabaseReq req)
 
   /** Test only */
-  common.TSStatus createManyDatabases()
+  common.TSStatus callSpecialProcedure(TTestOperation operation)
 
   // ======================================================
   // SchemaPartition


### PR DESCRIPTION
The previous code omitted an `!` when restoring the procedure, allowing the parent procedure to continue executing before the sub-procedure was finished. This issue has been fixed and an integration test has been added.