### PR TITLE
[To rc/1.3.3]Change the error infomation when insert a timestamp over Long.MaxValue && Fix potential NPE when write FileTimeIndexCache

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBDatetimeFormatIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBDatetimeFormatIT.java
@@ -128,5 +128,14 @@ public class IoTDBDatetimeFormatIT {
       e.printStackTrace();
       fail();
     }
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("insert into root.sg.d1(time,s2) values (16182830055860000000, 8.76);");
+      fail();
+    } catch (SQLException e) {
+      Assert.assertTrue(
+          e.getMessage()
+              .contains("please check whether the timestamp 16182830055860000000 is correct."));
+    }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/parser/ASTVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/parser/ASTVisitor.java
@@ -255,6 +255,7 @@ import java.util.stream.Collectors;
 import static org.apache.iotdb.commons.schema.SchemaConstant.ALL_RESULT_NODES;
 import static org.apache.iotdb.db.queryengine.plan.optimization.LimitOffsetPushDown.canPushDownLimitOffsetToGroupByTime;
 import static org.apache.iotdb.db.queryengine.plan.optimization.LimitOffsetPushDown.pushDownLimitOffsetToTimeParameter;
+import static org.apache.iotdb.db.utils.TimestampPrecisionUtils.TIMESTAMP_PRECISION;
 import static org.apache.iotdb.db.utils.TimestampPrecisionUtils.currPrecision;
 import static org.apache.iotdb.db.utils.constant.SqlConstant.CAST_FUNCTION;
 import static org.apache.iotdb.db.utils.constant.SqlConstant.CAST_TYPE;
@@ -1990,7 +1991,10 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
         return Long.parseLong(constant.INTEGER_LITERAL().getText());
       } catch (NumberFormatException e) {
         throw new SemanticException(
-            String.format("Can not parse %s to long value", constant.INTEGER_LITERAL().getText()));
+            String.format(
+                "Current system timestamp precision is %s, "
+                    + "please check whether the timestamp %s is correct.",
+                TIMESTAMP_PRECISION, constant.INTEGER_LITERAL().getText()));
       }
     } else if (constant.dateExpression() != null) {
       return parseDateExpression(constant.dateExpression(), CommonDateTimeUtils.currentTime());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/utils/fileTimeIndexCache/FileTimeIndexCacheWriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/utils/fileTimeIndexCache/FileTimeIndexCacheWriter.java
@@ -57,9 +57,11 @@ public class FileTimeIndexCacheWriter implements ILogWriter {
         // For UT env, logFile may not be created
         return;
       }
-      channel.write(logBuffer);
-      if (this.forceEachWrite) {
-        channel.force(true);
+      if (channel != null && channel.isOpen()) {
+        channel.write(logBuffer);
+        if (this.forceEachWrite) {
+          channel.force(true);
+        }
       }
     } catch (ClosedChannelException ignored) {
       logger.warn("someone interrupt current thread, so no need to do write for io safety");

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
@@ -1042,6 +1042,7 @@ expired_data_ratio=0.3
 timestamp_precision=ms
 
 # When the timestamp precision check is enabled, the timestamps those are over 13 digits for ms precision, or over 16 digits for us precision are not allowed to be inserted.
+# For all precisions, ms, us and ns, the timestamps cannot exceed the range of [-9223372036854775808, 9223372036854775807], regardless of whether the check is enabled or not.
 # effectiveMode: first_start
 # Datatype: Boolean
 timestamp_precision_check_enabled=true


### PR DESCRIPTION
## Description

cp 24d1191a8e7c7e05cf92c5261a6a8f44ed67d45a & 3c1eace43f0403cffa3916986638db8baa751034