### PR TITLE
Pipe: fix infinite loop with lock when retrying syncing tsfiles in async connector (which may cause selector & connector worker deadlock)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/client/IoTDBDataNodeAsyncClientManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/client/IoTDBDataNodeAsyncClientManager.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.commons.client.ClientPoolFactory;
 import org.apache.iotdb.commons.client.IClientManager;
 import org.apache.iotdb.commons.client.async.AsyncPipeDataTransferServiceClient;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
+import org.apache.iotdb.commons.pipe.config.PipeConfig;
 import org.apache.iotdb.commons.pipe.connector.client.IoTDBClientManager;
 import org.apache.iotdb.commons.pipe.connector.payload.thrift.common.PipeTransferHandshakeConstant;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
@@ -202,6 +203,8 @@ public class IoTDBDataNodeAsyncClientManager extends IoTDBClientManager
     params.put(
         PipeTransferHandshakeConstant.HANDSHAKE_KEY_TIME_PRECISION,
         CommonDescriptor.getInstance().getConfig().getTimestampPrecision());
+
+    client.setTimeoutDynamically(PipeConfig.getInstance().getPipeConnectorHandshakeTimeoutMs());
     client.pipeTransfer(PipeTransferDataNodeHandshakeV2Req.toTPipeTransferReq(params), callback);
     waitHandshakeFinished(isHandshakeFinished);
 
@@ -219,6 +222,7 @@ public class IoTDBDataNodeAsyncClientManager extends IoTDBClientManager
       resp.set(null);
       exception.set(null);
 
