### PR TITLE
[RatisConsensus] Bump ratis to 3.1.0-2fddd52-snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
       is for ensuring the SNAPSHOT will stay available. We should however have the Ratis folks do a
       new release soon, as releasing with this version is more than sub-ideal.
     -->
-        <ratis.version>3.1.0-611b80a-SNAPSHOT</ratis.version>
+        <ratis.version>3.1.0-2fddd52-SNAPSHOT</ratis.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <reactor-netty.version>1.1.13</reactor-netty.version>
         <reactor.version>3.5.10</reactor.version>


### PR DESCRIPTION
This is the latest snapshot that contains all the fixes and commits since 3.0.1