### PR TITLE
[To rc/1.3.3] Don't print warn log for sort tmp file delete

### DIFF
--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/FileUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/FileUtils.java
@@ -65,16 +65,19 @@ public class FileUtils {
     deleteFileOrDirectory(file, false);
   }
 
-  public static void deleteFileOrDirectory(File file, boolean quiteForNoSuchFile) {
+  public static void deleteFileOrDirectory(File file, boolean quietForNoSuchFile) {
     if (file.isDirectory()) {
-      for (File subfile : file.listFiles()) {
-        deleteFileOrDirectory(subfile);
+      File[] files = file.listFiles();
+      if (files != null) {
+        for (File subfile : files) {
+          deleteFileOrDirectory(subfile, quietForNoSuchFile);
+        }
       }
     }
     try {
       Files.delete(file.toPath());
     } catch (NoSuchFileException e) {
-      if (!quiteForNoSuchFile) {
+      if (!quietForNoSuchFile) {
         LOGGER.warn("{}: {}", e.getMessage(), Arrays.toString(file.list()), e);
       }
     } catch (DirectoryNotEmptyException e) {


### PR DESCRIPTION
(cherry picked from commit 0ea84cadb15f64273151c71994a9c1b2c44ffa13)