### PR TITLE
Optimize SeriesScanUtil by memorizing the order time and satisfied information for each Seq and Unseq Resource

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/driver/DataDriver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/driver/DataDriver.java
@@ -95,6 +95,8 @@ public class DataDriver extends Driver {
               QueryDataSource queryDataSource =
                   new QueryDataSource(dataSource.getSeqResources(), dataSource.getUnseqResources());
 
+              queryDataSource.setSingleDevice(queryDataSource.isSingleDevice());
+
               queryDataSource.setDataTTL(dataSource.getDataTTL());
 
               sourceOperator.initQueryDataSource(queryDataSource);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/driver/DataDriver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/driver/DataDriver.java
@@ -95,7 +95,7 @@ public class DataDriver extends Driver {
               QueryDataSource queryDataSource =
                   new QueryDataSource(dataSource.getSeqResources(), dataSource.getUnseqResources());
 
-              queryDataSource.setSingleDevice(queryDataSource.isSingleDevice());
+              queryDataSource.setSingleDevice(dataSource.isSingleDevice());
 
               queryDataSource.setDataTTL(dataSource.getDataTTL());
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceContext.java
@@ -372,6 +372,7 @@ public class FragmentInstanceContext extends QueryContext {
         closedFilePaths = new HashSet<>();
         unClosedFilePaths = new HashSet<>();
         addUsedFilesForQuery(sharedQueryDataSource);
+        sharedQueryDataSource.setSingleDevice(selectedDeviceIdSet.size() == 1);
       }
     } finally {
       setInitQueryDataSourceCost(System.nanoTime() - startTime);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/SeriesScanUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/SeriesScanUtil.java
@@ -33,6 +33,7 @@ import org.apache.iotdb.db.storageengine.dataregion.read.reader.common.PriorityM
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.tsfile.exception.write.UnSupportedDataTypeException;
 import org.apache.iotdb.tsfile.file.metadata.IChunkMetadata;
+import org.apache.iotdb.tsfile.file.metadata.IDeviceID;
 import org.apache.iotdb.tsfile.file.metadata.IMetadata;
 import org.apache.iotdb.tsfile.file.metadata.ITimeSeriesMetadata;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -68,6 +69,8 @@ public class SeriesScanUtil {
 
   // The path of the target series which will be scanned.
   protected final PartialPath seriesPath;
+
+  private final IDeviceID deviceID;
   protected boolean isAligned = false;
   private final TSDataType dataType;
 
@@ -113,6 +116,7 @@ public class SeriesScanUtil {
       SeriesScanOptions scanOptions,
       FragmentInstanceContext context) {
     this.seriesPath = seriesPath;
+    this.deviceID = seriesPath.getIDeviceID();
     this.dataType = seriesPath.getSeriesType();
 
     this.scanOptions = scanOptions;
@@ -1116,12 +1120,10 @@ public class SeriesScanUtil {
 
   private void unpackAllOverlappedTsFilesToTimeSeriesMetadata(long endpointTime)
       throws IOException {
-    while (orderUtils.hasNextUnseqResource()
-        && orderUtils.isOverlapped(endpointTime, orderUtils.getNextUnseqFileResource(false))) {
+    while (orderUtils.hasNextUnseqResource() && orderUtils.isCurUnSeqOverlappedWith(endpointTime)) {
       unpackUnseqTsFileResource();
     }
-    while (orderUtils.hasNextSeqResource()
-        && orderUtils.isOverlapped(endpointTime, orderUtils.getNextSeqFileResource(false))) {
+    while (orderUtils.hasNextSeqResource() && orderUtils.isCurSeqOverlappedWith(endpointTime)) {
       unpackSeqTsFileResource();
     }
   }
@@ -1256,15 +1258,15 @@ public class SeriesScanUtil {
 
     long getOrderTime(Statistics<? extends Object> statistics);
 
-    long getOrderTime(TsFileResource fileResource);
-
     long getOverlapCheckTime(Statistics<? extends Object> range);
 
     boolean isOverlapped(Statistics<? extends Object> left, Statistics<? extends Object> right);
 
     boolean isOverlapped(long time, Statistics<? extends Object> right);
 
-    boolean isOverlapped(long time, TsFileResource right);
+    boolean isCurSeqOverlappedWith(long time);
+
+    boolean isCurUnSeqOverlappedWith(long time);
 
     <T> Comparator<T> comparingLong(ToLongFunction<? super T> keyExtractor);
 
@@ -1302,12 +1304,6 @@ public class SeriesScanUtil {
 
     @SuppressWarnings("squid:S3740")
     @Override
-    public long getOrderTime(TsFileResource fileResource) {
-      return fileResource.getEndTime(seriesPath.getIDeviceID());
-    }
-
-    @SuppressWarnings("squid:S3740")
-    @Override
     public long getOverlapCheckTime(Statistics range) {
       return range.getStartTime();
     }
@@ -1325,8 +1321,13 @@ public class SeriesScanUtil {
     }
 
     @Override
-    public boolean isOverlapped(long time, TsFileResource right) {
-      return time <= right.getEndTime(seriesPath.getIDeviceID());
+    public boolean isCurSeqOverlappedWith(long time) {
+      return time <= dataSource.getCurrentSeqOrderTime(curSeqFileIndex);
+    }
+
+    @Override
+    public boolean isCurUnSeqOverlappedWith(long time) {
+      return time <= dataSource.getCurrentUnSeqOrderTime(curUnseqFileIndex);
     }
 
     @Override
@@ -1365,32 +1366,26 @@ public class SeriesScanUtil {
 
     @Override
     public boolean hasNextSeqResource() {
-      while (dataSource.hasNextSeqResource(curSeqFileIndex, getAscending())) {
-        TsFileResource tsFileResource = dataSource.getSeqResourceByIndex(curSeqFileIndex);
-        if (tsFileResource != null
-            && (dataSource.isSingleDevice()
-                || tsFileResource.isSatisfied(
-                    seriesPath.getIDeviceID(), scanOptions.getGlobalTimeFilter(), true, false))) {
+      while (dataSource.hasNextSeqResource(curSeqFileIndex, false, deviceID)) {
+        if (dataSource.isSeqSatisfied(
+            deviceID, curSeqFileIndex, scanOptions.getGlobalTimeFilter(), false)) {
           break;
         }
         curSeqFileIndex--;
       }
-      return dataSource.hasNextSeqResource(curSeqFileIndex, getAscending());
+      return dataSource.hasNextSeqResource(curSeqFileIndex, false, deviceID);
     }
 
     @Override
     public boolean hasNextUnseqResource() {
-      while (dataSource.hasNextUnseqResource(curUnseqFileIndex)) {
-        TsFileResource tsFileResource = dataSource.getUnseqResourceByIndex(curUnseqFileIndex);
-        if (tsFileResource != null
-            && (dataSource.isSingleDevice()
-                || tsFileResource.isSatisfied(
-                    seriesPath.getIDeviceID(), scanOptions.getGlobalTimeFilter(), false, false))) {
+      while (dataSource.hasNextUnseqResource(curUnseqFileIndex, false, deviceID)) {
+        if (dataSource.isUnSeqSatisfied(
+            deviceID, curUnseqFileIndex, scanOptions.getGlobalTimeFilter(), false)) {
           break;
         }
         curUnseqFileIndex++;
       }
-      return dataSource.hasNextUnseqResource(curUnseqFileIndex);
+      return dataSource.hasNextUnseqResource(curUnseqFileIndex, false, deviceID);
     }
 
     @Override
@@ -1427,12 +1422,6 @@ public class SeriesScanUtil {
 
     @SuppressWarnings("squid:S3740")
     @Override
-    public long getOrderTime(TsFileResource fileResource) {
-      return fileResource.getStartTime(seriesPath.getIDeviceID());
-    }
-
-    @SuppressWarnings("squid:S3740")
-    @Override
     public long getOverlapCheckTime(Statistics range) {
       return range.getEndTime();
     }
@@ -1450,8 +1439,13 @@ public class SeriesScanUtil {
     }
 
     @Override
-    public boolean isOverlapped(long time, TsFileResource right) {
-      return time >= right.getStartTime(seriesPath.getIDeviceID());
+    public boolean isCurSeqOverlappedWith(long time) {
+      return time >= dataSource.getCurrentSeqOrderTime(curSeqFileIndex);
+    }
+
+    @Override
+    public boolean isCurUnSeqOverlappedWith(long time) {
+      return time >= dataSource.getCurrentUnSeqOrderTime(curUnseqFileIndex);
     }
 
     @Override
@@ -1490,32 +1484,26 @@ public class SeriesScanUtil {
 
     @Override
     public boolean hasNextSeqResource() {
-      while (dataSource.hasNextSeqResource(curSeqFileIndex, getAscending())) {
-        TsFileResource tsFileResource = dataSource.getSeqResourceByIndex(curSeqFileIndex);
-        if (tsFileResource != null
-            && (dataSource.isSingleDevice()
-                || tsFileResource.isSatisfied(
-                    seriesPath.getIDeviceID(), scanOptions.getGlobalTimeFilter(), true, false))) {
+      while (dataSource.hasNextSeqResource(curSeqFileIndex, true, deviceID)) {
+        if (dataSource.isSeqSatisfied(
+            deviceID, curSeqFileIndex, scanOptions.getGlobalTimeFilter(), false)) {
           break;
         }
         curSeqFileIndex++;
       }
-      return dataSource.hasNextSeqResource(curSeqFileIndex, getAscending());
+      return dataSource.hasNextSeqResource(curSeqFileIndex, true, deviceID);
     }
 
     @Override
     public boolean hasNextUnseqResource() {
-      while (dataSource.hasNextUnseqResource(curUnseqFileIndex)) {
-        TsFileResource tsFileResource = dataSource.getUnseqResourceByIndex(curUnseqFileIndex);
-        if (tsFileResource != null
-            && (dataSource.isSingleDevice()
-                || tsFileResource.isSatisfied(
-                    seriesPath.getIDeviceID(), scanOptions.getGlobalTimeFilter(), false, false))) {
+      while (dataSource.hasNextUnseqResource(curUnseqFileIndex, true, deviceID)) {
+        if (dataSource.isUnSeqSatisfied(
+            deviceID, curUnseqFileIndex, scanOptions.getGlobalTimeFilter(), false)) {
           break;
         }
         curUnseqFileIndex++;
       }
-      return dataSource.hasNextUnseqResource(curUnseqFileIndex);
+      return dataSource.hasNextUnseqResource(curUnseqFileIndex, true, deviceID);
     }
 
     @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/SeriesScanUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/SeriesScanUtil.java
@@ -159,7 +159,7 @@ public class SeriesScanUtil {
    * @param dataSource the query data source
    */
   public void initQueryDataSource(QueryDataSource dataSource) {
-    dataSource.fillOrderIndexes(seriesPath.getDevice(), orderUtils.getAscending());
+    dataSource.fillOrderIndexes(deviceID, orderUtils.getAscending());
     this.dataSource = dataSource;
 
     // updated filter concerning TTL

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/SeriesScanUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/SeriesScanUtil.java
@@ -1368,8 +1368,9 @@ public class SeriesScanUtil {
       while (dataSource.hasNextSeqResource(curSeqFileIndex, getAscending())) {
         TsFileResource tsFileResource = dataSource.getSeqResourceByIndex(curSeqFileIndex);
         if (tsFileResource != null
-            && tsFileResource.isSatisfied(
-                seriesPath.getIDeviceID(), scanOptions.getGlobalTimeFilter(), true, false)) {
+            && (dataSource.isSingleDevice()
+                || tsFileResource.isSatisfied(
+                    seriesPath.getIDeviceID(), scanOptions.getGlobalTimeFilter(), true, false))) {
           break;
         }
         curSeqFileIndex--;
@@ -1382,8 +1383,9 @@ public class SeriesScanUtil {
       while (dataSource.hasNextUnseqResource(curUnseqFileIndex)) {
         TsFileResource tsFileResource = dataSource.getUnseqResourceByIndex(curUnseqFileIndex);
         if (tsFileResource != null
-            && tsFileResource.isSatisfied(
-                seriesPath.getIDeviceID(), scanOptions.getGlobalTimeFilter(), false, false)) {
+            && (dataSource.isSingleDevice()
+                || tsFileResource.isSatisfied(
+                    seriesPath.getIDeviceID(), scanOptions.getGlobalTimeFilter(), false, false))) {
           break;
         }
         curUnseqFileIndex++;
@@ -1491,8 +1493,9 @@ public class SeriesScanUtil {
       while (dataSource.hasNextSeqResource(curSeqFileIndex, getAscending())) {
         TsFileResource tsFileResource = dataSource.getSeqResourceByIndex(curSeqFileIndex);
         if (tsFileResource != null
-            && tsFileResource.isSatisfied(
-                seriesPath.getIDeviceID(), scanOptions.getGlobalTimeFilter(), true, false)) {
+            && (dataSource.isSingleDevice()
+                || tsFileResource.isSatisfied(
+                    seriesPath.getIDeviceID(), scanOptions.getGlobalTimeFilter(), true, false))) {
           break;
         }
         curSeqFileIndex++;
@@ -1505,8 +1508,9 @@ public class SeriesScanUtil {
       while (dataSource.hasNextUnseqResource(curUnseqFileIndex)) {
         TsFileResource tsFileResource = dataSource.getUnseqResourceByIndex(curUnseqFileIndex);
         if (tsFileResource != null
-            && tsFileResource.isSatisfied(
-                seriesPath.getIDeviceID(), scanOptions.getGlobalTimeFilter(), false, false)) {
+            && (dataSource.isSingleDevice()
+                || tsFileResource.isSatisfied(
+                    seriesPath.getIDeviceID(), scanOptions.getGlobalTimeFilter(), false, false))) {
           break;
         }
         curUnseqFileIndex++;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/buffer/TimeSeriesMetadataCache.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/buffer/TimeSeriesMetadataCache.java
@@ -261,7 +261,7 @@ public class TimeSeriesMetadataCache {
 
     private static final long INSTANCE_SIZE =
         RamUsageEstimator.shallowSizeOfInstance(TimeSeriesMetadataCacheKey.class)
-            + 2 * RamUsageEstimator.shallowSizeOfInstance(String.class);
+            + RamUsageEstimator.shallowSizeOfInstance(String.class);
 
     private final int regionId;
     private final long timePartitionId;
@@ -296,9 +296,7 @@ public class TimeSeriesMetadataCache {
     }
 
     public long getRetainedSizeInBytes() {
-      return INSTANCE_SIZE
-          + sizeOfCharArray(((PlainDeviceID) device).toStringID().length())
-          + sizeOfCharArray(measurement.length());
+      return INSTANCE_SIZE + device.ramBytesUsed() + sizeOfCharArray(measurement.length());
     }
 
     @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/performer/impl/ReadPointCompactionPerformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/performer/impl/ReadPointCompactionPerformer.java
@@ -117,7 +117,7 @@ public class ReadPointCompactionPerformer
         Pair<IDeviceID, Boolean> deviceInfo = deviceIterator.nextDevice();
         IDeviceID device = deviceInfo.left;
         boolean isAligned = deviceInfo.right;
-        queryDataSource.fillOrderIndexes(((PlainDeviceID) device).toStringID(), true);
+        queryDataSource.fillOrderIndexes(device, true);
 
         if (isAligned) {
           compactAlignedSeries(
@@ -220,7 +220,7 @@ public class ReadPointCompactionPerformer
                         device,
                         measurementListArray[i],
                         fragmentInstanceContext,
-                        queryDataSource,
+                        new QueryDataSource(queryDataSource),
                         compactionWriter,
                         schemaMap,
                         i)));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/QueryDataSource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/QueryDataSource.java
@@ -136,7 +136,7 @@ public class QueryDataSource {
     if (res && curIndex != this.curUnSeqIndex) {
       this.curUnSeqIndex = curIndex;
       this.curUnSeqOrderTime =
-          seqResources.get(unSeqFileOrderIndex[curIndex]).getOrderTime(deviceID, ascending);
+          unseqResources.get(unSeqFileOrderIndex[curIndex]).getOrderTime(deviceID, ascending);
       this.curUnSeqSatisfied = null;
     }
     return res;
@@ -150,7 +150,7 @@ public class QueryDataSource {
               "curIndex %d is not equal to curUnSeqIndex %d", curIndex, this.curUnSeqIndex));
     }
     if (curUnSeqSatisfied == null) {
-      TsFileResource tsFileResource = seqResources.get(unSeqFileOrderIndex[curIndex]);
+      TsFileResource tsFileResource = unseqResources.get(unSeqFileOrderIndex[curIndex]);
       curUnSeqSatisfied =
           tsFileResource != null
               && (isSingleDevice || tsFileResource.isSatisfied(deviceID, timeFilter, false, debug));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/QueryDataSource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/QueryDataSource.java
@@ -43,6 +43,8 @@ public class QueryDataSource {
 
   private final List<TsFileResource> unseqResources;
 
+  private boolean isSingleDevice;
+
   /* The traversal order of unseqResources (different for each device) */
   private int[] unSeqFileOrderIndex;
 
@@ -123,5 +125,13 @@ public class QueryDataSource {
       }
     }
     this.unSeqFileOrderIndex = unSeqFileOrderIndexArray;
+  }
+
+  public boolean isSingleDevice() {
+    return isSingleDevice;
+  }
+
+  public void setSingleDevice(boolean singleDevice) {
+    isSingleDevice = singleDevice;
   }
 }

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/PlainDeviceID.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/file/metadata/PlainDeviceID.java
@@ -35,7 +35,7 @@ public class PlainDeviceID implements IDeviceID {
   private static final long INSTANCE_SIZE =
       RamUsageEstimator.shallowSizeOfInstance(PlainDeviceID.class)
           + RamUsageEstimator.shallowSizeOfInstance(String.class);
-  String deviceID;
+  private final String deviceID;
 
   public PlainDeviceID(String deviceID) {
     this.deviceID = deviceID;


### PR DESCRIPTION
We can memorize the order time and satisfied information for each Seq and Unseq Resource instead of getting it from resource ITimeIndex map each time, in which way we can save much time by avoiding time consuming map.get();