### PR TITLE
Do not remove top-level load dir after load & add retry for getting disk space

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/load/LoadTsFileManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/load/LoadTsFileManager.java
@@ -296,22 +296,6 @@ public class LoadTsFileManager {
     if (Objects.nonNull(writerManager)) {
       writerManager.close();
     }
-
-    for (final Path loadDirPath :
-        Arrays.stream(LOAD_BASE_DIRS.get())
-            .map(File::new)
-            .filter(File::exists)
-            .map(File::toPath)
-            .collect(Collectors.toList())) {
-      try {
-        Files.deleteIfExists(loadDirPath);
-        LOGGER.info("Load dir {} was deleted.", loadDirPath);
-      } catch (DirectoryNotEmptyException e) {
-        LOGGER.info("Load dir {} is not empty, skip deleting.", loadDirPath);
-      } catch (Exception e) {
-        LOGGER.info(MESSAGE_DELETE_FAIL, loadDirPath);
-      }
-    }
   }
 
   public static void updateWritePointCountMetrics(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/load/LoadTsFileManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/load/LoadTsFileManager.java
@@ -65,7 +65,6 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/strategy/SequenceStrategy.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/strategy/SequenceStrategy.java
@@ -62,7 +62,7 @@ public class SequenceStrategy extends DirectoryStrategy {
     while (!JVMCommonUtils.hasSpace(dir)) {
       File dirFile = FSFactoryProducer.getFSFactory().getFile(dir);
 
-      Long lastPrintTime = dirLastPrintTimeMap.putIfAbsent(index, -1L);
+      Long lastPrintTime = dirLastPrintTimeMap.computeIfAbsent(index, i -> -1L);
       if (System.currentTimeMillis() - lastPrintTime > PRINT_INTERVAL_MS) {
         long freeSpace = dirFile.getFreeSpace();
         long totalSpace = dirFile.getTotalSpace();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/strategy/SequenceStrategy.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/strategy/SequenceStrategy.java
@@ -78,6 +78,7 @@ public class SequenceStrategy extends DirectoryStrategy {
         throw new DiskSpaceInsufficientException(folders);
       }
       index = (index + 1) % folders.size();
+      dir = folders.get(index);
     }
     return index;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/strategy/SequenceStrategy.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/strategy/SequenceStrategy.java
@@ -18,14 +18,20 @@
  */
 package org.apache.iotdb.db.storageengine.rescon.disk.strategy;
 
+import java.io.File;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.iotdb.commons.utils.JVMCommonUtils;
 import org.apache.iotdb.db.exception.DiskSpaceInsufficientException;
 
 import java.util.List;
+import org.apache.tsfile.fileSystem.FSFactoryProducer;
 
 public class SequenceStrategy extends DirectoryStrategy {
 
+  private static final long PRINT_INTERVAL_MS = 3600 * 1000L;
   private int currentIndex;
+  private Map<Integer, Long> dirLastPrintTimeMap = new ConcurrentHashMap<>();
 
   @Override
   public void setFolders(List<String> folders) throws DiskSpaceInsufficientException {
@@ -52,7 +58,18 @@ public class SequenceStrategy extends DirectoryStrategy {
 
   private int tryGetNextIndex(int start) throws DiskSpaceInsufficientException {
     int index = (start + 1) % folders.size();
-    while (!JVMCommonUtils.hasSpace(folders.get(index))) {
+    String dir = folders.get(index);
+    while (!JVMCommonUtils.hasSpace(dir)) {
+      File dirFile = FSFactoryProducer.getFSFactory().getFile(dir);
+
+      Long lastPrintTime = dirLastPrintTimeMap.putIfAbsent(index, -1L);
+      if (System.currentTimeMillis() - lastPrintTime > PRINT_INTERVAL_MS) {
+        long freeSpace = dirFile.getFreeSpace();
+        long totalSpace = dirFile.getTotalSpace();
+        LOGGER.warn("{} is above the warning threshold, free space {}, total space{}", dir,
+            freeSpace, totalSpace);
+        dirLastPrintTimeMap.put(index, System.currentTimeMillis());
+      }
       if (index == start) {
         throw new DiskSpaceInsufficientException(folders);
       }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/strategy/SequenceStrategy.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/strategy/SequenceStrategy.java
@@ -18,14 +18,15 @@
  */
 package org.apache.iotdb.db.storageengine.rescon.disk.strategy;
 
-import java.io.File;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import org.apache.iotdb.commons.utils.JVMCommonUtils;
 import org.apache.iotdb.db.exception.DiskSpaceInsufficientException;
 
-import java.util.List;
 import org.apache.tsfile.fileSystem.FSFactoryProducer;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class SequenceStrategy extends DirectoryStrategy {
 
@@ -66,8 +67,11 @@ public class SequenceStrategy extends DirectoryStrategy {
       if (System.currentTimeMillis() - lastPrintTime > PRINT_INTERVAL_MS) {
         long freeSpace = dirFile.getFreeSpace();
         long totalSpace = dirFile.getTotalSpace();
-        LOGGER.warn("{} is above the warning threshold, free space {}, total space{}", dir,
-            freeSpace, totalSpace);
+        LOGGER.warn(
+            "{} is above the warning threshold, free space {}, total space{}",
+            dir,
+            freeSpace,
+            totalSpace);
         dirLastPrintTimeMap.put(index, System.currentTimeMillis());
       }
       if (index == start) {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/JVMCommonUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/JVMCommonUtils.java
@@ -29,8 +29,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class JVMCommonUtils {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JVMCommonUtils.class);
   /** Default executor pool maximum size. */
   public static final int MAX_EXECUTOR_POOL_SIZE = Math.max(100, getCpuCores() * 5);
 
@@ -67,7 +71,9 @@ public class JVMCommonUtils {
 
   public static double getDiskFreeRatio(String dir) {
     File dirFile = FSFactoryProducer.getFSFactory().getFile(dir);
-    dirFile.mkdirs();
+    if (!dirFile.mkdirs() && !dirFile.isDirectory()) {
+      LOGGER.error("Cannot create directory {}", dir);
+    }
     return 1.0 * dirFile.getFreeSpace() / dirFile.getTotalSpace();
   }
 


### PR DESCRIPTION
As the title indicates.
The frequent deletion and re-creation of the top-level load dir may cause concurrent issues, which lead to failures of getting disk space. 