### PR TITLE
Fixed an issue where LoadSnapshot could cause out-of-heap memory statistics to leak

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/StorageEngine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/StorageEngine.java
@@ -817,8 +817,9 @@ public class StorageEngine implements IService {
   public void setDataRegion(DataRegionId regionId, DataRegion newRegion) {
     if (dataRegionMap.containsKey(regionId)) {
       DataRegion oldRegion = dataRegionMap.get(regionId);
-      oldRegion.syncCloseAllWorkingTsFileProcessors();
+      oldRegion.markDeleted();
       oldRegion.abortCompaction();
+      oldRegion.syncCloseAllWorkingTsFileProcessors();
     }
     dataRegionMap.put(regionId, newRegion);
   }


### PR DESCRIPTION
just as title said

![img_v3_02ba_953383a1-bd20-4170-9976-1f4ba6aa3b0g](https://github.com/apache/iotdb/assets/32640567/7ed77bff-bcbe-4cd6-ae2d-0d5468ffbf6b)
