### PR TITLE
Pipe: fix deadlock caused by PipeResourceManagerHolder.<clinit> and PipePeriodicalJobExecutor

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/runtime/PipePeriodicalJobExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/runtime/PipePeriodicalJobExecutor.java
@@ -56,10 +56,9 @@ public class PipePeriodicalJobExecutor {
   private Future<?> executorFuture;
 
   // <Periodical job, Interval in rounds>
-  private static final List<Pair<WrappedRunnable, Long>> periodicalJobs =
-      new CopyOnWriteArrayList<>();
+  private final List<Pair<WrappedRunnable, Long>> periodicalJobs = new CopyOnWriteArrayList<>();
 
-  public synchronized void register(String id, Runnable periodicalJob, long intervalInSeconds) {
+  public void register(String id, Runnable periodicalJob, long intervalInSeconds) {
     periodicalJobs.add(
         new Pair<>(
             new WrappedRunnable() {
@@ -94,7 +93,7 @@ public class PipePeriodicalJobExecutor {
     }
   }
 
-  private synchronized void execute() {
+  private void execute() {
     ++rounds;
 
     for (final Pair<WrappedRunnable, Long> periodicalJob : periodicalJobs) {
@@ -113,7 +112,7 @@ public class PipePeriodicalJobExecutor {
   }
 
   @TestOnly
-  public synchronized void clear() {
+  public void clear() {
     periodicalJobs.clear();
     LOGGER.info("All pipe periodical jobs are cleared successfully.");
   }


### PR DESCRIPTION
jstack:

```
"pool-69-IoTDB-IoTConsensusRPC-Processor-3" #932 prio=5 os_prio=0 tid=0x00007faa3000e000 nid=0x1459a9 waiting for monitor entry [0x00007faa8c26c000]
   java.lang.Thread.State: BLOCKED (on object monitor)
	at org.apache.iotdb.db.pipe.agent.runtime.PipePeriodicalJobExecutor.register(PipePeriodicalJobExecutor.java:63)
	- waiting to lock <0x00000001c0154100> (a org.apache.iotdb.db.pipe.agent.runtime.PipePeriodicalJobExecutor)
	at org.apache.iotdb.db.pipe.agent.runtime.PipeDataNodeRuntimeAgent.registerPeriodicalJob(PipeDataNodeRuntimeAgent.java:199)
	at org.apache.iotdb.db.pipe.resource.memory.PipeMemoryManager.<init>(PipeMemoryManager.java:70)
	at org.apache.iotdb.db.pipe.resource.PipeResourceManager.<init>(PipeResourceManager.java:78)
	at org.apache.iotdb.db.pipe.resource.PipeResourceManager.<init>(PipeResourceManager.java:34)
	at org.apache.iotdb.db.pipe.resource.PipeResourceManager$PipeResourceManagerHolder.<clinit>(PipeResourceManager.java:83)
	at org.apache.iotdb.db.pipe.resource.PipeResourceManager.memory(PipeResourceManager.java:65)
	at org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALInsertNodeCache.<init>(WALInsertNodeCache.java:81)
	at org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALInsertNodeCache.<init>(WALInsertNodeCache.java:57)
	at org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALInsertNodeCache$InstanceHolder.lambda$getOrCreateInstance$0(WALInsertNodeCache.java:321)
	at org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALInsertNodeCache$InstanceHolder$$Lambda$1533/1966987578.apply(Unknown Source)
	at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1660)
	- locked <0x000000022d60c6d8> (a java.util.concurrent.ConcurrentHashMap$ReservationNode)
	at org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALInsertNodeCache$InstanceHolder.getOrCreateInstance(WALInsertNodeCache.java:321)
	at org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALInsertNodeCache.getInstance(WALInsertNodeCache.java:313)
	at org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALEntryPosition.setWalNode(WALEntryPosition.java:157)
	at org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALEntryHandler.setWalNode(WALEntryHandler.java:185)
	at org.apache.iotdb.db.storageengine.dataregion.wal.node.WALNode.log(WALNode.java:150)
	at org.apache.iotdb.db.storageengine.dataregion.wal.node.WALNode.log(WALNode.java:130)
	at org.apache.iotdb.db.storageengine.dataregion.memtable.TsFileProcessor.insert(TsFileProcessor.java:272)
	at org.apache.iotdb.db.storageengine.dataregion.DataRegion.insertToTsFileProcessors(DataRegion.java:1251)
	at org.apache.iotdb.db.storageengine.dataregion.DataRegion.insert(DataRegion.java:3295)
	at org.apache.iotdb.db.consensus.statemachine.dataregion.DataExecutionVisitor.visitInsertRows(DataExecutionVisitor.java:114)
	at org.apache.iotdb.db.consensus.statemachine.dataregion.DataExecutionVisitor.visitInsertRows(DataExecutionVisitor.java:50)
	at org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertRowsNode.accept(InsertRowsNode.java:255)
	at org.apache.iotdb.db.consensus.statemachine.dataregion.DataRegionStateMachine.write(DataRegionStateMachine.java:249)
	at org.apache.iotdb.db.consensus.statemachine.dataregion.IoTConsensusDataRegionStateMachine.write(IoTConsensusDataRegionStateMachine.java:63)
	at org.apache.iotdb.consensus.iot.IoTConsensusServerImpl$SyncLogCacheQueue.cacheAndInsertLatestNode(IoTConsensusServerImpl.java:951)
	at org.apache.iotdb.consensus.iot.IoTConsensusServerImpl$SyncLogCacheQueue.access$000(IoTConsensusServerImpl.java:861)
	at org.apache.iotdb.consensus.iot.IoTConsensusServerImpl.syncLog(IoTConsensusServerImpl.java:835)
	at org.apache.iotdb.consensus.iot.service.IoTConsensusRPCServiceProcessor.syncLogEntries(IoTConsensusRPCServiceProcessor.java:125)
	at org.apache.iotdb.consensus.iot.thrift.IoTConsensusIService$AsyncProcessor$syncLogEntries.start(IoTConsensusIService.java:922)
	at org.apache.iotdb.consensus.iot.thrift.IoTConsensusIService$AsyncProcessor$syncLogEntries.start(IoTConsensusIService.java:865)
	at org.apache.thrift.TBaseAsyncProcessor.process(TBaseAsyncProcessor.java:103)
	at org.apache.thrift.server.AbstractNonblockingServer$AsyncFrameBuffer.invoke(AbstractNonblockingServer.java:603)
	at org.apache.thrift.server.Invocation.run(Invocation.java:18)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)

   Locked ownable synchronizers:
	- <0x00000001c283b3e8> (a java.util.concurrent.locks.ReentrantReadWriteLock$NonfairSync)
	- <0x000000022d389828> (a java.util.concurrent.ThreadPoolExecutor$Worker)
	- <0x000000022d38aa28> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)



"pool-2-IoTDB-Pipe-Runtime-Periodical-Job-Executor-1" #131 prio=5 os_prio=0 tid=0x00007fab0cf33b70 nid=0x14566e in Object.wait() [0x00007fa9eea57000]
   java.lang.Thread.State: RUNNABLE
	at org.apache.iotdb.db.pipe.resource.PipeResourceManager.log(PipeResourceManager.java:69)
	at org.apache.iotdb.db.pipe.resource.tsfile.PipeTsFileResourceManager.ttlCheck(PipeTsFileResourceManager.java:85)
	at org.apache.iotdb.db.pipe.resource.tsfile.PipeTsFileResourceManager.tryTtlCheck(PipeTsFileResourceManager.java:68)
	at org.apache.iotdb.db.pipe.resource.tsfile.PipeTsFileResourceManager$$Lambda$1542/1640386138.run(Unknown Source)
	at org.apache.iotdb.db.pipe.agent.runtime.PipePeriodicalJobExecutor$1.runMayThrow(PipePeriodicalJobExecutor.java:69)
	at org.apache.iotdb.commons.concurrent.WrappedRunnable.run(WrappedRunnable.java:30)
	at org.apache.iotdb.db.pipe.agent.runtime.PipePeriodicalJobExecutor.execute(PipePeriodicalJobExecutor.java:102)
	- locked <0x00000001c0154100> (a org.apache.iotdb.db.pipe.agent.runtime.PipePeriodicalJobExecutor)
	at org.apache.iotdb.db.pipe.agent.runtime.PipePeriodicalJobExecutor$$Lambda$454/380394805.run(Unknown Source)
	at org.apache.iotdb.commons.concurrent.threadpool.ScheduledExecutorUtil.lambda$scheduleWithFixedDelay$1(ScheduledExecutorUtil.java:177)
	at org.apache.iotdb.commons.concurrent.threadpool.ScheduledExecutorUtil$$Lambda$314/766681183.run(Unknown Source)
	at org.apache.iotdb.commons.concurrent.WrappedRunnable$1.runMayThrow(WrappedRunnable.java:45)
	at org.apache.iotdb.commons.concurrent.WrappedRunnable.run(WrappedRunnable.java:30)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)

   Locked ownable synchronizers:
	- <0x00000001cb8b51c0> (a java.util.concurrent.ThreadPoolExecutor$Worker)
	- <0x000000022d719c18> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
```