### PR TITLE
Make DN wait when CN cluster's leader is not ready or down.

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/client/ConfigNodeClient.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/client/ConfigNodeClient.java
@@ -173,14 +173,15 @@ public class ConfigNodeClient implements IConfigNodeRPCService.Iface, ThriftClie
 
   private static final Logger logger = LoggerFactory.getLogger(ConfigNodeClient.class);
 
-  private static final int RETRY_NUM = 10;
+  private static final int RETRY_NUM = 15;
 
   public static final String MSG_RECONNECTION_FAIL =
       "Fail to connect to any config node. Please check status of ConfigNodes or logs of connected DataNode";
 
   private static final String MSG_RECONNECTION_DATANODE_FAIL =
       "Failed to connect to ConfigNode %s from DataNode %s when executing %s, Exception:";
-  private static final int RETRY_INTERVAL_MS = 1000;
+  private static final long RETRY_INTERVAL_MS = 1000L;
+  private static final long WAIT_CN_LEADER_ELECTION_INTERVAL_MS = 2000L;
 
   private final ThriftClientProperty property;
 
@@ -383,7 +384,7 @@ public class ConfigNodeClient implements IConfigNodeRPCService.Iface, ThriftClie
         detectedNodeNum = 0;
         // Wait to start the next try
         try {
-          Thread.sleep(RETRY_INTERVAL_MS);
+          Thread.sleep(WAIT_CN_LEADER_ELECTION_INTERVAL_MS);
         } catch (InterruptedException ignore) {
           Thread.currentThread().interrupt();
           logger.warn(


### PR DESCRIPTION
as title.

there is a case: when **CN1** leader is killed -9, The CN cluster may not be aware of this **immediately**, causing requests sent to the cluster to still be redirected to **CN1**. Due to the lack of waiting machinism in DN, DN may exhaust all retry count(10 times) in a very short time(about 500ms in 16C32G server) and all these retry requests will still be redirected to the 
dead node CN1, causing failure of user request.