### PR TITLE
Fix the issue of hard linking to target files in inner compaction

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
@@ -361,6 +361,7 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
     for (int i = 0; i < filesView.skippedSourceFiles.size(); i++) {
       TsFileResource resource = filesView.sortedAllSourceFilesInTask.get(i);
       File file = resource.getTsFile();
+      File skippedSourceFile = filesView.skippedSourceFiles.get(i).getTsFile();
       TsFileNameGenerator.TsFileName tsFileName = TsFileNameGenerator.getTsFileName(file.getName());
       String newFileName =
           String.format(
@@ -371,7 +372,7 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
               tsFileName.getCrossCompactionCnt() + 1);
       TsFileResource renamedTargetFile =
           new TsFileResource(
-              new File(file.getParentFile().getPath() + File.separator + newFileName),
+              new File(skippedSourceFile.getParentFile().getPath() + File.separator + newFileName),
               TsFileResourceStatus.COMPACTING);
       filesView.renamedTargetFiles.add(renamedTargetFile);
     }


### PR DESCRIPTION
## Description
Files that were skipped during inner compaction have been erroneously reassigned with the wrong parent file, resulting in an inability to create a hard link.