### PR TITLE
Fix IoTConsensus log explosion when stoping one node

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -1142,6 +1142,7 @@ public class IoTConsensusServerImpl {
                 request.getStartSyncIndex(),
                 e);
             Thread.currentThread().interrupt();
+            break;
           }
         }
         long sortTime = System.nanoTime();


### PR DESCRIPTION
<img width="1011" alt="image" src="https://github.com/user-attachments/assets/c61d718d-5b23-41fb-bce0-b395faa36463">
