### PR TITLE
Fix potential NPE when write FileTimeIndexCache

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/utils/fileTimeIndexCache/FileTimeIndexCacheWriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/utils/fileTimeIndexCache/FileTimeIndexCacheWriter.java
@@ -63,7 +63,8 @@ public class FileTimeIndexCacheWriter implements ILogWriter {
       }
     } catch (ClosedChannelException ignored) {
       logger.warn("someone interrupt current thread, so no need to do write for io safety");
-    }
+    } catch (Exception ignored) {
+    } // There may be an ignorable NPE if the channel is closed and set null here
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/utils/fileTimeIndexCache/FileTimeIndexCacheWriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/utils/fileTimeIndexCache/FileTimeIndexCacheWriter.java
@@ -57,14 +57,15 @@ public class FileTimeIndexCacheWriter implements ILogWriter {
         // For UT env, logFile may not be created
         return;
       }
-      channel.write(logBuffer);
-      if (this.forceEachWrite) {
-        channel.force(true);
+      if (channel != null && channel.isOpen()) {
+        channel.write(logBuffer);
+        if (this.forceEachWrite) {
+          channel.force(true);
+        }
       }
     } catch (ClosedChannelException ignored) {
       logger.warn("someone interrupt current thread, so no need to do write for io safety");
-    } catch (Exception ignored) {
-    } // There may be an ignorable NPE if the channel is closed and set null here
+    }
   }
 
   @Override


### PR DESCRIPTION
## Description

When insert data executed concurrently with migrating region or dropping database, there may be a NPE error log of writing FileTimeIndexCache printed. For these cases, we can skip the writing of FileTimeIndexCache.

![img_v3_02es_d23a849b-5eae-4ea3-b4fd-c4aef7c733dg](https://github.com/user-attachments/assets/fb4911e0-f1a1-402c-9126-96cc9a6cea8f)
