### PR TITLE
Add TimeSlice Control for TableScanOperator

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/AbstractSeriesScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/AbstractSeriesScanOperator.java
@@ -87,7 +87,7 @@ public abstract class AbstractSeriesScanOperator extends AbstractDataSourceOpera
     }
   }
 
-  private boolean readFileData() throws IOException {
+  protected boolean readFileData() throws IOException {
     while (seriesScanUtil.hasNextFile()) {
       if (readChunkData()) {
         return true;
@@ -96,7 +96,7 @@ public abstract class AbstractSeriesScanOperator extends AbstractDataSourceOpera
     return false;
   }
 
-  private boolean readChunkData() throws IOException {
+  protected boolean readChunkData() throws IOException {
     while (seriesScanUtil.hasNextChunk()) {
       if (readPageData()) {
         return true;
@@ -105,7 +105,7 @@ public abstract class AbstractSeriesScanOperator extends AbstractDataSourceOpera
     return false;
   }
 
-  private boolean readPageData() throws IOException {
+  protected boolean readPageData() throws IOException {
     if (seriesScanUtil.hasNextPage()) {
       TsBlock tsBlock = seriesScanUtil.nextPage();
       if (!isEmpty(tsBlock)) {
@@ -116,11 +116,11 @@ public abstract class AbstractSeriesScanOperator extends AbstractDataSourceOpera
     return false;
   }
 
-  private boolean isEmpty(TsBlock tsBlock) {
+  protected boolean isEmpty(TsBlock tsBlock) {
     return tsBlock == null || tsBlock.isEmpty();
   }
 
-  private void appendToBuilder(TsBlock tsBlock) {
+  protected void appendToBuilder(TsBlock tsBlock) {
     int size = tsBlock.getPositionCount();
     if (resultTsBlockBuilder.isEmpty() && size >= resultTsBlockBuilder.getMaxTsBlockLineNumber()) {
       retainedTsBlock = tsBlock;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/AlignedSeriesScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/AlignedSeriesScanOperator.java
@@ -86,22 +86,27 @@ public class AlignedSeriesScanOperator extends AbstractSeriesScanOperator {
 
   @Override
   protected void buildResult(TsBlock tsBlock) {
+    appendDataIntoBuilder(tsBlock, resultTsBlockBuilder);
+  }
+
+  public static void appendDataIntoBuilder(TsBlock tsBlock, TsBlockBuilder builder) {
     int size = tsBlock.getPositionCount();
-    TimeColumnBuilder timeColumnBuilder = resultTsBlockBuilder.getTimeColumnBuilder();
+    TimeColumnBuilder timeColumnBuilder = builder.getTimeColumnBuilder();
     TimeColumn timeColumn = tsBlock.getTimeColumn();
     for (int i = 0; i < size; i++) {
       timeColumnBuilder.writeLong(timeColumn.getLong(i));
-      resultTsBlockBuilder.declarePosition();
+      builder.declarePosition();
     }
     for (int columnIndex = 0, columnSize = tsBlock.getValueColumnCount();
         columnIndex < columnSize;
         columnIndex++) {
-      appendOneColumn(columnIndex, tsBlock, size);
+      appendOneColumn(columnIndex, tsBlock, size, builder);
     }
   }
 
-  private void appendOneColumn(int columnIndex, TsBlock tsBlock, int size) {
-    ColumnBuilder columnBuilder = resultTsBlockBuilder.getColumnBuilder(columnIndex);
+  private static void appendOneColumn(
+      int columnIndex, TsBlock tsBlock, int size, TsBlockBuilder builder) {
+    ColumnBuilder columnBuilder = builder.getColumnBuilder(columnIndex);
     Column column = tsBlock.getColumn(columnIndex);
     if (column.mayHaveNull()) {
       for (int i = 0; i < size; i++) {


### PR DESCRIPTION
Refactor the TableScanOperator according to https://github.com/apache/iotdb/pull/12750. Optimize the time slice control of TableScanOperator.