### PR TITLE
Add more query metrics for estimated memory and max overlapped page

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceContext.java
@@ -543,6 +543,9 @@ public class FragmentInstanceContext extends QueryContext {
             getQueryStatistics().pageReadersDecodeAlignedDiskTime.get(),
             getQueryStatistics().pageReadersDecodeNonAlignedMemTime.get(),
             getQueryStatistics().pageReadersDecodeNonAlignedDiskTime.get());
+
+    SeriesScanCostMetricSet.getInstance()
+        .updatePageReaderMemoryUsage(getQueryStatistics().pageReaderMaxUsedMemorySize.get());
   }
 
   private void releaseDataNodeQueryContext() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryStatistics.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryStatistics.java
@@ -69,6 +69,8 @@ public class QueryStatistics {
   public AtomicLong pageReadersDecodeNonAlignedMemCount = new AtomicLong(0);
   public AtomicLong pageReadersDecodeNonAlignedMemTime = new AtomicLong(0);
 
+  public AtomicLong pageReaderMaxUsedMemorySize = new AtomicLong(0);
+
   public TQueryStatistics toThrift() {
     return new TQueryStatistics(
         loadTimeSeriesMetadataDiskSeqCount.get(),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/SeriesScanUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/SeriesScanUtil.java
@@ -791,6 +791,10 @@ public class SeriesScanUtil {
                         firstPageReader.getAllSatisfiedPageData(orderUtils.getAscending())),
                     firstPageReader.version,
                     orderUtils.getOverlapCheckTime(firstPageReader.getStatistics()));
+                context
+                    .getQueryStatistics()
+                    .pageReaderMaxUsedMemorySize
+                    .updateAndGet(v -> Math.max(v, mergeReader.getUsedMemorySize()));
                 currentPageEndPointTime =
                     updateEndPointTime(currentPageEndPointTime, firstPageReader);
                 firstPageReader = null;
@@ -815,6 +819,10 @@ public class SeriesScanUtil {
                     getPointReader(pageReader.getAllSatisfiedPageData(orderUtils.getAscending())),
                     pageReader.version,
                     orderUtils.getOverlapCheckTime(pageReader.getStatistics()));
+                context
+                    .getQueryStatistics()
+                    .pageReaderMaxUsedMemorySize
+                    .updateAndGet(v -> Math.max(v, mergeReader.getUsedMemorySize()));
                 currentPageEndPointTime = updateEndPointTime(currentPageEndPointTime, pageReader);
               }
             }
@@ -987,6 +995,10 @@ public class SeriesScanUtil {
         getPointReader(pageReader.getAllSatisfiedPageData(orderUtils.getAscending())),
         pageReader.version,
         orderUtils.getOverlapCheckTime(pageReader.getStatistics()));
