### PR TITLE
Avoid infinite and unecessary loop when CN RPC processors are killed/interrupted by OS

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ClusterManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ClusterManager.java
@@ -63,7 +63,7 @@ public class ClusterManager {
         Thread.sleep(100);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
-        LOGGER.warn("Unexpected interruption during waiting for configNode leader ready.");
+        LOGGER.warn("Unexpected interruption during waiting for get cluster id.");
         break;
       }
     }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ClusterManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ClusterManager.java
@@ -63,6 +63,8 @@ public class ClusterManager {
         Thread.sleep(100);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
+        LOGGER.warn("Unexpected interruption during waiting for configNode leader ready.");
+        break;
       }
     }
     return clusterInfo.getClusterId();

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/consensus/ConsensusManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/consensus/ConsensusManager.java
@@ -408,6 +408,7 @@ public class ConsensusManager {
           } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             LOGGER.warn("Unexpected interruption during waiting for configNode leader ready.");
+            break;
           }
         }
         result.setMessage(


### PR DESCRIPTION
We found that in some scenarios, when the `stop-confignode.sh` command is executed, confignode does not exit immediately, but hangs for about 90 seconds, printing more than 3 million "Unexpected interruption during waiting for configNode leader ready." warning logs.

This problem is because in the code modified by this PR, the RPC thread of confignode will continue to sleep in the while loop. When the confignode process is killed, the OS will continuously try to interrupt the sleep thread, causing the sleep thread to be continuously interrupted and print logs in the while loop.

So we check the confignode for all threads that are sleeping in the while loop. If these threads will only be interrupted during shutdown during their life cycle, then they need to jump out of the while loop when they are interrupted to avoid infinite log printing and stop-confignode lags.

for detailed info, see https://jira.infra.timecho.com:8443/browse/TIMECHODB-750