### PR TITLE
Storage Engine: Fixed inaccurate compression ratio when writing duplicate data

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AlignedWritableMemChunk.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AlignedWritableMemChunk.java
@@ -388,12 +388,13 @@ public class AlignedWritableMemChunk implements IWritableMemChunk {
                   list.getValueIndex(sortedRowIndex);
             }
             if (timeDuplicateInfo[sortedRowIndex]) {
-              if (!list.isNullValue(sortedRowIndex, columnIndex)) {
+              if (!list.isNullValue(list.getValueIndex(sortedRowIndex), columnIndex)) {
                 long recordSize =
                     MemUtils.getRecordSize(
                         tsDataType,
                         tsDataType == TSDataType.TEXT
-                            ? list.getBinaryByValueIndex(sortedRowIndex, columnIndex)
+                            ? list.getBinaryByValueIndex(
+                                list.getValueIndex(sortedRowIndex), columnIndex)
                             : null,
                         true);
                 CompressionRatio.decreaseDuplicatedMemorySize(recordSize);


### PR DESCRIPTION
## Description
This PR fixed inaccurate compression ratio when writing duplicate data,

## Before this PR
The memory size may be reduced to negative values in aligned sequence scenarios and when writing duplicate data

## Before this PR
In the aligned sequence scenario and when writing duplicate data, the memory size will not become negative again