### PR TITLE
Update license information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -211,49 +211,6 @@ mvnw files from https://github.com/apache/maven-wrapper Apache 2.0
 
 --------------------------------------------------------------------------------
 
-The following class is modified from Apache commons-collections
-
-./iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/utils/Murmur128Hash.java
-Relevant pr is: https://github.com/apache/commons-collections/pull/83/
-
---------------------------------------------------------------------------------
-
-The following files include code modified from Michael Burman's gorilla-tsc project.
-
-./iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/encoder/GorillaEncoderV2.java
-./iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/encoder/IntGorillaEncoder.java
-./iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/encoder/LongGorillaEncoder.java
-./iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/encoder/SinglePrecisionEncoderV2.java
-./iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/encoder/DoublePrecisionEncoderV2.java
-./iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/decoder/GorillaDecoderV2.java
-./iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/decoder/IntGorillaDecoder.java
-./iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/decoder/LongGorillaDecoder.java
-./iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/decoder/SinglePrecisionDecoderV2.java
-./iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/decoder/DoublePrecisionDecoderV2.java
-
-Copyright: 2016-2018 Michael Burman and/or other contributors
-Project page: https://github.com/burmanm/gorilla-tsc
-License: http://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-The following files include code modified from Panagiotis Liakos, Katia Papakonstantinopoulou and Yannis Kotidis chimp project.
-
-./tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/decoder/DoublePrecisionChimpDecoder.java
-./tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/decoder/IntChimpDecoder.java
-./tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/decoder/LongChimpDecoder.java
-./tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/decoder/SinglePrecisionChimpDecoder.java
-./tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/encoder/DoublePrecisionChimpEncoder.java
-./tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/encoder/IntChimpEncoder.java
-./tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/encoder/LongChimpEncoder.java
-./tsfile/src/main/java/org/apache/iotdb/tsfile/encoding/encoder/SinglePrecisionChimpEncoder.java
-
-Copyright: 2022- Panagiotis Liakos, Katia Papakonstantinopoulou and Yannis Kotidis
-Project page: https://github.com/panagiotisl/chimp
-License: http://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
 The following files include code modified from Apache HBase project.
 
 ./iotdb-core/confignode/src/main/java/org/apache/iotdb/procedure/Procedure.java
@@ -267,13 +224,19 @@ License: http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-The following files include code modified from Eclipse Collections project.
+The following files include code modified from Largest-Triangle downsampling algorithm implementations for Java8 project,
+which is under Apache License 2.0:
 
-./tsfile/src/main/java/org/apache/iotdb/tsfile/utils/ByteArrayList.java
+./library-udf/src/main/java/org/apache/iotdb/library/dprofile/util/Area.java
+./library-udf/src/main/java/org/apache/iotdb/library/dprofile/util/Bucket.java
+./library-udf/src/main/java/org/apache/iotdb/library/dprofile/util/LTThreeBuckets.java
+./library-udf/src/main/java/org/apache/iotdb/library/dprofile/util/OnePassBucketizer.java
+./library-udf/src/main/java/org/apache/iotdb/library/dprofile/util/SlidingCollector.java
+./library-udf/src/main/java/org/apache/iotdb/library/dprofile/util/Triangle.java
 
-Copyright: 2021 Goldman Sachs
-Project page: https://www.eclipse.org/collections
-License: https://github.com/eclipse/eclipse-collections/blob/master/LICENSE-EDL-1.0.txt
+Copyright: 2016 Guillermo Gutierrez Almazor
+Project page: https://github.com/ggalmazor/lt_downsampling_java8
+License: https://github.com/ggalmazor/lt_downsampling_java8/blob/main/LICENSE
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

This PR is adding attribution information of the code modified from lt_downsampling_java8 project. It's also removing the attribution information of the code in tsfile, which should not be in IoTDB repo any more. 