### PR TITLE
Optimize fast compaction memory

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/AlignedSeriesCompactionExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/AlignedSeriesCompactionExecutor.java
@@ -36,7 +36,6 @@ import org.apache.iotdb.db.storageengine.dataregion.modification.Modification;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.utils.ModificationUtils;
 import org.apache.iotdb.tsfile.exception.write.PageException;
-import org.apache.iotdb.tsfile.file.MetaMarker;
 import org.apache.iotdb.tsfile.file.header.ChunkHeader;
 import org.apache.iotdb.tsfile.file.header.PageHeader;
 import org.apache.iotdb.tsfile.file.metadata.AlignedChunkMetadata;
@@ -265,88 +264,53 @@ public class AlignedSeriesCompactionExecutor extends SeriesCompactionExecutor {
   @SuppressWarnings("squid:S3776")
   void deserializeChunkIntoPageQueue(ChunkMetadataElement chunkMetadataElement) throws IOException {
     updateSummary(chunkMetadataElement, ChunkStatus.DESERIALIZE_CHUNK);
-    List<PageHeader> timePageHeaders = new ArrayList<>();
-    List<ByteBuffer> compressedTimePageDatas = new ArrayList<>();
-    List<List<PageHeader>> valuePageHeaders = new ArrayList<>();
-    List<List<ByteBuffer>> compressedValuePageDatas = new ArrayList<>();
 
     // deserialize time chunk
     Chunk timeChunk = chunkMetadataElement.chunk;
 
     CompactionChunkReader chunkReader = new CompactionChunkReader(timeChunk);
-    ByteBuffer chunkDataBuffer = timeChunk.getData();
-    ChunkHeader chunkHeader = timeChunk.getHeader();
-    while (chunkDataBuffer.remaining() > 0) {
-      // deserialize a PageHeader from chunkDataBuffer
-      PageHeader pageHeader;
-      if (((byte) (chunkHeader.getChunkType() & 0x3F)) == MetaMarker.ONLY_ONE_PAGE_CHUNK_HEADER) {
-        pageHeader = PageHeader.deserializeFrom(chunkDataBuffer, timeChunk.getChunkStatistic());
-      } else {
-        pageHeader = PageHeader.deserializeFrom(chunkDataBuffer, chunkHeader.getDataType());
-      }
-      ByteBuffer compressedPageData = chunkReader.readPageDataWithoutUncompressing(pageHeader);
-      timePageHeaders.add(pageHeader);
-      compressedTimePageDatas.add(compressedPageData);
-    }
+    List<Pair<PageHeader, ByteBuffer>> timePages = chunkReader.readPageDataWithoutUncompressing();
 
     // deserialize value chunks
+    List<List<Pair<PageHeader, ByteBuffer>>> valuePagesList = new ArrayList<>();
     List<Chunk> valueChunks = chunkMetadataElement.valueChunks;
     for (int i = 0; i < valueChunks.size(); i++) {
       Chunk valueChunk = valueChunks.get(i);
       if (valueChunk == null) {
         // value chunk has been deleted completely
-        valuePageHeaders.add(null);
-        compressedValuePageDatas.add(null);
+        valuePagesList.add(null);
         continue;
       }
-      chunkReader = new CompactionChunkReader(valueChunk);
-      chunkDataBuffer = valueChunk.getData();
-      chunkHeader = valueChunk.getHeader();
 
-      valuePageHeaders.add(new ArrayList<>());
-      compressedValuePageDatas.add(new ArrayList<>());
-      while (chunkDataBuffer.remaining() > 0) {
-        // deserialize a PageHeader from chunkDataBuffer
-        PageHeader pageHeader;
-        if (((byte) (chunkHeader.getChunkType() & 0x3F)) == MetaMarker.ONLY_ONE_PAGE_CHUNK_HEADER) {
-          pageHeader = PageHeader.deserializeFrom(chunkDataBuffer, valueChunk.getChunkStatistic());
-        } else {
-          pageHeader = PageHeader.deserializeFrom(chunkDataBuffer, chunkHeader.getDataType());
-        }
-        if (pageHeader.getCompressedSize() == 0) {
-          // empty value page
-          valuePageHeaders.get(i).add(null);
-          compressedValuePageDatas.get(i).add(null);
-        } else {
-          ByteBuffer compressedPageData = chunkReader.readPageDataWithoutUncompressing(pageHeader);
-          valuePageHeaders.get(i).add(pageHeader);
-          compressedValuePageDatas.get(i).add(compressedPageData);
-        }
-      }
+      chunkReader = new CompactionChunkReader(valueChunk);
+      List<Pair<PageHeader, ByteBuffer>> valuesPages =
+          chunkReader.readPageDataWithoutUncompressing();
+      valuePagesList.add(valuesPages);
     }
 
     // add aligned pages into page queue
-    for (int i = 0; i < timePageHeaders.size(); i++) {
+    for (int i = 0; i < timePages.size(); i++) {
       List<PageHeader> alignedPageHeaders = new ArrayList<>();
       List<ByteBuffer> alignedPageDatas = new ArrayList<>();
-      for (int j = 0; j < valuePageHeaders.size(); j++) {
-        if (valuePageHeaders.get(j) == null) {
+      for (int j = 0; j < valuePagesList.size(); j++) {
+        if (valuePagesList.get(j) == null) {
           alignedPageHeaders.add(null);
           alignedPageDatas.add(null);
           continue;
         }
-        alignedPageHeaders.add(valuePageHeaders.get(j).get(i));
-        alignedPageDatas.add(compressedValuePageDatas.get(j).get(i));
+        Pair<PageHeader, ByteBuffer> valuePage = valuePagesList.get(j).get(i);
+        alignedPageHeaders.add(valuePage == null ? null : valuePage.left);
+        alignedPageDatas.add(valuePage == null ? null : valuePage.right);
       }
       pageQueue.add(
           new AlignedPageElement(
-              timePageHeaders.get(i),
+              timePages.get(i).left,
               alignedPageHeaders,
-              compressedTimePageDatas.get(i),
+              timePages.get(i).right,
               alignedPageDatas,
               new CompactionAlignedChunkReader(timeChunk, valueChunks),
               chunkMetadataElement,
-              i == timePageHeaders.size() - 1,
+              i == timePages.size() - 1,
               chunkMetadataElement.priority));
     }
     chunkMetadataElement.clearChunks();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/NonAlignedSeriesCompactionExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/NonAlignedSeriesCompactionExecutor.java
@@ -34,7 +34,6 @@ import org.apache.iotdb.db.storageengine.dataregion.modification.Modification;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.utils.ModificationUtils;
 import org.apache.iotdb.tsfile.exception.write.PageException;
-import org.apache.iotdb.tsfile.file.MetaMarker;
 import org.apache.iotdb.tsfile.file.header.ChunkHeader;
 import org.apache.iotdb.tsfile.file.header.PageHeader;
 import org.apache.iotdb.tsfile.file.metadata.ChunkMetadata;
@@ -172,23 +171,13 @@ public class NonAlignedSeriesCompactionExecutor extends SeriesCompactionExecutor
     updateSummary(chunkMetadataElement, ChunkStatus.DESERIALIZE_CHUNK);
     Chunk chunk = chunkMetadataElement.chunk;
     CompactionChunkReader chunkReader = new CompactionChunkReader(chunk);
-    ByteBuffer chunkDataBuffer = chunk.getData();
-    ChunkHeader chunkHeader = chunk.getHeader();
-    while (chunkDataBuffer.remaining() > 0) {
-      // deserialize a PageHeader from chunkDataBuffer
-      PageHeader pageHeader;
-      if (((byte) (chunkHeader.getChunkType() & 0x3F)) == MetaMarker.ONLY_ONE_PAGE_CHUNK_HEADER) {
-        pageHeader = PageHeader.deserializeFrom(chunkDataBuffer, chunk.getChunkStatistic());
-      } else {
-        pageHeader = PageHeader.deserializeFrom(chunkDataBuffer, chunkHeader.getDataType());
-      }
-      ByteBuffer compressedPageData = chunkReader.readPageDataWithoutUncompressing(pageHeader);
-
-      boolean isLastPage = chunkDataBuffer.remaining() <= 0;
+    List<Pair<PageHeader, ByteBuffer>> pages = chunkReader.readPageDataWithoutUncompressing();
+    for (int i = 0; i < pages.size(); i++) {
+      boolean isLastPage = i == pages.size() - 1;
       pageQueue.add(
           new NonAlignedPageElement(
-              pageHeader,
-              compressedPageData,
+              pages.get(i).left,
+              pages.get(i).right,
               chunkReader,
               chunkMetadataElement,
               isLastPage,

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/element/AlignedPageElement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/element/AlignedPageElement.java
@@ -33,9 +33,9 @@ public class AlignedPageElement extends PageElement {
   private final List<PageHeader> valuePageHeaders;
 
   // compressed page data
-  private final ByteBuffer timePageData;
+  private ByteBuffer timePageData;
 
-  private final List<ByteBuffer> valuePageDataList;
+  private List<ByteBuffer> valuePageDataList;
 
   private final CompactionAlignedChunkReader chunkReader;
 
@@ -64,6 +64,9 @@ public class AlignedPageElement extends PageElement {
     pointReader =
         chunkReader.getPagePointReader(
             timePageHeader, valuePageHeaders, timePageData, valuePageDataList);
+    // friendly for gc
+    timePageData = null;
+    valuePageDataList = null;
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/element/NonAlignedPageElement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/element/NonAlignedPageElement.java
@@ -31,7 +31,7 @@ public class NonAlignedPageElement extends PageElement {
   private final PageHeader pageHeader;
 
   // compressed page data
-  private final ByteBuffer pageData;
+  private ByteBuffer pageData;
 
   private final CompactionChunkReader chunkReader;
 
@@ -52,6 +52,7 @@ public class NonAlignedPageElement extends PageElement {
   public void deserializePage() throws IOException {
     TsBlock batchData = chunkReader.readPageData(pageHeader, pageData);
     this.pointReader = batchData.getTsBlockSingleColumnIterator();
+    pageData = null;
   }
 
   @Override


### PR DESCRIPTION
### Optimize the memory usage of FastCompaction from the following two aspects:
- Release compressed chunk data buffer when deserializing chunk into page queue.
- Release compressed page data buffer when deserializing page into points.

### Experiment
**Experimental Scenario:**
There is one sequential file and two unsequential files, all of which completely overlap. Each file contains 5 devices, with each device having 80 time series. Each time series has only one chunk, and each chunk has one page, with 250,000 data points per page. Each timeseries adopts GZIP compression and PLAIN encoding. The experiment simulates a compaction scenario of three-way compacting, with 80 sub threads simultaneously compacting 80 timeseries.

**Experimental Procedure:**
Using binary search method, adjust the MAX_HEAP_SIZE parameter of the system gradually until the difference between the upper and lower bounds is less than 2M, and then determine the memory usage of the compaction algorithm.

**Experimental Results:**
Before optimization, FastCompaction algorithm occupies 1327M, and after optimization, it occupies 1187M.
