### PR TITLE
[Region Migration] Convert a Ratis exception to enable read retry

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -374,6 +374,8 @@ class RatisConsensus implements IConsensus {
       } else {
         throw new RatisRequestFailedException(e);
       }
+    } catch (GroupMismatchException e) {
+      throw new ConsensusGroupNotExistException(groupId);
     } catch (Exception e) {
       throw new RatisRequestFailedException(e);
     }


### PR DESCRIPTION
## Description
Fix a corner case where the group may not exist during the execution of a Ratis read.

<img width="1124" alt="image" src="https://github.com/user-attachments/assets/68304e52-02b6-4a6f-b2dc-936d0e5656b7">
