### PR TITLE
Fix WAL Exception catch & support new DataTypes in QueryDataSetUtils

### DIFF
--- a/example/session/src/main/java/org/apache/iotdb/TabletExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/TabletExample.java
@@ -90,9 +90,11 @@ public class TabletExample {
             case BOOLEAN:
               ret.get(measurement).add(Boolean.parseBoolean(items[idx]));
               break;
+            case DATE:
             case INT32:
               ret.get(measurement).add(Integer.parseInt(items[idx]));
               break;
+            case TIMESTAMP:
             case INT64:
               ret.get(measurement).add(Long.parseLong(items[idx]));
               break;
@@ -102,6 +104,8 @@ public class TabletExample {
             case DOUBLE:
               ret.get(measurement).add(Double.parseDouble(items[idx]));
               break;
+            case STRING:
+            case BLOB:
             case TEXT:
               ret.get(measurement).add(BytesUtils.valueOf(items[idx]));
               break;

--- a/example/udf/src/main/java/org/apache/iotdb/udf/UDAFExample.java
+++ b/example/udf/src/main/java/org/apache/iotdb/udf/UDAFExample.java
@@ -110,6 +110,10 @@ public class UDAFExample implements UDAF {
         return;
       case TEXT:
       case BOOLEAN:
+      case TIMESTAMP:
+      case STRING:
+      case BLOB:
+      case DATE:
       default:
         throw new UnSupportedDataTypeException(
             String.format("Unsupported data type in aggregation AVG : %s", dataType));

--- a/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/UDAFAvg.java
+++ b/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/UDAFAvg.java
@@ -104,6 +104,8 @@ public class UDAFAvg implements UDAF {
       case STRING:
       case BLOB:
       case BOOLEAN:
+      case TIMESTAMP:
+      case DATE:
       default:
         throw new UnSupportedDataTypeException(
             String.format("Unsupported data type in aggregation AVG : %s", dataType));

--- a/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/UDAFAvg.java
+++ b/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/UDAFAvg.java
@@ -101,6 +101,8 @@ public class UDAFAvg implements UDAF {
         addDoubleInput(avgState, columns, bitMap);
         return;
       case TEXT:
+      case STRING:
+      case BLOB:
       case BOOLEAN:
       default:
         throw new UnSupportedDataTypeException(

--- a/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/UDAFSum.java
+++ b/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/UDAFSum.java
@@ -104,6 +104,8 @@ public class UDAFSum implements UDAF {
       case STRING:
       case BLOB:
       case BOOLEAN:
+      case TIMESTAMP:
+      case DATE:
       default:
         throw new UnSupportedDataTypeException(
             String.format("Unsupported data type in aggregation AVG : %s", dataType));

--- a/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/UDAFSum.java
+++ b/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/UDAFSum.java
@@ -101,6 +101,8 @@ public class UDAFSum implements UDAF {
         addDoubleInput(sumState, columns, bitMap);
         return;
       case TEXT:
+      case STRING:
+      case BLOB:
       case BOOLEAN:
       default:
         throw new UnSupportedDataTypeException(

--- a/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/ImportData.java
+++ b/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/ImportData.java
@@ -1040,6 +1040,9 @@ public class ImportData extends AbstractDataTool {
           return Float.parseFloat(value);
         case DOUBLE:
           return Double.parseDouble(value);
+        case TIMESTAMP:
+        case DATE:
+        case BLOB:
         default:
           return null;
       }

--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/GroupedLSBWatermarkEncoder.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/GroupedLSBWatermarkEncoder.java
@@ -134,6 +134,10 @@ public class GroupedLSBWatermarkEncoder implements WatermarkEncoder {
           double originDoubleValue = field.getDoubleV();
           field.setDoubleV(encodeDouble(originDoubleValue, timestamp));
           break;
+        case BLOB:
+        case STRING:
+        case BOOLEAN:
+        case TEXT:
         default:
       }
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -2578,6 +2578,9 @@ public class IoTDBDescriptor {
         return conf.getDefaultFloatEncoding();
       case DOUBLE:
         return conf.getDefaultDoubleEncoding();
+      case STRING:
+      case BLOB:
+      case TEXT:
       default:
         return conf.getDefaultTextEncoding();
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/processor/aggregate/operator/intermediateresult/CustomizedReadableIntermediateResults.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/processor/aggregate/operator/intermediateresult/CustomizedReadableIntermediateResults.java
@@ -66,6 +66,10 @@ public class CustomizedReadableIntermediateResults {
         return (int) (float) value;
       case DOUBLE:
         return (int) (double) value;
+      case TEXT:
+      case BLOB:
+      case BOOLEAN:
+      case STRING:
       default:
         throw new UnsupportedOperationException(
             String.format("The type %s cannot be casted to int.", typeResultPair.getLeft()));
@@ -89,6 +93,10 @@ public class CustomizedReadableIntermediateResults {
         return (long) (float) value;
       case DOUBLE:
         return (long) (double) value;
+      case BOOLEAN:
+      case STRING:
+      case TEXT:
+      case BLOB:
       default:
         throw new UnsupportedOperationException(
             String.format("The type %s cannot be casted to long.", typeResultPair.getLeft()));
@@ -112,6 +120,10 @@ public class CustomizedReadableIntermediateResults {
         return (float) value;
       case DOUBLE:
         return (float) (double) value;
+      case TEXT:
+      case BLOB:
+      case BOOLEAN:
+      case STRING:
       default:
         throw new UnsupportedOperationException(
             String.format("The type %s cannot be casted to float.", typeResultPair.getLeft()));
@@ -135,6 +147,10 @@ public class CustomizedReadableIntermediateResults {
         return (float) value;
       case DOUBLE:
         return (double) value;
+      case BOOLEAN:
+      case STRING:
+      case TEXT:
+      case BLOB:
       default:
         throw new UnsupportedOperationException(
             String.format("The type %s cannot be casted to double.", typeResultPair.getLeft()));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/processor/aggregate/operator/intermediateresult/sametype/numeric/AbstractSameTypeNumericOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/processor/aggregate/operator/intermediateresult/sametype/numeric/AbstractSameTypeNumericOperator.java
@@ -128,6 +128,12 @@ public abstract class AbstractSameTypeNumericOperator implements IntermediateRes
         return new Pair<>(TSDataType.FLOAT, floatValue);
       case DOUBLE:
         return new Pair<>(TSDataType.DOUBLE, doubleValue);
+      case BLOB:
+      case TEXT:
+      case BOOLEAN:
+      case STRING:
+      case TIMESTAMP:
+      case DATE:
       default:
         return null;
     }
@@ -149,6 +155,12 @@ public abstract class AbstractSameTypeNumericOperator implements IntermediateRes
       case DOUBLE:
         ReadWriteIOUtils.write(doubleValue, outputStream);
         break;
+      case TIMESTAMP:
+      case DATE:
+      case BOOLEAN:
+      case STRING:
+      case TEXT:
+      case BLOB:
       default:
         throw new IOException(String.format("Unsupported output datatype %s", outPutDataType));
     }
@@ -170,6 +182,12 @@ public abstract class AbstractSameTypeNumericOperator implements IntermediateRes
       case DOUBLE:
         doubleValue = ReadWriteIOUtils.readDouble(byteBuffer);
         break;
+      case TEXT:
+      case BLOB:
+      case BOOLEAN:
+      case STRING:
+      case DATE:
+      case TIMESTAMP:
       default:
         throw new IOException(String.format("Unsupported output datatype %s", outPutDataType));
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/AccumulatorFactory.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/AccumulatorFactory.java
@@ -159,6 +159,10 @@ public class AccumulatorFactory {
         return new FloatModeAccumulator();
       case DOUBLE:
         return new DoubleModeAccumulator();
+      case BLOB:
+      case STRING:
+      case TIMESTAMP:
+      case DATE:
       default:
         throw new IllegalArgumentException("Unknown data type: " + tsDataType);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/AvgAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/AvgAccumulator.java
@@ -56,7 +56,11 @@ public class AvgAccumulator implements Accumulator {
         addDoubleInput(columns, bitMap);
         return;
       case TEXT:
+      case BLOB:
+      case STRING:
       case BOOLEAN:
+      case DATE:
+      case TIMESTAMP:
       default:
         throw new UnSupportedDataTypeException(
             String.format("Unsupported data type in aggregation AVG : %s", seriesDataType));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/ExtremeAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/ExtremeAccumulator.java
@@ -56,7 +56,11 @@ public class ExtremeAccumulator implements Accumulator {
         addDoubleInput(columns, bitMap);
         return;
       case TEXT:
+      case STRING:
+      case BLOB:
       case BOOLEAN:
+      case DATE:
+      case TIMESTAMP:
       default:
         throw new UnSupportedDataTypeException(
             String.format("Unsupported data type in Extreme: %s", seriesDataType));
@@ -84,7 +88,11 @@ public class ExtremeAccumulator implements Accumulator {
         updateDoubleResult(partialResult[0].getDouble(0));
         break;
       case TEXT:
+      case STRING:
+      case BLOB:
       case BOOLEAN:
+      case DATE:
+      case TIMESTAMP:
       default:
         throw new UnSupportedDataTypeException(
             String.format("Unsupported data type in Extreme: %s", seriesDataType));
@@ -114,7 +122,11 @@ public class ExtremeAccumulator implements Accumulator {
         updateDoubleResult((double) statistics.getMinValue());
         break;
       case TEXT:
+      case STRING:
+      case BLOB:
       case BOOLEAN:
+      case DATE:
+      case TIMESTAMP:
       default:
         throw new UnSupportedDataTypeException(
             String.format("Unsupported data type in Extreme: %s", seriesDataType));
@@ -141,7 +153,11 @@ public class ExtremeAccumulator implements Accumulator {
         extremeResult.setDouble(finalResult.getDouble(0));
         break;
       case TEXT:
+      case STRING:
+      case BLOB:
       case BOOLEAN:
+      case DATE:
+      case TIMESTAMP:
       default:
         throw new UnSupportedDataTypeException(
             String.format("Unsupported data type in Extreme: %s", seriesDataType));
@@ -170,7 +186,11 @@ public class ExtremeAccumulator implements Accumulator {
         columnBuilders[0].writeDouble(extremeResult.getDouble());
         break;
       case TEXT:
+      case STRING:
+      case BLOB:
       case BOOLEAN:
+      case DATE:
+      case TIMESTAMP:
       default:
         throw new UnSupportedDataTypeException(
             String.format("Unsupported data type in Extreme: %s", seriesDataType));
@@ -197,7 +217,11 @@ public class ExtremeAccumulator implements Accumulator {
         columnBuilder.writeDouble(extremeResult.getDouble());
         break;
       case TEXT:
+      case STRING:
+      case BLOB:
       case BOOLEAN:
+      case DATE:
+      case TIMESTAMP:
       default:
         throw new UnSupportedDataTypeException(
             String.format("Unsupported data type in Extreme: %s", seriesDataType));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/MaxMinByBaseAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/MaxMinByBaseAccumulator.java
@@ -86,6 +86,7 @@ public abstract class MaxMinByBaseAccumulator implements Accumulator {
         addBinaryInput(column, bitMap);
         return;
       case TEXT:
+      case BLOB:
       case BOOLEAN:
       default:
         throw new UnSupportedDataTypeException(String.format(UNSUPPORTED_TYPE_MESSAGE, yDataType));
@@ -438,6 +439,7 @@ public abstract class MaxMinByBaseAccumulator implements Accumulator {
         updateBinaryResult(time, binaryMaxVal, columnBuilder.build(), 0);
         break;
       case TEXT:
+      case BLOB:
       case BOOLEAN:
       default:
         throw new UnSupportedDataTypeException(String.format(UNSUPPORTED_TYPE_MESSAGE, yDataType));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/MaxValueAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/MaxValueAccumulator.java
@@ -63,6 +63,7 @@ public class MaxValueAccumulator implements Accumulator {
         addBinaryInput(columns, bitMap);
         return;
       case TEXT:
+      case BLOB:
       case BOOLEAN:
       default:
         throw new UnSupportedDataTypeException(
@@ -96,6 +97,7 @@ public class MaxValueAccumulator implements Accumulator {
         updateBinaryResult(partialResult[0].getBinary(0));
         break;
       case TEXT:
+      case BLOB:
       case BOOLEAN:
       default:
         throw new UnSupportedDataTypeException(
@@ -127,6 +129,7 @@ public class MaxValueAccumulator implements Accumulator {
         updateBinaryResult((Binary) statistics.getMaxValue());
         break;
       case TEXT:
+      case BLOB:
       case BOOLEAN:
       default:
         throw new UnSupportedDataTypeException(
@@ -160,6 +163,7 @@ public class MaxValueAccumulator implements Accumulator {
         maxResult.setBinary(finalResult.getBinary(0));
         break;
       case TEXT:
+      case BLOB:
       case BOOLEAN:
       default:
         throw new UnSupportedDataTypeException(
@@ -194,6 +198,7 @@ public class MaxValueAccumulator implements Accumulator {
         columnBuilders[0].writeBinary(maxResult.getBinary());
         break;
       case TEXT:
+      case BLOB:
       case BOOLEAN:
       default:
         throw new UnSupportedDataTypeException(
@@ -226,6 +231,7 @@ public class MaxValueAccumulator implements Accumulator {
         columnBuilder.writeBinary(maxResult.getBinary());
         break;
       case TEXT:
+      case BLOB:
       case BOOLEAN:
       default:
         throw new UnSupportedDataTypeException(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/MinValueAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/MinValueAccumulator.java
@@ -63,6 +63,7 @@ public class MinValueAccumulator implements Accumulator {
         addBinaryInput(columns, bitMap);
         return;
       case TEXT:
+      case BLOB:
       case BOOLEAN:
       default:
         throw new UnSupportedDataTypeException(
@@ -96,6 +97,7 @@ public class MinValueAccumulator implements Accumulator {
         updateBinaryResult(partialResult[0].getBinary(0));
         break;
       case TEXT:
+      case BLOB:
       case BOOLEAN:
       default:
         throw new UnSupportedDataTypeException(
@@ -127,6 +129,7 @@ public class MinValueAccumulator implements Accumulator {
         updateBinaryResult((Binary) statistics.getMinValue());
         break;
       case TEXT:
+      case BLOB:
       case BOOLEAN:
       default:
         throw new UnSupportedDataTypeException(
@@ -160,6 +163,7 @@ public class MinValueAccumulator implements Accumulator {
         minResult.setBinary(finalResult.getBinary(0));
         break;
       case TEXT:
+      case BLOB:
       case BOOLEAN:
       default:
         throw new UnSupportedDataTypeException(
@@ -194,6 +198,7 @@ public class MinValueAccumulator implements Accumulator {
         columnBuilders[0].writeBinary(minResult.getBinary());
         break;
       case TEXT:
+      case BLOB:
       case BOOLEAN:
       default:
         throw new UnSupportedDataTypeException(
@@ -226,6 +231,7 @@ public class MinValueAccumulator implements Accumulator {
         columnBuilder.writeBinary(minResult.getBinary());
         break;
       case TEXT:
+      case BLOB:
       case BOOLEAN:
       default:
         throw new UnSupportedDataTypeException(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/SumAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/SumAccumulator.java
@@ -56,7 +56,11 @@ public class SumAccumulator implements Accumulator {
         addDoubleInput(columns, bitMap);
         return;
       case TEXT:
+      case BLOB:
       case BOOLEAN:
+      case TIMESTAMP:
+      case DATE:
+      case STRING:
       default:
         throw new UnSupportedDataTypeException(
             String.format("Unsupported data type in aggregation AVG : %s", seriesDataType));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/VarianceAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/VarianceAccumulator.java
@@ -69,7 +69,11 @@ public class VarianceAccumulator implements Accumulator {
         addDoubleInput(columns, bitMap);
         return;
       case TEXT:
+      case BLOB:
       case BOOLEAN:
+      case DATE:
+      case STRING:
+      case TIMESTAMP:
       default:
         throw new UnSupportedDataTypeException(
             String.format("Unsupported data type in aggregation variance : %s", seriesDataType));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/window/WindowManagerFactory.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/window/WindowManagerFactory.java
@@ -69,6 +69,10 @@ public class WindowManagerFactory {
         return new EqualBinaryWindowManager(eventWindowParameter, ascending);
       case BOOLEAN:
         return new EqualBooleanWindowManager(eventWindowParameter, ascending);
+      case BLOB:
+      case STRING:
+      case TIMESTAMP:
+      case DATE:
       default:
         throw new UnSupportedDataTypeException(
             String.format(
@@ -88,6 +92,12 @@ public class WindowManagerFactory {
         return new VariationFloatWindowManager(eventWindowParameter, ascending);
       case DOUBLE:
         return new VariationDoubleWindowManager(eventWindowParameter, ascending);
+      case TIMESTAMP:
+      case DATE:
+      case STRING:
+      case BOOLEAN:
+      case BLOB:
+      case TEXT:
       default:
         throw new UnSupportedDataTypeException(
             String.format(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/unary/InColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/unary/InColumnTransformer.java
@@ -20,12 +20,6 @@
 package org.apache.iotdb.db.queryengine.transformation.dag.column.unary;
 
 import org.apache.iotdb.db.exception.sql.SemanticException;
-import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.BinaryLiteral;
-import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.BooleanLiteral;
-import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.DoubleLiteral;
-import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Literal;
-import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.LongLiteral;
-import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.StringLiteral;
 import org.apache.iotdb.db.queryengine.transformation.dag.column.ColumnTransformer;
 
 import org.apache.tsfile.block.column.Column;
@@ -34,10 +28,8 @@ import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.read.common.type.Type;
 import org.apache.tsfile.read.common.type.TypeEnum;
 import org.apache.tsfile.utils.Binary;
-import org.apache.tsfile.utils.DateUtils;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -163,84 +155,8 @@ public class InColumnTransformer extends UnaryColumnTransformer {
                 .map(v -> new Binary(v, TSFileConfig.STRING_CHARSET))
                 .collect(Collectors.toSet());
         break;
-      default:
-        throw new UnsupportedOperationException("unsupported data type: " + childType);
-    }
-  }
-
-  private void initTypedSet(List<Literal> values) {
-    if (childType == null) {
-      return;
-    }
-    String errorMsg = "\"%s\" cannot be cast to [%s]";
-    switch (childType) {
-      case INT32:
-        intSet = new HashSet<>();
-        for (Literal value : values) {
-          try {
-            intSet.add((int) ((LongLiteral) value).getParsedValue());
-          } catch (IllegalArgumentException e) {
-            throw new SemanticException(String.format(errorMsg, value, childType));
-          }
-        }
-        break;
-      case DATE:
-        intSet = new HashSet<>();
-        for (Literal value : values) {
-          intSet.add(DateUtils.parseDateExpressionToInt(((StringLiteral) value).getValue()));
-        }
-        break;
-      case INT64:
-      case TIMESTAMP:
-        longSet = new HashSet<>();
-        for (Literal value : values) {
-          try {
-            longSet.add((((LongLiteral) value).getParsedValue()));
-          } catch (IllegalArgumentException e) {
-            throw new SemanticException(String.format(errorMsg, value, childType));
-          }
-        }
-        break;
-      case FLOAT:
-        floatSet = new HashSet<>();
-        for (Literal value : values) {
-          try {
-            floatSet.add((float) ((DoubleLiteral) value).getValue());
-          } catch (IllegalArgumentException e) {
-            throw new SemanticException(String.format(errorMsg, value, childType));
-          }
-        }
-        break;
-      case DOUBLE:
-        doubleSet = new HashSet<>();
-        for (Literal value : values) {
-          try {
-            doubleSet.add(((DoubleLiteral) value).getValue());
-          } catch (IllegalArgumentException e) {
-            throw new SemanticException(String.format(errorMsg, value, childType));
-          }
-        }
-        break;
-      case BOOLEAN:
-        booleanSet = new HashSet<>();
-        for (Literal value : values) {
-          booleanSet.add(((BooleanLiteral) value).getValue());
-        }
-        break;
-      case TEXT:
-      case STRING:
-        stringSet = new HashSet<>();
-        for (Literal value : values) {
-          stringSet.add(
-              new Binary(((StringLiteral) value).getValue(), TSFileConfig.STRING_CHARSET));
-        }
-        break;
       case BLOB:
-        stringSet = new HashSet<>();
-        for (Literal value : values) {
-          stringSet.add(new Binary(((BinaryLiteral) value).getValue()));
-        }
-        break;
+      case DATE:
       default:
         throw new UnsupportedOperationException("unsupported data type: " + childType);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/unary/scalar/RoundColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/unary/scalar/RoundColumnTransformer.java
@@ -59,6 +59,12 @@ public class RoundColumnTransformer extends BinaryColumnTransformer {
             builder.writeDouble(
                 Math.rint(leftColumn.getDouble(i) * Math.pow(10, places)) / Math.pow(10, places));
             break;
+          case DATE:
+          case TEXT:
+          case BOOLEAN:
+          case BLOB:
+          case STRING:
+          case TIMESTAMP:
           default:
             throw new UnsupportedOperationException(
                 String.format("Unsupported source dataType: %s", sourceType));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/unary/scalar/RoundFunctionColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/unary/scalar/RoundFunctionColumnTransformer.java
@@ -59,6 +59,12 @@ public class RoundFunctionColumnTransformer extends UnaryColumnTransformer {
             columnBuilder.writeDouble(
                 Math.rint(column.getDouble(i) * Math.pow(10, places)) / Math.pow(10, places));
             break;
+          case TIMESTAMP:
+          case STRING:
+          case BOOLEAN:
+          case BLOB:
+          case TEXT:
+          case DATE:
           default:
             throw new UnsupportedOperationException(
                 String.format(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/input/ConstantInputReader.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/input/ConstantInputReader.java
@@ -91,6 +91,10 @@ public class ConstantInputReader implements LayerReader {
         Column booleanColumn = new BooleanColumn(1, Optional.empty(), booleanArray);
         cachedColumns[0] = new RunLengthEncodedColumn(booleanColumn, count);
         break;
+      case BLOB:
+      case STRING:
+      case TIMESTAMP:
+      case DATE:
       default:
         throw new QueryProcessException("Unsupported type: " + expression.getDataType());
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/unary/ArithmeticNegationTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/unary/ArithmeticNegationTransformer.java
@@ -55,6 +55,12 @@ public class ArithmeticNegationTransformer extends UnaryTransformer {
       case DOUBLE:
         transformDouble(columns, builder);
         return;
+      case DATE:
+      case TEXT:
+      case TIMESTAMP:
+      case BLOB:
+      case BOOLEAN:
+      case STRING:
       default:
         throw new QueryProcessException("Unsupported data type: " + layerReaderDataType);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/unary/InTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/unary/InTransformer.java
@@ -87,6 +87,7 @@ public class InTransformer extends UnaryTransformer {
       case STRING:
         stringSet = values;
         break;
+      case BLOB:
       default:
         throw new UnsupportedOperationException("unsupported data type: " + layerReaderDataType);
     }
@@ -122,6 +123,7 @@ public class InTransformer extends UnaryTransformer {
       case STRING:
         transformBinary(columns, builder);
         return;
+      case BLOB:
       default:
         throw new QueryProcessException("unsupported data type: " + layerReaderDataType);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/unary/scalar/CastFunctionTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/unary/scalar/CastFunctionTransformer.java
@@ -67,6 +67,10 @@ public class CastFunctionTransformer extends UnaryTransformer {
         return castBooleans(columns);
       case TEXT:
         return castBinaries(columns);
+      case BLOB:
+      case STRING:
+      case TIMESTAMP:
+      case DATE:
       default:
         throw new UnsupportedOperationException(
             String.format("Unsupported source dataType: %s", layerReaderDataType));
@@ -133,6 +137,11 @@ public class CastFunctionTransformer extends UnaryTransformer {
           }
         }
         break;
+      case STRING:
+      case BLOB:
+      case TIMESTAMP:
+      case DATE:
+      case INT32:
       default:
         throw new UnsupportedOperationException(
             String.format("Unsupported target dataType: %s", layerReaderDataType));
@@ -203,6 +212,11 @@ public class CastFunctionTransformer extends UnaryTransformer {
           }
         }
         break;
+      case BLOB:
+      case STRING:
+      case DATE:
+      case TIMESTAMP:
+      case INT64:
       default:
         throw new UnsupportedOperationException(
             String.format("Unsupported target dataType: %s", layerReaderDataType));
@@ -273,6 +287,11 @@ public class CastFunctionTransformer extends UnaryTransformer {
           }
         }
         break;
+      case BLOB:
+      case STRING:
+      case TIMESTAMP:
+      case DATE:
+      case FLOAT:
       default:
         throw new UnsupportedOperationException(
             String.format("Unsupported target dataType: %s", layerReaderDataType));
@@ -343,6 +362,11 @@ public class CastFunctionTransformer extends UnaryTransformer {
           }
         }
         break;
+      case BLOB:
+      case STRING:
+      case TIMESTAMP:
+      case DATE:
+      case DOUBLE:
       default:
         throw new UnsupportedOperationException(
             String.format("Unsupported target dataType: %s", layerReaderDataType));
@@ -413,6 +437,11 @@ public class CastFunctionTransformer extends UnaryTransformer {
           }
         }
         break;
+      case STRING:
+      case BLOB:
+      case DATE:
+      case TIMESTAMP:
+      case BOOLEAN:
       default:
         throw new UnsupportedOperationException(
             String.format("Unsupported target dataType: %s", layerReaderDataType));
@@ -488,6 +517,11 @@ public class CastFunctionTransformer extends UnaryTransformer {
           }
         }
         break;
+      case TIMESTAMP:
+      case DATE:
+      case STRING:
+      case BLOB:
+      case TEXT:
       default:
         throw new UnsupportedOperationException(
             String.format("Unsupported target dataType: %s", layerReaderDataType));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/unary/scalar/DiffFunctionTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/unary/scalar/DiffFunctionTransformer.java
@@ -61,6 +61,12 @@ public class DiffFunctionTransformer extends UnaryTransformer {
       case DOUBLE:
         transformDouble(columns, builder);
         return;
+      case BLOB:
+      case TEXT:
+      case DATE:
+      case STRING:
+      case TIMESTAMP:
+      case BOOLEAN:
       default:
         throw new QueryProcessException("Unsupported data type: " + layerReaderDataType);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/unary/scalar/RoundFunctionTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/transformer/unary/scalar/RoundFunctionTransformer.java
@@ -61,6 +61,12 @@ public class RoundFunctionTransformer extends UnaryTransformer {
       case DOUBLE:
         transformDouble(columns, builder);
         return;
+      case TIMESTAMP:
+      case BOOLEAN:
+      case DATE:
+      case STRING:
+      case TEXT:
+      case BLOB:
       default:
         throw new UnsupportedOperationException(
             String.format("Unsupported source dataType: %s", layerReaderDataType));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/util/TransformUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/util/TransformUtils.java
@@ -76,6 +76,10 @@ public class TransformUtils {
           return new BinaryColumn(1, Optional.empty(), new Binary[] {(Binary) value});
         case BOOLEAN:
           return new BooleanColumn(1, Optional.empty(), new boolean[] {(boolean) value});
+        case STRING:
+        case BLOB:
+        case DATE:
+        case TIMESTAMP:
         default:
           throw new UnSupportedDataTypeException(
               "Unsupported type: " + constantOperand.getDataType());
@@ -151,6 +155,10 @@ public class TransformUtils {
           valueRecorder.recordString(str);
         }
         break;
+      case TIMESTAMP:
+      case DATE:
+      case BLOB:
+      case STRING:
       default:
         throw new UnsupportedOperationException(
             "The data type of the state window strategy is not valid.");

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/util/TypeUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/util/TypeUtils.java
@@ -72,6 +72,9 @@ public class TypeUtils {
         return column.getDouble(index);
       case BOOLEAN:
         return column.getBoolean(index) ? 1 : 0;
+      case BLOB:
+      case STRING:
+      case TEXT:
       default:
         throw new QueryProcessException("Unsupported data type: " + type);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/QueryDataSetUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/QueryDataSetUtils.java
@@ -772,9 +772,11 @@ public class QueryDataSetUtils {
         case BOOLEAN:
           parseBooleanColumn(size, stream, values, i);
           break;
+        case DATE:
         case INT32:
           parseInt32Column(size, stream, values, i);
           break;
+        case TIMESTAMP:
         case INT64:
           parseInt64Column(size, stream, values, i);
           break;
@@ -785,6 +787,8 @@ public class QueryDataSetUtils {
           parseDoubleColumn(size, stream, values, i);
           break;
         case TEXT:
+        case BLOB:
+        case STRING:
           parseTextColumn(size, stream, values, i);
           break;
         default:

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALFileTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALFileTest.java
@@ -181,23 +181,27 @@ public class WALFileTest {
           TSDataType.INT64,
           TSDataType.INT32,
           TSDataType.BOOLEAN,
-          TSDataType.TEXT
+          TSDataType.TEXT,
+          TSDataType.STRING,
+          TSDataType.BLOB
         };
 
-    Object[] columns = new Object[6];
+    Object[] columns = new Object[8];
     columns[0] = 1.0;
     columns[1] = 2.0f;
     columns[2] = 10000L;
     columns[3] = 100;
     columns[4] = false;
     columns[5] = new Binary("hh" + 0, TSFileConfig.STRING_CHARSET);
+    columns[6] = new Binary("jj" + 0, TSFileConfig.STRING_CHARSET);
+    columns[7] = new Binary("kk" + 0, TSFileConfig.STRING_CHARSET);
 
     InsertRowNode insertRowNode =
         new InsertRowNode(
             new PlanNodeId(""),
             new PartialPath(devicePath),
             false,
-            new String[] {"s1", "s2", "s3", "s4", "s5", "s6"},
+            new String[] {"s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8"},
             dataTypes,
             time,
             columns,
@@ -211,6 +215,8 @@ public class WALFileTest {
           new MeasurementSchema("s4", dataTypes[3]),
           new MeasurementSchema("s5", dataTypes[4]),
           new MeasurementSchema("s6", dataTypes[5]),
+          new MeasurementSchema("s7", dataTypes[6]),
+          new MeasurementSchema("s8", dataTypes[7]),
         };
     insertRowNode.setMeasurementSchemas(schemas);
     return insertRowNode;
@@ -226,23 +232,27 @@ public class WALFileTest {
           TSDataType.INT64,
           TSDataType.INT32,
           TSDataType.BOOLEAN,
-          TSDataType.TEXT
+          TSDataType.TEXT,
+          TSDataType.STRING,
+          TSDataType.BLOB
         };
 
-    Object[] columns = new Object[6];
+    Object[] columns = new Object[8];
     columns[0] = 1.0;
     columns[1] = 2.0f;
     columns[2] = 10000L;
     columns[3] = 100;
     columns[4] = false;
     columns[5] = new Binary("hh" + 0, TSFileConfig.STRING_CHARSET);
+    columns[6] = new Binary("jj" + 0, TSFileConfig.STRING_CHARSET);
+    columns[7] = new Binary("kk" + 0, TSFileConfig.STRING_CHARSET);
 
     InsertRowNode insertRowNode =
         new InsertRowNode(
             new PlanNodeId(""),
             new PartialPath(devicePath),
             false,
-            new String[] {"s1", "s2", "s3", "s4", "s5", "s6"},
+            new String[] {"s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8"},
             dataTypes,
             time,
             columns,
@@ -256,6 +266,8 @@ public class WALFileTest {
           new MeasurementSchema("s4", dataTypes[3]),
           new MeasurementSchema("s5", dataTypes[4]),
           new MeasurementSchema("s6", dataTypes[5]),
+          new MeasurementSchema("s7", dataTypes[6]),
+          new MeasurementSchema("s8", dataTypes[7]),
         };
     insertRowNode.setMeasurementSchemas(schemas);
     insertRowsNode.addOneInsertRowNode(insertRowNode, 0);
@@ -266,7 +278,7 @@ public class WALFileTest {
             new PlanNodeId(""),
             new PartialPath(devicePath),
             false,
-            new String[] {"s1", "s2", "s3", "s4", "s5", "s6"},
+            new String[] {"s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8"},
             dataTypes,
             time,
             columns,
@@ -289,16 +301,20 @@ public class WALFileTest {
           TSDataType.INT64,
           TSDataType.INT32,
           TSDataType.BOOLEAN,
-          TSDataType.TEXT
+          TSDataType.TEXT,
+          TSDataType.STRING,
+          TSDataType.BLOB
         };
 
-    Object[] columns = new Object[6];
+    Object[] columns = new Object[8];
     columns[0] = new double[4];
     columns[1] = new float[4];
     columns[2] = new long[4];
     columns[3] = new int[4];
     columns[4] = new boolean[4];
     columns[5] = new Binary[4];
+    columns[6] = new Binary[4];
+    columns[7] = new Binary[4];
 
     for (int r = 0; r < 4; r++) {
       ((double[]) columns[0])[r] = 1.0 + r;
@@ -307,6 +323,8 @@ public class WALFileTest {
       ((int[]) columns[3])[r] = 100 + r;
       ((boolean[]) columns[4])[r] = (r % 2 == 0);
       ((Binary[]) columns[5])[r] = new Binary("hh" + r, TSFileConfig.STRING_CHARSET);
+      ((Binary[]) columns[6])[r] = new Binary("jj" + r, TSFileConfig.STRING_CHARSET);
+      ((Binary[]) columns[7])[r] = new Binary("kk" + r, TSFileConfig.STRING_CHARSET);
     }
 
     BitMap[] bitMaps = new BitMap[dataTypes.length];
@@ -324,13 +342,15 @@ public class WALFileTest {
           new MeasurementSchema("s4", dataTypes[3]),
           new MeasurementSchema("s5", dataTypes[4]),
           new MeasurementSchema("s6", dataTypes[5]),
+          new MeasurementSchema("s7", dataTypes[6]),
+          new MeasurementSchema("s8", dataTypes[7]),
         };
 
     return new InsertTabletNode(
         new PlanNodeId(""),
         new PartialPath(devicePath),
         false,
-        new String[] {"s1", "s2", "s3", "s4", "s5", "s6"},
+        new String[] {"s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8"},
         dataTypes,
         schemas,
         times,

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties
@@ -27,21 +27,21 @@ cluster_name=defaultCluster
 ### Seed ConfigNode
 ####################
 
-cn_seed_config_node=nel-22:10710
+cn_seed_config_node=127.0.0.1:10710
 
-dn_seed_config_node=nel-22:10710
+dn_seed_config_node=127.0.0.1:10710
 
 ####################
 ### Node RPC Configuration
 ####################
 
-cn_internal_address=nel-22
+cn_internal_address=127.0.0.1
 cn_internal_port=10710
 cn_consensus_port=10720
 
 dn_rpc_address=0.0.0.0
 dn_rpc_port=6667
-dn_internal_address=nel-22
+dn_internal_address=127.0.0.1
 dn_internal_port=10730
 dn_mpp_data_exchange_port=10740
 dn_schema_region_consensus_port=10750

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties
@@ -27,21 +27,21 @@ cluster_name=defaultCluster
 ### Seed ConfigNode
 ####################
 
-cn_seed_config_node=127.0.0.1:10710
+cn_seed_config_node=nel-22:10710
 
-dn_seed_config_node=127.0.0.1:10710
+dn_seed_config_node=nel-22:10710
 
 ####################
 ### Node RPC Configuration
 ####################
 
-cn_internal_address=127.0.0.1
+cn_internal_address=nel-22
 cn_internal_port=10710
 cn_consensus_port=10720
 
 dn_rpc_address=0.0.0.0
 dn_rpc_port=6667
-dn_internal_address=127.0.0.1
+dn_internal_address=nel-22
 dn_internal_port=10730
 dn_mpp_data_exchange_port=10740
 dn_schema_region_consensus_port=10750

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFAbs.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFAbs.java
@@ -97,8 +97,6 @@ public class UDTFAbs extends UDTFMath {
         return Math.abs(row.getFloat(0));
       case DOUBLE:
         return Math.abs(row.getDouble(0));
-      case VECTOR:
-      case UNKNOWN:
       case DATE:
       case BOOLEAN:
       case TEXT:

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFAbs.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFAbs.java
@@ -63,6 +63,14 @@ public class UDTFAbs extends UDTFMath {
       case DOUBLE:
         collector.putDouble(time, Math.abs(row.getDouble(0)));
         break;
+      case BLOB:
+      case STRING:
+      case TIMESTAMP:
+      case TEXT:
+      case DATE:
+      case BOOLEAN:
+      case VECTOR:
+      case UNKNOWN:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(
@@ -89,6 +97,14 @@ public class UDTFAbs extends UDTFMath {
         return Math.abs(row.getFloat(0));
       case DOUBLE:
         return Math.abs(row.getDouble(0));
+      case VECTOR:
+      case UNKNOWN:
+      case DATE:
+      case BOOLEAN:
+      case TEXT:
+      case TIMESTAMP:
+      case STRING:
+      case BLOB:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(
@@ -116,6 +132,12 @@ public class UDTFAbs extends UDTFMath {
       case DOUBLE:
         transformDouble(columns, builder);
         return;
+      case BLOB:
+      case STRING:
+      case TEXT:
+      case TIMESTAMP:
+      case BOOLEAN:
+      case DATE:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFBottomK.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFBottomK.java
@@ -72,6 +72,8 @@ public class UDTFBottomK extends UDTFSelectK {
                   return cs1.length() - cs2.length();
                 });
         break;
+      case BLOB:
+      case BOOLEAN:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFChangePoints.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFChangePoints.java
@@ -134,6 +134,12 @@ public class UDTFChangePoints implements UDTF {
             collector.putString(row.getTime(), cacheString);
           }
         }
+      case STRING:
+      case BLOB:
+      case DATE:
+      case TIMESTAMP:
+      default:
+        break;
     }
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFCommonDerivative.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFCommonDerivative.java
@@ -55,6 +55,12 @@ public class UDTFCommonDerivative extends UDTFDerivative {
         collector.putDouble(currentTime, (currentDouble - previousDouble) / timeDelta);
         previousDouble = currentDouble;
         break;
+      case DATE:
+      case BOOLEAN:
+      case TIMESTAMP:
+      case TEXT:
+      case STRING:
+      case BLOB:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFCommonValueDifference.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFCommonValueDifference.java
@@ -54,6 +54,12 @@ public class UDTFCommonValueDifference extends UDTFValueDifference {
         collector.putDouble(time, currentDouble - previousDouble);
         previousDouble = currentDouble;
         break;
+      case STRING:
+      case BLOB:
+      case TIMESTAMP:
+      case TEXT:
+      case BOOLEAN:
+      case DATE:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFContinuouslySatisfy.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFContinuouslySatisfy.java
@@ -100,6 +100,11 @@ public abstract class UDTFContinuouslySatisfy implements UDTF {
       case BOOLEAN:
         needAddNewRecord = transformBoolean(row.getTime(), row.getBoolean(0));
         break;
+      case TEXT:
+      case STRING:
+      case BLOB:
+      case TIMESTAMP:
+      case DATE:
       default:
         // This will not happen
         throw new UDFInputSeriesDataTypeNotValidException(
@@ -221,6 +226,11 @@ public abstract class UDTFContinuouslySatisfy implements UDTF {
           }
         }
         break;
+      case TIMESTAMP:
+      case DATE:
+      case STRING:
+      case BLOB:
+      case TEXT:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFEqualSizeBucketAggSample.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFEqualSizeBucketAggSample.java
@@ -481,6 +481,12 @@ public class UDTFEqualSizeBucketAggSample extends UDTFEqualSizeBucketSample {
       case DOUBLE:
         aggregator.aggregateDouble(rowWindow, collector);
         break;
+      case BLOB:
+      case TEXT:
+      case DATE:
+      case STRING:
+      case TIMESTAMP:
+      case BOOLEAN:
       default:
         // This will not happen
         throw new UDFInputSeriesDataTypeNotValidException(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFEqualSizeBucketM4Sample.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFEqualSizeBucketM4Sample.java
@@ -58,6 +58,12 @@ public class UDTFEqualSizeBucketM4Sample extends UDTFEqualSizeBucketSample {
       case DOUBLE:
         transformDouble(rowWindow, collector);
         break;
+      case TIMESTAMP:
+      case BOOLEAN:
+      case DATE:
+      case STRING:
+      case TEXT:
+      case BLOB:
       default:
         // This will not happen
         throw new UDFInputSeriesDataTypeNotValidException(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFEqualSizeBucketOutlierSample.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFEqualSizeBucketOutlierSample.java
@@ -656,6 +656,12 @@ public class UDTFEqualSizeBucketOutlierSample extends UDTFEqualSizeBucketSample 
       case DOUBLE:
         outlierSampler.outlierSampleDouble(rowWindow, collector);
         break;
+      case TEXT:
+      case BLOB:
+      case DATE:
+      case STRING:
+      case BOOLEAN:
+      case TIMESTAMP:
       default:
         // This will not happen
         throw new UDFInputSeriesDataTypeNotValidException(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFEqualSizeBucketRandomSample.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFEqualSizeBucketRandomSample.java
@@ -61,6 +61,12 @@ public class UDTFEqualSizeBucketRandomSample extends UDTFEqualSizeBucketSample {
       case DOUBLE:
         collector.putDouble(row.getTime(), row.getDouble(0));
         break;
+      case BOOLEAN:
+      case TIMESTAMP:
+      case DATE:
+      case STRING:
+      case BLOB:
+      case TEXT:
       default:
         // This will not happen
         throw new UDFInputSeriesDataTypeNotValidException(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFInRange.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFInRange.java
@@ -85,6 +85,12 @@ public class UDTFInRange implements UDTF {
       case DOUBLE:
         collector.putBoolean(time, row.getDouble(0) >= lower && upper >= row.getDouble(0));
         break;
+      case BLOB:
+      case TEXT:
+      case DATE:
+      case STRING:
+      case TIMESTAMP:
+      case BOOLEAN:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(
@@ -111,6 +117,12 @@ public class UDTFInRange implements UDTF {
         return row.getFloat(0) >= lower && upper >= row.getFloat(0);
       case DOUBLE:
         return row.getDouble(0) >= lower && upper >= row.getDouble(0);
+      case TIMESTAMP:
+      case BOOLEAN:
+      case DATE:
+      case STRING:
+      case TEXT:
+      case BLOB:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(
@@ -138,6 +150,12 @@ public class UDTFInRange implements UDTF {
       case DOUBLE:
         transformDouble(columns, builder);
         return;
+      case BLOB:
+      case TEXT:
+      case DATE:
+      case STRING:
+      case BOOLEAN:
+      case TIMESTAMP:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFJexl.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFJexl.java
@@ -94,6 +94,10 @@ public class UDTFJexl implements UDTF {
         case BOOLEAN:
           evaluator = new EvaluatorBooleanInput();
           break;
+        case STRING:
+        case TIMESTAMP:
+        case DATE:
+        case BLOB:
         default:
           throw new UDFInputSeriesDataTypeNotValidException(
               0,
@@ -162,6 +166,13 @@ public class UDTFJexl implements UDTF {
       case BOOLEAN:
         evaluator.evaluateBoolean(row, collector);
         break;
+      case TIMESTAMP:
+      case DATE:
+      case STRING:
+      case BLOB:
+      case INT64:
+      case INT32:
+      case FLOAT:
       default:
         // This will not happen.
         throw new UDFOutputSeriesDataTypeNotValidException(0, "[Number, String, Boolean]");
@@ -333,6 +344,10 @@ public class UDTFJexl implements UDTF {
           case BOOLEAN:
             values[i] = row.getBoolean(i);
             break;
+          case STRING:
+          case BLOB:
+          case DATE:
+          case TIMESTAMP:
           default:
             throw new UDFInputSeriesDataTypeNotValidException(
                 i,

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFM4.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFM4.java
@@ -137,6 +137,12 @@ public class UDTFM4 implements UDTF {
       case DOUBLE:
         transformDouble(rowWindow, collector);
         break;
+      case BLOB:
+      case DATE:
+      case STRING:
+      case TIMESTAMP:
+      case BOOLEAN:
+      case TEXT:
       default:
         // This will not happen
         throw new UDFInputSeriesDataTypeNotValidException(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFMath.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFMath.java
@@ -85,6 +85,12 @@ public abstract class UDTFMath implements UDTF {
       case DOUBLE:
         collector.putDouble(time, transformer.transform(row.getDouble(0)));
         break;
+      case BOOLEAN:
+      case TEXT:
+      case STRING:
+      case TIMESTAMP:
+      case DATE:
+      case BLOB:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(
@@ -111,6 +117,12 @@ public abstract class UDTFMath implements UDTF {
         return transformer.transform(row.getFloat(0));
       case DOUBLE:
         return transformer.transform(row.getDouble(0));
+      case DATE:
+      case BLOB:
+      case STRING:
+      case TIMESTAMP:
+      case TEXT:
+      case BOOLEAN:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(
@@ -138,6 +150,12 @@ public abstract class UDTFMath implements UDTF {
       case DOUBLE:
         transformDouble(columns, builder);
         return;
+      case TEXT:
+      case BOOLEAN:
+      case STRING:
+      case TIMESTAMP:
+      case BLOB:
+      case DATE:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFNonNegativeDerivative.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFNonNegativeDerivative.java
@@ -55,6 +55,12 @@ public class UDTFNonNegativeDerivative extends UDTFDerivative {
         collector.putDouble(currentTime, Math.abs(currentDouble - previousDouble) / timeDelta);
         previousDouble = currentDouble;
         break;
+      case DATE:
+      case BLOB:
+      case STRING:
+      case TIMESTAMP:
+      case BOOLEAN:
+      case TEXT:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFNonNegativeValueDifference.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFNonNegativeValueDifference.java
@@ -54,6 +54,12 @@ public class UDTFNonNegativeValueDifference extends UDTFValueDifference {
         collector.putDouble(time, Math.abs(currentDouble - previousDouble));
         previousDouble = currentDouble;
         break;
+      case BOOLEAN:
+      case TEXT:
+      case STRING:
+      case TIMESTAMP:
+      case BLOB:
+      case DATE:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFOnOff.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFOnOff.java
@@ -79,6 +79,12 @@ public class UDTFOnOff implements UDTF {
       case DOUBLE:
         collector.putBoolean(time, (row.getDouble(0) >= threshold));
         break;
+      case DATE:
+      case BLOB:
+      case STRING:
+      case TIMESTAMP:
+      case TEXT:
+      case BOOLEAN:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(
@@ -105,6 +111,12 @@ public class UDTFOnOff implements UDTF {
         return row.getFloat(0) >= threshold;
       case DOUBLE:
         return row.getDouble(0) >= threshold;
+      case TEXT:
+      case BOOLEAN:
+      case STRING:
+      case TIMESTAMP:
+      case BLOB:
+      case DATE:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(
@@ -132,6 +144,12 @@ public class UDTFOnOff implements UDTF {
       case DOUBLE:
         transformDouble(columns, builder);
         return;
+      case BLOB:
+      case DATE:
+      case STRING:
+      case TIMESTAMP:
+      case BOOLEAN:
+      case TEXT:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFSelectK.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFSelectK.java
@@ -106,6 +106,8 @@ public abstract class UDTFSelectK implements UDTF {
       case STRING:
         transformString(row.getTime(), row.getString(0));
         break;
+      case BLOB:
+      case BOOLEAN:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(
@@ -177,6 +179,8 @@ public abstract class UDTFSelectK implements UDTF {
           collector.putString(pair.left, pair.right);
         }
         break;
+      case BLOB:
+      case BOOLEAN:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFTopK.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFTopK.java
@@ -51,6 +51,8 @@ public class UDTFTopK extends UDTFSelectK {
       case STRING:
         stringPQ = new PriorityQueue<>(k, Comparator.comparing(o -> o.right));
         break;
+      case BOOLEAN:
+      case BLOB:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFValueTrend.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/UDTFValueTrend.java
@@ -65,6 +65,12 @@ public abstract class UDTFValueTrend implements UDTF {
       case DOUBLE:
         previousDouble = row.getDouble(0);
         break;
+      case TEXT:
+      case BOOLEAN:
+      case TIMESTAMP:
+      case STRING:
+      case DATE:
+      case BLOB:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/utils/MasterRepairUtil.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/utils/MasterRepairUtil.java
@@ -104,6 +104,12 @@ public class MasterRepairUtil {
         case DOUBLE:
           ans = row.getDouble(index);
           break;
+        case DATE:
+        case BLOB:
+        case STRING:
+        case TIMESTAMP:
+        case BOOLEAN:
+        case TEXT:
         default:
           throw new Exception("The value of the input time series is not numeric.\n");
       }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/SerializeUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/SerializeUtils.java
@@ -141,16 +141,20 @@ public class SerializeUtils {
     TSDataType dataType = TSDataType.values()[buffer.get()];
     BatchData batchData = BatchDataType.deserialize(buffer.get(), dataType);
     switch (dataType) {
+      case DATE:
       case INT32:
         for (int i = 0; i < length; i++) {
           batchData.putInt(buffer.getLong(), buffer.getInt());
         }
         break;
+      case TIMESTAMP:
       case INT64:
         for (int i = 0; i < length; i++) {
           batchData.putLong(buffer.getLong(), buffer.getLong());
         }
         break;
+      case BLOB:
+      case STRING:
       case TEXT:
         for (int i = 0; i < length; i++) {
           long time = buffer.getLong();
@@ -193,15 +197,19 @@ public class SerializeUtils {
                 case FLOAT:
                   values[j] = new TsPrimitiveType.TsFloat(buffer.getFloat());
                   break;
+                case BLOB:
+                case STRING:
                 case TEXT:
                   int len = buffer.getInt();
                   byte[] bytes = new byte[len];
                   buffer.get(bytes);
                   values[j] = new TsPrimitiveType.TsBinary(new Binary(bytes));
                   break;
+                case TIMESTAMP:
                 case INT64:
                   values[j] = new TsPrimitiveType.TsLong(buffer.getLong());
                   break;
+                case DATE:
                 case INT32:
                   values[j] = new TsPrimitiveType.TsInt(buffer.getInt());
                   break;
@@ -286,15 +294,19 @@ public class SerializeUtils {
       dataOutputStream.write(dataType.ordinal());
       dataOutputStream.writeInt(timeValuePairs.size());
       switch (timeValuePairs.get(0).getValue().getDataType()) {
+        case BLOB:
+        case STRING:
         case TEXT:
           serializeTextTVPairs(timeValuePairs, dataOutputStream);
           break;
         case BOOLEAN:
           serializeBooleanTVPairs(timeValuePairs, dataOutputStream);
           break;
+        case TIMESTAMP:
         case INT64:
           serializeLongTVPairs(timeValuePairs, dataOutputStream);
           break;
+        case DATE:
         case INT32:
           serializeIntTVPairs(timeValuePairs, dataOutputStream);
           break;
@@ -321,6 +333,8 @@ public class SerializeUtils {
     try {
       dataOutputStream.write(dataType.ordinal());
       switch (dataType) {
+        case STRING:
+        case BLOB:
         case TEXT:
           dataOutputStream.writeLong(timeValuePair.getTimestamp());
           if (timeValuePair.getTimestamp() != Long.MIN_VALUE) {
@@ -334,12 +348,14 @@ public class SerializeUtils {
             dataOutputStream.writeBoolean(timeValuePair.getValue().getBoolean());
           }
           break;
+        case TIMESTAMP:
         case INT64:
           dataOutputStream.writeLong(timeValuePair.getTimestamp());
           if (timeValuePair.getTimestamp() != Long.MIN_VALUE) {
             dataOutputStream.writeLong(timeValuePair.getValue().getLong());
           }
           break;
+        case DATE:
         case INT32:
           dataOutputStream.writeLong(timeValuePair.getTimestamp());
           if (timeValuePair.getTimestamp() != Long.MIN_VALUE) {
@@ -458,15 +474,19 @@ public class SerializeUtils {
       case FLOAT:
         deserializeFloatTVPairs(buffer, ret, size, dataType);
         break;
+      case DATE:
       case INT32:
         deserializeIntTVPairs(buffer, ret, size, dataType);
         break;
+      case TIMESTAMP:
       case INT64:
         deserializeLongTVPairs(buffer, ret, size, dataType);
         break;
       case BOOLEAN:
         deserializeBooleanTVPairs(buffer, ret, size, dataType);
         break;
+      case BLOB:
+      case STRING:
       case TEXT:
         deserializeTextTVPairs(buffer, ret, size, dataType);
         break;
@@ -490,12 +510,16 @@ public class SerializeUtils {
         return new TimeValuePair(time, TsPrimitiveType.getByType(dataType, buffer.getDouble()));
       case FLOAT:
         return new TimeValuePair(time, TsPrimitiveType.getByType(dataType, buffer.getFloat()));
+      case DATE:
       case INT32:
         return new TimeValuePair(time, TsPrimitiveType.getByType(dataType, buffer.getInt()));
+      case TIMESTAMP:
       case INT64:
         return new TimeValuePair(time, TsPrimitiveType.getByType(dataType, buffer.getLong()));
       case BOOLEAN:
         return new TimeValuePair(time, TsPrimitiveType.getByType(dataType, buffer.get() == 1));
+      case BLOB:
+      case STRING:
       case TEXT:
         int bytesLen = buffer.getInt();
         byte[] bytes = new byte[bytesLen];

--- a/library-udf/src/main/java/org/apache/iotdb/library/anomaly/UDTFKSigma.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/anomaly/UDTFKSigma.java
@@ -91,6 +91,12 @@ public class UDTFKSigma implements UDTF {
           case FLOAT:
             v.push(row.getFloat(0));
             break;
+          case TIMESTAMP:
+          case DATE:
+          case TEXT:
+          case STRING:
+          case BLOB:
+          case BOOLEAN:
           default:
             break;
         }
@@ -118,6 +124,12 @@ public class UDTFKSigma implements UDTF {
           case FLOAT:
             v.push(row.getFloat(0));
             break;
+          case BLOB:
+          case BOOLEAN:
+          case STRING:
+          case TEXT:
+          case DATE:
+          case TIMESTAMP:
           default:
             break;
         }

--- a/library-udf/src/main/java/org/apache/iotdb/library/anomaly/UDTFRange.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/anomaly/UDTFRange.java
@@ -86,6 +86,12 @@ public class UDTFRange implements UDTF {
           collector.putDouble(timestamp, doubleValue);
         }
         break;
+      case DATE:
+      case TIMESTAMP:
+      case TEXT:
+      case STRING:
+      case BOOLEAN:
+      case BLOB:
       default:
         throw new UDFException("No such kind of data type.");
     }

--- a/library-udf/src/main/java/org/apache/iotdb/library/anomaly/UDTFTwoSidedFilter.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/anomaly/UDTFTwoSidedFilter.java
@@ -81,6 +81,12 @@ public class UDTFTwoSidedFilter implements UDTF {
           collector.putLong(time[i], Math.round(repaired[i]));
         }
         break;
+      case BOOLEAN:
+      case BLOB:
+      case STRING:
+      case TEXT:
+      case TIMESTAMP:
+      case DATE:
       default:
         throw new UDFException("No such kind of data type.");
     }

--- a/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDAFPercentile.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDAFPercentile.java
@@ -89,6 +89,12 @@ public class UDAFPercentile implements UDTF {
       case DOUBLE:
         doubleDic = new HashMap<>();
         break;
+      case TIMESTAMP:
+      case DATE:
+      case TEXT:
+      case STRING:
+      case BLOB:
+      case BOOLEAN:
       default:
         break;
     }
@@ -111,6 +117,12 @@ public class UDAFPercentile implements UDTF {
         case DOUBLE:
           doubleDic.put(row.getDouble(0), row.getTime());
           break;
+        case BLOB:
+        case BOOLEAN:
+        case STRING:
+        case TEXT:
+        case DATE:
+        case TIMESTAMP:
         default:
           break;
       }
@@ -145,6 +157,12 @@ public class UDAFPercentile implements UDTF {
           time = doubleDic.getOrDefault(dres, 0L);
           collector.putDouble(time, dres);
           break;
+        case DATE:
+        case TIMESTAMP:
+        case TEXT:
+        case STRING:
+        case BOOLEAN:
+        case BLOB:
         default:
           break;
       }
@@ -163,6 +181,12 @@ public class UDAFPercentile implements UDTF {
         case DOUBLE:
           collector.putDouble(0, res);
           break;
+        case BOOLEAN:
+        case BLOB:
+        case STRING:
+        case TEXT:
+        case TIMESTAMP:
+        case DATE:
         default:
           break;
       }

--- a/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDAFQuantile.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDAFQuantile.java
@@ -86,6 +86,12 @@ public class UDAFQuantile implements UDTF {
       case DOUBLE:
         collector.putDouble(0, res);
         break;
+      case TIMESTAMP:
+      case DATE:
+      case TEXT:
+      case STRING:
+      case BLOB:
+      case BOOLEAN:
       default:
         break;
     }
@@ -104,6 +110,12 @@ public class UDAFQuantile implements UDTF {
       case DOUBLE:
         result = Double.doubleToLongBits((double) data);
         return (double) data >= 0d ? result : result ^ Long.MAX_VALUE;
+      case BLOB:
+      case BOOLEAN:
+      case STRING:
+      case TEXT:
+      case DATE:
+      case TIMESTAMP:
       default:
         return (long) data;
     }
@@ -119,6 +131,12 @@ public class UDAFQuantile implements UDTF {
         return Double.longBitsToDouble(result);
       case INT64:
       case INT32:
+      case DATE:
+      case TEXT:
+      case STRING:
+      case BOOLEAN:
+      case BLOB:
+      case TIMESTAMP:
       default:
         return (result);
     }

--- a/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDAFSpread.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDAFSpread.java
@@ -76,6 +76,12 @@ public class UDAFSpread implements UDTF {
       case DOUBLE:
         transformDouble(row);
         break;
+      case BLOB:
+      case TIMESTAMP:
+      case BOOLEAN:
+      case STRING:
+      case TEXT:
+      case DATE:
       default:
         break;
     }
@@ -96,6 +102,12 @@ public class UDAFSpread implements UDTF {
       case DOUBLE:
         pc.putDouble(0, doubleMax - doubleMin);
         break;
+      case TEXT:
+      case DATE:
+      case STRING:
+      case BOOLEAN:
+      case TIMESTAMP:
+      case BLOB:
       default:
         throw new NoNumberException();
     }

--- a/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDTFDistinct.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDTFDistinct.java
@@ -86,6 +86,10 @@ public class UDTFDistinct implements UDTF {
       case BOOLEAN:
         booleanSet = new BooleanHashSet();
         break;
+      case BLOB:
+      case STRING:
+      case TIMESTAMP:
+      case DATE:
       default:
         break;
     }
@@ -112,6 +116,10 @@ public class UDTFDistinct implements UDTF {
       case BOOLEAN:
         booleanSet.add(row.getBoolean(0));
         break;
+      case BLOB:
+      case STRING:
+      case TIMESTAMP:
+      case DATE:
       default:
         break;
     }
@@ -162,6 +170,10 @@ public class UDTFDistinct implements UDTF {
           i++;
         }
         break;
+      case BLOB:
+      case STRING:
+      case TIMESTAMP:
+      case DATE:
       default:
         break;
     }
@@ -188,6 +200,10 @@ public class UDTFDistinct implements UDTF {
       case BOOLEAN:
         booleanSet.clear();
         break;
+      case BLOB:
+      case STRING:
+      case TIMESTAMP:
+      case DATE:
       default:
         break;
     }

--- a/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDTFSample.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDTFSample.java
@@ -151,6 +151,12 @@ public class UDTFSample implements UDTF {
               case DOUBLE:
                 collector.putDouble(p.getLeft(), p.getRight());
                 break;
+              case TIMESTAMP:
+              case DATE:
+              case BLOB:
+              case BOOLEAN:
+              case STRING:
+              case TEXT:
               default:
                 throw new NoNumberException();
             }

--- a/library-udf/src/main/java/org/apache/iotdb/library/dprofile/util/ExactOrderStatistics.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/dprofile/util/ExactOrderStatistics.java
@@ -55,6 +55,12 @@ public class ExactOrderStatistics {
       case DOUBLE:
         doubleArrayList = new DoubleArrayList();
         break;
+      case STRING:
+      case TEXT:
+      case BOOLEAN:
+      case BLOB:
+      case DATE:
+      case TIMESTAMP:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(
@@ -82,6 +88,12 @@ public class ExactOrderStatistics {
           doubleArrayList.add(vd);
         }
         break;
+      case DATE:
+      case TIMESTAMP:
+      case BLOB:
+      case BOOLEAN:
+      case TEXT:
+      case STRING:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(
@@ -99,6 +111,12 @@ public class ExactOrderStatistics {
         return getMedian(floatArrayList);
       case DOUBLE:
         return getMedian(doubleArrayList);
+      case TEXT:
+      case STRING:
+      case BOOLEAN:
+      case BLOB:
+      case TIMESTAMP:
+      case DATE:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(
@@ -181,6 +199,12 @@ public class ExactOrderStatistics {
         return getMad(floatArrayList);
       case DOUBLE:
         return getMad(doubleArrayList);
+      case TIMESTAMP:
+      case DATE:
+      case BLOB:
+      case BOOLEAN:
+      case STRING:
+      case TEXT:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(
@@ -255,6 +279,12 @@ public class ExactOrderStatistics {
         return Float.toString(getPercentile(floatArrayList, phi));
       case DOUBLE:
         return Double.toString(getPercentile(doubleArrayList, phi));
+      case STRING:
+      case TEXT:
+      case BOOLEAN:
+      case BLOB:
+      case DATE:
+      case TIMESTAMP:
       default:
         // This will not happen.
         throw new UDFInputSeriesDataTypeNotValidException(

--- a/library-udf/src/main/java/org/apache/iotdb/library/drepair/UDTFTimestampRepair.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/drepair/UDTFTimestampRepair.java
@@ -95,6 +95,12 @@ public class UDTFTimestampRepair implements UDTF {
           collector.putLong(timestamp[i], (long) value[i]);
         }
         break;
+      case DATE:
+      case TIMESTAMP:
+      case BLOB:
+      case BOOLEAN:
+      case TEXT:
+      case STRING:
       default:
         throw new UDFException("");
     }

--- a/library-udf/src/main/java/org/apache/iotdb/library/drepair/UDTFValueFill.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/drepair/UDTFValueFill.java
@@ -98,6 +98,12 @@ public class UDTFValueFill implements UDTF {
           collector.putLong(time[i], Math.round(repaired[i]));
         }
         break;
+      case TEXT:
+      case STRING:
+      case BOOLEAN:
+      case BLOB:
+      case TIMESTAMP:
+      case DATE:
       default:
         throw new UDFException("");
     }

--- a/library-udf/src/main/java/org/apache/iotdb/library/drepair/UDTFValueRepair.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/drepair/UDTFValueRepair.java
@@ -115,6 +115,13 @@ public class UDTFValueRepair implements UDTF {
           collector.putLong(time[i], Math.round(repaired[i]));
         }
         break;
+      case TIMESTAMP:
+      case DATE:
+      case BLOB:
+      case BOOLEAN:
+      case STRING:
+      case TEXT:
+
       default:
         throw new Exception();
     }

--- a/library-udf/src/main/java/org/apache/iotdb/library/frequency/UDFEnvelopeAnalysis.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/frequency/UDFEnvelopeAnalysis.java
@@ -226,6 +226,12 @@ public class UDFEnvelopeAnalysis implements UDTF {
       case DOUBLE:
         ans = row.getDouble(index);
         break;
+      case TEXT:
+      case STRING:
+      case BOOLEAN:
+      case BLOB:
+      case DATE:
+      case TIMESTAMP:
       default:
         throw new UDFOutputSeriesDataTypeNotValidException(
             index, "Fail to get data type in row " + row.getTime());

--- a/library-udf/src/main/java/org/apache/iotdb/library/util/Util.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/util/Util.java
@@ -60,6 +60,12 @@ public class Util {
         case DOUBLE:
           ans = row.getDouble(index);
           break;
+        case DATE:
+        case BLOB:
+        case BOOLEAN:
+        case STRING:
+        case TEXT:
+        case TIMESTAMP:
         default:
           throw new NoNumberException();
       }
@@ -107,6 +113,10 @@ public class Util {
       case TEXT:
         ans = row.getString(0);
         break;
+      case BLOB:
+      case STRING:
+      case DATE:
+      case TIMESTAMP:
       default:
         break;
     }
@@ -138,6 +148,11 @@ public class Util {
       case BOOLEAN:
         pc.putBoolean(t, (Boolean) o);
         break;
+      case DATE:
+      case TIMESTAMP:
+      case TEXT:
+      case STRING:
+      case BLOB:
       default:
         break;
     }


### PR DESCRIPTION
One Tablet deserialization does not support new types in QueryDataSetUtils, which causes WAL recovery failure.
TsDataType switches are supplemented with all cases to indicate they are CONSIDERED rather than FORGOTTEN.