### PR TITLE
Fix recover duplicate

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/file/TsFilePlanRedoer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/file/TsFilePlanRedoer.java
@@ -41,15 +41,11 @@ import java.util.List;
  */
 public class TsFilePlanRedoer {
   private final TsFileResource tsFileResource;
-  // only unsequence file tolerates duplicated data
-  private final boolean sequence;
-
   // store data when redoing logs
   private IMemTable recoveryMemTable;
 
-  public TsFilePlanRedoer(TsFileResource tsFileResource, boolean sequence) {
+  public TsFilePlanRedoer(TsFileResource tsFileResource) {
     this.tsFileResource = tsFileResource;
-    this.sequence = sequence;
     this.recoveryMemTable =
         new PrimitiveMemTable(tsFileResource.getDatabaseName(), tsFileResource.getDataRegionId());
     WritingMetrics.getInstance().recordActiveMemTableCount(tsFileResource.getDataRegionId(), 1);
@@ -89,7 +85,7 @@ public class TsFilePlanRedoer {
       } else {
         minTimeInNode = ((InsertTabletNode) node).getTimes()[0];
       }
-      if (lastEndTime != Long.MIN_VALUE && lastEndTime >= minTimeInNode && sequence) {
+      if (lastEndTime != Long.MIN_VALUE && lastEndTime >= minTimeInNode) {
         return;
       }
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/file/UnsealedTsFileRecoverPerformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/file/UnsealedTsFileRecoverPerformer.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.storageengine.dataregion.wal.recover.file;
 
+import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.exception.DataRegionException;
 import org.apache.iotdb.db.pipe.agent.PipeAgent;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.DeleteDataNode;
@@ -188,6 +189,15 @@ public class UnsealedTsFileRecoverPerformer extends AbstractTsFileRecoverPerform
         case MEMORY_TABLE_SNAPSHOT:
           IMemTable memTable = (IMemTable) walEntry.getValue();
           if (!memTable.isSignalMemTable()) {
+            if (tsFileResource != null) {
+              for (IDeviceID device : tsFileResource.getDevices()) {
+                memTable.delete(
+                    new PartialPath(device, "*"),
+                    new PartialPath(device),
+                    tsFileResource.getStartTime(device),
+                    tsFileResource.getEndTime(device));
+              }
+            }
             walRedoer.resetRecoveryMemTable(memTable);
           }
           // update memtable's database and dataRegionId

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/file/UnsealedTsFileRecoverPerformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/file/UnsealedTsFileRecoverPerformer.java
@@ -80,7 +80,7 @@ public class UnsealedTsFileRecoverPerformer extends AbstractTsFileRecoverPerform
     this.dataRegionId = tsFileResource.getDataRegionId();
     this.sequence = sequence;
     this.callbackAfterUnsealedTsFileRecovered = callbackAfterUnsealedTsFileRecovered;
-    this.walRedoer = new TsFilePlanRedoer(tsFileResource, sequence);
+    this.walRedoer = new TsFilePlanRedoer(tsFileResource);
     this.recoverListener = new WALRecoverListener(tsFileResource.getTsFilePath());
   }
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/file/TsFilePlanRedoerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/file/TsFilePlanRedoerTest.java
@@ -146,7 +146,7 @@ public class TsFilePlanRedoerTest {
         });
 
     // redo InsertTabletPlan, vsg processor is used to test IdTable, don't test IdTable here
-    TsFilePlanRedoer planRedoer = new TsFilePlanRedoer(tsFileResource, true);
+    TsFilePlanRedoer planRedoer = new TsFilePlanRedoer(tsFileResource);
     planRedoer.redoInsert(insertRowNode);
 
     // check data in memTable
@@ -238,7 +238,7 @@ public class TsFilePlanRedoerTest {
         });
 
     // redo InsertTabletPlan, vsg processor is used to test IdTable, don't test IdTable here
-    TsFilePlanRedoer planRedoer = new TsFilePlanRedoer(tsFileResource, true);
+    TsFilePlanRedoer planRedoer = new TsFilePlanRedoer(tsFileResource);
     planRedoer.redoInsert(insertRowNode1);
     planRedoer.redoInsert(insertRowNode2);
 
@@ -326,7 +326,7 @@ public class TsFilePlanRedoerTest {
         });
 
     // redo InsertTabletPlan, vsg processor is used to test IdTable, don't test IdTable here
-    TsFilePlanRedoer planRedoer = new TsFilePlanRedoer(tsFileResource, true);
+    TsFilePlanRedoer planRedoer = new TsFilePlanRedoer(tsFileResource);
     planRedoer.redoInsert(insertTabletNode);
 
     // check data in memTable
