### PR TITLE
Fix the mistaken argument in LZ4Uncompressor

### DIFF
--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/compress/IUnCompressor.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/compress/IUnCompressor.java
@@ -238,7 +238,7 @@ public interface IUnCompressor {
     public int uncompress(byte[] byteArray, int offset, int length, byte[] output, int outOffset)
         throws IOException {
       try {
-        return decompressor.decompress(byteArray, offset, length, output, offset);
+        return decompressor.decompress(byteArray, offset, length, output, outOffset);
       } catch (RuntimeException e) {
         logger.error(UNCOMPRESS_INPUT_ERROR, e);
         throw new IOException(e);

--- a/iotdb-core/tsfile/src/test/java/org/apache/iotdb/tsfile/compress/LZ4Test.java
+++ b/iotdb-core/tsfile/src/test/java/org/apache/iotdb/tsfile/compress/LZ4Test.java
@@ -80,4 +80,25 @@ public class LZ4Test {
     byte[] uncompressed = unCompressor.uncompress(compressed);
     Assert.assertArrayEquals(uncom, uncompressed);
   }
+
+  @Test
+  public void testBytes3() throws IOException {
+    ICompressor.IOTDBLZ4Compressor compressor = new ICompressor.IOTDBLZ4Compressor();
+    IUnCompressor.LZ4UnCompressor unCompressor = new IUnCompressor.LZ4UnCompressor();
+
+    int n = 500000;
+    int offset = 100;
+    String input = randomString(n);
+    byte[] origin = input.getBytes(StandardCharsets.UTF_8);
+    byte[] compressed = new byte[origin.length * 2];
+    int compressedLength = compressor.compress(origin, 0, origin.length, compressed);
+    System.arraycopy(compressed, 0, compressed, offset, compressedLength);
+    for (int i = 0; i < offset; i++) {
+      compressed[i] = 0;
+    }
+
+    byte[] uncompressed = new byte[origin.length];
+    unCompressor.uncompress(compressed, offset, compressedLength, uncompressed, 0);
+    Assert.assertArrayEquals(origin, uncompressed);
+  }
 }


### PR DESCRIPTION
The LZ4Uncompress used the wrong argument for the offset of the output buffer, which is corrected in this PR.