### PR TITLE
Handle exception when the WAL initializtion is interrupted

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
@@ -296,10 +296,11 @@ public class TsFileProcessor {
       }
     } catch (Exception e) {
       rollbackMemoryInfo(memIncrements);
+      logger.warn("Exception during wal flush", e);
       throw new WriteProcessException(
           String.format(
-              "%s: %s write WAL failed",
-              storageGroupName, tsFileResource.getTsFile().getAbsolutePath()),
+              "%s: %s write WAL failed: %s",
+              storageGroupName, tsFileResource.getTsFile().getAbsolutePath(), e.getMessage()),
           e);
     } finally {
       // recordScheduleWalCost
@@ -370,10 +371,11 @@ public class TsFileProcessor {
       }
     } catch (Exception e) {
       rollbackMemoryInfo(memIncrements);
+      logger.warn("Exception during wal flush", e);
       throw new WriteProcessException(
           String.format(
-              "%s: %s write WAL failed",
-              storageGroupName, tsFileResource.getTsFile().getAbsolutePath()),
+              "%s: %s write WAL failed: %s",
+              storageGroupName, tsFileResource.getTsFile().getAbsolutePath(), e.getMessage()),
           e);
     } finally {
       // recordScheduleWalCost

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/allocation/FirstCreateStrategy.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/allocation/FirstCreateStrategy.java
@@ -51,8 +51,9 @@ public class FirstCreateStrategy extends AbstractNodeAllocationStrategy {
   public IWALNode applyForWALNode(String applicantUniqueId) {
     nodesLock.lock();
     try {
-      if (!identifier2Nodes.containsKey(applicantUniqueId)) {
-        IWALNode walNode = createWALNode(applicantUniqueId);
+      IWALNode walNode = identifier2Nodes.get(applicantUniqueId);
+      if (walNode == null) {
+        walNode = createWALNode(applicantUniqueId);
         if (walNode instanceof WALNode) {
           // avoid deletion
           walNode.setSafelyDeletedSearchIndex(
@@ -61,7 +62,7 @@ public class FirstCreateStrategy extends AbstractNodeAllocationStrategy {
         }
       }
 
-      return identifier2Nodes.get(applicantUniqueId);
+      return walNode;
     } finally {
       nodesLock.unlock();
     }


### PR DESCRIPTION
If the creation of a WAL node is interrupted and FirstCreateStrategy is used, a null WAL node will be returned, causing subsequent insertion to fail with an NPE.