### PR TITLE
Subscription IT: explicitly declare `setUp` method for test class to avoid `UNKNOWN-IT` test class name

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/subscription/it/dual/IoTDBSubscriptionTimePrecisionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/subscription/it/dual/IoTDBSubscriptionTimePrecisionIT.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.session.subscription.payload.SubscriptionMessage;
 import org.apache.iotdb.subscription.it.IoTDBSubscriptionITConstant;
 
 import org.apache.tsfile.write.record.Tablet;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -54,6 +55,12 @@ public class IoTDBSubscriptionTimePrecisionIT extends AbstractSubscriptionDualIT
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(IoTDBSubscriptionTimePrecisionIT.class);
+
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+  }
 
   @Override
   protected void setUpConfig() {

--- a/integration-test/src/test/java/org/apache/iotdb/subscription/it/dual/IoTDBSubscriptionTopicIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/subscription/it/dual/IoTDBSubscriptionTopicIT.java
@@ -44,6 +44,7 @@ import org.apache.tsfile.read.expression.QueryExpression;
 import org.apache.tsfile.read.query.dataset.QueryDataSet;
 import org.apache.tsfile.write.record.Tablet;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -72,6 +73,12 @@ import static org.junit.Assert.fail;
 public class IoTDBSubscriptionTopicIT extends AbstractSubscriptionDualIT {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IoTDBSubscriptionTopicIT.class);
+
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+  }
 
   @Override
   protected void setUpConfig() {

--- a/integration-test/src/test/java/org/apache/iotdb/subscription/it/local/IoTDBSubscriptionBasicIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/subscription/it/local/IoTDBSubscriptionBasicIT.java
@@ -39,6 +39,7 @@ import org.apache.tsfile.read.common.Path;
 import org.apache.tsfile.read.expression.QueryExpression;
 import org.apache.tsfile.read.query.dataset.QueryDataSet;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -64,6 +65,12 @@ import static org.junit.Assert.fail;
 public class IoTDBSubscriptionBasicIT extends AbstractSubscriptionLocalIT {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IoTDBSubscriptionBasicIT.class);
+
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+  }
 
   @Test
   public void testBasicPullConsumerWithCommitAsync() throws Exception {

--- a/integration-test/src/test/java/org/apache/iotdb/subscription/it/local/IoTDBSubscriptionDataTypeIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/subscription/it/local/IoTDBSubscriptionDataTypeIT.java
@@ -41,6 +41,7 @@ import org.apache.tsfile.read.query.dataset.QueryDataSet;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.write.record.Tablet;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -63,6 +64,12 @@ import static org.junit.Assert.fail;
 public class IoTDBSubscriptionDataTypeIT extends AbstractSubscriptionLocalIT {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IoTDBSubscriptionDataTypeIT.class);
+
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+  }
 
   // ----------------------------- //
   // SessionDataSetsHandler format //

--- a/integration-test/src/test/java/org/apache/iotdb/subscription/it/local/IoTDBSubscriptionIdempotentIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/subscription/it/local/IoTDBSubscriptionIdempotentIT.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.session.subscription.SubscriptionSession;
 import org.apache.iotdb.session.subscription.consumer.SubscriptionPullConsumer;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -39,6 +40,12 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class IoTDBSubscriptionIdempotentIT extends AbstractSubscriptionLocalIT {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IoTDBSubscriptionIdempotentIT.class);
+
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+  }
 
   @Test
   public void testSubscribeOrUnsubscribeNonExistedTopicTest() {

--- a/integration-test/src/test/java/org/apache/iotdb/subscription/it/local/IoTDBSubscriptionTopicIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/subscription/it/local/IoTDBSubscriptionTopicIT.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.session.subscription.SubscriptionSession;
 import org.apache.iotdb.session.subscription.model.Topic;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -39,8 +40,14 @@ import static org.junit.Assert.fail;
 @Category({LocalStandaloneIT.class})
 public class IoTDBSubscriptionTopicIT extends AbstractSubscriptionLocalIT {
 
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+  }
+
   @Test
-  public void testBasicCreateTopic() throws Exception {
+  public void testBasicCreateTopic() {
     final String host = EnvFactory.getEnv().getIP();
     final int port = Integer.parseInt(EnvFactory.getEnv().getPort());
 
@@ -76,7 +83,7 @@ public class IoTDBSubscriptionTopicIT extends AbstractSubscriptionLocalIT {
   }
 
   @Test
-  public void testBasicCreateTopicIfNotExists() throws Exception {
+  public void testBasicCreateTopicIfNotExists() {
     final String host = EnvFactory.getEnv().getIP();
     final int port = Integer.parseInt(EnvFactory.getEnv().getPort());
 
@@ -118,7 +125,7 @@ public class IoTDBSubscriptionTopicIT extends AbstractSubscriptionLocalIT {
       topic = session.getTopic(topicName);
       Assert.assertTrue(topic.isPresent());
       Assert.assertEquals(topicName, topic.get().getTopicName());
-      // Verify Topic Parameters
+      // verify Topic Parameters
       Assert.assertTrue(topic.get().getTopicAttributes().contains("path=root.**"));
       Assert.assertTrue(topic.get().getTopicAttributes().contains("start-time=2023-01-01"));
       Assert.assertFalse(topic.get().getTopicAttributes().contains("start-time=2023-01-02"));
@@ -131,7 +138,7 @@ public class IoTDBSubscriptionTopicIT extends AbstractSubscriptionLocalIT {
   }
 
   @Test
-  public void testBasicDropTopic() throws Exception {
+  public void testBasicDropTopic() {
     final String host = EnvFactory.getEnv().getIP();
     final int port = Integer.parseInt(EnvFactory.getEnv().getPort());
 
@@ -152,7 +159,7 @@ public class IoTDBSubscriptionTopicIT extends AbstractSubscriptionLocalIT {
   }
 
   @Test
-  public void testBasicDropTopicIfExists() throws Exception {
+  public void testBasicDropTopicIfExists() {
     final String host = EnvFactory.getEnv().getIP();
     final int port = Integer.parseInt(EnvFactory.getEnv().getPort());
 

--- a/integration-test/src/test/java/org/apache/iotdb/subscription/it/triple/regression/param/IoTDBTestParamSubscriptionSessionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/subscription/it/triple/regression/param/IoTDBTestParamSubscriptionSessionIT.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.session.subscription.SubscriptionSession;
 import org.apache.iotdb.subscription.it.triple.regression.AbstractSubscriptionRegressionIT;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -32,6 +33,12 @@ import org.junit.runner.RunWith;
 @RunWith(IoTDBTestRunner.class)
 @Category({MultiClusterIT2SubscriptionRegressionMisc.class})
 public class IoTDBTestParamSubscriptionSessionIT extends AbstractSubscriptionRegressionIT {
+
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+  }
 
   @Test
   public void testCreateSession_null_host() {


### PR DESCRIPTION
See the logic in `org.apache.iotdb.it.env.cluster.env.AbstractEnv#getTestClassName`, although some pipe tests can also obtain the test class name without being declared, such as `org.apache.iotdb.pipe.it.manual.IoTDBPipeInclusionIT#testPureSchemaInclusion`, which may be caused by the multi-inheritance hierarchy of the subscription IT...