### PR TITLE
Fix the error that columns in sort is not appear in projection

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBMultiIDsWithAttributesTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBMultiIDsWithAttributesTableIT.java
@@ -348,7 +348,7 @@ public class IoTDBMultiIDsWithAttributesTableIT {
   }
 
   @Test
-  public void selectSortTest() {
+  public void projectSortTest() {
     String[] expectedHeader = new String[] {"time", "level", "attr1", "device", "num", "date"};
     String[] retArray =
         new String[] {

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBMultiIDsWithAttributesTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBMultiIDsWithAttributesTableIT.java
@@ -349,34 +349,34 @@ public class IoTDBMultiIDsWithAttributesTableIT {
 
   @Test
   public void projectSortTest() {
-    String[] expectedHeader = new String[] {"time", "level", "attr1", "device", "num", "date"};
+    String[] expectedHeader = new String[] {"level", "attr1", "device", "num", "date"};
     String[] retArray =
         new String[] {
-          "1971-04-26T17:46:40.000Z,l2,yy,d1,12,null,",
-          "1970-01-01T00:00:00.020Z,l2,yy,d1,2,null,",
-          "1971-01-01T00:00:00.100Z,l2,yy,d1,10,null,",
-          "1970-01-01T00:00:00.000Z,l1,c,d1,3,null,",
-          "1971-01-01T00:01:40.000Z,l1,c,d1,11,null,",
-          "1971-01-01T00:00:00.000Z,l1,c,d1,6,null,",
+          "l2,yy,d1,2,null,",
+          "l2,yy,d1,10,null,",
+          "l2,yy,d1,12,null,",
+          "l1,c,d1,3,null,",
+          "l1,c,d1,6,null,",
+          "l1,c,d1,11,null,",
         };
     tableResultSetEqualTest(
-        "select time,level,attr1,device,num,date from table0 order by attr2 desc limit 6",
+        "select level,attr1,device,num,date from table0 order by attr2 desc,time limit 6",
         expectedHeader,
         retArray,
         DATABASE_NAME);
 
-    expectedHeader = new String[] {"time", "level", "attr1", "str"};
+    expectedHeader = new String[] {"time", "level", "attr2", "str"};
     retArray =
         new String[] {
+          "1970-01-01T00:00:00.040Z,l3,a,apricot,",
           "1970-01-01T00:00:00.040Z,l3,null,apricot,",
-          "1970-01-01T00:00:00.040Z,l3,t,apricot,",
-          "1970-01-01T00:00:00.020Z,l2,vv,pineapple,",
-          "1970-01-01T00:00:00.020Z,l2,yy,pineapple,",
+          "1970-01-01T00:00:00.020Z,l2,null,pineapple,",
+          "1970-01-01T00:00:00.020Z,l2,zz,pineapple,",
           "1970-01-01T00:00:00.000Z,l1,d,coconut,",
           "1970-01-01T00:00:00.000Z,l1,c,coconut,",
         };
     tableResultSetEqualTest(
-        "select time,level,attr1,str from table0 order by num+1 limit 6",
+        "select time,level,attr2,str from table0 order by num+1,attr1 limit 6",
         expectedHeader,
         retArray,
         DATABASE_NAME);

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBMultiIDsWithAttributesTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBMultiIDsWithAttributesTableIT.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iotdb.relational.it.query.old.orderBy;
+package org.apache.iotdb.relational.it.db.it;
 
 import org.apache.iotdb.it.env.EnvFactory;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
@@ -342,6 +342,41 @@ public class IoTDBMultiIDsWithAttributesTableIT {
         };
     tableResultSetEqualTest(
         "select time,level,attr1,device,num,date from table0 order by time desc,device desc limit 5",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+  }
+
+  @Test
+  public void selectSortTest() {
+    String[] expectedHeader = new String[] {"time", "level", "attr1", "device", "num", "date"};
+    String[] retArray =
+        new String[] {
+          "1971-04-26T17:46:40.000Z,l2,yy,d1,12,null,",
+          "1970-01-01T00:00:00.020Z,l2,yy,d1,2,null,",
+          "1971-01-01T00:00:00.100Z,l2,yy,d1,10,null,",
+          "1970-01-01T00:00:00.000Z,l1,c,d1,3,null,",
+          "1971-01-01T00:01:40.000Z,l1,c,d1,11,null,",
+          "1971-01-01T00:00:00.000Z,l1,c,d1,6,null,",
+        };
+    tableResultSetEqualTest(
+        "select time,level,attr1,device,num,date from table0 order by attr2 desc limit 6",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+
+    expectedHeader = new String[] {"time", "level", "attr1", "str"};
+    retArray =
+        new String[] {
+          "1970-01-01T00:00:00.040Z,l3,null,apricot,",
+          "1970-01-01T00:00:00.040Z,l3,t,apricot,",
+          "1970-01-01T00:00:00.020Z,l2,vv,pineapple,",
+          "1970-01-01T00:00:00.020Z,l2,yy,pineapple,",
+          "1970-01-01T00:00:00.000Z,l1,d,coconut,",
+          "1970-01-01T00:00:00.000Z,l1,c,coconut,",
+        };
+    tableResultSetEqualTest(
+        "select time,level,attr1,str from table0 order by num+1 limit 6",
         expectedHeader,
         retArray,
         DATABASE_NAME);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/TableOperatorGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/TableOperatorGenerator.java
@@ -677,7 +677,8 @@ public class TableOperatorGenerator extends PlanVisitor<Operator, LocalExecution
               Integer i = columnIndex.get(sortItem);
               if (i == null) {
                 throw new IllegalStateException(
-                    "Sort Item %s is not included in children's output columns");
+                    String.format(
+                        "Sort Item %s is not included in children's output columns", sortItem));
               }
               sortItemIndexList.add(i);
               sortItemDataTypeList.add(getTSDataType(typeProvider.getTableModelType(sortItem)));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/iterative/rule/MergeLimitOverProjectWithMergeSort.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/iterative/rule/MergeLimitOverProjectWithMergeSort.java
@@ -39,7 +39,7 @@ import static org.apache.iotdb.db.queryengine.plan.relational.planner.node.Patte
 import static org.apache.iotdb.db.queryengine.plan.relational.utils.matching.Capture.newCapture;
 
 /**
- * Transforms:
+ * <b>Optimization phase:</b> Distributed plan planning. Transforms:
  *
  * <pre>
  * - Limit (limit = x)

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/iterative/rule/MergeLimitOverProjectWithMergeSort.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/iterative/rule/MergeLimitOverProjectWithMergeSort.java
@@ -39,7 +39,9 @@ import static org.apache.iotdb.db.queryengine.plan.relational.planner.node.Patte
 import static org.apache.iotdb.db.queryengine.plan.relational.utils.matching.Capture.newCapture;
 
 /**
- * <b>Optimization phase:</b> Distributed plan planning. Transforms:
+ * <b>Optimization phase:</b> Distributed plan planning.
+ *
+ * <p>Transforms:
  *
  * <pre>
  * - Limit (limit = x)

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/iterative/rule/MergeLimitOverProjectWithSort.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/iterative/rule/MergeLimitOverProjectWithSort.java
@@ -38,7 +38,9 @@ import static org.apache.iotdb.db.queryengine.plan.relational.planner.node.Patte
 import static org.apache.iotdb.db.queryengine.plan.relational.utils.matching.Capture.newCapture;
 
 /**
- * Transforms:
+ * <b>Optimization phase:</b> Logical plan planning.
+ *
+ * <p>Transforms:
  *
  * <pre>
  * - Limit (limit = x)
@@ -78,9 +80,9 @@ public class MergeLimitOverProjectWithSort implements Rule<LimitNode> {
   @Override
   public Result apply(LimitNode parent, Captures captures, Context context) {
     ProjectNode project = captures.get(PROJECT);
-    SortNode sort = captures.get(SORT);
+    SortNode sortNode = captures.get(SORT);
 
-    if (sort instanceof StreamSortNode) {
+    if (sortNode instanceof StreamSortNode) {
       return Result.empty();
     }
 
@@ -89,10 +91,10 @@ public class MergeLimitOverProjectWithSort implements Rule<LimitNode> {
             ImmutableList.of(
                 new TopKNode(
                     parent.getPlanNodeId(),
-                    sort.getChildren(),
-                    sort.getOrderingScheme(),
+                    sortNode.getChildren(),
+                    sortNode.getOrderingScheme(),
                     parent.getCount(),
-                    parent.getOutputSymbols(),
-                    sort.isOrderByAllIdsAndTime()))));
+                    sortNode.getOutputSymbols(),
+                    sortNode.isOrderByAllIdsAndTime()))));
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/iterative/rule/MergeLimitWithMergeSort.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/iterative/rule/MergeLimitWithMergeSort.java
@@ -31,7 +31,7 @@ import static org.apache.iotdb.db.queryengine.plan.relational.planner.node.Patte
 import static org.apache.iotdb.db.queryengine.plan.relational.utils.matching.Capture.newCapture;
 
 /**
- * Transforms:
+ * <b>Optimization phase:</b> Distributed plan planning. Transforms:
  *
  * <pre>
  * - Limit (limit = x)
@@ -90,7 +90,7 @@ public class MergeLimitWithMergeSort implements Rule<LimitNode> {
               parent.getPlanNodeId(),
               mergeSortNode.getOrderingScheme(),
               parent.getCount(),
-              parent.getOutputSymbols(),
+              childOfMergeSort.getOutputSymbols(),
               true);
       for (PlanNode child : mergeSortNode.getChildren()) {
         LimitNode limitNode =
@@ -109,7 +109,7 @@ public class MergeLimitWithMergeSort implements Rule<LimitNode> {
               mergeSortNode.getChildren(),
               mergeSortNode.getOrderingScheme(),
               parent.getCount(),
-              parent.getOutputSymbols(),
+              childOfMergeSort.getOutputSymbols(),
               true);
     }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/iterative/rule/MergeLimitWithMergeSort.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/iterative/rule/MergeLimitWithMergeSort.java
@@ -31,7 +31,9 @@ import static org.apache.iotdb.db.queryengine.plan.relational.planner.node.Patte
 import static org.apache.iotdb.db.queryengine.plan.relational.utils.matching.Capture.newCapture;
 
 /**
- * <b>Optimization phase:</b> Distributed plan planning. Transforms:
+ * <b>Optimization phase:</b> Distributed plan planning.
+ *
+ * <p>Transforms:
  *
  * <pre>
  * - Limit (limit = x)

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/iterative/rule/MergeLimitWithSort.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/iterative/rule/MergeLimitWithSort.java
@@ -27,6 +27,7 @@ import static org.apache.iotdb.db.queryengine.plan.relational.planner.node.Patte
 import static org.apache.iotdb.db.queryengine.plan.relational.planner.node.Patterns.source;
 import static org.apache.iotdb.db.queryengine.plan.relational.utils.matching.Capture.newCapture;
 
+/** <b>Optimization phase:</b> Logical plan planning. */
 public class MergeLimitWithSort implements Rule<LimitNode> {
   private static final Capture<SortNode> CHILD = newCapture();
 
@@ -42,19 +43,19 @@ public class MergeLimitWithSort implements Rule<LimitNode> {
 
   @Override
   public Result apply(LimitNode parent, Captures captures, Context context) {
-    SortNode child = captures.get(CHILD);
+    SortNode sortNode = captures.get(CHILD);
 
-    if (child instanceof StreamSortNode) {
+    if (sortNode instanceof StreamSortNode) {
       return Result.empty();
     }
 
     return Result.ofPlanNode(
         new TopKNode(
             parent.getPlanNodeId(),
-            child.getChildren(),
-            child.getOrderingScheme(),
+            sortNode.getChildren(),
+            sortNode.getOrderingScheme(),
             parent.getCount(),
-            parent.getOutputSymbols(),
-            child.isOrderByAllIdsAndTime()));
+            sortNode.getOutputSymbols(),
+            sortNode.isOrderByAllIdsAndTime()));
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/SortTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/SortTest.java
@@ -74,11 +74,9 @@ public class SortTest {
   Analysis actualAnalysis;
   MPPQueryContext context;
   WarningCollector warningCollector = WarningCollector.NOOP;
-  LogicalPlanner logicalPlanner;
   LogicalQueryPlan logicalQueryPlan;
-  PlanNode rootNode;
+  PlanNode logicalPlanNode;
   OutputNode outputNode;
-  PlanNode mergeSortNode;
   ProjectNode projectNode;
   StreamSortNode streamSortNode;
   TableDistributedPlanner distributionPlanner;
@@ -103,15 +101,15 @@ public class SortTest {
     actualAnalysis = analyzeSQL(sql, metadata, context);
     logicalQueryPlan =
         new LogicalPlanner(context, metadata, sessionInfo, warningCollector).plan(actualAnalysis);
-    rootNode = logicalQueryPlan.getRootNode();
+    logicalPlanNode = logicalQueryPlan.getRootNode();
 
     // LogicalPlan: `Output-Offset-Limit-Project-StreamSort-Project-Filter-TableScan`
-    assertTrue(rootNode instanceof OutputNode);
-    assertTrue(getChildrenNode(rootNode, 1) instanceof OffsetNode);
-    assertTrue(getChildrenNode(rootNode, 2) instanceof LimitNode);
-    assertTrue(getChildrenNode(rootNode, 3) instanceof ProjectNode);
-    assertTrue(getChildrenNode(rootNode, 4) instanceof StreamSortNode);
-    streamSortNode = (StreamSortNode) getChildrenNode(rootNode, 4);
+    assertTrue(logicalPlanNode instanceof OutputNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 1) instanceof OffsetNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 2) instanceof LimitNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 3) instanceof ProjectNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 4) instanceof StreamSortNode);
+    streamSortNode = (StreamSortNode) getChildrenNode(logicalPlanNode, 4);
     assertTrue(getChildrenNode(streamSortNode, 1) instanceof ProjectNode);
     assertTrue(getChildrenNode(streamSortNode, 2) instanceof FilterNode);
     assertTrue(getChildrenNode(streamSortNode, 3) instanceof TableScanNode);
@@ -179,9 +177,9 @@ public class SortTest {
     actualAnalysis = analyzeSQL(sql, metadata, context);
     logicalQueryPlan =
         new LogicalPlanner(context, metadata, sessionInfo, warningCollector).plan(actualAnalysis);
-    rootNode = logicalQueryPlan.getRootNode();
+    logicalPlanNode = logicalQueryPlan.getRootNode();
     // LogicalPlan: `Output-Offset-Limit-StreamSort-TableScan`
-    assertTrue(getChildrenNode(rootNode, 3) instanceof StreamSortNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 3) instanceof StreamSortNode);
     distributionPlanner = new TableDistributedPlanner(actualAnalysis, logicalQueryPlan, context);
     distributedQueryPlan = distributionPlanner.plan();
     assertEquals(3, distributedQueryPlan.getFragments().size());
@@ -205,15 +203,15 @@ public class SortTest {
     actualAnalysis = analyzeSQL(sql, metadata, context);
     logicalQueryPlan =
         new LogicalPlanner(context, metadata, sessionInfo, warningCollector).plan(actualAnalysis);
-    rootNode = logicalQueryPlan.getRootNode();
+    logicalPlanNode = logicalQueryPlan.getRootNode();
 
     // LogicalPlan: `Output-Offset-Limit-Project-StreamSort-Project-Filter-TableScan`
-    assertTrue(rootNode instanceof OutputNode);
-    assertTrue(getChildrenNode(rootNode, 1) instanceof OffsetNode);
-    assertTrue(getChildrenNode(rootNode, 2) instanceof LimitNode);
-    assertTrue(getChildrenNode(rootNode, 3) instanceof ProjectNode);
-    assertTrue(getChildrenNode(rootNode, 4) instanceof StreamSortNode);
-    StreamSortNode streamSortNode = (StreamSortNode) getChildrenNode(rootNode, 4);
+    assertTrue(logicalPlanNode instanceof OutputNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 1) instanceof OffsetNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 2) instanceof LimitNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 3) instanceof ProjectNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 4) instanceof StreamSortNode);
+    StreamSortNode streamSortNode = (StreamSortNode) getChildrenNode(logicalPlanNode, 4);
     assertTrue(getChildrenNode(streamSortNode, 1) instanceof ProjectNode);
     assertTrue(getChildrenNode(streamSortNode, 2) instanceof FilterNode);
     assertTrue(getChildrenNode(streamSortNode, 3) instanceof TableScanNode);
@@ -283,13 +281,13 @@ public class SortTest {
     actualAnalysis = analyzeSQL(sql, metadata, context);
     logicalQueryPlan =
         new LogicalPlanner(context, metadata, sessionInfo, warningCollector).plan(actualAnalysis);
-    rootNode = logicalQueryPlan.getRootNode();
+    logicalPlanNode = logicalQueryPlan.getRootNode();
 
     // LogicalPlan: `Output-Project-StreamSort-Project-Filter-TableScan`
-    assertTrue(rootNode instanceof OutputNode);
-    assertTrue(getChildrenNode(rootNode, 1) instanceof ProjectNode);
-    assertTrue(getChildrenNode(rootNode, 2) instanceof StreamSortNode);
-    StreamSortNode streamSortNode = (StreamSortNode) getChildrenNode(rootNode, 2);
+    assertTrue(logicalPlanNode instanceof OutputNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 1) instanceof ProjectNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 2) instanceof StreamSortNode);
+    StreamSortNode streamSortNode = (StreamSortNode) getChildrenNode(logicalPlanNode, 2);
     assertTrue(getChildrenNode(streamSortNode, 1) instanceof ProjectNode);
     assertTrue(getChildrenNode(streamSortNode, 2) instanceof FilterNode);
     assertTrue(getChildrenNode(streamSortNode, 3) instanceof TableScanNode);
@@ -351,15 +349,15 @@ public class SortTest {
     actualAnalysis = analyzeSQL(sql, metadata, context);
     logicalQueryPlan =
         new LogicalPlanner(context, metadata, sessionInfo, warningCollector).plan(actualAnalysis);
-    rootNode = logicalQueryPlan.getRootNode();
+    logicalPlanNode = logicalQueryPlan.getRootNode();
 
     // LogicalPlan: `Output-Offset-Limit-Project-StreamSort-Project-Filter-TableScan`
-    assertTrue(rootNode instanceof OutputNode);
-    assertTrue(getChildrenNode(rootNode, 1) instanceof OffsetNode);
-    assertTrue(getChildrenNode(rootNode, 2) instanceof LimitNode);
-    assertTrue(getChildrenNode(rootNode, 3) instanceof ProjectNode);
-    assertTrue(getChildrenNode(rootNode, 4) instanceof StreamSortNode);
-    streamSortNode = (StreamSortNode) getChildrenNode(rootNode, 4);
+    assertTrue(logicalPlanNode instanceof OutputNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 1) instanceof OffsetNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 2) instanceof LimitNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 3) instanceof ProjectNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 4) instanceof StreamSortNode);
+    streamSortNode = (StreamSortNode) getChildrenNode(logicalPlanNode, 4);
     assertEquals(1, streamSortNode.getStreamCompareKeyEndIndex());
     assertTrue(getChildrenNode(streamSortNode, 1) instanceof ProjectNode);
     assertTrue(getChildrenNode(streamSortNode, 2) instanceof FilterNode);
