### PR TITLE
Fixed concurrency issues with RegionMigration thread pool

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/RegionMigrateService.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/RegionMigrateService.java
@@ -222,9 +222,7 @@ public class RegionMigrateService implements IService {
     private final Logger poolLogger = LoggerFactory.getLogger(RegionMigratePool.class);
 
     private RegionMigratePool() {
-      this.pool =
-          IoTDBThreadPoolFactory.newCachedThreadPool(
-              ThreadName.REGION_MIGRATE.getName(), Runtime.getRuntime().availableProcessors() / 2);
+      this.pool = IoTDBThreadPoolFactory.newCachedThreadPool(ThreadName.REGION_MIGRATE.getName());
     }
 
     @Override

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/IoTDBThreadPoolFactory.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/IoTDBThreadPoolFactory.java
@@ -178,18 +178,6 @@ public class IoTDBThreadPoolFactory {
         poolName);
   }
 
-  public static ExecutorService newCachedThreadPool(String poolName, int maximumPoolSize) {
-    logger.info(NEW_CACHED_THREAD_POOL_LOGGER_FORMAT, poolName);
-    return new WrappedThreadPoolExecutor(
-        0,
-        maximumPoolSize,
-        60L,
-        TimeUnit.SECONDS,
-        new LinkedBlockingQueue<>(),
-        new IoTThreadFactory(poolName),
-        poolName);
-  }
-
   public static ExecutorService newCachedThreadPool(
       String poolName, Thread.UncaughtExceptionHandler handler) {
     logger.info(NEW_CACHED_THREAD_POOL_LOGGER_FORMAT, poolName);


### PR DESCRIPTION
The current thread pool is still limited to a single task at most, which makes the parallelism of region migration a big problem