### PR TITLE
Pipe: fix legacy receiver's unsafe execution race problem (fix IoTDBPipeDataSinkIT.testLegacyConnector)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/legacy/IoTDBLegacyPipeConnector.java
@@ -104,8 +104,6 @@ public class IoTDBLegacyPipeConnector implements PipeConnector {
   private String syncConnectorVersion;
 
   private String pipeName;
-  private Long creationTime;
-
   private IoTDBSyncClient client;
 
   private SessionPool sessionPool;
@@ -205,7 +203,6 @@ public class IoTDBLegacyPipeConnector implements PipeConnector {
             CONNECTOR_IOTDB_SYNC_CONNECTOR_VERSION_DEFAULT_VALUE);
 
     pipeName = configuration.getRuntimeEnvironment().getPipeName();
-    creationTime = configuration.getRuntimeEnvironment().getCreationTime();
 
     useSSL = parameters.getBooleanOrDefault(SINK_IOTDB_SSL_ENABLE_KEY, false);
     trustStore = parameters.getString(SINK_IOTDB_SSL_TRUST_STORE_PATH_KEY);
@@ -230,7 +227,7 @@ public class IoTDBLegacyPipeConnector implements PipeConnector {
               trustStorePwd);
       final TSyncIdentityInfo identityInfo =
           new TSyncIdentityInfo(
-              pipeName, creationTime, syncConnectorVersion, IoTDBConstant.PATH_ROOT);
+              pipeName, System.currentTimeMillis(), syncConnectorVersion, IoTDBConstant.PATH_ROOT);
       final TSStatus status = client.handshake(identityInfo);
       if (status.code != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         String errorMsg =


### PR DESCRIPTION
As title.

CI fail examples:
* https://github.com/apache/iotdb/actions/runs/8220193293/job/22479018547
* https://github.com/apache/iotdb/actions/runs/8220193293/job/22479018451