### PR TITLE
Update pom.xml to fix security issue

### DIFF
--- a/example/schema/pom.xml
+++ b/example/schema/pom.xml
@@ -32,7 +32,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.3.13</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tsfile</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -223,11 +223,6 @@
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
-                <artifactId>spring-web</artifactId>
-                <version>${spring.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
                 <artifactId>spring-context</artifactId>
                 <version>${spring.version}</version>
             </dependency>
@@ -624,64 +619,6 @@
                     <exclusion>
                         <groupId>org.apache.ant</groupId>
                         <artifactId>ant</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.spark</groupId>
-                <artifactId>spark-core_2.11</artifactId>
-                <version>${spark-scala.2.11.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>ch.qos.reload4j</groupId>
-                        <artifactId>reload4j</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>javax.activation</groupId>
-                        <artifactId>activation</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>javax.ws.rs</groupId>
-                        <artifactId>javax.ws.rs-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.glassfish.hk2.external</groupId>
-                        <artifactId>javax.inject</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.glassfish.hk2.external</groupId>
-                        <artifactId>aopalliance-repackaged</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.glassfish.hk2.external</groupId>
-                        <artifactId>jakarta.inject</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-reload4j</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>jcl-over-slf4j</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.spark-project.spark</groupId>
-                        <artifactId>unused</artifactId>
-                    </exclusion>
-                    <!-- There is no way on earth that I can imagine that ivy is really needed (CVEs reported) -->
-                    <exclusion>
-                        <groupId>org.apache.ivy</groupId>
-                        <artifactId>ivy</artifactId>
-                    </exclusion>
-                    <!-- CVEs reported, but most probably not needed -->
-                    <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
-                    </exclusion>
-                    <!-- Multiple CVEs are reported for this version, but we're using a newer version -->
-                    <exclusion>
-                        <groupId>io.netty</groupId>
-                        <artifactId>netty</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1428,11 +1365,6 @@
         hive-exe (pulls in 3.4.6 and 3.6.3)
         hive-serde (pulls in 3.4.6 and 3.6.3)
       -->
-            <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>3.7.2</version>
-            </dependency>
             <!-- Conflict:
         hive-common (pulls in 9.3.20.v20170531)
         hadoop-common (pulls in 9.4.51.v20230217)

--- a/pom.xml
+++ b/pom.xml
@@ -76,15 +76,11 @@
         <enforcer.skip>true</enforcer.skip>
         <felix.version>5.1.9</felix.version>
         <findbugs.jsr305.version>3.0.2</findbugs.jsr305.version>
-        <flink-shaded-zookeeper-3.version>3.8.1-17.0</flink-shaded-zookeeper-3.version>
-        <flink.version>1.17.1</flink.version>
         <fusesource-mqtt-client.version>1.16</fusesource-mqtt-client.version>
         <!-- JDK1.8 only support google java format 1.7-->
         <google.java.format.version>1.22.0</google.java.format.version>
         <gson.version>2.10.1</gson.version>
         <guava.version>32.1.2-jre</guava.version>
-        <hadoop.version>3.3.6</hadoop.version>
-        <hive.version>3.1.3</hive.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <!--
@@ -129,7 +125,6 @@
         <oauth2-oidc-sdk.version>10.15</oauth2-oidc-sdk.version>
         <!-- This was the last version to support Java 8 -->
         <openapi.generator.version>6.6.0</openapi.generator.version>
-        <orc-core.version>1.9.1</orc-core.version>
         <osgi.version>7.0.0</osgi.version>
         <pax-jdbc-common.version>1.5.6</pax-jdbc-common.version>
         <powermock.version>2.0.9</powermock.version>
@@ -145,11 +140,6 @@
         <reactor-netty.version>1.1.13</reactor-netty.version>
         <reactor.version>3.5.10</reactor.version>
         <reflections.version>0.10.2</reflections.version>
-        <rocketmq-client.version>5.1.3</rocketmq-client.version>
-        <scala.library.version>2.12.19</scala.library.version>
-        <scala.version>2.12</scala.version>
-        <!-- Newer version requires refactoring of testsuite -->
-        <scalatest.version>3.0.9</scalatest.version>
         <slf4j.version>2.0.9</slf4j.version>
         <snappy-java.version>1.1.10.4</snappy-java.version>
         <sonar.coverage.jacoco.xmlReportPaths>target/jacoco-merged-reports/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
@@ -160,15 +150,9 @@
         <sonar.java.checkstyle.reportPaths>target/checkstyle-report.xml</sonar.java.checkstyle.reportPaths>
         <sonar.junit.reportPaths>target/surefire-reports,target/failsafe-reports</sonar.junit.reportPaths>
         <sonar.organization>apache</sonar.organization>
-        <spark-scala.2.11.version>2.4.8</spark-scala.2.11.version>
-        <spark-scala.2.12.version>3.5.0</spark-scala.2.12.version>
         <!-- Override this to `true`, if you want to disable spotless -->
         <spotless.skip>false</spotless.skip>
         <spotless.version>2.43.0</spotless.version>
-        <!-- This is the matching version of spring-boot for spring 5.3.30 -->
-        <spring-boot.version>2.7.18</spring-boot.version>
-        <!-- This is the last version to support the javax namespace -->
-        <spring.version>5.3.34</spring.version>
         <!-- This was the last version to support Java 8 -->
         <swagger.version>1.6.11</swagger.version>
         <thrift.exec-cmd.executable>chmod</thrift.exec-cmd.executable>
@@ -180,10 +164,7 @@
       we'll stay at 0.14.1.
     -->
         <thrift.version>0.14.1</thrift.version>
-        <!-- This was the last version to support Java 8 -->
-        <tomcat.version>9.0.86</tomcat.version>
         <xz.version>1.9</xz.version>
-        <zeppelin.version>0.11.1</zeppelin.version>
         <zstd-jni.version>1.5.5-5</zstd-jni.version>
         <tsfile.version>1.0.1-e1207ba-SNAPSHOT</tsfile.version>
     </properties>
@@ -200,46 +181,6 @@
                 <version>${netty.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot</artifactId>
-                <version>${spring-boot.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-autoconfigure</artifactId>
-                <version>${spring-boot.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-tx</artifactId>
-                <version>${spring.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-beans</artifactId>
-                <version>${spring.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-context</artifactId>
-                <version>${spring.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-webmvc</artifactId>
-                <version>${spring.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-jdbc</artifactId>
-                <version>${spring.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-test</artifactId>
-                <version>${spring.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
@@ -329,68 +270,6 @@
                 <version>${powermock.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.flink</groupId>
-                <artifactId>flink-clients</artifactId>
-                <version>${flink.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.flink</groupId>
-                <artifactId>flink-core</artifactId>
-                <version>${flink.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.flink</groupId>
-                <artifactId>flink-hadoop-fs</artifactId>
-                <version>${flink.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.flink</groupId>
-                <artifactId>flink-java</artifactId>
-                <version>${flink.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.flink</groupId>
-                <artifactId>flink-streaming-core</artifactId>
-                <version>${flink.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.flink</groupId>
-                <artifactId>flink-streaming-java</artifactId>
-                <version>${flink.version}</version>
-                <exclusions>
-                    <!-- This dependency pulls in loads of duplicate versions of all sorts of libraries -->
-                    <exclusion>
-                        <groupId>org.apache.flink</groupId>
-                        <artifactId>flink-shaded-zookeeper-3</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.flink</groupId>
-                <artifactId>flink-table-api-java-bridge</artifactId>
-                <version>${flink.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.flink</groupId>
-                <artifactId>flink-table-common</artifactId>
-                <version>${flink.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.flink</groupId>
-                <artifactId>flink-table-test-utils</artifactId>
-                <version>${flink.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.flink</groupId>
-                <artifactId>flink-shaded-zookeeper-3</artifactId>
-                <version>${flink-shaded-zookeeper-3.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.flink</groupId>
-                <artifactId>flink-table-api-java</artifactId>
-                <version>${flink.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
@@ -406,117 +285,6 @@
                 <version>${findbugs.jsr305.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.hadoop</groupId>
-                <artifactId>hadoop-client</artifactId>
-                <version>${hadoop.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>javax.xml.bind</groupId>
-                        <artifactId>jaxb-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>jcl-over-slf4j</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.hadoop</groupId>
-                <artifactId>hadoop-client-api</artifactId>
-                <version>${hadoop.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.hadoop</groupId>
-                <artifactId>hadoop-common</artifactId>
-                <version>${hadoop.version}</version>
-                <exclusions>
-                    <!-- This is a fork of log4j 1, and it duplicates all sorts of classes -->
-                    <exclusion>
-                        <groupId>ch.qos.reload4j</groupId>
-                        <artifactId>reload4j</artifactId>
-                    </exclusion>
-                    <!-- This is a fork of log4j 1, and it duplicates all sorts of classes -->
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-reload4j</artifactId>
-                    </exclusion>
-                    <!-- Multiple CVEs reported for this, however we are not using Log4j -->
-                    <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>javax.xml.bind</groupId>
-                        <artifactId>jaxb-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>javax.ws.rs</groupId>
-                        <artifactId>jsr311-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.sun.jersey</groupId>
-                        <artifactId>jersey-server</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.hadoop</groupId>
-                <artifactId>hadoop-client-runtime</artifactId>
-                <version>${hadoop.version}</version>
-                <exclusions>
-                    <!-- This is a fork of log4j 1, and it duplicates all sorts of classes -->
-                    <exclusion>
-                        <groupId>ch.qos.reload4j</groupId>
-                        <artifactId>reload4j</artifactId>
-                    </exclusion>
-                    <!-- This is a fork of log4j 1, and it duplicates all sorts of classes -->
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-reload4j</artifactId>
-                    </exclusion>
-                    <!-- Multiple CVEs reported for this, however we are not using Log4j -->
-                    <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.hadoop</groupId>
-                <artifactId>hadoop-mapreduce-client-core</artifactId>
-                <version>${hadoop.version}</version>
-                <exclusions>
-                    <!-- This is a fork of log4j 1, and it duplicates all sorts of classes -->
-                    <exclusion>
-                        <groupId>ch.qos.reload4j</groupId>
-                        <artifactId>reload4j</artifactId>
-                    </exclusion>
-                    <!-- This is a fork of log4j 1, and it duplicates all sorts of classes -->
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-reload4j</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>javax.xml.bind</groupId>
-                        <artifactId>jaxb-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.sun.jersey</groupId>
-                        <artifactId>jersey-server</artifactId>
-                    </exclusion>
-                    <!-- Multiple CVEs are reported for this version, but we're using a newer version -->
-                    <exclusion>
-                        <groupId>io.netty</groupId>
-                        <artifactId>netty</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.hadoop</groupId>
-                <artifactId>hadoop-yarn-registry</artifactId>
-                <version>${hadoop.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>${gson.version}</version>
@@ -527,201 +295,9 @@
                 <version>${jakarta.servlet-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.hive</groupId>
-                <artifactId>hive-exec</artifactId>
-                <version>${hive.version}</version>
-                <!-- Using the default adds a shaded version with loads of duplicate classes -->
-                <classifier>core</classifier>
-                <exclusions>
-                    <!-- This seems to only be available in a version with included protobuf and slf4j -->
-                    <exclusion>
-                        <groupId>org.apache.calcite.avatica</groupId>
-                        <artifactId>avatica</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.logging.log4j</groupId>
-                        <artifactId>log4j-1.2-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>javax.xml.bind</groupId>
-                        <artifactId>jaxb-api</artifactId>
-                    </exclusion>
-                    <!-- There is no way on earth that I can imagine that ivy is really needed (CVEs reported) -->
-                    <exclusion>
-                        <groupId>org.apache.ivy</groupId>
-                        <artifactId>ivy</artifactId>
-                    </exclusion>
-                    <!-- There is no way on earth that I can imagine that ivy is really needed (CVEs reported) -->
-                    <exclusion>
-                        <groupId>org.apache.ant</groupId>
-                        <artifactId>ant</artifactId>
-                    </exclusion>
-                    <!-- CVEs reported, but most probably not needed -->
-                    <exclusion>
-                        <groupId>org.bouncycastle</groupId>
-                        <artifactId>bcprov-jdk15on</artifactId>
-                    </exclusion>
-                    <!-- CVEs reported, but most probably not needed -->
-                    <exclusion>
-                        <groupId>org.bouncycastle</groupId>
-                        <artifactId>bcpkix-jdk15on</artifactId>
-                    </exclusion>
-                    <!-- CVEs reported, but most probably not needed -->
-                    <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
-                    </exclusion>
-                    <!-- CVEs reported, but most probably not needed -->
-                    <exclusion>
-                        <groupId>com.cedarsoftware</groupId>
-                        <artifactId>json-io</artifactId>
-                    </exclusion>
-                    <!-- CVEs reported, but most probably not needed -->
-                    <exclusion>
-                        <groupId>org.apache.calcite</groupId>
-                        <artifactId>calcite-core</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.hive</groupId>
-                <artifactId>hive-serde</artifactId>
-                <version>${hive.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.apache.logging.log4j</groupId>
-                        <artifactId>log4j-slf4j-impl</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.hive</groupId>
-                <artifactId>hive-common</artifactId>
-                <version>${hive.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.javolution</groupId>
-                        <artifactId>javolution</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>javax.xml.bind</groupId>
-                        <artifactId>jaxb-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.logging.log4j</groupId>
-                        <artifactId>log4j-1.2-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.logging.log4j</groupId>
-                        <artifactId>log4j-slf4j-impl</artifactId>
-                    </exclusion>
-                    <!-- There is no way on earth that I can imagine that ivy is really needed (CVEs reported) -->
-                    <exclusion>
-                        <groupId>org.apache.ant</groupId>
-                        <artifactId>ant</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.spark</groupId>
-                <artifactId>spark-sql_2.11</artifactId>
-                <version>${spark-scala.2.11.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.spark-project.spark</groupId>
-                        <artifactId>unused</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.spark</groupId>
-                <artifactId>spark-catalyst_2.11</artifactId>
-                <version>${spark-scala.2.11.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.spark-project.spark</groupId>
-                        <artifactId>unused</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.spark</groupId>
-                <artifactId>spark-core_2.12</artifactId>
-                <version>${spark-scala.2.12.version}</version>
-                <exclusions>
-                    <!-- There is no way on earth that I can imagine that ivy is really needed (CVEs reported) -->
-                    <exclusion>
-                        <groupId>org.apache.ivy</groupId>
-                        <artifactId>ivy</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.spark</groupId>
-                <artifactId>spark-common-utils_2.12</artifactId>
-                <version>${spark-scala.2.12.version}</version>
-                <exclusions>
-                    <!-- We don't want this in the classpath as we're using logback as provider -->
-                    <exclusion>
-                        <groupId>org.apache.logging.log4j</groupId>
-                        <artifactId>log4j-slf4j2-impl</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>jcl-over-slf4j</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.spark</groupId>
-                <artifactId>spark-sql_2.12</artifactId>
-                <version>${spark-scala.2.12.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.spark</groupId>
-                <artifactId>spark-catalyst_2.12</artifactId>
-                <version>${spark-scala.2.12.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.spark</groupId>
-                <artifactId>spark-sql-api_2.12</artifactId>
-                <version>${spark-scala.2.12.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.scala-lang</groupId>
-                <artifactId>scala-library</artifactId>
-                <version>${scala.library.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk18on</artifactId>
                 <version>1.78</version>
-            </dependency>
-            <dependency>
-                <groupId>org.scalatest</groupId>
-                <artifactId>scalatest_2.11</artifactId>
-                <version>${scalatest.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.scalactic</groupId>
-                <artifactId>scalactic_2.11</artifactId>
-                <version>${scalatest.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.zeppelin</groupId>
-                <artifactId>zeppelin-interpreter</artifactId>
-                <version>${zeppelin.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>jcl-over-slf4j</artifactId>
-                    </exclusion>
-                    <!-- CVEs reported, but most probably not needed -->
-                    <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
@@ -938,11 +514,6 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.apache.rocketmq</groupId>
-                <artifactId>rocketmq-client</artifactId>
-                <version>${rocketmq-client.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.fusesource.mqtt-client</groupId>
                 <artifactId>mqtt-client</artifactId>
                 <version>${fusesource-mqtt-client.version}</version>
@@ -990,11 +561,6 @@
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-core</artifactId>
-                <version>${dropwizard.metrics.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.dropwizard.metrics</groupId>
-                <artifactId>metrics-jmx</artifactId>
                 <version>${dropwizard.metrics.version}</version>
             </dependency>
             <dependency>
@@ -1058,15 +624,6 @@
                 <artifactId>awaitility</artifactId>
                 <version>${awaitility.version}</version>
             </dependency>
-            <!--
-        TODO: This dependency is only needed to run one single test-case ... possibly refactor?
-        (org.apache.iotdb.db.conf.IoTDBDescriptorTest)
-      -->
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-core</artifactId>
-                <version>${tomcat.version}</version>
-            </dependency>
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>
                 <artifactId>reactor-netty-http</artifactId>
@@ -1123,34 +680,9 @@
                 <version>${jersey.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.glassfish.jersey.core</groupId>
-                <artifactId>jersey-client</artifactId>
+                <groupId>org.glassfish.jersey.inject</groupId>
+                <artifactId>jersey-hk2</artifactId>
                 <version>${jersey.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.core</groupId>
-                <artifactId>jersey-core</artifactId>
-                <version>${jersey.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.core</groupId>
-                <artifactId>jersey-common</artifactId>
-                <version>${jersey.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.core</groupId>
-                <artifactId>jersey-server</artifactId>
-                <version>${jersey.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.containers</groupId>
-                <artifactId>jersey-container-servlet</artifactId>
-                <version>${jersey.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.rabbitmq</groupId>
-                <artifactId>amqp-client</artifactId>
-                <version>5.18.0</version>
             </dependency>
             <!-- Conflict:
         json-smart (pulls in 9.3),
@@ -1180,461 +712,6 @@
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
                 <version>${jackson.version}</version>
-            </dependency>
-            <!-- Conflict:
-        jackson-dataformat-yaml (pulls in 1.33),
-        swagger-core (pulls in 2.ß),
-        swagger-jaxrs (pulls in 2.0)
-      -->
-            <dependency>
-                <groupId>org.yaml</groupId>
-                <artifactId>snakeyaml</artifactId>
-                <version>2.0</version>
-            </dependency>
-            <!-- Conflict:
-        flink-core (pulls in 2.24.0)
-        chill-java (pulls in 2.21)
-      -->
-            <dependency>
-                <groupId>com.esotericsoftware.kryo</groupId>
-                <artifactId>kryo</artifactId>
-                <version>2.24.0</version>
-            </dependency>
-            <!-- Conflict:
-        hadoop-common (pulls in 4.2.1)
-        woodstox-core (pulls in 4.2)
-      -->
-            <dependency>
-                <groupId>org.codehaus.woodstox</groupId>
-                <artifactId>stax2-api</artifactId>
-                <version>4.2.1</version>
-            </dependency>
-            <!-- Conflict:
-        hadoop-mapreduce-client-core (pulls in 2.2.11)
-        jersey-json (pulls in 2.2.2)
-      -->
-            <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
-                <version>2.2.11</version>
-            </dependency>
-            <!-- Conflict:
-        hadoop-mapreduce-client-core (pulls in 1.21)
-        hadoop-common (pulls in 1.21)
-        avro (pulls in 1.4.1)
-      -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.26.0</version>
-            </dependency>
-            <!-- Conflict:
-        hadoop-mapreduce-client-core (pulls in 4.0 and 3.0)
-      -->
-            <dependency>
-                <groupId>com.google.inject.extensions</groupId>
-                <artifactId>guice-servlet</artifactId>
-                <version>4.0</version>
-            </dependency>
-            <!-- Conflict:
-        hadoop-mapreduce-client-core (pulls in 9.4.51.v20230217)
-        hadoop-common (pulls in 9.4.52.v20230823)
-      -->
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-io</artifactId>
-                <version>9.4.52.v20230823</version>
-            </dependency>
-            <!-- Conflict:
-        hadoop-common (pulls in 1.2 and 1.1.3)
-      -->
-            <dependency>
-                <groupId>commons-logging</groupId>
-                <artifactId>commons-logging</artifactId>
-                <version>1.2</version>
-            </dependency>
-            <!-- Conflict:
-        hadoop-mapreduce-client-core (pulls in 3.0 and 4.0)
-      -->
-            <dependency>
-                <groupId>com.google.inject</groupId>
-                <artifactId>guice</artifactId>
-                <version>4.0</version>
-            </dependency>
-            <!-- Conflict:
-        hadoop-mapreduce-client-core (pulls in 2.12.7 and 2.15.2)
-      -->
-            <dependency>
-                <groupId>com.fasterxml.jackson.module</groupId>
-                <artifactId>jackson-module-jaxb-annotations</artifactId>
-                <version>2.15.2</version>
-            </dependency>
-            <!-- Conflict:
-        hadoop-common (pulls in 1.9 and 1.10.0)
-      -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-text</artifactId>
-                <version>1.10.0</version>
-            </dependency>
-            <!-- Conflict:
-        hadoop-mapreduce-client-core (pulls in 1.2.2)
-        hadoop-common (pulls in 1.2.1)
-      -->
-            <dependency>
-                <groupId>jakarta.activation</groupId>
-                <artifactId>jakarta.activation-api</artifactId>
-                <version>1.2.2</version>
-            </dependency>
-            <!-- Conflict:
-        spring-boot (pulls in 5.3.19)
-        everything else (pulls in 5.3.30)
-      -->
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-core</artifactId>
-                <version>5.3.30</version>
-            </dependency>
-            <!-- Conflict:
-        hive-exec (pulls in 3.3.6 and 3.1.0)
-        hadoop-common (pulls in 3.3.6)
-      -->
-            <dependency>
-                <groupId>org.apache.hadoop</groupId>
-                <artifactId>hadoop-auth</artifactId>
-                <version>${hadoop.version}</version>
-            </dependency>
-            <!-- Conflict:
-        hive-exec (pulls in 3.3.6 and 3.1.0)
-        hive-connector (pulls in 3.3.6)
-      -->
-            <dependency>
-                <groupId>org.apache.hadoop</groupId>
-                <artifactId>hadoop-yarn-api</artifactId>
-                <version>${hadoop.version}</version>
-            </dependency>
-            <!-- Conflict:
-        hive-exec (pulls in 3.3.6 and 3.1.0)
-        hadoop-mapreduce-client-core (pulls in 3.3.6)
-        hadoop-mapreduce-client-core (pulls in 3.3.6)
-      -->
-            <dependency>
-                <groupId>org.apache.hadoop</groupId>
-                <artifactId>hadoop-yarn-common</artifactId>
-                <version>${hadoop.version}</version>
-            </dependency>
-            <!-- Conflict:
-        hive-serde (pulls in 3.1.0)
-        hadoop-mapreduce-client-core (pulls in 3.3.6)
-      -->
-            <dependency>
-                <groupId>org.apache.hadoop</groupId>
-                <artifactId>hadoop-yarn-server-resourcemanager</artifactId>
-                <version>${hadoop.version}</version>
-            </dependency>
-            <!-- Conflict:
-        hive-exec (pulls in 3.3.6 and 3.1.0)
-        hadoop-common (pulls in 3.3.6)
-        hadoop-mapreduce-client-core (pulls in 3.3.6)
-      -->
-            <dependency>
-                <groupId>org.apache.hadoop</groupId>
-                <artifactId>hadoop-annotations</artifactId>
-                <version>${hadoop.version}</version>
-            </dependency>
-            <!-- Conflict:
-        hive-serde (pulls in 1.5.4)
-        hadoop-common (puss in 1.1)
-      -->
-            <dependency>
-                <groupId>org.codehaus.jettison</groupId>
-                <artifactId>jettison</artifactId>
-                <version>1.5.4</version>
-            </dependency>
-            <!-- Conflict:
-        hive-common (pulls in 9.3.20.v20170531)
-        hadoop-mapreduce-client-core (pulls in 9.4.51.v20230217)
-      -->
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-client</artifactId>
-                <version>9.4.51.v20230217</version>
-            </dependency>
-            <!-- Conflict:
-        hadoop-common (pulls in 3.6.3)
-        hive-exe (pulls in 3.4.6 and 3.6.3)
-        hive-serde (pulls in 3.4.6 and 3.6.3)
-      -->
-            <!-- Conflict:
-        hive-common (pulls in 9.3.20.v20170531)
-        hadoop-common (pulls in 9.4.51.v20230217)
-      -->
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-webapp</artifactId>
-                <version>9.4.51.v20230217</version>
-            </dependency>
-            <!-- Conflict:
-        hive-serde (pulls in 1.8.2)
-        hadoop-mapreduce-client-core (pulls in 1.7.7)
-        hadoop-common (pulls in 1.7.7)
-      -->
-            <dependency>
-                <groupId>org.apache.avro</groupId>
-                <artifactId>avro</artifactId>
-                <version>1.11.3</version>
-                <exclusions>
-                    <!-- Jackson moved from codehaus to fasterxml and is now the new version -->
-                    <exclusion>
-                        <groupId>org.codehaus.jackson</groupId>
-                        <artifactId>jackson-core-asl</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.codehaus.jackson</groupId>
-                        <artifactId>jackson-mapper-asl</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <!-- Security Issue:
-        avro-mapred (pulls in vulnerable version of jackson)
-      -->
-            <dependency>
-                <groupId>org.apache.avro</groupId>
-                <artifactId>avro-mapred</artifactId>
-                <version>1.8.2</version>
-                <classifier>hadoop2</classifier>
-                <exclusions>
-                    <!-- Jackson moved from codehaus to fasterxml and is now the new version -->
-                    <exclusion>
-                        <groupId>org.codehaus.jackson</groupId>
-                        <artifactId>jackson-core-asl</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.codehaus.jackson</groupId>
-                        <artifactId>jackson-mapper-asl</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <!-- Security Issue:
-        parquet-hadoop (pulls in vulnerable version of jackson)
-      -->
-            <dependency>
-                <groupId>org.apache.parquet</groupId>
-                <artifactId>parquet-hadoop</artifactId>
-                <version>1.10.1</version>
-                <exclusions>
-                    <!-- Jackson moved from codehaus to fasterxml and is now the new version and for the codehaus version CVEs were reported -->
-                    <exclusion>
-                        <groupId>org.codehaus.jackson</groupId>
-                        <artifactId>jackson-core-asl</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.codehaus.jackson</groupId>
-                        <artifactId>jackson-mapper-asl</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <!-- Conflict:
-        hive-serde (pulls in 9.4.51.v20230217)
-        hive-common (pulls in 9.4.52.v20230823)
-      -->
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-util-ajax</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <!-- Conflict:
-        hive-serde (pulls in 2.12.0)
-        hadoop-common (pulls in 5.2.0)
-      -->
-            <dependency>
-                <groupId>org.apache.curator</groupId>
-                <artifactId>curator-framework</artifactId>
-                <version>5.2.0</version>
-            </dependency>
-            <!-- Conflict:
-        hive-exec (pulls in 5.2.0 and 2.12.0)
-        hadoop-common (pulls in 5.2.0)
-      -->
-            <dependency>
-                <groupId>org.apache.curator</groupId>
-                <artifactId>curator-recipes</artifactId>
-                <version>5.2.0</version>
-            </dependency>
-            <!-- Conflict:
-        hive-exec (pulls in 5.2.0 and 2.12.0)
-        hadoop-common (pulls in 5.2.0)
-      -->
-            <dependency>
-                <groupId>org.apache.curator</groupId>
-                <artifactId>curator-client</artifactId>
-                <version>5.2.0</version>
-            </dependency>
-            <!-- Conflict:
-        hive-serde (pulls in 1.2.22)
-        hadoop-mapreduce-client-core (pulls in 1.2.22 and 1.2.19)
-      -->
-            <dependency>
-                <groupId>ch.qos.reload4j</groupId>
-                <artifactId>reload4j</artifactId>
-                <version>1.2.22</version>
-            </dependency>
-            <!-- Conflict:
-        hive-exec (pulls in 2.8.1)
-        hive-serde (pulls in 2.9.9)
-        hive-common (pulls in 2.9.9)
-      -->
-            <dependency>
-                <groupId>joda-time</groupId>
-                <artifactId>joda-time</artifactId>
-                <version>2.9.9</version>
-            </dependency>
-            <!-- Conflict:
-        hive-exec (pulls in 3.9.0 and 3.6)
-        hadoop-common (pulls in 3.9.0)
-      -->
-            <dependency>
-                <groupId>commons-net</groupId>
-                <artifactId>commons-net</artifactId>
-                <version>3.9.0</version>
-            </dependency>
-            <!-- Conflict:
-        hive-exec (pulls in 3.5.2 and 3.3)
-      -->
-            <dependency>
-                <groupId>org.antlr</groupId>
-                <artifactId>antlr-runtime</artifactId>
-                <version>3.5.2</version>
-            </dependency>
-            <!-- Security Issue:
-        hadoop-mapreduce-client-core (pulls in vulnerable version)
-      -->
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib</artifactId>
-                <version>1.9.10</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib-common</artifactId>
-                <version>1.9.10</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib-jdk7</artifactId>
-                <version>1.9.10</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib-jdk8</artifactId>
-                <version>1.9.10</version>
-            </dependency>
-            <!-- Security Issue:
-        hadoop-mapreduce-client-core (pulls in vulnerable version)
-      -->
-            <dependency>
-                <groupId>com.squareup.okio</groupId>
-                <artifactId>okio</artifactId>
-                <version>3.5.0</version>
-            </dependency>
-            <!-- Security Issue:
-        hadoop-mapreduce-client-core (pulls in vulnerable version)
-      -->
-            <dependency>
-                <groupId>com.google.protobuf</groupId>
-                <artifactId>protobuf-java</artifactId>
-                <version>3.24.3</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.protobuf</groupId>
-                <artifactId>protobuf-java-util</artifactId>
-                <version>3.24.3</version>
-            </dependency>
-            <!-- Security Issue:
-        hive-exec (pulls in vulnerable version)
-      -->
-            <dependency>
-                <groupId>org.codehaus.janino</groupId>
-                <artifactId>janino</artifactId>
-                <version>3.1.10</version>
-            </dependency>
-            <dependency>
-                <groupId>org.codehaus.janino</groupId>
-                <artifactId>commons-compiler</artifactId>
-                <version>3.1.10</version>
-            </dependency>
-            <!-- Security Issue:
-        zeppelin-interpreter (pulls in vulnerable version)
-      -->
-            <dependency>
-                <groupId>io.atomix</groupId>
-                <artifactId>atomix</artifactId>
-                <version>3.1.12</version>
-            </dependency>
-            <dependency>
-                <groupId>io.atomix</groupId>
-                <artifactId>atomix-primitive</artifactId>
-                <version>3.1.12</version>
-            </dependency>
-            <dependency>
-                <groupId>io.atomix</groupId>
-                <artifactId>atomix-storage</artifactId>
-                <version>3.1.12</version>
-            </dependency>
-            <dependency>
-                <groupId>io.atomix</groupId>
-                <artifactId>atomix-cluster</artifactId>
-                <version>3.1.12</version>
-            </dependency>
-            <dependency>
-                <groupId>io.atomix</groupId>
-                <artifactId>atomix-utils</artifactId>
-                <version>3.1.12</version>
-            </dependency>
-            <dependency>
-                <groupId>io.atomix</groupId>
-                <artifactId>atomix-raft</artifactId>
-                <version>3.1.12</version>
-            </dependency>
-            <!-- Security Issue:
-       zeppelin-interpreter (pulls in vulnerable version)
-     -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-configuration2</artifactId>
-                <version>2.10.1</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.orc</groupId>
-                <artifactId>orc-core</artifactId>
-                <version>${orc-core.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.orc</groupId>
-                <artifactId>orc-core</artifactId>
-                <version>${orc-core.version}</version>
-                <classifier>nohive</classifier>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.orc</groupId>
-                <artifactId>orc-mapreduce</artifactId>
-                <version>${orc-core.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.orc</groupId>
-                <artifactId>orc-mapreduce</artifactId>
-                <version>${orc-core.version}</version>
-                <classifier>nohive</classifier>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.orc</groupId>
-                <artifactId>orc-shims</artifactId>
-                <version>${orc-core.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.inject</groupId>
-                <artifactId>jersey-hk2</artifactId>
-                <version>${jersey.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -964,21 +964,6 @@
                     <version>1.0.0</version>
                 </plugin>
                 <plugin>
-                    <groupId>com.github.eirslett</groupId>
-                    <artifactId>frontend-maven-plugin</artifactId>
-                    <version>1.14.0</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-antrun-plugin</artifactId>
-                    <version>3.1.0</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.scala-tools</groupId>
-                    <artifactId>maven-scala-plugin</artifactId>
-                    <version>2.15.2</version>
-                </plugin>
-                <plugin>
                     <groupId>org.antlr</groupId>
                     <artifactId>antlr4-maven-plugin</artifactId>
                     <version>${antlr4.version}</version>


### PR DESCRIPTION
## Description

https://github.com/apache/iotdb/security/dependabot

![image](https://github.com/apache/iotdb/assets/25913899/caaf24ea-584b-4bae-a3a6-eacf53ffc0b3)

These dependences are not using in IoTDB currently, just remove them to fix the security warning.
