### PR TITLE
Allow using python 3.6 and enable CI

### DIFF
--- a/.github/workflows/multi-language-client.yml
+++ b/.github/workflows/multi-language-client.yml
@@ -110,8 +110,8 @@ jobs:
         python: ['3.x']
         os: [ubuntu-latest]
         include:
-          - os: ubuntu-20.04
-            python: '3.6'
+          - python: '3.6'
+            os: ubuntu-20.04
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/multi-language-client.yml
+++ b/.github/workflows/multi-language-client.yml
@@ -107,8 +107,12 @@ jobs:
       fail-fast: false
       max-parallel: 15
       matrix:
-        python: ['3.6', '3.x']
-    runs-on: ubuntu-latest
+        python: ['3.x']
+        os: [ubuntu-latest]
+        include:
+          - os: ubuntu-20.04
+            version: '3.6'
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/multi-language-client.yml
+++ b/.github/workflows/multi-language-client.yml
@@ -111,7 +111,7 @@ jobs:
         os: [ubuntu-latest]
         include:
           - os: ubuntu-20.04
-            version: '3.6'
+            python: '3.6'
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/multi-language-client.yml
+++ b/.github/workflows/multi-language-client.yml
@@ -134,6 +134,7 @@ jobs:
       - name: Install IoTDB python client requirements
         run: pip3 install -r iotdb-client/client-py/requirements_dev.txt
       - name: Check code style
+        if: ${{ matrix.python == '3.x'}}
         shell: bash
         run: black iotdb-client/client-py/ --check --diff
       - name: Integration test

--- a/.github/workflows/multi-language-client.yml
+++ b/.github/workflows/multi-language-client.yml
@@ -103,6 +103,11 @@ jobs:
           make e2e_test_for_parent_git_repo e2e_test_clean_for_parent_git_repo
 
   python:
+    strategy:
+      fail-fast: false
+      max-parallel: 15
+      matrix:
+        python: ['3.6', '3.x']
     runs-on: ubuntu-latest
 
     steps:
@@ -119,6 +124,9 @@ jobs:
         run: |
           docker build . -f docker/src/main/Dockerfile-1c1d -t "iotdb:dev"
           docker images
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
       - name: Install IoTDB python client requirements
         run: pip3 install -r iotdb-client/client-py/requirements_dev.txt
       - name: Check code style

--- a/iotdb-client/client-py/iotdb/utils/IoTDBRpcDataSet.py
+++ b/iotdb-client/client-py/iotdb/utils/IoTDBRpcDataSet.py
@@ -348,7 +348,7 @@ class IoTDBRpcDataSet(object):
                     elif data_type == 2:
                         tmp_array = pd.Series(tmp_array).astype("Int64")
                     elif data_type == 0:
-                        tmp_array = pd.Series(tmp_array).astype("Boolean")
+                        tmp_array = pd.Series(tmp_array).astype(">?")
 
                     data_array = tmp_array
 
@@ -361,8 +361,8 @@ class IoTDBRpcDataSet(object):
                 result[k] = pd.Series(np.concatenate(v, axis=0)).astype("Int32")
             elif v[0].dtype == "Int64":
                 result[k] = pd.Series(np.concatenate(v, axis=0)).astype("Int64")
-            elif v[0].dtype == "Boolean":
-                result[k] = pd.Series(np.concatenate(v, axis=0)).astype("Boolean")
+            elif v[0].dtype == ">?":
+                result[k] = pd.Series(np.concatenate(v, axis=0)).astype("boolean")
             else:
                 result[k] = np.concatenate(v, axis=0)
 

--- a/iotdb-client/client-py/iotdb/utils/IoTDBRpcDataSet.py
+++ b/iotdb-client/client-py/iotdb/utils/IoTDBRpcDataSet.py
@@ -344,11 +344,11 @@ class IoTDBRpcDataSet(object):
                     tmp_array[bit_mask] = data_array
 
                     if data_type == 1:
-                        tmp_array = pd.Series(tmp_array).astype("Int32")
+                        tmp_array = pd.Series(tmp_array).astype("int32")
                     elif data_type == 2:
-                        tmp_array = pd.Series(tmp_array).astype("Int64")
+                        tmp_array = pd.Series(tmp_array).astype("int64")
                     elif data_type == 0:
-                        tmp_array = pd.Series(tmp_array).astype("boolean")
+                        tmp_array = pd.Series(tmp_array).astype("bool")
 
                     data_array = tmp_array
 
@@ -357,9 +357,9 @@ class IoTDBRpcDataSet(object):
         for k, v in result.items():
             if v is None or len(v) < 1 or v[0] is None:
                 result[k] = []
-            elif v[0].dtype == "Int32":
+            elif v[0].dtype == "int32":
                 result[k] = pd.Series(np.concatenate(v, axis=0)).astype("Int32")
-            elif v[0].dtype == "Int64":
+            elif v[0].dtype == "int64":
                 result[k] = pd.Series(np.concatenate(v, axis=0)).astype("Int64")
             elif v[0].dtype == "bool":
                 result[k] = pd.Series(np.concatenate(v, axis=0)).astype("boolean")

