### PR TITLE
Fixed simple consensus recover problem

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
@@ -295,8 +295,7 @@ public class ConfigRegionStateMachine implements IStateMachine, IStateMachine.Ev
     return CommonDescriptor.getInstance().getConfig().isReadOnly();
   }
 
-  /** TODO optimize the lock usage. */
-  private synchronized void writeLogForSimpleConsensus(ConfigPhysicalPlan plan) {
+  private void writeLogForSimpleConsensus(ConfigPhysicalPlan plan) {
     if (simpleLogFile.length() > LOG_FILE_MAX_SIZE) {
       try {
         simpleLogWriter.force();

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/simple/SimpleConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/simple/SimpleConsensusServerImpl.java
@@ -48,7 +48,7 @@ public class SimpleConsensusServerImpl implements IStateMachine {
   }
 
   @Override
-  public void start() {
+  public synchronized void start() {
     if (initialized.compareAndSet(false, true)) {
       stateMachine.start();
       // Notify itself as the leader
@@ -58,17 +58,17 @@ public class SimpleConsensusServerImpl implements IStateMachine {
   }
 
   @Override
-  public void stop() {
+  public synchronized void stop() {
     stateMachine.stop();
   }
 
   @Override
-  public boolean isReadOnly() {
+  public synchronized boolean isReadOnly() {
     return stateMachine.isReadOnly();
   }
 
   @Override
-  public TSStatus write(IConsensusRequest request) {
+  public synchronized TSStatus write(IConsensusRequest request) {
     return stateMachine.write(request);
   }
 
@@ -78,17 +78,17 @@ public class SimpleConsensusServerImpl implements IStateMachine {
   }
 
   @Override
-  public DataSet read(IConsensusRequest request) {
+  public synchronized DataSet read(IConsensusRequest request) {
     return stateMachine.read(request);
   }
 
   @Override
-  public boolean takeSnapshot(File snapshotDir) {
+  public synchronized boolean takeSnapshot(File snapshotDir) {
     return stateMachine.takeSnapshot(snapshotDir);
   }
 
   @Override
-  public void loadSnapshot(File latestSnapshotRootDir) {
+  public synchronized void loadSnapshot(File latestSnapshotRootDir) {
     stateMachine.loadSnapshot(latestSnapshotRootDir);
   }
 }


### PR DESCRIPTION
## Description
Previously, the simple consensus may write to the statemachine in parrallel, which may cause correctness problem and make the  operations in log not be in the same order of execution. This PR fixed this problem by adding synchronized to Simple consensus operations.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
