### PR TITLE
Unify string type inference

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/TypeInferenceUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/TypeInferenceUtils.java
@@ -58,7 +58,7 @@ public class TypeInferenceUtils {
     } catch (NumberFormatException e) {
       return false;
     }
-    return true;
+    return !s.endsWith("F") && !s.endsWith("f") && !s.endsWith("D") && !s.endsWith("d");
   }
 
   private static boolean isBoolean(String s) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/TypeInferenceUtilsTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/TypeInferenceUtilsTest.java
@@ -82,6 +82,8 @@ public class TypeInferenceUtilsTest {
       "4.9387406015404442E17",
       "4E5",
       "1.0",
+      "4F",
+      "4L"
     };
     TSDataType[] inferredTypes = {
       TSDataType.INT32,
@@ -100,7 +102,9 @@ public class TypeInferenceUtilsTest {
       config.getFloatingStringInferType(),
       config.getFloatingStringInferType(),
       config.getFloatingStringInferType(),
-      config.getFloatingStringInferType()
+      config.getFloatingStringInferType(),
+      TSDataType.TEXT,
+      TSDataType.TEXT,
     };
 
     for (int i = 0; i < values.length; i++) {


### PR DESCRIPTION
## Description

String ends with `F` and `L` should be inferred to the same type. In this PR, I unify them to `TEXT`.