### PR TITLE
IoTConsensus: Skip retry sending batch caused by TApplicationException

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/client/DispatchLogHandler.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/client/DispatchLogHandler.java
@@ -98,8 +98,8 @@ public class DispatchLogHandler implements AsyncMethodCallback<TSyncLogEntriesRe
       // skip TApplicationException caused by follower
       if (rootCause instanceof org.apache.thrift.TApplicationException) {
         completeBatch(batch);
-        logDispatcherThreadMetrics.recordSyncLogTimePerRequest(System.nanoTime() - createTime);
         logger.warn("Skip retrying this Batch {} because of TApplicationException.", batch);
+        logDispatcherThreadMetrics.recordSyncLogTimePerRequest(System.nanoTime() - createTime);
         return;
       }
     }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/client/DispatchLogHandler.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/client/DispatchLogHandler.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.consensus.iot.thrift.TSyncLogEntriesRes;
 import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.thrift.TApplicationException;
 import org.apache.thrift.async.AsyncMethodCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -96,7 +97,7 @@ public class DispatchLogHandler implements AsyncMethodCallback<TSyncLogEntriesRe
           retryCount,
           rootCause.toString());
       // skip TApplicationException caused by follower
-      if (rootCause instanceof org.apache.thrift.TApplicationException) {
+      if (rootCause instanceof TApplicationException) {
         completeBatch(batch);
         logger.warn("Skip retrying this Batch {} because of TApplicationException.", batch);
         logDispatcherThreadMetrics.recordSyncLogTimePerRequest(System.nanoTime() - createTime);


### PR DESCRIPTION
## Description

When the wal file is damaged, it will cause follower synchronization failure, causing leader synchronization to get stuck and infinite retries until wal blocks writing. The fix is to skip retrying send batches caused by TApplicationException and print a warn log.

