### PR TITLE
Bump jline version to 3.26.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <!-- This was the last version to support Java 8 -->
         <jetty.version>9.4.53.v20231009</jetty.version>
         <jjwt.version>0.11.5</jjwt.version>
-        <jline.version>3.25.0</jline.version>
+        <jline.version>3.26.2</jline.version>
         <jna.version>5.14.0</jna.version>
         <json-smart.version>2.5.0</json-smart.version>
         <jtransforms.version>3.1</jtransforms.version>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <!-- This was the last version to support Java 8 -->
         <jetty.version>9.4.53.v20231009</jetty.version>
         <jjwt.version>0.11.5</jjwt.version>
-        <jline.version>3.23.0</jline.version>
+        <jline.version>3.25.0</jline.version>
         <jna.version>5.14.0</jna.version>
         <json-smart.version>2.5.0</json-smart.version>
         <jtransforms.version>3.1</jtransforms.version>


### PR DESCRIPTION
## Description

Dependency maven:org.jline:jline:3.23.0 is vulnerable

Upgrade to 3.26.2

CVE-2023-50572,  Score: 5.5

An issue in the component "GroovyEngine.execute" of jline-groovy versions through 3.24.1 allows attackers to cause an OOM (OutofMemory) error.

Read More: https://devhub.checkmarx.com/cve-details/CVE-2023-50572?utm_source=jetbrains&utm_medium=referral
