### PR TITLE
Use milliseconds to express TTL

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBRestServiceIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBRestServiceIT.java
@@ -53,6 +53,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.iotdb.db.queryengine.common.header.ColumnHeaderConstant.COLUMN_TTL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -1063,7 +1064,7 @@ public class IoTDBRestServiceIT {
         new ArrayList<Object>() {
           {
             add("Device");
-            add("TTL");
+            add(COLUMN_TTL);
           }
         };
     List<Object> values1 =
@@ -1093,7 +1094,7 @@ public class IoTDBRestServiceIT {
         new ArrayList<Object>() {
           {
             add("Database");
-            add("TTL");
+            add(COLUMN_TTL);
             add("SchemaReplicationFactor");
             add("DataReplicationFactor");
             add("TimePartitionInterval");
@@ -1307,7 +1308,7 @@ public class IoTDBRestServiceIT {
             add("Device");
             add("IsAligned");
             add("Template");
-            add("TTL");
+            add(COLUMN_TTL);
           }
         };
     List<Object> values1 =
@@ -1345,7 +1346,7 @@ public class IoTDBRestServiceIT {
             add("Database");
             add("IsAligned");
             add("Template");
-            add("TTL");
+            add(COLUMN_TTL);
           }
         };
     List<Object> values1 =
@@ -1715,7 +1716,7 @@ public class IoTDBRestServiceIT {
         new ArrayList<Object>() {
           {
             add("Device");
-            add("TTL");
+            add(COLUMN_TTL);
           }
         };
     List<Object> values1 =
@@ -1745,7 +1746,7 @@ public class IoTDBRestServiceIT {
         new ArrayList<Object>() {
           {
             add("Database");
-            add("TTL");
+            add(COLUMN_TTL);
             add("SchemaReplicationFactor");
             add("DataReplicationFactor");
             add("TimePartitionInterval");
@@ -1959,7 +1960,7 @@ public class IoTDBRestServiceIT {
             add("Device");
             add("IsAligned");
             add("Template");
-            add("TTL");
+            add(COLUMN_TTL);
           }
         };
     List<Object> values1 =
@@ -1998,7 +1999,7 @@ public class IoTDBRestServiceIT {
             add("Database");
             add("IsAligned");
             add("Template");
-            add("TTL");
+            add(COLUMN_TTL);
           }
         };
     List<Object> values1 =

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBRestServiceIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBRestServiceIT.java
@@ -1094,7 +1094,6 @@ public class IoTDBRestServiceIT {
         new ArrayList<Object>() {
           {
             add("Database");
-            add(COLUMN_TTL);
             add("SchemaReplicationFactor");
             add("DataReplicationFactor");
             add("TimePartitionInterval");
@@ -1746,7 +1745,6 @@ public class IoTDBRestServiceIT {
         new ArrayList<Object>() {
           {
             add("Database");
-            add(COLUMN_TTL);
             add("SchemaReplicationFactor");
             add("DataReplicationFactor");
             add("TimePartitionInterval");

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBSeriesPermissionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBSeriesPermissionIT.java
@@ -163,7 +163,7 @@ public class IoTDBSeriesPermissionIT {
         showStorageGroupsColumnHeaders.stream()
             .map(ColumnHeader::getColumnName)
             .toArray(String[]::new),
-        new String[] {"root.test,10000,1,1,604800000,"},
+        new String[] {"root.test,1,1,604800000,"},
         "test1",
         "test123");
     resultSetEqualTest(

--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeDataSinkIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeDataSinkIT.java
@@ -249,7 +249,7 @@ public class IoTDBPipeDataSinkIT extends AbstractPipeDualAutoIT {
       TestUtils.assertDataEventuallyOnEnv(
           receiverEnv,
           "show devices root.ln.wf01.wt02",
-          "Device,IsAligned,Template,TTL,",
+          "Device,IsAligned,Template,TTL(ms),",
           Collections.singleton("root.ln.wf01.wt02,true,null,INF,"));
     }
   }

--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeExtractorIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeExtractorIT.java
@@ -497,7 +497,7 @@ public class IoTDBPipeExtractorIT extends AbstractPipeDualAutoIT {
       TestUtils.assertDataEventuallyOnEnv(
           receiverEnv,
           "show devices",
-          "Device,IsAligned,Template,TTL,",
+          "Device,IsAligned,Template,TTL(ms),",
           new HashSet<>(
               Arrays.asList(
                   "root.nonAligned.1TS,false,null,INF,",

--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/manual/IoTDBPipeMetaHistoricalIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/manual/IoTDBPipeMetaHistoricalIT.java
@@ -150,10 +150,10 @@ public class IoTDBPipeMetaHistoricalIT extends AbstractPipeDualManualIT {
       TestUtils.assertDataEventuallyOnEnv(
           receiverEnv,
           "show databases",
-          "Database,TTL(ms),SchemaReplicationFactor,DataReplicationFactor,TimePartitionInterval,",
+          "Database,SchemaReplicationFactor,DataReplicationFactor,TimePartitionInterval,",
           // Receiver's SchemaReplicationFactor/DataReplicationFactor shall be 3/2 regardless of the
           // sender
-          Collections.singleton("root.ln,3600000,3,2,604800000,"));
+          Collections.singleton("root.ln,3,2,604800000,"));
       TestUtils.assertDataEventuallyOnEnv(
           receiverEnv,
           "select * from root.**",
@@ -245,7 +245,7 @@ public class IoTDBPipeMetaHistoricalIT extends AbstractPipeDualManualIT {
       TestUtils.assertDataAlwaysOnEnv(
           receiverEnv,
           "show databases",
-          "Database,TTL(ms),SchemaReplicationFactor,DataReplicationFactor,TimePartitionInterval,",
+          "Database,SchemaReplicationFactor,DataReplicationFactor,TimePartitionInterval,",
           Collections.emptySet());
       TestUtils.assertDataAlwaysOnEnv(
           receiverEnv, "select * from root.**", "Time", Collections.emptySet());

--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/manual/IoTDBPipeMetaHistoricalIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/manual/IoTDBPipeMetaHistoricalIT.java
@@ -150,7 +150,7 @@ public class IoTDBPipeMetaHistoricalIT extends AbstractPipeDualManualIT {
       TestUtils.assertDataEventuallyOnEnv(
           receiverEnv,
           "show databases",
-          "Database,TTL,SchemaReplicationFactor,DataReplicationFactor,TimePartitionInterval,",
+          "Database,TTL(ms),SchemaReplicationFactor,DataReplicationFactor,TimePartitionInterval,",
           // Receiver's SchemaReplicationFactor/DataReplicationFactor shall be 3/2 regardless of the
           // sender
           Collections.singleton("root.ln,3600000,3,2,604800000,"));
@@ -245,7 +245,7 @@ public class IoTDBPipeMetaHistoricalIT extends AbstractPipeDualManualIT {
       TestUtils.assertDataAlwaysOnEnv(
           receiverEnv,
           "show databases",
-          "Database,TTL,SchemaReplicationFactor,DataReplicationFactor,TimePartitionInterval,",
+          "Database,TTL(ms),SchemaReplicationFactor,DataReplicationFactor,TimePartitionInterval,",
           Collections.emptySet());
       TestUtils.assertDataAlwaysOnEnv(
           receiverEnv, "select * from root.**", "Time", Collections.emptySet());

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/TTLManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/TTLManager.java
@@ -22,7 +22,6 @@ import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
-import org.apache.iotdb.commons.utils.CommonDateTimeUtils;
 import org.apache.iotdb.commons.utils.PathUtils;
 import org.apache.iotdb.confignode.consensus.request.read.ttl.ShowTTLPlan;
 import org.apache.iotdb.confignode.consensus.request.write.database.DatabaseSchemaPlan;
@@ -63,10 +62,6 @@ public class TTLManager {
       errorStatus.setMessage("The TTL should be positive.");
       return errorStatus;
     }
-    ttl =
-        CommonDateTimeUtils.convertMilliTimeWithPrecision(
-            ttl, CommonDescriptor.getInstance().getConfig().getTimestampPrecision());
-    ttl = ttl <= 0 ? Long.MAX_VALUE : ttl;
     SetTTLPlan setTTLPlan =
         new SetTTLPlan(
             PathUtils.splitPathToDetachedNodes(databaseSchemaPlan.getSchema().getName()), ttl);
@@ -92,13 +87,6 @@ public class TTLManager {
 
     // if path matches database, then set both path and path.**
     setTTLPlan.setDataBase(configManager.getPartitionManager().isDatabaseExist(path.getFullPath()));
-
-    long ttl =
-        CommonDateTimeUtils.convertMilliTimeWithPrecision(
-            setTTLPlan.getTTL(),
-            CommonDescriptor.getInstance().getConfig().getTimestampPrecision());
-    ttl = ttl <= 0 ? Long.MAX_VALUE : ttl;
-    setTTLPlan.setTTL(ttl);
 
     return configManager.getProcedureManager().setTTL(setTTLPlan, isGeneratedByPipe);
   }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/schema/ClusterSchemaManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/schema/ClusterSchemaManager.java
@@ -29,7 +29,6 @@ import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.path.PathPatternTree;
 import org.apache.iotdb.commons.schema.SchemaConstant;
 import org.apache.iotdb.commons.service.metric.MetricService;
-import org.apache.iotdb.commons.utils.CommonDateTimeUtils;
 import org.apache.iotdb.commons.utils.PathUtils;
 import org.apache.iotdb.commons.utils.StatusUtils;
 import org.apache.iotdb.confignode.client.CnToDnRequestType;
@@ -401,10 +400,6 @@ public class ClusterSchemaManager {
         if (ttl <= 0 || ttl == CommonDescriptor.getInstance().getConfig().getDefaultTTLInMs()) {
           continue;
         }
-        ttl =
-            CommonDateTimeUtils.convertMilliTimeWithPrecision(
-                ttl, CommonDescriptor.getInstance().getConfig().getTimestampPrecision());
-        ttl = ttl <= 0 ? Long.MAX_VALUE : ttl;
         infoMap.put(database, ttl);
       } catch (DatabaseNotExistsException e) {
         LOGGER.warn("Database: {} doesn't exist", databases, e);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/header/ColumnHeaderConstant.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/header/ColumnHeaderConstant.java
@@ -52,7 +52,7 @@ public class ColumnHeaderConstant {
   public static final String TEMPLATE = "Template";
 
   public static final String COUNT = "Count";
-  public static final String COLUMN_TTL = "TTL";
+  public static final String COLUMN_TTL = "TTL(ms)";
   public static final String SCHEMA_REPLICATION_FACTOR = "SchemaReplicationFactor";
   public static final String DATA_REPLICATION_FACTOR = "DataReplicationFactor";
   public static final String TIME_PARTITION_INTERVAL = "TimePartitionInterval";

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/header/ColumnHeaderConstant.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/header/ColumnHeaderConstant.java
@@ -252,7 +252,6 @@ public class ColumnHeaderConstant {
   public static final List<ColumnHeader> showStorageGroupsColumnHeaders =
       ImmutableList.of(
           new ColumnHeader(DATABASE, TSDataType.TEXT),
-          new ColumnHeader(COLUMN_TTL, TSDataType.TEXT),
           new ColumnHeader(SCHEMA_REPLICATION_FACTOR, TSDataType.INT32),
           new ColumnHeader(DATA_REPLICATION_FACTOR, TSDataType.INT32),
           new ColumnHeader(TIME_PARTITION_INTERVAL, TSDataType.INT64));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/source/DeviceSchemaSource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/source/DeviceSchemaSource.java
@@ -101,7 +101,7 @@ public class DeviceSchemaSource implements ISchemaSource<IDeviceSchemaInfo> {
         .getColumnBuilder(0)
         .writeBinary(new Binary(device.getFullPath(), TSFileConfig.STRING_CHARSET));
     int templateId = device.getTemplateId();
-    long ttl = DataNodeTTLCache.getInstance().getTTL(device.getPartialPath().getNodes());
+    long ttl = DataNodeTTLCache.getInstance().getTTLInMS(device.getPartialPath().getNodes());
     // TODO: make it more readable, like "30 days" or "10 hours"
     String ttlStr = ttl == Long.MAX_VALUE ? IoTDBConstant.TTL_INFINITE : String.valueOf(ttl);
     if (hasSgCol) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/DataNodeTTLCache.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/DataNodeTTLCache.java
@@ -88,9 +88,11 @@ public class DataNodeTTLCache {
   public long getTTL(String path) throws IllegalPathException {
     lock.readLock().lock();
     try {
-      return CommonDateTimeUtils.convertMilliTimeWithPrecision(
-          ttlCache.getClosestTTL(PathUtils.splitPathToDetachedNodes(path)),
-          CommonDescriptor.getInstance().getConfig().getTimestampPrecision());
+      long ttl = ttlCache.getClosestTTL(PathUtils.splitPathToDetachedNodes(path));
+      return ttl == Long.MAX_VALUE
+          ? ttl
+          : CommonDateTimeUtils.convertMilliTimeWithPrecision(
+              ttl, CommonDescriptor.getInstance().getConfig().getTimestampPrecision());
     } finally {
       lock.readLock().unlock();
     }
@@ -100,9 +102,11 @@ public class DataNodeTTLCache {
   public long getTTL(String[] path) {
     lock.readLock().lock();
     try {
-      return CommonDateTimeUtils.convertMilliTimeWithPrecision(
-          ttlCache.getClosestTTL(path),
-          CommonDescriptor.getInstance().getConfig().getTimestampPrecision());
+      long ttl = ttlCache.getClosestTTL(path);
+      return ttl == Long.MAX_VALUE
+          ? ttl
+          : CommonDateTimeUtils.convertMilliTimeWithPrecision(
+              ttl, CommonDescriptor.getInstance().getConfig().getTimestampPrecision());
     } finally {
       lock.readLock().unlock();
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/DataNodeTTLCache.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/DataNodeTTLCache.java
@@ -18,8 +18,10 @@
  */
 package org.apache.iotdb.db.queryengine.plan.analyze.cache.schema;
 
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.schema.ttl.TTLCache;
+import org.apache.iotdb.commons.utils.CommonDateTimeUtils;
 import org.apache.iotdb.commons.utils.PathUtils;
 import org.apache.iotdb.commons.utils.TestOnly;
 
@@ -70,16 +72,32 @@ public class DataNodeTTLCache {
     }
   }
 
+  /** Get ttl with time precision conversion. */
   public long getTTL(String path) throws IllegalPathException {
     lock.readLock().lock();
     try {
-      return ttlCache.getClosestTTL(PathUtils.splitPathToDetachedNodes(path));
+      return CommonDateTimeUtils.convertMilliTimeWithPrecision(
+          ttlCache.getClosestTTL(PathUtils.splitPathToDetachedNodes(path)),
+          CommonDescriptor.getInstance().getConfig().getTimestampPrecision());
     } finally {
       lock.readLock().unlock();
     }
   }
 
+  /** Get ttl with time precision conversion. */
   public long getTTL(String[] path) {
+    lock.readLock().lock();
+    try {
+      return CommonDateTimeUtils.convertMilliTimeWithPrecision(
+          ttlCache.getClosestTTL(path),
+          CommonDescriptor.getInstance().getConfig().getTimestampPrecision());
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  /** Get ttl without time precision conversion. */
+  public long getTTLInMS(String[] path) {
     lock.readLock().lock();
     try {
       return ttlCache.getClosestTTL(path);
@@ -88,8 +106,11 @@ public class DataNodeTTLCache {
     }
   }
 
-  /** Get ttl of one specific path node. If this node does not set ttl, then return -1. */
-  public long getNodeTTL(String path) throws IllegalPathException {
+  /**
+   * Get ttl of one specific path node without time precision conversion. If this node does not set
+   * ttl, then return -1.
+   */
+  public long getNodeTTLInMS(String path) throws IllegalPathException {
     lock.readLock().lock();
     try {
       return ttlCache.getLastNodeTTL(PathUtils.splitPathToDetachedNodes(path));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/metadata/ShowDatabaseStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/metadata/ShowDatabaseStatement.java
@@ -95,7 +95,7 @@ public class ShowDatabaseStatement extends ShowStatement implements IConfigState
       TDatabaseInfo storageGroupInfo = entry.getValue();
       long ttl =
           DataNodeTTLCache.getInstance()
-              .getNodeTTL(
+              .getNodeTTLInMS(
                   storageGroup
                       + IoTDBConstant.PATH_SEPARATOR
                       + IoTDBConstant.MULTI_LEVEL_PATH_WILDCARD);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/metadata/ShowDatabaseStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/metadata/ShowDatabaseStatement.java
@@ -19,17 +19,14 @@
 
 package org.apache.iotdb.db.queryengine.plan.statement.metadata;
 
-import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
-import org.apache.iotdb.commons.schema.ttl.TTLCache;
 import org.apache.iotdb.confignode.rpc.thrift.TDatabaseInfo;
 import org.apache.iotdb.db.queryengine.common.header.ColumnHeader;
 import org.apache.iotdb.db.queryengine.common.header.ColumnHeaderConstant;
 import org.apache.iotdb.db.queryengine.common.header.DatasetHeader;
 import org.apache.iotdb.db.queryengine.common.header.DatasetHeaderFactory;
 import org.apache.iotdb.db.queryengine.plan.analyze.QueryType;
-import org.apache.iotdb.db.queryengine.plan.analyze.cache.schema.DataNodeTTLCache;
 import org.apache.iotdb.db.queryengine.plan.execution.config.ConfigTaskResult;
 import org.apache.iotdb.db.queryengine.plan.statement.IConfigStatement;
 import org.apache.iotdb.db.queryengine.plan.statement.StatementVisitor;
@@ -93,35 +90,21 @@ public class ShowDatabaseStatement extends ShowStatement implements IConfigState
     for (Map.Entry<String, TDatabaseInfo> entry : storageGroupInfoMap.entrySet()) {
       String storageGroup = entry.getKey();
       TDatabaseInfo storageGroupInfo = entry.getValue();
-      long ttl =
-          DataNodeTTLCache.getInstance()
-              .getNodeTTLInMS(
-                  storageGroup
-                      + IoTDBConstant.PATH_SEPARATOR
-                      + IoTDBConstant.MULTI_LEVEL_PATH_WILDCARD);
-      String ttlStr = String.valueOf(ttl);
-      if (ttl == TTLCache.NULL_TTL) {
-        ttlStr = "null";
-      } else if (ttl == Long.MAX_VALUE) {
-        ttlStr = IoTDBConstant.TTL_INFINITE;
-      }
+
       builder.getTimeColumnBuilder().writeLong(0L);
       builder
           .getColumnBuilder(0)
           .writeBinary(new Binary(storageGroup, TSFileConfig.STRING_CHARSET));
-
-      builder.getColumnBuilder(1).writeBinary(new Binary(ttlStr, TSFileConfig.STRING_CHARSET));
-
-      builder.getColumnBuilder(2).writeInt(storageGroupInfo.getSchemaReplicationFactor());
-      builder.getColumnBuilder(3).writeInt(storageGroupInfo.getDataReplicationFactor());
-      builder.getColumnBuilder(4).writeLong(storageGroupInfo.getTimePartitionInterval());
+      builder.getColumnBuilder(1).writeInt(storageGroupInfo.getSchemaReplicationFactor());
+      builder.getColumnBuilder(2).writeInt(storageGroupInfo.getDataReplicationFactor());
+      builder.getColumnBuilder(3).writeLong(storageGroupInfo.getTimePartitionInterval());
       if (isDetailed) {
-        builder.getColumnBuilder(5).writeInt(storageGroupInfo.getSchemaRegionNum());
-        builder.getColumnBuilder(6).writeInt(storageGroupInfo.getMinSchemaRegionNum());
-        builder.getColumnBuilder(7).writeInt(storageGroupInfo.getMaxSchemaRegionNum());
-        builder.getColumnBuilder(8).writeInt(storageGroupInfo.getDataRegionNum());
-        builder.getColumnBuilder(9).writeInt(storageGroupInfo.getMinDataRegionNum());
-        builder.getColumnBuilder(10).writeInt(storageGroupInfo.getMaxDataRegionNum());
+        builder.getColumnBuilder(4).writeInt(storageGroupInfo.getSchemaRegionNum());
+        builder.getColumnBuilder(5).writeInt(storageGroupInfo.getMinSchemaRegionNum());
+        builder.getColumnBuilder(6).writeInt(storageGroupInfo.getMaxSchemaRegionNum());
+        builder.getColumnBuilder(7).writeInt(storageGroupInfo.getDataRegionNum());
+        builder.getColumnBuilder(8).writeInt(storageGroupInfo.getMinDataRegionNum());
+        builder.getColumnBuilder(9).writeInt(storageGroupInfo.getMaxDataRegionNum());
       }
       builder.declarePosition();
     }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/IoTDBConstant.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/IoTDBConstant.java
@@ -171,7 +171,6 @@ public class IoTDBConstant {
   public static final String STATEMENT = "statement";
 
   public static final String COLUMN_DATABASE = "database";
-  public static final String COLUMN_TTL = "ttl";
 
   public static final String COLUMN_FUNCTION_NAME = "function name";
   public static final String COLUMN_FUNCTION_TYPE = "function type";

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/schema/ttl/TTLCache.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/schema/ttl/TTLCache.java
@@ -21,7 +21,6 @@ package org.apache.iotdb.commons.schema.ttl;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.IllegalPathException;
-import org.apache.iotdb.commons.utils.CommonDateTimeUtils;
 import org.apache.iotdb.commons.utils.PathUtils;
 
 import org.apache.tsfile.utils.ReadWriteIOUtils;
@@ -47,12 +46,9 @@ public class TTLCache {
 
   public TTLCache() {
     ttlCacheTree = new CacheNode(IoTDBConstant.PATH_ROOT);
-    long defaultTTL =
-        CommonDateTimeUtils.convertMilliTimeWithPrecision(
-            CommonDescriptor.getInstance().getConfig().getDefaultTTLInMs(),
-            CommonDescriptor.getInstance().getConfig().getTimestampPrecision());
-    defaultTTL = defaultTTL <= 0 ? Long.MAX_VALUE : defaultTTL;
-    ttlCacheTree.addChild(IoTDBConstant.MULTI_LEVEL_PATH_WILDCARD, defaultTTL);
+    ttlCacheTree.addChild(
+        IoTDBConstant.MULTI_LEVEL_PATH_WILDCARD,
+        CommonDescriptor.getInstance().getConfig().getDefaultTTLInMs());
     ttlCount = 1;
   }
 
@@ -93,9 +89,7 @@ public class TTLCache {
       if (nodes[0].equals(IoTDBConstant.PATH_ROOT)
           && nodes[1].equals(IoTDBConstant.MULTI_LEVEL_PATH_WILDCARD)) {
         ttlCacheTree.getChild(IoTDBConstant.MULTI_LEVEL_PATH_WILDCARD).ttl =
-            CommonDateTimeUtils.convertMilliTimeWithPrecision(
-                CommonDescriptor.getInstance().getConfig().getDefaultTTLInMs(),
-                CommonDescriptor.getInstance().getConfig().getTimestampPrecision());
+            CommonDescriptor.getInstance().getConfig().getDefaultTTLInMs();
         return;
       }
     }
@@ -231,9 +225,7 @@ public class TTLCache {
     ttlCacheTree.removeAllChildren();
     ttlCacheTree.addChild(
         IoTDBConstant.MULTI_LEVEL_PATH_WILDCARD,
-        CommonDateTimeUtils.convertMilliTimeWithPrecision(
-            CommonDescriptor.getInstance().getConfig().getDefaultTTLInMs(),
-            CommonDescriptor.getInstance().getConfig().getTimestampPrecision()));
+        CommonDescriptor.getInstance().getConfig().getDefaultTTLInMs());
   }
 
   static class CacheNode {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/CommonDateTimeUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/CommonDateTimeUtils.java
@@ -42,7 +42,8 @@ public class CommonDateTimeUtils {
       default:
         break;
     }
-    return result;
+    // To avoid integer overflow
+    return result < 0 ? Long.MAX_VALUE : result;
   }
 
   public static long currentTime() {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/CommonDateTimeUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/CommonDateTimeUtils.java
@@ -21,10 +21,14 @@ package org.apache.iotdb.commons.utils;
 
 import org.apache.iotdb.commons.conf.CommonDescriptor;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.time.Duration;
 import java.util.function.BiConsumer;
 
 public class CommonDateTimeUtils {
+  protected static final Logger LOGGER = LoggerFactory.getLogger(CommonDateTimeUtils.class);
 
   public CommonDateTimeUtils() {
     // Empty constructor
@@ -43,7 +47,12 @@ public class CommonDateTimeUtils {
         break;
     }
     // To avoid integer overflow
-    return result < 0 ? Long.MAX_VALUE : result;
+    if (result < 0) {
+      LOGGER.warn(
+          "Integer overflow when converting {}ms to {}{}.", milliTime, result, timePrecision);
+      result = Long.MAX_VALUE;
+    }
+    return result;
   }
 
   public static long currentTime() {


### PR DESCRIPTION
1. Use milliseconds to express TTL. Eg：
<img width="388" alt="image" src="https://github.com/apache/iotdb/assets/45144903/2102bb13-64e8-4e8b-a97f-4970b55074ea">

The TTL values are always displayed and stored in milliseconds. They are converted to the corresponding unit based on the `TimestampPrecision` parameter only during filtering and cleaning processes. See details in [link](https://jira.infra.timecho.com:8443/browse/TIMECHODB-778)

2. Remove ttl column when showing databases.
