### PR TITLE
Fix error compare method in IT framework

### DIFF
--- a/integration-test/src/main/java/org/apache/iotdb/itbase/runtime/RequestDelegate.java
+++ b/integration-test/src/main/java/org/apache/iotdb/itbase/runtime/RequestDelegate.java
@@ -79,11 +79,35 @@ public abstract class RequestDelegate<T> {
     T data = results.get(0);
     for (int i = 1; i < results.size(); i++) {
       T anotherData = results.get(i);
-      if (!Objects.equals(data, anotherData)) {
+      if (!compare(data, anotherData)) {
         throw new InconsistentDataException(results, endpoints);
       }
     }
     return data;
+  }
+
+  private boolean compare(T data, T anotherData) {
+    if (data instanceof byte[] && anotherData instanceof byte[]) {
+      return Arrays.equals((byte[]) data, (byte[]) anotherData);
+    } else if (data instanceof short[] && anotherData instanceof short[]) {
+      return Arrays.equals((short[]) data, (short[]) anotherData);
+    } else if (data instanceof int[] && anotherData instanceof int[]) {
+      return Arrays.equals((int[]) data, (int[]) anotherData);
+    } else if (data instanceof long[] && anotherData instanceof long[]) {
+      return Arrays.equals((long[]) data, (long[]) anotherData);
+    } else if (data instanceof char[] && anotherData instanceof char[]) {
+      return Arrays.equals((char[]) data, (char[]) anotherData);
+    } else if (data instanceof float[] && anotherData instanceof float[]) {
+      return Arrays.equals((float[]) data, (float[]) anotherData);
+    } else if (data instanceof double[] && anotherData instanceof double[]) {
+      return Arrays.equals((double[]) data, (double[]) anotherData);
+    } else if (data instanceof boolean[] && anotherData instanceof boolean[]) {
+      return Arrays.equals((boolean[]) data, (boolean[]) anotherData);
+    } else if (data instanceof Object[] && anotherData instanceof Object[]) {
+      return Arrays.equals((Object[]) data, (Object[]) anotherData);
+    } else {
+      return Objects.equals(data, anotherData);
+    }
   }
 
   protected void handleExceptions(Exception[] exceptions) throws SQLException {


### PR DESCRIPTION
## Description

As shown in the figure, using Objects.equals returns the wrong result when T is a byte array. 

Arrays.equals should be used to compare array objects.

![img_v3_02b7_f5741319-dfcf-4523-b496-4846b8aadb2g](https://github.com/apache/iotdb/assets/43774645/0d2c6fe5-9d0b-474f-9650-95f7f5ab9479)