### PR TITLE
[RatisConsensus] Remove JavaUtils dependencies

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/utils/Retriable.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/utils/Retriable.java
@@ -81,8 +81,17 @@ public class Retriable {
   public static void attemptUntilTrue(
       BooleanSupplier condition, TimeDuration sleepTime, String name, Logger log)
       throws InterruptedException {
+    attemptUntilTrue(condition, -1, sleepTime, name, log);
+  }
+
+  /**
+   * Attempt indefinitely until the given {@param condition} holds or reaches {@param maxAttempts}
+   */
+  public static void attemptUntilTrue(
+      BooleanSupplier condition, int maxAttempts, TimeDuration sleepTime, String name, Logger log)
+      throws InterruptedException {
     Objects.requireNonNull(condition, "condition == null");
-    attempt(() -> null, ret -> !condition.getAsBoolean(), -1, sleepTime, () -> name, log);
+    attempt(() -> null, ret -> !condition.getAsBoolean(), maxAttempts, sleepTime, () -> name, log);
   }
 
   /**

--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/DiskGuardianTest.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/DiskGuardianTest.java
@@ -22,9 +22,9 @@ import org.apache.iotdb.commons.consensus.ConsensusGroupId;
 import org.apache.iotdb.commons.consensus.SchemaRegionId;
 import org.apache.iotdb.consensus.common.Peer;
 import org.apache.iotdb.consensus.config.RatisConfig;
+import org.apache.iotdb.consensus.ratis.utils.Retriable;
 import org.apache.iotdb.consensus.ratis.utils.Utils;
 
-import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.TimeDuration;
 import org.junit.After;
 import org.junit.Assert;
@@ -91,7 +91,7 @@ public class DiskGuardianTest {
     miniCluster.waitUntilActiveLeaderElectedAndReady();
     miniCluster.writeManySerial(0, 10);
     Assert.assertFalse(hasSnapshot(gid));
-    JavaUtils.attemptUntilTrue(
+    Retriable.attemptUntilTrue(
         () -> hasSnapshot(gid),
         12,
         TimeDuration.valueOf(5, TimeUnit.SECONDS),

--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/TestUtils.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/TestUtils.java
@@ -36,10 +36,10 @@ import org.apache.iotdb.consensus.config.ConsensusConfig;
 import org.apache.iotdb.consensus.config.RatisConfig;
 import org.apache.iotdb.consensus.exception.ConsensusException;
 import org.apache.iotdb.consensus.exception.RatisReadUnavailableException;
+import org.apache.iotdb.consensus.ratis.utils.Retriable;
 
 import org.apache.ratis.thirdparty.com.google.common.base.Preconditions;
 import org.apache.ratis.util.FileUtils;
-import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.TimeDuration;
 import org.apache.ratis.util.Timestamp;
 import org.junit.Assert;
@@ -347,7 +347,7 @@ public class TestUtils {
     }
 
     void waitUntilActiveLeaderElected() throws InterruptedException {
-      JavaUtils.attemptUntilTrue(
+      Retriable.attemptUntilTrue(
           () -> servers.stream().anyMatch(server -> server.isLeader(gid)),
           600,
           TimeDuration.valueOf(100, TimeUnit.MILLISECONDS),
@@ -356,7 +356,7 @@ public class TestUtils {
     }
 
     void waitUntilActiveLeaderElectedAndReady() throws InterruptedException {
-      JavaUtils.attemptUntilTrue(
+      Retriable.attemptUntilTrue(
           () -> servers.stream().anyMatch(server -> server.isLeaderReady(gid)),
           600,
           TimeDuration.valueOf(100, TimeUnit.MILLISECONDS),


### PR DESCRIPTION
In the following releases of Ratis, the `JavaUtils.attemptUntilTrue` will be removed.