### PR TITLE
Fix non-root user query data returns unexpected path

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBAuthIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBAuthIT.java
@@ -325,6 +325,35 @@ public class IoTDBAuthIT {
   }
 
   @Test
+  public void templateQueryTest() throws SQLException {
+    try (Connection adminCon = EnvFactory.getEnv().getConnection();
+        Statement adminStmt = adminCon.createStatement()) {
+      adminStmt.execute("CREATE USER tempuser 'temppw'");
+      try (Connection userCon = EnvFactory.getEnv().getConnection("tempuser", "temppw");
+          Statement userStmt = userCon.createStatement()) {
+        adminStmt.execute(
+            "GRANT READ_DATA ON root.sg.aligned_template.temperature TO USER tempuser");
+        adminStmt.execute("CREATE DATABASE root.sg");
+        adminStmt.execute(
+            "create device template t1 aligned (temperature FLOAT encoding=Gorilla, status BOOLEAN encoding=PLAIN);");
+        adminStmt.execute("set device template t1 to root.sg.aligned_template;");
+        adminStmt.execute("create timeseries using device template on root.sg.aligned_template;");
+        adminStmt.execute(
+            "insert into root.sg.aligned_template(time,temperature,status) values(1,20,false),(2,22.1,true),(3,18,false);");
+
+        ResultSet set1 = adminStmt.executeQuery("SELECT * from root.sg.aligned_template");
+        assertEquals(3, set1.getMetaData().getColumnCount());
+        assertEquals("root.sg.aligned_template.temperature", set1.getMetaData().getColumnName(2));
+        assertEquals("root.sg.aligned_template.status", set1.getMetaData().getColumnName(3));
+
+        ResultSet set2 = userStmt.executeQuery("SELECT * from root.sg.aligned_template");
+        assertEquals(2, set2.getMetaData().getColumnCount());
+        assertEquals("root.sg.aligned_template.temperature", set2.getMetaData().getColumnName(2));
+      }
+    }
+  }
+
+  @Test
   public void insertQueryTest() throws SQLException {
     try (Connection adminCon = EnvFactory.getEnv().getConnection();
         Statement adminStmt = adminCon.createStatement()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/schematree/ClusterSchemaTree.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/schematree/ClusterSchemaTree.java
@@ -21,7 +21,6 @@ package org.apache.iotdb.db.queryengine.common.schematree;
 
 import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.commons.path.PartialPath;
-import org.apache.iotdb.commons.path.PathPatternTree;
 import org.apache.iotdb.commons.schema.view.LogicalViewSchema;
 import org.apache.iotdb.commons.utils.PathUtils;
 import org.apache.iotdb.commons.utils.TestOnly;
@@ -76,8 +75,6 @@ public class ClusterSchemaTree implements ISchemaTree {
 
   private Map<Integer, Template> templateMap = new HashMap<>();
 
-  private PathPatternTree authorityScope;
-
   public ClusterSchemaTree() {
     root = new SchemaInternalNode(PATH_ROOT);
   }
@@ -102,7 +99,7 @@ public class ClusterSchemaTree implements ISchemaTree {
       PartialPath pathPattern, int slimit, int soffset, boolean isPrefixMatch) {
     try (SchemaTreeVisitorWithLimitOffsetWrapper<MeasurementPath> visitor =
         SchemaTreeVisitorFactory.createSchemaTreeMeasurementVisitor(
-            root, pathPattern, isPrefixMatch, slimit, soffset, authorityScope)) {
+            root, pathPattern, isPrefixMatch, slimit, soffset)) {
       visitor.setTemplateMap(templateMap);
       return new Pair<>(visitor.getAllResult(), visitor.getNextOffset());
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/schema/ClusterSchemaFetcher.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/schema/ClusterSchemaFetcher.java
@@ -92,7 +92,9 @@ public class ClusterSchemaFetcher implements ISchemaFetcher {
     Set<PartialPath> explicitDevicePatternList = new HashSet<>();
     int explicitDevicePatternCount = 0;
     for (PartialPath pattern : pathPatternList) {
-      if (pattern.hasExplicitDevice() && templateManager.checkTemplateSetInfo(pattern) != null) {
+      if (withTemplate
+          && pattern.hasExplicitDevice()
+          && templateManager.checkTemplateSetInfo(pattern) != null) {
         explicitDevicePatternList.add(pattern.getDevicePath());
         explicitDevicePatternCount++;
       } else if (!pattern.hasWildcard()) {


### PR DESCRIPTION
## Description


### Reproduce: 
```sql
create device template t1 aligned (temperature FLOAT encoding=Gorilla, status BOOLEAN encoding=PLAIN);
show device templates;
show nodes in device template t1;
set device template t1 to root.sg.aligned_template;
show paths set device template t1;
create timeseries using device template on root.sg.aligned_template;
show paths using device template t1;

insert into root.sg.aligned_template(time,temperature,status) values(1,20,false),(2,22.1,true),(3,18,false);

CREATE USER user03 'pass1234';

LIST PRIVILEGES OF USER `user03`;

GRANT READ_DATA ON root.sg.aligned_template.temperature TO USER user03;
```
then log in with user03:
```sql
[root@xzh-97 iotdb-enterprise-1.3.2-SNAPSHOT-bin]# ./sbin/start-cli.sh -u user03 -pw pass1234
---------------------
Starting IoTDB Cli
---------------------
 _____       _________  ______   ______    
|_   _|     |  _   _  ||_   _ `.|_   _ \   
  | |   .--.|_/ | | \_|  | | `. \ | |_) |  
  | | / .'`\ \  | |      | |  | | |  __'.  
 _| |_| \__. | _| |_    _| |_.' /_| |__) | 
|_____|'.__.' |_____|  |______.'|_______/  Enterprise version 1.3.2-SNAPSHOT (Build: 2fa45f5)
                                           Successfully login at 127.0.0.1:6667
IoTDB> list privileges of user user03;
+----+------------------------------------+----------+-----------+
|Role|                                Path|Privileges|GrantOption|
+----+------------------------------------+----------+-----------+
|    |root.sg.aligned_template.temperature| READ_DATA|      false|
+----+------------------------------------+----------+-----------+
Total line number = 1
It costs 0.053s
IoTDB> select * from root.sg.aligned_template;
+-----------------------------+------------------------------------+-------------------------------+
|                         Time|root.sg.aligned_template.temperature|root.sg.aligned_template.status|
+-----------------------------+------------------------------------+-------------------------------+
|1970-01-01T08:00:00.001+08:00|                                20.0|                          false|
|1970-01-01T08:00:00.002+08:00|                                22.1|                           true|
|1970-01-01T08:00:00.003+08:00|                                18.0|                          false|
+-----------------------------+------------------------------------+-------------------------------+
Total line number = 3
It costs 0.016s
```


### solution:
when fetch schema without template, SchemaFetchExecutor should not check template cache.