### PR TITLE
Lift the storage limit for tag and attribute management

### DIFF
--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppCommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppCommonConfig.java
@@ -426,6 +426,24 @@ public class MppCommonConfig extends MppBaseConfig implements CommonConfig {
     return this;
   }
 
+  @Override
+  public CommonConfig setTagAttributeTotalSize(int tagAttributeTotalSize) {
+    setProperty("tag_attribute_total_size", String.valueOf(tagAttributeTotalSize));
+    return this;
+  }
+
+  @Override
+  public CommonConfig setTagAttributeMaxNum(int tagAttributeMaxNum) {
+    setProperty("tag_attribute_max_num", String.valueOf(tagAttributeMaxNum));
+    return this;
+  }
+
+  @Override
+  public CommonConfig setTagAttributeEntryMaxSize(int tagAttributeEntryMaxSize) {
+    setProperty("tag_attribute_entry_max_size", String.valueOf(tagAttributeEntryMaxSize));
+    return this;
+  }
+
   // For part of the log directory
   public String getClusterConfigStr() {
     return fromConsensusFullNameToAbbr(properties.getProperty(CONFIG_NODE_CONSENSUS_PROTOCOL_CLASS))

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppSharedCommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppSharedCommonConfig.java
@@ -431,4 +431,25 @@ public class MppSharedCommonConfig implements CommonConfig {
     cnConfig.setWalMode(walMode);
     return this;
   }
+
+  @Override
+  public CommonConfig setTagAttributeTotalSize(int tagAttributeTotalSize) {
+    dnConfig.setTagAttributeTotalSize(tagAttributeTotalSize);
+    cnConfig.setTagAttributeTotalSize(tagAttributeTotalSize);
+    return this;
+  }
+
+  @Override
+  public CommonConfig setTagAttributeMaxNum(int tagAttributeMaxNum) {
+    dnConfig.setTagAttributeMaxNum(tagAttributeMaxNum);
+    cnConfig.setTagAttributeMaxNum(tagAttributeMaxNum);
+    return this;
+  }
+
+  @Override
+  public CommonConfig setTagAttributeEntryMaxSize(int tagAttributeEntryMaxSize) {
+    dnConfig.setTagAttributeEntryMaxSize(tagAttributeEntryMaxSize);
+    cnConfig.setTagAttributeEntryMaxSize(tagAttributeEntryMaxSize);
+    return this;
+  }
 }

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/remote/config/RemoteCommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/remote/config/RemoteCommonConfig.java
@@ -303,4 +303,19 @@ public class RemoteCommonConfig implements CommonConfig {
   public CommonConfig setWalMode(String walMode) {
     return this;
   }
+
+  @Override
+  public CommonConfig setTagAttributeTotalSize(int tagAttributeTotalSize) {
+    return this;
+  }
+
+  @Override
+  public CommonConfig setTagAttributeMaxNum(int tagAttributeMaxNum) {
+    return this;
+  }
+
+  @Override
+  public CommonConfig setTagAttributeEntryMaxSize(int tagAttributeEntryMaxSize) {
+    return this;
+  }
 }

--- a/integration-test/src/main/java/org/apache/iotdb/itbase/env/CommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/itbase/env/CommonConfig.java
@@ -135,4 +135,10 @@ public interface CommonConfig {
   CommonConfig setDriverTaskExecutionTimeSliceInMs(long driverTaskExecutionTimeSliceInMs);
 
   CommonConfig setWalMode(String walMode);
+
+  CommonConfig setTagAttributeTotalSize(int tagAttributeTotalSize);
+
+  CommonConfig setTagAttributeMaxNum(int tagAttributeMaxNum);
+
+  CommonConfig setTagAttributeEntryMaxSize(int tagAttributeEntryMaxSize);
 }

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBTagLimitIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBTagLimitIT.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.it.schema;
 
 import org.apache.iotdb.db.queryengine.common.header.ColumnHeaderConstant;
 import org.apache.iotdb.it.env.EnvFactory;
