### PR TITLE
Remove -XX:-UseBiasedLock in IoTDB JVM options

### DIFF
--- a/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.bat
+++ b/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.bat
@@ -126,7 +126,6 @@ set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -Xss512k
 @REM options below try to optimize safepoint stw time.
 set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:+UnlockDiagnosticVMOptions
 set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:GuaranteedSafepointInterval=0
-set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:-UseBiasedLocking
 @REM these two options print safepoints with pauses longer than 1000ms to the standard output. You can see these logs via redirection when starting in the background like "start-datanode.sh > log_datanode_safepoint.txt"
 set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:SafepointTimeoutDelay=1000
 set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:+SafepointTimeout

--- a/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.sh
+++ b/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.sh
@@ -280,7 +280,6 @@ IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xss512k"
 # options below try to optimize safepoint stw time.
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:+UnlockDiagnosticVMOptions"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:GuaranteedSafepointInterval=0"
-IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:-UseBiasedLocking"
 # these two options print safepoints with pauses longer than 1000ms to the standard output. You can see these logs via redirection when starting in the background like "start-datanode.sh > log_datanode_safepoint.log"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:SafepointTimeoutDelay=1000"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:+SafepointTimeout"


### PR DESCRIPTION
We have observed performance losses after adding `-XX:-UseBiasedLock` in some cases. Thus we remove it.

Detailed docs: https://apache-iotdb.feishu.cn/docx/JNvTdo0oOoOJr7xq3QecRe9Wnhc