### PR TITLE
Fix the error in aggregation merge sort when device locates in multi data regions

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/AggregationMergeSortOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/AggregationMergeSortOperator.java
@@ -147,7 +147,7 @@ public class AggregationMergeSortOperator extends AbstractConsumeAllOperator {
       outputResultToTsBlock();
     }
 
-    return tsBlockBuilder.build();
+    return tsBlockBuilder.getPositionCount() > 0 ? tsBlockBuilder.build() : null;
   }
 
   private void outputResultToTsBlock() {
@@ -160,6 +160,7 @@ public class AggregationMergeSortOperator extends AbstractConsumeAllOperator {
     }
     tsBlockBuilder.declarePosition();
     accumulators.forEach(Accumulator::reset);
+    lastDevice = null;
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/OperatorTreeGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/OperatorTreeGenerator.java
@@ -1176,7 +1176,7 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
             .addOperatorContext(
                 context.getNextOperatorId(),
                 node.getPlanNodeId(),
-                TreeMergeSortOperator.class.getSimpleName());
+                AggregationMergeSortOperator.class.getSimpleName());
     List<TSDataType> dataTypes = getOutputColumnTypes(node, context.getTypeProvider());
     List<Operator> children = dealWithConsumeAllChildrenPipelineBreaker(node, context);
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/AggregationMergeSortOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/AggregationMergeSortOperatorTest.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.execution.operator;
+
+import org.apache.iotdb.db.queryengine.execution.aggregation.Accumulator;
+import org.apache.iotdb.db.queryengine.execution.aggregation.CountAccumulator;
+import org.apache.iotdb.db.queryengine.execution.driver.DriverContext;
+import org.apache.iotdb.db.queryengine.execution.operator.process.AggregationMergeSortOperator;
+import org.apache.iotdb.db.queryengine.execution.operator.process.ProcessOperator;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
+import org.apache.iotdb.db.queryengine.plan.statement.component.Ordering;
+import org.apache.iotdb.db.queryengine.plan.statement.component.SortItem;
+import org.apache.iotdb.db.utils.datastructure.SortKey;
+
+import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.read.common.block.TsBlock;
+import org.apache.tsfile.read.common.block.column.BinaryColumn;
+import org.apache.tsfile.read.common.block.column.LongColumn;
+import org.apache.tsfile.utils.Binary;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+import static org.apache.iotdb.db.queryengine.execution.operator.process.join.merge.MergeSortComparator.getComparator;
+import static org.junit.Assert.assertEquals;
+
+public class AggregationMergeSortOperatorTest {
+
+  @Test
+  public void test() throws Exception {
+    OperatorContext operatorContext =
+        new OperatorContext(1, new PlanNodeId("1"), "aaa", new DriverContext());
+    List<TSDataType> dataTypes = Arrays.asList(TSDataType.TEXT, TSDataType.INT64);
+    List<Accumulator> accumulators = Collections.singletonList(new CountAccumulator());
+
+    MockDeviceViewOperator1 operator1 = new MockDeviceViewOperator1(operatorContext);
+    MockDeviceViewOperator1 operator2 = new MockDeviceViewOperator2(operatorContext);
+
+    List<Operator> children = Arrays.asList(operator1, operator2);
+
+    List<SortItem> sortItemList =
+        Arrays.asList(new SortItem("DEVICE", Ordering.ASC), new SortItem("TIME", Ordering.ASC));
+    List<Integer> sortItemIndexList = Arrays.asList(0, -1);
+    List<TSDataType> sortItemDataTypeList = Arrays.asList(TSDataType.TEXT, TSDataType.INT64);
+    Comparator<SortKey> comparator =
+        getComparator(sortItemList, sortItemIndexList, sortItemDataTypeList);
+
+    AggregationMergeSortOperator operator =
+        new AggregationMergeSortOperator(
+            operatorContext, children, dataTypes, accumulators, false, comparator);
+    int cnt = 0;
+    while (operator.isBlocked().isDone() && operator.hasNext()) {
+      TsBlock block = operator.next();
+      if (block != null && block.getPositionCount() > 0) {
+        if (cnt == 0) {
+          assertEquals("d1", block.getColumn(0).getBinary(0).toString());
+          assertEquals(2, block.getColumn(1).getLong(0));
+        } else {
+          assertEquals("d2", block.getColumn(0).getBinary(0).toString());
+          assertEquals(1, block.getColumn(1).getLong(0));
+        }
+        cnt++;
+      }
+    }
+  }
+
+  private static class MockDeviceViewOperator1 implements ProcessOperator {
+
+    OperatorContext operatorContext;
+
+    int a = 0;
+
+    public MockDeviceViewOperator1(OperatorContext operatorContext) {
+      this.operatorContext = operatorContext;
+    }
+
+    @Override
+    public OperatorContext getOperatorContext() {
+      return operatorContext;
+    }
+
+    @Override
+    public TsBlock next() throws Exception {
+      if (a == 0) {
+        a++;
+        return buildTsBlock("d1", 1);
+      }
+      return null;
+    }
+
+    @Override
+    public boolean hasNext() throws Exception {
+      return a < 1;
+    }
+
+    @Override
+    public void close() throws Exception {}
+
+    @Override
+    public boolean isFinished() throws Exception {
+      return a < 1;
+    }
+
+    @Override
+    public long calculateMaxPeekMemory() {
+      return 0;
+    }
+
+    @Override
+    public long calculateMaxReturnSize() {
+      return 0;
+    }
+
+    @Override
+    public long calculateRetainedSizeAfterCallingNext() {
+      return 0;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+      return 0;
+    }
+  }
+
+  private static class MockDeviceViewOperator2 extends MockDeviceViewOperator1 {
+
+    public MockDeviceViewOperator2(OperatorContext operatorContext) {
+      super(operatorContext);
+    }
+
+    @Override
+    public TsBlock next() throws Exception {
+      if (a == 0) {
+
+        a++;
+        return buildTsBlock("d1", 1);
+      } else if (a == 1) {
+
+        a++;
+        return buildTsBlock("d2", 1);
+      }
+      return null;
+    }
+
+    @Override
+    public boolean hasNext() throws Exception {
+      return a < 2;
+    }
+  }
+
+  private static TsBlock buildTsBlock(String device, int count) {
+    LongColumn timeColumn = new LongColumn(1, Optional.empty(), new long[] {0});
+    BinaryColumn deviceColumn =
+        new BinaryColumn(1, Optional.empty(), new Binary[] {new Binary(device.getBytes())});
+    LongColumn countColumn = new LongColumn(1, Optional.empty(), new long[] {count});
+    TsBlock tsBlock = new TsBlock(1, timeColumn, deviceColumn, countColumn);
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/AggregationMergeSortOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/AggregationMergeSortOperatorTest.java
@@ -48,9 +48,9 @@ import static org.junit.Assert.assertEquals;
 public class AggregationMergeSortOperatorTest {
 
   @Test
-  public void test() throws Exception {
+  public void deviceInTwoRegionTest() throws Exception {
     OperatorContext operatorContext =
-        new OperatorContext(1, new PlanNodeId("1"), "aaa", new DriverContext());
+        new OperatorContext(1, new PlanNodeId("1"), "test-type", new DriverContext());
     List<TSDataType> dataTypes = Arrays.asList(TSDataType.TEXT, TSDataType.INT64);
     List<Accumulator> accumulators = Collections.singletonList(new CountAccumulator());
 
@@ -75,10 +75,10 @@ public class AggregationMergeSortOperatorTest {
       if (block != null && block.getPositionCount() > 0) {
         if (cnt == 0) {
           assertEquals("d1", block.getColumn(0).getBinary(0).toString());
-          assertEquals(2, block.getColumn(1).getLong(0));
+          assertEquals(3, block.getColumn(1).getLong(0));
         } else {
           assertEquals("d2", block.getColumn(0).getBinary(0).toString());
-          assertEquals(1, block.getColumn(1).getLong(0));
+          assertEquals(5, block.getColumn(1).getLong(0));
         }
         cnt++;
       }
@@ -89,7 +89,7 @@ public class AggregationMergeSortOperatorTest {
 
     OperatorContext operatorContext;
 
-    int a = 0;
+    int invokeCount = 0;
 
     public MockDeviceViewOperator1(OperatorContext operatorContext) {
       this.operatorContext = operatorContext;
@@ -102,8 +102,8 @@ public class AggregationMergeSortOperatorTest {
 
     @Override
     public TsBlock next() throws Exception {
-      if (a == 0) {
-        a++;
+      if (invokeCount == 0) {
+        invokeCount++;
         return buildTsBlock("d1", 1);
       }
       return null;
@@ -111,7 +111,7 @@ public class AggregationMergeSortOperatorTest {
 
     @Override
     public boolean hasNext() throws Exception {
-      return a < 1;
+      return invokeCount < 1;
     }
 
     @Override
@@ -119,7 +119,7 @@ public class AggregationMergeSortOperatorTest {
 
     @Override
     public boolean isFinished() throws Exception {
-      return a < 1;
+      return invokeCount < 1;
     }
 
     @Override
@@ -151,21 +151,19 @@ public class AggregationMergeSortOperatorTest {
 
     @Override
     public TsBlock next() throws Exception {
-      if (a == 0) {
-
-        a++;
-        return buildTsBlock("d1", 1);
-      } else if (a == 1) {
-
-        a++;
-        return buildTsBlock("d2", 1);
+      if (invokeCount == 0) {
+        invokeCount++;
+        return buildTsBlock("d1", 2);
+      } else if (invokeCount == 1) {
+        invokeCount++;
+        return buildTsBlock("d2", 5);
       }
       return null;
     }
 
     @Override
     public boolean hasNext() throws Exception {
-      return a < 2;
+      return invokeCount < 2;
     }
   }
 
@@ -174,6 +172,6 @@ public class AggregationMergeSortOperatorTest {
     BinaryColumn deviceColumn =
         new BinaryColumn(1, Optional.empty(), new Binary[] {new Binary(device.getBytes())});
     LongColumn countColumn = new LongColumn(1, Optional.empty(), new long[] {count});
-    TsBlock tsBlock = new TsBlock(1, timeColumn, deviceColumn, countColumn);
+    return new TsBlock(1, timeColumn, deviceColumn, countColumn);
   }
 }


### PR DESCRIPTION
## Description

As the title, when one device locates in multi data regions, the query result may be wrong.

![image](https://github.com/user-attachments/assets/bd34a51c-9afc-44b2-ba0c-a250c66cbfb2)

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. 
- [x] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
