### PR TITLE
Pipe: Modified the confignode and datanode receiving file directory parameters: cn_pipe_receiver_file_dir, dn_pipe_receiver_file_dirs

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
@@ -302,11 +302,10 @@ public class ConfigNodeDescriptor {
     conf.setPipeReceiverFileDir(
         Optional.ofNullable(properties.getProperty("cn_pipe_receiver_file_dir"))
             .orElse(
-                properties
-                    .getProperty(
-                        "pipe_receiver_file_dir",
-                        conf.getSystemDir() + File.separator + "pipe" + File.separator + "receiver")
-            ).trim());
+                properties.getProperty(
+                    "pipe_receiver_file_dir",
+                    conf.getSystemDir() + File.separator + "pipe" + File.separator + "receiver"))
+            .trim());
 
     conf.setHeartbeatIntervalInMs(
         Long.parseLong(

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
@@ -300,11 +300,13 @@ public class ConfigNodeDescriptor {
     conf.setPipeDir(properties.getProperty("pipe_lib_dir", conf.getPipeDir()).trim());
 
     conf.setPipeReceiverFileDir(
-        properties
-            .getProperty(
-                "pipe_receiver_file_dir",
-                conf.getSystemDir() + File.separator + "pipe" + File.separator + "receiver")
-            .trim());
+        Optional.ofNullable(properties.getProperty("cn_pipe_receiver_file_dir"))
+            .orElse(
+                properties
+                    .getProperty(
+                        "pipe_receiver_file_dir",
+                        conf.getSystemDir() + File.separator + "pipe" + File.separator + "receiver")
+            ).trim());
 
     conf.setHeartbeatIntervalInMs(
         Long.parseLong(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -81,6 +81,7 @@ import java.nio.file.FileStore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -2258,11 +2259,13 @@ public class IoTDBDescriptor {
 
     conf.setPipeReceiverFileDirs(
         Arrays.stream(
-                properties
-                    .getProperty(
-                        "pipe_receiver_file_dirs", String.join(",", conf.getPipeReceiverFileDirs()))
-                    .trim()
-                    .split(","))
+            Optional.ofNullable(properties.getProperty("dn_pipe_receiver_file_dirs"))
+                .orElse(
+                    properties
+                        .getProperty(
+                            "pipe_receiver_file_dirs", String.join(",", conf.getPipeReceiverFileDirs())))
+                .trim()
+                .split(","))
             .filter(dir -> !dir.isEmpty())
             .toArray(String[]::new));
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -2259,13 +2259,13 @@ public class IoTDBDescriptor {
 
     conf.setPipeReceiverFileDirs(
         Arrays.stream(
-            Optional.ofNullable(properties.getProperty("dn_pipe_receiver_file_dirs"))
-                .orElse(
-                    properties
-                        .getProperty(
-                            "pipe_receiver_file_dirs", String.join(",", conf.getPipeReceiverFileDirs())))
-                .trim()
-                .split(","))
+                Optional.ofNullable(properties.getProperty("dn_pipe_receiver_file_dirs"))
+                    .orElse(
+                        properties.getProperty(
+                            "pipe_receiver_file_dirs",
+                            String.join(",", conf.getPipeReceiverFileDirs())))
+                    .trim()
+                    .split(","))
             .filter(dir -> !dir.isEmpty())
             .toArray(String[]::new));
 

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
@@ -187,18 +187,18 @@ cn_system_dir=data/confignode/system
 # If its prefix is "/", then the path is absolute. Otherwise, it is relative.
 cn_consensus_dir=data/confignode/consensus
 
-# pipe_receiver_file_dir
+# cn_pipe_receiver_file_dir
 # If this property is unset, system will save the data in the default relative path directory under the IoTDB folder(i.e., %IOTDB_HOME%/${cn_system_dir}/pipe/receiver).
 # If it is absolute, system will save the data in the exact location it points to.
 # If it is relative, system will save the data in the relative path directory it indicates under the IoTDB folder.
-# Note: If pipe_receiver_file_dir is assigned an empty string(i.e.,zero-size), it will be handled as a relative path.
+# Note: If cn_pipe_receiver_file_dir is assigned an empty string(i.e.,zero-size), it will be handled as a relative path.
 # effectiveMode: restart
 # For windows platform
 # If its prefix is a drive specifier followed by "\\", or if its prefix is "\\\\", then the path is absolute. Otherwise, it is relative.
-# pipe_receiver_file_dir=data\\confignode\\system\\pipe\\receiver
+# cn_pipe_receiver_file_dir=data\\confignode\\system\\pipe\\receiver
 # For Linux platform
 # If its prefix is "/", then the path is absolute. Otherwise, it is relative.
-pipe_receiver_file_dir=data/confignode/system/pipe/receiver
+cn_pipe_receiver_file_dir=data/confignode/system/pipe/receiver
 
 # system dir
 # If this property is unset, system will save the data in the default relative path directory under the IoTDB folder(i.e., %IOTDB_HOME%/data/datanode/system).
@@ -304,19 +304,19 @@ dn_sync_dir=data/datanode/sync
 # If its prefix is "/", then the path is absolute. Otherwise, it is relative.
 sort_tmp_dir=data/datanode/tmp
 
-# pipe_receiver_file_dirs
+# dn_pipe_receiver_file_dirs
 # If this property is unset, system will save the data in the default relative path directory under the IoTDB folder(i.e., %IOTDB_HOME%/${dn_system_dir}/pipe/receiver).
 # If it is absolute, system will save the data in the exact location it points to.
 # If it is relative, system will save the data in the relative path directory it indicates under the IoTDB folder.
 # If there are more than one directory, please separate them by commas ",".
-# Note: If pipe_receiver_file_dirs is assigned an empty string(i.e.,zero-size), it will be handled as a relative path.
+# Note: If dn_pipe_receiver_file_dirs is assigned an empty string(i.e.,zero-size), it will be handled as a relative path.
 # effectiveMode: restart
 # For windows platform
 # If its prefix is a drive specifier followed by "\\", or if its prefix is "\\\\", then the path is absolute. Otherwise, it is relative.
-# pipe_receiver_file_dirs=data\\datanode\\system\\pipe\\receiver
+# dn_pipe_receiver_file_dirs=data\\datanode\\system\\pipe\\receiver
 # For Linux platform
 # If its prefix is "/", then the path is absolute. Otherwise, it is relative.
-pipe_receiver_file_dirs=data/datanode/system/pipe/receiver
+dn_pipe_receiver_file_dirs=data/datanode/system/pipe/receiver
 
 # pipe_consensus_receiver_file_dirs
 # If this property is unset, system will save the data in the default relative path directory under the IoTDB folder(i.e., %IOTDB_HOME%/${dn_system_dir}/pipe/consensus/receiver).


### PR DESCRIPTION
…ers: cn_pipe_receiver_file_dir, dn_pipe_receiver_file_dirs

## Description
In the configuration file iotdb-system.properties, the file receiving directory parameters of confignode and datanode are pipe_receiver_file_dir and pipe_receiver_file_dirs respectively, which are not distinguishable. Change them to cn_pipe_receiver_file_dir and dn_pipe_receiver_file_dirs respectively
### Original code
```java
conf.setPipeReceiverFileDirs(
        Arrays.stream(
                properties
                    .getProperty(
                        "pipe_receiver_file_dirs", String.join(",", conf.getPipeReceiverFileDirs()))
                    .trim()
                    .split(","))
            .filter(dir -> !dir.isEmpty())
            .toArray(String[]::new));

conf.setPipeReceiverFileDir(
    properties
        .getProperty(
            "pipe_receiver_file_dir",
            conf.getSystemDir() + File.separator + "pipe" + File.separator + "receiver")
        .trim());
```

### Modified code
```java
conf.setPipeReceiverFileDirs(
        Arrays.stream(
            Optional.ofNullable(properties.getProperty("dn_pipe_receiver_file_dirs"))
                .orElse(
                    properties
                        .getProperty(
                            "pipe_receiver_file_dirs", String.join(",", conf.getPipeReceiverFileDirs())))
                        .trim()
                        .split(","))
            .filter(dir -> !dir.isEmpty())
            .toArray(String[]::new));

conf.setPipeReceiverFileDir(
        Optional.ofNullable(properties.getProperty("cn_pipe_receiver_file_dir"))
            .orElse(
                properties
                    .getProperty(
                        "pipe_receiver_file_dir",
                        conf.getSystemDir() + File.separator + "pipe" + File.separator + "receiver")
            ).trim());
```