### PR TITLE
Improve robustness of removing peer step of region migration 

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -654,23 +654,26 @@ public class IoTConsensusServerImpl {
   public boolean removeSyncLogChannel(Peer targetPeer) {
     // step 1, remove sync channel in LogDispatcher
     boolean exceptionHappened = false;
+    String suggestion = "";
     try {
       logDispatcher.removeLogDispatcherThread(targetPeer);
     } catch (Exception e) {
       logger.warn(
-          "[IoTConsensus] Exception happened during removing log dispatcher thread, but configuration.dat will still be remove",
+          "[IoTConsensus] Exception happened during removing log dispatcher thread, but configuration.dat will still be removed.",
           e);
+      suggestion = "It's suggested restart the DataNode to remove log dispatcher thread.";
       exceptionHappened = true;
     }
     if (!exceptionHappened) {
-      logger.info("[IoTConsensus] log dispatcher to {} removed and cleanup", targetPeer);
+      logger.info(
+          "[IoTConsensus] Log dispatcher thread to {} has been removed and cleanup", targetPeer);
     }
     // step 2, update configuration
     configuration.remove(targetPeer);
     checkAndUpdateSafeDeletedSearchIndex();
     // step 3, persist configuration
     persistConfiguration();
-    logger.info("[IoTConsensus] configuration updated to {}", this.configuration);
+    logger.info("[IoTConsensus] Configuration updated to {}. {}", this.configuration, suggestion);
     return !exceptionHappened;
   }
 

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/service/IoTConsensusRPCServiceProcessor.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/service/IoTConsensusRPCServiceProcessor.java
@@ -228,12 +228,11 @@ public class IoTConsensusRPCServiceProcessor implements IoTConsensusIService.Asy
       return;
     }
     TSStatus responseStatus;
-    try {
-      impl.removeSyncLogChannel(new Peer(groupId, req.nodeId, req.endPoint));
+    if (impl.removeSyncLogChannel(new Peer(groupId, req.nodeId, req.endPoint))) {
       responseStatus = new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
-    } catch (ConsensusGroupModifyPeerException e) {
+    } else {
       responseStatus = new TSStatus(TSStatusCode.INTERNAL_SERVER_ERROR.getStatusCode());
-      responseStatus.setMessage(e.getMessage());
+      responseStatus.setMessage("remove sync log channel failed");
     }
     resultHandler.onComplete(new TRemoveSyncLogChannelRes(responseStatus));
   }


### PR DESCRIPTION
This PR replace some `throw Exception` to `logger.warn`.

Because during removing region peer step, we always want the migration procedure continue, even if there are some mistake.