+import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 import org.apache.iotdb.rpc.TSStatusCode;
@@ -31,6 +32,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -44,6 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@RunWith(IoTDBTestRunner.class)
 @Category({LocalStandaloneIT.class, ClusterIT.class})
 public class IoTDBTagLimitIT extends AbstractSchemaIT {
 

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBTagLimitIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBTagLimitIT.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.it.schema;
+
+import org.apache.iotdb.db.queryengine.common.header.ColumnHeaderConstant;
+import org.apache.iotdb.it.env.EnvFactory;
+import org.apache.iotdb.itbase.category.ClusterIT;
+import org.apache.iotdb.itbase.category.LocalStandaloneIT;
+import org.apache.iotdb.rpc.TSStatusCode;
+import org.apache.iotdb.util.AbstractSchemaIT;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.iotdb.db.it.utils.TestUtils.prepareData;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@Category({LocalStandaloneIT.class, ClusterIT.class})
+public class IoTDBTagLimitIT extends AbstractSchemaIT {
+
+  public IoTDBTagLimitIT(SchemaTestMode schemaTestMode) {
+    super(schemaTestMode);
+  }
+
+  protected static final String[] SQLs =
+      new String[] {
+        "create database root.turbine",
+      };
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    EnvFactory.getEnv().getConfig().getCommonConfig().setTagAttributeTotalSize(50);
+    EnvFactory.getEnv().getConfig().getCommonConfig().setTagAttributeMaxNum(5);
+    EnvFactory.getEnv().getConfig().getCommonConfig().setTagAttributeEntryMaxSize(30);
+    EnvFactory.getEnv().initClusterEnvironment();
+    prepareData(SQLs);
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  @Test
+  public void testBasicFunctionInMultiTagAttributeTotalSize() throws Exception {
+    List<List<String>> rets = new java.util.ArrayList<>();
+    List<String> ret1 =
+        Collections.singletonList(
+            "root.turbine.d1.s1,temperature,root.turbine,FLOAT,RLE,SNAPPY,"
+                + "{\"oldTag1\":\"oldV1\",\"tag2\":\"v2\"},{\"att2\":\"a2\",\"att1\":\"a1\"}");
+    rets.add(ret1);
+    List<String> ret2 =
+        Collections.singletonList(
+            "root.turbine.d1.s1,temperature,root.turbine,FLOAT,RLE,SNAPPY,"
+                + "{\"tag1\":\"oldV1\",\"tag2\":\"v2\"},{\"att2\":\"a2\",\"att1\":\"a1\"}");
+    rets.add(ret2);
+    List<String> ret3 =
+        Collections.singletonList(
+            "root.turbine.d1.s1,temperature,root.turbine,FLOAT,RLE,SNAPPY,"
+                + "{\"tag1\":\"v1\",\"tag2\":\"v2\"},{\"att2\":\"a2\",\"att1\":\"a1\"}");
+    rets.add(ret3);
+    List<String> ret4 =
+        Collections.singletonList(
+            "root.turbine.d1.s1,temperature,root.turbine,FLOAT,RLE,SNAPPY,"
+                + "{\"tag1\":\"v1\",\"tag4\":\"v4\",\"tag5\":\"v5\",\"tag2\":\"v2\",\"tag3\":\"v3\"},{\"att2\":\"a2\",\"att1\":\"a1\"}");
+    rets.add(ret4);
+    List<String> ret5 =
+        Collections.singletonList(
+            "root.turbine.d1.s1,temperature,root.turbine,FLOAT,RLE,SNAPPY,"
+                + "{\"tag4\":\"v4\",\"tag1\":\"v1\",\"tag5\":\"v5\"},{\"att2\":\"a2\",\"att1\":\"a1\"}");
+    rets.add(ret5);
+
+    List<String> sqls = new java.util.ArrayList<>();
+    String sql1 =
+        "create timeseries root.turbine.d1.s1(temperature) with datatype=FLOAT, encoding=RLE, compression=SNAPPY "
+            + "tags('oldTag1'='oldV1', 'tag2'='v2') "
+            + "attributes('att1'='a1', 'att2'='a2')";
+    sqls.add(sql1);
+    String sql2 = "ALTER timeseries root.turbine.d1.s1 RENAME oldTag1 TO tag1";
+    sqls.add(sql2);
+    String sql3 = "ALTER timeseries root.turbine.d1.s1 SET tag1=v1";
+    sqls.add(sql3);
+    String sql4 = "ALTER timeseries root.turbine.d1.s1 ADD TAGS tag3=v3, tag4=v4, tag5=v5";
+    sqls.add(sql4);
+    String sql5 = "ALTER timeseries root.turbine.d1.s1 DROP tag2, tag3";
+    sqls.add(sql5);
+
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      for (int i = 0; i < sqls.size(); i++) {
+        statement.execute(sqls.get(i));
+        ResultSet resultSet = statement.executeQuery("show timeseries");
+        int count = 0;
+        try {
+          while (resultSet.next()) {
+            String ans =
+                resultSet.getString(ColumnHeaderConstant.TIMESERIES)
+                    + ","
+                    + resultSet.getString(ColumnHeaderConstant.ALIAS)
+                    + ","
+                    + resultSet.getString(ColumnHeaderConstant.DATABASE)
+                    + ","
+                    + resultSet.getString(ColumnHeaderConstant.DATATYPE)
+                    + ","
+                    + resultSet.getString(ColumnHeaderConstant.ENCODING)
+                    + ","
+                    + resultSet.getString(ColumnHeaderConstant.COMPRESSION)
+                    + ","
+                    + resultSet.getString(ColumnHeaderConstant.TAGS)
+                    + ","
+                    + resultSet.getString(ColumnHeaderConstant.ATTRIBUTES);
+            assertTrue(rets.get(i).contains(ans));
+            count++;
+          }
+        } finally {
+          resultSet.close();
+        }
+        assertEquals(rets.get(i).size(), count);
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail();
+    }
+    clearSchema();
+  }
+
+  @Test
+  public void testMapSizeAndEntryLimit() throws Exception {
+    List<String> sqls = new java.util.ArrayList<>();
+    String sql1 =
+        "create timeseries root.turbine.d1.s1 with datatype=FLOAT, encoding=RLE, compression=SNAPPY "
+            + "tags('tag1'='v1', 'tag2'='v2', 'tag3'='v3', 'tag4'='v4', 'tag5'='v5', 'tag6'='v6') "
+            + "attributes('att1'='a1', 'att2'='a2')";
+    sqls.add(sql1);
+    String sql2 =
+        "create timeseries root.turbine.d1.s2 with datatype=FLOAT, encoding=RLE, compression=SNAPPY "
+            + "tags('tag1tag2tag3tag4tag5'='v1v2v3v4v5') "
+            + "attributes('att1'='a1', 'att2'='a2')";
+    sqls.add(sql2);
+
+    List<String> errorMessages = new java.util.ArrayList<>();
+    String errorMessage1 =
+        TSStatusCode.METADATA_ERROR.getStatusCode()
+            + ": the emtry num of the map is over the tagAttributeMaxNum";
+    errorMessages.add(errorMessage1);
+    String errorMessage2 =
+        TSStatusCode.METADATA_ERROR.getStatusCode()
+            + ": An emtry of the map has a size which is over the tagAttributeMaxSize";
+    errorMessages.add(errorMessage2);
+
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      for (int i = 0; i < sqls.size(); i++) {
+        try {
+          statement.execute(sqls.get(i));
+          fail();
+        } catch (SQLException e) {
+          Assert.assertEquals(errorMessages.get(i), e.getMessage());
+        }
+      }
+    }
+    clearSchema();
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/impl/SchemaRegionMemoryImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/impl/SchemaRegionMemoryImpl.java
@@ -196,7 +196,7 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
       // do not write log when recover
       isRecovering = true;
 
-      tagManager = new TagManager(schemaRegionDirPath);
+      tagManager = new TagManager(schemaRegionDirPath, regionStatistics);
       mtree =
           new MTreeBelowSGMemoryImpl(
               new PartialPath(storageGroupFullPath),
@@ -455,7 +455,7 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
       isRecovering = true;
 
       long tagSnapshotStartTime = System.currentTimeMillis();
-      tagManager = TagManager.loadFromSnapshot(latestSnapshotRootDir, schemaRegionDirPath);
+      tagManager = TagManager.loadFromSnapshot(latestSnapshotRootDir, schemaRegionDirPath, regionStatistics);
       logger.info(
           "Tag snapshot loading of schemaRegion {} costs {}ms.",
           schemaRegionId,
@@ -984,11 +984,15 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
       throws MetadataException, IOException {
     // upsert alias
     upsertAlias(alias, fullPath);
+    if(tagsMap != null && !regionStatistics.isAllowToCreateNewSeries()) {
+        throw new SeriesOverflowException(
+                regionStatistics.getGlobalMemoryUsage(), regionStatistics.getGlobalSeriesNumber());
+    }
     IMeasurementMNode<IMemMNode> leafMNode = mtree.getMeasurementMNode(fullPath);
     if (tagsMap == null && attributesMap == null) {
       return;
     }
-
+    
     // no tag or attribute, we need to add a new record in log
     if (leafMNode.getOffset() < 0) {
       long offset = tagManager.writeTagFile(tagsMap, attributesMap);
@@ -1006,9 +1010,15 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
 
   private void upsertAlias(String alias, PartialPath fullPath)
       throws MetadataException, IOException {
-    if (mtree.changeAlias(alias, fullPath)) {
-      // persist to WAL
-      writeToMLog(SchemaRegionWritePlanFactory.getChangeAliasPlan(fullPath, alias));
+    if(alias != null) {
+      if (!regionStatistics.isAllowToCreateNewSeries()) {
+        throw new SeriesOverflowException(
+                regionStatistics.getGlobalMemoryUsage(), regionStatistics.getGlobalSeriesNumber());
+      }
+      if (mtree.changeAlias(alias, fullPath)) {
+        // persist to WAL
+        writeToMLog(SchemaRegionWritePlanFactory.getChangeAliasPlan(fullPath, alias));
+      }
     }
   }
 
@@ -1045,6 +1055,10 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
   @Override
   public void addTags(Map<String, String> tagsMap, PartialPath fullPath)
       throws MetadataException, IOException {
+    if (!regionStatistics.isAllowToCreateNewSeries()) {
+      throw new SeriesOverflowException(
+              regionStatistics.getGlobalMemoryUsage(), regionStatistics.getGlobalSeriesNumber());
+    }
     IMeasurementMNode<IMemMNode> leafMNode = mtree.getMeasurementMNode(fullPath);
     // no tag or attribute, we need to add a new record in log
     if (leafMNode.getOffset() < 0) {
@@ -1088,6 +1102,10 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
   @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
   public void setTagsOrAttributesValue(Map<String, String> alterMap, PartialPath fullPath)
       throws MetadataException, IOException {
+    if (!regionStatistics.isAllowToCreateNewSeries()) {
+      throw new SeriesOverflowException(
+              regionStatistics.getGlobalMemoryUsage(), regionStatistics.getGlobalSeriesNumber());
+    }
     IMeasurementMNode<IMemMNode> leafMNode = mtree.getMeasurementMNode(fullPath);
     if (leafMNode.getOffset() < 0) {
       throw new MetadataException(
@@ -1111,6 +1129,10 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
   @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
   public void renameTagOrAttributeKey(String oldKey, String newKey, PartialPath fullPath)
       throws MetadataException, IOException {
+    if (!regionStatistics.isAllowToCreateNewSeries()) {
+      throw new SeriesOverflowException(
+              regionStatistics.getGlobalMemoryUsage(), regionStatistics.getGlobalSeriesNumber());
+    }
     IMeasurementMNode<IMemMNode> leafMNode = mtree.getMeasurementMNode(fullPath);
     if (leafMNode.getOffset() < 0) {
       throw new MetadataException(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/impl/SchemaRegionMemoryImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/impl/SchemaRegionMemoryImpl.java
@@ -455,7 +455,8 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
       isRecovering = true;
 
       long tagSnapshotStartTime = System.currentTimeMillis();
-      tagManager = TagManager.loadFromSnapshot(latestSnapshotRootDir, schemaRegionDirPath, regionStatistics);
+      tagManager =
+          TagManager.loadFromSnapshot(latestSnapshotRootDir, schemaRegionDirPath, regionStatistics);
       logger.info(
           "Tag snapshot loading of schemaRegion {} costs {}ms.",
           schemaRegionId,
@@ -988,15 +989,15 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
       throws MetadataException, IOException {
     // upsert alias
     upsertAlias(alias, fullPath);
-    if(tagsMap != null && !regionStatistics.isAllowToCreateNewSeries()) {
-        throw new SeriesOverflowException(
-                regionStatistics.getGlobalMemoryUsage(), regionStatistics.getGlobalSeriesNumber());
+    if (tagsMap != null && !regionStatistics.isAllowToCreateNewSeries()) {
+      throw new SeriesOverflowException(
+          regionStatistics.getGlobalMemoryUsage(), regionStatistics.getGlobalSeriesNumber());
     }
     IMeasurementMNode<IMemMNode> leafMNode = mtree.getMeasurementMNode(fullPath);
     if (tagsMap == null && attributesMap == null) {
       return;
     }
-    
+
     // no tag or attribute, we need to add a new record in log
     if (leafMNode.getOffset() < 0) {
       long offset = tagManager.writeTagFile(tagsMap, attributesMap);
@@ -1014,10 +1015,10 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
 
   private void upsertAlias(String alias, PartialPath fullPath)
       throws MetadataException, IOException {
-    if(alias != null) {
+    if (alias != null) {
       if (!regionStatistics.isAllowToCreateNewSeries()) {
         throw new SeriesOverflowException(
-                regionStatistics.getGlobalMemoryUsage(), regionStatistics.getGlobalSeriesNumber());
+            regionStatistics.getGlobalMemoryUsage(), regionStatistics.getGlobalSeriesNumber());
       }
       if (mtree.changeAlias(alias, fullPath)) {
         // persist to WAL
@@ -1061,7 +1062,7 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
       throws MetadataException, IOException {
     if (!regionStatistics.isAllowToCreateNewSeries()) {
       throw new SeriesOverflowException(
-              regionStatistics.getGlobalMemoryUsage(), regionStatistics.getGlobalSeriesNumber());
+          regionStatistics.getGlobalMemoryUsage(), regionStatistics.getGlobalSeriesNumber());
     }
     IMeasurementMNode<IMemMNode> leafMNode = mtree.getMeasurementMNode(fullPath);
     // no tag or attribute, we need to add a new record in log
@@ -1108,7 +1109,7 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
       throws MetadataException, IOException {
     if (!regionStatistics.isAllowToCreateNewSeries()) {
       throw new SeriesOverflowException(
-              regionStatistics.getGlobalMemoryUsage(), regionStatistics.getGlobalSeriesNumber());
+          regionStatistics.getGlobalMemoryUsage(), regionStatistics.getGlobalSeriesNumber());
     }
     IMeasurementMNode<IMemMNode> leafMNode = mtree.getMeasurementMNode(fullPath);
     if (leafMNode.getOffset() < 0) {
@@ -1135,7 +1136,7 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
       throws MetadataException, IOException {
     if (!regionStatistics.isAllowToCreateNewSeries()) {
       throw new SeriesOverflowException(
-              regionStatistics.getGlobalMemoryUsage(), regionStatistics.getGlobalSeriesNumber());
+          regionStatistics.getGlobalMemoryUsage(), regionStatistics.getGlobalSeriesNumber());
     }
     IMeasurementMNode<IMemMNode> leafMNode = mtree.getMeasurementMNode(fullPath);
     if (leafMNode.getOffset() < 0) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/impl/SchemaRegionPBTreeImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/impl/SchemaRegionPBTreeImpl.java
@@ -33,10 +33,7 @@ import org.apache.iotdb.commons.schema.view.viewExpression.ViewExpression;
 import org.apache.iotdb.consensus.ConsensusFactory;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
-import org.apache.iotdb.db.exception.metadata.AliasAlreadyExistException;
-import org.apache.iotdb.db.exception.metadata.PathAlreadyExistException;
-import org.apache.iotdb.db.exception.metadata.SchemaDirCreationFailureException;
-import org.apache.iotdb.db.exception.metadata.SchemaQuotaExceededException;
+import org.apache.iotdb.db.exception.metadata.*;
 import org.apache.iotdb.db.queryengine.common.schematree.ClusterSchemaTree;
 import org.apache.iotdb.db.schemaengine.metric.ISchemaRegionMetric;
 import org.apache.iotdb.db.schemaengine.metric.SchemaRegionCachedMetric;
@@ -193,7 +190,7 @@ public class SchemaRegionPBTreeImpl implements ISchemaRegion {
       // do not write log when recover
       isRecovering = true;
 
-      tagManager = new TagManager(schemaRegionDirPath);
+      tagManager = new TagManager(schemaRegionDirPath, regionStatistics);
       mtree =
           new MTreeBelowSGCachedImpl(
               new PartialPath(storageGroupFullPath),
@@ -509,7 +506,7 @@ public class SchemaRegionPBTreeImpl implements ISchemaRegion {
       isRecovering = true;
 
       long tagSnapshotStartTime = System.currentTimeMillis();
-      tagManager = TagManager.loadFromSnapshot(latestSnapshotRootDir, schemaRegionDirPath);
+      tagManager = TagManager.loadFromSnapshot(latestSnapshotRootDir, schemaRegionDirPath, regionStatistics);
       logger.info(
           "Tag snapshot loading of schemaRegion {} costs {}ms.",
           schemaRegionId,
@@ -1068,6 +1065,9 @@ public class SchemaRegionPBTreeImpl implements ISchemaRegion {
       throws MetadataException, IOException {
     // upsert alias
     upsertAlias(alias, fullPath);
+    while (!regionStatistics.isAllowToCreateNewSeries()) {
+      ReleaseFlushMonitor.getInstance().waitIfReleasing();
+    }
     IMeasurementMNode<ICachedMNode> leafMNode = mtree.getMeasurementMNode(fullPath);
     try {
       if (tagsMap == null && attributesMap == null) {
@@ -1094,9 +1094,14 @@ public class SchemaRegionPBTreeImpl implements ISchemaRegion {
 
   private void upsertAlias(String alias, PartialPath fullPath)
       throws MetadataException, IOException {
-    if (mtree.changeAlias(alias, fullPath)) {
-      // persist to WAL
-      writeToMLog(SchemaRegionWritePlanFactory.getChangeAliasPlan(fullPath, alias));
+    if(alias != null) {
+      while (!regionStatistics.isAllowToCreateNewSeries()) {
+        ReleaseFlushMonitor.getInstance().waitIfReleasing();
+      }
+      if (mtree.changeAlias(alias, fullPath)) {
+        // persist to WAL
+        writeToMLog(SchemaRegionWritePlanFactory.getChangeAliasPlan(fullPath, alias));
+      }
     }
   }
 
@@ -1136,6 +1141,9 @@ public class SchemaRegionPBTreeImpl implements ISchemaRegion {
   @Override
   public void addTags(Map<String, String> tagsMap, PartialPath fullPath)
       throws MetadataException, IOException {
+    while (!regionStatistics.isAllowToCreateNewSeries()) {
+      ReleaseFlushMonitor.getInstance().waitIfReleasing();
+    }
     IMeasurementMNode<ICachedMNode> leafMNode = mtree.getMeasurementMNode(fullPath);
     try {
       // no tag or attribute, we need to add a new record in log
@@ -1190,6 +1198,9 @@ public class SchemaRegionPBTreeImpl implements ISchemaRegion {
   @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
   public void setTagsOrAttributesValue(Map<String, String> alterMap, PartialPath fullPath)
       throws MetadataException, IOException {
+    while (!regionStatistics.isAllowToCreateNewSeries()) {
+      ReleaseFlushMonitor.getInstance().waitIfReleasing();
+    }
     IMeasurementMNode<ICachedMNode> leafMNode = mtree.getMeasurementMNode(fullPath);
     try {
       if (leafMNode.getOffset() < 0) {
@@ -1217,6 +1228,9 @@ public class SchemaRegionPBTreeImpl implements ISchemaRegion {
   @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
   public void renameTagOrAttributeKey(String oldKey, String newKey, PartialPath fullPath)
       throws MetadataException, IOException {
+    while (!regionStatistics.isAllowToCreateNewSeries()) {
+      ReleaseFlushMonitor.getInstance().waitIfReleasing();
+    }
     IMeasurementMNode<ICachedMNode> leafMNode = mtree.getMeasurementMNode(fullPath);
     try {
       if (leafMNode.getOffset() < 0) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/tag/TagLogFile.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/tag/TagLogFile.java
@@ -97,8 +97,7 @@ public class TagLogFile implements AutoCloseable {
    * @return tags map, attributes map
    * @throws IOException error occurred when reading disk
    */
-  public Pair<Map<String, String>, Map<String, String>> read(long position)
-      throws IOException {
+  public Pair<Map<String, String>, Map<String, String>> read(long position) throws IOException {
     if (position < 0) {
       return new Pair<>(Collections.emptyMap(), Collections.emptyMap());
     }
@@ -116,26 +115,26 @@ public class TagLogFile implements AutoCloseable {
     ByteBuffer byteBuffer = ByteBuffer.allocate(MAX_LENGTH);
     fileChannel.read(byteBuffer, position);
     byteBuffer.flip();
-    if(byteBuffer.limit() > 0){ // 表明该位置有数据
+    if (byteBuffer.limit() > 0) { // 表明该位置有数据
       int firstInt = ReadWriteIOUtils.readInt(byteBuffer); // 读取第一个int
       byteBuffer.position(0);
-      if(firstInt < -1){ // 表明这个位置是blockNum，原有的数据占据多个block
-          int blockNum = -firstInt;
-          ByteBuffer byteBuffers = ByteBuffer.allocate(blockNum*MAX_LENGTH);
-          byteBuffers.put(byteBuffer);
-          byteBuffers.position(4); // 跳过blockNum
-          List<Long> blockOffset = new ArrayList<>();
-          blockOffset.add(position);
-          for(int i = 1; i < blockNum; i++){
-            blockOffset.add(ReadWriteIOUtils.readLong(byteBuffers));
-            // 每读取一个offset，就用filechannel的read读出来
-            byteBuffers.position(MAX_LENGTH*i);
-            byteBuffers.limit(MAX_LENGTH*(i+1));
-            fileChannel.read(byteBuffers, blockOffset.get(i));
-            byteBuffers.position(4+i*Long.BYTES);
-          }
-          byteBuffers.limit(byteBuffers.capacity());
-          return byteBuffers;
+      if (firstInt < -1) { // 表明这个位置是blockNum，原有的数据占据多个block
+        int blockNum = -firstInt;
+        ByteBuffer byteBuffers = ByteBuffer.allocate(blockNum * MAX_LENGTH);
+        byteBuffers.put(byteBuffer);
+        byteBuffers.position(4); // 跳过blockNum
+        List<Long> blockOffset = new ArrayList<>();
+        blockOffset.add(position);
+        for (int i = 1; i < blockNum; i++) {
+          blockOffset.add(ReadWriteIOUtils.readLong(byteBuffers));
+          // 每读取一个offset，就用filechannel的read读出来
+          byteBuffers.position(MAX_LENGTH * i);
+          byteBuffers.limit(MAX_LENGTH * (i + 1));
+          fileChannel.read(byteBuffers, blockOffset.get(i));
+          byteBuffers.position(4 + i * Long.BYTES);
+        }
+        byteBuffers.limit(byteBuffers.capacity());
+        return byteBuffers;
       }
     }
     return byteBuffer;
@@ -148,24 +147,26 @@ public class TagLogFile implements AutoCloseable {
     ByteBuffer byteBuffer = ByteBuffer.allocate(MAX_LENGTH);
     fileChannel.read(byteBuffer, position);
     byteBuffer.flip();
-    if(byteBuffer.limit() > 0){ // 表明该位置有数据
+    if (byteBuffer.limit() > 0) { // 表明该位置有数据
       int firstInt = ReadWriteIOUtils.readInt(byteBuffer); // 读取第一个int
       byteBuffer.position(0);
-      if(firstInt < -1){ // 表明这个位置是blockNum，原有的数据占据多个block
+      if (firstInt < -1) { // 表明这个位置是blockNum，原有的数据占据多个block
         int blockNum = -firstInt;
-        int blockOffsetStoreLen = (((blockNum-1)*Long.BYTES+4)/MAX_LENGTH + 1)*MAX_LENGTH; // blockOffset存储的长度
+        int blockOffsetStoreLen =
+            (((blockNum - 1) * Long.BYTES + 4) / MAX_LENGTH + 1) * MAX_LENGTH; // blockOffset存储的长度
         ByteBuffer blockBuffer = ByteBuffer.allocate(blockOffsetStoreLen);
         blockBuffer.put(byteBuffer);
         blockBuffer.position(4); // 跳过blockNum
 
-        for(int i = 1; i < blockNum; i++){
+        for (int i = 1; i < blockNum; i++) {
           blockOffset.add(ReadWriteIOUtils.readLong(blockBuffer));
           // 每读取一个offset，就用filechannel的read读出来
-          if(MAX_LENGTH*(i+1) <= blockOffsetStoreLen){ // 相比于直接读取bytebuffer减了一些读取操作，只读offset的内容
-            blockBuffer.position(MAX_LENGTH*i);
-            blockBuffer.limit(MAX_LENGTH*(i+1));
+          if (MAX_LENGTH * (i + 1)
+              <= blockOffsetStoreLen) { // 相比于直接读取bytebuffer减了一些读取操作，只读offset的内容
+            blockBuffer.position(MAX_LENGTH * i);
+            blockBuffer.limit(MAX_LENGTH * (i + 1));
             fileChannel.read(blockBuffer, blockOffset.get(i));
-            blockBuffer.position(4+i*Long.BYTES);
+            blockBuffer.position(4 + i * Long.BYTES);
           }
         }
       }
@@ -207,53 +208,50 @@ public class TagLogFile implements AutoCloseable {
     // 占位符块
     ByteBuffer byteBufferNull = ByteBuffer.allocate(MAX_LENGTH);
     // 写入实际的数据
-    int blockNumReal = byteBuffer.capacity()/MAX_LENGTH;
-    if(blockNumReal < 1){
-      throw new RuntimeException("ByteBuffer capacity is smaller than tagAttributeTotalSize, which is not allowed.");
+    int blockNumReal = byteBuffer.capacity() / MAX_LENGTH;
+    if (blockNumReal < 1) {
+      throw new RuntimeException(
+          "ByteBuffer capacity is smaller than tagAttributeTotalSize, which is not allowed.");
     }
-    if(blockNumReal == 1 && blockOffset.size() == 1){
+    if (blockNumReal == 1 && blockOffset.size() == 1) {
       // 实际写入的数据占据1个block
       fileChannel.write(byteBuffer, blockOffset.get(0));
-    }
-    else {
-      if(blockOffset.size() > blockNumReal){ // 如果现在比原有的空间小，那么还会使用原有的空间
-          ByteBuffer byteBufferFinal = ByteBuffer.allocate(blockOffset.size()*MAX_LENGTH);
-          byteBufferFinal.putInt(-blockOffset.size());
-          for(int i = 1;i < blockOffset.size(); i++){
-            byteBufferFinal.putLong(blockOffset.get(i));
-          }
-          if(blockNumReal > 1){ // 实际数据占据1block，但是以前占据多个block，按照多个block处理
-            byteBuffer.position((blockNumReal-1)*Long.BYTES+4);
-          }
-          else{ // 实际数据占据多个block
-            byteBuffer.position(0);
-          }
-          byteBufferFinal.put(byteBuffer);
-          for(int i = 0;i < blockOffset.size(); i++){
-            byteBufferFinal.position(i*MAX_LENGTH);
-            byteBufferFinal.limit((i+1)*MAX_LENGTH);
-            fileChannel.write(byteBufferFinal, blockOffset.get(i));
-          }
-      }
-      else{
+    } else {
+      if (blockOffset.size() > blockNumReal) { // 如果现在比原有的空间小，那么还会使用原有的空间
+        ByteBuffer byteBufferFinal = ByteBuffer.allocate(blockOffset.size() * MAX_LENGTH);
+        byteBufferFinal.putInt(-blockOffset.size());
+        for (int i = 1; i < blockOffset.size(); i++) {
+          byteBufferFinal.putLong(blockOffset.get(i));
+        }
+        if (blockNumReal > 1) { // 实际数据占据1block，但是以前占据多个block，按照多个block处理
+          byteBuffer.position((blockNumReal - 1) * Long.BYTES + 4);
+        } else { // 实际数据占据多个block
+          byteBuffer.position(0);
+        }
+        byteBufferFinal.put(byteBuffer);
+        for (int i = 0; i < blockOffset.size(); i++) {
+          byteBufferFinal.position(i * MAX_LENGTH);
+          byteBufferFinal.limit((i + 1) * MAX_LENGTH);
+          fileChannel.write(byteBufferFinal, blockOffset.get(i));
+        }
+      } else {
         // 如果现在等于或者大于原有的空间，需要在末尾补充新的空间
         // 准备偏移量数据的bytebuffer
-        int blockOffsetStoreLen = (blockNumReal-1)*Long.BYTES+4;
+        int blockOffsetStoreLen = (blockNumReal - 1) * Long.BYTES + 4;
         ByteBuffer byteBufferOffset = ByteBuffer.allocate(blockOffsetStoreLen);
         byteBufferOffset.putInt(-blockNumReal);
 
         // 写入已有的bytebuffer数据
-        for(int i = 0; i < blockNumReal; i++) {
-          byteBuffer.position(i*MAX_LENGTH);
-          byteBuffer.limit((i+1)*MAX_LENGTH);
+        for (int i = 0; i < blockNumReal; i++) {
+          byteBuffer.position(i * MAX_LENGTH);
+          byteBuffer.limit((i + 1) * MAX_LENGTH);
 
-          if (i < blockOffset.size()){ // 说明现在写的空间是原来就有的空间
-            if(i > 0){ // 首个块的偏移量不记录
+          if (i < blockOffset.size()) { // 说明现在写的空间是原来就有的空间
+            if (i > 0) { // 首个块的偏移量不记录
               byteBufferOffset.putLong(blockOffset.get(i));
             }
             fileChannel.write(byteBuffer, blockOffset.get(i));
-          }
-          else{ // 说明现在想要写的空间是原来没有的
+          } else { // 说明现在想要写的空间是原来没有的
             // TODO: 以后可以将这里的从最后开始写，修改为先写空闲块，空闲块没了再从最后开始写
             byteBufferOffset.putLong(fileChannel.size());
             blockOffset.add(fileChannel.size());
@@ -263,15 +261,14 @@ public class TagLogFile implements AutoCloseable {
 
         // 写入byteBufferOffset
         byteBufferOffset.flip();
-        for(int i = 0; i < blockOffset.size(); i++){
-          byteBufferOffset.position(i*MAX_LENGTH);
-          if((i+1)*MAX_LENGTH > byteBufferOffset.capacity()){
+        for (int i = 0; i < blockOffset.size(); i++) {
+          byteBufferOffset.position(i * MAX_LENGTH);
+          if ((i + 1) * MAX_LENGTH > byteBufferOffset.capacity()) {
             byteBufferOffset.limit(byteBufferOffset.capacity());
             fileChannel.write(byteBufferOffset, blockOffset.get(i));
             break;
-          }
-          else{
-            byteBufferOffset.limit((i+1)*MAX_LENGTH);
+          } else {
+            byteBufferOffset.limit((i + 1) * MAX_LENGTH);
             fileChannel.write(byteBufferOffset, blockOffset.get(i));
           }
         }
@@ -287,18 +284,24 @@ public class TagLogFile implements AutoCloseable {
   }
 
   private ByteBuffer convertMapToByteBuffer(
-          Map<String, String> tagMap, Map<String, String> attributeMap) throws MetadataException {
+      Map<String, String> tagMap, Map<String, String> attributeMap) throws MetadataException {
     int TotalMapSize = calculateMapSize(tagMap) + calculateMapSize(attributeMap);
     ByteBuffer byteBuffer;
-    if(TotalMapSize <= MAX_LENGTH){
+    if (TotalMapSize <= MAX_LENGTH) {
       byteBuffer = ByteBuffer.allocate(MAX_LENGTH);
-    }
-    else{
-      double blockNumMinLimit = (TotalMapSize + 4 - MAX_LENGTH)/ (double) (MAX_LENGTH - Long.BYTES); // 这个式子是不等式的计算结果，Num*MAX_LENGTH < TotalMapSize + 4 + Long.BYTES*Num <= MAX_LENGTH*(Num + 1)
+    } else {
+      double blockNumMinLimit =
+          (TotalMapSize + 4 - MAX_LENGTH)
+              / (double)
+                  (MAX_LENGTH - Long.BYTES); // 这个式子是不等式的计算结果，Num*MAX_LENGTH < TotalMapSize + 4 +
+      // Long.BYTES*Num <= MAX_LENGTH*(Num + 1)
       int blockNum = (int) Math.round(Math.ceil(blockNumMinLimit)) + 1; // 在结果的范围内最多有两个解，这个取小的解，节约空间
 
-      byteBuffer = ByteBuffer.allocate(blockNum*MAX_LENGTH);
-      byteBuffer.position(4+(blockNum-1)*Long.BYTES); // 4 bytes for blockNumSize, blockNum*Long.BYTES for blockOffset
+      byteBuffer = ByteBuffer.allocate(blockNum * MAX_LENGTH);
+      byteBuffer.position(
+          4
+              + (blockNum - 1)
+                  * Long.BYTES); // 4 bytes for blockNumSize, blockNum*Long.BYTES for blockOffset
     }
     serializeMap(tagMap, byteBuffer);
     serializeMap(attributeMap, byteBuffer);
@@ -311,22 +314,28 @@ public class TagLogFile implements AutoCloseable {
     int length = 0;
     if (map != null) {
       length += 4; // mapSize is 4 byte
-      for (Map.Entry<String, String> entry : map.entrySet()) { // while mapSize is 0, this for loop will not be executed
+      for (Map.Entry<String, String> entry :
+          map.entrySet()) { // while mapSize is 0, this for loop will not be executed
         String key = entry.getKey();
         String value = entry.getValue();
 
         length += 4; // keySize is 4 byte
         if (key != null) {
-          length += key.getBytes().length; // only key is not null then add key length, while key is null, only store the keySize marker which is -1 (4 bytes)
+          length +=
+              key.getBytes()
+                  .length; // only key is not null then add key length, while key is null, only
+          // store the keySize marker which is -1 (4 bytes)
         }
 
         length += 4; // valueSize is 4 byte
         if (value != null) {
-          length += value.getBytes().length; // only value is not null then add value length, while value is null, only store the valueSize marker which is -1 (4 bytes)
+          length +=
+              value.getBytes()
+                  .length; // only value is not null then add value length, while value is null,
+          // only store the valueSize marker which is -1 (4 bytes)
         }
       }
-    }
-    else{
+    } else {
       length += 4; // while map is null, the mapSize is writed to -1 which is 4 byte
     }
     return length;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/tag/TagLogFile.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/tag/TagLogFile.java
@@ -130,7 +130,7 @@ public class TagLogFile implements AutoCloseable {
         byteBuffers.put(byteBuffer);
         byteBuffers.position(4); // Skip blockNum
         for (int i = 1; i < blockNum; i++) {
-          Long nextPosition = ReadWriteIOUtils.readLong(byteBuffers);
+          long nextPosition = ReadWriteIOUtils.readLong(byteBuffers);
           // read one offset, then use filechannel's read to read it
           byteBuffers.position(MAX_LENGTH * i);
           byteBuffers.limit(MAX_LENGTH * (i + 1));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/tag/TagLogFile.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/tag/TagLogFile.java
@@ -37,7 +37,9 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.FileChannel;
 import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 public class TagLogFile implements AutoCloseable {
@@ -95,22 +97,80 @@ public class TagLogFile implements AutoCloseable {
    * @return tags map, attributes map
    * @throws IOException error occurred when reading disk
    */
-  public Pair<Map<String, String>, Map<String, String>> read(int size, long position)
+  public Pair<Map<String, String>, Map<String, String>> read(long position)
       throws IOException {
     if (position < 0) {
       return new Pair<>(Collections.emptyMap(), Collections.emptyMap());
     }
-    ByteBuffer byteBuffer = ByteBuffer.allocate(size);
-    fileChannel.read(byteBuffer, position);
-    byteBuffer.flip();
+    ByteBuffer byteBuffer = ParseByteBuffer(position);
     return new Pair<>(ReadWriteIOUtils.readMap(byteBuffer), ReadWriteIOUtils.readMap(byteBuffer));
   }
 
-  public Map<String, String> readTag(int size, long position) throws IOException {
-    ByteBuffer byteBuffer = ByteBuffer.allocate(size);
+  public Map<String, String> readTag(long position) throws IOException {
+    ByteBuffer byteBuffer = ParseByteBuffer(position);
+    return ReadWriteIOUtils.readMap(byteBuffer);
+  }
+
+  private ByteBuffer ParseByteBuffer(long position) throws IOException {
+    // 读取第一个块
+    ByteBuffer byteBuffer = ByteBuffer.allocate(MAX_LENGTH);
     fileChannel.read(byteBuffer, position);
     byteBuffer.flip();
-    return ReadWriteIOUtils.readMap(byteBuffer);
+    if(byteBuffer.limit() > 0){ // 表明该位置有数据
+      int firstInt = ReadWriteIOUtils.readInt(byteBuffer); // 读取第一个int
+      byteBuffer.position(0);
+      if(firstInt < -1){ // 表明这个位置是blockNum，原有的数据占据多个block
+          int blockNum = -firstInt;
+          ByteBuffer byteBuffers = ByteBuffer.allocate(blockNum*MAX_LENGTH);
+          byteBuffers.put(byteBuffer);
+          byteBuffers.position(4); // 跳过blockNum
+          List<Long> blockOffset = new ArrayList<>();
+          blockOffset.add(position);
+          for(int i = 1; i < blockNum; i++){
+            blockOffset.add(ReadWriteIOUtils.readLong(byteBuffers));
+            // 每读取一个offset，就用filechannel的read读出来
+            byteBuffers.position(MAX_LENGTH*i);
+            byteBuffers.limit(MAX_LENGTH*(i+1));
+            fileChannel.read(byteBuffers, blockOffset.get(i));
+            byteBuffers.position(4+i*Long.BYTES);
+          }
+          byteBuffers.limit(byteBuffers.capacity());
+          return byteBuffers;
+      }
+    }
+    return byteBuffer;
+  }
+
+  private List<Long> ParseOffsetList(long position) throws IOException {
+    List<Long> blockOffset = new ArrayList<>();
+    blockOffset.add(position);
+    // 读取第一个块
+    ByteBuffer byteBuffer = ByteBuffer.allocate(MAX_LENGTH);
+    fileChannel.read(byteBuffer, position);
+    byteBuffer.flip();
+    if(byteBuffer.limit() > 0){ // 表明该位置有数据
+      int firstInt = ReadWriteIOUtils.readInt(byteBuffer); // 读取第一个int
+      byteBuffer.position(0);
+      if(firstInt < -1){ // 表明这个位置是blockNum，原有的数据占据多个block
+        int blockNum = -firstInt;
+        int blockOffsetStoreLen = (((blockNum-1)*Long.BYTES+4)/MAX_LENGTH + 1)*MAX_LENGTH; // blockOffset存储的长度
+        ByteBuffer blockBuffer = ByteBuffer.allocate(blockOffsetStoreLen);
+        blockBuffer.put(byteBuffer);
+        blockBuffer.position(4); // 跳过blockNum
+
+        for(int i = 1; i < blockNum; i++){
+          blockOffset.add(ReadWriteIOUtils.readLong(blockBuffer));
+          // 每读取一个offset，就用filechannel的read读出来
+          if(MAX_LENGTH*(i+1) <= blockOffsetStoreLen){ // 相比于直接读取bytebuffer减了一些读取操作，只读offset的内容
+            blockBuffer.position(MAX_LENGTH*i);
+            blockBuffer.limit(MAX_LENGTH*(i+1));
+            fileChannel.read(blockBuffer, blockOffset.get(i));
+            blockBuffer.position(4+i*Long.BYTES);
+          }
+        }
+      }
+    }
+    return blockOffset;
   }
 
   public long write(Map<String, String> tagMap, Map<String, String> attributeMap)
@@ -137,11 +197,89 @@ public class TagLogFile implements AutoCloseable {
    * @return beginning position of the record in tagFile
    */
   private synchronized long write(ByteBuffer byteBuffer, long position) throws IOException {
+    // 矫正写入初始偏移量
     if (position < 0) {
       // append the record to file tail
       position = fileChannel.size();
     }
-    fileChannel.write(byteBuffer, position);
+    // 读取原有的数据，获取原有的空间偏移量
+    List<Long> blockOffset = ParseOffsetList(position);
+    // 占位符块
+    ByteBuffer byteBufferNull = ByteBuffer.allocate(MAX_LENGTH);
+    // 写入实际的数据
+    int blockNumReal = byteBuffer.capacity()/MAX_LENGTH;
+    if(blockNumReal < 1){
+      throw new RuntimeException("ByteBuffer capacity is smaller than tagAttributeTotalSize, which is not allowed.");
+    }
+    if(blockNumReal == 1 && blockOffset.size() == 1){
+      // 实际写入的数据占据1个block
+      fileChannel.write(byteBuffer, blockOffset.get(0));
+    }
+    else {
+      if(blockNumReal == 1 && blockOffset.size() > 1){ // 实际数据占据1block，但是以前占据多个block，按照多个block处理
+        ByteBuffer byteBufferFinal = ByteBuffer.allocate(blockOffset.size()*MAX_LENGTH);
+        byteBufferFinal.putInt(-blockOffset.size());
+        for(int i = 1;i < blockOffset.size(); i++){
+          byteBufferFinal.putLong(blockOffset.get(i));
+        }
+        byteBufferFinal.put(byteBuffer);
+
+        for(int i = 0;i < blockOffset.size(); i++){
+          byteBufferFinal.position(i*MAX_LENGTH);
+          byteBufferFinal.limit((i+1)*MAX_LENGTH);
+          fileChannel.write(byteBufferFinal, blockOffset.get(i));
+        }
+      }
+      else{
+        // 实际写入的数据占据多个block
+        // 准备偏移量数据的bytebuffer
+        int blockOffsetStoreLen = (blockNumReal-1)*Long.BYTES+4;
+        ByteBuffer byteBufferOffset = ByteBuffer.allocate(blockOffsetStoreLen);
+        byteBufferOffset.putInt(-blockNumReal);
+
+        // 写入已有的bytebuffer数据
+        for(int i = 0; i < blockNumReal; i++) {
+          byteBuffer.position(i*MAX_LENGTH);
+          byteBuffer.limit((i+1)*MAX_LENGTH);
+
+          if (i < blockOffset.size()){ // 说明现在写的空间是原来就有的空间
+            if(i > 0){
+              byteBufferOffset.putLong(blockOffset.get(i));
+            }
+            fileChannel.write(byteBuffer, blockOffset.get(i));
+          }
+          else{ // 说明现在想要写的空间是原来没有的
+            // TODO: 以后可以将这里的从最后开始写，修改为先写空闲块，空闲块没了再从最后开始写
+            byteBufferOffset.putLong(fileChannel.size());
+            blockOffset.add(fileChannel.size());
+            fileChannel.write(byteBuffer, fileChannel.size());
+          }
+        }
+
+        // 如果原来的block数量比现在更多，给其他block空间填充空
+        for(int i = blockNumReal; i < blockOffset.size(); i++) {
+          byteBufferOffset.putLong(blockOffset.get(i));
+          byteBufferNull.position(0);
+          fileChannel.write(byteBufferNull, blockOffset.get(i));
+        }
+
+        // 写入byteBufferOffset
+        byteBufferOffset.flip();
+        for(int i = 0; i < blockOffset.size(); i++){
+          byteBufferOffset.position(i*MAX_LENGTH);
+          if((i+1)*MAX_LENGTH > byteBufferOffset.capacity()){
+            byteBufferOffset.limit(byteBufferOffset.capacity());
+            fileChannel.write(byteBufferOffset, blockOffset.get(i));
+            break;
+          }
+          else{
+            byteBufferOffset.limit((i+1)*MAX_LENGTH);
+            fileChannel.write(byteBufferOffset, blockOffset.get(i));
+          }
+        }
+      }
+    }
+
     unFlushedRecordNum++;
     if (unFlushedRecordNum >= RECORD_FLUSH_INTERVAL) {
       fileChannel.force(true);
@@ -151,14 +289,49 @@ public class TagLogFile implements AutoCloseable {
   }
 
   private ByteBuffer convertMapToByteBuffer(
-      Map<String, String> tagMap, Map<String, String> attributeMap) throws MetadataException {
-    ByteBuffer byteBuffer = ByteBuffer.allocate(MAX_LENGTH);
+          Map<String, String> tagMap, Map<String, String> attributeMap) throws MetadataException {
+    int TotalMapSize = calculateMapSize(tagMap) + calculateMapSize(attributeMap);
+    ByteBuffer byteBuffer;
+    if(TotalMapSize <= MAX_LENGTH){
+      byteBuffer = ByteBuffer.allocate(MAX_LENGTH);
+    }
+    else{
+      double blockNumMinLimit = (TotalMapSize + 4 - MAX_LENGTH)/ (double) (MAX_LENGTH - Long.BYTES); // 这个式子是不等式的计算结果，Num*MAX_LENGTH < TotalMapSize + 4 + Long.BYTES*Num <= MAX_LENGTH*(Num + 1)
+      int blockNum = (int) Math.round(Math.ceil(blockNumMinLimit)) + 1; // 在结果的范围内最多有两个解，这个取小的解，节约空间
+
+      byteBuffer = ByteBuffer.allocate(blockNum*MAX_LENGTH);
+      byteBuffer.position(4+(blockNum-1)*Long.BYTES); // 4 bytes for blockNumSize, blockNum*Long.BYTES for blockOffset
+    }
     serializeMap(tagMap, byteBuffer);
     serializeMap(attributeMap, byteBuffer);
-
     // set position to 0 and the content in this buffer could be read
     byteBuffer.position(0);
     return byteBuffer;
+  }
+
+  public static int calculateMapSize(Map<String, String> map) {
+    int length = 0;
+    if (map != null) {
+      length += 4; // mapSize is 4 byte
+      for (Map.Entry<String, String> entry : map.entrySet()) { // while mapSize is 0, this for loop will not be executed
+        String key = entry.getKey();
+        String value = entry.getValue();
+
+        length += 4; // keySize is 4 byte
+        if (key != null) {
+          length += key.getBytes().length; // only key is not null then add key length, while key is null, only store the keySize marker which is -1 (4 bytes)
+        }
+
+        length += 4; // valueSize is 4 byte
+        if (value != null) {
+          length += value.getBytes().length; // only value is not null then add value length, while value is null, only store the valueSize marker which is -1 (4 bytes)
+        }
+      }
+    }
+    else{
+      length += 4; // while map is null, the mapSize is writed to -1 which is 4 byte
+    }
+    return length;
   }
 
   private void serializeMap(Map<String, String> map, ByteBuffer byteBuffer)

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/tag/TagLogFile.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/tag/TagLogFile.java
@@ -121,7 +121,7 @@ public class TagLogFile implements AutoCloseable {
     ByteBuffer byteBuffer = ByteBuffer.allocate(MAX_LENGTH);
     fileChannel.read(byteBuffer, position);
     byteBuffer.flip();
-    if (byteBuffer.limit() > 0) {// This indicates that there is data at this position
+    if (byteBuffer.limit() > 0) { // This indicates that there is data at this position
       int firstInt = ReadWriteIOUtils.readInt(byteBuffer); // first int
       byteBuffer.position(0);
       if (firstInt < -1) { // This position is blockNum, the original data occupies multiple blocks
@@ -159,7 +159,8 @@ public class TagLogFile implements AutoCloseable {
       if (firstInt < -1) { // This position is blockNum, the original data occupies multiple blocks
         int blockNum = -firstInt;
         int blockOffsetStoreLen =
-            (((blockNum - 1) * Long.BYTES + 4) / MAX_LENGTH + 1) * MAX_LENGTH; // blockOffset storage length
+            (((blockNum - 1) * Long.BYTES + 4) / MAX_LENGTH + 1)
+                * MAX_LENGTH; // blockOffset storage length
         ByteBuffer blockBuffer = ByteBuffer.allocate(blockOffsetStoreLen);
         blockBuffer.put(byteBuffer);
         blockBuffer.position(4); // Skip blockNum
@@ -168,7 +169,9 @@ public class TagLogFile implements AutoCloseable {
           blockOffset.add(ReadWriteIOUtils.readLong(blockBuffer));
           // Every time you read an offset, use filechannel's read to read it
           if (MAX_LENGTH * (i + 1)
-              <= blockOffsetStoreLen) { // Compared with directly reading bytebuffer, some reading operations are reduced, only the content of offset is read
+              <= blockOffsetStoreLen) { // Compared with directly reading bytebuffer, some reading
+            // operations are reduced, only the content of offset is
+            // read
             blockBuffer.position(MAX_LENGTH * i);
             blockBuffer.limit(MAX_LENGTH * (i + 1));
             fileChannel.read(blockBuffer, blockOffset.get(i));
@@ -218,10 +221,13 @@ public class TagLogFile implements AutoCloseable {
           "ByteBuffer capacity is smaller than tagAttributeTotalSize, which is not allowed.");
     }
     if (blockNumReal == 1 && blockOffset.size() == 1) {
-      // If the original data occupies only one block and the new data occupies only one block, the original space is used
+      // If the original data occupies only one block and the new data occupies only one block, the
+      // original space is used
       fileChannel.write(byteBuffer, blockOffset.get(0));
     } else {
-      if (blockOffset.size() > blockNumReal) { // if the original space is larger than the new space, the original space is used
+      if (blockOffset.size()
+          > blockNumReal) { // if the original space is larger than the new space, the original
+        // space is used
         ByteBuffer byteBufferFinal = ByteBuffer.allocate(blockOffset.size() * MAX_LENGTH);
         byteBufferFinal.putInt(-blockOffset.size());
         for (int i = 1; i < blockOffset.size(); i++) {
@@ -296,17 +302,14 @@ public class TagLogFile implements AutoCloseable {
     } else {
       // get from Num*MAX_LENGTH < TotalMapSize + 4 + Long.BYTES*Num <= MAX_LENGTH*(Num + 1)
       double blockNumMinLimit =
-          (TotalMapSize + 4 - MAX_LENGTH)
-              / (double)
-                  (MAX_LENGTH - Long.BYTES);
-      int blockNum = (int) Math.round(Math.ceil(blockNumMinLimit)) + 1; // there are two solution, but choose the smaller one
+          (TotalMapSize + 4 - MAX_LENGTH) / (double) (MAX_LENGTH - Long.BYTES);
+      int blockNum =
+          (int) Math.round(Math.ceil(blockNumMinLimit))
+              + 1; // there are two solution, but choose the smaller one
 
       byteBuffer = ByteBuffer.allocate(blockNum * MAX_LENGTH);
       // 4 bytes for blockNumSize, blockNum*Long.BYTES for blockOffset
-      byteBuffer.position(
-          4
-              + (blockNum - 1)
-                  * Long.BYTES);
+      byteBuffer.position(4 + (blockNum - 1) * Long.BYTES);
     }
     serializeMap(tagMap, byteBuffer);
     serializeMap(attributeMap, byteBuffer);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/tag/TagManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/tag/TagManager.java
@@ -310,8 +310,7 @@ public class TagManager {
     if (node.getOffset() < 0) {
       return;
     }
-    Map<String, String> tagMap =
-        tagLogFile.readTag(node.getOffset());
+    Map<String, String> tagMap = tagLogFile.readTag(node.getOffset());
     if (tagMap != null) {
       for (Map.Entry<String, String> entry : tagMap.entrySet()) {
         if (tagIndex.containsKey(entry.getKey())
@@ -359,8 +358,7 @@ public class TagManager {
       IMeasurementMNode<?> leafMNode)
       throws MetadataException, IOException {
 
-    Pair<Map<String, String>, Map<String, String>> pair =
-        tagLogFile.read(leafMNode.getOffset());
+    Pair<Map<String, String>, Map<String, String>> pair = tagLogFile.read(leafMNode.getOffset());
 
     if (tagsMap != null) {
       for (Map.Entry<String, String> entry : tagsMap.entrySet()) {
@@ -424,8 +422,7 @@ public class TagManager {
       Map<String, String> attributesMap, PartialPath fullPath, IMeasurementMNode<?> leafMNode)
       throws MetadataException, IOException {
 
-    Pair<Map<String, String>, Map<String, String>> pair =
-        tagLogFile.read(leafMNode.getOffset());
+    Pair<Map<String, String>, Map<String, String>> pair = tagLogFile.read(leafMNode.getOffset());
 
     for (Map.Entry<String, String> entry : attributesMap.entrySet()) {
       String key = entry.getKey();
@@ -453,8 +450,7 @@ public class TagManager {
       Map<String, String> tagsMap, PartialPath fullPath, IMeasurementMNode<?> leafMNode)
       throws MetadataException, IOException {
 
-    Pair<Map<String, String>, Map<String, String>> pair =
-        tagLogFile.read(leafMNode.getOffset());
+    Pair<Map<String, String>, Map<String, String>> pair = tagLogFile.read(leafMNode.getOffset());
 
     for (Map.Entry<String, String> entry : tagsMap.entrySet()) {
       String key = entry.getKey();
@@ -484,8 +480,7 @@ public class TagManager {
   public void dropTagsOrAttributes(
       Set<String> keySet, PartialPath fullPath, IMeasurementMNode<?> leafMNode)
       throws MetadataException, IOException {
-    Pair<Map<String, String>, Map<String, String>> pair =
-        tagLogFile.read(leafMNode.getOffset());
+    Pair<Map<String, String>, Map<String, String>> pair = tagLogFile.read(leafMNode.getOffset());
 
     Map<String, String> deleteTag = new HashMap<>();
     for (String key : keySet) {
@@ -557,8 +552,7 @@ public class TagManager {
       Map<String, String> alterMap, PartialPath fullPath, IMeasurementMNode<?> leafMNode)
       throws MetadataException, IOException {
     // tags, attributes
-    Pair<Map<String, String>, Map<String, String>> pair =
-        tagLogFile.read(leafMNode.getOffset());
+    Pair<Map<String, String>, Map<String, String>> pair = tagLogFile.read(leafMNode.getOffset());
     Map<String, String> oldTagValue = new HashMap<>();
     Map<String, String> newTagValue = new HashMap<>();
 
@@ -628,8 +622,7 @@ public class TagManager {
       String oldKey, String newKey, PartialPath fullPath, IMeasurementMNode<?> leafMNode)
       throws MetadataException, IOException {
     // tags, attributes
-    Pair<Map<String, String>, Map<String, String>> pair =
-        tagLogFile.read(leafMNode.getOffset());
+    Pair<Map<String, String>, Map<String, String>> pair = tagLogFile.read(leafMNode.getOffset());
 
     // current name has existed
     if (pair.left.containsKey(newKey) || pair.right.containsKey(newKey)) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/tag/TagManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/tag/TagManager.java
@@ -178,14 +178,14 @@ public class TagManager {
     measurementsSet.add(measurementMNode);
     int measurementsSetNewSize = measurementsSet.size();
 
-    int memorySize = 0;
+    long memorySize = 0;
     if (tagIndexNewSize - tagIndexOldSize == 1) {
       // the last 4 is the memory occupied by the size of tagvaluemap
-      memorySize += (int) (RamUsageEstimator.sizeOf(tagKey) + 4);
+      memorySize += RamUsageEstimator.sizeOf(tagKey) + 4;
     }
     if (tagValueMapNewSize - tagValueMapOldSize == 1) {
       // the last 4 is the memory occupied by the size of measurementsSet
-      memorySize += (int) (RamUsageEstimator.sizeOf(tagValue) + 4);
+      memorySize += RamUsageEstimator.sizeOf(tagValue) + 4;
     }
     if (measurementsSetNewSize - measurementsSetOldSize == 1) {
       // 8 is the memory occupied by the length of the IMeasurementMNode
@@ -207,20 +207,20 @@ public class TagManager {
       return;
     }
     // init memory size
-    int memorySize = 0;
+    long memorySize = 0;
     if (tagIndex.get(tagKey).get(tagValue).remove(measurementMNode)) {
       memorySize += RamUsageEstimator.NUM_BYTES_OBJECT_REF + 4;
     }
     if (tagIndex.get(tagKey).get(tagValue).isEmpty()) {
       if (tagIndex.get(tagKey).remove(tagValue) != null) {
         // the last 4 is the memory occupied by the size of IMeasurementMNodeSet
-        memorySize += (int) (RamUsageEstimator.sizeOf(tagValue) + 4);
+        memorySize += RamUsageEstimator.sizeOf(tagValue) + 4;
       }
     }
     if (tagIndex.get(tagKey).isEmpty()) {
       if (tagIndex.remove(tagKey) != null) {
         // the last 4 is the memory occupied by the size of tagValueMap
-        memorySize += (int) (RamUsageEstimator.sizeOf(tagKey) + 4);
+        memorySize += RamUsageEstimator.sizeOf(tagKey) + 4;
       }
     }
     releaseMemory(memorySize);
@@ -747,13 +747,13 @@ public class TagManager {
     }
   }
 
-  private void requestMemory(int size) {
+  private void requestMemory(long size) {
     if (regionStatistics != null) {
       regionStatistics.requestMemory(size);
     }
   }
 
-  private void releaseMemory(int size) {
+  private void releaseMemory(long size) {
     if (regionStatistics != null) {
       regionStatistics.releaseMemory(size);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/tag/TagManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/tag/TagManager.java
@@ -143,7 +143,7 @@ public class TagManager {
 
   public boolean recoverIndex(long offset, IMeasurementMNode<?> measurementMNode)
       throws IOException {
-    Map<String, String> tags = tagLogFile.readTag(COMMON_CONFIG.getTagAttributeTotalSize(), offset);
+    Map<String, String> tags = tagLogFile.readTag(offset);
     if (tags == null || tags.isEmpty()) {
       return false;
     } else {
@@ -311,7 +311,7 @@ public class TagManager {
       return;
     }
     Map<String, String> tagMap =
-        tagLogFile.readTag(COMMON_CONFIG.getTagAttributeTotalSize(), node.getOffset());
+        tagLogFile.readTag(node.getOffset());
     if (tagMap != null) {
       for (Map.Entry<String, String> entry : tagMap.entrySet()) {
         if (tagIndex.containsKey(entry.getKey())
@@ -360,7 +360,7 @@ public class TagManager {
       throws MetadataException, IOException {
 
     Pair<Map<String, String>, Map<String, String>> pair =
-        tagLogFile.read(COMMON_CONFIG.getTagAttributeTotalSize(), leafMNode.getOffset());
+        tagLogFile.read(leafMNode.getOffset());
 
     if (tagsMap != null) {
       for (Map.Entry<String, String> entry : tagsMap.entrySet()) {
@@ -425,7 +425,7 @@ public class TagManager {
       throws MetadataException, IOException {
 
     Pair<Map<String, String>, Map<String, String>> pair =
-        tagLogFile.read(COMMON_CONFIG.getTagAttributeTotalSize(), leafMNode.getOffset());
+        tagLogFile.read(leafMNode.getOffset());
 
     for (Map.Entry<String, String> entry : attributesMap.entrySet()) {
       String key = entry.getKey();
@@ -454,7 +454,7 @@ public class TagManager {
       throws MetadataException, IOException {
 
     Pair<Map<String, String>, Map<String, String>> pair =
-        tagLogFile.read(COMMON_CONFIG.getTagAttributeTotalSize(), leafMNode.getOffset());
+        tagLogFile.read(leafMNode.getOffset());
 
     for (Map.Entry<String, String> entry : tagsMap.entrySet()) {
       String key = entry.getKey();
@@ -485,7 +485,7 @@ public class TagManager {
       Set<String> keySet, PartialPath fullPath, IMeasurementMNode<?> leafMNode)
       throws MetadataException, IOException {
     Pair<Map<String, String>, Map<String, String>> pair =
-        tagLogFile.read(COMMON_CONFIG.getTagAttributeTotalSize(), leafMNode.getOffset());
+        tagLogFile.read(leafMNode.getOffset());
 
     Map<String, String> deleteTag = new HashMap<>();
     for (String key : keySet) {
@@ -558,7 +558,7 @@ public class TagManager {
       throws MetadataException, IOException {
     // tags, attributes
     Pair<Map<String, String>, Map<String, String>> pair =
-        tagLogFile.read(COMMON_CONFIG.getTagAttributeTotalSize(), leafMNode.getOffset());
+        tagLogFile.read(leafMNode.getOffset());
     Map<String, String> oldTagValue = new HashMap<>();
     Map<String, String> newTagValue = new HashMap<>();
 
@@ -629,7 +629,7 @@ public class TagManager {
       throws MetadataException, IOException {
     // tags, attributes
     Pair<Map<String, String>, Map<String, String>> pair =
-        tagLogFile.read(COMMON_CONFIG.getTagAttributeTotalSize(), leafMNode.getOffset());
+        tagLogFile.read(leafMNode.getOffset());
 
     // current name has existed
     if (pair.left.containsKey(newKey) || pair.right.containsKey(newKey)) {
@@ -691,7 +691,7 @@ public class TagManager {
 
   public Pair<Map<String, String>, Map<String, String>> readTagFile(long tagFileOffset)
       throws IOException {
-    return tagLogFile.read(COMMON_CONFIG.getTagAttributeTotalSize(), tagFileOffset);
+    return tagLogFile.read(tagFileOffset);
   }
 
   /**

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/tag/TagManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/tag/TagManager.java
@@ -181,18 +181,14 @@ public class TagManager {
 
     int memorySize = 0;
     if (tagIndexNewSize - tagIndexOldSize == 1) {
-      // 4 is the memory occupied by the length of the string, tagKey.length() is the length of tagKey, and the last 4 is the memory occupied by the size of tagvaluemap
-      memorySize +=
-          4
-              + tagKey.length()
-              + 4;
+      // 4 is the memory occupied by the length of the string, tagKey.length() is the length of
+      // tagKey, and the last 4 is the memory occupied by the size of tagvaluemap
+      memorySize += 4 + tagKey.length() + 4;
     }
     if (tagValueMapNewSize - tagValueMapOldSize == 1) {
-      // 4 is the memory occupied by the length of the string, tagValue.length() is the length of tagValue, and the last 4 is the memory occupied by the size of measurementsSet
-      memorySize +=
-          4
-              + tagValue.length()
-              + 4;
+      // 4 is the memory occupied by the length of the string, tagValue.length() is the length of
+      // tagValue, and the last 4 is the memory occupied by the size of measurementsSet
+      memorySize += 4 + tagValue.length() + 4;
     }
     if (measurementsSetNewSize - measurementsSetOldSize == 1) {
       // 8 is the memory occupied by the length of the IMeasurementMNode
@@ -220,18 +216,16 @@ public class TagManager {
     }
     if (tagIndex.get(tagKey).get(tagValue).isEmpty()) {
       if (tagIndex.get(tagKey).remove(tagValue) != null) {
-        // 4 is the memory occupied by the length of the string, tagValue.length() is the length of tagValue, and the last 4 is the memory occupied by the size of IMeasurementMNodeSet
-        memorySize +=
-            4
-                + tagValue.length()
-                + 4;
+        // 4 is the memory occupied by the length of the string, tagValue.length() is the length of
+        // tagValue, and the last 4 is the memory occupied by the size of IMeasurementMNodeSet
+        memorySize += 4 + tagValue.length() + 4;
       }
     }
     if (tagIndex.get(tagKey).isEmpty()) {
       if (tagIndex.remove(tagKey) != null) {
-        // 4 is the memory occupied by the length of the string, tagKey.length() is the length of tagKey, and the last 4 is the memory occupied by the size of tagValueMap
-        memorySize +=
-            4 + tagKey.length() + 4;
+        // 4 is the memory occupied by the length of the string, tagKey.length() is the length of
+        // tagKey, and the last 4 is the memory occupied by the size of tagValueMap
+        memorySize += 4 + tagKey.length() + 4;
       }
     }
     releaseMemory(memorySize);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/schema/SRStatementGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/schema/SRStatementGenerator.java
@@ -62,6 +62,7 @@ import static org.apache.iotdb.commons.schema.SchemaConstant.MEASUREMENT_MNODE_T
 import static org.apache.iotdb.commons.schema.SchemaConstant.STORAGE_GROUP_ENTITY_MNODE_TYPE;
 import static org.apache.iotdb.commons.schema.SchemaConstant.STORAGE_GROUP_MNODE_TYPE;
 import static org.apache.iotdb.commons.schema.SchemaConstant.isStorageGroupType;
+import static org.apache.iotdb.db.schemaengine.schemaregion.tag.TagLogFile.parseByteBuffer;
 
 public class SRStatementGenerator implements Iterator<Statement>, Iterable<Statement> {
 
@@ -293,10 +294,7 @@ public class SRStatementGenerator implements Iterator<Statement>, Iterable<State
         if (node.getOffset() >= 0) {
           if (tagFileChannel != null) {
             try {
-              final ByteBuffer byteBuffer =
-                  ByteBuffer.allocate(COMMON_CONFIG.getTagAttributeTotalSize());
-              tagFileChannel.read(byteBuffer, node.getOffset());
-              byteBuffer.flip();
+              final ByteBuffer byteBuffer = parseByteBuffer(tagFileChannel, node.getOffset());
               final Pair<Map<String, String>, Map<String, String>> tagsAndAttributes =
                   new Pair<>(
                       ReadWriteIOUtils.readMap(byteBuffer), ReadWriteIOUtils.readMap(byteBuffer));
@@ -340,9 +338,7 @@ public class SRStatementGenerator implements Iterator<Statement>, Iterable<State
         if (measurement.getAsMeasurementMNode().getOffset() >= 0) {
           if (tagFileChannel != null) {
             try {
-              ByteBuffer byteBuffer = ByteBuffer.allocate(COMMON_CONFIG.getTagAttributeTotalSize());
-              tagFileChannel.read(byteBuffer, measurement.getAsMeasurementMNode().getOffset());
-              byteBuffer.flip();
+              ByteBuffer byteBuffer = parseByteBuffer(tagFileChannel, measurement.getAsMeasurementMNode().getOffset());
               Pair<Map<String, String>, Map<String, String>> tagsAndAttributes =
                   new Pair<>(
                       ReadWriteIOUtils.readMap(byteBuffer), ReadWriteIOUtils.readMap(byteBuffer));

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-common.properties
@@ -251,10 +251,22 @@ data_replication_factor=1
 # It is possible to lose at most tag_attribute_flush_interval records
 # tag_attribute_flush_interval=1000
 
-# max size for tag and attribute of one time series
+# max size for a storage block for tags and attributes of one time series. If the combined size of tags and
+# attributes exceeds the tag_attribute_total_size, a new storage block will be allocated to continue storing
+# the excess data.
 # the unit is byte
 # Datatype: int
 # tag_attribute_total_size=700
+
+# Maximum number of map entries allowed for each of tagMap and attributeMap separately
+# the unit is byte
+# Datatype: int
+# tag_attribute_max_num = 20
+
+# Maximum size allowed for each of map entry separately
+# the unit is byte
+# Datatype: int
+# tag_attribute_entry_max_size = 100
 
 # max measurement num of internal request
 # When creating timeseries with Session.createMultiTimeseries, the user input plan, the timeseries num of

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -250,9 +250,9 @@ public class CommonConfig {
   private boolean lastCacheEnable = true;
 
   // Max size for tag and attribute of one time series
-  private int tagAttributeTotalSize = 50;
-  private int tagAttributeEachMaxNum = 3;
-  private int tagAttributeEachMaxSize = 30;
+  private int tagAttributeTotalSize = 700;
+  private int tagAttributeEachMaxNum = 20;
+  private int tagAttributeEachMaxSize = 100;
 
   // maximum number of Cluster Databases allowed
   private int databaseLimitThreshold = -1;

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -251,8 +251,8 @@ public class CommonConfig {
 
   // Max size for tag and attribute of one time series
   private int tagAttributeTotalSize = 700;
-  private int tagAttributeEachMaxNum = 20;
-  private int tagAttributeEachMaxSize = 100;
+  private int tagAttributeMaxNum = 20;
+  private int tagAttributeEntryMaxSize = 100;
 
   // maximum number of Cluster Databases allowed
   private int databaseLimitThreshold = -1;
@@ -1099,12 +1099,20 @@ public class CommonConfig {
     this.tagAttributeTotalSize = tagAttributeTotalSize;
   }
 
-  public int getTagAttributeEachMaxNum() {
-    return tagAttributeEachMaxNum;
+  public int getTagAttributeMaxNum() {
+    return tagAttributeMaxNum;
   }
 
-  public int getTagAttributeEachMaxSize() {
-    return tagAttributeEachMaxSize;
+  public void setTagAttributeMaxNum(int tagAttributeMaxNum) {
+    this.tagAttributeMaxNum = tagAttributeMaxNum;
+  }
+
+  public int getTagAttributeEntryMaxSize() {
+    return tagAttributeEntryMaxSize;
+  }
+
+  public void setTagAttributeEntryMaxSize(int tagAttributeEntryMaxSize) {
+    this.tagAttributeEntryMaxSize = tagAttributeEntryMaxSize;
   }
 
   public int getDatabaseLimitThreshold() {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -246,6 +246,9 @@ public class CommonConfig {
 
   // Max size for tag and attribute of one time series
   private int tagAttributeTotalSize = 50;
+  private int tagAttributeEachMaxNum = 3;
+  private int tagAttributeEachMaxSize = 30;
+
 
   // maximum number of Cluster Databases allowed
   private int databaseLimitThreshold = -1;
@@ -1054,6 +1057,14 @@ public class CommonConfig {
 
   public void setTagAttributeTotalSize(int tagAttributeTotalSize) {
     this.tagAttributeTotalSize = tagAttributeTotalSize;
+  }
+
+  public int getTagAttributeEachMaxNum(){
+    return tagAttributeEachMaxNum;
+  }
+
+  public int getTagAttributeEachMaxSize(){
+    return tagAttributeEachMaxSize;
   }
 
   public int getDatabaseLimitThreshold() {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -245,7 +245,7 @@ public class CommonConfig {
   private boolean lastCacheEnable = true;
 
   // Max size for tag and attribute of one time series
-  private int tagAttributeTotalSize = 700;
+  private int tagAttributeTotalSize = 50;
 
   // maximum number of Cluster Databases allowed
   private int databaseLimitThreshold = -1;

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -254,7 +254,6 @@ public class CommonConfig {
   private int tagAttributeEachMaxNum = 3;
   private int tagAttributeEachMaxSize = 30;
 
-
   // maximum number of Cluster Databases allowed
   private int databaseLimitThreshold = -1;
 
@@ -1100,11 +1099,11 @@ public class CommonConfig {
     this.tagAttributeTotalSize = tagAttributeTotalSize;
   }
 
-  public int getTagAttributeEachMaxNum(){
+  public int getTagAttributeEachMaxNum() {
     return tagAttributeEachMaxNum;
   }
 
-  public int getTagAttributeEachMaxSize(){
+  public int getTagAttributeEachMaxSize() {
     return tagAttributeEachMaxSize;
   }
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -220,10 +220,22 @@ public class CommonDescriptor {
             properties.getProperty(
                 "tag_attribute_total_size", String.valueOf(config.getTagAttributeTotalSize()))));
 
+    config.setTagAttributeMaxNum(
+        Integer.parseInt(
+            properties.getProperty(
+                "tag_attribute_max_num", String.valueOf(config.getTagAttributeMaxNum()))));
+
+    config.setTagAttributeEntryMaxSize(
+        Integer.parseInt(
+            properties.getProperty(
+                "tag_attribute_entry_max_size",
+                String.valueOf(config.getTagAttributeEntryMaxSize()))));
+
     config.setTimePartitionInterval(
         Long.parseLong(
             properties.getProperty(
                 "time_partition_interval", String.valueOf(config.getTimePartitionInterval()))));
+
     config.setDatabaseLimitThreshold(
         Integer.parseInt(
             properties.getProperty(


### PR DESCRIPTION
The goal of this implementation is that for a tagmap that stores more than tagAttributeTotalSize, the program can support continuing to allocate a new space of the length of tagAttributeTotalSize and continue to store it.

- Storage design:
   - How to record the newly allocated space with a length of tagAttributeTotalSize: During tagmap serialization, identification is distinguished between tags that exceed tagAttributeTotalSize and those that do not exceed tagAttributeTotalSize. Currently, the identifier is considered to be the first read int value.
     - If this tagmap does not exceed tagAttributeTotalSize, it is based on the original storage format (mapsize key-value key-value). The first value is MapSize and is recorded as a positive number, 0, -1. (When map is null, mapsize is -1, map is not null, but when empty is true, mapsize is 0)
     - If this tagmap exceeds tagAttributeTotalSize, record the number of storage blocks it occupies offsetListNum, recorded as -offsetListNum. The format is -offsetlistnum offset1 ... offsetn. Note that offset1 records the offset of the second storage block. The offset of the starting block has been recorded in measurenode, so the number of offsets is 1 less than offsetlistnum. The follow-up is to record the MapSzie key-value key-value pairs according to the normal storage.
   - In this way, the storage format of the old data is not modified, the storage of new data can be supported, and the original deserialization interface can be reused.

- Implementation details:
   - The read and readtag interfaces of taglogfile have been modified and simplified to only require offset parameters. On the one hand, the read length is no longer a fixed length, and the caller does not know how much space is needed. On the other hand, this taglogfile provides an external interface and requires relatively complete encapsulation. The specific length is something that the caller does not need to care about.
   - Calculate the number of required offsets through the inequality Num * MAX_LENGTH < TotalMapSize + 4 + Long.BYTES * Num <= MAX_LENGTH * (Num + 1). There are at most two solutions within the range of the result. This one takes the smaller solution to save space. There are two solutions that are easy to understand, that is, just adding the offset will exceed the current block upper limit.

- Current reading process:
   - The current reading processes of read and readtag are very similar, except that read will read one more attribute, so the reading process is abstracted into a function parsebytebuffer.
   - In this function, a blocksize data will be read first. According to the first int of blocksize, if the first int is greater than or equal to -1, then it is a block, otherwise it is multiple blocks. If it is a block, you can return after restoring the offset. If there are multiple blocks, you can create a very large bytebuffer that can accommodate all data based on offsetlistsize and put the data of the first block. Then after the first int, the 8-byte offset is continuously read, and after reading the block corresponding to the offset, it is put into the super large bytebuffer. After loop reading, the entire bytebuffer can be read out, and the offset of the bytebuffer is set before the tagmapsize to return.

- Current writing process:
   - Serialize the content: First calculate the actual length of the serialized content. If it does not exceed 1 blocksize, then store it according to the storage format of a block (also the old storage format). If the actual length exceeds 1 blocksize, then you need to reserve space for offsetlist and serialize the actual content behind it.
   - Write content to file:
     - During the writing process, if the writing offset is a negative number, it means writing from the end.
     - First, you need to read the original data of the offset that needs to be written and obtain the space block position it occupies. The function parseoffsetlist function is used here to implement this process. Compared with parsebytebuffer, it has been pruned to a certain extent. It only needs to read the offset sequence of the sequence header, reducing the complexity of processing.
     - This is then divided into three situations for processing:
       - Situation 1: It turns out that there is only one block in this place, and now there is only one block to write, so just write it directly.
       - Situation 2: It turns out that the block occupied by this place is more than the amount of data to be written currently, so the original block needs to be reused at this time. Create a bytebuffer with the original blocksize, reserve the original offset space, and then put the currently written data into it. If there are multiple blocks now, remember to adjust the offset to skip the space reserved during serialization. Then you only need to write the corresponding blocks to the corresponding offset positions in sequence according to the original offset list.
       - Case 3: The space written now is greater than or equal to the original space. At this time, the space reserved during serialization is sufficient. However, since some offsets need to be written to obtain, the serialization results without offsets need to be written first according to the offset records of the original block. If the block is not enough, then continue writing at the end of the filechannel, and then record the offset position into the offset list. Finally, the data of the offset list is also combined into a buffer, and then written sequentially from the starting position according to the offset list. In this way, the entire writing process is completed.

- The difficulty in this part is that the offset of the file will change with reading and writing. You need to always pay attention to the changes in the position and limit of the bytebuffer and make adjustments.

- extra work
  - Optimization of SRStatementGenerator: Found and fixed the non-standard implementation of reading tagmap in SRStatementGenerator. By setting the parsebytebuffer function to static, the SRStatementGenerator is allowed to be called directly, reducing modifications to the source code and avoiding inconsistency issues.
  - Increase the number and size limits of Tags and Attributes: Restrictive parameters for the number of Tags and Attributes and their individual sizes are introduced. Currently, the number of supported tags and attributes has the same upper limit, rather than the upper limit of both together, which is relatively reasonable. Currently, this quantity and size restrictive parameter is implemented in the serialization of the writing process. During serialization, the serialization size of tagmap and attributemap needs to be calculated. Checks for mapsize and entrysize are added here to ensure that the checks are completed before writing and that the length will not be processed repeatedly.
  - Add tagindex to the memory control of metadata: Detailed memory increase and decrease calculations are implemented for the addindex and removeindex functions in tagmanager. At the same time, the assignment and recycling of the storage structure are completed, and the basic memory calculation interface for the increase or decrease of index is completed. In the case of memory overflow, new tags cannot be created. Here, the corresponding tags are added in renameTagOrAttributeKey, setTagsOrAttributesValue, addTags, and upsertAliasAndTagsAndAttributes in schemaregionmemoryimpl and schemaregionpbtreeimpl when the corresponding tag is not empty. If memory overflows, execution will be refused and an error will be thrown.
  - Fix memory control omissions: The original alisa is involved in memory control, but for the addition and modification of alisa, there is no check for memory overflow. That is to say, when the memory overflows, alisa can still be added normally, which will cause further memory overflow. The current modification is upsertAlias in schemaregionmemoryimpl and schemaregionpbtreeimpl, which checks whether the memory overflows when alisa is not null.