### PR TITLE
[IOTDB-6335] Redundant rows when using GROUP BY TIME with LIMIT

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/optimization/LimitOffsetPushDown.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/optimization/LimitOffsetPushDown.java
@@ -335,7 +335,8 @@ public class LimitOffsetPushDown implements PlanOptimizer {
       if (queryStatement.getResultTimeOrder() == Ordering.ASC) {
         startTime = startTime + offsetSize * step;
       } else {
-        startTime = startTime + (size - offsetSize - limitSize) * step;
+        long startTimeInterval = size - offsetSize - limitSize;
+        startTime = startTime + (startTimeInterval < 0 ? 0 : startTimeInterval) * step;
       }
       endTime =
           limitSize == 0

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/optimization/LimitOffsetPushDownTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/optimization/LimitOffsetPushDownTest.java
@@ -322,6 +322,34 @@ public class LimitOffsetPushDownTest {
     checkGroupByTimePushDown(sql, 154, 354, 0, 0);
   }
 
+  @Test
+  public void testGroupByTimePushDown12() {
+    String sql =
+        "select avg(s1),sum(s2) from root.** group by ([4, 899), 200ms) order by time desc limit 3";
+    checkGroupByTimePushDown(sql, 404, 899, 0, 0);
+  }
+
+  @Test
+  public void testGroupByTimePushDown13() {
+    String sql =
+        "select avg(s1),sum(s2) from root.** group by ([4, 899), 200ms) order by time desc limit 5";
+    checkGroupByTimePushDown(sql, 4, 899, 0, 0);
+  }
+
+  @Test
+  public void testGroupByTimePushDown14() {
+    String sql =
+        "select avg(s1),sum(s2) from root.** group by ([4, 899), 200ms) order by time desc offset 2 limit 5";
+    checkGroupByTimePushDown(sql, 4, 899, 0, 0);
+  }
+
+  @Test
+  public void testGroupByTimePushDown15() {
+    String sql =
+        "select avg(s1),sum(s2) from root.** group by ([4, 899), 200ms) order by time desc limit 6";
+    checkGroupByTimePushDown(sql, 4, 899, 0, 0);
+  }
+
   private void checkGroupByTimePushDown(
       String sql, long startTime, long endTime, long rowLimit, long rowOffset) {
     QueryStatement queryStatement =


### PR DESCRIPTION
Details in https://issues.apache.org/jira/browse/IOTDB-6335.
Wrong way to caculation new startTime leading to a negative value resultinng in redudant rows.