### PR TITLE
Pipe: fix event counter decrement operations to avoid inconsistent final counts

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/metric/PipeDataRegionEventCounter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/metric/PipeDataRegionEventCounter.java
@@ -76,11 +76,11 @@ public class PipeDataRegionEventCounter extends PipeEventCounter {
       return;
     }
     if (event instanceof PipeHeartbeatEvent) {
-      pipeHeartbeatEventCount.getAndUpdate(count -> count > 0 ? count - 1 : 0);
+      pipeHeartbeatEventCount.decrementAndGet();
     } else if (event instanceof TabletInsertionEvent) {
-      tabletInsertionEventCount.getAndUpdate(count -> count > 0 ? count - 1 : 0);
+      tabletInsertionEventCount.decrementAndGet();
     } else if (event instanceof TsFileInsertionEvent) {
-      tsFileInsertionEventCount.getAndUpdate(count -> count > 0 ? count - 1 : 0);
+      tsFileInsertionEventCount.decrementAndGet();
     }
   }
 


### PR DESCRIPTION
fixup #13250, @Caideyipi found that for the following concurrency sequence enqueue -> dequeue -> decrease -> increase, the decrease event counter would fail...