### PR TITLE
Fixed issue where the wal version kept increasing after the write load stopped

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/buffer/AbstractWALBuffer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/buffer/AbstractWALBuffer.java
@@ -84,8 +84,8 @@ public abstract class AbstractWALBuffer implements IWALBuffer {
   }
 
   @Override
-  public long getCurrentWALFileSize() {
-    return currentWALFileWriter.size();
+  public long getCurrentWALOriginalFileSize() {
+    return currentWALFileWriter.originalSize();
   }
 
   /**

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/buffer/IWALBuffer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/buffer/IWALBuffer.java
@@ -36,7 +36,7 @@ public interface IWALBuffer extends AutoCloseable {
   /** Get current log version id. */
   long getCurrentWALFileVersion();
 
-  /** Get current wal file's size. */
+  /** Get current wal file's original size. */
   long getCurrentWALOriginalFileSize();
 
   /** Get current search index. */

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/buffer/IWALBuffer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/buffer/IWALBuffer.java
@@ -37,7 +37,7 @@ public interface IWALBuffer extends AutoCloseable {
   long getCurrentWALFileVersion();
 
   /** Get current wal file's size. */
-  long getCurrentWALFileSize();
+  long getCurrentWALOriginalFileSize();
 
   /** Get current search index. */
   long getCurrentSearchIndex();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/LogWriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/LogWriter.java
@@ -46,7 +46,6 @@ public abstract class LogWriter implements ILogWriter {
   protected final File logFile;
   protected final FileOutputStream logStream;
   protected final FileChannel logChannel;
-  protected long size = 0;
   protected long originalSize = 0;
 
   /**
@@ -76,7 +75,6 @@ public abstract class LogWriter implements ILogWriter {
               version == WALFileVersion.V1
                   ? WALWriter.MAGIC_STRING_V1.getBytes(StandardCharsets.UTF_8)
                   : WALWriter.MAGIC_STRING_V2.getBytes(StandardCharsets.UTF_8)));
-      size += logChannel.position();
     }
   }
 
@@ -109,7 +107,6 @@ public abstract class LogWriter implements ILogWriter {
       buffer.flip();
       compressed = true;
     }
-    size += bufferSize;
     /*
      Header structure:
      [CompressionType(1 byte)][dataBufferSize(4 bytes)][uncompressedSize(4 bytes)]
@@ -121,7 +118,6 @@ public abstract class LogWriter implements ILogWriter {
     if (compressed) {
       headerBuffer.putInt(uncompressedSize);
     }
-    size += headerBuffer.position();
     try {
       headerBuffer.flip();
       logChannel.write(headerBuffer);
@@ -146,7 +142,7 @@ public abstract class LogWriter implements ILogWriter {
 
   @Override
   public long size() {
-    return size;
+    return logFile.length();
   }
 
   public long originalSize() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/LogWriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/LogWriter.java
@@ -108,9 +108,6 @@ public abstract class LogWriter implements ILogWriter {
       bufferSize = buffer.position();
       buffer.flip();
       compressed = true;
-      size += COMPRESSED_HEADER_SIZE;
-    } else {
-      size += UN_COMPRESSED_HEADER_SIZE;
     }
     size += bufferSize;
     /*

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALWriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALWriter.java
@@ -86,7 +86,6 @@ public class WALWriter extends LogWriter {
     buffer.put(
         (version != WALFileVersion.V2 ? MAGIC_STRING_V1 : MAGIC_STRING_V2)
             .getBytes(StandardCharsets.UTF_8));
-    size += buffer.position();
     writeMetadata(buffer);
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALWriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALWriter.java
@@ -90,7 +90,6 @@ public class WALWriter extends LogWriter {
   }
 
   private void writeMetadata(ByteBuffer buffer) throws IOException {
-    size += buffer.position();
     buffer.flip();
     logChannel.write(buffer);
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
@@ -296,7 +296,7 @@ public class WALNode implements IWALNode {
       long firstVersionId = checkpointManager.getFirstValidWALVersionId();
       if (firstVersionId == Long.MIN_VALUE) {
         // roll wal log writer to delete current wal file
-        if (buffer.getCurrentWALFileSize() > 0) {
+        if (buffer.getCurrentWALOriginalFileSize() > 0) {
           rollWALFile();
         }
       }


### PR DESCRIPTION
<img width="677" alt="image" src="https://github.com/user-attachments/assets/2ed5271c-4c6a-49fb-aa37-0408762e0c2a">

<img width="866" alt="image" src="https://github.com/user-attachments/assets/b3bc1e8c-3f2c-484c-a3e6-a27a6485118d">

![img_v3_02cs_06c78a62-0d3b-4352-84cc-a8e96dcfb8cg](https://github.com/user-attachments/assets/246dd2f6-f71a-482d-96de-4117c7955056)





Ensure that the wal file does not trigger a file switch if it contains only a Magic String Header of length 6