### PR TITLE
Fix the error usage of HierarchyFieldIndex

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/RelationPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/RelationPlanner.java
@@ -60,7 +60,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
@@ -139,20 +138,12 @@ public class RelationPlanner extends AstVisitor<RelationPlan, Void> {
             qualifiedName.getPrefix().map(QualifiedName::toString).orElse(null),
             qualifiedName.getSuffix());
 
-    Set<String> usedColumns = analysis.getUsedColumns(qualifiedObjectName);
-
     // on the basis of that the order of fields is same with the column category order of segments
     // in DeviceEntry
     Map<Symbol, Integer> idAndAttributeIndexMap = new HashMap<>();
     int idIndex = 0;
     for (Field field : fields) {
       TsTableColumnCategory category = field.getColumnCategory();
-      // only keep used columns and all ID columns
-      if (category != TsTableColumnCategory.ID
-          && field.getOriginColumnName().isPresent()
-          && !usedColumns.contains(field.getOriginColumnName().get())) {
-        continue;
-      }
       Symbol symbol = symbolAllocator.newSymbol(field);
       outputSymbolsBuilder.add(symbol);
       symbolToColumnSchema.put(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/TranslationMap.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/TranslationMap.java
@@ -382,11 +382,7 @@ public class TranslationMap {
     ResolvedField field = analysis.getColumnReferenceFields().get(NodeRef.of(expression));
 
     if (scope.isLocalScope(field.getScope())) {
-      if (field.getField().getOriginColumnName().isPresent()) {
-        return Optional.of(Symbol.of(field.getField().getOriginColumnName().get()));
-      } else {
-        return Optional.of(fieldSymbols[field.getHierarchyFieldIndex()]);
-      }
+      return Optional.of(fieldSymbols[field.getHierarchyFieldIndex()]);
     }
 
     if (outerContext.isPresent()) {


### PR DESCRIPTION
## Description

If not use HierarchyFieldIndex, some cases such as Join situation may cause errors.

### Content1 ...

### Content2 ...

### Content3 ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
