### PR TITLE
Fix NumberFormatException when upgrade from old version

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/MemUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/MemUtils.java
@@ -203,7 +203,7 @@ public class MemUtils {
   }
 
   public static long strToBytesCnt(String str) {
-    if (str == null) {
+    if (str == null || str.isEmpty()) {
       return 0;
     }
     str = str.toLowerCase();


### PR DESCRIPTION
## Description
When upgrading from an older version(before 1.3), if only sbin is updated without simultaneously updating the env script in the conf directory, a NumberFormatException may occur.