### PR TITLE
Pipe: support alter pipe source

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeAlterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeAlterIT.java
@@ -53,7 +53,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
     // Create pipe
     final String sql =
         String.format(
-            "create pipe a2b with source ('source' = 'iotdb-source' ) with processor ('processor'='do-nothing-processor') with sink ('node-urls'='%s')",
+            "create pipe a2b with source ('source' = 'iotdb-source', 'source.pattern' = 'root.**' ) with processor ('processor'='do-nothing-processor') with sink ('node-urls'='%s')",
             receiverDataNode.getIpAndPortString());
     try (final Connection connection = senderEnv.getConnection();
         final Statement statement = connection.createStatement()) {
@@ -72,6 +72,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       Assert.assertEquals("RUNNING", showPipeResult.get(0).state);
       // Check configurations
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
+      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.**"));
       Assert.assertTrue(
           showPipeResult.get(0).pipeProcessor.contains("processor=do-nothing-processor"));
       Assert.assertTrue(
@@ -116,7 +117,9 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // Check status
       Assert.assertEquals("STOPPED", showPipeResult.get(0).state);
       // Check configurations
+      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source.path=root.timecho"));
+      Assert.assertFalse(showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.**"));
       Assert.assertTrue(
           showPipeResult.get(0).pipeProcessor.contains("processor=do-nothing-processor"));
       Assert.assertTrue(
@@ -457,7 +460,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
   }
 
   @Test
-  public void testPipeSourceAndProcessor() {
+  public void testAlterPipeSourceAndProcessor() {
     final DataNodeWrapper receiverDataNode = receiverEnv.getDataNodeWrapper(0);
 
     // Create pipe

--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeAlterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeAlterIT.java
@@ -116,8 +116,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // Check status
       Assert.assertEquals("STOPPED", showPipeResult.get(0).state);
       // Check configurations
-      Assert.assertTrue(
-          showPipeResult.get(0).pipeExtractor.contains("source.path=root.timecho"));
+      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source.path=root.timecho"));
       Assert.assertTrue(
           showPipeResult.get(0).pipeProcessor.contains("processor=do-nothing-processor"));
       Assert.assertTrue(
@@ -510,10 +509,10 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
 
     // Insert data on sender
     if (!TestUtils.tryExecuteNonQueriesWithRetry(
-            senderEnv,
-            Arrays.asList(
-                    "insert into root.db.d1 (time, at1) values (11000, 1), (11500, 2), (12000, 3), (12500, 4), (13000, 5)",
-                    "flush"))) {
+        senderEnv,
+        Arrays.asList(
+            "insert into root.db.d1 (time, at1) values (11000, 1), (11500, 2), (12000, 3), (12500, 4), (13000, 5)",
+            "flush"))) {
       fail();
     }
 

--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeAlterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeAlterIT.java
@@ -103,7 +103,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
     // Alter pipe (modify)
     try (final Connection connection = senderEnv.getConnection();
         final Statement statement = connection.createStatement()) {
-      statement.execute("alter pipe a2b modify source ('source.pattern'='root.timecho')");
+      statement.execute("alter pipe a2b modify source ('source.path'='root.timecho')");
     } catch (SQLException e) {
       fail(e.getMessage());
     }
@@ -117,7 +117,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       Assert.assertEquals("STOPPED", showPipeResult.get(0).state);
       // Check configurations
       Assert.assertTrue(
-          showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho"));
+          showPipeResult.get(0).pipeExtractor.contains("source.path=root.timecho"));
       Assert.assertTrue(
           showPipeResult.get(0).pipeProcessor.contains("processor=do-nothing-processor"));
       Assert.assertTrue(
@@ -136,7 +136,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
     try (final Connection connection = senderEnv.getConnection();
         final Statement statement = connection.createStatement()) {
       statement.execute(
-          "alter pipe a2b replace source ('source' = 'iotdb-source','source.pattern'='root.timecho.wf01')");
+          "alter pipe a2b replace source ('source' = 'iotdb-source','source.path'='root.timecho.wf01')");
     } catch (SQLException e) {
       fail(e.getMessage());
     }
@@ -151,7 +151,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // check configurations
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertTrue(
-          showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
+          showPipeResult.get(0).pipeExtractor.contains("source.path=root.timecho.wf01"));
       Assert.assertTrue(
           showPipeResult.get(0).pipeProcessor.contains("processor=do-nothing-processor"));
       Assert.assertTrue(
@@ -184,7 +184,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // Check configurations
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertTrue(
-          showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
+          showPipeResult.get(0).pipeExtractor.contains("source.path=root.timecho.wf01"));
       Assert.assertTrue(showPipeResult.get(0).pipeConnector.contains("batch.enable=false"));
       Assert.assertTrue(
           showPipeResult.get(0).pipeProcessor.contains("processor=do-nothing-processor"));
@@ -227,7 +227,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // check configurations
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertTrue(
-          showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
+          showPipeResult.get(0).pipeExtractor.contains("source.path=root.timecho.wf01"));
       Assert.assertTrue(
           showPipeResult
               .get(0)
@@ -264,7 +264,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // Check configurations
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertTrue(
-          showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
+          showPipeResult.get(0).pipeExtractor.contains("source.path=root.timecho.wf01"));
       Assert.assertTrue(showPipeResult.get(0).pipeConnector.contains("batch.enable=true"));
       Assert.assertTrue(
           showPipeResult
@@ -301,7 +301,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // check configurations
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertTrue(
-          showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
+          showPipeResult.get(0).pipeExtractor.contains("source.path=root.timecho.wf01"));
       Assert.assertTrue(showPipeResult.get(0).pipeConnector.contains("batch.enable=true"));
       Assert.assertTrue(
           showPipeResult
@@ -338,7 +338,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // check configurations
       Assert.assertFalse(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertFalse(
-          showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
+          showPipeResult.get(0).pipeExtractor.contains("source.path=root.timecho.wf01"));
       Assert.assertTrue(showPipeResult.get(0).pipeConnector.contains("batch.enable=true"));
       Assert.assertTrue(
           showPipeResult
@@ -375,7 +375,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // check configurations
       Assert.assertFalse(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertFalse(
-          showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
+          showPipeResult.get(0).pipeExtractor.contains("source.path=root.timecho.wf01"));
       Assert.assertTrue(showPipeResult.get(0).pipeConnector.contains("batch.enable=true"));
       Assert.assertFalse(
           showPipeResult
@@ -488,9 +488,9 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
     expectedResSet.add("2000,3.0,");
     expectedResSet.add("3000,5.0,");
     TestUtils.assertDataEventuallyOnEnv(
-        receiverEnv, "select * from root.db.d1", "Time,root.db.d1.at1,", expectedResSet);
+        receiverEnv, "select * from root.db.**", "Time,root.db.d1.at1,", expectedResSet);
 
-    // Alter pipe (modify 'source.pattern' and 'processor.tumbling-time.interval-seconds')
+    // Alter pipe (modify 'source.path' and 'processor.tumbling-time.interval-seconds')
     try (final Connection connection = senderEnv.getConnection();
         final Statement statement = connection.createStatement()) {
       statement.execute(
@@ -508,13 +508,22 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       fail();
     }
 
+    // Insert data on sender
+    if (!TestUtils.tryExecuteNonQueriesWithRetry(
+            senderEnv,
+            Arrays.asList(
+                    "insert into root.db.d1 (time, at1) values (11000, 1), (11500, 2), (12000, 3), (12500, 4), (13000, 5)",
+                    "flush"))) {
+      fail();
+    }
+
     // Check data on receiver
     expectedResSet.clear();
     expectedResSet.add("11000,1.0,");
     expectedResSet.add("13000,5.0,");
     TestUtils.assertDataEventuallyOnEnv(
         receiverEnv,
-        "select * from root.db.d2 where time > 10000",
+        "select * from root.db.** where time > 10000",
         "Time,root.db.d2.at1,",
         expectedResSet);
   }

--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeAlterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeAlterIT.java
@@ -518,12 +518,12 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
 
     // Check data on receiver
     expectedResSet.clear();
-    expectedResSet.add("11000,1.0,");
-    expectedResSet.add("13000,5.0,");
+    expectedResSet.add("11000,null,1.0,");
+    expectedResSet.add("13000,null,5.0,");
     TestUtils.assertDataEventuallyOnEnv(
         receiverEnv,
         "select * from root.db.** where time > 10000",
-        "Time,root.db.d2.at1,",
+        "Time,root.db.d1.at1,root.db.d2.at1,",
         expectedResSet);
   }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeAlterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeAlterIT.java
@@ -53,7 +53,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
     // Create pipe
     final String sql =
         String.format(
-            "create pipe a2b with source ('source' = 'iotdb-source', 'source.pattern' = 'root.**' ) with processor ('processor'='do-nothing-processor') with sink ('node-urls'='%s')",
+            "create pipe a2b with source ('source'='iotdb-source', 'source.pattern'='root.test1', 'source.path'='root.test2.**') with processor ('processor'='do-nothing-processor') with sink ('node-urls'='%s')",
             receiverDataNode.getIpAndPortString());
     try (final Connection connection = senderEnv.getConnection();
         final Statement statement = connection.createStatement()) {
@@ -73,6 +73,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // Check configurations
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.test1"));
+      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source.path=root.test2.**"));
       Assert.assertTrue(
           showPipeResult.get(0).pipeProcessor.contains("processor=do-nothing-processor"));
       Assert.assertTrue(
@@ -118,8 +119,9 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       Assert.assertEquals("STOPPED", showPipeResult.get(0).state);
       // Check configurations
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
+      Assert.assertFalse(showPipeResult.get(0).pipeExtractor.contains("source.path=root.test2.**"));
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.**"));
-      Assert.assertFalse(showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.test1"));
+      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.test1"));
       Assert.assertTrue(
           showPipeResult.get(0).pipeProcessor.contains("processor=do-nothing-processor"));
       Assert.assertTrue(
@@ -138,7 +140,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
     try (final Connection connection = senderEnv.getConnection();
         final Statement statement = connection.createStatement()) {
       statement.execute(
-          "alter pipe a2b replace source ('source' = 'iotdb-source','source.path'='root.test1.wf01')");
+          "alter pipe a2b replace source ('source'='iotdb-source', 'source.path'='root.test1.wf01')");
     } catch (SQLException e) {
       fail(e.getMessage());
     }
@@ -155,6 +157,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       Assert.assertTrue(
           showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.wf01"));
       Assert.assertFalse(showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.**"));
+      Assert.assertFalse(showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.test1"));
       Assert.assertTrue(
           showPipeResult.get(0).pipeProcessor.contains("processor=do-nothing-processor"));
       Assert.assertTrue(

--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeAlterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeAlterIT.java
@@ -53,7 +53,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
     // Create pipe
     final String sql =
         String.format(
-            "create pipe a2b with source ('source'='iotdb-source', 'source.pattern'='root.test1', 'source.path'='root.test2.**') with processor ('processor'='do-nothing-processor') with sink ('node-urls'='%s')",
+            "create pipe a2b with source ('source'='iotdb-source', 'source.pattern'='root.test1', 'source.realtime.mode'='stream') with processor ('processor'='do-nothing-processor') with sink ('node-urls'='%s')",
             receiverDataNode.getIpAndPortString());
     try (final Connection connection = senderEnv.getConnection();
         final Statement statement = connection.createStatement()) {
@@ -73,7 +73,8 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // Check configurations
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.test1"));
-      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source.path=root.test2.**"));
+      Assert.assertTrue(
+          showPipeResult.get(0).pipeExtractor.contains("source.realtime.mode=stream"));
       Assert.assertTrue(
           showPipeResult.get(0).pipeProcessor.contains("processor=do-nothing-processor"));
       Assert.assertTrue(
@@ -105,7 +106,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
     // Alter pipe (modify)
     try (final Connection connection = senderEnv.getConnection();
         final Statement statement = connection.createStatement()) {
-      statement.execute("alter pipe a2b modify source ('source.path'='root.test1.**')");
+      statement.execute("alter pipe a2b modify source ('source.pattern'='root.test2')");
     } catch (SQLException e) {
       fail(e.getMessage());
     }
@@ -119,9 +120,9 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       Assert.assertEquals("STOPPED", showPipeResult.get(0).state);
       // Check configurations
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
-      Assert.assertFalse(showPipeResult.get(0).pipeExtractor.contains("source.path=root.test2.**"));
-      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.**"));
-      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.test1"));
+      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.test2"));
+      Assert.assertTrue(
+          showPipeResult.get(0).pipeExtractor.contains("source.realtime.mode=stream"));
       Assert.assertTrue(
           showPipeResult.get(0).pipeProcessor.contains("processor=do-nothing-processor"));
       Assert.assertTrue(
@@ -140,7 +141,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
     try (final Connection connection = senderEnv.getConnection();
         final Statement statement = connection.createStatement()) {
       statement.execute(
-          "alter pipe a2b replace source ('source'='iotdb-source', 'source.path'='root.test1.wf01')");
+          "alter pipe a2b replace source ('source'='iotdb-source', 'source.path'='root.test1.**')");
     } catch (SQLException e) {
       fail(e.getMessage());
     }
@@ -154,10 +155,10 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       Assert.assertEquals("STOPPED", showPipeResult.get(0).state);
       // check configurations
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
-      Assert.assertTrue(
-          showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.wf01"));
-      Assert.assertFalse(showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.**"));
-      Assert.assertFalse(showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.test1"));
+      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.**"));
+      Assert.assertFalse(showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.test2"));
+      Assert.assertFalse(
+          showPipeResult.get(0).pipeExtractor.contains("source.realtime.mode=stream"));
       Assert.assertTrue(
           showPipeResult.get(0).pipeProcessor.contains("processor=do-nothing-processor"));
       Assert.assertTrue(
@@ -189,8 +190,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       Assert.assertEquals("STOPPED", showPipeResult.get(0).state);
       // Check configurations
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
-      Assert.assertTrue(
-          showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.wf01"));
+      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.**"));
       Assert.assertTrue(showPipeResult.get(0).pipeConnector.contains("batch.enable=false"));
       Assert.assertTrue(
           showPipeResult.get(0).pipeProcessor.contains("processor=do-nothing-processor"));
@@ -232,8 +232,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       Assert.assertEquals("RUNNING", showPipeResult.get(0).state);
       // check configurations
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
-      Assert.assertTrue(
-          showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.wf01"));
+      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.**"));
       Assert.assertTrue(
           showPipeResult
               .get(0)
@@ -269,8 +268,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       Assert.assertEquals("RUNNING", showPipeResult.get(0).state);
       // Check configurations
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
-      Assert.assertTrue(
-          showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.wf01"));
+      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.**"));
       Assert.assertTrue(showPipeResult.get(0).pipeConnector.contains("batch.enable=true"));
       Assert.assertTrue(
           showPipeResult
@@ -306,8 +304,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       Assert.assertEquals("RUNNING", showPipeResult.get(0).state);
       // check configurations
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
-      Assert.assertTrue(
-          showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.wf01"));
+      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.**"));
       Assert.assertTrue(showPipeResult.get(0).pipeConnector.contains("batch.enable=true"));
       Assert.assertTrue(
           showPipeResult
@@ -343,8 +340,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       Assert.assertEquals("RUNNING", showPipeResult.get(0).state);
       // check configurations
       Assert.assertFalse(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
-      Assert.assertFalse(
-          showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.wf01"));
+      Assert.assertFalse(showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.**"));
       Assert.assertTrue(showPipeResult.get(0).pipeConnector.contains("batch.enable=true"));
       Assert.assertTrue(
           showPipeResult
@@ -380,8 +376,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       Assert.assertEquals("RUNNING", showPipeResult.get(0).state);
       // check configurations
       Assert.assertFalse(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
-      Assert.assertFalse(
-          showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.wf01"));
+      Assert.assertFalse(showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.**"));
       Assert.assertTrue(showPipeResult.get(0).pipeConnector.contains("batch.enable=true"));
       Assert.assertFalse(
           showPipeResult

--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeAlterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeAlterIT.java
@@ -72,7 +72,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       Assert.assertEquals("RUNNING", showPipeResult.get(0).state);
       // Check configurations
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
-      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.**"));
+      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.test1"));
       Assert.assertTrue(
           showPipeResult.get(0).pipeProcessor.contains("processor=do-nothing-processor"));
       Assert.assertTrue(
@@ -104,7 +104,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
     // Alter pipe (modify)
     try (final Connection connection = senderEnv.getConnection();
         final Statement statement = connection.createStatement()) {
-      statement.execute("alter pipe a2b modify source ('source.path'='root.timecho')");
+      statement.execute("alter pipe a2b modify source ('source.path'='root.test1.**')");
     } catch (SQLException e) {
       fail(e.getMessage());
     }
@@ -118,8 +118,8 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       Assert.assertEquals("STOPPED", showPipeResult.get(0).state);
       // Check configurations
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
-      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source.path=root.timecho"));
-      Assert.assertFalse(showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.**"));
+      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.**"));
+      Assert.assertFalse(showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.test1"));
       Assert.assertTrue(
           showPipeResult.get(0).pipeProcessor.contains("processor=do-nothing-processor"));
       Assert.assertTrue(
@@ -138,7 +138,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
     try (final Connection connection = senderEnv.getConnection();
         final Statement statement = connection.createStatement()) {
       statement.execute(
-          "alter pipe a2b replace source ('source' = 'iotdb-source','source.path'='root.timecho.wf01')");
+          "alter pipe a2b replace source ('source' = 'iotdb-source','source.path'='root.test1.wf01')");
     } catch (SQLException e) {
       fail(e.getMessage());
     }
@@ -153,7 +153,8 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // check configurations
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertTrue(
-          showPipeResult.get(0).pipeExtractor.contains("source.path=root.timecho.wf01"));
+          showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.wf01"));
+      Assert.assertFalse(showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.**"));
       Assert.assertTrue(
           showPipeResult.get(0).pipeProcessor.contains("processor=do-nothing-processor"));
       Assert.assertTrue(
@@ -186,7 +187,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // Check configurations
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertTrue(
-          showPipeResult.get(0).pipeExtractor.contains("source.path=root.timecho.wf01"));
+          showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.wf01"));
       Assert.assertTrue(showPipeResult.get(0).pipeConnector.contains("batch.enable=false"));
       Assert.assertTrue(
           showPipeResult.get(0).pipeProcessor.contains("processor=do-nothing-processor"));
@@ -229,7 +230,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // check configurations
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertTrue(
-          showPipeResult.get(0).pipeExtractor.contains("source.path=root.timecho.wf01"));
+          showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.wf01"));
       Assert.assertTrue(
           showPipeResult
               .get(0)
@@ -266,7 +267,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // Check configurations
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertTrue(
-          showPipeResult.get(0).pipeExtractor.contains("source.path=root.timecho.wf01"));
+          showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.wf01"));
       Assert.assertTrue(showPipeResult.get(0).pipeConnector.contains("batch.enable=true"));
       Assert.assertTrue(
           showPipeResult
@@ -303,7 +304,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // check configurations
       Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertTrue(
-          showPipeResult.get(0).pipeExtractor.contains("source.path=root.timecho.wf01"));
+          showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.wf01"));
       Assert.assertTrue(showPipeResult.get(0).pipeConnector.contains("batch.enable=true"));
       Assert.assertTrue(
           showPipeResult
@@ -340,7 +341,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // check configurations
       Assert.assertFalse(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertFalse(
-          showPipeResult.get(0).pipeExtractor.contains("source.path=root.timecho.wf01"));
+          showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.wf01"));
       Assert.assertTrue(showPipeResult.get(0).pipeConnector.contains("batch.enable=true"));
       Assert.assertTrue(
           showPipeResult
@@ -377,7 +378,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // check configurations
       Assert.assertFalse(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertFalse(
-          showPipeResult.get(0).pipeExtractor.contains("source.path=root.timecho.wf01"));
+          showPipeResult.get(0).pipeExtractor.contains("source.path=root.test1.wf01"));
       Assert.assertTrue(showPipeResult.get(0).pipeConnector.contains("batch.enable=true"));
       Assert.assertFalse(
           showPipeResult

--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeAlterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeAlterIT.java
@@ -71,8 +71,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // Check status
       Assert.assertEquals("RUNNING", showPipeResult.get(0).state);
       // Check configurations
-      Assert.assertTrue(
-              showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
+      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertTrue(
           showPipeResult.get(0).pipeProcessor.contains("processor=do-nothing-processor"));
       Assert.assertTrue(
@@ -103,7 +102,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
 
     // Alter pipe (modify)
     try (final Connection connection = senderEnv.getConnection();
-         final Statement statement = connection.createStatement()) {
+        final Statement statement = connection.createStatement()) {
       statement.execute("alter pipe a2b modify source ('source.pattern'='root.timecho')");
     } catch (SQLException e) {
       fail(e.getMessage());
@@ -111,20 +110,21 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
 
     // Show pipe
     try (final SyncConfigNodeIServiceClient client =
-                 (SyncConfigNodeIServiceClient) senderEnv.getLeaderConfigNodeConnection()) {
+        (SyncConfigNodeIServiceClient) senderEnv.getLeaderConfigNodeConnection()) {
       final List<TShowPipeInfo> showPipeResult = client.showPipe(new TShowPipeReq()).pipeInfoList;
       Assert.assertEquals(1, showPipeResult.size());
       // Check status
       Assert.assertEquals("STOPPED", showPipeResult.get(0).state);
       // Check configurations
-      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho"));
       Assert.assertTrue(
-              showPipeResult.get(0).pipeProcessor.contains("processor=do-nothing-processor"));
+          showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho"));
       Assert.assertTrue(
-              showPipeResult
-                      .get(0)
-                      .pipeConnector
-                      .contains(String.format("node-urls=%s", receiverDataNode.getIpAndPortString())));
+          showPipeResult.get(0).pipeProcessor.contains("processor=do-nothing-processor"));
+      Assert.assertTrue(
+          showPipeResult
+              .get(0)
+              .pipeConnector
+              .contains(String.format("node-urls=%s", receiverDataNode.getIpAndPortString())));
       // Check creation time and record last creation time
       Assert.assertTrue(showPipeResult.get(0).creationTime > lastCreationTime);
       lastCreationTime = showPipeResult.get(0).creationTime;
@@ -134,35 +134,31 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
 
     // Alter pipe (replace)
     try (final Connection connection = senderEnv.getConnection();
-         final Statement statement = connection.createStatement()) {
+        final Statement statement = connection.createStatement()) {
       statement.execute(
-              "alter pipe a2b replace source ('source' = 'iotdb-source','source.pattern'='root.timecho.wf01')");
+          "alter pipe a2b replace source ('source' = 'iotdb-source','source.pattern'='root.timecho.wf01')");
     } catch (SQLException e) {
       fail(e.getMessage());
     }
 
     // Show pipe
     try (final SyncConfigNodeIServiceClient client =
-                 (SyncConfigNodeIServiceClient) senderEnv.getLeaderConfigNodeConnection()) {
+        (SyncConfigNodeIServiceClient) senderEnv.getLeaderConfigNodeConnection()) {
       final List<TShowPipeInfo> showPipeResult = client.showPipe(new TShowPipeReq()).pipeInfoList;
       Assert.assertEquals(1, showPipeResult.size());
       // check status
       Assert.assertEquals("STOPPED", showPipeResult.get(0).state);
       // check configurations
+      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertTrue(
-              showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
+          showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
       Assert.assertTrue(
-              showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
+          showPipeResult.get(0).pipeProcessor.contains("processor=do-nothing-processor"));
       Assert.assertTrue(
-              showPipeResult
-                      .get(0)
-                      .pipeProcessor
-                      .contains("processor=do-nothing-processor"));
-      Assert.assertTrue(
-              showPipeResult
-                      .get(0)
-                      .pipeConnector
-                      .contains(String.format("node-urls=%s", receiverDataNode.getIpAndPortString())));
+          showPipeResult
+              .get(0)
+              .pipeConnector
+              .contains(String.format("node-urls=%s", receiverDataNode.getIpAndPortString())));
       // Check creation time and record last creation time
       Assert.assertTrue(showPipeResult.get(0).creationTime > lastCreationTime);
       lastCreationTime = showPipeResult.get(0).creationTime;
@@ -186,10 +182,9 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // Check status
       Assert.assertEquals("STOPPED", showPipeResult.get(0).state);
       // Check configurations
+      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertTrue(
-              showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
-      Assert.assertTrue(
-              showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
+          showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
       Assert.assertTrue(showPipeResult.get(0).pipeConnector.contains("batch.enable=false"));
       Assert.assertTrue(
           showPipeResult.get(0).pipeProcessor.contains("processor=do-nothing-processor"));
@@ -230,10 +225,9 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // check status
       Assert.assertEquals("RUNNING", showPipeResult.get(0).state);
       // check configurations
+      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertTrue(
-              showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
-      Assert.assertTrue(
-              showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
+          showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
       Assert.assertTrue(
           showPipeResult
               .get(0)
@@ -268,10 +262,9 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // Check status
       Assert.assertEquals("RUNNING", showPipeResult.get(0).state);
       // Check configurations
+      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertTrue(
-              showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
-      Assert.assertTrue(
-              showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
+          showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
       Assert.assertTrue(showPipeResult.get(0).pipeConnector.contains("batch.enable=true"));
       Assert.assertTrue(
           showPipeResult
@@ -292,7 +285,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
 
     // Alter pipe (modify empty)
     try (final Connection connection = senderEnv.getConnection();
-         final Statement statement = connection.createStatement()) {
+        final Statement statement = connection.createStatement()) {
       statement.execute("alter pipe a2b modify source ()");
     } catch (SQLException e) {
       fail(e.getMessage());
@@ -300,27 +293,26 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
 
     // show pipe
     try (final SyncConfigNodeIServiceClient client =
-                 (SyncConfigNodeIServiceClient) senderEnv.getLeaderConfigNodeConnection()) {
+        (SyncConfigNodeIServiceClient) senderEnv.getLeaderConfigNodeConnection()) {
       final List<TShowPipeInfo> showPipeResult = client.showPipe(new TShowPipeReq()).pipeInfoList;
       Assert.assertEquals(1, showPipeResult.size());
       // check status
       Assert.assertEquals("RUNNING", showPipeResult.get(0).state);
       // check configurations
+      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertTrue(
-              showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
-      Assert.assertTrue(
-              showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
+          showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
       Assert.assertTrue(showPipeResult.get(0).pipeConnector.contains("batch.enable=true"));
       Assert.assertTrue(
-              showPipeResult
-                      .get(0)
-                      .pipeProcessor
-                      .contains("processor=tumbling-time-sampling-processor"));
+          showPipeResult
+              .get(0)
+              .pipeProcessor
+              .contains("processor=tumbling-time-sampling-processor"));
       Assert.assertTrue(
-              showPipeResult
-                      .get(0)
-                      .pipeConnector
-                      .contains(String.format("node-urls=%s", receiverDataNode.getIpAndPortString())));
+          showPipeResult
+              .get(0)
+              .pipeConnector
+              .contains(String.format("node-urls=%s", receiverDataNode.getIpAndPortString())));
       // Check creation time and record last creation time
       Assert.assertTrue(showPipeResult.get(0).creationTime > lastCreationTime);
       lastCreationTime = showPipeResult.get(0).creationTime;
@@ -330,7 +322,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
 
     // Alter pipe (replace empty)
     try (final Connection connection = senderEnv.getConnection();
-         final Statement statement = connection.createStatement()) {
+        final Statement statement = connection.createStatement()) {
       statement.execute("alter pipe a2b replace source ()");
     } catch (SQLException e) {
       fail(e.getMessage());
@@ -338,27 +330,26 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
 
     // show pipe
     try (final SyncConfigNodeIServiceClient client =
-                 (SyncConfigNodeIServiceClient) senderEnv.getLeaderConfigNodeConnection()) {
+        (SyncConfigNodeIServiceClient) senderEnv.getLeaderConfigNodeConnection()) {
       final List<TShowPipeInfo> showPipeResult = client.showPipe(new TShowPipeReq()).pipeInfoList;
       Assert.assertEquals(1, showPipeResult.size());
       // check status
       Assert.assertEquals("RUNNING", showPipeResult.get(0).state);
       // check configurations
+      Assert.assertFalse(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertFalse(
-              showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
-      Assert.assertFalse(
-              showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
+          showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
       Assert.assertTrue(showPipeResult.get(0).pipeConnector.contains("batch.enable=true"));
       Assert.assertTrue(
-              showPipeResult
-                      .get(0)
-                      .pipeProcessor
-                      .contains("processor=tumbling-time-sampling-processor"));
+          showPipeResult
+              .get(0)
+              .pipeProcessor
+              .contains("processor=tumbling-time-sampling-processor"));
       Assert.assertTrue(
-              showPipeResult
-                      .get(0)
-                      .pipeConnector
-                      .contains(String.format("node-urls=%s", receiverDataNode.getIpAndPortString())));
+          showPipeResult
+              .get(0)
+              .pipeConnector
+              .contains(String.format("node-urls=%s", receiverDataNode.getIpAndPortString())));
       // Check creation time and record last creation time
       Assert.assertTrue(showPipeResult.get(0).creationTime > lastCreationTime);
       lastCreationTime = showPipeResult.get(0).creationTime;
@@ -382,10 +373,9 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // check status
       Assert.assertEquals("RUNNING", showPipeResult.get(0).state);
       // check configurations
+      Assert.assertFalse(showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertFalse(
-              showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
-      Assert.assertFalse(
-              showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
+          showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
       Assert.assertTrue(showPipeResult.get(0).pipeConnector.contains("batch.enable=true"));
       Assert.assertFalse(
           showPipeResult

--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeAlterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeAlterIT.java
@@ -53,7 +53,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
     // Create pipe
     final String sql =
         String.format(
-            "create pipe a2b with processor ('processor'='do-nothing-processor') with sink ('node-urls'='%s')",
+            "create pipe a2b with source ('source' = 'iotdb-source' ) with processor ('processor'='do-nothing-processor') with sink ('node-urls'='%s')",
             receiverDataNode.getIpAndPortString());
     try (final Connection connection = senderEnv.getConnection();
         final Statement statement = connection.createStatement()) {
@@ -71,6 +71,8 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // Check status
       Assert.assertEquals("RUNNING", showPipeResult.get(0).state);
       // Check configurations
+      Assert.assertTrue(
+              showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
       Assert.assertTrue(
           showPipeResult.get(0).pipeProcessor.contains("processor=do-nothing-processor"));
       Assert.assertTrue(
@@ -101,6 +103,75 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
 
     // Alter pipe (modify)
     try (final Connection connection = senderEnv.getConnection();
+         final Statement statement = connection.createStatement()) {
+      statement.execute("alter pipe a2b modify source ('source.pattern'='root.timecho')");
+    } catch (SQLException e) {
+      fail(e.getMessage());
+    }
+
+    // Show pipe
+    try (final SyncConfigNodeIServiceClient client =
+                 (SyncConfigNodeIServiceClient) senderEnv.getLeaderConfigNodeConnection()) {
+      final List<TShowPipeInfo> showPipeResult = client.showPipe(new TShowPipeReq()).pipeInfoList;
+      Assert.assertEquals(1, showPipeResult.size());
+      // Check status
+      Assert.assertEquals("STOPPED", showPipeResult.get(0).state);
+      // Check configurations
+      Assert.assertTrue(showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho"));
+      Assert.assertTrue(
+              showPipeResult.get(0).pipeProcessor.contains("processor=do-nothing-processor"));
+      Assert.assertTrue(
+              showPipeResult
+                      .get(0)
+                      .pipeConnector
+                      .contains(String.format("node-urls=%s", receiverDataNode.getIpAndPortString())));
+      // Check creation time and record last creation time
+      Assert.assertTrue(showPipeResult.get(0).creationTime > lastCreationTime);
+      lastCreationTime = showPipeResult.get(0).creationTime;
+      // Check exception message
+      Assert.assertEquals("", showPipeResult.get(0).exceptionMessage);
+    }
+
+    // Alter pipe (replace)
+    try (final Connection connection = senderEnv.getConnection();
+         final Statement statement = connection.createStatement()) {
+      statement.execute(
+              "alter pipe a2b replace source ('source' = 'iotdb-source','source.pattern'='root.timecho.wf01')");
+    } catch (SQLException e) {
+      fail(e.getMessage());
+    }
+
+    // Show pipe
+    try (final SyncConfigNodeIServiceClient client =
+                 (SyncConfigNodeIServiceClient) senderEnv.getLeaderConfigNodeConnection()) {
+      final List<TShowPipeInfo> showPipeResult = client.showPipe(new TShowPipeReq()).pipeInfoList;
+      Assert.assertEquals(1, showPipeResult.size());
+      // check status
+      Assert.assertEquals("STOPPED", showPipeResult.get(0).state);
+      // check configurations
+      Assert.assertTrue(
+              showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
+      Assert.assertTrue(
+              showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
+      Assert.assertTrue(
+              showPipeResult
+                      .get(0)
+                      .pipeProcessor
+                      .contains("processor=do-nothing-processor"));
+      Assert.assertTrue(
+              showPipeResult
+                      .get(0)
+                      .pipeConnector
+                      .contains(String.format("node-urls=%s", receiverDataNode.getIpAndPortString())));
+      // Check creation time and record last creation time
+      Assert.assertTrue(showPipeResult.get(0).creationTime > lastCreationTime);
+      lastCreationTime = showPipeResult.get(0).creationTime;
+      // check exception message
+      Assert.assertEquals("", showPipeResult.get(0).exceptionMessage);
+    }
+
+    // Alter pipe (modify)
+    try (final Connection connection = senderEnv.getConnection();
         final Statement statement = connection.createStatement()) {
       statement.execute("alter pipe a2b modify sink ('sink.batch.enable'='false')");
     } catch (SQLException e) {
@@ -115,6 +186,10 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // Check status
       Assert.assertEquals("STOPPED", showPipeResult.get(0).state);
       // Check configurations
+      Assert.assertTrue(
+              showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
+      Assert.assertTrue(
+              showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
       Assert.assertTrue(showPipeResult.get(0).pipeConnector.contains("batch.enable=false"));
       Assert.assertTrue(
           showPipeResult.get(0).pipeProcessor.contains("processor=do-nothing-processor"));
@@ -156,6 +231,10 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       Assert.assertEquals("RUNNING", showPipeResult.get(0).state);
       // check configurations
       Assert.assertTrue(
+              showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
+      Assert.assertTrue(
+              showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
+      Assert.assertTrue(
           showPipeResult
               .get(0)
               .pipeProcessor
@@ -189,6 +268,10 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // Check status
       Assert.assertEquals("RUNNING", showPipeResult.get(0).state);
       // Check configurations
+      Assert.assertTrue(
+              showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
+      Assert.assertTrue(
+              showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
       Assert.assertTrue(showPipeResult.get(0).pipeConnector.contains("batch.enable=true"));
       Assert.assertTrue(
           showPipeResult
@@ -200,6 +283,82 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
               .get(0)
               .pipeConnector
               .contains(String.format("node-urls=%s", receiverDataNode.getIpAndPortString())));
+      // Check creation time and record last creation time
+      Assert.assertTrue(showPipeResult.get(0).creationTime > lastCreationTime);
+      lastCreationTime = showPipeResult.get(0).creationTime;
+      // Check exception message
+      Assert.assertEquals("", showPipeResult.get(0).exceptionMessage);
+    }
+
+    // Alter pipe (modify empty)
+    try (final Connection connection = senderEnv.getConnection();
+         final Statement statement = connection.createStatement()) {
+      statement.execute("alter pipe a2b modify source ()");
+    } catch (SQLException e) {
+      fail(e.getMessage());
+    }
+
+    // show pipe
+    try (final SyncConfigNodeIServiceClient client =
+                 (SyncConfigNodeIServiceClient) senderEnv.getLeaderConfigNodeConnection()) {
+      final List<TShowPipeInfo> showPipeResult = client.showPipe(new TShowPipeReq()).pipeInfoList;
+      Assert.assertEquals(1, showPipeResult.size());
+      // check status
+      Assert.assertEquals("RUNNING", showPipeResult.get(0).state);
+      // check configurations
+      Assert.assertTrue(
+              showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
+      Assert.assertTrue(
+              showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
+      Assert.assertTrue(showPipeResult.get(0).pipeConnector.contains("batch.enable=true"));
+      Assert.assertTrue(
+              showPipeResult
+                      .get(0)
+                      .pipeProcessor
+                      .contains("processor=tumbling-time-sampling-processor"));
+      Assert.assertTrue(
+              showPipeResult
+                      .get(0)
+                      .pipeConnector
+                      .contains(String.format("node-urls=%s", receiverDataNode.getIpAndPortString())));
+      // Check creation time and record last creation time
+      Assert.assertTrue(showPipeResult.get(0).creationTime > lastCreationTime);
+      lastCreationTime = showPipeResult.get(0).creationTime;
+      // Check exception message
+      Assert.assertEquals("", showPipeResult.get(0).exceptionMessage);
+    }
+
+    // Alter pipe (replace empty)
+    try (final Connection connection = senderEnv.getConnection();
+         final Statement statement = connection.createStatement()) {
+      statement.execute("alter pipe a2b replace source ()");
+    } catch (SQLException e) {
+      fail(e.getMessage());
+    }
+
+    // show pipe
+    try (final SyncConfigNodeIServiceClient client =
+                 (SyncConfigNodeIServiceClient) senderEnv.getLeaderConfigNodeConnection()) {
+      final List<TShowPipeInfo> showPipeResult = client.showPipe(new TShowPipeReq()).pipeInfoList;
+      Assert.assertEquals(1, showPipeResult.size());
+      // check status
+      Assert.assertEquals("RUNNING", showPipeResult.get(0).state);
+      // check configurations
+      Assert.assertFalse(
+              showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
+      Assert.assertFalse(
+              showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
+      Assert.assertTrue(showPipeResult.get(0).pipeConnector.contains("batch.enable=true"));
+      Assert.assertTrue(
+              showPipeResult
+                      .get(0)
+                      .pipeProcessor
+                      .contains("processor=tumbling-time-sampling-processor"));
+      Assert.assertTrue(
+              showPipeResult
+                      .get(0)
+                      .pipeConnector
+                      .contains(String.format("node-urls=%s", receiverDataNode.getIpAndPortString())));
       // Check creation time and record last creation time
       Assert.assertTrue(showPipeResult.get(0).creationTime > lastCreationTime);
       lastCreationTime = showPipeResult.get(0).creationTime;
@@ -223,6 +382,10 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
       // check status
       Assert.assertEquals("RUNNING", showPipeResult.get(0).state);
       // check configurations
+      Assert.assertFalse(
+              showPipeResult.get(0).pipeExtractor.contains("source=iotdb-source"));
+      Assert.assertFalse(
+              showPipeResult.get(0).pipeExtractor.contains("source.pattern=root.timecho.wf01"));
       Assert.assertTrue(showPipeResult.get(0).pipeConnector.contains("batch.enable=true"));
       Assert.assertFalse(
           showPipeResult
@@ -305,13 +468,13 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
   }
 
   @Test
-  public void testAlterPipeProcessor() {
+  public void testPipeSourceAndProcessor() {
     final DataNodeWrapper receiverDataNode = receiverEnv.getDataNodeWrapper(0);
 
     // Create pipe
     final String sql =
         String.format(
-            "create pipe a2b with processor ('processor'='tumbling-time-sampling-processor', 'processor.tumbling-time.interval-seconds'='1', 'processor.down-sampling.split-file'='true') with sink ('node-urls'='%s', 'batch.enable'='false')",
+            "create pipe a2b with source ('source' = 'iotdb-source','source.pattern' = 'root.db.d1') with processor ('processor'='tumbling-time-sampling-processor', 'processor.tumbling-time.interval-seconds'='1', 'processor.down-sampling.split-file'='true') with sink ('node-urls'='%s', 'batch.enable'='false')",
             receiverDataNode.getIpAndPortString());
     try (final Connection connection = senderEnv.getConnection();
         final Statement statement = connection.createStatement()) {
@@ -335,13 +498,13 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
     expectedResSet.add("2000,3.0,");
     expectedResSet.add("3000,5.0,");
     TestUtils.assertDataEventuallyOnEnv(
-        receiverEnv, "select * from root.**", "Time,root.db.d1.at1,", expectedResSet);
+        receiverEnv, "select * from root.db.d1", "Time,root.db.d1.at1,", expectedResSet);
 
-    // Alter pipe (modify 'processor.tumbling-time.interval-seconds')
+    // Alter pipe (modify 'source.pattern' and 'processor.tumbling-time.interval-seconds')
     try (final Connection connection = senderEnv.getConnection();
         final Statement statement = connection.createStatement()) {
       statement.execute(
-          "alter pipe a2b modify processor ('processor.tumbling-time.interval-seconds'='2')");
+          "alter pipe a2b modify source('source' = 'iotdb-source','source.pattern'='root.db.d2') modify processor ('processor.tumbling-time.interval-seconds'='2')");
     } catch (SQLException e) {
       fail(e.getMessage());
     }
@@ -350,7 +513,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
     if (!TestUtils.tryExecuteNonQueriesWithRetry(
         senderEnv,
         Arrays.asList(
-            "insert into root.db.d1 (time, at1) values (11000, 1), (11500, 2), (12000, 3), (12500, 4), (13000, 5)",
+            "insert into root.db.d2 (time, at1) values (11000, 1), (11500, 2), (12000, 3), (12500, 4), (13000, 5)",
             "flush"))) {
       fail();
     }
@@ -361,8 +524,8 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
     expectedResSet.add("13000,5.0,");
     TestUtils.assertDataEventuallyOnEnv(
         receiverEnv,
-        "select * from root.** where time > 10000",
-        "Time,root.db.d1.at1,",
+        "select * from root.db.d2 where time > 10000",
+        "Time,root.db.d2.at1,",
         expectedResSet);
   }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeAlterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeAlterIT.java
@@ -464,7 +464,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
     // Create pipe
     final String sql =
         String.format(
-            "create pipe a2b with source ('source' = 'iotdb-source','source.pattern' = 'root.db.d1') with processor ('processor'='tumbling-time-sampling-processor', 'processor.tumbling-time.interval-seconds'='1', 'processor.down-sampling.split-file'='true') with sink ('node-urls'='%s', 'batch.enable'='false')",
+            "create pipe a2b with source ('source' = 'iotdb-source','source.path' = 'root.db.d1.**') with processor ('processor'='tumbling-time-sampling-processor', 'processor.tumbling-time.interval-seconds'='1', 'processor.down-sampling.split-file'='true') with sink ('node-urls'='%s', 'batch.enable'='false')",
             receiverDataNode.getIpAndPortString());
     try (final Connection connection = senderEnv.getConnection();
         final Statement statement = connection.createStatement()) {
@@ -494,7 +494,7 @@ public class IoTDBPipeAlterIT extends AbstractPipeDualAutoIT {
     try (final Connection connection = senderEnv.getConnection();
         final Statement statement = connection.createStatement()) {
       statement.execute(
-          "alter pipe a2b modify source('source' = 'iotdb-source','source.pattern'='root.db.d2') modify processor ('processor.tumbling-time.interval-seconds'='2')");
+          "alter pipe a2b modify source('source' = 'iotdb-source','source.path'='root.db.d2.**') modify processor ('processor.tumbling-time.interval-seconds'='2')");
     } catch (SQLException e) {
       fail(e.getMessage());
     }

--- a/iotdb-core/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IoTDBSqlParser.g4
+++ b/iotdb-core/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IoTDBSqlParser.g4
@@ -576,8 +576,16 @@ connectorAttributeClause
 
 alterPipe
     : ALTER PIPE pipeName=identifier
+        alterExtractorAttributesClause?
         alterProcessorAttributesClause?
         alterConnectorAttributesClause?
+    ;
+
+alterExtractorAttributesClause
+    : (MODIFY | REPLACE) (EXTRACTOR | SOURCE)
+        LR_BRACKET
+        (extractorAttributeClause COMMA)* extractorAttributeClause?
+        RR_BRACKET
     ;
 
 alterProcessorAttributesClause

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipeTaskInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipeTaskInfo.java
@@ -213,6 +213,20 @@ public class PipeTaskInfo implements SnapshotProcessor {
     //   1.1. if they are empty, the original attributes are filled directly.
     //   1.2. Otherwise, corresponding updates on original attributes are performed.
     // 2. In replace mode, do nothing here.
+    if (!alterPipeRequest.isReplaceAllExtractorAttributes) { // modify mode
+      if (alterPipeRequest.getExtractorAttributes().isEmpty()) {
+        alterPipeRequest.setExtractorAttributes(
+            copiedPipeStaticMetaFromCoordinator.getExtractorParameters().getAttribute());
+      } else {
+        alterPipeRequest.setExtractorAttributes(
+            copiedPipeStaticMetaFromCoordinator
+                .getExtractorParameters()
+                .addOrReplaceEquivalentAttributes(
+                    new PipeParameters(alterPipeRequest.getExtractorAttributes()))
+                .getAttribute());
+      }
+    }
+
     if (!alterPipeRequest.isReplaceAllProcessorAttributes) { // modify mode
       if (alterPipeRequest.getProcessorAttributes().isEmpty()) {
         alterPipeRequest.setProcessorAttributes(
@@ -226,6 +240,7 @@ public class PipeTaskInfo implements SnapshotProcessor {
                 .getAttribute());
       }
     }
+
     if (!alterPipeRequest.isReplaceAllConnectorAttributes) { // modify mode
       if (alterPipeRequest.getConnectorAttributes().isEmpty()) {
         alterPipeRequest.setConnectorAttributes(

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/AlterPipeProcedureV2.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/AlterPipeProcedureV2.java
@@ -116,10 +116,7 @@ public class AlterPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
         new PipeStaticMeta(
             alterPipeRequest.getPipeName(),
             System.currentTimeMillis(),
-            new HashMap<>(
-                currentPipeStaticMeta
-                    .getExtractorParameters()
-                    .getAttribute()), // reuse pipe source plugin
+            new HashMap<>(alterPipeRequest.getExtractorAttributes()), // reuse pipe source plugin
             new HashMap<>(alterPipeRequest.getProcessorAttributes()),
             new HashMap<>(alterPipeRequest.getConnectorAttributes()));
 
@@ -262,6 +259,11 @@ public class AlterPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
     stream.writeShort(ProcedureType.ALTER_PIPE_PROCEDURE_V2.getTypeCode());
     super.serialize(stream);
     ReadWriteIOUtils.write(alterPipeRequest.getPipeName(), stream);
+    ReadWriteIOUtils.write(alterPipeRequest.getExtractorAttributesSize(), stream);
+    for (Map.Entry<String, String> entry : alterPipeRequest.getExtractorAttributes().entrySet()) {
+      ReadWriteIOUtils.write(entry.getKey(), stream);
+      ReadWriteIOUtils.write(entry.getValue(), stream);
+    }
     ReadWriteIOUtils.write(alterPipeRequest.getProcessorAttributesSize(), stream);
     for (Map.Entry<String, String> entry : alterPipeRequest.getProcessorAttributes().entrySet()) {
       ReadWriteIOUtils.write(entry.getKey(), stream);
@@ -272,6 +274,7 @@ public class AlterPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
       ReadWriteIOUtils.write(entry.getKey(), stream);
       ReadWriteIOUtils.write(entry.getValue(), stream);
     }
+    ReadWriteIOUtils.write(alterPipeRequest.isReplaceAllExtractorAttributes, stream);
     ReadWriteIOUtils.write(alterPipeRequest.isReplaceAllProcessorAttributes, stream);
     ReadWriteIOUtils.write(alterPipeRequest.isReplaceAllConnectorAttributes, stream);
     if (currentPipeStaticMeta != null) {
@@ -311,6 +314,12 @@ public class AlterPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
     int size = ReadWriteIOUtils.readInt(byteBuffer);
     for (int i = 0; i < size; ++i) {
       alterPipeRequest
+          .getExtractorAttributes()
+          .put(ReadWriteIOUtils.readString(byteBuffer), ReadWriteIOUtils.readString(byteBuffer));
+    }
+    size = ReadWriteIOUtils.readInt(byteBuffer);
+    for (int i = 0; i < size; ++i) {
+      alterPipeRequest
           .getProcessorAttributes()
           .put(ReadWriteIOUtils.readString(byteBuffer), ReadWriteIOUtils.readString(byteBuffer));
     }
@@ -320,6 +329,7 @@ public class AlterPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
           .getConnectorAttributes()
           .put(ReadWriteIOUtils.readString(byteBuffer), ReadWriteIOUtils.readString(byteBuffer));
     }
+    alterPipeRequest.isReplaceAllExtractorAttributes = ReadWriteIOUtils.readBool((byteBuffer));
     alterPipeRequest.isReplaceAllProcessorAttributes = ReadWriteIOUtils.readBool(byteBuffer);
     alterPipeRequest.isReplaceAllConnectorAttributes = ReadWriteIOUtils.readBool(byteBuffer);
     if (ReadWriteIOUtils.readBool(byteBuffer)) {
@@ -347,6 +357,10 @@ public class AlterPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
     AlterPipeProcedureV2 that = (AlterPipeProcedureV2) o;
     return this.alterPipeRequest.getPipeName().equals(that.alterPipeRequest.getPipeName())
         && this.alterPipeRequest
+            .getExtractorAttributes()
+            .toString()
+            .equals(that.alterPipeRequest.getExtractorAttributes().toString())
+        && this.alterPipeRequest
             .getProcessorAttributes()
             .toString()
             .equals(that.alterPipeRequest.getProcessorAttributes().toString())
@@ -360,6 +374,7 @@ public class AlterPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
   public int hashCode() {
     return Objects.hash(
         alterPipeRequest.getPipeName(),
+        alterPipeRequest.getExtractorAttributes(),
         alterPipeRequest.getProcessorAttributes(),
         alterPipeRequest.getConnectorAttributes());
   }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/AlterPipeProcedureV2.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/AlterPipeProcedureV2.java
@@ -309,6 +309,7 @@ public class AlterPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
     alterPipeRequest =
         new TAlterPipeReq()
             .setPipeName(ReadWriteIOUtils.readString(byteBuffer))
+            .setExtractorAttributes(new HashMap<>())
             .setProcessorAttributes(new HashMap<>())
             .setConnectorAttributes(new HashMap<>());
     int size = ReadWriteIOUtils.readInt(byteBuffer);

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/AlterPipeProcedureV2.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/AlterPipeProcedureV2.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.commons.pipe.task.meta.PipeStaticMeta;
 import org.apache.iotdb.commons.pipe.task.meta.PipeStatus;
 import org.apache.iotdb.commons.pipe.task.meta.PipeTaskMeta;
 import org.apache.iotdb.commons.schema.SchemaConstant;
+import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.confignode.conf.ConfigNodeDescriptor;
 import org.apache.iotdb.confignode.consensus.request.write.pipe.task.AlterPipePlanV2;
 import org.apache.iotdb.confignode.manager.pipe.coordinator.PipeManager;
@@ -75,6 +76,7 @@ public class AlterPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
     procedureType = ProcedureType.ALTER_PIPE_PROCEDURE_V3;
   }
 
+  @TestOnly
   public AlterPipeProcedureV2(TAlterPipeReq alterPipeRequest, ProcedureType procedureType)
       throws PipeException {
     super();

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/AlterPipeProcedureV2.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/AlterPipeProcedureV2.java
@@ -90,7 +90,7 @@ public class AlterPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
         .getPipePluginCoordinator()
         .getPipePluginInfo()
         .checkPipePluginExistence(
-            new HashMap<>(), // no need to check pipe source plugin
+            alterPipeRequest.getExtractorAttributes(),
             alterPipeRequest.getProcessorAttributes(),
             alterPipeRequest.getConnectorAttributes());
 
@@ -116,7 +116,7 @@ public class AlterPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
         new PipeStaticMeta(
             alterPipeRequest.getPipeName(),
             System.currentTimeMillis(),
-            new HashMap<>(alterPipeRequest.getExtractorAttributes()), // reuse pipe source plugin
+            new HashMap<>(alterPipeRequest.getExtractorAttributes()),
             new HashMap<>(alterPipeRequest.getProcessorAttributes()),
             new HashMap<>(alterPipeRequest.getConnectorAttributes()));
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/store/ProcedureFactory.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/store/ProcedureFactory.java
@@ -153,7 +153,10 @@ public class ProcedureFactory implements IProcedureFactory {
         procedure = new DropPipeProcedureV2();
         break;
       case ALTER_PIPE_PROCEDURE_V2:
-        procedure = new AlterPipeProcedureV2();
+        procedure = new AlterPipeProcedureV2(ProcedureType.ALTER_PIPE_PROCEDURE_V2);
+        break;
+      case ALTER_PIPE_PROCEDURE_V3:
+        procedure = new AlterPipeProcedureV2(ProcedureType.ALTER_PIPE_PROCEDURE_V3);
         break;
       case PIPE_HANDLE_LEADER_CHANGE_PROCEDURE:
         procedure = new PipeHandleLeaderChangeProcedure();

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/store/ProcedureType.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/store/ProcedureType.java
@@ -74,6 +74,7 @@ public enum ProcedureType {
   STOP_PIPE_PROCEDURE_V2((short) 1002),
   DROP_PIPE_PROCEDURE_V2((short) 1003),
   ALTER_PIPE_PROCEDURE_V2((short) 1004),
+  ALTER_PIPE_PROCEDURE_V3((short) 1005),
 
   /** Pipe Runtime */
   PIPE_HANDLE_LEADER_CHANGE_PROCEDURE((short) 1100),

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/AlterPipeProcedureV2Test.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/AlterPipeProcedureV2Test.java
@@ -38,9 +38,11 @@ public class AlterPipeProcedureV2Test {
   public void serializeDeserializeTest() {
     PublicBAOS byteArrayOutputStream = new PublicBAOS();
     DataOutputStream outputStream = new DataOutputStream(byteArrayOutputStream);
-
+    Map<String, String> extractorAttributes = new HashMap<>();
     Map<String, String> processorAttributes = new HashMap<>();
     Map<String, String> connectorAttributes = new HashMap<>();
+    extractorAttributes.put("source", "iotdb-source");
+    extractorAttributes.put("source.pattern", "root.timecho.wf01");
     processorAttributes.put("processor", "do-nothing-processor");
     connectorAttributes.put("connector", "iotdb-thrift-connector");
     connectorAttributes.put("host", "127.0.0.1");
@@ -50,7 +52,7 @@ public class AlterPipeProcedureV2Test {
         new AlterPipeProcedureV2(
             new TAlterPipeReq(
                 "testPipe",
-                new HashMap<>(),
+                extractorAttributes,
                 processorAttributes,
                 connectorAttributes,
                 false,
@@ -66,6 +68,7 @@ public class AlterPipeProcedureV2Test {
 
       assertEquals(proc, proc2);
     } catch (Exception e) {
+      e.printStackTrace();
       fail();
     }
   }

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/AlterPipeProcedureV2Test.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/AlterPipeProcedureV2Test.java
@@ -68,7 +68,6 @@ public class AlterPipeProcedureV2Test {
 
       assertEquals(proc, proc2);
     } catch (Exception e) {
-      e.printStackTrace();
       fail();
     }
   }

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/AlterPipeProcedureV2Test.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/AlterPipeProcedureV2Test.java
@@ -48,7 +48,14 @@ public class AlterPipeProcedureV2Test {
 
     AlterPipeProcedureV2 proc =
         new AlterPipeProcedureV2(
-            new TAlterPipeReq("testPipe", processorAttributes, connectorAttributes, false, true));
+            new TAlterPipeReq(
+                "testPipe",
+                new HashMap<>(),
+                processorAttributes,
+                connectorAttributes,
+                false,
+                false,
+                true));
 
     try {
       proc.serialize(outputStream);

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/AlterPipeProcedureV2Test.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/AlterPipeProcedureV2Test.java
@@ -38,9 +38,11 @@ public class AlterPipeProcedureV2Test {
   public void serializeDeserializeTest() {
     PublicBAOS byteArrayOutputStream = new PublicBAOS();
     DataOutputStream outputStream = new DataOutputStream(byteArrayOutputStream);
+
     Map<String, String> extractorAttributes = new HashMap<>();
     Map<String, String> processorAttributes = new HashMap<>();
     Map<String, String> connectorAttributes = new HashMap<>();
+
     extractorAttributes.put("source", "iotdb-source");
     extractorAttributes.put("source.pattern", "root.timecho.wf01");
     processorAttributes.put("processor", "do-nothing-processor");

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/AlterPipeProcedureV3Test.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/AlterPipeProcedureV3Test.java
@@ -45,7 +45,7 @@ public class AlterPipeProcedureV3Test {
     Map<String, String> connectorAttributes = new HashMap<>();
 
     extractorAttributes.put("source", "iotdb-source");
-    extractorAttributes.put("source.pattern", "root.timecho.wf01");
+    extractorAttributes.put("source.pattern", "root.test1.wf01");
     processorAttributes.put("processor", "do-nothing-processor");
     connectorAttributes.put("connector", "iotdb-thrift-connector");
     connectorAttributes.put("host", "127.0.0.1");

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/AlterPipeProcedureV3Test.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/AlterPipeProcedureV3Test.java
@@ -20,7 +20,6 @@
 package org.apache.iotdb.confignode.procedure.impl.pipe.task;
 
 import org.apache.iotdb.confignode.procedure.store.ProcedureFactory;
-import org.apache.iotdb.confignode.procedure.store.ProcedureType;
 import org.apache.iotdb.confignode.rpc.thrift.TAlterPipeReq;
 
 import org.apache.tsfile.utils.PublicBAOS;
@@ -34,7 +33,8 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-public class AlterPipeProcedureV2Test {
+public class AlterPipeProcedureV3Test {
+
   @Test
   public void serializeDeserializeTest() {
     PublicBAOS byteArrayOutputStream = new PublicBAOS();
@@ -44,6 +44,8 @@ public class AlterPipeProcedureV2Test {
     Map<String, String> processorAttributes = new HashMap<>();
     Map<String, String> connectorAttributes = new HashMap<>();
 
+    extractorAttributes.put("source", "iotdb-source");
+    extractorAttributes.put("source.pattern", "root.timecho.wf01");
     processorAttributes.put("processor", "do-nothing-processor");
     connectorAttributes.put("connector", "iotdb-thrift-connector");
     connectorAttributes.put("host", "127.0.0.1");
@@ -53,17 +55,16 @@ public class AlterPipeProcedureV2Test {
         new TAlterPipeReq("testPipe", processorAttributes, connectorAttributes, false, true);
     req.setExtractorAttributes(extractorAttributes);
     req.setIsReplaceAllExtractorAttributes(false);
-    AlterPipeProcedureV2 proc =
-        new AlterPipeProcedureV2(req, ProcedureType.ALTER_PIPE_PROCEDURE_V2);
+    AlterPipeProcedureV2 proc = new AlterPipeProcedureV2(req);
 
     try {
       proc.serialize(outputStream);
       ByteBuffer buffer =
           ByteBuffer.wrap(byteArrayOutputStream.getBuf(), 0, byteArrayOutputStream.size());
-      AlterPipeProcedureV2 proc2 =
+      AlterPipeProcedureV2 proc3 =
           (AlterPipeProcedureV2) ProcedureFactory.getInstance().create(buffer);
 
-      assertEquals(proc, proc2);
+      assertEquals(proc, proc3);
     } catch (Exception e) {
       fail();
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/executor/ClusterConfigTaskExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/executor/ClusterConfigTaskExecutor.java
@@ -1814,12 +1814,12 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
       final TAlterPipeReq req =
           new TAlterPipeReq(
               pipeName,
-              alterPipeStatement.getExtractorAttributes(),
               alterPipeStatement.getProcessorAttributes(),
               alterPipeStatement.getConnectorAttributes(),
-              alterPipeStatement.isReplaceAllExtractorAttributes(),
               alterPipeStatement.isReplaceAllProcessorAttributes(),
               alterPipeStatement.isReplaceAllConnectorAttributes());
+      req.setExtractorAttributes(alterPipeStatement.getExtractorAttributes());
+      req.setIsReplaceAllExtractorAttributes(alterPipeStatement.isReplaceAllExtractorAttributes());
       final TSStatus tsStatus = configNodeClient.alterPipe(req);
       if (TSStatusCode.SUCCESS_STATUS.getStatusCode() != tsStatus.getCode()) {
         LOGGER.warn("Failed to alter pipe {} in config node, status is {}.", pipeName, tsStatus);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/executor/ClusterConfigTaskExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/executor/ClusterConfigTaskExecutor.java
@@ -1789,6 +1789,10 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
     // Validate pipe plugin before alteration - only validate replace mode
     final String pipeName = alterPipeStatement.getPipeName();
     try {
+      if (!alterPipeStatement.getExtractorAttributes().isEmpty()
+          && alterPipeStatement.isReplaceAllExtractorAttributes()) {
+        PipeDataNodeAgent.plugin().validateExtractor(alterPipeStatement.getExtractorAttributes());
+      }
       if (!alterPipeStatement.getProcessorAttributes().isEmpty()
           && alterPipeStatement.isReplaceAllProcessorAttributes()) {
         PipeDataNodeAgent.plugin().validateProcessor(alterPipeStatement.getProcessorAttributes());
@@ -1810,8 +1814,10 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
       final TAlterPipeReq req =
           new TAlterPipeReq(
               pipeName,
+              alterPipeStatement.getExtractorAttributes(),
               alterPipeStatement.getProcessorAttributes(),
               alterPipeStatement.getConnectorAttributes(),
+              alterPipeStatement.isReplaceAllExtractorAttributes(),
               alterPipeStatement.isReplaceAllProcessorAttributes(),
               alterPipeStatement.isReplaceAllConnectorAttributes());
       final TSStatus tsStatus = configNodeClient.alterPipe(req);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/parser/ASTVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/parser/ASTVisitor.java
@@ -3730,6 +3730,18 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
       throw new SemanticException(
           "Not support for this sql in ALTER PIPE, please enter pipe name.");
     }
+
+    if (ctx.alterExtractorAttributesClause() != null) {
+      alterPipeStatement.setExtractorAttributes(
+          parseExtractorAttributesClause(
+              ctx.alterExtractorAttributesClause().extractorAttributeClause()));
+      alterPipeStatement.setReplaceAllExtractorAttributes(
+          Objects.nonNull(ctx.alterExtractorAttributesClause().REPLACE()));
+    } else {
+      alterPipeStatement.setExtractorAttributes(new HashMap<>());
+      alterPipeStatement.setReplaceAllExtractorAttributes(false);
+    }
+
     if (ctx.alterProcessorAttributesClause() != null) {
       alterPipeStatement.setProcessorAttributes(
           parseProcessorAttributesClause(
@@ -3740,6 +3752,7 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
       alterPipeStatement.setProcessorAttributes(new HashMap<>());
       alterPipeStatement.setReplaceAllProcessorAttributes(false);
     }
+
     if (ctx.alterConnectorAttributesClause() != null) {
       alterPipeStatement.setConnectorAttributes(
           parseConnectorAttributesClause(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/metadata/pipe/AlterPipeStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/metadata/pipe/AlterPipeStatement.java
@@ -37,8 +37,10 @@ import java.util.Map;
 public class AlterPipeStatement extends Statement implements IConfigStatement {
 
   private String pipeName;
+  private Map<String, String> extractorAttributes;
   private Map<String, String> processorAttributes;
   private Map<String, String> connectorAttributes;
+  private boolean isReplaceAllExtractorAttributes;
   private boolean isReplaceAllProcessorAttributes;
   private boolean isReplaceAllConnectorAttributes;
 
@@ -48,6 +50,14 @@ public class AlterPipeStatement extends Statement implements IConfigStatement {
 
   public String getPipeName() {
     return pipeName;
+  }
+
+  public Map<String, String> getExtractorAttributes() {
+    return extractorAttributes;
+  }
+
+  public boolean isReplaceAllExtractorAttributes() {
+    return isReplaceAllExtractorAttributes;
   }
 
   public Map<String, String> getProcessorAttributes() {
@@ -70,12 +80,20 @@ public class AlterPipeStatement extends Statement implements IConfigStatement {
     this.pipeName = pipeName;
   }
 
+  public void setExtractorAttributes(Map<String, String> extractorAttributes) {
+    this.extractorAttributes = extractorAttributes;
+  }
+
   public void setProcessorAttributes(Map<String, String> processorAttributes) {
     this.processorAttributes = processorAttributes;
   }
 
   public void setConnectorAttributes(Map<String, String> connectorAttributes) {
     this.connectorAttributes = connectorAttributes;
+  }
+
+  public void setReplaceAllExtractorAttributes(boolean replaceAllExtractorAttributes) {
+    isReplaceAllExtractorAttributes = replaceAllExtractorAttributes;
   }
 
   public void setReplaceAllProcessorAttributes(boolean replaceAllProcessorAttributes) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/metadata/pipe/AlterPipeStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/metadata/pipe/AlterPipeStatement.java
@@ -56,16 +56,16 @@ public class AlterPipeStatement extends Statement implements IConfigStatement {
     return extractorAttributes;
   }
 
-  public boolean isReplaceAllExtractorAttributes() {
-    return isReplaceAllExtractorAttributes;
-  }
-
   public Map<String, String> getProcessorAttributes() {
     return processorAttributes;
   }
 
   public Map<String, String> getConnectorAttributes() {
     return connectorAttributes;
+  }
+
+  public boolean isReplaceAllExtractorAttributes() {
+    return isReplaceAllExtractorAttributes;
   }
 
   public boolean isReplaceAllProcessorAttributes() {

--- a/iotdb-protocol/thrift-confignode/src/main/thrift/confignode.thrift
+++ b/iotdb-protocol/thrift-confignode/src/main/thrift/confignode.thrift
@@ -713,10 +713,12 @@ struct TCreatePipeReq {
 
 struct TAlterPipeReq {
     1: required string pipeName
-    2: required map<string, string> processorAttributes
-    3: required map<string, string> connectorAttributes
-    4: required bool isReplaceAllProcessorAttributes
-    5: required bool isReplaceAllConnectorAttributes
+    2: required map<string, string> extractorAttributes
+    3: required map<string, string> processorAttributes
+    4: required map<string, string> connectorAttributes
+    5: required bool isReplaceAllExtractorAttributes
+    6: required bool isReplaceAllProcessorAttributes
+    7: required bool isReplaceAllConnectorAttributes
 }
 
 // Deprecated, restored for compatibility

--- a/iotdb-protocol/thrift-confignode/src/main/thrift/confignode.thrift
+++ b/iotdb-protocol/thrift-confignode/src/main/thrift/confignode.thrift
@@ -713,12 +713,12 @@ struct TCreatePipeReq {
 
 struct TAlterPipeReq {
     1: required string pipeName
-    2: required map<string, string> extractorAttributes
-    3: required map<string, string> processorAttributes
-    4: required map<string, string> connectorAttributes
-    5: required bool isReplaceAllExtractorAttributes
-    6: required bool isReplaceAllProcessorAttributes
-    7: required bool isReplaceAllConnectorAttributes
+    2: required map<string, string> processorAttributes
+    3: required map<string, string> connectorAttributes
+    4: required bool isReplaceAllProcessorAttributes
+    5: required bool isReplaceAllConnectorAttributes
+    6: optional map<string, string> extractorAttributes
+    7: optional bool isReplaceAllExtractorAttributes
 }
 
 // Deprecated, restored for compatibility


### PR DESCRIPTION
## Description
Enhancing the existing Alter Pipe SQL functionality, the upgrade now permits dynamic adjustments to the Pipe Source configuration. Users can seamlessly adapt their data synchronization strategies to real-time changes in resources and requirements, thus improving the efficiency and effectiveness of their data stream processing.
```SQL
Alter Pipe <pipe_name>
    modify|replace source(...)
    modify|replace processor(...)
    modify|replace sink(...)
```

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [x] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
