### PR TITLE
UDF: add "timestamp_precision" on UDFParameters

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/UDAFAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/UDAFAccumulator.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.queryengine.execution.aggregation;
 import org.apache.iotdb.commons.udf.service.UDFManagementService;
 import org.apache.iotdb.commons.udf.utils.UDFDataTypeTransformer;
 import org.apache.iotdb.db.queryengine.plan.expression.Expression;
+import org.apache.iotdb.db.queryengine.transformation.dag.udf.UDFParametersFactory;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
 import org.apache.iotdb.tsfile.file.metadata.statistics.Statistics;
 import org.apache.iotdb.tsfile.read.common.block.column.Column;
@@ -93,10 +94,8 @@ public class UDAFAccumulator implements Accumulator {
     state = udaf.createState();
 
     final UDFParameters parameters =
-        new UDFParameters(
-            childExpressions,
-            UDFDataTypeTransformer.transformToUDFDataTypeList(childExpressionDataTypes),
-            attributes);
+        UDFParametersFactory.buildUdfParameters(
+            childExpressions, childExpressionDataTypes, attributes);
 
     // Only validate for raw input
     // There is no need to validate for partial input

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/udf/UDAFInformationInferrer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/udf/UDAFInformationInferrer.java
@@ -68,10 +68,8 @@ public class UDAFInformationInferrer {
     UDAF udaf = (UDAF) UDFManagementService.getInstance().reflect(functionName);
 
     UDFParameters parameters =
-        new UDFParameters(
-            childExpressions,
-            UDFDataTypeTransformer.transformToUDFDataTypeList(childExpressionDataTypes),
-            attributes);
+        UDFParametersFactory.buildUdfParameters(
+            childExpressions, childExpressionDataTypes, attributes);
     udaf.validate(new UDFParameterValidator(parameters));
 
     // currently UDAF configuration does not need Zone ID

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/udf/UDFParametersFactory.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/udf/UDFParametersFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.transformation.dag.udf;
+
+import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
+import org.apache.iotdb.commons.udf.utils.UDFDataTypeTransformer;
+import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.udf.api.customizer.parameter.UDFParameters;
+
+import java.util.List;
+import java.util.Map;
+
+public class UDFParametersFactory {
+
+  private static final CommonConfig config = CommonDescriptor.getInstance().getConfig();
+
+  public static final String timestampPrecisionConstant = "timestamp_precision";
+
+  public static UDFParameters buildUdfParameters(
+      List<String> childExpressions,
+      List<TSDataType> childExpressionDataTypes,
+      Map<String, String> attributes) {
+    attributes.put(timestampPrecisionConstant, config.getTimestampPrecision());
+    return new UDFParameters(
+        childExpressions,
+        UDFDataTypeTransformer.transformToUDFDataTypeList(childExpressionDataTypes),
+        attributes);
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/udf/UDTFExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/udf/UDTFExecutor.java
@@ -85,10 +85,8 @@ public class UDTFExecutor {
     udtf = (UDTF) UDFManagementService.getInstance().reflect(functionName);
 
     final UDFParameters parameters =
-        new UDFParameters(
-            childExpressions,
-            UDFDataTypeTransformer.transformToUDFDataTypeList(childExpressionDataTypes),
-            attributes);
+        UDFParametersFactory.buildUdfParameters(
+            childExpressions, childExpressionDataTypes, attributes);
 
     try {
       udtf.validate(new UDFParameterValidator(parameters));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/udf/UDTFInformationInferrer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/udf/UDTFInformationInferrer.java
@@ -84,12 +84,9 @@ public class UDTFInformationInferrer {
       Map<String, String> attributes)
       throws Exception {
     UDTF udtf = (UDTF) UDFManagementService.getInstance().reflect(functionName);
-
     UDFParameters parameters =
-        new UDFParameters(
-            childExpressions,
-            UDFDataTypeTransformer.transformToUDFDataTypeList(childExpressionDataTypes),
-            attributes);
+        UDFParametersFactory.buildUdfParameters(
+            childExpressions, childExpressionDataTypes, attributes);
     udtf.validate(new UDFParameterValidator(parameters));
 
     // use ZoneId.systemDefault() because UDF's data type is ZoneId independent


### PR DESCRIPTION
## Description

This PR adds a time precision parameter to the UDF framework that users can retrieve from UDFParamters when developing UDFs

## How to use
When  `beforeStart(UDFParameters parameters, UDTFConfigurations configurations)` is carried out, you can use ` parameters.getStringOrDefault("timestamp_precision","ms") ` to obtain the properties of the precision time this time accuracy and consistent in the Server