### PR TITLE
fix md5 suffix too many

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/IStateMachine.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/IStateMachine.java
@@ -29,7 +29,6 @@ import org.apache.iotdb.consensus.common.request.IConsensusRequest;
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.io.File;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Function;
 
@@ -117,7 +116,7 @@ public interface IStateMachine {
    * @param latestSnapshotRootDir dir where the latest snapshot sits
    * @return List of real snapshot files.
    */
-  default List<Path> getSnapshotFiles(File latestSnapshotRootDir) {
+  default List<File> getSnapshotFiles(File latestSnapshotRootDir) {
     return Utils.listAllRegularFilesRecursively(latestSnapshotRootDir);
   }
 

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/common/Utils.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/common/Utils.java
@@ -37,8 +37,8 @@ public class Utils {
 
   private Utils() {}
 
-  public static List<Path> listAllRegularFilesRecursively(File rootDir) {
-    List<Path> allFiles = new ArrayList<>();
+  public static List<File> listAllRegularFilesRecursively(File rootDir) {
+    List<File> allFiles = new ArrayList<>();
     try {
       Files.walkFileTree(
           rootDir.toPath(),
@@ -51,7 +51,7 @@ public class Utils {
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
               if (attrs.isRegularFile()) {
-                allFiles.add(file);
+                allFiles.add(file.toFile());
               }
               return FileVisitResult.CONTINUE;
             }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
@@ -166,7 +166,17 @@ public class SnapshotStorage implements StateMachineStorage {
         continue;
       }
       FileInfo fileInfo;
-      fileInfo = new FileInfo(file.toPath(), null);
+      try {
+        if (getSnapshotDir() == null) {
+          fileInfo = new FileInfo(file.toPath(), null);
+        } else {
+
+          fileInfo = new FileInfo(file.toPath().toRealPath(), null);
+        }
+      } catch (IOException e) {
+        logger.warn("{} cannot resolve real path of {} due to ", this, file, e);
+        return null;
+      }
       fileInfos.add(fileInfo);
     }
 

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
@@ -155,29 +155,18 @@ public class SnapshotStorage implements StateMachineStorage {
     }
     TermIndex snapshotTermIndex = Utils.getTermIndexFromDir(latestSnapshotDir);
 
-    List<Path> actualSnapshotFiles = applicationStateMachine.getSnapshotFiles(latestSnapshotDir);
+    List<File> actualSnapshotFiles = applicationStateMachine.getSnapshotFiles(latestSnapshotDir);
     if (actualSnapshotFiles == null) {
       return null;
     }
 
     List<FileInfo> fileInfos = new ArrayList<>();
-    for (Path file : actualSnapshotFiles) {
-      if (file.endsWith(".md5")) {
+    for (File file : actualSnapshotFiles) {
+      if (file.getName().endsWith(".md5")) {
         continue;
       }
       FileInfo fileInfo;
-      try {
-        if (getSnapshotDir() == null) {
-          // For regions that place the snapshot in default sm folder, use relative path
-          fileInfo = new FileInfo(file, null);
-        } else {
-          // For regions that have a separate snapshot installation path, use absolute path
-          fileInfo = new FileInfo(file.toRealPath(), null);
-        }
-      } catch (IOException e) {
-        logger.warn("{} cannot resolve real path of {} due to ", this, file, e);
-        return null;
-      }
+      fileInfo = new FileInfo(file.toPath(), null);
       fileInfos.add(fileInfo);
     }
 

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
@@ -171,6 +171,7 @@ public class SnapshotStorage implements StateMachineStorage {
           // For regions that place the snapshot in default sm folder, use relative path
           fileInfo = new FileInfo(file.toPath(), null);
         } else {
+          // For regions that place the snapshot in default sm folder, use absolute path
           fileInfo = new FileInfo(file.toPath().toRealPath(), null);
         }
       } catch (IOException e) {

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
@@ -168,9 +168,9 @@ public class SnapshotStorage implements StateMachineStorage {
       FileInfo fileInfo;
       try {
         if (getSnapshotDir() == null) {
+          // For regions that place the snapshot in default sm folder, use relative path
           fileInfo = new FileInfo(file.toPath(), null);
         } else {
-
           fileInfo = new FileInfo(file.toPath().toRealPath(), null);
         }
       } catch (IOException e) {

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/SnapshotStorage.java
@@ -171,7 +171,7 @@ public class SnapshotStorage implements StateMachineStorage {
           // For regions that place the snapshot in default sm folder, use relative path
           fileInfo = new FileInfo(file.toPath(), null);
         } else {
-          // For regions that place the snapshot in default sm folder, use absolute path
+          // For regions that have a separate snapshot installation path, use absolute path
           fileInfo = new FileInfo(file.toPath().toRealPath(), null);
         }
       } catch (IOException e) {

--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/SnapshotTest.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/ratis/SnapshotTest.java
@@ -39,7 +39,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Scanner;
@@ -174,7 +173,7 @@ public class SnapshotTest {
     }
 
     @Override
-    public List<Path> getSnapshotFiles(File latestSnapshotRootDir) {
+    public List<File> getSnapshotFiles(File latestSnapshotRootDir) {
       File log = new File(latestSnapshotRootDir.getAbsolutePath() + File.separator + "record");
       Assert.assertTrue(log.exists());
       Scanner scanner = null;
@@ -188,7 +187,7 @@ public class SnapshotTest {
       }
       Assert.assertNotNull(scanner);
 
-      return Collections.singletonList(new File(latestSnapshotRootDir, relativePath).toPath());
+      return Collections.singletonList(new File(latestSnapshotRootDir, relativePath));
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataRegionStateMachine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataRegionStateMachine.java
@@ -52,10 +52,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class DataRegionStateMachine extends BaseStateMachine {
 
@@ -240,13 +238,13 @@ public class DataRegionStateMachine extends BaseStateMachine {
   }
 
   @Override
-  public List<Path> getSnapshotFiles(File latestSnapshotRootDir) {
+  public List<File> getSnapshotFiles(File latestSnapshotRootDir) {
     try {
       return new SnapshotLoader(
               latestSnapshotRootDir.getAbsolutePath(),
               region.getDatabaseName(),
               region.getDataRegionId())
-          .getSnapshotFileInfo().stream().map(File::toPath).collect(Collectors.toList());
+          .getSnapshotFileInfo();
     } catch (IOException e) {
       logger.error(
           "Meets error when getting snapshot files for {}-{}",
@@ -322,7 +320,9 @@ public class DataRegionStateMachine extends BaseStateMachine {
               + region.getDatabaseName()
               + "-"
               + region.getDataRegionId();
-      return new File(snapshotDir).getCanonicalFile();
+      File file = new File(snapshotDir).getCanonicalFile();
+      logger.info("snapshotDir: {},  file: {}", file.toString(), snapshotDir);
+      return file;
     } catch (IOException | NullPointerException e) {
       logger.warn("{}: cannot get the canonical file of {} due to {}", this, snapshotDir, e);
       return null;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataRegionStateMachine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataRegionStateMachine.java
@@ -320,9 +320,7 @@ public class DataRegionStateMachine extends BaseStateMachine {
               + region.getDatabaseName()
               + "-"
               + region.getDataRegionId();
-      File file = new File(snapshotDir).getCanonicalFile();
-      logger.info("snapshotDir: {},  file: {}", file.toString(), snapshotDir);
-      return file;
+      return new File(snapshotDir).getCanonicalFile();
     } catch (IOException | NullPointerException e) {
       logger.warn("{}: cannot get the canonical file of {} due to {}", this, snapshotDir, e);
       return null;


### PR DESCRIPTION
the .md5 suffix is not filtered in Path.endWith(".md5"), so we should get the filename of string