### PR TITLE
[RatisConsensus] Synchronize takeSnapshotAsync on RaftGroupID

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -771,14 +771,22 @@ class RatisConsensus implements IConsensus {
             300000,
             force ? 1 : 0);
 
-    final RaftClientReply reply;
-    try {
-      reply = server.get().snapshotManagement(request);
-      if (!reply.isSuccess()) {
-        throw new RatisRequestFailedException(reply.getException());
+    synchronized (raftGroupId) {
+      final RaftClientReply reply;
+      try {
+        reply = server.get().snapshotManagement(request);
+        if (!reply.isSuccess()) {
+          throw new RatisRequestFailedException(reply.getException());
+        }
+        logger.info(
+            "{} group {}: successfully taken snapshot at index {} with force = {}",
+            this,
+            raftGroupId,
+            reply.getLogIndex(),
+            force);
+      } catch (IOException ioException) {
+        throw new RatisRequestFailedException(ioException);
       }
-    } catch (IOException ioException) {
-      throw new RatisRequestFailedException(ioException);
     }
   }
 


### PR DESCRIPTION
1. Log every successful snapshot actions
2. Synchronize on takeSnapshotAsync so that the daemons will not affect force actions