### PR TITLE
Remove global timefilter in Analysis

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceContext.java
@@ -359,6 +359,15 @@ public class FragmentInstanceContext extends QueryContext {
     return globalTimeFilter;
   }
 
+  public void setTimeFilterForTableModel(Filter timeFilter) {
+    if (globalTimeFilter == null) {
+      globalTimeFilter = timeFilter;
+    } else {
+      throw new IllegalStateException(
+          "globalTimeFilter in FragmentInstanceContext should only be set once in Table Model!");
+    }
+  }
+
   public IDataRegionForQuery getDataRegion() {
     return dataRegion;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/TableScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/TableScanOperator.java
@@ -38,7 +38,6 @@ import org.apache.tsfile.block.column.ColumnBuilder;
 import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.common.conf.TSFileDescriptor;
 import org.apache.tsfile.enums.TSDataType;
-import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.read.common.block.TsBlock;
 import org.apache.tsfile.read.common.block.TsBlockBuilder;
 import org.apache.tsfile.read.common.block.column.BinaryColumn;
@@ -375,16 +374,8 @@ public class TableScanOperator extends AbstractDataSourceOperator {
       DeviceEntry deviceEntry,
       List<String> measurementColumnNames,
       List<IMeasurementSchema> measurementSchemas) {
-    String[] devicePath = new String[1 + deviceEntry.getDeviceID().segmentNum()];
-    devicePath[0] = "root";
-    for (int i = 1; i < devicePath.length; i++) {
-      devicePath[i] = (String) deviceEntry.getDeviceID().segment(i - 1);
-    }
-
     return new AlignedFullPath(
-        IDeviceID.Factory.DEFAULT_FACTORY.create(devicePath),
-        measurementColumnNames,
-        measurementSchemas);
+        deviceEntry.getDeviceID(), measurementColumnNames, measurementSchemas);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/FragmentInstance.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/FragmentInstance.java
@@ -115,6 +115,19 @@ public class FragmentInstance implements IConsensusRequest {
   public FragmentInstance(
       PlanFragment fragment,
       FragmentInstanceId id,
+      QueryType type,
+      long timeOut,
+      SessionInfo sessionInfo,
+      boolean isExplainAnalyze,
+      boolean isRoot) {
+    this(fragment, id, null, type, timeOut, sessionInfo);
+    this.isRoot = isRoot;
+    this.isExplainAnalyze = isExplainAnalyze;
+  }
+
+  public FragmentInstance(
+      PlanFragment fragment,
+      FragmentInstanceId id,
       TimePredicate globalTimePredicate,
       QueryType type,
       long timeOut,

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/Analysis.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/Analysis.java
@@ -154,10 +154,10 @@ public class Analysis implements IAnalysis {
 
   private final Set<NodeRef<Relation>> aliasedRelations = new LinkedHashSet<>();
 
-  private Expression globalTableModelTimePredicate;
-
+  // only be used in write plan and won't be used in query
   private DataPartition dataPartition;
 
+  // only be used in write plan and won't be used in query
   private SchemaPartition schemaPartition;
 
   private DatasetHeader respDatasetHeader;
@@ -166,14 +166,6 @@ public class Analysis implements IAnalysis {
 
   // indicate is there a value filter
   private boolean hasValueFilter = false;
-
-  public Expression getGlobalTableModelTimePredicate() {
-    return this.globalTableModelTimePredicate;
-  }
-
-  public void setGlobalTableModelTimePredicate(Expression globalTableModelTimePredicate) {
-    this.globalTableModelTimePredicate = globalTableModelTimePredicate;
-  }
 
   public DataPartition getDataPartition() {
     return dataPartition;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/QueryPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/QueryPlanner.java
@@ -255,7 +255,6 @@ public class QueryPlanner {
       queryContext.setGlobalTimeFilter(
           globalTimePredicate.accept(new ConvertPredicateToTimeFilterVisitor(), null));
     }
-    analysis.setGlobalTableModelTimePredicate(globalTimePredicate);
     boolean hasValueFilter = resultPair.right;
     if (!hasValueFilter) {
       return planBuilder;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/distribute/TableModelQueryFragmentPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/distribute/TableModelQueryFragmentPlanner.java
@@ -27,13 +27,11 @@ import org.apache.iotdb.db.queryengine.plan.analyze.QueryType;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.FragmentInstance;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.PlanFragment;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.SubPlan;
-import org.apache.iotdb.db.queryengine.plan.planner.plan.TableModelTimePredicate;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.process.ExchangeNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.sink.MultiChildrenSinkNode;
 import org.apache.iotdb.db.queryengine.plan.relational.analyzer.Analysis;
-import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Expression;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Query;
 
 import org.apache.tsfile.utils.Pair;
@@ -96,12 +94,10 @@ public class TableModelQueryFragmentPlanner {
   }
 
   private void produceFragmentInstance(PlanFragment fragment) {
-    Expression globalTimePredicate = analysis.getGlobalTableModelTimePredicate();
     FragmentInstance fragmentInstance =
         new FragmentInstance(
             fragment,
             fragment.getId().genFragmentInstanceId(),
-            globalTimePredicate == null ? null : new TableModelTimePredicate(globalTimePredicate),
             QueryType.READ,
             queryContext.getTimeOut(),
             queryContext.getSession(),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/node/TableScanNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/node/TableScanNode.java
@@ -39,6 +39,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class TableScanNode extends SourceNode {
@@ -55,6 +56,13 @@ public class TableScanNode extends SourceNode {
   // Currently, we only support TIMESTAMP_ASC and TIMESTAMP_DESC here.
   // The default order is TIMESTAMP_ASC, which means "order by timestamp asc"
   private Ordering scanOrder = Ordering.ASC;
+
+  // extracted time filter expression in where clause
+  // case 1: where s1 > 1 and time >= 0 and time <= 10, time predicate will be time >= 0 and time <=
+  // 10, pushDownPredicate will be s1 > 1
+  // case 2: where s1 > 1 or time < 10, time predicate will be null, pushDownPredicate will be s1 >
+  // 1 or time < 10
+  @Nullable private Expression timePredicate;
 
   // push down predicate for current series, could be null if it doesn't exist
   @Nullable private Expression pushDownPredicate;
@@ -362,5 +370,9 @@ public class TableScanNode extends SourceNode {
 
   public void setRegionReplicaSet(TRegionReplicaSet regionReplicaSet) {
     this.regionReplicaSet = regionReplicaSet;
+  }
+
+  public Optional<Expression> getTimePredicate() {
+    return Optional.ofNullable(timePredicate);
   }
 }


### PR DESCRIPTION
1. Remove global timefilter in Analysis
2. correct the `TableScanOperator.constructAlignedPath` for Table Model
3. remove duplicated `canPushIntoScan` while constructing TableScanOperator, because we already did this in fe.