### PR TITLE
Check duplicate in start-node and stop-node scripts

### DIFF
--- a/iotdb-core/confignode/src/assembly/resources/sbin/stop-confignode.sh
+++ b/iotdb-core/confignode/src/assembly/resources/sbin/stop-confignode.sh
@@ -18,6 +18,7 @@
 # under the License.
 #
 
+source "$(dirname "$0")/iotdb-common.sh"
 CONFIGNODE_CONF="$(dirname "$0")/../conf"
 
 if [ -f "${CONFIGNODE_CONF}/iotdb-system.properties" ]; then
@@ -26,6 +27,7 @@ else
     cn_internal_port=$(sed '/^cn_internal_port=/!d;s/.*=//' "${CONFIGNODE_CONF}"/iotdb-confignode.properties)
 fi
 
+check_config_unique "cn_internal_port" "$cn_internal_port"
 
 echo Check whether the internal_port is used..., port is "$cn_internal_port"
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/sync/SyncConfigNodeClientPool.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/sync/SyncConfigNodeClientPool.java
@@ -92,6 +92,8 @@ public class SyncConfigNodeClientPool {
             return client.stopConfigNode((TConfigNodeLocation) req);
           case SET_CONFIGURATION:
             return client.setConfiguration((TSetConfigurationReq) req);
+          case SHOW_CONFIGURATION:
+            return client.showConfiguration((int) req);
           case SUBMIT_TEST_CONNECTION_TASK:
             return client.submitTestConnectionTask((TNodeLocations) req);
           case TEST_CONNECTION:

--- a/iotdb-core/datanode/src/assembly/resources/sbin/stop-datanode.sh
+++ b/iotdb-core/datanode/src/assembly/resources/sbin/stop-datanode.sh
@@ -18,6 +18,7 @@
 # under the License.
 #
 
+source "$(dirname "$0")/iotdb-common.sh"
 DATANODE_CONF="`dirname "$0"`/../conf"
 
 if [ -f "${DATANODE_CONF}/iotdb-system.properties" ]; then
@@ -25,6 +26,8 @@ if [ -f "${DATANODE_CONF}/iotdb-system.properties" ]; then
 else
     dn_rpc_port=`sed '/^dn_rpc_port=/!d;s/.*=//' ${DATANODE_CONF}/iotdb-datanode.properties`
 fi
+
+check_config_unique "dn_rpc_port" "$dn_rpc_port"
 
 force=""
 

--- a/iotdb-core/node-commons/src/assembly/resources/sbin/iotdb-common.sh
+++ b/iotdb-core/node-commons/src/assembly/resources/sbin/iotdb-common.sh
@@ -150,6 +150,18 @@ checkAllConfigNodeVariables()
   fi
 }
 
