### PR TITLE
[IOTDB-6337] Refine the count calculation in RegionScan framework

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/regionscan/IoTDBActiveRegionScanIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/regionscan/IoTDBActiveRegionScanIT.java
@@ -286,6 +286,28 @@ public class IoTDBActiveRegionScanIT {
   }
 
   @Test
+  public void showActiveDeviceEmptyTest() {
+    String sql = "show devices root.empty where time < 50";
+    String[] retArray = new String[] {};
+    basicShowActiveDeviceTest(sql, SHOW_DEVICES_COLUMN_NAMES, retArray);
+
+    sql = "count devices root.empty where time < 50";
+    long value = 0;
+    basicCountActiveDeviceTest(sql, COUNT_DEVICES_COLUMN_NAMES, value);
+  }
+
+  @Test
+  public void showActiveTimeseriesEmptyTest() {
+    String sql = "show timeseries root.empty where time < 50";
+    String[] retArray = new String[] {};
+    basicShowActiveDeviceTest(sql, SHOW_TIMESERIES_COLUMN_NAMES, retArray);
+
+    sql = "count timeseries root.empty where time < 50";
+    long value = 0;
+    basicCountActiveDeviceTest(sql, COUNT_TIMESERIES_COLUMN_NAMES, value);
+  }
+
+  @Test
   public void showActiveTimeseriesTest() {
     String sql = "show timeseries where time = 4";
     String[] retArray =

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/regionscan/IoTDBActiveRegionScanIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/regionscan/IoTDBActiveRegionScanIT.java
@@ -461,7 +461,6 @@ public class IoTDBActiveRegionScanIT {
 
       try (ResultSet resultSet = statement.executeQuery(sql)) {
         ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
-        Map<String, Integer> map = new HashMap<>();
         assertEquals(1, resultSetMetaData.getColumnCount());
         assertEquals(columnName, resultSetMetaData.getColumnName(1));
         int cnt = 0;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/ActiveDeviceRegionScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/ActiveDeviceRegionScanOperator.java
@@ -51,7 +51,9 @@ public class ActiveDeviceRegionScanOperator extends AbstractRegionScanDataSource
       OperatorContext operatorContext,
       PlanNodeId sourceId,
       Map<IDeviceID, Boolean> deviceToAlignedMap,
-      Filter timeFilter) {
+      Filter timeFilter,
+      boolean outputCount) {
+    this.outputCount = outputCount;
     this.sourceId = sourceId;
     this.operatorContext = operatorContext;
     this.deviceToAlignedMap = deviceToAlignedMap;
@@ -70,26 +72,36 @@ public class ActiveDeviceRegionScanOperator extends AbstractRegionScanDataSource
 
   @Override
   protected void updateActiveData() {
-    TimeColumnBuilder timeColumnBuilder = resultTsBlockBuilder.getTimeColumnBuilder();
-    ColumnBuilder[] columnBuilders = resultTsBlockBuilder.getValueColumnBuilders();
-
     List<IDeviceID> activeDevices =
         ((RegionScanForActiveDeviceUtil) regionScanUtil).getActiveDevices();
-    for (IDeviceID deviceID : activeDevices) {
-      timeColumnBuilder.writeLong(-1);
-      columnBuilders[0].writeBinary(new Binary(deviceID.getBytes()));
-      columnBuilders[1].writeBinary(
-          new Binary(
-              String.valueOf(deviceToAlignedMap.get(deviceID)), TSFileConfig.STRING_CHARSET));
-      columnBuilders[2].appendNull();
-      columnBuilders[3].appendNull();
-      resultTsBlockBuilder.declarePosition();
-      deviceToAlignedMap.remove(deviceID);
+
+    if (this.outputCount) {
+      count += activeDevices.size();
+      activeDevices.forEach(deviceToAlignedMap.keySet()::remove);
+    } else {
+      TimeColumnBuilder timeColumnBuilder = resultTsBlockBuilder.getTimeColumnBuilder();
+      ColumnBuilder[] columnBuilders = resultTsBlockBuilder.getValueColumnBuilders();
+      for (IDeviceID deviceID : activeDevices) {
+        timeColumnBuilder.writeLong(-1);
+        columnBuilders[0].writeBinary(new Binary(deviceID.getBytes()));
+        columnBuilders[1].writeBinary(
+            new Binary(
+                String.valueOf(deviceToAlignedMap.get(deviceID)), TSFileConfig.STRING_CHARSET));
+        columnBuilders[2].appendNull();
+        columnBuilders[3].appendNull();
+        resultTsBlockBuilder.declarePosition();
+        deviceToAlignedMap.remove(deviceID);
+      }
     }
   }
 
   @Override
   protected List<TSDataType> getResultDataTypes() {
+    if (outputCount) {
+      return ColumnHeaderConstant.countDevicesColumnHeaders.stream()
+          .map(ColumnHeader::getColumnType)
+          .collect(Collectors.toList());
+    }
     return ColumnHeaderConstant.showDevicesColumnHeaders.stream()
         .map(ColumnHeader::getColumnType)
         .collect(Collectors.toList());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/ActiveTimeSeriesRegionScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/ActiveTimeSeriesRegionScanOperator.java
@@ -54,7 +54,9 @@ public class ActiveTimeSeriesRegionScanOperator extends AbstractRegionScanDataSo
       OperatorContext operatorContext,
       PlanNodeId sourceId,
       Map<IDeviceID, Map<String, TimeseriesSchemaInfo>> timeSeriesToSchemasInfo,
-      Filter timeFilter) {
+      Filter timeFilter,
+      boolean isOutputCount) {
+    this.outputCount = isOutputCount;
     this.operatorContext = operatorContext;
     this.sourceId = sourceId;
     this.timeSeriesToSchemasInfo = timeSeriesToSchemasInfo;
@@ -95,6 +97,16 @@ public class ActiveTimeSeriesRegionScanOperator extends AbstractRegionScanDataSo
 
     Map<IDeviceID, List<String>> activeTimeSeries =
         ((RegionScanForActiveTimeSeriesUtil) regionScanUtil).getActiveTimeSeries();
+
+    if (outputCount) {
+      for (Map.Entry<IDeviceID, List<String>> entry : activeTimeSeries.entrySet()) {
+        List<String> timeSeriesList = entry.getValue();
+        count += timeSeriesList.size();
+        removeTimeseriesListFromDevice(entry.getKey(), timeSeriesList);
+      }
+      return;
+    }
+
     for (Map.Entry<IDeviceID, List<String>> entry : activeTimeSeries.entrySet()) {
       IDeviceID deviceID = entry.getKey();
       String deviceStr = ((PlainDeviceID) deviceID).toStringID();
@@ -117,11 +129,18 @@ public class ActiveTimeSeriesRegionScanOperator extends AbstractRegionScanDataSo
         checkAndAppend(schemaInfo.getDeadbandParameters(), columnBuilders[9]); // DeadbandParameters
         columnBuilders[10].writeBinary(VIEW_TYPE); // ViewType
         resultTsBlockBuilder.declarePosition();
-        timeSeriesInfo.remove(timeSeries);
       }
-      if (timeSeriesInfo.isEmpty()) {
-        timeSeriesToSchemasInfo.remove(deviceID);
-      }
+      removeTimeseriesListFromDevice(deviceID, timeSeriesList);
+    }
+  }
+
+  private void removeTimeseriesListFromDevice(IDeviceID deviceID, List<String> timeSeriesList) {
+    Map<String, TimeseriesSchemaInfo> timeSeriesInfo = timeSeriesToSchemasInfo.get(deviceID);
+    for (String timeSeries : timeSeriesList) {
+      timeSeriesInfo.remove(timeSeries);
+    }
+    if (timeSeriesInfo.isEmpty()) {
+      timeSeriesToSchemasInfo.remove(deviceID);
     }
   }
 
@@ -131,6 +150,11 @@ public class ActiveTimeSeriesRegionScanOperator extends AbstractRegionScanDataSo
 
   @Override
   protected List<TSDataType> getResultDataTypes() {
+    if (outputCount) {
+      return ColumnHeaderConstant.countTimeSeriesColumnHeaders.stream()
+          .map(ColumnHeader::getColumnType)
+          .collect(Collectors.toList());
+    }
     return ColumnHeaderConstant.showTimeSeriesColumnHeaders.stream()
         .map(ColumnHeader::getColumnType)
         .collect(Collectors.toList());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
@@ -2928,6 +2928,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
             analyzeTimeseriesRegionScan(
                 showTimeSeriesStatement.getTimeCondition(), patternTree, analysis, context);
         if (!hasSchema) {
+          analysis.setRespDatasetHeader(DatasetHeaderFactory.getShowTimeSeriesHeader());
           return analysis;
         }
       } catch (IllegalPathException e) {
@@ -3007,7 +3008,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     schemaTree.removeLogicalView();
   }
 
-  private boolean analyzeDeviceRegionScan(
+  private void analyzeDeviceRegionScan(
       WhereCondition timeCondition,
       PathPatternTree patternTree,
       Analysis analysis,
@@ -3019,7 +3020,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     ISchemaTree schemaTree = schemaFetcher.fetchSchemaInDeviceLevel(patternTree, context);
     if (schemaTree.isEmpty()) {
       analysis.setFinishQueryAfterAnalyze(true);
-      return false;
+      return;
     }
 
     // fetch Data partition
@@ -3037,7 +3038,6 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
             schemaTree,
             context);
     analysis.setDataPartitionInfo(dataPartition);
-    return true;
   }
 
   @Override
@@ -3051,12 +3051,8 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
         showDevicesStatement.getPathPattern().concatNode(IoTDBConstant.ONE_LEVEL_PATH_WILDCARD));
 
     if (showDevicesStatement.hasTimeCondition()) {
-      boolean hasSchema =
-          analyzeDeviceRegionScan(
-              showDevicesStatement.getTimeCondition(), patternTree, analysis, context);
-      if (!hasSchema) {
-        return analysis;
-      }
+      analyzeDeviceRegionScan(
+          showDevicesStatement.getTimeCondition(), patternTree, analysis, context);
     } else {
       SchemaPartition schemaPartitionInfo = partitionFetcher.getSchemaPartition(patternTree);
       analysis.setSchemaPartitionInfo(schemaPartitionInfo);
@@ -3117,12 +3113,8 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     patternTree.appendPathPattern(
         countDevicesStatement.getPathPattern().concatNode(IoTDBConstant.ONE_LEVEL_PATH_WILDCARD));
     if (countDevicesStatement.hasTimeCondition()) {
-      boolean hasSchema =
-          analyzeDeviceRegionScan(
-              countDevicesStatement.getTimeCondition(), patternTree, analysis, context);
-      if (!hasSchema) {
-        return analysis;
-      }
+      analyzeDeviceRegionScan(
+          countDevicesStatement.getTimeCondition(), patternTree, analysis, context);
     } else {
       SchemaPartition schemaPartitionInfo = partitionFetcher.getSchemaPartition(patternTree);
       analysis.setSchemaPartitionInfo(schemaPartitionInfo);
@@ -3147,6 +3139,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
             analyzeTimeseriesRegionScan(
                 countTimeSeriesStatement.getTimeCondition(), patternTree, analysis, context);
         if (!hasSchema) {
+          analysis.setRespDatasetHeader(DatasetHeaderFactory.getCountTimeSeriesHeader());
           return analysis;
         }
       } catch (IllegalPathException e) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/OperatorTreeGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/OperatorTreeGenerator.java
@@ -3540,7 +3540,7 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
     }
     ActiveDeviceRegionScanOperator regionScanOperator =
         new ActiveDeviceRegionScanOperator(
-            operatorContext, node.getPlanNodeId(), deviceIDToAligned, filter);
+            operatorContext, node.getPlanNodeId(), deviceIDToAligned, filter, node.isOutputCount());
 
     DataDriverContext dataDriverContext = (DataDriverContext) context.getDriverContext();
     dataDriverContext.addSourceOperator(regionScanOperator);
@@ -3573,7 +3573,11 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
     }
     ActiveTimeSeriesRegionScanOperator regionScanOperator =
         new ActiveTimeSeriesRegionScanOperator(
-            operatorContext, node.getPlanNodeId(), timeseriesToSchemaInfo, filter);
+            operatorContext,
+            node.getPlanNodeId(),
+            timeseriesToSchemaInfo,
+            filter,
+            node.isOutputCount());
 
     dataDriverContext.addSourceOperator(regionScanOperator);
     dataDriverContext.setQueryDataSourceType(QueryDataSourceType.TIME_SERIES_REGION_SCAN);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/SourceRewriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/SourceRewriter.java
@@ -774,6 +774,7 @@ public class SourceRewriter extends BaseSourceRewriter<DistributionPlanContext> 
                   RegionScanNode regionScanNode = (RegionScanNode) node.clone();
                   regionScanNode.setPlanNodeId(context.queryContext.getQueryId().genPlanNodeId());
                   regionScanNode.setRegionReplicaSet(dataRegion);
+                  regionScanNode.setOutputCount(node.isOutputCount());
                   regionScanNode.clearPath();
                   return regionScanNode;
                 })


### PR DESCRIPTION
Details in https://issues.apache.org/jira/browse/IOTDB-6337
1. This pr fixed NPE problem when schema is empty for COUNT
2. The pr supported COUNT push down to regionScan which also fixed the bug of failing of COUNT when there is only one region.