### PR TITLE
Add 'deserialize_resource' metric item in compaction

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/metrics/CompactionMetrics.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/metrics/CompactionMetrics.java
@@ -93,8 +93,6 @@ public class CompactionMetrics implements IMetricSet {
     }
   }
 
-  private Counter totalCompactionWriteInfoCounter = DoNothingMetricManager.DO_NOTHING_COUNTER;
-
   private void bindWriteInfo(AbstractMetricService metricService) {
     for (CompactionType compactionType : CompactionType.values()) {
       writeCounters.put(
@@ -123,14 +121,6 @@ public class CompactionMetrics implements IMetricSet {
                 METADATA)
           });
     }
-    totalCompactionWriteInfoCounter =
-        metricService.getOrCreateCounter(
-            Metric.DATA_WRITTEN.toString(),
-            MetricLevel.IMPORTANT,
-            Tag.NAME.toString(),
-            "compaction",
-            Tag.TYPE.toString(),
-            "total");
   }
 
   private void unbindWriteInfo(AbstractMetricService metricService) {
@@ -157,13 +147,6 @@ public class CompactionMetrics implements IMetricSet {
           Tag.NAME.toString(),
           METADATA);
     }
-    metricService.remove(
-        MetricType.COUNTER,
-        Metric.DATA_WRITTEN.toString(),
-        Tag.NAME.toString(),
-        "compaction",
-        Tag.TYPE.toString(),
-        "total");
   }
 
   public void recordWriteInfo(
@@ -172,13 +155,11 @@ public class CompactionMetrics implements IMetricSet {
     if (counters != null) {
       counters[dataType.getValue()].inc(byteNum);
     }
-    totalCompactionWriteInfoCounter.inc(byteNum);
   }
 
   // endregion
 
   // region compaction read info
-  private Counter totalCompactionReadInfoCounter = DoNothingMetricManager.DO_NOTHING_COUNTER;
   private Counter deserializeResourceCounter = DoNothingMetricManager.DO_NOTHING_COUNTER;
 
   private void bindReadInfo(AbstractMetricService metricService) {
@@ -209,13 +190,12 @@ public class CompactionMetrics implements IMetricSet {
                 METADATA)
           });
     }
-    totalCompactionReadInfoCounter =
-        metricService.getOrCreateCounter(
-            Metric.DATA_READ.toString(), MetricLevel.IMPORTANT, Tag.NAME.toString(), "compaction");
     deserializeResourceCounter =
         metricService.getOrCreateCounter(
             Metric.DATA_READ.toString(),
             MetricLevel.IMPORTANT,
+            Tag.TYPE.toString(),
+            "total",
             Tag.NAME.toString(),
             "deserialize_resource");
   }
@@ -245,10 +225,10 @@ public class CompactionMetrics implements IMetricSet {
           METADATA);
     }
     metricService.remove(
-        MetricType.COUNTER, Metric.DATA_READ.toString(), Tag.NAME.toString(), "compaction");
-    metricService.remove(
         MetricType.COUNTER,
         Metric.DATA_READ.toString(),
+        Tag.TYPE.toString(),
+        "total",
         Tag.NAME.toString(),
         "deserialize_resource");
   }
@@ -259,7 +239,6 @@ public class CompactionMetrics implements IMetricSet {
     if (counters != null) {
       counters[dataType.getValue()].inc(byteNum);
     }
-    totalCompactionReadInfoCounter.inc(byteNum);
   }
 
   public void recordDeserializeResourceInfo(long byteNum) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/performer/impl/RepairUnsortedFileCompactionPerformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/performer/impl/RepairUnsortedFileCompactionPerformer.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.storageengine.dataregion.compaction.execute.performer.impl;
 
