### PR TITLE
Pipe: handle insert data type mismatch exceptions as idempotent exceptions when partial insert is enabled

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/exception/metadata/DataTypeMismatchException.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/exception/metadata/DataTypeMismatchException.java
@@ -24,6 +24,10 @@ import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.tsfile.enums.TSDataType;
 
 public class DataTypeMismatchException extends MetadataException {
+
+  // NOTICE: DO NOT CHANGE THIS STRING, IT IS USED IN THE ERROR HANDLING OF PIPE
+  public static final String REGISTERED_TYPE_STRING = "registered type";
+
   public DataTypeMismatchException(
       String deviceName,
       String measurementName,
@@ -34,9 +38,10 @@ public class DataTypeMismatchException extends MetadataException {
     super(
         String.format(
             "data type of %s.%s is not consistent, "
-                + "registered type %s, inserting type %s, timestamp %s, value %s",
+                + "%s %s, inserting type %s, timestamp %s, value %s",
             deviceName,
             measurementName,
+            REGISTERED_TYPE_STRING,
             typeInSchema,
             insertType,
             time,


### PR DESCRIPTION
As title.