### PR TITLE
Fix missing of linux memory metrics

### DIFF
--- a/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/system/SystemMetrics.java
+++ b/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/system/SystemMetrics.java
@@ -169,6 +169,7 @@ public class SystemMetrics implements IMetricSet {
         a -> osMxBean.getCommittedVirtualMemorySize(),
         SystemTag.NAME.toString(),
         SYSTEM);
+    logger.info("System type: {}", CONFIG.getSystemType());
     if (CONFIG.getSystemType() == SystemType.LINUX) {
       metricService.createAutoGauge(
           SystemMetric.LINUX_MEMORY_SIZE.toString(),
@@ -227,11 +228,11 @@ public class SystemMetrics implements IMetricSet {
             result.append(line).append("\n");
           }
         }
-        String[] lines = result.toString().split("\n");
+        String[] lines = result.toString().trim().split("\n");
         // if failed to get result
         if (lines.length >= 2) {
           String[] memParts = lines[1].trim().split("\\s+");
-          if (memParts.length == linuxMemoryTitles.length) {
+          if (memParts.length >= linuxMemoryTitles.length) {
             usedMemory = Long.parseLong(memParts[2]) * 1024;
             sharedMemory = Long.parseLong(memParts[4]) * 1024;
             buffCacheMemory = Long.parseLong(memParts[5]) * 1024;

--- a/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/system/SystemMetrics.java
+++ b/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/system/SystemMetrics.java
@@ -169,7 +169,6 @@ public class SystemMetrics implements IMetricSet {
         a -> osMxBean.getCommittedVirtualMemorySize(),
         SystemTag.NAME.toString(),
         SYSTEM);
-    logger.info("System type: {}", CONFIG.getSystemType());
     if (CONFIG.getSystemType() == SystemType.LINUX) {
       metricService.createAutoGauge(
           SystemMetric.LINUX_MEMORY_SIZE.toString(),


### PR DESCRIPTION
Fix missing of linux memory metrics: 
<img width="540" alt="image" src="https://github.com/apache/iotdb/assets/46039728/66869bcb-31fc-4a22-9f60-21367546df75">
