### PR TITLE
Perfect the print result of dispatch and timeseries metadata modification in explain analyze

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/MPPQueryContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/MPPQueryContext.java
@@ -258,8 +258,12 @@ public class MPPQueryContext {
     return queryPlanStatistics.getLogicalOptimizationCost();
   }
 
-  public long getDispatchCost() {
-    return queryPlanStatistics.getDispatchCost();
+  public void setDispatchStartTime(long time) {
+    this.queryPlanStatistics.setDispatchStartTime(time);
+  }
+
+  public long getDispatchStartTime() {
+    return queryPlanStatistics.getDispatchStartTime();
   }
 
   public void setAnalyzeCost(long analyzeCost) {
@@ -302,13 +306,6 @@ public class MPPQueryContext {
       queryPlanStatistics = new QueryPlanStatistics();
     }
     queryPlanStatistics.setLogicalOptimizationCost(logicalOptimizeCost);
-  }
-
-  public void recordDispatchCost(long dispatchCost) {
-    if (queryPlanStatistics == null) {
-      queryPlanStatistics = new QueryPlanStatistics();
-    }
-    queryPlanStatistics.recordDispatchCost(dispatchCost);
   }
 
   // region =========== FE memory related, make sure its not called concurrently ===========

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/FragmentInstanceDispatcherImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/FragmentInstanceDispatcherImpl.java
@@ -125,6 +125,7 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
   //  topological dispatch according to dependency relations between FragmentInstances
   private Future<FragInstanceDispatchResult> dispatchRead(List<FragmentInstance> instances) {
     long startTime = System.nanoTime();
+    queryContext.setDispatchStartTime(startTime);
     for (FragmentInstance instance : instances) {
       try (SetThreadName threadName = new SetThreadName(instance.getId().getFullId())) {
         dispatchOneInstance(instance);
@@ -146,11 +147,10 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
           // TypeProvider is not used in EXPLAIN ANALYZE, so we can clear it
           instance.getFragment().clearTypeProvider();
         }
+        QUERY_EXECUTION_METRIC_SET.recordExecutionCost(
+            DISPATCH_READ, System.nanoTime() - startTime);
       }
     }
-    long dispatchReadTime = System.nanoTime() - startTime;
-    QUERY_EXECUTION_METRIC_SET.recordExecutionCost(DISPATCH_READ, dispatchReadTime);
-    queryContext.recordDispatchCost(dispatchReadTime);
     return immediateFuture(new FragInstanceDispatchResult(true));
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/FragmentInstanceDispatcherImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/FragmentInstanceDispatcherImpl.java
@@ -124,8 +124,8 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
   //  unsafe for current FragmentInstance scheduler framework. We need to implement the
   //  topological dispatch according to dependency relations between FragmentInstances
   private Future<FragInstanceDispatchResult> dispatchRead(List<FragmentInstance> instances) {
+    long startTime = System.nanoTime();
     for (FragmentInstance instance : instances) {
-      long startTime = System.nanoTime();
       try (SetThreadName threadName = new SetThreadName(instance.getId().getFullId())) {
         dispatchOneInstance(instance);
       } catch (FragmentInstanceDispatchException e) {
@@ -146,11 +146,11 @@ public class FragmentInstanceDispatcherImpl implements IFragInstanceDispatcher {
           // TypeProvider is not used in EXPLAIN ANALYZE, so we can clear it
           instance.getFragment().clearTypeProvider();
         }
-        long dispatchReadTime = System.nanoTime() - startTime;
-        QUERY_EXECUTION_METRIC_SET.recordExecutionCost(DISPATCH_READ, dispatchReadTime);
-        queryContext.recordDispatchCost(dispatchReadTime);
       }
     }
+    long dispatchReadTime = System.nanoTime() - startTime;
+    QUERY_EXECUTION_METRIC_SET.recordExecutionCost(DISPATCH_READ, dispatchReadTime);
+    queryContext.recordDispatchCost(dispatchReadTime);
     return immediateFuture(new FragInstanceDispatchResult(true));
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/statistics/FragmentInstanceStatisticsDrawer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/statistics/FragmentInstanceStatisticsDrawer.java
@@ -72,7 +72,9 @@ public class FragmentInstanceStatisticsDrawer {
     addLine(
         planHeader,
         0,
-        String.format("Dispatch Cost: %.3f ms", context.getDispatchCost() * NS_TO_MS_FACTOR));
+        String.format(
+            "Single Dispatch Cost: %.3f ms",
+            (System.nanoTime() - context.getDispatchStartTime()) * NS_TO_MS_FACTOR));
   }
 
   public List<StatisticLine> renderFragmentInstances(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/statistics/FragmentInstanceStatisticsDrawer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/statistics/FragmentInstanceStatisticsDrawer.java
@@ -245,6 +245,26 @@ public class FragmentInstanceStatisticsDrawer {
         2,
         "loadTimeSeriesMetadataAlignedMemUnSeqTime",
         queryStatistics.loadTimeSeriesMetadataAlignedMemUnSeqTime * NS_TO_MS_FACTOR);
+    addLineWithValueCheck(
+        singleFragmentInstanceArea,
+        2,
+        "alignedTimeSeriesMetadataModificationCount",
+        queryStatistics.getAlignedTimeSeriesMetadataModificationCount());
+    addLineWithValueCheck(
+        singleFragmentInstanceArea,
+        2,
+        "alignedTimeSeriesMetadataModificationTime",
+        queryStatistics.getAlignedTimeSeriesMetadataModificationTime() * NS_TO_MS_FACTOR);
+    addLineWithValueCheck(
+        singleFragmentInstanceArea,
+        2,
+        "nonAlignedTimeSeriesMetadataModificationCount",
+        queryStatistics.getNonAlignedTimeSeriesMetadataModificationCount());
+    addLineWithValueCheck(
+        singleFragmentInstanceArea,
+        2,
+        "nonAlignedTimeSeriesMetadataModificationTime",
+        queryStatistics.getNonAlignedTimeSeriesMetadataModificationTime() * NS_TO_MS_FACTOR);
 
     addLineWithValueCheck(
         singleFragmentInstanceArea,
@@ -333,26 +353,6 @@ public class FragmentInstanceStatisticsDrawer {
         2,
         "pageReaderMaxUsedMemorySize",
         queryStatistics.pageReaderMaxUsedMemorySize);
-    addLineWithValueCheck(
-        singleFragmentInstanceArea,
-        1,
-        "AlignedTimeSeriesMetadataModificationCount",
-        queryStatistics.getAlignedTimeSeriesMetadataModificationCount());
-    addLineWithValueCheck(
-        singleFragmentInstanceArea,
-        1,
-        "AlignedTimeSeriesMetadataModificationTime",
-        queryStatistics.getAlignedTimeSeriesMetadataModificationTime() * NS_TO_MS_FACTOR);
-    addLineWithValueCheck(
-        singleFragmentInstanceArea,
-        1,
-        "NonAlignedTimeSeriesMetadataModificationCount",
-        queryStatistics.getNonAlignedTimeSeriesMetadataModificationCount());
-    addLineWithValueCheck(
-        singleFragmentInstanceArea,
-        1,
-        "NonAlignedTimeSeriesMetadataModificationTime",
-        queryStatistics.getNonAlignedTimeSeriesMetadataModificationTime() * NS_TO_MS_FACTOR);
   }
 
   private void addLine(List<StatisticLine> resultForSingleInstance, int level, String value) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/statistics/QueryPlanStatistics.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/statistics/QueryPlanStatistics.java
@@ -26,7 +26,7 @@ public class QueryPlanStatistics {
   private long logicalPlanCost;
   private long logicalOptimizationCost;
   private long distributionPlanCost;
-  private long dispatchCost = 0;
+  private long dispatchStartTime = 0;
 
   public void setAnalyzeCost(long analyzeCost) {
     this.analyzeCost = analyzeCost;
@@ -50,10 +50,6 @@ public class QueryPlanStatistics {
 
   public void setLogicalOptimizationCost(long logicalOptimizationCost) {
     this.logicalOptimizationCost = logicalOptimizationCost;
-  }
-
-  public void recordDispatchCost(long dispatchCost) {
-    this.dispatchCost += dispatchCost;
   }
 
   public long getAnalyzeCost() {
@@ -80,7 +76,11 @@ public class QueryPlanStatistics {
     return logicalOptimizationCost;
   }
 
-  public long getDispatchCost() {
-    return dispatchCost;
+  public void setDispatchStartTime(long dispatchStartTime) {
+    this.dispatchStartTime = dispatchStartTime;
+  }
+
+  public long getDispatchStartTime() {
+    return dispatchStartTime;
   }
 }


### PR DESCRIPTION
## Description

an example output:

|Analyze Cost: 26.489 ms                                                                        |
|Fetch Partition Cost: 3.825 ms                                                                 |
|Fetch Schema Cost: 21.259 ms                                                                   |
|Logical Plan Cost: 0.340 ms                                                                    |
|Logical Optimization Cost: 0.010 ms                                                            |
|Distribution Plan Cost: 1.019 ms                                                               |
|Single Dispatch Cost: 0.795 ms                                                                 |
|Fragment Instances Count: 4

|FRAGMENT-INSTANCE[Id: 20240712_140939_00011_1.3.0][IP: 0.0.0.0][DataRegion: 1][State: FINISHED]|
|  Total Wall Time: 13 ms                                                                       |
|  Cost of initDataQuerySource: 0.039 ms                                                        |
|  Seq File(unclosed): 0, Seq File(closed): 6                                                   |
|  UnSeq File(unclosed): 0, UnSeq File(closed): 0                                               |
|  ready queued time: 1.909 ms, blocked queued time: 3.114 ms                                   |
|  Query Statistics:                                                                            |
|    loadTimeSeriesMetadataDiskSeqCount: 24                                                     |
|    loadTimeSeriesMetadataDiskSeqTime: 6.259                                                   |
|    nonAlignedTimeSeriesMetadataModificationCount: 1                                           |
|    nonAlignedTimeSeriesMetadataModificationTime: 0.345                                        |
|    constructNonAlignedChunkReadersDiskCount: 21                                               |
|    constructNonAlignedChunkReadersDiskTime: 1.467                                             |
|    pageReadersDecodeNonAlignedDiskCount: 21                                                   |
|    pageReadersDecodeNonAlignedDiskTime: 1.833                                                 |
|    [PlanNodeId 42]: IdentitySinkNode(IdentitySinkOperator)                                    |
|        CPU Time: 3.767 ms

