### PR TITLE
Fix query stuck while DN restarting & keep quite while cleaning sort tmp file

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/driver/Driver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/driver/Driver.java
@@ -445,7 +445,7 @@ public abstract class Driver implements IDriver {
     if (!tmpPipeLineDir.exists()) {
       return;
     }
-    FileUtils.deleteFileOrDirectory(tmpPipeLineDir);
+    FileUtils.deleteFileOrDirectory(tmpPipeLineDir, true);
   }
 
   private static Throwable addSuppressedException(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceExecution.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceExecution.java
@@ -358,7 +358,7 @@ public class FragmentInstanceExecution {
               + File.separator;
       File tmpFile = new File(tmpFilePath);
       if (tmpFile.exists()) {
-        FileUtils.deleteFileOrDirectory(tmpFile);
+        FileUtils.deleteFileOrDirectory(tmpFile, true);
       }
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceState.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceState.java
@@ -47,7 +47,7 @@ public enum FragmentInstanceState {
   /** Instance execution failed. */
   FAILED(true, true),
   /** Instance is not found. */
-  NO_SUCH_INSTANCE(false, false);
+  NO_SUCH_INSTANCE(false, true);
 
   public static final Set<FragmentInstanceState> TERMINAL_INSTANCE_STATES =
       Stream.of(FragmentInstanceState.values())

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/FixedRateFragInsStateTracker.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/FixedRateFragInsStateTracker.java
@@ -88,16 +88,22 @@ public class FixedRateFragInsStateTracker extends AbstractFragInsStateTracker {
       return res;
     }
     for (FragmentInstanceId fragmentInstanceId : instanceIds) {
-      InstanceStateMetrics stateMetrics = instanceStateMap.get(fragmentInstanceId);
-      if (stateMetrics == null
-          || stateMetrics.lastState == null
-          || !stateMetrics.lastState.isDone()) {
+      if (unfinished(fragmentInstanceId)) {
         // FI whose state has not been updated is considered to be unfinished.(In Query with limit
         // clause, it's possible that the query is finished before the state of FI being recorded.)
         res.add(fragmentInstanceId);
       }
     }
     return res;
+  }
+
+  private boolean unfinished(FragmentInstanceId fragmentInstanceId) {
+    InstanceStateMetrics stateMetrics = instanceStateMap.get(fragmentInstanceId);
+    // FI whose state has not been updated is considered to be unfinished.(In Query with limit
+    // clause, it's possible that the query is finished before the state of FI being recorded.)
+    return stateMetrics == null
+        || stateMetrics.lastState == null
+        || !stateMetrics.lastState.isDone();
   }
 
   @Override
@@ -117,27 +123,29 @@ public class FixedRateFragInsStateTracker extends AbstractFragInsStateTracker {
 
   private void fetchStateAndUpdate() {
     for (FragmentInstance instance : instances) {
-      try (SetThreadName threadName = new SetThreadName(instance.getId().getFullId())) {
-        FragmentInstanceInfo instanceInfo = fetchInstanceInfo(instance);
-        synchronized (this) {
-          InstanceStateMetrics metrics =
-              instanceStateMap.computeIfAbsent(
-                  instance.getId(), k -> new InstanceStateMetrics(instance.isRoot()));
-          if (needPrintState(
-              metrics.lastState, instanceInfo.getState(), metrics.durationToLastPrintInMS)) {
-            if (logger.isDebugEnabled()) {
-              logger.debug("[PrintFIState] state is {}", instanceInfo.getState());
+      if (unfinished(instance.getId())) {
+        try (SetThreadName threadName = new SetThreadName(instance.getId().getFullId())) {
+          FragmentInstanceInfo instanceInfo = fetchInstanceInfo(instance);
+          synchronized (this) {
+            InstanceStateMetrics metrics =
+                instanceStateMap.computeIfAbsent(
+                    instance.getId(), k -> new InstanceStateMetrics(instance.isRoot()));
+            if (needPrintState(
+                metrics.lastState, instanceInfo.getState(), metrics.durationToLastPrintInMS)) {
+              if (logger.isDebugEnabled()) {
+                logger.debug("[PrintFIState] state is {}", instanceInfo.getState());
+              }
+              metrics.reset(instanceInfo.getState());
+            } else {
+              metrics.addDuration(STATE_FETCH_INTERVAL_IN_MS);
             }
-            metrics.reset(instanceInfo.getState());
-          } else {
-            metrics.addDuration(STATE_FETCH_INTERVAL_IN_MS);
-          }
 
-          updateQueryState(instance.getId(), instanceInfo);
+            updateQueryState(instance.getId(), instanceInfo);
+          }
+        } catch (ClientManagerException | TException e) {
+          // TODO: do nothing ?
+          logger.warn("error happened while fetching query state", e);
         }
-      } catch (ClientManagerException | TException e) {
-        // TODO: do nothing ?
-        logger.warn("error happened while fetching query state", e);
       }
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/FixedRateFragInsStateTracker.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/FixedRateFragInsStateTracker.java
@@ -143,6 +143,14 @@ public class FixedRateFragInsStateTracker extends AbstractFragInsStateTracker {
   }
 
   private void updateQueryState(FragmentInstanceId instanceId, FragmentInstanceInfo instanceInfo) {
+    // no such instance may be caused by DN restarting
+    if (instanceInfo.getState() == FragmentInstanceState.NO_SUCH_INSTANCE) {
+      stateMachine.transitionToFailed(
+          new RuntimeException(
+              String.format(
+                  "FragmentInstance[%s] is failed. %s, may be caused by DN restarting.",
+                  instanceId, instanceInfo.getMessage())));
+    }
     if (instanceInfo.getState().isFailed()) {
       if (instanceInfo.getFailureInfoList() == null
           || instanceInfo.getFailureInfoList().isEmpty()) {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/FileUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/FileUtils.java
@@ -62,6 +62,10 @@ public class FileUtils {
   }
 
   public static void deleteFileOrDirectory(File file) {
+    deleteFileOrDirectory(file, false);
+  }
+
+  public static void deleteFileOrDirectory(File file, boolean quiteForNoSuchFile) {
     if (file.isDirectory()) {
       for (File subfile : file.listFiles()) {
         deleteFileOrDirectory(subfile);
@@ -69,7 +73,11 @@ public class FileUtils {
     }
     try {
       Files.delete(file.toPath());
-    } catch (NoSuchFileException | DirectoryNotEmptyException e) {
+    } catch (NoSuchFileException e) {
+      if (!quiteForNoSuchFile) {
+        LOGGER.warn("{}: {}", e.getMessage(), Arrays.toString(file.list()), e);
+      }
+    } catch (DirectoryNotEmptyException e) {
       LOGGER.warn("{}: {}", e.getMessage(), Arrays.toString(file.list()), e);
     } catch (Exception e) {
       LOGGER.warn("{}: {}", e.getMessage(), file.getName(), e);


### PR DESCRIPTION
1. while restarting a DN, and meawhile the ongoing query's root FI is on that DN, will cause the query stuck forever, because previously we think FragmentInstanceState.NO_SUCH_INSTANCE is not a failure state.
2. clean sort tmp files more quitely, because we will do clean work in both FI callback and Driver close, so it may concurrently delete same file, but it's ok for cleaning work, so we don't need to print warn log for such case.