### PR TITLE
PipeConsensus: keep consistent with IoTConsensus in WAL, lastCache and other scenarios

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBStartCheck.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBStartCheck.java
@@ -216,7 +216,10 @@ public class IoTDBStartCheck {
     properties = systemPropertiesHandler.read();
 
     if (systemPropertiesHandler.isFirstStart()) {
-      if (config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)
+      if ((config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)
+              || config
+                  .getDataRegionConsensusProtocolClass()
+                  .equals(ConsensusFactory.IOT_CONSENSUS_V2))
           && config.getWalMode().equals(WALMode.DISABLE)) {
         throw new ConfigurationException(
             "Configuring the WALMode as disable is not supported under IoTConsensus");

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/pipeconsensus/PipeConsensusReceiver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/pipeconsensus/PipeConsensusReceiver.java
@@ -285,6 +285,7 @@ public class PipeConsensusReceiver {
         Optional.ofNullable(pipeConsensus.getImpl(consensusGroupId))
             .orElseThrow(() -> new ConsensusGroupNotExistException(consensusGroupId));
     final InsertNode insertNode = req.getInsertNode();
+    insertNode.markAsGeneratedByPipe();
     insertNode.setProgressIndex(
         ProgressIndexType.deserializeFrom(ByteBuffer.wrap(req.getProgressIndex())));
     return new TPipeConsensusTransferResp(impl.writeOnFollowerReplica(insertNode));
@@ -297,6 +298,7 @@ public class PipeConsensusReceiver {
         Optional.ofNullable(pipeConsensus.getImpl(consensusGroupId))
             .orElseThrow(() -> new ConsensusGroupNotExistException(consensusGroupId));
     final InsertNode insertNode = req.convertToInsertNode();
+    insertNode.markAsGeneratedByPipe();
     insertNode.setProgressIndex(
         ProgressIndexType.deserializeFrom(ByteBuffer.wrap(req.getProgressIndex())));
     return new TPipeConsensusTransferResp(impl.writeOnFollowerReplica(insertNode));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/pipeconsensus/PipeConsensusReceiver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/pipeconsensus/PipeConsensusReceiver.java
@@ -285,7 +285,7 @@ public class PipeConsensusReceiver {
         Optional.ofNullable(pipeConsensus.getImpl(consensusGroupId))
             .orElseThrow(() -> new ConsensusGroupNotExistException(consensusGroupId));
     final InsertNode insertNode = req.getInsertNode();
-    insertNode.markAsGeneratedByPipe();
+    insertNode.markAsGeneratedByRemoteConsensusLeader();
     insertNode.setProgressIndex(
         ProgressIndexType.deserializeFrom(ByteBuffer.wrap(req.getProgressIndex())));
     return new TPipeConsensusTransferResp(impl.writeOnFollowerReplica(insertNode));
@@ -298,7 +298,7 @@ public class PipeConsensusReceiver {
         Optional.ofNullable(pipeConsensus.getImpl(consensusGroupId))
             .orElseThrow(() -> new ConsensusGroupNotExistException(consensusGroupId));
     final InsertNode insertNode = req.convertToInsertNode();
-    insertNode.markAsGeneratedByPipe();
+    insertNode.markAsGeneratedByRemoteConsensusLeader();
     insertNode.setProgressIndex(
         ProgressIndexType.deserializeFrom(ByteBuffer.wrap(req.getProgressIndex())));
     return new TPipeConsensusTransferResp(impl.writeOnFollowerReplica(insertNode));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/PlanNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/PlanNode.java
@@ -49,7 +49,6 @@ public abstract class PlanNode implements IConsensusRequest {
   protected PlanNodeId id;
 
   protected boolean isGeneratedByPipe = false;
-  protected boolean isGeneratedByRemoteConsensusLeader = false;
 
   protected PlanNode(PlanNodeId id) {
     requireNonNull(id, "id is null");
@@ -68,17 +67,8 @@ public abstract class PlanNode implements IConsensusRequest {
     return isGeneratedByPipe;
   }
 
-  public boolean isGeneratedByRemoteConsensusLeader() {
-    return isGeneratedByRemoteConsensusLeader;
-  }
-
   public void markAsGeneratedByPipe() {
     isGeneratedByPipe = true;
-  }
-
-  @Override
-  public void markAsGeneratedByRemoteConsensusLeader() {
-    isGeneratedByRemoteConsensusLeader = true;
   }
 
   public abstract List<PlanNode> getChildren();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/pipe/PipeEnrichedInsertNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/pipe/PipeEnrichedInsertNode.java
@@ -251,11 +251,6 @@ public class PipeEnrichedInsertNode extends InsertNode {
   }
 
   @Override
-  public boolean isSyncFromLeaderWhenUsingIoTConsensus() {
-    return insertNode.isSyncFromLeaderWhenUsingIoTConsensus();
-  }
-
-  @Override
   public void markFailedMeasurement(int index) {
     insertNode.markFailedMeasurement(index);
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertNode.java
@@ -24,7 +24,10 @@ import org.apache.iotdb.commons.consensus.index.ComparableConsensusRequest;
 import org.apache.iotdb.commons.consensus.index.ProgressIndex;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.utils.TestOnly;
+import org.apache.iotdb.consensus.ConsensusFactory;
 import org.apache.iotdb.consensus.iot.log.ConsensusReqReader;
+import org.apache.iotdb.db.conf.IoTDBConfig;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.WritePlanNode;
 import org.apache.iotdb.db.storageengine.dataregion.memtable.DeviceIDFactory;
@@ -47,6 +50,8 @@ public abstract class InsertNode extends WritePlanNode implements ComparableCons
 
   /** this insert node doesn't need to participate in iot consensus */
   public static final long NO_CONSENSUS_INDEX = ConsensusReqReader.DEFAULT_SEARCH_INDEX;
+
+  private static final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
 
   /**
    * if use id table, this filed is id form of device path <br>
@@ -72,6 +77,8 @@ public abstract class InsertNode extends WritePlanNode implements ComparableCons
    * value should start from 1
    */
   protected long searchIndex = NO_CONSENSUS_INDEX;
+
+  protected boolean isGeneratedByRemoteConsensusLeader = false;
 
   /** Physical address of data region after splitting */
   protected TRegionReplicaSet dataRegionReplicaSet;
@@ -169,6 +176,27 @@ public abstract class InsertNode extends WritePlanNode implements ComparableCons
     this.searchIndex = searchIndex;
   }
 
+  public boolean isGeneratedByRemoteConsensusLeader() {
+    switch (config.getDataRegionConsensusProtocolClass()) {
+      case ConsensusFactory.IOT_CONSENSUS:
+        // NOTE: ONLY in IoTConsensus, isSyncFromLeaderWhenUsingIoTConsensus == true means this node
+        // is a follower
+        return searchIndex == ConsensusReqReader.DEFAULT_SEARCH_INDEX;
+      case ConsensusFactory.IOT_CONSENSUS_V2:
+      case ConsensusFactory.FAST_IOT_CONSENSUS:
+      case ConsensusFactory.RATIS_CONSENSUS:
+        return isGeneratedByRemoteConsensusLeader;
+      case ConsensusFactory.SIMPLE_CONSENSUS:
+        return false;
+    }
+    return false;
+  }
+
+  @Override
+  public void markAsGeneratedByRemoteConsensusLeader() {
+    isGeneratedByRemoteConsensusLeader = true;
+  }
+
   @Override
   protected void serializeAttributes(ByteBuffer byteBuffer) {
     throw new NotImplementedException("serializeAttributes of InsertNode is not implemented");
@@ -230,15 +258,6 @@ public abstract class InsertNode extends WritePlanNode implements ComparableCons
   }
 
   public abstract long getMinTime();
-
-  /**
-   * Notice: Call this method ONLY when using IOT_CONSENSUS, other consensus protocol cannot
-   * distinguish whether the insertNode sync from leader by this method.
-   * isSyncFromLeaderWhenUsingIoTConsensus == true means this node is a follower
-   */
-  public boolean isSyncFromLeaderWhenUsingIoTConsensus() {
-    return searchIndex == ConsensusReqReader.DEFAULT_SEARCH_INDEX;
-  }
 
   // region partial insert
   @TestOnly

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertNode.java
@@ -179,9 +179,6 @@ public abstract class InsertNode extends WritePlanNode implements ComparableCons
   public boolean isGeneratedByRemoteConsensusLeader() {
     switch (config.getDataRegionConsensusProtocolClass()) {
       case ConsensusFactory.IOT_CONSENSUS:
-        // NOTE: ONLY in IoTConsensus, isSyncFromLeaderWhenUsingIoTConsensus == true means this node
-        // is a follower
-        return searchIndex == ConsensusReqReader.DEFAULT_SEARCH_INDEX;
       case ConsensusFactory.IOT_CONSENSUS_V2:
       case ConsensusFactory.FAST_IOT_CONSENSUS:
       case ConsensusFactory.RATIS_CONSENSUS:

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -1105,7 +1105,7 @@ public class DataRegion implements IDataRegionForQuery {
                 || config
                     .getDataRegionConsensusProtocolClass()
                     .equals(ConsensusFactory.IOT_CONSENSUS_V2))
-            && node.isGeneratedByPipe())) {
+            && node.isGeneratedByRemoteConsensusLeader())) {
       // disable updating last cache on follower
       return;
     }
@@ -1157,7 +1157,7 @@ public class DataRegion implements IDataRegionForQuery {
                   || config
                       .getDataRegionConsensusProtocolClass()
                       .equals(ConsensusFactory.IOT_CONSENSUS_V2))
-              && insertRowNode.isGeneratedByPipe())) {
+              && insertRowNode.isGeneratedByRemoteConsensusLeader())) {
         return tsFileProcessor;
       }
       // disable updating last cache on follower
@@ -1261,7 +1261,7 @@ public class DataRegion implements IDataRegionForQuery {
                   || config
                       .getDataRegionConsensusProtocolClass()
                       .equals(ConsensusFactory.IOT_CONSENSUS_V2))
-              && insertRowsNode.isGeneratedByPipe())) {
+              && insertRowsNode.isGeneratedByRemoteConsensusLeader())) {
         return;
       }
       // disable updating last cache on follower
@@ -3366,7 +3366,7 @@ public class DataRegion implements IDataRegionForQuery {
                     || config
                         .getDataRegionConsensusProtocolClass()
                         .equals(ConsensusFactory.IOT_CONSENSUS_V2))
-                && insertRowsOfOneDeviceNode.isGeneratedByPipe())) {
+                && insertRowsOfOneDeviceNode.isGeneratedByRemoteConsensusLeader())) {
           return;
         }
         // disable updating last cache on follower

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -1097,15 +1097,7 @@ public class DataRegion implements IDataRegionForQuery {
 
   private void tryToUpdateInsertTabletLastCache(InsertTabletNode node) {
     if (!CommonDescriptor.getInstance().getConfig().isLastCacheEnable()
-        || (config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)
-            && node.isSyncFromLeaderWhenUsingIoTConsensus())
-        || ((config
-                    .getDataRegionConsensusProtocolClass()
-                    .equals(ConsensusFactory.FAST_IOT_CONSENSUS)
-                || config
-                    .getDataRegionConsensusProtocolClass()
-                    .equals(ConsensusFactory.IOT_CONSENSUS_V2))
-            && node.isGeneratedByRemoteConsensusLeader())) {
+        || node.isGeneratedByRemoteConsensusLeader()) {
       // disable updating last cache on follower
       return;
     }
@@ -1149,15 +1141,7 @@ public class DataRegion implements IDataRegionForQuery {
     PERFORMANCE_OVERVIEW_METRICS.recordScheduleMemTableCost(costsForMetrics[3]);
 
     if (CommonDescriptor.getInstance().getConfig().isLastCacheEnable()) {
-      if ((config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)
-              && insertRowNode.isSyncFromLeaderWhenUsingIoTConsensus())
-          || ((config
-                      .getDataRegionConsensusProtocolClass()
-                      .equals(ConsensusFactory.FAST_IOT_CONSENSUS)
-                  || config
-                      .getDataRegionConsensusProtocolClass()
-                      .equals(ConsensusFactory.IOT_CONSENSUS_V2))
-              && insertRowNode.isGeneratedByRemoteConsensusLeader())) {
+      if (insertRowNode.isGeneratedByRemoteConsensusLeader()) {
         return tsFileProcessor;
       }
       // disable updating last cache on follower
@@ -1253,15 +1237,7 @@ public class DataRegion implements IDataRegionForQuery {
     PERFORMANCE_OVERVIEW_METRICS.recordScheduleMemTableCost(costsForMetrics[3]);
 
     if (CommonDescriptor.getInstance().getConfig().isLastCacheEnable()) {
-      if ((config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)
-              && insertRowsNode.isSyncFromLeaderWhenUsingIoTConsensus())
-          || ((config
-                      .getDataRegionConsensusProtocolClass()
-                      .equals(ConsensusFactory.FAST_IOT_CONSENSUS)
-                  || config
-                      .getDataRegionConsensusProtocolClass()
-                      .equals(ConsensusFactory.IOT_CONSENSUS_V2))
-              && insertRowsNode.isGeneratedByRemoteConsensusLeader())) {
+      if (insertRowsNode.isGeneratedByRemoteConsensusLeader()) {
         return;
       }
       // disable updating last cache on follower
@@ -3358,15 +3334,7 @@ public class DataRegion implements IDataRegionForQuery {
       PERFORMANCE_OVERVIEW_METRICS.recordScheduleWalCost(costsForMetrics[2]);
       PERFORMANCE_OVERVIEW_METRICS.recordScheduleMemTableCost(costsForMetrics[3]);
       if (CommonDescriptor.getInstance().getConfig().isLastCacheEnable()) {
-        if ((config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)
-                && insertRowsOfOneDeviceNode.isSyncFromLeaderWhenUsingIoTConsensus())
-            || ((config
-                        .getDataRegionConsensusProtocolClass()
-                        .equals(ConsensusFactory.FAST_IOT_CONSENSUS)
-                    || config
-                        .getDataRegionConsensusProtocolClass()
-                        .equals(ConsensusFactory.IOT_CONSENSUS_V2))
-                && insertRowsOfOneDeviceNode.isGeneratedByRemoteConsensusLeader())) {
+        if (insertRowsOfOneDeviceNode.isGeneratedByRemoteConsensusLeader()) {
           return;
         }
         // disable updating last cache on follower

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -1098,7 +1098,14 @@ public class DataRegion implements IDataRegionForQuery {
   private void tryToUpdateInsertTabletLastCache(InsertTabletNode node) {
     if (!CommonDescriptor.getInstance().getConfig().isLastCacheEnable()
         || (config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)
-            && node.isSyncFromLeaderWhenUsingIoTConsensus())) {
+            && node.isSyncFromLeaderWhenUsingIoTConsensus())
+        || ((config
+                    .getDataRegionConsensusProtocolClass()
+                    .equals(ConsensusFactory.FAST_IOT_CONSENSUS)
+                || config
+                    .getDataRegionConsensusProtocolClass()
+                    .equals(ConsensusFactory.IOT_CONSENSUS_V2))
+            && node.isGeneratedByPipe())) {
       // disable updating last cache on follower
       return;
     }
@@ -1143,7 +1150,14 @@ public class DataRegion implements IDataRegionForQuery {
 
     if (CommonDescriptor.getInstance().getConfig().isLastCacheEnable()) {
       if ((config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)
-          && insertRowNode.isSyncFromLeaderWhenUsingIoTConsensus())) {
+              && insertRowNode.isSyncFromLeaderWhenUsingIoTConsensus())
+          || ((config
+                      .getDataRegionConsensusProtocolClass()
+                      .equals(ConsensusFactory.FAST_IOT_CONSENSUS)
+                  || config
+                      .getDataRegionConsensusProtocolClass()
+                      .equals(ConsensusFactory.IOT_CONSENSUS_V2))
+              && insertRowNode.isGeneratedByPipe())) {
         return tsFileProcessor;
       }
       // disable updating last cache on follower
@@ -1240,7 +1254,14 @@ public class DataRegion implements IDataRegionForQuery {
 
     if (CommonDescriptor.getInstance().getConfig().isLastCacheEnable()) {
       if ((config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)
-          && insertRowsNode.isSyncFromLeaderWhenUsingIoTConsensus())) {
+              && insertRowsNode.isSyncFromLeaderWhenUsingIoTConsensus())
+          || ((config
+                      .getDataRegionConsensusProtocolClass()
+                      .equals(ConsensusFactory.FAST_IOT_CONSENSUS)
+                  || config
+                      .getDataRegionConsensusProtocolClass()
+                      .equals(ConsensusFactory.IOT_CONSENSUS_V2))
+              && insertRowsNode.isGeneratedByPipe())) {
         return;
       }
       // disable updating last cache on follower
@@ -3338,7 +3359,14 @@ public class DataRegion implements IDataRegionForQuery {
       PERFORMANCE_OVERVIEW_METRICS.recordScheduleMemTableCost(costsForMetrics[3]);
       if (CommonDescriptor.getInstance().getConfig().isLastCacheEnable()) {
         if ((config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)
-            && insertRowsOfOneDeviceNode.isSyncFromLeaderWhenUsingIoTConsensus())) {
+                && insertRowsOfOneDeviceNode.isSyncFromLeaderWhenUsingIoTConsensus())
+            || ((config
+                        .getDataRegionConsensusProtocolClass()
+                        .equals(ConsensusFactory.FAST_IOT_CONSENSUS)
+                    || config
+                        .getDataRegionConsensusProtocolClass()
+                        .equals(ConsensusFactory.IOT_CONSENSUS_V2))
+                && insertRowsOfOneDeviceNode.isGeneratedByPipe())) {
           return;
         }
         // disable updating last cache on follower
@@ -3617,7 +3645,9 @@ public class DataRegion implements IDataRegionForQuery {
 
   private void acquireDirectBufferMemory() throws DataRegionException {
     long acquireDirectBufferMemCost = 0;
-    if (config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)) {
+    if (config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)
+        || config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.FAST_IOT_CONSENSUS)
+        || config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS_V2)) {
       acquireDirectBufferMemCost = config.getWalBufferSize();
     } else if (config
         .getDataRegionConsensusProtocolClass()

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/WALManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/WALManager.java
@@ -69,7 +69,11 @@ public class WALManager implements IService {
   private final AtomicLong totalFileNum = new AtomicLong();
 
   private WALManager() {
-    if (config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)) {
+    if (config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)
+        || config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS_V2)
+        || config
+            .getDataRegionConsensusProtocolClass()
+            .equals(ConsensusFactory.FAST_IOT_CONSENSUS)) {
       walNodesManager = new FirstCreateStrategy();
     } else if (config.getMaxWalNodesNum() == 0) {
       walNodesManager = new ElasticStrategy();
@@ -80,6 +84,12 @@ public class WALManager implements IService {
 
   public static String getApplicantUniqueId(String storageGroupName, boolean sequence) {
     return config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)
+            || config
+                .getDataRegionConsensusProtocolClass()
+                .equals(ConsensusFactory.IOT_CONSENSUS_V2)
+            || config
+                .getDataRegionConsensusProtocolClass()
+                .equals(ConsensusFactory.FAST_IOT_CONSENSUS)
         ? storageGroupName
         : storageGroupName
             + IoTDBConstant.FILE_NAME_SEPARATOR
@@ -95,11 +105,17 @@ public class WALManager implements IService {
     return walNodesManager.applyForWALNode(applicantUniqueId);
   }
 
-  /** WAL node will be registered only when using iot consensus protocol. */
+  /** WAL node will be registered only when using iot series consensus protocol. */
   public void registerWALNode(
       String applicantUniqueId, String logDirectory, long startFileVersion, long startSearchIndex) {
     if (config.getWalMode() == WALMode.DISABLE
-        || !config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)) {
+        || (!config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)
+            && !config
+                .getDataRegionConsensusProtocolClass()
+                .equals(ConsensusFactory.IOT_CONSENSUS_V2)
+            && !config
+                .getDataRegionConsensusProtocolClass()
+                .equals(ConsensusFactory.FAST_IOT_CONSENSUS))) {
       return;
     }
 
@@ -114,7 +130,10 @@ public class WALManager implements IService {
         || (!config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)
             && !config
                 .getDataRegionConsensusProtocolClass()
-                .equals(ConsensusFactory.IOT_CONSENSUS_V2))) {
+                .equals(ConsensusFactory.IOT_CONSENSUS_V2)
+            && !config
+                .getDataRegionConsensusProtocolClass()
+                .equals(ConsensusFactory.FAST_IOT_CONSENSUS))) {
       return;
     }
 


### PR DESCRIPTION
As title, and please NOTE:

1. pipe consensus will keep consistent with IoTConsensus regarding to WAL strategy, including register, delete etc.
2. in pipe consensus, followers will try to NOT update last cache when receiving replicates from leader.