### PR TITLE
Fix insert rows mem control error

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AbstractMemTable.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AbstractMemTable.java
@@ -399,6 +399,9 @@ public abstract class AbstractMemTable implements IMemTable {
   @Override
   public long getCurrentTVListSize(IDeviceID deviceId, String measurement) {
     IWritableMemChunkGroup memChunkGroup = memTableMap.get(deviceId);
+    if (null == memChunkGroup) {
+      return 0;
+    }
     return memChunkGroup.getCurrentTVListSize(measurement);
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
@@ -586,9 +586,7 @@ public class TsFileProcessor {
               ((currentChunkPointNum + addingPointNum) % PrimitiveArrayManager.ARRAY_SIZE) == 0
                   ? TVList.tvListArrayMemCost(dataTypes[i])
                   : 0;
-          increasingMemTableInfo
-              .get(deviceId)
-              .computeIfPresent(measurements[i], (k, v) -> v + 1);
+          increasingMemTableInfo.get(deviceId).computeIfPresent(measurements[i], (k, v) -> v + 1);
         }
         // TEXT data mem size
         if (dataTypes[i] == TSDataType.TEXT && values[i] != null) {
@@ -668,8 +666,7 @@ public class TsFileProcessor {
     long textDataIncrement = 0L;
     long chunkMetadataIncrement = 0L;
     // device -> (measurements -> datatype, adding aligned TVList size)
-    Map<IDeviceID, Pair<Map<String, TSDataType>, Integer>> increasingMemTableInfo =
-        new HashMap<>();
+    Map<IDeviceID, Pair<Map<String, TSDataType>, Integer>> increasingMemTableInfo = new HashMap<>();
     for (InsertRowNode insertRowNode : insertRowsNode.getInsertRowNodeList()) {
       IDeviceID deviceId = insertRowNode.getDeviceID();
       TSDataType[] dataTypes = insertRowNode.getDataTypes();
@@ -713,8 +710,7 @@ public class TsFileProcessor {
           }
 
           Pair<Map<String, TSDataType>, Integer> addingPointNumInfo =
-              increasingMemTableInfo.computeIfAbsent(
-                  deviceId, k -> new Pair<>(new HashMap<>(), 0));
+              increasingMemTableInfo.computeIfAbsent(deviceId, k -> new Pair<>(new HashMap<>(), 0));
           int addingPointNum = addingPointNumInfo.getRight();
           // Extending the column of aligned mem chunk
           if ((alignedMemChunk != null && !alignedMemChunk.containsMeasurement(measurements[i]))

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
@@ -710,7 +710,8 @@ public class TsFileProcessor {
           }
 
           // Extending the column of aligned mem chunk
-          if (!alignedMemChunk.containsMeasurement(measurements[i])) {
+          if (!alignedMemChunk.containsMeasurement(measurements[i])
+              || !increasingMemTableMemInfo.get(deviceId).left.contains(measurements[i])) {
             memTableIncrement +=
                 (alignedMemChunk.alignedListSize() / PrimitiveArrayManager.ARRAY_SIZE + 1)
                     * AlignedTVList.valueListArrayMemCost(dataTypes[i]);
@@ -722,7 +723,9 @@ public class TsFileProcessor {
           }
         }
         // Here currentChunkPointNum >= 1
-        if ((alignedMemChunk.alignedListSize() % PrimitiveArrayManager.ARRAY_SIZE) == 0) {
+        if (((alignedMemChunk.alignedListSize()
+            + increasingMemTableMemInfo.get(deviceId).right)
+            % PrimitiveArrayManager.ARRAY_SIZE) == 0) {
           dataTypesInTVList.addAll(((AlignedTVList) alignedMemChunk.getTVList()).getTsDataTypes());
           memTableIncrement += AlignedTVList.alignedTvListArrayMemCost(dataTypesInTVList);
         }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
@@ -703,14 +703,14 @@ public class TsFileProcessor {
             memChunkGroup == null ? null : memChunkGroup.getAlignedMemChunk();
         long currentChunkPointNum = alignedMemChunk == null ? 0 : alignedMemChunk.alignedListSize();
         List<TSDataType> dataTypesInTVList = new ArrayList<>();
+        Pair<Map<String, TSDataType>, Integer> addingPointNumInfo =
+            increasingMemTableInfo.computeIfAbsent(deviceId, k -> new Pair<>(new HashMap<>(), 0));
         for (int i = 0; i < dataTypes.length; i++) {
           // Skip failed Measurements
           if (dataTypes[i] == null || measurements[i] == null) {
             continue;
           }
 
-          Pair<Map<String, TSDataType>, Integer> addingPointNumInfo =
-              increasingMemTableInfo.computeIfAbsent(deviceId, k -> new Pair<>(new HashMap<>(), 0));
           int addingPointNum = addingPointNumInfo.getRight();
           // Extending the column of aligned mem chunk
           if ((alignedMemChunk != null && !alignedMemChunk.containsMeasurement(measurements[i]))
@@ -726,7 +726,7 @@ public class TsFileProcessor {
           }
         }
         int addingPointNum = increasingMemTableInfo.get(deviceId).getRight();
-        // Here currentChunkPointNum >= 1
+        // Here currentChunkPointNum + addingPointNum >= 1
         if (((currentChunkPointNum + addingPointNum) % PrimitiveArrayManager.ARRAY_SIZE) == 0) {
           if (alignedMemChunk != null) {
             dataTypesInTVList.addAll(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/WritableMemChunkGroup.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/WritableMemChunkGroup.java
@@ -161,6 +161,9 @@ public class WritableMemChunkGroup implements IWritableMemChunkGroup {
 
   @Override
   public long getCurrentTVListSize(String measurement) {
+    if (!memChunkMap.containsKey(measurement)) {
+      return 0;
+    }
     return memChunkMap.get(measurement).getTVList().rowCount();
   }
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessorTest.java
@@ -539,7 +539,9 @@ public class TsFileProcessorTest {
     for (int i = 1; i <= 100; i++) {
       TSRecord record = new TSRecord(i, deviceId);
       record.addTuple(DataPoint.getDataPoint(dataType, measurementId, String.valueOf(i)));
-      insertRowsNode.addOneInsertRowNode(buildInsertRowNodeByTSRecord(record), i - 1);
+      InsertRowNode node = buildInsertRowNodeByTSRecord(record);
+      node.setAligned(true);
+      insertRowsNode.addOneInsertRowNode(node, i - 1);
     }
     processor2.insert(insertRowsNode, new long[4]);
     IMemTable memTable2 = processor2.getWorkMemTable();

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessorTest.java
@@ -494,6 +494,19 @@ public class TsFileProcessorTest {
     Assert.assertEquals(memTable1.getTVListsRamCost(), memTable2.getTVListsRamCost());
     Assert.assertEquals(memTable1.getTotalPointsNum(), memTable2.getTotalPointsNum());
     Assert.assertEquals(memTable1.memSize(), memTable2.memSize());
+
+    // Insert rows with all column null
+    insertRowsNode = new InsertRowsNode(new PlanNodeId(""));
+    insertRowNode1.setDataTypes(new TSDataType[1]);
+    insertRowNode1.setMeasurements(new String[1]);
+    insertRowNode1.setValues(new String[1]);
+    insertRowsNode.addOneInsertRowNode(insertRowNode1, 0);
+    processor2.insert(insertRowsNode, new long[4]);
+
+    processor1.insert(insertRowNode1, new long[4]);
+    Assert.assertEquals(memTable1.getTVListsRamCost(), memTable2.getTVListsRamCost());
+    Assert.assertEquals(memTable1.getTotalPointsNum(), memTable2.getTotalPointsNum());
+    Assert.assertEquals(memTable1.memSize(), memTable2.memSize());
   }
 
   @Test
@@ -581,6 +594,20 @@ public class TsFileProcessorTest {
     insertRowsNode.setAligned(true);
     processor2.insert(insertRowsNode, new long[4]);
 
+    Assert.assertEquals(memTable1.getTVListsRamCost(), memTable2.getTVListsRamCost());
+    Assert.assertEquals(memTable1.getTotalPointsNum(), memTable2.getTotalPointsNum());
+    Assert.assertEquals(memTable1.memSize(), memTable2.memSize());
+
+    // Insert rows with all column null
+    insertRowsNode = new InsertRowsNode(new PlanNodeId(""));
+    insertRowNode1.setDataTypes(new TSDataType[1]);
+    insertRowNode1.setMeasurements(new String[1]);
+    insertRowNode1.setValues(new String[1]);
+    insertRowsNode.addOneInsertRowNode(insertRowNode1, 0);
+    insertRowsNode.setAligned(true);
+    processor2.insert(insertRowsNode, new long[4]);
+
+    processor1.insert(insertRowNode1, new long[4]);
     Assert.assertEquals(memTable1.getTVListsRamCost(), memTable2.getTVListsRamCost());
     Assert.assertEquals(memTable1.getTotalPointsNum(), memTable2.getTotalPointsNum());
     Assert.assertEquals(memTable1.memSize(), memTable2.memSize());


### PR DESCRIPTION
## Description

In https://github.com/apache/iotdb/pull/12271 , there was a bug that causes memtable size smaller and more tsfiles generated than the normal situation when using insertRecords API. 

After this patch, the tsfile number will be back to normal.

![image](https://github.com/apache/iotdb/assets/25913899/1e5f007a-c3ae-43ec-84aa-4e50634ed904)



