### PR TITLE
Fix return value of fetch schmea with incorrect template info

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/schema/ClusterSchemaFetcher.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/schema/ClusterSchemaFetcher.java
@@ -92,12 +92,11 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
     Set<PartialPath> explicitDevicePatternList = new HashSet<>();
     int explicitDevicePatternCount = 0;
     for (PartialPath pattern : pathPatternList) {
-      if (!pattern.hasWildcard()) {
-        explicitPathList.add(pattern);
-      } else if (pattern.hasExplicitDevice()
-          && templateManager.checkTemplateSetInfo(pattern) != null) {
+      if (pattern.hasExplicitDevice() && templateManager.checkTemplateSetInfo(pattern) != null) {
         explicitDevicePatternList.add(pattern.getDevicePath());
         explicitDevicePatternCount++;
+      } else if (!pattern.hasWildcard()) {
+        explicitPathList.add(pattern);
       }
     }
 


### PR DESCRIPTION
## Description

### Reproduce 

```SQL
create device template t1 aligned (attr BOOLEAN, fuel_state DOUBLE, current_load INT32, status INT32);
create database root.template;
set device template t1 to root.template;
create timeseries using device template on root.template.d1;
insert into root.template.d1(time,status) aligned values(1,1);
```


then 
```SQL
select status from root.template.d1 where status <= 1 align by device;
```


return value of fetch schema should include hasNormalTimeSeries=false because all time series is template series

![img_v3_02ap_1cc5238b-6975-4104-831b-4b00b7cfdecg](https://github.com/apache/iotdb/assets/43774645/11679e66-454a-4776-b134-5f5eb200c3e1)

