### PR TITLE
RegionMigrate: Fix migrating region with ratisConsensus cause the region is unavailable.

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RegionMaintainHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RegionMaintainHandler.java
@@ -715,7 +715,6 @@ public class RegionMaintainHandler {
             SyncDataNodeClientPool.getInstance()
                 .changeRegionLeader(
                     regionId, originalDataNode.getInternalEndPoint(), newLeaderNode.get());
-
         if (resp.getStatus().getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
           timestamp = resp.getConsensusLogicalTimestamp();
           break;

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RegionMaintainHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RegionMaintainHandler.java
@@ -736,7 +736,7 @@ public class RegionMaintainHandler {
             Collections.singletonMap(
                 regionId,
                 new ConsensusGroupHeartbeatSample(timestamp, newLeaderNode.get().getDataNodeId())));
-    // configManager.getLoadManager().getRouteBalancer().balanceRegionLeaderAndPriority();
+    configManager.getLoadManager().getRouteBalancer().balanceRegionLeaderAndPriority();
 
     LOGGER.info(
         "{}, Change region leader finished, regionId: {}, newLeaderNode: {}",

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RegionMaintainHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RegionMaintainHandler.java
@@ -758,8 +758,7 @@ public class RegionMaintainHandler {
    */
   public Optional<TDataNodeLocation> filterDataNodeWithOtherRegionReplica(
       TConsensusGroupId regionId, TDataNodeLocation filterLocation) {
-    List<TDataNodeLocation> filterLocations = new ArrayList<>();
-    filterLocations.add(filterLocation);
+    List<TDataNodeLocation> filterLocations = Collections.singletonList(filterLocation);
     return filterDataNodeWithOtherRegionReplica(regionId, filterLocations);
   }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RegionMaintainHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RegionMaintainHandler.java
@@ -453,7 +453,7 @@ public class RegionMaintainHandler {
         getIdWithRpcEndpoint(deprecatedLocation),
         status);
     configManager.getLoadManager().removeRegionCache(regionId, deprecatedLocation.getDataNodeId());
-    // configManager.getLoadManager().getRouteBalancer().balanceRegionLeaderAndPriority();
+    configManager.getLoadManager().getRouteBalancer().balanceRegionLeaderAndPriority();
   }
 
   /**

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RegionMaintainHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RegionMaintainHandler.java
@@ -669,8 +669,6 @@ public class RegionMaintainHandler {
       TConsensusGroupId regionId, TDataNodeLocation originalDataNode, TDataNodeLocation coodinator)
       throws ProcedureException, InterruptedException {
     // find new leader
-    final int findNewLeaderTimeLimitSecond = 10;
-    long startTime = System.nanoTime();
     Optional<TDataNodeLocation> newLeaderNode = Optional.empty();
     List<TDataNodeLocation> excludeDataNode = new ArrayList<>();
     excludeDataNode.add(originalDataNode);

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RegionMaintainHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RegionMaintainHandler.java
@@ -667,8 +667,7 @@ public class RegionMaintainHandler {
    */
   public void transferRegionLeader(TConsensusGroupId regionId, TDataNodeLocation originalDataNode)
       throws ProcedureException, InterruptedException {
-    List<TDataNodeLocation> excludeDataNode = new ArrayList<>();
-    excludeDataNode.add(originalDataNode);
+    List<TDataNodeLocation> excludeDataNode = Collections.singletonList(originalDataNode);
     transferRegionLeader(regionId, originalDataNode, excludeDataNode);
   }
 
@@ -706,11 +705,9 @@ public class RegionMaintainHandler {
       Integer leaderId = configManager.getLoadManager().getRegionLeaderMap().get(regionId);
 
       if (leaderId != -1) {
-        // The migrated node is not leader, so we specify the transfer leader to current leader node
+        // The migrated node is not leader, so we don't need to transfer temporarily
         if (originalDataNode.getDataNodeId() != leaderId) {
-          newLeaderNode =
-              Optional.of(
-                  configManager.getNodeManager().getRegisteredDataNode(leaderId).getLocation());
+          return;
         }
       }
       while (true) {
@@ -776,9 +773,7 @@ public class RegionMaintainHandler {
 
   public Optional<TDataNodeLocation> filterDataNodeWithOtherRegionReplica(
       TConsensusGroupId regionId, TDataNodeLocation filterLocation, NodeStatus... allowingStatus) {
-    List<TDataNodeLocation> excludeLocations = new ArrayList<>();
-    excludeLocations.add(filterLocation);
-
+    List<TDataNodeLocation> excludeLocations = Collections.singletonList(filterLocation);
     return filterDataNodeWithOtherRegionReplica(regionId, excludeLocations, allowingStatus);
   }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RegionMaintainHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RegionMaintainHandler.java
@@ -675,21 +675,11 @@ public class RegionMaintainHandler {
     List<TDataNodeLocation> excludeDataNode = new ArrayList<>();
     excludeDataNode.add(originalDataNode);
     excludeDataNode.add(coodinator);
-    while (System.nanoTime() - startTime < TimeUnit.SECONDS.toNanos(findNewLeaderTimeLimitSecond)) {
-      newLeaderNode = filterDataNodeWithOtherRegionReplica(regionId, excludeDataNode);
-      if (newLeaderNode.isPresent()) {
-        break;
-      }
-    }
+    newLeaderNode = filterDataNodeWithOtherRegionReplica(regionId, excludeDataNode);
     if (!newLeaderNode.isPresent()) {
       // If we have no choice, we use it
       newLeaderNode = Optional.of(coodinator);
     }
-    newLeaderNode.orElseThrow(
-        () ->
-            new ProcedureException(
-                "Cannot find the new leader after " + findNewLeaderTimeLimitSecond + " seconds"));
-
     // ratis needs DataNode to do election by itself
     long timestamp = System.nanoTime();
     if (TConsensusGroupType.SchemaRegion.equals(regionId.getType())

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/region/RegionMigrateProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/region/RegionMigrateProcedure.java
@@ -40,7 +40,6 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Objects;
-import java.util.Optional;
 
 /** Region migrate procedure */
 public class RegionMigrateProcedure
@@ -110,10 +109,7 @@ public class RegionMigrateProcedure
         case REMOVE_REGION_PEER:
           addChildProcedure(
               new RemoveRegionPeerProcedure(
-                  consensusGroupId,
-                  coordinatorForRemovePeer,
-                  originalDataNode,
-                  Optional.ofNullable(destDataNode)));
+                  consensusGroupId, coordinatorForRemovePeer, originalDataNode));
           setNextState(RegionTransitionState.CHECK_REMOVE_REGION_PEER);
           break;
         case CHECK_REMOVE_REGION_PEER:

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/region/RegionMigrateProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/region/RegionMigrateProcedure.java
@@ -40,6 +40,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Objects;
+import java.util.Optional;
 
 /** Region migrate procedure */
 public class RegionMigrateProcedure
@@ -109,7 +110,10 @@ public class RegionMigrateProcedure
         case REMOVE_REGION_PEER:
           addChildProcedure(
               new RemoveRegionPeerProcedure(
-                  consensusGroupId, coordinatorForRemovePeer, originalDataNode));
+                  consensusGroupId,
+                  coordinatorForRemovePeer,
+                  originalDataNode,
+                  Optional.ofNullable(destDataNode)));
           setNextState(RegionTransitionState.CHECK_REMOVE_REGION_PEER);
           break;
         case CHECK_REMOVE_REGION_PEER:

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/region/RemoveRegionPeerProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/region/RemoveRegionPeerProcedure.java
@@ -47,7 +47,6 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 import static org.apache.iotdb.commons.utils.KillPoint.KillPoint.setKillPoint;
 import static org.apache.iotdb.confignode.procedure.state.RemoveRegionPeerState.DELETE_OLD_REGION_PEER;
@@ -61,7 +60,6 @@ public class RemoveRegionPeerProcedure
   private TConsensusGroupId consensusGroupId;
   private TDataNodeLocation coordinator;
   private TDataNodeLocation targetDataNode;
-  private Optional<TDataNodeLocation> destDataNode;
 
   public RemoveRegionPeerProcedure() {
     super();
@@ -71,19 +69,9 @@ public class RemoveRegionPeerProcedure
       TConsensusGroupId consensusGroupId,
       TDataNodeLocation coordinator,
       TDataNodeLocation targetDataNode) {
-    this(consensusGroupId, coordinator, targetDataNode, Optional.empty());
-  }
-
-  public RemoveRegionPeerProcedure(
-      TConsensusGroupId consensusGroupId,
-      TDataNodeLocation coordinator,
-      TDataNodeLocation targetDataNode,
-      Optional<TDataNodeLocation> destDataNode) {
-    super();
     this.consensusGroupId = consensusGroupId;
     this.coordinator = coordinator;
     this.targetDataNode = targetDataNode;
-    this.destDataNode = destDataNode;
   }
 
   private void handleTransferLeader(RegionMaintainHandler handler)
@@ -96,7 +84,7 @@ public class RemoveRegionPeerProcedure
     handler.forceUpdateRegionCache(consensusGroupId, targetDataNode, RegionStatus.Removing);
     List<TDataNodeLocation> excludeDataNode = new ArrayList<>();
     excludeDataNode.add(targetDataNode);
-    destDataNode.ifPresent(excludeDataNode::add);
+    excludeDataNode.add(coordinator);
     handler.transferRegionLeader(consensusGroupId, targetDataNode, excludeDataNode);
   }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/region/RemoveRegionPeerProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/region/RemoveRegionPeerProcedure.java
@@ -112,6 +112,7 @@ public class RemoveRegionPeerProcedure
       switch (state) {
         case TRANSFER_REGION_LEADER:
           handleTransferLeader(handler);
+          setKillPoint(state);
           setNextState(REMOVE_REGION_PEER);
           break;
         case REMOVE_REGION_PEER:

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/region/RemoveRegionPeerProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/region/RemoveRegionPeerProcedure.java
@@ -44,8 +44,6 @@ import org.slf4j.LoggerFactory;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 import static org.apache.iotdb.commons.utils.KillPoint.KillPoint.setKillPoint;
@@ -82,10 +80,7 @@ public class RemoveRegionPeerProcedure
         consensusGroupId.getId(),
         targetDataNode.getDataNodeId());
     handler.forceUpdateRegionCache(consensusGroupId, targetDataNode, RegionStatus.Removing);
-    List<TDataNodeLocation> excludeDataNode = new ArrayList<>();
-    excludeDataNode.add(targetDataNode);
-    excludeDataNode.add(coordinator);
-    handler.transferRegionLeader(consensusGroupId, targetDataNode, excludeDataNode);
+    handler.transferRegionLeader(consensusGroupId, targetDataNode, coordinator);
   }
 
   @Override

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisClient.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisClient.java
@@ -29,6 +29,7 @@ import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.client.RaftClientRpc;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.protocol.RaftGroup;
+import org.apache.ratis.protocol.exceptions.LeaderNotReadyException;
 import org.apache.ratis.protocol.exceptions.LeaderSteppingDownException;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.protocol.exceptions.RaftException;
@@ -230,15 +231,18 @@ class RatisClient implements AutoCloseable {
 
     @Override
     public Action handleAttemptFailure(Event event) {
-      if (event.getCause() instanceof ReconfigurationInProgressException
+      if (event.getCause() == null
+          || event.getCause() instanceof ReconfigurationInProgressException
           || event.getCause() instanceof TimeoutIOException
           || event.getCause() instanceof LeaderSteppingDownException
           || event.getCause() instanceof ReconfigurationTimeoutException
           || event.getCause() instanceof ServerNotReadyException
-          || event.getCause() instanceof NotLeaderException) {
+          || event.getCause() instanceof NotLeaderException
+          || event.getCause() instanceof LeaderNotReadyException) {
         return defaultPolicy.handleAttemptFailure(event);
       }
-      return NO_RETRY_ACTION;
+
+      return defaultPolicy.handleAttemptFailure(event);
     }
   }
 }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisClient.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisClient.java
@@ -217,15 +217,14 @@ class RatisClient implements AutoCloseable {
     }
   }
 
-  // This policy is used to raft configuration change
-  //
+  /** This policy is used to raft configuration change
+   */
   private static class RatisEndlessRetryPolicy implements RetryPolicy {
 
     private static final Logger logger = LoggerFactory.getLogger(RatisEndlessRetryPolicy.class);
     private final RetryPolicy defaultPolicy;
 
     RatisEndlessRetryPolicy() {
-      // about 1 hour wait Time.
       defaultPolicy =
           RetryPolicies.retryForeverWithSleep(TimeDuration.valueOf(2, TimeUnit.SECONDS));
     }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisClient.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisClient.java
@@ -224,6 +224,8 @@ class RatisClient implements AutoCloseable {
       int basicSleep = 500;
       for (int i = 0; i < 5; i++) {
         str += basicRetry + "," + basicSleep + ",";
+        basicRetry -= 10;
+        basicSleep += 500;
       }
 
       defaultPolicy =

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisClient.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisClient.java
@@ -219,13 +219,24 @@ class RatisClient implements AutoCloseable {
 
     static {
       String str = "";
-      // 50, 500ms, 40, 1000ms, 30, 1500ms, 20, 2000ms, 10, 2500ms
+      /**
+       * Given pairs of number of retries and sleep time (n0, t0), (n1, t1), ..., the first n0
+       * retries sleep t0 milliseconds on average, the following n1 retries sleep t1 milliseconds on
+       * average, and so on.
+       *
+       * <p>For all the sleep, the actual sleep time is randomly uniform distributed in the close
+       * interval [0.5t, 1.5t], where t is the sleep time specified.
+       *
+       * <p>The objects of this class are immutable.
+       *
+       * @copy from ratis.MultipleLinearRandomRetry comment
+       */
       int basicRetry = 50;
-      int basicSleep = 500;
+      int basicSleep = 1000;
       for (int i = 0; i < 5; i++) {
         str += basicRetry + "," + basicSleep + ",";
         basicRetry -= 10;
-        basicSleep += 500;
+        basicSleep += 1000;
       }
 
       defaultPolicy =

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisClient.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisClient.java
@@ -217,8 +217,7 @@ class RatisClient implements AutoCloseable {
     }
   }
 
-  /** This policy is used to raft configuration change
-   */
+  /** This policy is used to raft configuration change */
   private static class RatisEndlessRetryPolicy implements RetryPolicy {
 
     private static final Logger logger = LoggerFactory.getLogger(RatisEndlessRetryPolicy.class);
@@ -231,22 +230,12 @@ class RatisClient implements AutoCloseable {
 
     @Override
     public Action handleAttemptFailure(Event event) {
-      if (event.getCause() instanceof ReconfigurationInProgressException) {
-        return defaultPolicy.handleAttemptFailure(event);
-      }
-      if (event.getCause() instanceof TimeoutIOException) {
-        return defaultPolicy.handleAttemptFailure(event);
-      }
-      if (event.getCause() instanceof LeaderSteppingDownException) {
-        return defaultPolicy.handleAttemptFailure(event);
-      }
-      if (event.getCause() instanceof ReconfigurationTimeoutException) {
-        return defaultPolicy.handleAttemptFailure(event);
-      }
-      if (event.getCause() instanceof ServerNotReadyException) {
-        return defaultPolicy.handleAttemptFailure(event);
-      }
-      if (event.getCause() instanceof NotLeaderException) {
+      if (event.getCause() instanceof ReconfigurationInProgressException
+          || event.getCause() instanceof TimeoutIOException
+          || event.getCause() instanceof LeaderSteppingDownException
+          || event.getCause() instanceof ReconfigurationTimeoutException
+          || event.getCause() instanceof ServerNotReadyException
+          || event.getCause() instanceof NotLeaderException) {
         return defaultPolicy.handleAttemptFailure(event);
       }
       return NO_RETRY_ACTION;

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -883,17 +883,14 @@ class RatisConsensus implements IConsensus {
     // notify the group leader of configuration change
     RaftClientReply reply;
     try (RatisClient client = getConfigurationRaftClient(newGroupConf)) {
-      while (true) {
         reply =
             client
                 .getRaftClient()
                 .admin()
                 .setConfiguration(new ArrayList<>(newGroupConf.getPeers()));
-        if (reply.isSuccess()) {
-          break;
+        if (!reply.isSuccess()) {
+          throw new RatisRequestFailedException(reply.getException());
         }
-        throw new RatisRequestFailedException(reply.getException());
-      }
     } catch (Exception e) {
       throw new RatisRequestFailedException(e);
     }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -597,7 +597,6 @@ class RatisConsensus implements IConsensus {
   @Override
   public void transferLeader(ConsensusGroupId groupId, Peer newLeader) throws ConsensusException {
     // first fetch the newest information
-    logger.info("transfer consensusGroup {} leader to {}", groupId, newLeader);
     final RaftGroupId raftGroupId = Utils.fromConsensusGroupIdToRaftGroupId(groupId);
     final RaftGroup raftGroup =
         Optional.ofNullable(getGroupInfo(raftGroupId))
@@ -609,11 +608,10 @@ class RatisConsensus implements IConsensus {
     final RaftClientReply reply;
     try {
       Peer leader = getLeader(groupId);
-      logger.info("oldleader {}", leader);
       if (leader != null) {
         if (leader.getNodeId() == newLeader.getNodeId()
             && leader.getGroupId() == newLeader.getGroupId()) {
-          logger.info("leader {} is already the leader of group {}", newLeader, groupId);
+          logger.info("Don't need to transfer groupd {} leader to {}", groupId, newLeader);
           return;
         }
       }
@@ -913,7 +911,6 @@ class RatisConsensus implements IConsensus {
           logger.info("reConfiguration success");
           break;
         }
-        logger.warn("setConfiguration ReplyException is: {}", reply.getException().toString());
         if (reply.getException() instanceof ReconfigurationInProgressException
             || reply.getException() instanceof LeaderSteppingDownException
             || reply.getException() instanceof TransferLeadershipException) {

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -232,6 +232,7 @@ class RatisConsensus implements IConsensus {
       Thread.currentThread().interrupt();
     } finally {
       clientManager.close();
+      reconfigurationClientManager.close();
       server.get().close();
       MetricService.getInstance().removeMetricSet(this.ratisMetricSet);
     }
@@ -586,9 +587,6 @@ class RatisConsensus implements IConsensus {
     final RaftGroup raftGroup =
         Optional.ofNullable(getGroupInfo(raftGroupId))
             .orElseThrow(() -> new ConsensusGroupNotExistException(groupId));
-    if (raftGroup.getPeers() == null) {
-      throw new ConsensusException("group " + groupId + " has no peers");
-    }
     final RaftPeer newRaftLeader = Utils.fromPeerAndPriorityToRaftPeer(newLeader, DEFAULT_PRIORITY);
     final RaftClientReply reply;
     try {
@@ -845,6 +843,7 @@ class RatisConsensus implements IConsensus {
       if (lastSeenGroup != null && !lastSeenGroup.equals(raftGroup)) {
         // delete the pooled raft-client of the out-dated group and cache the latest
         clientManager.clear(lastSeenGroup);
+        reconfigurationClientManager.clear(lastSeenGroup);
         lastSeen.put(raftGroupId, raftGroup);
       }
     } catch (IOException e) {

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -883,14 +883,11 @@ class RatisConsensus implements IConsensus {
     // notify the group leader of configuration change
     RaftClientReply reply;
     try (RatisClient client = getConfigurationRaftClient(newGroupConf)) {
-        reply =
-            client
-                .getRaftClient()
-                .admin()
-                .setConfiguration(new ArrayList<>(newGroupConf.getPeers()));
-        if (!reply.isSuccess()) {
-          throw new RatisRequestFailedException(reply.getException());
-        }
+      reply =
+          client.getRaftClient().admin().setConfiguration(new ArrayList<>(newGroupConf.getPeers()));
+      if (!reply.isSuccess()) {
+        throw new RatisRequestFailedException(reply.getException());
+      }
     } catch (Exception e) {
       throw new RatisRequestFailedException(e);
     }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -924,8 +924,8 @@ class RatisConsensus implements IConsensus {
 
     private final boolean isReconfiguration;
 
-    RatisClientPoolFactory(boolean isReConfiguration) {
-      this.isReconfiguration = isReConfiguration;
+    RatisClientPoolFactory(boolean isReconfiguration) {
+      this.isReconfiguration = isReconfiguration;
     }
 
     @Override


### PR DESCRIPTION
If the current region configuration is [a, b, c], we execute the migrate region id from c to d, and the leader is a. During the region migration process, due to the need to catch up with the new node d, if the data is large, it may take a long time.
 
Assuming that the operations before the execution of the Remove phase are successful, the region configuration at this time should be [a, b, c, d], and then start executing RemoveRegion, but due to some reasons, the RemoveRegion operation has not been completed, resulting in the failure of the DELETE_REGION_PEER phase timeout in the executeFromState function of RemoveProcessure, and then enter the DELETE_OLD_REGION_PEER, the new node d has not caught up with a successfully, and the old node c has been deleted. 

If the leaderTransfership is executed midway, such as a to b or a to d, then the entire region group will be in a state without a leader, which is permanent because c thinks it is not in the region group, but other nodes [a, b, d] It is believed that if it is in the region group and the new node d has not caught up with the old leader, d will not execute the vote (due to the lifeCycle of ratis), then this region group will never be elected as the leader because the candidate will not receive the majority vote.

We modify the member change part and wait for the raft member change to complete or throw an exception before returning


In the previous region migration implementation, we randomly selected an available node a and relinquished the existing leader privileges to this available node a. This may result in selecting a new node whose data has not yet caught up with the previous leader. This useless election is wasted because other nodes will never vote for node a.
In this PR, we fixed this issue, and if the migrated node is not the leader, then we do not perform the leader transfer