+check_config_unique() {
+  local key=$1
+  local values=$2
+
+  line_count=$(echo "$values" | wc -l)
+
+  if [ "$line_count" -gt 1 ]; then
+    echo "Error: Duplicate $key entries found"
+    exit 1
+  fi
+}
+
 checkDataNodePortUsages () {
   echo "Checking whether the ports are already occupied..."
   if [ "$(id -u)" -ne 0 ]; then
@@ -183,6 +195,13 @@ checkDataNodePortUsages () {
   else
     echo "Warning: cannot find iotdb-system.properties or iotdb-datanode.properties, check the default configuration"
   fi
+
+  check_config_unique "dn_rpc_port" "$dn_rpc_port"
+  check_config_unique "dn_internal_port" "$dn_internal_port"
+  check_config_unique "dn_mpp_data_exchange_port" "$dn_mpp_data_exchange_port"
+  check_config_unique "dn_schema_region_consensus_port" "$dn_schema_region_consensus_port"
+  check_config_unique "dn_data_region_consensus_port" "$dn_data_region_consensus_port"
+
   dn_rpc_port=${dn_rpc_port:-6667}
   dn_internal_port=${dn_internal_port:-10730}
   dn_mpp_data_exchange_port=${dn_mpp_data_exchange_port:-10740}
@@ -271,6 +290,10 @@ checkConfigNodePortUsages () {
   else
     echo "Cannot find iotdb-system.properties or iotdb-confignode.properties, check the default configuration"
   fi
+
+  check_config_unique "cn_internal_port" "$cn_internal_port"
+  check_config_unique "cn_consensus_port" "$cn_consensus_port"
+
   cn_internal_port=${cn_internal_port:-10710}
   cn_consensus_port=${cn_consensus_port:-10720}
   if type lsof >/dev/null 2>&1; then

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/ConfigurationFileUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/ConfigurationFileUtils.java
@@ -51,8 +51,9 @@ public class ConfigurationFileUtils {
   private static final long maxTimeMillsToAcquireLock = TimeUnit.SECONDS.toMillis(20);
   private static final long waitTimeMillsPerCheck = TimeUnit.MILLISECONDS.toMillis(100);
   private static Logger logger = LoggerFactory.getLogger(ConfigurationFileUtils.class);
-  private static String license =
-      new StringJoiner("#")
+  private static final String lineSeparator = "\n";
+  private static final String license =
+      new StringJoiner(lineSeparator)
           .add("# Licensed to the Apache Software Foundation (ASF) under one")
           .add("# or more contributor license agreements.  See the NOTICE file")
           .add("# distributed with this work for additional information")
@@ -165,7 +166,7 @@ public class ConfigurationFileUtils {
         BufferedReader reader = new BufferedReader(isr)) {
       String line;
       while ((line = reader.readLine()) != null) {
-        content.append(line).append(System.lineSeparator());
+        content.append(line).append(lineSeparator);
       }
     } catch (IOException e) {
       logger.warn("Failed to read configuration template", e);
@@ -199,7 +200,7 @@ public class ConfigurationFileUtils {
     StringBuilder contentsOfNewConfigurationFile = new StringBuilder();
     for (String currentLine : lines) {
       if (currentLine.trim().isEmpty() || currentLine.trim().startsWith("#")) {
-        contentsOfNewConfigurationFile.append(currentLine).append(System.lineSeparator());
+        contentsOfNewConfigurationFile.append(currentLine).append(lineSeparator);
         continue;
       }
       int equalsIndex = currentLine.indexOf('=');
@@ -208,17 +209,14 @@ public class ConfigurationFileUtils {
         String key = currentLine.substring(0, equalsIndex).trim();
         String value = currentLine.substring(equalsIndex + 1).trim();
         if (!newConfigItems.containsKey(key)) {
-          contentsOfNewConfigurationFile.append(currentLine).append(System.lineSeparator());
+          contentsOfNewConfigurationFile.append(currentLine).append(lineSeparator);
           continue;
         }
         if (newConfigItems.getProperty(key).equals(value)) {
-          contentsOfNewConfigurationFile.append(currentLine).append(System.lineSeparator());
+          contentsOfNewConfigurationFile.append(currentLine).append(lineSeparator);
           newConfigItems.remove(key);
         } else {
-          contentsOfNewConfigurationFile
-              .append("#")
-              .append(currentLine)
-              .append(System.lineSeparator());
+          contentsOfNewConfigurationFile.append("#").append(currentLine).append(lineSeparator);
         }
       }
     }
@@ -233,9 +231,9 @@ public class ConfigurationFileUtils {
       try (BufferedWriter writer = new BufferedWriter(new FileWriter(lockFile))) {
         writer.write(contentsOfNewConfigurationFile.toString());
         // Properties.store is not used as Properties.store may generate '\' automatically
-        writer.write("#" + new Date().toString() + System.lineSeparator());
+        writer.write("#" + new Date().toString() + lineSeparator);
         for (String key : newConfigItems.stringPropertyNames()) {
-          writer.write(key + "=" + newConfigItems.get(key) + System.lineSeparator());
+          writer.write(key + "=" + newConfigItems.get(key) + lineSeparator);
         }
         writer.flush();
       }


### PR DESCRIPTION
## Description
1. Check duplicate in start-node and stop-node scripts
2. Properties.store is not used as Properties.store may generate '\\' automatically
3. Fix config node send showConfiguration to config node throw ClassCastException