### PR TITLE
Revert `-XX:GuaranteedSafepointInterval=0` JVM option

### DIFF
--- a/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.bat
+++ b/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.bat
@@ -123,9 +123,6 @@ set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -Djdk.nio.maxCachedBufferSize=%MAX_CACHED_
 set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:+CrashOnOutOfMemoryError
 set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:+UseAdaptiveSizePolicy
 set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -Xss512k
-@REM options below try to optimize safepoint stw time.
-set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:+UnlockDiagnosticVMOptions
-set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:GuaranteedSafepointInterval=0
 @REM these two options print safepoints with pauses longer than 1000ms to the standard output. You can see these logs via redirection when starting in the background like "start-datanode.sh > log_datanode_safepoint.txt"
 set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:SafepointTimeoutDelay=1000
 set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:+SafepointTimeout

--- a/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.sh
+++ b/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.sh
@@ -277,9 +277,6 @@ IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Djdk.nio.maxCachedBufferSize=${MAX_CACHED_BUFFE
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:+CrashOnOutOfMemoryError"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:+UseAdaptiveSizePolicy"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xss512k"
-# options below try to optimize safepoint stw time.
-IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:+UnlockDiagnosticVMOptions"
-IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:GuaranteedSafepointInterval=0"
 # these two options print safepoints with pauses longer than 1000ms to the standard output. You can see these logs via redirection when starting in the background like "start-datanode.sh > log_datanode_safepoint.log"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:SafepointTimeoutDelay=1000"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:+SafepointTimeout"


### PR DESCRIPTION
According to https://bugs.openjdk.org/browse/JDK-8304316 and https://bugs.openjdk.org/browse/JDK-8305994, when `-XX:GuaranteedSafepointInterval=0` and certain versions of JDK 15 ~ JDK 17 are used, the JVM's monitor memory may continue to expand, causing Java's non-heap memory to occupy a large amount of RSS. So we revert `-XX:GuaranteedSafepointInterval=0`