### PR TITLE
Reduce synchronized cost in compaction

### DIFF
--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/UnsynchronizedPublicBAOS.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/UnsynchronizedPublicBAOS.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.tsfile.utils;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+
+/**
+ * This class extends ByteArrayOutputStream and intentionally remove the 'synchronized' keyword in
+ * write methods for better performance. (Not thread safe)
+ */
+public class UnsynchronizedPublicBAOS extends PublicBAOS {
+  private void ensureCapacity(int minCapacity) {
+    // overflow-conscious code
+    if (minCapacity - buf.length > 0) grow(minCapacity);
+  }
+
+  private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+
+  private void grow(int minCapacity) {
+    // overflow-conscious code
+    int oldCapacity = buf.length;
+    int newCapacity = oldCapacity << 1;
+    if (newCapacity - minCapacity < 0) newCapacity = minCapacity;
+    if (newCapacity - MAX_ARRAY_SIZE > 0) newCapacity = hugeCapacity(minCapacity);
+    buf = Arrays.copyOf(buf, newCapacity);
+  }
+
+  private static int hugeCapacity(int minCapacity) {
+    if (minCapacity < 0) // overflow
+    throw new OutOfMemoryError();
+    return (minCapacity > MAX_ARRAY_SIZE) ? Integer.MAX_VALUE : MAX_ARRAY_SIZE;
+  }
+
+  @Override
+  public void write(int b) {
+    ensureCapacity(count + 1);
+    buf[count] = (byte) b;
+    count += 1;
+  }
+
+  @Override
+  public void write(byte b[], int off, int len) {
+    if ((off < 0) || (off > b.length) || (len < 0) || ((off + len) - b.length > 0)) {
+      throw new IndexOutOfBoundsException();
+    }
+    ensureCapacity(count + len);
+    System.arraycopy(b, off, buf, count, len);
+    count += len;
+  }
+
+  @Override
+  public byte[] toByteArray() {
+    return Arrays.copyOf(buf, count);
+  }
+
+  @Override
+  public String toString() {
+    return new String(buf, 0, count);
+  }
+
+  @Override
+  public String toString(String charsetName) throws UnsupportedEncodingException {
+    return new String(buf, 0, count, charsetName);
+  }
+}

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ChunkWriterImpl.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ChunkWriterImpl.java
@@ -29,6 +29,7 @@ import org.apache.iotdb.tsfile.file.metadata.statistics.Statistics;
 import org.apache.iotdb.tsfile.utils.Binary;
 import org.apache.iotdb.tsfile.utils.PublicBAOS;
 import org.apache.iotdb.tsfile.utils.ReadWriteForEncodingUtils;
+import org.apache.iotdb.tsfile.utils.UnsynchronizedPublicBAOS;
 import org.apache.iotdb.tsfile.write.page.PageWriter;
 import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
 import org.apache.iotdb.tsfile.write.writer.TsFileIOWriter;
