### PR TITLE
Fixed ConfigNode startup error in SimpleConsensus

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/simple/SimpleConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/simple/SimpleConsensus.java
@@ -168,11 +168,13 @@ class SimpleConsensus implements IConsensus {
                     return null;
                   }
 
-                  SimpleConsensusServerImpl impl =
-                      new SimpleConsensusServerImpl(peers.get(0), registry.apply(groupId));
-                  impl.start();
-                  return impl;
+                  return new SimpleConsensusServerImpl(peers.get(0), registry.apply(groupId));
                 }))
+        .map(
+            impl -> {
+              impl.start();
+              return impl;
+            })
         .orElseThrow(
             () ->
                 new ConsensusException(

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/simple/SimpleConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/simple/SimpleConsensusServerImpl.java
@@ -26,11 +26,13 @@ import org.apache.iotdb.consensus.common.Peer;
 import org.apache.iotdb.consensus.common.request.IConsensusRequest;
 
 import java.io.File;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class SimpleConsensusServerImpl implements IStateMachine {
 
   private final Peer peer;
   private final IStateMachine stateMachine;
+  private final AtomicBoolean initialized = new AtomicBoolean(false);
 
   public SimpleConsensusServerImpl(Peer peer, IStateMachine stateMachine) {
     this.peer = peer;
@@ -47,10 +49,12 @@ public class SimpleConsensusServerImpl implements IStateMachine {
 
   @Override
   public void start() {
-    stateMachine.start();
-    // Notify itself as the leader
-    stateMachine.event().notifyLeaderChanged(peer.getGroupId(), peer.getNodeId());
-    stateMachine.event().notifyLeaderReady();
+    if (initialized.compareAndSet(false, true)) {
+      stateMachine.start();
+      // Notify itself as the leader
+      stateMachine.event().notifyLeaderChanged(peer.getGroupId(), peer.getNodeId());
+      stateMachine.event().notifyLeaderReady();
+    }
   }
 
   @Override


### PR DESCRIPTION
SimpleConsensus triggers the start and notifyLeaderReady functions of SimpleConsensusImpl before the consensusGroup in the map has been written. In the initialization logic of some asynchronous calls, if it is executed fast enough, SimpleConsensus may still have a map size of 0, causing an error to fail startup.

The fix is as simple as calling start after a successful put