### PR TITLE
Fix AINode restart functionality and enhance error clarity

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/node/ClusterNodeStartUtils.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/node/ClusterNodeStartUtils.java
@@ -260,6 +260,14 @@ public class ClusterNodeStartUtils {
                   configManager.getNodeManager().getRegisteredConfigNodes());
         }
         break;
+      case AINode:
+        if (nodeLocation instanceof TAINodeLocation) {
+          matchedNodeLocation =
+              matchRegisteredAINode(
+                  (TAINodeLocation) nodeLocation,
+                  configManager.getNodeManager().getRegisteredAINodes());
+        }
+        break;
       case DataNode:
       default:
         if (nodeLocation instanceof TDataNodeLocation) {
@@ -426,6 +434,24 @@ public class ClusterNodeStartUtils {
     for (TConfigNodeLocation registeredConfigNode : registeredConfigNodes) {
       if (registeredConfigNode.getConfigNodeId() == configNodeLocation.getConfigNodeId()) {
         return registeredConfigNode;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Check if there exists a registered AINode who has the same index of the given one.
+   *
+   * @param aiNodeLocation The given AINode
+   * @param registeredAINodes Registered AINodes
+   * @return The AINodeLocation who has the same index of the given one, null otherwise.
+   */
+  public static TAINodeLocation matchRegisteredAINode(
+      TAINodeLocation aiNodeLocation, List<TAINodeConfiguration> registeredAINodes) {
+    for (TAINodeConfiguration registeredAINode : registeredAINodes) {
+      if (registeredAINode.getLocation().getAiNodeId() == aiNodeLocation.getAiNodeId()) {
+        return registeredAINode.getLocation();
       }
     }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/ErrorHandlingUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/ErrorHandlingUtils.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.commons.exception.IoTDBRuntimeException;
 import org.apache.iotdb.db.exception.BatchProcessException;
 import org.apache.iotdb.db.exception.QueryInBatchStatementException;
 import org.apache.iotdb.db.exception.StorageGroupNotReadyException;
+import org.apache.iotdb.db.exception.ainode.ModelException;
 import org.apache.iotdb.db.exception.query.QueryProcessException;
 import org.apache.iotdb.db.exception.query.QueryTimeoutRuntimeException;
 import org.apache.iotdb.db.exception.sql.SemanticException;
@@ -157,6 +158,8 @@ public class ErrorHandlingUtils {
       return RpcUtils.getStatus(TSStatusCode.SEMANTIC_ERROR, rootCause.getMessage());
     } else if (t instanceof IoTDBRuntimeException) {
       return RpcUtils.getStatus(((IoTDBRuntimeException) t).getErrorCode(), t.getMessage());
+    } else if (t instanceof ModelException) {
+      return RpcUtils.getStatus(((ModelException) t).getStatusCode(), rootCause.getMessage());
     } else if (t instanceof MemoryNotEnoughException) {
       return RpcUtils.getStatus(TSStatusCode.QUOTA_MEM_QUERY_NOT_ENOUGH, rootCause.getMessage());
     }


### PR DESCRIPTION
1. Currently confignode is lack of the logic for AINode to restart, this PR add relating codes.
2. Add exception information handling for AINode.