### PR TITLE
fix delete dead lock.

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/DataNodeSchemaCache.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/DataNodeSchemaCache.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.queryengine.plan.analyze.cache.schema;
 
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.service.metric.MetricService;
@@ -216,6 +217,30 @@ public class DataNodeSchemaCache {
 
   public TimeValuePair getLastCache(PartialPath seriesPath) {
     return timeSeriesSchemaCache.getLastCache(seriesPath);
+  }
+
+  public void invalidateLastCache(PartialPath path) {
+    if (!CommonDescriptor.getInstance().getConfig().isLastCacheEnable()) {
+      return;
+    }
+    takeReadLock();
+    try {
+      timeSeriesSchemaCache.invalidateLastCache(path);
+    } finally {
+      releaseReadLock();
+    }
+  }
+
+  public void invalidateLastCacheInDataRegion(String database) {
+    if (!CommonDescriptor.getInstance().getConfig().isLastCacheEnable()) {
+      return;
+    }
+    takeReadLock();
+    try {
+      timeSeriesSchemaCache.invalidateDataRegionLastCache(database);
+    } finally {
+      releaseReadLock();
+    }
   }
 
   /** get SchemaCacheEntry and update last cache */

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/SchemaCacheEntry.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/SchemaCacheEntry.java
@@ -163,4 +163,12 @@ public class SchemaCacheEntry implements IMeasurementSchemaInfo {
   public boolean isLogicalView() {
     return this.iMeasurementSchema.isLogicalView();
   }
+
+  public int invalidateLastCache() {
+    if (this.lastCacheContainer == null || this.lastCacheContainer.getCachedLast() == null) {
+      return 0;
+    }
+
+    return this.lastCacheContainer.invalidateLastCache();
+  }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/TimeSeriesSchemaCache.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/TimeSeriesSchemaCache.java
@@ -393,6 +393,38 @@ public class TimeSeriesSchemaCache {
     dualKeyCache.invalidate(database);
   }
 
+  public void invalidateLastCache(PartialPath path) {
+    if (!path.hasWildcard()) {
+      SchemaCacheEntry entry = dualKeyCache.get(path.getDevicePath(), path.getMeasurement());
+      if (null == entry) {
+        return;
+      }
+      dualKeyCache.update(
+          new IDualKeyCacheUpdating<PartialPath, String, SchemaCacheEntry>() {
+            @Override
+            public PartialPath getFirstKey() {
+              return path.getDevicePath();
+            }
+
+            @Override
+            public String[] getSecondKeyList() {
+              return new String[] {path.getMeasurement()};
+            }
+
+            @Override
+            public int updateValue(int index, SchemaCacheEntry value) {
+              return DataNodeLastCacheManager.invalidateLastCache(value);
+            }
+          });
+    } else {
+      dualKeyCache.invalidateLastCache(path);
+    }
+  }
+
+  public void invalidateDataRegionLastCache(String database) {
+    dualKeyCache.invalidateDataRegionLastCache(database);
+  }
+
   public void invalidate(List<PartialPath> partialPathList) {
     dualKeyCache.invalidate(partialPathList);
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/dualkeycache/IDualKeyCache.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/dualkeycache/IDualKeyCache.java
@@ -55,6 +55,15 @@ public interface IDualKeyCache<FK, SK, V> {
   void put(FK firstKey, SK secondKey, V value);
 
   /**
+   * Invalidate last cache in datanode schema cache. Do not invalidate time series cache.
+   *
+   * @param partialPathList
+   */
+  void invalidateLastCache(PartialPath partialPath);
+
+  void invalidateDataRegionLastCache(String database);
+
+  /**
    * Invalidate all cache values in the cache and clear related cache keys. The cache status and
    * statistics won't be clear and they can still be accessed via cache.stats().
    */

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/dualkeycache/impl/DualKeyCacheImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/dualkeycache/impl/DualKeyCacheImpl.java
@@ -22,10 +22,12 @@ package org.apache.iotdb.db.queryengine.plan.analyze.cache.schema.dualkeycache.i
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.path.PathPatternUtil;
 import org.apache.iotdb.commons.utils.TestOnly;
+import org.apache.iotdb.db.queryengine.plan.analyze.cache.schema.SchemaCacheEntry;
 import org.apache.iotdb.db.queryengine.plan.analyze.cache.schema.dualkeycache.IDualKeyCache;
 import org.apache.iotdb.db.queryengine.plan.analyze.cache.schema.dualkeycache.IDualKeyCacheComputation;
 import org.apache.iotdb.db.queryengine.plan.analyze.cache.schema.dualkeycache.IDualKeyCacheStats;
 import org.apache.iotdb.db.queryengine.plan.analyze.cache.schema.dualkeycache.IDualKeyCacheUpdating;
+import org.apache.iotdb.db.queryengine.plan.analyze.cache.schema.lastcache.DataNodeLastCacheManager;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -237,6 +239,63 @@ class DualKeyCacheImpl<FK, SK, V, T extends ICacheEntry<SK, V>>
             });
       }
       return evictedSize.get();
+    }
+  }
+
+  @Override
+  public void invalidateLastCache(PartialPath path) {
+    String measurement = path.getMeasurement();
+    PartialPath devicePath = path.getDevicePath();
+    Function<FK, Boolean> deviceFilter = null;
+    Function<SK, Boolean> measurementFilter = null;
+
+    if (PathPatternUtil.hasWildcard(devicePath.getFullPath())) {
+      deviceFilter = d -> devicePath.matchFullPath((PartialPath) d);
+    }
+    if (PathPatternUtil.isMultiLevelMatchWildcard(measurement)) {
+      measurementFilter = m -> true;
+    }
+    if (deviceFilter == null) {
+      deviceFilter = d -> ((PartialPath) d).equals(devicePath);
+    }
+
+    if (measurementFilter == null) {
+      measurementFilter = m -> PathPatternUtil.isNodeMatch(measurement, m.toString());
+    }
+
+    for (FK device : firstKeyMap.getAllKeys()) {
+      if (Boolean.TRUE.equals(deviceFilter.apply(device))) {
+        ICacheEntryGroup<FK, SK, V, T> entryGroup = firstKeyMap.get(device);
+        for (Iterator<Map.Entry<SK, T>> it = entryGroup.getAllCacheEntries(); it.hasNext(); ) {
+          Map.Entry<SK, T> entry = it.next();
+          if (Boolean.TRUE.equals(measurementFilter.apply(entry.getKey()))) {
+            T cacheEntry = entry.getValue();
+            synchronized (cacheEntry) {
+              SchemaCacheEntry schemaCacheEntry = (SchemaCacheEntry) cacheEntry.getValue();
+              cacheStats.decreaseMemoryUsage(
+                  DataNodeLastCacheManager.invalidateLastCache(schemaCacheEntry));
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @Override
+  public void invalidateDataRegionLastCache(String database) {
+    for (FK device : firstKeyMap.getAllKeys()) {
+      if (device.toString().startsWith(database)) {
+        ICacheEntryGroup<FK, SK, V, T> entryGroup = firstKeyMap.get(device);
+        for (Iterator<Map.Entry<SK, T>> it = entryGroup.getAllCacheEntries(); it.hasNext(); ) {
+          Map.Entry<SK, T> entry = it.next();
+          T cacheEntry = entry.getValue();
+          synchronized (cacheEntry) {
+            SchemaCacheEntry schemaCacheEntry = (SchemaCacheEntry) cacheEntry.getValue();
+            cacheStats.decreaseMemoryUsage(
+                DataNodeLastCacheManager.invalidateLastCache(schemaCacheEntry));
+          }
+        }
+      }
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/lastcache/DataNodeLastCacheManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/lastcache/DataNodeLastCacheManager.java
@@ -65,4 +65,11 @@ public class DataNodeLastCacheManager {
     }
     return entry.updateLastCache(timeValuePair, highPriorityUpdate, latestFlushedTime);
   }
+
+  public static int invalidateLastCache(SchemaCacheEntry entry) {
+    if (!CACHE_ENABLED || null == entry) {
+      return 0;
+    }
+    return entry.invalidateLastCache();
+  }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/lastcache/ILastCacheContainer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/lastcache/ILastCacheContainer.java
@@ -28,7 +28,7 @@ public interface ILastCacheContainer {
   TimeValuePair getCachedLast();
 
   /**
-   * update last point cache
+   * update last point cache and enable last cache.
    *
    * @param timeValuePair last point
    * @param highPriorityUpdate whether it's a high priority update
@@ -37,6 +37,9 @@ public interface ILastCacheContainer {
    */
   int updateCachedLast(
       TimeValuePair timeValuePair, boolean highPriorityUpdate, Long latestFlushedTime);
+
+  /** Invalidate Last cache. */
+  int invalidateLastCache();
 
   int estimateSize();
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/lastcache/LastCacheContainer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/lastcache/LastCacheContainer.java
@@ -70,6 +70,13 @@ public class LastCacheContainer implements ILastCacheContainer {
     return 0;
   }
 
+  @Override
+  public int invalidateLastCache() {
+    int size = lastCacheValue.estimateSize();
+    lastCacheValue = null;
+    return size;
+  }
+
   private int getDiffSize(TsPrimitiveType oldValue, TsPrimitiveType newValue) {
     if (oldValue == null) {
       return newValue == null ? 0 : newValue.getSize();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -23,7 +23,6 @@ import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.cluster.NodeStatus;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.consensus.DataRegionId;
-import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.file.SystemFileFactory;
 import org.apache.iotdb.commons.path.PartialPath;
@@ -1945,17 +1944,8 @@ public class DataRegion implements IDataRegionForQuery {
     boolean hasReleasedLock = false;
 
     try {
-
+      DataNodeSchemaCache.getInstance().invalidateLastCache(pattern);
       Set<PartialPath> devicePaths = new HashSet<>(pattern.getDevicePathPattern());
-
-      // delete Last cache record if necessary
-      DataNodeSchemaCache.getInstance().takeWriteLock();
-      try {
-        DataNodeSchemaCache.getInstance().invalidate(Collections.singletonList(pattern));
-      } finally {
-        DataNodeSchemaCache.getInstance().releaseWriteLock();
-      }
-
       // write log to impacted working TsFileProcessors
       List<WALFlushListener> walListeners =
           logDeletionInWAL(startTime, endTime, searchIndex, pattern);
@@ -1980,7 +1970,6 @@ public class DataRegion implements IDataRegionForQuery {
       hasReleasedLock = true;
 
       deleteDataInFiles(sealedTsFileResource, deletion, devicePaths, deviceMatchInfo);
-
     } catch (Exception e) {
       throw new IOException(e);
     } finally {
@@ -2000,15 +1989,9 @@ public class DataRegion implements IDataRegionForQuery {
 
     writeLock("deleteDataDirect");
     boolean releasedLock = false;
-    try {
-      // delete last cache record if necessary
-      DataNodeSchemaCache.getInstance().takeWriteLock();
-      try {
-        DataNodeSchemaCache.getInstance().invalidate(databaseName);
-      } finally {
-        DataNodeSchemaCache.getInstance().releaseWriteLock();
-      }
 
+    try {
+      DataNodeSchemaCache.getInstance().invalidateLastCacheInDataRegion(getDatabaseName());
       // write log to impacted working TsFileProcessors
       List<WALFlushListener> walListeners =
           logDeletionInWAL(startTime, endTime, searchIndex, pathToDelete);
@@ -2539,18 +2522,6 @@ public class DataRegion implements IDataRegionForQuery {
     }
   }
 
-  private void resetLastCacheWhenLoadingTsFile() throws IllegalPathException {
-    if (!CommonDescriptor.getInstance().getConfig().isLastCacheEnable()) {
-      return;
-    }
-    DataNodeSchemaCache.getInstance().takeWriteLock();
-    try {
-      DataNodeSchemaCache.getInstance().invalidateAll();
-    } finally {
-      DataNodeSchemaCache.getInstance().releaseWriteLock();
-    }
-  }
-
   /**
    * Load a new tsfile to unsequence dir.
    *
@@ -2603,10 +2574,6 @@ public class DataRegion implements IDataRegionForQuery {
               false,
               newTsFileResource.getTsFile().getName());
 
-      // Update last cache
-      resetLastCacheWhenLoadingTsFile();
-
-      // Update last flush time & help last flush time map degrade
       if (config.isEnableSeparateData()) {
         final DataRegionId dataRegionId = new DataRegionId(Integer.parseInt(this.dataRegionId));
         final long timePartitionId = newTsFileResource.getTimePartition();
@@ -2637,12 +2604,9 @@ public class DataRegion implements IDataRegionForQuery {
           tsfileToBeInserted.getAbsolutePath(),
           tsfileToBeInserted.getParentFile().getName());
       throw new LoadFileException(e);
-    } catch (IllegalPathException e) {
-      logger.error(
-          "Failed to reset last cache when loading file {}", newTsFileResource.getTsFilePath());
-      throw new LoadFileException(e);
     } finally {
       writeUnlock();
+      DataNodeSchemaCache.getInstance().invalidateLastCacheInDataRegion(databaseName);
     }
   }
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/cache/dualkeycache/DualKeyCacheTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/cache/dualkeycache/DualKeyCacheTest.java
@@ -374,4 +374,118 @@ public class DualKeyCacheTest {
     Assert.assertEquals(expectSize, dualKeyCache.stats().memoryUsage());
     return dualKeyCache;
   }
+
+  private IDualKeyCache<PartialPath, String, SchemaCacheEntry> generateLastCache()
+      throws IllegalPathException {
+    DualKeyCacheBuilder<PartialPath, String, SchemaCacheEntry> dualKeyCacheBuilder =
+        new DualKeyCacheBuilder<>();
+    IDualKeyCache<PartialPath, String, SchemaCacheEntry> dualKeyCache =
+        dualKeyCacheBuilder
+            .cacheEvictionPolicy(DualKeyCachePolicy.valueOf(policy))
+            .memoryCapacity(2000) // actual threshold is 1600
+            .firstKeySizeComputer(PartialPath::estimateSize)
+            .secondKeySizeComputer(this::computeStringSize)
+            .valueSizeComputer(SchemaCacheEntry::estimateSize)
+            .build();
+    SchemaCacheEntry cacheEntry1 =
+        new SchemaCacheEntry(
+            "root.db1",
+            new MeasurementSchema("s1", TSDataType.INT32),
+            Collections.emptyMap(),
+            false);
+    cacheEntry1.updateLastCache(new TimeValuePair(1L, new TsPrimitiveType.TsInt(1)), true, 0L);
+    dualKeyCache.put(new PartialPath("root.db1.d1"), "s1", cacheEntry1);
+
+    SchemaCacheEntry cacheEntry2 =
+        new SchemaCacheEntry(
+            "root.db1",
+            new MeasurementSchema("s2", TSDataType.INT32),
+            Collections.emptyMap(),
+            false);
+    cacheEntry2.updateLastCache(new TimeValuePair(1L, new TsPrimitiveType.TsInt(1)), true, 0L);
+    dualKeyCache.put(new PartialPath("root.db1.d1"), "s2", cacheEntry2);
+
+    SchemaCacheEntry cacheEntry3 =
+        new SchemaCacheEntry(
+            "root.db2",
+            new MeasurementSchema("s2", TSDataType.INT32),
+            Collections.emptyMap(),
+            false);
+    cacheEntry3.updateLastCache(new TimeValuePair(1L, new TsPrimitiveType.TsInt(1)), true, 0L);
+    dualKeyCache.put(new PartialPath("root.db2.d1"), "s2", cacheEntry3);
+
+    SchemaCacheEntry cacheEntry4 =
+        new SchemaCacheEntry(
+            "root.db2",
+            new MeasurementSchema("s2", TSDataType.INT32),
+            Collections.emptyMap(),
+            false);
+    cacheEntry4.updateLastCache(new TimeValuePair(1L, new TsPrimitiveType.TsInt(1)), true, 0L);
+    dualKeyCache.put(new PartialPath("root.db2.d1"), "s1", cacheEntry4);
+
+    SchemaCacheEntry cacheEntry5 =
+        new SchemaCacheEntry(
+            "root.db1",
+            new MeasurementSchema("s2", TSDataType.INT32),
+            Collections.emptyMap(),
+            false);
+    cacheEntry5.updateLastCache(new TimeValuePair(1L, new TsPrimitiveType.TsInt(1)), true, 0L);
+    dualKeyCache.put(new PartialPath("root.db1"), "s2", cacheEntry5);
+
+    Assert.assertNotNull(dualKeyCache.get(new PartialPath("root.db1.d1"), "s1"));
+    Assert.assertNotNull(dualKeyCache.get(new PartialPath("root.db1.d1"), "s2"));
+    Assert.assertNotNull(dualKeyCache.get(new PartialPath("root.db1"), "s2"));
+    Assert.assertNotNull(dualKeyCache.get(new PartialPath("root.db2.d1"), "s1"));
+    Assert.assertNotNull(dualKeyCache.get(new PartialPath("root.db2.d1"), "s2"));
+
+    int expectSize =
+        PartialPath.estimateSize(new PartialPath("root.db1.d1")) * 2
+            + PartialPath.estimateSize(new PartialPath("root.db1"))
+            + computeStringSize("s1") * 5
+            + SchemaCacheEntry.estimateSize(cacheEntry1) * 5;
+    Assert.assertEquals(expectSize, dualKeyCache.stats().memoryUsage());
+    return dualKeyCache;
+  }
+
+  @Test
+  public void testInvalidateSimpleTimeseriesAndDataRegion() throws IllegalPathException {
+    IDualKeyCache<PartialPath, String, SchemaCacheEntry> dualKeyCache = generateLastCache();
+    long memUse = dualKeyCache.stats().memoryUsage();
+
+    dualKeyCache.invalidateLastCache(new PartialPath("root.db1.d1.s1"));
+    SchemaCacheEntry cacheEntry = dualKeyCache.get(new PartialPath("root.db1.d1"), "s1");
+    Assert.assertNull(cacheEntry.getLastCacheContainer().getCachedLast());
+
+    dualKeyCache.invalidateLastCache(new PartialPath("root.db1.d1.*"));
+    cacheEntry = dualKeyCache.get(new PartialPath("root.db1.d1"), "s2");
+    Assert.assertNull(cacheEntry.getLastCacheContainer().getCachedLast());
+
+    dualKeyCache.invalidateLastCache(new PartialPath("root.db2.d1.**"));
+    cacheEntry = dualKeyCache.get(new PartialPath("root.db2.d1"), "s2");
+    Assert.assertNull(cacheEntry.getLastCacheContainer().getCachedLast());
+
+    dualKeyCache.invalidateDataRegionLastCache("root.db2");
+    cacheEntry = dualKeyCache.get(new PartialPath("root.db2.d1"), "s1");
+    Assert.assertNull(cacheEntry.getLastCacheContainer().getCachedLast());
+
+    cacheEntry = dualKeyCache.get(new PartialPath("root.db1"), "s2");
+    // last cache container' estimateSize(): header 8b + Ilastcachevalueref 8b +  lastcache's size
+    // invalidate operation: make Ilastcachevalueref = null.
+    // So the amount of change in size is estimateSize() - 8b - 8b
+    int size = cacheEntry.getLastCacheContainer().estimateSize() - 16;
+    Assert.assertEquals(memUse - size * 4, dualKeyCache.stats().memoryUsage());
+  }
+
+  @Test
+  public void testComplexInvalidate() throws IllegalPathException {
+    IDualKeyCache<PartialPath, String, SchemaCacheEntry> dualKeyCache = generateLastCache();
+
+    dualKeyCache.invalidateLastCache(new PartialPath("root.db1.*.s1"));
+    SchemaCacheEntry cacheEntry = dualKeyCache.get(new PartialPath("root.db1.d1"), "s1");
+    Assert.assertNull(cacheEntry.getLastCacheContainer().getCachedLast());
+
+    dualKeyCache.invalidateLastCache(new PartialPath("root.db1.**.s2"));
+    cacheEntry = dualKeyCache.get(new PartialPath("root.db1.d1"), "s2");
+    Assert.assertNull(cacheEntry.getLastCacheContainer().getCachedLast());
+  }
 }


### PR DESCRIPTION
The current system has a deadlock problem when the deletion is concurrent with query and insertion:
1. Query worker 's num is limit as core num.
2. Deletion will acquire Dataregion's write lock and Datanode Schemacache's write lock.
3. Insert or query will request additional queries to obtain metadata in the case of acquiring a read lock.

DeadLock cycle like this:
```mermaid
graph BT
A[#QueryWorker# get one core to run query]
B[#QueryWorker# hold read lock on dataregion]
A-->B
C[#DeleteData# hold write lock on dataregion]
D[#DeleteData# hold write lock on datanode schema]
C-->D
E[#InsertData# holdread lock on datanode schema]
F[#InsertData# get one core to run fetch schema]
E-->F
B-->C
F-->A
D-->E
```

In this pr:
1. Optimize the lock order to prevent deadlocks
5. Add invalidate last cache operation.  The deletion operation does not need to clean up all caches, but should clean the corresponding last cache. 
6.  You can use the following patch to reproduce the deadlock problem.
[0001-to-cause-dead-lock-when-delete.patch](https://github.com/apache/iotdb/files/14900114/0001-to-cause-dead-lock-when-delete.patch)
In this patch, datanodeCache will always be empty, so query or insert will fetch remote schema. Besides the query worker's num is limit to 1 and the program will wait about 20s/30s after acquiring the critical lock.
To reproduce the problem, run these three queries in three sessions within 30s:
session1:  `insert into root.sg1.t1(t) values(1);`
session2: ` delete from root.sg1.t1.**;`
session3: `select * from root.sg1.**;`



