### PR TITLE
Left rotate time column to the end of input columns in UDAF

### DIFF
--- a/example/udf/src/main/java/org/apache/iotdb/udf/UDAFExample.java
+++ b/example/udf/src/main/java/org/apache/iotdb/udf/UDAFExample.java
@@ -150,9 +150,9 @@ public class UDAFExample implements UDAF {
       if (bitMap != null && !bitMap.isMarked(i)) {
         continue;
       }
-      if (!columns[1].isNull(i)) {
+      if (!columns[0].isNull(i)) {
         state.count++;
-        state.sum += columns[1].getInt(i);
+        state.sum += columns[0].getInt(i);
       }
     }
   }
@@ -163,9 +163,9 @@ public class UDAFExample implements UDAF {
       if (bitMap != null && !bitMap.isMarked(i)) {
         continue;
       }
-      if (!columns[1].isNull(i)) {
+      if (!columns[0].isNull(i)) {
         avgState.count++;
-        avgState.sum += columns[1].getLong(i);
+        avgState.sum += columns[0].getLong(i);
       }
     }
   }
@@ -176,9 +176,9 @@ public class UDAFExample implements UDAF {
       if (bitMap != null && !bitMap.isMarked(i)) {
         continue;
       }
-      if (!columns[1].isNull(i)) {
+      if (!columns[0].isNull(i)) {
         avgState.count++;
-        avgState.sum += columns[1].getFloat(i);
+        avgState.sum += columns[0].getFloat(i);
       }
     }
   }
@@ -189,9 +189,9 @@ public class UDAFExample implements UDAF {
       if (bitMap != null && !bitMap.isMarked(i)) {
         continue;
       }
-      if (!columns[1].isNull(i)) {
+      if (!columns[0].isNull(i)) {
         avgState.count++;
-        avgState.sum += columns[1].getDouble(i);
+        avgState.sum += columns[0].getDouble(i);
       }
     }
   }

--- a/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/UDAFAvg.java
+++ b/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/UDAFAvg.java
@@ -142,9 +142,9 @@ public class UDAFAvg implements UDAF {
       if (bitMap != null && !bitMap.isMarked(i)) {
         continue;
       }
-      if (!columns[1].isNull(i)) {
+      if (!columns[0].isNull(i)) {
         state.count++;
-        state.sum += columns[1].getInt(i);
+        state.sum += columns[0].getInt(i);
       }
     }
   }
@@ -155,9 +155,9 @@ public class UDAFAvg implements UDAF {
       if (bitMap != null && !bitMap.isMarked(i)) {
         continue;
       }
-      if (!columns[1].isNull(i)) {
+      if (!columns[0].isNull(i)) {
         avgState.count++;
-        avgState.sum += columns[1].getLong(i);
+        avgState.sum += columns[0].getLong(i);
       }
     }
   }
@@ -168,9 +168,9 @@ public class UDAFAvg implements UDAF {
       if (bitMap != null && !bitMap.isMarked(i)) {
         continue;
       }
-      if (!columns[1].isNull(i)) {
+      if (!columns[0].isNull(i)) {
         avgState.count++;
-        avgState.sum += columns[1].getFloat(i);
+        avgState.sum += columns[0].getFloat(i);
       }
     }
   }
@@ -181,9 +181,9 @@ public class UDAFAvg implements UDAF {
       if (bitMap != null && !bitMap.isMarked(i)) {
         continue;
       }
-      if (!columns[1].isNull(i)) {
+      if (!columns[0].isNull(i)) {
         avgState.count++;
-        avgState.sum += columns[1].getDouble(i);
+        avgState.sum += columns[0].getDouble(i);
       }
     }
   }

--- a/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/UDAFCount.java
+++ b/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/UDAFCount.java
@@ -82,7 +82,7 @@ public class UDAFCount implements UDAF {
       if (bitMap != null && !bitMap.isMarked(i)) {
         continue;
       }
-      if (!column[1].isNull(i)) {
+      if (!column[0].isNull(i)) {
         countState.count++;
       }
     }

--- a/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/UDAFSum.java
+++ b/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/UDAFSum.java
@@ -141,9 +141,9 @@ public class UDAFSum implements UDAF {
       if (bitMap != null && !bitMap.isMarked(i)) {
         continue;
       }
-      if (!columns[1].isNull(i)) {
+      if (!columns[0].isNull(i)) {
         state.initResult = true;
-        state.sum += columns[1].getInt(i);
+        state.sum += columns[0].getInt(i);
       }
     }
   }
@@ -154,9 +154,9 @@ public class UDAFSum implements UDAF {
       if (bitMap != null && !bitMap.isMarked(i)) {
         continue;
       }
-      if (!columns[1].isNull(i)) {
+      if (!columns[0].isNull(i)) {
         state.initResult = true;
-        state.sum += columns[1].getLong(i);
+        state.sum += columns[0].getLong(i);
       }
     }
   }
@@ -167,9 +167,9 @@ public class UDAFSum implements UDAF {
       if (bitMap != null && !bitMap.isMarked(i)) {
         continue;
       }
-      if (!columns[1].isNull(i)) {
+      if (!columns[0].isNull(i)) {
         state.initResult = true;
-        state.sum += columns[1].getFloat(i);
+        state.sum += columns[0].getFloat(i);
       }
     }
   }
@@ -180,9 +180,9 @@ public class UDAFSum implements UDAF {
       if (bitMap != null && !bitMap.isMarked(i)) {
         continue;
       }
-      if (!columns[1].isNull(i)) {
+      if (!columns[0].isNull(i)) {
         state.initResult = true;
-        state.sum += columns[1].getDouble(i);
+        state.sum += columns[0].getDouble(i);
       }
     }
   }

--- a/iotdb-api/udf-api/src/main/java/org/apache/iotdb/udf/api/UDAF.java
+++ b/iotdb-api/udf-api/src/main/java/org/apache/iotdb/udf/api/UDAF.java
@@ -36,7 +36,7 @@ public interface UDAF extends UDF {
    * values
    *
    * @param state state to be updated
-   * @param columns input columns from IoTDB TsBlock, column[0] is always the time column, the
+   * @param columns input columns from IoTDB TsBlock, time column is always the last column, the
    *     remaining columns are their parameter value columns
    * @param bitMap define some filtered position in columns
    */

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/UDAFAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/UDAFAccumulator.java
@@ -117,6 +117,14 @@ public class UDAFAccumulator implements Accumulator {
 
   @Override
   public void addInput(Column[] columns, BitMap bitMap) {
+    // To be consistent with UDTF
+    // Left rotate the first time column to the end of input columns
+    Column timeColumn = columns[0];
+    for (int i = 0; i < columns.length - 1; i++) {
+      columns[i] = columns[i + 1];
+    }
+    columns[columns.length - 1] = timeColumn;
+
     udaf.addInput(state, columns, bitMap);
   }
 


### PR DESCRIPTION
In order to keep consistent with UDTF, which put timestamp value as the last field of row.
We left rotate the first column (i.e. time column) to the end of input columns for UDAF.

If you want to update state, for example, accumulate value for sum UDAF, you may change your implementation from:
```java
// Origin
state.sum += columns[1].getFloat(i);
```
to
```java
// After this PR
state.sum += columns[0].getFloat(i);
```
The latter looks more intuitive.