### PR TITLE
Pipe Plugin: Pipe Task Safe Deletion, Plugin Directory Structure Reorganization, and Isolated Pipe Plugin ClassLoader Implementation

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipePluginInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipePluginInfo.java
@@ -100,13 +100,6 @@ public class PipePluginInfo implements SnapshotProcessor {
               "Failed to create PipePlugin [%s], the same name PipePlugin has been created",
               pluginName));
     }
-
-    if (pipePluginMetaKeeper.jarNameExistsAndMatchesMd5(jarName, jarMD5)) {
-      throw new PipeException(
-          String.format(
-              "Failed to create PipePlugin [%s], the same name Jar [%s] but different MD5 [%s] has existed",
-              pluginName, jarName, jarMD5));
-    }
   }
 
   public void validateBeforeDroppingPipePlugin(final String pluginName) {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipePluginInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipePluginInfo.java
@@ -240,6 +240,9 @@ public class PipePluginInfo implements SnapshotProcessor {
       final List<ByteBuffer> jarList = new ArrayList<>();
       for (final String jarName : getPipePluginJarPlan.getJarNames()) {
         String pluginName = pipePluginMetaKeeper.getPluginNameByJarName(jarName);
+        if (pluginName == null) {
+          throw new PipeException(String.format("%s does not exist", jarName));
+        }
         jarList.add(
             ExecutableManager.transferToBytebuffer(
                 PipePluginExecutableManager.getInstance()

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipeTaskInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipeTaskInfo.java
@@ -353,7 +353,6 @@ public class PipeTaskInfo implements SnapshotProcessor {
 
   public void validatePipePluginUsageByPipe(String pluginName) {
     acquireReadLock();
-    String exceptionMessage = null;
     try {
       Iterable<PipeMeta> pipeMetas = getPipeMetaList();
       for (PipeMeta pipeMeta : pipeMetas) {
@@ -364,20 +363,22 @@ public class PipeTaskInfo implements SnapshotProcessor {
                     PipeExtractorConstant.EXTRACTOR_KEY, PipeExtractorConstant.SOURCE_KEY),
                 BuiltinPipePlugin.IOTDB_EXTRACTOR.getPipePluginName());
         if (pluginName.equals(extractorPluginName)) {
-          exceptionMessage =
+          String exceptionMessage =
               String.format(
                   "PipePlugin '%s' is already used by Pipe '%s' as a source.",
                   pluginName, pipeMeta.getStaticMeta().getPipeName());
+          throw new PipeException(exceptionMessage);
         }
 
         PipeParameters processorParameters = pipeMeta.getStaticMeta().getProcessorParameters();
         final String processorPluginName =
             processorParameters.getString(PipeProcessorConstant.PROCESSOR_KEY);
         if (pluginName.equals(processorPluginName)) {
-          exceptionMessage =
+          String exceptionMessage =
               String.format(
                   "PipePlugin '%s' is already used by Pipe '%s' as a processor.",
                   pluginName, pipeMeta.getStaticMeta().getPipeName());
+          throw new PipeException(exceptionMessage);
         }
 
         PipeParameters connectorParameters = pipeMeta.getStaticMeta().getConnectorParameters();
@@ -386,17 +387,15 @@ public class PipeTaskInfo implements SnapshotProcessor {
                 Arrays.asList(PipeConnectorConstant.CONNECTOR_KEY, PipeConnectorConstant.SINK_KEY),
                 IOTDB_THRIFT_CONNECTOR.getPipePluginName());
         if (pluginName.equals(connectorPluginName)) {
-          exceptionMessage =
+          String exceptionMessage =
               String.format(
                   "PipePlugin '%s' is already used by Pipe '%s' as a sink.",
                   pluginName, pipeMeta.getStaticMeta().getPipeName());
+          throw new PipeException(exceptionMessage);
         }
       }
     } finally {
       releaseReadLock();
-    }
-    if (exceptionMessage != null) {
-      throw new PipeException(exceptionMessage);
     }
   }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipeTaskInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipeTaskInfo.java
@@ -24,6 +24,10 @@ import org.apache.iotdb.commons.consensus.index.impl.MinimumProgressIndex;
 import org.apache.iotdb.commons.exception.pipe.PipeRuntimeCriticalException;
 import org.apache.iotdb.commons.exception.pipe.PipeRuntimeException;
 import org.apache.iotdb.commons.pipe.config.PipeConfig;
+import org.apache.iotdb.commons.pipe.config.constant.PipeConnectorConstant;
+import org.apache.iotdb.commons.pipe.config.constant.PipeExtractorConstant;
+import org.apache.iotdb.commons.pipe.config.constant.PipeProcessorConstant;
+import org.apache.iotdb.commons.pipe.plugin.builtin.BuiltinPipePlugin;
 import org.apache.iotdb.commons.pipe.task.meta.PipeMeta;
 import org.apache.iotdb.commons.pipe.task.meta.PipeMetaKeeper;
 import org.apache.iotdb.commons.pipe.task.meta.PipeRuntimeMeta;
@@ -61,6 +65,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -70,6 +75,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+
+import static org.apache.iotdb.commons.pipe.plugin.builtin.BuiltinPipePlugin.IOTDB_THRIFT_CONNECTOR;
 
 public class PipeTaskInfo implements SnapshotProcessor {
 
@@ -341,6 +348,55 @@ public class PipeTaskInfo implements SnapshotProcessor {
           && !isStoppedByRuntimeException(pipeName);
     } finally {
       releaseReadLock();
+    }
+  }
+
+  public void validatePipePluginUsageByPipe(String pluginName) {
+    acquireReadLock();
+    String exceptionMessage = null;
+    try {
+      Iterable<PipeMeta> pipeMetas = getPipeMetaList();
+      for (PipeMeta pipeMeta : pipeMetas) {
+        PipeParameters extractorParameters = pipeMeta.getStaticMeta().getExtractorParameters();
+        final String extractorPluginName =
+            extractorParameters.getStringOrDefault(
+                Arrays.asList(
+                    PipeExtractorConstant.EXTRACTOR_KEY, PipeExtractorConstant.SOURCE_KEY),
+                BuiltinPipePlugin.IOTDB_EXTRACTOR.getPipePluginName());
+        if (pluginName.equals(extractorPluginName)) {
+          exceptionMessage =
+              String.format(
+                  "PipePlugin '%s' is already used by Pipe '%s' as a source.",
+                  pluginName, pipeMeta.getStaticMeta().getPipeName());
+        }
+
+        PipeParameters processorParameters = pipeMeta.getStaticMeta().getProcessorParameters();
+        final String processorPluginName =
+            processorParameters.getString(PipeProcessorConstant.PROCESSOR_KEY);
+        if (pluginName.equals(processorPluginName)) {
+          exceptionMessage =
+              String.format(
+                  "PipePlugin '%s' is already used by Pipe '%s' as a processor.",
+                  pluginName, pipeMeta.getStaticMeta().getPipeName());
+        }
+
+        PipeParameters connectorParameters = pipeMeta.getStaticMeta().getConnectorParameters();
+        final String connectorPluginName =
+            connectorParameters.getStringOrDefault(
+                Arrays.asList(PipeConnectorConstant.CONNECTOR_KEY, PipeConnectorConstant.SINK_KEY),
+                IOTDB_THRIFT_CONNECTOR.getPipePluginName());
+        if (pluginName.equals(connectorPluginName)) {
+          exceptionMessage =
+              String.format(
+                  "PipePlugin '%s' is already used by Pipe '%s' as a sink.",
+                  pluginName, pipeMeta.getStaticMeta().getPipeName());
+        }
+      }
+    } finally {
+      releaseReadLock();
+    }
+    if (exceptionMessage != null) {
+      throw new PipeException(exceptionMessage);
     }
   }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipeTaskInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipeTaskInfo.java
@@ -354,48 +354,51 @@ public class PipeTaskInfo implements SnapshotProcessor {
   public void validatePipePluginUsageByPipe(String pluginName) {
     acquireReadLock();
     try {
-      Iterable<PipeMeta> pipeMetas = getPipeMetaList();
-      for (PipeMeta pipeMeta : pipeMetas) {
-        PipeParameters extractorParameters = pipeMeta.getStaticMeta().getExtractorParameters();
-        final String extractorPluginName =
-            extractorParameters.getStringOrDefault(
-                Arrays.asList(
-                    PipeExtractorConstant.EXTRACTOR_KEY, PipeExtractorConstant.SOURCE_KEY),
-                BuiltinPipePlugin.IOTDB_EXTRACTOR.getPipePluginName());
-        if (pluginName.equals(extractorPluginName)) {
-          String exceptionMessage =
-              String.format(
-                  "PipePlugin '%s' is already used by Pipe '%s' as a source.",
-                  pluginName, pipeMeta.getStaticMeta().getPipeName());
-          throw new PipeException(exceptionMessage);
-        }
-
-        PipeParameters processorParameters = pipeMeta.getStaticMeta().getProcessorParameters();
-        final String processorPluginName =
-            processorParameters.getString(PipeProcessorConstant.PROCESSOR_KEY);
-        if (pluginName.equals(processorPluginName)) {
-          String exceptionMessage =
-              String.format(
-                  "PipePlugin '%s' is already used by Pipe '%s' as a processor.",
-                  pluginName, pipeMeta.getStaticMeta().getPipeName());
-          throw new PipeException(exceptionMessage);
-        }
-
-        PipeParameters connectorParameters = pipeMeta.getStaticMeta().getConnectorParameters();
-        final String connectorPluginName =
-            connectorParameters.getStringOrDefault(
-                Arrays.asList(PipeConnectorConstant.CONNECTOR_KEY, PipeConnectorConstant.SINK_KEY),
-                IOTDB_THRIFT_CONNECTOR.getPipePluginName());
-        if (pluginName.equals(connectorPluginName)) {
-          String exceptionMessage =
-              String.format(
-                  "PipePlugin '%s' is already used by Pipe '%s' as a sink.",
-                  pluginName, pipeMeta.getStaticMeta().getPipeName());
-          throw new PipeException(exceptionMessage);
-        }
-      }
+      validatePipePluginUsageByPipeInternal(pluginName);
     } finally {
       releaseReadLock();
+    }
+  }
+
+  private void validatePipePluginUsageByPipeInternal(String pluginName) {
+    Iterable<PipeMeta> pipeMetas = getPipeMetaList();
+    for (PipeMeta pipeMeta : pipeMetas) {
+      PipeParameters extractorParameters = pipeMeta.getStaticMeta().getExtractorParameters();
+      final String extractorPluginName =
+          extractorParameters.getStringOrDefault(
+              Arrays.asList(PipeExtractorConstant.EXTRACTOR_KEY, PipeExtractorConstant.SOURCE_KEY),
+              BuiltinPipePlugin.IOTDB_EXTRACTOR.getPipePluginName());
+      if (pluginName.equals(extractorPluginName)) {
+        String exceptionMessage =
+            String.format(
+                "PipePlugin '%s' is already used by Pipe '%s' as a source.",
+                pluginName, pipeMeta.getStaticMeta().getPipeName());
+        throw new PipeException(exceptionMessage);
+      }
+
+      PipeParameters processorParameters = pipeMeta.getStaticMeta().getProcessorParameters();
+      final String processorPluginName =
+          processorParameters.getString(PipeProcessorConstant.PROCESSOR_KEY);
+      if (pluginName.equals(processorPluginName)) {
+        String exceptionMessage =
+            String.format(
+                "PipePlugin '%s' is already used by Pipe '%s' as a processor.",
+                pluginName, pipeMeta.getStaticMeta().getPipeName());
+        throw new PipeException(exceptionMessage);
+      }
+
+      PipeParameters connectorParameters = pipeMeta.getStaticMeta().getConnectorParameters();
+      final String connectorPluginName =
+          connectorParameters.getStringOrDefault(
+              Arrays.asList(PipeConnectorConstant.CONNECTOR_KEY, PipeConnectorConstant.SINK_KEY),
+              IOTDB_THRIFT_CONNECTOR.getPipePluginName());
+      if (pluginName.equals(connectorPluginName)) {
+        String exceptionMessage =
+            String.format(
+                "PipePlugin '%s' is already used by Pipe '%s' as a sink.",
+                pluginName, pipeMeta.getStaticMeta().getPipeName());
+        throw new PipeException(exceptionMessage);
+      }
     }
   }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/plugin/DropPipePluginProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/plugin/DropPipePluginProcedure.java
@@ -129,11 +129,10 @@ public class DropPipePluginProcedure extends AbstractNodeProcedure<DropPipePlugi
     } catch (PipeException e) {
       // if the pipe plugin is a built-in plugin, we should not drop it
       LOGGER.warn(e.getMessage());
-      setFailure(new ProcedureException(e.getMessage()));
-      return Flow.NO_MORE_STATE;
-    } finally {
       pipePluginCoordinator.unlock();
       env.getConfigManager().getPipeManager().getPipeTaskCoordinator().unlock();
+      setFailure(new ProcedureException(e.getMessage()));
+      return Flow.NO_MORE_STATE;
     }
 
     try {
@@ -141,7 +140,6 @@ public class DropPipePluginProcedure extends AbstractNodeProcedure<DropPipePlugi
     } catch (ConsensusException e) {
       LOGGER.warn("Failed in the write API executing the consensus layer due to: ", e);
     }
-
     setNextState(DropPipePluginState.DROP_ON_DATA_NODES);
     return Flow.HAS_MORE_STATE;
   }
@@ -176,7 +174,7 @@ public class DropPipePluginProcedure extends AbstractNodeProcedure<DropPipePlugi
     LOGGER.info("DropPipePluginProcedure: executeFromUnlock({})", pluginName);
 
     env.getConfigManager().getPipeManager().getPipePluginCoordinator().unlock();
-
+    env.getConfigManager().getPipeManager().getPipeTaskCoordinator().unlock();
     return Flow.NO_MORE_STATE;
   }
 
@@ -200,6 +198,7 @@ public class DropPipePluginProcedure extends AbstractNodeProcedure<DropPipePlugi
     LOGGER.info("DropPipePluginProcedure: rollbackFromLock({})", pluginName);
 
     env.getConfigManager().getPipeManager().getPipePluginCoordinator().unlock();
+    env.getConfigManager().getPipeManager().getPipeTaskCoordinator().unlock();
   }
 
   private void rollbackFromDropOnDataNodes(ConfigNodeProcedureEnv env) {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/plugin/DropPipePluginProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/plugin/DropPipePluginProcedure.java
@@ -114,8 +114,8 @@ public class DropPipePluginProcedure extends AbstractNodeProcedure<DropPipePlugi
     if (pipeTaskInfo == null) {
       String exceptionMessage =
           String.format(
-              "ProcedureId %d failed to acquire pipe lock due to high contention with other pipe operations. "
-                  + "The pipeTaskInfo is being frequently accessed by other concurrent pipe activities.",
+              "ProcedureId %d failed to acquire pipe lock due to high competition with other pipe operations. "
+                  + "The PipeTaskInfo is frequently accessed by other operations.",
               getProcId());
       LOGGER.warn(exceptionMessage);
       setFailure(new ProcedureException(exceptionMessage));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/plugin/PipeDataNodePluginAgent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/plugin/PipeDataNodePluginAgent.java
@@ -77,7 +77,7 @@ public class PipeDataNodePluginAgent {
 
       // register process from here
       checkIfRegistered(pipePluginMeta);
-      saveJarFileIfNeeded(pipePluginMeta.getJarName(), jarFile);
+      saveJarFileIfNeeded(pipePluginMeta.getPluginName(), pipePluginMeta.getJarName(), jarFile);
       doRegister(pipePluginMeta);
     } finally {
       lock.unlock();
@@ -102,7 +102,8 @@ public class PipeDataNodePluginAgent {
     }
 
     if (PipePluginExecutableManager.getInstance()
-            .hasFileUnderInstallDir(pipePluginMeta.getJarName())
+            .hasPluginFileUnderInstallDir(
+                pipePluginMeta.getPluginName(), pipePluginMeta.getJarName())
         && !PipePluginExecutableManager.getInstance().isLocalJarMatched(pipePluginMeta)) {
       String errMsg =
           String.format(
@@ -118,9 +119,11 @@ public class PipeDataNodePluginAgent {
     // we allow users to register the same pipe plugin multiple times without any error
   }
 
-  private void saveJarFileIfNeeded(String jarName, ByteBuffer byteBuffer) throws IOException {
+  private void saveJarFileIfNeeded(String pluginName, String jarName, ByteBuffer byteBuffer)
+      throws IOException {
     if (byteBuffer != null) {
-      PipePluginExecutableManager.getInstance().saveToInstallDir(byteBuffer, jarName);
+      PipePluginExecutableManager.getInstance()
+          .savePluginToInstallDir(byteBuffer, pluginName, jarName);
     }
   }
 
@@ -136,9 +139,10 @@ public class PipeDataNodePluginAgent {
     final String className = pipePluginMeta.getClassName();
 
     try {
+      String pluginDirPath =
+          PipePluginExecutableManager.getInstance().getPluginsDirPath(pluginName);
       final PipePluginClassLoader currentActiveClassLoader =
-          PipePluginClassLoaderManager.getInstance().updateAndGetActiveClassLoader();
-      updateAllRegisteredClasses(currentActiveClassLoader);
+          PipePluginClassLoaderManager.getInstance().updateAndGetActiveClassLoader(pluginDirPath);
 
       final Class<?> pluginClass = Class.forName(className, true, currentActiveClassLoader);
 
@@ -146,7 +150,7 @@ public class PipeDataNodePluginAgent {
       final PipePlugin ignored = (PipePlugin) pluginClass.getDeclaredConstructor().newInstance();
 
       pipePluginMetaKeeper.addPipePluginMeta(pluginName, pipePluginMeta);
-      pipePluginMetaKeeper.addPluginAndClass(pluginName, pluginClass);
+      pipePluginMetaKeeper.addPluginAndClassLoader(pluginName, currentActiveClassLoader);
     } catch (IOException
         | InstantiationException
         | InvocationTargetException
@@ -164,13 +168,6 @@ public class PipeDataNodePluginAgent {
     }
   }
 
-  private void updateAllRegisteredClasses(PipePluginClassLoader activeClassLoader)
-      throws ClassNotFoundException {
-    for (PipePluginMeta information : pipePluginMetaKeeper.getAllPipePluginMeta()) {
-      pipePluginMetaKeeper.updatePluginClass(information, activeClassLoader);
-    }
-  }
-
   public void deregister(String pluginName, boolean needToDeleteJar) throws PipeException {
     lock.lock();
     try {
@@ -185,11 +182,12 @@ public class PipeDataNodePluginAgent {
 
       // remove anyway
       pipePluginMetaKeeper.removePipePluginMeta(pluginName);
-      pipePluginMetaKeeper.removePluginClass(pluginName);
+      pipePluginMetaKeeper.removePluginClassLoader(pluginName);
 
       // if it is needed to delete jar file of the pipe plugin, delete both jar file and md5
       if (information != null && needToDeleteJar) {
-        PipePluginExecutableManager.getInstance().removeFileUnderLibRoot(information.getJarName());
+        PipePluginExecutableManager.getInstance()
+            .removePluginFileUnderLibRoot(information.getPluginName(), information.getJarName());
         PipePluginExecutableManager.getInstance()
             .removeFileUnderTemporaryRoot(pluginName.toUpperCase() + ".txt");
       }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/runtime/PipeAgentLauncher.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/runtime/PipeAgentLauncher.java
@@ -114,7 +114,8 @@ class PipeAgentLauncher {
       }
       // If jar does not exist, add current pipePluginMeta to list
       if (!PipePluginExecutableManager.getInstance()
-          .hasFileUnderInstallDir(pipePluginMeta.getJarName())) {
+          .hasPluginFileUnderInstallDir(
+              pipePluginMeta.getPluginName(), pipePluginMeta.getJarName())) {
         pipePluginMetaList.add(pipePluginMeta);
       } else {
         try {
@@ -144,7 +145,10 @@ class PipeAgentLauncher {
       final List<ByteBuffer> jarList = resp.getJarList();
       for (int i = 0; i < pipePluginMetaList.size(); i++) {
         PipePluginExecutableManager.getInstance()
-            .saveToInstallDir(jarList.get(i), pipePluginMetaList.get(i).getJarName());
+            .savePluginToInstallDir(
+                jarList.get(i),
+                pipePluginMetaList.get(i).getPluginName(),
+                pipePluginMetaList.get(i).getJarName());
       }
     } catch (IOException | TException | ClientManagerException e) {
       throw new StartupException(e);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/plugin/PipeDataNodePluginAgentTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/plugin/PipeDataNodePluginAgentTest.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.commons.pipe.config.constant.PipeProcessorConstant;
 import org.apache.iotdb.commons.pipe.plugin.builtin.BuiltinPipePlugin;
 import org.apache.iotdb.commons.pipe.plugin.meta.PipePluginMeta;
 import org.apache.iotdb.commons.pipe.plugin.service.PipePluginClassLoaderManager;
+import org.apache.iotdb.commons.pipe.plugin.service.PipePluginExecutableManager;
 import org.apache.iotdb.db.pipe.connector.protocol.thrift.async.IoTDBDataRegionAsyncConnector;
 import org.apache.iotdb.db.pipe.extractor.dataregion.IoTDBDataRegionExtractor;
 import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameters;
@@ -40,13 +41,17 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 
 public class PipeDataNodePluginAgentTest {
-  private static final String TMP_DIR = "PipePluginAgentTest_libroot";
+  private static final String TMP_LIB_TOOR_DIR = "PipePluginAgentTest_libroot";
+  private static final String TMP_TEMP_LIB_ROOT_DIR = "PipePluginAgentTest_temporarylibroot";
+  private static final String PLUGIN_NAME = "plugin-name";
 
   @Before
   public void before() {
     try {
-      Files.createDirectory(Paths.get(TMP_DIR));
-      PipePluginClassLoaderManager.setupAndGetInstance(TMP_DIR);
+      PipePluginExecutableManager.setupAndGetInstance(TMP_LIB_TOOR_DIR, TMP_TEMP_LIB_ROOT_DIR);
+      PipePluginClassLoaderManager.setupAndGetInstance(TMP_LIB_TOOR_DIR);
+      String pluginPath = PipePluginExecutableManager.getInstance().getPluginsDirPath(PLUGIN_NAME);
+      Files.createDirectories(Paths.get(pluginPath));
     } catch (IOException e) {
       Assert.fail();
     }
@@ -55,7 +60,11 @@ public class PipeDataNodePluginAgentTest {
   @After
   public void after() {
     try {
-      Files.deleteIfExists(Paths.get(TMP_DIR));
+      String pluginPath = PipePluginExecutableManager.getInstance().getPluginsDirPath(PLUGIN_NAME);
+      Files.deleteIfExists(Paths.get(pluginPath));
+      Files.deleteIfExists(Paths.get(PipePluginExecutableManager.getInstance().getInstallDir()));
+      Files.deleteIfExists(Paths.get(TMP_TEMP_LIB_ROOT_DIR));
+      Files.deleteIfExists(Paths.get(TMP_LIB_TOOR_DIR));
     } catch (IOException e) {
       Assert.fail();
     }
@@ -67,13 +76,13 @@ public class PipeDataNodePluginAgentTest {
     try {
       agent.register(
           new PipePluginMeta(
-              "plugin-name",
+              PLUGIN_NAME,
               "org.apache.iotdb.db.pipe.extractor.dataregion.IoTDBDataRegionExtractor",
               false,
-              "jar",
+              "IoTDBDataRegionExtractor.jar",
               "md5"),
           null);
-      agent.deregister("plugin-name", false);
+      agent.deregister(PLUGIN_NAME, false);
     } catch (Exception e) {
       Assert.fail();
     }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/plugin/PipeDataNodePluginAgentTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/plugin/PipeDataNodePluginAgentTest.java
@@ -41,7 +41,7 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 
 public class PipeDataNodePluginAgentTest {
-  private static final String TMP_LIB_TOOR_DIR = "PipePluginAgentTest_libroot";
+  private static final String TMP_LIB_ROOT_DIR = "PipePluginAgentTest_libroot";
   private static final String TMP_TEMP_LIB_ROOT_DIR = "PipePluginAgentTest_temporarylibroot";
   private static final PipePluginMeta PIPE_PLUGIN_META =
       new PipePluginMeta(
@@ -54,8 +54,8 @@ public class PipeDataNodePluginAgentTest {
   @Before
   public void before() {
     try {
-      PipePluginExecutableManager.setupAndGetInstance(TMP_LIB_TOOR_DIR, TMP_TEMP_LIB_ROOT_DIR);
-      PipePluginClassLoaderManager.setupAndGetInstance(TMP_LIB_TOOR_DIR);
+      PipePluginExecutableManager.setupAndGetInstance(TMP_LIB_ROOT_DIR, TMP_TEMP_LIB_ROOT_DIR);
+      PipePluginClassLoaderManager.setupAndGetInstance(TMP_LIB_ROOT_DIR);
       String pluginPath =
           PipePluginExecutableManager.getInstance()
               .getPluginsDirPath(PIPE_PLUGIN_META.getPluginName());
@@ -74,7 +74,7 @@ public class PipeDataNodePluginAgentTest {
       Files.deleteIfExists(Paths.get(pluginPath));
       Files.deleteIfExists(Paths.get(PipePluginExecutableManager.getInstance().getInstallDir()));
       Files.deleteIfExists(Paths.get(TMP_TEMP_LIB_ROOT_DIR));
-      Files.deleteIfExists(Paths.get(TMP_LIB_TOOR_DIR));
+      Files.deleteIfExists(Paths.get(TMP_LIB_ROOT_DIR));
     } catch (IOException e) {
       Assert.fail();
     }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/plugin/PipeDataNodePluginAgentTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/plugin/PipeDataNodePluginAgentTest.java
@@ -43,14 +43,22 @@ import java.util.HashMap;
 public class PipeDataNodePluginAgentTest {
   private static final String TMP_LIB_TOOR_DIR = "PipePluginAgentTest_libroot";
   private static final String TMP_TEMP_LIB_ROOT_DIR = "PipePluginAgentTest_temporarylibroot";
-  private static final String PLUGIN_NAME = "plugin-name";
+  private static final PipePluginMeta PIPE_PLUGIN_META =
+      new PipePluginMeta(
+          "PLUGIN-NAME",
+          "org.apache.iotdb.db.pipe.extractor.dataregion.IoTDBDataRegionExtractor",
+          false,
+          "IoTDBDataRegionExtractor.jar",
+          "md5");
 
   @Before
   public void before() {
     try {
       PipePluginExecutableManager.setupAndGetInstance(TMP_LIB_TOOR_DIR, TMP_TEMP_LIB_ROOT_DIR);
       PipePluginClassLoaderManager.setupAndGetInstance(TMP_LIB_TOOR_DIR);
-      String pluginPath = PipePluginExecutableManager.getInstance().getPluginsDirPath(PLUGIN_NAME);
+      String pluginPath =
+          PipePluginExecutableManager.getInstance()
+              .getPluginsDirPath(PIPE_PLUGIN_META.getPluginName());
       Files.createDirectories(Paths.get(pluginPath));
     } catch (IOException e) {
       Assert.fail();
@@ -60,7 +68,9 @@ public class PipeDataNodePluginAgentTest {
   @After
   public void after() {
     try {
-      String pluginPath = PipePluginExecutableManager.getInstance().getPluginsDirPath(PLUGIN_NAME);
+      String pluginPath =
+          PipePluginExecutableManager.getInstance()
+              .getPluginsDirPath(PIPE_PLUGIN_META.getPluginName());
       Files.deleteIfExists(Paths.get(pluginPath));
       Files.deleteIfExists(Paths.get(PipePluginExecutableManager.getInstance().getInstallDir()));
       Files.deleteIfExists(Paths.get(TMP_TEMP_LIB_ROOT_DIR));
@@ -73,16 +83,10 @@ public class PipeDataNodePluginAgentTest {
   @Test
   public void testPipePluginAgent() {
     PipeDataNodePluginAgent agent = new PipeDataNodePluginAgent();
+
     try {
-      agent.register(
-          new PipePluginMeta(
-              PLUGIN_NAME,
-              "org.apache.iotdb.db.pipe.extractor.dataregion.IoTDBDataRegionExtractor",
-              false,
-              "IoTDBDataRegionExtractor.jar",
-              "md5"),
-          null);
-      agent.deregister(PLUGIN_NAME, false);
+      agent.register(PIPE_PLUGIN_META, null);
+      agent.deregister(PIPE_PLUGIN_META.getPluginName(), true);
     } catch (Exception e) {
       Assert.fail();
     }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/executable/ExecutableManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/executable/ExecutableManager.java
@@ -130,6 +130,31 @@ public class ExecutableManager {
         Paths.get(this.libRoot + File.separator + INSTALL_DIR + File.separator + fileName));
   }
 
+  public boolean hasPluginFileUnderInstallDir(String pluginName, String fileName) {
+    return Files.exists(Paths.get(getPluginInstallPath(pluginName, fileName)));
+  }
+
+  public String getPluginsDirPath(String pluginName) {
+    return this.libRoot + File.separator + INSTALL_DIR + File.separator + pluginName;
+  }
+
+  public void removePluginFileUnderLibRoot(String pluginName, String fileName) throws IOException {
+    String pluginPath = getPluginInstallPath(pluginName, fileName);
+    Path path = Paths.get(pluginPath);
+    Files.deleteIfExists(path);
+    Files.deleteIfExists(path.getParent());
+  }
+
+  public String getPluginInstallPath(String pluginName, String fileName) {
+    return this.libRoot
+        + File.separator
+        + INSTALL_DIR
+        + File.separator
+        + pluginName
+        + File.separator
+        + fileName;
+  }
+
   // endregion
 
   // ======================================================
@@ -232,6 +257,7 @@ public class ExecutableManager {
     try {
       Path path = Paths.get(destination);
       if (!Files.exists(path)) {
+        createParentDir(path);
         Files.createFile(path);
       }
       // FileOutPutStream is not in append mode by default, so the file will be overridden if it
@@ -244,6 +270,14 @@ public class ExecutableManager {
       LOGGER.warn(
           "Error occurred during writing bytebuffer to {} , the cause is {}", destination, e);
       throw e;
+    }
+  }
+
+  private void createParentDir(Path path) throws IOException {
+    Path parent = path.getParent();
+    if (!Files.exists(parent)) {
+      createParentDir(parent);
+      Files.createDirectories(parent);
     }
   }
 
@@ -263,6 +297,18 @@ public class ExecutableManager {
    */
   public void saveToInstallDir(ByteBuffer byteBuffer, String fileName) throws IOException {
     String destination = this.libRoot + File.separator + INSTALL_DIR + File.separator + fileName;
+    saveToDir(byteBuffer, destination);
+  }
+
+  /**
+   * @param byteBuffer file
+   * @param pluginName
+   * @param fileName Absolute Path will be libRoot + File_Separator + INSTALL_DIR + File_Separator +
+   *     pluginName + File_Separator + fileName
+   */
+  public void savePluginToInstallDir(ByteBuffer byteBuffer, String pluginName, String fileName)
+      throws IOException {
+    String destination = getPluginInstallPath(pluginName, fileName);
     saveToDir(byteBuffer, destination);
   }
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/executable/ExecutableManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/executable/ExecutableManager.java
@@ -130,31 +130,6 @@ public class ExecutableManager {
         Paths.get(this.libRoot + File.separator + INSTALL_DIR + File.separator + fileName));
   }
 
-  public boolean hasPluginFileUnderInstallDir(String pluginName, String fileName) {
-    return Files.exists(Paths.get(getPluginInstallPath(pluginName, fileName)));
-  }
-
-  public String getPluginsDirPath(String pluginName) {
-    return this.libRoot + File.separator + INSTALL_DIR + File.separator + pluginName;
-  }
-
-  public void removePluginFileUnderLibRoot(String pluginName, String fileName) throws IOException {
-    String pluginPath = getPluginInstallPath(pluginName, fileName);
-    Path path = Paths.get(pluginPath);
-    Files.deleteIfExists(path);
-    Files.deleteIfExists(path.getParent());
-  }
-
-  public String getPluginInstallPath(String pluginName, String fileName) {
-    return this.libRoot
-        + File.separator
-        + INSTALL_DIR
-        + File.separator
-        + pluginName
-        + File.separator
-        + fileName;
-  }
-
   // endregion
 
   // ======================================================
@@ -276,7 +251,6 @@ public class ExecutableManager {
   private void createParentDir(Path path) throws IOException {
     Path parent = path.getParent();
     if (!Files.exists(parent)) {
-      createParentDir(parent);
       Files.createDirectories(parent);
     }
   }
@@ -297,18 +271,6 @@ public class ExecutableManager {
    */
   public void saveToInstallDir(ByteBuffer byteBuffer, String fileName) throws IOException {
     String destination = this.libRoot + File.separator + INSTALL_DIR + File.separator + fileName;
-    saveToDir(byteBuffer, destination);
-  }
-
-  /**
-   * @param byteBuffer file
-   * @param pluginName
-   * @param fileName Absolute Path will be libRoot + File_Separator + INSTALL_DIR + File_Separator +
-   *     pluginName + File_Separator + fileName
-   */
-  public void savePluginToInstallDir(ByteBuffer byteBuffer, String pluginName, String fileName)
-      throws IOException {
-    String destination = getPluginInstallPath(pluginName, fileName);
     saveToDir(byteBuffer, destination);
   }
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/executable/ExecutableManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/executable/ExecutableManager.java
@@ -232,7 +232,9 @@ public class ExecutableManager {
     try {
       Path path = Paths.get(destination);
       if (!Files.exists(path)) {
-        createParentDir(path);
+        if (!Files.exists(path.getParent())) {
+          Files.createDirectories(path.getParent());
+        }
         Files.createFile(path);
       }
       // FileOutPutStream is not in append mode by default, so the file will be overridden if it
@@ -245,13 +247,6 @@ public class ExecutableManager {
       LOGGER.warn(
           "Error occurred during writing bytebuffer to {} , the cause is {}", destination, e);
       throw e;
-    }
-  }
-
-  private void createParentDir(Path path) throws IOException {
-    Path parent = path.getParent();
-    if (!Files.exists(parent)) {
-      Files.createDirectories(parent);
     }
   }
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/plugin/PipePluginConstructor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/plugin/PipePluginConstructor.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.commons.pipe.agent.plugin;
 
 import org.apache.iotdb.commons.pipe.plugin.meta.PipePluginMeta;
 import org.apache.iotdb.commons.pipe.plugin.meta.PipePluginMetaKeeper;
+import org.apache.iotdb.commons.pipe.plugin.service.PipePluginClassLoader;
 import org.apache.iotdb.pipe.api.PipePlugin;
 import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameters;
 import org.apache.iotdb.pipe.api.exception.PipeException;
@@ -82,12 +83,16 @@ public abstract class PipePluginConstructor {
     }
 
     try {
-      return (PipePlugin)
-          pluginMetaKeeper.getPluginClass(pluginName).getDeclaredConstructor().newInstance();
+
+      PipePluginClassLoader classLoader = pluginMetaKeeper.getPluginClassLoader(pluginName);
+      final Class<?> pluginClass = Class.forName(information.getClassName(), true, classLoader);
+
+      return (PipePlugin) pluginClass.getDeclaredConstructor().newInstance();
     } catch (InstantiationException
         | InvocationTargetException
         | NoSuchMethodException
-        | IllegalAccessException e) {
+        | IllegalAccessException
+        | ClassNotFoundException e) {
       String errorMessage =
           String.format(
               "Failed to reflect PipePlugin %s(%s) instance, because %s",

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/plugin/PipePluginConstructor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/plugin/PipePluginConstructor.java
@@ -21,7 +21,6 @@ package org.apache.iotdb.commons.pipe.agent.plugin;
 
 import org.apache.iotdb.commons.pipe.plugin.meta.PipePluginMeta;
 import org.apache.iotdb.commons.pipe.plugin.meta.PipePluginMetaKeeper;
-import org.apache.iotdb.commons.pipe.plugin.service.PipePluginClassLoader;
 import org.apache.iotdb.commons.pipe.plugin.service.PipePluginClassLoaderManager;
 import org.apache.iotdb.pipe.api.PipePlugin;
 import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameters;
@@ -84,13 +83,13 @@ public abstract class PipePluginConstructor {
     }
 
     try {
-      if (information.isBuiltin()) {
-        Class<?> builtinClass = pluginMetaKeeper.getBuiltinPluginClass(information.getPluginName());
-        return (PipePlugin) builtinClass.getDeclaredConstructor().newInstance();
-      }
-      PipePluginClassLoader classLoader =
-          PipePluginClassLoaderManager.getInstance().getPluginClassLoader(pluginName);
-      final Class<?> pluginClass = Class.forName(information.getClassName(), true, classLoader);
+      final Class<?> pluginClass =
+          information.isBuiltin()
+              ? pluginMetaKeeper.getBuiltinPluginClass(information.getPluginName())
+              : Class.forName(
+                  information.getClassName(),
+                  true,
+                  PipePluginClassLoaderManager.getInstance().getPluginClassLoader(pluginName));
       return (PipePlugin) pluginClass.getDeclaredConstructor().newInstance();
     } catch (InstantiationException
         | InvocationTargetException

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/plugin/PipePluginConstructor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/plugin/PipePluginConstructor.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.commons.pipe.agent.plugin;
 import org.apache.iotdb.commons.pipe.plugin.meta.PipePluginMeta;
 import org.apache.iotdb.commons.pipe.plugin.meta.PipePluginMetaKeeper;
 import org.apache.iotdb.commons.pipe.plugin.service.PipePluginClassLoader;
+import org.apache.iotdb.commons.pipe.plugin.service.PipePluginClassLoaderManager;
 import org.apache.iotdb.pipe.api.PipePlugin;
 import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameters;
 import org.apache.iotdb.pipe.api.exception.PipeException;
@@ -83,10 +84,13 @@ public abstract class PipePluginConstructor {
     }
 
     try {
-
-      PipePluginClassLoader classLoader = pluginMetaKeeper.getPluginClassLoader(pluginName);
+      if (information.isBuiltin()) {
+        Class<?> builtinClass = pluginMetaKeeper.getBuiltinPluginClass(information.getPluginName());
+        return (PipePlugin) builtinClass.getDeclaredConstructor().newInstance();
+      }
+      PipePluginClassLoader classLoader =
+          PipePluginClassLoaderManager.getInstance().getPluginClassLoader(pluginName);
       final Class<?> pluginClass = Class.forName(information.getClassName(), true, classLoader);
-
       return (PipePlugin) pluginClass.getDeclaredConstructor().newInstance();
     } catch (InstantiationException
         | InvocationTargetException

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/meta/PipePluginMetaKeeper.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/meta/PipePluginMetaKeeper.java
@@ -20,7 +20,6 @@
 package org.apache.iotdb.commons.pipe.plugin.meta;
 
 import org.apache.iotdb.commons.pipe.plugin.builtin.BuiltinPipePlugin;
-import org.apache.iotdb.commons.pipe.plugin.service.PipePluginClassLoader;
 
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 
@@ -34,11 +33,9 @@ import java.util.concurrent.ConcurrentHashMap;
 public abstract class PipePluginMetaKeeper {
 
   protected final Map<String, PipePluginMeta> pipePluginNameToMetaMap = new ConcurrentHashMap<>();
-  protected final Map<String, PipePluginClassLoader> pipePluginNameToClassLoaderMap;
   protected final Map<String, Class<?>> builtinPipePluginNameToClassMap;
 
   public PipePluginMetaKeeper() {
-    pipePluginNameToClassLoaderMap = new ConcurrentHashMap<>();
     builtinPipePluginNameToClassMap = new ConcurrentHashMap<>();
     loadBuiltInPlugins();
   }
@@ -49,7 +46,7 @@ public abstract class PipePluginMetaKeeper {
           builtinPipePlugin.getPipePluginName(),
           new PipePluginMeta(
               builtinPipePlugin.getPipePluginName(), builtinPipePlugin.getClassName()));
-      addBuiltInPluginClass(
+      addBuiltinPluginClass(
           builtinPipePlugin.getPipePluginName(), builtinPipePlugin.getPipePluginClass());
     }
   }
@@ -74,24 +71,12 @@ public abstract class PipePluginMetaKeeper {
     return pipePluginNameToMetaMap.containsKey(pluginName.toUpperCase());
   }
 
-  public void addPluginAndClassLoader(String pluginName, PipePluginClassLoader classLoader) {
-    pipePluginNameToClassLoaderMap.put(pluginName.toUpperCase(), classLoader);
-  }
-
-  private void addBuiltInPluginClass(String pluginName, Class<?> builtinPipePluginClass) {
+  private void addBuiltinPluginClass(String pluginName, Class<?> builtinPipePluginClass) {
     builtinPipePluginNameToClassMap.put(pluginName.toUpperCase(), builtinPipePluginClass);
   }
 
-  public PipePluginClassLoader getPluginClassLoader(String pluginName) {
-    return pipePluginNameToClassLoaderMap.get(pluginName.toUpperCase());
-  }
-
-  public Class<?> getBuiltPluginClass(String pluginName) {
+  public Class<?> getBuiltinPluginClass(String pluginName) {
     return builtinPipePluginNameToClassMap.get(pluginName.toUpperCase());
-  }
-
-  public void removePluginClassLoader(String pluginName) {
-    pipePluginNameToClassLoaderMap.remove(pluginName.toUpperCase());
   }
 
   public String getPluginNameByJarName(String jarName) {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/meta/PipePluginMetaKeeper.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/meta/PipePluginMetaKeeper.java
@@ -37,10 +37,10 @@ public abstract class PipePluginMetaKeeper {
 
   public PipePluginMetaKeeper() {
     builtinPipePluginNameToClassMap = new ConcurrentHashMap<>();
-    loadBuiltInPlugins();
+    loadBuiltinPlugins();
   }
 
-  protected void loadBuiltInPlugins() {
+  protected void loadBuiltinPlugins() {
     for (final BuiltinPipePlugin builtinPipePlugin : BuiltinPipePlugin.values()) {
       addPipePluginMeta(
           builtinPipePlugin.getPipePluginName(),

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/service/PipePluginClassLoaderManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/service/PipePluginClassLoaderManager.java
@@ -46,9 +46,10 @@ public class PipePluginClassLoaderManager implements IService {
     activeClassLoader = new PipePluginClassLoader(libRoot);
   }
 
-  public PipePluginClassLoader updateAndGetActiveClassLoader() throws IOException {
+  public PipePluginClassLoader updateAndGetActiveClassLoader(String pluginDirPath)
+      throws IOException {
     PipePluginClassLoader deprecatedClassLoader = activeClassLoader;
-    activeClassLoader = new PipePluginClassLoader(libRoot);
+    activeClassLoader = new PipePluginClassLoader(pluginDirPath);
     if (deprecatedClassLoader != null) {
       deprecatedClassLoader.markAsDeprecated();
     }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/service/PipePluginClassLoaderManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/service/PipePluginClassLoaderManager.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.commons.exception.StartupException;
 import org.apache.iotdb.commons.file.SystemFileFactory;
 import org.apache.iotdb.commons.service.IService;
 import org.apache.iotdb.commons.service.ServiceType;
+import org.apache.iotdb.pipe.api.PipePlugin;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -36,11 +37,12 @@ public class PipePluginClassLoaderManager implements IService {
   private final String libRoot;
 
   /**
-   * Each PipePlugin is equipped with a dedicated {@link PipePluginClassLoader}. When a PipePlugin
-   * is created, the corresponding {@link PipePluginClassLoader} is generated and used to load the
-   * PipePlugin. When the PipePlugin is deleted, its associated {@link PipePluginClassLoader} is
-   * also removed. The lifecycle of the {@link PipePluginClassLoader} is strictly consistent with
-   * the lifecycle of the PipePlugin it serves.
+   * Each {@link PipePlugin} is equipped with a dedicated {@link PipePluginClassLoader}. When a
+   * {@link PipePlugin} is created, the corresponding {@link PipePluginClassLoader} is generated and
+   * used to load the {@link PipePlugin}. When the {@link PipePlugin} is deleted, its associated
+   * {@link PipePluginClassLoader} is also removed. The lifecycle of the {@link
+   * PipePluginClassLoader} is strictly consistent with the lifecycle of the {@link PipePlugin} it
+   * serves.
    */
   private final Map<String, PipePluginClassLoader> pipePluginNameToClassLoaderMap;
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/service/PipePluginClassLoaderManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/service/PipePluginClassLoaderManager.java
@@ -36,10 +36,11 @@ public class PipePluginClassLoaderManager implements IService {
   private final String libRoot;
 
   /**
-   * Each PipePlugin is equipped with a dedicated ClassLoader. When a PipePlugin is created, the
-   * corresponding ClassLoader is generated and used to load the PipePlugin. When the PipePlugin is
-   * deleted, its associated ClassLoader is also removed. The lifecycle of the ClassLoader is
-   * strictly consistent with the lifecycle of the PipePlugin it serves.
+   * Each PipePlugin is equipped with a dedicated {@link PipePluginClassLoader}. When a PipePlugin
+   * is created, the corresponding {@link PipePluginClassLoader} is generated and used to load the
+   * PipePlugin. When the PipePlugin is deleted, its associated {@link PipePluginClassLoader} is
+   * also removed. The lifecycle of the {@link PipePluginClassLoader} is strictly consistent with
+   * the lifecycle of the PipePlugin it serves.
    */
   private final Map<String, PipePluginClassLoader> pipePluginNameToClassLoaderMap;
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/service/PipePluginClassLoaderManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/service/PipePluginClassLoaderManager.java
@@ -51,7 +51,9 @@ public class PipePluginClassLoaderManager implements IService {
   public void removePluginClassLoader(String pluginName) throws IOException {
     PipePluginClassLoader classLoader =
         pipePluginNameToClassLoaderMap.remove(pluginName.toUpperCase());
-    classLoader.markAsDeprecated();
+    if (classLoader != null) {
+      classLoader.markAsDeprecated();
+    }
   }
 
   public PipePluginClassLoader getPluginClassLoader(String pluginName) {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/service/PipePluginExecutableManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/service/PipePluginExecutableManager.java
@@ -30,7 +30,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public class PipePluginExecutableManager extends ExecutableManager {
@@ -90,5 +92,42 @@ public class PipePluginExecutableManager extends ExecutableManager {
 
   public static PipePluginExecutableManager getInstance() {
     return instance;
+  }
+
+  public boolean hasPluginFileUnderInstallDir(String pluginName, String fileName) {
+    return Files.exists(Paths.get(getPluginInstallPath(pluginName, fileName)));
+  }
+
+  public String getPluginsDirPath(String pluginName) {
+    return this.libRoot + File.separator + INSTALL_DIR + File.separator + pluginName;
+  }
+
+  public void removePluginFileUnderLibRoot(String pluginName, String fileName) throws IOException {
+    String pluginPath = getPluginInstallPath(pluginName, fileName);
+    Path path = Paths.get(pluginPath);
+    Files.deleteIfExists(path);
+    Files.deleteIfExists(path.getParent());
+  }
+
+  public String getPluginInstallPath(String pluginName, String fileName) {
+    return this.libRoot
+        + File.separator
+        + INSTALL_DIR
+        + File.separator
+        + pluginName
+        + File.separator
+        + fileName;
+  }
+
+  /**
+   * @param byteBuffer file
+   * @param pluginName
+   * @param fileName Absolute Path will be libRoot + File_Separator + INSTALL_DIR + File_Separator +
+   *     pluginName + File_Separator + fileName
+   */
+  public void savePluginToInstallDir(ByteBuffer byteBuffer, String pluginName, String fileName)
+      throws IOException {
+    String destination = getPluginInstallPath(pluginName, fileName);
+    saveToDir(byteBuffer, destination);
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/service/PipePluginExecutableManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/plugin/service/PipePluginExecutableManager.java
@@ -45,7 +45,7 @@ public class PipePluginExecutableManager extends ExecutableManager {
     final String pluginName = pipePluginMeta.getPluginName();
     final String md5FilePath = pluginName + ".txt";
 
-    if (hasFileUnderInstallDir(md5FilePath)) {
+    if (hasFileUnderTemporaryRoot(md5FilePath)) {
       try {
         return readTextFromFileUnderTemporaryRoot(md5FilePath).equals(pipePluginMeta.getJarMD5());
       } catch (IOException e) {
@@ -58,7 +58,7 @@ public class PipePluginExecutableManager extends ExecutableManager {
       final String md5 =
           DigestUtils.md5Hex(
               Files.newInputStream(
-                  Paths.get(getInstallDir() + File.separator + pipePluginMeta.getJarName())));
+                  Paths.get(getPluginInstallPath(pluginName, pipePluginMeta.getJarName()))));
       // Save the md5 in a txt under trigger temporary lib
       saveTextAsFileUnderTemporaryRoot(md5, md5FilePath);
       return md5.equals(pipePluginMeta.getJarMD5());

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/pipe/plugin/meta/PipePluginMetaTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/pipe/plugin/meta/PipePluginMetaTest.java
@@ -54,6 +54,6 @@ public class PipePluginMetaTest {
     DataNodePipePluginMetaKeeper keeper = new DataNodePipePluginMetaKeeper();
     Assert.assertEquals(
         BuiltinPipePlugin.IOTDB_EXTRACTOR.getPipePluginClass(),
-        keeper.getPluginClass(BuiltinPipePlugin.IOTDB_EXTRACTOR.getPipePluginName()));
+        keeper.getBuiltPluginClass(BuiltinPipePlugin.IOTDB_EXTRACTOR.getPipePluginName()));
   }
 }

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/pipe/plugin/meta/PipePluginMetaTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/pipe/plugin/meta/PipePluginMetaTest.java
@@ -54,6 +54,6 @@ public class PipePluginMetaTest {
     DataNodePipePluginMetaKeeper keeper = new DataNodePipePluginMetaKeeper();
     Assert.assertEquals(
         BuiltinPipePlugin.IOTDB_EXTRACTOR.getPipePluginClass(),
-        keeper.getBuiltPluginClass(BuiltinPipePlugin.IOTDB_EXTRACTOR.getPipePluginName()));
+        keeper.getBuiltinPluginClass(BuiltinPipePlugin.IOTDB_EXTRACTOR.getPipePluginName()));
   }
 }


### PR DESCRIPTION
## Description
### Problem Description

Currently, IOTDB allows PipePlugins that are being used by Pipes to be deleted. When users drop a PipePlugin and then create a new PipePlugin with the same fully qualified class name, IOTDB is unable to properly load the newly created PipePlugin. The reason is that after IOTDB drops a PipePlugin, the corresponding jar file is not deleted, and the class loader behavior in loading the same fully qualified class name in the Install directory is random, as there is no unified standard, which leads to the above error.

### Solutions

1. **New Directory Structure**: Adopt a new directory structure `install->pluginName->jar`. The advantage of using this new directory is that the class loader does not need to load all jars. However, using this form will also not support the case where different jars reference each other. For example, if plugin A references some utility classes in the jar of plugin B, this situation will not be allowed.



3. **Improve Drop Plugin Process**: For the process of dropping a plugin, it is necessary to verify whether it can be deleted during the Lock process. Therefore, it is possible to check in the Lock step whether there is a Pipe using this plugin. If there is a Pipe using this plugin, the check fails; if not, continue with the following process.

4. **ClassLoader for Each Create Plugin**: Create a new ClassLoader each time a plugin is created. Each ClassLoader can only load a class with the same fully qualified name, so using the same class loader may lead to exceptions. However, the current strategy is to save the plugin's bytecode object class, and we can implement on-demand loading, that is, only load into memory when it is necessary to run the corresponding bytecode. Each plugin saves a ClassLoader, and the one needed is loaded through this classLoader.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