@@ -431,15 +429,15 @@ public class SortTest {
     actualAnalysis = analyzeSQL(sql, metadata, context);
     logicalQueryPlan =
         new LogicalPlanner(context, metadata, sessionInfo, warningCollector).plan(actualAnalysis);
-    rootNode = logicalQueryPlan.getRootNode();
+    logicalPlanNode = logicalQueryPlan.getRootNode();
 
     // LogicalPlan: `Output-Offset-Limit-Project-StreamSort-Project-Filter-TableScan`
-    assertTrue(rootNode instanceof OutputNode);
-    assertTrue(getChildrenNode(rootNode, 1) instanceof OffsetNode);
-    assertTrue(getChildrenNode(rootNode, 2) instanceof LimitNode);
-    assertTrue(getChildrenNode(rootNode, 3) instanceof ProjectNode);
-    assertTrue(getChildrenNode(rootNode, 4) instanceof StreamSortNode);
-    streamSortNode = (StreamSortNode) getChildrenNode(rootNode, 4);
+    assertTrue(logicalPlanNode instanceof OutputNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 1) instanceof OffsetNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 2) instanceof LimitNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 3) instanceof ProjectNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 4) instanceof StreamSortNode);
+    streamSortNode = (StreamSortNode) getChildrenNode(logicalPlanNode, 4);
     assertEquals(2, streamSortNode.getStreamCompareKeyEndIndex());
     assertTrue(getChildrenNode(streamSortNode, 1) instanceof ProjectNode);
     assertTrue(getChildrenNode(streamSortNode, 2) instanceof FilterNode);
