### PR TITLE
Consider TTL of device in Region  scan for active data

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/regionscan/IoTDBActiveRegionScanWithTTLIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/regionscan/IoTDBActiveRegionScanWithTTLIT.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.it.schema.regionscan;
+
+import org.apache.iotdb.it.env.EnvFactory;
+import org.apache.iotdb.itbase.category.ClusterIT;
+import org.apache.iotdb.itbase.category.LocalStandaloneIT;
+import org.apache.iotdb.util.AbstractSchemaIT;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.sql.Connection;
+import java.sql.Statement;
+
+import static org.apache.iotdb.db.it.schema.regionscan.IoTDBActiveRegionScanIT.COUNT_DEVICES_COLUMN_NAMES;
+import static org.apache.iotdb.db.it.schema.regionscan.IoTDBActiveRegionScanIT.COUNT_TIMESERIES_COLUMN_NAMES;
+import static org.apache.iotdb.db.it.schema.regionscan.IoTDBActiveRegionScanIT.SHOW_DEVICES_COLUMN_NAMES;
+import static org.apache.iotdb.db.it.schema.regionscan.IoTDBActiveRegionScanIT.SHOW_TIMESERIES_COLUMN_NAMES;
+import static org.apache.iotdb.db.it.schema.regionscan.IoTDBActiveRegionScanIT.basicCountActiveDeviceTest;
+import static org.apache.iotdb.db.it.schema.regionscan.IoTDBActiveRegionScanIT.basicShowActiveDeviceTest;
+import static org.apache.iotdb.db.it.schema.regionscan.IoTDBActiveRegionScanIT.common_insert_sqls;
+import static org.junit.Assert.fail;
+
+@Category({LocalStandaloneIT.class, ClusterIT.class})
+public class IoTDBActiveRegionScanWithTTLIT extends AbstractSchemaIT {
+
+    private static String[] sqls =
+            new String[] {
+                    "create timeseries root.sg.d1.s1 WITH DATATYPE=INT64, encoding=RLE",
+                    "create timeseries root.sg.d1.s2 WITH DATATYPE=INT32, encoding=Gorilla",
+                    "create timeseries root.sg.d2.s1 WITH DATATYPE=INT64, encoding=RLE",
+                    "create timeseries root.sg.d2.s2 WITH DATATYPE=INT32, encoding=Gorilla",
+                    "insert into root.sg.d1(time, s1, s2) values(1, 1, 2)",
+                    "insert into root.sg.d1(time, s1, s2) values(2, 2, 3)",
+                    "insert into root.sg.d1(time, s1, s2) values(3, 3, 4)",
+                    "insert into root.sg.d1(time, s1, s2) values(5, 5, 6)",
+                    "insert into root.sg.d1(time, s1, s2) values(6, 6, 7)",
+                    "insert into root.sg.d1(time, s1, s2) values(7, 7, 8)",
+                    "insert into root.sg.d1(time, s1, s2) values(8, null, 9)",
+                    "insert into root.sg.d1(time, s1, s2) values(9, 9, 10)",
+                    "insert into root.sg.d1(time, s1, s2) values(10, 10, 11)",
+                    "flush",
+                    "insert into root.sg.d2(time, s1, s2) values(now(), null, 9)",
+                    "insert into root.sg.d2(time, s1, s2) values(now(), 9, 10)",
+                    "insert into root.sg.d2(time, s1, s2) values(now(), 10, 11)"
+                };
+
+    public IoTDBActiveRegionScanWithModsIT(SchemaTestMode schemaTestMode) {
+        super(schemaTestMode);
+    }
+
+    public static void insertData() {
+        try (Connection connection = EnvFactory.getEnv().getConnection();
+             Statement statement = connection.createStatement()) {
+
+            // create aligned and non-aligned time series
+            for (String sql : common_insert_sqls) {
+                statement.addBatch(sql);
+            }
+            statement.executeBatch();
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    private static void setTTL(){
+
+        String[] ttl_sqls = {
+                "set ttl to root.sg.d1 3600000",
+                "set ttl to root.sg.d2 3600000"
+        };
+        try (Connection connection = EnvFactory.getEnv().getConnection();
+             Statement statement = connection.createStatement()) {
+            // create aligned and non-aligned time series
+            for (String sql : ttl_sqls) {
+                statement.addBatch(sql);
+            }
+            statement.executeBatch();
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        EnvFactory.getEnv()
+                .getConfig()
+                .getCommonConfig()
+                .setEnableSeqSpaceCompaction(false)
+                .setEnableUnseqSpaceCompaction(false)
+                .setEnableCrossSpaceCompaction(false);
+        EnvFactory.getEnv().initClusterEnvironment();
+        insertData();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        EnvFactory.getEnv().cleanClusterEnvironment();
+    }
+
+    @Test
+    public void showActiveDataWithMods() {
+        String sql = "show devices where time > 0";
+        String[] retArray = new String[] {"root.sg.d1","root.sg.d2"};
+        basicShowActiveDeviceTest(sql, SHOW_DEVICES_COLUMN_NAMES, retArray);
+
+        setTTL();
+
+        String[] retArray = new String[] {"root.sg.d2"};
+        basicShowActiveDeviceTest(sql, SHOW_DEVICES_COLUMN_NAMES, retArray);
+    }
+}
+

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/regionscan/IoTDBActiveRegionScanWithTTLIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/regionscan/IoTDBActiveRegionScanWithTTLIT.java
@@ -32,102 +32,105 @@ import org.junit.experimental.categories.Category;
 import java.sql.Connection;
 import java.sql.Statement;
 
-import static org.apache.iotdb.db.it.schema.regionscan.IoTDBActiveRegionScanIT.COUNT_DEVICES_COLUMN_NAMES;
-import static org.apache.iotdb.db.it.schema.regionscan.IoTDBActiveRegionScanIT.COUNT_TIMESERIES_COLUMN_NAMES;
 import static org.apache.iotdb.db.it.schema.regionscan.IoTDBActiveRegionScanIT.SHOW_DEVICES_COLUMN_NAMES;
-import static org.apache.iotdb.db.it.schema.regionscan.IoTDBActiveRegionScanIT.SHOW_TIMESERIES_COLUMN_NAMES;
-import static org.apache.iotdb.db.it.schema.regionscan.IoTDBActiveRegionScanIT.basicCountActiveDeviceTest;
 import static org.apache.iotdb.db.it.schema.regionscan.IoTDBActiveRegionScanIT.basicShowActiveDeviceTest;
-import static org.apache.iotdb.db.it.schema.regionscan.IoTDBActiveRegionScanIT.common_insert_sqls;
 import static org.junit.Assert.fail;
 
 @Category({LocalStandaloneIT.class, ClusterIT.class})
 public class IoTDBActiveRegionScanWithTTLIT extends AbstractSchemaIT {
 
-    private static String[] sqls =
-            new String[] {
-                    "create timeseries root.sg.d1.s1 WITH DATATYPE=INT64, encoding=RLE",
-                    "create timeseries root.sg.d1.s2 WITH DATATYPE=INT32, encoding=Gorilla",
-                    "create timeseries root.sg.d2.s1 WITH DATATYPE=INT64, encoding=RLE",
-                    "create timeseries root.sg.d2.s2 WITH DATATYPE=INT32, encoding=Gorilla",
-                    "insert into root.sg.d1(time, s1, s2) values(1, 1, 2)",
-                    "insert into root.sg.d1(time, s1, s2) values(2, 2, 3)",
-                    "insert into root.sg.d1(time, s1, s2) values(3, 3, 4)",
-                    "insert into root.sg.d1(time, s1, s2) values(5, 5, 6)",
-                    "insert into root.sg.d1(time, s1, s2) values(6, 6, 7)",
-                    "insert into root.sg.d1(time, s1, s2) values(7, 7, 8)",
-                    "insert into root.sg.d1(time, s1, s2) values(8, null, 9)",
-                    "insert into root.sg.d1(time, s1, s2) values(9, 9, 10)",
-                    "insert into root.sg.d1(time, s1, s2) values(10, 10, 11)",
-                    "flush",
-                    "insert into root.sg.d2(time, s1, s2) values(now(), null, 9)",
-                    "insert into root.sg.d2(time, s1, s2) values(now(), 9, 10)",
-                    "insert into root.sg.d2(time, s1, s2) values(now(), 10, 11)"
-                };
+  public IoTDBActiveRegionScanWithTTLIT(SchemaTestMode schemaTestMode) {
+    super(schemaTestMode);
+  }
 
-    public IoTDBActiveRegionScanWithModsIT(SchemaTestMode schemaTestMode) {
-        super(schemaTestMode);
+  private static String[] sqls =
+      new String[] {
+        "create timeseries root.sg.d1.s1 WITH DATATYPE=INT64, encoding=RLE",
+        "create timeseries root.sg.d1.s2 WITH DATATYPE=INT32, encoding=Gorilla",
+        "create timeseries root.sg.d2.s1 WITH DATATYPE=INT64, encoding=RLE",
+        "create timeseries root.sg.d2.s2 WITH DATATYPE=INT32, encoding=Gorilla",
+        "insert into root.sg.d1(time, s1, s2) values(1, 1, 2)",
+        "insert into root.sg.d1(time, s1, s2) values(2, 2, 3)",
+        "insert into root.sg.d1(time, s1, s2) values(3, 3, 4)",
+        "insert into root.sg.d1(time, s1, s2) values(5, 5, 6)",
+        "insert into root.sg.d1(time, s1, s2) values(6, 6, 7)",
+        "insert into root.sg.d1(time, s1, s2) values(7, 7, 8)",
+        "insert into root.sg.d1(time, s1, s2) values(8, null, 9)",
+        "insert into root.sg.d1(time, s1, s2) values(9, 9, 10)",
+        "insert into root.sg.d1(time, s1, s2) values(10, 10, 11)",
+        "flush",
+        "insert into root.sg.d2(time, s1, s2) values(now(), null, 9)",
+        "insert into root.sg.d2(time, s1, s2) values(now(), 9, 10)",
+        "insert into root.sg.d2(time, s1, s2) values(now(), 10, 11)"
+      };
+
+  public static void insertData() {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+
+      for (String sql : sqls) {
+        statement.addBatch(sql);
+      }
+      statement.executeBatch();
+    } catch (Exception e) {
+      fail(e.getMessage());
     }
+  }
 
-    public static void insertData() {
-        try (Connection connection = EnvFactory.getEnv().getConnection();
-             Statement statement = connection.createStatement()) {
-
-            // create aligned and non-aligned time series
-            for (String sql : common_insert_sqls) {
-                statement.addBatch(sql);
-            }
-            statement.executeBatch();
-        } catch (Exception e) {
-            fail(e.getMessage());
-        }
+  private static void setTTL() {
+    String[] ttl_sqls = {"set ttl to root.sg.d1 3600000", "set ttl to root.sg.d2 3600000"};
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      for (String sql : ttl_sqls) {
+        statement.addBatch(sql);
+      }
+      statement.executeBatch();
+    } catch (Exception e) {
+      fail(e.getMessage());
     }
+  }
 
-    private static void setTTL(){
-
-        String[] ttl_sqls = {
-                "set ttl to root.sg.d1 3600000",
-                "set ttl to root.sg.d2 3600000"
-        };
-        try (Connection connection = EnvFactory.getEnv().getConnection();
-             Statement statement = connection.createStatement()) {
-            // create aligned and non-aligned time series
-            for (String sql : ttl_sqls) {
-                statement.addBatch(sql);
-            }
-            statement.executeBatch();
-        } catch (Exception e) {
-            fail(e.getMessage());
-        }
+  private static void unsetTTL() {
+    String[] ttl_sqls = {"unset ttl to root.sg.d1", "unset ttl to root.sg.d2"};
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      for (String sql : ttl_sqls) {
+        statement.addBatch(sql);
+      }
+      statement.executeBatch();
+    } catch (Exception e) {
+      fail(e.getMessage());
     }
+  }
 
-    @BeforeClass
-    public static void setUp() throws Exception {
-        EnvFactory.getEnv()
-                .getConfig()
-                .getCommonConfig()
-                .setEnableSeqSpaceCompaction(false)
-                .setEnableUnseqSpaceCompaction(false)
-                .setEnableCrossSpaceCompaction(false);
-        EnvFactory.getEnv().initClusterEnvironment();
-        insertData();
-    }
+  @BeforeClass
+  public static void setUp() throws Exception {
+    EnvFactory.getEnv()
+        .getConfig()
+        .getCommonConfig()
+        .setEnableSeqSpaceCompaction(false)
+        .setEnableUnseqSpaceCompaction(false)
+        .setEnableCrossSpaceCompaction(false);
+    EnvFactory.getEnv().initClusterEnvironment();
+    insertData();
+  }
 
-    @AfterClass
-    public static void tearDown() throws Exception {
-        EnvFactory.getEnv().cleanClusterEnvironment();
-    }
+  @AfterClass
+  public static void tearDown() throws Exception {
+    EnvFactory.getEnv().cleanClusterEnvironment();
+  }
 
-    @Test
-    public void showActiveDataWithMods() {
-        String sql = "show devices where time > 0";
-        String[] retArray = new String[] {"root.sg.d1","root.sg.d2"};
-        basicShowActiveDeviceTest(sql, SHOW_DEVICES_COLUMN_NAMES, retArray);
+  @Test
+  public void showActiveDataWithMods() {
+    String sql = "show devices where time > 0";
+    String[] retArray = new String[] {"root.sg.d1", "root.sg.d2"};
+    basicShowActiveDeviceTest(sql, SHOW_DEVICES_COLUMN_NAMES, retArray);
 
-        setTTL();
+    setTTL();
 
-        String[] retArray = new String[] {"root.sg.d2"};
-        basicShowActiveDeviceTest(sql, SHOW_DEVICES_COLUMN_NAMES, retArray);
-    }
+    retArray = new String[] {"root.sg.d2"};
+    basicShowActiveDeviceTest(sql, SHOW_DEVICES_COLUMN_NAMES, retArray);
+
+    unsetTTL();
+  }
 }
-

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/AbstractRegionScanForActiveDataUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/AbstractRegionScanForActiveDataUtil.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 public abstract class AbstractRegionScanForActiveDataUtil implements Accountable {
 
@@ -60,8 +61,8 @@ public abstract class AbstractRegionScanForActiveDataUtil implements Accountable
   protected Iterator<IChunkHandle> chunkHandleIterator = null;
   protected IChunkHandle currentChunkHandle = null;
 
-  protected AbstractRegionScanForActiveDataUtil(Filter timeFilter) {
-    this.timeFilter = new TimeFilterForDeviceTTL(timeFilter);
+  protected AbstractRegionScanForActiveDataUtil(Filter timeFilter, Map<IDeviceID, Long> ttlCache) {
+    this.timeFilter = new TimeFilterForDeviceTTL(timeFilter, ttlCache);
   }
 
   public void initQueryDataSource(IQueryDataSource dataSource) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/AbstractRegionScanForActiveDataUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/AbstractRegionScanForActiveDataUtil.java
@@ -153,10 +153,10 @@ public abstract class AbstractRegionScanForActiveDataUtil implements Accountable
       return true;
     }
 
-    if ((timeFilter.satisfy(pageStatistics[0], null)
+    if ((timeFilter.satisfy(pageStatistics[0], curDevice)
             && !curFileScanHandle.isTimeSeriesTimeDeleted(
                 curDevice, curMeasurement, pageStatistics[0]))
-        || (timeFilter.satisfy(pageStatistics[1], null)
+        || (timeFilter.satisfy(pageStatistics[1], curDevice)
             && !curFileScanHandle.isTimeSeriesTimeDeleted(
                 curDevice, curMeasurement, pageStatistics[1]))) {
       // If the page in curChunk has valid start time, curChunk is active in this time range.
@@ -167,7 +167,7 @@ public abstract class AbstractRegionScanForActiveDataUtil implements Accountable
     // 3. check page data
     long[] timeDataForPage = currentChunkHandle.getDataTime();
     for (long time : timeDataForPage) {
-      if (!timeFilter.satisfy(time, null)) {
+      if (!timeFilter.satisfy(time, curDevice)) {
         continue;
       }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/ActiveDeviceRegionScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/ActiveDeviceRegionScanOperator.java
@@ -91,7 +91,6 @@ public class ActiveDeviceRegionScanOperator extends AbstractRegionScanDataSource
         int templateId = deviceContext.getTemplateId();
         // TODO: use IDeviceID interface to get ttl
         long ttl = DataNodeTTLCache.getInstance().getTTL(deviceID);
-
         // TODO: make it more readable, like "30 days" or "10 hours"
         String ttlStr = ttl == Long.MAX_VALUE ? IoTDBConstant.TTL_INFINITE : String.valueOf(ttl);
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/ActiveDeviceRegionScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/ActiveDeviceRegionScanOperator.java
@@ -57,12 +57,13 @@ public class ActiveDeviceRegionScanOperator extends AbstractRegionScanDataSource
       PlanNodeId sourceId,
       Map<IDeviceID, DeviceContext> deviceContextMap,
       Filter timeFilter,
+      Map<IDeviceID, Long> ttlCache,
       boolean outputCount) {
     this.outputCount = outputCount;
     this.sourceId = sourceId;
     this.operatorContext = operatorContext;
     this.deviceContextMap = deviceContextMap;
-    this.regionScanUtil = new RegionScanForActiveDeviceUtil(timeFilter);
+    this.regionScanUtil = new RegionScanForActiveDeviceUtil(timeFilter, ttlCache);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/ActiveTimeSeriesRegionScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/ActiveTimeSeriesRegionScanOperator.java
@@ -55,12 +55,13 @@ public class ActiveTimeSeriesRegionScanOperator extends AbstractRegionScanDataSo
       PlanNodeId sourceId,
       Map<IDeviceID, Map<String, TimeseriesContext>> timeSeriesToSchemasInfo,
       Filter timeFilter,
+      Map<IDeviceID, Long> ttlCache,
       boolean isOutputCount) {
     this.outputCount = isOutputCount;
     this.operatorContext = operatorContext;
     this.sourceId = sourceId;
     this.timeSeriesToSchemasInfo = timeSeriesToSchemasInfo;
-    this.regionScanUtil = new RegionScanForActiveTimeSeriesUtil(timeFilter);
+    this.regionScanUtil = new RegionScanForActiveTimeSeriesUtil(timeFilter, ttlCache);
     this.dataBaseName =
         new Binary(
             operatorContext

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/RegionScanForActiveDeviceUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/RegionScanForActiveDeviceUtil.java
@@ -86,10 +86,10 @@ public class RegionScanForActiveDeviceUtil extends AbstractRegionScanForActiveDa
         continue;
       }
 
-      if ((timeFilter.satisfy(startTime, null)
+      if ((timeFilter.satisfy(startTime, deviceID)
               && !curFileScanHandle.isDeviceTimeDeleted(deviceID, startTime))
           || (endTime >= 0
-              && timeFilter.satisfy(endTime, null)
+              && timeFilter.satisfy(endTime, deviceID)
               && !curFileScanHandle.isDeviceTimeDeleted(deviceID, endTime))) {
         activeDevices.add(deviceID);
       } else {
@@ -141,9 +141,9 @@ public class RegionScanForActiveDeviceUtil extends AbstractRegionScanForActiveDa
       String measurement = valueChunkMetaData.getMeasurementUid();
       // If the chunkMeta in curDevice has valid start or end time, curDevice is active in this
       // time range.
-      if ((timeFilter.satisfy(startTime, null)
+      if ((timeFilter.satisfy(startTime, deviceID)
               && !curFileScanHandle.isTimeSeriesTimeDeleted(deviceID, measurement, startTime))
-          || (timeFilter.satisfy(endTime, null)
+          || (timeFilter.satisfy(endTime, deviceID)
               && !curFileScanHandle.isTimeSeriesTimeDeleted(deviceID, measurement, endTime))) {
         return true;
       }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/RegionScanForActiveDeviceUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/RegionScanForActiveDeviceUtil.java
@@ -50,8 +50,8 @@ public class RegionScanForActiveDeviceUtil extends AbstractRegionScanForActiveDa
   private final Set<IDeviceID> deviceSetForCurrentTsFile;
   private final List<IDeviceID> activeDevices;
 
-  public RegionScanForActiveDeviceUtil(Filter timeFilter) {
-    super(timeFilter);
+  public RegionScanForActiveDeviceUtil(Filter timeFilter, Map<IDeviceID, Long> ttlCache) {
+    super(timeFilter, ttlCache);
     this.deviceSetForCurrentTsFile = new HashSet<>();
     this.activeDevices = new ArrayList<>();
   }
@@ -123,6 +123,7 @@ public class RegionScanForActiveDeviceUtil extends AbstractRegionScanForActiveDa
     // Chunk is active means relating device is active, too.
     deviceSetForCurrentTsFile.remove(deviceID);
     activeDevices.add(deviceID);
+    timeFilter.removeTTLCache(deviceID);
     currentChunkHandle = null;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/RegionScanForActiveTimeSeriesUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/RegionScanForActiveTimeSeriesUtil.java
@@ -73,7 +73,7 @@ public class RegionScanForActiveTimeSeriesUtil extends AbstractRegionScanForActi
       long startTime = deviceStartEndTime.getStartTime();
       long endTime = deviceStartEndTime.getEndTime();
       if (!targetTimeseries.containsKey(deviceID)
-          || (endTime >= 0 && !timeFilter.satisfyStartEndTime(startTime, endTime))) {
+          || (endTime >= 0 && !timeFilter.satisfyStartEndTime(startTime, endTime, deviceID))) {
         continue;
       }
 
@@ -132,7 +132,7 @@ public class RegionScanForActiveTimeSeriesUtil extends AbstractRegionScanForActi
       Set<String> measurementForCurrentTsFile = timeSeriesForCurrentTsFile.get(deviceID);
       if (!(measurementForCurrentTsFile != null
               && measurementForCurrentTsFile.contains(measurementId))
-          || !timeFilter.satisfyStartEndTime(startTime, endTime)) {
+          || !timeFilter.satisfyStartEndTime(startTime, endTime, deviceID)) {
         continue;
       }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/RegionScanForActiveTimeSeriesUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/RegionScanForActiveTimeSeriesUtil.java
@@ -49,8 +49,8 @@ public class RegionScanForActiveTimeSeriesUtil extends AbstractRegionScanForActi
       RamUsageEstimator.shallowSizeOfInstance(Map.class)
           + RamUsageEstimator.shallowSizeOfInstance(Map.class);
 
-  public RegionScanForActiveTimeSeriesUtil(Filter timeFilter) {
-    super(timeFilter);
+  public RegionScanForActiveTimeSeriesUtil(Filter timeFilter, Map<IDeviceID, Long> ttlCache) {
+    super(timeFilter, ttlCache);
     this.timeSeriesForCurrentTsFile = new HashMap<>();
     this.activeTimeSeries = new HashMap<>();
   }
@@ -161,6 +161,7 @@ public class RegionScanForActiveTimeSeriesUtil extends AbstractRegionScanForActi
       measurements.remove(measurementPath);
       if (measurements.isEmpty()) {
         timeSeriesForCurrentTsFile.remove(deviceID);
+        timeFilter.removeTTLCache(deviceID);
       }
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/RegionScanForActiveTimeSeriesUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/RegionScanForActiveTimeSeriesUtil.java
@@ -136,9 +136,9 @@ public class RegionScanForActiveTimeSeriesUtil extends AbstractRegionScanForActi
         continue;
       }
 
-      if ((timeFilter.satisfy(startTime, null)
+      if ((timeFilter.satisfy(startTime, deviceID)
               && !curFileScanHandle.isTimeSeriesTimeDeleted(deviceID, measurementId, startTime))
-          || (timeFilter.satisfy(endTime, null)
+          || (timeFilter.satisfy(endTime, deviceID)
               && !curFileScanHandle.isTimeSeriesTimeDeleted(deviceID, measurementId, endTime))) {
         removeTimeSeriesForCurrentTsFile(deviceID, measurementId);
         activeTimeSeries.computeIfAbsent(deviceID, k -> new ArrayList<>()).add(measurementId);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/TimeFilterForDeviceTTL.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/TimeFilterForDeviceTTL.java
@@ -25,16 +25,18 @@ import org.apache.iotdb.db.queryengine.plan.analyze.cache.schema.DataNodeTTLCach
 import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.read.filter.basic.Filter;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class TimeFilterForDeviceTTL {
 
   private final Filter timeFilter;
 
-  private Map<IDeviceID, Long> ttlCached;
+  private final Map<IDeviceID, Long> ttlCached;
 
   public TimeFilterForDeviceTTL(Filter timeFilter) {
     this.timeFilter = timeFilter;
+    ttlCached = new HashMap<>();
   }
 
   public boolean satisfyStartEndTime(long startTime, long endTime, IDeviceID deviceID) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/TimeFilterForDeviceTTL.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/TimeFilterForDeviceTTL.java
@@ -1,0 +1,54 @@
+package org.apache.iotdb.db.utils;
+
+import org.apache.iotdb.commons.utils.CommonDateTimeUtils;
+import org.apache.iotdb.db.queryengine.plan.analyze.cache.schema.DataNodeTTLCache;
+import org.apache.tsfile.file.metadata.IDeviceID;
+import org.apache.tsfile.read.filter.basic.Filter;
+
+import java.util.Map;
+
+public class TimeFilterForDeviceTTL {
+
+    private Filter timeFilter;
+
+    private Map<IDeviceID, Long> ttlCached;
+
+    public TimeFilterForDeviceTTL(Filter timeFilter) {
+        this.timeFilter = timeFilter;
+    }
+
+    public boolean satisfyStartEndTIme(long startTime, long endTime, IDeviceID deviceID){
+        long ttl = getTTL(deviceID);
+        if(ttl != Long.MAX_VALUE){
+            long validStartTime = CommonDateTimeUtils.currentTime() - ttl;
+            if(validStartTime > endTime){
+                return false;
+            }
+            return timeFilter.satisfyStartEndTime(validStartTime, endTime);
+        }
+        return timeFilter.satisfyStartEndTime(startTime, endTime);
+    }
+
+    public boolean satisfy(long time, IDeviceID deviceID){
+        long ttl = getTTL(deviceID);
+        if(ttl != Long.MAX_VALUE) {
+            long validStartTime = CommonDateTimeUtils.currentTime() - ttl;
+            if(validStartTime > time){
+                return false;
+            }
+            return timeFilter.satisfy(validStartTime, null);
+        }
+        return timeFilter.satisfy(time, null);
+    }
+
+    private long getTTL(IDeviceID deviceID){
+        if(ttlCached.containsKey(deviceID)){
+            return ttlCached.get(deviceID);
+        }
+        long ttl = DataNodeTTLCache.getInstance().getTTL(deviceID);
+        ttlCached.put(deviceID, ttl);
+        return ttl;
+    }
+
+
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/TimeFilterForDeviceTTL.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/TimeFilterForDeviceTTL.java
@@ -2,6 +2,7 @@ package org.apache.iotdb.db.utils;
 
 import org.apache.iotdb.commons.utils.CommonDateTimeUtils;
 import org.apache.iotdb.db.queryengine.plan.analyze.cache.schema.DataNodeTTLCache;
+
 import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.read.filter.basic.Filter;
 
@@ -9,46 +10,44 @@ import java.util.Map;
 
 public class TimeFilterForDeviceTTL {
 
-    private Filter timeFilter;
+  private final Filter timeFilter;
 
-    private Map<IDeviceID, Long> ttlCached;
+  private Map<IDeviceID, Long> ttlCached;
 
-    public TimeFilterForDeviceTTL(Filter timeFilter) {
-        this.timeFilter = timeFilter;
+  public TimeFilterForDeviceTTL(Filter timeFilter) {
+    this.timeFilter = timeFilter;
+  }
+
+  public boolean satisfyStartEndTime(long startTime, long endTime, IDeviceID deviceID) {
+    long ttl = getTTL(deviceID);
+    if (ttl != Long.MAX_VALUE) {
+      long validStartTime = CommonDateTimeUtils.currentTime() - ttl;
+      if (validStartTime > endTime) {
+        return false;
+      }
+      return timeFilter.satisfyStartEndTime(validStartTime, endTime);
     }
+    return timeFilter.satisfyStartEndTime(startTime, endTime);
+  }
 
-    public boolean satisfyStartEndTIme(long startTime, long endTime, IDeviceID deviceID){
-        long ttl = getTTL(deviceID);
-        if(ttl != Long.MAX_VALUE){
-            long validStartTime = CommonDateTimeUtils.currentTime() - ttl;
-            if(validStartTime > endTime){
-                return false;
-            }
-            return timeFilter.satisfyStartEndTime(validStartTime, endTime);
-        }
-        return timeFilter.satisfyStartEndTime(startTime, endTime);
+  public boolean satisfy(long time, IDeviceID deviceID) {
+    long ttl = getTTL(deviceID);
+    if (ttl != Long.MAX_VALUE) {
+      long validStartTime = CommonDateTimeUtils.currentTime() - ttl;
+      if (validStartTime > time) {
+        return false;
+      }
+      return timeFilter.satisfy(validStartTime, null);
     }
+    return timeFilter.satisfy(time, null);
+  }
 
-    public boolean satisfy(long time, IDeviceID deviceID){
-        long ttl = getTTL(deviceID);
-        if(ttl != Long.MAX_VALUE) {
-            long validStartTime = CommonDateTimeUtils.currentTime() - ttl;
-            if(validStartTime > time){
-                return false;
-            }
-            return timeFilter.satisfy(validStartTime, null);
-        }
-        return timeFilter.satisfy(time, null);
+  private long getTTL(IDeviceID deviceID) {
+    if (ttlCached.containsKey(deviceID)) {
+      return ttlCached.get(deviceID);
     }
-
-    private long getTTL(IDeviceID deviceID){
-        if(ttlCached.containsKey(deviceID)){
-            return ttlCached.get(deviceID);
-        }
-        long ttl = DataNodeTTLCache.getInstance().getTTL(deviceID);
-        ttlCached.put(deviceID, ttl);
-        return ttl;
-    }
-
-
+    long ttl = DataNodeTTLCache.getInstance().getTTL(deviceID);
+    ttlCached.put(deviceID, ttl);
+    return ttl;
+  }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/TimeFilterForDeviceTTL.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/TimeFilterForDeviceTTL.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.iotdb.db.utils;
 
 import org.apache.iotdb.commons.utils.CommonDateTimeUtils;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/TimeFilterForDeviceTTL.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/TimeFilterForDeviceTTL.java
@@ -20,12 +20,10 @@
 package org.apache.iotdb.db.utils;
 
 import org.apache.iotdb.commons.utils.CommonDateTimeUtils;
-import org.apache.iotdb.db.queryengine.plan.analyze.cache.schema.DataNodeTTLCache;
 
 import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.read.filter.basic.Filter;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public class TimeFilterForDeviceTTL {
@@ -34,9 +32,9 @@ public class TimeFilterForDeviceTTL {
 
   private final Map<IDeviceID, Long> ttlCached;
 
-  public TimeFilterForDeviceTTL(Filter timeFilter) {
+  public TimeFilterForDeviceTTL(Filter timeFilter, Map<IDeviceID, Long> ttlCached) {
     this.timeFilter = timeFilter;
-    ttlCached = new HashMap<>();
+    this.ttlCached = ttlCached;
   }
 
   public boolean satisfyStartEndTime(long startTime, long endTime, IDeviceID deviceID) {
@@ -64,11 +62,15 @@ public class TimeFilterForDeviceTTL {
   }
 
   private long getTTL(IDeviceID deviceID) {
-    if (ttlCached.containsKey(deviceID)) {
-      return ttlCached.get(deviceID);
+    Long ttl = ttlCached.get(deviceID);
+    if (ttl == null) {
+      throw new IllegalArgumentException(
+          "deviceID should not be empty in getTTL method in TimeFilterForDeviceTTL");
     }
-    long ttl = DataNodeTTLCache.getInstance().getTTL(deviceID);
-    ttlCached.put(deviceID, ttl);
     return ttl;
+  }
+
+  public void removeTTLCache(IDeviceID deviceID) {
+    ttlCached.remove(deviceID);
   }
 }


### PR DESCRIPTION
Data may remains in database even if it's out-dated due to the TTL. We need to filter such data in region scan.

Different from series scan which contains only one device which can use the TTL info of that device to update timeFilter,
a lot of devices share the same timeFilter in region scan.

So we can't update the timeFilter in advance, we need to calculate the real time range by TTL of the specified device one by one. In such procedure, we can use some cache technology to reduce the cost.

In this PR, we use a new timeFilter TimeFilterForDeviceTTL to replace the original timeFilter for above purpose. 