@@ -96,7 +97,7 @@ public class ChunkWriterImpl implements IChunkWriter {
   public ChunkWriterImpl(IMeasurementSchema schema) {
     this.measurementSchema = schema;
     this.compressor = ICompressor.getCompressor(schema.getCompressor());
-    this.pageBuffer = new PublicBAOS();
+    this.pageBuffer = new UnsynchronizedPublicBAOS();
 
     this.pageSizeThreshold = TSFileDescriptor.getInstance().getConfig().getPageSizeInByte();
     this.maxNumberOfPointsInPage =

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/TimeChunkWriter.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/TimeChunkWriter.java
@@ -32,6 +32,7 @@ import org.apache.iotdb.tsfile.file.metadata.statistics.Statistics;
 import org.apache.iotdb.tsfile.file.metadata.statistics.TimeStatistics;
 import org.apache.iotdb.tsfile.utils.PublicBAOS;
 import org.apache.iotdb.tsfile.utils.ReadWriteForEncodingUtils;
+import org.apache.iotdb.tsfile.utils.UnsynchronizedPublicBAOS;
 import org.apache.iotdb.tsfile.write.page.TimePageWriter;
 import org.apache.iotdb.tsfile.write.writer.TsFileIOWriter;
 
@@ -88,7 +89,7 @@ public class TimeChunkWriter {
     this.measurementId = measurementId;
     this.encodingType = encodingType;
     this.compressionType = compressionType;
-    this.pageBuffer = new PublicBAOS();
+    this.pageBuffer = new UnsynchronizedPublicBAOS();
 
     this.pageSizeThreshold = TSFileDescriptor.getInstance().getConfig().getPageSizeInByte();
     this.maxNumberOfPointsInPage =

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ValueChunkWriter.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/chunk/ValueChunkWriter.java
@@ -32,6 +32,7 @@ import org.apache.iotdb.tsfile.file.metadata.statistics.Statistics;
 import org.apache.iotdb.tsfile.utils.Binary;
 import org.apache.iotdb.tsfile.utils.PublicBAOS;
 import org.apache.iotdb.tsfile.utils.ReadWriteForEncodingUtils;
+import org.apache.iotdb.tsfile.utils.UnsynchronizedPublicBAOS;
 import org.apache.iotdb.tsfile.write.page.ValuePageWriter;
 import org.apache.iotdb.tsfile.write.writer.TsFileIOWriter;
 
@@ -93,7 +94,7 @@ public class ValueChunkWriter {
     this.encodingType = encodingType;
     this.dataType = dataType;
     this.compressionType = compressionType;
-    this.pageBuffer = new PublicBAOS();
+    this.pageBuffer = new UnsynchronizedPublicBAOS();
     this.pageSizeThreshold = TSFileDescriptor.getInstance().getConfig().getPageSizeInByte();
     this.maxNumberOfPointsInPage =
         TSFileDescriptor.getInstance().getConfig().getMaxNumberOfPointsInPage();

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/page/PageWriter.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/page/PageWriter.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.tsfile.file.metadata.statistics.Statistics;
 import org.apache.iotdb.tsfile.utils.Binary;
 import org.apache.iotdb.tsfile.utils.PublicBAOS;
 import org.apache.iotdb.tsfile.utils.ReadWriteForEncodingUtils;
+import org.apache.iotdb.tsfile.utils.UnsynchronizedPublicBAOS;
 import org.apache.iotdb.tsfile.write.schema.IMeasurementSchema;
 
 import org.slf4j.Logger;
@@ -71,8 +72,8 @@ public class PageWriter {
   }
 
   private PageWriter(Encoder timeEncoder, Encoder valueEncoder) {
-    this.timeOut = new PublicBAOS();
-    this.valueOut = new PublicBAOS();
+    this.timeOut = new UnsynchronizedPublicBAOS();
+    this.valueOut = new UnsynchronizedPublicBAOS();
     this.timeEncoder = timeEncoder;
     this.valueEncoder = valueEncoder;
   }

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/page/TimePageWriter.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/page/TimePageWriter.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.tsfile.file.metadata.enums.CompressionType;
 import org.apache.iotdb.tsfile.file.metadata.statistics.TimeStatistics;
 import org.apache.iotdb.tsfile.utils.PublicBAOS;
 import org.apache.iotdb.tsfile.utils.ReadWriteForEncodingUtils;
+import org.apache.iotdb.tsfile.utils.UnsynchronizedPublicBAOS;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,7 +55,7 @@ public class TimePageWriter {
   private TimeStatistics statistics;
 
   public TimePageWriter(Encoder timeEncoder, ICompressor compressor) {
-    this.timeOut = new PublicBAOS();
+    this.timeOut = new UnsynchronizedPublicBAOS();
     this.timeEncoder = timeEncoder;
     this.statistics = new TimeStatistics();
     this.compressor = compressor;

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/page/ValuePageWriter.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/page/ValuePageWriter.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.tsfile.file.metadata.statistics.Statistics;
 import org.apache.iotdb.tsfile.utils.Binary;
 import org.apache.iotdb.tsfile.utils.PublicBAOS;
 import org.apache.iotdb.tsfile.utils.ReadWriteForEncodingUtils;
+import org.apache.iotdb.tsfile.utils.UnsynchronizedPublicBAOS;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,10 +65,10 @@ public class ValuePageWriter {
   private static final int MASK = 1 << 7;
 
   public ValuePageWriter(Encoder valueEncoder, ICompressor compressor, TSDataType dataType) {
-    this.valueOut = new PublicBAOS();
+    this.valueOut = new UnsynchronizedPublicBAOS();
     this.bitmap = 0;
     this.size = 0;
-    this.bitmapOut = new PublicBAOS();
+    this.bitmapOut = new UnsynchronizedPublicBAOS();
     this.valueEncoder = valueEncoder;
     this.statistics = Statistics.getStatsByType(dataType);
     this.compressor = compressor;

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/LocalTsFileOutput.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/write/writer/LocalTsFileOutput.java
@@ -41,31 +41,31 @@ public class LocalTsFileOutput extends OutputStream implements TsFileOutput {
   }
 
   @Override
-  public synchronized void write(int b) throws IOException {
+  public void write(int b) throws IOException {
     bufferedStream.write(b);
     position++;
   }
 
   @Override
-  public synchronized void write(byte[] b) throws IOException {
+  public void write(byte[] b) throws IOException {
     bufferedStream.write(b);
     position += b.length;
   }
 
   @Override
-  public synchronized void write(byte b) throws IOException {
+  public void write(byte b) throws IOException {
     bufferedStream.write(b);
     position++;
   }
 
   @Override
-  public synchronized void write(byte[] buf, int start, int offset) throws IOException {
+  public void write(byte[] buf, int start, int offset) throws IOException {
     bufferedStream.write(buf, start, offset);
     position += offset;
   }
 
   @Override
-  public synchronized void write(ByteBuffer b) throws IOException {
+  public void write(ByteBuffer b) throws IOException {
     bufferedStream.write(b.array());
     position += b.array().length;
   }


### PR DESCRIPTION
## Description
Reduce synchronized cost in compaction.
1. Add UnsynchronizedPublicBAOS, which extend ByteArrayOutputStream and intentionally remove the 'synchronized' keyword in write methods for better performance.
2. Remove synchronized in LocalTsFileOutput.