### PR TITLE
Fix IoTConsensus sync stuck problem 

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataExecutionVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataExecutionVisitor.java
@@ -77,7 +77,6 @@ public class DataExecutionVisitor extends PlanVisitor<TSStatus, DataRegion> {
   public TSStatus visitInsertTablet(InsertTabletNode node, DataRegion dataRegion) {
     try {
       dataRegion.insertTablet(node);
-      LOGGER.info("insert tablet success, {}", node.getSearchIndex());
       return StatusUtils.OK;
     } catch (OutOfTTLException e) {
       LOGGER.warn("Error in executing plan node: {}, caused by {}", node, e.getMessage());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataExecutionVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataExecutionVisitor.java
@@ -236,7 +236,6 @@ public class DataExecutionVisitor extends PlanVisitor<TSStatus, DataRegion> {
         }
       }
       PipeInsertionDataNodeListener.getInstance().listenToDeleteData(node);
-      LOGGER.info("delete data success, {}", node.getSearchIndex());
       return StatusUtils.OK;
     } catch (IOException | IllegalPathException e) {
       LOGGER.error("Error in executing plan node: {}", node, e);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataExecutionVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataExecutionVisitor.java
@@ -77,6 +77,7 @@ public class DataExecutionVisitor extends PlanVisitor<TSStatus, DataRegion> {
   public TSStatus visitInsertTablet(InsertTabletNode node, DataRegion dataRegion) {
     try {
       dataRegion.insertTablet(node);
+      LOGGER.info("insert tablet success, {}", node.getSearchIndex());
       return StatusUtils.OK;
     } catch (OutOfTTLException e) {
       LOGGER.warn("Error in executing plan node: {}, caused by {}", node, e.getMessage());
@@ -236,6 +237,7 @@ public class DataExecutionVisitor extends PlanVisitor<TSStatus, DataRegion> {
         }
       }
       PipeInsertionDataNodeListener.getInstance().listenToDeleteData(node);
+      LOGGER.info("delete data success, {}", node.getSearchIndex());
       return StatusUtils.OK;
     } catch (IOException | IllegalPathException e) {
       LOGGER.error("Error in executing plan node: {}", node, e);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataRegionStateMachine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataRegionStateMachine.java
@@ -289,7 +289,7 @@ public class DataRegionStateMachine extends BaseStateMachine {
   @Override
   public DataSet read(IConsensusRequest request) {
     if (request instanceof GetConsensusReqReaderPlan) {
-      return region.getWALNode();
+      return region.getWALNode().orElseThrow(UnsupportedOperationException::new);
     } else {
       FragmentInstance fragmentInstance;
       try {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataRegionStateMachine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataRegionStateMachine.java
@@ -283,6 +283,15 @@ public class DataRegionStateMachine extends BaseStateMachine {
         break;
       }
     }
+    if (planNode instanceof InsertNode) {
+      if (result.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+        InsertNode insertNode = (InsertNode) planNode;
+        logger.info(
+            "plan node {} executed success, {}",
+            insertNode.getClass(),
+            insertNode.getSearchIndex());
+      }
+    }
     return result;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataRegionStateMachine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataRegionStateMachine.java
@@ -283,15 +283,6 @@ public class DataRegionStateMachine extends BaseStateMachine {
         break;
       }
     }
-    if (planNode instanceof InsertNode) {
-      if (result.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
-        InsertNode insertNode = (InsertNode) planNode;
-        logger.info(
-            "plan node {} executed success, {}",
-            insertNode.getClass(),
-            insertNode.getSearchIndex());
-      }
-    }
     return result;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/DeleteDataNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/DeleteDataNode.java
@@ -55,19 +55,13 @@ import java.util.stream.Collectors;
 import static org.apache.iotdb.commons.conf.IoTDBConstant.MULTI_LEVEL_PATH_WILDCARD;
 import static org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertNode.NO_CONSENSUS_INDEX;
 
-public class DeleteDataNode extends WritePlanNode implements WALEntryValue {
+public class DeleteDataNode extends SearchNode implements WALEntryValue {
   /** byte: type, integer: pathList.size(), long: deleteStartTime, deleteEndTime, searchIndex */
   private static final int FIXED_SERIALIZED_SIZE = Short.BYTES + Integer.BYTES + Long.BYTES * 3;
 
   private final List<PartialPath> pathList;
   private final long deleteStartTime;
   private final long deleteEndTime;
-
-  /**
-   * this index is used by wal search, its order should be protected by the upper layer, and the
-   * value should start from 1
-   */
-  protected long searchIndex = NO_CONSENSUS_INDEX;
 
   private TRegionReplicaSet regionReplicaSet;
 
@@ -102,15 +96,6 @@ public class DeleteDataNode extends WritePlanNode implements WALEntryValue {
 
   public long getDeleteEndTime() {
     return deleteEndTime;
-  }
-
-  public long getSearchIndex() {
-    return searchIndex;
-  }
-
-  /** Search index should start from 1 */
-  public void setSearchIndex(long searchIndex) {
-    this.searchIndex = searchIndex;
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/DeleteDataNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/DeleteDataNode.java
@@ -53,7 +53,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static org.apache.iotdb.commons.conf.IoTDBConstant.MULTI_LEVEL_PATH_WILDCARD;
-import static org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertNode.NO_CONSENSUS_INDEX;
 
 public class DeleteDataNode extends SearchNode implements WALEntryValue {
   /** byte: type, integer: pathList.size(), long: deleteStartTime, deleteEndTime, searchIndex */

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertNode.java
@@ -46,10 +46,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Objects;
 
-public abstract class InsertNode extends WritePlanNode implements ComparableConsensusRequest {
-
-  /** this insert node doesn't need to participate in iot consensus */
-  public static final long NO_CONSENSUS_INDEX = ConsensusReqReader.DEFAULT_SEARCH_INDEX;
+public abstract class InsertNode extends SearchNode implements ComparableConsensusRequest {
 
   private static final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
 
@@ -72,13 +69,7 @@ public abstract class InsertNode extends WritePlanNode implements ComparableCons
    */
   protected IDeviceID deviceID;
 
-  /**
-   * this index is used by wal search, its order should be protected by the upper layer, and the
-   * value should start from 1
-   */
-  protected long searchIndex = NO_CONSENSUS_INDEX;
-
-  protected boolean isGeneratedByRemoteConsensusLeader = false;
+    protected boolean isGeneratedByRemoteConsensusLeader = false;
 
   /** Physical address of data region after splitting */
   protected TRegionReplicaSet dataRegionReplicaSet;
@@ -167,33 +158,23 @@ public abstract class InsertNode extends WritePlanNode implements ComparableCons
     this.deviceID = deviceID;
   }
 
-  public long getSearchIndex() {
-    return searchIndex;
-  }
-
-  /** Search index should start from 1 */
-  public void setSearchIndex(long searchIndex) {
-    this.searchIndex = searchIndex;
-  }
-
-  public boolean isGeneratedByRemoteConsensusLeader() {
-    switch (config.getDataRegionConsensusProtocolClass()) {
-      case ConsensusFactory.IOT_CONSENSUS:
-      case ConsensusFactory.IOT_CONSENSUS_V2:
-      case ConsensusFactory.FAST_IOT_CONSENSUS:
-      case ConsensusFactory.RATIS_CONSENSUS:
-        return isGeneratedByRemoteConsensusLeader;
-      case ConsensusFactory.SIMPLE_CONSENSUS:
+    public boolean isGeneratedByRemoteConsensusLeader() {
+        switch (config.getDataRegionConsensusProtocolClass()) {
+            case ConsensusFactory.IOT_CONSENSUS:
+            case ConsensusFactory.IOT_CONSENSUS_V2:
+            case ConsensusFactory.FAST_IOT_CONSENSUS:
+            case ConsensusFactory.RATIS_CONSENSUS:
+                return isGeneratedByRemoteConsensusLeader;
+            case ConsensusFactory.SIMPLE_CONSENSUS:
+                return false;
+        }
         return false;
     }
-    return false;
-  }
 
-  @Override
-  public void markAsGeneratedByRemoteConsensusLeader() {
-    isGeneratedByRemoteConsensusLeader = true;
-  }
-
+    @Override
+    public void markAsGeneratedByRemoteConsensusLeader() {
+        isGeneratedByRemoteConsensusLeader = true;
+    }
   @Override
   protected void serializeAttributes(ByteBuffer byteBuffer) {
     throw new NotImplementedException("serializeAttributes of InsertNode is not implemented");

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertNode.java
@@ -25,11 +25,9 @@ import org.apache.iotdb.commons.consensus.index.ProgressIndex;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.consensus.ConsensusFactory;
-import org.apache.iotdb.consensus.iot.log.ConsensusReqReader;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
-import org.apache.iotdb.db.queryengine.plan.planner.plan.node.WritePlanNode;
 import org.apache.iotdb.db.storageengine.dataregion.memtable.DeviceIDFactory;
 import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.IWALByteBufferView;
 import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALWriteUtils;
@@ -69,7 +67,7 @@ public abstract class InsertNode extends SearchNode implements ComparableConsens
    */
   protected IDeviceID deviceID;
 
-    protected boolean isGeneratedByRemoteConsensusLeader = false;
+  protected boolean isGeneratedByRemoteConsensusLeader = false;
 
   /** Physical address of data region after splitting */
   protected TRegionReplicaSet dataRegionReplicaSet;
@@ -158,23 +156,24 @@ public abstract class InsertNode extends SearchNode implements ComparableConsens
     this.deviceID = deviceID;
   }
 
-    public boolean isGeneratedByRemoteConsensusLeader() {
-        switch (config.getDataRegionConsensusProtocolClass()) {
-            case ConsensusFactory.IOT_CONSENSUS:
-            case ConsensusFactory.IOT_CONSENSUS_V2:
-            case ConsensusFactory.FAST_IOT_CONSENSUS:
-            case ConsensusFactory.RATIS_CONSENSUS:
-                return isGeneratedByRemoteConsensusLeader;
-            case ConsensusFactory.SIMPLE_CONSENSUS:
-                return false;
-        }
+  public boolean isGeneratedByRemoteConsensusLeader() {
+    switch (config.getDataRegionConsensusProtocolClass()) {
+      case ConsensusFactory.IOT_CONSENSUS:
+      case ConsensusFactory.IOT_CONSENSUS_V2:
+      case ConsensusFactory.FAST_IOT_CONSENSUS:
+      case ConsensusFactory.RATIS_CONSENSUS:
+        return isGeneratedByRemoteConsensusLeader;
+      case ConsensusFactory.SIMPLE_CONSENSUS:
         return false;
     }
+    return false;
+  }
 
-    @Override
-    public void markAsGeneratedByRemoteConsensusLeader() {
-        isGeneratedByRemoteConsensusLeader = true;
-    }
+  @Override
+  public void markAsGeneratedByRemoteConsensusLeader() {
+    isGeneratedByRemoteConsensusLeader = true;
+  }
+
   @Override
   protected void serializeAttributes(ByteBuffer byteBuffer) {
     throw new NotImplementedException("serializeAttributes of InsertNode is not implemented");

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/SearchNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/SearchNode.java
@@ -25,27 +25,27 @@ import org.apache.iotdb.db.queryengine.plan.planner.plan.node.WritePlanNode;
 
 import static org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertNode.NO_CONSENSUS_INDEX;
 
-abstract public class SearchNode extends WritePlanNode {
+public abstract class SearchNode extends WritePlanNode {
 
-    /** this insert node doesn't need to participate in iot consensus */
-    public static final long NO_CONSENSUS_INDEX = ConsensusReqReader.DEFAULT_SEARCH_INDEX;
+  /** this insert node doesn't need to participate in iot consensus */
+  public static final long NO_CONSENSUS_INDEX = ConsensusReqReader.DEFAULT_SEARCH_INDEX;
 
-    /**
-     * this index is used by wal search, its order should be protected by the upper layer, and the
-     * value should start from 1
-     */
-    protected long searchIndex = NO_CONSENSUS_INDEX;
+  /**
+   * this index is used by wal search, its order should be protected by the upper layer, and the
+   * value should start from 1
+   */
+  protected long searchIndex = NO_CONSENSUS_INDEX;
 
-    protected SearchNode(PlanNodeId id) {
-        super(id);
-    }
+  protected SearchNode(PlanNodeId id) {
+    super(id);
+  }
 
-    public long getSearchIndex() {
-        return searchIndex;
-    }
+  public long getSearchIndex() {
+    return searchIndex;
+  }
 
-    /** Search index should start from 1 */
-    public void setSearchIndex(long searchIndex) {
-        this.searchIndex = searchIndex;
-    }
+  /** Search index should start from 1 */
+  public void setSearchIndex(long searchIndex) {
+    this.searchIndex = searchIndex;
+  }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/SearchNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/SearchNode.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.plan.planner.plan.node.write;
+
+import org.apache.iotdb.consensus.iot.log.ConsensusReqReader;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.WritePlanNode;
+
+import static org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertNode.NO_CONSENSUS_INDEX;
+
+abstract public class SearchNode extends WritePlanNode {
+
+    /** this insert node doesn't need to participate in iot consensus */
+    public static final long NO_CONSENSUS_INDEX = ConsensusReqReader.DEFAULT_SEARCH_INDEX;
+
+    /**
+     * this index is used by wal search, its order should be protected by the upper layer, and the
+     * value should start from 1
+     */
+    protected long searchIndex = NO_CONSENSUS_INDEX;
+
+    protected SearchNode(PlanNodeId id) {
+        super(id);
+    }
+
+    public long getSearchIndex() {
+        return searchIndex;
+    }
+
+    /** Search index should start from 1 */
+    public void setSearchIndex(long searchIndex) {
+        this.searchIndex = searchIndex;
+    }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -1066,7 +1066,7 @@ public class DataRegion implements IDataRegionForQuery {
       long timePartitionId) {
     // return when start >= end or all measurement failed
     if (start >= end || insertTabletNode.allMeasurementFailed()) {
-      logger.info(
+      logger.debug(
           "Won't insert tablet {}, because {}",
           insertTabletNode.getSearchIndex(),
           start >= end ? "start >= end" : "insertTabletNode allMeasurementFailed");
@@ -2163,6 +2163,9 @@ public class DataRegion implements IDataRegionForQuery {
         walFlushListeners.add(walFlushListener);
       }
     }
+    // Some time the deletion operation doesn't have any related tsfile processor or memtable,
+    // but it's still necessary to write to the WAL, so that iotconsensus can synchronize the delete
+    // operation to other nodes.
     if (walFlushListeners.isEmpty()) {
       walFlushListeners.add(getWALNode().log(TsFileProcessor.MEMTABLE_NOT_EXIST, deleteDataNode));
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -935,6 +935,8 @@ public class DataRegion implements IDataRegionForQuery {
     PERFORMANCE_OVERVIEW_METRICS.recordScheduleLockCost(System.nanoTime() - startTime);
     try {
       if (deleted) {
+        logger.info(
+            "won't insert tablet {}, because region is deleted", insertTabletNode.getSearchIndex());
         return;
       }
       TSStatus[] results = new TSStatus[insertTabletNode.getRowCount()];
@@ -1063,6 +1065,9 @@ public class DataRegion implements IDataRegionForQuery {
       long timePartitionId) {
     // return when start >= end or all measurement failed
     if (start >= end || insertTabletNode.allMeasurementFailed()) {
+      logger.info(
+          "return true, because {}",
+          start >= end ? "start >= end" : "insertTabletNode allMeasurementFailed");
       return true;
     }
 
@@ -1079,6 +1084,9 @@ public class DataRegion implements IDataRegionForQuery {
 
     try {
       tsFileProcessor.insertTablet(insertTabletNode, start, end, results);
+      logger.info(
+          "tsFileProcessor insert tablet success, the search index is {}",
+          insertTabletNode.getSearchIndex());
     } catch (WriteProcessRejectException e) {
       logger.warn("insert to TsFileProcessor rejected, {}", e.getMessage());
       return false;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -936,7 +936,7 @@ public class DataRegion implements IDataRegionForQuery {
     try {
       if (deleted) {
         logger.info(
-            "won't insert tablet {}, because region is deleted", insertTabletNode.getSearchIndex());
+            "Won't insert tablet {}, because region is deleted", insertTabletNode.getSearchIndex());
         return;
       }
       TSStatus[] results = new TSStatus[insertTabletNode.getRowCount()];
@@ -1066,7 +1066,8 @@ public class DataRegion implements IDataRegionForQuery {
     // return when start >= end or all measurement failed
     if (start >= end || insertTabletNode.allMeasurementFailed()) {
       logger.info(
-          "return true, because {}",
+          "Won't insert tablet {}, because {}",
+          insertTabletNode.getSearchIndex(),
           start >= end ? "start >= end" : "insertTabletNode allMeasurementFailed");
       return true;
     }
@@ -1084,9 +1085,6 @@ public class DataRegion implements IDataRegionForQuery {
 
     try {
       tsFileProcessor.insertTablet(insertTabletNode, start, end, results);
-      logger.info(
-          "tsFileProcessor insert tablet success, the search index is {}",
-          insertTabletNode.getSearchIndex());
     } catch (WriteProcessRejectException e) {
       logger.warn("insert to TsFileProcessor rejected, {}", e.getMessage());
       return false;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -159,7 +159,6 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.apache.iotdb.commons.conf.IoTDBConstant.FILE_NAME_SEPARATOR;
 import static org.apache.iotdb.db.queryengine.metric.QueryResourceMetricSet.SEQUENCE_TSFILE;
@@ -2038,13 +2037,12 @@ public class DataRegion implements IDataRegionForQuery {
       List<TsFileResource> unsealedResource,
       long startTime,
       long endTime) {
-    Stream<TsFileResource> tsFileResources =
-        tsFileManager.getTsFileList(true, startTime, endTime).stream();
-    Stream.concat(tsFileResources, tsFileManager.getTsFileList(false, startTime, endTime).stream());
-    sealedResource.addAll(
-        tsFileResources.filter(TsFileResource::isClosed).collect(Collectors.toList()));
-    unsealedResource.addAll(
-        tsFileResources.filter(resource -> !resource.isClosed()).collect(Collectors.toList()));
+    List<TsFileResource> tsFileResources = tsFileManager.getTsFileList(true, startTime, endTime);
+    tsFileResources.addAll(tsFileManager.getTsFileList(false, startTime, endTime));
+    tsFileResources.stream().filter(TsFileResource::isClosed).forEach(sealedResource::add);
+    tsFileResources.stream()
+        .filter(resource -> !resource.isClosed())
+        .forEach(unsealedResource::add);
   }
 
   /**

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -2167,6 +2167,7 @@ public class DataRegion implements IDataRegionForQuery {
     // but it's still necessary to write to the WAL, so that iotconsensus can synchronize the delete
     // operation to other nodes.
     if (walFlushListeners.isEmpty()) {
+      // TODO: IoTConsensusV2 deletion support
       getWALNode()
           .ifPresent(
               walNode ->

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -2177,6 +2177,9 @@ public class DataRegion implements IDataRegionForQuery {
         walFlushListeners.add(walFlushListener);
       }
     }
+    if (walFlushListeners.isEmpty()) {
+      walFlushListeners.add(getWALNode().log(TsFileProcessor.MEMTABLE_NOT_EXIST, deleteDataNode));
+    }
     return walFlushListeners;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
@@ -201,6 +201,8 @@ public class TsFileProcessor {
   private static final PerformanceOverviewMetrics PERFORMANCE_OVERVIEW_METRICS =
       PerformanceOverviewMetrics.getInstance();
 
+  public static final int MEMTABLE_NOT_EXIST = -1;
+
   @SuppressWarnings("squid:S107")
   public TsFileProcessor(
       String storageGroupName,

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
@@ -128,12 +128,20 @@ public class WALNode implements IWALNode {
 
   @Override
   public WALFlushListener log(long memTableId, InsertRowNode insertRowNode) {
+    logger.info(
+        "WAL node-{} logs insertRowNode, the search index is {}.",
+        identifier,
+        insertRowNode.getSearchIndex());
     WALEntry walEntry = new WALInfoEntry(memTableId, insertRowNode);
     return log(walEntry);
   }
 
   @Override
   public WALFlushListener log(long memTableId, InsertRowsNode insertRowsNode) {
+    logger.info(
+        "WAL node-{} logs insertRowsNode, the search index is {}.",
+        identifier,
+        insertRowsNode.getSearchIndex());
     WALEntry walEntry = new WALInfoEntry(memTableId, insertRowsNode);
     return log(walEntry);
   }
@@ -141,12 +149,20 @@ public class WALNode implements IWALNode {
   @Override
   public WALFlushListener log(
       long memTableId, InsertTabletNode insertTabletNode, int start, int end) {
+    logger.info(
+        "WAL node-{} logs insertTabletNode, the search index is {}.",
+        identifier,
+        insertTabletNode.getSearchIndex());
     WALEntry walEntry = new WALInfoEntry(memTableId, insertTabletNode, start, end);
     return log(walEntry);
   }
 
   @Override
   public WALFlushListener log(long memTableId, DeleteDataNode deleteDataNode) {
+    logger.info(
+        "WAL node-{} logs deleteDataNode, the search index is {}.",
+        identifier,
+        deleteDataNode.getSearchIndex());
     WALEntry walEntry = new WALInfoEntry(memTableId, deleteDataNode);
     return log(walEntry);
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
@@ -128,7 +128,7 @@ public class WALNode implements IWALNode {
 
   @Override
   public WALFlushListener log(long memTableId, InsertRowNode insertRowNode) {
-    logger.info(
+    logger.debug(
         "WAL node-{} logs insertRowNode, the search index is {}.",
         identifier,
         insertRowNode.getSearchIndex());
@@ -138,7 +138,7 @@ public class WALNode implements IWALNode {
 
   @Override
   public WALFlushListener log(long memTableId, InsertRowsNode insertRowsNode) {
-    logger.info(
+    logger.debug(
         "WAL node-{} logs insertRowsNode, the search index is {}.",
         identifier,
         insertRowsNode.getSearchIndex());
@@ -149,7 +149,7 @@ public class WALNode implements IWALNode {
   @Override
   public WALFlushListener log(
       long memTableId, InsertTabletNode insertTabletNode, int start, int end) {
-    logger.info(
+    logger.debug(
         "WAL node-{} logs insertTabletNode, the search index is {}.",
         identifier,
         insertTabletNode.getSearchIndex());
@@ -159,7 +159,7 @@ public class WALNode implements IWALNode {
 
   @Override
   public WALFlushListener log(long memTableId, DeleteDataNode deleteDataNode) {
-    logger.info(
+    logger.debug(
         "WAL node-{} logs deleteDataNode, the search index is {}.",
         identifier,
         deleteDataNode.getSearchIndex());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/WALNodeRecoverTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/WALNodeRecoverTask.java
@@ -82,7 +82,7 @@ public class WALNodeRecoverTask implements Runnable {
     logger.info("Start recovering WAL node in the directory {}", logDirectory);
 
     // recover version id and search index
-    long[] indexInfo = recoverLastFile();
+    long[] indexInfo = readLastFileInfoAndRepairIt();
     long lastVersionId = indexInfo[0];
     long lastSearchIndex = indexInfo[1];
 
@@ -155,7 +155,7 @@ public class WALNodeRecoverTask implements Runnable {
     }
   }
 
-  private long[] recoverLastFile() {
+  private long[] readLastFileInfoAndRepairIt() {
     File[] walFiles = WALFileUtils.listAllWALFiles(logDirectory);
     if (walFiles == null || walFiles.length == 0) {
       return new long[] {0L, 0L};
@@ -217,7 +217,6 @@ public class WALNodeRecoverTask implements Runnable {
     CheckpointRecoverUtils.CheckpointInfo info =
         CheckpointRecoverUtils.recoverMemTableInfo(logDirectory);
     memTableId2Info = info.getMemTableId2Info();
-    memTableId2RecoverPerformer = new HashMap<>();
     // update init memTable id
     long maxMemTableId = info.getMaxMemTableId();
     AtomicLong memTableIdCounter = AbstractMemTable.memTableIdCounter;
@@ -228,6 +227,7 @@ public class WALNodeRecoverTask implements Runnable {
       }
     }
     // update firstValidVersionId and get recover performer from WALRecoverManager
+    memTableId2RecoverPerformer = new HashMap<>();
     for (MemTableInfo memTableInfo : memTableId2Info.values()) {
       firstValidVersionId = Math.min(firstValidVersionId, memTableInfo.getFirstFileVersionId());
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/WALNodeRecoverTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/WALNodeRecoverTask.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.DeleteDataNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertNode;
 import org.apache.iotdb.db.storageengine.dataregion.memtable.AbstractMemTable;
+import org.apache.iotdb.db.storageengine.dataregion.memtable.TsFileProcessor;
 import org.apache.iotdb.db.storageengine.dataregion.wal.WALManager;
 import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.WALEntry;
 import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.WALEntryType;
@@ -190,7 +191,9 @@ public class WALNodeRecoverTask implements Runnable {
           }
         }
         metaData.setTruncateOffSet(walReader.getWALCurrentReadOffset());
-        metaData.add(walEntry.serializedSize(), searchIndex, walEntry.getMemTableId());
+        if (walEntry.getMemTableId() != TsFileProcessor.MEMTABLE_NOT_EXIST) {
+          metaData.add(walEntry.serializedSize(), searchIndex, walEntry.getMemTableId());
+        }
       }
     } catch (Exception e) {
       logger.warn("Fail to read wal logs from {}, skip them", lastWALFile, e);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/WALNodeRecoverTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/WALNodeRecoverTask.java
@@ -26,7 +26,6 @@ import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.SearchNode;
 import org.apache.iotdb.db.storageengine.dataregion.memtable.AbstractMemTable;
-import org.apache.iotdb.db.storageengine.dataregion.memtable.TsFileProcessor;
 import org.apache.iotdb.db.storageengine.dataregion.wal.WALManager;
 import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.WALEntry;
 import org.apache.iotdb.db.storageengine.dataregion.wal.checkpoint.MemTableInfo;
@@ -180,9 +179,7 @@ public class WALNodeRecoverTask implements Runnable {
           }
         }
         metaData.setTruncateOffSet(walReader.getWALCurrentReadOffset());
-        if (walEntry.getMemTableId() != TsFileProcessor.MEMTABLE_NOT_EXIST) {
-          metaData.add(walEntry.serializedSize(), searchIndex, walEntry.getMemTableId());
-        }
+        metaData.add(walEntry.serializedSize(), searchIndex, walEntry.getMemTableId());
       }
     } catch (Exception e) {
       logger.warn("Fail to read wal logs from {}, skip them", lastWALFile, e);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/WALRepairWriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/WALRepairWriter.java
@@ -35,15 +35,15 @@ import static org.apache.iotdb.db.storageengine.dataregion.wal.io.WALWriter.MAGI
 import static org.apache.iotdb.db.storageengine.dataregion.wal.io.WALWriter.MAGIC_STRING_V2;
 import static org.apache.iotdb.db.storageengine.dataregion.wal.io.WALWriter.MAGIC_STRING_V2_BYTES;
 
-/** Check whether the wal file is broken and recover it. */
-public class WALRecoverWriter {
+/** Check whether the wal file is broken and repair it. */
+public class WALRepairWriter {
   private final File logFile;
 
-  public WALRecoverWriter(File logFile) {
+  public WALRepairWriter(File logFile) {
     this.logFile = logFile;
   }
 
-  public void recover(WALMetaData metaData) throws IOException {
+  public void repair(WALMetaData metaData) throws IOException {
     // locate broken data
     long truncateSize;
     WALFileVersion version = WALFileVersion.getVersion(logFile);
@@ -66,7 +66,7 @@ public class WALRecoverWriter {
     try (FileChannel channel = FileChannel.open(logFile.toPath(), StandardOpenOption.APPEND)) {
       channel.truncate(truncateSize);
     }
-    // flush metadata
+    // flush metadata TODO: 什么意思
     try (WALWriter walWriter = new WALWriter(logFile, version)) {
       walWriter.updateMetaData(metaData);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/WALRepairWriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/WALRepairWriter.java
@@ -66,7 +66,7 @@ public class WALRepairWriter {
     try (FileChannel channel = FileChannel.open(logFile.toPath(), StandardOpenOption.APPEND)) {
       channel.truncate(truncateSize);
     }
-    // flush metadata TODO: 什么意思
+    // flush metadata
     try (WALWriter walWriter = new WALWriter(logFile, version)) {
       walWriter.updateMetaData(metaData);
     }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/AbstractCompactionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/AbstractCompactionTest.java
@@ -40,6 +40,7 @@ import org.apache.iotdb.db.storageengine.dataregion.read.control.FileReaderManag
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileManager;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResourceStatus;
+import org.apache.iotdb.db.storageengine.dataregion.wal.WALManager;
 import org.apache.iotdb.db.tools.validate.TsFileValidationTool;
 import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.iotdb.db.utils.constant.TestConstant;
@@ -471,6 +472,8 @@ public class AbstractCompactionTest {
     ChunkCache.getInstance().clear();
     TimeSeriesMetadataCache.getInstance().clear();
     BloomFilterCache.getInstance().clear();
+    WALManager.getInstance().clear();
+
     EnvironmentUtils.cleanAllDir();
 
     if (SEQ_DIRS.exists()) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/cross/RewriteCrossSpaceCompactionWithFastPerformerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/cross/RewriteCrossSpaceCompactionWithFastPerformerTest.java
@@ -55,6 +55,8 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -70,6 +72,9 @@ import static org.junit.Assert.assertEquals;
 
 public class RewriteCrossSpaceCompactionWithFastPerformerTest extends AbstractCompactionTest {
 
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(RewriteCrossSpaceCompactionWithFastPerformerTest.class);
+
   private final String oldThreadName = Thread.currentThread().getName();
 
   @Before
@@ -83,7 +88,11 @@ public class RewriteCrossSpaceCompactionWithFastPerformerTest extends AbstractCo
 
   @After
   public void tearDown() throws IOException, StorageEngineException {
-    super.tearDown();
+    try {
+      super.tearDown();
+    } catch (IOException e) {
+      LOGGER.warn("Exception during tearDown will be ignored: ", e);
+    }
     Thread.currentThread().setName(oldThreadName);
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
   }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/cross/RewriteCrossSpaceCompactionWithFastPerformerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/cross/RewriteCrossSpaceCompactionWithFastPerformerTest.java
@@ -88,11 +88,7 @@ public class RewriteCrossSpaceCompactionWithFastPerformerTest extends AbstractCo
 
   @After
   public void tearDown() throws IOException, StorageEngineException {
-    try {
-      super.tearDown();
-    } catch (IOException e) {
-      LOGGER.warn("Exception during tearDown will be ignored: ", e);
-    }
+    super.tearDown();
     Thread.currentThread().setName(oldThreadName);
     FileReaderManager.getInstance().closeAndRemoveAllOpenedReaders();
   }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/WALRepairWriterTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/WALRepairWriterTest.java
@@ -68,9 +68,8 @@ public class WALRepairWriterTest {
     logFile.createNewFile();
     long firstSearchIndex = WALFileUtils.parseStartSearchIndex(logFile.getName());
     WALMetaData walMetaData = new WALMetaData(firstSearchIndex, new ArrayList<>(), new HashSet<>());
-    // recover
-    WALRepairWriter walRecoverWriter = new WALRepairWriter(logFile);
-    walRecoverWriter.repair(walMetaData);
+    // repair
+    new WALRepairWriter(logFile).repair(walMetaData);
     // verify file, marker + metadata(search index + size number) + metadata size + head magic
     // string + tail magic string
     Assert.assertEquals(
@@ -94,9 +93,8 @@ public class WALRepairWriterTest {
     }
     long firstSearchIndex = WALFileUtils.parseStartSearchIndex(logFile.getName());
     WALMetaData walMetaData = new WALMetaData(firstSearchIndex, new ArrayList<>(), new HashSet<>());
-    // recover
-    WALRepairWriter walRecoverWriter = new WALRepairWriter(logFile);
-    walRecoverWriter.repair(walMetaData);
+    // repair
+    new WALRepairWriter(logFile).repair(walMetaData);
     // verify file, marker + metadata(search index + size number) + metadata size + magic string
     Assert.assertEquals(
         Byte.BYTES
@@ -122,9 +120,8 @@ public class WALRepairWriterTest {
     try (WALWriter walWriter = new WALWriter(logFile)) {
       walWriter.write(buffer.getBuffer(), walMetaData);
     }
-    // recover
-    WALRepairWriter walRecoverWriter = new WALRepairWriter(logFile);
-    walRecoverWriter.repair(walMetaData);
+    // repair
+    new WALRepairWriter(logFile).repair(walMetaData);
     // verify file
     try (WALByteBufReader reader = new WALByteBufReader(logFile)) {
       Assert.assertTrue(reader.hasNext());
@@ -146,9 +143,8 @@ public class WALRepairWriterTest {
     try (WALWriter walWriter = new WALWriter(logFile)) {
       walWriter.write(buffer.getBuffer(), walMetaData);
     }
-    // recover
-    WALRepairWriter walRecoverWriter = new WALRepairWriter(logFile);
-    walRecoverWriter.repair(walMetaData);
+    // repair
+    new WALRepairWriter(logFile).repair(walMetaData);
     // verify file
     try (WALByteBufReader reader = new WALByteBufReader(logFile)) {
       Assert.assertTrue(reader.hasNext());
@@ -175,9 +171,8 @@ public class WALRepairWriterTest {
     try (FileChannel channel = FileChannel.open(logFile.toPath(), StandardOpenOption.APPEND)) {
       channel.truncate(len - 1);
     }
-    // recover
-    WALRepairWriter walRecoverWriter = new WALRepairWriter(logFile);
-    walRecoverWriter.repair(walMetaData);
+    // repair
+    new WALRepairWriter(logFile).repair(walMetaData);
     // verify file
     try (WALByteBufReader reader = new WALByteBufReader(logFile)) {
       Assert.assertTrue(reader.hasNext());

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/WALRepairWriterTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/WALRepairWriterTest.java
@@ -51,7 +51,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.HashSet;
 
-public class WALRecoverWriterTest {
+public class WALRepairWriterTest {
   private final File logFile =
       new File(
           TestConstant.BASE_OUTPUT_PATH.concat(
@@ -69,8 +69,8 @@ public class WALRecoverWriterTest {
     long firstSearchIndex = WALFileUtils.parseStartSearchIndex(logFile.getName());
     WALMetaData walMetaData = new WALMetaData(firstSearchIndex, new ArrayList<>(), new HashSet<>());
     // recover
-    WALRecoverWriter walRecoverWriter = new WALRecoverWriter(logFile);
-    walRecoverWriter.recover(walMetaData);
+    WALRepairWriter walRecoverWriter = new WALRepairWriter(logFile);
+    walRecoverWriter.repair(walMetaData);
     // verify file, marker + metadata(search index + size number) + metadata size + head magic
     // string + tail magic string
     Assert.assertEquals(
@@ -95,8 +95,8 @@ public class WALRecoverWriterTest {
     long firstSearchIndex = WALFileUtils.parseStartSearchIndex(logFile.getName());
     WALMetaData walMetaData = new WALMetaData(firstSearchIndex, new ArrayList<>(), new HashSet<>());
     // recover
-    WALRecoverWriter walRecoverWriter = new WALRecoverWriter(logFile);
-    walRecoverWriter.recover(walMetaData);
+    WALRepairWriter walRecoverWriter = new WALRepairWriter(logFile);
+    walRecoverWriter.repair(walMetaData);
     // verify file, marker + metadata(search index + size number) + metadata size + magic string
     Assert.assertEquals(
         Byte.BYTES
@@ -123,8 +123,8 @@ public class WALRecoverWriterTest {
       walWriter.write(buffer.getBuffer(), walMetaData);
     }
     // recover
-    WALRecoverWriter walRecoverWriter = new WALRecoverWriter(logFile);
-    walRecoverWriter.recover(walMetaData);
+    WALRepairWriter walRecoverWriter = new WALRepairWriter(logFile);
+    walRecoverWriter.repair(walMetaData);
     // verify file
     try (WALByteBufReader reader = new WALByteBufReader(logFile)) {
       Assert.assertTrue(reader.hasNext());
@@ -147,8 +147,8 @@ public class WALRecoverWriterTest {
       walWriter.write(buffer.getBuffer(), walMetaData);
     }
     // recover
-    WALRecoverWriter walRecoverWriter = new WALRecoverWriter(logFile);
-    walRecoverWriter.recover(walMetaData);
+    WALRepairWriter walRecoverWriter = new WALRepairWriter(logFile);
+    walRecoverWriter.repair(walMetaData);
     // verify file
     try (WALByteBufReader reader = new WALByteBufReader(logFile)) {
       Assert.assertTrue(reader.hasNext());
@@ -176,8 +176,8 @@ public class WALRecoverWriterTest {
       channel.truncate(len - 1);
     }
     // recover
-    WALRecoverWriter walRecoverWriter = new WALRecoverWriter(logFile);
-    walRecoverWriter.recover(walMetaData);
+    WALRepairWriter walRecoverWriter = new WALRepairWriter(logFile);
+    walRecoverWriter.repair(walMetaData);
     // verify file
     try (WALByteBufReader reader = new WALByteBufReader(logFile)) {
       Assert.assertTrue(reader.hasNext());


### PR DESCRIPTION
The IoTConsensus protocol requires any write or delete operations to be recorded in the WAL file to synchronize data changes to other nodes. 

Currently, if a delete operation cannot correspond to any MemTable, it will not be recorded in the WAL, causing the synchronization between IoTConsensus nodes to be stuck. 

This PR fixes this issue by treating such delete operations as if they have a MemTable id of -1, and records them in the WAL in the same way. During restart recovery, WALs with a MemTable id of -1 will not be recovered.