### PR TITLE
Optimize log for broken wal

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/buffer/WALBuffer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/buffer/WALBuffer.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertNode;
 import org.apache.iotdb.db.service.metrics.WritingMetrics;
 import org.apache.iotdb.db.storageengine.dataregion.wal.checkpoint.Checkpoint;
 import org.apache.iotdb.db.storageengine.dataregion.wal.checkpoint.CheckpointManager;
+import org.apache.iotdb.db.storageengine.dataregion.wal.exception.BrokenWALFileException;
 import org.apache.iotdb.db.storageengine.dataregion.wal.exception.WALNodeClosedException;
 import org.apache.iotdb.db.storageengine.dataregion.wal.io.WALMetaData;
 import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALFileStatus;
@@ -740,14 +741,20 @@ public class WALBuffer extends AbstractWALBuffer {
             return WALMetaData.readFromWALFile(
                     file, FileChannel.open(file.toPath(), StandardOpenOption.READ))
                 .getMemTablesId();
+          } catch (BrokenWALFileException e) {
+            logger.warn(
+                "Fail to read memTable ids from the wal file {} of wal node {}: {}",
+                id,
+                identifier,
+                e.getMessage());
           } catch (IOException e) {
             logger.warn(
                 "Fail to read memTable ids from the wal file {} of wal node {}.",
                 id,
                 identifier,
                 e);
-            return Collections.emptySet();
           }
+          return Collections.emptySet();
         });
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/exception/BrokenWALFileException.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/exception/BrokenWALFileException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.storageengine.dataregion.wal.exception;
+
+import java.io.File;
+import java.io.IOException;
+
+public class BrokenWALFileException extends IOException {
+
+  public BrokenWALFileException(File logFile) {
+    super(String.format("Broken wal file %s, size %d", logFile, logFile.length()));
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALMetaData.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALMetaData.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.storageengine.dataregion.wal.io;
 
 import org.apache.iotdb.consensus.iot.log.ConsensusReqReader;
+import org.apache.iotdb.db.storageengine.dataregion.wal.exception.BrokenWALFileException;
 import org.apache.iotdb.db.utils.SerializedSize;
 
 import org.slf4j.Logger;
@@ -131,8 +132,7 @@ public class WALMetaData implements SerializedSize {
 
   public static WALMetaData readFromWALFile(File logFile, FileChannel channel) throws IOException {
     if (channel.size() < WALWriter.MAGIC_STRING_V2_BYTES || !isValidMagicString(channel)) {
-      throw new IOException(
-          String.format("Broken wal file %s, size %d", logFile, logFile.length()));
+      throw new BrokenWALFileException(logFile);
     }
 
     // load metadata size
@@ -168,8 +168,7 @@ public class WALMetaData implements SerializedSize {
         }
       }
     } catch (IllegalArgumentException e) {
-      throw new IOException(
-          String.format("Broken wal file %s, size %d", logFile, logFile.length()));
+      throw new BrokenWALFileException(logFile);
     } catch (IOException e) {
       throw e;
     } catch (Exception e) {


### PR DESCRIPTION
Do not print stack traces when the exception is a known one.