### PR TITLE
Extend fucntion of EXPLAIN ANALYZE 

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/MPPQueryContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/MPPQueryContext.java
@@ -258,6 +258,10 @@ public class MPPQueryContext {
     return queryPlanStatistics.getLogicalOptimizationCost();
   }
 
+  public long getDispatchCost() {
+    return queryPlanStatistics.getDispatchCost();
+  }
+
   public void setAnalyzeCost(long analyzeCost) {
     if (queryPlanStatistics == null) {
       queryPlanStatistics = new QueryPlanStatistics();
@@ -298,6 +302,13 @@ public class MPPQueryContext {
       queryPlanStatistics = new QueryPlanStatistics();
     }
     queryPlanStatistics.setLogicalOptimizationCost(logicalOptimizeCost);
+  }
+
+  public void recordDispatchCost(long dispatchCost) {
+    if (queryPlanStatistics == null) {
+      queryPlanStatistics = new QueryPlanStatistics();
+    }
+    queryPlanStatistics.recordDispatchCost(dispatchCost);
   }
 
   // region =========== FE memory related, make sure its not called concurrently ===========

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceExecution.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceExecution.java
@@ -170,6 +170,16 @@ public class FragmentInstanceExecution {
     statistics.setSeqUnclosedNum(context.getUnclosedSeqFileNum());
     statistics.setUnseqClosedNum(context.getClosedUnseqFileNum());
     statistics.setUnseqUnclosedNum(context.getUnclosedUnseqFileNum());
+
+    statistics.setAlignedTimeSeriesMetadataModificationCount(
+        context.getQueryStatistics().getAlignedTimeSeriesMetadataModificationCount().get());
+    statistics.setNonAlignedTimeSeriesMetadataModificationCount(
+        context.getQueryStatistics().getNonAlignedTimeSeriesMetadataModificationCount().get());
+    statistics.setAlignedTimeSeriesMetadataModificationTime(
+        context.getQueryStatistics().getAlignedTimeSeriesMetadataModificationTime().get());
+    statistics.setNonAlignedTimeSeriesMetadataModificationTime(
+        context.getQueryStatistics().getNonAlignedTimeSeriesMetadataModificationTime().get());
+
     return true;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceExecution.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceExecution.java
@@ -171,15 +171,6 @@ public class FragmentInstanceExecution {
     statistics.setUnseqClosedNum(context.getClosedUnseqFileNum());
     statistics.setUnseqUnclosedNum(context.getUnclosedUnseqFileNum());
 
-    statistics.setAlignedTimeSeriesMetadataModificationCount(
-        context.getQueryStatistics().getAlignedTimeSeriesMetadataModificationCount().get());
-    statistics.setNonAlignedTimeSeriesMetadataModificationCount(
-        context.getQueryStatistics().getNonAlignedTimeSeriesMetadataModificationCount().get());
-    statistics.setAlignedTimeSeriesMetadataModificationTime(
-        context.getQueryStatistics().getAlignedTimeSeriesMetadataModificationTime().get());
-    statistics.setNonAlignedTimeSeriesMetadataModificationTime(
-        context.getQueryStatistics().getNonAlignedTimeSeriesMetadataModificationTime().get());
-
     return true;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryStatistics.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryStatistics.java
@@ -259,6 +259,10 @@ public class QueryStatistics {
         pageReadersDecodeNonAlignedDiskTime.get(),
         pageReadersDecodeNonAlignedMemCount.get(),
         pageReadersDecodeNonAlignedMemTime.get(),
-        pageReaderMaxUsedMemorySize.get());
+        pageReaderMaxUsedMemorySize.get(),
+        alignedTimeSeriesMetadataModificationCount.get(),
+        alignedTimeSeriesMetadataModificationTime.get(),
+        nonAlignedTimeSeriesMetadataModificationCount.get(),
+        nonAlignedTimeSeriesMetadataModificationTime.get());
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryStatistics.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryStatistics.java
@@ -104,6 +104,7 @@ public class QueryStatistics {
         pageReadersDecodeNonAlignedDiskCount.get(),
         pageReadersDecodeNonAlignedDiskTime.get(),
         pageReadersDecodeNonAlignedMemCount.get(),
-        pageReadersDecodeNonAlignedMemTime.get());
+        pageReadersDecodeNonAlignedMemTime.get(),
+        pageReaderMaxUsedMemorySize.get());
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/FilterAndProjectOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/FilterAndProjectOperator.java
@@ -72,6 +72,8 @@ public class FilterAndProjectOperator implements ProcessOperator {
   // false when we only need to do projection
   private final boolean hasFilter;
 
+  private long filteredRowCount = 0;
+
   @SuppressWarnings("squid:S107")
   public FilterAndProjectOperator(
       OperatorContext operatorContext,
@@ -114,7 +116,7 @@ public class FilterAndProjectOperator implements ProcessOperator {
 
     long inputRowCount = input.getPositionCount();
     TsBlock filterResult = getFilterTsBlock(input);
-    long filteredRowCount =
+    filteredRowCount +=
         filterResult == null ? inputRowCount : inputRowCount - filterResult.getPositionCount();
     operatorContext.recordSpecifiedInfo("Filtered Rows", Long.toString(filteredRowCount));
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/FileLoaderUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/FileLoaderUtils.java
@@ -105,15 +105,18 @@ public class FileLoaderUtils {
           timeSeriesMetadata.setModified(!pathModifications.isEmpty());
           timeSeriesMetadata.setChunkMetadataLoader(
               new DiskChunkMetadataLoader(resource, context, globalTimeFilter, pathModifications));
-          long costTime = System.nanoTime() - t2;
-          context
-              .getQueryStatistics()
-              .getNonAlignedTimeSeriesMetadataModificationCount()
-              .getAndAdd(pathModifications.size());
-          context
-              .getQueryStatistics()
-              .getNonAlignedTimeSeriesMetadataModificationTime()
-              .getAndAdd(costTime);
+          int modificationCount = pathModifications.size();
+          if (modificationCount != 0) {
+            long costTime = System.nanoTime() - t2;
+            context
+                .getQueryStatistics()
+                .getNonAlignedTimeSeriesMetadataModificationCount()
+                .getAndAdd(modificationCount);
+            context
+                .getQueryStatistics()
+                .getNonAlignedTimeSeriesMetadataModificationTime()
+                .getAndAdd(costTime);
+          }
         }
       } else { // if the tsfile is unclosed, we just get it directly from TsFileResource
         loadFromMem = true;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/FragmentInstanceDispatcherImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/FragmentInstanceDispatcherImpl.java
@@ -146,8 +146,9 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
           // TypeProvider is not used in EXPLAIN ANALYZE, so we can clear it
           instance.getFragment().clearTypeProvider();
         }
-        QUERY_EXECUTION_METRIC_SET.recordExecutionCost(
-            DISPATCH_READ, System.nanoTime() - startTime);
+        long dispatchReadTime = System.nanoTime() - startTime;
+        QUERY_EXECUTION_METRIC_SET.recordExecutionCost(DISPATCH_READ, dispatchReadTime);
+        queryContext.recordDispatchCost(dispatchReadTime);
       }
     }
     return immediateFuture(new FragInstanceDispatchResult(true));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/sys/ExplainAnalyzeStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/sys/ExplainAnalyzeStatement.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.queryengine.plan.statement.sys;
 
+import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.queryengine.plan.statement.Statement;
 import org.apache.iotdb.db.queryengine.plan.statement.StatementType;
@@ -36,6 +37,11 @@ public class ExplainAnalyzeStatement extends Statement {
   public ExplainAnalyzeStatement(QueryStatement queryStatement) {
     statementType = StatementType.QUERY;
     this.queryStatement = queryStatement;
+  }
+
+  @Override
+  public TSStatus checkPermissionBeforeProcess(String userName) {
+    return queryStatement.checkPermissionBeforeProcess(userName);
   }
 
   public QueryStatement getQueryStatement() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/statistics/FragmentInstanceStatisticsDrawer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/statistics/FragmentInstanceStatisticsDrawer.java
@@ -69,6 +69,10 @@ public class FragmentInstanceStatisticsDrawer {
         String.format(
             "Distribution Plan Cost: %.3f ms",
             context.getDistributionPlanCost() * NS_TO_MS_FACTOR));
+    addLine(
+        planHeader,
+        0,
+        String.format("Dispatch Cost: %.3f ms", context.getDispatchCost() * NS_TO_MS_FACTOR));
   }
 
   public List<StatisticLine> renderFragmentInstances(
@@ -324,6 +328,11 @@ public class FragmentInstanceStatisticsDrawer {
         2,
         "pageReadersDecodeNonAlignedMemTime",
         queryStatistics.pageReadersDecodeNonAlignedMemTime * NS_TO_MS_FACTOR);
+    addLineWithValueCheck(
+        singleFragmentInstanceArea,
+        2,
+        "pageReaderMaxUsedMemorySize",
+        queryStatistics.pageReaderMaxUsedMemorySize);
   }
 
   private void addLine(List<StatisticLine> resultForSingleInstance, int level, String value) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/statistics/FragmentInstanceStatisticsDrawer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/statistics/FragmentInstanceStatisticsDrawer.java
@@ -126,30 +126,6 @@ public class FragmentInstanceStatisticsDrawer {
           singleFragmentInstanceArea,
           1,
           String.format(
-              "Aligned TimeSeriesMetadata Modification Count: %s",
-              statistics.getAlignedTimeSeriesMetadataModificationCount()));
-      addLine(
-          singleFragmentInstanceArea,
-          1,
-          String.format(
-              "Aligned TimeSeriesMetadata Modification Time: %.3f ms",
-              statistics.getAlignedTimeSeriesMetadataModificationTime() * NS_TO_MS_FACTOR));
-      addLine(
-          singleFragmentInstanceArea,
-          1,
-          String.format(
-              "NonAligned TimeSeriesMetadata Modification Count: %s",
-              statistics.getNonAlignedTimeSeriesMetadataModificationCount()));
-      addLine(
-          singleFragmentInstanceArea,
-          1,
-          String.format(
-              "NonAligned TimeSeriesMetadata Modification Time: %.3f ms",
-              statistics.getNonAlignedTimeSeriesMetadataModificationTime() * NS_TO_MS_FACTOR));
-      addLine(
-          singleFragmentInstanceArea,
-          1,
-          String.format(
               "ready queued time: %.3f ms, blocked queued time: %.3f ms",
               statistics.getReadyQueuedTime() * NS_TO_MS_FACTOR,
               statistics.getBlockQueuedTime() * NS_TO_MS_FACTOR));
@@ -357,6 +333,26 @@ public class FragmentInstanceStatisticsDrawer {
         2,
         "pageReaderMaxUsedMemorySize",
         queryStatistics.pageReaderMaxUsedMemorySize);
+    addLineWithValueCheck(
+        singleFragmentInstanceArea,
+        1,
+        "AlignedTimeSeriesMetadataModificationCount",
+        queryStatistics.getAlignedTimeSeriesMetadataModificationCount());
+    addLineWithValueCheck(
+        singleFragmentInstanceArea,
+        1,
+        "AlignedTimeSeriesMetadataModificationTime",
+        queryStatistics.getAlignedTimeSeriesMetadataModificationTime() * NS_TO_MS_FACTOR);
+    addLineWithValueCheck(
+        singleFragmentInstanceArea,
+        1,
+        "NonAlignedTimeSeriesMetadataModificationCount",
+        queryStatistics.getNonAlignedTimeSeriesMetadataModificationCount());
+    addLineWithValueCheck(
+        singleFragmentInstanceArea,
+        1,
+        "NonAlignedTimeSeriesMetadataModificationTime",
+        queryStatistics.getNonAlignedTimeSeriesMetadataModificationTime() * NS_TO_MS_FACTOR);
   }
 
   private void addLine(List<StatisticLine> resultForSingleInstance, int level, String value) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/statistics/FragmentInstanceStatisticsDrawer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/statistics/FragmentInstanceStatisticsDrawer.java
