### PR TITLE
Support special path for device TTL

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/TTLManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/TTLManager.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.utils.CommonDateTimeUtils;
+import org.apache.iotdb.commons.utils.PathUtils;
 import org.apache.iotdb.confignode.consensus.request.read.ttl.ShowTTLPlan;
 import org.apache.iotdb.confignode.consensus.request.write.database.DatabaseSchemaPlan;
 import org.apache.iotdb.confignode.consensus.request.write.database.SetTTLPlan;
@@ -38,7 +39,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Map;
 
 import static org.apache.iotdb.commons.conf.IoTDBConstant.ONE_LEVEL_PATH_WILDCARD;
-import static org.apache.tsfile.common.constant.TsFileConstant.PATH_SEPARATER_NO_REGEX;
 
 public class TTLManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(TTLManager.class);
@@ -55,7 +55,8 @@ public class TTLManager {
   }
 
   /** Set ttl when creating database. */
-  public TSStatus setTTL(DatabaseSchemaPlan databaseSchemaPlan, final boolean isGeneratedByPipe) {
+  public TSStatus setTTL(DatabaseSchemaPlan databaseSchemaPlan, final boolean isGeneratedByPipe)
+      throws IllegalPathException {
     long ttl = databaseSchemaPlan.getSchema().getTTL();
     if (ttl <= 0) {
       TSStatus errorStatus = new TSStatus(TSStatusCode.TTL_CONFIG_ERROR.getStatusCode());
@@ -68,7 +69,7 @@ public class TTLManager {
     ttl = ttl <= 0 ? Long.MAX_VALUE : ttl;
     SetTTLPlan setTTLPlan =
         new SetTTLPlan(
-            databaseSchemaPlan.getSchema().getName().split(PATH_SEPARATER_NO_REGEX), ttl);
+            PathUtils.splitPathToDetachedNodes(databaseSchemaPlan.getSchema().getName()), ttl);
     setTTLPlan.setDataBase(true);
     return configManager.getProcedureManager().setTTL(setTTLPlan, isGeneratedByPipe);
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/DataNodeInternalRPCServiceImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/DataNodeInternalRPCServiceImpl.java
@@ -1758,7 +1758,11 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
 
   @Override
   public TSStatus setTTL(TSetTTLReq req) throws TException {
-    return storageEngine.setTTL(req);
+    try {
+      return storageEngine.setTTL(req);
+    } catch (IllegalPathException e) {
+      return RpcUtils.getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR, e.getMessage());
+    }
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/source/DeviceSchemaSource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/source/DeviceSchemaSource.java
@@ -101,7 +101,7 @@ public class DeviceSchemaSource implements ISchemaSource<IDeviceSchemaInfo> {
         .getColumnBuilder(0)
         .writeBinary(new Binary(device.getFullPath(), TSFileConfig.STRING_CHARSET));
     int templateId = device.getTemplateId();
-    long ttl = DataNodeTTLCache.getInstance().getTTL(device.getFullPath());
+    long ttl = DataNodeTTLCache.getInstance().getTTL(device.getPartialPath().getNodes());
     // TODO: make it more readable, like "30 days" or "10 hours"
     String ttlStr = ttl == Long.MAX_VALUE ? IoTDBConstant.TTL_INFINITE : String.valueOf(ttl);
     if (hasSgCol) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/SeriesScanUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/SeriesScanUtil.java
@@ -175,7 +175,8 @@ public class SeriesScanUtil implements Accountable {
     this.dataSource = dataSource;
 
     // updated filter concerning TTL
-    scanOptions.setTTL(DataNodeTTLCache.getInstance().getTTL(seriesPath.getDevice()));
+    scanOptions.setTTL(
+        DataNodeTTLCache.getInstance().getTTL(seriesPath.getDevicePath().getNodes()));
 
     // init file index
     orderUtils.setCurSeqFileIndex(dataSource);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/executor/ClusterConfigTaskExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/executor/ClusterConfigTaskExecutor.java
@@ -31,6 +31,7 @@ import org.apache.iotdb.commons.client.exception.ClientManagerException;
 import org.apache.iotdb.commons.cluster.NodeStatus;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.consensus.ConfigRegionId;
+import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.exception.IoTDBException;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.executable.ExecutableManager;
@@ -355,7 +356,7 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
       TShowDatabaseResp resp = client.showDatabase(req);
       // build TSBlock
       showDatabaseStatement.buildTSBlock(resp.getDatabaseInfoMap(), future);
-    } catch (IOException | ClientManagerException | TException e) {
+    } catch (IOException | ClientManagerException | TException | IllegalPathException e) {
       future.setException(e);
     }
     return future;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/OperatorTreeGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/OperatorTreeGenerator.java
@@ -2625,7 +2625,7 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
     } else if (!LastQueryUtil.satisfyFilter(
         updateFilterUsingTTL(
             context.getGlobalTimeFilter(),
-            DataNodeTTLCache.getInstance().getTTL(seriesPath.getDevice())),
+            DataNodeTTLCache.getInstance().getTTL(seriesPath.getDevicePath().getNodes())),
         timeValuePair)) { // cached last value is not satisfied
 
       if (!isFilterGtOrGe(context.getGlobalTimeFilter())) {
@@ -2836,7 +2836,7 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
       } else if (!LastQueryUtil.satisfyFilter(
           updateFilterUsingTTL(
               context.getGlobalTimeFilter(),
-              DataNodeTTLCache.getInstance().getTTL(devicePath.getFullPath())),
+              DataNodeTTLCache.getInstance().getTTL(devicePath.getNodes())),
           timeValuePair)) { // cached last value is not satisfied
 
         if (!isFilterGtOrGe(context.getGlobalTimeFilter())) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/metadata/ShowDatabaseStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/metadata/ShowDatabaseStatement.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.queryengine.plan.statement.metadata;
 
 import org.apache.iotdb.commons.conf.IoTDBConstant;
+import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.schema.ttl.TTLCache;
 import org.apache.iotdb.confignode.rpc.thrift.TDatabaseInfo;
@@ -76,7 +77,8 @@ public class ShowDatabaseStatement extends ShowStatement implements IConfigState
   }
 
   public void buildTSBlock(
-      Map<String, TDatabaseInfo> storageGroupInfoMap, SettableFuture<ConfigTaskResult> future) {
+      Map<String, TDatabaseInfo> storageGroupInfoMap, SettableFuture<ConfigTaskResult> future)
+      throws IllegalPathException {
 
     List<TSDataType> outputDataTypes =
         isDetailed

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/metrics/CompactionMetrics.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/metrics/CompactionMetrics.java
@@ -926,7 +926,7 @@ public class CompactionMetrics implements IMetricSet {
             Metric.COMPACTION_TASK_SELECTION_COST.toString(),
             MetricLevel.IMPORTANT,
             Tag.NAME.toString(),
-            "insertion");
+            "settle");
     seqInnerSpaceCompactionTaskSelectedFileNum =
         metricService.getOrCreateHistogram(
             Metric.COMPACTION_TASK_SELECTED_FILE.toString(),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -873,7 +873,7 @@ public class DataRegion implements IDataRegionForQuery {
   public void insert(InsertRowNode insertRowNode) throws WriteProcessException {
     // reject insertions that are out of ttl
     long deviceTTL =
-        DataNodeTTLCache.getInstance().getTTL(insertRowNode.getDevicePath().getFullPath());
+        DataNodeTTLCache.getInstance().getTTL(insertRowNode.getDevicePath().getNodes());
     if (!isAlive(insertRowNode.getTime(), deviceTTL)) {
       throw new OutOfTTLException(
           insertRowNode.getTime(), (CommonDateTimeUtils.currentTime() - deviceTTL));
@@ -939,7 +939,7 @@ public class DataRegion implements IDataRegionForQuery {
       Arrays.fill(results, RpcUtils.SUCCESS_STATUS);
       boolean noFailure = true;
       long deviceTTL =
-          DataNodeTTLCache.getInstance().getTTL(insertTabletNode.getDevicePath().getFullPath());
+          DataNodeTTLCache.getInstance().getTTL(insertTabletNode.getDevicePath().getNodes());
 
       /*
        * assume that batch has been sorted by client
@@ -3227,7 +3227,7 @@ public class DataRegion implements IDataRegionForQuery {
       }
       long deviceTTL =
           DataNodeTTLCache.getInstance()
-              .getTTL(insertRowsOfOneDeviceNode.getDevicePath().getFullPath());
+              .getTTL(insertRowsOfOneDeviceNode.getDevicePath().getNodes());
       long[] costsForMetrics = new long[4];
       Map<TsFileProcessor, InsertRowsNode> tsFileProcessorMap = new HashMap<>();
       for (int i = 0; i < insertRowsOfOneDeviceNode.getInsertRowNodeList().size(); i++) {
@@ -3343,7 +3343,7 @@ public class DataRegion implements IDataRegionForQuery {
       for (int i = 0; i < insertRowsNode.getInsertRowNodeList().size(); i++) {
         InsertRowNode insertRowNode = insertRowsNode.getInsertRowNodeList().get(i);
         long deviceTTL =
-            DataNodeTTLCache.getInstance().getTTL(insertRowNode.getDevicePath().getFullPath());
+            DataNodeTTLCache.getInstance().getTTL(insertRowNode.getDevicePath().getNodes());
         if (!isAlive(insertRowNode.getTime(), deviceTTL)) {
           insertRowsNode
               .getResults()

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/performer/impl/FastCompactionPerformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/performer/impl/FastCompactionPerformer.java
@@ -131,13 +131,18 @@ public class FastCompactionPerformer
         sortedSourceFiles.addAll(seqFiles);
         sortedSourceFiles.addAll(unseqFiles);
         sortedSourceFiles.removeIf(
-            x ->
-                x.definitelyNotContains(device)
+            x -> {
+              try {
+                return x.definitelyNotContains(device)
                     || !x.isDeviceAlive(
                         device,
                         DataNodeTTLCache.getInstance()
                             // TODO: remove deviceId conversion
-                            .getTTL(((PlainDeviceID) device).toStringID())));
+                            .getTTL(((PlainDeviceID) device).toStringID()));
+              } catch (IllegalPathException e) {
+                throw new RuntimeException(e);
+              }
+            });
         sortedSourceFiles.sort(Comparator.comparingLong(x -> x.getStartTime(device)));
 
         if (sortedSourceFiles.isEmpty()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/MultiTsFileDeviceIterator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/MultiTsFileDeviceIterator.java
@@ -403,14 +403,14 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
               List<Modification> list =
                   new LinkedList<>(ModificationFile.getNormalMods(r).getModifications());
               // add outdated device mods by ttl
-              for (IDeviceID device : r.getDevices()) {
-                // TODO: remove deviceId conversion
-                long timeLowerBound =
-                    CommonDateTimeUtils.currentTime()
-                        - DataNodeTTLCache.getInstance()
-                            .getTTL(((PlainDeviceID) device).toStringID());
-                if (r.getStartTime(device) < timeLowerBound) {
-                  try {
+              try {
+                for (IDeviceID device : r.getDevices()) {
+                  // TODO: remove deviceId conversion
+                  long timeLowerBound =
+                      CommonDateTimeUtils.currentTime()
+                          - DataNodeTTLCache.getInstance()
+                              .getTTL(((PlainDeviceID) device).toStringID());
+                  if (r.getStartTime(device) < timeLowerBound) {
                     list.add(
                         new Deletion(
                             CompactionPathUtils.getPath(device)
@@ -418,10 +418,10 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
                             Long.MAX_VALUE,
                             Long.MIN_VALUE,
                             timeLowerBound));
-                  } catch (IllegalPathException e) {
-                    throw new RuntimeException(e);
                   }
                 }
+              } catch (IllegalPathException e) {
+                throw new RuntimeException(e);
               }
               return list;
             });
@@ -629,14 +629,14 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
                     List<Modification> list =
                         new LinkedList<>(ModificationFile.getNormalMods(r).getModifications());
                     // add outdated device mods by ttl
-                    for (IDeviceID device : r.getDevices()) {
-                      // TODO: remove deviceId conversion
-                      long timeLowerBound =
-                          CommonDateTimeUtils.currentTime()
-                              - DataNodeTTLCache.getInstance()
-                                  .getTTL(((PlainDeviceID) device).toStringID());
-                      if (r.getStartTime(device) < timeLowerBound) {
-                        try {
+                    try {
+                      for (IDeviceID device : r.getDevices()) {
+                        // TODO: remove deviceId conversion
+                        long timeLowerBound =
+                            CommonDateTimeUtils.currentTime()
+                                - DataNodeTTLCache.getInstance()
+                                    .getTTL(((PlainDeviceID) device).toStringID());
+                        if (r.getStartTime(device) < timeLowerBound) {
                           list.add(
                               new Deletion(
                                   CompactionPathUtils.getPath(device)
@@ -644,10 +644,10 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
                                   Long.MAX_VALUE,
                                   Long.MIN_VALUE,
                                   timeLowerBound));
-                        } catch (IllegalPathException e) {
-                          throw new RuntimeException(e);
                         }
                       }
+                    } catch (IllegalPathException e) {
+                      throw new RuntimeException(e);
                     }
                     return list;
                   });

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/utils/TsFileResourceUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/utils/TsFileResourceUtils.java
@@ -122,8 +122,8 @@ public class TsFileResourceUtils {
   }
 
   public static boolean validateTsFileIsComplete(TsFileResource resource) {
-    if (!resource.getTsFile().exists()
-        || resource.getTsFile().length()
+    if (resource.getTsFile().exists()
+        && resource.getTsFile().length()
             < TSFileConfig.MAGIC_STRING.getBytes().length * 2L + Byte.BYTES) {
       // the file does not exist or file size is smaller than magic string and version number
       logger.error(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/utils/TsFileResourceUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/utils/TsFileResourceUtils.java
@@ -125,7 +125,7 @@ public class TsFileResourceUtils {
     if (resource.getTsFile().exists()
         && resource.getTsFile().length()
             < TSFileConfig.MAGIC_STRING.getBytes().length * 2L + Byte.BYTES) {
-      // the file does not exist or file size is smaller than magic string and version number
+      // file size is smaller than magic string and version number
       logger.error(
           String.format(
               "target file %s is smaller than magic string and version number size", resource));

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/schema/SchemaQueryScanOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/schema/SchemaQueryScanOperatorTest.java
@@ -91,6 +91,7 @@ public class SchemaQueryScanOperatorTest {
           .thenReturn(META_SCAN_OPERATOR_TEST_SG + ".device0");
       Mockito.when(deviceSchemaInfo.isAligned()).thenReturn(false);
       Mockito.when(deviceSchemaInfo.getTemplateId()).thenReturn(-1);
+      Mockito.when(deviceSchemaInfo.getPartialPath()).thenReturn(partialPath);
       operatorContext.setDriverContext(
           new SchemaDriverContext(fragmentInstanceContext, schemaRegion, 0));
       ISchemaSource<IDeviceSchemaInfo> deviceSchemaSource =

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/settle/SettleCompactionTaskTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/settle/SettleCompactionTaskTest.java
@@ -330,11 +330,17 @@ public class SettleCompactionTaskTest extends AbstractCompactionTest {
         readSourceFiles(createTimeseries(6, 6, isAligned), Collections.emptyList());
 
     List<TsFileResource> selectedFiles = new ArrayList<>(seqResources);
-    selectedFiles.addAll(unseqResources);
 
     SettleCompactionTask task =
         new SettleCompactionTask(
             0, tsFileManager, Collections.emptyList(), selectedFiles, true, getPerformer(), 0);
+    Assert.assertTrue(task.start());
+
+    selectedFiles.clear();
+    selectedFiles.addAll(unseqResources);
+    task =
+        new SettleCompactionTask(
+            0, tsFileManager, Collections.emptyList(), selectedFiles, false, getPerformer(), 0);
     Assert.assertTrue(task.start());
 
     for (TsFileResource tsFileResource : seqResources) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/settle/SettleCompactionTaskTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/settle/SettleCompactionTaskTest.java
@@ -316,6 +316,42 @@ public class SettleCompactionTaskTest extends AbstractCompactionTest {
   }
 
   @Test
+  public void settleWithOnlyAllDirtyFilesByTTL2()
+      throws MetadataException, IOException, WriteProcessException {
+    createFiles(6, 5, 10, 100, 0, 0, 0, 0, isAligned, true);
+    createFiles(5, 2, 3, 50, 0, 10000, 50, 50, isAligned, false);
+
+    generateTTL(5, 10);
+
+    tsFileManager.addAll(seqResources, true);
+    tsFileManager.addAll(unseqResources, false);
+
+    Map<PartialPath, List<TimeValuePair>> sourceDatas =
+        readSourceFiles(createTimeseries(6, 6, isAligned), Collections.emptyList());
+
+    List<TsFileResource> selectedFiles = new ArrayList<>(seqResources);
+    selectedFiles.addAll(unseqResources);
+
+    SettleCompactionTask task =
+        new SettleCompactionTask(
+            0, tsFileManager, Collections.emptyList(), selectedFiles, true, getPerformer(), 0);
+    Assert.assertTrue(task.start());
+
+    for (TsFileResource tsFileResource : seqResources) {
+      Assert.assertEquals(TsFileResourceStatus.DELETED, tsFileResource.getStatus());
+    }
+    for (TsFileResource tsFileResource : unseqResources) {
+      Assert.assertEquals(TsFileResourceStatus.DELETED, tsFileResource.getStatus());
+    }
+
+    Assert.assertEquals(0, tsFileManager.getTsFileList(true).size());
+    Assert.assertEquals(0, tsFileManager.getTsFileList(false).size());
+
+    DataNodeTTLCache.getInstance().clearAllTTL();
+    validateTargetDatas(sourceDatas, Collections.emptyList());
+  }
+
+  @Test
   public void settleWithOnlyPartialDirtyFilesByTTL()
       throws IOException, MetadataException, WriteProcessException {
     createFiles(6, 5, 10, 100, 0, 0, 0, 0, isAligned, true);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/settle/SettleCompactionTaskTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/settle/SettleCompactionTaskTest.java
@@ -430,7 +430,7 @@ public class SettleCompactionTaskTest extends AbstractCompactionTest {
     return timeseriesPath;
   }
 
-  protected void generateTTL(int deviceNum, long ttl) {
+  protected void generateTTL(int deviceNum, long ttl) throws IllegalPathException {
     for (int dIndex = 0; dIndex < deviceNum; dIndex++) {
       DataNodeTTLCache.getInstance()
           .setTTL(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/schema/ttl/TTLCache.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/schema/ttl/TTLCache.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+/** TTL Cache Tree, which is a prefix B+ tree with each node storing TTL. */
 @NotThreadSafe
 public class TTLCache {
 


### PR DESCRIPTION
This pr accomplishes two things as following:
- support special path for device ttl, eg: `root.db.'test.device'`
- use a more efficient interface for DataNodeTTLCache.
