### PR TITLE
Pipe: Filter devices by pattern before reading device metadata from TsFile

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/TsFileInsertionDataContainer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/TsFileInsertionDataContainer.java
@@ -51,11 +51,13 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Set;
 
 public class TsFileInsertionDataContainer implements AutoCloseable {
 
@@ -126,8 +128,7 @@ public class TsFileInsertionDataContainer implements AutoCloseable {
 
         // Filter devices that may overlap with pattern first
         // to avoid reading all time-series of all devices.
-        final List<IDeviceID> devices =
-            filterDevicesByPattern(tsFileSequenceReader.getAllDevices());
+        final Set<IDeviceID> devices = filterDevicesByPattern(deviceIsAlignedMap.keySet());
 
         measurementDataTypeMap = readFilteredFullPathDataTypeMap(devices);
         memoryRequiredInBytes += PipeMemoryWeighUtil.memoryOfStr2TSDataType(measurementDataTypeMap);
@@ -206,12 +207,12 @@ public class TsFileInsertionDataContainer implements AutoCloseable {
     return deviceIsAlignedResultMap;
   }
 
-  private List<IDeviceID> filterDevicesByPattern(final List<IDeviceID> devices) {
+  private Set<IDeviceID> filterDevicesByPattern(final Set<IDeviceID> devices) {
     if (Objects.isNull(pattern) || pattern.isRoot()) {
       return devices;
     }
 
-    final List<IDeviceID> filteredDevices = new ArrayList<>();
+    final Set<IDeviceID> filteredDevices = new HashSet<>();
     for (final IDeviceID device : devices) {
       final String deviceId = ((PlainDeviceID) device).toStringID();
       if (pattern.coversDevice(deviceId) || pattern.mayOverlapWithDevice(deviceId)) {
@@ -225,7 +226,7 @@ public class TsFileInsertionDataContainer implements AutoCloseable {
    * This method is similar to {@link TsFileSequenceReader#getFullPathDataTypeMap()}, but only reads
    * the given devices.
    */
-  private Map<String, TSDataType> readFilteredFullPathDataTypeMap(final List<IDeviceID> devices)
+  private Map<String, TSDataType> readFilteredFullPathDataTypeMap(final Set<IDeviceID> devices)
       throws IOException {
     final Map<String, TSDataType> result = new HashMap<>();
 
@@ -250,7 +251,7 @@ public class TsFileInsertionDataContainer implements AutoCloseable {
    * reads the given devices.
    */
   private Map<IDeviceID, List<String>> readFilteredDeviceMeasurementsMap(
-      final List<IDeviceID> devices) throws IOException {
+      final Set<IDeviceID> devices) throws IOException {
     final Map<IDeviceID, List<String>> result = new HashMap<>();
 
     for (IDeviceID device : devices) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/TsFileInsertionDataContainer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/TsFileInsertionDataContainer.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.commons.pipe.config.PipeConfig;
 import org.apache.iotdb.commons.pipe.event.EnrichedEvent;
 import org.apache.iotdb.commons.pipe.pattern.PipePattern;
 import org.apache.iotdb.commons.pipe.task.meta.PipeTaskMeta;
+import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.db.pipe.event.common.tablet.PipeRawTabletInsertionEvent;
 import org.apache.iotdb.db.pipe.resource.PipeResourceManager;
 import org.apache.iotdb.db.pipe.resource.memory.PipeMemoryBlock;
@@ -77,6 +78,7 @@ public class TsFileInsertionDataContainer implements AutoCloseable {
 
   private boolean shouldParsePattern = false;
 
+  @TestOnly
   public TsFileInsertionDataContainer(
       final File tsFile, final PipePattern pattern, final long startTime, final long endTime)
       throws IOException {
@@ -122,15 +124,21 @@ public class TsFileInsertionDataContainer implements AutoCloseable {
         deviceIsAlignedMap = readDeviceIsAlignedMap();
         memoryRequiredInBytes += PipeMemoryWeighUtil.memoryOfIDeviceId2Bool(deviceIsAlignedMap);
 
-        measurementDataTypeMap = tsFileSequenceReader.getFullPathDataTypeMap();
+        // Filter devices that may overlap with pattern first
+        // to avoid reading all time-series of all devices.
+        final List<IDeviceID> devices =
+            filterDevicesByPattern(tsFileSequenceReader.getAllDevices());
+
+        measurementDataTypeMap = readFilteredFullPathDataTypeMap(devices);
         memoryRequiredInBytes += PipeMemoryWeighUtil.memoryOfStr2TSDataType(measurementDataTypeMap);
 
-        deviceMeasurementsMap = tsFileSequenceReader.getDeviceMeasurementsMap();
+        deviceMeasurementsMap = readFilteredDeviceMeasurementsMap(devices);
         memoryRequiredInBytes +=
             PipeMemoryWeighUtil.memoryOfIDeviceID2StrList(deviceMeasurementsMap);
       }
       allocatedMemoryBlock = PipeResourceManager.memory().forceAllocate(memoryRequiredInBytes);
 
+      // Filter again to get the final deviceMeasurementsMap that exactly matches the pattern.
       deviceMeasurementsMapIterator =
           filterDeviceMeasurementsMapByPattern(deviceMeasurementsMap).entrySet().iterator();
 
@@ -196,6 +204,67 @@ public class TsFileInsertionDataContainer implements AutoCloseable {
       deviceIsAlignedResultMap.put(deviceIsAlignedPair.getLeft(), deviceIsAlignedPair.getRight());
     }
     return deviceIsAlignedResultMap;
+  }
+
+  private List<IDeviceID> filterDevicesByPattern(final List<IDeviceID> devices) {
+    if (Objects.isNull(pattern) || pattern.isRoot()) {
+      return devices;
+    }
+
+    final List<IDeviceID> filteredDevices = new ArrayList<>();
+    for (final IDeviceID device : devices) {
+      final String deviceId = ((PlainDeviceID) device).toStringID();
+      if (pattern.coversDevice(deviceId) || pattern.mayOverlapWithDevice(deviceId)) {
+        filteredDevices.add(device);
+      }
+    }
+    return filteredDevices;
+  }
+
+  /**
+   * This method is similar to {@link TsFileSequenceReader#getFullPathDataTypeMap()}, but only reads
+   * the given devices.
+   */
+  private Map<String, TSDataType> readFilteredFullPathDataTypeMap(final List<IDeviceID> devices)
+      throws IOException {
+    final Map<String, TSDataType> result = new HashMap<>();
+
+    for (IDeviceID device : devices) {
+      tsFileSequenceReader
+          .readDeviceMetadata(device)
+          .values()
+          .forEach(
+              timeseriesMetadata ->
+                  result.put(
+                      ((PlainDeviceID) device).toStringID()
+                          + "."
+                          + timeseriesMetadata.getMeasurementId(),
+                      timeseriesMetadata.getTsDataType()));
+    }
+
+    return result;
+  }
+
+  /**
+   * This method is similar to {@link TsFileSequenceReader#getDeviceMeasurementsMap()}, but only
+   * reads the given devices.
+   */
+  private Map<IDeviceID, List<String>> readFilteredDeviceMeasurementsMap(
+      final List<IDeviceID> devices) throws IOException {
+    final Map<IDeviceID, List<String>> result = new HashMap<>();
+
+    for (IDeviceID device : devices) {
+      tsFileSequenceReader
+          .readDeviceMetadata(device)
+          .values()
+          .forEach(
+              timeseriesMetadata ->
+                  result
+                      .computeIfAbsent(device, d -> new ArrayList<>())
+                      .add(timeseriesMetadata.getMeasurementId()));
+    }
+
+    return result;
   }
 
   /**


### PR DESCRIPTION
Currently we read the metadata of **all** devices and measurements when constructing a TsFileInsertionDataContainer. This is both time-consuming and memory-wasting if only **a few** devices match the pattern. This PR filters the devices by pattern before reading the metadata of devices and measurements, saving memory and I/O cost when there are many unmatched devices.

Note: this only works when TsFile metadata are **not** cached (due to high memory usage of TsFile metadata cache), because cached metadata can not be filtered so that pipes with arbitrary patterns can use it.