### PR TITLE
Support schema region snapshot parser.

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/mem/snapshot/MemMTreeSnapshotUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/mem/snapshot/MemMTreeSnapshotUtil.java
@@ -357,7 +357,7 @@ public class MemMTreeSnapshotUtil {
     }
   }
 
-  private static class MNodeDeserializer {
+  public static class MNodeDeserializer {
 
     public IMemMNode deserializeInternalMNode(InputStream inputStream) throws IOException {
       String name = ReadWriteIOUtils.readString(inputStream);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/schema/SRStatementGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/schema/SRStatementGenerator.java
@@ -1,0 +1,355 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.tools.schema;
+
+import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.schema.node.IMNode;
+import org.apache.iotdb.commons.schema.node.common.AbstractDatabaseMNode;
+import org.apache.iotdb.commons.schema.node.common.AbstractMeasurementMNode;
+import org.apache.iotdb.commons.schema.node.utils.IMNodeContainer;
+import org.apache.iotdb.commons.schema.node.visitor.MNodeVisitor;
+import org.apache.iotdb.db.queryengine.plan.statement.Statement;
+import org.apache.iotdb.db.queryengine.plan.statement.metadata.CreateAlignedTimeSeriesStatement;
+import org.apache.iotdb.db.queryengine.plan.statement.metadata.CreateTimeSeriesStatement;
+import org.apache.iotdb.db.queryengine.plan.statement.metadata.template.ActivateTemplateStatement;
+import org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.mem.mnode.IMemMNode;
+import org.apache.iotdb.db.schemaengine.schemaregion.mtree.impl.mem.snapshot.MemMTreeSnapshotUtil;
+import org.apache.iotdb.tsfile.utils.Pair;
+import org.apache.iotdb.tsfile.utils.ReadWriteIOUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import static org.apache.iotdb.commons.schema.SchemaConstant.ENTITY_MNODE_TYPE;
+import static org.apache.iotdb.commons.schema.SchemaConstant.INTERNAL_MNODE_TYPE;
+import static org.apache.iotdb.commons.schema.SchemaConstant.LOGICAL_VIEW_MNODE_TYPE;
+import static org.apache.iotdb.commons.schema.SchemaConstant.MEASUREMENT_MNODE_TYPE;
+import static org.apache.iotdb.commons.schema.SchemaConstant.STORAGE_GROUP_ENTITY_MNODE_TYPE;
+import static org.apache.iotdb.commons.schema.SchemaConstant.STORAGE_GROUP_MNODE_TYPE;
+import static org.apache.iotdb.commons.schema.SchemaConstant.isStorageGroupType;
+
+public class SRStatementGenerator implements Iterator<Statement>, Iterable<Statement> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SRStatementGenerator.class);
+  private IMemMNode curNode;
+
+  // Iterable<> cannot throw exception, so you should check lastExcept to make sure
+  // that the parsing process is error-free.
+  private Exception lastExcept = null;
+
+  // input file stream: mtree file and tag file
+  private final InputStream inputStream;
+
+  private final FileChannel tagFileChannel;
+
+  // help to record the state of traversing
+  private final Deque<IMemMNode> ancestors = new ArrayDeque<>();
+  private final Deque<Integer> restChildrenNum = new ArrayDeque<>();
+  private final PartialPath databaseFullPath;
+
+  private static final CommonConfig COMMON_CONFIG = CommonDescriptor.getInstance().getConfig();
+
+  // Iterable statements
+
+  private final Deque<Statement> statements = new ArrayDeque<>();
+
+  // utils
+
+  private final MNodeTranslater translater = new MNodeTranslater();
+
+  private final MemMTreeSnapshotUtil.MNodeDeserializer deserializer =
+      new MemMTreeSnapshotUtil.MNodeDeserializer();
+
+  private int nodeCount = 0;
+
+  public SRStatementGenerator(File mtreeFile, File tagFile, PartialPath databaseFullPath)
+      throws IOException {
+
+    inputStream = Files.newInputStream(mtreeFile.toPath());
+
+    if (tagFile != null) {
+      tagFileChannel = FileChannel.open(tagFile.toPath(), StandardOpenOption.READ);
+    } else {
+      tagFileChannel = null;
+    }
+
+    this.databaseFullPath = databaseFullPath;
+
+    Byte version = ReadWriteIOUtils.readByte(inputStream);
+    curNode = deserializeMNode(ancestors, restChildrenNum, deserializer, inputStream);
+    nodeCount++;
+  }
+
+  @Override
+  public Iterator<Statement> iterator() {
+    return this;
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (!statements.isEmpty()) {
+      return true;
+    }
+    if (lastExcept != null) {
+      return false;
+    }
+    while (!ancestors.isEmpty()) {
+      int childNum = restChildrenNum.pop();
+      if (childNum == 0) {
+        IMemMNode node = ancestors.pop();
+        if (node.isDevice() && node.getAsDeviceMNode().isAligned()) {
+          Statement stmt =
+              genAlignedTimeseriesStatement(
+                  node, databaseFullPath.getDevicePath().concatPath(node.getPartialPath()));
+          statements.push(stmt);
+        }
+        cleanMtreeNode(node);
+        if (!statements.isEmpty()) {
+          return true;
+        }
+      } else {
+        restChildrenNum.push(childNum - 1);
+        try {
+          curNode = deserializeMNode(ancestors, restChildrenNum, deserializer, inputStream);
+          nodeCount++;
+        } catch (IOException ioe) {
+          lastExcept = ioe;
+          try {
+            inputStream.close();
+            tagFileChannel.close();
+
+          } catch (IOException e) {
+            lastExcept = e;
+          }
+          return false;
+        }
+        Statement stmt =
+            curNode.accept(
+                translater, databaseFullPath.getDevicePath().concatPath(curNode.getPartialPath()));
+        if (stmt != null) {
+          statements.push(stmt);
+        }
+        if (!statements.isEmpty()) {
+          return true;
+        }
+      }
+    }
+    try {
+      inputStream.close();
+      if (tagFileChannel != null) {
+        tagFileChannel.close();
+      }
+    } catch (IOException e) {
+      lastExcept = e;
+    }
+    return false;
+  }
+
+  @Override
+  public Statement next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+    return statements.pop();
+  }
+
+  public void checkException() throws IOException {
+    if (lastExcept != null) {
+      throw new IOException(lastExcept);
+    }
+  }
+
+  private void cleanMtreeNode(IMNode node) {
+    IMNodeContainer<IMemMNode> children = node.getAsInternalMNode().getChildren();
+    nodeCount = nodeCount - children.size();
+    node.getChildren().clear();
+  }
+
+  private static IMemMNode deserializeMNode(
+      Deque<IMemMNode> ancestors,
+      Deque<Integer> restChildrenNum,
+      MemMTreeSnapshotUtil.MNodeDeserializer deserializer,
+      InputStream inputStream)
+      throws IOException {
+    byte type = ReadWriteIOUtils.readByte(inputStream);
+    int childrenNum;
+    IMemMNode node;
+    switch (type) {
+      case INTERNAL_MNODE_TYPE:
+        childrenNum = ReadWriteIOUtils.readInt(inputStream);
+        node = deserializer.deserializeInternalMNode(inputStream);
+        break;
+      case STORAGE_GROUP_MNODE_TYPE:
+        childrenNum = ReadWriteIOUtils.readInt(inputStream);
+        node = deserializer.deserializeStorageGroupMNode(inputStream);
+        break;
+      case ENTITY_MNODE_TYPE:
+        childrenNum = ReadWriteIOUtils.readInt(inputStream);
+        node = deserializer.deserializeEntityMNode(inputStream);
+        break;
+      case STORAGE_GROUP_ENTITY_MNODE_TYPE:
+        childrenNum = ReadWriteIOUtils.readInt(inputStream);
+        node = deserializer.deserializeStorageGroupEntityMNode(inputStream);
+        break;
+      case MEASUREMENT_MNODE_TYPE:
+        childrenNum = 0;
+        node = deserializer.deserializeMeasurementMNode(inputStream);
+        break;
+      case LOGICAL_VIEW_MNODE_TYPE:
+        childrenNum = 0;
+        node = deserializer.deserializeLogicalViewMNode(inputStream);
+        break;
+      default:
+        throw new IOException("Unrecognized MNode type" + type);
+    }
+
+    if (!ancestors.isEmpty()) {
+      IMemMNode parent = ancestors.peek();
+      node.setParent(ancestors.peek());
+      parent.addChild(node);
+    }
+
+    if (childrenNum > 0 || isStorageGroupType(type)) {
+      ancestors.push(node);
+      restChildrenNum.push(childrenNum);
+    }
+    return node;
+  }
+
+  private class MNodeTranslater extends MNodeVisitor<Statement, PartialPath> {
+
+    @Override
+    public Statement visitBasicMNode(IMNode<?> node, PartialPath path) {
+      if (node.isDevice()) {
+        // Aligned timeserie will be created when node pop.
+        return SRStatementGenerator.genActivateTemplateStatement(node, path);
+      }
+      return null;
+    }
+
+    @Override
+    public Statement visitDatabaseMNode(
+        AbstractDatabaseMNode<?, ? extends IMNode<?>> node, PartialPath path) {
+      if (node.isDevice()) {
+        return SRStatementGenerator.genActivateTemplateStatement(node, path);
+      }
+      return null;
+    }
+
+    @Override
+    public Statement visitMeasurementMNode(
+        AbstractMeasurementMNode<?, ? extends IMNode<?>> node, PartialPath path) {
+      if (node.isLogicalView() || node.getParent().getAsDeviceMNode().isAligned()) {
+        return null;
+      } else {
+        CreateTimeSeriesStatement stmt = new CreateTimeSeriesStatement();
+        stmt.setPath(path);
+        stmt.setAlias(node.getAlias());
+        stmt.setCompressor(node.getAsMeasurementMNode().getSchema().getCompressor());
+        stmt.setDataType(node.getDataType());
+        stmt.setEncoding(node.getAsMeasurementMNode().getSchema().getEncodingType());
+        if (node.getOffset() != 0) {
+          if (tagFileChannel != null) {
+            try {
+              ByteBuffer byteBuffer = ByteBuffer.allocate(COMMON_CONFIG.getTagAttributeTotalSize());
+              tagFileChannel.read(byteBuffer, node.getOffset());
+              byteBuffer.flip();
+              Pair<Map<String, String>, Map<String, String>> tagsAndAttributes =
+                  new Pair<>(
+                      ReadWriteIOUtils.readMap(byteBuffer), ReadWriteIOUtils.readMap(byteBuffer));
+              stmt.setTags(tagsAndAttributes.left);
+              stmt.setAttributes(tagsAndAttributes.right);
+            } catch (IOException exception) {
+              lastExcept = exception;
+              LOGGER.warn("error when parser tag and attributes files", exception);
+            }
+          } else {
+            LOGGER.warn("timeserie has attributes and tags but don't find tag file");
+          }
+        }
+        return stmt;
+      }
+    }
+  }
+
+  private static Statement genActivateTemplateStatement(IMNode node, PartialPath path) {
+    if (node.getAsDeviceMNode().isUseTemplate()) {
+      return new ActivateTemplateStatement(path);
+    }
+    return null;
+  }
+
+  private Statement genAlignedTimeseriesStatement(IMNode node, PartialPath path) {
+    IMNodeContainer<IMemMNode> measurements = node.getAsInternalMNode().getChildren();
+    if (node.getAsDeviceMNode().isAligned()) {
+      CreateAlignedTimeSeriesStatement stmt = new CreateAlignedTimeSeriesStatement();
+      stmt.setDevicePath(path);
+      for (IMemMNode measurement : measurements.values()) {
+        stmt.addMeasurement(measurement.getName());
+        stmt.addDataType(measurement.getAsMeasurementMNode().getDataType());
+        if (measurement.getAlias() != null) {
+          stmt.addAliasList(measurement.getAlias());
+        } else {
+          stmt.addAliasList(null);
+        }
+        stmt.addEncoding(measurement.getAsMeasurementMNode().getSchema().getEncodingType());
+        stmt.addCompressor(measurement.getAsMeasurementMNode().getSchema().getCompressor());
+        if (measurement.getAsMeasurementMNode().getOffset() >= 0) {
+          if (tagFileChannel != null) {
+            try {
+              ByteBuffer byteBuffer = ByteBuffer.allocate(COMMON_CONFIG.getTagAttributeTotalSize());
+              tagFileChannel.read(byteBuffer, measurement.getAsMeasurementMNode().getOffset());
+              byteBuffer.flip();
+              Pair<Map<String, String>, Map<String, String>> tagsAndAttributes =
+                  new Pair<>(
+                      ReadWriteIOUtils.readMap(byteBuffer), ReadWriteIOUtils.readMap(byteBuffer));
+              stmt.addAttributesList(tagsAndAttributes.right);
+              stmt.addTagsList(tagsAndAttributes.left);
+            } catch (IOException exception) {
+              lastExcept = exception;
+              LOGGER.warn(
+                  "error when parse tag and attributes file of node path {}",
+                  measurement.getPartialPath(),
+                  exception);
+            }
+          } else {
+            LOGGER.warn("measurement has set attributes or tags, but dont find snapshot files");
+          }
+        }
+      }
+      return stmt;
+    }
+    return null;
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/schema/SchemaRegionSnapshotParser.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/schema/SchemaRegionSnapshotParser.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.tools.schema;
+
+import org.apache.iotdb.commons.file.SystemFileFactory;
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.schema.SchemaConstant;
+import org.apache.iotdb.db.conf.IoTDBConfig;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.tsfile.utils.Pair;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class SchemaRegionSnapshotParser {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SchemaRegionSnapshotParser.class);
+
+  private static final IoTDBConfig CONFIG = IoTDBDescriptor.getInstance().getConfig();
+
+  private SchemaRegionSnapshotParser() {
+    // empty constructor
+  }
+
+  private static Path getLatestSnapshotPath(List<Path> snapshotPathList) {
+    if (snapshotPathList.isEmpty()) {
+      return null;
+    }
+    Path[] pathArray = snapshotPathList.toArray(new Path[0]);
+    Arrays.sort(
+        pathArray,
+        (o1, o2) -> {
+          String index1 = o1.toFile().getName().split("_")[1];
+          String index2 = o2.toFile().getName().split("_")[2];
+          return Long.compare(Long.parseLong(index1), Long.parseLong(index2));
+        });
+    return pathArray[0];
+  }
+
+  // return all schema region's latest snapshot units in this datanode.
+  public static List<Pair<Path, Path>> getSnapshotPaths() {
+    String snapshotPath = CONFIG.getSchemaRegionConsensusDir();
+    File snapshotDir = new File(snapshotPath);
+    ArrayList<Pair<Path, Path>> snapshotUnits = new ArrayList<>();
+
+    // get schema regin path
+    try (DirectoryStream<Path> stream =
+        Files.newDirectoryStream(snapshotDir.toPath(), "[0-9]*-[0-9]*-[0-9]*-[0-9]*-[0-9]*")) {
+      for (Path path : stream) {
+        try (DirectoryStream<Path> filestream =
+            Files.newDirectoryStream(Paths.get(path.toString() + File.separator + "sm"))) {
+          // find the latest snapshots
+          ArrayList<Path> snapshotList = new ArrayList<>();
+          for (Path snapshotFolder : filestream) {
+            if (snapshotFolder.toFile().isDirectory()) {
+              snapshotList.add(snapshotFolder);
+            }
+          }
+          Path latestSnapshotPath = getLatestSnapshotPath(snapshotList);
+          if (latestSnapshotPath != null) {
+            // get metadata from the latest snapshot folder.
+            File mtreeSnapshot =
+                SystemFileFactory.INSTANCE.getFile(
+                    latestSnapshotPath + File.separator + SchemaConstant.MTREE_SNAPSHOT);
+            File tagSnapshot =
+                SystemFileFactory.INSTANCE.getFile(
+                    latestSnapshotPath + File.separator + SchemaConstant.TAG_LOG_SNAPSHOT);
+            if (mtreeSnapshot.exists()) {
+              snapshotUnits.add(
+                  new Pair<>(
+                      mtreeSnapshot.toPath(), tagSnapshot.exists() ? tagSnapshot.toPath() : null));
+            }
+          }
+        }
+      }
+    } catch (IOException exception) {
+      LOGGER.warn("cannot construct snapshot directory stream", exception);
+    }
+    return snapshotUnits;
+  }
+
+  // in schema snapshot path: datanode/consensus/schema_region/47474747-4747-4747-4747-000200000000
+  // this func will get schema region id = 47474747-4747-4747-4747-000200000000's latest snapshot.
+  // In one schema region, there is only one snapshot unit.
+  public static Pair<Path, Path> getSnapshotPaths(String schemaRegionId) {
+    String snapshotPath = CONFIG.getSchemaRegionConsensusDir();
+    File snapshotDir =
+        new File(snapshotPath + File.separator + schemaRegionId + File.separator + "sm");
+
+    // get the latest snapshot file
+    ArrayList<Path> snapshotList = new ArrayList<>();
+    try (DirectoryStream<Path> stream =
+        Files.newDirectoryStream(snapshotDir.toPath(), "[0-9]*_[0-9]*")) {
+      for (Path path : stream) {
+        snapshotList.add(path);
+      }
+    } catch (IOException ioException) {
+      LOGGER.warn("ioexception when get {}'s folder", schemaRegionId, ioException);
+      return null;
+    }
+    Path latestSnapshotPath = getLatestSnapshotPath(snapshotList);
+    if (latestSnapshotPath != null) {
+      // get metadata from the latest snapshot folder.
+      File mtreeSnapshot =
+          SystemFileFactory.INSTANCE.getFile(
+              latestSnapshotPath + File.separator + SchemaConstant.MTREE_SNAPSHOT);
+      File tagSnapshot =
+          SystemFileFactory.INSTANCE.getFile(
+              latestSnapshotPath + File.separator + SchemaConstant.TAG_LOG_SNAPSHOT);
+      if (mtreeSnapshot.exists()) {
+        return new Pair<>(
+            mtreeSnapshot.toPath(), tagSnapshot.exists() ? tagSnapshot.toPath() : null);
+      }
+    }
+    return null;
+  }
+
+  public static SRStatementGenerator translate2Statements(
+      Path mtreePath, Path tagFilePath, PartialPath databasePath) throws IOException {
+    if (mtreePath == null) {
+      return null;
+    }
+    File mtreefile = mtreePath.toFile();
+    File tagfile;
+    if (tagFilePath != null && tagFilePath.toFile().exists()) {
+      tagfile = tagFilePath.toFile();
+    } else {
+      tagfile = null;
+    }
+
+    if (!mtreefile.exists()) {
+      return null;
+    }
+
+    if (!mtreefile.getName().equals(SchemaConstant.MTREE_SNAPSHOT)) {
+      throw new IllegalArgumentException(
+          String.format(
+              "%s is not allowed, only support %s",
+              mtreefile.getName(), SchemaConstant.MTREE_SNAPSHOT));
+    }
+    if (tagfile != null && !tagfile.getName().equals(SchemaConstant.TAG_LOG_SNAPSHOT)) {
+      throw new IllegalArgumentException(
+          String.format(
+              " %s is not allowed, only support %s",
+              tagfile.getName(), SchemaConstant.TAG_LOG_SNAPSHOT));
+    }
+    return new SRStatementGenerator(mtreefile, tagfile, databasePath);
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/SchemaRegionSnapshotParserTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/SchemaRegionSnapshotParserTest.java
@@ -1,0 +1,694 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.utils;
+
+import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
+import org.apache.iotdb.commons.consensus.SchemaRegionId;
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.schema.SchemaConstant;
+import org.apache.iotdb.db.conf.IoTDBConfig;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.queryengine.plan.statement.Statement;
+import org.apache.iotdb.db.queryengine.plan.statement.metadata.CreateAlignedTimeSeriesStatement;
+import org.apache.iotdb.db.queryengine.plan.statement.metadata.CreateTimeSeriesStatement;
+import org.apache.iotdb.db.queryengine.plan.statement.metadata.template.ActivateTemplateStatement;
+import org.apache.iotdb.db.schemaengine.SchemaEngine;
+import org.apache.iotdb.db.schemaengine.schemaregion.ISchemaRegion;
+import org.apache.iotdb.db.schemaengine.schemaregion.ISchemaRegionPlan;
+import org.apache.iotdb.db.schemaengine.schemaregion.write.req.IActivateTemplateInClusterPlan;
+import org.apache.iotdb.db.schemaengine.schemaregion.write.req.ICreateAlignedTimeSeriesPlan;
+import org.apache.iotdb.db.schemaengine.schemaregion.write.req.ICreateTimeSeriesPlan;
+import org.apache.iotdb.db.schemaengine.schemaregion.write.req.SchemaRegionWritePlanFactory;
+import org.apache.iotdb.db.schemaengine.template.Template;
+import org.apache.iotdb.db.tools.schema.SRStatementGenerator;
+import org.apache.iotdb.db.tools.schema.SchemaRegionSnapshotParser;
+import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSEncoding;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RunWith(Parameterized.class)
+public class SchemaRegionSnapshotParserTest {
+
+  private static final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
+  private static final CommonConfig COMMON_CONFIG = CommonDescriptor.getInstance().getConfig();
+
+  private SchemaRegionSnapshotParserTestParams rawConfig;
+
+  protected final SchemaRegionSnapshotParserTestParams testParams;
+
+  protected static class SchemaRegionSnapshotParserTestParams {
+    private final String testModeName;
+    private final String schemaRegionMode;
+    private final boolean isClusterMode;
+
+    private SchemaRegionSnapshotParserTestParams(
+        String testModeName, String schemaEngineMode, boolean isClusterMode) {
+      this.testModeName = testModeName;
+      this.schemaRegionMode = schemaEngineMode;
+      this.isClusterMode = isClusterMode;
+    }
+
+    public String getTestModeName() {
+      return this.testModeName;
+    }
+
+    public String getSchemaRegionMode() {
+      return this.schemaRegionMode;
+    }
+
+    public boolean getClusterMode() {
+      return this.isClusterMode;
+    }
+
+    @Override
+    public String toString() {
+      return testModeName;
+    }
+  }
+
+  private String snapshotFileName;
+
+  @Parameterized.Parameters(name = "{0}")
+  public static List<SchemaRegionSnapshotParserTestParams> getTestModes() {
+    return Arrays.asList(
+        new SchemaRegionSnapshotParserTestParams("MemoryMode", "Memory", true),
+        new SchemaRegionSnapshotParserTestParams("PBTree", "PBTree", true));
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    rawConfig =
+        new SchemaRegionSnapshotParserTestParams(
+            "Raw-Config", COMMON_CONFIG.getSchemaEngineMode(), config.isClusterMode());
+    COMMON_CONFIG.setSchemaEngineMode(testParams.schemaRegionMode);
+    config.setClusterMode(testParams.isClusterMode);
+    SchemaEngine.getInstance().init();
+    if (testParams.schemaRegionMode.equals("Memory")) {
+      snapshotFileName = SchemaConstant.MTREE_SNAPSHOT;
+    } else if (testParams.schemaRegionMode.equals("PBTree")) {
+      snapshotFileName = SchemaConstant.PBTREE_SNAPSHOT;
+    }
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    SchemaEngine.getInstance().clear();
+    cleanEnv();
+    COMMON_CONFIG.setSchemaEngineMode(rawConfig.schemaRegionMode);
+    config.setClusterMode(rawConfig.isClusterMode);
+  }
+
+  protected void cleanEnv() throws IOException {
+    FileUtils.deleteDirectory(new File(IoTDBDescriptor.getInstance().getConfig().getSchemaDir()));
+  }
+
+  public SchemaRegionSnapshotParserTest(SchemaRegionSnapshotParserTestParams params) {
+    this.testParams = params;
+  }
+
+  public ISchemaRegion getSchemaRegion(String database, int schemaRegionId) throws Exception {
+    SchemaRegionId regionId = new SchemaRegionId(schemaRegionId);
+    if (SchemaEngine.getInstance().getSchemaRegion(regionId) == null) {
+      SchemaEngine.getInstance().createSchemaRegion(new PartialPath(database), regionId);
+    }
+    return SchemaEngine.getInstance().getSchemaRegion(regionId);
+  }
+
+  @Test
+  public void testSimpleTranslateSnapshot() throws Exception {
+    if (testParams.testModeName.equals("PBTree")) {
+      return;
+    }
+    ISchemaRegion schemaRegion = getSchemaRegion("root.sg", 0);
+    PartialPath databasePath = new PartialPath("root.sg");
+    // Tree in memtree:
+    // root->sg->s1->g1->temp
+    //          |     |->status
+    //          |->s2->g2->t2->temp
+    //              |->g4->status
+    //              |->g5->level
+    HashMap<String, ICreateTimeSeriesPlan> planMap = new HashMap<>();
+    planMap.put(
+        "root.sg.s1.g1.temp",
+        SchemaRegionWritePlanFactory.getCreateTimeSeriesPlan(
+            new PartialPath("root.sg.s1.g1.temp"),
+            TSDataType.FLOAT,
+            TSEncoding.RLE,
+            CompressionType.SNAPPY,
+            null,
+            null,
+            null,
+            null));
+    planMap.put(
+        "root.sg.s1.g1.status",
+        SchemaRegionWritePlanFactory.getCreateTimeSeriesPlan(
+            new PartialPath("root.sg.s1.g1.status"),
+            TSDataType.INT64,
+            TSEncoding.TS_2DIFF,
+            CompressionType.LZ4,
+            null,
+            null,
+            null,
+            null));
+    planMap.put(
+        "root.sg.s2.g2.t2.temp",
+        SchemaRegionWritePlanFactory.getCreateTimeSeriesPlan(
+            new PartialPath("root.sg.s2.g2.t2.temp"),
+            TSDataType.DOUBLE,
+            TSEncoding.RLE,
+            CompressionType.GZIP,
+            null,
+            null,
+            null,
+            null));
+    planMap.put(
+        "root.sg.s2.g4.status",
+        SchemaRegionWritePlanFactory.getCreateTimeSeriesPlan(
+            new PartialPath("root.sg.s2.g4.status"),
+            TSDataType.INT64,
+            TSEncoding.RLE,
+            CompressionType.ZSTD,
+            null,
+            null,
+            null,
+            null));
+    planMap.put(
+        "root.sg.s2.g5.level",
+        SchemaRegionWritePlanFactory.getCreateTimeSeriesPlan(
+            new PartialPath("root.sg.s2.g5.level"),
+            TSDataType.INT32,
+            TSEncoding.GORILLA,
+            CompressionType.LZMA2,
+            null,
+            null,
+            null,
+            null));
+    for (ICreateTimeSeriesPlan plan : planMap.values()) {
+      schemaRegion.createTimeseries(plan, -1);
+    }
+
+    File snapshotDir = new File(config.getSchemaDir() + File.separator + "snapshot");
+    snapshotDir.mkdir();
+    schemaRegion.createSnapshot(snapshotDir);
+
+    SRStatementGenerator statements =
+        SchemaRegionSnapshotParser.translate2Statements(
+            Paths.get(
+                config.getSchemaDir()
+                    + File.separator
+                    + "snapshot"
+                    + File.separator
+                    + snapshotFileName),
+            null,
+            databasePath);
+
+    assert statements != null;
+    for (Statement stmt : statements) {
+      CreateTimeSeriesStatement createTimeSeriesStatement = (CreateTimeSeriesStatement) stmt;
+      ICreateTimeSeriesPlan plan =
+          planMap.get(createTimeSeriesStatement.getPaths().get(0).toString());
+      Assert.assertEquals(plan.getEncoding(), createTimeSeriesStatement.getEncoding());
+      Assert.assertEquals(plan.getCompressor(), createTimeSeriesStatement.getCompressor());
+      Assert.assertEquals(plan.getDataType(), createTimeSeriesStatement.getDataType());
+      Assert.assertEquals(plan.getAlias(), createTimeSeriesStatement.getAlias());
+      Assert.assertEquals(plan.getProps(), createTimeSeriesStatement.getProps());
+      Assert.assertEquals(plan.getAttributes(), createTimeSeriesStatement.getAttributes());
+      Assert.assertEquals(plan.getTags(), createTimeSeriesStatement.getTags());
+    }
+    statements.checkException();
+  }
+
+  @Test
+  public void testAlignedTimeseriesTranslateSnapshot() throws Exception {
+    if (testParams.testModeName.equals("PBTree")) {
+      return;
+    }
+    ISchemaRegion schemaRegion = getSchemaRegion("root.sg", 0);
+    PartialPath database = new PartialPath("root.sg");
+    ICreateAlignedTimeSeriesPlan plan =
+        SchemaRegionWritePlanFactory.getCreateAlignedTimeSeriesPlan(
+            new PartialPath("root.sg.t1.t2"),
+            Arrays.asList("s1", "s2"),
+            Arrays.asList(TSDataType.INT32, TSDataType.INT64),
+            Arrays.asList(TSEncoding.PLAIN, TSEncoding.RLE),
+            Arrays.asList(CompressionType.SNAPPY, CompressionType.LZ4),
+            Arrays.asList("alias1", "alias2"),
+            Arrays.asList(
+                new HashMap<String, String>() {
+                  {
+                    put("tag1", "t1");
+                  }
+                },
+                new HashMap<String, String>() {
+                  {
+                    put("tag2", "t2");
+                  }
+                }),
+            Arrays.asList(
+                new HashMap<String, String>() {
+                  {
+                    put("attr1", "a1");
+                  }
+                },
+                new HashMap<String, String>() {
+                  {
+                    put("attr2", "a2");
+                  }
+                }));
+    schemaRegion.createAlignedTimeSeries(plan);
+    File snapshotDir = new File(config.getSchemaDir() + File.separator + "snapshot");
+    snapshotDir.mkdir();
+    schemaRegion.createSnapshot(snapshotDir);
+    SRStatementGenerator statements =
+        SchemaRegionSnapshotParser.translate2Statements(
+            Paths.get(
+                config.getSchemaDir()
+                    + File.separator
+                    + "snapshot"
+                    + File.separator
+                    + snapshotFileName),
+            Paths.get(
+                config.getSchemaDir()
+                    + File.separator
+                    + "snapshot"
+                    + File.separator
+                    + SchemaConstant.TAG_LOG_SNAPSHOT),
+            database);
+    assert statements != null;
+    for (Statement stmt : statements) {
+      CreateAlignedTimeSeriesStatement createAlignedTimeSeriesStatement =
+          (CreateAlignedTimeSeriesStatement) stmt;
+      Assert.assertEquals(plan.getDevicePath(), createAlignedTimeSeriesStatement.getDevicePath());
+      Assert.assertEquals(
+          plan.getMeasurements(), createAlignedTimeSeriesStatement.getMeasurements());
+      Assert.assertEquals(plan.getAliasList(), createAlignedTimeSeriesStatement.getAliasList());
+      Assert.assertEquals(plan.getEncodings(), createAlignedTimeSeriesStatement.getEncodings());
+      Assert.assertEquals(plan.getCompressors(), createAlignedTimeSeriesStatement.getCompressors());
+      Assert.assertEquals(
+          plan.getAttributesList(), createAlignedTimeSeriesStatement.getAttributesList());
+      Assert.assertEquals(plan.getTagsList(), createAlignedTimeSeriesStatement.getTagsList());
+    }
+    statements.checkException();
+  }
+
+  @Test
+  public void testTemplateActivateTranslateSnapshot() throws Exception {
+    if (testParams.testModeName.equals("PBTree")) {
+      return;
+    }
+    ISchemaRegion schemaRegion = getSchemaRegion("root.sg", 0);
+    PartialPath databasePath = new PartialPath("root.sg");
+    schemaRegion.createTimeseries(
+        SchemaRegionWritePlanFactory.getCreateTimeSeriesPlan(
+            new PartialPath("root.sg.s1.g1.temp"),
+            TSDataType.FLOAT,
+            TSEncoding.RLE,
+            CompressionType.SNAPPY,
+            null,
+            null,
+            null,
+            null),
+        0);
+    schemaRegion.createTimeseries(
+        SchemaRegionWritePlanFactory.getCreateTimeSeriesPlan(
+            new PartialPath("root.sg.s1.g3.temp"),
+            TSDataType.FLOAT,
+            TSEncoding.RLE,
+            CompressionType.SNAPPY,
+            null,
+            null,
+            null,
+            null),
+        0);
+    schemaRegion.createTimeseries(
+        SchemaRegionWritePlanFactory.getCreateTimeSeriesPlan(
+            new PartialPath("root.sg.s2.g1.temp"),
+            TSDataType.FLOAT,
+            TSEncoding.RLE,
+            CompressionType.SNAPPY,
+            null,
+            null,
+            null,
+            null),
+        0);
+    Template template =
+        new Template(
+            "t1",
+            Collections.singletonList("s1"),
+            Collections.singletonList(TSDataType.INT64),
+            Collections.singletonList(TSEncoding.PLAIN),
+            Collections.singletonList(CompressionType.GZIP));
+    template.setId(0);
+    HashMap<String, IActivateTemplateInClusterPlan> planMap = new HashMap<>();
+    IActivateTemplateInClusterPlan plan1 =
+        SchemaRegionWritePlanFactory.getActivateTemplateInClusterPlan(
+            new PartialPath("root.sg.s2"), 1, template.getId());
+    IActivateTemplateInClusterPlan plan2 =
+        SchemaRegionWritePlanFactory.getActivateTemplateInClusterPlan(
+            new PartialPath("root.sg.s3"), 1, template.getId());
+    planMap.put("root.sg.s2", plan1);
+    planMap.put("root.sg.s3", plan2);
+    schemaRegion.activateSchemaTemplate(plan1, template);
+    schemaRegion.activateSchemaTemplate(plan2, template);
+    File snapshotDir = new File(config.getSchemaDir() + File.separator + "snapshot");
+    snapshotDir.mkdir();
+    schemaRegion.createSnapshot(snapshotDir);
+
+    SRStatementGenerator statements =
+        SchemaRegionSnapshotParser.translate2Statements(
+            Paths.get(
+                config.getSchemaDir()
+                    + File.separator
+                    + "snapshot"
+                    + File.separator
+                    + snapshotFileName),
+            null,
+            databasePath);
+    int count = 0;
+    assert statements != null;
+    for (Statement stmt : statements) {
+      if (stmt instanceof ActivateTemplateStatement) {
+        ActivateTemplateStatement ATStatement = (ActivateTemplateStatement) stmt;
+        IActivateTemplateInClusterPlan plan = planMap.get(ATStatement.getPath().toString());
+        Assert.assertEquals(plan.getActivatePath(), ATStatement.getPath());
+        count++;
+      }
+    }
+    Assert.assertEquals(2, count);
+    statements.checkException();
+  }
+
+  @Test
+  public void testComplicatedSnapshotParser() throws Exception {
+    if (testParams.testModeName.equals("PBTree")) {
+      return;
+    }
+
+    // ----------------------------------------------------------------------
+    //                            Schema Tree
+    // ----------------------------------------------------------------------
+    // This test will construct a complicated mtree. This tree will have
+    // aligned timeseries, tags and attributes, normal timeseries device template.
+    //
+    //
+    //
+    //                          status(BOOLEAN, RLE) alias(stat)
+    //                         /
+    //                      t2------temperature(INT64, TS_2DIFF,LZ4)
+    //                     /
+    //          sg1------s1------t1(activate template: t1)
+    //         /
+    // root ->|
+    //         \
+    //          sg2-------t1(aligned)------status(INT64, TS_2DIFF, LZMA2){attr1:atr1}
+    //            \
+    //             t2-------level{tags:"tag1"="t1", attributes: "attri1"="attr1"}
+    //              \
+    //                t1(aligned)-------temperature(INT32, TS_2DIFF, LZ4){attributes:"attr1"="a1"}
+    //                     \
+    //                      level(INT32m RLE){tags:"tag1"="t1"} alias(lev)
+    //
+    //
+    ISchemaRegion schemaRegion = getSchemaRegion("root", 0);
+    PartialPath databasePath = new PartialPath("root");
+    Template template = new Template();
+    template.setId(1);
+    template.addMeasurement("date", TSDataType.INT64, TSEncoding.RLE, CompressionType.UNCOMPRESSED);
+    HashMap<String, ISchemaRegionPlan> planMap = new HashMap<>();
+    planMap.put(
+        "root.sg1.s1.t1",
+        SchemaRegionWritePlanFactory.getActivateTemplateInClusterPlan(
+            new PartialPath("root.sg1.s1.t1"), 3, 1));
+    planMap.put(
+        "root.sg1.s1.t2.temperature",
+        SchemaRegionWritePlanFactory.getCreateTimeSeriesPlan(
+            new PartialPath("root.sg1.s1.t2.temperature"),
+            TSDataType.INT64,
+            TSEncoding.TS_2DIFF,
+            CompressionType.LZ4,
+            null,
+            null,
+            null,
+            null));
+    planMap.put(
+        "root.sg1.s1.t2.status",
+        SchemaRegionWritePlanFactory.getCreateTimeSeriesPlan(
+            new PartialPath("root.sg1.s1.t2.status"),
+            TSDataType.BOOLEAN,
+            TSEncoding.RLE,
+            CompressionType.SNAPPY,
+            null,
+            null,
+            null,
+            "statusA"));
+    planMap.put(
+        "root.sg2.t1",
+        SchemaRegionWritePlanFactory.getCreateAlignedTimeSeriesPlan(
+            new PartialPath("root.sg2.t1"),
+            new ArrayList<String>() {
+              {
+                add("status");
+              }
+            },
+            new ArrayList<TSDataType>() {
+              {
+                add(TSDataType.INT64);
+              }
+            },
+            new ArrayList<TSEncoding>() {
+              {
+                add(TSEncoding.TS_2DIFF);
+              }
+            },
+            new ArrayList<CompressionType>() {
+              {
+                add(CompressionType.SNAPPY);
+              }
+            },
+            new ArrayList<String>() {
+              {
+                add("stat");
+              }
+            },
+            new ArrayList<Map<String, String>>() {
+              {
+                add(new HashMap<>());
+              }
+            },
+            new ArrayList<Map<String, String>>() {
+              {
+                add(
+                    new HashMap<String, String>() {
+                      {
+                        put("attr1", "a1");
+                      }
+                    });
+              }
+            }));
+    planMap.put(
+        "root.sg2.t2.level",
+        SchemaRegionWritePlanFactory.getCreateTimeSeriesPlan(
+            new PartialPath("root.sg2.t2.level"),
+            TSDataType.INT64,
+            TSEncoding.RLE,
+            CompressionType.UNCOMPRESSED,
+            null,
+            new HashMap<String, String>() {
+              {
+                put("tag1", "t1");
+              }
+            },
+            new HashMap<String, String>() {
+              {
+                put("attri1", "atr1");
+              }
+            },
+            null));
+    planMap.put(
+        "root.sg2.t2.t1",
+        SchemaRegionWritePlanFactory.getCreateAlignedTimeSeriesPlan(
+            new PartialPath("root.sg2.t2.t1"),
+            new ArrayList<String>() {
+              {
+                add("temperature");
+                add("level");
+              }
+            },
+            new ArrayList<TSDataType>() {
+              {
+                add(TSDataType.INT64);
+                add(TSDataType.INT32);
+              }
+            },
+            new ArrayList<TSEncoding>() {
+              {
+                add(TSEncoding.RLE);
+                add(TSEncoding.RLE);
+              }
+            },
+            new ArrayList<CompressionType>() {
+              {
+                add(CompressionType.SNAPPY);
+                add(CompressionType.UNCOMPRESSED);
+              }
+            },
+            new ArrayList<String>() {
+              {
+                add(null);
+                add("lev");
+              }
+            },
+            new ArrayList<Map<String, String>>() {
+              {
+                add(new HashMap<>());
+                add(
+                    new HashMap<String, String>() {
+                      {
+                        put("tag1", "t1");
+                      }
+                    });
+              }
+            },
+            new ArrayList<Map<String, String>>() {
+              {
+                add(
+                    new HashMap<String, String>() {
+                      {
+                        put("attr1", "a1");
+                      }
+                    });
+                add(new HashMap<>());
+              }
+            }));
+    for (ISchemaRegionPlan plan : planMap.values()) {
+      if (plan instanceof ICreateTimeSeriesPlan) {
+        schemaRegion.createTimeseries((ICreateTimeSeriesPlan) plan, 0);
+      } else if (plan instanceof ICreateAlignedTimeSeriesPlan) {
+        schemaRegion.createAlignedTimeSeries((ICreateAlignedTimeSeriesPlan) plan);
+      } else if (plan instanceof IActivateTemplateInClusterPlan) {
+        schemaRegion.activateSchemaTemplate((IActivateTemplateInClusterPlan) plan, template);
+      }
+    }
+
+    File snapshotDir = new File(config.getSchemaDir() + File.separator + "snapshot");
+    snapshotDir.mkdir();
+    schemaRegion.createSnapshot(snapshotDir);
+
+    SRStatementGenerator statements =
+        SchemaRegionSnapshotParser.translate2Statements(
+            Paths.get(
+                config.getSchemaDir()
+                    + File.separator
+                    + "snapshot"
+                    + File.separator
+                    + snapshotFileName),
+            Paths.get(
+                config.getSchemaDir()
+                    + File.separator
+                    + "snapshot"
+                    + File.separator
+                    + SchemaConstant.TAG_LOG_SNAPSHOT),
+            databasePath);
+    assert statements != null;
+    int count = 0;
+    Comparator<String> comparator =
+        new Comparator<String>() {
+          @Override
+          public int compare(String o1, String o2) {
+            if (o1 == null && o2 == null) {
+              return 0;
+            } else if (o1 == null) {
+              return 1;
+            } else if (o2 == null) {
+              return -1;
+            } else {
+              return o1.compareTo(o2);
+            }
+          }
+        };
+    for (Statement stmt : statements) {
+      if (stmt instanceof CreateAlignedTimeSeriesStatement) {
+        CreateAlignedTimeSeriesStatement createAlignedTimeSeriesStatement =
+            (CreateAlignedTimeSeriesStatement) stmt;
+        ICreateAlignedTimeSeriesPlan plan =
+            (ICreateAlignedTimeSeriesPlan)
+                planMap.get(createAlignedTimeSeriesStatement.getDevicePath().toString());
+        Assert.assertNotNull(plan);
+        Collections.sort(plan.getMeasurements());
+        Collections.sort(createAlignedTimeSeriesStatement.getMeasurements());
+        Assert.assertEquals(
+            plan.getMeasurements(), createAlignedTimeSeriesStatement.getMeasurements());
+        Collections.sort(plan.getAliasList(), comparator);
+        Collections.sort(createAlignedTimeSeriesStatement.getAliasList(), comparator);
+        Assert.assertEquals(plan.getAliasList(), createAlignedTimeSeriesStatement.getAliasList());
+        Assert.assertEquals(plan.getEncodings(), createAlignedTimeSeriesStatement.getEncodings());
+        Collections.sort(plan.getCompressors());
+        Collections.sort(createAlignedTimeSeriesStatement.getCompressors());
+        Assert.assertEquals(
+            plan.getCompressors(), createAlignedTimeSeriesStatement.getCompressors());
+        Assert.assertEquals(
+            plan.getAttributesList().size(),
+            createAlignedTimeSeriesStatement.getAttributesList().size());
+        Assert.assertEquals(
+            plan.getTagsList().size(), createAlignedTimeSeriesStatement.getTagsList().size());
+      } else if (stmt instanceof CreateTimeSeriesStatement) {
+        CreateTimeSeriesStatement createTimeSeriesStatement = (CreateTimeSeriesStatement) stmt;
+        ICreateTimeSeriesPlan plan =
+            (ICreateTimeSeriesPlan) planMap.get(createTimeSeriesStatement.getPath().toString());
+        Assert.assertNotNull(plan);
+        Assert.assertEquals(plan.getEncoding(), createTimeSeriesStatement.getEncoding());
+        Assert.assertEquals(plan.getCompressor(), createTimeSeriesStatement.getCompressor());
+        Assert.assertEquals(plan.getDataType(), createTimeSeriesStatement.getDataType());
+        Assert.assertEquals(plan.getAlias(), createTimeSeriesStatement.getAlias());
+        Assert.assertEquals(plan.getProps(), createTimeSeriesStatement.getProps());
+        Assert.assertEquals(plan.getAttributes(), createTimeSeriesStatement.getAttributes());
+        Assert.assertEquals(plan.getTags(), createTimeSeriesStatement.getTags());
+      } else if (stmt instanceof ActivateTemplateStatement) {
+        ActivateTemplateStatement activateTemplateStatement = (ActivateTemplateStatement) stmt;
+        IActivateTemplateInClusterPlan plan =
+            (IActivateTemplateInClusterPlan)
+                planMap.get(activateTemplateStatement.getPath().toString());
+        Assert.assertNotNull(plan);
+      }
+      count++;
+    }
+    Assert.assertEquals(planMap.size(), count);
+    statements.checkException();
+  }
+}


### PR DESCRIPTION
In this pr:
1. Support translating snapshot file to statements, so you can use schema region snapshot parser to construct a same Schema tree in another cluster.
2. Add some UTs.
3. refine memory use when translating schema region snapshot. The node num depends on the longest path and Its children num. If one path is root.t1.t2.t3, and It has 100 measurements, so the node num will be 4 + 100.

![152201eb8e7e6b2425a492d1c8c8c26](https://github.com/apache/iotdb/assets/105656576/14c839a0-5fa9-414b-81f9-04f9009633d2)
