### PR TITLE
Fix empty wal file deletion

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/buffer/WALBuffer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/buffer/WALBuffer.java
@@ -712,7 +712,7 @@ public class WALBuffer extends AbstractWALBuffer {
 
   public Set<Long> getMemTableIds(long fileVersionId) {
     if (fileVersionId >= currentWALFileVersion) {
-      return Collections.emptySet();
+      return null;
     }
     return memTableIdsOfWal.computeIfAbsent(
         fileVersionId,

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALMetaData.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALMetaData.java
@@ -138,6 +138,7 @@ public class WALMetaData implements SerializedSize {
     channel.read(metadataBuf, position - metadataSize);
     metadataBuf.flip();
     WALMetaData metaData = WALMetaData.deserialize(metadataBuf);
+    // versions before V1.3, should recover memTable ids from entries
     if (metaData.memTablesId.isEmpty()) {
       int offset = Byte.BYTES;
       for (int size : metaData.buffersSize) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
@@ -325,13 +325,15 @@ public class WALNode implements IWALNode {
       // calculate effective information ratio
       long costOfActiveMemTables = checkpointManager.getTotalCostOfActiveMemTables();
       MemTableInfo oldestUnpinnedMemTableInfo = checkpointManager.getOldestUnpinnedMemTableInfo();
+      long avgFileSize =
+          getFileNum() != 0
+              ? getTotalSize() / getFileNum()
+              : config.getWalFileSizeThresholdInByte();
       long totalCost =
           oldestUnpinnedMemTableInfo == null
               ? costOfActiveMemTables
-              : (getCurrentWALFileVersion()
-                      - oldestUnpinnedMemTableInfo.getFirstFileVersionId()
-                      + 1)
-                  * config.getWalFileSizeThresholdInByte();
+              : (getCurrentWALFileVersion() - oldestUnpinnedMemTableInfo.getFirstFileVersionId())
+                  * avgFileSize;
       if (totalCost == 0) {
         return;
       }
@@ -573,7 +575,7 @@ public class WALNode implements IWALNode {
       // If this set is empty, there is a case where WalEntry has been logged but not persisted,
       // because WalEntry is persisted asynchronously. In this case, the file cannot be deleted
       // directly, so it is considered active
-      if (memTableIdsOfCurrentWal == null || memTableIdsOfCurrentWal.isEmpty()) {
+      if (memTableIdsOfCurrentWal == null) {
         return true;
       }
       return !Collections.disjoint(


### PR DESCRIPTION
Cannnot delete empty wal file because wal uses empty set to represent active file. To fix this problem, I remove this rule and use null to represent active file.
Besides, I use avg size to calculate effective ratio and exclude active file from the calculation. By doing so, wal deletion can cover more corner cases.