### PR TITLE
Automatically trigger CI for active non-committer 

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -46,5 +46,3 @@ github:
     - DanielWang2035
     - Pengzna
     - Wei-hao-Li
-    - Colinleeo
-    - Caideyipi


### PR DESCRIPTION
Remove two members temporarily to trigger invitation again