### PR TITLE
Fix schema query stuck when system is readonly

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ApplicationStateMachineProxy.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ApplicationStateMachineProxy.java
@@ -158,13 +158,13 @@ public class ApplicationStateMachineProxy extends BaseStateMachine {
             new ResponseMessage(
                 new TSStatus(TSStatusCode.INTERNAL_SERVER_ERROR.getStatusCode())
                     .setMessage("internal error. statemachine throws a runtime exception: " + rte));
-        if (Utils.stallApply()) {
+        if (Utils.stallApply(consensusGroupType)) {
           waitUntilSystemAllowApply();
         } else {
           break;
         }
       }
-    } while (Utils.stallApply());
+    } while (Utils.stallApply(consensusGroupType));
 
     if (isLeader) {
       // only record time cost for data region in Performance Overview Dashboard
@@ -183,7 +183,10 @@ public class ApplicationStateMachineProxy extends BaseStateMachine {
   private void waitUntilSystemAllowApply() {
     try {
       Retriable.attemptUntilTrue(
-          () -> !Utils.stallApply(), TimeDuration.ONE_MINUTE, "waitUntilSystemAllowApply", logger);
+          () -> !Utils.stallApply(consensusGroupType),
+          TimeDuration.ONE_MINUTE,
+          "waitUntilSystemAllowApply",
+          logger);
     } catch (InterruptedException e) {
       logger.warn("{}: interrupted when waiting until system ready: ", this, e);
       Thread.currentThread().interrupt();

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -278,7 +278,7 @@ class RatisConsensus implements IConsensus {
     }
 
     // current Peer is group leader and in ReadOnly State
-    if (isLeader(groupId) && Utils.rejectWrite()) {
+    if (isLeader(groupId) && Utils.rejectWrite(consensusGroupType)) {
       try {
         forceStepDownLeader(raftGroup);
       } catch (Exception e) {

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/utils/Utils.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/utils/Utils.java
@@ -210,18 +210,18 @@ public class Utils {
     return consensusGroupType;
   }
 
-  public static boolean rejectWrite() {
-    return config.isReadOnly();
+  public static boolean rejectWrite(TConsensusGroupType type) {
+    return type == TConsensusGroupType.DataRegion && config.isReadOnly();
   }
 
   /**
    * Normally, the RatisConsensus should reject write when system is read-only, i.e, {@link
-   * #rejectWrite()}. However, Ratis RaftServer close() will wait for applyIndex advancing to
-   * commitIndex. So when the system is shutting down, RatisConsensus should still allow
-   * statemachine to apply while rejecting new client write requests.
+   * #rejectWrite(TConsensusGroupType type)}. However, Ratis RaftServer close() will wait for
+   * applyIndex advancing to commitIndex. So when the system is shutting down, RatisConsensus should
+   * still allow statemachine to apply while rejecting new client write requests.
    */
-  public static boolean stallApply() {
-    return config.isReadOnly() && !config.isStopping();
+  public static boolean stallApply(TConsensusGroupType type) {
+    return type == TConsensusGroupType.DataRegion && config.isReadOnly() && !config.isStopping();
   }
 
   /** return the max wait duration for retry */


### PR DESCRIPTION
Currently, SchemaRegion has LINEARIZABLE reads set up, and its state machine stops writing when the system is readonly, potentially causing the query to freeze indefinitely.
![img_v3_02cd_b5506948-93bf-41a6-b8d1-9c34ed85caeg](https://github.com/apache/iotdb/assets/32640567/7fc427cd-ff51-4e63-9626-36c0dbb22774)
![img_v3_02cd_53be8b5c-389f-47b6-a2e0-2d804b36a1ag](https://github.com/apache/iotdb/assets/32640567/7ae42cce-9b34-454f-9759-0d3e11812ceb)


In fact, we only need to process dataRegion, because the semantics of readonly itself does not prevent metadata from being written. In addition, dataregion is not LINEARIZABLE read by default. Therefore, even if the dataregion is ratis, there will be no stuck problem.

In addition, the problem comes from the earliest [issue](https://issues.apache.org/jira/browse/IOTDB-5843), the current shutdownhook would stop the RPC client service at the beginning, Therefore, this change will not cause any worse effects.