### PR TITLE
Ensure the DataNode can obtain the complete list of ConfigNodes

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/AsyncDataNodeClientPool.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/AsyncDataNodeClientPool.java
@@ -163,6 +163,13 @@ public class AsyncDataNodeClientPool {
       if (clientHandler.getRequestIndices().isEmpty()) {
         return;
       }
+
+      try {
+        Thread.sleep(1000);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        LOGGER.warn("Sleep was interrupted");
+      }
     }
 
     if (!clientHandler.getRequestIndices().isEmpty()) {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/AsyncDataNodeClientPool.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/AsyncDataNodeClientPool.java
@@ -163,13 +163,6 @@ public class AsyncDataNodeClientPool {
       if (clientHandler.getRequestIndices().isEmpty()) {
         return;
       }
-
-      try {
-        Thread.sleep(1000);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        LOGGER.warn("Sleep was interrupted");
-      }
     }
 
     if (!clientHandler.getRequestIndices().isEmpty()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -216,6 +216,9 @@ public class DataNode implements DataNodeMBean {
       // Setup rpc service
       setUpRPCService();
 
+      // Preload some classes to reduce the time consumed during first time insertion.
+      classLoader();
+
       // Serialize mutable system properties
       IoTDBStartCheck.getInstance().serializeMutableSystemPropertiesIfNecessary();
 
@@ -565,7 +568,6 @@ public class DataNode implements DataNodeMBean {
 
     logger.info("Recover the schema...");
     initSchemaEngine();
-    classLoader();
     registerManager.register(FlushManager.getInstance());
     registerManager.register(CacheHitRatioMonitor.getInstance());
 


### PR DESCRIPTION
Over the past period, some initialization work has been brought forward to the DataNode startup phase, which has slightly slowed down the startup speed of the DataNode, and in turn, increased the time between DataNode registration and the start of the RPC service.

Now, if the ConfigNode and DataNode are started simultaneously, a fault may occur where the DataNode cannot obtain a complete list of ConfigNodes.

The occurrence of this fault requires a specific sequence of events:

- When the DataNode registration returns, because the ConfigNode has not completed registration, the DataNode does not get a complete list of ConfigNodes.
- After the ConfigNode registration is complete, it fails to send the complete list to the DataNode via RPC because the DataNode RPC service has not yet started.

A temporary solution to this problem is to move the classLoader() function somewhere after RPC service starting.

By the way, the classLoader function :
```java
  private void classLoader() {
    try {
      // StatementGenerator
      Class.forName(StatementGenerator.class.getName());
      Class.forName(ASTVisitor.class.getName());
      Class.forName(SqlLexer.class.getName());
      Class.forName(CommonTokenStream.class.getName());
      Class.forName(IoTDBSqlParser.class.getName());
      // SourceRewriter
      Class.forName(SourceRewriter.class.getName());
      Class.forName(DistributionPlanContext.class.getName());
      // LogicalPlaner
      Class.forName(LogicalPlanVisitor.class.getName());
      Class.forName(LogicalQueryPlan.class.getName());
      // TsFileProcessor
      Class.forName(TsFileProcessor.class.getName());
    } catch (ClassNotFoundException e) {
      logger.error("load class error: ", e);
    }
  }
```