### PR TITLE
[RatisConsensus] Notify term index change when configuration changes

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ApplicationStateMachineProxy.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ApplicationStateMachineProxy.java
@@ -293,6 +293,7 @@ public class ApplicationStateMachineProxy extends BaseStateMachine {
   @Override
   public void notifyConfigurationChanged(
       long term, long index, RaftConfigurationProto newRaftConfiguration) {
+    updateLastAppliedTermIndex(term, index);
     applicationStateMachine
         .event()
         .notifyConfigurationChanged(

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ApplicationStateMachineProxy.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ApplicationStateMachineProxy.java
@@ -293,7 +293,9 @@ public class ApplicationStateMachineProxy extends BaseStateMachine {
   @Override
   public void notifyConfigurationChanged(
       long term, long index, RaftConfigurationProto newRaftConfiguration) {
-    updateLastAppliedTermIndex(term, index);
+    if (index > getLastAppliedTermIndex().getIndex()) {
+      updateLastAppliedTermIndex(term, index);
+    }
     applicationStateMachine
         .event()
         .notifyConfigurationChanged(


### PR DESCRIPTION
Currently the statemachine's apply index is not updated for configuration change logs.
This may block the readIndex since the readIndex will compare the applyIndex and currentIndex. During unstable clusters where configuration logs are not followed by statemachine logs, the readIndex may never return.