### PR TITLE
JDBC: Support different charsets

### DIFF
--- a/example/jdbc/src/main/java/org/apache/iotdb/JDBCCharsetExample.java
+++ b/example/jdbc/src/main/java/org/apache/iotdb/JDBCCharsetExample.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb;
+
+import org.apache.iotdb.jdbc.IoTDBSQLException;
+import org.apache.iotdb.jdbc.charset.IoTDBCharsetConstant;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.UnsupportedEncodingException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class JDBCCharsetExample {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JDBCCharsetExample.class);
+
+  public static void main(String[] args) throws ClassNotFoundException, SQLException {
+    Class.forName("org.apache.iotdb.jdbc.IoTDBDriver");
+    try (Connection connection =
+            DriverManager.getConnection(
+                "jdbc:iotdb://127.0.0.1:6667?charset=GB18030", "root", "root");
+        Statement statement = connection.createStatement()) {
+
+      String sql = "CREATE TIMESERIES root.数据库.设备.测点 WITH DATATYPE=TEXT";
+      String sqlGB18030 =
+          new String(sql.getBytes(IoTDBCharsetConstant.GB18030), IoTDBCharsetConstant.GB18030);
+
+      statement.execute(sqlGB18030);
+
+      ResultSet resultSet = statement.executeQuery("select ** from root");
+      outputResult(resultSet);
+    } catch (IoTDBSQLException e) {
+      LOGGER.error("IoTDB Jdbc Charset example error", e);
+    } catch (UnsupportedEncodingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static void outputResult(ResultSet resultSet) throws SQLException {
+    if (resultSet != null) {
+      System.out.println("--------------------------");
+      final ResultSetMetaData metaData = resultSet.getMetaData();
+      final int columnCount = metaData.getColumnCount();
+      for (int i = 0; i < columnCount; i++) {
+        System.out.print(metaData.getColumnLabel(i + 1) + " ");
+      }
+      System.out.println();
+      while (resultSet.next()) {
+        for (int i = 1; ; i++) {
+          System.out.print(resultSet.getString(i));
+          if (i < columnCount) {
+            System.out.print(", ");
+          } else {
+            System.out.println();
+            break;
+          }
+        }
+      }
+      System.out.println("--------------------------\n");
+    }
+  }
+}

--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/AbstractIoTDBJDBCResultSet.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/AbstractIoTDBJDBCResultSet.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.jdbc;
 
+import org.apache.iotdb.jdbc.charset.IoTDBCharsetUtils;
 import org.apache.iotdb.rpc.IoTDBJDBCDataSet;
 import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
@@ -65,6 +66,7 @@ public abstract class AbstractIoTDBJDBCResultSet implements ResultSet {
   private boolean isRpcFetchResult = true;
   private List<String> sgColumns;
   private BitSet aliasColumnMap;
+  protected final String charset;
 
   @SuppressWarnings("squid:S107") // ignore Methods should not have too many parameters
   public AbstractIoTDBJDBCResultSet(
@@ -102,6 +104,7 @@ public abstract class AbstractIoTDBJDBCResultSet implements ResultSet {
     this.statement = statement;
     this.columnTypeList = columnTypeList;
     this.aliasColumnMap = aliasColumnMap;
+    this.charset = ((IoTDBStatement) statement).getCharset();
   }
 
   @SuppressWarnings("squid:S107") // ignore Methods should not have too many parameters
@@ -137,6 +140,7 @@ public abstract class AbstractIoTDBJDBCResultSet implements ResultSet {
     this.statement = statement;
     this.columnTypeList = columnTypeList;
     this.isRpcFetchResult = isRpcFetchResult;
+    this.charset = ((IoTDBStatement) statement).getCharset();
   }
 
   @Override
@@ -192,7 +196,8 @@ public abstract class AbstractIoTDBJDBCResultSet implements ResultSet {
 
   @Override
   public int findColumn(String columnName) {
-    return ioTDBRpcDataSet.findColumn(columnName);
+    String columnNameUtf8 = IoTDBCharsetUtils.convertToUTF8(columnName, charset);
+    return ioTDBRpcDataSet.findColumn(columnNameUtf8);
   }
 
   @Override
@@ -282,7 +287,8 @@ public abstract class AbstractIoTDBJDBCResultSet implements ResultSet {
   @Override
   public boolean getBoolean(String columnName) throws SQLException {
     try {
-      return ioTDBRpcDataSet.getBoolean(columnName);
+      String columnNameUtf8 = IoTDBCharsetUtils.convertToUTF8(columnName, charset);
+      return ioTDBRpcDataSet.getBoolean(columnNameUtf8);
     } catch (StatementExecutionException e) {
       throw new SQLException(e.getMessage());
     }
@@ -345,7 +351,8 @@ public abstract class AbstractIoTDBJDBCResultSet implements ResultSet {
 
   @Override
   public Date getDate(String columnName) throws SQLException {
-    return getDate(findColumn(columnName));
+    String columnNameUtf8 = IoTDBCharsetUtils.convertToUTF8(columnName, charset);
+    return getDate(findColumn(columnNameUtf8));
   }
 
   @Override
@@ -370,7 +377,8 @@ public abstract class AbstractIoTDBJDBCResultSet implements ResultSet {
   @Override
   public double getDouble(String columnName) throws SQLException {
     try {
-      return ioTDBRpcDataSet.getDouble(columnName);
+      String columnNameUtf8 = IoTDBCharsetUtils.convertToUTF8(columnName, charset);
+      return ioTDBRpcDataSet.getDouble(columnNameUtf8);
     } catch (StatementExecutionException e) {
       throw new SQLException(e.getMessage());
     }
@@ -408,7 +416,8 @@ public abstract class AbstractIoTDBJDBCResultSet implements ResultSet {
   @Override
   public float getFloat(String columnName) throws SQLException {
     try {
-      return ioTDBRpcDataSet.getFloat(columnName);
+      String columnNameUtf8 = IoTDBCharsetUtils.convertToUTF8(columnName, charset);
+      return ioTDBRpcDataSet.getFloat(columnNameUtf8);
     } catch (StatementExecutionException e) {
       throw new SQLException(e.getMessage());
     }
@@ -431,7 +440,8 @@ public abstract class AbstractIoTDBJDBCResultSet implements ResultSet {
   @Override
   public int getInt(String columnName) throws SQLException {
     try {
-      return ioTDBRpcDataSet.getInt(columnName);
+      String columnNameUtf8 = IoTDBCharsetUtils.convertToUTF8(columnName, charset);
+      return ioTDBRpcDataSet.getInt(columnNameUtf8);
     } catch (StatementExecutionException e) {
       throw new SQLException(e.getMessage());
     }
@@ -596,7 +606,8 @@ public abstract class AbstractIoTDBJDBCResultSet implements ResultSet {
 
   @Override
   public String getString(String columnName) throws SQLException {
-    return getValueByName(columnName);
+    String columnNameUtf8 = IoTDBCharsetUtils.convertToUTF8(columnName, charset);
+    return getValueByName(columnNameUtf8);
   }
 
   @Override

--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/Config.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/Config.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.jdbc;
 
 import org.apache.iotdb.jdbc.Constant.Version;
+import org.apache.iotdb.jdbc.charset.IoTDBCharsetConstant;
 
 public class Config {
 
@@ -78,4 +79,9 @@ public class Config {
   public static final String TRUST_STORE = "trust_store";
 
   public static final String TRUST_STORE_PWD = "trust_store_pwd";
+
+  /** Key of the charset. */
+  public static final String CHARSET = "charset";
+
+  public static final String DEFAULT_CHARSET = IoTDBCharsetConstant.UTF_8;
 }

--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
@@ -91,6 +91,7 @@ public class IoTDBConnection implements Connection {
   private ZoneId zoneId;
   private boolean autoCommit;
   private String url;
+  private String charset;
 
   public String getUserName() {
     return userName;
@@ -111,6 +112,7 @@ public class IoTDBConnection implements Connection {
     this.userName = info.get("user").toString();
     this.networkTimeout = params.getNetworkTimeout();
     this.zoneId = ZoneId.of(params.getTimeZone());
+    this.charset = params.getCharset();
     openTransport();
     if (Config.rpcThriftCompressionEnable) {
       setClient(new IClientRPCService.Client(new TCompactProtocol(transport)));
@@ -587,5 +589,9 @@ public class IoTDBConnection implements Connection {
 
   public ServerProperties getServerProperties() throws TException {
     return getClient().getProperties();
+  }
+
+  public String getCharset() {
+    return charset;
   }
 }

--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnectionParams.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnectionParams.java
@@ -45,6 +45,8 @@ public class IoTDBConnectionParams {
   private String trustStore;
   private String trustStorePwd;
 
+  private String charset = Config.DEFAULT_CHARSET;
+
   public IoTDBConnectionParams(String url) {
     this.jdbcUriString = url;
   }
@@ -163,5 +165,13 @@ public class IoTDBConnectionParams {
 
   public void setTrustStorePwd(String trustStorePwd) {
     this.trustStorePwd = trustStorePwd;
+  }
+
+  public String getCharset() {
+    return charset;
+  }
+
+  public void setCharset(String charset) {
+    this.charset = charset;
   }
 }

--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBPreparedStatement.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBPreparedStatement.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.jdbc;
 
+import org.apache.iotdb.jdbc.charset.IoTDBCharsetUtils;
 import org.apache.iotdb.service.rpc.thrift.IClientRPCService.Iface;
 
 import org.apache.thrift.TException;
@@ -75,7 +76,7 @@ public class IoTDBPreparedStatement extends IoTDBStatement implements PreparedSt
       IoTDBConnection connection, Iface client, Long sessionId, String sql, ZoneId zoneId)
       throws SQLException {
     super(connection, client, sessionId, zoneId);
-    this.sql = sql;
+    this.sql = IoTDBCharsetUtils.convertToUTF8(sql, charset);
   }
 
   @Override
@@ -880,11 +881,14 @@ public class IoTDBPreparedStatement extends IoTDBStatement implements PreparedSt
 
   @Override
   public void setString(int parameterIndex, String x) {
+    String xUtf8 = IoTDBCharsetUtils.convertToUTF8(x, charset);
     // if the sql is insert and the value is not a string literal, add double quotes
-    if (sql.trim().toUpperCase().startsWith("INSERT") && !x.startsWith("\"") && !x.endsWith("'")) {
-      this.parameters.put(parameterIndex, "\"" + x + "\"");
+    if (sql.trim().toUpperCase().startsWith("INSERT")
+        && !xUtf8.startsWith("\"")
+        && !xUtf8.endsWith("'")) {
+      this.parameters.put(parameterIndex, "\"" + xUtf8 + "\"");
     } else {
-      this.parameters.put(parameterIndex, x);
+      this.parameters.put(parameterIndex, xUtf8);
     }
   }
 

--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
@@ -105,7 +105,8 @@ public class IoTDBStatement implements Statement {
       long sessionId,
       ZoneId zoneId,
       int seconds,
-      long statementId) {
+      long statementId,
+      String charset) {
     this.connection = connection;
     this.client = client;
     this.sessionId = sessionId;
@@ -114,6 +115,7 @@ public class IoTDBStatement implements Statement {
     this.zoneId = zoneId;
     this.queryTimeout = seconds;
     this.stmtId = statementId;
+    this.charset = charset;
   }
 
   IoTDBStatement(

--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/Utils.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/Utils.java
@@ -25,6 +25,8 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.apache.iotdb.jdbc.Config.CHARSET;
+
 /** Utils to convert between thrift format and TsFile format. */
 public class Utils {
 
@@ -117,6 +119,10 @@ public class Utils {
       params.setTrustStorePwd(info.getProperty(Config.TRUST_STORE_PWD));
     }
 
+    if (info.containsKey(CHARSET)) {
+      params.setCharset(info.getProperty(Config.CHARSET));
+    }
+
     return params;
   }
 
@@ -154,6 +160,7 @@ public class Utils {
         case Config.TRUST_STORE_PWD:
         case Config.VERSION:
         case Config.NETWORK_TIMEOUT:
+        case Config.CHARSET:
           info.put(key, value);
           break;
         case Config.TIME_ZONE:

--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/charset/IoTDBCharsetConstant.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/charset/IoTDBCharsetConstant.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.jdbc.charset;
+
+public class IoTDBCharsetConstant {
+  private IoTDBCharsetConstant() {}
+
+  public static final String UTF_8 = "UTF-8";
+  public static final String GB18030 = "GB18030";
+}

--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/charset/IoTDBCharsetUtils.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/charset/IoTDBCharsetUtils.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.jdbc.charset;
+
+import java.nio.charset.Charset;
+import java.util.List;
+
+public class IoTDBCharsetUtils {
+
+  public static String convertToUTF8(String str, String charset) {
+    return charset.equalsIgnoreCase(IoTDBCharsetConstant.UTF_8)
+        ? str
+        : convertCharset(str, charset, IoTDBCharsetConstant.UTF_8);
+  }
+
+  public static String convertFromUTF8(String str, String charset) {
+    return charset.equalsIgnoreCase(IoTDBCharsetConstant.UTF_8)
+        ? str
+        : convertCharset(str, IoTDBCharsetConstant.UTF_8, charset);
+  }
+
+  public static List<String> convertBatchFromUTF8(List<String> strList, String charset) {
+    if (charset.equalsIgnoreCase(IoTDBCharsetConstant.UTF_8)) {
+      return strList;
+    }
+    strList.replaceAll(str -> convertCharset(str, IoTDBCharsetConstant.UTF_8, charset));
+    return strList;
+  }
+
+  public static String convertCharset(String str, String fromCharset, String toCharset) {
+    if (str == null) {
+      return null;
+    }
+
+    if (!Charset.isSupported(fromCharset) || !Charset.isSupported(toCharset)) {
+      throw new RuntimeException("Unsupported charset: " + fromCharset + " or " + toCharset);
+    }
+
+    try {
+      return new String(str.getBytes(fromCharset), toCharset);
+    } catch (Exception e) {
+      throw new RuntimeException(
+          "Failed to convert charset from " + fromCharset + " to " + toCharset, e);
+    }
+  }
+}

--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/charset/IoTDBCharsetUtils.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/charset/IoTDBCharsetUtils.java
@@ -25,39 +25,38 @@ import java.util.List;
 public class IoTDBCharsetUtils {
 
   public static String convertToUTF8(String str, String charset) {
-    return charset.equalsIgnoreCase(IoTDBCharsetConstant.UTF_8)
+    return IoTDBCharsetConstant.UTF_8.equalsIgnoreCase(charset)
         ? str
-        : convertCharset(str, charset, IoTDBCharsetConstant.UTF_8);
+        : convertToCharset(str, IoTDBCharsetConstant.UTF_8);
   }
 
   public static String convertFromUTF8(String str, String charset) {
     return charset.equalsIgnoreCase(IoTDBCharsetConstant.UTF_8)
         ? str
-        : convertCharset(str, IoTDBCharsetConstant.UTF_8, charset);
+        : convertToCharset(str, charset);
   }
 
   public static List<String> convertBatchFromUTF8(List<String> strList, String charset) {
     if (charset.equalsIgnoreCase(IoTDBCharsetConstant.UTF_8)) {
       return strList;
     }
-    strList.replaceAll(str -> convertCharset(str, IoTDBCharsetConstant.UTF_8, charset));
+    strList.replaceAll(str -> convertToCharset(str, charset));
     return strList;
   }
 
-  public static String convertCharset(String str, String fromCharset, String toCharset) {
+  public static String convertToCharset(String str, String charset) {
     if (str == null) {
       return null;
     }
 
-    if (!Charset.isSupported(fromCharset) || !Charset.isSupported(toCharset)) {
-      throw new RuntimeException("Unsupported charset: " + fromCharset + " or " + toCharset);
+    if (!Charset.isSupported(charset)) {
+      throw new RuntimeException("Unsupported charset: " + charset);
     }
 
     try {
-      return new String(str.getBytes(fromCharset), toCharset);
+      return new String(str.getBytes(charset), charset);
     } catch (Exception e) {
-      throw new RuntimeException(
-          "Failed to convert charset from " + fromCharset + " to " + toCharset, e);
+      throw new RuntimeException("Failed to convert charset to " + charset, e);
     }
   }
 }

--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/charset/IoTDBCharsetUtils.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/charset/IoTDBCharsetUtils.java
@@ -31,7 +31,7 @@ public class IoTDBCharsetUtils {
   }
 
   public static String convertFromUTF8(String str, String charset) {
-    return charset.equalsIgnoreCase(IoTDBCharsetConstant.UTF_8)
+    return IoTDBCharsetConstant.UTF_8.equalsIgnoreCase(charset)
         ? str
         : convertToCharset(str, charset);
   }

--- a/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/BatchTest.java
+++ b/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/BatchTest.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.jdbc;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
+import org.apache.iotdb.jdbc.charset.IoTDBCharsetConstant;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
@@ -59,7 +60,9 @@ public class BatchTest {
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
     when(connection.createStatement())
-        .thenReturn(new IoTDBStatement(connection, client, sessionId, zoneID, 0, 1L));
+        .thenReturn(
+            new IoTDBStatement(
+                connection, client, sessionId, zoneID, 0, 1L, IoTDBCharsetConstant.UTF_8));
   }
 
   @After

--- a/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBDatabaseMetadataTest.java
+++ b/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBDatabaseMetadataTest.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.jdbc;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
+import org.apache.iotdb.jdbc.charset.IoTDBCharsetConstant;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
@@ -69,7 +70,9 @@ public class IoTDBDatabaseMetadataTest {
     MockitoAnnotations.initMocks(this);
 
     when(connection.createStatement())
-        .thenReturn(new IoTDBStatement(connection, client, sessionId, zoneID, 0, 1L));
+        .thenReturn(
+            new IoTDBStatement(
+                connection, client, sessionId, zoneID, 0, 1L, IoTDBCharsetConstant.UTF_8));
     databaseMetaData = new IoTDBDatabaseMetadata(connection, client, sessionId, zoneID);
     when(client.executeStatementV2(any(TSExecuteStatementReq.class))).thenReturn(execStatementResp);
     when(client.getProperties()).thenReturn(properties);

--- a/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSetTest.java
+++ b/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSetTest.java
@@ -121,11 +121,6 @@ public class IoTDBJDBCResultSetTest {
   @Before
   public void before() throws Exception {
     MockitoAnnotations.initMocks(this);
-
-    statement = new IoTDBStatement(connection, client, sessionId, zoneID);
-
-    execResp.queryResult = FakedFirstFetchTsBlockResult();
-
     when(connection.getCharset()).thenReturn(IoTDBCharsetConstant.UTF_8);
     when(connection.isClosed()).thenReturn(false);
     when(client.executeStatementV2(any(TSExecuteStatementReq.class))).thenReturn(execResp);
@@ -140,6 +135,9 @@ public class IoTDBJDBCResultSetTest {
 
     TSStatus closeResp = successStatus;
     when(client.closeOperation(any(TSCloseOperationReq.class))).thenReturn(closeResp);
+
+    statement = new IoTDBStatement(connection, client, sessionId, zoneID);
+    execResp.queryResult = FakedFirstFetchTsBlockResult();
   }
 
   @SuppressWarnings("resource")

--- a/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSetTest.java
+++ b/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSetTest.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.jdbc;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
+import org.apache.iotdb.jdbc.charset.IoTDBCharsetConstant;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.service.rpc.thrift.IClientRPCService;
 import org.apache.iotdb.service.rpc.thrift.TSCloseOperationReq;
@@ -125,6 +126,7 @@ public class IoTDBJDBCResultSetTest {
 
     execResp.queryResult = FakedFirstFetchTsBlockResult();
 
+    when(connection.getCharset()).thenReturn(IoTDBCharsetConstant.UTF_8);
     when(connection.isClosed()).thenReturn(false);
     when(client.executeStatementV2(any(TSExecuteStatementReq.class))).thenReturn(execResp);
     when(execResp.getQueryId()).thenReturn(queryId);

--- a/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBPreparedStatementTest.java
+++ b/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBPreparedStatementTest.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.jdbc;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
+import org.apache.iotdb.jdbc.charset.IoTDBCharsetConstant;
 import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.service.rpc.thrift.IClientRPCService.Iface;
 import org.apache.iotdb.service.rpc.thrift.TSExecuteStatementReq;
@@ -62,6 +63,8 @@ public class IoTDBPreparedStatementTest {
     when(execStatementResp.getQueryId()).thenReturn(queryId);
 
     when(client.executeStatementV2(any(TSExecuteStatementReq.class))).thenReturn(execStatementResp);
+
+    when(connection.getCharset()).thenReturn(IoTDBCharsetConstant.UTF_8);
   }
 
   @SuppressWarnings("resource")

--- a/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBStatementTest.java
+++ b/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBStatementTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.jdbc;
 
+import org.apache.iotdb.jdbc.charset.IoTDBCharsetConstant;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.service.rpc.thrift.IClientRPCService.Iface;
 import org.apache.iotdb.service.rpc.thrift.TSFetchMetadataReq;
@@ -55,6 +56,7 @@ public class IoTDBStatementTest {
     MockitoAnnotations.initMocks(this);
     when(connection.getMetaData())
         .thenReturn(new IoTDBDatabaseMetadata(connection, client, sessionId, zoneID));
+    when(connection.getCharset()).thenReturn(IoTDBCharsetConstant.UTF_8);
     when(connection.isClosed()).thenReturn(false);
     when(client.fetchMetadata(any(TSFetchMetadataReq.class))).thenReturn(fetchMetadataResp);
     when(fetchMetadataResp.getStatus()).thenReturn(RpcUtils.SUCCESS_STATUS);


### PR DESCRIPTION
## Description
When initializing a connection, you can specify the charset type in the URL.

```java
try (Connection connection =
        DriverManager.getConnection(
            "jdbc:iotdb://127.0.0.1:6667?charset=GB18030", "root", "root");
    Statement statement = connection.createStatement())
```
The default charset of IoTDB is UTF-8, so the charset does't need to be set when the system default charset is UTF-8