### PR TITLE
Fix python client dependency issue

### DIFF
--- a/.github/workflows/multi-language-client.yml
+++ b/.github/workflows/multi-language-client.yml
@@ -107,12 +107,8 @@ jobs:
       fail-fast: false
       max-parallel: 15
       matrix:
-        python: ['3.x']
-        os: [ubuntu-latest]
-        include:
-          - python: '3.6'
-            os: ubuntu-20.04
-    runs-on: ${{ matrix.os }}
+        python: [ '3.6', '3.x' ]
+    runs-on: ${{ (matrix.python == '3.6' && 'ubuntu-20.04') || 'ubuntu-latest' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/iotdb-client/client-py/pom.xml
+++ b/iotdb-client/client-py/pom.xml
@@ -37,6 +37,12 @@
             <version>1.3.3-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.iotdb</groupId>
+            <artifactId>iotdb-thrift</artifactId>
+            <version>1.3.3-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>
@@ -188,6 +194,7 @@
                     <usedDependencies>
                         <!-- This dependency is only used for ensuring the build order -->
                         <usedDependency>org.apache.iotdb:iotdb-thrift-commons</usedDependency>
+                        <usedDependency>org.apache.iotdb:iotdb-thrift</usedDependency>
                     </usedDependencies>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## Description

The maven module of the client-py is missing the dependency of iotdb-thrift. It will cause an unexpected issue when package the python client. 

When we released 1.3.2 python client, we included a local thrift file of the master branch instead of building it again.

A new package https://pypi.org/project/apache-iotdb/1.3.2.post0/ released.

