### PR TITLE
Fix query stuck caused by restarting DN while doing query

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/FixedRateFragInsStateTracker.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/FixedRateFragInsStateTracker.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 public class FixedRateFragInsStateTracker extends AbstractFragInsStateTracker {
 
@@ -175,12 +176,19 @@ public class FixedRateFragInsStateTracker extends AbstractFragInsStateTracker {
         stateMachine.transitionToFailed(instanceInfo.getFailureInfoList().get(0).toException());
       }
     }
-    boolean queryFinished =
+    boolean queryFinished = false;
+    List<InstanceStateMetrics> rootInstanceStateMetricsList =
         instanceStateMap.values().stream()
             .filter(instanceStateMetrics -> instanceStateMetrics.isRootInstance)
-            .allMatch(
-                instanceStateMetrics ->
-                    instanceStateMetrics.lastState == FragmentInstanceState.FINISHED);
+            .collect(Collectors.toList());
+    if (!rootInstanceStateMetricsList.isEmpty()) {
+      queryFinished =
+          rootInstanceStateMetricsList.stream()
+              .allMatch(
+                  instanceStateMetrics ->
+                      instanceStateMetrics.lastState == FragmentInstanceState.FINISHED);
+    }
+
     if (queryFinished) {
       stateMachine.transitionToFinished();
     }


### PR DESCRIPTION
If we restart a DN while doing a query and then fetchStateAndUpdate may throw TException and won't record that FI's state.
If that FI is just rootFI, then if we use the old code:
```
    boolean queryFinished =
        instanceStateMap.values().stream()
            .filter(instanceStateMetrics -> instanceStateMetrics.isRootInstance)
            .allMatch(
                instanceStateMetrics ->
                    instanceStateMetrics.lastState == FragmentInstanceState.FINISHED);
```

It will return true.