### PR TITLE
Eventually consistent heartbeat samples

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/AbstractLoadCache.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/AbstractLoadCache.java
@@ -56,7 +56,7 @@ public abstract class AbstractLoadCache {
       // And un-sequential heartbeats will be discarded.
       if (getLastSample() == null
           || getLastSample().getSampleLogicalTimestamp()
-              < newHeartbeatSample.getSampleLogicalTimestamp()) {
+              <= newHeartbeatSample.getSampleLogicalTimestamp()) {
         slidingWindow.add(newHeartbeatSample);
       }
 


### PR DESCRIPTION
As the term and leader reported by the Ratis interfaces might inconsistent with a small probability, the ConfigNode might end up with caching incorrect leader location. By caching all heartbeat samples, the ConfigNode can ensure the eventually consistency for all leader locations of all RegionGroups use the Ratis consensus protocol.
