### PR TITLE
Fix filter push down is not valid in template align by device situation

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/TemplatedLogicalPlanBuilder.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/TemplatedLogicalPlanBuilder.java
@@ -114,7 +114,7 @@ public class TemplatedLogicalPlanBuilder extends LogicalPlanBuilder {
       return this;
     }
 
-    this.root =
+    FilterNode filterNode =
         new FilterNode(
             context.getQueryId().genPlanNodeId(),
             this.getRoot(),
@@ -122,6 +122,9 @@ public class TemplatedLogicalPlanBuilder extends LogicalPlanBuilder {
             filterExpression,
             isGroupByTime,
             scanOrder);
+    analysis.setFromWhere(filterNode);
+
+    this.root = filterNode;
 
     return this;
   }


### PR DESCRIPTION
## Description

Before fix, FilterNode is the parent of AlignedSeriesScanNode:
![image](https://github.com/apache/iotdb/assets/6756545/896c3292-692a-43aa-8939-ac8f60dd8459)

After fix, there is no FilterNode, pushDownFilter is in AlignedSeriesScanNode.
![image](https://github.com/apache/iotdb/assets/6756545/80d71a31-0bca-4871-831c-481924dbfa74)
