### PR TITLE
Pipe: eliminate progress index for raw tablet event to avoid endless rebind

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEvent.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.commons.pipe.event.EnrichedEvent;
 import org.apache.iotdb.commons.pipe.pattern.PipePattern;
 import org.apache.iotdb.commons.pipe.task.meta.PipeTaskMeta;
 import org.apache.iotdb.commons.utils.TestOnly;
+import org.apache.iotdb.db.pipe.event.common.tsfile.PipeTsFileInsertionEvent;
 import org.apache.iotdb.db.pipe.resource.PipeDataNodeResourceManager;
 import org.apache.iotdb.db.pipe.resource.memory.PipeMemoryWeightUtil;
 import org.apache.iotdb.db.pipe.resource.memory.PipeTabletMemoryBlock;
@@ -51,7 +52,7 @@ public class PipeRawTabletInsertionEvent extends EnrichedEvent implements Tablet
 
   private TabletInsertionDataContainer dataContainer;
 
-  private ProgressIndex overridingProgressIndex;
+  private volatile ProgressIndex overridingProgressIndex;
 
   private PipeRawTabletInsertionEvent(
       final Tablet tablet,
@@ -136,6 +137,9 @@ public class PipeRawTabletInsertionEvent extends EnrichedEvent implements Tablet
   protected void reportProgress() {
     if (needToReport) {
       super.reportProgress();
+      if (sourceEvent instanceof PipeTsFileInsertionEvent) {
+        ((PipeTsFileInsertionEvent) sourceEvent).eliminateProgressIndex();
+      }
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEvent.java
@@ -72,7 +72,7 @@ public class PipeTsFileInsertionEvent extends EnrichedEvent implements TsFileIns
   // May be updated after it is flushed. Should be negative if not set.
   private long flushPointCount = TsFileProcessor.FLUSH_POINT_COUNT_NOT_SET;
 
-  private ProgressIndex overridingProgressIndex;
+  private volatile ProgressIndex overridingProgressIndex;
 
   public PipeTsFileInsertionEvent(
       final TsFileResource resource,
@@ -302,6 +302,10 @@ public class PipeTsFileInsertionEvent extends EnrichedEvent implements TsFileIns
   @Override
   protected void reportProgress() {
     super.reportProgress();
+    this.eliminateProgressIndex();
+  }
+
+  public void eliminateProgressIndex() {
     if (Objects.isNull(overridingProgressIndex)) {
       PipeTimePartitionProgressIndexKeeper.getInstance()
           .eliminateProgressIndex(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/realtime/assigner/PipeTimePartitionProgressIndexKeeper.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/realtime/assigner/PipeTimePartitionProgressIndexKeeper.java
@@ -25,6 +25,7 @@ import org.apache.tsfile.utils.Pair;
 
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class PipeTimePartitionProgressIndexKeeper {
@@ -58,7 +59,7 @@ public class PipeTimePartitionProgressIndexKeeper {
               if (v == null) {
                 return null;
               }
-              if (v.getRight() && v.getLeft().equals(progressIndex)) {
+              if (v.getRight() && !v.getLeft().isAfter(progressIndex)) {
                 return new Pair<>(v.getLeft(), false);
               }
               return v;
@@ -75,7 +76,8 @@ public class PipeTimePartitionProgressIndexKeeper {
         .map(Entry::getValue)
         .filter(pair -> pair.right)
         .map(Pair::getLeft)
-        .anyMatch(index -> progressIndex.isAfter(index) || progressIndex.equals(index));
+        .filter(Objects::nonNull)
+        .anyMatch(index -> !index.isAfter(progressIndex));
   }
 
   //////////////////////////// singleton ////////////////////////////


### PR DESCRIPTION
fixup #13483