### PR TITLE
[region migration] Ignore old region migration procedure during procedure framework updating

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/region/RegionMigrateProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/region/RegionMigrateProcedure.java
@@ -215,11 +215,12 @@ public class RegionMigrateProcedure
       coordinatorForAddPeer = ThriftCommonsSerDeUtils.deserializeTDataNodeLocation(byteBuffer);
       coordinatorForRemovePeer = ThriftCommonsSerDeUtils.deserializeTDataNodeLocation(byteBuffer);
     } catch (ThriftSerDeException e) {
-      LOGGER.error(
-          "Error in deserialize {} (procID {}), this procedure may belong to old version and already cannot be used.",
+      LOGGER.warn(
+          "Error in deserialize {} (procID {}). This procedure will be ignored. It may belong to old version and cannot be used now.",
           this.getClass(),
           this.getProcId(),
           e);
+      throw e;
     }
   }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/store/ProcedureFactory.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/store/ProcedureFactory.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.confignode.procedure.store;
 
+import org.apache.iotdb.commons.exception.runtime.ThriftSerDeException;
 import org.apache.iotdb.confignode.procedure.Procedure;
 import org.apache.iotdb.confignode.procedure.impl.cq.CreateCQProcedure;
 import org.apache.iotdb.confignode.procedure.impl.node.AddConfigNodeProcedure;
@@ -277,7 +278,13 @@ public class ProcedureFactory implements IProcedureFactory {
         LOGGER.error("Unknown Procedure type: {}", typeCode);
         throw new IOException("Unknown Procedure type: " + typeCode);
     }
-    procedure.deserialize(buffer);
+    try {
+      procedure.deserialize(buffer);
+    } catch (ThriftSerDeException e) {
+      LOGGER.warn(
+          "Catch exception while deserializing procedure, this procedure will be ignored.", e);
+      procedure = null;
+    }
     return procedure;
   }
 


### PR DESCRIPTION
<img width="1557" alt="image" src="https://github.com/user-attachments/assets/21b8d10e-8e1a-4eb7-981e-68d319bbf352">
