### PR TITLE
Fix concurrent load and compaction

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/load/LoadTsFileManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/load/LoadTsFileManager.java
@@ -37,6 +37,7 @@ import org.apache.iotdb.db.storageengine.dataregion.DataRegion;
 import org.apache.iotdb.db.storageengine.dataregion.flush.MemTableFlushTask;
 import org.apache.iotdb.db.storageengine.dataregion.modification.ModificationFile;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
+import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResourceStatus;
 import org.apache.iotdb.db.storageengine.dataregion.utils.TsFileResourceUtils;
 import org.apache.iotdb.metrics.utils.MetricLevel;
 import org.apache.iotdb.tsfile.common.constant.TsFileConstant;
@@ -317,7 +318,10 @@ public class LoadTsFileManager {
         writer.endFile();
 
         DataRegion dataRegion = entry.getKey().getDataRegion();
-        dataRegion.loadNewTsFile(generateResource(writer, progressIndex), true, isGeneratedByPipe);
+        dataRegion.loadNewTsFile(
+            generateResource(writer, progressIndex, TsFileResourceStatus.UNCLOSED),
+            true,
+            isGeneratedByPipe);
 
         dataRegion
             .getNonSystemDatabaseName()
@@ -343,9 +347,13 @@ public class LoadTsFileManager {
       }
     }
 
-    private TsFileResource generateResource(TsFileIOWriter writer, ProgressIndex progressIndex)
+    private TsFileResource generateResource(
+        TsFileIOWriter writer,
+        ProgressIndex progressIndex,
+        TsFileResourceStatus tsFileResourceStatus)
         throws IOException {
-      TsFileResource tsFileResource = TsFileResourceUtils.generateTsFileResource(writer);
+      TsFileResource tsFileResource =
+          TsFileResourceUtils.generateTsFileResource(writer, tsFileResourceStatus);
       tsFileResource.setProgressIndex(progressIndex);
       tsFileResource.serialize();
       return tsFileResource;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/LoadTsfileAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/LoadTsfileAnalyzer.java
@@ -58,7 +58,6 @@ import org.apache.iotdb.db.queryengine.plan.statement.crud.LoadTsFileStatement;
 import org.apache.iotdb.db.queryengine.plan.statement.metadata.DatabaseSchemaStatement;
 import org.apache.iotdb.db.queryengine.plan.statement.metadata.ShowDatabaseStatement;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
-import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResourceStatus;
 import org.apache.iotdb.db.storageengine.dataregion.utils.TsFileResourceUtils;
 import org.apache.iotdb.db.utils.TimestampPrecisionUtils;
 import org.apache.iotdb.db.utils.constant.SqlConstant;
@@ -246,7 +245,6 @@ public class LoadTsfileAnalyzer {
       }
 
       TimestampPrecisionUtils.checkTimestampPrecision(tsFileResource.getFileEndTime());
-      tsFileResource.setStatus(TsFileResourceStatus.NORMAL);
 
       loadTsFileStatement.addTsFileResource(tsFileResource);
       loadTsFileStatement.addWritePointCount(writePointCount);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -2636,6 +2636,7 @@ public class DataRegion implements IDataRegionForQuery {
 
       // help tsfile resource degrade
       TsFileResourceManager.getInstance().registerSealedTsFileResource(newTsFileResource);
+      newTsFileResource.setStatus(TsFileResourceStatus.NORMAL);
 
       logger.info("TsFile {} is successfully loaded in unsequence list.", newFileName);
     } catch (DiskSpaceInsufficientException e) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/utils/TsFileResourceUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/utils/TsFileResourceUtils.java
@@ -413,9 +413,11 @@ public class TsFileResourceUtils {
    * Index of this writer.
    *
    * @param writer a {@link TsFileIOWriter}
+   * @param tsFileResourceStatus the status of the generated TsFileResource
    * @return a updated {@link TsFileResource}
    */
-  public static TsFileResource generateTsFileResource(TsFileIOWriter writer) {
+  public static TsFileResource generateTsFileResource(
+      TsFileIOWriter writer, TsFileResourceStatus tsFileResourceStatus) {
     TsFileResource resource = new TsFileResource(writer.getFile());
     for (ChunkGroupMetadata chunkGroupMetadata : writer.getChunkGroupMetadataList()) {
       IDeviceID device = chunkGroupMetadata.getDevice();
@@ -424,7 +426,7 @@ public class TsFileResourceUtils {
         resource.updateEndTime(device, chunkMetadata.getEndTime());
       }
     }
-    resource.setStatus(TsFileResourceStatus.NORMAL);
+    resource.setStatus(tsFileResourceStatus);
     return resource;
   }
 }


### PR DESCRIPTION
## Description
Fix concurrent load and compaction.
If a TsFileResource is added in TsFileManager first, then compaction module can get this resource through TsFileManager. However, at this time the actual file `tsFileToLoad` has not been moved in disk. This pr modify the initial TsFileResourceStatus of tsFileToLoad from `NORMAL` to `UNCLOSED`, and the TsFileResourceStatus of it will be set to `NORMAL` after all file is prepared.