### PR TITLE
Throw `IndexOutOfBound` exception in single column UDTF

### DIFF
--- a/iotdb-api/udf-api/src/main/java/org/apache/iotdb/udf/api/utils/RowImpl.java
+++ b/iotdb-api/udf-api/src/main/java/org/apache/iotdb/udf/api/utils/RowImpl.java
@@ -45,36 +45,57 @@ public class RowImpl implements Row {
 
   @Override
   public int getInt(int columnIndex) {
+    if (columnIndex >= size()) {
+      throw new IndexOutOfBoundsException("Index out of bound error!");
+    }
     return (int) rowRecord[columnIndex];
   }
 
   @Override
   public long getLong(int columnIndex) {
+    if (columnIndex >= size()) {
+      throw new IndexOutOfBoundsException("Index out of bound error!");
+    }
     return (long) rowRecord[columnIndex];
   }
 
   @Override
   public float getFloat(int columnIndex) {
+    if (columnIndex >= size()) {
+      throw new IndexOutOfBoundsException("Index out of bound error!");
+    }
     return (float) rowRecord[columnIndex];
   }
 
   @Override
   public double getDouble(int columnIndex) {
+    if (columnIndex >= size()) {
+      throw new IndexOutOfBoundsException("Index out of bound error!");
+    }
     return (double) rowRecord[columnIndex];
   }
 
   @Override
   public boolean getBoolean(int columnIndex) {
+    if (columnIndex >= size()) {
+      throw new IndexOutOfBoundsException("Index out of bound error!");
+    }
     return (boolean) rowRecord[columnIndex];
   }
 
   @Override
   public Binary getBinary(int columnIndex) {
+    if (columnIndex >= size()) {
+      throw new IndexOutOfBoundsException("Index out of bound error!");
+    }
     return transformToUDFBinary((org.apache.tsfile.utils.Binary) rowRecord[columnIndex]);
   }
 
   @Override
   public String getString(int columnIndex) {
+    if (columnIndex >= size()) {
+      throw new IndexOutOfBoundsException("Index out of bound error!");
+    }
     return rowRecord[columnIndex].toString();
   }
 


### PR DESCRIPTION
## Description
In old UDTF execution framework, if user only pass one column in UDTF, then whatever column index passed in row, the `getXXX()` method will always return the first column, which can be a little confused.

As contrast, new UDTF execution throws `IndexOutOfBound` exception when user only pass one column in those UDTF which reference multiple columns.