+      client.setTimeoutDynamically(PipeConfig.getInstance().getPipeConnectorHandshakeTimeoutMs());
       client.pipeTransfer(
           PipeTransferDataNodeHandshakeV1Req.toTPipeTransferReq(
               CommonDescriptor.getInstance().getConfig().getTimestampPrecision()),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBDataRegionAsyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBDataRegionAsyncConnector.java
@@ -430,7 +430,7 @@ public class IoTDBDataRegionAsyncConnector extends IoTDBConnector {
    *
    * @param event event to retry
    */
-  public synchronized void addFailureEventToRetryQueue(final Event event) {
+  public void addFailureEventToRetryQueue(final Event event) {
     if (isClosed.get()) {
       if (event instanceof EnrichedEvent) {
         ((EnrichedEvent) event).clearReferenceCount(IoTDBDataRegionAsyncConnector.class.getName());
@@ -442,6 +442,12 @@ public class IoTDBDataRegionAsyncConnector extends IoTDBConnector {
     if (LOGGER.isDebugEnabled()) {
       LOGGER.debug("Added event {} to retry queue.", event);
     }
+
+    if (isClosed.get()) {
+      if (event instanceof EnrichedEvent) {
+        ((EnrichedEvent) event).clearReferenceCount(IoTDBDataRegionAsyncConnector.class.getName());
+      }
+    }
   }
 
   /**
@@ -449,7 +455,7 @@ public class IoTDBDataRegionAsyncConnector extends IoTDBConnector {
    *
    * @param events events to retry
    */
-  public synchronized void addFailureEventsToRetryQueue(final Iterable<Event> events) {
+  public void addFailureEventsToRetryQueue(final Iterable<Event> events) {
     for (final Event event : events) {
       addFailureEventToRetryQueue(event);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBDataRegionAsyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBDataRegionAsyncConnector.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.pipe.connector.protocol.thrift.async;
 
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.commons.client.async.AsyncPipeDataTransferServiceClient;
+import org.apache.iotdb.commons.pipe.config.PipeConfig;
 import org.apache.iotdb.commons.pipe.connector.protocol.IoTDBConnector;
 import org.apache.iotdb.commons.pipe.event.EnrichedEvent;
 import org.apache.iotdb.db.pipe.connector.client.IoTDBDataNodeAsyncClientManager;
@@ -46,6 +47,7 @@ import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameters;
 import org.apache.iotdb.pipe.api.event.Event;
 import org.apache.iotdb.pipe.api.event.dml.insertion.TabletInsertionEvent;
 import org.apache.iotdb.pipe.api.event.dml.insertion.TsFileInsertionEvent;
+import org.apache.iotdb.pipe.api.exception.PipeConnectionException;
 import org.apache.iotdb.service.rpc.thrift.TPipeTransferReq;
 
 import org.slf4j.Logger;
@@ -82,6 +84,11 @@ public class IoTDBDataRegionAsyncConnector extends IoTDBConnector {
 
   private IoTDBDataNodeAsyncClientManager clientManager;
 
+  private final int maxAllowedQueuedEventNumber =
+      Math.max(
+              PipeConfig.getInstance().getPipeAsyncConnectorMaxClientNumber(),
+              PipeConfig.getInstance().getPipeAsyncConnectorSelectorNumber())
+          * 2;
   private final IoTDBDataRegionSyncConnector retryConnector = new IoTDBDataRegionSyncConnector();
   private final BlockingQueue<Event> retryEventQueue = new LinkedBlockingQueue<>();
 
@@ -360,8 +367,16 @@ public class IoTDBDataRegionAsyncConnector extends IoTDBConnector {
 
     while (!retryEventQueue.isEmpty()) {
       synchronized (this) {
-        if (isClosed.get() || retryEventQueue.isEmpty() || alreadyRetriedTimes++ >= maxRetryTimes) {
+        if (isClosed.get() || retryEventQueue.isEmpty()) {
           return;
+        }
+
+        if (alreadyRetriedTimes++ >= maxRetryTimes) {
+          if (retryEventQueue.size() < maxAllowedQueuedEventNumber) {
+            return;
+          }
+          throw new PipeConnectionException(
+              "The retry event queue is full. Please check the receiver status and the network connection.");
         }
 
         final Event peekedEvent = retryEventQueue.peek();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBDataRegionAsyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBDataRegionAsyncConnector.java
@@ -301,6 +301,8 @@ public class IoTDBDataRegionAsyncConnector extends IoTDBConnector {
       final PipeTransferTsFileInsertionEventHandler pipeTransferTsFileInsertionEventHandler) {
     AsyncPipeDataTransferServiceClient client = null;
     try {
+      // We assume that borrowClient will return or throw an exception in limited time.
+      // Or it may block the whole pipe.
       client = clientManager.borrowClient();
       pipeTransferTsFileInsertionEventHandler.transfer(clientManager, client);
     } catch (final Exception ex) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBDataRegionAsyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBDataRegionAsyncConnector.java
@@ -301,8 +301,6 @@ public class IoTDBDataRegionAsyncConnector extends IoTDBConnector {
       final PipeTransferTsFileInsertionEventHandler pipeTransferTsFileInsertionEventHandler) {
     AsyncPipeDataTransferServiceClient client = null;
     try {
-      // We assume that borrowClient will return or throw an exception in limited time.
-      // Or it may block the whole pipe.
       client = clientManager.borrowClient();
       pipeTransferTsFileInsertionEventHandler.transfer(clientManager, client);
     } catch (final Exception ex) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTsFileInsertionEventHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTsFileInsertionEventHandler.java
@@ -242,11 +242,14 @@ public class PipeTransferTsFileInsertionEventHandler
     } catch (final IOException e) {
       LOGGER.warn("Failed to close file reader when failed to transfer file.", e);
     } finally {
-      connector.addFailureEventToRetryQueue(event);
-
-      if (client != null) {
-        client.setShouldReturnSelf(true);
-        client.returnSelf();
+      try {
+        // addFailureEventToRetryQueue's execution may be blocked, so return the client first
+        if (client != null) {
+          client.setShouldReturnSelf(true);
+          client.returnSelf();
+        }
+      } finally {
+        connector.addFailureEventToRetryQueue(event);
       }
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTsFileInsertionEventHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTsFileInsertionEventHandler.java
@@ -243,7 +243,6 @@ public class PipeTransferTsFileInsertionEventHandler
       LOGGER.warn("Failed to close file reader when failed to transfer file.", e);
     } finally {
       try {
-        // addFailureEventToRetryQueue's execution may be blocked, so return the client first
         if (client != null) {
           client.setShouldReturnSelf(true);
           client.returnSelf();

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncPipeDataTransferServiceClient.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncPipeDataTransferServiceClient.java
@@ -141,7 +141,8 @@ public class AsyncPipeDataTransferServiceClient extends IClientRPCService.AsyncC
         LOGGER.error(
             "Unexpected exception occurs in {}, error msg is {}",
             this,
-            ExceptionUtils.getRootCause(e).toString());
+            ExceptionUtils.getRootCause(e).toString(),
+            e);
       }
       return false;
     }


### PR DESCRIPTION
As title.