+    context
+        .getQueryStatistics()
+        .pageReaderMaxUsedMemorySize
+        .updateAndGet(v -> Math.max(v, mergeReader.getUsedMemorySize()));
   }
 
   private TsBlock nextOverlappedPage() throws IOException {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/metric/QueryRelatedResourceMetricSet.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/metric/QueryRelatedResourceMetricSet.java
@@ -99,6 +99,12 @@ public class QueryRelatedResourceMetricSet implements IMetricSet {
       LocalExecutionPlanner.getInstance();
   private static final String LOCAL_EXECUTION_PLANNER = Metric.LOCAL_EXECUTION_PLANNER.toString();
   private static final String FREE_MEMORY_FOR_OPERATORS = "free_memory_for_operators";
+  private static final String ESTIMATED_MEMORY_SIZE = "estimated_memory_size";
+  private Histogram estimatedMemoryHistogram = DoNothingMetricManager.DO_NOTHING_HISTOGRAM;
+
+  public void updateEstimatedMemory(long memory) {
+    estimatedMemoryHistogram.update(memory);
+  }
 
   @Override
   public void bindTo(AbstractMetricService metricService) {
@@ -179,6 +185,12 @@ public class QueryRelatedResourceMetricSet implements IMetricSet {
         LocalExecutionPlanner::getFreeMemoryForOperators,
         Tag.NAME.toString(),
         FREE_MEMORY_FOR_OPERATORS);
+    estimatedMemoryHistogram =
+        metricService.getOrCreateHistogram(
+            LOCAL_EXECUTION_PLANNER,
+            MetricLevel.IMPORTANT,
+            Tag.NAME.toString(),
+            ESTIMATED_MEMORY_SIZE);
   }
 
   @Override
@@ -231,6 +243,8 @@ public class QueryRelatedResourceMetricSet implements IMetricSet {
         LOCAL_EXECUTION_PLANNER,
         Tag.NAME.toString(),
         FREE_MEMORY_FOR_OPERATORS);
+    metricService.remove(
+        MetricType.HISTOGRAM, LOCAL_EXECUTION_PLANNER, Tag.NAME.toString(), ESTIMATED_MEMORY_SIZE);
   }
 
   private QueryRelatedResourceMetricSet() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/metric/SeriesScanCostMetricSet.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/metric/SeriesScanCostMetricSet.java
@@ -1096,10 +1096,8 @@ public class SeriesScanCostMetricSet implements IMetricSet {
 
     pageReaderMaxMemoryHistogram =
         metricService.getOrCreateHistogram(
-            Metric.SERIES_SCAN_COST.toString(),
+            Metric.MEMORY_USAGE_MONITOR.toString(),
             MetricLevel.IMPORTANT,
-            Tag.STAGE.toString(),
-            HISTOGRAM_BUILD_TSBLOCK_FROM_PAGE_READER,
             Tag.TYPE.toString(),
             PAGE_READER_MAX_USED_MEMORY_SIZE);
   }
@@ -1142,9 +1140,7 @@ public class SeriesScanCostMetricSet implements IMetricSet {
 
     metricService.remove(
         MetricType.HISTOGRAM,
-        Metric.SERIES_SCAN_COST.toString(),
-        Tag.STAGE.toString(),
-        HISTOGRAM_BUILD_TSBLOCK_FROM_PAGE_READER,
+        Metric.MEMORY_USAGE_MONITOR.toString(),
         Tag.TYPE.toString(),
         PAGE_READER_MAX_USED_MEMORY_SIZE);
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/metric/SeriesScanCostMetricSet.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/metric/SeriesScanCostMetricSet.java
@@ -970,6 +970,7 @@ public class SeriesScanCostMetricSet implements IMetricSet {
   private static final String BUILD_TSBLOCK_FROM_PAGE_READER = "build_tsblock_from_page_reader";
   private static final String HISTOGRAM_BUILD_TSBLOCK_FROM_PAGE_READER =
       "histogram_build_tsblock_from_page_reader";
+  private static final String PAGE_READER_MAX_USED_MEMORY_SIZE = "page_reader_max_used_memory_size";
 
   private Histogram pageReadersDecodeAlignedMemHistogram =
       DoNothingMetricManager.DO_NOTHING_HISTOGRAM;
@@ -979,6 +980,8 @@ public class SeriesScanCostMetricSet implements IMetricSet {
       DoNothingMetricManager.DO_NOTHING_HISTOGRAM;
   private Histogram pageReadersDecodeNonAlignedDiskHistogram =
       DoNothingMetricManager.DO_NOTHING_HISTOGRAM;
+
+  private Histogram pageReaderMaxMemoryHistogram = DoNothingMetricManager.DO_NOTHING_HISTOGRAM;
 
   private Timer pageReadersDecodeAlignedMemTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
   private Timer pageReadersDecodeAlignedDiskTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
@@ -1002,6 +1005,10 @@ public class SeriesScanCostMetricSet implements IMetricSet {
     pageReadersDecodeAlignedDiskTimer.updateNanos(alignedDiskTime);
     pageReadersDecodeNonAlignedMemTimer.updateNanos(nonAlignedMemTime);
     pageReadersDecodeNonAlignedDiskTimer.updateNanos(nonAlignedDiskTime);
+  }
+
+  public void updatePageReaderMemoryUsage(long memorySize) {
+    pageReaderMaxMemoryHistogram.update(memorySize);
   }
 
   private void bindTsBlockFromPageReader(AbstractMetricService metricService) {
@@ -1086,6 +1093,15 @@ public class SeriesScanCostMetricSet implements IMetricSet {
             NON_ALIGNED,
             Tag.FROM.toString(),
             DISK);
+
+    pageReaderMaxMemoryHistogram =
+        metricService.getOrCreateHistogram(
+            Metric.SERIES_SCAN_COST.toString(),
+            MetricLevel.IMPORTANT,
+            Tag.STAGE.toString(),
+            HISTOGRAM_BUILD_TSBLOCK_FROM_PAGE_READER,
+            Tag.TYPE.toString(),
+            PAGE_READER_MAX_USED_MEMORY_SIZE);
   }
 
   private void unbindTsBlockFromPageReader(AbstractMetricService metricService) {
@@ -1093,6 +1109,8 @@ public class SeriesScanCostMetricSet implements IMetricSet {
     pageReadersDecodeAlignedDiskHistogram = DoNothingMetricManager.DO_NOTHING_HISTOGRAM;
     pageReadersDecodeNonAlignedMemHistogram = DoNothingMetricManager.DO_NOTHING_HISTOGRAM;
     pageReadersDecodeNonAlignedDiskHistogram = DoNothingMetricManager.DO_NOTHING_HISTOGRAM;
+    pageReaderMaxMemoryHistogram = DoNothingMetricManager.DO_NOTHING_HISTOGRAM;
+
     pageReadersDecodeAlignedMemTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
     pageReadersDecodeAlignedDiskTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
     pageReadersDecodeNonAlignedMemTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
@@ -1121,6 +1139,14 @@ public class SeriesScanCostMetricSet implements IMetricSet {
             from);
       }
     }
+
+    metricService.remove(
+        MetricType.HISTOGRAM,
+        Metric.SERIES_SCAN_COST.toString(),
+        Tag.STAGE.toString(),
+        HISTOGRAM_BUILD_TSBLOCK_FROM_PAGE_READER,
+        Tag.TYPE.toString(),
+        PAGE_READER_MAX_USED_MEMORY_SIZE);
   }
 
   /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LocalExecutionPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LocalExecutionPlanner.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.db.queryengine.execution.fragment.DataNodeQueryContext;
 import org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext;
 import org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceStateMachine;
 import org.apache.iotdb.db.queryengine.execution.operator.Operator;
+import org.apache.iotdb.db.queryengine.metric.QueryRelatedResourceMetricSet;
 import org.apache.iotdb.db.queryengine.plan.analyze.TypeProvider;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.schemaengine.schemaregion.ISchemaRegion;
@@ -54,8 +55,7 @@ public class LocalExecutionPlanner {
     ALLOCATE_MEMORY_FOR_OPERATORS = CONFIG.getAllocateMemoryForOperators();
     MAX_REST_MEMORY_FOR_LOAD =
         (long)
-            (((double) ALLOCATE_MEMORY_FOR_OPERATORS)
-                * (1.0 - CONFIG.getMaxAllocateMemoryRatioForLoad()));
+            ((ALLOCATE_MEMORY_FOR_OPERATORS) * (1.0 - CONFIG.getMaxAllocateMemoryRatioForLoad()));
   }
 
   /** allocated memory for operator execution */
@@ -126,6 +126,7 @@ public class LocalExecutionPlanner {
     }
 
     long estimatedMemorySize = root.calculateMaxPeekMemoryWithCounter();
+    QueryRelatedResourceMetricSet.getInstance().updateEstimatedMemory(estimatedMemorySize);
 
     synchronized (this) {
       if (estimatedMemorySize > freeMemoryForOperators) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/MemChunkReader.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/MemChunkReader.java
@@ -99,6 +99,12 @@ public class MemChunkReader implements IChunkReader, IPointReader {
   }
 
   @Override
+  public long getUsedMemorySize() {
+    // not used
+    return timeValuePairIterator.getUsedMemorySize();
+  }
+
+  @Override
   public void close() {
     // Do nothing because mem chunk reader will not open files
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/common/Element.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/common/Element.java
@@ -26,9 +26,9 @@ import java.io.IOException;
 
 public class Element {
 
-  public PriorityMergeReader.MergeReaderPriority priority;
-  protected IPointReader reader;
-  public TimeValuePair timeValuePair;
+  private final PriorityMergeReader.MergeReaderPriority priority;
+  private final IPointReader reader;
+  private TimeValuePair timeValuePair;
 
   public Element(
       IPointReader reader,
@@ -65,6 +65,10 @@ public class Element {
 
   public TimeValuePair getTimeValuePair() {
     return timeValuePair;
+  }
+
+  public void setTimeValuePair(TimeValuePair timeValuePair) {
+    this.timeValuePair = timeValuePair;
   }
 
   public PriorityMergeReader.MergeReaderPriority getPriority() {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/transformation/builder/EvaluationDAGBuilderTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/transformation/builder/EvaluationDAGBuilderTest.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.queryengine.transformation.builder;
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.commons.concurrent.IoTDBThreadPoolFactory;
 import org.apache.iotdb.commons.udf.service.UDFClassLoaderManager;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.queryengine.common.FragmentInstanceId;
 import org.apache.iotdb.db.queryengine.common.MPPQueryContext;
 import org.apache.iotdb.db.queryengine.common.PlanFragmentId;
@@ -67,6 +68,7 @@ public class EvaluationDAGBuilderTest {
     String sql =
         "select s1 + 1, s1 * 2, s1 - 2, s1 / 3, sin(s1), m4(s1,'windowSize'='10') from root.sg.d1;";
     try {
+      IoTDBDescriptor.getInstance().getConfig().setDataNodeId(1);
       Operator operator = generateOperatorTree(sql);
       Assert.assertNotNull(operator);
       TransformOperator transformOperator =

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/common/FakedSeriesReader.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/common/FakedSeriesReader.java
@@ -81,5 +81,11 @@ public class FakedSeriesReader implements IPointReader {
   }
 
   @Override
+  public long getUsedMemorySize() {
+    // not used
+    return 0;
+  }
+
+  @Override
   public void close() {}
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/metric/enums/Metric.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/metric/enums/Metric.java
@@ -101,6 +101,7 @@ public enum Metric {
   OPERATOR_EXECUTION_COST("operator_execution_cost"),
   OPERATOR_EXECUTION_COUNT("operator_execution_count"),
   SERIES_SCAN_COST("series_scan_cost"),
+  MEMORY_USAGE_MONITOR("memory_usage_monitor"),
   METRIC_LOAD_TIME_SERIES_METADATA("metric_load_time_series_metadata"),
   QUERY_METADATA_COST("query_metadata_cost"),
   DISPATCHER("dispatcher"),

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/BatchData.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/BatchData.java
@@ -856,6 +856,12 @@ public class BatchData {
     }
 
     @Override
+    public long getUsedMemorySize() {
+      // not used
+      return 0;
+    }
+
+    @Override
     public void close() {
       // do nothing
     }

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/TsBlock.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/TsBlock.java
@@ -306,6 +306,11 @@ public class TsBlock {
     }
 
     @Override
+    public long getUsedMemorySize() {
+      return getRetainedSizeInBytes();
+    }
+
+    @Override
     public void close() {
       // do nothing
     }
@@ -370,6 +375,10 @@ public class TsBlock {
 
     public TsBlockAlignedRowIterator(int rowIndex) {
       this.rowIndex = rowIndex;
+    }
+
+    public long getRes() {
+      return getRetainedSizeInBytes();
     }
 
     @Override
@@ -438,6 +447,11 @@ public class TsBlock {
     public TimeValuePair currentTimeValuePair() {
       return new TimeValuePair(
           timeColumn.getLong(rowIndex), new TsPrimitiveType.TsVector(currentValue()));
+    }
+
+    @Override
+    public long getUsedMemorySize() {
+      return getRetainedSizeInBytes();
     }
 
     @Override

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/TsBlock.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/TsBlock.java
@@ -377,10 +377,6 @@ public class TsBlock {
       this.rowIndex = rowIndex;
     }
 
-    public long getRes() {
-      return getRetainedSizeInBytes();
-    }
-
     @Override
     public boolean hasNext() {
       return rowIndex < positionCount;

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/IPointReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/IPointReader.java
@@ -31,5 +31,7 @@ public interface IPointReader {
 
   TimeValuePair currentTimeValuePair() throws IOException;
 
+  long getUsedMemorySize();
+
   void close() throws IOException;
 }

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/LazyLoadAlignedPagePointReader.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/reader/page/LazyLoadAlignedPagePointReader.java
@@ -32,8 +32,8 @@ import java.util.List;
  */
 public class LazyLoadAlignedPagePointReader implements IPointReader {
 
-  private TimePageReader timeReader;
-  private List<ValuePageReader> valueReaders;
+  private final TimePageReader timeReader;
+  private final List<ValuePageReader> valueReaders;
 
   private boolean hasNextRow = false;
 
@@ -93,5 +93,13 @@ public class LazyLoadAlignedPagePointReader implements IPointReader {
   }
 
   @Override
-  public void close() throws IOException {}
+  public long getUsedMemorySize() {
+    // not used
+    return 0;
+  }
+
+  @Override
+  public void close() throws IOException {
+    // do nothing
+  }
 }


### PR DESCRIPTION
## Description

Grafana screenshot is as below:

1. query estimated memory size:
![image](https://github.com/apache/iotdb/assets/6756545/32896f37-3a85-4058-9fbc-935b76e2145a)

2. max unsequence reader used memory:
![image](https://github.com/apache/iotdb/assets/6756545/897e9b13-d423-4a21-993a-654978f246cc)

