### PR TITLE
Avoid the brain split phenomenon in the symmetric network partition scenario

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
@@ -240,40 +240,48 @@ public class ConfigRegionStateMachine implements IStateMachine, IStateMachine.Ev
     int currentNodeId = ConfigNodeDescriptor.getInstance().getConf().getConfigNodeId();
     if (currentNodeId != newLeaderId) {
       LOGGER.info(
-          "Current node [nodeId:{}, ip:port: {}] is not longer the leader, "
+          "Current node [nodeId:{}, ip:port: {}] is no longer the leader, "
               + "the new leader is [nodeId:{}]",
           currentNodeId,
           currentNodeTEndPoint,
           newLeaderId);
-
-      // Stop leader scheduling services
-      configManager.getPipeManager().getPipeRuntimeCoordinator().stopPipeMetaSync();
-      configManager.getPipeManager().getPipeRuntimeCoordinator().stopPipeHeartbeat();
-      configManager
-          .getSubscriptionManager()
-          .getSubscriptionCoordinator()
-          .stopSubscriptionMetaSync();
-      configManager.getLoadManager().stopLoadServices();
-      configManager.getProcedureManager().stopExecutor();
-      configManager.getRetryFailedTasksThread().stopRetryFailedTasksService();
-      configManager.getPartitionManager().stopRegionCleaner();
-      configManager.getCQManager().stopCQScheduler();
-      configManager.getClusterSchemaManager().clearSchemaQuotaCache();
-      // Remove Metric after leader change
-      configManager.removeMetrics();
-
-      // Shutdown leader related service for config pipe
-      PipeConfigNodeAgent.runtime().notifyLeaderUnavailable();
-
-      // Clean receiver file dir
-      PipeConfigNodeAgent.receiver().cleanPipeReceiverDir();
-
-      LOGGER.info(
-          "Current node [nodeId:{}, ip:port: {}] is not longer the leader, "
-              + "all services on old leader are unavailable now.",
-          currentNodeId,
-          currentNodeTEndPoint);
     }
+  }
+
+  @Override
+  public void notifyNotLeader() {
+    // We get currentNodeId here because the currentNodeId
+    // couldn't initialize earlier than the ConfigRegionStateMachine
+    int currentNodeId = ConfigNodeDescriptor.getInstance().getConf().getConfigNodeId();
+    LOGGER.info(
+        "Current node [nodeId:{}, ip:port: {}] is no longer the leader, "
+            + "start cleaning up related services",
+        currentNodeId,
+        currentNodeTEndPoint);
+    // Stop leader scheduling services
+    configManager.getPipeManager().getPipeRuntimeCoordinator().stopPipeMetaSync();
+    configManager.getPipeManager().getPipeRuntimeCoordinator().stopPipeHeartbeat();
+    configManager.getSubscriptionManager().getSubscriptionCoordinator().stopSubscriptionMetaSync();
+    configManager.getLoadManager().stopLoadServices();
+    configManager.getProcedureManager().stopExecutor();
+    configManager.getRetryFailedTasksThread().stopRetryFailedTasksService();
+    configManager.getPartitionManager().stopRegionCleaner();
+    configManager.getCQManager().stopCQScheduler();
+    configManager.getClusterSchemaManager().clearSchemaQuotaCache();
+    // Remove Metric after leader change
+    configManager.removeMetrics();
+
+    // Shutdown leader related service for config pipe
+    PipeConfigNodeAgent.runtime().notifyLeaderUnavailable();
+
+    // Clean receiver file dir
+    PipeConfigNodeAgent.receiver().cleanPipeReceiverDir();
+
+    LOGGER.info(
+        "Current node [nodeId:{}, ip:port: {}] is no longer the leader, "
+            + "all services on old leader are unavailable now.",
+        currentNodeId,
+        currentNodeTEndPoint);
   }
 
   @Override
