### PR TITLE
Filter those time series metadata whose endTime is less than startTime

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/FileLoaderUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/FileLoaderUtils.java
@@ -192,8 +192,8 @@ public class FileLoaderUtils {
       if (alignedTimeSeriesMetadata != null) {
         final long t2 = System.nanoTime();
         try {
-          if (alignedTimeSeriesMetadata.getTimeseriesMetadata().getStatistics().getStartTime()
-              > alignedTimeSeriesMetadata.getTimeseriesMetadata().getStatistics().getEndTime()) {
+          if (alignedTimeSeriesMetadata.getStatistics().getStartTime()
+              > alignedTimeSeriesMetadata.getStatistics().getEndTime()) {
             return null;
           }
           if (globalTimeFilter != null && globalTimeFilter.canSkip(alignedTimeSeriesMetadata)) {


### PR DESCRIPTION
if there exists time series metadata whose endTime is less than startTime, it will cause query thread run into dead while-loop