### PR TITLE
Deduplication IoTConsensus Configuration And Remove Unuseless File Delete

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -82,6 +82,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.PriorityQueue;
@@ -987,7 +988,14 @@ public class IoTConsensusServerImpl {
 
   public void removeDuplicateConfiguration() {
     Set<Peer> seen = new HashSet<>();
-    configuration.removeIf(peer -> !seen.add(peer));
+    Iterator<Peer> it = configuration.iterator();
+
+    while (it.hasNext()) {
+      Peer peer = it.next();
+      if (!seen.add(peer)) {
+        it.remove();
+      }
+    }
   }
 
   /**

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -81,9 +81,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.PriorityQueue;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -630,8 +632,8 @@ public class IoTConsensusServerImpl {
     // step 2, update configuration
     configuration.add(targetPeer);
     // step 3, persist configuration
-    logger.info("[IoTConsensus] persist new configuration: {}", configuration);
     persistConfiguration();
+    logger.info("[IoTConsensus] persist new configuration: {}", configuration);
   }
 
   public void removeSyncLogChannel(Peer targetPeer) throws ConsensusGroupModifyPeerException {
@@ -652,6 +654,7 @@ public class IoTConsensusServerImpl {
 
   public void persistConfiguration() {
     try {
+      removeDuplicateConfiguration();
       renameTmpConfigurationFileToRemoveSuffix();
       serializeConfigurationAndFsyncToDisk();
       deleteConfiguration();
@@ -981,6 +984,11 @@ public class IoTConsensusServerImpl {
                 }
               });
     }
+  }
+
+  public void removeDuplicateConfiguration() {
+    Set<Peer> seen = new HashSet<>();
+    configuration.removeIf(peer -> !seen.add(peer));
   }
 
   /**

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -710,7 +710,6 @@ public class IoTConsensusServerImpl {
       configuration.add(Peer.deserialize(buffer));
     }
     persistConfiguration();
-    Files.delete(oldConfigurationPath);
   }
 
   public static String generateConfigurationDatFileName(int nodeId, String suffix) {


### PR DESCRIPTION
## Description

- remove duplicate IoTConsensus configuration
- remove delete oldConfiguration in `recoverFromOldConfigurationFile` because it has been deleted in `persistConfiguration`