### PR TITLE
Optimize WALNode.PlanNodeIterator.hasNext

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNode.java
@@ -722,6 +722,12 @@ public class WALNode implements IWALNode {
           currentFileIndex < filesToSearch.length - 1
               && insertNodes.size() < MOST_COLLECT_NUM_IN_ONE_ROUND;
           currentFileIndex++) {
+        // cannot find any in this file, so all slices of last plan node are found
+        if (WALFileUtils.parseStatusCode(filesToSearch[currentFileIndex].getName())
+            == WALFileStatus.CONTAINS_NONE_SEARCH_INDEX) {
+          tryToCollectInsertNodeAndBumpIndex.run();
+          continue;
+        }
         try (WALByteBufReader walByteBufReader =
             new WALByteBufReader(filesToSearch[currentFileIndex])) {
           while (walByteBufReader.hasNext()) {


### PR DESCRIPTION
The previous code of `PlanNodeIterator` was very confusing (especially the `hasNext()` function). This PR organizes and simplifies the logic of the `hasNext()` function, removing some unnecessary special judgments, variables, and loops. Now, PlanNodeIterator works according to the following principles:

As an iterator, it has two "loop invariants". First, the member variable `nextSearchIndex` monotonically increases and always points to the SearchIndex that is currently collecting WalEntry. Once all related WalEntries are collected, `nextSearchIndex` will increment. Second, `filesToSearch[currentFileIndex]` always points to the WAL file currently being read.

Each time hasNext() is called, it will sequentially traverse the files, continuously collecting WalEntries with `nextSearchIndex` from the files. After confirming that the current collection is complete, this batch of WalEntries will be added to the member array `insertNodes`. Then, it continues to handle the case of nextSearchIndex+1. This loop continues until the last file is read, or if many WalEntries have already been collected in this call, it will no longer continue to collect.