### PR TITLE
Warn user if they use GraalVM

### DIFF
--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/StartupChecks.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/StartupChecks.java
@@ -83,11 +83,12 @@ public abstract class StartupChecks {
     RuntimeMXBean bean = ManagementFactory.getRuntimeMXBean();
     logger.info("JVM version is {} {}.", bean.getVmName(), bean.getVmVersion());
     try {
+      // For more information, visit https://github.com/oracle/graal/issues/8638
       Class.forName("org.graalvm.home.Version");
     } catch (ClassNotFoundException e) {
       return;
     }
-    logger.error(
+    logger.warn(
         "Perhaps you are using GraalVM, which is strongly not recommended. Using GraalVM may cause strange problems after the system runs for a while. Please check your JVM version.");
   }
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/StartupChecks.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/StartupChecks.java
@@ -88,7 +88,7 @@ public abstract class StartupChecks {
       return;
     }
     logger.error(
-        "Perhaps you are using GraalVM, which is strongly not recommended. Please check your JVM version.");
+        "Perhaps you are using GraalVM, which is strongly not recommended. Using GraalVM may cause strange problems after the system has been running for a while. Please check your JVM version.");
   }
 
   protected void envCheck() {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/StartupChecks.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/StartupChecks.java
@@ -25,6 +25,8 @@ import org.apache.iotdb.commons.utils.JVMCommonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,18 +35,7 @@ public abstract class StartupChecks {
   private static final Logger logger = LoggerFactory.getLogger(StartupChecks.class);
 
   private final String nodeRole;
-  private static final StartupCheck checkJDK =
-      () -> {
-        int version = JVMCommonUtils.getJdkVersion();
-        if (version < IoTDBConstant.MIN_SUPPORTED_JDK_VERSION) {
-          throw new StartupException(
-              String.format(
-                  "Requires JDK version >= %d, current version is %d.",
-                  IoTDBConstant.MIN_SUPPORTED_JDK_VERSION, version));
-        } else {
-          logger.info("JDK version is {}.", version);
-        }
-      };
+
   protected final List<StartupCheck> preChecks = new ArrayList<>();
 
   protected StartupChecks(String nodeRole) {
@@ -76,9 +67,34 @@ public abstract class StartupChecks {
     }
   }
 
+  private void checkJDK() throws StartupException {
+    int version = JVMCommonUtils.getJdkVersion();
+    if (version < IoTDBConstant.MIN_SUPPORTED_JDK_VERSION) {
+      throw new StartupException(
+          String.format(
+              "Requires JDK version >= %d, current version is %d.",
+              IoTDBConstant.MIN_SUPPORTED_JDK_VERSION, version));
+    } else {
+      logger.info("JDK version is {}.", version);
+    }
+  }
+
+  private void checkJVM() {
+    RuntimeMXBean bean = ManagementFactory.getRuntimeMXBean();
+    logger.info("JVM version is {} {}.", bean.getVmName(), bean.getVmVersion());
+    try {
+      Class.forName("org.graalvm.home.Version");
+    } catch (ClassNotFoundException e) {
+      return;
+    }
+    logger.error(
+        "Perhaps you are using GraalVM, which is strongly not recommended. Please check your JVM version.");
+  }
+
   protected void envCheck() {
     preChecks.add(() -> checkJMXPort(nodeRole));
-    preChecks.add(checkJDK);
+    preChecks.add(this::checkJDK);
+    preChecks.add(this::checkJVM);
   }
   /** execute every pretest. */
   protected void verify() throws StartupException {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/StartupChecks.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/StartupChecks.java
@@ -88,7 +88,7 @@ public abstract class StartupChecks {
       return;
     }
     logger.error(
-        "Perhaps you are using GraalVM, which is strongly not recommended. Using GraalVM may cause strange problems after the system has been running for a while. Please check your JVM version.");
+        "Perhaps you are using GraalVM, which is strongly not recommended. Using GraalVM may cause strange problems after the system runs for a while. Please check your JVM version.");
   }
 
   protected void envCheck() {


### PR DESCRIPTION
For more information, visit https://github.com/oracle/graal/issues/8638.
```
125  [main] INFO  o.a.i.commons.service.StartupChecks - JDK version is 17. 
125  [main] INFO  o.a.i.commons.service.StartupChecks - JVM version is Java HotSpot(TM) 64-Bit Server VM 17.0.10+11-LTS-jvmci-23.0-b27. 
126  [main] ERROR  o.a.i.commons.service.StartupChecks - Perhaps you are using GraalVM, which is strongly not recommended. Using GraalVM may cause strange problems after the system runs for a while. Please check your JVM version.
```