@@ -126,8 +126,8 @@ public class FragmentInstanceStatisticsDrawer {
           singleFragmentInstanceArea,
           1,
           String.format(
-              "NonAligned TimeSeriesMetadata Modification Count: %s",
-              statistics.getNonAlignedTimeSeriesMetadataModificationCount()));
+              "Aligned TimeSeriesMetadata Modification Count: %s",
+              statistics.getAlignedTimeSeriesMetadataModificationCount()));
       addLine(
           singleFragmentInstanceArea,
           1,
@@ -138,15 +138,14 @@ public class FragmentInstanceStatisticsDrawer {
           singleFragmentInstanceArea,
           1,
           String.format(
-              "Aligned TimeSeriesMetadata Modification Count: %s",
-              statistics.getAlignedTimeSeriesMetadataModificationCount()));
+              "NonAligned TimeSeriesMetadata Modification Count: %s",
+              statistics.getNonAlignedTimeSeriesMetadataModificationCount()));
       addLine(
           singleFragmentInstanceArea,
           1,
           String.format(
               "NonAligned TimeSeriesMetadata Modification Time: %.3f ms",
               statistics.getNonAlignedTimeSeriesMetadataModificationTime() * NS_TO_MS_FACTOR));
-
       addLine(
           singleFragmentInstanceArea,
           1,

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/statistics/FragmentInstanceStatisticsDrawer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/statistics/FragmentInstanceStatisticsDrawer.java
@@ -126,6 +126,31 @@ public class FragmentInstanceStatisticsDrawer {
           singleFragmentInstanceArea,
           1,
           String.format(
+              "NonAligned TimeSeriesMetadata Modification Count: %s",
+              statistics.getNonAlignedTimeSeriesMetadataModificationCount()));
+      addLine(
+          singleFragmentInstanceArea,
+          1,
+          String.format(
+              "Aligned TimeSeriesMetadata Modification Time: %.3f ms",
+              statistics.getAlignedTimeSeriesMetadataModificationTime() * NS_TO_MS_FACTOR));
+      addLine(
+          singleFragmentInstanceArea,
+          1,
+          String.format(
+              "Aligned TimeSeriesMetadata Modification Count: %s",
+              statistics.getAlignedTimeSeriesMetadataModificationCount()));
+      addLine(
+          singleFragmentInstanceArea,
+          1,
+          String.format(
+              "NonAligned TimeSeriesMetadata Modification Time: %.3f ms",
+              statistics.getNonAlignedTimeSeriesMetadataModificationTime() * NS_TO_MS_FACTOR));
+
+      addLine(
+          singleFragmentInstanceArea,
+          1,
+          String.format(
               "ready queued time: %.3f ms, blocked queued time: %.3f ms",
               statistics.getReadyQueuedTime() * NS_TO_MS_FACTOR,
               statistics.getBlockQueuedTime() * NS_TO_MS_FACTOR));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/statistics/QueryPlanStatistics.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/statistics/QueryPlanStatistics.java
@@ -26,6 +26,7 @@ public class QueryPlanStatistics {
   private long logicalPlanCost;
   private long logicalOptimizationCost;
   private long distributionPlanCost;
+  private long dispatchCost = 0;
 
   public void setAnalyzeCost(long analyzeCost) {
     this.analyzeCost = analyzeCost;
@@ -51,6 +52,10 @@ public class QueryPlanStatistics {
     this.logicalOptimizationCost = logicalOptimizationCost;
   }
 
+  public void recordDispatchCost(long dispatchCost) {
+    this.dispatchCost += dispatchCost;
+  }
+
   public long getAnalyzeCost() {
     return analyzeCost;
   }
@@ -73,5 +78,9 @@ public class QueryPlanStatistics {
 
   public long getLogicalOptimizationCost() {
     return logicalOptimizationCost;
+  }
+
+  public long getDispatchCost() {
+    return dispatchCost;
   }
 }

--- a/iotdb-protocol/thrift-datanode/src/main/thrift/datanode.thrift
+++ b/iotdb-protocol/thrift-datanode/src/main/thrift/datanode.thrift
@@ -618,7 +618,12 @@ struct TFetchFragmentInstanceStatisticsResp {
   14: optional i64 blockQueuedTime
   15: optional string ip
   16: optional string state
+  17: optional i64 alignedTimeSeriesMetadataModificationCount
+  18: optional i64 nonAlignedTimeSeriesMetadataModificationCount
+  19: optional i64 alignedTimeSeriesMetadataModificationTime
+  20: optional i64 nonAlignedTimeSeriesMetadataModificationTime
 }
+
 /**
 * END: Used for EXPLAIN ANALYZE
 **/

--- a/iotdb-protocol/thrift-datanode/src/main/thrift/datanode.thrift
+++ b/iotdb-protocol/thrift-datanode/src/main/thrift/datanode.thrift
@@ -594,6 +594,11 @@ struct TQueryStatistics {
   31: i64 pageReadersDecodeNonAlignedMemCount,
   32: i64 pageReadersDecodeNonAlignedMemTime,
   33: i64 pageReaderMaxUsedMemorySize
+
+  34: i64 alignedTimeSeriesMetadataModificationCount
+  35: i64 alignedTimeSeriesMetadataModificationTime
+  36: i64 nonAlignedTimeSeriesMetadataModificationCount
+  37: i64 nonAlignedTimeSeriesMetadataModificationTime
 }
 
 
@@ -618,10 +623,6 @@ struct TFetchFragmentInstanceStatisticsResp {
   14: optional i64 blockQueuedTime
   15: optional string ip
   16: optional string state
-  17: optional i64 alignedTimeSeriesMetadataModificationCount
-  18: optional i64 nonAlignedTimeSeriesMetadataModificationCount
-  19: optional i64 alignedTimeSeriesMetadataModificationTime
-  20: optional i64 nonAlignedTimeSeriesMetadataModificationTime
 }
 
 /**

--- a/iotdb-protocol/thrift-datanode/src/main/thrift/datanode.thrift
+++ b/iotdb-protocol/thrift-datanode/src/main/thrift/datanode.thrift
@@ -592,7 +592,8 @@ struct TQueryStatistics {
   29: i64 pageReadersDecodeNonAlignedDiskCount,
   30: i64 pageReadersDecodeNonAlignedDiskTime,
   31: i64 pageReadersDecodeNonAlignedMemCount,
-  32: i64 pageReadersDecodeNonAlignedMemTime
+  32: i64 pageReadersDecodeNonAlignedMemTime,
+  33: i64 pageReaderMaxUsedMemorySize
 }
 
 


### PR DESCRIPTION
This PR add some new metrics for EXPLAIN ANALYZE  and fix some bugs:

## new metrics
1. the cost to dispatch FragmentInstance for one query
2. pageReaderMaxUsedMemorySize for one FragmentInstance
3. TimeSeriesMetadataModificationCount/Time for one FragmentInstance

## bug fixed
1. Fix wrong filteredRowCount in FilterAndTransformOperator
2. Fix permission of EXPLAIN ANALYZE to keep it the same query SQL. 