### PR TITLE
[IOTDB-6343] Fix the device path construction bug in visitSingleDeviceViewNode of AggragationPushDown

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/optimization/AggregationPushDown.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/optimization/AggregationPushDown.java
@@ -224,7 +224,13 @@ public class AggregationPushDown implements PlanOptimizer {
     @Override
     public PlanNode visitSingleDeviceView(SingleDeviceViewNode node, RewriterContext context) {
       context.setCurDevice(node.getDevice());
-      context.setCurDevicePath(new PartialPath(node.getDevice().split(",")));
+      try {
+        context.setCurDevicePath(new PartialPath(node.getDevice()));
+      } catch (IllegalPathException e) {
+        throw new IllegalStateException(
+            String.format(
+                "Illegal device path: %s in AggregationPushDown rule.", node.getDevice()));
+      }
       PlanNode rewrittenChild = node.getChild().accept(this, context);
       node.setChild(rewrittenChild);
       return node;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/PlanGraphPrinter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/PlanGraphPrinter.java
@@ -123,6 +123,8 @@ public class PlanGraphPrinter extends PlanVisitor<List<String>, PlanGraphPrinter
       boxValue.add(String.format("Predicate: %s", predicate));
     }
 
+    boxValue.add(String.format("ScanOrder: %s", node.getScanOrder()));
+
     boxValue.add(printRegion(node.getRegionReplicaSet()));
     return render(node, boxValue, context);
   }
@@ -151,6 +153,7 @@ public class PlanGraphPrinter extends PlanVisitor<List<String>, PlanGraphPrinter
     }
 
     boxValue.add(String.format("QueryAllSensors: %s", node.isQueryAllSensors()));
+    boxValue.add(String.format("ScanOrder: %s", node.getScanOrder()));
     boxValue.add(printRegion(node.getRegionReplicaSet()));
     return render(node, boxValue, context);
   }
@@ -171,6 +174,7 @@ public class PlanGraphPrinter extends PlanVisitor<List<String>, PlanGraphPrinter
     if (predicate != null) {
       boxValue.add(String.format("Predicate: %s", predicate));
     }
+    boxValue.add(String.format("ScanOrder: %s", node.getScanOrder()));
     boxValue.add(printRegion(node.getRegionReplicaSet()));
     return render(node, boxValue, context);
   }
@@ -194,6 +198,7 @@ public class PlanGraphPrinter extends PlanVisitor<List<String>, PlanGraphPrinter
     if (predicate != null) {
       boxValue.add(String.format("Predicate: %s", predicate));
     }
+    boxValue.add(String.format("ScanOrder: %s", node.getScanOrder()));
     boxValue.add(printRegion(node.getRegionReplicaSet()));
     return render(node, boxValue, context);
   }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/node/PlanGraphPrinterTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/node/PlanGraphPrinterTest.java
@@ -62,7 +62,7 @@ public class PlanGraphPrinterTest {
     topKNode.addChild(deviceViewNode);
 
     List<String> result = getGraph(topKNode);
-    assertEquals(18, result.size());
+    assertEquals(19, result.size());
     assertEquals("│TopK-1                                 │", result.get(1));
     assertEquals("            │DeviceView-2  │             ", result.get(8));
     assertEquals("        │SeriesScan-3           │        ", result.get(14));


### PR DESCRIPTION
## Description

Before fix, order by time align by device query with template will meet error. 

The code below can reproduce this problem.

```
CREATE database root.sg3;

CREATE schema template t1 (s1 FLOAT encoding=RLE, s2 BOOLEAN encoding=PLAIN compression=SNAPPY, s3 INT32);

SET SCHEMA TEMPLATE t2 to root.sg3;

INSERT INTO root.sg3.d1(timestamp,s1,s2,s3) values(1,1.1,false,1), (2,2.2,false,2), (5,5.5,true,5), (1314000000000,13.14,true,1314);

delete from root.sg3.d1.s1 where time <= 5;

select count(s1) from root.sg3.** order by time align by device;
```