--- a/iotdb-client/client-py/iotdb/utils/IoTDBRpcDataSet.py
+++ b/iotdb-client/client-py/iotdb/utils/IoTDBRpcDataSet.py
@@ -344,11 +344,11 @@ class IoTDBRpcDataSet(object):
                     tmp_array[bit_mask] = data_array
 
                     if data_type == 1:
-                        tmp_array = pd.Series(tmp_array).astype("int32")
+                        tmp_array = pd.Series(tmp_array).astype("Int32")
                     elif data_type == 2:
-                        tmp_array = pd.Series(tmp_array).astype("int64")
+                        tmp_array = pd.Series(tmp_array).astype("Int64")
                     elif data_type == 0:
-                        tmp_array = pd.Series(tmp_array).astype("bool")
+                        tmp_array = pd.Series(tmp_array).astype(bool)
 
                     data_array = tmp_array
 
@@ -357,11 +357,11 @@ class IoTDBRpcDataSet(object):
         for k, v in result.items():
             if v is None or len(v) < 1 or v[0] is None:
                 result[k] = []
-            elif v[0].dtype == "int32":
+            elif v[0].dtype == "Int32":
                 result[k] = pd.Series(np.concatenate(v, axis=0)).astype("Int32")
-            elif v[0].dtype == "int64":
+            elif v[0].dtype == "Int64":
                 result[k] = pd.Series(np.concatenate(v, axis=0)).astype("Int64")
-            elif v[0].dtype == "bool":
+            elif v[0].dtype == bool:
                 result[k] = pd.Series(np.concatenate(v, axis=0)).astype("boolean")
             else:
                 result[k] = np.concatenate(v, axis=0)

--- a/iotdb-client/client-py/iotdb/utils/IoTDBRpcDataSet.py
+++ b/iotdb-client/client-py/iotdb/utils/IoTDBRpcDataSet.py
@@ -348,7 +348,7 @@ class IoTDBRpcDataSet(object):
                     elif data_type == 2:
                         tmp_array = pd.Series(tmp_array).astype("Int64")
                     elif data_type == 0:
-                        tmp_array = pd.Series(tmp_array).astype(">?")
+                        tmp_array = pd.Series(tmp_array).astype("boolean")
 
                     data_array = tmp_array
 
@@ -361,7 +361,7 @@ class IoTDBRpcDataSet(object):
                 result[k] = pd.Series(np.concatenate(v, axis=0)).astype("Int32")
             elif v[0].dtype == "Int64":
                 result[k] = pd.Series(np.concatenate(v, axis=0)).astype("Int64")
-            elif v[0].dtype == ">?":
+            elif v[0].dtype == bool:
                 result[k] = pd.Series(np.concatenate(v, axis=0)).astype("boolean")
             else:
                 result[k] = np.concatenate(v, axis=0)

--- a/iotdb-client/client-py/iotdb/utils/IoTDBRpcDataSet.py
+++ b/iotdb-client/client-py/iotdb/utils/IoTDBRpcDataSet.py
@@ -348,7 +348,7 @@ class IoTDBRpcDataSet(object):
                     elif data_type == 2:
                         tmp_array = pd.Series(tmp_array).astype("Int64")
                     elif data_type == 0:
-                        tmp_array = pd.Series(tmp_array).astype("Bool")
+                        tmp_array = pd.Series(tmp_array).astype("Boolean")
 
                     data_array = tmp_array
 
@@ -361,8 +361,8 @@ class IoTDBRpcDataSet(object):
                 result[k] = pd.Series(np.concatenate(v, axis=0)).astype("Int32")
             elif v[0].dtype == "Int64":
                 result[k] = pd.Series(np.concatenate(v, axis=0)).astype("Int64")
-            elif v[0].dtype == "Bool":
-                result[k] = pd.Series(np.concatenate(v, axis=0)).astype("boolean")
+            elif v[0].dtype == "Boolean":
+                result[k] = pd.Series(np.concatenate(v, axis=0)).astype("Boolean")
             else:
                 result[k] = np.concatenate(v, axis=0)
 

--- a/iotdb-client/client-py/iotdb/utils/IoTDBRpcDataSet.py
+++ b/iotdb-client/client-py/iotdb/utils/IoTDBRpcDataSet.py
@@ -361,7 +361,7 @@ class IoTDBRpcDataSet(object):
                 result[k] = pd.Series(np.concatenate(v, axis=0)).astype("Int32")
             elif v[0].dtype == "Int64":
                 result[k] = pd.Series(np.concatenate(v, axis=0)).astype("Int64")
-            elif v[0].dtype == "boolean":
+            elif v[0].dtype == "bool":
                 result[k] = pd.Series(np.concatenate(v, axis=0)).astype("boolean")
             else:
                 result[k] = np.concatenate(v, axis=0)

