### PR TITLE
Pipe: Introduce counter to reduce historical data buildup in PipeRealtimePriorityBlockingQueue

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/subscription/it/local/IoTDBSubscriptionBasicIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/subscription/it/local/IoTDBSubscriptionBasicIT.java
@@ -162,11 +162,12 @@ public class IoTDBSubscriptionBasicIT extends AbstractSubscriptionLocalIT {
     // Check row count
     try {
       // Keep retrying if there are execution failures
-      AWAIT.untilAsserted(() -> {
-        Assert.assertEquals(100, rowCount.get());
-        Assert.assertTrue(commitSuccessCount.get() > lastCommitSuccessCount.get());
-        Assert.assertEquals(0, commitFailureCount.get());
-      });
+      AWAIT.untilAsserted(
+          () -> {
+            Assert.assertEquals(100, rowCount.get());
+            Assert.assertTrue(commitSuccessCount.get() > lastCommitSuccessCount.get());
+            Assert.assertEquals(0, commitFailureCount.get());
+          });
     } catch (final Exception e) {
       e.printStackTrace();
       fail(e.getMessage());
@@ -190,11 +191,12 @@ public class IoTDBSubscriptionBasicIT extends AbstractSubscriptionLocalIT {
     // Check row count
     try {
       // Keep retrying if there are execution failures
-      AWAIT.untilAsserted(() -> {
-        Assert.assertEquals(200, rowCount.get());
-        Assert.assertTrue(commitSuccessCount.get() > lastCommitSuccessCount.get());
-        Assert.assertEquals(0, commitFailureCount.get());
-      });
+      AWAIT.untilAsserted(
+          () -> {
+            Assert.assertEquals(200, rowCount.get());
+            Assert.assertTrue(commitSuccessCount.get() > lastCommitSuccessCount.get());
+            Assert.assertEquals(0, commitFailureCount.get());
+          });
     } catch (final Exception e) {
       e.printStackTrace();
       fail(e.getMessage());

--- a/integration-test/src/test/java/org/apache/iotdb/subscription/it/local/IoTDBSubscriptionBasicIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/subscription/it/local/IoTDBSubscriptionBasicIT.java
@@ -163,10 +163,10 @@ public class IoTDBSubscriptionBasicIT extends AbstractSubscriptionLocalIT {
     try {
       // Keep retrying if there are execution failures
       AWAIT.untilAsserted(() -> {
-        Assert.assertEquals(100, rowCount.get()));
+        Assert.assertEquals(100, rowCount.get());
         Assert.assertTrue(commitSuccessCount.get() > lastCommitSuccessCount.get());
         Assert.assertEquals(0, commitFailureCount.get());
-      }
+      });
     } catch (final Exception e) {
       e.printStackTrace();
       fail(e.getMessage());

--- a/integration-test/src/test/java/org/apache/iotdb/subscription/it/local/IoTDBSubscriptionBasicIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/subscription/it/local/IoTDBSubscriptionBasicIT.java
@@ -188,9 +188,11 @@ public class IoTDBSubscriptionBasicIT extends AbstractSubscriptionLocalIT {
     // Check row count
     try {
       // Keep retrying if there are execution failures
-      AWAIT.untilAsserted(() -> Assert.assertEquals(200, rowCount.get()));
-      Assert.assertTrue(commitSuccessCount.get() > lastCommitSuccessCount.get());
-      Assert.assertEquals(0, commitFailureCount.get());
+      AWAIT.untilAsserted(() -> {
+        Assert.assertEquals(200, rowCount.get());
+        Assert.assertTrue(commitSuccessCount.get() > lastCommitSuccessCount.get());
+        Assert.assertEquals(0, commitFailureCount.get());
+      });
     } catch (final Exception e) {
       e.printStackTrace();
       fail(e.getMessage());

--- a/integration-test/src/test/java/org/apache/iotdb/subscription/it/local/IoTDBSubscriptionBasicIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/subscription/it/local/IoTDBSubscriptionBasicIT.java
@@ -162,9 +162,11 @@ public class IoTDBSubscriptionBasicIT extends AbstractSubscriptionLocalIT {
     // Check row count
     try {
       // Keep retrying if there are execution failures
-      AWAIT.untilAsserted(() -> Assert.assertEquals(100, rowCount.get()));
-      Assert.assertTrue(commitSuccessCount.get() > lastCommitSuccessCount.get());
-      Assert.assertEquals(0, commitFailureCount.get());
+      AWAIT.untilAsserted(() -> {
+        Assert.assertEquals(100, rowCount.get()));
+        Assert.assertTrue(commitSuccessCount.get() > lastCommitSuccessCount.get());
+        Assert.assertEquals(0, commitFailureCount.get());
+      }
     } catch (final Exception e) {
       e.printStackTrace();
       fail(e.getMessage());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/connector/PipeRealtimePriorityBlockingQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/connector/PipeRealtimePriorityBlockingQueue.java
@@ -97,12 +97,12 @@ public class PipeRealtimePriorityBlockingQueue extends UnboundedBlockingPendingQ
   }
 
   /**
-   * When the number of polls exceeds the realtimeConsumeThreshold, the {@link TsFileInsertionEvent}
-   * of the earliest write to the queue is returned. if the realtimeConsumeThreshold is not reached
-   * then an attempt is made to poll the queue for the latest insertion {@link Event}. First, it
-   * tries to poll the first provided If there is no such {@link Event}, poll the last supplied
-   * {@link TsFileInsertionEvent}. If no {@link Event} is available, it blocks until a {@link Event}
-   * is available.
+   * When the number of polls exceeds the pollHistoryThreshold, the {@link TsFileInsertionEvent} of
+   * the earliest write to the queue is returned. if the pollHistoryThreshold is not reached then an
+   * attempt is made to poll the queue for the latest insertion {@link Event}. First, it tries to
+   * poll the first provided If there is no such {@link Event}, poll the last supplied {@link
+   * TsFileInsertionEvent}. If no {@link Event} is available, it blocks until a {@link Event} is
+   * available.
    *
    * @return the freshest insertion {@link Event}. can be {@code null} if no {@link Event} is
    *     available.

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/connector/PipeRealtimePriorityBlockingQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/task/subtask/connector/PipeRealtimePriorityBlockingQueue.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.pipe.task.subtask.connector;
 
+import org.apache.iotdb.commons.pipe.config.PipeConfig;
 import org.apache.iotdb.commons.pipe.event.EnrichedEvent;
 import org.apache.iotdb.commons.pipe.task.connection.UnboundedBlockingPendingQueue;
 import org.apache.iotdb.db.pipe.event.common.heartbeat.PipeHeartbeatEvent;
@@ -41,9 +42,8 @@ public class PipeRealtimePriorityBlockingQueue extends UnboundedBlockingPendingQ
 
   private final AtomicInteger eventCount = new AtomicInteger(0);
 
-  private static final int pendingQueueConsumeThreshold = 1000;
-
-  private static final int concurrentAttemptLimit = 20;
+  private static final int realTimeEventConsumeThreshold =
+      PipeConfig.getInstance().getPipeRealTimeFirstDequeHistoryThreshold();
 
   public PipeRealtimePriorityBlockingQueue() {
     super(new PipeDataRegionEventCounter());
@@ -79,46 +79,52 @@ public class PipeRealtimePriorityBlockingQueue extends UnboundedBlockingPendingQ
   @Override
   public Event directPoll() {
     Event event = null;
-    if (eventCount.get() >= pendingQueueConsumeThreshold && !tsfileInsertEventDeque.isEmpty()) {
-      event = tsfileInsertEventDeque.pollLast();
-      resetEventCount();
+    if (eventCount.get() >= realTimeEventConsumeThreshold) {
+      event = tsfileInsertEventDeque.pollFirst();
+      eventCount.set(0);
     }
-
     if (Objects.isNull(event)) {
       event = super.directPoll();
-      eventCount.incrementAndGet();
+      if (Objects.isNull(event)) {
+        event = tsfileInsertEventDeque.pollLast();
+      }
+      if (event != null) {
+        eventCount.incrementAndGet();
+      }
     }
 
-    if (Objects.isNull(event)) {
-      event = tsfileInsertEventDeque.pollLast();
-      resetEventCount();
-    }
     return event;
   }
 
   /**
-   * Try to poll the freshest insertion event from the queue. First, try to poll the first offered
-   * non-TsFileInsertionEvent. If no such event is available, poll the last offered
-   * TsFileInsertionEvent. If no event is available, block until an event is available.
+   * When the number of polls exceeds the realtimeConsumeThreshold, the {@link TsFileInsertionEvent}
+   * of the earliest write to the queue is returned. if the realtimeConsumeThreshold is not reached
+   * then an attempt is made to poll the queue for the latest insertion {@link Event}. First, it
+   * tries to poll the first provided If there is no such {@link Event}, poll the last supplied
+   * {@link TsFileInsertionEvent}. If no {@link Event} is available, it blocks until a {@link Event}
+   * is available.
    *
-   * @return the freshest insertion event. can be null if no event is available.
+   * @return the freshest insertion {@link Event}. can be {@code null} if no event is available.
    */
   @Override
   public Event waitedPoll() {
     Event event = null;
-
-    if (eventCount.get() >= pendingQueueConsumeThreshold) {
-      event = tsfileInsertEventDeque.pollLast();
-      resetEventCount();
+    if (eventCount.get() >= realTimeEventConsumeThreshold) {
+      event = tsfileInsertEventDeque.pollFirst();
+      if (event != null) {
+        eventCount.set(0);
+      }
     }
     if (event == null && !super.isEmpty()) {
       // Sequentially poll the first offered non-TsFileInsertionEvent
       event = super.directPoll();
-      eventCount.incrementAndGet();
-    } else if (!tsfileInsertEventDeque.isEmpty()) {
-      // Always poll the last offered event
-      event = tsfileInsertEventDeque.pollLast();
-      resetEventCount();
+      if (event == null && !tsfileInsertEventDeque.isEmpty()) {
+        // Always poll the last offered event
+        event = tsfileInsertEventDeque.pollLast();
+      }
+      if (event != null) {
+        eventCount.incrementAndGet();
+      }
     }
 
     // If no event is available, block until an event is available
@@ -126,7 +132,9 @@ public class PipeRealtimePriorityBlockingQueue extends UnboundedBlockingPendingQ
       event = super.waitedPoll();
       if (Objects.isNull(event)) {
         event = tsfileInsertEventDeque.pollLast();
-        resetEventCount();
+      }
+      if (event != null) {
+        eventCount.incrementAndGet();
       }
     }
 
@@ -164,15 +172,5 @@ public class PipeRealtimePriorityBlockingQueue extends UnboundedBlockingPendingQ
   @Override
   public int getTsFileInsertionEventCount() {
     return tsfileInsertEventDeque.size();
-  }
-
-  private void resetEventCount() {
-    long v = 0;
-    while (eventCount.compareAndSet(eventCount.get(), 0)) {
-      v++;
-      if (v > concurrentAttemptLimit) {
-        break;
-      }
-    }
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -182,7 +182,7 @@ public class CommonConfig {
 
   private boolean pipeHardLinkWALEnabled = false;
 
-  private int pipeRealTimeFirstDequeHistoryThreshold = 100;
+  private int pipeRealTimeQueuePollHistoryThreshold = 100;
 
   /** The maximum number of threads that can be used to execute subtasks in PipeSubtaskExecutor. */
   private int pipeSubtaskExecutorMaxThreadNum =
@@ -847,13 +847,12 @@ public class CommonConfig {
         pipeSubtaskExecutorCronHeartbeatEventIntervalSeconds;
   }
 
-  public int getPipeRealTimeFirstDequeHistoryThreshold() {
-    return pipeRealTimeFirstDequeHistoryThreshold;
+  public int getPipeRealTimeQueuePollHistoryThreshold() {
+    return pipeRealTimeQueuePollHistoryThreshold;
   }
 
-  public void setPipeRealTimeFirstDequeHistoryThreshold(
-      int pipeRealTimeFirstDequeHistoryThreshold) {
-    this.pipeRealTimeFirstDequeHistoryThreshold = pipeRealTimeFirstDequeHistoryThreshold;
+  public void setPipeRealTimeQueuePollHistoryThreshold(int pipeRealTimeQueuePollHistoryThreshold) {
+    this.pipeRealTimeQueuePollHistoryThreshold = pipeRealTimeQueuePollHistoryThreshold;
   }
 
   public void setPipeAirGapReceiverEnabled(boolean pipeAirGapReceiverEnabled) {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -182,6 +182,8 @@ public class CommonConfig {
 
   private boolean pipeHardLinkWALEnabled = false;
 
+  private int pipeRealTimeFirstDequeHistoryThreshold = 100;
+
   /** The maximum number of threads that can be used to execute subtasks in PipeSubtaskExecutor. */
   private int pipeSubtaskExecutorMaxThreadNum =
       Math.min(5, Math.max(1, Runtime.getRuntime().availableProcessors() / 2));
@@ -843,6 +845,15 @@ public class CommonConfig {
       long pipeSubtaskExecutorCronHeartbeatEventIntervalSeconds) {
     this.pipeSubtaskExecutorCronHeartbeatEventIntervalSeconds =
         pipeSubtaskExecutorCronHeartbeatEventIntervalSeconds;
+  }
+
+  public int getPipeRealTimeFirstDequeHistoryThreshold() {
+    return pipeRealTimeFirstDequeHistoryThreshold;
+  }
+
+  public void setPipeRealTimeFirstDequeHistoryThreshold(
+      int pipeRealTimeFirstDequeHistoryThreshold) {
+    this.pipeRealTimeFirstDequeHistoryThreshold = pipeRealTimeFirstDequeHistoryThreshold;
   }
 
   public void setPipeAirGapReceiverEnabled(boolean pipeAirGapReceiverEnabled) {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -276,11 +276,11 @@ public class CommonDescriptor {
                 String.valueOf(
                     config.getPipeDataStructureTabletMemoryBlockAllocationRejectThreshold()))));
 
-    config.setPipeRealTimeFirstDequeHistoryThreshold(
+    config.setPipeRealTimeQueuePollHistoryThreshold(
         Integer.parseInt(
             properties.getProperty(
-                "pipe_realtime_first_deque_history_threshold",
-                Integer.toString(config.getPipeRealTimeFirstDequeHistoryThreshold()))));
+                "pipe_realtime_queue_poll_history_threshold",
+                Integer.toString(config.getPipeRealTimeQueuePollHistoryThreshold()))));
 
     config.setPipeSubtaskExecutorMaxThreadNum(
         Integer.parseInt(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -276,6 +276,12 @@ public class CommonDescriptor {
                 String.valueOf(
                     config.getPipeDataStructureTabletMemoryBlockAllocationRejectThreshold()))));
 
+    config.setPipeRealTimeFirstDequeHistoryThreshold(
+        Integer.parseInt(
+            properties.getProperty(
+                "pipe_realtime_first_deque_history_threshold",
+                Integer.toString(config.getPipeRealTimeFirstDequeHistoryThreshold()))));
+
     config.setPipeSubtaskExecutorMaxThreadNum(
         Integer.parseInt(
             properties.getProperty(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeConfig.java
@@ -60,8 +60,8 @@ public class PipeConfig {
 
   /////////////////////////////// Subtask Connector ///////////////////////////////
 
-  public int getPipeRealTimeFirstDequeHistoryThreshold() {
-    return COMMON_CONFIG.getPipeRealTimeFirstDequeHistoryThreshold();
+  public int getPipeRealTimeQueuePollHistoryThreshold() {
+    return COMMON_CONFIG.getPipeRealTimeQueuePollHistoryThreshold();
   }
 
   /////////////////////////////// Subtask Executor ///////////////////////////////
@@ -312,7 +312,7 @@ public class PipeConfig {
         getPipeDataStructureTabletMemoryBlockAllocationRejectThreshold());
 
     LOGGER.info(
-        "PipeRealTimeFirstDequeHistoryThreshold: {}", getPipeRealTimeFirstDequeHistoryThreshold());
+        "PipeRealTimeQueuePollHistoryThreshold: {}", getPipeRealTimeQueuePollHistoryThreshold());
 
     LOGGER.info("PipeSubtaskExecutorMaxThreadNum: {}", getPipeSubtaskExecutorMaxThreadNum());
     LOGGER.info(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeConfig.java
@@ -58,6 +58,12 @@ public class PipeConfig {
     return COMMON_CONFIG.getPipeDataStructureTabletMemoryBlockAllocationRejectThreshold();
   }
 
+  /////////////////////////////// Subtask Connector ///////////////////////////////
+
+  public int getPipeRealTimeFirstDequeHistoryThreshold() {
+    return COMMON_CONFIG.getPipeRealTimeFirstDequeHistoryThreshold();
+  }
+
   /////////////////////////////// Subtask Executor ///////////////////////////////
 
   public int getPipeSubtaskExecutorMaxThreadNum() {
@@ -304,6 +310,9 @@ public class PipeConfig {
     LOGGER.info(
         "PipeDataStructureTabletMemoryBlockAllocationRejectThreshold: {}",
         getPipeDataStructureTabletMemoryBlockAllocationRejectThreshold());
+
+    LOGGER.info(
+        "PipeRealTimeFirstDequeHistoryThreshold: {}", getPipeRealTimeFirstDequeHistoryThreshold());
 
     LOGGER.info("PipeSubtaskExecutorMaxThreadNum: {}", getPipeSubtaskExecutorMaxThreadNum());
     LOGGER.info(


### PR DESCRIPTION
## Description
Introduce counter to return TsFileInsertionEvent if event consumption goes over 'pendingQueueConsumeThreshold'

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
