### PR TITLE
Allows for unit tests to be run in parallel

### DIFF
--- a/iotdb-client/cli/src/test/java/org/apache/iotdb/tool/WriteDataFileTest.java
+++ b/iotdb-client/cli/src/test/java/org/apache/iotdb/tool/WriteDataFileTest.java
@@ -19,8 +19,10 @@
 
 package org.apache.iotdb.tool;
 
+import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -28,6 +30,18 @@ import java.util.List;
 import static org.junit.Assert.assertTrue;
 
 public class WriteDataFileTest {
+
+  /**
+   * Create the 'target' directory before the tests run. When running tests with multiple threads,
+   * the working directory might be 'target/fork_#' which would changes the assumption that the
+   * 'target' directory exists already. When running tests via an IDE, the working directory might
+   * be the project directory, and the target directory likely already exists.
+   */
+  @Before
+  public void createTestDirectory() {
+    new File("target").mkdirs();
+  }
+
   @Test
   public void writeCsvFileTest() {
     List<String> headerNames =

--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/TestUtils.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/TestUtils.java
@@ -51,6 +51,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.net.ServerSocket;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -251,7 +252,7 @@ public class TestUtils {
       this.servers = new ArrayList<>();
 
       for (int i = 0; i < replicas; i++) {
-        peers.add(new Peer(gid, i, new TEndPoint("127.0.0.1", 6001 + i)));
+        peers.add(new Peer(gid, i, new TEndPoint("127.0.0.1", randomFreePort())));
 
         final File storage = storageProvider.apply(i);
         FileUtils.deleteFileQuietly(storage);
@@ -491,6 +492,14 @@ public class TestUtils {
 
     MiniCluster create() {
       return new MiniCluster(gid, replicas, peerStorageProvider, smProvider, ratisConfig);
+    }
+  }
+
+  private static int randomFreePort() {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      return socket.getLocalPort();
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to find free server socket port.", e);
     }
   }
 }

--- a/iotdb-core/datanode/pom.xml
+++ b/iotdb-core/datanode/pom.xml
@@ -370,7 +370,7 @@
                 <configuration>
                     <skipTests>${iotdb.ut.skip}</skipTests>
                     <systemProperties>
-                        <IOTDB_CONF>src/test/resources</IOTDB_CONF>
+                        <IOTDB_CONF>${project.basedir}/src/test/resources</IOTDB_CONF>
                     </systemProperties>
                     <reuseForks>false</reuseForks>
                     <runOrder>random</runOrder>

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/constant/TestConstant.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/constant/TestConstant.java
@@ -25,7 +25,7 @@ import java.io.File;
 
 public class TestConstant {
 
-  public static final String BASE_OUTPUT_PATH = "target".concat(File.separator);
+  public static final String BASE_OUTPUT_PATH = baseOutputDirectory();
   public static final String OUTPUT_DATA_DIR =
       BASE_OUTPUT_PATH.concat("data").concat(File.separator);
   public static final String PARTIAL_PATH_STRING =
@@ -108,5 +108,11 @@ public class TestConstant {
         logicalStorageGroupName,
         virtualStorageGroupId,
         timePartitionId);
+  }
+
+  private static String baseOutputDirectory() {
+    File dir = new File("target");
+    dir.mkdirs();
+    return dir.getPath().concat(File.separator);
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALFileTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALFileTest.java
@@ -67,6 +67,8 @@ public class WALFileTest {
   public void setUp() throws Exception {
     if (walFile.exists()) {
       Files.delete(walFile.toPath());
+    } else {
+      walFile.getParentFile().mkdirs();
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -743,6 +743,8 @@
                     <version>3.1.2</version>
                     <configuration>
                         <argLine>${argLine} -Xmx1024m</argLine>
+                        <!-- Force the working directory to be different for each fork, so forks don't trample each other -->
+                        <workingDirectory>${project.build.directory}/fork_${surefire.forkNumber}</workingDirectory>
                     </configuration>
                 </plugin>
                 <!--


### PR DESCRIPTION
> [!NOTE]
> This does NOT set Surefire's `forkCount` property, that will be done on an isolated commit
This is to ensure these changes don't negatively affect the existing build.

Details on changes:

- Change to test working directory

  The working directory was changed from `${project.build.directory}` to `${project.build.directory}/fork_${surefire.forkNumber}` (single fork builds would be `<module_name>/target/fork_1`),
  This isolates any test output written to relative paths.  Long term tests may want to be more explicit where they write output to, (e.g. using JUnit 5's `@TempDir` annotation)

- IOTDB_CONF property

  Becuse the working directory change, the IOTDB_CONF directory needs to resolve differently, however, even without parallel tests, this property _should_ use an absolute path

- Test run `mkdirs`

  The tests assumed that the `./target` directory was always present (relative to the working directory), a change to the working directory invalidated this assumption, so any directories a test uses should be created.
  This is probably a good idea even without the parallel test concern. (but in the future this could be replaced with something like JUnit 5's `@TempDir` annotation)

- Hardcoded Ports

  TestUtils, was using a hardcodes sequentially from `6001`, it now uses free JUnit 5's `@TempDir` annotation ports

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->

> [!Tip]
> To test this you can run a build with `-DforkCount=1C`
> On my M1 Max, this took the UT build from ~30 minutes to ~11 minutes

<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