--- a/iotdb-client/client-py/iotdb/utils/IoTDBRpcDataSet.py
+++ b/iotdb-client/client-py/iotdb/utils/IoTDBRpcDataSet.py
@@ -348,7 +348,7 @@ class IoTDBRpcDataSet(object):
                     elif data_type == 2:
                         tmp_array = pd.Series(tmp_array).astype("Int64")
                     elif data_type == 0:
-                        tmp_array = pd.Series(tmp_array).astype(bool)
+                        tmp_array = pd.Series(tmp_array).astype("Bool")
 
                     data_array = tmp_array
 
@@ -361,7 +361,7 @@ class IoTDBRpcDataSet(object):
                 result[k] = pd.Series(np.concatenate(v, axis=0)).astype("Int32")
             elif v[0].dtype == "Int64":
                 result[k] = pd.Series(np.concatenate(v, axis=0)).astype("Int64")
-            elif v[0].dtype == bool:
+            elif v[0].dtype == "Bool":
                 result[k] = pd.Series(np.concatenate(v, axis=0)).astype("boolean")
             else:
                 result[k] = np.concatenate(v, axis=0)

--- a/iotdb-client/client-py/requirements.txt
+++ b/iotdb-client/client-py/requirements.txt
@@ -17,8 +17,8 @@
 #
 
 # Pandas Export
-pandas>=1.3.5
-numpy>=1.21.4
+pandas>=1.0.0
+numpy>=1.0.0
 thrift>=0.14.1
 # SQLAlchemy Dialect
 sqlalchemy<1.5,>=1.4

--- a/iotdb-client/client-py/requirements_dev.txt
+++ b/iotdb-client/client-py/requirements_dev.txt
@@ -18,11 +18,11 @@
 
 -r requirements.txt
 # Pytest to run tests
-pytest==7.2.0
-flake8==3.9.0
-black==24.3.0
+pytest>=7.0.0
+flake8>=5.0.0
+black>=22.8.0
 # Testcontainer
 testcontainers==3.4.2
 # For releases
 twine==3.4.1
-wheel==0.38.1
+wheel>=0.37.1

--- a/iotdb-client/client-py/resources/setup.py
+++ b/iotdb-client/client-py/resources/setup.py
@@ -53,7 +53,7 @@ setuptools.setup(
         "Topic :: Software Development :: Libraries",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.6",
     license="Apache License, Version 2.0",
     website="https://iotdb.apache.org",
     entry_points={

--- a/iotdb-client/client-py/resources/setup.py
+++ b/iotdb-client/client-py/resources/setup.py
@@ -41,8 +41,8 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         "thrift>=0.14.1",
-        "pandas>=1.3.5",
-        "numpy>=1.21.4",
+        "pandas>=1.0.0",
+        "numpy>=1.0.0",
         "sqlalchemy<1.5,>=1.4",
         "sqlalchemy-utils>=0.37.8",
     ],

--- a/iotdb-client/client-py/tests/test_todf.py
+++ b/iotdb-client/client-py/tests/test_todf.py
@@ -98,7 +98,7 @@ def test_simple_query():
         df_output = df_output[df_input.columns.tolist()]
 
         session.close()
-    assert_frame_equal(df_input, df_output)
+    assert_frame_equal(df_input, df_output, check_frame_type=False)
 
 
 def test_with_null_query():
@@ -178,7 +178,7 @@ def test_with_null_query():
         df_output = df_output[df_input.columns.tolist()]
 
         session.close()
-    assert_frame_equal(df_input, df_output)
+    assert_frame_equal(df_input, df_output, check_frame_type=False)
 
 
 def test_multi_fetch():
@@ -216,4 +216,4 @@ def test_multi_fetch():
         df_output = df_output[df_input.columns.tolist()]
 
         session.close()
-    assert_frame_equal(df_input, df_output)
+    assert_frame_equal(df_input, df_output, check_frame_type=False)

--- a/iotdb-client/client-py/tests/test_todf.py
+++ b/iotdb-client/client-py/tests/test_todf.py
@@ -98,7 +98,7 @@ def test_simple_query():
         df_output = df_output[df_input.columns.tolist()]
 
         session.close()
-    assert_frame_equal(df_input, df_output, check_frame_type=False)
+    assert_frame_equal(df_input, df_output, check_dtype=False)
 
 
 def test_with_null_query():
@@ -178,7 +178,7 @@ def test_with_null_query():
         df_output = df_output[df_input.columns.tolist()]
 
         session.close()
-    assert_frame_equal(df_input, df_output, check_frame_type=False)
+    assert_frame_equal(df_input, df_output, check_dtype=False)
 
 
 def test_multi_fetch():
@@ -216,4 +216,4 @@ def test_multi_fetch():
         df_output = df_output[df_input.columns.tolist()]
 
         session.close()
-    assert_frame_equal(df_input, df_output, check_frame_type=False)
+    assert_frame_equal(df_input, df_output, check_dtype=False)


### PR DESCRIPTION
## Description

This PR allowed using the iotdb client with Python 3.6. 
It also fixed a bug when using a low version of numpy.

![image](https://github.com/apache/iotdb/assets/25913899/f8eb35e3-2d4d-4279-94f7-7515e81de559)


