### PR TITLE
fix fail file directory when import tools failed

### DIFF
--- a/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/ImportData.java
+++ b/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/ImportData.java
@@ -268,7 +268,7 @@ public class ImportData extends AbstractDataTool {
       if (!file.isDirectory()) {
         file.mkdir();
         failedFileDirectory = file.getAbsolutePath() + File.separator;
-      }else if(!failedFileDirectory.endsWith("/") && !failedFileDirectory.endsWith("\\")){
+      } else if (!failedFileDirectory.endsWith("/") && !failedFileDirectory.endsWith("\\")) {
         failedFileDirectory += File.separator;
       }
     }

--- a/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/ImportData.java
+++ b/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/ImportData.java
@@ -268,6 +268,8 @@ public class ImportData extends AbstractDataTool {
       if (!file.isDirectory()) {
         file.mkdir();
         failedFileDirectory = file.getAbsolutePath() + File.separator;
+      }else if(!failedFileDirectory.endsWith("/") && !failedFileDirectory.endsWith("\\")){
+        failedFileDirectory += File.separator;
       }
     }
     if (commandLine.getOptionValue(ALIGNED_ARGS) != null) {

--- a/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/ImportSchema.java
+++ b/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/ImportSchema.java
@@ -163,6 +163,8 @@ public class ImportSchema extends AbstractSchemaTool {
       if (!file.isDirectory()) {
         file.mkdir();
         failedFileDirectory = file.getAbsolutePath() + File.separator;
+      }else if(!failedFileDirectory.endsWith("/") && !failedFileDirectory.endsWith("\\")){
+        failedFileDirectory += File.separator;
       }
     }
     if (commandLine.getOptionValue(ALIGNED_ARGS) != null) {

--- a/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/ImportSchema.java
+++ b/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/ImportSchema.java
@@ -163,7 +163,7 @@ public class ImportSchema extends AbstractSchemaTool {
       if (!file.isDirectory()) {
         file.mkdir();
         failedFileDirectory = file.getAbsolutePath() + File.separator;
-      }else if(!failedFileDirectory.endsWith("/") && !failedFileDirectory.endsWith("\\")){
+      } else if (!failedFileDirectory.endsWith("/") && !failedFileDirectory.endsWith("\\")) {
         failedFileDirectory += File.separator;
       }
     }


### PR DESCRIPTION
When importing data and schema data, if a failure occurs and the failure directory does not exist, the failed file will not be placed in the specified directory