### PR TITLE
Pipe: timely reload file list according to compaction

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEvent.java
@@ -150,6 +150,10 @@ public class PipeTsFileInsertionEvent extends EnrichedEvent implements TsFileIns
     return tsFile;
   }
 
+  public String getTsFilePath() {
+    return resource.getTsFilePath();
+  }
+
   public File getModFile() {
     return modFile;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/realtime/listener/PipeCompactionListener.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/realtime/listener/PipeCompactionListener.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.pipe.extractor.dataregion.realtime.listener;
+
+import org.apache.iotdb.commons.pipe.config.PipeConfig;
+import org.apache.iotdb.db.pipe.agent.PipeAgent;
+import org.apache.iotdb.db.pipe.extractor.dataregion.realtime.PipeRealtimeDataRegionExtractor;
+import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class PipeCompactionListener {
+  private final Map<String, Map<String, PipeRealtimeDataRegionExtractor>> dataRegionId2Extractors =
+      new ConcurrentHashMap<>();
+
+  private Map<String, PipeDataRegionCompactionRecorder> dataRegionId2CompactionRecorder =
+      new ConcurrentHashMap<>();
+
+  public synchronized void startListenTo(
+      String dataRegionId, PipeRealtimeDataRegionExtractor extractor) {
+    if (!PipeConfig.getInstance().isPipeRefreshFileListByCompactionEnabled()) {
+      return;
+    }
+
+    dataRegionId2Extractors
+        .computeIfAbsent(dataRegionId, o -> new ConcurrentHashMap<>())
+        .put(extractor.getTaskID(), extractor);
+  }
+
+  public synchronized void stopListenTo(
+      String dataRegionId, PipeRealtimeDataRegionExtractor extractor) {
+    if (!PipeConfig.getInstance().isPipeRefreshFileListByCompactionEnabled()) {
+      return;
+    }
+
+    Map<String, PipeRealtimeDataRegionExtractor> extractors =
+        dataRegionId2Extractors.get(dataRegionId);
+    if (Objects.isNull(extractors)) {
+      return;
+    }
+    extractors.remove(extractor.getTaskID());
+    if (extractors.isEmpty()) {
+      dataRegionId2Extractors.remove(dataRegionId);
+    }
+  }
+
+  public synchronized void listenToCompaction(
+      String dataRegionId,
+      @NonNull List<TsFileResource> sourceResources,
+      @NonNull List<TsFileResource> targetResources) {
+    if (Objects.isNull(dataRegionId2CompactionRecorder.get(dataRegionId))) {
+      dataRegionId2CompactionRecorder.put(
+          dataRegionId, new PipeDataRegionCompactionRecorder(sourceResources, targetResources));
+    } else {
+      dataRegionId2CompactionRecorder
+          .get(dataRegionId)
+          .addCompaction(sourceResources, targetResources);
+    }
+  }
+
+  private void refreshFileList() {
+    final Map<String, PipeDataRegionCompactionRecorder> dataRegionId2CompactionRecorderSnapshot;
+
+    synchronized (this) {
+      // Get a snapshot of this.dataRegionId2CompactionRecorder
+      dataRegionId2CompactionRecorderSnapshot = this.dataRegionId2CompactionRecorder;
+      this.dataRegionId2CompactionRecorder = new ConcurrentHashMap<>();
+    }
+
+    for (Map.Entry<String, Map<String, PipeRealtimeDataRegionExtractor>> entry :
+        dataRegionId2Extractors.entrySet()) {
+      if (dataRegionId2CompactionRecorderSnapshot.containsKey(entry.getKey())
+          && !dataRegionId2CompactionRecorderSnapshot.get(entry.getKey()).isEmpty()) {
+        for (PipeRealtimeDataRegionExtractor extractor : entry.getValue().values()) {
+          extractor.refreshFileList(dataRegionId2CompactionRecorderSnapshot.get(entry.getKey()));
+          // Should reset the "visited" bits.
+          dataRegionId2CompactionRecorderSnapshot.get(entry.getKey()).resetVisited();
+        }
+      }
+    }
+
+    // Close to unpin TsFiles
+    for (PipeDataRegionCompactionRecorder recorder :
+        dataRegionId2CompactionRecorderSnapshot.values()) {
+      recorder.close();
+    }
+  }
+
+  /////////////////////////////// singleton ///////////////////////////////
+
+  private PipeCompactionListener() {
+    if (!PipeConfig.getInstance().isPipeRefreshFileListByCompactionEnabled()) {
+      return;
+    }
+
+    PipeAgent.runtime()
+        .registerPeriodicalJob(
+            "PipeCompactionListener#refreshFileList()",
+            this::refreshFileList,
+            PipeConfig.getInstance().getPipeRefreshFileListByCompactionIntervalSeconds());
+  }
+
+  public static PipeCompactionListener getInstance() {
+    return PipeCompactionListenerHolder.INSTANCE;
+  }
+
+  private static class PipeCompactionListenerHolder {
+    private static final PipeCompactionListener INSTANCE = new PipeCompactionListener();
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/realtime/listener/PipeDataRegionCompactionRecorder.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/realtime/listener/PipeDataRegionCompactionRecorder.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.pipe.extractor.dataregion.realtime.listener;
+
+import org.apache.iotdb.db.pipe.event.realtime.PipeRealtimeEvent;
+import org.apache.iotdb.db.pipe.event.realtime.PipeRealtimeEventFactory;
+import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
+import org.apache.iotdb.tsfile.utils.Pair;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * This class is used to record whenever a compaction is performed. It records the source files and
+ * target files of a compaction, and build {@link PipeRealtimeEvent} for each target file. When an
+ * extractor refreshes its pending file list, it will check if each file is a source file of a
+ * compaction, and if so, it will remove the file and add the target files of this compaction to its
+ * pending queue.
+ */
+public class PipeDataRegionCompactionRecorder implements AutoCloseable {
+  // Map from each source file path to a pair of target files and a boolean indicating
+  // whether the target files have been visited (to avoid adding the same file twice).
+  // All source files of one compaction will be mapped to the same value.
+  private final Map<String, Pair<List<PipeRealtimeEvent>, Boolean>> sourcePath2targetEvents;
+
+  public PipeDataRegionCompactionRecorder() {
+    this.sourcePath2targetEvents = new HashMap<>();
+  }
+
+  public PipeDataRegionCompactionRecorder(
+      List<TsFileResource> sourceList, List<TsFileResource> targetList) {
+    this.sourcePath2targetEvents = new HashMap<>();
+    for (TsFileResource source : sourceList) {
+      this.sourcePath2targetEvents.put(
+          source.getTsFilePath(),
+          new Pair<>(
+              targetList.stream()
+                  .map(
+                      resource -> {
+                        // Build a PipeRealtimeEvent for each target file and increase its reference
+                        // count,
+                        // TsFile will be pinned here.
+                        PipeRealtimeEvent event =
+                            PipeRealtimeEventFactory.createRealtimeEvent(resource, false, false);
+                        event.increaseReferenceCount(
+                            PipeDataRegionCompactionRecorder.class.getName());
+                        return event;
+                      })
+                  .collect(Collectors.toList()),
+              false));
+    }
+  }
+
+  public void addCompaction(List<TsFileResource> sourceList, List<TsFileResource> targetList) {
+    for (TsFileResource source : sourceList) {
+      this.sourcePath2targetEvents.put(
+          source.getTsFilePath(),
+          new Pair<>(
+              targetList.stream()
+                  .map(
+                      resource -> {
+                        // Build a PipeRealtimeEvent for each target file and increase its reference
+                        // count,
+                        // TsFile will be pinned here.
+                        PipeRealtimeEvent event =
+                            PipeRealtimeEventFactory.createRealtimeEvent(resource, false, false);
+                        event.increaseReferenceCount(
+                            PipeDataRegionCompactionRecorder.class.getName());
+                        return event;
+                      })
+                  .collect(Collectors.toList()),
+              false));
+    }
+  }
+
+  public Pair<List<PipeRealtimeEvent>, Boolean> getTargetRealtimeEventList(String sourcePath) {
+    return this.sourcePath2targetEvents.get(sourcePath);
+  }
+
+  /** Reset the visit state. */
+  public void resetVisited() {
+    for (Pair<List<PipeRealtimeEvent>, Boolean> pair : this.sourcePath2targetEvents.values()) {
+      pair.right = false;
+    }
+  }
+
+  public boolean isEmpty() {
+    return this.sourcePath2targetEvents.isEmpty();
+  }
+
+  @Override
+  public void close() {
+    for (Pair<List<PipeRealtimeEvent>, Boolean> pair : this.sourcePath2targetEvents.values()) {
+      for (PipeRealtimeEvent event : pair.left) {
+        // Decrease the reference count.
+        event.decreaseReferenceCount(PipeDataRegionCompactionRecorder.class.getName(), false);
+      }
+    }
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/realtime/listener/PipeInsertionDataNodeListener.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/realtime/listener/PipeInsertionDataNodeListener.java
@@ -157,10 +157,10 @@ public class PipeInsertionDataNodeListener {
   }
 
   public static PipeInsertionDataNodeListener getInstance() {
-    return PipeChangeDataCaptureListenerHolder.INSTANCE;
+    return PipeInsertionDataNodeListenerHolder.INSTANCE;
   }
 
-  private static class PipeChangeDataCaptureListenerHolder {
+  private static class PipeInsertionDataNodeListenerHolder {
     private static final PipeInsertionDataNodeListener INSTANCE =
         new PipeInsertionDataNodeListener();
   }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -227,6 +227,8 @@ public class CommonConfig {
   private long pipeMemoryExpanderIntervalSeconds = (long) 3 * 60; // 3Min
   private float pipeLeaderCacheMemoryUsagePercentage = 0.1F;
   private long pipeListeningQueueTransferSnapshotThreshold = 1000;
+  private boolean pipeRefreshFileListByCompactionEnabled = true;
+  private long pipeRefreshFileListByCompactionIntervalSeconds = 180;
 
   private int subscriptionSubtaskExecutorMaxThreadNum =
       Math.min(5, Math.max(1, Runtime.getRuntime().availableProcessors() / 2));
@@ -959,6 +961,25 @@ public class CommonConfig {
   public void setPipeListeningQueueTransferSnapshotThreshold(
       long pipeListeningQueueTransferSnapshotThreshold) {
     this.pipeListeningQueueTransferSnapshotThreshold = pipeListeningQueueTransferSnapshotThreshold;
+  }
+
+  public boolean isPipeRefreshFileListByCompactionEnabled() {
+    return pipeRefreshFileListByCompactionEnabled;
+  }
+
+  public void setPipeRefreshFileListByCompactionEnabled(
+      boolean pipeRefreshFileListByCompactionEnabled) {
+    this.pipeRefreshFileListByCompactionEnabled = pipeRefreshFileListByCompactionEnabled;
+  }
+
+  public long getPipeRefreshFileListByCompactionIntervalSeconds() {
+    return pipeRefreshFileListByCompactionIntervalSeconds;
+  }
+
+  public void setPipeRefreshFileListByCompactionIntervalSeconds(
+      long pipeRefreshFileListByCompactionIntervalSeconds) {
+    this.pipeRefreshFileListByCompactionIntervalSeconds =
+        pipeRefreshFileListByCompactionIntervalSeconds;
   }
 
   public int getSubscriptionSubtaskExecutorMaxThreadNum() {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -516,6 +516,17 @@ public class CommonDescriptor {
             properties.getProperty(
                 "pipe_listening_queue_transfer_snapshot_threshold",
                 String.valueOf(config.getPipeListeningQueueTransferSnapshotThreshold()))));
+
+    config.setPipeRefreshFileListByCompactionEnabled(
+        Boolean.parseBoolean(
+            properties.getProperty(
+                "pipe_refresh_file_list_by_compaction_enabled",
+                String.valueOf(config.isPipeRefreshFileListByCompactionEnabled()))));
+    config.setPipeRefreshFileListByCompactionIntervalSeconds(
+        Long.parseLong(
+            properties.getProperty(
+                "pipe_refresh_file_list_by_compaction_interval_seconds",
+                String.valueOf(config.getPipeRefreshFileListByCompactionIntervalSeconds()))));
   }
 
   private void loadSubscriptionProps(Properties properties) {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeConfig.java
@@ -135,6 +135,14 @@ public class PipeConfig {
     return COMMON_CONFIG.getPipeListeningQueueTransferSnapshotThreshold();
   }
 
+  public boolean isPipeRefreshFileListByCompactionEnabled() {
+    return COMMON_CONFIG.isPipeRefreshFileListByCompactionEnabled();
+  }
+
+  public long getPipeRefreshFileListByCompactionIntervalSeconds() {
+    return COMMON_CONFIG.getPipeRefreshFileListByCompactionIntervalSeconds();
+  }
+
   /////////////////////////////// Meta Consistency ///////////////////////////////
 
   public boolean isSeperatedPipeHeartbeatEnabled() {
@@ -291,6 +299,8 @@ public class PipeConfig {
     LOGGER.info(
         "PipeListeningQueueTransferSnapshotThreshold: {}",
         getPipeListeningQueueTransferSnapshotThreshold());
+    LOGGER.info(
+        "PipeRefreshFileListByCompactionEnabled: {}", isPipeRefreshFileListByCompactionEnabled());
 
     LOGGER.info("PipeAsyncConnectorSelectorNumber: {}", getPipeAsyncConnectorSelectorNumber());
     LOGGER.info("PipeAsyncConnectorMaxClientNumber: {}", getPipeAsyncConnectorMaxClientNumber());

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/task/connection/BlockingPendingQueue.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/task/connection/BlockingPendingQueue.java
@@ -108,6 +108,10 @@ public abstract class BlockingPendingQueue<E extends Event> {
     pendingQueue.forEach(action);
   }
 
+  public boolean remove(E event) {
+    return pendingQueue.remove(event);
+  }
+
   public boolean isEmpty() {
     return pendingQueue.isEmpty();
   }


### PR DESCRIPTION
This PR:
- added a listener for pipe to listen to compactions and record source/target files
- added a timed job to refresh realtime extractors' pending queue according to compactions

This PR has:
- [ ] been self-reviewed.
