### PR TITLE
Add new optimization rule: remove `Project` under `RawDataAggregation`

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/optimization/AggregationPushDown.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/optimization/AggregationPushDown.java
@@ -225,6 +225,11 @@ public class AggregationPushDown implements PlanOptimizer {
     @Override
     public PlanNode visitRawDataAggregation(RawDataAggregationNode node, RewriterContext context) {
       PlanNode child = node.getChild();
+      if (child instanceof ProjectNode) {
+        // remove ProjectNode
+        node.setChild(((ProjectNode) child).getChild());
+        return visitRawDataAggregation(node, context);
+      }
       if (child instanceof FullOuterTimeJoinNode || child instanceof SeriesScanSourceNode) {
         boolean isSingleSource = child instanceof SeriesScanSourceNode;
         boolean needCheckAscending = node.getGroupByTimeParameter() == null;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/source/AlignedSeriesAggregationScanNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/source/AlignedSeriesAggregationScanNode.java
@@ -49,7 +49,7 @@ import java.util.Objects;
 public class AlignedSeriesAggregationScanNode extends SeriesAggregationSourceNode {
 
   // The paths of the target series which will be aggregated.
-  private final AlignedPath alignedPath;
+  private AlignedPath alignedPath;
 
   // The id of DataRegion where the node will run
   private TRegionReplicaSet regionReplicaSet;
@@ -110,6 +110,10 @@ public class AlignedSeriesAggregationScanNode extends SeriesAggregationSourceNod
 
   public AlignedPath getAlignedPath() {
     return alignedPath;
+  }
+
+  public void setAlignedPath(AlignedPath alignedPath) {
+    this.alignedPath = alignedPath;
   }
 
   @Override

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/optimization/AggregationPushDownTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/optimization/AggregationPushDownTest.java
@@ -272,7 +272,7 @@ public class AggregationPushDownTest {
         new TestPlanBuilder()
             .alignedAggregationScan(
                 "4",
-                schemaMap.get("aligned_root.sg.d2.a.s1"),
+                schemaMap.get("root.sg.d2.a"),
                 aggregationDescriptorList1,
                 groupByTimeParameter,
                 false,

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/optimization/TestPlanBuilder.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/optimization/TestPlanBuilder.java
@@ -170,6 +170,26 @@ public class TestPlanBuilder {
     return this;
   }
 
+  public TestPlanBuilder alignedAggregationScan(
+      String id,
+      PartialPath path,
+      List<AggregationDescriptor> aggregationDescriptors,
+      GroupByTimeParameter groupByTimeParameter,
+      boolean outputEndTime,
+      Expression pushDownPredicate) {
+    AlignedSeriesAggregationScanNode aggregationScanNode =
+        new AlignedSeriesAggregationScanNode(
+            new PlanNodeId(id),
+            (AlignedPath) path,
+            aggregationDescriptors,
+            Ordering.ASC,
+            groupByTimeParameter);
+    aggregationScanNode.setOutputEndTime(outputEndTime);
+    aggregationScanNode.setPushDownPredicate(pushDownPredicate);
+    this.root = aggregationScanNode;
+    return this;
+  }
+
   public TestPlanBuilder rawDataAggregation(
       String id,
       List<AggregationDescriptor> aggregationDescriptors,

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/AggregationAlignByDeviceTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/AggregationAlignByDeviceTest.java
@@ -209,17 +209,6 @@ public class AggregationAlignByDeviceTest {
         firstFiTopNode.getChildren().get(0).getChildren().get(0) instanceof RawDataAggregationNode);
     assertTrue(
         firstFiTopNode.getChildren().get(0).getChildren().get(0).getChildren().get(0)
-            instanceof ProjectNode);
-    assertTrue(
-        firstFiTopNode
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
             instanceof LeftOuterTimeJoinNode);
 
     secondFiRoot = plan.getInstances().get(1).getFragment().getPlanNodeTree();
@@ -229,17 +218,6 @@ public class AggregationAlignByDeviceTest {
         secondFiRoot.getChildren().get(0).getChildren().get(0) instanceof RawDataAggregationNode);
     assertTrue(
         secondFiRoot.getChildren().get(0).getChildren().get(0).getChildren().get(0)
-            instanceof ProjectNode);
-    assertTrue(
-        secondFiRoot
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
             instanceof LeftOuterTimeJoinNode);
 
     // two aggregation measurement, two devices, with filter
@@ -260,17 +238,6 @@ public class AggregationAlignByDeviceTest {
         firstFiTopNode.getChildren().get(0).getChildren().get(0) instanceof RawDataAggregationNode);
     assertTrue(
         firstFiTopNode.getChildren().get(0).getChildren().get(0).getChildren().get(0)
-            instanceof ProjectNode);
-    assertTrue(
-        firstFiTopNode
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
             instanceof LeftOuterTimeJoinNode);
 
     secondFiRoot = plan.getInstances().get(1).getFragment().getPlanNodeTree();
@@ -280,17 +247,6 @@ public class AggregationAlignByDeviceTest {
         secondFiRoot.getChildren().get(0).getChildren().get(0) instanceof RawDataAggregationNode);
     assertTrue(
         secondFiRoot.getChildren().get(0).getChildren().get(0).getChildren().get(0)
-            instanceof ProjectNode);
-    assertTrue(
-        secondFiRoot
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
             instanceof LeftOuterTimeJoinNode);
   }
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/AlignedByDeviceTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/AlignedByDeviceTest.java
@@ -137,14 +137,16 @@ public class AlignedByDeviceTest {
     assertTrue(f1Root.getChildren().get(0).getChildren().get(0) instanceof DeviceViewNode);
     assertTrue(
         f1Root.getChildren().get(0).getChildren().get(0).getChildren().get(0)
-            instanceof RawDataAggregationNode);
+            instanceof SeriesAggregationScanNode);
     assertTrue(
-        f1Root.getChildren().get(0).getChildren().get(0).getChildren().get(0).getChildren().get(0)
-            instanceof ProjectNode);
+        f1Root.getChildren().get(0).getChildren().get(0).getChildren().get(1)
+            instanceof SeriesAggregationScanNode);
     assertTrue(f2Root instanceof IdentitySinkNode);
     assertTrue(f2Root.getChildren().get(0) instanceof DeviceViewNode);
-    assertTrue(f2Root.getChildren().get(0).getChildren().get(0) instanceof RawDataAggregationNode);
-    assertTrue(f2Root.getChildren().get(0).getChildren().get(1) instanceof RawDataAggregationNode);
+    assertTrue(
+        f2Root.getChildren().get(0).getChildren().get(0) instanceof SeriesAggregationScanNode);
+    assertTrue(
+        f2Root.getChildren().get(0).getChildren().get(1) instanceof SeriesAggregationScanNode);
 
     // test of MULTI_SERIES
     sql =
@@ -163,22 +165,10 @@ public class AlignedByDeviceTest {
         f1Root.getChildren().get(0).getChildren().get(0).getChildren().get(0)
             instanceof RawDataAggregationNode);
     assertTrue(
-        f1Root
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
+        f1Root.getChildren().get(0).getChildren().get(0).getChildren().get(0).getChildren().get(0)
             instanceof LeftOuterTimeJoinNode);
     assertTrue(
         f1Root
-                .getChildren()
-                .get(0)
                 .getChildren()
                 .get(0)
                 .getChildren()
@@ -371,106 +361,26 @@ public class AlignedByDeviceTest {
     assertTrue(f1Root.getChildren().get(0).getChildren().get(0) instanceof SingleDeviceViewNode);
     assertTrue(
         f1Root.getChildren().get(0).getChildren().get(0).getChildren().get(0)
-            instanceof RawDataAggregationNode);
+            instanceof AggregationNode);
     assertTrue(
         f1Root.getChildren().get(0).getChildren().get(0).getChildren().get(0).getChildren().get(0)
-            instanceof ProjectNode);
+            instanceof SeriesAggregationScanNode);
     assertTrue(
-        f1Root
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-            instanceof FullOuterTimeJoinNode);
-    assertTrue(
-        f1Root
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-            instanceof SeriesScanNode);
-    assertTrue(
-        f1Root
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(1)
+        f1Root.getChildren().get(0).getChildren().get(0).getChildren().get(0).getChildren().get(1)
             instanceof ExchangeNode);
     assertTrue(f1Root.getChildren().get(0).getChildren().get(1) instanceof SingleDeviceViewNode);
     assertTrue(
         f1Root.getChildren().get(0).getChildren().get(1).getChildren().get(0)
-            instanceof RawDataAggregationNode);
+            instanceof AggregationNode);
     assertTrue(
         f1Root.getChildren().get(0).getChildren().get(1).getChildren().get(0).getChildren().get(0)
-            instanceof ProjectNode);
+            instanceof SeriesAggregationScanNode);
     assertTrue(
-        f1Root
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(1)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-            instanceof FullOuterTimeJoinNode);
-    assertTrue(
-        f1Root
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(1)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-            instanceof SeriesScanNode);
-    assertTrue(
-        f1Root
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(1)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(1)
+        f1Root.getChildren().get(0).getChildren().get(1).getChildren().get(0).getChildren().get(1)
             instanceof ExchangeNode);
     assertTrue(f2Root instanceof ShuffleSinkNode);
-    assertTrue(f2Root.getChildren().get(0) instanceof SeriesSourceNode);
-    assertTrue(f2Root.getChildren().get(1) instanceof SeriesSourceNode);
+    assertTrue(f2Root.getChildren().get(0) instanceof SeriesAggregationScanNode);
+    assertTrue(f2Root.getChildren().get(1) instanceof SeriesAggregationScanNode);
 
     // test of MULTI_SERIES
     sql =
@@ -490,24 +400,9 @@ public class AlignedByDeviceTest {
             instanceof RawDataAggregationNode);
     assertTrue(
         f1Root.getChildren().get(0).getChildren().get(0).getChildren().get(0).getChildren().get(0)
-            instanceof ProjectNode);
-    assertTrue(
-        f1Root
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
             instanceof LeftOuterTimeJoinNode);
     assertTrue(
         f1Root
-                .getChildren()
-                .get(0)
                 .getChildren()
                 .get(0)
                 .getChildren()
@@ -533,13 +428,9 @@ public class AlignedByDeviceTest {
                 .get(0)
                 .getChildren()
                 .get(0)
-                .getChildren()
-                .get(0)
             instanceof SeriesSourceNode);
     assertTrue(
         f1Root
-                .getChildren()
-                .get(0)
                 .getChildren()
                 .get(0)
                 .getChildren()
@@ -559,19 +450,6 @@ public class AlignedByDeviceTest {
             instanceof RawDataAggregationNode);
     assertTrue(
         f1Root.getChildren().get(0).getChildren().get(1).getChildren().get(0).getChildren().get(0)
-            instanceof ProjectNode);
-    assertTrue(
-        f1Root
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(1)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
             instanceof LeftOuterTimeJoinNode);
     assertTrue(
         f1Root
@@ -579,8 +457,6 @@ public class AlignedByDeviceTest {
                 .get(0)
                 .getChildren()
                 .get(1)
-                .getChildren()
-                .get(0)
                 .getChildren()
                 .get(0)
                 .getChildren()
@@ -602,8 +478,6 @@ public class AlignedByDeviceTest {
                 .get(0)
                 .getChildren()
                 .get(0)
-                .getChildren()
-                .get(0)
             instanceof SeriesSourceNode);
     assertTrue(
         f1Root
@@ -611,8 +485,6 @@ public class AlignedByDeviceTest {
                 .get(0)
                 .getChildren()
                 .get(1)
-                .getChildren()
-                .get(0)
                 .getChildren()
                 .get(0)
                 .getChildren()
@@ -739,23 +611,7 @@ public class AlignedByDeviceTest {
     assertTrue(f1Root.getChildren().get(0).getChildren().get(0) instanceof DeviceViewNode);
     assertTrue(
         f1Root.getChildren().get(0).getChildren().get(0).getChildren().get(0)
-            instanceof RawDataAggregationNode);
-    assertTrue(
-        f1Root.getChildren().get(0).getChildren().get(0).getChildren().get(0).getChildren().get(0)
-            instanceof ProjectNode);
-    assertTrue(
-        f1Root
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-            instanceof SeriesScanNode);
+            instanceof SeriesAggregationScanNode);
     assertTrue(f2Root instanceof IdentitySinkNode);
     assertTrue(f2Root.getChildren().get(0) instanceof DeviceViewNode);
     assertTrue(f3Root instanceof IdentitySinkNode);
@@ -778,8 +634,8 @@ public class AlignedByDeviceTest {
         f1Root.getChildren().get(0).getChildren().get(0).getChildren().get(0)
             instanceof RawDataAggregationNode);
     assertTrue(
-        f1Root.getChildren().get(0).getChildren().get(0).getChildren().get(0).getChildren().get(0)
-            instanceof ProjectNode);
+        f1Root.getChildren().get(0).getChildren().get(0).getChildren().get(1)
+            instanceof RawDataAggregationNode);
     assertTrue(f2Root instanceof IdentitySinkNode);
     assertTrue(f2Root.getChildren().get(0) instanceof DeviceViewNode);
     assertTrue(f3Root instanceof IdentitySinkNode);
@@ -961,107 +817,27 @@ public class AlignedByDeviceTest {
     assertTrue(f1Root.getChildren().get(0).getChildren().get(0) instanceof SingleDeviceViewNode);
     assertTrue(
         f1Root.getChildren().get(0).getChildren().get(0).getChildren().get(0)
-            instanceof RawDataAggregationNode);
+            instanceof AggregationNode);
     assertTrue(
         f1Root.getChildren().get(0).getChildren().get(0).getChildren().get(0).getChildren().get(0)
-            instanceof ProjectNode);
+            instanceof SeriesAggregationScanNode);
     assertTrue(
-        f1Root
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-            instanceof FullOuterTimeJoinNode);
-    assertTrue(
-        f1Root
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-            instanceof SeriesScanNode);
-    assertTrue(
-        f1Root
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(1)
+        f1Root.getChildren().get(0).getChildren().get(0).getChildren().get(0).getChildren().get(1)
             instanceof ExchangeNode);
     assertTrue(f1Root.getChildren().get(0).getChildren().get(1) instanceof SingleDeviceViewNode);
     assertTrue(
         f1Root.getChildren().get(0).getChildren().get(1).getChildren().get(0)
-            instanceof RawDataAggregationNode);
+            instanceof AggregationNode);
     assertTrue(
         f1Root.getChildren().get(0).getChildren().get(1).getChildren().get(0).getChildren().get(0)
-            instanceof ProjectNode);
+            instanceof SeriesAggregationScanNode);
     assertTrue(
-        f1Root
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(1)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-            instanceof FullOuterTimeJoinNode);
-    assertTrue(
-        f1Root
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(1)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-            instanceof SeriesScanNode);
-    assertTrue(
-        f1Root
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(1)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(1)
+        f1Root.getChildren().get(0).getChildren().get(1).getChildren().get(0).getChildren().get(1)
             instanceof ExchangeNode);
     assertTrue(f2Root instanceof ShuffleSinkNode);
-    assertTrue(f2Root.getChildren().get(0) instanceof SeriesScanNode);
+    assertTrue(f2Root.getChildren().get(0) instanceof SeriesAggregationScanNode);
     assertTrue(f3Root instanceof ShuffleSinkNode);
-    assertTrue(f3Root.getChildren().get(0) instanceof SeriesScanNode);
+    assertTrue(f3Root.getChildren().get(0) instanceof SeriesAggregationScanNode);
 
     // test of MULTI_SERIES
     sql =
@@ -1082,24 +858,9 @@ public class AlignedByDeviceTest {
             instanceof RawDataAggregationNode);
     assertTrue(
         f1Root.getChildren().get(0).getChildren().get(0).getChildren().get(0).getChildren().get(0)
-            instanceof ProjectNode);
-    assertTrue(
-        f1Root
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
             instanceof LeftOuterTimeJoinNode);
     assertTrue(
         f1Root
-                .getChildren()
-                .get(0)
                 .getChildren()
                 .get(0)
                 .getChildren()
@@ -1125,13 +886,9 @@ public class AlignedByDeviceTest {
                 .get(0)
                 .getChildren()
                 .get(0)
-                .getChildren()
-                .get(0)
             instanceof SeriesSourceNode);
     assertTrue(
         f1Root
-                .getChildren()
-                .get(0)
                 .getChildren()
                 .get(0)
                 .getChildren()
@@ -1156,14 +913,10 @@ public class AlignedByDeviceTest {
                 .getChildren()
                 .get(0)
                 .getChildren()
-                .get(0)
-                .getChildren()
                 .get(1)
             instanceof FullOuterTimeJoinNode);
     assertTrue(
         f1Root
-                .getChildren()
-                .get(0)
                 .getChildren()
                 .get(0)
                 .getChildren()
@@ -1179,8 +932,6 @@ public class AlignedByDeviceTest {
             instanceof SeriesSourceNode);
     assertTrue(
         f1Root
-                .getChildren()
-                .get(0)
                 .getChildren()
                 .get(0)
                 .getChildren()
@@ -1200,19 +951,6 @@ public class AlignedByDeviceTest {
             instanceof RawDataAggregationNode);
     assertTrue(
         f1Root.getChildren().get(0).getChildren().get(1).getChildren().get(0).getChildren().get(0)
-            instanceof ProjectNode);
-    assertTrue(
-        f1Root
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(1)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
-                .getChildren()
-                .get(0)
             instanceof LeftOuterTimeJoinNode);
     assertTrue(
         f1Root
@@ -1220,8 +958,6 @@ public class AlignedByDeviceTest {
                 .get(0)
                 .getChildren()
                 .get(1)
-                .getChildren()
-                .get(0)
                 .getChildren()
                 .get(0)
                 .getChildren()
@@ -1243,8 +979,6 @@ public class AlignedByDeviceTest {
                 .get(0)
                 .getChildren()
                 .get(0)
-                .getChildren()
-                .get(0)
             instanceof SeriesSourceNode);
     assertTrue(
         f1Root
@@ -1252,8 +986,6 @@ public class AlignedByDeviceTest {
                 .get(0)
                 .getChildren()
                 .get(1)
-                .getChildren()
-                .get(0)
                 .getChildren()
                 .get(0)
                 .getChildren()
@@ -1274,8 +1006,6 @@ public class AlignedByDeviceTest {
                 .getChildren()
                 .get(0)
                 .getChildren()
-                .get(0)
-                .getChildren()
                 .get(1)
             instanceof FullOuterTimeJoinNode);
     assertTrue(
@@ -1284,8 +1014,6 @@ public class AlignedByDeviceTest {
                 .get(0)
                 .getChildren()
                 .get(1)
-                .getChildren()
-                .get(0)
                 .getChildren()
                 .get(0)
                 .getChildren()
@@ -1301,8 +1029,6 @@ public class AlignedByDeviceTest {
                 .get(0)
                 .getChildren()
                 .get(1)
-                .getChildren()
-                .get(0)
                 .getChildren()
                 .get(0)
                 .getChildren()


### PR DESCRIPTION
The `RawDataAggregation` operator contains the capabilities of the `Project` operator, so it is possible to remove the redundant `Project`.

`RawDataAggregation - Project  => RawDataAggregation`

This allows for more situations where aggregation can be push into scan.