@@ -482,6 +490,7 @@ public class ConfigRegionStateMachine implements IStateMachine, IStateMachine.Ev
   }
 
   static class FileComparator implements Comparator<String> {
+
     @Override
     public int compare(String filename1, String filename2) {
       long id1 = parseEndIndex(filename1);

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/IStateMachine.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/IStateMachine.java
@@ -158,6 +158,11 @@ public interface IStateMachine {
     default void notifyLeaderReady() {
       // do nothing default
     }
+
+    /** Notify the {@link IStateMachine} that this server is no longer the leader. */
+    default void notifyNotLeader() {
+      // do nothing default
+    }
   }
 
   /**

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ApplicationStateMachineProxy.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/ApplicationStateMachineProxy.java
@@ -54,6 +54,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 
@@ -294,6 +295,11 @@ public class ApplicationStateMachineProxy extends BaseStateMachine {
   @Override
   public void notifyLeaderReady() {
     applicationStateMachine.event().notifyLeaderReady();
+  }
+
+  @Override
+  public void notifyNotLeader(Collection<TransactionContext> pendingEntries) throws IOException {
+    applicationStateMachine.event().notifyNotLeader();
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/schemaregion/SchemaRegionStateMachine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/schemaregion/SchemaRegionStateMachine.java
@@ -69,24 +69,33 @@ public class SchemaRegionStateMachine extends BaseStateMachine {
 
   @Override
   public void notifyLeaderChanged(ConsensusGroupId groupId, int newLeaderId) {
-    if (schemaRegion.getSchemaRegionId().equals(groupId)
-        && newLeaderId != IoTDBDescriptor.getInstance().getConfig().getDataNodeId()) {
+    if (newLeaderId != IoTDBDescriptor.getInstance().getConfig().getDataNodeId()) {
       logger.info(
           "Current node [nodeId: {}] is no longer the schema region leader [regionId: {}], "
               + "the new leader is [nodeId:{}]",
           IoTDBDescriptor.getInstance().getConfig().getDataNodeId(),
           schemaRegion.getSchemaRegionId(),
           newLeaderId);
-
-      // Shutdown leader related service for schema pipe
-      PipeDataNodeAgent.runtime().notifySchemaLeaderUnavailable(schemaRegion.getSchemaRegionId());
-
-      logger.info(
-          "Current node [nodeId: {}] is no longer the schema region leader [regionId: {}], "
-              + "all services on old leader are unavailable now.",
-          IoTDBDescriptor.getInstance().getConfig().getDataNodeId(),
-          schemaRegion.getSchemaRegionId());
     }
+  }
+
+  @Override
+  public void notifyNotLeader() {
+    int dataNodeId = IoTDBDescriptor.getInstance().getConfig().getDataNodeId();
+    logger.info(
+        "Current node [nodeId: {}] is no longer the schema region leader [regionId: {}], "
+            + "start cleaning up related services.",
+        dataNodeId,
+        schemaRegion.getSchemaRegionId());
+
+    // Shutdown leader related service for schema pipe
+    PipeDataNodeAgent.runtime().notifySchemaLeaderUnavailable(schemaRegion.getSchemaRegionId());
+
+    logger.info(
+        "Current node [nodeId: {}] is no longer the schema region leader [regionId: {}], "
+            + "all services on old leader are unavailable now.",
+        dataNodeId,
+        schemaRegion.getSchemaRegionId());
   }
 
   @Override


### PR DESCRIPTION
The current Ratis module's Leader may step down voluntarily without knowing who the new Leader is, which will not trigger the state machine's notifyLeaderChange callback. As a result, some modules that rely on this interface to determine whether the current node is no longer the Leader might delay resource release, potentially causing split-brain issues with multiple Leaders.

<img width="1103" alt="image" src="https://github.com/user-attachments/assets/360b8b71-d3bf-4157-84b2-83c3c93deb19">

<img width="901" alt="image" src="https://github.com/user-attachments/assets/5d5d9195-cb7f-4eee-a1b5-6d00dea4734c">

For example, in a 3-node ConfigNode setup, if a symmetric network partition fault is injected into the Leader node, the other two nodes will elect a new Leader. However, certain services (such as heartbeat, procedure, etc.) on the old Leader will not be cleared, leading to a split-brain scenario, which could cause some unexpected behavior.

![image](https://github.com/user-attachments/assets/45e4db18-5a85-49ac-afea-fdffdda05fc3)

After this PR, even if the new Leader is unknown, Ratis will still call the notifyNotReady function, thereby preventing split-brain issues from occurring.
