### PR TITLE
Delete doc for FastIoTConsensus temporarily

### DIFF
--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
@@ -154,7 +154,6 @@ data_replication_factor=1
 # 1. org.apache.iotdb.consensus.simple.SimpleConsensus   (The data_replication_factor can only be set to 1)
 # 2. org.apache.iotdb.consensus.iot.IoTConsensus
 # 3. org.apache.iotdb.consensus.ratis.RatisConsensus
-# 4. org.apache.iotdb.consensus.iot.FastIoTConsensus
 # effectiveMode: first_start
 # Datatype: string
 data_region_consensus_protocol_class=org.apache.iotdb.consensus.iot.IoTConsensus


### PR DESCRIPTION
Currently, fastiotconsensus is not stable, we do not recommend users to use it, so we can directly hide the introduction in the template file