### PR TITLE
Fix error log when drop database or migrate region

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/timeindex/FileTimeIndexCacheRecorder.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/timeindex/FileTimeIndexCacheRecorder.java
@@ -193,7 +193,7 @@ public class FileTimeIndexCacheRecorder {
   }
 
   public void removeFileTimeIndexCache(int dataRegionId) {
-    FileTimeIndexCacheWriter writer = writerMap.get(dataRegionId);
+    FileTimeIndexCacheWriter writer = writerMap.remove(dataRegionId);
     if (writer != null) {
       try {
         writer.close();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/timeindex/FileTimeIndexCacheRecorder.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/timeindex/FileTimeIndexCacheRecorder.java
@@ -42,7 +42,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.iotdb.commons.utils.FileUtils.deleteDirectoryAndEmptyParent;
+import static org.apache.iotdb.commons.utils.FileUtils.deleteFileOrDirectory;
 import static org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource.getFileTimeIndexSerializedSize;
 
 public class FileTimeIndexCacheRecorder {
@@ -193,10 +193,11 @@ public class FileTimeIndexCacheRecorder {
   }
 
   public void removeFileTimeIndexCache(int dataRegionId) {
-    for (FileTimeIndexCacheWriter writer : writerMap.values()) {
+    FileTimeIndexCacheWriter writer = writerMap.get(dataRegionId);
+    if (writer != null) {
       try {
         writer.close();
-        deleteDirectoryAndEmptyParent(writer.getLogFile());
+        deleteFileOrDirectory(writer.getLogFile(), true);
       } catch (IOException e) {
         LOGGER.warn("Meet error when close FileTimeIndexCache: {}", e.getMessage());
       }


### PR DESCRIPTION
## Description

When execute the following sqls, there is some error log printed.
```
insert into root.sg.d1(time,s1) values(1,2)
flush
drop database root.**
```
![image](https://github.com/user-attachments/assets/305f04ec-0aaa-4593-9403-497c3f1cfeee)

This pr is fixing this issue. 
<img width="1753" alt="image" src="https://github.com/user-attachments/assets/9d0c053f-8461-4128-8032-ea022df9da1c">

