### PR TITLE
Degrade configNode leader redirection log level and avoid meaningless log print when ConfigNodeClient is first constructed.

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/client/ConfigNodeClient.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/client/ConfigNodeClient.java
@@ -182,6 +182,8 @@ public class ConfigNodeClient implements IConfigNodeRPCService.Iface, ThriftClie
 
   private int cursor = 0;
 
+  private boolean isFirstInitiated;
+
   private final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
 
   ClientManager<ConfigRegionId, ConfigNodeClient> clientManager;
@@ -198,6 +200,7 @@ public class ConfigNodeClient implements IConfigNodeRPCService.Iface, ThriftClie
     this.clientManager = clientManager;
     // Set the first configNode as configLeader for a tentative connection
     this.configLeader = this.configNodes.get(0);
+    this.isFirstInitiated = true;
 
     connectAndSync();
   }
@@ -297,21 +300,27 @@ public class ConfigNodeClient implements IConfigNodeRPCService.Iface, ThriftClie
   }
 
   private boolean updateConfigNodeLeader(TSStatus status) {
-    if (status.getCode() == TSStatusCode.REDIRECTION_RECOMMEND.getStatusCode()) {
-      if (status.isSetRedirectNode()) {
-        configLeader =
-            new TEndPoint(status.getRedirectNode().getIp(), status.getRedirectNode().getPort());
-      } else {
-        configLeader = null;
+    try {
+      if (status.getCode() == TSStatusCode.REDIRECTION_RECOMMEND.getStatusCode()) {
+        if (status.isSetRedirectNode()) {
+          configLeader =
+              new TEndPoint(status.getRedirectNode().getIp(), status.getRedirectNode().getPort());
+        } else {
+          configLeader = null;
+        }
+        if (!isFirstInitiated) {
+          logger.info(
+              "Failed to connect to ConfigNode {} from DataNode {}, because the current node is not "
+                  + "leader or not ready yet, will try again later",
+              configNode,
+              config.getAddressAndPort());
+        }
+        return true;
       }
-      logger.warn(
-          "Failed to connect to ConfigNode {} from DataNode {}, because the current node is not "
-              + "leader or not ready yet, will try again later",
-          configNode,
-          config.getAddressAndPort());
-      return true;
+      return false;
+    } finally {
+      isFirstInitiated = false;
     }
-    return false;
   }
 
   /**


### PR DESCRIPTION
as title