### PR TITLE
fix start-confignode.sh, Support -H

### DIFF
--- a/iotdb-core/confignode/src/assembly/resources/conf/confignode-env.sh
+++ b/iotdb-core/confignode/src/assembly/resources/conf/confignode-env.sh
@@ -172,12 +172,12 @@ jvmver=`echo "$java_ver_output" | grep '[openjdk|java] version' | awk -F'"' 'NR=
 JVM_VERSION=${jvmver%_*}
 JVM_PATCH_VERSION=${jvmver#*_}
 if [ "$JVM_VERSION" \< "1.8" ] ; then
-    echo "IoTDB requires Java 8u40 or later."
+    echo "IoTDB requires Java 8u92 or later."
     exit 1;
 fi
 
-if [ "$JVM_VERSION" \< "1.8" ] && [ "$JVM_PATCH_VERSION" -lt 40 ] ; then
-    echo "IoTDB requires Java 8u40 or later."
+if [ "$JVM_VERSION" \< "1.8" ] && [ "$JVM_PATCH_VERSION" -lt 92 ] ; then
+    echo "IoTDB requires Java 8u92 or later."
     exit 1;
 fi
 

--- a/iotdb-core/confignode/src/assembly/resources/sbin/start-confignode.sh
+++ b/iotdb-core/confignode/src/assembly/resources/sbin/start-confignode.sh
@@ -120,6 +120,7 @@ PARAMS="-s $PARAMS"
 #initEnv is in iotdb-common.sh
 initConfigNodeEnv
 
+CONFIGNODE_JMX_OPTS="$CONFIGNODE_JMX_OPTS $IOTDB_HEAP_DUMP_COMMAND"
 
 CLASSPATH=""
 for f in "${CONFIGNODE_HOME}"/lib/*.jar; do

--- a/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.sh
+++ b/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.sh
@@ -166,12 +166,12 @@ jvmver=`echo "$java_ver_output" | grep '[openjdk|java] version' | awk -F'"' 'NR=
 JVM_VERSION=${jvmver%_*}
 JVM_PATCH_VERSION=${jvmver#*_}
 if [ "$JVM_VERSION" \< "1.8" ] ; then
-    echo "IoTDB requires Java 8u40 or later."
+    echo "IoTDB requires Java 8u92 or later."
     exit 1;
 fi
 
-if [ "$JVM_VERSION" \< "1.8" ] && [ "$JVM_PATCH_VERSION" -lt 40 ] ; then
-    echo "IoTDB requires Java 8u40 or later."
+if [ "$JVM_VERSION" \< "1.8" ] && [ "$JVM_PATCH_VERSION" -lt 92 ] ; then
+    echo "IoTDB requires Java 8u92 or later."
     exit 1;
 fi
 


### PR DESCRIPTION
1. fix start-confignode.sh, Support -H
2. Require 8u92 or higher version