### PR TITLE
Fix uncaught IllegalArgumentException when reading broken WAL files

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALMetaData.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALMetaData.java
@@ -131,7 +131,8 @@ public class WALMetaData implements SerializedSize {
 
   public static WALMetaData readFromWALFile(File logFile, FileChannel channel) throws IOException {
     if (channel.size() < WALWriter.MAGIC_STRING_V2_BYTES || !isValidMagicString(channel)) {
-      throw new IOException(String.format("Broken wal file %s, size %d", logFile, logFile.length()));
+      throw new IOException(
+          String.format("Broken wal file %s, size %d", logFile, logFile.length()));
     }
 
     // load metadata size
@@ -144,8 +145,8 @@ public class WALMetaData implements SerializedSize {
           channel.size()
               - Integer.BYTES
               - (version == WALFileVersion.V2
-              ? WALWriter.MAGIC_STRING_V2_BYTES
-              : WALWriter.MAGIC_STRING_V1_BYTES);
+                  ? WALWriter.MAGIC_STRING_V2_BYTES
+                  : WALWriter.MAGIC_STRING_V1_BYTES);
       channel.read(metadataSizeBuf, position);
       metadataSizeBuf.flip();
       // load metadata
@@ -167,7 +168,8 @@ public class WALMetaData implements SerializedSize {
         }
       }
     } catch (IllegalArgumentException e) {
-      throw new IOException(String.format("Broken wal file %s, size %d", logFile, logFile.length()));
+      throw new IOException(
+          String.format("Broken wal file %s, size %d", logFile, logFile.length()));
     }
     return metaData;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALMetaData.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALMetaData.java
@@ -131,38 +131,43 @@ public class WALMetaData implements SerializedSize {
 
   public static WALMetaData readFromWALFile(File logFile, FileChannel channel) throws IOException {
     if (channel.size() < WALWriter.MAGIC_STRING_V2_BYTES || !isValidMagicString(channel)) {
-      throw new IOException(String.format("Broken wal file %s", logFile));
+      throw new IOException(String.format("Broken wal file %s, size %d", logFile, logFile.length()));
     }
 
     // load metadata size
-    ByteBuffer metadataSizeBuf = ByteBuffer.allocate(Integer.BYTES);
+    WALMetaData metaData = null;
     long position;
-    WALFileVersion version = WALFileVersion.getVersion(channel);
-    position =
-        channel.size()
-            - Integer.BYTES
-            - (version == WALFileVersion.V2
-                ? WALWriter.MAGIC_STRING_V2_BYTES
-                : WALWriter.MAGIC_STRING_V1_BYTES);
-    channel.read(metadataSizeBuf, position);
-    metadataSizeBuf.flip();
-    // load metadata
-    int metadataSize = metadataSizeBuf.getInt();
-    ByteBuffer metadataBuf = ByteBuffer.allocate(metadataSize);
-    channel.read(metadataBuf, position - metadataSize);
-    metadataBuf.flip();
-    WALMetaData metaData = WALMetaData.deserialize(metadataBuf);
-    // versions before V1.3, should recover memTable ids from entries
-    if (metaData.memTablesId.isEmpty()) {
-      int offset = Byte.BYTES;
-      for (int size : metaData.buffersSize) {
-        channel.position(offset);
-        ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
-        channel.read(buffer);
-        buffer.clear();
-        metaData.memTablesId.add(buffer.getLong());
-        offset += size;
+    try {
+      ByteBuffer metadataSizeBuf = ByteBuffer.allocate(Integer.BYTES);
+      WALFileVersion version = WALFileVersion.getVersion(channel);
+      position =
+          channel.size()
+              - Integer.BYTES
+              - (version == WALFileVersion.V2
+              ? WALWriter.MAGIC_STRING_V2_BYTES
+              : WALWriter.MAGIC_STRING_V1_BYTES);
+      channel.read(metadataSizeBuf, position);
+      metadataSizeBuf.flip();
+      // load metadata
+      int metadataSize = metadataSizeBuf.getInt();
+      ByteBuffer metadataBuf = ByteBuffer.allocate(metadataSize);
+      channel.read(metadataBuf, position - metadataSize);
+      metadataBuf.flip();
+      metaData = WALMetaData.deserialize(metadataBuf);
+      // versions before V1.3, should recover memTable ids from entries
+      if (metaData.memTablesId.isEmpty()) {
+        int offset = Byte.BYTES;
+        for (int size : metaData.buffersSize) {
+          channel.position(offset);
+          ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+          channel.read(buffer);
+          buffer.clear();
+          metaData.memTablesId.add(buffer.getLong());
+          offset += size;
+        }
       }
+    } catch (IllegalArgumentException e) {
+      throw new IOException(String.format("Broken wal file %s, size %d", logFile, logFile.length()));
     }
     return metaData;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALMetaData.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALMetaData.java
@@ -170,6 +170,10 @@ public class WALMetaData implements SerializedSize {
     } catch (IllegalArgumentException e) {
       throw new IOException(
           String.format("Broken wal file %s, size %d", logFile, logFile.length()));
+    } catch (IOException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IOException("Unexpected exception", e);
     }
     return metaData;
   }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALFileTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALFileTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iotdb.db.storageengine.dataregion.wal.io;
 
-import java.nio.channels.FileChannel;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
@@ -46,6 +45,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -160,10 +160,12 @@ public class WALFileTest {
   @Test
   public void testReadMetadataFromBrokenFile() throws IOException {
     ILogWriter walWriter = new WALWriter(walFile);
-    assertThrows(IOException.class, () -> WALMetaData.readFromWALFile(walFile, FileChannel.open(walFile.toPath())));
+    assertThrows(
+        IOException.class,
+        () -> WALMetaData.readFromWALFile(walFile, FileChannel.open(walFile.toPath())));
     walWriter.close();
-    WALMetaData walMetaData = WALMetaData.readFromWALFile(walFile,
-        FileChannel.open(walFile.toPath()));
+    WALMetaData walMetaData =
+        WALMetaData.readFromWALFile(walFile, FileChannel.open(walFile.toPath()));
     assertTrue(walMetaData.getMemTablesId().isEmpty());
   }
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALFileTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALFileTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.storageengine.dataregion.wal.io;
 
+import java.nio.channels.FileChannel;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
@@ -51,6 +52,8 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class WALFileTest {
 
@@ -152,6 +155,16 @@ public class WALFileTest {
       }
     }
     assertEquals(expectedWALEntries, actualWALEntries);
+  }
+
+  @Test
+  public void testReadMetadataFromBrokenFile() throws IOException {
+    ILogWriter walWriter = new WALWriter(walFile);
+    assertThrows(IOException.class, () -> WALMetaData.readFromWALFile(walFile, FileChannel.open(walFile.toPath())));
+    walWriter.close();
+    WALMetaData walMetaData = WALMetaData.readFromWALFile(walFile,
+        FileChannel.open(walFile.toPath()));
+    assertTrue(walMetaData.getMemTablesId().isEmpty());
   }
 
   public static InsertRowNode getInsertRowNode(String devicePath) throws IllegalPathException {


### PR DESCRIPTION
As the title indicates.