### PR TITLE
Fix deadlock when flush an empty TsFile and query concurrently

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -2356,19 +2356,21 @@ public class DataRegion implements IDataRegionForQuery {
       tsFileProcessor.close();
       if (isEmptyFile) {
         tsFileProcessor.getTsFileResource().remove();
-        tsFileManager.remove(tsFileProcessor.getTsFileResource(), tsFileProcessor.isSequence());
       } else if (isValidateTsFileFailed) {
         String tsFilePath = tsFileProcessor.getTsFileResource().getTsFile().getAbsolutePath();
         renameAndHandleError(tsFilePath, tsFilePath + BROKEN_SUFFIX);
         renameAndHandleError(
             tsFilePath + RESOURCE_SUFFIX, tsFilePath + RESOURCE_SUFFIX + BROKEN_SUFFIX);
-        tsFileManager.remove(tsFileProcessor.getTsFileResource(), tsFileProcessor.isSequence());
       } else {
         tsFileResourceManager.registerSealedTsFileResource(tsFileProcessor.getTsFileResource());
       }
     } finally {
       closeQueryLock.writeLock().unlock();
     }
+    if (isEmptyFile || isValidateTsFileFailed) {
+      tsFileManager.remove(tsFileProcessor.getTsFileResource(), tsFileProcessor.isSequence());
+    }
+
     // closingSequenceTsFileProcessor is a thread safety class.
 
     synchronized (closeStorageGroupCondition) {


### PR DESCRIPTION
## Description

https://apache-iotdb.feishu.cn/docx/RrBrdXHPgoJTcxxoPxMc8eNXndd

When all data in a memtable is deleted, the memtable is flushed by mechanisms such as Timed flush, resulting in an empty Tsfile. When an empty file is generated, the flush thread takes the closeQueryLock and then tries to delete the empty file by taking the TsFileManager write lock. If a query thread holds the TsFileManager read lock and tries to acquire the closeQueryLock read lock, it will block because the flush thread holds the closeQueryLock write lock first, creating a deadlock problem.