### PR TITLE
[To rc/1.3.3] [RatisConsensus] Bump ratis version to 3.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
       is for ensuring the SNAPSHOT will stay available. We should however have the Ratis folks do a
       new release soon, as releasing with this version is more than sub-ideal.
     -->
-        <ratis.version>3.1.1-0133c90-SNAPSHOT</ratis.version>
+        <ratis.version>3.1.1</ratis.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <reactor-netty.version>1.1.20</reactor-netty.version>
         <reactor.version>3.5.18</reactor.version>


### PR DESCRIPTION
cp from https://github.com/apache/iotdb/pull/13629