### PR TITLE
Pipe: Avoid `show pipes` command returning too much garbage logs

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/response/pipe/task/PipeTableResp.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/response/pipe/task/PipeTableResp.java
@@ -139,9 +139,6 @@ public class PipeTableResp implements DataSet {
         }
       }
 
-      int size = pipeExceptionMessage2NodeIdsMap.size();
-      int count = 0;
-
       for (final Map.Entry<String, Set<Integer>> entry :
           pipeExceptionMessage2NodeIdsMap.entrySet()) {
         final String exceptionMessage = entry.getKey();
@@ -150,18 +147,12 @@ public class PipeTableResp implements DataSet {
             .append("nodeIds: ")
             .append(nodeIds)
             .append(", ")
-            .append(exceptionMessage);
-        if (++count < size) {
-          exceptionMessageBuilder.append("; ");
-        }
+            .append(exceptionMessage)
+            .append("; ");
       }
 
-      if (exceptionMessageBuilder.length() > 0) {
-        exceptionMessageBuilder.append("\n");
-      }
-
-      size = pipeExceptionMessage2RegionIdsMap.size();
-      count = 0;
+      final int size = pipeExceptionMessage2RegionIdsMap.size();
+      int count = 0;
 
       for (final Map.Entry<String, Set<Integer>> entry :
           pipeExceptionMessage2RegionIdsMap.entrySet()) {


### PR DESCRIPTION
## fixed the issue that show pipes prints too much garbage logs

Use map to store and remove duplicates from the logs, with the log as the key and the partition id as the value in order. The final printed log format is as follows:

regionId: [9, 10, 11, 12, 13],2024-07-08T10:33:43.751, All clients are dead, please check the connection to the receiver., root cause: All clients are dead, please check the connection to the receiver.;regionId: [1],2024-07-08T10:50:26.270, Failed to handle pipe meta changes for test104, because Failed to construct PipeConnector, because of Error occurred while connecting to receiver 47.108.188.22:6667, please check network connectivity or SSL configurations when enable SSL transmission;