### PR TITLE
Fix flush command failed when dataregion using ratis consensus

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
@@ -66,7 +66,7 @@ public class ConfigNodeConfig {
   private int schemaReplicationFactor = 1;
 
   /** Data region consensus protocol. */
-  private String dataRegionConsensusProtocolClass = ConsensusFactory.IOT_CONSENSUS;
+  private String dataRegionConsensusProtocolClass = ConsensusFactory.RATIS_CONSENSUS;
 
   /** Default number of DataRegion replicas. */
   private int dataReplicationFactor = 1;

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
@@ -66,7 +66,7 @@ public class ConfigNodeConfig {
   private int schemaReplicationFactor = 1;
 
   /** Data region consensus protocol. */
-  private String dataRegionConsensusProtocolClass = ConsensusFactory.RATIS_CONSENSUS;
+  private String dataRegionConsensusProtocolClass = ConsensusFactory.IOT_CONSENSUS;
 
   /** Default number of DataRegion replicas. */
   private int dataReplicationFactor = 1;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/WALManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/WALManager.java
@@ -273,6 +273,9 @@ public class WALManager implements IService {
   }
 
   public void syncDeleteOutdatedFilesInWALNodes() {
+    if (config.getWalMode() == WALMode.DISABLE || walDeleteThread == null) {
+      return;
+    }
     Future<?> future = walDeleteThread.submit(this::deleteOutdatedFilesInWALNodes);
     try {
       future.get();


### PR DESCRIPTION
## Description

When dataregion using ratis consensus and execute a `flush` command, an 301 error appears.
![image](https://github.com/apache/iotdb/assets/25913899/d62f4174-6399-405f-8e21-ada9a13c5766)

![image](https://github.com/apache/iotdb/assets/25913899/e47d8c91-5d7c-4757-af88-7c421d1840a0)

The reason of this bug is syncDeleteOutdatedFilesInWALNodes doesn't consider that walDeleteThread is null when dataregion using ratis consensus. 