### PR TITLE
[To rc/1.3.3] Subscription: reduce the length of the stringified subscription event & do not print warn logs for eagerly pollable events

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingQueue.java
@@ -251,7 +251,12 @@ public abstract class SubscriptionPrefetchingQueue {
             }
 
             // nack pollable event and re-enqueue it to prefetchingQueue
-            if (ev.pollable()) {
+            if (ev.eagerlyPollable()) {
+              ev.nack(); // now pollable (the nack operation here is actually unnecessary)
+              enqueueEventToPrefetchingQueue(ev);
+              // no need to log warn for eagerly pollable event
+              return null; // remove this entry
+            } else if (ev.pollable()) {
               ev.nack(); // now pollable
               enqueueEventToPrefetchingQueue(ev);
               LOGGER.warn(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeTabletEventBatch.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeTabletEventBatch.java
@@ -201,15 +201,24 @@ public class SubscriptionPipeTabletEventBatch extends SubscriptionPipeEventBatch
   @Override
   protected Map<String, String> coreReportMessage() {
     final Map<String, String> coreReportMessage = super.coreReportMessage();
-    coreReportMessage.put(
-        "enrichedEvents",
-        enrichedEvents.stream()
-            .map(EnrichedEvent::coreReportMessage)
-            .collect(Collectors.toList())
-            .toString());
+    coreReportMessage.put("enrichedEvents", formatEnrichedEvents(enrichedEvents, 4));
     coreReportMessage.put("size of tablets", String.valueOf(tablets.size()));
     coreReportMessage.put("firstEventProcessingTime", String.valueOf(firstEventProcessingTime));
     coreReportMessage.put("totalBufferSize", String.valueOf(totalBufferSize));
     return coreReportMessage;
+  }
+
+  private static String formatEnrichedEvents(
+      final List<EnrichedEvent> enrichedEvents, final int threshold) {
+    final List<String> eventMessageList =
+        enrichedEvents.stream()
+            .limit(threshold)
+            .map(EnrichedEvent::coreReportMessage)
+            .collect(Collectors.toList());
+    if (eventMessageList.size() > threshold) {
+      eventMessageList.add(
+          String.format("omit the remaining %s event(s)...", eventMessageList.size() - threshold));
+    }
+    return eventMessageList.toString();
   }
 }


### PR DESCRIPTION
cherry-pick #13405 to https://github.com/apache/iotdb/tree/rc/1.3.3