@@ -509,7 +507,7 @@ public class SortTest {
     actualAnalysis = analyzeSQL(sql, metadata, context);
     logicalQueryPlan =
         new LogicalPlanner(context, metadata, sessionInfo, warningCollector).plan(actualAnalysis);
-    rootNode = logicalQueryPlan.getRootNode();
+    logicalPlanNode = logicalQueryPlan.getRootNode();
 
     assertTopKNoFilter(originalDeviceEntries1, originalDeviceEntries2, DESC, 15, 0, true);
 
@@ -521,7 +519,7 @@ public class SortTest {
     actualAnalysis = analyzeSQL(sql, metadata, context);
     logicalQueryPlan =
         new LogicalPlanner(context, metadata, sessionInfo, warningCollector).plan(actualAnalysis);
-    rootNode = logicalQueryPlan.getRootNode();
+    logicalPlanNode = logicalQueryPlan.getRootNode();
     assertTopKWithFilter(originalDeviceEntries1, originalDeviceEntries2, DESC, 0, 0, false);
 
     // order by time, others, all_ids; has filter
@@ -532,7 +530,7 @@ public class SortTest {
     actualAnalysis = analyzeSQL(sql, metadata, context);
     logicalQueryPlan =
         new LogicalPlanner(context, metadata, sessionInfo, warningCollector).plan(actualAnalysis);
-    rootNode = logicalQueryPlan.getRootNode();
+    logicalPlanNode = logicalQueryPlan.getRootNode();
     assertTopKWithFilter(originalDeviceEntries1, originalDeviceEntries2, DESC, 0, 0, false);
 
     // order by time, all_ids, others; has filter
@@ -543,7 +541,7 @@ public class SortTest {
     actualAnalysis = analyzeSQL(sql, metadata, context);
     logicalQueryPlan =
         new LogicalPlanner(context, metadata, sessionInfo, warningCollector).plan(actualAnalysis);
-    rootNode = logicalQueryPlan.getRootNode();
+    logicalPlanNode = logicalQueryPlan.getRootNode();
 
     assertTopKWithFilter(originalDeviceEntries1, originalDeviceEntries2, DESC, 0, 0, false);
   }
@@ -558,7 +556,7 @@ public class SortTest {
     actualAnalysis = analyzeSQL(sql, metadata, context);
     logicalQueryPlan =
         new LogicalPlanner(context, metadata, sessionInfo, warningCollector).plan(actualAnalysis);
-    rootNode = logicalQueryPlan.getRootNode();
+    logicalPlanNode = logicalQueryPlan.getRootNode();
     assertTopKNoFilter(originalDeviceEntries1, originalDeviceEntries2, ASC, 0, 0, false);
 
     // order by others, all_ids, time
@@ -569,7 +567,7 @@ public class SortTest {
     actualAnalysis = analyzeSQL(sql, metadata, context);
     logicalQueryPlan =
         new LogicalPlanner(context, metadata, sessionInfo, warningCollector).plan(actualAnalysis);
-    rootNode = logicalQueryPlan.getRootNode();
+    logicalPlanNode = logicalQueryPlan.getRootNode();
     assertTopKWithFilter(originalDeviceEntries1, originalDeviceEntries2, ASC, 0, 0, false);
 
     // order by others, time, some_ids
@@ -580,7 +578,7 @@ public class SortTest {
     actualAnalysis = analyzeSQL(sql, metadata, context);
     logicalQueryPlan =
         new LogicalPlanner(context, metadata, sessionInfo, warningCollector).plan(actualAnalysis);
-    rootNode = logicalQueryPlan.getRootNode();
+    logicalPlanNode = logicalQueryPlan.getRootNode();
     assertTopKWithFilter(originalDeviceEntries1, originalDeviceEntries2, ASC, 0, 0, false);
 
     // order by others, time, all_ids
@@ -591,8 +589,29 @@ public class SortTest {
     actualAnalysis = analyzeSQL(sql, metadata, context);
     logicalQueryPlan =
         new LogicalPlanner(context, metadata, sessionInfo, warningCollector).plan(actualAnalysis);
-    rootNode = logicalQueryPlan.getRootNode();
+    logicalPlanNode = logicalQueryPlan.getRootNode();
     assertTopKWithFilter(originalDeviceEntries1, originalDeviceEntries2, ASC, 0, 0, false);
+  }
+
+  @Test
+  public void selectOrderTest() {
+    // columns in order and select is different
+    sql = "SELECT time, attr1, s1 FROM table1 order by attr2 limit 5";
+    context = new MPPQueryContext(sql, queryId, sessionInfo, null, null);
+    actualAnalysis = analyzeSQL(sql, metadata, context);
+    logicalQueryPlan =
+        new LogicalPlanner(context, metadata, sessionInfo, warningCollector).plan(actualAnalysis);
+    logicalPlanNode = logicalQueryPlan.getRootNode();
+    distributionPlanner = new TableDistributedPlanner(actualAnalysis, logicalQueryPlan, context);
+    distributedQueryPlan = distributionPlanner.plan();
+    assertEquals(3, distributedQueryPlan.getFragments().size());
+    IdentitySinkNode sinkNode =
+        (IdentitySinkNode) distributedQueryPlan.getFragments().get(0).getPlanNodeTree();
+    assertTrue(getChildrenNode(sinkNode, 1) instanceof OutputNode);
+    assertTrue(getChildrenNode(sinkNode, 2) instanceof ProjectNode);
+    assertTrue(getChildrenNode(sinkNode, 3) instanceof TopKNode);
+    TopKNode topKNode = (TopKNode) getChildrenNode(sinkNode, 3);
+    assertEquals(4, topKNode.getOutputSymbols().size());
   }
 
   public void assertTopKWithFilter(
@@ -603,14 +622,14 @@ public class SortTest {
       long expectedPushDownOffset,
       boolean isPushLimitToEachDevice) {
     // LogicalPlan: `Output - Offset - Project - TopK - Project - FilterNode - TableScan`
-    assertTrue(rootNode instanceof OutputNode);
-    assertTrue(getChildrenNode(rootNode, 1) instanceof OffsetNode);
-    assertTrue(getChildrenNode(rootNode, 2) instanceof ProjectNode);
-    assertTrue(getChildrenNode(rootNode, 3) instanceof TopKNode);
-    assertTrue(getChildrenNode(rootNode, 4) instanceof ProjectNode);
-    assertTrue(getChildrenNode(rootNode, 5) instanceof FilterNode);
-    assertTrue(getChildrenNode(rootNode, 6) instanceof TableScanNode);
-    tableScanNode = (TableScanNode) getChildrenNode(rootNode, 6);
+    assertTrue(logicalPlanNode instanceof OutputNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 1) instanceof OffsetNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 2) instanceof ProjectNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 3) instanceof TopKNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 4) instanceof ProjectNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 5) instanceof FilterNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 6) instanceof TableScanNode);
+    tableScanNode = (TableScanNode) getChildrenNode(logicalPlanNode, 6);
     assertEquals("testdb.table1", tableScanNode.getQualifiedObjectName().toString());
     assertEquals(8, tableScanNode.getAssignments().size());
     assertEquals(6, tableScanNode.getDeviceEntries().size());
@@ -672,13 +691,13 @@ public class SortTest {
       long expectedPushDownOffset,
       boolean isPushLimitToEachDevice) {
     // LogicalPlan: `Output - Offset - Project - TopK - Project -  TableScan`
-    assertTrue(rootNode instanceof OutputNode);
-    assertTrue(getChildrenNode(rootNode, 1) instanceof OffsetNode);
-    assertTrue(getChildrenNode(rootNode, 2) instanceof ProjectNode);
-    assertTrue(getChildrenNode(rootNode, 3) instanceof TopKNode);
-    assertTrue(getChildrenNode(rootNode, 4) instanceof ProjectNode);
-    assertTrue(getChildrenNode(rootNode, 5) instanceof TableScanNode);
-    tableScanNode = (TableScanNode) getChildrenNode(rootNode, 5);
+    assertTrue(logicalPlanNode instanceof OutputNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 1) instanceof OffsetNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 2) instanceof ProjectNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 3) instanceof TopKNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 4) instanceof ProjectNode);
+    assertTrue(getChildrenNode(logicalPlanNode, 5) instanceof TableScanNode);
+    tableScanNode = (TableScanNode) getChildrenNode(logicalPlanNode, 5);
     assertEquals("testdb.table1", tableScanNode.getQualifiedObjectName().toString());
     assertEquals(8, tableScanNode.getAssignments().size());
     assertEquals(6, tableScanNode.getDeviceEntries().size());

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/SortTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/SortTest.java
@@ -594,7 +594,7 @@ public class SortTest {
   }
 
   @Test
-  public void selectOrderTest() {
+  public void projectSortTest() {
     // columns in order and select is different
     sql = "SELECT time, attr1, s1 FROM table1 order by attr2 limit 5";
     context = new MPPQueryContext(sql, queryId, sessionInfo, null, null);


### PR DESCRIPTION
## Description

As the title.

Before fix, sql `SELECT time, attr1, s1 FROM table1 order by attr2 limit 5` will throw errors.

### Content1 ...

### Content2 ...

### Content3 ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
