### PR TITLE
Modify 'set configuration' in relational grammar

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBInsertTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBInsertTableIT.java
@@ -172,7 +172,7 @@ public class IoTDBInsertTableIT {
     try (Connection connection = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
         Statement statement = connection.createStatement()) {
       statement.execute("USE \"test\"");
-      statement.execute("SET CONFIGURATION enable_auto_create_schema=false");
+      statement.execute("SET CONFIGURATION enable_auto_create_schema='false'");
       statement.execute(
           "create table sg5 (id1 string id, s1 text measurement, s2 double measurement)");
 
@@ -184,7 +184,7 @@ public class IoTDBInsertTableIT {
     } finally {
       try (Connection connection = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
           Statement statement = connection.createStatement()) {
-        statement.execute("SET CONFIGURATION enable_auto_create_schema=true");
+        statement.execute("SET CONFIGURATION enable_auto_create_schema='true'");
       }
     }
 
@@ -231,7 +231,7 @@ public class IoTDBInsertTableIT {
   public void testPartialInsertTablet() {
     try (ISession session = EnvFactory.getEnv().getSessionConnection(BaseEnv.TABLE_SQL_DIALECT)) {
       session.executeNonQueryStatement("use \"test\"");
-      session.executeNonQueryStatement("SET CONFIGURATION enable_auto_create_schema=false");
+      session.executeNonQueryStatement("SET CONFIGURATION enable_auto_create_schema='false'");
       session.executeNonQueryStatement(
           "create table sg6 (id1 string id, s1 int64 measurement, s2 int64 measurement)");
       List<IMeasurementSchema> schemaList = new ArrayList<>();
@@ -281,7 +281,7 @@ public class IoTDBInsertTableIT {
           fail(e.getMessage());
         }
       } finally {
-        session.executeNonQueryStatement("SET CONFIGURATION enable_auto_create_schema=false");
+        session.executeNonQueryStatement("SET CONFIGURATION enable_auto_create_schema='false'");
       }
       try (SessionDataSet dataSet = session.executeQueryStatement("SELECT * FROM sg6")) {
         assertEquals(dataSet.getColumnNames().size(), 4);

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBSetConfigurationTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBSetConfigurationTableIT.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.commons.conf.CommonConfig;
 import org.apache.iotdb.it.env.EnvFactory;
 import org.apache.iotdb.it.env.cluster.node.AbstractNodeWrapper;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
+import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 import org.apache.iotdb.itbase.env.BaseEnv;
 
@@ -41,7 +42,7 @@ import java.sql.Statement;
 import java.util.Arrays;
 
 @RunWith(IoTDBTestRunner.class)
-@Category({LocalStandaloneIT.class})
+@Category({LocalStandaloneIT.class, ClusterIT.class})
 public class IoTDBSetConfigurationTableIT {
   @BeforeClass
   public static void setUp() throws Exception {
@@ -58,10 +59,19 @@ public class IoTDBSetConfigurationTableIT {
     try (Connection connection = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
         Statement statement = connection.createStatement()) {
       statement.execute("set configuration \"enable_seq_space_compaction\"='false'");
-      statement.execute("set configuration enable_unseq_space_compaction=\'false\' on 0");
-      statement.execute("set configuration \"enable_cross_space_compaction\"='false' on 1");
-      statement.execute(
-          "set configuration max_inner_compaction_candidate_file_num='1',max_cross_compaction_candidate_file_num='1' on 1");
+      int configNodeNum = EnvFactory.getEnv().getConfigNodeWrapperList().size();
+      int dataNodeNum = EnvFactory.getEnv().getDataNodeWrapperList().size();
+
+      for (int i = 0; i < configNodeNum; i++) {
+        statement.execute("set configuration enable_unseq_space_compaction=\'false\' on " + i);
+      }
+      for (int i = 0; i < dataNodeNum; i++) {
+        int dnId = configNodeNum + i;
+        statement.execute("set configuration \"enable_cross_space_compaction\"='false' on " + dnId);
+        statement.execute(
+            "set configuration max_inner_compaction_candidate_file_num='1',max_cross_compaction_candidate_file_num='1' on "
+                + dnId);
+      }
     } catch (Exception e) {
       Assert.fail(e.getMessage());
     }

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBSetConfigurationTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBSetConfigurationTableIT.java
@@ -57,11 +57,11 @@ public class IoTDBSetConfigurationTableIT {
   public void testSetConfiguration() {
     try (Connection connection = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
         Statement statement = connection.createStatement()) {
-      statement.execute("set configuration enable_seq_space_compaction=\"false\"");
+      statement.execute("set configuration \"enable_seq_space_compaction\"='false'");
       statement.execute("set configuration enable_unseq_space_compaction=\'false\' on 0");
-      statement.execute("set configuration enable_cross_space_compaction=false on 1");
+      statement.execute("set configuration \"enable_cross_space_compaction\"='false' on 1");
       statement.execute(
-          "set configuration max_inner_compaction_candidate_file_num=1,max_cross_compaction_candidate_file_num=1 on 1");
+          "set configuration max_inner_compaction_candidate_file_num='1',max_cross_compaction_candidate_file_num='1' on 1");
     } catch (Exception e) {
       Assert.fail(e.getMessage());
     }
@@ -96,7 +96,6 @@ public class IoTDBSetConfigurationTableIT {
               + CommonConfig.SYSTEM_CONFIG_NAME;
       File f = new File(systemPropertiesPath);
       String fileContent = new String(Files.readAllBytes(f.toPath()));
-      System.out.println(fileContent);
       return Arrays.stream(contents).allMatch(fileContent::contains);
     } catch (IOException ignore) {
       return false;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/parser/AstBuilder.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/parser/AstBuilder.java
@@ -125,6 +125,7 @@ import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Statement;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.StringLiteral;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.SubqueryExpression;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Table;
+import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.TableExpressionType;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.TableSubquery;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.TimeRange;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Trim;
@@ -179,7 +180,6 @@ import static org.apache.iotdb.commons.schema.table.column.TsTableColumnCategory
 import static org.apache.iotdb.commons.schema.table.column.TsTableColumnCategory.MEASUREMENT;
 import static org.apache.iotdb.commons.schema.table.column.TsTableColumnCategory.TIME;
 import static org.apache.iotdb.db.queryengine.plan.parser.ASTVisitor.parseDateTimeFormat;
-import static org.apache.iotdb.db.queryengine.plan.parser.ASTVisitor.parseStringLiteral;
 import static org.apache.iotdb.db.queryengine.plan.relational.sql.ast.GroupingSets.Type.CUBE;
 import static org.apache.iotdb.db.queryengine.plan.relational.sql.ast.GroupingSets.Type.EXPLICIT;
 import static org.apache.iotdb.db.queryengine.plan.relational.sql.ast.GroupingSets.Type.ROLLUP;
@@ -703,8 +703,13 @@ public class AstBuilder extends RelationalSqlBaseVisitor<Node> {
       properties = visit(ctx.propertyAssignments().property(), Property.class);
     }
     for (Property property : properties) {
-      String key = parseStringLiteral(property.getName().getValue());
-      String value = parseStringLiteral(property.getNonDefaultValue().toString());
+      String key = property.getName().getValue();
+      Expression propertyValue = property.getNonDefaultValue();
+      if (!propertyValue.getExpressionType().equals(TableExpressionType.STRING_LITERAL)) {
+        throw new IllegalArgumentException(
+            propertyValue.getExpressionType() + " is not supported for 'set configuration'");
+      }
+      String value = ((StringLiteral) propertyValue).getValue();
       configItems.put(key, value);
     }
     setConfigurationStatement.setNodeId(nodeId);


### PR DESCRIPTION
## Description
Modify 'set configuration' in relational grammar.
Previous modification is https://github.com/apache/iotdb/pull/13089. Some usages are no longer supported.
### example
```
set configuration "a"='1',b='1' on 1
```
```
set configuration "a"='1',b='1'
```
```
set configuration a='1'
```