### PR TITLE
Automatically trigger CI for active non-committer again

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -39,12 +39,12 @@ github:
     # disable rebase button:
     rebase:  true
   collaborators:
-    - Caideyipi
     - shuwenwei
     - liyuheng55555
     - CritasWang
     - HxpSerein
     - DanielWang2035
     - Pengzna
-    - Colinleeo
     - Wei-hao-Li
+    - Colinleeo
+    - Caideyipi


### PR DESCRIPTION
Attempt to trigger again because the invitation link of some collaborators has expired