### PR TITLE
Fix default authentication of C++ Client

### DIFF
--- a/iotdb-client/client-cpp/src/main/Session.h
+++ b/iotdb-client/client-cpp/src/main/Session.h
@@ -1004,7 +1004,7 @@ private:
     void initZoneId();
 
 public:
-    Session(const std::string &host, int rpcPort) : username("user"), password("password"), version(Version::V_1_0) {
+    Session(const std::string &host, int rpcPort) : username("root"), password("root"), version(Version::V_1_0) {
         this->host = host;
         this->rpcPort = rpcPort;
         initZoneId();


### PR DESCRIPTION
The previous default authentication (username and password) in Client-CPP is inconsistent with Client-Java.