### PR TITLE
Append time column at the end of input columns in mappable UDTF

### DIFF
--- a/iotdb-api/udf-api/src/main/java/org/apache/iotdb/udf/api/utils/RowImpl.java
+++ b/iotdb-api/udf-api/src/main/java/org/apache/iotdb/udf/api/utils/RowImpl.java
@@ -38,7 +38,8 @@ public class RowImpl implements Row {
 
   @Override
   public long getTime() {
-    return (long) rowRecord[size];
+    // Time column is always the last column
+    return (long) rowRecord[size - 1];
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/visitor/ColumnTransformerVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/visitor/ColumnTransformerVisitor.java
@@ -235,7 +235,8 @@ public class ColumnTransformerVisitor
           context.cache.put(
               functionExpression, getBuiltInScalarFunctionTransformer(functionExpression, context));
         } else {
-          ColumnTransformer[] inputColumnTransformers = new ColumnTransformer[expressions.size() + 1];
+          ColumnTransformer[] inputColumnTransformers =
+              new ColumnTransformer[expressions.size() + 1];
           for (int i = 0; i < expressions.size(); i++) {
             inputColumnTransformers[i] = this.process(expressions.get(i), context);
           }
@@ -251,7 +252,6 @@ public class ColumnTransformerVisitor
                   });
           columnTransformer.addReferenceCount();
           inputColumnTransformers[expressions.size()] = columnTransformer;
-
 
           UDTFExecutor executor =
               context.udtfContext.getExecutorByFunctionExpression(functionExpression);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/visitor/ColumnTransformerVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/visitor/ColumnTransformerVisitor.java
@@ -70,6 +70,7 @@ import org.apache.iotdb.db.queryengine.transformation.dag.udf.UDTFContext;
 import org.apache.iotdb.db.queryengine.transformation.dag.udf.UDTFExecutor;
 import org.apache.iotdb.db.queryengine.transformation.dag.util.TransformUtils;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
+import org.apache.iotdb.tsfile.read.common.type.LongType;
 import org.apache.iotdb.tsfile.read.common.type.Type;
 import org.apache.iotdb.tsfile.read.common.type.TypeFactory;
 
