### PR TITLE
Fix Concurrent bug between NodeSupplier.close() and its run()

### DIFF
--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/NodesSupplier.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/NodesSupplier.java
@@ -170,8 +170,11 @@ public class NodesSupplier implements INodeSupplier, Runnable {
       }
     }
 
-    if (client != null && !updateDataNodeList()) {
-      destroyCurrentClient();
+    // make sure the following code block can run thread-safely with close() method.
+    synchronized (this) {
+      if (client != null && !updateDataNodeList()) {
+        destroyCurrentClient();
+      }
     }
   }
 


### PR DESCRIPTION
More details about this bug can be seen in https://jira.infra.timecho.com:8443/browse/TIMECHODB-607.

The reason for this bug is that we call the SessionPool.close() method and in this method we will also call `NodeSupplier.close()` which will call client.close(), so in server, we will clear all the info for this connection. However, at the same time, the NodeSupplier.run is also being called, it will try to do the `show datanodes` query, and then the exception will throw.