### PR TITLE
Fix AuditLogger may cause IoTDB read only when session using incorrect password

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/audit/AuditLogger.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/audit/AuditLogger.java
@@ -90,9 +90,9 @@ public class AuditLogger {
     insertStatement.setAligned(false);
     insertStatement.setValues(
         new Object[] {
-          new Binary(log, TSFileConfig.STRING_CHARSET),
-          new Binary(username, TSFileConfig.STRING_CHARSET),
-          new Binary(address, TSFileConfig.STRING_CHARSET)
+          new Binary(log == null ? "null" : log, TSFileConfig.STRING_CHARSET),
+          new Binary(address == null ? "null" : address, TSFileConfig.STRING_CHARSET),
+          new Binary(username == null ? "null" : username, TSFileConfig.STRING_CHARSET)
         });
     insertStatement.setDataTypes(
         new TSDataType[] {TSDataType.TEXT, TSDataType.TEXT, TSDataType.TEXT});

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/audit/AuditLogger.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/audit/AuditLogger.java
@@ -91,8 +91,8 @@ public class AuditLogger {
     insertStatement.setValues(
         new Object[] {
           new Binary(log == null ? "null" : log, TSFileConfig.STRING_CHARSET),
-          new Binary(address == null ? "null" : address, TSFileConfig.STRING_CHARSET),
-          new Binary(username == null ? "null" : username, TSFileConfig.STRING_CHARSET)
+          new Binary(username == null ? "null" : username, TSFileConfig.STRING_CHARSET),
+          new Binary(address == null ? "null" : address, TSFileConfig.STRING_CHARSET)
         });
     insertStatement.setDataTypes(
         new TSDataType[] {TSDataType.TEXT, TSDataType.TEXT, TSDataType.TEXT});


### PR DESCRIPTION
As title.