### PR TITLE
Fix allocate symbol by Expression

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/PlanBuilder.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/PlanBuilder.java
@@ -132,8 +132,7 @@ public class PlanBuilder {
       // or that are duplicated in the list of exp
       if (!mappings.containsKey(scopeAwareKey(expression, analysis, translations.getScope()))
           && !alreadyHasTranslation.test(translations, expression)) {
-        Symbol symbol =
-            symbolAllocator.newSymbol(expression.toString(), analysis.getType(expression));
+        Symbol symbol = symbolAllocator.newSymbol(expression, analysis.getType(expression));
         queryContext.getTypeProvider().putTableModelType(symbol, analysis.getType(expression));
         projections.put(symbol, rewriter.apply(translations, expression));
         mappings.put(scopeAwareKey(expression, analysis, translations.getScope()), symbol);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/QueryPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/QueryPlanner.java
@@ -25,7 +25,6 @@ import org.apache.iotdb.db.queryengine.plan.relational.planner.node.OffsetNode;
 import org.apache.iotdb.db.queryengine.plan.relational.planner.node.SortNode;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Delete;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Expression;
-import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.FieldReference;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Node;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Offset;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.OrderBy;
@@ -204,12 +203,7 @@ public class QueryPlanner {
       PlanBuilder builder, List<Expression> outputExpressions) {
     ImmutableList.Builder<Symbol> outputSymbols = ImmutableList.builder();
     for (Expression expression : outputExpressions) {
-      Symbol symbol = null;
-      if (expression instanceof FieldReference) {
-        FieldReference reference = (FieldReference) expression;
-        symbol = builder.getFieldSymbols()[reference.getFieldIndex()];
-      }
-      outputSymbols.add(symbol != null ? symbol : builder.translate(expression));
+      outputSymbols.add(builder.translate(expression));
     }
     return outputSymbols.build();
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/QueryPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/QueryPlanner.java
@@ -209,7 +209,7 @@ public class QueryPlanner {
         FieldReference reference = (FieldReference) expression;
         symbol = builder.getFieldSymbols()[reference.getFieldIndex()];
       }
-      outputSymbols.add(symbol != null ? symbol : new Symbol(expression.toString()));
+      outputSymbols.add(symbol != null ? symbol : builder.translate(expression));
     }
     return outputSymbols.build();
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/ir/ExpressionTreeRewriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/ir/ExpressionTreeRewriter.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Cast;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.CoalesceExpression;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.ComparisonExpression;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Expression;
+import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.FieldReference;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.FunctionCall;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Identifier;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.InPredicate;
@@ -471,6 +472,19 @@ public final class ExpressionTreeRewriter<C> {
 
       if (node.getExpression() != expression) {
         return new Cast(expression, node.getType(), node.isSafe());
+      }
+
+      return node;
+    }
+
+    @Override
+    protected Expression visitFieldReference(FieldReference node, Context<C> context) {
+      if (!context.isDefaultRewrite()) {
+        Expression result =
+            rewriter.rewriteFieldReference(node, context.get(), ExpressionTreeRewriter.this);
+        if (result != null) {
+          return result;
+        }
       }
 
       return node;


### PR DESCRIPTION
The `outputSymbols` of `OutputNode` is previously computed by `expression.toString()`,  which may not equals to the symbol of its child after `TranslationMap` introduced. 
![image](https://github.com/apache/iotdb/assets/60659567/91b58a3a-0377-46eb-a261-67f55296c4d6)

This will cause the child node of `OutputNode` cannot detect the column referenced by `OutputNode` . 
![image](https://github.com/apache/iotdb/assets/60659567/958cc5dc-5855-4157-a394-5e6141b7ffa6)
