### PR TITLE
Fix negative compression ratios after restarted

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/file/UnsealedTsFileRecoverPerformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/recover/file/UnsealedTsFileRecoverPerformer.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.pipe.agent.PipeDataNodeAgent;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.DeleteDataNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertRowsNode;
+import org.apache.iotdb.db.storageengine.dataregion.flush.CompressionRatio;
 import org.apache.iotdb.db.storageengine.dataregion.flush.MemTableFlushTask;
 import org.apache.iotdb.db.storageengine.dataregion.memtable.IMemTable;
 import org.apache.iotdb.db.storageengine.dataregion.memtable.IWritableMemChunk;
@@ -258,6 +259,24 @@ public class UnsealedTsFileRecoverPerformer extends AbstractTsFileRecoverPerform
 
         // set recover progress index for pipe
         PipeDataNodeAgent.runtime().assignProgressIndexForTsFileRecovery(tsFileResource);
+
+        try {
+          long memTableSize = recoveryMemTable.memSize();
+          double compressionRatio = ((double) memTableSize) / writer.getPos();
+          logger.info(
+              "The compression ratio of tsfile {} is {}, totalMemTableSize: {}, the file size: {}",
+              writer.getFile().getAbsolutePath(),
+              String.format("%.2f", compressionRatio),
+              memTableSize,
+              writer.getPos());
+          CompressionRatio.getInstance().updateRatio(memTableSize, writer.getPos());
+        } catch (IOException e) {
+          logger.error(
+              "{}: {} update compression ratio failed",
+              databaseName,
+              tsFileResource.getTsFile().getName(),
+              e);
+        }
 
         // if we put following codes in the 'if' clause above, this file can be continued writing
         // into it


### PR DESCRIPTION
## Description

There is a bug that may cause negative compression ratios after restarted.

To reproduce, you can try the following operations.
1. insert the following sql `insert into root.sg.d1(time,s1) values(1,1)` twice.
2. kill -9 datanode
3. restart datanode
4. execute `insert into root.sg.d1(time,s2) values(1,false)` and `flush`
5. check the file name in `data/datanode/system/compression_ratio`