### PR TITLE
Add datatype check for restapi insertRecords and fix query bug

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/exception/metadata/DataTypeMismatchException.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/exception/metadata/DataTypeMismatchException.java
@@ -48,6 +48,19 @@ public class DataTypeMismatchException extends MetadataException {
             value == null ? "null" : processValue(value.toString())));
   }
 
+  public DataTypeMismatchException(
+      String deviceName, String measurementName, TSDataType insertType, long time, Object value) {
+    super(
+        String.format(
+            "data type and value of %s.%s is not consistent, "
+                + "inserting type %s, timestamp %s, value %s",
+            deviceName,
+            measurementName,
+            insertType,
+            time,
+            value == null ? "null" : processValue(value.toString())));
+  }
+
   private static String processValue(String value) {
     return value.length() < 100 ? value : value.substring(0, 100);
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/rest/utils/InsertRowDataUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/rest/utils/InsertRowDataUtils.java
@@ -25,6 +25,7 @@ import org.apache.tsfile.utils.Binary;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.iotdb.session.Session.MSG_UNSUPPORTED_DATA_TYPE;
 
@@ -68,7 +69,8 @@ public class InsertRowDataUtils {
     return valuesList.isEmpty();
   }
 
-  public static List<Object> reGenValues(List<TSDataType> types, List<Object> values)
+  public static List<Object> reGenValues(
+      List<TSDataType> types, List<Object> values, Map<Integer, Object> mismatchedInfo)
       throws IoTDBConnectionException {
     for (int i = 0; i < values.size(); i++) {
       if (values.get(i) == null) {
@@ -77,23 +79,38 @@ public class InsertRowDataUtils {
       Object val = values.get(i);
       switch (types.get(i)) {
         case BOOLEAN:
+          if (!(val instanceof Boolean)) {
+            mismatchedInfo.put(i, val);
+          }
+          break;
         case INT32:
         case DATE:
+          if (val instanceof Number) {
+            values.set(i, ((Number) val).intValue());
+          } else {
+            mismatchedInfo.put(i, val);
+          }
           break;
         case INT64:
         case TIMESTAMP:
           if (val instanceof Number) {
             values.set(i, ((Number) val).longValue());
+          } else {
+            mismatchedInfo.put(i, val);
           }
           break;
         case FLOAT:
           if (val instanceof Number) {
             values.set(i, ((Number) val).floatValue());
+          } else {
+            mismatchedInfo.put(i, val);
           }
           break;
         case DOUBLE:
           if (val instanceof Number) {
             values.set(i, ((Number) val).doubleValue());
+          } else {
+            mismatchedInfo.put(i, val);
           }
           break;
         case TEXT:
@@ -105,6 +122,7 @@ public class InsertRowDataUtils {
           throw new IoTDBConnectionException(MSG_UNSUPPORTED_DATA_TYPE + types.get(i));
       }
     }
+
     return values;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/utils/ResourceByPathUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/utils/ResourceByPathUtils.java
@@ -266,7 +266,8 @@ class AlignedResourceByPathUtils extends ResourceByPathUtils {
         // if all the sub sensors doesn't exist, it will be false
         boolean exits = false;
         for (List<ChunkMetadata> chunkMetadata : valueChunkMetadataList) {
-          boolean currentExist = i < chunkMetadata.size();
+          boolean currentExist =
+              i < chunkMetadata.size() && chunkMetadata.get(i).getNumOfPoints() > 0;
           exits = (exits || currentExist);
           valueChunkMetadata.add(currentExist ? chunkMetadata.get(i) : null);
         }


### PR DESCRIPTION
## Description

rest insertRecords api doesn't check whether is the datatype and  the value matching. This pr is fixing this issue.

Besides, this PR also fixed the bug that query may loop endlessly.