### PR TITLE
Hide ttl_rule_capacity from properties and modify the error message

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/TTLInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/TTLInfo.java
@@ -70,8 +70,10 @@ public class TTLInfo implements SnapshotProcessor {
       if (getTTLCount() >= tTlRuleCapacity) {
         TSStatus errorStatus = new TSStatus(TSStatusCode.OVERSIZE_TTL.getStatusCode());
         errorStatus.setMessage(
-            String.format("The number of TTL rules has reached the limit (%d). Please delete "
-                + "some existing rules first.", tTlRuleCapacity));
+            String.format(
+                "The number of TTL rules has reached the limit (%d). Please delete "
+                    + "some existing rules first.",
+                tTlRuleCapacity));
         return errorStatus;
       }
       ttlCache.setTTL(plan.getPathPattern(), plan.getTTL());

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/TTLInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/TTLInfo.java
@@ -66,10 +66,12 @@ public class TTLInfo implements SnapshotProcessor {
     lock.writeLock().lock();
     try {
       // check ttl rule capacity
-      if (getTTLCount() >= CommonDescriptor.getInstance().getConfig().getTTlRuleCapacity()) {
+      final int tTlRuleCapacity = CommonDescriptor.getInstance().getConfig().getTTlRuleCapacity();
+      if (getTTLCount() >= tTlRuleCapacity) {
         TSStatus errorStatus = new TSStatus(TSStatusCode.OVERSIZE_TTL.getStatusCode());
         errorStatus.setMessage(
-            "The number of TTL stored in the system has reached threshold, please increase the ttl_rule_capacity parameter.");
+            String.format("The number of TTL rules has reached the limit (%d). Please delete "
+                + "some existing rules first.", tTlRuleCapacity));
         return errorStatus;
       }
       ttlCache.setTTL(plan.getPathPattern(), plan.getTTL());

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/TTLInfoTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/TTLInfoTest.java
@@ -25,10 +25,9 @@ import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.confignode.consensus.request.read.ttl.ShowTTLPlan;
 import org.apache.iotdb.confignode.consensus.request.write.database.SetTTLPlan;
 import org.apache.iotdb.confignode.consensus.response.ttl.ShowTTLResp;
+import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.iotdb.db.queryengine.plan.analyze.cache.schema.DataNodeTTLCache;
-import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.thrift.TException;
 import org.apache.tsfile.read.common.parser.PathNodesGenerator;
 import org.junit.After;
@@ -44,7 +43,6 @@ import java.util.Map;
 
 import static org.apache.iotdb.db.utils.constant.TestConstant.BASE_OUTPUT_PATH;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 public class TTLInfoTest {
 
@@ -212,16 +210,15 @@ public class TTLInfoTest {
 
   @Test
   public void testTooManyTTL() {
-    final int tTlRuleCapacity =
-        CommonDescriptor.getInstance().getConfig().getTTlRuleCapacity();
+    final int tTlRuleCapacity = CommonDescriptor.getInstance().getConfig().getTTlRuleCapacity();
     for (int i = 0; i < tTlRuleCapacity - 1; i++) {
       SetTTLPlan setTTLPlan =
           new SetTTLPlan(PathNodesGenerator.splitPathToNodes("root.sg1.d" + i + ".**"), 1000);
       assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), ttlInfo.setTTL(setTTLPlan).code);
     }
     SetTTLPlan setTTLPlan =
-        new SetTTLPlan(PathNodesGenerator.splitPathToNodes("root.sg1.d" + tTlRuleCapacity + ".**"),
-            1000);
+        new SetTTLPlan(
+            PathNodesGenerator.splitPathToNodes("root.sg1.d" + tTlRuleCapacity + ".**"), 1000);
     final TSStatus status = ttlInfo.setTTL(setTTLPlan);
     assertEquals(TSStatusCode.OVERSIZE_TTL.getStatusCode(), status.code);
     assertEquals(

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/TTLInfoTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/TTLInfoTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.confignode.persistence;
 
+import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
@@ -26,7 +27,10 @@ import org.apache.iotdb.confignode.consensus.request.write.database.SetTTLPlan;
 import org.apache.iotdb.confignode.consensus.response.ttl.ShowTTLResp;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.iotdb.db.queryengine.plan.analyze.cache.schema.DataNodeTTLCache;
+import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.thrift.TException;
+import org.apache.tsfile.read.common.parser.PathNodesGenerator;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -39,8 +43,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.iotdb.db.utils.constant.TestConstant.BASE_OUTPUT_PATH;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class TTLInfoTest {
+
   private TTLInfo ttlInfo;
   private final File snapshotDir = new File(BASE_OUTPUT_PATH, "ttlInfo-snapshot");
   private final long ttl = 123435565323L;
@@ -201,6 +208,25 @@ public class TTLInfoTest {
     resultMap.remove(path.getFullPath());
     Assert.assertEquals(resultMap, ttlInfo.showTTL(new ShowTTLPlan()).getPathTTLMap());
     Assert.assertEquals(4, ttlInfo.getTTLCount());
+  }
+
+  @Test
+  public void testTooManyTTL() {
+    final int tTlRuleCapacity =
+        CommonDescriptor.getInstance().getConfig().getTTlRuleCapacity();
+    for (int i = 0; i < tTlRuleCapacity - 1; i++) {
+      SetTTLPlan setTTLPlan =
+          new SetTTLPlan(PathNodesGenerator.splitPathToNodes("root.sg1.d" + i + ".**"), 1000);
+      assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), ttlInfo.setTTL(setTTLPlan).code);
+    }
+    SetTTLPlan setTTLPlan =
+        new SetTTLPlan(PathNodesGenerator.splitPathToNodes("root.sg1.d" + tTlRuleCapacity + ".**"),
+            1000);
+    final TSStatus status = ttlInfo.setTTL(setTTLPlan);
+    assertEquals(TSStatusCode.OVERSIZE_TTL.getStatusCode(), status.code);
+    assertEquals(
+        "The number of TTL rules has reached the limit (1000). Please delete some existing rules first.",
+        status.message);
   }
 
   @Test

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/TTLTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/TTLTest.java
@@ -20,6 +20,7 @@
 
 package org.apache.iotdb.db.storageengine.dataregion;
 
+import org.apache.iotdb.commons.conf.CommonConfig;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.consensus.DataRegionId;

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/TTLTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/TTLTest.java
@@ -20,7 +20,6 @@
 
 package org.apache.iotdb.db.storageengine.dataregion;
 
-import org.apache.iotdb.commons.conf.CommonConfig;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.consensus.DataRegionId;

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
@@ -1030,12 +1030,6 @@ timestamp_precision_check_enabled=true
 # Unit: ms
 default_ttl_in_ms=-1
 
-# The maximum number of TTL rules stored in the system, the default is 1000.
-# effectiveMode: restart
-# Negative value means the threshold is unlimited.
-# Datatype: int
-ttl_rule_capacity=1000
-
 # The interval of TTL check task in each database. The TTL check task will inspect and select files with a higher volume of expired data for compaction. Default is 2 hours.
 # Notice: It is not recommended to change it too small, as it will affect the read and write performance of the system.
 # effectiveMode: restart

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -105,13 +105,6 @@ public class CommonDescriptor {
     }
     config.setTierTTLInMs(tierTTL);
 
-    int ttlRuleCapacity =
-        Integer.parseInt(
-            properties.getProperty(
-                "ttl_rule_capacity", String.valueOf(config.getTTlRuleCapacity())));
-    ttlRuleCapacity = ttlRuleCapacity < 0 ? Integer.MAX_VALUE : ttlRuleCapacity;
-    config.setTTlRuleCapacity(ttlRuleCapacity);
-
     config.setSyncDir(properties.getProperty("dn_sync_dir", config.getSyncDir()).trim());
 
     config.setWalDirs(


### PR DESCRIPTION
Hide `ttl_rule_capacity` from properties and modify the error message accordingly.