@@ -432,7 +432,7 @@ public class TsFilePlanRedoerTest {
         });
 
     // redo InsertTabletPlan, vsg processor is used to test IdTable, don't test IdTable here
-    TsFilePlanRedoer planRedoer = new TsFilePlanRedoer(tsFileResource, true);
+    TsFilePlanRedoer planRedoer = new TsFilePlanRedoer(tsFileResource);
     planRedoer.redoInsert(insertTabletNode);
 
     // check data in memTable
@@ -510,7 +510,7 @@ public class TsFilePlanRedoerTest {
             times.length);
 
     // redo InsertTabletPlan, vsg processor is used to test IdTable, don't test IdTable here
-    TsFilePlanRedoer planRedoer = new TsFilePlanRedoer(tsFileResource, true);
+    TsFilePlanRedoer planRedoer = new TsFilePlanRedoer(tsFileResource);
     planRedoer.redoInsert(insertTabletNode);
 
     // check data in memTable
@@ -561,7 +561,7 @@ public class TsFilePlanRedoerTest {
             times.length);
 
     // redo InsertTabletPlan, vsg processor is used to test IdTable, don't test IdTable here
-    TsFilePlanRedoer planRedoer = new TsFilePlanRedoer(tsFileResource, false);
+    TsFilePlanRedoer planRedoer = new TsFilePlanRedoer(tsFileResource);
     planRedoer.redoInsert(insertTabletNode);
 
     // check data in memTable
@@ -619,7 +619,7 @@ public class TsFilePlanRedoerTest {
     // redo DeleteDataNode, vsg processor is used to test IdTable, don't test IdTable here
     File modsFile = new File(FILE_NAME.concat(ModificationFile.FILE_SUFFIX));
     assertFalse(modsFile.exists());
-    TsFilePlanRedoer planRedoer = new TsFilePlanRedoer(tsFileResource, false);
+    TsFilePlanRedoer planRedoer = new TsFilePlanRedoer(tsFileResource);
     planRedoer.redoDelete(deleteDataNode);
     assertTrue(modsFile.exists());
   }
@@ -692,7 +692,7 @@ public class TsFilePlanRedoerTest {
             columns,
             times.length);
     // redo InsertTabletPlan, data region is used to test IdTable, don't test IdTable here
-    TsFilePlanRedoer planRedoer = new TsFilePlanRedoer(tsFileResource, true);
+    TsFilePlanRedoer planRedoer = new TsFilePlanRedoer(tsFileResource);
     insertTabletNode.setMeasurementSchemas(schemas);
     planRedoer.redoInsert(insertTabletNode);
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/file/TsFilePlanRedoerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/file/TsFilePlanRedoerTest.java
@@ -572,29 +572,13 @@ public class TsFilePlanRedoerTest {
             DEVICE1_NAME, "s1", new MeasurementSchema("s1", TSDataType.INT32, TSEncoding.RLE));
     ReadOnlyMemChunk memChunk =
         recoveryMemTable.query(new QueryContext(), fullPath, Long.MIN_VALUE, null);
-    IPointReader iterator = memChunk.getPointReader();
-    int time = 1;
-    while (iterator.hasNextTimeValuePair()) {
-      TimeValuePair timeValuePair = iterator.nextTimeValuePair();
-      assertEquals(time, timeValuePair.getTimestamp());
-      assertEquals(100, timeValuePair.getValue().getInt());
-      ++time;
-    }
-    assertEquals(3, time);
+    assertTrue(memChunk == null || memChunk.isEmpty());
     // check d1.s2
     fullPath =
         new MeasurementPath(
             DEVICE1_NAME, "s2", new MeasurementSchema("s2", TSDataType.INT64, TSEncoding.RLE));
     memChunk = recoveryMemTable.query(new QueryContext(), fullPath, Long.MIN_VALUE, null);
-    iterator = memChunk.getPointReader();
-    time = 1;
-    while (iterator.hasNextTimeValuePair()) {
-      TimeValuePair timeValuePair = iterator.nextTimeValuePair();
-      assertEquals(time, timeValuePair.getTimestamp());
-      assertEquals(10000, timeValuePair.getValue().getLong());
-      ++time;
-    }
-    assertEquals(3, time);
+    assertTrue(memChunk == null || memChunk.isEmpty());
   }
 
   @Test


### PR DESCRIPTION
## Description
This pr fix two problems of recover:
1. When recover a snapshot memTable WALEntry, the overlap check is skipped. 
2. The overlap check of unsequence file is skipped.

If the overlap check is not performed correctly, the TsFile may have repeated data after recover, which cause compaction failed.