### PR TITLE
feat: Refactored the visibility of some methods to make it possible to add BasicAuthorizer implementations in other packages.

### DIFF
--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/authorizer/BasicAuthorizer.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/authorizer/BasicAuthorizer.java
@@ -69,7 +69,7 @@ public abstract class BasicAuthorizer implements IAuthorizer, IService {
 
   // FOR PRE VERSION END -----
 
-  BasicAuthorizer(IUserManager userManager, IRoleManager roleManager) throws AuthException {
+  public BasicAuthorizer(IUserManager userManager, IRoleManager roleManager) throws AuthException {
     this.userManager = userManager;
     this.roleManager = roleManager;
   }
@@ -113,7 +113,7 @@ public abstract class BasicAuthorizer implements IAuthorizer, IService {
   }
 
   /** Checks if a user has admin privileges */
-  abstract boolean isAdmin(String username);
+  protected abstract boolean isAdmin(String username);
 
   @Override
   public boolean login(String username, String password) throws AuthException {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/authorizer/LocalFileAuthorizer.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/authorizer/LocalFileAuthorizer.java
@@ -35,7 +35,7 @@ public class LocalFileAuthorizer extends BasicAuthorizer {
   }
 
   @Override
-  boolean isAdmin(String username) {
+  protected boolean isAdmin(String username) {
     return config.getAdminName().equals(username);
   }
 }


### PR DESCRIPTION
The visibility of some methods prevented being able to implement custom authenticators outside of the org.apache.iotdb.commons.auth.authorizer package.

This should now be fixed.