### PR TITLE
Optimize time cost on rewrite pattern by authority pattern

### DIFF
--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTree.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTree.java
@@ -326,7 +326,7 @@ public class PathPatternTree {
           if (tmp.size() == 1 && tmp.get(0).getName().equals(nodes[i])) {
             curNode = tmp.get(0);
             if (tarNode.getChildren(nodes[i]) == null) {
-              tarNode.addChild(new PathPatternNode<>(nodes[i], VoidSerializer.getInstance()));
+              tarNode.addChild(curNode);
             }
             tarNode = tarNode.getChildren(nodes[i]);
           } else {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTree.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTree.java
@@ -309,6 +309,56 @@ public class PathPatternTree {
     return false;
   }
 
+  public PathPatternTree intersectWithFullPathPrefixTree(PathPatternTree fullPathPrefixTree) {
+    PathPatternTree result = new PathPatternTree(containWildcard);
+    List<PartialPath> partialPathList = null;
+
+    for (PartialPath fullPathOrPrefix : fullPathPrefixTree.getAllPathPatterns()) {
+      PathPatternNode<Void, VoidSerializer> curNode = root;
+      PathPatternNode<Void, VoidSerializer> tarNode = result.root;
+      String[] nodes = fullPathOrPrefix.nodes;
+      boolean done = false;
+      if (fullPathOrPrefix.endWithMultiLevelWildcard()) {
+        // if prefix match, directly construct result tree
+        for (int i = 1; i < nodes.length - 1; i++) {
+          done = true;
+          List<PathPatternNode<Void, VoidSerializer>> tmp = curNode.getMatchChildren(nodes[i]);
+          if (tmp.size() == 1 && tmp.get(0).getName().equals(nodes[i])) {
+            curNode = tmp.get(0);
+            if (tarNode.getChildren(nodes[i]) == null) {
+              tarNode.addChild(new PathPatternNode<>(nodes[i], VoidSerializer.getInstance()));
+            }
+            tarNode = tarNode.getChildren(nodes[i]);
+          } else {
+            done = false;
+            break;
+          }
+        }
+      }
+      if (!done) {
+        // this branch is to construct intersection one by one
+        if (partialPathList == null) {
+          partialPathList = getAllPathPatterns();
+        }
+        for (PartialPath pathPattern : partialPathList) {
+          if (fullPathOrPrefix.endWithMultiLevelWildcard()) {
+            // prefix
+            for (PartialPath temp : pathPattern.intersectWithPrefixPattern(fullPathOrPrefix)) {
+              result.appendPathPattern(temp);
+            }
+          } else {
+            // full path
+            if (pathPattern.matchFullPath(fullPathOrPrefix)) {
+              result.appendPathPattern(fullPathOrPrefix);
+            }
+          }
+        }
+      }
+    }
+    result.constructTree();
+    return result;
+  }
+
   /////////////////////////////////////////////////////////////////////////////////////////////////
   // serialize & deserialize
   /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTree.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTree.java
@@ -326,7 +326,7 @@ public class PathPatternTree {
           if (tmp.size() == 1 && tmp.get(0).getName().equals(nodes[i])) {
             curNode = tmp.get(0);
             if (tarNode.getChildren(nodes[i]) == null) {
-              tarNode.addChild(curNode);
+              tarNode.addChild(new PathPatternNode<>(nodes[i], VoidSerializer.getInstance()));
             }
             tarNode = tarNode.getChildren(nodes[i]);
           } else {
@@ -335,7 +335,11 @@ public class PathPatternTree {
           }
         }
       }
-      if (!done) {
+      if (done) {
+        for (PathPatternNode<Void, VoidSerializer> node : curNode.getChildren().values()) {
+          tarNode.addChild(node);
+        }
+      } else {
         // this branch is to construct intersection one by one
         if (partialPathList == null) {
           partialPathList = getAllPathPatterns();

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTreeUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTreeUtils.java
@@ -36,23 +36,6 @@ public class PathPatternTreeUtils {
     if (SchemaConstant.ALL_MATCH_SCOPE.equals(fullPathPrefixTree)) {
       return patternTree;
     }
-    PathPatternTree result = new PathPatternTree(patternTree.isContainWildcard());
-    for (PartialPath pathPattern : patternTree.getAllPathPatterns()) {
-      for (PartialPath fullPathOrPrefix : fullPathPrefixTree.getAllPathPatterns()) {
-        if (fullPathOrPrefix.endWithMultiLevelWildcard()) {
-          // prefix
-          for (PartialPath temp : pathPattern.intersectWithPrefixPattern(fullPathOrPrefix)) {
-            result.appendPathPattern(temp);
-          }
-        } else {
-          // full path
-          if (pathPattern.matchFullPath(fullPathOrPrefix)) {
-            result.appendPathPattern(fullPathOrPrefix);
-          }
-        }
-      }
-    }
-    result.constructTree();
-    return result;
+    return patternTree.intersectWithFullPathPrefixTree(fullPathPrefixTree);
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTreeUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTreeUtils.java
@@ -36,7 +36,7 @@ public class PathPatternTreeUtils {
     if (SchemaConstant.ALL_MATCH_SCOPE.equals(fullPathPrefixTree)) {
       return patternTree;
     }
-    PathPatternTree result = new PathPatternTree();
+    PathPatternTree result = new PathPatternTree(patternTree.isContainWildcard());
     for (PartialPath pathPattern : patternTree.getAllPathPatterns()) {
       for (PartialPath fullPathOrPrefix : fullPathPrefixTree.getAllPathPatterns()) {
         if (fullPathOrPrefix.endWithMultiLevelWildcard()) {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTreeUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/path/PathPatternTreeUtils.java
@@ -19,6 +19,8 @@
 
 package org.apache.iotdb.commons.path;
 
+import org.apache.iotdb.commons.schema.SchemaConstant;
+
 public class PathPatternTreeUtils {
   /**
    * Intersect the pattern tree with the full path prefix tree, and return the intersected pattern
@@ -31,6 +33,9 @@ public class PathPatternTreeUtils {
    */
   public static PathPatternTree intersectWithFullPathPrefixTree(
       PathPatternTree patternTree, PathPatternTree fullPathPrefixTree) {
+    if (SchemaConstant.ALL_MATCH_SCOPE.equals(fullPathPrefixTree)) {
+      return patternTree;
+    }
     PathPatternTree result = new PathPatternTree();
     for (PartialPath pathPattern : patternTree.getAllPathPatterns()) {
       for (PartialPath fullPathOrPrefix : fullPathPrefixTree.getAllPathPatterns()) {


### PR DESCRIPTION
## Problem

Execute SQL below, it will cost lots of time in construct query pattern tree with authority pattern.

```
explain analyze verbose  select last_value(`PPS_SREP_TotW_mag`),last_value(`PPS_SREP_NumFltRunInv_mag`),last_value(`PPS_SREP_PlnSupWhDay_mag`),last_value(`PPS_LPHD_Num_mag`),last_value(`PPS_SREP_SupWhYear_mag`),last_value(`mpg`),last_value(`PPS_SREP_SupWhDay_mag`),last_value(`PPS_SREP_WCap_mag`),last_value(`nbq_state`),last_value(`PPS_SREP_PlnSupWhYear_mag`),last_value(`PPS_SREP_PlnEqTmhYear_mag`),last_value(`PPS_SREP_NumLowpInv_mag`),last_value(`p`),last_value(`ypg`),last_value(`PPS_SREP_SupWhMon_mag`),last_value(`PPS_SREP_EqTmhYear_mag`),last_value(`PPS_SREP_PlnSupWhMon_mag`),last_value(`PPS_SREP_NumFltStpInv_mag`),last_value(`PPS_SREP_NumNotFltStpInv_mag`),last_value(`PVINV_EnergyLN_SupWhHr_mag`),last_value(`PPS_SREP_NumComFltInv_mag`),last_value(`dpg`),last_value(`cpg`),last_value(`PPS_SREP_NumFltInv_mag`) from root.data.A05_2004_GF2004NB30401514,root.data.A05_2004_GF2004NB30401513,root.data.A05_2004_GF2004NB30401516,root.data.A05_2004_GF2004NB30401515,root.data.A05_2004_GF2004NB30300816,root.data.A05_2004_GF2004NB30300817,root.data.A05_2004_GF2004NB30401517,root.data.A05_2004_GF2004NB30300812,root.data.A05_2004_GF2004NB30502216,root.data.A05_2004_GF2004NB30300813,root.data.A05_2004_GF2004NB30502217,root.data.A05_2004_GF2004NB30300814,root.data.A05_2004_GF2004NB30502214,root.data.A05_2004_GF2004NB30300815,root.data.A05_2004_GF2004NB30502215,root.data.A05_2004_GF2004NB30502212,root.data.A05_2004_GF2004NB30502213,root.data.A05_2004_GF2004NB30300810,root.data.A05_2004_GF2004NB30502210,root.data.A05_2004_GF2004NB30300811,root.data.A05_2004_GF2004NB30502211,root.data.A05_2004_GF2004NB30502209,root.data.A05_2004_GF2004NB30502207,root.data.A05_2004_GF2004NB30502208,root.data.A05_2004_GF2004NB30401402,root.data.A05_2004_GF2004NB30401401,root.data.A05_2004_GF2004NB30300809,root.data.A05_2004_GF2004NB30401503,root.data.A05_2004_GF2004NB30401502,root.data.A05_2004_GF2004NB30401505,root.data.A05_2004_GF2004NB30401504,root.data.A05_2004_GF2004NB30300805,root.data.A05_2004_GF2004NB30401507,root.data.A05_2004_GF2004NB30300806,root.data.A05_2004_GF2004NB30401506,root.data.A05_2004_GF2004NB30300807,root.data.A05_2004_GF2004NB30401509,root.data.A05_2004_GF2004NB30300808,root.data.A05_2004_GF2004NB30401508,root.data.A05_2004_GF2004NB30300801,root.data.A05_2004_GF2004NB30502106,root.data.A05_2004_GF2004NB30300802,root.data.A05_2004_GF2004NB30502107,root.data.A05_2004_GF2004NB30300803,root.data.A05_2004_GF2004NB30502104,root.data.A05_2004_GF2004NB30300804,root.data.A05_2004_GF2004NB30502105,root.data.A05_2004_GF2004NB30502102,root.data.A05_2004_GF2004NB30502103,root.data.A05_2004_GF2004NB30502101,root.data.A05_2004_GF2004NB30401510,root.data.A05_2004_GF2004NB30401512,root.data.A05_2004_GF2004NB30401511,root.data.A05_2004_GF2004NB30401415,root.data.A05_2004_GF2004NB30401414,root.data.A05_2004_GF2004NB30401417,root.data.A05_2004_GF2004NB30401416,root.data.A05_2004_GF2004NB30300915,root.data.A05_2004_GF2004NB30300916,root.data.A05_2004_GF2004NB30300917,root.data.A05_2004_GF2004NB30300911,root.data.A05_2004_GF2004NB30502315,root.data.A05_2004_GF2004NB30300912,root.data.A05_2004_GF2004NB30502316,root.data.A05_2004_GF2004NB30300913,root.data.A05_2004_GF2004NB30502313,root.data.A05_2004_GF2004NB30300914,root.data.A05_2004_GF2004NB30502314,root.data.A05_2004_GF2004NB30502311,root.data.A05_2004_GF2004NB30502312,root.data.A05_2004_GF2004NB30300910,root.data.A05_2004_GF2004NB30502310,root.data.A05_2004_GF2004NB30502308,root.data.A05_2004_GF2004NB30502309,root.data.A05_2004_GF2004NB30502306,root.data.A05_2004_GF2004NB30502307,root.data.A05_2004_GF2004NB30401301,root.data.A05_2004_GF2004NB30401303,root.data.A05_2004_GF2004NB30401302,root.data.A05_2004_GF2004NB30300908,root.data.A05_2004_GF2004NB30401404,root.data.A05_2004_GF2004NB30300909,root.data.A05_2004_GF2004NB30401403,root.data.A05_2004_GF2004NB30401406,root.data.A05_2004_GF2004NB30401405,root.data.A05_2004_GF2004NB30300904,root.data.A05_2004_GF2004NB30401408,root.data.A05_2004_GF2004NB30300905,root.data.A05_2004_GF2004NB30401407,root.data.A05_2004_GF2004NB30300906,root.data.A05_2004_GF2004NB30300907,root.data.A05_2004_GF2004NB30401409,root.data.A05_2004_GF2004NB30502205,root.data.A05_2004_GF2004NB30300901,root.data.A05_2004_GF2004NB30502206,root.data.A05_2004_GF2004NB30300902,root.data.A05_2004_GF2004NB30502203,root.data.A05_2004_GF2004NB30300903,root.data.A05_2004_GF2004NB30502204,root.data.A05_2004_GF2004NB30502201,root.data.A05_2004_GF2004NB30502202,root.data.A05_2004_GF2004NB30502317,root.data.A05_2004_GF2004NB30401411,root.data.A05_2004_GF2004NB30401410,root.data.A05_2004_GF2004NB30401413,root.data.A05_2004_GF2004NB30401412,root.data.A05_2004_GF2004NB30400501,root.data.A05_2004_GF2004NB30502010,root.data.A05_2004_GF2004NB30400502,root.data.A05_2004_GF2004NB30502011,root.data.A05_2004_GF2004NB30400503,root.data.A05_2004_GF2004NB30400504,root.data.A05_2004_GF2004NB30400505,root.data.A05_2004_GF2004NB30400506,root.data.A05_2004_GF2004NB30400507,root.data.A05_2004_GF2004NB30400508,root.data.A05_2004_GF2004NB30400509,root.data.A05_2004_GF2004NB30502016,root.data.A05_2004_GF2004NB30502017,root.data.A05_2004_GF2004NB30502014,root.data.A05_2004_GF2004NB30502015,root.data.A05_2004_GF2004NB30502012,root.data.A05_2004_GF2004NB30502013,root.data.A05_2004_GF2004NB30502009,root.data.A05_2004_GF2004NB30400510,root.data.A05_2004_GF2004NB30400511,root.data.A05_2004_GF2004NB30502110,root.data.A05_2004_GF2004NB30502113,root.data.A05_2004_GF2004NB30502114,root.data.A05_2004_GF2004NB30502111,root.data.A05_2004_GF2004NB30502112,root.data.A05_2004_GF2004NB30502108,root.data.A05_2004_GF2004NB30502109,root.data.A05_2004_GF2004NB30401501,root.data.A05_2004_GF2004NB30400512,root.data.A05_2004_GF2004NB30400513,root.data.A05_2004_GF2004NB30400514,root.data.A05_2004_GF2004NB30600709,root.data.A05_2004_GF2004NB30400515,root.data.A05_2004_GF2004NB30400516,root.data.A05_2004_GF2004NB30400517,root.data.A05_2004_GF2004NB30502007,root.data.A05_2004_GF2004NB30600703,root.data.A05_2004_GF2004NB30502008,root.data.A05_2004_GF2004NB30600704,root.data.A05_2004_GF2004NB30502005,root.data.A05_2004_GF2004NB30600701,root.data.A05_2004_GF2004NB30502006,root.data.A05_2004_GF2004NB30600702,root.data.A05_2004_GF2004NB30502003,root.data.A05_2004_GF2004NB30600707,root.data.A05_2004_GF2004NB30502004,root.data.A05_2004_GF2004NB30600708,root.data.A05_2004_GF2004NB30502001,root.data.A05_2004_GF2004NB30600705,root.data.A05_2004_GF2004NB30502002,root.data.A05_2004_GF2004NB30600706,root.data.A05_2004_GF2004NB30600710,root.data.A05_2004_GF2004NB30600711,root.data.A05_2004_GF2004NB30401117,root.data.A05_2004_GF2004NB30600714,root.data.A05_2004_GF2004NB30600715,root.data.A05_2004_GF2004NB30600712,root.data.A05_2004_GF2004NB30600713,root.data.A05_2004_GF2004NB30600716,root.data.A05_2004_GF2004NB30600717,root.data.A05_2004_GF2004NB30600601,root.data.A05_2004_GF2004NB30401107,root.data.A05_2004_GF2004NB30401106,root.data.A05_2004_GF2004NB30401109,root.data.A05_2004_GF2004NB30401108,root.data.A05_2004_GF2004NB30602909,root.data.A05_2004_GF2004NB30301615,root.data.A05_2004_GF2004NB30602904,root.data.A05_2004_GF2004NB30600604,root.data.A05_2004_GF2004NB30301616,root.data.A05_2004_GF2004NB30602903,root.data.A05_2004_GF2004NB30600605,root.data.A05_2004_GF2004NB30301617,root.data.A05_2004_GF2004NB30602902,root.data.A05_2004_GF2004NB30600602,root.data.A05_2004_GF2004NB30602901,root.data.A05_2004_GF2004NB30600603,root.data.A05_2004_GF2004NB30301611,root.data.A05_2004_GF2004NB30602908,root.data.A05_2004_GF2004NB30600608,root.data.A05_2004_GF2004NB30301612,root.data.A05_2004_GF2004NB30602907,root.data.A05_2004_GF2004NB30600609,root.data.A05_2004_GF2004NB30301613,root.data.A05_2004_GF2004NB30602906,root.data.A05_2004_GF2004NB30600606,root.data.A05_2004_GF2004NB30301614,root.data.A05_2004_GF2004NB30602905,root.data.A05_2004_GF2004NB30600607,root.data.A05_2004_GF2004NB30602911,root.data.A05_2004_GF2004NB30600611,root.data.A05_2004_GF2004NB30602910,root.data.A05_2004_GF2004NB30600612,root.data.A05_2004_GF2004NB30600610,root.data.A05_2004_GF2004NB30401110,root.data.A05_2004_GF2004NB30401112,root.data.A05_2004_GF2004NB30401111,root.data.A05_2004_GF2004NB30401114,root.data.A05_2004_GF2004NB30401113,root.data.A05_2004_GF2004NB30401116,root.data.A05_2004_GF2004NB30401115,root.data.A05_2004_GF2004NB30301608,root.data.A05_2004_GF2004NB30301609,root.data.A05_2004_GF2004NB30301604,root.data.A05_2004_GF2004NB30602915,root.data.A05_2004_GF2004NB30600615,root.data.A05_2004_GF2004NB30301605,root.data.A05_2004_GF2004NB30602914,root.data.A05_2004_GF2004NB30600616,root.data.A05_2004_GF2004NB30301606,root.data.A05_2004_GF2004NB30602913,root.data.A05_2004_GF2004NB30600613,root.data.A05_2004_GF2004NB30301607,root.data.A05_2004_GF2004NB30602912,root.data.A05_2004_GF2004NB30600614,root.data.A05_2004_GF2004NB30301601,root.data.A05_2004_GF2004NB30301602,root.data.A05_2004_GF2004NB30600617,root.data.A05_2004_GF2004NB30301603,root.data.A05_2004_GF2004NB30602916,root.data.A05_2004_GF2004NB30301610,root.data.A05_2004_GF2004NB30602801,root.data.A05_2004_GF2004NB30301714,root.data.A05_2004_GF2004NB30602805,root.data.A05_2004_GF2004NB30301715,root.data.A05_2004_GF2004NB30602804,root.data.A05_2004_GF2004NB30301716,root.data.A05_2004_GF2004NB30602803,root.data.A05_2004_GF2004NB30301717,root.data.A05_2004_GF2004NB30602802,root.data.A05_2004_GF2004NB30301710,root.data.A05_2004_GF2004NB30602809,root.data.A05_2004_GF2004NB30301711,root.data.A05_2004_GF2004NB30602808,root.data.A05_2004_GF2004NB30301712,root.data.A05_2004_GF2004NB30602807,root.data.A05_2004_GF2004NB30301713,root.data.A05_2004_GF2004NB30602806,root.data.A05_2004_GF2004NB30602812,root.data.A05_2004_GF2004NB30602811,root.data.A05_2004_GF2004NB30602810,root.data.A05_2004_GF2004NB30401316,root.data.A05_2004_GF2004NB30401315,root.data.A05_2004_GF2004NB30401317,root.data.A05_2004_GF2004NB30301707,root.data.A05_2004_GF2004NB30301708,root.data.A05_2004_GF2004NB30301709,root.data.A05_2004_GF2004NB30301703,root.data.A05_2004_GF2004NB30301704,root.data.A05_2004_GF2004NB30301705,root.data.A05_2004_GF2004NB30602814,root.data.A05_2004_GF2004NB30301706,root.data.A05_2004_GF2004NB30602813,root.data.A05_2004_GF2004NB30301701,root.data.A05_2004_GF2004NB30301702,root.data.A05_2004_GF2004NB30602702,root.data.A05_2004_GF2004NB30602701,root.data.A05_2004_GF2004NB30401202,root.data.A05_2004_GF2004NB30401201,root.data.A05_2004_GF2004NB30401204,root.data.A05_2004_GF2004NB30401203,root.data.A05_2004_GF2004NB30401305,root.data.A05_2004_GF2004NB30401304,root.data.A05_2004_GF2004NB30401307,root.data.A05_2004_GF2004NB30401306,root.data.A05_2004_GF2004NB30401309,root.data.A05_2004_GF2004NB30401308,root.data.A05_2004_GF2004NB30602706,root.data.A05_2004_GF2004NB30602705,root.data.A05_2004_GF2004NB30602704,root.data.A05_2004_GF2004NB30602703,root.data.A05_2004_GF2004NB30602709,root.data.A05_2004_GF2004NB30602708,root.data.A05_2004_GF2004NB30602707,root.data.A05_2004_GF2004NB30602713,root.data.A05_2004_GF2004NB30602712,root.data.A05_2004_GF2004NB30602711,root.data.A05_2004_GF2004NB30602710,root.data.A05_2004_GF2004NB30401310,root.data.A05_2004_GF2004NB30401312,root.data.A05_2004_GF2004NB30401311,root.data.A05_2004_GF2004NB30401314,root.data.A05_2004_GF2004NB30401313,root.data.A05_2004_GF2004NB30401217,root.data.A05_2004_GF2004NB30401216,root.data.A05_2004_GF2004NB30602717,root.data.A05_2004_GF2004NB30602716,root.data.A05_2004_GF2004NB30602715,root.data.A05_2004_GF2004NB30602714,root.data.A05_2004_GF2004NB30602603,root.data.A05_2004_GF2004NB30602602,root.data.A05_2004_GF2004NB30602601,root.data.A05_2004_GF2004NB30401101,root.data.A05_2004_GF2004NB30401103,root.data.A05_2004_GF2004NB30401102,root.data.A05_2004_GF2004NB30401105,root.data.A05_2004_GF2004NB30401104,root.data.A05_2004_GF2004NB30401206,root.data.A05_2004_GF2004NB30401205,root.data.A05_2004_GF2004NB30401208,root.data.A05_2004_GF2004NB30401207,root.data.A05_2004_GF2004NB30401209,root.data.A05_2004_GF2004NB30602607,root.data.A05_2004_GF2004NB30602606,root.data.A05_2004_GF2004NB30602605,root.data.A05_2004_GF2004NB30602604,root.data.A05_2004_GF2004NB30602609,root.data.A05_2004_GF2004NB30602608,root.data.A05_2004_GF2004NB30602610,root.data.A05_2004_GF2004NB30602614,root.data.A05_2004_GF2004NB30602613,root.data.A05_2004_GF2004NB30602612,root.data.A05_2004_GF2004NB30602611,root.data.A05_2004_GF2004NB30401211,root.data.A05_2004_GF2004NB30401210,root.data.A05_2004_GF2004NB30401213,root.data.A05_2004_GF2004NB30401212,root.data.A05_2004_GF2004NB30401215,root.data.A05_2004_GF2004NB30401214,root.data.A05_2004_GF2004NB30602617,root.data.A05_2004_GF2004NB30602616,root.data.A05_2004_GF2004NB30602615,root.data.A05_2004_GF2004NB30501916,root.data.A05_2004_GF2004NB30501917,root.data.A05_2004_GF2004NB30501914,root.data.A05_2004_GF2004NB30501915,root.data.A05_2004_GF2004NB30501912,root.data.A05_2004_GF2004NB30602504,root.data.A05_2004_GF2004NB30501913,root.data.A05_2004_GF2004NB30602503,root.data.A05_2004_GF2004NB30501910,root.data.A05_2004_GF2004NB30602502,root.data.A05_2004_GF2004NB30501911,root.data.A05_2004_GF2004NB30602501,root.data.A05_2004_GF2004NB30602508,root.data.A05_2004_GF2004NB30501810,root.data.A05_2004_GF2004NB30602507,root.data.A05_2004_GF2004NB30602506,root.data.A05_2004_GF2004NB30602505,root.data.A05_2004_GF2004NB30602509,root.data.A05_2004_GF2004NB30501806,root.data.A05_2004_GF2004NB30602511,root.data.A05_2004_GF2004NB30501807,root.data.A05_2004_GF2004NB30602510,root.data.A05_2004_GF2004NB30501804,root.data.A05_2004_GF2004NB30501805,root.data.A05_2004_GF2004NB30501802,root.data.A05_2004_GF2004NB30602515,root.data.A05_2004_GF2004NB30501803,root.data.A05_2004_GF2004NB30602514,root.data.A05_2004_GF2004NB30602513,root.data.A05_2004_GF2004NB30501801,root.data.A05_2004_GF2004NB30602512,root.data.A05_2004_GF2004NB30501808,root.data.A05_2004_GF2004NB30501809,root.data.A05_2004_GF2004NB30602517,root.data.A05_2004_GF2004NB30602516,root.data.A05_2004_GF2004NB30501905,root.data.A05_2004_GF2004NB30501906,root.data.A05_2004_GF2004NB30501903,root.data.A05_2004_GF2004NB30501904,root.data.A05_2004_GF2004NB30501901,root.data.A05_2004_GF2004NB30501902,root.data.A05_2004_GF2004NB30501909,root.data.A05_2004_GF2004NB30501907,root.data.A05_2004_GF2004NB30501908,root.data.A05_2004_GF2004NB30700117,root.data.A05_2004_GF2004NB30700116,root.data.A05_2004_GF2004NB30700115,root.data.A05_2004_GF2004NB30700114,root.data.A05_2004_GF2004NB30700113,root.data.A05_2004_GF2004NB30700112,root.data.A05_2004_GF2004NB30700111,root.data.A05_2004_GF2004NB30700110,root.data.A05_2004_GF2004NB30700109,root.data.A05_2004_GF2004NB30700108,root.data.A05_2004_GF2004NB30501817,root.data.A05_2004_GF2004NB30501815,root.data.A05_2004_GF2004NB30501816,root.data.A05_2004_GF2004NB30501813,root.data.A05_2004_GF2004NB30501814,root.data.A05_2004_GF2004NB30501811,root.data.A05_2004_GF2004NB30501812,root.data.A05_2004_GF2004NB30700206,root.data.A05_2004_GF2004NB30700205,root.data.A05_2004_GF2004NB30700204,root.data.A05_2004_GF2004NB30700203,root.data.A05_2004_GF2004NB30700202,root.data.A05_2004_GF2004NB30700201,root.data.A05_2004_GF2004NB30700313,root.data.A05_2004_GF2004NB30700312,root.data.A05_2004_GF2004NB30700311,root.data.A05_2004_GF2004NB30700310,root.data.A05_2004_GF2004NB30700309,root.data.A05_2004_GF2004NB30700308,root.data.A05_2004_GF2004NB30700307,root.data.A05_2004_GF2004NB30700306,root.data.A05_2004_GF2004NB30700107,root.data.A05_2004_GF2004NB30700106,root.data.A05_2004_GF2004NB30700105,root.data.A05_2004_GF2004NB30700104,root.data.A05_2004_GF2004NB30700103,root.data.A05_2004_GF2004NB30700102,root.data.A05_2004_GF2004NB30700101,root.data.A05_2004_GF2004NB30700217,root.data.A05_2004_GF2004NB30700216,root.data.A05_2004_GF2004NB30700215,root.data.A05_2004_GF2004NB30700214,root.data.A05_2004_GF2004NB30700213,root.data.A05_2004_GF2004NB30700212,root.data.A05_2004_GF2004NB30700211,root.data.A05_2004_GF2004NB30700210,root.data.A05_2004,root.data.A05_2004_GF2004NB30700209,root.data.A05_2004_GF2004NB30700208,root.data.A05_2004_GF2004NB30700207,root.data.A05_2004_GF2004NB30700404,root.data.A05_2004_GF2004NB30700403,root.data.A05_2004_GF2004NB30700402,root.data.A05_2004_GF2004NB30700401,root.data.A05_2004_GF2004NB30502414,root.data.A05_2004_GF2004NB30502415,root.data.A05_2004_GF2004NB30502412,root.data.A05_2004_GF2004NB30502413,root.data.A05_2004_GF2004NB30502410,root.data.A05_2004_GF2004NB30502411,root.data.A05_2004_GF2004NB30502409,root.data.A05_2004_GF2004NB30502407,root.data.A05_2004_GF2004NB30502408,root.data.A05_2004_GF2004NB30502405,root.data.A05_2004_GF2004NB30502406,root.data.A05_2004_GF2004NB30502304,root.data.A05_2004_GF2004NB30502305,root.data.A05_2004_GF2004NB30502302,root.data.A05_2004_GF2004NB30502303,root.data.A05_2004_GF2004NB30301017,root.data.A05_2004_GF2004NB30502301,root.data.A05_2004_GF2004NB30603006,root.data.A05_2004_GF2004NB30603005,root.data.A05_2004_GF2004NB30603004,root.data.A05_2004_GF2004NB30603003,root.data.A05_2004_GF2004NB30603009,root.data.A05_2004_GF2004NB30502416,root.data.A05_2004_GF2004NB30603008,root.data.A05_2004_GF2004NB30502417,root.data.A05_2004_GF2004NB30603007,root.data.A05_2004_GF2004NB30603002,root.data.A05_2004_GF2004NB30603001,root.data.A05_2004_GF2004NB30700305,root.data.A05_2004_GF2004NB30700304,root.data.A05_2004_GF2004NB30700303,root.data.A05_2004_GF2004NB30700302,root.data.A05_2004_GF2004NB30700301,root.data.A05_2004_GF2004NB30301006,root.data.A05_2004_GF2004NB30301007,root.data.A05_2004_GF2004NB30301008,root.data.A05_2004_GF2004NB30301009,root.data.A05_2004_GF2004NB30301013,root.data.A05_2004_GF2004NB30603017,root.data.A05_2004_GF2004NB30301014,root.data.A05_2004_GF2004NB30603016,root.data.A05_2004_GF2004NB30301015,root.data.A05_2004_GF2004NB30603015,root.data.A05_2004_GF2004NB30301016,root.data.A05_2004_GF2004NB30603014,root.data.A05_2004_GF2004NB30301010,root.data.A05_2004_GF2004NB30301011,root.data.A05_2004_GF2004NB30301012,root.data.A05_2004_GF2004NB30603013,root.data.A05_2004_GF2004NB30603012,root.data.A05_2004_GF2004NB30603011,root.data.A05_2004_GF2004NB30603010,root.data.A05_2004_GF2004NB30700415,root.data.A05_2004_GF2004NB30700414,root.data.A05_2004_GF2004NB30700413,root.data.A05_2004_GF2004NB30700412,root.data.A05_2004_GF2004NB30700411,root.data.A05_2004_GF2004NB30700410,root.data.A05_2004_GF2004NB30502403,root.data.A05_2004_GF2004NB30502404,root.data.A05_2004_GF2004NB30502401,root.data.A05_2004_GF2004NB30502402,root.data.A05_2004_GF2004NB30301002,root.data.A05_2004_GF2004NB30301003,root.data.A05_2004_GF2004NB30301004,root.data.A05_2004_GF2004NB30301005,root.data.A05_2004_GF2004NB30301001,root.data.A05_2004_GF2004NB30700409,root.data.A05_2004_GF2004NB30700408,root.data.A05_2004_GF2004NB30700407,root.data.A05_2004_GF2004NB30700406,root.data.A05_2004_GF2004NB30700405 where time < 1711679840000
```

<img width="775" alt="image" src="https://github.com/apache/iotdb/assets/43774645/e315942a-233a-4998-a2dd-68215f89da08">


====== Consume Time: 11343

## Analyze

<img width="780" alt="image" src="https://github.com/apache/iotdb/assets/43774645/858598f3-35ed-4b47-8ac8-b02409464a9f">

Found that almost all time is cost on `appendPathPattern`.

## Solution

1. Skip re-construct pattern when using root user.
2. Skip checking when appendPathPattern without wildcard

After optimization, consume time is 11. Reduced time by 99.8%.