### PR TITLE
Fix NPE in SessionConnection while first node in nodeurls is unavailable

### DIFF
--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -1224,22 +1224,26 @@ public class Session implements ISession {
     // remove the cached broken leader session
     if (enableRedirection) {
       TEndPoint endPoint = null;
-      for (Iterator<Entry<TEndPoint, SessionConnection>> it =
-              endPointToSessionConnection.entrySet().iterator();
-          it.hasNext(); ) {
-        Entry<TEndPoint, SessionConnection> entry = it.next();
-        if (entry.getValue().equals(sessionConnection)) {
-          endPoint = entry.getKey();
-          it.remove();
-          break;
+      if (endPointToSessionConnection != null) {
+        for (Iterator<Entry<TEndPoint, SessionConnection>> it =
+                endPointToSessionConnection.entrySet().iterator();
+            it.hasNext(); ) {
+          Entry<TEndPoint, SessionConnection> entry = it.next();
+          if (entry.getValue().equals(sessionConnection)) {
+            endPoint = entry.getKey();
+            it.remove();
+            break;
+          }
         }
       }
 
-      for (Iterator<Entry<String, TEndPoint>> it = deviceIdToEndpoint.entrySet().iterator();
-          it.hasNext(); ) {
-        Entry<String, TEndPoint> entry = it.next();
-        if (entry.getValue().equals(endPoint)) {
-          it.remove();
+      if (deviceIdToEndpoint != null) {
+        for (Iterator<Entry<String, TEndPoint>> it = deviceIdToEndpoint.entrySet().iterator();
+            it.hasNext(); ) {
+          Entry<String, TEndPoint> entry = it.next();
+          if (entry.getValue().equals(endPoint)) {
+            it.remove();
+          }
         }
       }
     }

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -80,6 +80,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.StringJoiner;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -1406,6 +1407,9 @@ public class SessionConnection {
         session.removeBrokenSessionConnection(this);
         session.defaultEndPoint = this.endPoint;
         session.defaultSessionConnection = this;
+        if (session.endPointToSessionConnection == null) {
+          session.endPointToSessionConnection = new ConcurrentHashMap<>();
+        }
         session.endPointToSessionConnection.put(session.defaultEndPoint, this);
         break;
       }


### PR DESCRIPTION
more details can be seen in https://jira.infra.timecho.com:8443/browse/TIMECHODB-611.

If a `SessionConnection`'s first node in its nodeurls is unavailable and it will try to reconnect to other nodes in nodeurls, and it will succeed to connect to other nodes, however currently its `endPointToSessionConnection` and `deviceIdToEndpoint` are not inited, so the logic in reconnect may cause NPE.