### PR TITLE
Enhance the automatic metadata creation logic of root.__system prefixed devices

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/metrics/IoTDBInternalLocalReporter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/metrics/IoTDBInternalLocalReporter.java
@@ -102,6 +102,7 @@ public class IoTDBInternalLocalReporter extends IoTDBInternalReporter {
         databaseSchema.setMaxSchemaRegionGroupNum(1);
         databaseSchema.setMinSchemaRegionGroupNum(1);
         databaseSchema.setMaxDataRegionGroupNum(1);
+        databaseSchema.setMinDataRegionGroupNum(1);
         TSStatus tsStatus = client.setDatabase(databaseSchema);
         if (TSStatusCode.SUCCESS_STATUS.getStatusCode() != tsStatus.getCode()) {
           LOGGER.error("IoTDBSessionReporter checkOrCreateDatabase failed.");

--- a/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/reporter/iotdb/IoTDBSessionReporter.java
+++ b/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/reporter/iotdb/IoTDBSessionReporter.java
@@ -75,7 +75,7 @@ public class IoTDBSessionReporter extends IoTDBReporter {
       if (!result.hasNext()) {
         try (SessionDataSetWrapper result2 =
             this.sessionPool.executeQueryStatement(
-                "CREATE "
+                "CREATE DATABASE "
                     + metricConfig.getInternalDatabase()
                     + " WITH SCHEMA_REPLICATION_FACTOR=1, DATA_REPLICATION_FACTOR=1, SCHEMA_REGION_GROUP_NUM=1, DATA_REGION_GROUP_NUM=1")) {
           if (!result2.hasNext()) {


### PR DESCRIPTION
The device paths prefixed with root.__system will no longer be affected by the default_storage_group_level configuration when created automatically. The root.__system system database will always be created automatically.