### PR TITLE
[IOTDB-6339] Optimize the time slice control of SeriesScanOperator and AlignedSeriesScanOperator

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/AbstractSeriesScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/AbstractSeriesScanOperator.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.execution.operator.source;
+
+import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.read.common.block.TsBlock;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public abstract class AbstractSeriesScanOperator extends AbstractDataSourceOperator {
+
+  private boolean finished = false;
+
+  @Override
+  public TsBlock next() throws Exception {
+    if (retainedTsBlock != null) {
+      return getResultFromRetainedTsBlock();
+    }
+    // we don't get any data in current batch time slice, just return null
+    if (resultTsBlockBuilder.isEmpty()) {
+      return null;
+    }
+    resultTsBlock = resultTsBlockBuilder.build();
+    resultTsBlockBuilder.reset();
+    return checkTsBlockSizeAndGetResult();
+  }
+
+  @Override
+  public boolean isFinished() throws Exception {
+    return finished;
+  }
+
+  @SuppressWarnings("squid:S112")
+  @Override
+  public boolean hasNext() throws Exception {
+    if (retainedTsBlock != null) {
+      return true;
+    }
+    try {
+
+      // start stopwatch
+      long maxRuntime = operatorContext.getMaxRunTime().roundTo(TimeUnit.NANOSECONDS);
+      long start = System.nanoTime();
+
+      boolean noMoreData = false;
+
+      // here use do-while to promise doing this at least once
+      do {
+        /*
+         * 1. consume page data firstly
+         * 2. consume chunk data secondly
+         * 3. consume next file finally
+         */
+        if (!readPageData() && !readChunkData() && !readFileData()) {
+          noMoreData = true;
+          break;
+        }
+
+      } while (System.nanoTime() - start < maxRuntime
+          && !resultTsBlockBuilder.isFull()
+          && retainedTsBlock == null);
+
+      finished = (resultTsBlockBuilder.isEmpty() && retainedTsBlock == null && noMoreData);
+
+      return !finished;
+    } catch (IOException e) {
+      throw new RuntimeException("Error happened while scanning the file", e);
+    }
+  }
+
+  private boolean readFileData() throws IOException {
+    while (seriesScanUtil.hasNextFile()) {
+      if (readChunkData()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean readChunkData() throws IOException {
+    while (seriesScanUtil.hasNextChunk()) {
+      if (readPageData()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean readPageData() throws IOException {
+    if (seriesScanUtil.hasNextPage()) {
+      TsBlock tsBlock = seriesScanUtil.nextPage();
+      if (!isEmpty(tsBlock)) {
+        appendToBuilder(tsBlock);
+      }
+      return true;
+    }
+    return false;
+  }
+
+  private boolean isEmpty(TsBlock tsBlock) {
+    return tsBlock == null || tsBlock.isEmpty();
+  }
+
+  private void appendToBuilder(TsBlock tsBlock) {
+    int size = tsBlock.getPositionCount();
+    if (resultTsBlockBuilder.isEmpty() && size >= resultTsBlockBuilder.getMaxTsBlockLineNumber()) {
+      retainedTsBlock = tsBlock;
+      return;
+    }
+    buildResult(tsBlock);
+  }
+
+  protected abstract void buildResult(TsBlock tsBlock);
+
+  @Override
+  protected List<TSDataType> getResultDataTypes() {
+    return seriesScanUtil.getTsDataTypeList();
+  }
+
+  @Override
+  public long calculateMaxReturnSize() {
+    return maxReturnSize;
+  }
+
+  @Override
+  public long calculateRetainedSizeAfterCallingNext() {
+    return calculateMaxPeekMemoryWithCounter() - calculateMaxReturnSize();
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/AlignedSeriesScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/AlignedSeriesScanOperator.java
@@ -38,16 +38,13 @@ import org.apache.tsfile.read.common.block.column.TimeColumn;
 import org.apache.tsfile.read.common.block.column.TimeColumnBuilder;
 import org.apache.tsfile.utils.RamUsageEstimator;
 
-import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
-public class AlignedSeriesScanOperator extends AbstractDataSourceOperator {
+public class AlignedSeriesScanOperator extends AbstractSeriesScanOperator {
   private static final long INSTANCE_SIZE =
       RamUsageEstimator.shallowSizeOfInstance(AlignedSeriesScanOperator.class);
 
   private final int valueColumnCount;
-  private boolean finished = false;
   private int maxTsBlockLineNum = -1;
 
   public AlignedSeriesScanOperator(
@@ -79,56 +76,6 @@ public class AlignedSeriesScanOperator extends AbstractDataSourceOperator {
   }
 
   @Override
-  public TsBlock next() throws Exception {
-    if (retainedTsBlock != null) {
-      return getResultFromRetainedTsBlock();
-    }
-    resultTsBlock = resultTsBlockBuilder.build();
-    resultTsBlockBuilder.reset();
-    return checkTsBlockSizeAndGetResult();
-  }
-
-  @SuppressWarnings("squid:S112")
-  @Override
-  public boolean hasNext() throws Exception {
-    if (retainedTsBlock != null) {
-      return true;
-    }
-    try {
-
-      // start stopwatch
-      long maxRuntime = operatorContext.getMaxRunTime().roundTo(TimeUnit.NANOSECONDS);
-      long start = System.nanoTime();
-
-      // here use do-while to promise doing this at least once
-      do {
-        /*
-         * 1. consume page data firstly
-         * 2. consume chunk data secondly
-         * 3. consume next file finally
-         */
-        if (!readPageData() && !readChunkData() && !readFileData()) {
-          break;
-        }
-
-      } while (System.nanoTime() - start < maxRuntime
-          && !resultTsBlockBuilder.isFull()
-          && retainedTsBlock == null);
-
-      finished = (resultTsBlockBuilder.isEmpty() && retainedTsBlock == null);
-
-      return !finished;
-    } catch (IOException e) {
-      throw new RuntimeException("Error happened while scanning the file", e);
-    }
-  }
-
-  @Override
-  public boolean isFinished() throws Exception {
-    return finished;
-  }
-
-  @Override
   public long calculateMaxPeekMemory() {
     return Math.max(
         maxReturnSize,
@@ -138,51 +85,8 @@ public class AlignedSeriesScanOperator extends AbstractDataSourceOperator {
   }
 
   @Override
-  public long calculateMaxReturnSize() {
-    return maxReturnSize;
-  }
-
-  @Override
-  public long calculateRetainedSizeAfterCallingNext() {
-    return calculateMaxPeekMemoryWithCounter() - calculateMaxReturnSize();
-  }
-
-  private boolean readFileData() throws IOException {
-    while (seriesScanUtil.hasNextFile()) {
-      if (readChunkData()) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private boolean readChunkData() throws IOException {
-    while (seriesScanUtil.hasNextChunk()) {
-      if (readPageData()) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private boolean readPageData() throws IOException {
-    while (seriesScanUtil.hasNextPage()) {
-      TsBlock tsBlock = seriesScanUtil.nextPage();
-      if (!isEmpty(tsBlock)) {
-        appendToBuilder(tsBlock);
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private void appendToBuilder(TsBlock tsBlock) {
+  protected void buildResult(TsBlock tsBlock) {
     int size = tsBlock.getPositionCount();
-    if (resultTsBlockBuilder.isEmpty()
-        && tsBlock.getPositionCount() >= resultTsBlockBuilder.getMaxTsBlockLineNumber()) {
-      retainedTsBlock = tsBlock;
-      return;
-    }
     TimeColumnBuilder timeColumnBuilder = resultTsBlockBuilder.getTimeColumnBuilder();
     TimeColumn timeColumn = tsBlock.getTimeColumn();
     for (int i = 0; i < size; i++) {
@@ -212,16 +116,6 @@ public class AlignedSeriesScanOperator extends AbstractDataSourceOperator {
         columnBuilder.write(column, i);
       }
     }
-  }
-
-  private boolean isEmpty(TsBlock tsBlock) {
-    return tsBlock == null || tsBlock.isEmpty();
-  }
-
-  @Override
-  protected List<TSDataType> getResultDataTypes() {
-    // time + all value columns
-    return seriesScanUtil.getTsDataTypeList();
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/SeriesScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/SeriesScanOperator.java
@@ -29,21 +29,14 @@ import org.apache.iotdb.db.queryengine.plan.statement.component.Ordering;
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnBuilder;
 import org.apache.tsfile.common.conf.TSFileDescriptor;
-import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.read.common.block.TsBlock;
 import org.apache.tsfile.read.common.block.column.TimeColumn;
 import org.apache.tsfile.read.common.block.column.TimeColumnBuilder;
 import org.apache.tsfile.utils.RamUsageEstimator;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-public class SeriesScanOperator extends AbstractDataSourceOperator {
+public class SeriesScanOperator extends AbstractSeriesScanOperator {
   private static final long INSTANCE_SIZE =
       RamUsageEstimator.shallowSizeOfInstance(SeriesScanOperator.class);
-
-  private boolean finished = false;
 
   public SeriesScanOperator(
       OperatorContext context,
@@ -60,106 +53,21 @@ public class SeriesScanOperator extends AbstractDataSourceOperator {
   }
 
   @Override
-  public TsBlock next() throws Exception {
-    if (retainedTsBlock != null) {
-      return getResultFromRetainedTsBlock();
-    }
-    resultTsBlock = resultTsBlockBuilder.build();
-    resultTsBlockBuilder.reset();
-    return checkTsBlockSizeAndGetResult();
-  }
-
-  @SuppressWarnings("squid:S112")
-  @Override
-  public boolean hasNext() throws Exception {
-    if (retainedTsBlock != null) {
-      return true;
-    }
-    try {
-
-      // start stopwatch
-      long maxRuntime = operatorContext.getMaxRunTime().roundTo(TimeUnit.NANOSECONDS);
-      long start = System.nanoTime();
-
-      // here use do-while to promise doing this at least once
-      do {
-        /*
-         * 1. consume page data firstly
-         * 2. consume chunk data secondly
-         * 3. consume next file finally
-         */
-        if (!readPageData() && !readChunkData() && !readFileData()) {
-          break;
-        }
-      } while (System.nanoTime() - start < maxRuntime && !resultTsBlockBuilder.isFull());
-
-      finished = resultTsBlockBuilder.isEmpty();
-
-      return !finished;
-    } catch (IOException e) {
-      throw new RuntimeException("Error happened while scanning the file", e);
-    }
-  }
-
-  @Override
-  public boolean isFinished() throws Exception {
-    return finished;
-  }
-
-  @Override
   public long calculateMaxPeekMemory() {
     return Math.max(
         maxReturnSize, TSFileDescriptor.getInstance().getConfig().getPageSizeInByte() * 3L);
   }
 
   @Override
-  public long calculateMaxReturnSize() {
-    return maxReturnSize;
-  }
-
-  @Override
-  public long calculateRetainedSizeAfterCallingNext() {
-    return calculateMaxPeekMemoryWithCounter() - calculateMaxReturnSize();
-  }
-
-  private boolean readFileData() throws IOException {
-    while (seriesScanUtil.hasNextFile()) {
-      if (readChunkData()) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private boolean readChunkData() throws IOException {
-    while (seriesScanUtil.hasNextChunk()) {
-      if (readPageData()) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private boolean readPageData() throws IOException {
-    while (seriesScanUtil.hasNextPage()) {
-      TsBlock tsBlock = seriesScanUtil.nextPage();
-
-      if (!isEmpty(tsBlock)) {
-        appendToBuilder(tsBlock);
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private void appendToBuilder(TsBlock tsBlock) {
+  protected void buildResult(TsBlock tsBlock) {
+    int size = tsBlock.getPositionCount();
     TimeColumnBuilder timeColumnBuilder = resultTsBlockBuilder.getTimeColumnBuilder();
     TimeColumn timeColumn = tsBlock.getTimeColumn();
     ColumnBuilder columnBuilder = resultTsBlockBuilder.getColumnBuilder(0);
     Column column = tsBlock.getColumn(0);
 
     if (column.mayHaveNull()) {
-      for (int i = 0, size = tsBlock.getPositionCount(); i < size; i++) {
+      for (int i = 0; i < size; i++) {
         timeColumnBuilder.writeLong(timeColumn.getLong(i));
         if (column.isNull(i)) {
           columnBuilder.appendNull();
@@ -169,21 +77,12 @@ public class SeriesScanOperator extends AbstractDataSourceOperator {
         resultTsBlockBuilder.declarePosition();
       }
     } else {
-      for (int i = 0, size = tsBlock.getPositionCount(); i < size; i++) {
+      for (int i = 0; i < size; i++) {
         timeColumnBuilder.writeLong(timeColumn.getLong(i));
         columnBuilder.write(column, i);
         resultTsBlockBuilder.declarePosition();
       }
     }
-  }
-
-  private boolean isEmpty(TsBlock tsBlock) {
-    return tsBlock == null || tsBlock.isEmpty();
-  }
-
-  @Override
-  protected List<TSDataType> getResultDataTypes() {
-    return seriesScanUtil.getTsDataTypeList();
   }
 
   @Override


### PR DESCRIPTION
Previously, we will scan until we get at least one satisfied row and then we have chance to do time slice control.
However, when we do the predicate push down optimization, we may need much more time to get a satisfied row from tsfile, so we need to change the control processing of SeriesScanOperator and AlignedSeriesScanOperator.

We will do time check after we got one page data from SeriesScanUtil, even if it's an empty TsBlock.