### PR TITLE
Fix Concurrency Instability When IoTConsensus LogDispatcher Exits

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -82,6 +82,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.PriorityQueue;
@@ -987,7 +988,14 @@ public class IoTConsensusServerImpl {
 
   public void removeDuplicateConfiguration() {
     Set<Peer> seen = new HashSet<>();
-    configuration.removeIf(peer -> !seen.add(peer));
+    Iterator<Peer> it = configuration.iterator();
+
+    while (it.hasNext()) {
+      Peer peer = it.next();
+      if (!seen.add(peer)) {
+        it.remove();
+      }
+    }
   }
 
   /**

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -81,9 +81,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.PriorityQueue;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -630,8 +632,8 @@ public class IoTConsensusServerImpl {
     // step 2, update configuration
     configuration.add(targetPeer);
     // step 3, persist configuration
-    logger.info("[IoTConsensus] persist new configuration: {}", configuration);
     persistConfiguration();
+    logger.info("[IoTConsensus] persist new configuration: {}", configuration);
   }
 
   public void removeSyncLogChannel(Peer targetPeer) throws ConsensusGroupModifyPeerException {
@@ -652,6 +654,7 @@ public class IoTConsensusServerImpl {
 
   public void persistConfiguration() {
     try {
+      removeDuplicateConfiguration();
       renameTmpConfigurationFileToRemoveSuffix();
       serializeConfigurationAndFsyncToDisk();
       deleteConfiguration();
@@ -981,6 +984,11 @@ public class IoTConsensusServerImpl {
                 }
               });
     }
+  }
+
+  public void removeDuplicateConfiguration() {
+    Set<Peer> seen = new HashSet<>();
+    configuration.removeIf(peer -> !seen.add(peer));
   }
 
   /**

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -710,7 +710,6 @@ public class IoTConsensusServerImpl {
       configuration.add(Peer.deserialize(buffer));
     }
     persistConfiguration();
-    Files.delete(oldConfigurationPath);
   }
 
   public static String generateConfigurationDatFileName(int nodeId, String suffix) {

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/LogDispatcher.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/LogDispatcher.java
@@ -365,6 +365,14 @@ public class LogDispatcher {
                 Thread.sleep(config.getReplication().getMaxWaitingTimeForAccumulatingBatchInMs());
               }
             }
+            // Immediately check for interrupts after poll and sleep
+            if (Thread.interrupted()) {
+              throw new InterruptedException("Interrupted after polling and sleeping");
+            }
+          }
+          // Immediately check for interrupts after a time-consuming getBatch() operation
+          if (Thread.interrupted()) {
+            throw new InterruptedException("Interrupted after getting a batch");
           }
           logDispatcherThreadMetrics.recordConstructBatchTime(System.nanoTime() - startTime);
           // we may block here if the synchronization pipeline is full

--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/ReplicateTest.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/ReplicateTest.java
@@ -50,6 +50,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -211,9 +212,17 @@ public class ReplicateTest {
       stopServer();
       initServer();
 
-      Assert.assertEquals(peers, servers.get(0).getImpl(gid).getConfiguration());
-      Assert.assertEquals(peers, servers.get(1).getImpl(gid).getConfiguration());
-      Assert.assertEquals(peers, servers.get(2).getImpl(gid).getConfiguration());
+      List<Peer> configuration = servers.get(0).getImpl(gid).getConfiguration();
+      configuration.sort(Comparator.comparingInt(Peer::getNodeId));
+      Assert.assertEquals(peers, configuration);
+
+      configuration = servers.get(1).getImpl(gid).getConfiguration();
+      configuration.sort(Comparator.comparingInt(Peer::getNodeId));
+      Assert.assertEquals(peers, configuration);
+
+      configuration = servers.get(2).getImpl(gid).getConfiguration();
+      configuration.sort(Comparator.comparingInt(Peer::getNodeId));
+      Assert.assertEquals(peers, configuration);
 
       Assert.assertEquals(CHECK_POINT_GAP, servers.get(0).getImpl(gid).getSearchIndex());
       Assert.assertEquals(CHECK_POINT_GAP, servers.get(1).getImpl(gid).getSearchIndex());
@@ -275,9 +284,17 @@ public class ReplicateTest {
 
       servers.get(2).createLocalPeer(group.getGroupId(), group.getPeers());
 
-      Assert.assertEquals(peers, servers.get(0).getImpl(gid).getConfiguration());
-      Assert.assertEquals(peers, servers.get(1).getImpl(gid).getConfiguration());
-      Assert.assertEquals(peers, servers.get(2).getImpl(gid).getConfiguration());
+      List<Peer> configuration = servers.get(0).getImpl(gid).getConfiguration();
+      configuration.sort(Comparator.comparingInt(Peer::getNodeId));
+      Assert.assertEquals(peers, configuration);
+
+      configuration = servers.get(1).getImpl(gid).getConfiguration();
+      configuration.sort(Comparator.comparingInt(Peer::getNodeId));
+      Assert.assertEquals(peers, configuration);
+
+      configuration = servers.get(2).getImpl(gid).getConfiguration();
+      configuration.sort(Comparator.comparingInt(Peer::getNodeId));
+      Assert.assertEquals(peers, configuration);
 
       Assert.assertEquals(CHECK_POINT_GAP, servers.get(0).getImpl(gid).getSearchIndex());
       Assert.assertEquals(CHECK_POINT_GAP, servers.get(1).getImpl(gid).getSearchIndex());

--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/ReplicateTest.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/ReplicateTest.java
@@ -113,6 +113,13 @@ public class ReplicateTest {
           Paths.get(new File(storageDir, CONFIGURATION_TMP_FILE_NAME).getAbsolutePath());
       Path configurationPath =
           Paths.get(new File(storageDir, CONFIGURATION_FILE_NAME).getAbsolutePath());
+      if (!Files.exists(configurationPath) && !Files.exists(tmpConfigurationPath)) {
+        return;
+      }
+      if (!Files.exists(tmpConfigurationPath)) {
+        Files.createDirectories(tmpConfigurationPath.getParent());
+        Files.createFile(tmpConfigurationPath);
+      }
       Files.write(tmpConfigurationPath, publicBAOS.getBuf());
       if (Files.exists(configurationPath)) {
         Files.delete(configurationPath);


### PR DESCRIPTION
## Description

- Immediately check `Thread.interrupted()` for interrupts after `getBatch()`
- Fix configuration logic in ReplicateTest