### PR TITLE
[IOTDB-6326] Normalize the table headers of Auth related statement

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBRestServiceIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBRestServiceIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.it;
 
+import org.apache.iotdb.db.queryengine.common.header.ColumnHeaderConstant;
 import org.apache.iotdb.it.env.EnvFactory;
 import org.apache.iotdb.it.env.cluster.node.DataNodeWrapper;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
@@ -1385,7 +1386,7 @@ public class IoTDBRestServiceIT {
     List<Object> columnNames =
         new ArrayList<Object>() {
           {
-            add("user");
+            add(ColumnHeaderConstant.USER);
           }
         };
     List<Object> values1 =
@@ -2036,7 +2037,7 @@ public class IoTDBRestServiceIT {
     List<Object> columnNames =
         new ArrayList<Object>() {
           {
-            add("user");
+            add(ColumnHeaderConstant.USER);
           }
         };
     List<Object> values1 =

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBSyntaxConventionIdentifierIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBSyntaxConventionIdentifierIT.java
@@ -615,7 +615,7 @@ public class IoTDBSyntaxConventionIdentifierIT {
       Set<String> expectedResult = new HashSet<>(Arrays.asList(resultNames));
       try (ResultSet resultSet = statement.executeQuery("list user")) {
         while (resultSet.next()) {
-          String user = resultSet.getString("user").toLowerCase();
+          String user = resultSet.getString(ColumnHeaderConstant.USER).toLowerCase();
           Assert.assertTrue(expectedResult.contains(user));
           expectedResult.remove(user);
         }
@@ -678,7 +678,7 @@ public class IoTDBSyntaxConventionIdentifierIT {
       Set<String> expectedResult = new HashSet<>(Arrays.asList(resultNames));
       try (ResultSet resultSet = statement.executeQuery("list role")) {
         while (resultSet.next()) {
-          String role = resultSet.getString("role").toLowerCase();
+          String role = resultSet.getString(ColumnHeaderConstant.ROLE).toLowerCase();
           Assert.assertTrue(expectedResult.contains(role));
           expectedResult.remove(role);
         }

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBClusterAuthorityIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBClusterAuthorityIT.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.confignode.rpc.thrift.IConfigNodeRPCService;
 import org.apache.iotdb.confignode.rpc.thrift.TAuthorizerReq;
 import org.apache.iotdb.confignode.rpc.thrift.TAuthorizerResp;
 import org.apache.iotdb.confignode.rpc.thrift.TCheckUserPrivilegesReq;
+import org.apache.iotdb.db.queryengine.common.header.ColumnHeaderConstant;
 import org.apache.iotdb.db.queryengine.plan.statement.AuthorType;
 import org.apache.iotdb.it.env.EnvFactory;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
@@ -366,7 +367,7 @@ public class IoTDBClusterAuthorityIT {
       authorizerResp = client.queryPermission(authorizerReq);
       status = authorizerResp.getStatus();
       assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), status.getCode());
-      assertEquals(IoTDBConstant.COLUMN_PRIVILEGE, authorizerResp.getTag());
+      assertEquals(ColumnHeaderConstant.PRIVILEGES, authorizerResp.getTag());
       assertEquals("tempuser0", authorizerResp.getPermissionInfo().getUserInfo().getUsername());
       assertEquals(
           new ArrayList<>(), authorizerResp.getPermissionInfo().getUserInfo().getPrivilegeList());

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBClusterAuthorityIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBClusterAuthorityIT.java
@@ -22,7 +22,6 @@ package org.apache.iotdb.db.it.auth;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.auth.entity.PrivilegeType;
 import org.apache.iotdb.commons.client.sync.SyncConfigNodeIServiceClient;
-import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.utils.AuthUtils;

--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/manual/IoTDBPipeMetaHistoricalIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/manual/IoTDBPipeMetaHistoricalIT.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.commons.client.sync.SyncConfigNodeIServiceClient;
 import org.apache.iotdb.confignode.rpc.thrift.TCreatePipeReq;
 import org.apache.iotdb.consensus.ConsensusFactory;
 import org.apache.iotdb.db.it.utils.TestUtils;
+import org.apache.iotdb.db.queryengine.common.header.ColumnHeaderConstant;
 import org.apache.iotdb.it.env.MultiEnvFactory;
 import org.apache.iotdb.it.env.cluster.node.DataNodeWrapper;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
@@ -136,7 +137,10 @@ public class IoTDBPipeMetaHistoricalIT extends AbstractPipeDualManualIT {
           TSStatusCode.SUCCESS_STATUS.getStatusCode(), client.startPipe("testPipe").getCode());
 
       TestUtils.assertDataAlwaysOnEnv(
-          receiverEnv, "list user", "user,", Collections.singleton("root,"));
+          receiverEnv,
+          "list user",
+          ColumnHeaderConstant.USER + ",",
+          Collections.singleton("root,"));
       TestUtils.assertDataAlwaysOnEnv(receiverEnv, "list role", "role,", Collections.emptySet());
 
       TestUtils.assertDataEventuallyOnEnv(

--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/manual/IoTDBPipeMetaHistoricalIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/manual/IoTDBPipeMetaHistoricalIT.java
@@ -141,7 +141,8 @@ public class IoTDBPipeMetaHistoricalIT extends AbstractPipeDualManualIT {
           "list user",
           ColumnHeaderConstant.USER + ",",
           Collections.singleton("root,"));
-      TestUtils.assertDataAlwaysOnEnv(receiverEnv, "list role", "role,", Collections.emptySet());
+      TestUtils.assertDataAlwaysOnEnv(
+          receiverEnv, "list role", ColumnHeaderConstant.ROLE + ",", Collections.emptySet());
 
       TestUtils.assertDataEventuallyOnEnv(
           receiverEnv,
@@ -220,11 +221,20 @@ public class IoTDBPipeMetaHistoricalIT extends AbstractPipeDualManualIT {
           TSStatusCode.SUCCESS_STATUS.getStatusCode(), client.startPipe("testPipe").getCode());
 
       TestUtils.assertDataEventuallyOnEnv(
-          receiverEnv, "list user of role `admin`", "user,", Collections.singleton("thulab,"));
+          receiverEnv,
+          "list user of role `admin`",
+          ColumnHeaderConstant.USER + ",",
+          Collections.singleton("thulab,"));
       TestUtils.assertDataEventuallyOnEnv(
           receiverEnv,
           "list privileges of role `admin`",
-          "ROLE,PATH,PRIVILEGES,GRANT OPTION,",
+          ColumnHeaderConstant.ROLE
+              + ","
+              + ColumnHeaderConstant.PATH
+              + ","
+              + ColumnHeaderConstant.PRIVILEGES
+              + ","
+              + ColumnHeaderConstant.GRANT_OPTION,
           new HashSet<>(
               Arrays.asList("admin,root.**,READ_DATA,false,", "admin,root.**,READ_SCHEMA,false,")));
 
@@ -241,7 +251,10 @@ public class IoTDBPipeMetaHistoricalIT extends AbstractPipeDualManualIT {
       }
 
       TestUtils.assertDataEventuallyOnEnv(
-          receiverEnv, "list role", "role,", new HashSet<>(Arrays.asList("admin,", "test,")));
+          receiverEnv,
+          "list role",
+          ColumnHeaderConstant.ROLE + ",",
+          new HashSet<>(Arrays.asList("admin,", "test,")));
     }
   }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/manual/IoTDBPipeMetaHistoricalIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/manual/IoTDBPipeMetaHistoricalIT.java
@@ -234,7 +234,8 @@ public class IoTDBPipeMetaHistoricalIT extends AbstractPipeDualManualIT {
               + ","
               + ColumnHeaderConstant.PRIVILEGES
               + ","
-              + ColumnHeaderConstant.GRANT_OPTION,
+              + ColumnHeaderConstant.GRANT_OPTION
+              + ",",
           new HashSet<>(
               Arrays.asList("admin,root.**,READ_DATA,false,", "admin,root.**,READ_SCHEMA,false,")));
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/AuthorInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/AuthorInfo.java
@@ -45,6 +45,7 @@ import org.apache.iotdb.confignode.rpc.thrift.TPathPrivilege;
 import org.apache.iotdb.confignode.rpc.thrift.TPermissionInfoResp;
 import org.apache.iotdb.confignode.rpc.thrift.TRoleResp;
 import org.apache.iotdb.confignode.rpc.thrift.TUserResp;
+import org.apache.iotdb.db.queryengine.common.header.ColumnHeaderConstant;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
 
@@ -337,7 +338,7 @@ public class AuthorInfo implements SnapshotProcessor {
         }
       }
     }
