### PR TITLE
[IOTDB-6310] Optimize for query resource init

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -1792,7 +1792,7 @@ public class DataRegion implements IDataRegionForQuery {
     try {
       List<TsFileResource> seqResources =
           getFileResourceListForQuery(
-              tsFileManager.getTsFileList(true, timePartitions),
+              tsFileManager.getTsFileList(true, timePartitions, globalTimeFilter),
               pathList,
               singleDeviceId,
               context,
@@ -1800,7 +1800,7 @@ public class DataRegion implements IDataRegionForQuery {
               true);
       List<TsFileResource> unseqResources =
           getFileResourceListForQuery(
-              tsFileManager.getTsFileList(false, timePartitions),
+              tsFileManager.getTsFileList(false, timePartitions, globalTimeFilter),
               pathList,
               singleDeviceId,
               context,

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/TimePartitionUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/TimePartitionUtils.java
@@ -70,7 +70,12 @@ public class TimePartitionUtils {
   public static boolean satisfyPartitionStartTime(Filter timeFilter, long partitionStartTime) {
     return timeFilter == null
         || timeFilter.satisfyStartEndTime(
-            partitionStartTime, partitionStartTime + timePartitionInterval);
+            partitionStartTime, partitionStartTime + timePartitionInterval - 1);
+  }
+
+  public static boolean satisfyTimePartition(Filter timeFilter, long partitionId) {
+    long partitionStartTime = partitionId * timePartitionInterval;
+    return satisfyPartitionStartTime(timeFilter, partitionStartTime);
   }
 
   public static void setTimePartitionInterval(long timePartitionInterval) {


### PR DESCRIPTION
we use timefilter to filter useless timepartition instead of getting all of them and then filter tsfile in them one by one.

We insert `0~9999` points whose timestamp is also `0~9999` and execute `flush` after each point insert and then insert one point with timestamp now(). As so, we will get two partitions, one contains 10,000 tsfiles, another one contains only one tsfile.

execute the following sql: (only the last tsfile satisfies)
```
select s1 from root.db.d1 where time > now() - 1h;
```

before opt, the time for query init tsfile list are:(about 2.5ms)

```
3057000
2356292
3258834
2415417
2876041
2395750
2564833
```

after opt, the time for query init tsfile list are:(about 0.047 ms)
```
47500
39792
33875
31958
37584
56666
45709
```

