### PR TITLE
Pipe: make progress index immutable

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/historical/PipeHistoricalDataRegionTsFileExtractor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/historical/PipeHistoricalDataRegionTsFileExtractor.java
@@ -260,7 +260,7 @@ public class PipeHistoricalDataRegionTsFileExtractor implements PipeHistoricalDa
     pipeName = environment.getPipeName();
     creationTime = environment.getCreationTime();
     pipeTaskMeta = environment.getPipeTaskMeta();
-    startIndex = environment.getPipeTaskMeta().getProgressIndex().deepCopy();
+    startIndex = environment.getPipeTaskMeta().getProgressIndex();
 
     dataRegionId = environment.getRegionId();
     synchronized (DATA_REGION_ID_TO_PIPE_FLUSHED_TIME_MAP) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/realtime/assigner/PipeDataRegionAssigner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/realtime/assigner/PipeDataRegionAssigner.java
@@ -160,7 +160,7 @@ public class PipeDataRegionAssigner implements Closeable {
     if (PipeTimePartitionProgressIndexKeeper.getInstance()
         .isProgressIndexAfterOrEquals(
             dataRegionId, event.getTimePartitionId(), event.getProgressIndex())) {
-      event.bindProgressIndex(maxProgressIndexForTsFileInsertionEvent.deepCopy());
+      event.bindProgressIndex(maxProgressIndexForTsFileInsertionEvent);
       LOGGER.warn(
           "Data region {} bind {} to event {} because it was flushed prematurely.",
           dataRegionId,

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/realtime/assigner/PipeTimePartitionProgressIndexKeeper.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/realtime/assigner/PipeTimePartitionProgressIndexKeeper.java
@@ -41,7 +41,7 @@ public class PipeTimePartitionProgressIndexKeeper {
             timePartitionId,
             (k, v) -> {
               if (v == null) {
-                return new Pair<>(progressIndex.deepCopy(), true);
+                return new Pair<>(progressIndex, true);
               }
               return new Pair<>(
                   v.getLeft().updateToMinimumEqualOrIsAfterProgressIndex(progressIndex), true);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/processor/twostage/plugin/TwoStageCountProcessor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/processor/twostage/plugin/TwoStageCountProcessor.java
@@ -172,10 +172,8 @@ public class TwoStageCountProcessor implements PipeProcessor {
             : ((PipeRawTabletInsertionEvent) event).count();
     localCount.accumulateAndGet(count, Long::sum);
 
-    localCommitProgressIndex.set(
-        localCommitProgressIndex
-            .get()
-            .updateToMinimumEqualOrIsAfterProgressIndex(event.getProgressIndex()));
+    localCommitProgressIndex.updateAndGet(
+        index -> index.updateToMinimumEqualOrIsAfterProgressIndex(event.getProgressIndex()));
   }
 
   @Override
@@ -199,10 +197,8 @@ public class TwoStageCountProcessor implements PipeProcessor {
     final long count = event.count(true);
     localCount.accumulateAndGet(count, Long::sum);
 
-    localCommitProgressIndex.set(
-        localCommitProgressIndex
-            .get()
-            .updateToMinimumEqualOrIsAfterProgressIndex(event.getProgressIndex()));
+    localCommitProgressIndex.updateAndGet(
+        index -> index.updateToMinimumEqualOrIsAfterProgressIndex(event.getProgressIndex()));
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertMultiTabletsNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertMultiTabletsNode.java
@@ -284,7 +284,7 @@ public class InsertMultiTabletsNode extends InsertNode {
 
   @Override
   public void setProgressIndex(ProgressIndex progressIndex) {
-    this.progressIndex = progressIndex.deepCopy();
+    this.progressIndex = progressIndex;
     insertTabletNodeList.forEach(node -> node.setProgressIndex(progressIndex));
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertNode.java
@@ -332,7 +332,7 @@ public abstract class InsertNode extends SearchNode implements ComparableConsens
 
   @Override
   public void setProgressIndex(ProgressIndex progressIndex) {
-    this.progressIndex = progressIndex.deepCopy();
+    this.progressIndex = progressIndex;
   }
 
   // endregion

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertRowsNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertRowsNode.java
@@ -293,7 +293,7 @@ public class InsertRowsNode extends InsertNode implements WALEntryValue {
 
   @Override
   public void setProgressIndex(ProgressIndex progressIndex) {
-    this.progressIndex = progressIndex.deepCopy();
+    this.progressIndex = progressIndex;
     insertRowNodeList.forEach(insertRowNode -> insertRowNode.setProgressIndex(progressIndex));
   }
 
@@ -304,7 +304,7 @@ public class InsertRowsNode extends InsertNode implements WALEntryValue {
 
     this.progressIndex =
         (this.progressIndex == null)
-            ? progressIndex.deepCopy()
+            ? progressIndex
             : this.progressIndex.updateToMinimumEqualOrIsAfterProgressIndex(progressIndex);
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertRowsOfOneDeviceNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertRowsOfOneDeviceNode.java
@@ -335,7 +335,7 @@ public class InsertRowsOfOneDeviceNode extends InsertNode {
 
   @Override
   public void setProgressIndex(ProgressIndex progressIndex) {
-    this.progressIndex = progressIndex.deepCopy();
+    this.progressIndex = progressIndex;
     insertRowNodeList.forEach(insertRowNode -> insertRowNode.setProgressIndex(progressIndex));
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
@@ -1138,7 +1138,7 @@ public class TsFileResource {
 
     maxProgressIndex =
         (maxProgressIndex == null
-            ? progressIndex.deepCopy()
+            ? progressIndex
             : maxProgressIndex.updateToMinimumEqualOrIsAfterProgressIndex(progressIndex));
 
     PipeTimePartitionProgressIndexKeeper.getInstance()
@@ -1150,7 +1150,7 @@ public class TsFileResource {
       return;
     }
 
-    maxProgressIndex = progressIndex.deepCopy();
+    maxProgressIndex = progressIndex;
 
     PipeTimePartitionProgressIndexKeeper.getInstance()
         .updateProgressIndex(getDataRegionId(), getTimePartition(), maxProgressIndex);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/TsFileResourceProgressIndexTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/TsFileResourceProgressIndexTest.java
@@ -107,15 +107,26 @@ public class TsFileResourceProgressIndexTest {
   public void testProgressIndexRecorder() {
     HybridProgressIndex hybridProgressIndex =
         new HybridProgressIndex(new SimpleProgressIndex(3, 4));
-    hybridProgressIndex.updateToMinimumEqualOrIsAfterProgressIndex(new SimpleProgressIndex(6, 6));
-    hybridProgressIndex.updateToMinimumEqualOrIsAfterProgressIndex(
-        new RecoverProgressIndex(1, new SimpleProgressIndex(1, 2)));
-    hybridProgressIndex.updateToMinimumEqualOrIsAfterProgressIndex(
-        new RecoverProgressIndex(1, new SimpleProgressIndex(1, 3)));
-    hybridProgressIndex.updateToMinimumEqualOrIsAfterProgressIndex(
-        new RecoverProgressIndex(2, new SimpleProgressIndex(4, 3)));
-    hybridProgressIndex.updateToMinimumEqualOrIsAfterProgressIndex(
-        new RecoverProgressIndex(3, new SimpleProgressIndex(5, 5)));
+    hybridProgressIndex =
+        (HybridProgressIndex)
+            hybridProgressIndex.updateToMinimumEqualOrIsAfterProgressIndex(
+                new SimpleProgressIndex(6, 6));
+    hybridProgressIndex =
+        (HybridProgressIndex)
+            hybridProgressIndex.updateToMinimumEqualOrIsAfterProgressIndex(
+                new RecoverProgressIndex(1, new SimpleProgressIndex(1, 2)));
+    hybridProgressIndex =
+        (HybridProgressIndex)
+            hybridProgressIndex.updateToMinimumEqualOrIsAfterProgressIndex(
+                new RecoverProgressIndex(1, new SimpleProgressIndex(1, 3)));
+    hybridProgressIndex =
+        (HybridProgressIndex)
+            hybridProgressIndex.updateToMinimumEqualOrIsAfterProgressIndex(
+                new RecoverProgressIndex(2, new SimpleProgressIndex(4, 3)));
+    hybridProgressIndex =
+        (HybridProgressIndex)
+            hybridProgressIndex.updateToMinimumEqualOrIsAfterProgressIndex(
+                new RecoverProgressIndex(3, new SimpleProgressIndex(5, 5)));
     Assert.assertTrue(hybridProgressIndex.isAfter(new SimpleProgressIndex(6, 5)));
     Assert.assertTrue(
         hybridProgressIndex.isAfter(new RecoverProgressIndex(3, new SimpleProgressIndex(5, 4))));
@@ -195,11 +206,6 @@ public class TsFileResourceProgressIndexTest {
     }
 
     @Override
-    public ProgressIndex deepCopy() {
-      return new MockProgressIndex(type, val);
-    }
-
-    @Override
     public ProgressIndex updateToMinimumEqualOrIsAfterProgressIndex(ProgressIndex progressIndex) {
       if (!(progressIndex instanceof MockProgressIndex)) {
         throw new IllegalStateException("Mock update error.");
@@ -228,9 +234,11 @@ public class TsFileResourceProgressIndexTest {
     final IoTProgressIndex ioTProgressIndex = new IoTProgressIndex(1, 123L);
     final RecoverProgressIndex recoverProgressIndex =
         new RecoverProgressIndex(1, new SimpleProgressIndex(2, 2));
-    final HybridProgressIndex hybridProgressIndex = new HybridProgressIndex(ioTProgressIndex);
+    HybridProgressIndex hybridProgressIndex = new HybridProgressIndex(ioTProgressIndex);
 
-    hybridProgressIndex.updateToMinimumEqualOrIsAfterProgressIndex(recoverProgressIndex);
+    hybridProgressIndex =
+        (HybridProgressIndex)
+            hybridProgressIndex.updateToMinimumEqualOrIsAfterProgressIndex(recoverProgressIndex);
 
     Assert.assertTrue(hybridProgressIndex.isAfter(new IoTProgressIndex(1, 100L)));
     Assert.assertTrue(
@@ -334,18 +342,22 @@ public class TsFileResourceProgressIndexTest {
                       new IoTProgressIndex(
                           random.nextInt(peerIdRange), (long) random.nextInt(searchIndexRange)));
               if (random.nextInt(2) == 1) {
-                hybridProgressIndex.updateToMinimumEqualOrIsAfterProgressIndex(
-                    new SimpleProgressIndex(
-                        random.nextInt(rebootTimesRange),
-                        random.nextInt(memtableFlushOrderIdRange)));
+                hybridProgressIndex =
+                    (HybridProgressIndex)
+                        hybridProgressIndex.updateToMinimumEqualOrIsAfterProgressIndex(
+                            new SimpleProgressIndex(
+                                random.nextInt(rebootTimesRange),
+                                random.nextInt(memtableFlushOrderIdRange)));
               }
               if (random.nextInt(2) == 1) {
-                hybridProgressIndex.updateToMinimumEqualOrIsAfterProgressIndex(
-                    new RecoverProgressIndex(
-                        random.nextInt(dataNodeIdRange),
-                        new SimpleProgressIndex(
-                            random.nextInt(rebootTimesRange),
-                            random.nextInt(memtableFlushOrderIdRange))));
+                hybridProgressIndex =
+                    (HybridProgressIndex)
+                        hybridProgressIndex.updateToMinimumEqualOrIsAfterProgressIndex(
+                            new RecoverProgressIndex(
+                                random.nextInt(dataNodeIdRange),
+                                new SimpleProgressIndex(
+                                    random.nextInt(rebootTimesRange),
+                                    random.nextInt(memtableFlushOrderIdRange))));
               }
               progressIndexList.add(hybridProgressIndex);
             });

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/ProgressIndex.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/ProgressIndex.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -41,6 +42,16 @@ import java.util.stream.LongStream;
  * chain. Since strict total order relations can be defined on each of these causal chains, the
  * progress index is considered to be composed of an n-tuple of total order relations
  * (S<sub>1</sub>,S<sub>2</sub>,S<sub>3</sub>,.... ,S<sub>n</sub>).
+ *
+ * <p>This class is designed to be immutable, meaning that instances of {@link ProgressIndex} can be
+ * treated as value objects. Immutability ensures thread safety, as no external synchronization is
+ * required for concurrent access to instances of this class. It also simplifies reasoning about the
+ * state of the object as it cannot change once created.
+ *
+ * <p>However, if a {@link ProgressIndex} instance holds any mutable objects, like a {@link Map},
+ * they must be deeply copied during construction or when exposed through accessors to maintain the
+ * immutability contract. This prevents unintended modifications to the underlying mutable state
+ * from affecting other parts of the program.
  */
 public abstract class ProgressIndex {
 
@@ -96,22 +107,6 @@ public abstract class ProgressIndex {
   }
 
   /**
-   * Creates and returns a deep copy of this {@link ProgressIndex} instance.
-   *
-   * <p>This method performs a deep copy, meaning all nested objects and fields within this {@link
-   * ProgressIndex} are recursively copied, resulting in a new instance that is independent of the
-   * original. Modifications to the copied instance will not affect the original instance and vice
-   * versa.
-   *
-   * <p>When constructing or updating another {@link ProgressIndex} using an existing {@link
-   * ProgressIndex}, it is recommended to perform a deep copy of the existing instance to avoid
-   * unintended modifications or shared state between the instances.
-   *
-   * @return a new {@link ProgressIndex} instance that is a deep copy of this progress index
-   */
-  public abstract ProgressIndex deepCopy();
-
-  /**
    * Define the isEqualOrAfter relation, A.isEqualOrAfter(B) if and only if each tuple member in A
    * is greater than or equal to B in the corresponding total order relation.
    *
@@ -128,13 +123,11 @@ public abstract class ProgressIndex {
    * A.updateToMinimumIsAfterProgressIndex(B).equals(B.updateToMinimumIsAfterProgressIndex(A)) is
    * {@code true}
    *
-   * <p>Note: this function may modify the caller (this) but will not modify {@param progressIndex}.
+   * <p>Note: this function will not modify the caller (this) and {@param progressIndex}.
    *
    * @param progressIndex the {@link ProgressIndex} to be compared
    * @return the minimum {@link ProgressIndex} after the given {@link ProgressIndex} and this {@link
-   *     ProgressIndex}, the returned {@link ProgressIndex} will contain deep copies of all
-   *     references to the given {@param progressIndex}, ensuring no shared state between the
-   *     original and the result
+   *     ProgressIndex}.
    */
   public abstract ProgressIndex updateToMinimumEqualOrIsAfterProgressIndex(
       ProgressIndex progressIndex);
@@ -183,9 +176,7 @@ public abstract class ProgressIndex {
    *     should be the minimum {@link ProgressIndex} equal or after the first {@link ProgressIndex}
    *     and the second {@link ProgressIndex}
    * @return the minimum {@link ProgressIndex} after the first {@link ProgressIndex} and the second
-   *     {@link ProgressIndex}, the returned {@link ProgressIndex} will contain deep copies of all
-   *     references to {@param progressIndex1} and {@param progressIndex2}, ensuring that the result
-   *     is independent and modifications to it do not affect the original instances
+   *     {@link ProgressIndex}.
    */
   protected static ProgressIndex blendProgressIndex(
       ProgressIndex progressIndex1, ProgressIndex progressIndex2) {
@@ -193,14 +184,14 @@ public abstract class ProgressIndex {
       return MinimumProgressIndex.INSTANCE;
     }
     if (progressIndex1 == null || progressIndex1 instanceof MinimumProgressIndex) {
-      return progressIndex2 == null ? MinimumProgressIndex.INSTANCE : progressIndex2.deepCopy();
+      return progressIndex2 == null ? MinimumProgressIndex.INSTANCE : progressIndex2;
     }
     if (progressIndex2 == null || progressIndex2 instanceof MinimumProgressIndex) {
-      return progressIndex1.deepCopy(); // progressIndex1 is not null
+      return progressIndex1; // progressIndex1 is not null
     }
 
     return progressIndex1 instanceof StateProgressIndex
-        ? progressIndex1.deepCopy().updateToMinimumEqualOrIsAfterProgressIndex(progressIndex2)
+        ? progressIndex1.updateToMinimumEqualOrIsAfterProgressIndex(progressIndex2)
         : new HybridProgressIndex(progressIndex1)
             .updateToMinimumEqualOrIsAfterProgressIndex(progressIndex2);
   }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/MetaProgressIndex.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/MetaProgressIndex.java
@@ -37,14 +37,10 @@ public class MetaProgressIndex extends ProgressIndex {
 
   private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
-  private long index;
+  private final long index;
 
   public MetaProgressIndex(long index) {
     this.index = index;
-  }
-
-  private MetaProgressIndex() {
-    // Empty constructor
   }
 
   public long getIndex() {
@@ -135,11 +131,6 @@ public class MetaProgressIndex extends ProgressIndex {
   }
 
   @Override
-  public ProgressIndex deepCopy() {
-    return new MetaProgressIndex(index);
-  }
-
-  @Override
   public ProgressIndex updateToMinimumEqualOrIsAfterProgressIndex(ProgressIndex progressIndex) {
     lock.writeLock().lock();
     try {
@@ -147,8 +138,10 @@ public class MetaProgressIndex extends ProgressIndex {
         return ProgressIndex.blendProgressIndex(this, progressIndex);
       }
 
-      this.index = Math.max(this.index, ((MetaProgressIndex) progressIndex).index);
-      return this;
+      final MetaProgressIndex thisMetaProgressIndex = this;
+      final MetaProgressIndex thatMetaProgressIndex = (MetaProgressIndex) progressIndex;
+      return new MetaProgressIndex(
+          Math.max(thisMetaProgressIndex.index, thatMetaProgressIndex.index));
     } finally {
       lock.writeLock().unlock();
     }
@@ -169,15 +162,11 @@ public class MetaProgressIndex extends ProgressIndex {
   }
 
   public static MetaProgressIndex deserializeFrom(ByteBuffer byteBuffer) {
-    final MetaProgressIndex metaProgressIndex = new MetaProgressIndex();
-    metaProgressIndex.index = ReadWriteIOUtils.readLong(byteBuffer);
-    return metaProgressIndex;
+    return new MetaProgressIndex(ReadWriteIOUtils.readLong(byteBuffer));
   }
 
   public static MetaProgressIndex deserializeFrom(InputStream stream) throws IOException {
-    final MetaProgressIndex metaProgressIndex = new MetaProgressIndex();
-    metaProgressIndex.index = ReadWriteIOUtils.readLong(stream);
-    return metaProgressIndex;
+    return new MetaProgressIndex(ReadWriteIOUtils.readLong(stream));
   }
 
   @Override

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/MinimumProgressIndex.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/MinimumProgressIndex.java
@@ -73,13 +73,8 @@ public class MinimumProgressIndex extends ProgressIndex {
   }
 
   @Override
-  public ProgressIndex deepCopy() {
-    return INSTANCE;
-  }
-
-  @Override
   public ProgressIndex updateToMinimumEqualOrIsAfterProgressIndex(ProgressIndex progressIndex) {
-    return progressIndex == null ? this : progressIndex.deepCopy();
+    return progressIndex == null ? this : progressIndex;
   }
 
   @Override

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/SimpleProgressIndex.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/SimpleProgressIndex.java
@@ -141,11 +141,6 @@ public class SimpleProgressIndex extends ProgressIndex {
   }
 
   @Override
-  public ProgressIndex deepCopy() {
-    return new SimpleProgressIndex(rebootTimes, memtableFlushOrderId);
-  }
-
-  @Override
   public ProgressIndex updateToMinimumEqualOrIsAfterProgressIndex(ProgressIndex progressIndex) {
     lock.writeLock().lock();
     try {
@@ -159,7 +154,7 @@ public class SimpleProgressIndex extends ProgressIndex {
         return this;
       }
       if (thisSimpleProgressIndex.rebootTimes < thatSimpleProgressIndex.rebootTimes) {
-        return progressIndex.deepCopy();
+        return progressIndex;
       }
       // thisSimpleProgressIndex.rebootTimes == thatSimpleProgressIndex.rebootTimes
       if (thisSimpleProgressIndex.memtableFlushOrderId
@@ -168,7 +163,7 @@ public class SimpleProgressIndex extends ProgressIndex {
       }
       if (thisSimpleProgressIndex.memtableFlushOrderId
           < thatSimpleProgressIndex.memtableFlushOrderId) {
-        return progressIndex.deepCopy();
+        return progressIndex;
       }
       // thisSimpleProgressIndex.memtableFlushOrderId ==
       // thatSimpleProgressIndex.memtableFlushOrderId

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/StateProgressIndex.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/StateProgressIndex.java
@@ -37,6 +37,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+/**
+ * NOTE: Currently, {@link StateProgressIndex} does not perform deep copies of the {@link Binary}
+ * during construction or when exposed through accessors, which may lead to unintended shared state
+ * or modifications. This behavior should be reviewed and adjusted as necessary to ensure the
+ * integrity and independence of the progress index instances.
+ */
 public class StateProgressIndex extends ProgressIndex {
 
   private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/StateProgressIndex.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/StateProgressIndex.java
@@ -37,25 +37,19 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-/**
- * NOTE: Currently, {@link StateProgressIndex} does not perform deep copies of the {@link Binary}
- * during construction or updates, which may lead to unintended shared state or modifications. This
- * behavior should be reviewed and adjusted as necessary to ensure the integrity and independence of
- * the progress index instances.
- */
 public class StateProgressIndex extends ProgressIndex {
 
   private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
-  private long version;
-  private Map<String, Binary> state;
-  private ProgressIndex innerProgressIndex;
+  private final long version;
+  private final Map<String, Binary> state;
+  private final ProgressIndex innerProgressIndex;
 
   public StateProgressIndex(
       long version, Map<String, Binary> state, ProgressIndex innerProgressIndex) {
     this.version = version;
     this.state = new HashMap<>(state);
-    this.innerProgressIndex = innerProgressIndex.deepCopy();
+    this.innerProgressIndex = innerProgressIndex;
   }
 
   public long getVersion() {
@@ -63,9 +57,7 @@ public class StateProgressIndex extends ProgressIndex {
   }
 
   public ProgressIndex getInnerProgressIndex() {
-    return innerProgressIndex == null
-        ? MinimumProgressIndex.INSTANCE
-        : innerProgressIndex.deepCopy();
+    return innerProgressIndex == null ? MinimumProgressIndex.INSTANCE : innerProgressIndex;
   }
 
   public Map<String, Binary> getState() {
@@ -168,14 +160,13 @@ public class StateProgressIndex extends ProgressIndex {
   }
 
   @Override
-  public ProgressIndex deepCopy() {
-    return new StateProgressIndex(version, state, innerProgressIndex);
-  }
-
-  @Override
   public ProgressIndex updateToMinimumEqualOrIsAfterProgressIndex(ProgressIndex progressIndex) {
     lock.writeLock().lock();
     try {
+      long version = this.version;
+      Map<String, Binary> state = new HashMap<>(this.state);
+      ProgressIndex innerProgressIndex = this.innerProgressIndex;
+
       innerProgressIndex =
           innerProgressIndex.updateToMinimumEqualOrIsAfterProgressIndex(
               progressIndex instanceof StateProgressIndex
@@ -186,7 +177,7 @@ public class StateProgressIndex extends ProgressIndex {
         version = ((StateProgressIndex) progressIndex).version;
         state = ((StateProgressIndex) progressIndex).state;
       }
-      return this;
+      return new StateProgressIndex(version, state, innerProgressIndex);
     } finally {
       lock.writeLock().unlock();
     }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/TimeWindowStateProgressIndex.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/TimeWindowStateProgressIndex.java
@@ -41,9 +41,9 @@ import java.util.stream.Collectors;
 
 /**
  * NOTE: Currently, {@link TimeWindowStateProgressIndex} does not perform deep copies of the {@link
- * ByteBuffer} during construction or when exposed through accessors, which may lead to unintended
- * shared state or modifications. This behavior should be reviewed and adjusted as necessary to
- * ensure the integrity and independence of the progress index instances.
+ * ByteBuffer} and {@link Pair} during construction or when exposed through accessors, which may
+ * lead to unintended shared state or modifications. This behavior should be reviewed and adjusted
+ * as necessary to ensure the integrity and independence of the progress index instances.
  */
 public class TimeWindowStateProgressIndex extends ProgressIndex {
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/TimeWindowStateProgressIndex.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/TimeWindowStateProgressIndex.java
@@ -32,24 +32,19 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
-/**
- * NOTE: Currently, {@link TimeWindowStateProgressIndex} does not perform deep copies of the {@link
- * ByteBuffer} during construction or updates, which may lead to unintended shared state or
- * modifications. This behavior should be reviewed and adjusted as necessary to ensure the integrity
- * and independence of the progress index instances.
- */
 public class TimeWindowStateProgressIndex extends ProgressIndex {
 
   private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
   // Only the byteBuffer is nullable, the timeSeries, pair and timestamp must not be null
-  private Map<String, Pair<Long, ByteBuffer>> timeSeries2TimestampWindowBufferPairMap;
+  private final Map<String, Pair<Long, ByteBuffer>> timeSeries2TimestampWindowBufferPairMap;
 
   public TimeWindowStateProgressIndex(
       @Nonnull Map<String, Pair<Long, ByteBuffer>> timeSeries2TimestampWindowBufferPairMap) {
@@ -58,7 +53,7 @@ public class TimeWindowStateProgressIndex extends ProgressIndex {
   }
 
   private TimeWindowStateProgressIndex() {
-    // Empty constructor
+    this(Collections.emptyMap());
   }
 
   public Map<String, Pair<Long, ByteBuffer>> getTimeSeries2TimestampWindowBufferPairMap() {
@@ -195,11 +190,6 @@ public class TimeWindowStateProgressIndex extends ProgressIndex {
   }
 
   @Override
-  public ProgressIndex deepCopy() {
-    return new TimeWindowStateProgressIndex(timeSeries2TimestampWindowBufferPairMap);
-  }
-
-  @Override
   public ProgressIndex updateToMinimumEqualOrIsAfterProgressIndex(ProgressIndex progressIndex) {
     lock.writeLock().lock();
     try {
@@ -207,18 +197,23 @@ public class TimeWindowStateProgressIndex extends ProgressIndex {
         return this;
       }
 
-      this.timeSeries2TimestampWindowBufferPairMap.putAll(
-          ((TimeWindowStateProgressIndex) progressIndex)
-              .timeSeries2TimestampWindowBufferPairMap.entrySet().stream()
-                  .filter(
-                      entry ->
-                          !this.timeSeries2TimestampWindowBufferPairMap.containsKey(entry.getKey())
-                              || this.timeSeries2TimestampWindowBufferPairMap
-                                      .get(entry.getKey())
-                                      .getLeft()
-                                  <= entry.getValue().getLeft())
-                  .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-      return this;
+      final TimeWindowStateProgressIndex thisTimeWindowStateProgressIndex = this;
+      final TimeWindowStateProgressIndex thatTimeWindowStateProgressIndex =
+          (TimeWindowStateProgressIndex) progressIndex;
+      final Map<String, Pair<Long, ByteBuffer>> timeSeries2TimestampWindowBufferPairMap =
+          new HashMap<>(thisTimeWindowStateProgressIndex.timeSeries2TimestampWindowBufferPairMap);
+      timeSeries2TimestampWindowBufferPairMap.putAll(
+          thatTimeWindowStateProgressIndex
+              .timeSeries2TimestampWindowBufferPairMap
+              .entrySet()
+              .stream()
+              .filter(
+                  entry ->
+                      !timeSeries2TimestampWindowBufferPairMap.containsKey(entry.getKey())
+                          || timeSeries2TimestampWindowBufferPairMap.get(entry.getKey()).getLeft()
+                              <= entry.getValue().getLeft())
+              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+      return new TimeWindowStateProgressIndex(timeSeries2TimestampWindowBufferPairMap);
     } finally {
       lock.writeLock().unlock();
     }
@@ -238,7 +233,6 @@ public class TimeWindowStateProgressIndex extends ProgressIndex {
   public static TimeWindowStateProgressIndex deserializeFrom(ByteBuffer byteBuffer) {
     final TimeWindowStateProgressIndex timeWindowStateProgressIndex =
         new TimeWindowStateProgressIndex();
-    timeWindowStateProgressIndex.timeSeries2TimestampWindowBufferPairMap = new HashMap<>();
 
     final int size = ReadWriteIOUtils.readInt(byteBuffer);
     for (int i = 0; i < size; ++i) {
@@ -261,7 +255,6 @@ public class TimeWindowStateProgressIndex extends ProgressIndex {
       throws IOException {
     final TimeWindowStateProgressIndex timeWindowStateProgressIndex =
         new TimeWindowStateProgressIndex();
-    timeWindowStateProgressIndex.timeSeries2TimestampWindowBufferPairMap = new HashMap<>();
 
     final int size = ReadWriteIOUtils.readInt(stream);
     for (int i = 0; i < size; ++i) {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/TimeWindowStateProgressIndex.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/TimeWindowStateProgressIndex.java
@@ -39,6 +39,12 @@ import java.util.Objects;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
+/**
+ * NOTE: Currently, {@link TimeWindowStateProgressIndex} does not perform deep copies of the {@link
+ * ByteBuffer} during construction or when exposed through accessors, which may lead to unintended
+ * shared state or modifications. This behavior should be reviewed and adjusted as necessary to
+ * ensure the integrity and independence of the progress index instances.
+ */
 public class TimeWindowStateProgressIndex extends ProgressIndex {
 
   private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/pipe/task/meta/PipeMetaDeSerTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/pipe/task/meta/PipeMetaDeSerTest.java
@@ -68,8 +68,14 @@ public class PipeMetaDeSerTest {
 
     HybridProgressIndex hybridProgressIndex =
         new HybridProgressIndex(new SimpleProgressIndex(1, 2));
-    hybridProgressIndex.updateToMinimumEqualOrIsAfterProgressIndex(new SimpleProgressIndex(2, 4));
-    hybridProgressIndex.updateToMinimumEqualOrIsAfterProgressIndex(new IoTProgressIndex(3, 6L));
+    hybridProgressIndex =
+        (HybridProgressIndex)
+            hybridProgressIndex.updateToMinimumEqualOrIsAfterProgressIndex(
+                new SimpleProgressIndex(2, 4));
+    hybridProgressIndex =
+        (HybridProgressIndex)
+            hybridProgressIndex.updateToMinimumEqualOrIsAfterProgressIndex(
+                new IoTProgressIndex(3, 6L));
 
     Map<String, Pair<Long, ByteBuffer>> timeSeries2TimestampWindowBufferPairMap = new HashMap<>();
     ByteBuffer buffer;
@@ -80,6 +86,7 @@ public class PipeMetaDeSerTest {
     }
     timeSeries2TimestampWindowBufferPairMap.put("root.test.a1", new Pair<>(123L, buffer));
 
+    final HybridProgressIndex finalHybridProgressIndex = hybridProgressIndex;
     PipeRuntimeMeta pipeRuntimeMeta =
         new PipeRuntimeMeta(
             new ConcurrentHashMap<Integer, PipeTaskMeta>() {
@@ -87,7 +94,7 @@ public class PipeMetaDeSerTest {
                 put(123, new PipeTaskMeta(MinimumProgressIndex.INSTANCE, 987));
                 put(234, new PipeTaskMeta(new IoTProgressIndex(1, 2L), 789));
                 put(345, new PipeTaskMeta(new SimpleProgressIndex(3, 4), 789));
-                put(456, new PipeTaskMeta(hybridProgressIndex, 789));
+                put(456, new PipeTaskMeta(finalHybridProgressIndex, 789));
                 put(
                     567,
                     new PipeTaskMeta(


### PR DESCRIPTION
In Java, immutable objects have clear requirements:

1. The state of the object cannot be modified after creation.
2. All member variables of the object are final.
3. The object is correctly created (during the creation of the object, the `this` reference does not escape).

This class is designed to be immutable, meaning that instances of ProgressIndex can be treated as value objects. Immutability ensures thread safety, as no external synchronization is required for concurrent access to instances of this class. It also simplifies reasoning about the state of the object as it cannot change once created.

However, if a ProgressIndex instance holds any mutable objects, like a Map, they must be deeply copied during construction or when exposed through accessors to maintain the immutability contract. This prevents unintended modifications to the underlying mutable state from affecting other parts of the program.