### PR TITLE
Fix NPE when concurrently dropping database and deleting wal

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
@@ -461,6 +461,9 @@ public class WALNode implements IWALNode {
         logger.error("Fail to get data region processor for {}", oldestTsFile, e);
         return false;
       }
+      if (dataRegion == null) {
+        return false;
+      }
 
       // snapshot or flush memTable, flush memTable when it belongs to an old time partition, or
       // it's snapshot count or size reach threshold.


### PR DESCRIPTION
NPE occurs because drop database operation remove dataregion and wal deletion thread gets null. To fix it, I add if clause to avoid using null.