### PR TITLE
Add hot reload for IoTConsensus transit snapshot rate limiter and fix init

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/IConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/IConsensus.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.commons.consensus.ConsensusGroupId;
 import org.apache.iotdb.consensus.common.DataSet;
 import org.apache.iotdb.consensus.common.Peer;
 import org.apache.iotdb.consensus.common.request.IConsensusRequest;
+import org.apache.iotdb.consensus.config.ConsensusConfig;
 import org.apache.iotdb.consensus.exception.ConsensusException;
 import org.apache.iotdb.consensus.exception.ConsensusGroupAlreadyExistException;
 import org.apache.iotdb.consensus.exception.ConsensusGroupNotExistException;
@@ -234,4 +235,11 @@ public interface IConsensus {
    * @return region directory
    */
   String getRegionDirFromConsensusGroupId(ConsensusGroupId groupId);
+
+  /**
+   * Reload the consensus config.
+   *
+   * @param consensusConfig the new consensus config
+   */
+  void reloadConsensusConfig(ConsensusConfig consensusConfig);
 }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensus.java
@@ -92,7 +92,7 @@ public class IoTConsensus implements IConsensus {
       new ConcurrentHashMap<>();
   private final IoTConsensusRPCService service;
   private final RegisterManager registerManager = new RegisterManager();
-  private final IoTConsensusConfig config;
+  private IoTConsensusConfig config;
   private final IClientManager<TEndPoint, AsyncIoTConsensusServiceClient> clientManager;
   private final IClientManager<TEndPoint, SyncIoTConsensusServiceClient> syncClientManager;
   private final ScheduledExecutorService backgroundTaskService;
@@ -462,6 +462,15 @@ public class IoTConsensus implements IConsensus {
   @Override
   public String getRegionDirFromConsensusGroupId(ConsensusGroupId groupId) {
     return buildPeerDir(storageDir, groupId);
+  }
+
+  @Override
+  public void reloadConsensusConfig(ConsensusConfig consensusConfig) {
+    config = consensusConfig.getIotConsensusConfig();
+
+    // only update region migration speed limit for now
+    IoTConsensusRateLimiter.getInstance()
+        .init(config.getReplication().getRegionMigrationSpeedLimitBytesPerSecond());
   }
 
   public void resetPeerList(ConsensusGroupId groupId, List<Peer> correctPeers)

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/snapshot/IoTConsensusRateLimiter.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/snapshot/IoTConsensusRateLimiter.java
@@ -31,7 +31,10 @@ public class IoTConsensusRateLimiter {
   private IoTConsensusRateLimiter() {}
 
   public void init(long regionMigrationSpeedLimitBytesPerSecond) {
-    rateLimiter.setRate(regionMigrationSpeedLimitBytesPerSecond);
+    rateLimiter.setRate(
+        regionMigrationSpeedLimitBytesPerSecond <= 0
+            ? Double.MAX_VALUE
+            : regionMigrationSpeedLimitBytesPerSecond);
   }
 
   /**

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -734,6 +734,11 @@ class RatisConsensus implements IConsensus {
   }
 
   @Override
+  public void reloadConsensusConfig(ConsensusConfig consensusConfig) {
+    // do not support reload consensus config for now
+  }
+
+  @Override
   public void triggerSnapshot(ConsensusGroupId groupId, boolean force) throws ConsensusException {
     final RaftGroupId raftGroupId = Utils.fromConsensusGroupIdToRaftGroupId(groupId);
     final RaftGroup groupInfo = getGroupInfo(raftGroupId);

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/simple/SimpleConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/simple/SimpleConsensus.java
@@ -260,6 +260,11 @@ class SimpleConsensus implements IConsensus {
   }
 
   @Override
+  public void reloadConsensusConfig(ConsensusConfig consensusConfig) {
+    // do not support reload consensus config for now
+  }
+
+  @Override
   public void resetPeerList(ConsensusGroupId groupId, List<Peer> peers) throws ConsensusException {
     throw new ConsensusException("SimpleConsensus does not support reset peer list");
   }

--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/ReplicateTest.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/ReplicateTest.java
@@ -50,9 +50,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 public class ReplicateTest {
 
@@ -212,17 +212,23 @@ public class ReplicateTest {
       stopServer();
       initServer();
 
-      List<Peer> configuration = servers.get(0).getImpl(gid).getConfiguration();
-      configuration.sort(Comparator.comparingInt(Peer::getNodeId));
-      Assert.assertEquals(peers, configuration);
+      Assert.assertEquals(
+          peers.stream().map(Peer::getNodeId).collect(Collectors.toSet()),
+          servers.get(0).getImpl(gid).getConfiguration().stream()
+              .map(Peer::getNodeId)
+              .collect(Collectors.toSet()));
 
-      configuration = servers.get(1).getImpl(gid).getConfiguration();
-      configuration.sort(Comparator.comparingInt(Peer::getNodeId));
-      Assert.assertEquals(peers, configuration);
+      Assert.assertEquals(
+          peers.stream().map(Peer::getNodeId).collect(Collectors.toSet()),
+          servers.get(1).getImpl(gid).getConfiguration().stream()
+              .map(Peer::getNodeId)
+              .collect(Collectors.toSet()));
 
-      configuration = servers.get(2).getImpl(gid).getConfiguration();
-      configuration.sort(Comparator.comparingInt(Peer::getNodeId));
-      Assert.assertEquals(peers, configuration);
+      Assert.assertEquals(
+          peers.stream().map(Peer::getNodeId).collect(Collectors.toSet()),
+          servers.get(2).getImpl(gid).getConfiguration().stream()
+              .map(Peer::getNodeId)
+              .collect(Collectors.toSet()));
 
       Assert.assertEquals(CHECK_POINT_GAP, servers.get(0).getImpl(gid).getSearchIndex());
       Assert.assertEquals(CHECK_POINT_GAP, servers.get(1).getImpl(gid).getSearchIndex());
@@ -283,18 +289,23 @@ public class ReplicateTest {
       initServer();
 
       servers.get(2).createLocalPeer(group.getGroupId(), group.getPeers());
+      Assert.assertEquals(
+          peers.stream().map(Peer::getNodeId).collect(Collectors.toSet()),
+          servers.get(0).getImpl(gid).getConfiguration().stream()
+              .map(Peer::getNodeId)
+              .collect(Collectors.toSet()));
 
-      List<Peer> configuration = servers.get(0).getImpl(gid).getConfiguration();
-      configuration.sort(Comparator.comparingInt(Peer::getNodeId));
-      Assert.assertEquals(peers, configuration);
+      Assert.assertEquals(
+          peers.stream().map(Peer::getNodeId).collect(Collectors.toSet()),
+          servers.get(1).getImpl(gid).getConfiguration().stream()
+              .map(Peer::getNodeId)
+              .collect(Collectors.toSet()));
 
-      configuration = servers.get(1).getImpl(gid).getConfiguration();
-      configuration.sort(Comparator.comparingInt(Peer::getNodeId));
-      Assert.assertEquals(peers, configuration);
-
-      configuration = servers.get(2).getImpl(gid).getConfiguration();
-      configuration.sort(Comparator.comparingInt(Peer::getNodeId));
-      Assert.assertEquals(peers, configuration);
+      Assert.assertEquals(
+          peers.stream().map(Peer::getNodeId).collect(Collectors.toSet()),
+          servers.get(2).getImpl(gid).getConfiguration().stream()
+              .map(Peer::getNodeId)
+              .collect(Collectors.toSet()));
 
       Assert.assertEquals(CHECK_POINT_GAP, servers.get(0).getImpl(gid).getSearchIndex());
       Assert.assertEquals(CHECK_POINT_GAP, servers.get(1).getImpl(gid).getSearchIndex());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -1053,9 +1053,9 @@ public class IoTDBDescriptor {
     loadIoTConsensusProps(properties);
   }
 
-  private void reloadIoTConsensusProps(Properties properties) {
+  private void reloadConsensusProps(Properties properties) {
     loadIoTConsensusProps(properties);
-    DataRegionConsensusImpl.reloadConsensusConfig(conf);
+    DataRegionConsensusImpl.reloadConsensusConfig();
   }
 
   private void loadIoTConsensusProps(Properties properties) {
@@ -1713,8 +1713,8 @@ public class IoTDBDescriptor {
                   "merge_threshold_of_explain_analyze",
                   String.valueOf(conf.getMergeThresholdOfExplainAnalyze()))));
 
-      // update IoTConsensus config
-      reloadIoTConsensusProps(properties);
+      // update Consensus config
+      reloadConsensusProps(properties);
     } catch (Exception e) {
       throw new QueryProcessException(String.format("Fail to reload configuration because %s", e));
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -28,6 +28,7 @@ import org.apache.iotdb.commons.utils.NodeUrlUtils;
 import org.apache.iotdb.confignode.rpc.thrift.TCQConfig;
 import org.apache.iotdb.confignode.rpc.thrift.TGlobalConfig;
 import org.apache.iotdb.confignode.rpc.thrift.TRatisConfig;
+import org.apache.iotdb.db.consensus.DataRegionConsensusImpl;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.service.metrics.IoTDBInternalLocalReporter;
 import org.apache.iotdb.db.storageengine.StorageEngine;
@@ -1052,6 +1053,11 @@ public class IoTDBDescriptor {
     loadIoTConsensusProps(properties);
   }
 
+  private void reloadIoTConsensusProps(Properties properties) {
+    loadIoTConsensusProps(properties);
+    DataRegionConsensusImpl.reloadConsensusConfig(conf);
+  }
+
   private void loadIoTConsensusProps(Properties properties) {
     conf.setMaxLogEntriesNumPerBatch(
         Integer.parseInt(
@@ -1707,6 +1713,8 @@ public class IoTDBDescriptor {
                   "merge_threshold_of_explain_analyze",
                   String.valueOf(conf.getMergeThresholdOfExplainAnalyze()))));
 
+      // update IoTConsensus config
+      reloadIoTConsensusProps(properties);
     } catch (Exception e) {
       throw new QueryProcessException(String.format("Fail to reload configuration because %s", e));
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/DataRegionConsensusImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/DataRegionConsensusImpl.java
@@ -61,9 +61,15 @@ public class DataRegionConsensusImpl {
     DataRegionConsensusImpl.DataRegionConsensusImplHolder.reinitializeStatics();
   }
 
+  public static void reloadConsensusConfig(IoTDBConfig conf) {
+    DataRegionConsensusImpl.DataRegionConsensusImplHolder.CONF = conf;
+    ConsensusConfig consensusConfig = DataRegionConsensusImplHolder.buildConsensusConfig();
+    getInstance().reloadConsensusConfig(consensusConfig);
+  }
+
   private static class DataRegionConsensusImplHolder {
 
-    private static final IoTDBConfig CONF = IoTDBDescriptor.getInstance().getConfig();
+    private static IoTDBConfig CONF = IoTDBDescriptor.getInstance().getConfig();
 
     private static IConsensus INSTANCE;
 
@@ -76,141 +82,7 @@ public class DataRegionConsensusImpl {
       INSTANCE =
           ConsensusFactory.getConsensusImpl(
                   CONF.getDataRegionConsensusProtocolClass(),
-                  ConsensusConfig.newBuilder()
-                      .setThisNodeId(CONF.getDataNodeId())
-                      .setThisNode(
-                          new TEndPoint(
-                              CONF.getInternalAddress(), CONF.getDataRegionConsensusPort()))
-                      .setStorageDir(CONF.getDataRegionConsensusDir())
-                      .setConsensusGroupType(TConsensusGroupType.DataRegion)
-                      .setIoTConsensusConfig(
-                          IoTConsensusConfig.newBuilder()
-                              .setRpc(
-                                  RPC.newBuilder()
-                                      .setConnectionTimeoutInMs(CONF.getConnectionTimeoutInMS())
-                                      .setRpcSelectorThreadNum(CONF.getRpcSelectorThreadCount())
-                                      .setRpcMinConcurrentClientNum(
-                                          CONF.getRpcMinConcurrentClientNum())
-                                      .setRpcMaxConcurrentClientNum(
-                                          CONF.getRpcMaxConcurrentClientNum())
-                                      .setRpcThriftCompressionEnabled(
-                                          CONF.isRpcThriftCompressionEnable())
-                                      .setSelectorNumOfClientManager(
-                                          CONF.getSelectorNumOfClientManager())
-                                      .setThriftServerAwaitTimeForStopService(
-                                          CONF.getThriftServerAwaitTimeForStopService())
-                                      .setThriftMaxFrameSize(CONF.getThriftMaxFrameSize())
-                                      .setMaxClientNumForEachNode(CONF.getMaxClientNumForEachNode())
-                                      .build())
-                              .setReplication(
-                                  IoTConsensusConfig.Replication.newBuilder()
-                                      .setWalThrottleThreshold(CONF.getThrottleThreshold())
-                                      .setAllocateMemoryForConsensus(
-                                          CONF.getAllocateMemoryForConsensus())
-                                      .setMaxLogEntriesNumPerBatch(
-                                          CONF.getMaxLogEntriesNumPerBatch())
-                                      .setMaxSizePerBatch(CONF.getMaxSizePerBatch())
-                                      .setMaxPendingBatchesNum(CONF.getMaxPendingBatchesNum())
-                                      .setMaxMemoryRatioForQueue(CONF.getMaxMemoryRatioForQueue())
-                                      .setRegionMigrationSpeedLimitBytesPerSecond(
-                                          CONF.getRegionMigrationSpeedLimitBytesPerSecond())
-                                      .build())
-                              .build())
-                      .setRatisConfig(
-                          RatisConfig.newBuilder()
-                              // An empty log is committed after each restart, even if no data is
-                              // written. This setting ensures that compaction work is not discarded
-                              // even if there are frequent restarts
-                              .setSnapshot(
-                                  Snapshot.newBuilder()
-                                      .setCreationGap(1)
-                                      .setAutoTriggerThreshold(
-                                          CONF.getDataRatisConsensusSnapshotTriggerThreshold())
-                                      .build())
-                              .setLog(
-                                  RatisConfig.Log.newBuilder()
-                                      .setUnsafeFlushEnabled(
-                                          CONF.isDataRatisConsensusLogUnsafeFlushEnable())
-                                      .setForceSyncNum(CONF.getDataRatisConsensusLogForceSyncNum())
-                                      .setSegmentSizeMax(
-                                          SizeInBytes.valueOf(
-                                              CONF.getDataRatisConsensusLogSegmentSizeMax()))
-                                      .setPreserveNumsWhenPurge(
-                                          CONF.getDataRatisConsensusPreserveWhenPurge())
-                                      .build())
-                              .setGrpc(
-                                  RatisConfig.Grpc.newBuilder()
-                                      .setFlowControlWindow(
-                                          SizeInBytes.valueOf(
-                                              CONF.getDataRatisConsensusGrpcFlowControlWindow()))
-                                      .setLeaderOutstandingAppendsMax(
-                                          CONF
-                                              .getDataRatisConsensusGrpcLeaderOutstandingAppendsMax())
-                                      .build())
-                              .setRpc(
-                                  RatisConfig.Rpc.newBuilder()
-                                      .setTimeoutMin(
-                                          TimeDuration.valueOf(
-                                              CONF
-                                                  .getDataRatisConsensusLeaderElectionTimeoutMinMs(),
-                                              TimeUnit.MILLISECONDS))
-                                      .setTimeoutMax(
-                                          TimeDuration.valueOf(
-                                              CONF
-                                                  .getDataRatisConsensusLeaderElectionTimeoutMaxMs(),
-                                              TimeUnit.MILLISECONDS))
-                                      .setRequestTimeout(
-                                          TimeDuration.valueOf(
-                                              CONF.getDataRatisConsensusRequestTimeoutMs(),
-                                              TimeUnit.MILLISECONDS))
-                                      .setSlownessTimeout(
-                                          TimeDuration.valueOf(
-                                              CONF.getDataRatisConsensusRequestTimeoutMs() * 6,
-                                              TimeUnit.MILLISECONDS))
-                                      .setFirstElectionTimeoutMin(
-                                          TimeDuration.valueOf(
-                                              CONF.getRatisFirstElectionTimeoutMinMs(),
-                                              TimeUnit.MILLISECONDS))
-                                      .setFirstElectionTimeoutMax(
-                                          TimeDuration.valueOf(
-                                              CONF.getRatisFirstElectionTimeoutMaxMs(),
-                                              TimeUnit.MILLISECONDS))
-                                      .build())
-                              .setClient(
-                                  RatisConfig.Client.newBuilder()
-                                      .setClientRequestTimeoutMillis(
-                                          CONF.getDataRatisConsensusRequestTimeoutMs())
-                                      .setClientMaxRetryAttempt(
-                                          CONF.getDataRatisConsensusMaxRetryAttempts())
-                                      .setClientRetryInitialSleepTimeMs(
-                                          CONF.getDataRatisConsensusInitialSleepTimeMs())
-                                      .setClientRetryMaxSleepTimeMs(
-                                          CONF.getDataRatisConsensusMaxSleepTimeMs())
-                                      .setMaxClientNumForEachNode(CONF.getMaxClientNumForEachNode())
-                                      .build())
-                              .setImpl(
-                                  RatisConfig.Impl.newBuilder()
-                                      .setRaftLogSizeMaxThreshold(CONF.getDataRatisLogMax())
-                                      .setForceSnapshotInterval(
-                                          CONF.getDataRatisPeriodicSnapshotInterval())
-                                      .setRetryTimesMax(10)
-                                      .setRetryWaitMillis(CONF.getConnectionTimeoutInMS() / 10)
-                                      .build())
-                              .setLeaderLogAppender(
-                                  RatisConfig.LeaderLogAppender.newBuilder()
-                                      .setBufferByteLimit(
-                                          CONF.getDataRatisConsensusLogAppenderBufferSizeMax())
-                                      .build())
-                              .setRead(
-                                  RatisConfig.Read.newBuilder()
-                                      // use thrift connection timeout to unify read timeout
-                                      .setReadTimeout(
-                                          TimeDuration.valueOf(
-                                              CONF.getConnectionTimeoutInMS(),
-                                              TimeUnit.MILLISECONDS))
-                                      .build())
-                              .build())
-                      .build(),
+                  buildConsensusConfig(),
                   DataRegionConsensusImplHolder::createDataRegionStateMachine)
               .orElseThrow(
                   () ->
@@ -227,6 +99,123 @@ public class DataRegionConsensusImpl {
       } else {
         return new DataRegionStateMachine(dataRegion);
       }
+    }
+
+    private static ConsensusConfig buildConsensusConfig() {
+      return ConsensusConfig.newBuilder()
+          .setThisNodeId(CONF.getDataNodeId())
+          .setThisNode(new TEndPoint(CONF.getInternalAddress(), CONF.getDataRegionConsensusPort()))
+          .setStorageDir(CONF.getDataRegionConsensusDir())
+          .setConsensusGroupType(TConsensusGroupType.DataRegion)
+          .setIoTConsensusConfig(
+              IoTConsensusConfig.newBuilder()
+                  .setRpc(
+                      RPC.newBuilder()
+                          .setConnectionTimeoutInMs(CONF.getConnectionTimeoutInMS())
+                          .setRpcSelectorThreadNum(CONF.getRpcSelectorThreadCount())
+                          .setRpcMinConcurrentClientNum(CONF.getRpcMinConcurrentClientNum())
+                          .setRpcMaxConcurrentClientNum(CONF.getRpcMaxConcurrentClientNum())
+                          .setRpcThriftCompressionEnabled(CONF.isRpcThriftCompressionEnable())
+                          .setSelectorNumOfClientManager(CONF.getSelectorNumOfClientManager())
+                          .setThriftServerAwaitTimeForStopService(
+                              CONF.getThriftServerAwaitTimeForStopService())
+                          .setThriftMaxFrameSize(CONF.getThriftMaxFrameSize())
+                          .setMaxClientNumForEachNode(CONF.getMaxClientNumForEachNode())
+                          .build())
+                  .setReplication(
+                      IoTConsensusConfig.Replication.newBuilder()
+                          .setWalThrottleThreshold(CONF.getThrottleThreshold())
+                          .setAllocateMemoryForConsensus(CONF.getAllocateMemoryForConsensus())
+                          .setMaxLogEntriesNumPerBatch(CONF.getMaxLogEntriesNumPerBatch())
+                          .setMaxSizePerBatch(CONF.getMaxSizePerBatch())
+                          .setMaxPendingBatchesNum(CONF.getMaxPendingBatchesNum())
+                          .setMaxMemoryRatioForQueue(CONF.getMaxMemoryRatioForQueue())
+                          .setRegionMigrationSpeedLimitBytesPerSecond(
+                              CONF.getRegionMigrationSpeedLimitBytesPerSecond())
+                          .build())
+                  .build())
+          .setRatisConfig(
+              RatisConfig.newBuilder()
+                  // An empty log is committed after each restart, even if no data is
+                  // written. This setting ensures that compaction work is not discarded
+                  // even if there are frequent restarts
+                  .setSnapshot(
+                      Snapshot.newBuilder()
+                          .setCreationGap(1)
+                          .setAutoTriggerThreshold(
+                              CONF.getDataRatisConsensusSnapshotTriggerThreshold())
+                          .build())
+                  .setLog(
+                      RatisConfig.Log.newBuilder()
+                          .setUnsafeFlushEnabled(CONF.isDataRatisConsensusLogUnsafeFlushEnable())
+                          .setForceSyncNum(CONF.getDataRatisConsensusLogForceSyncNum())
+                          .setSegmentSizeMax(
+                              SizeInBytes.valueOf(CONF.getDataRatisConsensusLogSegmentSizeMax()))
+                          .setPreserveNumsWhenPurge(CONF.getDataRatisConsensusPreserveWhenPurge())
+                          .build())
+                  .setGrpc(
+                      RatisConfig.Grpc.newBuilder()
+                          .setFlowControlWindow(
+                              SizeInBytes.valueOf(
+                                  CONF.getDataRatisConsensusGrpcFlowControlWindow()))
+                          .setLeaderOutstandingAppendsMax(
+                              CONF.getDataRatisConsensusGrpcLeaderOutstandingAppendsMax())
+                          .build())
+                  .setRpc(
+                      RatisConfig.Rpc.newBuilder()
+                          .setTimeoutMin(
+                              TimeDuration.valueOf(
+                                  CONF.getDataRatisConsensusLeaderElectionTimeoutMinMs(),
+                                  TimeUnit.MILLISECONDS))
+                          .setTimeoutMax(
+                              TimeDuration.valueOf(
+                                  CONF.getDataRatisConsensusLeaderElectionTimeoutMaxMs(),
+                                  TimeUnit.MILLISECONDS))
+                          .setRequestTimeout(
+                              TimeDuration.valueOf(
+                                  CONF.getDataRatisConsensusRequestTimeoutMs(),
+                                  TimeUnit.MILLISECONDS))
+                          .setSlownessTimeout(
+                              TimeDuration.valueOf(
+                                  CONF.getDataRatisConsensusRequestTimeoutMs() * 6,
+                                  TimeUnit.MILLISECONDS))
+                          .setFirstElectionTimeoutMin(
+                              TimeDuration.valueOf(
+                                  CONF.getRatisFirstElectionTimeoutMinMs(), TimeUnit.MILLISECONDS))
+                          .setFirstElectionTimeoutMax(
+                              TimeDuration.valueOf(
+                                  CONF.getRatisFirstElectionTimeoutMaxMs(), TimeUnit.MILLISECONDS))
+                          .build())
+                  .setClient(
+                      RatisConfig.Client.newBuilder()
+                          .setClientRequestTimeoutMillis(
+                              CONF.getDataRatisConsensusRequestTimeoutMs())
+                          .setClientMaxRetryAttempt(CONF.getDataRatisConsensusMaxRetryAttempts())
+                          .setClientRetryInitialSleepTimeMs(
+                              CONF.getDataRatisConsensusInitialSleepTimeMs())
+                          .setClientRetryMaxSleepTimeMs(CONF.getDataRatisConsensusMaxSleepTimeMs())
+                          .setMaxClientNumForEachNode(CONF.getMaxClientNumForEachNode())
+                          .build())
+                  .setImpl(
+                      RatisConfig.Impl.newBuilder()
+                          .setRaftLogSizeMaxThreshold(CONF.getDataRatisLogMax())
+                          .setForceSnapshotInterval(CONF.getDataRatisPeriodicSnapshotInterval())
+                          .setRetryTimesMax(10)
+                          .setRetryWaitMillis(CONF.getConnectionTimeoutInMS() / 10)
+                          .build())
+                  .setLeaderLogAppender(
+                      RatisConfig.LeaderLogAppender.newBuilder()
+                          .setBufferByteLimit(CONF.getDataRatisConsensusLogAppenderBufferSizeMax())
+                          .build())
+                  .setRead(
+                      RatisConfig.Read.newBuilder()
+                          // use thrift connection timeout to unify read timeout
+                          .setReadTimeout(
+                              TimeDuration.valueOf(
+                                  CONF.getConnectionTimeoutInMS(), TimeUnit.MILLISECONDS))
+                          .build())
+                  .build())
+          .build();
     }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/DataRegionConsensusImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/DataRegionConsensusImpl.java
@@ -61,15 +61,13 @@ public class DataRegionConsensusImpl {
     DataRegionConsensusImpl.DataRegionConsensusImplHolder.reinitializeStatics();
   }
 
-  public static void reloadConsensusConfig(IoTDBConfig conf) {
-    DataRegionConsensusImpl.DataRegionConsensusImplHolder.CONF = conf;
-    ConsensusConfig consensusConfig = DataRegionConsensusImplHolder.buildConsensusConfig();
-    getInstance().reloadConsensusConfig(consensusConfig);
+  public static void reloadConsensusConfig() {
+    getInstance().reloadConsensusConfig(DataRegionConsensusImplHolder.buildConsensusConfig());
   }
 
   private static class DataRegionConsensusImplHolder {
 
-    private static IoTDBConfig CONF = IoTDBDescriptor.getInstance().getConfig();
+    private static final IoTDBConfig CONF = IoTDBDescriptor.getInstance().getConfig();
 
     private static IConsensus INSTANCE;
 

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -782,6 +782,7 @@ data_replication_factor=1
 # data_region_iot_max_memory_ratio_for_queue = 0.6
 
 # The maximum transit size in byte per second for region migration
+# values less than or equal to 0 means no limit
 # Datatype: long
 # region_migration_speed_limit_bytes_per_second = 33554432
 


### PR DESCRIPTION
## Description
- add hot reload for `region_migration_speed_limit_bytes_per_second`
- values less than or equal to 0 means no limit