-    result.setTag(IoTDBConstant.COLUMN_USER);
+    result.setTag(ColumnHeaderConstant.USER);
     result.setMemberInfo(userList);
     result.setStatus(RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS));
     return result;
@@ -359,7 +360,7 @@ public class AuthorInfo implements SnapshotProcessor {
       }
       roleList.addAll(user.getRoleList());
     }
-    result.setTag(IoTDBConstant.COLUMN_ROLE);
+    result.setTag(ColumnHeaderConstant.ROLE);
     result.setMemberInfo(roleList);
     result.setStatus(RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS));
     return result;
@@ -393,7 +394,7 @@ public class AuthorInfo implements SnapshotProcessor {
     roleInfo.put(role.getName(), roleResp);
     resp.setRoleInfo(roleInfo);
     resp.setStatus(RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS));
-    result.setTag(IoTDBConstant.COLUMN_PRIVILEGE);
+    result.setTag(ColumnHeaderConstant.PRIVILEGES);
     result.setPermissionInfoResp(resp);
     result.setStatus(RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS));
     result.setMemberInfo(permissionInfo);
@@ -410,7 +411,7 @@ public class AuthorInfo implements SnapshotProcessor {
     }
     TPermissionInfoResp resp = getUserPermissionInfo(plan.getUserName());
     resp.setStatus(RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS));
