### PR TITLE
Display 'UNKNOWN' in `SHOW FUNCTIONS` when CN accidentally drop DN's function.

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/metadata/ShowFunctionsTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/metadata/ShowFunctionsTask.java
@@ -51,6 +51,7 @@ import static org.apache.iotdb.commons.conf.IoTDBConstant.FUNCTION_TYPE_BUILTIN_
 import static org.apache.iotdb.commons.conf.IoTDBConstant.FUNCTION_TYPE_EXTERNAL_UDAF;
 import static org.apache.iotdb.commons.conf.IoTDBConstant.FUNCTION_TYPE_EXTERNAL_UDTF;
 import static org.apache.iotdb.commons.conf.IoTDBConstant.FUNCTION_TYPE_NATIVE;
+import static org.apache.iotdb.commons.conf.IoTDBConstant.FUNCTION_TYPE_UNKNOWN;
 
 public class ShowFunctionsTask implements IConfigTask {
 
@@ -120,7 +121,7 @@ public class ShowFunctionsTask implements IConfigTask {
   }
 
   private static String getFunctionType(UDFInformation udfInformation) {
-    String functionType = null;
+    String functionType = FUNCTION_TYPE_UNKNOWN;
     if (udfInformation.isBuiltin()) {
       if (UDFManagementService.getInstance().isUDTF(udfInformation.getFunctionName())) {
         functionType = FUNCTION_TYPE_BUILTIN_UDTF;

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/IoTDBConstant.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/IoTDBConstant.java
@@ -183,6 +183,7 @@ public class IoTDBConstant {
   public static final String FUNCTION_TYPE_BUILTIN_UDTF = "built-in UDTF";
   public static final String FUNCTION_TYPE_EXTERNAL_UDAF = "external UDAF";
   public static final String FUNCTION_TYPE_EXTERNAL_UDTF = "external UDTF";
+  public static final String FUNCTION_TYPE_UNKNOWN = "UNKNOWN";
 
   public static final String COLUMN_TRIGGER_NAME = "trigger name";
   public static final String COLUMN_TRIGGER_STATUS = "status";


### PR DESCRIPTION
When CNs execute `DROP FUNCTION`, the deletion will fail if one of DNs went down, but other DNs will still be affected, i.e., they will drop relevant information about this function.
After that, CNs consider that the to-be-deleted function still exists, so when it executes `SHOW FUNCTIONS`, it sends its information to DNs. It's DN's responsibility to add more detail on top of that.
However, from DN's perspective, the function is already dropped. So it will throw Null Pointer Exception.

In this PR, we display `UNKNOWN` if DN cannot find function, and thus avoids this issue.
![20240321-131427](https://github.com/apache/iotdb/assets/43316505/f0365e3d-b988-4e2a-8e76-6e51eb4e707e)
