### PR TITLE
Fix the bug in using negation for timestamp type

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/query/IoTDBArithmeticTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/query/IoTDBArithmeticTableIT.java
@@ -198,6 +198,18 @@ public class IoTDBArithmeticTableIT {
   }
 
   @Test
+  public void testTimestampNegation() {
+    String sql = "select -s6 from table1";
+    tableResultSetEqualTest(
+        sql,
+        new String[] {"_col0"},
+        new String[] {
+          "1969-12-31T23:59:59.990Z,", "1969-12-31T23:59:59.980Z,", "1969-12-31T23:59:59.970Z,"
+        },
+        DATABASE_NAME);
+  }
+
+  @Test
   public void testBinaryWrongType() {
 
     testBinaryDifferentCombinationsFail(

--- a/iotdb-core/datanode/src/main/codegen/templates/ArithmeticColumnTransformerApi.ftl
+++ b/iotdb-core/datanode/src/main/codegen/templates/ArithmeticColumnTransformerApi.ftl
@@ -23,12 +23,12 @@ import org.apache.iotdb.db.queryengine.plan.relational.function.arithmetic.Divis
 import org.apache.iotdb.db.queryengine.plan.relational.function.arithmetic.ModulusResolver;
 import org.apache.iotdb.db.queryengine.plan.relational.function.arithmetic.MultiplicationResolver;
 import org.apache.iotdb.db.queryengine.plan.relational.function.arithmetic.SubtractionResolver;
-import org.apache.iotdb.db.queryengine.plan.relational.metadata.OperatorNotFoundException;
 import org.apache.iotdb.db.queryengine.transformation.dag.column.ColumnTransformer;
 import org.apache.iotdb.db.queryengine.transformation.dag.column.unary.DoubleNegationColumnTransformer;
 import org.apache.iotdb.db.queryengine.transformation.dag.column.unary.FloatNegationColumnTransformer;
 import org.apache.iotdb.db.queryengine.transformation.dag.column.unary.IntNegationColumnTransformer;
 import org.apache.iotdb.db.queryengine.transformation.dag.column.unary.LongNegationColumnTransformer;
+import org.apache.iotdb.db.queryengine.transformation.dag.column.unary.TimestampNegationColumnTransformer;
 
 import java.time.ZoneId;
 import java.util.Arrays;
@@ -63,13 +63,20 @@ public class ArithmeticColumnTransformerApi {
   public static ColumnTransformer getNegationTransformer(ColumnTransformer columnTransformer) {
     switch (columnTransformer.getType().getTypeEnum()) {
       case INT32:
-        return new IntNegationColumnTransformer(columnTransformer.getType(), columnTransformer);
+        return new IntNegationColumnTransformer(
+            columnTransformer.getType(), columnTransformer);
       case INT64:
-        return new LongNegationColumnTransformer(columnTransformer.getType(), columnTransformer);
+        return new LongNegationColumnTransformer(
+            columnTransformer.getType(), columnTransformer);
       case FLOAT:
-        return new FloatNegationColumnTransformer(columnTransformer.getType(), columnTransformer);
+        return new FloatNegationColumnTransformer(
+            columnTransformer.getType(), columnTransformer);
       case DOUBLE:
-        return new DoubleNegationColumnTransformer(columnTransformer.getType(), columnTransformer);
+        return new DoubleNegationColumnTransformer(
+            columnTransformer.getType(), columnTransformer);
+      case TIMESTAMP:
+        return new TimestampNegationColumnTransformer(
+            columnTransformer.getType(), columnTransformer);
       default:
         throw new UnsupportedOperationException("Unsupported Type");
     }

--- a/iotdb-core/datanode/src/main/codegen/templates/ArithmeticUnaryColumnTransformer.ftl
+++ b/iotdb-core/datanode/src/main/codegen/templates/ArithmeticUnaryColumnTransformer.ftl
@@ -16,7 +16,7 @@
 <#list mathematicalDataType.types as type>
   <#assign newType = type.type?replace("Type","")>
   <#assign className = "${newType}NegationColumnTransformer">
-<#if newType != "Date" && newType != "Timestamp">
+<#if newType != "Date">
   <@pp.changeOutputFile name="/org/apache/iotdb/db/queryengine/transformation/dag/column/unary/${className}.java" />
 package org.apache.iotdb.db.queryengine.transformation.dag.column.unary;
 
@@ -55,8 +55,8 @@ public class ${className} extends UnaryColumnTransformer {
   }
 
   public static ${type.dataType} transform(${type.dataType} value){
-    <#if type.dataType == "Int" || type.dataType == "Long">
-    if(value == ${type.dataType}.MIN_VALUE){
+    <#if type.dataType == "int" || type.dataType == "long">
+    if(value == <#if type.dataType == "int">Integer<#else>Long</#if>.MIN_VALUE){
       throw new IoTDBRuntimeException(String.format("The %s is out of range of ${type.dataType}.", value), NUMERIC_VALUE_OUT_OF_RANGE.getStatusCode(), true);
     }
     </#if>


### PR DESCRIPTION
## Description

This PR fixe bug in using Negation for Timestamp Type

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
