### PR TITLE
Wraps DateTimeUtilsTest in a session

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/DateTimeUtilsTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/DateTimeUtilsTest.java
@@ -18,6 +18,10 @@
  */
 package org.apache.iotdb.db.utils;
 
+import org.apache.iotdb.db.protocol.session.IClientSession;
+import org.apache.iotdb.db.protocol.session.InternalClientSession;
+import org.apache.iotdb.db.protocol.session.SessionManager;
+
 import org.apache.tsfile.utils.TimeDuration;
 import org.junit.Assert;
 import org.junit.Test;
@@ -25,6 +29,7 @@ import org.junit.Test;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
 
@@ -147,29 +152,41 @@ public class DateTimeUtilsTest {
   /** Test convert duration including natural month unit. Time includes: 1970-01-01 ~ 1970-12-01 */
   @Test
   public void getConvertDurationIncludingMonthUnit() {
-    Assert.assertEquals(31 * 86400000L, DateTimeUtils.convertDurationStrToLong(0, 1, "mo", "ms"));
-    Assert.assertEquals(
-        28 * 86400000L, DateTimeUtils.convertDurationStrToLong(2678400000L, 1, "mo", "ms"));
-    Assert.assertEquals(
-        31 * 86400000L, DateTimeUtils.convertDurationStrToLong(5097600000L, 1, "mo", "ms"));
-    Assert.assertEquals(
-        30 * 86400000L, DateTimeUtils.convertDurationStrToLong(7776000000L, 1, "mo", "ms"));
-    Assert.assertEquals(
-        31 * 86400000L, DateTimeUtils.convertDurationStrToLong(10368000000L, 1, "mo", "ms"));
-    Assert.assertEquals(
-        30 * 86400000L, DateTimeUtils.convertDurationStrToLong(13046400000L, 1, "mo", "ms"));
-    Assert.assertEquals(
-        31 * 86400000L, DateTimeUtils.convertDurationStrToLong(15638400000L, 1, "mo", "ms"));
-    Assert.assertEquals(
-        31 * 86400000L, DateTimeUtils.convertDurationStrToLong(18316800000L, 1, "mo", "ms"));
-    Assert.assertEquals(
-        30 * 86400000L, DateTimeUtils.convertDurationStrToLong(20995200000L, 1, "mo", "ms"));
-    Assert.assertEquals(
-        31 * 86400000L, DateTimeUtils.convertDurationStrToLong(23587200000L, 1, "mo", "ms"));
-    Assert.assertEquals(
-        30 * 86400000L, DateTimeUtils.convertDurationStrToLong(26265600000L, 1, "mo", "ms"));
-    Assert.assertEquals(
-        31 * 86400000L, DateTimeUtils.convertDurationStrToLong(28857600000L, 1, "mo", "ms"));
+    // force the current session's timezone to be UTC
+    IClientSession session = new InternalClientSession("getConvertDurationIncludingMonthUnit");
+    session.setZoneId(ZoneId.of("UTC"));
+
+    try {
+      SessionManager.getInstance().registerSession(session);
+
+      Assert.assertEquals(31 * 86400000L, DateTimeUtils.convertDurationStrToLong(0, 1, "mo", "ms"));
+      Assert.assertEquals(
+          28 * 86400000L, DateTimeUtils.convertDurationStrToLong(2678400000L, 1, "mo", "ms"));
+      TimeZone.getTimeZone(ZoneOffset.UTC);
+      Assert.assertEquals(
+          31 * 86400000L, DateTimeUtils.convertDurationStrToLong(5097600000L, 1, "mo", "ms"));
+      Assert.assertEquals(
+          30 * 86400000L, DateTimeUtils.convertDurationStrToLong(7776000000L, 1, "mo", "ms"));
+      Assert.assertEquals(
+          31 * 86400000L, DateTimeUtils.convertDurationStrToLong(10368000000L, 1, "mo", "ms"));
+      Assert.assertEquals(
+          30 * 86400000L, DateTimeUtils.convertDurationStrToLong(13046400000L, 1, "mo", "ms"));
+      Assert.assertEquals(
+          31 * 86400000L, DateTimeUtils.convertDurationStrToLong(15638400000L, 1, "mo", "ms"));
+      Assert.assertEquals(
+          31 * 86400000L, DateTimeUtils.convertDurationStrToLong(18316800000L, 1, "mo", "ms"));
+      Assert.assertEquals(
+          30 * 86400000L, DateTimeUtils.convertDurationStrToLong(20995200000L, 1, "mo", "ms"));
+      Assert.assertEquals(
+          31 * 86400000L, DateTimeUtils.convertDurationStrToLong(23587200000L, 1, "mo", "ms"));
+      Assert.assertEquals(
+          30 * 86400000L, DateTimeUtils.convertDurationStrToLong(26265600000L, 1, "mo", "ms"));
+      Assert.assertEquals(
+          31 * 86400000L, DateTimeUtils.convertDurationStrToLong(28857600000L, 1, "mo", "ms"));
+    } finally {
+      // clean up the session after test
+      SessionManager.getInstance().removeCurrSession();
+    }
   }
 
   public void testConvertDatetimeStrToLongWithoutMS(


### PR DESCRIPTION
## NOTE:

This is a guess at a fix. There are probably other ways to fix this test too:
- For a UTC timezone via surefire system properties
- Change the timestamps
- probably a few more, with a bit more knowledge of IoTDB...

## Description

DateTimeUtilsTest.getConvertDurationIncludingMonthUnit() uses dates conversions that are TZ specfic.
Wrapping the test in a session, allows this single test to use a set timezone, while not affecting the behavior of other tests

Fixes: #12970


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
