### PR TITLE
Introducing a memory control mechanism during the query planning stage

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/MPPQueryContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/MPPQueryContext.java
@@ -344,7 +344,7 @@ public class MPPQueryContext {
         bytesToRelease = bytes - bytesToBeReservedForFrontEnd;
         bytesToBeReservedForFrontEnd = 0;
         LOCAL_EXECUTION_PLANNER.releaseToFreeMemoryForOperators(bytesToRelease);
-        reservedBytesInTotalForFrontEnd -= bytes;
+        reservedBytesInTotalForFrontEnd -= bytesToRelease;
       }
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/MPPQueryContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/MPPQueryContext.java
@@ -82,7 +82,8 @@ public class MPPQueryContext {
 
   private long bytesToBeReservedForFrontEnd = 0;
 
-  // To avoid reserving memory too frequently, we choose to do it in batches. This is upper limit
+  // To avoid reserving memory too frequently, we choose to do it in batches. This is the lower
+  // bound
   // for each batch.
   private static final long MEMORY_BATCH_THRESHOLD = 1024L * 1024L;
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/exception/MemoryNotEnoughException.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/exception/MemoryNotEnoughException.java
@@ -19,12 +19,9 @@
 
 package org.apache.iotdb.db.queryengine.exception;
 
-import org.apache.iotdb.commons.exception.IoTDBException;
-import org.apache.iotdb.rpc.TSStatusCode;
-
-public class MemoryNotEnoughException extends IoTDBException {
+public class MemoryNotEnoughException extends RuntimeException {
 
   public MemoryNotEnoughException(String message) {
-    super(message, TSStatusCode.QUOTA_MEM_QUERY_NOT_ENOUGH.getStatusCode(), true);
+    super(message);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/MemoryEstimationHelper.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/MemoryEstimationHelper.java
@@ -76,8 +76,10 @@ public class MemoryEstimationHelper {
       totalSize += MEASUREMENT_PATH_INSTANCE_SIZE;
       MeasurementPath measurementPath = (MeasurementPath) partialPath;
       totalSize += RamUsageEstimator.sizeOf(measurementPath.getMeasurementAlias());
-      totalSize +=
-          RamUsageEstimator.sizeOf(measurementPath.getMeasurementSchema().getMeasurementId());
+      if (measurementPath.getMeasurementSchema() != null) {
+        totalSize +=
+            RamUsageEstimator.sizeOf(measurementPath.getMeasurementSchema().getMeasurementId());
+      }
     } else {
       totalSize += PARTIAL_PATH_INSTANCE_SIZE;
       totalSize += RamUsageEstimator.sizeOf(partialPath.getMeasurement());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/Coordinator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/Coordinator.java
@@ -141,6 +141,9 @@ public class Coordinator {
       }
       return result;
     } finally {
+      if (queryContext != null) {
+        queryContext.releaseMemoryForFrontEnd();
+      }
       if (queryContext != null && !queryContext.getAcquiredLockNumMap().isEmpty()) {
         Map<SchemaLockType, Integer> lockMap = queryContext.getAcquiredLockNumMap();
         for (Map.Entry<SchemaLockType, Integer> entry : lockMap.entrySet()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
@@ -291,20 +291,21 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
           deviceList = pushDownLimitOffsetInGroupByTimeForDevice(deviceList, queryStatement);
         }
 
-        outputExpressions = analyzeSelect(analysis, queryStatement, schemaTree, deviceList);
+        outputExpressions =
+            analyzeSelect(analysis, queryStatement, schemaTree, deviceList, context);
         if (outputExpressions.isEmpty()) {
           return finishQuery(queryStatement, analysis);
         }
 
-        analyzeDeviceToWhere(analysis, queryStatement, schemaTree, deviceList);
+        analyzeDeviceToWhere(analysis, queryStatement, schemaTree, deviceList, context);
         if (deviceList.isEmpty()) {
           return finishQuery(queryStatement, analysis, outputExpressions);
         }
         analysis.setDeviceList(deviceList);
 
-        analyzeDeviceToGroupBy(analysis, queryStatement, schemaTree, deviceList);
-        analyzeDeviceToOrderBy(analysis, queryStatement, schemaTree, deviceList);
-        analyzeHaving(analysis, queryStatement, schemaTree, deviceList);
+        analyzeDeviceToGroupBy(analysis, queryStatement, schemaTree, deviceList, context);
+        analyzeDeviceToOrderBy(analysis, queryStatement, schemaTree, deviceList, context);
+        analyzeHaving(analysis, queryStatement, schemaTree, deviceList, context);
 
         analyzeDeviceToAggregation(analysis, queryStatement);
         analyzeDeviceToSourceTransform(analysis, queryStatement);
@@ -321,22 +322,25 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
               new GroupByLevelHelper(queryStatement.getGroupByLevelComponent().getLevels());
 
           outputExpressions =
-              analyzeGroupByLevelSelect(analysis, queryStatement, schemaTree, groupByLevelHelper);
+              analyzeGroupByLevelSelect(
+                  analysis, queryStatement, schemaTree, groupByLevelHelper, context);
           if (outputExpressions.isEmpty()) {
             return finishQuery(queryStatement, analysis);
           }
           analysis.setOutputExpressions(outputExpressions);
           setSelectExpressions(analysis, queryStatement, outputExpressions);
 
-          analyzeGroupByLevelHaving(analysis, queryStatement, schemaTree, groupByLevelHelper);
+          analyzeGroupByLevelHaving(
+              analysis, queryStatement, schemaTree, groupByLevelHelper, context);
 
-          analyzeGroupByLevelOrderBy(analysis, queryStatement, schemaTree, groupByLevelHelper);
+          analyzeGroupByLevelOrderBy(
+              analysis, queryStatement, schemaTree, groupByLevelHelper, context);
 
           checkDataTypeConsistencyInGroupByLevel(
               analysis, groupByLevelHelper.getGroupByLevelExpressions());
           analysis.setCrossGroupByExpressions(groupByLevelHelper.getGroupByLevelExpressions());
         } else {
-          outputExpressions = analyzeSelect(analysis, queryStatement, schemaTree);
+          outputExpressions = analyzeSelect(analysis, queryStatement, schemaTree, context);
 
           analyzeGroupByTag(analysis, queryStatement, outputExpressions);
 
@@ -346,17 +350,17 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
           analysis.setOutputExpressions(outputExpressions);
           setSelectExpressions(analysis, queryStatement, outputExpressions);
 
-          analyzeHaving(analysis, queryStatement, schemaTree);
+          analyzeHaving(analysis, queryStatement, schemaTree, context);
 
-          analyzeOrderBy(analysis, queryStatement, schemaTree);
+          analyzeOrderBy(analysis, queryStatement, schemaTree, context);
         }
 
         // analyze aggregation
         analyzeAggregation(analysis, queryStatement);
 
         // analyze aggregation input
-        analyzeGroupBy(analysis, queryStatement, schemaTree);
-        analyzeWhere(analysis, queryStatement, schemaTree);
+        analyzeGroupBy(analysis, queryStatement, schemaTree, context);
+        analyzeWhere(analysis, queryStatement, schemaTree, context);
         if (analysis.getWhereExpression() != null
             && analysis.getWhereExpression().equals(ConstantOperand.FALSE)) {
           return finishQuery(queryStatement, analysis, outputExpressions);
@@ -395,7 +399,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     queryStatement =
         (QueryStatement)
             concatPathRewriter.rewrite(
-                queryStatement, new PathPatternTree(queryStatement.useWildcard()));
+                queryStatement, new PathPatternTree(queryStatement.useWildcard()), context);
     analysis.setStatement(queryStatement);
 
     // request schema fetch API
@@ -495,7 +499,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     for (ResultColumn resultColumn : queryStatement.getSelectComponent().getResultColumns()) {
       selectExpressions.add(resultColumn.getExpression());
     }
-    analyzeLastSource(analysis, selectExpressions, schemaTree);
+    analyzeLastSource(analysis, selectExpressions, schemaTree, context);
 
     analysis.setRespDatasetHeader(DatasetHeaderFactory.getLastQueryHeader());
 
@@ -506,14 +510,17 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
   }
 
   private void analyzeLastSource(
-      Analysis analysis, List<Expression> selectExpressions, ISchemaTree schemaTree) {
+      Analysis analysis,
+      List<Expression> selectExpressions,
+      ISchemaTree schemaTree,
+      MPPQueryContext context) {
     Set<Expression> sourceExpressions = new LinkedHashSet<>();
     Set<Expression> lastQueryBaseExpressions = new LinkedHashSet<>();
     Map<Expression, List<Expression>> lastQueryNonWritableViewSourceExpressionMap = null;
 
     for (Expression selectExpression : selectExpressions) {
       for (Expression lastQuerySourceExpression :
-          bindSchemaForExpression(selectExpression, schemaTree)) {
+          bindSchemaForExpression(selectExpression, schemaTree, context)) {
         if (lastQuerySourceExpression instanceof TimeSeriesOperand) {
           lastQueryBaseExpressions.add(lastQuerySourceExpression);
           sourceExpressions.add(lastQuerySourceExpression);
@@ -584,7 +591,8 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       Analysis analysis,
       QueryStatement queryStatement,
       ISchemaTree schemaTree,
-      GroupByLevelHelper groupByLevelHelper) {
+      GroupByLevelHelper groupByLevelHelper,
+      MPPQueryContext queryContext) {
     Map<Integer, Set<Pair<Expression, String>>> outputExpressionMap = new HashMap<>();
     int columnIndex = 0;
 
@@ -592,7 +600,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       Set<Pair<Expression, String>> outputExpressionSet = new LinkedHashSet<>();
 
       List<Expression> resultExpressions =
-          bindSchemaForExpression(resultColumn.getExpression(), schemaTree);
+          bindSchemaForExpression(resultColumn.getExpression(), schemaTree, queryContext);
       boolean isCountStar =
           resultColumn.getExpression().getExpressionType().equals(ExpressionType.FUNCTION)
               && ((FunctionExpression) resultColumn.getExpression()).isCountStar();
@@ -640,7 +648,10 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
 
   /** process select component for align by time. */
   private List<Pair<Expression, String>> analyzeSelect(
-      Analysis analysis, QueryStatement queryStatement, ISchemaTree schemaTree) {
+      Analysis analysis,
+      QueryStatement queryStatement,
+      ISchemaTree schemaTree,
+      MPPQueryContext queryContext) {
     Map<Integer, List<Pair<Expression, String>>> outputExpressionMap = new HashMap<>();
 
     ColumnPaginationController paginationController =
@@ -654,7 +665,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     for (ResultColumn resultColumn : queryStatement.getSelectComponent().getResultColumns()) {
       List<Pair<Expression, String>> outputExpressions = new ArrayList<>();
       List<Expression> resultExpressions =
-          bindSchemaForExpression(resultColumn.getExpression(), schemaTree);
+          bindSchemaForExpression(resultColumn.getExpression(), schemaTree, queryContext);
 
       for (Expression resultExpression : resultExpressions) {
         if (paginationController.hasCurOffset()) {
@@ -710,7 +721,8 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       Analysis analysis,
       QueryStatement queryStatement,
       ISchemaTree schemaTree,
-      List<PartialPath> deviceList) {
+      List<PartialPath> deviceList,
+      MPPQueryContext queryContext) {
     List<Pair<Expression, String>> outputExpressions = new ArrayList<>();
     Map<String, Set<Expression>> deviceToSelectExpressions = new HashMap<>();
     ColumnPaginationController paginationController =
@@ -726,7 +738,8 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
           new LinkedHashMap<>();
       for (PartialPath device : deviceList) {
         List<Expression> selectExpressionsOfOneDevice =
-            concatDeviceAndBindSchemaForExpression(selectExpression, device, schemaTree);
+            concatDeviceAndBindSchemaForExpression(
+                selectExpression, device, schemaTree, queryContext);
         if (selectExpressionsOfOneDevice.isEmpty()) {
           continue;
         }
@@ -863,14 +876,16 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       Analysis analysis,
       QueryStatement queryStatement,
       ISchemaTree schemaTree,
-      UnaryOperator<Expression> havingExpressionAnalyzer) {
+      UnaryOperator<Expression> havingExpressionAnalyzer,
+      MPPQueryContext queryContext) {
     // get removeWildcard Expressions in Having
     List<Expression> conJunctions =
         ExpressionAnalyzer.bindSchemaForPredicate(
             queryStatement.getHavingCondition().getPredicate(),
             queryStatement.getFromComponent().getPrefixPaths(),
             schemaTree,
-            true);
+            true,
+            queryContext);
     Expression havingExpression =
         PredicateUtils.combineConjuncts(
             conJunctions.stream().distinct().collect(Collectors.toList()));
@@ -888,20 +903,28 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
   }
 
   private void analyzeHaving(
-      Analysis analysis, QueryStatement queryStatement, ISchemaTree schemaTree) {
+      Analysis analysis,
+      QueryStatement queryStatement,
+      ISchemaTree schemaTree,
+      MPPQueryContext queryContext) {
     if (!queryStatement.hasHaving()) {
       return;
     }
 
     analyzeHavingBase(
-        analysis, queryStatement, schemaTree, ExpressionAnalyzer::normalizeExpression);
+        analysis,
+        queryStatement,
+        schemaTree,
+        ExpressionAnalyzer::normalizeExpression,
+        queryContext);
   }
 
   private void analyzeGroupByLevelHaving(
       Analysis analysis,
       QueryStatement queryStatement,
       ISchemaTree schemaTree,
-      GroupByLevelHelper groupByLevelHelper) {
+      GroupByLevelHelper groupByLevelHelper,
+      MPPQueryContext queryContext) {
     if (!queryStatement.hasHaving()) {
       return;
     }
@@ -912,7 +935,8 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
         schemaTree,
         havingExpression ->
             PredicateUtils.removeDuplicateConjunct(
-                groupByLevelHelper.applyLevels(havingExpression, analysis)));
+                groupByLevelHelper.applyLevels(havingExpression, analysis)),
+        queryContext);
     // update groupByLevelExpressions
     groupByLevelHelper.updateGroupByLevelExpressions(analysis.getHavingExpression());
   }
@@ -921,7 +945,8 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       Analysis analysis,
       QueryStatement queryStatement,
       ISchemaTree schemaTree,
-      List<PartialPath> deviceSet) {
+      List<PartialPath> deviceSet,
+      MPPQueryContext queryContext) {
     if (!queryStatement.hasHaving()) {
       return;
     }
@@ -937,7 +962,8 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
 
     for (PartialPath device : deviceSet) {
       List<Expression> expressionsInHaving =
-          concatDeviceAndBindSchemaForExpression(havingExpression, device, schemaTree);
+          concatDeviceAndBindSchemaForExpression(
+              havingExpression, device, schemaTree, queryContext);
 
       conJunctions.addAll(
           expressionsInHaving.stream()
@@ -1341,7 +1367,8 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       Analysis analysis,
       QueryStatement queryStatement,
       ISchemaTree schemaTree,
-      List<PartialPath> deviceSet) {
+      List<PartialPath> deviceSet,
+      MPPQueryContext queryContext) {
     if (!queryStatement.hasWhere()) {
       return;
     }
@@ -1352,7 +1379,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     while (deviceIterator.hasNext()) {
       PartialPath devicePath = deviceIterator.next();
       Expression whereExpression =
-          analyzeWhereSplitByDevice(queryStatement, devicePath, schemaTree);
+          analyzeWhereSplitByDevice(queryStatement, devicePath, schemaTree, queryContext);
       if (whereExpression.equals(ConstantOperand.FALSE)) {
         deviceIterator.remove();
       } else if (whereExpression.equals(ConstantOperand.TRUE)) {
@@ -1371,7 +1398,10 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
   }
 
   private void analyzeWhere(
-      Analysis analysis, QueryStatement queryStatement, ISchemaTree schemaTree) {
+      Analysis analysis,
+      QueryStatement queryStatement,
+      ISchemaTree schemaTree,
+      MPPQueryContext queryContext) {
     if (!queryStatement.hasWhere()) {
       return;
     }
@@ -1380,7 +1410,8 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
             queryStatement.getWhereCondition().getPredicate(),
             queryStatement.getFromComponent().getPrefixPaths(),
             schemaTree,
-            true);
+            true,
+            queryContext);
     Expression whereExpression = convertConJunctionsToWhereExpression(conJunctions);
     if (whereExpression.equals(ConstantOperand.TRUE)) {
       analysis.setWhereExpression(null);
@@ -1396,10 +1427,17 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
   }
 
   private Expression analyzeWhereSplitByDevice(
-      QueryStatement queryStatement, PartialPath devicePath, ISchemaTree schemaTree) {
+      final QueryStatement queryStatement,
+      final PartialPath devicePath,
+      final ISchemaTree schemaTree,
+      final MPPQueryContext queryContext) {
     List<Expression> conJunctions =
         ExpressionAnalyzer.concatDeviceAndBindSchemaForPredicate(
-            queryStatement.getWhereCondition().getPredicate(), devicePath, schemaTree, true);
+            queryStatement.getWhereCondition().getPredicate(),
+            devicePath,
+            schemaTree,
+            true,
+            queryContext);
     return convertConJunctionsToWhereExpression(conJunctions);
   }
 
@@ -1568,11 +1606,13 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       Analysis analysis,
       QueryStatement queryStatement,
       ISchemaTree schemaTree,
-      UnaryOperator<List<Expression>> orderByExpressionAnalyzer) {
+      UnaryOperator<List<Expression>> orderByExpressionAnalyzer,
+      MPPQueryContext queryContext) {
     Set<Expression> orderByExpressions = new LinkedHashSet<>();
     for (Expression expressionForItem : queryStatement.getExpressionSortItemList()) {
       // Expression in a sortItem only indicates one column
-      List<Expression> expressions = bindSchemaForExpression(expressionForItem, schemaTree);
+      List<Expression> expressions =
+          bindSchemaForExpression(expressionForItem, schemaTree, queryContext);
       if (expressions.isEmpty()) {
         throw new SemanticException(
             String.format(
@@ -1600,19 +1640,24 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
   }
 
   private void analyzeOrderBy(
-      Analysis analysis, QueryStatement queryStatement, ISchemaTree schemaTree) {
+      Analysis analysis,
+      QueryStatement queryStatement,
+      ISchemaTree schemaTree,
+      MPPQueryContext queryContext) {
     if (!queryStatement.hasOrderByExpression()) {
       return;
     }
 
-    analyzeOrderByBase(analysis, queryStatement, schemaTree, expressions -> expressions);
+    analyzeOrderByBase(
+        analysis, queryStatement, schemaTree, expressions -> expressions, queryContext);
   }
 
   private void analyzeGroupByLevelOrderBy(
       Analysis analysis,
       QueryStatement queryStatement,
       ISchemaTree schemaTree,
-      GroupByLevelHelper groupByLevelHelper) {
+      GroupByLevelHelper groupByLevelHelper,
+      MPPQueryContext queryContext) {
     if (!queryStatement.hasOrderByExpression()) {
       return;
     }
@@ -1627,7 +1672,8 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
             groupedExpressions.add(groupByLevelHelper.applyLevels(expression, analysis));
           }
           return new ArrayList<>(groupedExpressions);
-        });
+        },
+        queryContext);
     // update groupByLevelExpressions
     for (Expression orderByExpression : analysis.getOrderByExpressions()) {
       groupByLevelHelper.updateGroupByLevelExpressions(orderByExpression);
@@ -1642,7 +1688,8 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       Analysis analysis,
       QueryStatement queryStatement,
       ISchemaTree schemaTree,
-      List<PartialPath> deviceSet) {
+      List<PartialPath> deviceSet,
+      MPPQueryContext queryContext) {
     if (queryStatement.getGroupByComponent() == null) {
       return;
     }
@@ -1654,7 +1701,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       Expression expression = groupByComponent.getControlColumnExpression();
       for (PartialPath device : deviceSet) {
         List<Expression> groupByExpressionsOfOneDevice =
-            concatDeviceAndBindSchemaForExpression(expression, device, schemaTree);
+            concatDeviceAndBindSchemaForExpression(expression, device, schemaTree, queryContext);
 
         if (groupByExpressionsOfOneDevice.isEmpty()) {
           throw new SemanticException(
@@ -1713,7 +1760,8 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       Analysis analysis,
       QueryStatement queryStatement,
       ISchemaTree schemaTree,
-      List<PartialPath> deviceSet) {
+      List<PartialPath> deviceSet,
+      MPPQueryContext queryContext) {
     if (!queryStatement.hasOrderByExpression()) {
       return;
     }
@@ -1726,7 +1774,8 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       Set<Expression> orderByExpressionsForOneDevice = new LinkedHashSet<>();
       for (Expression expressionForItem : queryStatement.getExpressionSortItemList()) {
         List<Expression> expressions =
-            concatDeviceAndBindSchemaForExpression(expressionForItem, device, schemaTree);
+            concatDeviceAndBindSchemaForExpression(
+                expressionForItem, device, schemaTree, queryContext);
         if (expressions.isEmpty()) {
           throw new SemanticException(
               String.format(
@@ -1763,7 +1812,10 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
   }
 
   private void analyzeGroupBy(
-      Analysis analysis, QueryStatement queryStatement, ISchemaTree schemaTree) {
+      Analysis analysis,
+      QueryStatement queryStatement,
+      ISchemaTree schemaTree,
+      MPPQueryContext queryContext) {
 
     if (queryStatement.getGroupByComponent() == null) {
       return;
@@ -1775,7 +1827,8 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     if (queryStatement.hasGroupByExpression()) {
       groupByExpression = groupByComponent.getControlColumnExpression();
       // Expression in group by variation clause only indicates one column
-      List<Expression> expressions = bindSchemaForExpression(groupByExpression, schemaTree);
+      List<Expression> expressions =
+          bindSchemaForExpression(groupByExpression, schemaTree, queryContext);
       if (expressions.isEmpty()) {
         throw new SemanticException(
             String.format(
@@ -2891,7 +2944,8 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
           analysis,
           Collections.singletonList(
               new TimeSeriesOperand(showTimeSeriesStatement.getPathPattern())),
-          schemaTree);
+          schemaTree,
+          context);
       analyzeDataPartition(analysis, new QueryStatement(), schemaTree, context);
     }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/ExpressionAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/ExpressionAnalyzer.java
@@ -410,7 +410,9 @@ public class ExpressionAnalyzer {
    *     expressions
    */
   public static List<Expression> bindSchemaForExpression(
-      Expression expression, ISchemaTree schemaTree, MPPQueryContext queryContext) {
+      final Expression expression,
+      final ISchemaTree schemaTree,
+      final MPPQueryContext queryContext) {
     return new BindSchemaForExpressionVisitor()
         .process(expression, new BindSchemaForExpressionVisitor.Context(schemaTree, queryContext));
   }
@@ -425,11 +427,11 @@ public class ExpressionAnalyzer {
    * @return the expression list with full path and after binding schema
    */
   public static List<Expression> bindSchemaForPredicate(
-      Expression predicate,
-      List<PartialPath> prefixPaths,
-      ISchemaTree schemaTree,
-      boolean isRoot,
-      MPPQueryContext queryContext) {
+      final Expression predicate,
+      final List<PartialPath> prefixPaths,
+      final ISchemaTree schemaTree,
+      final boolean isRoot,
+      final MPPQueryContext queryContext) {
     return new BindSchemaForPredicateVisitor()
         .process(
             predicate,

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/ExpressionAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/ExpressionAnalyzer.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.commons.path.PathPatternTree;
 import org.apache.iotdb.commons.udf.builtin.BuiltinScalarFunction;
 import org.apache.iotdb.commons.udf.builtin.BuiltinTimeSeriesGeneratingFunction;
 import org.apache.iotdb.db.exception.sql.SemanticException;
+import org.apache.iotdb.db.queryengine.common.MPPQueryContext;
 import org.apache.iotdb.db.queryengine.common.header.ColumnHeader;
 import org.apache.iotdb.db.queryengine.common.schematree.ISchemaTree;
 import org.apache.iotdb.db.queryengine.plan.expression.Expression;
@@ -264,11 +265,15 @@ public class ExpressionAnalyzer {
    * @return the concatenated expression list
    */
   public static List<Expression> concatExpressionWithSuffixPaths(
-      Expression expression, List<PartialPath> prefixPaths, PathPatternTree patternTree) {
+      final Expression expression,
+      final List<PartialPath> prefixPaths,
+      final PathPatternTree patternTree,
+      final MPPQueryContext queryContext) {
     return new ConcatExpressionWithSuffixPathsVisitor()
         .process(
             expression,
-            new ConcatExpressionWithSuffixPathsVisitor.Context(prefixPaths, patternTree));
+            new ConcatExpressionWithSuffixPathsVisitor.Context(
+                prefixPaths, patternTree, queryContext));
   }
 
   /**
@@ -405,8 +410,9 @@ public class ExpressionAnalyzer {
    *     expressions
    */
   public static List<Expression> bindSchemaForExpression(
-      Expression expression, ISchemaTree schemaTree) {
-    return new BindSchemaForExpressionVisitor().process(expression, schemaTree);
+      Expression expression, ISchemaTree schemaTree, MPPQueryContext queryContext) {
+    return new BindSchemaForExpressionVisitor()
+        .process(expression, new BindSchemaForExpressionVisitor.Context(schemaTree, queryContext));
   }
 
   /**
@@ -419,10 +425,16 @@ public class ExpressionAnalyzer {
    * @return the expression list with full path and after binding schema
    */
   public static List<Expression> bindSchemaForPredicate(
-      Expression predicate, List<PartialPath> prefixPaths, ISchemaTree schemaTree, boolean isRoot) {
+      Expression predicate,
+      List<PartialPath> prefixPaths,
+      ISchemaTree schemaTree,
+      boolean isRoot,
+      MPPQueryContext queryContext) {
     return new BindSchemaForPredicateVisitor()
         .process(
-            predicate, new BindSchemaForPredicateVisitor.Context(prefixPaths, schemaTree, isRoot));
+            predicate,
+            new BindSchemaForPredicateVisitor.Context(
+                prefixPaths, schemaTree, isRoot, queryContext));
   }
 
   public static Expression replaceRawPathWithGroupedPath(
@@ -445,11 +457,15 @@ public class ExpressionAnalyzer {
    * @return expression list with full path and after binding schema
    */
   public static List<Expression> concatDeviceAndBindSchemaForExpression(
-      Expression expression, PartialPath devicePath, ISchemaTree schemaTree) {
+      final Expression expression,
+      final PartialPath devicePath,
+      final ISchemaTree schemaTree,
+      final MPPQueryContext queryContext) {
     return new ConcatDeviceAndBindSchemaForExpressionVisitor()
         .process(
             expression,
-            new ConcatDeviceAndBindSchemaForExpressionVisitor.Context(devicePath, schemaTree));
+            new ConcatDeviceAndBindSchemaForExpressionVisitor.Context(
+                devicePath, schemaTree, queryContext));
   }
 
   /**
@@ -459,12 +475,16 @@ public class ExpressionAnalyzer {
    * @return the expression list with full path and after binding schema
    */
   public static List<Expression> concatDeviceAndBindSchemaForPredicate(
-      Expression predicate, PartialPath devicePath, ISchemaTree schemaTree, boolean isWhere) {
+      final Expression predicate,
+      final PartialPath devicePath,
+      final ISchemaTree schemaTree,
+      final boolean isWhere,
+      final MPPQueryContext queryContext) {
     return new ConcatDeviceAndBindSchemaForPredicateVisitor()
         .process(
             predicate,
             new ConcatDeviceAndBindSchemaForPredicateVisitor.Context(
-                devicePath, schemaTree, isWhere));
+                devicePath, schemaTree, isWhere, queryContext));
   }
 
   /**

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/TemplatedAnalyze.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/TemplatedAnalyze.java
@@ -183,7 +183,7 @@ public class TemplatedAnalyze {
     }
     analysis.setDeviceList(deviceList);
 
-    analyzeDeviceToOrderBy(analysis, queryStatement, schemaTree, deviceList);
+    analyzeDeviceToOrderBy(analysis, queryStatement, schemaTree, deviceList, context);
     analyzeDeviceToSourceTransform(analysis);
     analyzeDeviceToSource(analysis);
 
@@ -272,7 +272,8 @@ public class TemplatedAnalyze {
       Analysis analysis,
       QueryStatement queryStatement,
       ISchemaTree schemaTree,
-      List<PartialPath> deviceSet) {
+      List<PartialPath> deviceSet,
+      MPPQueryContext queryContext) {
     if (!queryStatement.hasOrderByExpression()) {
       return;
     }
@@ -285,7 +286,8 @@ public class TemplatedAnalyze {
       Set<Expression> orderByExpressionsForOneDevice = new LinkedHashSet<>();
       for (Expression expressionForItem : queryStatement.getExpressionSortItemList()) {
         List<Expression> expressions =
-            concatDeviceAndBindSchemaForExpression(expressionForItem, device, schemaTree);
+            concatDeviceAndBindSchemaForExpression(
+                expressionForItem, device, schemaTree, queryContext);
         if (expressions.isEmpty()) {
           throw new SemanticException(
               String.format(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/TemplatedAnalyze.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/TemplatedAnalyze.java
@@ -129,6 +129,8 @@ public class TemplatedAnalyze {
               TimeSeriesOperand measurementPath =
                   new TimeSeriesOperand(
                       new MeasurementPath(new String[] {measurementName}, measurementSchema));
+              // reserve memory for this expression
+              context.reserveMemoryForFrontEnd(measurementPath.ramBytesUsed());
               outputExpressions.add(new Pair<>(measurementPath, null));
               paginationController.consumeLimit();
             } else {
@@ -150,6 +152,8 @@ public class TemplatedAnalyze {
               TimeSeriesOperand measurementPath =
                   new TimeSeriesOperand(
                       new MeasurementPath(new String[] {measurementName}, measurementSchema));
+              // reserve memory for this expression
+              context.reserveMemoryForFrontEnd(measurementPath.ramBytesUsed());
               outputExpressions.add(new Pair<>(measurementPath, resultColumn.getAlias()));
             } else {
               break;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/QueryExecution.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/QueryExecution.java
@@ -179,6 +179,9 @@ public class QueryExecution implements IQueryExecution {
     PERFORMANCE_OVERVIEW_METRICS.recordPlanCost(System.nanoTime() - startTime);
     schedule();
 
+    // The last batch of memory reserved by the front end
+    context.reserveMemoryForFrontEndImmediately();
+
     // friendly for gc
     logicalPlan.clearUselessMemory();
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/Expression.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/Expression.java
@@ -56,6 +56,7 @@ import org.apache.iotdb.db.queryengine.transformation.dag.memory.LayerMemoryAssi
 import org.apache.iotdb.db.queryengine.transformation.dag.udf.UDTFExecutor;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.utils.Accountable;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 
 import java.io.DataOutputStream;
@@ -71,7 +72,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 
 /** A skeleton class for expression */
-public abstract class Expression extends StatementNode {
+public abstract class Expression extends StatementNode implements Accountable {
   /////////////////////////////////////////////////////////////////////////////////////////////////
   // Operations that Class Expression is not responsible for should be done through a visitor
   /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/binary/BinaryExpression.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/binary/BinaryExpression.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.queryengine.plan.expression.binary;
 
 import org.apache.iotdb.db.queryengine.common.NodeRef;
+import org.apache.iotdb.db.queryengine.execution.MemoryEstimationHelper;
 import org.apache.iotdb.db.queryengine.plan.expression.Expression;
 import org.apache.iotdb.db.queryengine.plan.expression.visitor.ExpressionVisitor;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.parameter.InputLocation;
@@ -27,6 +28,7 @@ import org.apache.iotdb.db.queryengine.transformation.dag.memory.LayerMemoryAssi
 import org.apache.iotdb.db.queryengine.transformation.dag.udf.UDTFExecutor;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.utils.RamUsageEstimator;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -37,6 +39,9 @@ import java.util.List;
 import java.util.Map;
 
 public abstract class BinaryExpression extends Expression {
+
+  private static final long INSTANCE_SIZE =
+      RamUsageEstimator.shallowSizeOfInstance(BinaryExpression.class);
 
   protected Expression leftExpression;
   protected Expression rightExpression;
@@ -154,6 +159,13 @@ public abstract class BinaryExpression extends Expression {
     String right = this.getRightExpression().getOutputSymbol();
 
     return buildExpression(left, right);
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return INSTANCE_SIZE
+        + MemoryEstimationHelper.getEstimatedSizeOfAccountableObject(leftExpression)
+        + MemoryEstimationHelper.getEstimatedSizeOfAccountableObject(rightExpression);
   }
 
   private String buildExpression(String left, String right) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/leaf/ConstantOperand.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/leaf/ConstantOperand.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.queryengine.plan.planner.plan.parameter.InputLocation
 import org.apache.iotdb.db.queryengine.transformation.dag.memory.LayerMemoryAssigner;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 
 import java.io.DataOutputStream;
@@ -39,6 +40,9 @@ public class ConstantOperand extends LeafOperand {
 
   public static final ConstantOperand FALSE = new ConstantOperand(TSDataType.BOOLEAN, "false");
   public static final ConstantOperand TRUE = new ConstantOperand(TSDataType.BOOLEAN, "true");
+
+  private static final long INSTANCE_SIZE =
+      RamUsageEstimator.shallowSizeOfInstance(ConstantOperand.class);
 
   private final String valueString;
   private final TSDataType dataType;
@@ -115,5 +119,10 @@ public class ConstantOperand extends LeafOperand {
   protected void serialize(DataOutputStream stream) throws IOException {
     dataType.serializeTo(stream);
     ReadWriteIOUtils.write(valueString, stream);
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return INSTANCE_SIZE + RamUsageEstimator.sizeOf(valueString);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/leaf/NullOperand.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/leaf/NullOperand.java
@@ -24,6 +24,8 @@ import org.apache.iotdb.db.queryengine.plan.expression.visitor.ExpressionVisitor
 import org.apache.iotdb.db.queryengine.plan.planner.plan.parameter.InputLocation;
 import org.apache.iotdb.db.queryengine.transformation.dag.memory.LayerMemoryAssigner;
 
+import org.apache.tsfile.utils.RamUsageEstimator;
+
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -31,6 +33,9 @@ import java.util.List;
 import java.util.Map;
 
 public class NullOperand extends LeafOperand {
+  private static final long INSTANCE_SIZE =
+      RamUsageEstimator.shallowSizeOfInstance(NullOperand.class);
+
   @Override
   public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
     return visitor.visitNullOperand(this, context);
@@ -70,5 +75,10 @@ public class NullOperand extends LeafOperand {
   @Override
   protected void serialize(DataOutputStream stream) throws IOException {
     // do nothing
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return INSTANCE_SIZE;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/leaf/TimeSeriesOperand.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/leaf/TimeSeriesOperand.java
@@ -22,12 +22,14 @@ package org.apache.iotdb.db.queryengine.plan.expression.leaf;
 import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.path.PathDeserializeUtil;
+import org.apache.iotdb.db.queryengine.execution.MemoryEstimationHelper;
 import org.apache.iotdb.db.queryengine.plan.expression.ExpressionType;
 import org.apache.iotdb.db.queryengine.plan.expression.visitor.ExpressionVisitor;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.parameter.InputLocation;
 import org.apache.iotdb.db.queryengine.transformation.dag.memory.LayerMemoryAssigner;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.utils.RamUsageEstimator;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -36,6 +38,9 @@ import java.util.List;
 import java.util.Map;
 
 public class TimeSeriesOperand extends LeafOperand {
+
+  private static final long INSTANCE_SIZE =
+      RamUsageEstimator.shallowSizeOfInstance(TimeSeriesOperand.class);
 
   private PartialPath path;
 
@@ -105,5 +110,10 @@ public class TimeSeriesOperand extends LeafOperand {
   @Override
   protected void serialize(DataOutputStream stream) throws IOException {
     path.serialize(stream);
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return INSTANCE_SIZE + MemoryEstimationHelper.getEstimatedSizeOfPartialPath(path);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/leaf/TimestampOperand.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/leaf/TimestampOperand.java
@@ -24,6 +24,8 @@ import org.apache.iotdb.db.queryengine.plan.expression.visitor.ExpressionVisitor
 import org.apache.iotdb.db.queryengine.plan.planner.plan.parameter.InputLocation;
 import org.apache.iotdb.db.queryengine.transformation.dag.memory.LayerMemoryAssigner;
 
+import org.apache.tsfile.utils.RamUsageEstimator;
+
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -31,6 +33,9 @@ import java.util.List;
 import java.util.Map;
 
 public class TimestampOperand extends LeafOperand {
+
+  private static final long INSTANCE_SIZE =
+      RamUsageEstimator.shallowSizeOfInstance(TimeSeriesOperand.class);
 
   public static final String TIMESTAMP_EXPRESSION_STRING = "Time";
 
@@ -81,5 +86,10 @@ public class TimestampOperand extends LeafOperand {
   @Override
   protected void serialize(DataOutputStream stream) throws IOException {
     // do nothing
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return INSTANCE_SIZE;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/other/CaseWhenThenExpression.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/other/CaseWhenThenExpression.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.queryengine.plan.expression.other;
 
 import org.apache.iotdb.db.queryengine.common.NodeRef;
+import org.apache.iotdb.db.queryengine.execution.MemoryEstimationHelper;
 import org.apache.iotdb.db.queryengine.plan.expression.Expression;
 import org.apache.iotdb.db.queryengine.plan.expression.ExpressionType;
 import org.apache.iotdb.db.queryengine.plan.expression.binary.WhenThenExpression;
@@ -31,6 +32,7 @@ import org.apache.iotdb.db.queryengine.transformation.dag.udf.UDTFExecutor;
 
 import org.apache.commons.lang3.Validate;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 
 import java.io.DataOutputStream;
@@ -42,6 +44,9 @@ import java.util.List;
 import java.util.Map;
 
 public class CaseWhenThenExpression extends Expression {
+
+  private static final long INSTANCE_SIZE =
+      RamUsageEstimator.shallowSizeOfInstance(CaseWhenThenExpression.class);
   protected List<WhenThenExpression> whenThenExpressions = new ArrayList<>();
   protected Expression elseExpression;
 
@@ -182,5 +187,16 @@ public class CaseWhenThenExpression extends Expression {
   @Override
   public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
     return visitor.visitCaseWhenThenExpression(this, context);
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return INSTANCE_SIZE
+        + MemoryEstimationHelper.getEstimatedSizeOfAccountableObject(elseExpression)
+        + (whenThenExpressions == null
+            ? 0
+            : whenThenExpressions.stream()
+                .mapToLong(MemoryEstimationHelper::getEstimatedSizeOfAccountableObject)
+                .sum());
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/other/GroupByTimeExpression.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/other/GroupByTimeExpression.java
@@ -28,6 +28,7 @@ import org.apache.iotdb.db.queryengine.transformation.dag.memory.LayerMemoryAssi
 import org.apache.iotdb.db.queryengine.transformation.dag.udf.UDTFExecutor;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 import org.apache.tsfile.utils.TimeDuration;
 
@@ -40,6 +41,9 @@ import java.util.Map;
 
 /** Only used for representing GROUP BY TIME filter. */
 public class GroupByTimeExpression extends Expression {
+
+  private static final long INSTANCE_SIZE =
+      RamUsageEstimator.shallowSizeOfInstance(GroupByTimeExpression.class);
 
   // [startTime, endTime]
   private final long startTime;
@@ -156,5 +160,10 @@ public class GroupByTimeExpression extends Expression {
   @Override
   public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
     return visitor.visitGroupByTimeExpression(this, context);
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return INSTANCE_SIZE;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/ternary/BetweenExpression.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/ternary/BetweenExpression.java
@@ -21,10 +21,12 @@
 
 package org.apache.iotdb.db.queryengine.plan.expression.ternary;
 
+import org.apache.iotdb.db.queryengine.execution.MemoryEstimationHelper;
 import org.apache.iotdb.db.queryengine.plan.expression.Expression;
 import org.apache.iotdb.db.queryengine.plan.expression.ExpressionType;
 import org.apache.iotdb.db.queryengine.plan.expression.visitor.ExpressionVisitor;
 
+import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 
 import java.io.DataOutputStream;
@@ -32,6 +34,10 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 public class BetweenExpression extends TernaryExpression {
+
+  private static final long INSTANCE_SIZE =
+      RamUsageEstimator.shallowSizeOfInstance(TernaryExpression.class);
+
   private final boolean isNotBetween;
 
   public boolean isNotBetween() {
@@ -101,5 +107,13 @@ public class BetweenExpression extends TernaryExpression {
   @Override
   public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
     return visitor.visitBetweenExpression(this, context);
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return INSTANCE_SIZE
+        + MemoryEstimationHelper.getEstimatedSizeOfAccountableObject(firstExpression)
+        + MemoryEstimationHelper.getEstimatedSizeOfAccountableObject(secondExpression)
+        + MemoryEstimationHelper.getEstimatedSizeOfAccountableObject(thirdExpression);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/unary/InExpression.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/unary/InExpression.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.queryengine.plan.expression.unary;
 
+import org.apache.iotdb.db.queryengine.execution.MemoryEstimationHelper;
 import org.apache.iotdb.db.queryengine.plan.expression.Expression;
 import org.apache.iotdb.db.queryengine.plan.expression.ExpressionType;
 import org.apache.iotdb.db.queryengine.plan.expression.leaf.ConstantOperand;
@@ -27,6 +28,7 @@ import org.apache.iotdb.db.queryengine.plan.expression.leaf.TimeSeriesOperand;
 import org.apache.iotdb.db.queryengine.plan.expression.multi.FunctionExpression;
 import org.apache.iotdb.db.queryengine.plan.expression.visitor.ExpressionVisitor;
 
+import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 
 import javax.validation.constraints.NotNull;
@@ -38,7 +40,8 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 
 public class InExpression extends UnaryExpression {
-
+  private static final long INSTANCE_SIZE =
+      RamUsageEstimator.shallowSizeOfInstance(InExpression.class);
   private final boolean isNotIn;
   private final LinkedHashSet<String> values;
 
@@ -137,5 +140,12 @@ public class InExpression extends UnaryExpression {
   @Override
   public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
     return visitor.visitInExpression(this, context);
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return INSTANCE_SIZE
+        + MemoryEstimationHelper.getEstimatedSizeOfAccountableObject(expression)
+        + (values == null ? 0 : values.stream().mapToLong(RamUsageEstimator::sizeOf).sum());
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/unary/IsNullExpression.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/unary/IsNullExpression.java
@@ -19,10 +19,12 @@
 
 package org.apache.iotdb.db.queryengine.plan.expression.unary;
 
+import org.apache.iotdb.db.queryengine.execution.MemoryEstimationHelper;
 import org.apache.iotdb.db.queryengine.plan.expression.Expression;
 import org.apache.iotdb.db.queryengine.plan.expression.ExpressionType;
 import org.apache.iotdb.db.queryengine.plan.expression.visitor.ExpressionVisitor;
 
+import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 
 import java.io.DataOutputStream;
@@ -30,6 +32,9 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 public class IsNullExpression extends UnaryExpression {
+
+  private static final long INSTANCE_SIZE =
+      RamUsageEstimator.shallowSizeOfInstance(IsNullExpression.class);
   private final boolean isNot;
 
   public IsNullExpression(Expression expression, boolean isNot) {
@@ -76,5 +81,10 @@ public class IsNullExpression extends UnaryExpression {
   @Override
   public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
     return visitor.visitIsNullExpression(this, context);
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return INSTANCE_SIZE + MemoryEstimationHelper.getEstimatedSizeOfAccountableObject(expression);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/unary/LikeExpression.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/unary/LikeExpression.java
@@ -19,10 +19,12 @@
 
 package org.apache.iotdb.db.queryengine.plan.expression.unary;
 
+import org.apache.iotdb.db.queryengine.execution.MemoryEstimationHelper;
 import org.apache.iotdb.db.queryengine.plan.expression.Expression;
 import org.apache.iotdb.db.queryengine.plan.expression.ExpressionType;
 import org.apache.iotdb.db.queryengine.plan.expression.visitor.ExpressionVisitor;
 
+import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 
 import java.io.DataOutputStream;
@@ -34,6 +36,9 @@ import static org.apache.tsfile.utils.RegexUtils.compileRegex;
 import static org.apache.tsfile.utils.RegexUtils.parseLikePatternToRegex;
 
 public class LikeExpression extends UnaryExpression {
+
+  private static final long INSTANCE_SIZE =
+      RamUsageEstimator.shallowSizeOfInstance(LikeExpression.class);
 
   private final String patternString;
   private final Pattern pattern;
@@ -106,5 +111,12 @@ public class LikeExpression extends UnaryExpression {
   @Override
   public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
     return visitor.visitLikeExpression(this, context);
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return INSTANCE_SIZE
+        + MemoryEstimationHelper.getEstimatedSizeOfAccountableObject(expression)
+        + RamUsageEstimator.sizeOf(patternString);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/unary/LogicNotExpression.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/unary/LogicNotExpression.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.queryengine.plan.expression.unary;
 
+import org.apache.iotdb.db.queryengine.execution.MemoryEstimationHelper;
 import org.apache.iotdb.db.queryengine.plan.expression.Expression;
 import org.apache.iotdb.db.queryengine.plan.expression.ExpressionType;
 import org.apache.iotdb.db.queryengine.plan.expression.leaf.ConstantOperand;
@@ -27,9 +28,14 @@ import org.apache.iotdb.db.queryengine.plan.expression.leaf.TimeSeriesOperand;
 import org.apache.iotdb.db.queryengine.plan.expression.multi.FunctionExpression;
 import org.apache.iotdb.db.queryengine.plan.expression.visitor.ExpressionVisitor;
 
+import org.apache.tsfile.utils.RamUsageEstimator;
+
 import java.nio.ByteBuffer;
 
 public class LogicNotExpression extends UnaryExpression {
+
+  private static final long INSTANCE_SIZE =
+      RamUsageEstimator.shallowSizeOfInstance(LogicNotExpression.class);
 
   public LogicNotExpression(Expression expression) {
     super(expression);
@@ -63,5 +69,10 @@ public class LogicNotExpression extends UnaryExpression {
   @Override
   public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
     return visitor.visitLogicNotExpression(this, context);
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return INSTANCE_SIZE + MemoryEstimationHelper.getEstimatedSizeOfAccountableObject(expression);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/unary/NegationExpression.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/unary/NegationExpression.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.queryengine.plan.expression.unary;
 
+import org.apache.iotdb.db.queryengine.execution.MemoryEstimationHelper;
 import org.apache.iotdb.db.queryengine.plan.expression.Expression;
 import org.apache.iotdb.db.queryengine.plan.expression.ExpressionType;
 import org.apache.iotdb.db.queryengine.plan.expression.leaf.ConstantOperand;
@@ -27,9 +28,14 @@ import org.apache.iotdb.db.queryengine.plan.expression.leaf.TimeSeriesOperand;
 import org.apache.iotdb.db.queryengine.plan.expression.multi.FunctionExpression;
 import org.apache.iotdb.db.queryengine.plan.expression.visitor.ExpressionVisitor;
 
+import org.apache.tsfile.utils.RamUsageEstimator;
+
 import java.nio.ByteBuffer;
 
 public class NegationExpression extends UnaryExpression {
+
+  private static final long INSTANCE_SIZE =
+      RamUsageEstimator.shallowSizeOfInstance(NegationExpression.class);
 
   public NegationExpression(Expression expression) {
     super(expression);
@@ -69,5 +75,10 @@ public class NegationExpression extends UnaryExpression {
   @Override
   public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
     return visitor.visitNegationExpression(this, context);
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return INSTANCE_SIZE + MemoryEstimationHelper.getEstimatedSizeOfAccountableObject(expression);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/unary/RegularExpression.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/unary/RegularExpression.java
@@ -19,11 +19,13 @@
 
 package org.apache.iotdb.db.queryengine.plan.expression.unary;
 
+import org.apache.iotdb.db.queryengine.execution.MemoryEstimationHelper;
 import org.apache.iotdb.db.queryengine.plan.expression.Expression;
 import org.apache.iotdb.db.queryengine.plan.expression.ExpressionType;
 import org.apache.iotdb.db.queryengine.plan.expression.visitor.ExpressionVisitor;
 
 import org.apache.commons.lang3.Validate;
+import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 
 import java.io.DataOutputStream;
@@ -34,6 +36,9 @@ import java.util.regex.Pattern;
 import static org.apache.tsfile.utils.RegexUtils.compileRegex;
 
 public class RegularExpression extends UnaryExpression {
+
+  private static final long INSTANCE_SIZE =
+      RamUsageEstimator.shallowSizeOfInstance(RegularExpression.class);
 
   private final String patternString;
   private final Pattern pattern;
@@ -110,5 +115,12 @@ public class RegularExpression extends UnaryExpression {
   @Override
   public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
     return visitor.visitRegularExpression(this, context);
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return INSTANCE_SIZE
+        + MemoryEstimationHelper.getEstimatedSizeOfAccountableObject(expression)
+        + RamUsageEstimator.sizeOf(patternString);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/visitor/cartesian/CartesianProductVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/visitor/cartesian/CartesianProductVisitor.java
@@ -32,34 +32,39 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.apache.iotdb.db.queryengine.plan.analyze.ExpressionUtils.cartesianProduct;
-import static org.apache.iotdb.db.queryengine.plan.analyze.ExpressionUtils.reconstructBinaryExpressions;
+import static org.apache.iotdb.db.queryengine.plan.analyze.ExpressionUtils.reconstructBinaryExpressionsWithMemoryCheck;
 import static org.apache.iotdb.db.queryengine.plan.analyze.ExpressionUtils.reconstructCaseWhenThenExpression;
-import static org.apache.iotdb.db.queryengine.plan.analyze.ExpressionUtils.reconstructTernaryExpressions;
-import static org.apache.iotdb.db.queryengine.plan.analyze.ExpressionUtils.reconstructUnaryExpressions;
+import static org.apache.iotdb.db.queryengine.plan.analyze.ExpressionUtils.reconstructTernaryExpressionsWithMemoryCheck;
+import static org.apache.iotdb.db.queryengine.plan.analyze.ExpressionUtils.reconstructUnaryExpressionsWithMemoryCheck;
 
-public abstract class CartesianProductVisitor<C>
+public abstract class CartesianProductVisitor<C extends QueryContextProvider>
     extends ExpressionAnalyzeVisitor<List<Expression>, C> {
   @Override
   public List<Expression> visitTernaryExpression(TernaryExpression ternaryExpression, C context) {
     List<List<Expression>> childResultsList = getResultsFromChild(ternaryExpression, context);
-    return reconstructTernaryExpressions(
+    return reconstructTernaryExpressionsWithMemoryCheck(
         ternaryExpression,
         childResultsList.get(0),
         childResultsList.get(1),
-        childResultsList.get(2));
+        childResultsList.get(2),
+        context.getQueryContext());
   }
 
   @Override
   public List<Expression> visitBinaryExpression(BinaryExpression binaryExpression, C context) {
     List<List<Expression>> childResultsList = getResultsFromChild(binaryExpression, context);
-    return reconstructBinaryExpressions(
-        binaryExpression, childResultsList.get(0), childResultsList.get(1));
+    return reconstructBinaryExpressionsWithMemoryCheck(
+        binaryExpression,
+        childResultsList.get(0),
+        childResultsList.get(1),
+        context.getQueryContext());
   }
 
   @Override
   public List<Expression> visitUnaryExpression(UnaryExpression unaryExpression, C context) {
     List<List<Expression>> childResultsList = getResultsFromChild(unaryExpression, context);
-    return reconstructUnaryExpressions(unaryExpression, childResultsList.get(0));
+    return reconstructUnaryExpressionsWithMemoryCheck(
+        unaryExpression, childResultsList.get(0), context.getQueryContext());
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/visitor/cartesian/QueryContextProvider.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/visitor/cartesian/QueryContextProvider.java
@@ -17,21 +17,10 @@
  * under the License.
  */
 
-package org.apache.iotdb.db.queryengine.exception;
+package org.apache.iotdb.db.queryengine.plan.expression.visitor.cartesian;
 
-import org.apache.iotdb.rpc.TSStatusCode;
+import org.apache.iotdb.db.queryengine.common.MPPQueryContext;
 
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-public class MemoryNotEnoughExceptionTest {
-
-  @Test
-  public void testMemoryNotEnoughExceptionStatusCode() {
-    MemoryNotEnoughException e = new MemoryNotEnoughException("test");
-    assertEquals(TSStatusCode.QUOTA_MEM_QUERY_NOT_ENOUGH.getStatusCode(), e.getErrorCode());
-    assertTrue(e.isUserException());
-  }
+public interface QueryContextProvider {
+  MPPQueryContext getQueryContext();
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/optimization/AggregationPushDown.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/optimization/AggregationPushDown.java
@@ -91,9 +91,13 @@ public class AggregationPushDown implements PlanOptimizer {
 
     RewriterContext rewriterContext =
         new RewriterContext(analysis, context, queryStatement.isAlignByDevice());
-    PlanNode node = plan.accept(new Rewriter(), rewriterContext);
-    // release the last batch of memory
-    rewriterContext.releaseMemoryForFrontEndImmediately();
+    PlanNode node;
+    try {
+      node = plan.accept(new Rewriter(), rewriterContext);
+    } finally {
+      // release the last batch of memory
+      rewriterContext.releaseMemoryForFrontEndImmediately();
+    }
     return node;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LocalExecutionPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LocalExecutionPlanner.java
@@ -213,7 +213,27 @@ public class LocalExecutionPlanner {
     }
   }
 
-  public synchronized void releaseToFreeMemoryForOperators(long memoryInBytes) {
+  public synchronized void reserveMemoryForQueryFrontEnd(
+      final long memoryInBytes, final long reservedBytes, final String queryId) {
+    if (memoryInBytes > freeMemoryForOperators) {
+      throw new MemoryNotEnoughException(
+          String.format(
+              "There is not enough memory for planning-stage of Query %s, "
+                  + "current remaining free memory is %dB, "
+                  + "estimated memory usage is %dB, reserved memory for FE of this query in total is %dB",
+              queryId, freeMemoryForOperators, memoryInBytes, reservedBytes));
+    } else {
+      freeMemoryForOperators -= memoryInBytes;
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug(
+            "[ConsumeMemory] consume: {}, current remaining memory: {}",
+            memoryInBytes,
+            freeMemoryForOperators);
+      }
+    }
+  }
+
+  public synchronized void releaseToFreeMemoryForOperators(final long memoryInBytes) {
     freeMemoryForOperators += memoryInBytes;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LocalExecutionPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LocalExecutionPlanner.java
@@ -57,7 +57,6 @@ public class LocalExecutionPlanner {
     MAX_REST_MEMORY_FOR_LOAD =
         (long)
             ((ALLOCATE_MEMORY_FOR_OPERATORS) * (1.0 - CONFIG.getMaxAllocateMemoryRatioForLoad()));
-    LOGGER.info("freeMemoryForOperators is : {}", ALLOCATE_MEMORY_FOR_OPERATORS);
   }
 
   /** allocated memory for operator execution */

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LocalExecutionPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LocalExecutionPlanner.java
@@ -57,6 +57,7 @@ public class LocalExecutionPlanner {
     MAX_REST_MEMORY_FOR_LOAD =
         (long)
             ((ALLOCATE_MEMORY_FOR_OPERATORS) * (1.0 - CONFIG.getMaxAllocateMemoryRatioForLoad()));
+    LOGGER.info("freeMemoryForOperators is : {}", ALLOCATE_MEMORY_FOR_OPERATORS);
   }
 
   /** allocated memory for operator execution */

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/DistributionPlanContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/DistributionPlanContext.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.queryengine.plan.planner.distribution;
 import org.apache.iotdb.db.queryengine.common.MPPQueryContext;
 import org.apache.iotdb.db.queryengine.plan.expression.Expression;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.tsfile.read.filter.basic.Filter;
 
 import java.util.List;
@@ -43,6 +44,7 @@ public class DistributionPlanContext {
 
   protected DistributionPlanContext(MPPQueryContext queryContext) {
     this.isRoot = true;
+    Validate.notNull(queryContext, "Query context cannot be null");
     this.queryContext = queryContext;
   }
 
@@ -89,5 +91,9 @@ public class DistributionPlanContext {
 
   public boolean isOneSeriesInMultiRegion() {
     return oneSeriesInMultiRegion;
+  }
+
+  public MPPQueryContext getQueryContext() {
+    return queryContext;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/SourceRewriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/SourceRewriter.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.commons.path.PathPatternTree;
 import org.apache.iotdb.commons.schema.SchemaConstant;
 import org.apache.iotdb.commons.utils.TimePartitionUtils;
 import org.apache.iotdb.db.queryengine.common.MPPQueryContext;
+import org.apache.iotdb.db.queryengine.execution.MemoryEstimationHelper;
 import org.apache.iotdb.db.queryengine.plan.analyze.Analysis;
 import org.apache.iotdb.db.queryengine.plan.expression.Expression;
 import org.apache.iotdb.db.queryengine.plan.expression.multi.FunctionExpression;
@@ -799,6 +800,10 @@ public class SourceRewriter extends BaseSourceRewriter<DistributionPlanContext> 
       SeriesSourceNode split = (SeriesSourceNode) node.clone();
       split.setPlanNodeId(context.queryContext.getQueryId().genPlanNodeId());
       split.setRegionReplicaSet(dataRegion);
+      context
+          .getQueryContext()
+          .reserveMemoryForFrontEnd(
+              MemoryEstimationHelper.getEstimatedSizeOfAccountableObject(split));
       ret.add(split);
     }
     return ret;
@@ -858,6 +863,10 @@ public class SourceRewriter extends BaseSourceRewriter<DistributionPlanContext> 
       split.setAggregationDescriptorList(leafAggDescriptorList);
       split.setPlanNodeId(context.queryContext.getQueryId().genPlanNodeId());
       split.setRegionReplicaSet(dataRegion);
+      context
+          .getQueryContext()
+          .reserveMemoryForFrontEnd(
+              MemoryEstimationHelper.getEstimatedSizeOfAccountableObject(split));
       aggregationNode.addChild(split);
     }
     return Collections.singletonList(aggregationNode);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/source/AlignedLastQueryScanNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/source/AlignedLastQueryScanNode.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.commons.path.AlignedPath;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.path.PathDeserializeUtil;
+import org.apache.iotdb.db.queryengine.execution.MemoryEstimationHelper;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeType;
@@ -30,6 +31,7 @@ import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeUtil;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanVisitor;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 import org.eclipse.jetty.util.StringUtil;
 
@@ -43,6 +45,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.apache.iotdb.db.queryengine.plan.planner.plan.node.source.LastQueryScanNode.LAST_QUERY_HEADER_COLUMNS;
 
 public class AlignedLastQueryScanNode extends LastSeriesSourceNode {
+  private static final long INSTANCE_SIZE =
+      RamUsageEstimator.shallowSizeOfInstance(AlignedLastQueryScanNode.class);
+
   // The path of the target series which will be scanned.
   private final AlignedPath seriesPath;
 
@@ -228,5 +233,13 @@ public class AlignedLastQueryScanNode extends LastSeriesSourceNode {
   @Override
   public PartialPath getPartitionPath() {
     return getSeriesPath();
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return INSTANCE_SIZE
+        + MemoryEstimationHelper.getEstimatedSizeOfAccountableObject(id)
+        + MemoryEstimationHelper.getEstimatedSizeOfPartialPath(seriesPath)
+        + RamUsageEstimator.sizeOf(outputViewPath);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/source/AlignedSeriesAggregationScanNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/source/AlignedSeriesAggregationScanNode.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.commons.path.AlignedPath;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.path.PathDeserializeUtil;
+import org.apache.iotdb.db.queryengine.execution.MemoryEstimationHelper;
 import org.apache.iotdb.db.queryengine.plan.expression.Expression;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
@@ -35,6 +36,7 @@ import org.apache.iotdb.db.queryengine.plan.planner.plan.parameter.GroupByTimePa
 import org.apache.iotdb.db.queryengine.plan.statement.component.Ordering;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 
 import javax.annotation.Nullable;
@@ -47,6 +49,8 @@ import java.util.List;
 import java.util.Objects;
 
 public class AlignedSeriesAggregationScanNode extends SeriesAggregationSourceNode {
+  private static final long INSTANCE_SIZE =
+      RamUsageEstimator.shallowSizeOfInstance(AlignedSeriesAggregationScanNode.class);
 
   // The paths of the target series which will be aggregated.
   private AlignedPath alignedPath;
@@ -293,5 +297,12 @@ public class AlignedSeriesAggregationScanNode extends SeriesAggregationSourceNod
         this.getAlignedPath().getFormattedString(),
         this.getAggregationDescriptorList(),
         PlanNodeUtil.printRegionReplicaSet(getRegionReplicaSet()));
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return INSTANCE_SIZE
+        + MemoryEstimationHelper.getEstimatedSizeOfAccountableObject(id)
+        + MemoryEstimationHelper.getEstimatedSizeOfPartialPath(alignedPath);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/source/AlignedSeriesScanNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/source/AlignedSeriesScanNode.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.commons.path.AlignedPath;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.path.PathDeserializeUtil;
+import org.apache.iotdb.db.queryengine.execution.MemoryEstimationHelper;
 import org.apache.iotdb.db.queryengine.plan.analyze.TypeProvider;
 import org.apache.iotdb.db.queryengine.plan.expression.Expression;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNode;
@@ -33,6 +34,7 @@ import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanVisitor;
 import org.apache.iotdb.db.queryengine.plan.statement.component.Ordering;
 
 import org.apache.tsfile.common.constant.TsFileConstant;
+import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 
 import javax.annotation.Nullable;
@@ -45,6 +47,9 @@ import java.util.List;
 import java.util.Objects;
 
 public class AlignedSeriesScanNode extends SeriesScanSourceNode {
+
+  private static final long INSTANCE_SIZE =
+      RamUsageEstimator.shallowSizeOfInstance(AlignedSeriesScanNode.class);
 
   // The paths of the target series which will be scanned.
   private final AlignedPath alignedPath;
@@ -259,5 +264,12 @@ public class AlignedSeriesScanNode extends SeriesScanSourceNode {
   @Override
   public PartialPath getPartitionPath() {
     return getAlignedPath();
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return INSTANCE_SIZE
+        + MemoryEstimationHelper.getEstimatedSizeOfAccountableObject(id)
+        + MemoryEstimationHelper.getEstimatedSizeOfPartialPath(alignedPath);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/source/LastQueryScanNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/source/LastQueryScanNode.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.path.PathDeserializeUtil;
 import org.apache.iotdb.db.queryengine.common.header.ColumnHeaderConstant;
+import org.apache.iotdb.db.queryengine.execution.MemoryEstimationHelper;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeType;
@@ -30,6 +31,7 @@ import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeUtil;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanVisitor;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 import org.eclipse.jetty.util.StringUtil;
 
@@ -41,6 +43,9 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class LastQueryScanNode extends LastSeriesSourceNode {
+
+  private static final long INSTANCE_SIZE =
+      RamUsageEstimator.shallowSizeOfInstance(LastQueryScanNode.class);
 
   public static final List<String> LAST_QUERY_HEADER_COLUMNS =
       ImmutableList.of(
@@ -228,5 +233,13 @@ public class LastQueryScanNode extends LastSeriesSourceNode {
     } else {
       return outputViewPath;
     }
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return INSTANCE_SIZE
+        + MemoryEstimationHelper.getEstimatedSizeOfAccountableObject(id)
+        + MemoryEstimationHelper.getEstimatedSizeOfPartialPath(seriesPath)
+        + RamUsageEstimator.sizeOf(outputViewPath);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/source/SeriesAggregationScanNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/source/SeriesAggregationScanNode.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.path.PathDeserializeUtil;
+import org.apache.iotdb.db.queryengine.execution.MemoryEstimationHelper;
 import org.apache.iotdb.db.queryengine.plan.expression.Expression;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
@@ -34,6 +35,7 @@ import org.apache.iotdb.db.queryengine.plan.planner.plan.parameter.GroupByTimePa
 import org.apache.iotdb.db.queryengine.plan.statement.component.Ordering;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 
 import javax.annotation.Nullable;
@@ -61,6 +63,9 @@ import java.util.Objects;
  * meaningless.
  */
 public class SeriesAggregationScanNode extends SeriesAggregationSourceNode {
+
+  private static final long INSTANCE_SIZE =
+      RamUsageEstimator.shallowSizeOfInstance(SeriesAggregationScanNode.class);
 
   // The path of the target series which will be aggregated.
   private final MeasurementPath seriesPath;
@@ -296,5 +301,12 @@ public class SeriesAggregationScanNode extends SeriesAggregationSourceNode {
         this.getSeriesPath(),
         this.getAggregationDescriptorList(),
         PlanNodeUtil.printRegionReplicaSet(this.getRegionReplicaSet()));
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return INSTANCE_SIZE
+        + MemoryEstimationHelper.getEstimatedSizeOfAccountableObject(id)
+        + MemoryEstimationHelper.getEstimatedSizeOfPartialPath(seriesPath);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/source/SeriesScanNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/source/SeriesScanNode.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.path.PathDeserializeUtil;
+import org.apache.iotdb.db.queryengine.execution.MemoryEstimationHelper;
 import org.apache.iotdb.db.queryengine.plan.expression.Expression;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
@@ -31,6 +32,7 @@ import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanVisitor;
 import org.apache.iotdb.db.queryengine.plan.statement.component.Ordering;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 
 import javax.annotation.Nullable;
@@ -49,6 +51,9 @@ import java.util.Objects;
  * <p>Children type: no child is allowed for SeriesScanNode
  */
 public class SeriesScanNode extends SeriesScanSourceNode {
+
+  private static final long INSTANCE_SIZE =
+      RamUsageEstimator.shallowSizeOfInstance(SeriesScanNode.class);
 
   // The path of the target series which will be scanned.
   private final MeasurementPath seriesPath;
@@ -194,5 +199,12 @@ public class SeriesScanNode extends SeriesScanSourceNode {
   @Override
   public PartialPath getPartitionPath() {
     return getSeriesPath();
+  }
+
+  @Override
+  public long ramBytesUsed() {
+    return INSTANCE_SIZE
+        + MemoryEstimationHelper.getEstimatedSizeOfAccountableObject(id)
+        + MemoryEstimationHelper.getEstimatedSizeOfPartialPath(seriesPath);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/source/SeriesSourceNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/source/SeriesSourceNode.java
@@ -23,7 +23,9 @@ import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.queryengine.plan.expression.Expression;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
 
-public abstract class SeriesSourceNode extends SourceNode {
+import org.apache.tsfile.utils.Accountable;
+
+public abstract class SeriesSourceNode extends SourceNode implements Accountable {
   protected SeriesSourceNode(PlanNodeId id) {
     super(id);
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/ErrorHandlingUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/ErrorHandlingUtils.java
@@ -28,6 +28,7 @@ import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.exception.query.QueryTimeoutRuntimeException;
 import org.apache.iotdb.db.exception.sql.SemanticException;
 import org.apache.iotdb.db.protocol.thrift.OperationType;
+import org.apache.iotdb.db.queryengine.exception.MemoryNotEnoughException;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
 
@@ -147,6 +148,8 @@ public class ErrorHandlingUtils {
             ((IoTDBException) t.getCause()).getErrorCode(), rootCause.getMessage());
       }
       return RpcUtils.getStatus(TSStatusCode.SEMANTIC_ERROR, rootCause.getMessage());
+    } else if (t instanceof MemoryNotEnoughException) {
+      return RpcUtils.getStatus(TSStatusCode.QUOTA_MEM_QUERY_NOT_ENOUGH, rootCause.getMessage());
     }
 
     if (t instanceof RuntimeException && rootCause instanceof IoTDBException) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/analyze/ExpressionAnalyzerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/analyze/ExpressionAnalyzerTest.java
@@ -22,6 +22,8 @@ package org.apache.iotdb.db.queryengine.plan.analyze;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.path.PathPatternTree;
+import org.apache.iotdb.db.queryengine.common.MPPQueryContext;
+import org.apache.iotdb.db.queryengine.common.QueryId;
 import org.apache.iotdb.db.queryengine.common.schematree.ISchemaTree;
 
 import org.junit.Test;
@@ -55,7 +57,8 @@ public class ExpressionAnalyzerTest {
             and(gt(timeSeries("s1"), intValue("1")), gt(timeSeries("s2"), intValue("1"))),
             prefixPaths,
             fakeSchemaTree,
-            true));
+            true,
+            new MPPQueryContext(new QueryId("test"))));
 
     assertEquals(
         Arrays.asList(
@@ -79,6 +82,7 @@ public class ExpressionAnalyzerTest {
             count(and(gt(timeSeries("s1"), intValue("1")), gt(timeSeries("s2"), intValue("1")))),
             prefixPaths,
             fakeSchemaTree,
-            true));
+            true,
+            new MPPQueryContext(new QueryId("test"))));
   }
 }


### PR DESCRIPTION
This PR mainly introduces a memory control mechanism during the query planning stage. Currently, the IoTDB query engine does not implement memory control at the FE (Frontend) stage. In scenarios with massive series queries (e.g., select * from root.**), the query plans generated at the FE stage can become excessively large. Roughly estimating, the size of a single SeriesScanNode is about 1/2 KB, which means that two million series corresponding to two million SeriesScanNodes would occupy 1 GB, posing a potential risk of Out-Of-Memory (OOM). In high concurrency scenarios, even if a single query plan is not large, the total memory occupied by multiple query plans can still lead to OOM.
Therefore, it is now desired to introduce memory size control for FE query plans within the query engine.
Related docs：https://apache-iotdb.feishu.cn/docx/F7nidsysKofhO4xTi35cuDhynCh