### PR TITLE
Multiple fixes regarding database specification

### DIFF
--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/env/AbstractEnv.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/env/AbstractEnv.java
@@ -55,6 +55,7 @@ import org.apache.iotdb.jdbc.IoTDBConnection;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.session.Session;
+import org.apache.iotdb.session.Session.Builder;
 import org.apache.iotdb.session.pool.SessionPool;
 
 import org.apache.thrift.TException;
@@ -417,6 +418,11 @@ public abstract class AbstractEnv implements BaseEnv {
 
   @Override
   public ISession getSessionConnection(String sqlDialect) throws IoTDBConnectionException {
+    if (manualRun) {
+      Session session = new Builder().host("127.0.0.1").port(6667).sqlDialect(sqlDialect).build();
+      session.open();
+      return session;
+    }
     DataNodeWrapper dataNode =
         this.dataNodeWrapperList.get(rand.nextInt(this.dataNodeWrapperList.size()));
     Session session =

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/env/AbstractEnv.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/env/AbstractEnv.java
@@ -55,7 +55,6 @@ import org.apache.iotdb.jdbc.IoTDBConnection;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.session.Session;
-import org.apache.iotdb.session.Session.Builder;
 import org.apache.iotdb.session.pool.SessionPool;
 
 import org.apache.thrift.TException;
@@ -418,11 +417,6 @@ public abstract class AbstractEnv implements BaseEnv {
 
   @Override
   public ISession getSessionConnection(String sqlDialect) throws IoTDBConnectionException {
-    if (manualRun) {
-      Session session = new Builder().host("127.0.0.1").port(6667).sqlDialect(sqlDialect).build();
-      session.open();
-      return session;
-    }
     DataNodeWrapper dataNode =
         this.dataNodeWrapperList.get(rand.nextInt(this.dataNodeWrapperList.size()));
     Session session =

--- a/integration-test/src/main/java/org/apache/iotdb/itbase/env/BaseEnv.java
+++ b/integration-test/src/main/java/org/apache/iotdb/itbase/env/BaseEnv.java
@@ -39,15 +39,12 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 
 public interface BaseEnv {
-
-  boolean manualRun = false;
 
   String TREE_SQL_DIALECT = "tree";
 
@@ -108,62 +105,32 @@ public interface BaseEnv {
   List<String> getMetricPrometheusReporterContents();
 
   default Connection getConnection() throws SQLException {
-    if (manualRun) {
-      return DriverManager.getConnection(
-          Config.IOTDB_URL_PREFIX + "localhost" + ":" + 6667,
-          BaseEnv.constructProperties("root", "root", TREE_SQL_DIALECT));
-    }
     return getConnection(
         SessionConfig.DEFAULT_USER, SessionConfig.DEFAULT_PASSWORD, TREE_SQL_DIALECT);
   }
 
   default Connection getTableConnection() throws SQLException {
-    if (manualRun) {
-      return DriverManager.getConnection(
-          Config.IOTDB_URL_PREFIX + "localhost" + ":" + 6667,
-          BaseEnv.constructProperties("root", "root", TABLE_SQL_DIALECT));
-    }
     return getConnection(
         SessionConfig.DEFAULT_USER, SessionConfig.DEFAULT_PASSWORD, TABLE_SQL_DIALECT);
   }
 
   default Connection getConnection(String sqlDialect) throws SQLException {
-    if (manualRun) {
-      return DriverManager.getConnection(
-          Config.IOTDB_URL_PREFIX + "localhost" + ":" + 6667,
-          BaseEnv.constructProperties("root", "root", sqlDialect));
-    }
     return getConnection(SessionConfig.DEFAULT_USER, SessionConfig.DEFAULT_PASSWORD, sqlDialect);
   }
 
   default Connection getConnection(Constant.Version version) throws SQLException {
-    if (manualRun) {
-      return DriverManager.getConnection(
-          Config.IOTDB_URL_PREFIX + "localhost" + ":" + 6667,
-          BaseEnv.constructProperties("root", "root", TREE_SQL_DIALECT));
-    }
     return getConnection(
         version, SessionConfig.DEFAULT_USER, SessionConfig.DEFAULT_PASSWORD, TREE_SQL_DIALECT);
   }
 
   default Connection getConnection(Constant.Version version, String sqlDialect)
       throws SQLException {
-    if (manualRun) {
-      return DriverManager.getConnection(
-          Config.IOTDB_URL_PREFIX + "localhost" + ":" + 6667,
-          BaseEnv.constructProperties("root", "root", sqlDialect));
-    }
     return getConnection(
         version, SessionConfig.DEFAULT_USER, SessionConfig.DEFAULT_PASSWORD, sqlDialect);
   }
 
   default Connection getConnection(Constant.Version version, String username, String password)
       throws SQLException {
-    if (manualRun) {
-      return DriverManager.getConnection(
-          Config.IOTDB_URL_PREFIX + "localhost" + ":" + 6667,
-          BaseEnv.constructProperties("root", "root", TREE_SQL_DIALECT));
-    }
     return getConnection(version, username, password, TREE_SQL_DIALECT);
   }
 
@@ -172,11 +139,6 @@ public interface BaseEnv {
       throws SQLException;
 
   default Connection getConnection(String username, String password) throws SQLException {
-    if (manualRun) {
-      return DriverManager.getConnection(
-          Config.IOTDB_URL_PREFIX + "localhost" + ":" + 6667,
-          BaseEnv.constructProperties("root", "root", TREE_SQL_DIALECT));
-    }
     return getConnection(username, password, TREE_SQL_DIALECT);
   }
 

--- a/integration-test/src/main/java/org/apache/iotdb/itbase/env/BaseEnv.java
+++ b/integration-test/src/main/java/org/apache/iotdb/itbase/env/BaseEnv.java
@@ -39,12 +39,15 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.sql.Connection;
+import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 
 public interface BaseEnv {
+
+  boolean manualRun = false;
 
   String TREE_SQL_DIALECT = "tree";
 
@@ -105,32 +108,62 @@ public interface BaseEnv {
   List<String> getMetricPrometheusReporterContents();
 
   default Connection getConnection() throws SQLException {
+    if (manualRun) {
+      return DriverManager.getConnection(
+          Config.IOTDB_URL_PREFIX + "localhost" + ":" + 6667,
+          BaseEnv.constructProperties("root", "root", TREE_SQL_DIALECT));
+    }
     return getConnection(
         SessionConfig.DEFAULT_USER, SessionConfig.DEFAULT_PASSWORD, TREE_SQL_DIALECT);
   }
 
   default Connection getTableConnection() throws SQLException {
+    if (manualRun) {
+      return DriverManager.getConnection(
+          Config.IOTDB_URL_PREFIX + "localhost" + ":" + 6667,
+          BaseEnv.constructProperties("root", "root", TABLE_SQL_DIALECT));
+    }
     return getConnection(
         SessionConfig.DEFAULT_USER, SessionConfig.DEFAULT_PASSWORD, TABLE_SQL_DIALECT);
   }
 
   default Connection getConnection(String sqlDialect) throws SQLException {
+    if (manualRun) {
+      return DriverManager.getConnection(
+          Config.IOTDB_URL_PREFIX + "localhost" + ":" + 6667,
+          BaseEnv.constructProperties("root", "root", sqlDialect));
+    }
     return getConnection(SessionConfig.DEFAULT_USER, SessionConfig.DEFAULT_PASSWORD, sqlDialect);
   }
 
   default Connection getConnection(Constant.Version version) throws SQLException {
+    if (manualRun) {
+      return DriverManager.getConnection(
+          Config.IOTDB_URL_PREFIX + "localhost" + ":" + 6667,
+          BaseEnv.constructProperties("root", "root", TREE_SQL_DIALECT));
+    }
     return getConnection(
         version, SessionConfig.DEFAULT_USER, SessionConfig.DEFAULT_PASSWORD, TREE_SQL_DIALECT);
   }
 
   default Connection getConnection(Constant.Version version, String sqlDialect)
       throws SQLException {
+    if (manualRun) {
+      return DriverManager.getConnection(
+          Config.IOTDB_URL_PREFIX + "localhost" + ":" + 6667,
+          BaseEnv.constructProperties("root", "root", sqlDialect));
+    }
     return getConnection(
         version, SessionConfig.DEFAULT_USER, SessionConfig.DEFAULT_PASSWORD, sqlDialect);
   }
 
   default Connection getConnection(Constant.Version version, String username, String password)
       throws SQLException {
+    if (manualRun) {
+      return DriverManager.getConnection(
+          Config.IOTDB_URL_PREFIX + "localhost" + ":" + 6667,
+          BaseEnv.constructProperties("root", "root", TREE_SQL_DIALECT));
+    }
     return getConnection(version, username, password, TREE_SQL_DIALECT);
   }
 
@@ -139,6 +172,11 @@ public interface BaseEnv {
       throws SQLException;
 
   default Connection getConnection(String username, String password) throws SQLException {
+    if (manualRun) {
+      return DriverManager.getConnection(
+          Config.IOTDB_URL_PREFIX + "localhost" + ":" + 6667,
+          BaseEnv.constructProperties("root", "root", TREE_SQL_DIALECT));
+    }
     return getConnection(username, password, TREE_SQL_DIALECT);
   }
 

--- a/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionRelationalIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionRelationalIT.java
@@ -35,7 +35,9 @@ import org.apache.tsfile.write.record.Tablet.ColumnType;
 import org.apache.tsfile.write.schema.IMeasurementSchema;
 import org.apache.tsfile.write.schema.MeasurementSchema;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -46,103 +48,95 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.apache.iotdb.itbase.env.BaseEnv.TABLE_SQL_DIALECT;
+import static org.apache.iotdb.itbase.env.BaseEnv.TREE_SQL_DIALECT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
 
 @RunWith(IoTDBTestRunner.class)
 public class IoTDBSessionRelationalIT {
 
+  @BeforeClass
+  public static void classSetUp() throws Exception {
+    EnvFactory.getEnv().initClusterEnvironment();
+  }
+
   @Before
   public void setUp() throws Exception {
-    EnvFactory.getEnv().initClusterEnvironment();
     try (ISession session = EnvFactory.getEnv().getSessionConnection(TABLE_SQL_DIALECT)) {
-      session.executeNonQueryStatement("CREATE DATABASE db1");
+      session.executeNonQueryStatement("CREATE DATABASE IF NOT EXISTS db1");
+      session.executeNonQueryStatement("CREATE DATABASE IF NOT EXISTS db2");
     }
   }
 
   @After
   public void tearDown() throws Exception {
     try (ISession session = EnvFactory.getEnv().getSessionConnection(TABLE_SQL_DIALECT)) {
-      session.executeNonQueryStatement("DROP DATABASE db1");
+      session.executeNonQueryStatement("DROP DATABASE IF EXISTS db1");
     }
+  }
+
+  @AfterClass
+  public static void classTearDown() {
     EnvFactory.getEnv().cleanClusterEnvironment();
   }
 
   // for manual debugging
   public static void main(String[] args)
       throws IoTDBConnectionException, StatementExecutionException {
-    try (ISession session =
-        new Session.Builder().host("127.0.0.1").port(6667).sqlDialect(TABLE_SQL_DIALECT).build()) {
-      session.open();
-
-      session.executeNonQueryStatement("CREATE DATABASE IF NOT EXISTS \"db1\"");
-
+    try (ISession session = EnvFactory.getEnv().getSessionConnection(TABLE_SQL_DIALECT)) {
+      session.executeNonQueryStatement("CREATE DATABASE \"db1\"");
+      session.executeNonQueryStatement("CREATE DATABASE \"db2\"");
       session.executeNonQueryStatement("USE \"db1\"");
-      // only one column in this table, and others should be auto-created
-      session.executeNonQueryStatement("CREATE TABLE table1 (id1 string id)");
+      session.executeNonQueryStatement(
+          "CREATE TABLE table10 (id1 string id, attr1 string attribute, "
+              + "m1 double "
+              + "measurement)");
+    }
+    // insert without db
+    try (ISession session = EnvFactory.getEnv().getSessionConnection(TABLE_SQL_DIALECT)) {
+      long timestamp;
 
-      List<IMeasurementSchema> schemaList = new ArrayList<>();
-      schemaList.add(new MeasurementSchema("id2", TSDataType.STRING));
-      schemaList.add(new MeasurementSchema("attr1", TSDataType.STRING));
-      schemaList.add(new MeasurementSchema("m1", TSDataType.DOUBLE));
-      final List<ColumnType> columnTypes =
-          Arrays.asList(ColumnType.ID, ColumnType.ATTRIBUTE, ColumnType.MEASUREMENT);
+      // no db in session and sql
+      assertThrows(
+          StatementExecutionException.class,
+          () ->
+              session.executeNonQueryStatement(
+                  String.format(
+                      "INSERT INTO table10 (time, id1, attr1, m1) VALUES (%d, '%s', '%s', %f)",
+                      0, "id:" + 0, "attr:" + 0, 0 * 1.0)));
 
-      long timestamp = 0;
-      Tablet tablet = new Tablet("table1", schemaList, columnTypes, 15);
-
+      // specify db in sql
       for (long row = 0; row < 15; row++) {
-        int rowIndex = tablet.rowSize++;
-        tablet.addTimestamp(rowIndex, timestamp + row);
-        tablet.addValue("id2", rowIndex, "id:" + row);
-        tablet.addValue("attr1", rowIndex, "attr:" + row);
-        tablet.addValue("m1", rowIndex, row * 1.0);
-        if (tablet.rowSize == tablet.getMaxRowNumber()) {
-          session.insertRelationalTablet(tablet, true);
-          tablet.reset();
-        }
-      }
-
-      if (tablet.rowSize != 0) {
-        session.insertRelationalTablet(tablet);
-        tablet.reset();
+        session.executeNonQueryStatement(
+            String.format(
+                "INSERT INTO db1.table10 (time, id1, attr1, m1) VALUES (%d, '%s', '%s', %f)",
+                row, "id:" + row, "attr:" + row, row * 1.0));
       }
 
       session.executeNonQueryStatement("FLush");
 
       for (long row = 15; row < 30; row++) {
-        int rowIndex = tablet.rowSize++;
-        tablet.addTimestamp(rowIndex, timestamp + row);
-        tablet.addValue("id2", rowIndex, "id:" + row);
-        tablet.addValue("attr1", rowIndex, "attr:" + row);
-        tablet.addValue("m1", rowIndex, row * 1.0);
-        if (tablet.rowSize == tablet.getMaxRowNumber()) {
-          session.insertRelationalTablet(tablet, true);
-          tablet.reset();
-        }
+        session.executeNonQueryStatement(
+            String.format(
+                "INSERT INTO db1.table10 (time, id1, attr1, m1) VALUES (%d, '%s', '%s', %f)",
+                row, "id:" + row, "attr:" + row, row * 1.0));
       }
 
-      if (tablet.rowSize != 0) {
-        session.insertRelationalTablet(tablet);
-        tablet.reset();
-      }
-
-      SessionDataSet dataSet = session.executeQueryStatement("select * from table1 order by time");
+      SessionDataSet dataSet =
+          session.executeQueryStatement("select * from db1.table10 order by time");
       int cnt = 0;
       while (dataSet.hasNext()) {
         RowRecord rowRecord = dataSet.next();
         timestamp = rowRecord.getFields().get(0).getLongV();
-        // id 1 should be null
-        assertNull(rowRecord.getFields().get(1).getDataType());
-        assertEquals("id:" + timestamp, rowRecord.getFields().get(2).getBinaryV().toString());
-        assertEquals("attr:" + timestamp, rowRecord.getFields().get(3).getBinaryV().toString());
-        assertEquals(timestamp * 1.0, rowRecord.getFields().get(4).getDoubleV(), 0.0001);
+        assertEquals("id:" + timestamp, rowRecord.getFields().get(1).getBinaryV().toString());
+        assertEquals("attr:" + timestamp, rowRecord.getFields().get(2).getBinaryV().toString());
+        assertEquals(timestamp * 1.0, rowRecord.getFields().get(3).getDoubleV(), 0.0001);
         cnt++;
       }
       assertEquals(30, cnt);
     }
-    //    insertRelationalTabletPerformanceTest();
   }
 
   private static void insertRelationalTabletPerformanceTest()
@@ -269,16 +263,15 @@ public class IoTDBSessionRelationalIT {
   @Category({LocalStandaloneIT.class, ClusterIT.class})
   public void partialInsertRelationalRowTest()
       throws IoTDBConnectionException, StatementExecutionException {
-    // disable auto-creation only for this test
-    EnvFactory.getEnv().cleanClusterEnvironment();
-    EnvFactory.getEnv().getConfig().getCommonConfig().setAutoCreateSchemaEnabled(false);
-    EnvFactory.getEnv().initClusterEnvironment();
+    try (ISession session = EnvFactory.getEnv().getSessionConnection(TREE_SQL_DIALECT)) {
+      // disable auto-creation only for this test
+      session.executeNonQueryStatement("SET CONFIGURATION \"enable_auto_create_schema\"=\"false\"");
+    }
     try (ISession session = EnvFactory.getEnv().getSessionConnection(TABLE_SQL_DIALECT)) {
-      session.executeNonQueryStatement("CREATE DATABASE \"db1\"");
       session.executeNonQueryStatement("USE \"db1\"");
       // the table is missing column "m2"
       session.executeNonQueryStatement(
-          "CREATE TABLE table1 (id1 string id, attr1 string attribute, "
+          "CREATE TABLE table2 (id1 string id, attr1 string attribute, "
               + "m1 double "
               + "measurement)");
 
@@ -304,7 +297,7 @@ public class IoTDBSessionRelationalIT {
         Object[] values = new Object[] {"id:" + row, "attr:" + row, row * 1.0, row * 1.0};
         try {
           session.insertRelationalRecord(
-              "table1", timestamp + row, measurementIds, dataTypes, columnTypes, values);
+              "table2", timestamp + row, measurementIds, dataTypes, columnTypes, values);
         } catch (StatementExecutionException e) {
           if (!e.getMessage()
               .equals(
@@ -320,7 +313,7 @@ public class IoTDBSessionRelationalIT {
         Object[] values = new Object[] {"id:" + row, "attr:" + row, row * 1.0, row * 1.0};
         try {
           session.insertRelationalRecord(
-              "table1", timestamp + row, measurementIds, dataTypes, columnTypes, values);
+              "table2", timestamp + row, measurementIds, dataTypes, columnTypes, values);
         } catch (StatementExecutionException e) {
           if (!e.getMessage()
               .equals(
@@ -330,7 +323,7 @@ public class IoTDBSessionRelationalIT {
         }
       }
 
-      SessionDataSet dataSet = session.executeQueryStatement("select * from table1 order by time");
+      SessionDataSet dataSet = session.executeQueryStatement("select * from table2 order by time");
       int cnt = 0;
       while (dataSet.hasNext()) {
         RowRecord rowRecord = dataSet.next();
@@ -344,7 +337,10 @@ public class IoTDBSessionRelationalIT {
       }
       assertEquals(30, cnt);
     } finally {
-      EnvFactory.getEnv().getConfig().getCommonConfig().setAutoCreateSchemaEnabled(true);
+      try (ISession session = EnvFactory.getEnv().getSessionConnection(TREE_SQL_DIALECT)) {
+        session.executeNonQueryStatement(
+            "SET CONFIGURATION \"enable_auto_create_schema\"=\"true\"");
+      }
     }
   }
 
@@ -355,7 +351,7 @@ public class IoTDBSessionRelationalIT {
     try (ISession session = EnvFactory.getEnv().getSessionConnection(TABLE_SQL_DIALECT)) {
       session.executeNonQueryStatement("USE \"db1\"");
       session.executeNonQueryStatement(
-          "CREATE TABLE table1 (id1 string id, attr1 string attribute, "
+          "CREATE TABLE table3 (id1 string id, attr1 string attribute, "
               + "m1 double "
               + "measurement)");
 
@@ -377,7 +373,7 @@ public class IoTDBSessionRelationalIT {
       for (long row = 0; row < 15; row++) {
         Object[] values = new Object[] {"id:" + row, "attr:" + row, row * 1.0};
         session.insertRelationalRecord(
-            "table1", timestamp + row, measurementIds, dataTypes, columnTypes, values);
+            "table3", timestamp + row, measurementIds, dataTypes, columnTypes, values);
       }
 
       session.executeNonQueryStatement("FLush");
@@ -385,10 +381,10 @@ public class IoTDBSessionRelationalIT {
       for (long row = 15; row < 30; row++) {
         Object[] values = new Object[] {"id:" + row, "attr:" + row, row * 1.0};
         session.insertRelationalRecord(
-            "table1", timestamp + row, measurementIds, dataTypes, columnTypes, values);
+            "table3", timestamp + row, measurementIds, dataTypes, columnTypes, values);
       }
 
-      SessionDataSet dataSet = session.executeQueryStatement("select * from table1 order by time");
+      SessionDataSet dataSet = session.executeQueryStatement("select * from table3 order by time");
       int cnt = 0;
       while (dataSet.hasNext()) {
         RowRecord rowRecord = dataSet.next();
@@ -406,16 +402,15 @@ public class IoTDBSessionRelationalIT {
   @Category({LocalStandaloneIT.class, ClusterIT.class})
   public void partialInsertRelationalTabletTest()
       throws IoTDBConnectionException, StatementExecutionException {
-    // disable auto-creation only for this test
-    EnvFactory.getEnv().cleanClusterEnvironment();
-    EnvFactory.getEnv().getConfig().getCommonConfig().setAutoCreateSchemaEnabled(false);
-    EnvFactory.getEnv().initClusterEnvironment();
+    try (ISession session = EnvFactory.getEnv().getSessionConnection(TREE_SQL_DIALECT)) {
+      // disable auto-creation only for this test
+      session.executeNonQueryStatement("SET CONFIGURATION \"enable_auto_create_schema\"=\"false\"");
+    }
     try (ISession session = EnvFactory.getEnv().getSessionConnection(TABLE_SQL_DIALECT)) {
-      session.executeNonQueryStatement("CREATE DATABASE \"db1\"");
       session.executeNonQueryStatement("USE \"db1\"");
       // the table is missing column "m2"
       session.executeNonQueryStatement(
-          "CREATE TABLE table1 (id1 string id, attr1 string attribute, "
+          "CREATE TABLE table4 (id1 string id, attr1 string attribute, "
               + "m1 double "
               + "measurement)");
 
@@ -430,7 +425,7 @@ public class IoTDBSessionRelationalIT {
               ColumnType.ID, ColumnType.ATTRIBUTE, ColumnType.MEASUREMENT, ColumnType.MEASUREMENT);
 
       long timestamp = 0;
-      Tablet tablet = new Tablet("table1", schemaList, columnTypes, 15);
+      Tablet tablet = new Tablet("table4", schemaList, columnTypes, 15);
 
       for (long row = 0; row < 15; row++) {
         int rowIndex = tablet.rowSize++;
@@ -503,7 +498,7 @@ public class IoTDBSessionRelationalIT {
         tablet.reset();
       }
 
-      SessionDataSet dataSet = session.executeQueryStatement("select * from table1 order by time");
+      SessionDataSet dataSet = session.executeQueryStatement("select * from table4 order by time");
       int cnt = 0;
       while (dataSet.hasNext()) {
         RowRecord rowRecord = dataSet.next();
@@ -517,7 +512,10 @@ public class IoTDBSessionRelationalIT {
       }
       assertEquals(30, cnt);
     } finally {
-      EnvFactory.getEnv().getConfig().getCommonConfig().setAutoCreateSchemaEnabled(true);
+      try (ISession session = EnvFactory.getEnv().getSessionConnection(TREE_SQL_DIALECT)) {
+        session.executeNonQueryStatement(
+            "SET CONFIGURATION \"enable_auto_create_schema\"=\"true\"");
+      }
     }
   }
 
@@ -528,7 +526,7 @@ public class IoTDBSessionRelationalIT {
     try (ISession session = EnvFactory.getEnv().getSessionConnection(TABLE_SQL_DIALECT)) {
       session.executeNonQueryStatement("USE \"db1\"");
       session.executeNonQueryStatement(
-          "CREATE TABLE table1 (id1 string id, attr1 string attribute, "
+          "CREATE TABLE table5 (id1 string id, attr1 string attribute, "
               + "m1 double "
               + "measurement)");
 
@@ -540,7 +538,7 @@ public class IoTDBSessionRelationalIT {
           Arrays.asList(ColumnType.ID, ColumnType.ATTRIBUTE, ColumnType.MEASUREMENT);
 
       long timestamp = 0;
-      Tablet tablet = new Tablet("table1", schemaList, columnTypes, 15);
+      Tablet tablet = new Tablet("table5", schemaList, columnTypes, 15);
 
       for (long row = 0; row < 15; row++) {
         int rowIndex = tablet.rowSize++;
@@ -579,7 +577,7 @@ public class IoTDBSessionRelationalIT {
       }
 
       int cnt = 0;
-      SessionDataSet dataSet = session.executeQueryStatement("select * from table1 order by time");
+      SessionDataSet dataSet = session.executeQueryStatement("select * from table5 order by time");
       while (dataSet.hasNext()) {
         RowRecord rowRecord = dataSet.next();
         timestamp = rowRecord.getFields().get(0).getLongV();
@@ -617,7 +615,7 @@ public class IoTDBSessionRelationalIT {
       for (long row = 0; row < 15; row++) {
         Object[] values = new Object[] {"id:" + row, "attr:" + row, row * 1.0};
         session.insertRelationalRecord(
-            "table1", timestamp + row, measurementIds, dataTypes, columnTypes, values);
+            "table6", timestamp + row, measurementIds, dataTypes, columnTypes, values);
       }
 
       session.executeNonQueryStatement("FLush");
@@ -625,11 +623,11 @@ public class IoTDBSessionRelationalIT {
       for (long row = 15; row < 30; row++) {
         Object[] values = new Object[] {"id:" + row, "attr:" + row, row * 1.0};
         session.insertRelationalRecord(
-            "table1", timestamp + row, measurementIds, dataTypes, columnTypes, values);
+            "table6", timestamp + row, measurementIds, dataTypes, columnTypes, values);
       }
 
       int cnt = 0;
-      SessionDataSet dataSet = session.executeQueryStatement("select * from table1 order by time");
+      SessionDataSet dataSet = session.executeQueryStatement("select * from table6 order by time");
       while (dataSet.hasNext()) {
         RowRecord rowRecord = dataSet.next();
         timestamp = rowRecord.getFields().get(0).getLongV();
@@ -649,7 +647,7 @@ public class IoTDBSessionRelationalIT {
     try (ISession session = EnvFactory.getEnv().getSessionConnection(TABLE_SQL_DIALECT)) {
       session.executeNonQueryStatement("USE \"db1\"");
       // only one column in this table, and others should be auto-created
-      session.executeNonQueryStatement("CREATE TABLE table1 (id1 string id)");
+      session.executeNonQueryStatement("CREATE TABLE table7 (id1 string id)");
 
       List<IMeasurementSchema> schemaList = new ArrayList<>();
       schemaList.add(new MeasurementSchema("id1", TSDataType.STRING));
@@ -659,7 +657,7 @@ public class IoTDBSessionRelationalIT {
           Arrays.asList(ColumnType.ID, ColumnType.ATTRIBUTE, ColumnType.MEASUREMENT);
 
       long timestamp = 0;
-      Tablet tablet = new Tablet("table1", schemaList, columnTypes, 15);
+      Tablet tablet = new Tablet("table7", schemaList, columnTypes, 15);
 
       for (long row = 0; row < 15; row++) {
         int rowIndex = tablet.rowSize++;
@@ -697,7 +695,7 @@ public class IoTDBSessionRelationalIT {
         tablet.reset();
       }
 
-      SessionDataSet dataSet = session.executeQueryStatement("select * from table1 order by time");
+      SessionDataSet dataSet = session.executeQueryStatement("select * from table7 order by time");
       int cnt = 0;
       while (dataSet.hasNext()) {
         RowRecord rowRecord = dataSet.next();
@@ -718,7 +716,7 @@ public class IoTDBSessionRelationalIT {
     try (ISession session = EnvFactory.getEnv().getSessionConnection(TABLE_SQL_DIALECT)) {
       session.executeNonQueryStatement("USE \"db1\"");
       // only one column in this table, and others should be auto-created
-      session.executeNonQueryStatement("CREATE TABLE table1 (id1 string id)");
+      session.executeNonQueryStatement("CREATE TABLE table8 (id1 string id)");
 
       List<IMeasurementSchema> schemaList = new ArrayList<>();
       schemaList.add(new MeasurementSchema("id2", TSDataType.STRING));
@@ -728,7 +726,7 @@ public class IoTDBSessionRelationalIT {
           Arrays.asList(ColumnType.ID, ColumnType.ATTRIBUTE, ColumnType.MEASUREMENT);
 
       long timestamp = 0;
-      Tablet tablet = new Tablet("table1", schemaList, columnTypes, 15);
+      Tablet tablet = new Tablet("table8", schemaList, columnTypes, 15);
 
       for (long row = 0; row < 15; row++) {
         int rowIndex = tablet.rowSize++;
@@ -766,7 +764,7 @@ public class IoTDBSessionRelationalIT {
         tablet.reset();
       }
 
-      SessionDataSet dataSet = session.executeQueryStatement("select * from table1 order by time");
+      SessionDataSet dataSet = session.executeQueryStatement("select * from table8 order by time");
       int cnt = 0;
       while (dataSet.hasNext()) {
         RowRecord rowRecord = dataSet.next();
@@ -786,12 +784,10 @@ public class IoTDBSessionRelationalIT {
   @Category({LocalStandaloneIT.class, ClusterIT.class})
   public void autoAdjustIdTest() throws IoTDBConnectionException, StatementExecutionException {
     try (ISession session = EnvFactory.getEnv().getSessionConnection(TABLE_SQL_DIALECT)) {
-      session.executeNonQueryStatement("DROP DATABASE IF EXISTS db1");
-      session.executeNonQueryStatement("CREATE DATABASE db1");
       session.executeNonQueryStatement("USE \"db1\"");
       // the id order in the table is (id1, id2)
       session.executeNonQueryStatement(
-          "CREATE TABLE table1 (id1 string id, id2 string id, attr1 string attribute, "
+          "CREATE TABLE table9 (id1 string id, id2 string id, attr1 string attribute, "
               + "m1 double "
               + "measurement)");
 
@@ -815,7 +811,7 @@ public class IoTDBSessionRelationalIT {
       for (long row = 0; row < 15; row++) {
         Object[] values = new Object[] {"id2:" + row, "id1:" + row, "attr1:" + row, row * 1.0};
         session.insertRelationalRecord(
-            "table1", timestamp + row, measurementIds, dataTypes, columnTypes, values);
+            "table9", timestamp + row, measurementIds, dataTypes, columnTypes, values);
       }
 
       session.executeNonQueryStatement("FLush");
@@ -823,10 +819,10 @@ public class IoTDBSessionRelationalIT {
       for (long row = 15; row < 30; row++) {
         Object[] values = new Object[] {"id2:" + row, "id1:" + row, "attr1:" + row, row * 1.0};
         session.insertRelationalRecord(
-            "table1", timestamp + row, measurementIds, dataTypes, columnTypes, values);
+            "table9", timestamp + row, measurementIds, dataTypes, columnTypes, values);
       }
 
-      SessionDataSet dataSet = session.executeQueryStatement("select * from table1 order by time");
+      SessionDataSet dataSet = session.executeQueryStatement("select * from table9 order by time");
       int cnt = 0;
       while (dataSet.hasNext()) {
         RowRecord rowRecord = dataSet.next();
@@ -838,6 +834,138 @@ public class IoTDBSessionRelationalIT {
         cnt++;
       }
       assertEquals(30, cnt);
+    }
+  }
+
+  @Test
+  @Category({LocalStandaloneIT.class, ClusterIT.class})
+  public void insertRelationalSqlWithoutDBTest()
+      throws IoTDBConnectionException, StatementExecutionException {
+    try (ISession session = EnvFactory.getEnv().getSessionConnection(TABLE_SQL_DIALECT)) {
+      session.executeNonQueryStatement("USE \"db1\"");
+      session.executeNonQueryStatement(
+          "CREATE TABLE table10 (id1 string id, attr1 string attribute, "
+              + "m1 double "
+              + "measurement)");
+    }
+    // insert without db
+    try (ISession session = EnvFactory.getEnv().getSessionConnection(TABLE_SQL_DIALECT)) {
+      long timestamp;
+
+      // no db in session and sql
+      assertThrows(
+          StatementExecutionException.class,
+          () ->
+              session.executeNonQueryStatement(
+                  String.format(
+                      "INSERT INTO table10 (time, id1, attr1, m1) VALUES (%d, '%s', '%s', %f)",
+                      0, "id:" + 0, "attr:" + 0, 0 * 1.0)));
+
+      // specify db in sql
+      for (long row = 0; row < 15; row++) {
+        session.executeNonQueryStatement(
+            String.format(
+                "INSERT INTO db1.table10 (time, id1, attr1, m1) VALUES (%d, '%s', '%s', %f)",
+                row, "id:" + row, "attr:" + row, row * 1.0));
+      }
+
+      session.executeNonQueryStatement("FLush");
+
+      for (long row = 15; row < 30; row++) {
+        session.executeNonQueryStatement(
+            String.format(
+                "INSERT INTO db1.table10 (time, id1, attr1, m1) VALUES (%d, '%s', '%s', %f)",
+                row, "id:" + row, "attr:" + row, row * 1.0));
+      }
+
+      SessionDataSet dataSet =
+          session.executeQueryStatement("select * from db1.table10 order by time");
+      int cnt = 0;
+      while (dataSet.hasNext()) {
+        RowRecord rowRecord = dataSet.next();
+        timestamp = rowRecord.getFields().get(0).getLongV();
+        assertEquals("id:" + timestamp, rowRecord.getFields().get(1).getBinaryV().toString());
+        assertEquals("attr:" + timestamp, rowRecord.getFields().get(2).getBinaryV().toString());
+        assertEquals(timestamp * 1.0, rowRecord.getFields().get(3).getDoubleV(), 0.0001);
+        cnt++;
+      }
+      assertEquals(30, cnt);
+    }
+  }
+
+  @Test
+  @Category({LocalStandaloneIT.class, ClusterIT.class})
+  public void insertRelationalSqlAnotherDBTest()
+      throws IoTDBConnectionException, StatementExecutionException {
+    try (ISession session = EnvFactory.getEnv().getSessionConnection(TABLE_SQL_DIALECT)) {
+      session.executeNonQueryStatement("USE \"db1\"");
+      session.executeNonQueryStatement(
+          "CREATE TABLE table11 (id1 string id, attr1 string attribute, "
+              + "m1 double "
+              + "measurement)");
+    }
+    // use db2 but insert db1
+    try (ISession session = EnvFactory.getEnv().getSessionConnection(TABLE_SQL_DIALECT)) {
+      long timestamp;
+      session.executeNonQueryStatement("USE \"db2\"");
+
+      // specify db in sql
+      for (long row = 0; row < 15; row++) {
+        session.executeNonQueryStatement(
+            String.format(
+                "INSERT INTO db1.table11 (time, id1, attr1, m1) VALUES (%d, '%s', '%s', %f)",
+                row, "id:" + row, "attr:" + row, row * 1.0));
+      }
+
+      session.executeNonQueryStatement("FLush");
+
+      for (long row = 15; row < 30; row++) {
+        session.executeNonQueryStatement(
+            String.format(
+                "INSERT INTO db1.table11 (time, id1, attr1, m1) VALUES (%d, '%s', '%s', %f)",
+                row, "id:" + row, "attr:" + row, row * 1.0));
+      }
+
+      SessionDataSet dataSet =
+          session.executeQueryStatement("select * from db1.table11 order by time");
+      int cnt = 0;
+      while (dataSet.hasNext()) {
+        RowRecord rowRecord = dataSet.next();
+        timestamp = rowRecord.getFields().get(0).getLongV();
+        assertEquals("id:" + timestamp, rowRecord.getFields().get(1).getBinaryV().toString());
+        assertEquals("attr:" + timestamp, rowRecord.getFields().get(2).getBinaryV().toString());
+        assertEquals(timestamp * 1.0, rowRecord.getFields().get(3).getDoubleV(), 0.0001);
+        cnt++;
+      }
+      assertEquals(30, cnt);
+    }
+  }
+
+  @Test
+  @Category({LocalStandaloneIT.class, ClusterIT.class})
+  public void insertNonExistDBTest() throws IoTDBConnectionException, StatementExecutionException {
+    try (ISession session = EnvFactory.getEnv().getSessionConnection(TABLE_SQL_DIALECT)) {
+      session.executeNonQueryStatement("USE \"db1\"");
+
+      try {
+        session.executeNonQueryStatement(
+            String.format(
+                "INSERT INTO table13 (time, id1, attr1, m1) VALUES (%d, '%s', '%s', %f)",
+                0, "id:" + 0, "attr:" + 0, 0 * 1.0));
+        fail("Exception expected");
+      } catch (StatementExecutionException e) {
+        assertEquals("507: Table table13 does not exist", e.getMessage());
+      }
+
+      try {
+        session.executeNonQueryStatement(
+            String.format(
+                "INSERT INTO db2.table13 (time, id1, attr1, m1) VALUES (%d, '%s', '%s', %f)",
+                0, "id:" + 0, "attr:" + 0, 0 * 1.0));
+        fail("Exception expected");
+      } catch (StatementExecutionException e) {
+        assertEquals("507: Table table13 does not exist", e.getMessage());
+      }
     }
   }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionRelationalIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionRelationalIT.java
@@ -945,7 +945,8 @@ public class IoTDBSessionRelationalIT {
 
   @Test
   @Category({LocalStandaloneIT.class, ClusterIT.class})
-  public void insertNonExistTableTest() throws IoTDBConnectionException, StatementExecutionException {
+  public void insertNonExistTableTest()
+      throws IoTDBConnectionException, StatementExecutionException {
     try (ISession session = EnvFactory.getEnv().getSessionConnection(TABLE_SQL_DIALECT)) {
       session.executeNonQueryStatement("USE \"db1\"");
 

--- a/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionRelationalIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionRelationalIT.java
@@ -853,13 +853,15 @@ public class IoTDBSessionRelationalIT {
       long timestamp;
 
       // no db in session and sql
-      assertThrows(
-          StatementExecutionException.class,
-          () ->
-              session.executeNonQueryStatement(
-                  String.format(
-                      "INSERT INTO table10 (time, id1, attr1, m1) VALUES (%d, '%s', '%s', %f)",
-                      0, "id:" + 0, "attr:" + 0, 0 * 1.0)));
+      try {
+        session.executeNonQueryStatement(
+            String.format(
+                "INSERT INTO table10 (time, id1, attr1, m1) VALUES (%d, '%s', '%s', %f)",
+                0, "id:" + 0, "attr:" + 0, 0 * 1.0));
+        fail("Exception expected");
+      } catch (StatementExecutionException e) {
+        assertEquals("701: database is not specified", e.getMessage());
+      }
 
       // specify db in sql
       for (long row = 0; row < 15; row++) {
@@ -943,7 +945,7 @@ public class IoTDBSessionRelationalIT {
 
   @Test
   @Category({LocalStandaloneIT.class, ClusterIT.class})
-  public void insertNonExistDBTest() throws IoTDBConnectionException, StatementExecutionException {
+  public void insertNonExistTableTest() throws IoTDBConnectionException, StatementExecutionException {
     try (ISession session = EnvFactory.getEnv().getSessionConnection(TABLE_SQL_DIALECT)) {
       session.executeNonQueryStatement("USE \"db1\"");
 
@@ -961,6 +963,24 @@ public class IoTDBSessionRelationalIT {
         session.executeNonQueryStatement(
             String.format(
                 "INSERT INTO db2.table13 (time, id1, attr1, m1) VALUES (%d, '%s', '%s', %f)",
+                0, "id:" + 0, "attr:" + 0, 0 * 1.0));
+        fail("Exception expected");
+      } catch (StatementExecutionException e) {
+        assertEquals("507: Table table13 does not exist", e.getMessage());
+      }
+    }
+  }
+
+  @Test
+  @Category({LocalStandaloneIT.class, ClusterIT.class})
+  public void insertNonExistDBTest() throws IoTDBConnectionException, StatementExecutionException {
+    try (ISession session = EnvFactory.getEnv().getSessionConnection(TABLE_SQL_DIALECT)) {
+      session.executeNonQueryStatement("USE \"db1\"");
+
+      try {
+        session.executeNonQueryStatement(
+            String.format(
+                "INSERT INTO db3.table13 (time, id1, attr1, m1) VALUES (%d, '%s', '%s', %f)",
                 0, "id:" + 0, "attr:" + 0, 0 * 1.0));
         fail("Exception expected");
       } catch (StatementExecutionException e) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/exception/sql/ColumnCreationFailException.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/exception/sql/ColumnCreationFailException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.exception.sql;
+
+public class ColumnCreationFailException extends SemanticException {
+
+  public ColumnCreationFailException(String message) {
+    super(message);
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/MPPQueryContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/MPPQueryContext.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * This class is used to record the context of a query including QueryId, query statement, session
@@ -349,5 +350,9 @@ public class MPPQueryContext {
 
   public void setTableQuery(boolean tableQuery) {
     isTableQuery = tableQuery;
+  }
+
+  public Optional<String> getDatabaseName() {
+    return session.getDatabaseName();
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeUtils.java
@@ -87,7 +87,7 @@ public class AnalyzeUtils {
     if (statement.getDatabaseName().isPresent()) {
       return statement.getDatabaseName().get();
     }
-    if (context.getDatabaseName().isPresent()) {
+    if (context != null && context.getDatabaseName().isPresent()) {
       return context.getDatabaseName().get();
     }
     return null;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeUtils.java
@@ -90,7 +90,7 @@ public class AnalyzeUtils {
     if (context.getDatabaseName().isPresent()) {
       return context.getDatabaseName().get();
     }
-    throw new SemanticException("database not specified");
+    return null;
   }
 
   public static List<DataPartitionQueryParam> computeTableDataPartitionParams(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeUtils.java
@@ -83,6 +83,16 @@ public class AnalyzeUtils {
     return realStatement;
   }
 
+  public static String getDatabaseName(InsertBaseStatement statement, MPPQueryContext context) {
+    if (statement.getDatabaseName().isPresent()) {
+      return statement.getDatabaseName().get();
+    }
+    if (context.getDatabaseName().isPresent()) {
+      return context.getDatabaseName().get();
+    }
+    throw new SemanticException("database not specified");
+  }
+
   public static List<DataPartitionQueryParam> computeTableDataPartitionParams(
       InsertBaseStatement statement, MPPQueryContext context) {
     if (statement instanceof InsertTabletStatement) {
@@ -93,8 +103,7 @@ public class AnalyzeUtils {
             .computeIfAbsent(insertTabletStatement.getTableDeviceID(i), id -> new HashSet<>())
             .add(insertTabletStatement.getTimePartitionSlot(i));
       }
-      return computeDataPartitionParams(
-          timePartitionSlotMap, context.getSession().getDatabaseName().orElse(null));
+      return computeDataPartitionParams(timePartitionSlotMap, getDatabaseName(statement, context));
     } else if (statement instanceof InsertMultiTabletsStatement) {
       InsertMultiTabletsStatement insertMultiTabletsStatement =
           (InsertMultiTabletsStatement) statement;
@@ -107,15 +116,14 @@ public class AnalyzeUtils {
               .add(insertTabletStatement.getTimePartitionSlot(i));
         }
       }
-      return computeDataPartitionParams(
-          timePartitionSlotMap, context.getSession().getDatabaseName().orElse(null));
+      return computeDataPartitionParams(timePartitionSlotMap, getDatabaseName(statement, context));
     } else if (statement instanceof InsertRowStatement) {
       InsertRowStatement insertRowStatement = (InsertRowStatement) statement;
       return computeDataPartitionParams(
           Collections.singletonMap(
               insertRowStatement.getTableDeviceID(),
               Collections.singleton(insertRowStatement.getTimePartitionSlot())),
-          context.getSession().getDatabaseName().orElse(null));
+          getDatabaseName(statement, context));
     } else if (statement instanceof InsertRowsStatement) {
       InsertRowsStatement insertRowsStatement = (InsertRowsStatement) statement;
       Map<IDeviceID, Set<TTimePartitionSlot>> timePartitionSlotMap = new HashMap<>();
@@ -125,8 +133,7 @@ public class AnalyzeUtils {
             .computeIfAbsent(insertRowStatement.getTableDeviceID(), id -> new HashSet<>())
             .add(insertRowStatement.getTimePartitionSlot());
       }
-      return computeDataPartitionParams(
-          timePartitionSlotMap, context.getSession().getDatabaseName().orElse(null));
+      return computeDataPartitionParams(timePartitionSlotMap, getDatabaseName(statement, context));
     }
     throw new UnsupportedOperationException("computeDataPartitionParams for " + statement);
   }
@@ -150,7 +157,7 @@ public class AnalyzeUtils {
         timePartitionSlotSet.addAll(insertTabletStatement.getTimePartitionSlots());
       }
       return computeDataPartitionParams(
-          dataPartitionQueryParamMap, context.getSession().getDatabaseName().orElse(null));
+          dataPartitionQueryParamMap, getDatabaseName(statement, context));
     } else if (statement instanceof InsertRowsStatement) {
       final InsertRowsStatement insertRowsStatement = (InsertRowsStatement) statement;
       Map<IDeviceID, Set<TTimePartitionSlot>> dataPartitionQueryParamMap = new HashMap<>();
@@ -163,7 +170,7 @@ public class AnalyzeUtils {
         timePartitionSlotSet.add(insertRowStatement.getTimePartitionSlot());
       }
       return computeDataPartitionParams(
-          dataPartitionQueryParamMap, context.getSession().getDatabaseName().orElse(null));
+          dataPartitionQueryParamMap, getDatabaseName(statement, context));
     }
     throw new UnsupportedOperationException("computeDataPartitionParams for " + statement);
   }
@@ -173,7 +180,7 @@ public class AnalyzeUtils {
     DataPartitionQueryParam dataPartitionQueryParam = new DataPartitionQueryParam();
     dataPartitionQueryParam.setDeviceID(statement.getDevicePath().getIDeviceIDAsFullDevice());
     dataPartitionQueryParam.setTimePartitionSlotList(statement.getTimePartitionSlots());
-    dataPartitionQueryParam.setDatabaseName(context.getSession().getDatabaseName().orElse(null));
+    dataPartitionQueryParam.setDatabaseName(getDatabaseName(statement, context));
     return dataPartitionQueryParam;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
@@ -246,7 +246,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
     Analysis analysis = visitQuery(explainStatement.getQueryStatement(), context);
     analysis.setRealStatement(explainStatement);
     analysis.setFinishQueryAfterAnalyze(true);
-    analysis.setDatabaseName(context.getSession().getDatabaseName().orElse(null));
+    analysis.setDatabaseName(context.getDatabaseName().orElse(null));
     return analysis;
   }
 
@@ -261,7 +261,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
             Collections.singletonList(
                 new ColumnHeader(ColumnHeaderConstant.EXPLAIN_ANALYZE, TSDataType.TEXT, null)),
             true));
-    analysis.setDatabaseName(context.getSession().getDatabaseName().orElse(null));
+    analysis.setDatabaseName(context.getDatabaseName().orElse(null));
     return analysis;
   }
 
@@ -2796,7 +2796,7 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
   public Analysis visitPipeEnrichedStatement(
       PipeEnrichedStatement pipeEnrichedStatement, MPPQueryContext context) {
     Analysis analysis = pipeEnrichedStatement.getInnerStatement().accept(this, context);
-    analysis.setDatabaseName(context.getSession().getDatabaseName().orElse(null));
+    analysis.setDatabaseName(context.getDatabaseName().orElse(null));
 
     // statement may be changed because of logical view
     pipeEnrichedStatement.setInnerStatement(analysis.getTreeStatement());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/Analyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/Analyzer.java
@@ -47,7 +47,7 @@ public class Analyzer {
         new AnalyzeVisitor(partitionFetcher, schemaFetcher).process(statement, context);
     if (context.getSession() != null) {
       // for test compatibility
-      analysis.setDatabaseName(context.getSession().getDatabaseName().orElse(null));
+      analysis.setDatabaseName(context.getDatabaseName().orElse(null));
     }
 
     if (statement.isQuery()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/executor/ClusterConfigTaskExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/executor/ClusterConfigTaskExecutor.java
@@ -2301,7 +2301,7 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
     createLogicalViewStatement.setQueryStatement(alterLogicalViewStatement.getQueryStatement());
 
     final Analysis analysis = Analyzer.analyze(createLogicalViewStatement, context);
-    analysis.setDatabaseName(context.getSession().getDatabaseName().orElse(null));
+    analysis.setDatabaseName(context.getDatabaseName().orElse(null));
     if (analysis.isFailed()) {
       future.setException(
           new IoTDBException(
@@ -2886,19 +2886,19 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
   public SettableFuture<ConfigTaskResult> useDatabase(Use useDB, IClientSession clientSession) {
     SettableFuture<ConfigTaskResult> future = SettableFuture.create();
     // Construct request using statement
-    List<String> databasePathPattern = Arrays.asList(ROOT, useDB.getDatabase().getValue());
+    List<String> databasePathPattern = Arrays.asList(ROOT, useDB.getDatabaseId().getValue());
     try (ConfigNodeClient client =
         CONFIG_NODE_CLIENT_MANAGER.borrowClient(ConfigNodeInfo.CONFIG_REGION_ID)) {
       // Send request to some API server
       TGetDatabaseReq req = new TGetDatabaseReq(databasePathPattern, ALL_MATCH_SCOPE.serialize());
       TShowDatabaseResp resp = client.showDatabase(req);
       if (!resp.getDatabaseInfoMap().isEmpty()) {
-        clientSession.setDatabaseName(useDB.getDatabase().getValue());
+        clientSession.setDatabaseName(useDB.getDatabaseId().getValue());
         future.set(new ConfigTaskResult(TSStatusCode.SUCCESS_STATUS));
       } else {
         future.setException(
             new IoTDBException(
-                String.format("Unknown database %s", useDB.getDatabase().getValue()),
+                String.format("Unknown database %s", useDB.getDatabaseId().getValue()),
                 TSStatusCode.DATABASE_NOT_EXIST.getStatusCode()));
       }
     } catch (IOException | ClientManagerException | TException e) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/Analyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/Analyzer.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.queryengine.execution.warnings.WarningCollector;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Expression;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Parameter;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Statement;
+import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.WrappedInsertStatement;
 
 import java.util.List;
 import java.util.Map;
@@ -58,10 +59,19 @@ public class Analyzer {
 
   public Analysis analyze(Statement statement) {
     Analysis analysis = new Analysis(statement, parameterLookup);
-    if (!session.getDatabaseName().isPresent()) {
-      throw new SemanticException("database is not specified");
+    if (statement instanceof WrappedInsertStatement) {
+      WrappedInsertStatement insertStatement = (WrappedInsertStatement) statement;
+      if (insertStatement.getDatabase() != null) {
+        analysis.setDatabaseName(insertStatement.getDatabase());
+      } else if (session.getDatabaseName().isPresent()) {
+        analysis.setDatabaseName(session.getDatabaseName().get());
+      } else {
+        throw new SemanticException("database is not specified for insert:" + statement);
+      }
+    } else if (session.getDatabaseName().isPresent()) {
+      analysis.setDatabaseName(session.getDatabaseName().get());
     }
-    analysis.setDatabaseName(session.getDatabaseName().get());
+
     StatementAnalyzer analyzer =
         statementAnalyzerFactory.createStatementAnalyzer(
             analysis, session, warningCollector, CorrelationSupport.ALLOWED);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/Metadata.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/Metadata.java
@@ -103,7 +103,7 @@ public interface Metadata {
    *     are not STRING or Category, Type of any missing ColumnSchema is null
    */
   Optional<TableSchema> validateTableHeaderSchema(
-      String database, TableSchema tableSchema, MPPQueryContext context);
+      String database, TableSchema tableSchema, MPPQueryContext context, boolean allowCreateTable);
 
   /**
    * This method is used for table device validation and should be invoked after column validation.

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/MetadataUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/MetadataUtil.java
@@ -70,15 +70,15 @@ public class MetadataUtil {
       SessionInfo session, Node node, QualifiedName name) {
     requireNonNull(session, "session is null");
     requireNonNull(name, "name is null");
-    if (name.getParts().size() > 3) {
+    if (name.getParts().size() > 2) {
       throw new SemanticException(String.format("Too many dots in table name: %s", name));
     }
 
     List<String> parts = Lists.reverse(name.getParts());
     String objectName = parts.get(0);
     String databaseName =
-        (parts.size() > 2)
-            ? parts.get(2)
+        (parts.size() > 1)
+            ? parts.get(1)
             : session
                 .getDatabaseName()
                 .orElseThrow(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableMetadataImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableMetadataImpl.java
@@ -317,9 +317,9 @@ public class TableMetadataImpl implements Metadata {
 
   @Override
   public Optional<TableSchema> validateTableHeaderSchema(
-      String database, TableSchema tableSchema, MPPQueryContext context) {
+      String database, TableSchema tableSchema, MPPQueryContext context, boolean allowCreateTable) {
     return TableHeaderSchemaValidator.getInstance()
-        .validateTableHeaderSchema(database, tableSchema, context);
+        .validateTableHeaderSchema(database, tableSchema, context, allowCreateTable);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/fetcher/TableHeaderSchemaValidator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/fetcher/TableHeaderSchemaValidator.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.commons.schema.table.column.MeasurementColumnSchema;
 import org.apache.iotdb.commons.schema.table.column.TsTableColumnCategory;
 import org.apache.iotdb.commons.schema.table.column.TsTableColumnSchema;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.exception.sql.ColumnCreationFailException;
 import org.apache.iotdb.db.exception.sql.SemanticException;
 import org.apache.iotdb.db.queryengine.common.MPPQueryContext;
 import org.apache.iotdb.db.queryengine.plan.analyze.lock.DataNodeSchemaLockManager;
@@ -76,7 +77,7 @@ public class TableHeaderSchemaValidator {
   }
 
   public Optional<TableSchema> validateTableHeaderSchema(
-      String database, TableSchema tableSchema, MPPQueryContext context) {
+      String database, TableSchema tableSchema, MPPQueryContext context, boolean allowCreateTable) {
     // The schema cache R/W and fetch operation must be locked together thus the cache clean
     // operation executed by delete timeseries will be effective.
     DataNodeSchemaLockManager.getInstance().takeReadLock(SchemaLockType.VALIDATE_VS_DELETION);
@@ -96,11 +97,15 @@ public class TableHeaderSchemaValidator {
       // auto create missing table
       // it's ok that many write requests concurrently auto create same table, the thread safety
       // will be guaranteed by ProcedureManager.createTable in CN
-      autoCreateTable(database, tableSchema);
-      table = DataNodeTableCache.getInstance().getTable(database, tableSchema.getTableName());
-      if (table == null) {
-        throw new IllegalStateException(
-            "auto create table succeed, but cannot get table schema in current node's DataNodeTableCache, may be caused by concurrently auto creating table");
+      if (allowCreateTable) {
+        autoCreateTable(database, tableSchema);
+        table = DataNodeTableCache.getInstance().getTable(database, tableSchema.getTableName());
+        if (table == null) {
+          throw new IllegalStateException(
+              "auto create table succeed, but cannot get table schema in current node's DataNodeTableCache, may be caused by concurrently auto creating table");
+        }
+      } else {
+        throw new SemanticException("Table " + tableSchema.getTableName() + " does not exist");
       }
     }
 
@@ -181,7 +186,7 @@ public class TableHeaderSchemaValidator {
     for (ColumnSchema columnSchema : columnSchemas) {
       TsTableColumnCategory category = columnSchema.getColumnCategory();
       if (category == null) {
-        throw new SemanticException(
+        throw new ColumnCreationFailException(
             "Cannot create column " + columnSchema.getName() + " category is not provided");
       }
       String columnName = columnSchema.getName();
@@ -191,7 +196,7 @@ public class TableHeaderSchemaValidator {
       }
       TSDataType dataType = getTSDataType(columnSchema.getType());
       if (dataType == null) {
-        throw new SemanticException(
+        throw new ColumnCreationFailException(
             "Cannot create column " + columnSchema.getName() + " datatype is not provided");
       }
       generateColumnSchema(tsTable, category, columnName, dataType);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/fetcher/TableHeaderSchemaValidator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/fetcher/TableHeaderSchemaValidator.java
@@ -182,9 +182,7 @@ public class TableHeaderSchemaValidator {
       TsTableColumnCategory category = columnSchema.getColumnCategory();
       if (category == null) {
         throw new SemanticException(
-            "Cannot create column category for column "
-                + columnSchema.getName()
-                + " category is not provided");
+            "Cannot create column " + columnSchema.getName() + " category is not provided");
       }
       String columnName = columnSchema.getName();
       if (tsTable.getColumnSchema(columnName) != null) {
@@ -194,9 +192,7 @@ public class TableHeaderSchemaValidator {
       TSDataType dataType = getTSDataType(columnSchema.getType());
       if (dataType == null) {
         throw new SemanticException(
-            "Cannot create column category for column "
-                + columnSchema.getName()
-                + " datatype is not provided");
+            "Cannot create column " + columnSchema.getName() + " datatype is not provided");
       }
       generateColumnSchema(tsTable, category, columnName, dataType);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/InsertRow.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/InsertRow.java
@@ -22,7 +22,6 @@ package org.apache.iotdb.db.queryengine.plan.relational.sql.ast;
 import org.apache.iotdb.commons.schema.table.column.TsTableColumnCategory;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.queryengine.common.MPPQueryContext;
-import org.apache.iotdb.db.queryengine.plan.analyze.AnalyzeUtils;
 import org.apache.iotdb.db.queryengine.plan.statement.crud.InsertRowStatement;
 
 import java.util.ArrayList;
@@ -48,11 +47,6 @@ public class InsertRow extends WrappedInsertStatement {
   @Override
   public void updateAfterSchemaValidation(MPPQueryContext context) throws QueryProcessException {
     getInnerTreeStatement().updateAfterSchemaValidation(context);
-  }
-
-  @Override
-  public String getDatabase() {
-    return AnalyzeUtils.getDatabaseName(getInnerTreeStatement(), context);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/InsertRow.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/InsertRow.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.queryengine.plan.relational.sql.ast;
 import org.apache.iotdb.commons.schema.table.column.TsTableColumnCategory;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.queryengine.common.MPPQueryContext;
+import org.apache.iotdb.db.queryengine.plan.analyze.AnalyzeUtils;
 import org.apache.iotdb.db.queryengine.plan.statement.crud.InsertRowStatement;
 
 import java.util.ArrayList;
@@ -51,7 +52,7 @@ public class InsertRow extends WrappedInsertStatement {
 
   @Override
   public String getDatabase() {
-    return context.getSession().getDatabaseName().orElse(null);
+    return AnalyzeUtils.getDatabaseName(getInnerTreeStatement(), context);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/InsertRows.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/InsertRows.java
@@ -23,7 +23,6 @@ import org.apache.iotdb.commons.schema.table.column.TsTableColumnCategory;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.exception.sql.SemanticException;
 import org.apache.iotdb.db.queryengine.common.MPPQueryContext;
-import org.apache.iotdb.db.queryengine.plan.analyze.AnalyzeUtils;
 import org.apache.iotdb.db.queryengine.plan.relational.metadata.ITableDeviceSchemaValidation;
 import org.apache.iotdb.db.queryengine.plan.relational.metadata.Metadata;
 import org.apache.iotdb.db.queryengine.plan.relational.metadata.TableSchema;
@@ -56,11 +55,6 @@ public class InsertRows extends WrappedInsertStatement {
   }
 
   @Override
-  public String getDatabase() {
-    return AnalyzeUtils.getDatabaseName(getInnerTreeStatement(), context);
-  }
-
-  @Override
   public String getTableName() {
     return getInnerTreeStatement().getDevicePath().getFullPath();
   }
@@ -85,7 +79,7 @@ public class InsertRows extends WrappedInsertStatement {
 
   @Override
   public void validateTableSchema(Metadata metadata, MPPQueryContext context) {
-    String databaseName = AnalyzeUtils.getDatabaseName(getInnerTreeStatement(), context);
+    String databaseName = getDatabase();
     for (InsertRowStatement insertRowStatement :
         getInnerTreeStatement().getInsertRowStatementList()) {
       final TableSchema incomingTableSchema = toTableSchema(insertRowStatement);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/InsertRows.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/InsertRows.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.commons.schema.table.column.TsTableColumnCategory;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.exception.sql.SemanticException;
 import org.apache.iotdb.db.queryengine.common.MPPQueryContext;
+import org.apache.iotdb.db.queryengine.plan.analyze.AnalyzeUtils;
 import org.apache.iotdb.db.queryengine.plan.relational.metadata.ITableDeviceSchemaValidation;
 import org.apache.iotdb.db.queryengine.plan.relational.metadata.Metadata;
 import org.apache.iotdb.db.queryengine.plan.relational.metadata.TableSchema;
@@ -56,7 +57,7 @@ public class InsertRows extends WrappedInsertStatement {
 
   @Override
   public String getDatabase() {
-    return context.getSession().getDatabaseName().orElse(null);
+    return AnalyzeUtils.getDatabaseName(getInnerTreeStatement(), context);
   }
 
   @Override
@@ -84,13 +85,13 @@ public class InsertRows extends WrappedInsertStatement {
 
   @Override
   public void validateTableSchema(Metadata metadata, MPPQueryContext context) {
-    String databaseName = context.getSession().getDatabaseName().orElse(null);
+    String databaseName = AnalyzeUtils.getDatabaseName(getInnerTreeStatement(), context);
     for (InsertRowStatement insertRowStatement :
         getInnerTreeStatement().getInsertRowStatementList()) {
       final TableSchema incomingTableSchema = toTableSchema(insertRowStatement);
       final TableSchema realSchema =
           metadata
-              .validateTableHeaderSchema(databaseName, incomingTableSchema, context)
+              .validateTableHeaderSchema(databaseName, incomingTableSchema, context, false)
               .orElse(null);
       if (realSchema == null) {
         throw new SemanticException(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/InsertTablet.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/InsertTablet.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.queryengine.plan.relational.sql.ast;
 import org.apache.iotdb.commons.schema.table.column.TsTableColumnCategory;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.queryengine.common.MPPQueryContext;
+import org.apache.iotdb.db.queryengine.plan.analyze.AnalyzeUtils;
 import org.apache.iotdb.db.queryengine.plan.statement.crud.InsertTabletStatement;
 
 import org.apache.tsfile.file.metadata.IDeviceID;
@@ -52,7 +53,7 @@ public class InsertTablet extends WrappedInsertStatement {
 
   @Override
   public String getDatabase() {
-    return context.getSession().getDatabaseName().get();
+    return AnalyzeUtils.getDatabaseName(getInnerTreeStatement(), context);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/InsertTablet.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/InsertTablet.java
@@ -22,7 +22,6 @@ package org.apache.iotdb.db.queryengine.plan.relational.sql.ast;
 import org.apache.iotdb.commons.schema.table.column.TsTableColumnCategory;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.queryengine.common.MPPQueryContext;
-import org.apache.iotdb.db.queryengine.plan.analyze.AnalyzeUtils;
 import org.apache.iotdb.db.queryengine.plan.statement.crud.InsertTabletStatement;
 
 import org.apache.tsfile.file.metadata.IDeviceID;
@@ -49,11 +48,6 @@ public class InsertTablet extends WrappedInsertStatement {
   @Override
   public void updateAfterSchemaValidation(MPPQueryContext context) throws QueryProcessException {
     getInnerTreeStatement().updateAfterSchemaValidation(context);
-  }
-
-  @Override
-  public String getDatabase() {
-    return AnalyzeUtils.getDatabaseName(getInnerTreeStatement(), context);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/Use.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/Use.java
@@ -43,7 +43,7 @@ public final class Use extends Statement {
     this.db = requireNonNull(db, "db is null");
   }
 
-  public Identifier getDatabase() {
+  public Identifier getDatabaseId() {
     return db;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/WrappedInsertStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/WrappedInsertStatement.java
@@ -92,7 +92,7 @@ public abstract class WrappedInsertStatement extends WrappedStatement
   }
 
   public void validateTableSchema(Metadata metadata, MPPQueryContext context) {
-    String databaseName = AnalyzeUtils.getDatabaseName(getInnerTreeStatement(), context);
+    String databaseName = getDatabase();
     final TableSchema incomingSchema = getTableSchema();
     final TableSchema realSchema =
         metadata
@@ -211,6 +211,10 @@ public abstract class WrappedInsertStatement extends WrappedStatement
   }
 
   public String getDatabase() {
-    return null;
+    String databaseName = AnalyzeUtils.getDatabaseName(getInnerTreeStatement(), context);
+    if (databaseName == null) {
+      throw new SemanticException("database is not specified");
+    }
+    return databaseName;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/WrappedInsertStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/WrappedInsertStatement.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.commons.schema.table.column.TsTableColumnCategory;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.exception.sql.SemanticException;
 import org.apache.iotdb.db.queryengine.common.MPPQueryContext;
+import org.apache.iotdb.db.queryengine.plan.analyze.AnalyzeUtils;
 import org.apache.iotdb.db.queryengine.plan.relational.metadata.ColumnSchema;
 import org.apache.iotdb.db.queryengine.plan.relational.metadata.ITableDeviceSchemaValidation;
 import org.apache.iotdb.db.queryengine.plan.relational.metadata.Metadata;
@@ -91,10 +92,12 @@ public abstract class WrappedInsertStatement extends WrappedStatement
   }
 
   public void validateTableSchema(Metadata metadata, MPPQueryContext context) {
-    String databaseName = context.getSession().getDatabaseName().orElse(null);
+    String databaseName = AnalyzeUtils.getDatabaseName(getInnerTreeStatement(), context);
     final TableSchema incomingSchema = getTableSchema();
     final TableSchema realSchema =
-        metadata.validateTableHeaderSchema(databaseName, incomingSchema, context).orElse(null);
+        metadata
+            .validateTableHeaderSchema(databaseName, incomingSchema, context, true)
+            .orElse(null);
     if (realSchema == null) {
       throw new SemanticException(
           "Schema validation failed, table cannot be created: " + incomingSchema);
@@ -205,5 +208,9 @@ public abstract class WrappedInsertStatement extends WrappedStatement
 
   public void validateDeviceSchema(Metadata metadata, MPPQueryContext context) {
     metadata.validateDeviceSchema(this, context);
+  }
+
+  public String getDatabase() {
+    return null;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertBaseStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertBaseStatement.java
@@ -37,6 +37,7 @@ import org.apache.iotdb.db.queryengine.plan.relational.metadata.ColumnSchema;
 import org.apache.iotdb.db.queryengine.plan.relational.type.InternalTypeManager;
 import org.apache.iotdb.db.queryengine.plan.statement.Statement;
 import org.apache.iotdb.db.utils.CommonUtils;
+import org.apache.iotdb.db.utils.annotations.TableModel;
 import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.apache.tsfile.enums.TSDataType;
@@ -50,6 +51,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -95,6 +97,8 @@ public abstract class InsertBaseStatement extends Statement {
 
   /** it is the end of current range. */
   int recordedEndOfLogicalViewSchemaList = 0;
+
+  @TableModel private String databaseName;
 
   // endregion
 
@@ -538,5 +542,14 @@ public abstract class InsertBaseStatement extends Statement {
     }
   }
 
+  @TableModel
+  public void setDatabaseName(String databaseName) {
+    this.databaseName = databaseName;
+  }
+
+  @TableModel
+  public Optional<String> getDatabaseName() {
+    return Optional.ofNullable(databaseName);
+  }
   // endregion
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertRowStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertRowStatement.java
@@ -39,6 +39,7 @@ import org.apache.iotdb.db.queryengine.plan.statement.StatementType;
 import org.apache.iotdb.db.queryengine.plan.statement.StatementVisitor;
 import org.apache.iotdb.db.utils.CommonUtils;
 import org.apache.iotdb.db.utils.TypeInferenceUtils;
+import org.apache.iotdb.db.utils.annotations.TableModel;
 
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.file.metadata.IDeviceID;
@@ -460,6 +461,7 @@ public class InsertRowStatement extends InsertBaseStatement implements ISchemaVa
         this.recordedBeginOfLogicalViewSchemaList, this.recordedEndOfLogicalViewSchemaList);
   }
 
+  @TableModel
   public IDeviceID getTableDeviceID() {
     if (deviceID == null) {
       String[] deviceIdSegments = new String[getIdColumnIndices().size() + 1];
@@ -475,11 +477,13 @@ public class InsertRowStatement extends InsertBaseStatement implements ISchemaVa
     return deviceID;
   }
 
+  @TableModel
   @Override
   public Statement toRelationalStatement(MPPQueryContext context) {
     return new InsertRow(this, context);
   }
 
+  @TableModel
   @Override
   public void insertColumn(int pos, ColumnSchema columnSchema) {
     super.insertColumn(pos, columnSchema);
@@ -489,6 +493,7 @@ public class InsertRowStatement extends InsertBaseStatement implements ISchemaVa
     values = tmpValues;
   }
 
+  @TableModel
   @Override
   public void swapColumn(int src, int target) {
     super.swapColumn(src, target);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/annotations/TableModel.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/annotations/TableModel.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.utils.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation indicates that the related filed, method, or constructor is only used for
+ * TableModel.
+ */
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.CONSTRUCTOR})
+@Retention(RetentionPolicy.SOURCE)
+public @interface TableModel {}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/annotations/TreeModel.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/annotations/TreeModel.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.utils.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation indicates that the related filed, method, or constructor is only used for
+ * TreeModel.
+ */
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.CONSTRUCTOR})
+@Retention(RetentionPolicy.SOURCE)
+public @interface TreeModel {}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/AnalyzerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/AnalyzerTest.java
@@ -846,7 +846,7 @@ public class AnalyzerTest {
     return new TestMatadata() {
       @Override
       public Optional<TableSchema> validateTableHeaderSchema(
-          String database, TableSchema schema, MPPQueryContext context) {
+          String database, TableSchema schema, MPPQueryContext context, boolean allowCreateTable) {
         TableSchema tableSchema = StatementTestUtils.genTableSchema();
         assertEquals(tableSchema, schema);
         return Optional.of(tableSchema);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/TestMatadata.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/TestMatadata.java
@@ -218,7 +218,7 @@ public class TestMatadata implements Metadata {
 
   @Override
   public Optional<TableSchema> validateTableHeaderSchema(
-      String database, TableSchema tableSchema, MPPQueryContext context) {
+      String database, TableSchema tableSchema, MPPQueryContext context, boolean allowCreateTable) {
     throw new UnsupportedOperationException();
   }
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/statement/InsertStatementTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/statement/InsertStatementTest.java
@@ -92,7 +92,7 @@ public class InsertStatementTest {
                 TsTableColumnCategory.MEASUREMENT));
     tableSchema = new TableSchema("table1", columnSchemas);
     when(metadata.validateTableHeaderSchema(
-            any(String.class), any(TableSchema.class), any(MPPQueryContext.class)))
+            any(String.class), any(TableSchema.class), any(MPPQueryContext.class), true))
         .thenReturn(Optional.of(tableSchema));
     when(queryContext.getSession()).thenReturn(sessionInfo);
     when(sessionInfo.getDatabaseName()).thenReturn(Optional.of("test"));
@@ -177,7 +177,7 @@ public class InsertStatementTest {
                 TsTableColumnCategory.ATTRIBUTE));
     tableSchema = new TableSchema("table1", columnSchemas);
     when(metadata.validateTableHeaderSchema(
-            any(String.class), any(TableSchema.class), any(MPPQueryContext.class)))
+            any(String.class), any(TableSchema.class), any(MPPQueryContext.class), true))
         .thenReturn(Optional.of(tableSchema));
 
     assertThrows(
@@ -203,7 +203,7 @@ public class InsertStatementTest {
                 "id2", TypeFactory.getType(TSDataType.STRING), false, TsTableColumnCategory.ID));
     tableSchema = new TableSchema("table1", columnSchemas);
     when(metadata.validateTableHeaderSchema(
-            any(String.class), any(TableSchema.class), any(MPPQueryContext.class)))
+            any(String.class), any(TableSchema.class), any(MPPQueryContext.class), true))
         .thenReturn(Optional.of(tableSchema));
 
     assertThrows(

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/statement/InsertStatementTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/statement/InsertStatementTest.java
@@ -92,9 +92,13 @@ public class InsertStatementTest {
                 TsTableColumnCategory.MEASUREMENT));
     tableSchema = new TableSchema("table1", columnSchemas);
     when(metadata.validateTableHeaderSchema(
-            any(String.class), any(TableSchema.class), any(MPPQueryContext.class), true))
+            any(String.class),
+            any(TableSchema.class),
+            any(MPPQueryContext.class),
+            any(Boolean.class)))
         .thenReturn(Optional.of(tableSchema));
     when(queryContext.getSession()).thenReturn(sessionInfo);
+    when(queryContext.getDatabaseName()).thenReturn(Optional.of("test"));
     when(sessionInfo.getDatabaseName()).thenReturn(Optional.of("test"));
   }
 
@@ -177,7 +181,10 @@ public class InsertStatementTest {
                 TsTableColumnCategory.ATTRIBUTE));
     tableSchema = new TableSchema("table1", columnSchemas);
     when(metadata.validateTableHeaderSchema(
-            any(String.class), any(TableSchema.class), any(MPPQueryContext.class), true))
+            any(String.class),
+            any(TableSchema.class),
+            any(MPPQueryContext.class),
+            any(Boolean.class)))
         .thenReturn(Optional.of(tableSchema));
 
     assertThrows(
@@ -203,7 +210,10 @@ public class InsertStatementTest {
                 "id2", TypeFactory.getType(TSDataType.STRING), false, TsTableColumnCategory.ID));
     tableSchema = new TableSchema("table1", columnSchemas);
     when(metadata.validateTableHeaderSchema(
-            any(String.class), any(TableSchema.class), any(MPPQueryContext.class), true))
+            any(String.class),
+            any(TableSchema.class),
+            any(MPPQueryContext.class),
+            any(Boolean.class)))
         .thenReturn(Optional.of(tableSchema));
 
     assertThrows(


### PR DESCRIPTION
Insert statement can specify the database within it.
An exception is thrown when both session and statement do not have db.
Clarify exception message when the table does not exist.
The database name is retrieved from the qualified name correctly. 