+import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.utils.CompactionUtils;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.utils.writer.AbstractCompactionWriter;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.utils.writer.RepairUnsortedFileCompactionWriter;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
@@ -66,7 +67,7 @@ public class RepairUnsortedFileCompactionPerformer extends ReadPointCompactionPe
     if (timeIndex instanceof ArrayDeviceTimeIndex) {
       targetFile.setTimeIndex(timeIndex);
     } else {
-      targetFile.setTimeIndex(seqSourceFile.buildDeviceTimeIndex());
+      targetFile.setTimeIndex(CompactionUtils.buildDeviceTimeIndex(seqSourceFile));
     }
     if (seqSourceFile.modFileExists()) {
       Files.createLink(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/CompactionUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/CompactionUtils.java
@@ -23,11 +23,14 @@ import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.service.metric.MetricService;
 import org.apache.iotdb.commons.service.metric.enums.Tag;
+import org.apache.iotdb.db.service.metrics.CompactionMetrics;
 import org.apache.iotdb.db.service.metrics.FileMetrics;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.constant.CompactionTaskType;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.schedule.CompactionTaskManager;
 import org.apache.iotdb.db.storageengine.dataregion.modification.Modification;
 import org.apache.iotdb.db.storageengine.dataregion.modification.ModificationFile;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
+import org.apache.iotdb.db.storageengine.dataregion.tsfile.timeindex.ArrayDeviceTimeIndex;
 import org.apache.iotdb.metrics.utils.MetricLevel;
 import org.apache.iotdb.metrics.utils.SystemMetric;
 
@@ -362,5 +365,19 @@ public class CompactionUtils {
           > CommonDescriptor.getInstance().getConfig().getDiskSpaceWarningThreshold() + redundancy;
     }
     return true;
+  }
+
+  public static ArrayDeviceTimeIndex buildDeviceTimeIndex(TsFileResource resource)
+      throws IOException {
+    long resourceFileSize =
+        new File(resource.getTsFilePath() + TsFileResource.RESOURCE_SUFFIX).length();
+    CompactionTaskManager.getInstance().getCompactionReadOperationRateLimiter().acquire(1);
+    while (resourceFileSize > 0) {
+      int readSize = (int) Math.min(resourceFileSize, Integer.MAX_VALUE);
+      CompactionTaskManager.getInstance().getCompactionReadRateLimiter().acquire(readSize);
+      resourceFileSize -= readSize;
+    }
+    CompactionMetrics.getInstance().recordDeserializeResourceInfo(resourceFileSize);
+    return resource.buildDeviceTimeIndex();
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/repair/RepairDataFileScanUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/repair/RepairDataFileScanUtil.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.storageengine.dataregion.compaction.repair;
 
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.exception.CompactionLastTimeCheckFailedException;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.utils.CompactionUtils;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.utils.executor.fast.reader.CompactionChunkReader;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.io.CompactionTsFileReader;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.schedule.constant.CompactionType;
@@ -290,6 +291,6 @@ public class RepairDataFileScanUtil {
     if (timeIndex instanceof ArrayDeviceTimeIndex) {
       return (ArrayDeviceTimeIndex) timeIndex;
     }
-    return resource.buildDeviceTimeIndex();
+    return CompactionUtils.buildDeviceTimeIndex(resource);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/AbstractCompactionEstimator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/AbstractCompactionEstimator.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.storageengine.dataregion.compaction.selector.estimat
 
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.utils.CompactionUtils;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResourceStatus;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.timeindex.ArrayDeviceTimeIndex;
@@ -161,7 +162,7 @@ public abstract class AbstractCompactionEstimator {
     }
     ITimeIndex timeIndex = resource.getTimeIndex();
     if (timeIndex instanceof FileTimeIndex) {
-      timeIndex = resource.buildDeviceTimeIndex();
+      timeIndex = CompactionUtils.buildDeviceTimeIndex(resource);
     }
     deviceTimeIndexCache.put(resource, (ArrayDeviceTimeIndex) timeIndex);
     return (ArrayDeviceTimeIndex) timeIndex;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/impl/SettleSelectorImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/impl/SettleSelectorImpl.java
@@ -202,7 +202,7 @@ public class SettleSelectorImpl implements ISettleSelector {
     ModificationFile modFile = resource.getModFile();
     ITimeIndex timeIndex = resource.getTimeIndex();
     if (timeIndex instanceof FileTimeIndex) {
-      timeIndex = resource.buildDeviceTimeIndex();
+      timeIndex = CompactionUtils.buildDeviceTimeIndex(resource);
     }
     Set<IDeviceID> deletedDevices = new HashSet<>();
     boolean hasExpiredTooLong = false;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/utils/TsFileResourceCandidate.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/utils/TsFileResourceCandidate.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.storageengine.dataregion.compaction.selector.utils;
 
+import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.utils.CompactionUtils;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.schedule.CompactionScheduleContext;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileRepairStatus;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
@@ -87,7 +88,7 @@ public class TsFileResourceCandidate {
           hasDetailedDeviceInfo = false;
           return;
         }
-        ArrayDeviceTimeIndex timeIndex = resource.buildDeviceTimeIndex();
+        ArrayDeviceTimeIndex timeIndex = CompactionUtils.buildDeviceTimeIndex(resource);
         for (IDeviceID deviceId : timeIndex.getDevices()) {
           deviceInfoMap.put(
               deviceId,

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/utils/TsFileResourceUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/utils/TsFileResourceUtils.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.storageengine.dataregion.utils;
 
+import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.utils.CompactionUtils;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResourceStatus;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.timeindex.ArrayDeviceTimeIndex;
@@ -379,7 +380,7 @@ public class TsFileResourceUtils {
       if (resource.getTimeIndexType() == ITimeIndex.FILE_TIME_INDEX_TYPE) {
         // if time index is not device time index, then deserialize it from resource file
         try {
-          timeIndex = resource.buildDeviceTimeIndex();
+          timeIndex = CompactionUtils.buildDeviceTimeIndex(resource);
         } catch (IOException e) {
           // skip such files
           continue;


### PR DESCRIPTION
## Description
1. Add 'deserialize_resource' metric item in compaction
2. Record deserialized resource file size in rate limiter
3. Remove 'totalCompactionReadInfoCounter'(whose tag is not correctly set in past version) and 'totalCompactionWriteInfoCounter'