### PR TITLE
Change database in SessionConnection while using db

### DIFF
--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -108,7 +108,7 @@ public class SessionConnection {
 
   private final String sqlDialect;
 
-  private final String database;
+  private String database;
 
   // ms is 1_000, us is 1_000_000, ns is 1_000_000_000
   private int timeFactor = 1_000;
@@ -520,7 +520,9 @@ public class SessionConnection {
     request.setStatementId(statementId);
     TSExecuteStatementResp resp = client.executeUpdateStatementV2(request);
     if (resp.isSetDatabase()) {
-      session.changeDatabase(resp.getDatabase());
+      String dbName = resp.getDatabase();
+      session.changeDatabase(dbName);
+      this.database = dbName;
     }
     return resp.status;
   }


### PR DESCRIPTION
While using `use XXX` in Session.executeNonQueryStatement, we should also update the database field in SessionConnection, because while retrying, we will reconnect to any node and then redo request which will use the local database field in SessionConnection.

So, we may see the following error msg in client if retrying phase happens.
![img_v3_02ff_5789ce5d-b736-4be1-828e-abf01b99f38g](https://github.com/user-attachments/assets/661e39ac-aab1-448d-b61b-2a04b8e9a567)
