### PR TITLE
[IOTDB-6336] Add max retry time duration and whether to retry for unknown errors configurations

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -1824,6 +1824,9 @@ public class IoTDBDescriptor {
 
       // update Consensus config
       reloadConsensusProps(properties);
+
+      // update retry config
+      commonDescriptor.loadRetryProperties(properties);
     } catch (Exception e) {
       throw new QueryProcessException(String.format("Fail to reload configuration because %s", e));
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/AsyncPlanNodeSender.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/AsyncPlanNodeSender.java
@@ -44,7 +44,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class AsyncPlanNodeSender {
 
-  private static final Logger logger = LoggerFactory.getLogger(AsyncPlanNodeSender.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(AsyncPlanNodeSender.class);
   private final IClientManager<TEndPoint, AsyncDataNodeInternalServiceClient>
       asyncInternalServiceClientManager;
   private final List<FragmentInstance> instances;
@@ -116,14 +116,14 @@ public class AsyncPlanNodeSender {
       status = entry.getValue().getStatus();
       if (!entry.getValue().accepted) {
         if (status == null) {
-          logger.warn(
+          LOGGER.warn(
               "dispatch write failed. message: {}, node {}",
               entry.getValue().message,
               instances.get(entry.getKey()).getHostDataNode().getInternalEndPoint());
           failureStatusList.add(
               RpcUtils.getStatus(TSStatusCode.WRITE_PROCESS_ERROR, entry.getValue().getMessage()));
         } else {
-          logger.warn(
+          LOGGER.warn(
               "dispatch write failed. status: {}, code: {}, message: {}, node {}",
               entry.getValue().status,
               TSStatusCode.representOf(status.code),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/FragmentInstanceDispatcherImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/FragmentInstanceDispatcherImpl.java
@@ -25,6 +25,8 @@ import org.apache.iotdb.commons.client.IClientManager;
 import org.apache.iotdb.commons.client.async.AsyncDataNodeInternalServiceClient;
 import org.apache.iotdb.commons.client.exception.ClientManagerException;
 import org.apache.iotdb.commons.client.sync.SyncDataNodeInternalServiceClient;
+import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.consensus.ConsensusGroupId;
 import org.apache.iotdb.commons.service.metric.PerformanceOverviewMetrics;
 import org.apache.iotdb.consensus.exception.RatisReadUnavailableException;
@@ -66,8 +68,11 @@ import static org.apache.iotdb.db.queryengine.metric.QueryExecutionMetricSet.DIS
 
 public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
 
-  private static final Logger logger =
+  private static final Logger LOGGER =
       LoggerFactory.getLogger(FragmentInstanceDispatcherImpl.class);
+
+  private static final CommonConfig COMMON_CONFIG = CommonDescriptor.getInstance().getConfig();
+
   private final ExecutorService executor;
   private final ExecutorService writeOperationExecutor;
   private final QueryType type;
@@ -126,7 +131,7 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
       } catch (FragmentInstanceDispatchException e) {
         return immediateFuture(new FragInstanceDispatchResult(e.getFailureStatus()));
       } catch (Throwable t) {
-        logger.warn(DISPATCH_FAILED, t);
+        LOGGER.warn(DISPATCH_FAILED, t);
         return immediateFuture(
             new FragInstanceDispatchResult(
                 RpcUtils.getStatus(
@@ -165,7 +170,7 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
           }
         }
       } catch (Throwable t) {
-        logger.warn(DISPATCH_FAILED, t);
+        LOGGER.warn(DISPATCH_FAILED, t);
         failureStatusList.add(
             RpcUtils.getStatus(
                 TSStatusCode.INTERNAL_SERVER_ERROR, UNEXPECTED_ERRORS + t.getMessage()));
@@ -210,7 +215,7 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
         } catch (FragmentInstanceDispatchException e) {
           dataNodeFailureList.add(e.getFailureStatus());
         } catch (Throwable t) {
-          logger.warn(DISPATCH_FAILED, t);
+          LOGGER.warn(DISPATCH_FAILED, t);
           dataNodeFailureList.add(
               RpcUtils.getStatus(
                   TSStatusCode.INTERNAL_SERVER_ERROR, UNEXPECTED_ERRORS + t.getMessage()));
@@ -222,11 +227,10 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
     // wait until remote dispatch done
     try {
       asyncPlanNodeSender.waitUntilCompleted();
-
-      if (asyncPlanNodeSender.needRetry()) {
+      final int maxRetryTimes = COMMON_CONFIG.getRemoteWriteMaxRetryCount();
+      if (maxRetryTimes > 0 && asyncPlanNodeSender.needRetry()) {
         // retry failed remote FIs
         int retry = 0;
-        final int maxRetryTimes = 10;
         long waitMillis = getRetrySleepTime(retry);
 
         while (asyncPlanNodeSender.needRetry()) {
@@ -237,13 +241,14 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
           }
           // still need to retry, sleep some time before make another retry.
           Thread.sleep(waitMillis);
+          PERFORMANCE_OVERVIEW_METRICS.recordRemoteRetrySleepCost(waitMillis * 1_000_000L);
           waitMillis = getRetrySleepTime(retry);
         }
       }
 
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      logger.error("Interrupted when dispatching write async", e);
+      LOGGER.error("Interrupted when dispatching write async", e);
       return immediateFuture(
           new FragInstanceDispatchResult(
               RpcUtils.getStatus(
@@ -308,7 +313,7 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
           TSendFragmentInstanceResp sendFragmentInstanceResp =
               client.sendFragmentInstance(sendFragmentInstanceReq);
           if (!sendFragmentInstanceResp.accepted) {
-            logger.warn(sendFragmentInstanceResp.message);
+            LOGGER.warn(sendFragmentInstanceResp.message);
             if (sendFragmentInstanceResp.isSetNeedRetry()
                 && sendFragmentInstanceResp.isNeedRetry()) {
               throw new RatisReadUnavailableException(sendFragmentInstanceResp.message);
@@ -330,7 +335,7 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
           TSendSinglePlanNodeResp sendPlanNodeResp =
               client.sendBatchPlanNode(sendPlanNodeReq).getResponses().get(0);
           if (!sendPlanNodeResp.accepted) {
-            logger.warn(
+            LOGGER.warn(
                 "dispatch write failed. status: {}, code: {}, message: {}, node {}",
                 sendPlanNodeResp.status,
                 TSStatusCode.representOf(sendPlanNodeResp.status.code),
@@ -366,7 +371,7 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
     try {
       dispatchRemoteHelper(instance, endPoint);
     } catch (ClientManagerException | TException | RatisReadUnavailableException e) {
-      logger.warn(
+      LOGGER.warn(
           "can't execute request on node {}, error msg is {}, and we try to reconnect this node.",
           endPoint,
           ExceptionUtils.getRootCause(e).toString());
@@ -374,7 +379,7 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
       try {
         dispatchRemoteHelper(instance, endPoint);
       } catch (ClientManagerException | TException | RatisReadUnavailableException e1) {
-        logger.warn(
+        LOGGER.warn(
             "can't execute request on node  {} in second try, error msg is {}.",
             endPoint,
             ExceptionUtils.getRootCause(e1).toString());
@@ -398,7 +403,7 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
             ConsensusGroupId.Factory.createFromTConsensusGroupId(
                 instance.getRegionReplicaSet().getRegionId());
       } catch (Throwable t) {
-        logger.warn("Deserialize ConsensusGroupId failed. ", t);
+        LOGGER.warn("Deserialize ConsensusGroupId failed. ", t);
         throw new FragmentInstanceDispatchException(
             RpcUtils.getStatus(
                 TSStatusCode.EXECUTE_STATEMENT_ERROR,
@@ -414,7 +419,7 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
                 ? readExecutor.execute(instance)
                 : readExecutor.execute(groupId, instance);
         if (!readResult.isAccepted()) {
-          logger.warn(readResult.getMessage());
+          LOGGER.warn(readResult.getMessage());
           throw new FragmentInstanceDispatchException(
               RpcUtils.getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR, readResult.getMessage()));
         }
@@ -426,7 +431,7 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
         if (!writeResult.isAccepted()) {
           // DO NOT LOG READ_ONLY ERROR
           if (writeResult.getStatus().getCode() != TSStatusCode.SYSTEM_READ_ONLY.getStatusCode()) {
-            logger.warn(
+            LOGGER.warn(
                 "write locally failed. TSStatus: {}, message: {}",
                 writeResult.getStatus(),
                 writeResult.getMessage());

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties
@@ -1856,13 +1856,13 @@ data_replication_factor=1
 ### Retry Configuration
 ####################
 
-# The maximum times for retrying write request remotely dispatching.
+# The maximum retrying time for write request remotely dispatching, time unit is milliseconds.
 # It only takes effect for write request remotely dispatching, not including locally dispatching and query
 # Set to 0 or negative number to disable remote dispatching write request retrying
 # We will sleep for some time between each retry, 100ms, 200ms, 400ms, 800ms and so on, util reaching 20,000ms, we won't increase the sleeping time any more
 # effectiveMode: hot_reload
-# Datatype: int
-# write_request_remote_dispatch_max_retry_count=10
+# Datatype: long
+# write_request_remote_dispatch_max_retry_duration_in_ms=60000
 
 # Whether retrying for unknown errors.
 # Current unknown errors includes EXECUTE_STATEMENT_ERROR(301) and INTERNAL_SERVER_ERROR(305)

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties
@@ -1868,4 +1868,4 @@ data_replication_factor=1
 # Current unknown errors includes EXECUTE_STATEMENT_ERROR(301) and INTERNAL_SERVER_ERROR(305)
 # effectiveMode: hot_reload
 # Datatype: boolean
-# enable_retry_for_unknown_error=true
+# enable_retry_for_unknown_error=false

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties
@@ -1850,10 +1850,8 @@ data_replication_factor=1
 # Datatype: int
 # load_write_throughput_bytes_per_second=-1
 
-
-
 ####################
-### Retry Configuration
+### Dispatch Retry Configuration
 ####################
 
 # The maximum retrying time for write request remotely dispatching, time unit is milliseconds.

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties
@@ -1849,3 +1849,23 @@ data_replication_factor=1
 # Default value is -1, which means no limit.
 # Datatype: int
 # load_write_throughput_bytes_per_second=-1
+
+
+
+####################
+### Retry Configuration
+####################
+
+# The maximum times for retrying write request remotely dispatching.
+# It only takes effect for write request remotely dispatching, not including locally dispatching and query
+# Set to 0 or negative number to disable remote dispatching write request retrying
+# We will sleep for some time between each retry, 100ms, 200ms, 400ms, 800ms and so on, util reaching 20,000ms, we won't increase the sleeping time any more
+# effectiveMode: hot_reload
+# Datatype: int
+# write_request_remote_dispatch_max_retry_count=10
+
+# Whether retrying for unknown errors.
+# Current unknown errors includes EXECUTE_STATEMENT_ERROR(301) and INTERNAL_SERVER_ERROR(305)
+# effectiveMode: hot_reload
+# Datatype: boolean
+# enable_retry_for_unknown_error=true

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -280,6 +280,10 @@ public class CommonConfig {
   private final Set<String> enabledKillPoints =
       KillPoint.parseKillPoints(System.getProperty(IoTDBConstant.INTEGRATION_TEST_KILL_POINTS));
 
+  private volatile boolean retryForUnknownErrors = true;
+
+  private volatile int remoteWriteMaxRetryCount = 10;
+
   CommonConfig() {
     // Empty constructor
   }
@@ -1209,5 +1213,21 @@ public class CommonConfig {
 
   public Set<String> getEnabledKillPoints() {
     return enabledKillPoints;
+  }
+
+  public boolean isRetryForUnknownErrors() {
+    return retryForUnknownErrors;
+  }
+
+  public void setRetryForUnknownErrors(boolean retryForUnknownErrors) {
+    this.retryForUnknownErrors = retryForUnknownErrors;
+  }
+
+  public int getRemoteWriteMaxRetryCount() {
+    return remoteWriteMaxRetryCount;
+  }
+
+  public void setRemoteWriteMaxRetryCount(int remoteWriteMaxRetryCount) {
+    this.remoteWriteMaxRetryCount = remoteWriteMaxRetryCount;
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -282,7 +282,7 @@ public class CommonConfig {
 
   private volatile boolean retryForUnknownErrors = true;
 
-  private volatile int remoteWriteMaxRetryCount = 10;
+  private volatile long remoteWriteMaxRetryDurationInMs = 60000;
 
   CommonConfig() {
     // Empty constructor
@@ -1223,11 +1223,11 @@ public class CommonConfig {
     this.retryForUnknownErrors = retryForUnknownErrors;
   }
 
-  public int getRemoteWriteMaxRetryCount() {
-    return remoteWriteMaxRetryCount;
+  public long getRemoteWriteMaxRetryDurationInMs() {
+    return remoteWriteMaxRetryDurationInMs;
   }
 
-  public void setRemoteWriteMaxRetryCount(int remoteWriteMaxRetryCount) {
-    this.remoteWriteMaxRetryCount = remoteWriteMaxRetryCount;
+  public void setRemoteWriteMaxRetryDurationInMs(long remoteWriteMaxRetryDurationInMs) {
+    this.remoteWriteMaxRetryDurationInMs = remoteWriteMaxRetryDurationInMs;
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -280,7 +280,7 @@ public class CommonConfig {
   private final Set<String> enabledKillPoints =
       KillPoint.parseKillPoints(System.getProperty(IoTDBConstant.INTEGRATION_TEST_KILL_POINTS));
 
-  private volatile boolean retryForUnknownErrors = true;
+  private volatile boolean retryForUnknownErrors = false;
 
   private volatile long remoteWriteMaxRetryDurationInMs = 60000;
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -617,11 +617,11 @@ public class CommonDescriptor {
   }
 
   public void loadRetryProperties(Properties properties) {
-    config.setRemoteWriteMaxRetryCount(
-        Integer.parseInt(
+    config.setRemoteWriteMaxRetryDurationInMs(
+        Long.parseLong(
             properties.getProperty(
-                "write_request_remote_dispatch_max_retry_count",
-                String.valueOf(config.getRemoteWriteMaxRetryCount()))));
+                "write_request_remote_dispatch_max_retry_duration_in_ms",
+                String.valueOf(config.getRemoteWriteMaxRetryDurationInMs()))));
 
     config.setRetryForUnknownErrors(
         Boolean.parseBoolean(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -246,6 +246,8 @@ public class CommonDescriptor {
             properties.getProperty(
                 "cluster_device_limit_threshold",
                 String.valueOf(config.getDeviceLimitThreshold()))));
+
+    loadRetryProperties(properties);
   }
 
   private void loadPipeProps(Properties properties) {
@@ -612,6 +614,20 @@ public class CommonDescriptor {
             properties.getProperty(
                 "subscription_read_file_buffer_size",
                 String.valueOf(config.getSubscriptionReadFileBufferSize()))));
+  }
+
+  public void loadRetryProperties(Properties properties) {
+    config.setRemoteWriteMaxRetryCount(
+        Integer.parseInt(
+            properties.getProperty(
+                "write_request_remote_dispatch_max_retry_count",
+                String.valueOf(config.getRemoteWriteMaxRetryCount()))));
+
+    config.setRetryForUnknownErrors(
+        Boolean.parseBoolean(
+            properties.getProperty(
+                "enable_retry_for_unknown_error",
+                String.valueOf(config.isRetryForUnknownErrors()))));
   }
 
   public void loadGlobalConfig(TGlobalConfig globalConfig) {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/metric/PerformanceOverviewMetrics.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/metric/PerformanceOverviewMetrics.java
@@ -112,6 +112,8 @@ public class PerformanceOverviewMetrics implements IMetricSet {
   private static final String LOCAL_SCHEDULE = "local_scheduler";
   private static final String REMOTE_SCHEDULE = "remote_scheduler";
 
+  private static final String REMOTE_RETRY_SLEEP = "remote_retry";
+
   static {
     metricInfoMap.put(
         LOCAL_SCHEDULE,
@@ -127,10 +129,19 @@ public class PerformanceOverviewMetrics implements IMetricSet {
             PERFORMANCE_OVERVIEW_SCHEDULE_DETAIL,
             Tag.STAGE.toString(),
             REMOTE_SCHEDULE));
+    metricInfoMap.put(
+        REMOTE_RETRY_SLEEP,
+        new MetricInfo(
+            MetricType.TIMER,
+            PERFORMANCE_OVERVIEW_SCHEDULE_DETAIL,
+            Tag.STAGE.toString(),
+            REMOTE_RETRY_SLEEP));
   }
 
   private Timer localScheduleTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
   private Timer remoteScheduleTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
+
+  private Timer remoteRetrySleepTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
 
   /** Record the time cost of local schedule. */
   public void recordScheduleLocalCost(long costTimeInNanos) {
@@ -140,6 +151,11 @@ public class PerformanceOverviewMetrics implements IMetricSet {
   /** Record the time cost of remote schedule. */
   public void recordScheduleRemoteCost(long costTimeInNanos) {
     remoteScheduleTimer.updateNanos(costTimeInNanos);
+  }
+
+  /** Record the time cost of remote schedule. */
+  public void recordRemoteRetrySleepCost(long costTimeInNanos) {
+    remoteRetrySleepTimer.updateNanos(costTimeInNanos);
   }
 
   // endregion
@@ -327,6 +343,13 @@ public class PerformanceOverviewMetrics implements IMetricSet {
             MetricLevel.CORE,
             Tag.STAGE.toString(),
             REMOTE_SCHEDULE);
+    remoteRetrySleepTimer =
+        metricService.getOrCreateTimer(
+            PERFORMANCE_OVERVIEW_SCHEDULE_DETAIL,
+            MetricLevel.CORE,
+            Tag.STAGE.toString(),
+            REMOTE_RETRY_SLEEP);
+
     // bind local schedule metrics
     schemaValidateTimer =
         metricService.getOrCreateTimer(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/metric/PerformanceOverviewMetrics.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/metric/PerformanceOverviewMetrics.java
@@ -111,7 +111,6 @@ public class PerformanceOverviewMetrics implements IMetricSet {
       Metric.PERFORMANCE_OVERVIEW_SCHEDULE_DETAIL.toString();
   private static final String LOCAL_SCHEDULE = "local_scheduler";
   private static final String REMOTE_SCHEDULE = "remote_scheduler";
-
   private static final String REMOTE_RETRY_SLEEP = "remote_retry";
 
   static {
@@ -140,7 +139,6 @@ public class PerformanceOverviewMetrics implements IMetricSet {
 
   private Timer localScheduleTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
   private Timer remoteScheduleTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
-
   private Timer remoteRetrySleepTimer = DoNothingMetricManager.DO_NOTHING_TIMER;
 
   /** Record the time cost of local schedule. */


### PR DESCRIPTION
In this pr, we add two hot loaded configuration:

```
# The maximum retrying time for write request remotely dispatching, time unit is milliseconds.
# It only takes effect for write request remotely dispatching, not including locally dispatching and query
# Set to 0 or negative number to disable remote dispatching write request retrying
# We will sleep for some time between each retry, 100ms, 200ms, 400ms, 800ms and so on, util reaching 20,000ms, we won't increase the sleeping time any more
# effectiveMode: hot_reload
# Datatype: long
# write_request_remote_dispatch_max_retry_duration_in_ms=60000

# Whether retrying for unknown errors.
# Current unknown errors includes EXECUTE_STATEMENT_ERROR(301) and INTERNAL_SERVER_ERROR(305)
# effectiveMode: hot_reload
# Datatype: boolean
# enable_retry_for_unknown_error=false

```

And I also add metrics for retry sleeping time.


More details can be seen in https://issues.apache.org/jira/browse/IOTDB-6336