### PR TITLE
Fix cpp client IT on macos

### DIFF
--- a/.github/workflows/multi-language-client.yml
+++ b/.github/workflows/multi-language-client.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - master
       - "rc/*"
-      - HTHou-patch-2
     paths:
       - 'pom.xml'
       - 'iotdb-client/pom.xml'
@@ -57,6 +56,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install libboost-all-dev
       - name: Install CPP Dependencies (Mac)
+        # remove some xcode to release disk space
         if: runner.os == 'macOS'
         shell: bash
         run: |

--- a/.github/workflows/multi-language-client.yml
+++ b/.github/workflows/multi-language-client.yml
@@ -61,7 +61,6 @@ jobs:
         shell: bash
         run: |
           brew install boost
-          brew install bison
       - name: Install CPP Dependencies (Windows)
         if: runner.os == 'Windows'
         run: |
@@ -77,7 +76,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.m2
-          key: client-${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2-
       - name: Build IoTDB server
         shell: bash

--- a/.github/workflows/multi-language-client.yml
+++ b/.github/workflows/multi-language-client.yml
@@ -99,7 +99,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: cpp-IT-${{ runner.os }}
-          path: iotdb-client/client-cpp/target/build/test/Testing
+          path: distribution/target/apache-iotdb-1.4.0-SNAPSHOT-all-bin/apache-iotdb-1.4.0-SNAPSHOT-all-bin/logs
           retention-days: 1
 
   go:

--- a/.github/workflows/multi-language-client.yml
+++ b/.github/workflows/multi-language-client.yml
@@ -50,6 +50,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: corretto
+          java-version: 17
       - name: Install CPP Dependencies (Ubuntu)
         if: runner.os == 'Linux'
         shell: bash

--- a/.github/workflows/multi-language-client.yml
+++ b/.github/workflows/multi-language-client.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - "rc/*"
+      - HTHou-patch-2
     paths:
       - 'pom.xml'
       - 'iotdb-client/pom.xml'

--- a/.github/workflows/multi-language-client.yml
+++ b/.github/workflows/multi-language-client.yml
@@ -50,11 +50,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          distribution: corretto
-          java-version: 17
       - name: Install CPP Dependencies (Ubuntu)
         if: runner.os == 'Linux'
         shell: bash
@@ -66,6 +61,11 @@ jobs:
         shell: bash
         run: |
           brew install boost
+          sudo rm -rf /Applications/Xcode_14.3.1.app
+          sudo rm -rf /Applications/Xcode_15.0.1.app
+          sudo rm -rf /Applications/Xcode_15.1.app
+          sudo rm -rf /Applications/Xcode_15.2.app
+          sudo rm -rf /Applications/Xcode_15.3.app
       - name: Install CPP Dependencies (Windows)
         if: runner.os == 'Windows'
         run: |
@@ -104,7 +104,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: cpp-IT-${{ runner.os }}
-          path: distribution/target/apache-iotdb-1.4.0-SNAPSHOT-all-bin/apache-iotdb-1.4.0-SNAPSHOT-all-bin/logs
+          path: distribution/target/apache-iotdb-*-all-bin/apache-iotdb-*-all-bin/logs
           retention-days: 1
 
   go:


### PR DESCRIPTION
## Description

The free disk space is reduced on macos runner, which may cause the IoTDB start failed. 
![img_v3_02ec_9babbac5-95de-4a81-83c0-91ea61a0bd0g](https://github.com/user-attachments/assets/bb84a60f-0c73-40a5-88c1-05ab5f41191d)


Fix this issue by removing some useless xcode.
https://github.com/actions/runner-images/issues/10511