-    result.setTag(IoTDBConstant.COLUMN_PRIVILEGE);
+    result.setTag(ColumnHeaderConstant.PRIVILEGES);
     result.setPermissionInfoResp(resp);
     result.setStatus(RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS));
     return result;

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/AuthorInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/AuthorInfo.java
@@ -30,7 +30,6 @@ import org.apache.iotdb.commons.auth.entity.Role;
 import org.apache.iotdb.commons.auth.entity.User;
 import org.apache.iotdb.commons.conf.CommonConfig;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
-import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.path.PathPatternTree;
 import org.apache.iotdb.commons.snapshot.SnapshotProcessor;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/auth/AuthorityChecker.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/auth/AuthorityChecker.java
@@ -23,7 +23,6 @@ import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.auth.AuthException;
 import org.apache.iotdb.commons.auth.entity.PrivilegeType;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
-import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.path.PathPatternTree;
 import org.apache.iotdb.commons.service.metric.PerformanceOverviewMetrics;
@@ -226,8 +225,10 @@ public class AuthorityChecker {
       }
     } else {
       headerList = LIST_USER_PRIVILEGES_Column_HEADERS;
-      types = LIST_USER_PRIVILEGES_Column_HEADERS.stream().map(ColumnHeader::getColumnType)
-          .collect(Collectors.toList());
+      types =
+          LIST_USER_PRIVILEGES_Column_HEADERS.stream()
+              .map(ColumnHeader::getColumnType)
+              .collect(Collectors.toList());
       builder = new TsBlockBuilder(types);
       TUserResp user = authResp.getPermissionInfo().getUserInfo();
       if (user != null) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/header/ColumnHeaderConstant.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/header/ColumnHeaderConstant.java
@@ -68,6 +68,7 @@ public class ColumnHeaderConstant {
   public static final String VERSION = "Version";
   public static final String BUILD_INFO = "BuildInfo";
   public static final String PATHS = "Paths";
+  public static final String PATH = "Path";
   public static final String VARIABLE = "Variable";
 
   // column names for count statement
@@ -198,6 +199,11 @@ public class ColumnHeaderConstant {
 
   // column names for show current timestamp
   public static final String CURRENT_TIMESTAMP = "CurrentTimestamp";
+
+  public static final String PRIVILEGES = "Privileges";
+
+  public static final String GRANT_OPTION = "GrantOption";
+
 
   public static final List<ColumnHeader> lastQueryColumnHeaders =
       ImmutableList.of(
@@ -488,4 +494,11 @@ public class ColumnHeaderConstant {
 
   public static final List<ColumnHeader> showCurrentTimestampColumnHeaders =
       ImmutableList.of(new ColumnHeader(CURRENT_TIMESTAMP, TSDataType.INT64));
+
+  public static final List<ColumnHeader> LIST_USER_PRIVILEGES_Column_HEADERS =
+      ImmutableList.of(
+          new ColumnHeader(ROLE, TSDataType.TEXT),
+          new ColumnHeader(PATH, TSDataType.TEXT),
+          new ColumnHeader(PRIVILEGES, TSDataType.TEXT),
+          new ColumnHeader(GRANT_OPTION, TSDataType.TEXT));
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/header/ColumnHeaderConstant.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/header/ColumnHeaderConstant.java
@@ -204,7 +204,6 @@ public class ColumnHeaderConstant {
 
   public static final String GRANT_OPTION = "GrantOption";
 
-
   public static final List<ColumnHeader> lastQueryColumnHeaders =
       ImmutableList.of(
           new ColumnHeader(TIMESERIES, TSDataType.TEXT),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/header/ColumnHeaderConstant.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/header/ColumnHeaderConstant.java
@@ -500,5 +500,5 @@ public class ColumnHeaderConstant {
           new ColumnHeader(ROLE, TSDataType.TEXT),
           new ColumnHeader(PATH, TSDataType.TEXT),
           new ColumnHeader(PRIVILEGES, TSDataType.TEXT),
-          new ColumnHeader(GRANT_OPTION, TSDataType.TEXT));
+          new ColumnHeader(GRANT_OPTION, TSDataType.BOOLEAN));
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/IoTDBConstant.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/IoTDBConstant.java
@@ -169,7 +169,7 @@ public class IoTDBConstant {
   public static final String COLUMN_DISTRIBUTION_PLAN = "distribution plan";
   public static final String QUERY_ID = "queryId";
   public static final String STATEMENT = "statement";
-  
+
   public static final String COLUMN_DATABASE = "database";
   public static final String COLUMN_TTL = "ttl";
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/IoTDBConstant.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/IoTDBConstant.java
@@ -169,11 +169,7 @@ public class IoTDBConstant {
   public static final String COLUMN_DISTRIBUTION_PLAN = "distribution plan";
   public static final String QUERY_ID = "queryId";
   public static final String STATEMENT = "statement";
-
-  public static final String COLUMN_ROLE = "role";
-  public static final String COLUMN_USER = "user";
-  public static final String COLUMN_PRIVILEGE = "privilege";
-
+  
   public static final String COLUMN_DATABASE = "database";
   public static final String COLUMN_TTL = "ttl";
 


### PR DESCRIPTION
more details can be seen in https://issues.apache.org/jira/browse/IOTDB-6326.

After this pr merged, we will get table headers like the following:
<img width="991" alt="image" src="https://github.com/apache/iotdb/assets/16079446/5893d5e6-9860-46ff-8d33-e0b89e32cef1">
