### PR TITLE
Subscription: improve deduplication logic for PipeRawTabletInsertionEvent

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/subscription/it/local/IoTDBSubscriptionBasicIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/subscription/it/local/IoTDBSubscriptionBasicIT.java
@@ -539,10 +539,7 @@ public class IoTDBSubscriptionBasicIT extends AbstractSubscriptionLocalIT {
       consumer.open();
       consumer.subscribe(topicName);
 
-      AWAIT.untilAsserted(
-          () -> {
-            Assert.assertEquals(100, rowCount.get());
-          });
+      AWAIT.untilAsserted(() -> Assert.assertEquals(100, rowCount.get()));
     } catch (final Exception e) {
       e.printStackTrace();
       fail(e.getMessage());

--- a/integration-test/src/test/java/org/apache/iotdb/subscription/it/local/IoTDBSubscriptionBasicIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/subscription/it/local/IoTDBSubscriptionBasicIT.java
@@ -482,4 +482,70 @@ public class IoTDBSubscriptionBasicIT extends AbstractSubscriptionLocalIT {
       fail(e.getMessage());
     }
   }
+
+  @Test
+  public void testDataSetDeduplication() {
+    // Insert some historical data
+    try (final ISession session = EnvFactory.getEnv().getSessionConnection()) {
+      session.createDatabase("root.db");
+      for (int i = 0; i < 100; ++i) {
+        session.executeNonQueryStatement(
+            String.format("insert into root.db.d1(time, s1, s2) values (%s, 1, 2)", i));
+        session.executeNonQueryStatement(
+            String.format("insert into root.db.d2(time, s1, s2) values (%s, 3, 4)", i));
+      }
+      // DO NOT FLUSH HERE
+    } catch (final Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+
+    // Create topic
+    final String topicName = "topic6";
+    final String host = EnvFactory.getEnv().getIP();
+    final int port = Integer.parseInt(EnvFactory.getEnv().getPort());
+    try (final SubscriptionSession session = new SubscriptionSession(host, port)) {
+      session.open();
+      final Properties config = new Properties();
+      config.put(TopicConstant.PATTERN_KEY, "root.db.d1.s1");
+      session.createTopic(topicName, config);
+    } catch (final Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+
+    // Subscription
+    final AtomicInteger rowCount = new AtomicInteger();
+    try (final SubscriptionPushConsumer consumer =
+        new SubscriptionPushConsumer.Builder()
+            .host(host)
+            .port(port)
+            .consumerId("c1")
+            .consumerGroupId("cg1")
+            .ackStrategy(AckStrategy.AFTER_CONSUME)
+            .consumeListener(
+                message -> {
+                  for (final SubscriptionSessionDataSet dataSet :
+                      message.getSessionDataSetsHandler()) {
+                    while (dataSet.hasNext()) {
+                      dataSet.next();
+                      rowCount.addAndGet(1);
+                    }
+                  }
+                  return ConsumeResult.SUCCESS;
+                })
+            .buildPushConsumer()) {
+
+      consumer.open();
+      consumer.subscribe(topicName);
+
+      AWAIT.untilAsserted(
+          () -> {
+            Assert.assertEquals(100, rowCount.get());
+          });
+    } catch (final Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEvent.java
@@ -206,6 +206,10 @@ public class PipeRawTabletInsertionEvent extends EnrichedEvent implements Tablet
     return Objects.nonNull(tablet) ? tablet.deviceId : deviceId;
   }
 
+  public EnrichedEvent getSourceEvent() {
+    return sourceEvent;
+  }
+
   /////////////////////////// TabletInsertionEvent ///////////////////////////
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEvent.java
@@ -63,6 +63,7 @@ public class PipeTsFileInsertionEvent extends EnrichedEvent implements TsFileIns
   private final boolean isLoaded;
   private final boolean isGeneratedByPipe;
   private final boolean isGeneratedByPipeConsensus;
+  private final boolean isGeneratedByHistoricalExtractor;
 
   private final AtomicBoolean isClosed;
   private TsFileInsertionDataContainer dataContainer;
@@ -72,13 +73,17 @@ public class PipeTsFileInsertionEvent extends EnrichedEvent implements TsFileIns
   private long flushPointCount = TsFileProcessor.FLUSH_POINT_COUNT_NOT_SET;
 
   public PipeTsFileInsertionEvent(
-      final TsFileResource resource, final boolean isLoaded, final boolean isGeneratedByPipe) {
+      final TsFileResource resource,
+      final boolean isLoaded,
+      final boolean isGeneratedByPipe,
+      final boolean isGeneratedByHistoricalExtractor) {
     // The modFile must be copied before the event is assigned to the listening pipes
     this(
         resource,
         true,
         isLoaded,
         isGeneratedByPipe,
+        isGeneratedByHistoricalExtractor,
         null,
         0,
         null,
@@ -92,6 +97,7 @@ public class PipeTsFileInsertionEvent extends EnrichedEvent implements TsFileIns
       final boolean isWithMod,
       final boolean isLoaded,
       final boolean isGeneratedByPipe,
+      final boolean isGeneratedByHistoricalExtractor,
       final String pipeName,
       final long creationTime,
       final PipeTaskMeta pipeTaskMeta,
@@ -110,6 +116,7 @@ public class PipeTsFileInsertionEvent extends EnrichedEvent implements TsFileIns
     this.isLoaded = isLoaded;
     this.isGeneratedByPipe = isGeneratedByPipe;
     this.isGeneratedByPipeConsensus = resource.isGeneratedByPipeConsensus();
+    this.isGeneratedByHistoricalExtractor = isGeneratedByHistoricalExtractor;
 
     isClosed = new AtomicBoolean(resource.isClosed());
     // Register close listener if TsFile is not closed
@@ -291,6 +298,7 @@ public class PipeTsFileInsertionEvent extends EnrichedEvent implements TsFileIns
         isWithMod,
         isLoaded,
         isGeneratedByPipe,
+        isGeneratedByHistoricalExtractor,
         pipeName,
         creationTime,
         pipeTaskMeta,
@@ -368,6 +376,10 @@ public class PipeTsFileInsertionEvent extends EnrichedEvent implements TsFileIns
   /** The method is used to prevent circular replication in PipeConsensus */
   public boolean isGeneratedByPipeConsensus() {
     return isGeneratedByPipeConsensus;
+  }
+
+  public boolean isGeneratedByHistoricalExtractor() {
+    return isGeneratedByHistoricalExtractor;
   }
 
   private TsFileInsertionDataContainer initDataContainer() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/realtime/PipeRealtimeEventFactory.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/realtime/PipeRealtimeEventFactory.java
@@ -37,7 +37,7 @@ public class PipeRealtimeEventFactory {
   public static PipeRealtimeEvent createRealtimeEvent(
       final TsFileResource resource, final boolean isLoaded, final boolean isGeneratedByPipe) {
     return TS_FILE_EPOCH_MANAGER.bindPipeTsFileInsertionEvent(
-        new PipeTsFileInsertionEvent(resource, isLoaded, isGeneratedByPipe), resource);
+        new PipeTsFileInsertionEvent(resource, isLoaded, isGeneratedByPipe, false), resource);
   }
 
   public static PipeRealtimeEvent createRealtimeEvent(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/historical/PipeHistoricalDataRegionTsFileExtractor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/historical/PipeHistoricalDataRegionTsFileExtractor.java
@@ -588,6 +588,7 @@ public class PipeHistoricalDataRegionTsFileExtractor implements PipeHistoricalDa
             shouldTransferModFile,
             false,
             false,
+            true,
             pipeName,
             creationTime,
             pipeTaskMeta,

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/TsFileDeduplicationBlockingPendingQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/TsFileDeduplicationBlockingPendingQueue.java
@@ -62,6 +62,7 @@ public class TsFileDeduplicationBlockingPendingQueue extends SubscriptionBlockin
     if (Objects.isNull(event)) {
       return null;
     }
+
     if (event instanceof PipeRawTabletInsertionEvent) {
       final PipeRawTabletInsertionEvent pipeRawTabletInsertionEvent =
           (PipeRawTabletInsertionEvent) event;
@@ -74,6 +75,7 @@ public class TsFileDeduplicationBlockingPendingQueue extends SubscriptionBlockin
         return null;
       }
     }
+
     if (event instanceof PipeTsFileInsertionEvent) {
       final PipeTsFileInsertionEvent pipeTsFileInsertionEvent = (PipeTsFileInsertionEvent) event;
       if (isDuplicated(pipeTsFileInsertionEvent)) {
@@ -83,6 +85,7 @@ public class TsFileDeduplicationBlockingPendingQueue extends SubscriptionBlockin
         return null;
       }
     }
+
     return event;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/TsFileDeduplicationBlockingPendingQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/TsFileDeduplicationBlockingPendingQueue.java
@@ -47,7 +47,7 @@ public class TsFileDeduplicationBlockingPendingQueue extends SubscriptionBlockin
 
     this.hashCodeToIsGeneratedByHistoricalExtractor =
         Caffeine.newBuilder()
-            .expireAfterWrite(
+            .expireAfterAccess(
                 SubscriptionConfig.getInstance().getSubscriptionTsFileDeduplicationWindowSeconds(),
                 TimeUnit.SECONDS)
             .build();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/TsFileDeduplicationBlockingPendingQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/TsFileDeduplicationBlockingPendingQueue.java
@@ -19,8 +19,10 @@
 
 package org.apache.iotdb.db.subscription.broker;
 
+import org.apache.iotdb.commons.pipe.event.EnrichedEvent;
 import org.apache.iotdb.commons.pipe.task.connection.UnboundedBlockingPendingQueue;
 import org.apache.iotdb.commons.subscription.config.SubscriptionConfig;
+import org.apache.iotdb.db.pipe.event.common.tablet.PipeRawTabletInsertionEvent;
 import org.apache.iotdb.db.pipe.event.common.tsfile.PipeTsFileInsertionEvent;
 import org.apache.iotdb.pipe.api.event.Event;
 
@@ -37,13 +39,13 @@ public class TsFileDeduplicationBlockingPendingQueue extends SubscriptionBlockin
   private static final Logger LOGGER =
       LoggerFactory.getLogger(TsFileDeduplicationBlockingPendingQueue.class);
 
-  private final Cache<Integer, Integer> polledTsFiles;
+  private final Cache<Integer, Boolean> hashCodeToIsGeneratedByHistoricalExtractor;
 
   public TsFileDeduplicationBlockingPendingQueue(
       final UnboundedBlockingPendingQueue<Event> inputPendingQueue) {
     super(inputPendingQueue);
 
-    this.polledTsFiles =
+    this.hashCodeToIsGeneratedByHistoricalExtractor =
         Caffeine.newBuilder()
             .expireAfterWrite(
                 SubscriptionConfig.getInstance().getSubscriptionTsFileDeduplicationWindowSeconds(),
@@ -60,22 +62,47 @@ public class TsFileDeduplicationBlockingPendingQueue extends SubscriptionBlockin
     if (Objects.isNull(event)) {
       return null;
     }
-
+    if (event instanceof PipeRawTabletInsertionEvent) {
+      final PipeRawTabletInsertionEvent pipeRawTabletInsertionEvent =
+          (PipeRawTabletInsertionEvent) event;
+      final EnrichedEvent sourceEvent = pipeRawTabletInsertionEvent.getSourceEvent();
+      if (sourceEvent instanceof PipeTsFileInsertionEvent
+          && isDuplicated((PipeTsFileInsertionEvent) sourceEvent)) {
+        // commit directly
+        pipeRawTabletInsertionEvent.decreaseReferenceCount(
+            TsFileDeduplicationBlockingPendingQueue.class.getName(), true);
+        return null;
+      }
+    }
     if (event instanceof PipeTsFileInsertionEvent) {
       final PipeTsFileInsertionEvent pipeTsFileInsertionEvent = (PipeTsFileInsertionEvent) event;
-      final int hashcode = pipeTsFileInsertionEvent.getTsFile().hashCode();
-      if (Objects.nonNull(polledTsFiles.getIfPresent(hashcode))) {
-        LOGGER.info(
-            "Subscription: Detect duplicated PipeTsFileInsertionEvent {}, commit it directly",
-            pipeTsFileInsertionEvent.coreReportMessage());
+      if (isDuplicated(pipeTsFileInsertionEvent)) {
         // commit directly
         pipeTsFileInsertionEvent.decreaseReferenceCount(
             TsFileDeduplicationBlockingPendingQueue.class.getName(), true);
         return null;
       }
-      polledTsFiles.put(hashcode, hashcode);
     }
-
     return event;
+  }
+
+  private boolean isDuplicated(final PipeTsFileInsertionEvent event) {
+    final int hashCode = event.getTsFile().hashCode();
+    final boolean isGeneratedByHistoricalExtractor = event.isGeneratedByHistoricalExtractor();
+    final Boolean existedIsGeneratedByHistoricalExtractor =
+        hashCodeToIsGeneratedByHistoricalExtractor.getIfPresent(hashCode);
+    if (Objects.isNull(existedIsGeneratedByHistoricalExtractor)) {
+      hashCodeToIsGeneratedByHistoricalExtractor.put(hashCode, isGeneratedByHistoricalExtractor);
+      return false;
+    }
+    // Multiple PipeRawTabletInsertionEvents parsed from the same PipeTsFileInsertionEvent (i.e.,
+    // with the same isGeneratedByHistoricalExtractor field) are not considered duplicates.
+    if (Objects.equals(existedIsGeneratedByHistoricalExtractor, isGeneratedByHistoricalExtractor)) {
+      return false;
+    }
+    LOGGER.info(
+        "Subscription: Detect duplicated PipeTsFileInsertionEvent {}, commit it directly",
+        event.coreReportMessage());
+    return true;
   }
 }


### PR DESCRIPTION
Improve #12887.

If two identical tsfiles (one extracted as historical data and one extracted as real-time data) are parsed into PipeRawTabletInsertionEvent in the processor stage, the existing deduplication code cannot detect this situation.