### PR TITLE
Remove Repair Data ClusterIT

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBRepairDataIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBRepairDataIT.java
@@ -22,7 +22,6 @@ package org.apache.iotdb.db.it;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.generator.TsFileNameGenerator;
 import org.apache.iotdb.it.env.EnvFactory;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
-import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 import org.apache.iotdb.tsfile.file.metadata.PlainDeviceID;
 import org.apache.iotdb.tsfile.file.metadata.enums.TSDataType;
@@ -51,7 +50,7 @@ import static org.apache.iotdb.db.utils.constant.TestConstant.TIMESTAMP_STR;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(IoTDBTestRunner.class)
-@Category({LocalStandaloneIT.class, ClusterIT.class})
+@Category({LocalStandaloneIT.class})
 public class IoTDBRepairDataIT {
 
   @BeforeClass


### PR DESCRIPTION
## Description
Remove Repair Data ClusterIT
The ClusterIT will compare the query result of all nodes, which may cause the repair data test failed.