### PR TITLE
Check duplicated measurements in one row for all insert APIs

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
@@ -2212,7 +2212,6 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
   @Override
   public Analysis visitInsert(InsertStatement insertStatement, MPPQueryContext context) {
     context.setQueryType(QueryType.WRITE);
-    insertStatement.semanticCheck();
     long[] timeArray = insertStatement.getTimes();
     PartialPath devicePath = insertStatement.getDevice();
     String[] measurementList = insertStatement.getMeasurementList();
@@ -2541,6 +2540,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
   public Analysis visitInsertTablet(
       InsertTabletStatement insertTabletStatement, MPPQueryContext context) {
     context.setQueryType(QueryType.WRITE);
+    insertTabletStatement.semanticCheck();
     Analysis analysis = new Analysis();
     validateSchema(analysis, insertTabletStatement, context);
     InsertBaseStatement realStatement = removeLogicalView(analysis, insertTabletStatement);
@@ -2572,6 +2572,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
   @Override
   public Analysis visitInsertRow(InsertRowStatement insertRowStatement, MPPQueryContext context) {
     context.setQueryType(QueryType.WRITE);
+    insertRowStatement.semanticCheck();
     Analysis analysis = new Analysis();
     validateSchema(analysis, insertRowStatement, context);
     InsertBaseStatement realInsertStatement = removeLogicalView(analysis, insertRowStatement);
@@ -2622,6 +2623,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
   public Analysis visitInsertRows(
       InsertRowsStatement insertRowsStatement, MPPQueryContext context) {
     context.setQueryType(QueryType.WRITE);
+    insertRowsStatement.semanticCheck();
     Analysis analysis = new Analysis();
     validateSchema(analysis, insertRowsStatement, context);
     InsertRowsStatement realInsertRowsStatement =
@@ -2661,6 +2663,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
   public Analysis visitInsertMultiTablets(
       InsertMultiTabletsStatement insertMultiTabletsStatement, MPPQueryContext context) {
     context.setQueryType(QueryType.WRITE);
+    insertMultiTabletsStatement.semanticCheck();
     Analysis analysis = new Analysis();
     validateSchema(analysis, insertMultiTabletsStatement, context);
     InsertMultiTabletsStatement realStatement =
@@ -2678,6 +2681,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
   public Analysis visitInsertRowsOfOneDevice(
       InsertRowsOfOneDeviceStatement insertRowsOfOneDeviceStatement, MPPQueryContext context) {
     context.setQueryType(QueryType.WRITE);
+    insertRowsOfOneDeviceStatement.semanticCheck();
     Analysis analysis = new Analysis();
     validateSchema(analysis, insertRowsOfOneDeviceStatement, context);
     InsertBaseStatement realInsertStatement =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
@@ -2222,9 +2222,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       insertRowStatement.setTime(timeArray[0]);
       insertRowStatement.setMeasurements(measurementList);
       insertRowStatement.setDataTypes(new TSDataType[measurementList.length]);
-      Object[] values = new Object[measurementList.length];
-      System.arraycopy(insertStatement.getValuesList().get(0), 0, values, 0, values.length);
-      insertRowStatement.setValues(values);
+      insertRowStatement.setValues(insertStatement.getValuesList().get(0));
       insertRowStatement.setNeedInferType(true);
       insertRowStatement.setAligned(insertStatement.isAligned());
       return insertRowStatement.accept(this, context);
@@ -2256,9 +2254,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
         statement.setTime(timeArray[i]);
         TSDataType[] dataTypes = new TSDataType[measurementList.length];
         statement.setDataTypes(dataTypes);
-        Object[] values = new Object[measurementList.length];
-        System.arraycopy(insertStatement.getValuesList().get(i), 0, values, 0, values.length);
-        statement.setValues(values);
+        statement.setValues(insertStatement.getValuesList().get(i));
         statement.setAligned(insertStatement.isAligned());
         statement.setNeedInferType(true);
         insertRowStatementList.add(statement);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/parser/ASTVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/parser/ASTVisitor.java
@@ -1885,13 +1885,13 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
     if (timeIndex == -1 && rows.size() != 1) {
       throw new SemanticException("need timestamps when insert multi rows");
     }
-    List<String[]> valuesList = new ArrayList<>();
+    List<Object[]> valuesList = new ArrayList<>();
     long[] timeArray = new long[rows.size()];
     for (int i = 0, size = rows.size(); i < size; i++) {
       IoTDBSqlParser.RowContext row = rows.get(i);
       // parse timestamp
       long timestamp;
-      List<String> valueList = new ArrayList<>();
+      List<Object> valueList = new ArrayList<>();
       // using now() instead
       if (timeIndex == -1) {
         timestamp = CommonDateTimeUtils.currentTime();
@@ -1913,7 +1913,7 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
         }
       }
 
-      valuesList.add(valueList.toArray(new String[0]));
+      valuesList.add(valueList.toArray(new Object[0]));
     }
     insertStatement.setTimes(timeArray);
     insertStatement.setValuesList(valuesList);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertBaseStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertBaseStatement.java
@@ -199,6 +199,21 @@ public abstract class InsertBaseStatement extends Statement {
 
   public abstract Object getFirstValueOfIndex(int index);
 
+  public void semanticCheck() {
+    Set<String> deduplicatedMeasurements = new HashSet<>();
+    for (String measurement : measurements) {
+      if (measurement == null || measurement.isEmpty()) {
+        throw new SemanticException(
+            "Measurement contains null or empty string: " + Arrays.toString(measurements));
+      }
+      if (deduplicatedMeasurements.contains(measurement)) {
+        throw new SemanticException("Insertion contains duplicated measurement: " + measurement);
+      } else {
+        deduplicatedMeasurements.add(measurement);
+      }
+    }
+  }
+
   // region partial insert
   /**
    * Mark failed measurement, measurements[index], dataTypes[index] and values/columns[index] would
@@ -310,7 +325,7 @@ public abstract class InsertBaseStatement extends Statement {
       }
     }
     // construct map from device to measurements and record the index of its measurement
-    // schemaengine
+    // schema
     Map<PartialPath, List<Pair<String, Integer>>> mapFromDeviceToMeasurementAndIndex =
         new HashMap<>();
     for (int i = 0; i < this.measurements.length; i++) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertMultiTabletsStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertMultiTabletsStatement.java
@@ -111,6 +111,13 @@ public class InsertMultiTabletsStatement extends InsertBaseStatement {
   }
 
   @Override
+  public void semanticCheck() {
+    for (InsertTabletStatement insertTabletStatement : insertTabletStatementList) {
+      insertTabletStatement.semanticCheck();
+    }
+  }
+
+  @Override
   public long getMinTime() {
     throw new NotImplementedException();
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertRowStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertRowStatement.java
@@ -255,6 +255,17 @@ public class InsertRowStatement extends InsertBaseStatement implements ISchemaVa
     values[index] = null;
   }
 
+  @Override
+  public void semanticCheck() {
+    super.semanticCheck();
+    if (measurements.length != values.length) {
+      throw new SemanticException(
+          String.format(
+              "the measurementList's size %d is not consistent with the valueList's size %d",
+              measurements.length, values.length));
+    }
+  }
+
   public boolean isNeedSplit() {
     return hasLogicalViewNeedProcess();
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertRowsOfOneDeviceStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertRowsOfOneDeviceStatement.java
@@ -130,6 +130,13 @@ public class InsertRowsOfOneDeviceStatement extends InsertBaseStatement {
   }
 
   @Override
+  public void semanticCheck() {
+    for (InsertRowStatement insertRowStatement : insertRowStatementList) {
+      insertRowStatement.semanticCheck();
+    }
+  }
+
+  @Override
   public long getMinTime() {
     throw new NotImplementedException();
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertRowsStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertRowsStatement.java
@@ -129,6 +129,13 @@ public class InsertRowsStatement extends InsertBaseStatement {
   }
 
   @Override
+  public void semanticCheck() {
+    for (InsertRowStatement insertRowStatement : insertRowStatementList) {
+      insertRowStatement.semanticCheck();
+    }
+  }
+
+  @Override
   public long getMinTime() {
     throw new NotImplementedException();
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertStatement.java
@@ -23,17 +23,13 @@ import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.auth.entity.PrivilegeType;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.auth.AuthorityChecker;
-import org.apache.iotdb.db.exception.sql.SemanticException;
 import org.apache.iotdb.db.queryengine.plan.statement.Statement;
 import org.apache.iotdb.db.queryengine.plan.statement.StatementType;
 import org.apache.iotdb.db.queryengine.plan.statement.StatementVisitor;
 import org.apache.iotdb.rpc.TSStatusCode;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 /** this class extends {@code Statement} and process insert statement. */
 public class InsertStatement extends Statement {
@@ -117,30 +113,5 @@ public class InsertStatement extends Statement {
   @Override
   public <R, C> R accept(StatementVisitor<R, C> visitor, C context) {
     return visitor.visitInsert(this, context);
-  }
-
-  public void semanticCheck() {
-    Set<String> deduplicatedMeasurements = new HashSet<>();
-    for (String measurement : measurementList) {
-      if (measurement == null || measurement.isEmpty()) {
-        throw new SemanticException(
-            "Measurement contains null or empty string: " + Arrays.toString(measurementList));
-      }
-      if (deduplicatedMeasurements.contains(measurement)) {
-        throw new SemanticException("Insertion contains duplicated measurement: " + measurement);
-      } else {
-        deduplicatedMeasurements.add(measurement);
-      }
-    }
-
-    int measurementsNum = measurementList.length;
-    for (int i = 0; i < times.length; i++) {
-      if (measurementsNum != valuesList.get(i).length) {
-        throw new SemanticException(
-            String.format(
-                "the measurementList's size %d is not consistent with the valueList's size %d",
-                measurementsNum, valuesList.get(i).length));
-      }
-    }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertStatement.java
@@ -39,7 +39,7 @@ public class InsertStatement extends Statement {
   private long[] times;
   private String[] measurementList;
 
-  private List<String[]> valuesList;
+  private List<Object[]> valuesList;
 
   private boolean isAligned;
 
@@ -86,11 +86,11 @@ public class InsertStatement extends Statement {
     this.measurementList = measurementList;
   }
 
-  public List<String[]> getValuesList() {
+  public List<Object[]> getValuesList() {
     return valuesList;
   }
 
-  public void setValuesList(List<String[]> valuesList) {
+  public void setValuesList(List<Object[]> valuesList) {
     this.valuesList = valuesList;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertTabletStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertTabletStatement.java
@@ -194,6 +194,17 @@ public class InsertTabletStatement extends InsertBaseStatement implements ISchem
     columns[index] = null;
   }
 
+  @Override
+  public void semanticCheck() {
+    super.semanticCheck();
+    if (measurements.length != columns.length) {
+      throw new SemanticException(
+          String.format(
+              "the measurementList's size %d is not consistent with the columnList's size %d",
+              measurements.length, columns.length));
+    }
+  }
+
   public boolean isNeedSplit() {
     return hasLogicalViewNeedProcess();
   }


### PR DESCRIPTION
## Description

Previous version only checks the duplicated measurements of one row when using insert SQL statements. However, this check should be in all insert methods. 