@@ -234,10 +235,23 @@ public class ColumnTransformerVisitor
           context.cache.put(
               functionExpression, getBuiltInScalarFunctionTransformer(functionExpression, context));
         } else {
-          ColumnTransformer[] inputColumnTransformers =
-              expressions.stream()
-                  .map(expression -> this.process(expression, context))
-                  .toArray(ColumnTransformer[]::new);
+          ColumnTransformer[] inputColumnTransformers = new ColumnTransformer[expressions.size() + 1];
+          for (int i = 0; i < expressions.size(); i++) {
+            inputColumnTransformers[i] = this.process(expressions.get(i), context);
+          }
+          // Append time column at the end of input columns for mappable UDTF
+          ColumnTransformer columnTransformer =
+              context.cache.computeIfAbsent(
+                  new TimestampOperand(),
+                  e -> {
+                    TimeColumnTransformer timeColumnTransformer =
+                        new TimeColumnTransformer(LongType.getInstance());
+                    context.leafList.add(timeColumnTransformer);
+                    return timeColumnTransformer;
+                  });
+          columnTransformer.addReferenceCount();
+          inputColumnTransformers[expressions.size()] = columnTransformer;
+
 
           UDTFExecutor executor =
               context.udtfContext.getExecutorByFunctionExpression(functionExpression);

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/String/UDTFConcat.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/String/UDTFConcat.java
@@ -104,18 +104,18 @@ public class UDTFConcat implements UDTF {
     int rowCount = columns[0].getPositionCount();
 
     Binary[][] inputFrame = new Binary[colCount][rowCount];
-    for (int i = 0; i < colCount; i++) {
+    for (int i = 0; i < colCount - 1; i++) {
       inputFrame[i] = columns[i].getBinaries();
     }
 
     boolean[][] isNullFrame = new boolean[colCount][rowCount];
-    for (int i = 0; i < colCount; i++) {
+    for (int i = 0; i < colCount - 1; i++) {
       isNullFrame[i] = columns[i].isNull();
     }
 
     for (int row = 0; row < rowCount; row++) {
       StringBuilder concatSeries = new StringBuilder();
-      for (int col = 0; col < colCount; col++) {
+      for (int col = 0; col < colCount - 1; col++) {
         if (isNullFrame[col][row]) {
           continue;
         }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFConst.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFConst.java
@@ -157,8 +157,8 @@ public class UDTFConst implements UDTF {
       case INT32:
         for (int i = 0; i < count; i++) {
           boolean hasWritten = false;
-          for (Column column : columns) {
-            if (!column.isNull(i)) {
+          for (int j = 0; j < columns.length - 1; j++) {
+            if (!columns[j].isNull(i)) {
               builder.writeInt(intValue);
               hasWritten = true;
               break;
@@ -172,8 +172,8 @@ public class UDTFConst implements UDTF {
       case INT64:
         for (int i = 0; i < count; i++) {
           boolean hasWritten = false;
-          for (Column column : columns) {
-            if (!column.isNull(i)) {
+          for (int j = 0; j < columns.length - 1; j++) {
+            if (!columns[j].isNull(i)) {
               builder.writeLong(longValue);
               hasWritten = true;
               break;
@@ -187,8 +187,8 @@ public class UDTFConst implements UDTF {
       case FLOAT:
         for (int i = 0; i < count; i++) {
           boolean hasWritten = false;
-          for (Column column : columns) {
-            if (!column.isNull(i)) {
+          for (int j = 0; j < columns.length - 1; j++) {
+            if (!columns[j].isNull(i)) {
               builder.writeFloat(floatValue);
               hasWritten = true;
               break;
@@ -202,8 +202,8 @@ public class UDTFConst implements UDTF {
       case DOUBLE:
         for (int i = 0; i < count; i++) {
           boolean hasWritten = false;
-          for (Column column : columns) {
-            if (!column.isNull(i)) {
+          for (int j = 0; j < columns.length - 1; j++) {
+            if (!columns[j].isNull(i)) {
               builder.writeDouble(doubleValue);
               hasWritten = true;
               break;
@@ -217,8 +217,8 @@ public class UDTFConst implements UDTF {
       case BOOLEAN:
         for (int i = 0; i < count; i++) {
           boolean hasWritten = false;
-          for (Column column : columns) {
-            if (!column.isNull(i)) {
+          for (int j = 0; j < columns.length - 1; j++) {
+            if (!columns[j].isNull(i)) {
               builder.writeBoolean(booleanValue);
               hasWritten = true;
               break;
@@ -232,8 +232,8 @@ public class UDTFConst implements UDTF {
       case TEXT:
         for (int i = 0; i < count; i++) {
           boolean hasWritten = false;
-          for (Column column : columns) {
-            if (!column.isNull(i)) {
+          for (int j = 0; j < columns.length - 1; j++) {
+            if (!columns[j].isNull(i)) {
               builder.writeBinary(binaryValue);
               hasWritten = true;
               break;

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFConstE.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFConstE.java
@@ -52,12 +52,12 @@ public class UDTFConstE implements UDTF {
 
   @Override
   public void transform(Column[] columns, ColumnBuilder builder) throws Exception {
-    int colCount = columns[0].getPositionCount();
+    int rowCount = columns[0].getPositionCount();
 
-    for (int i = 0; i < colCount; i++) {
+    for (int i = 0; i < rowCount; i++) {
       boolean hasWritten = false;
-      for (Column column : columns) {
-        if (!column.isNull(i)) {
+      for (int j = 0; j < columns.length - 1; j++) {
+        if (!columns[j].isNull(i)) {
           builder.writeDouble(Math.E);
           hasWritten = true;
           break;

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFConstPi.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFConstPi.java
@@ -52,12 +52,12 @@ public class UDTFConstPi implements UDTF {
 
   @Override
   public void transform(Column[] columns, ColumnBuilder builder) throws Exception {
-    int colCount = columns[0].getPositionCount();
+    int rowCount = columns[0].getPositionCount();
 
-    for (int i = 0; i < colCount; i++) {
+    for (int i = 0; i < rowCount; i++) {
       boolean hasWritten = false;
-      for (Column column : columns) {
-        if (!column.isNull(i)) {
+      for (int j = 0; j < columns.length - 1; j++) {
+        if (!columns[j].isNull(i)) {
           builder.writeDouble(Math.PI);
           hasWritten = true;
           break;

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/TimeColumn.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/TimeColumn.java
@@ -145,6 +145,11 @@ public class TimeColumn implements Column {
   }
 
   @Override
+  public long[] getLongs() {
+    return getTimes();
+  }
+
+  @Override
   public int getInstanceSize() {
     return INSTANCE_SIZE;
   }


### PR DESCRIPTION
For single row interface, you can call `row.getTime()` to get the timestamp value of current row.
```java
@Override
public Object transform(Row row) throws Exception {
  return row.getTime();
}
```

For batch interface, **the last column is the time column**, use `.getLongs()` to acquire the timestamp values of all rows.
```java
@Override
public void transform(Column[] columns, ColumnBuilder builder) throws Exception {
  long[] timestamps = columns[columns.size() - 1].getLongs();

  int count = columns[0].getPositionCount();
  for (int i = 0; i < count; i++) {
    builder.writeLong(timestamps[i]);
  }
}
```