### PR TITLE
Modify the exception thrown when the date conversion year overflows

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/builtinfunction/scalar/IoTDBCastFunctionTableSpecialIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/builtinfunction/scalar/IoTDBCastFunctionTableSpecialIT.java
@@ -19,6 +19,7 @@ import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.TableClusterIT;
 import org.apache.iotdb.itbase.category.TableLocalStandaloneIT;
 import org.apache.iotdb.itbase.env.BaseEnv;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/builtinfunction/scalar/IoTDBCastFunctionTableSpecialIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/builtinfunction/scalar/IoTDBCastFunctionTableSpecialIT.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iotdb.relational.it.query.old.builtinfunction.scalar;
+
+import org.apache.iotdb.it.env.EnvFactory;
+import org.apache.iotdb.it.framework.IoTDBTestRunner;
+import org.apache.iotdb.itbase.category.TableClusterIT;
+import org.apache.iotdb.itbase.category.TableLocalStandaloneIT;
+import org.apache.iotdb.itbase.env.BaseEnv;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.sql.Connection;
+import java.sql.Statement;
+
+import static org.apache.iotdb.db.it.utils.TestUtils.tableAssertTestFail;
+
+@RunWith(IoTDBTestRunner.class)
+@Category({TableLocalStandaloneIT.class, TableClusterIT.class})
+public class IoTDBCastFunctionTableSpecialIT {
+
+  private static final String DATABASE_NAME = "db";
+
+  private static final String[] SQLs =
+      new String[] {
+        "CREATE DATABASE " + DATABASE_NAME,
+        "USE " + DATABASE_NAME,
+        "create table special(device_id STRING ID, s1 DATE MEASUREMENT)",
+        "INSERT INTO special(time, device_id, s1) values(1, 'd1', '2262-04-13')",
+        "INSERT INTO special(time, device_id, s1) values(2, 'd1', '1677-09-21')",
+      };
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    EnvFactory.getEnv().getConfig().getCommonConfig().setTimestampPrecision("ns");
+    EnvFactory.getEnv().initClusterEnvironment();
+    insertData();
+  }
+
+  protected static void insertData() {
+    try (Connection connection = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
+        Statement statement = connection.createStatement()) {
+
+      for (String sql : SQLs) {
+        statement.execute(sql);
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  @Test
+  public void testTimestampOverflow() {
+    tableAssertTestFail(
+        "select cast(s1 as TIMESTAMP) from special where time = 1",
+        "750: Timestamp overflow",
+        DATABASE_NAME);
+
+    tableAssertTestFail(
+        "select cast(s1 as TIMESTAMP) from special where time = 2",
+        "750: Timestamp overflow",
+        DATABASE_NAME);
+  }
+}

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/query/IoTDBArithmeticTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/query/IoTDBArithmeticTableIT.java
@@ -69,6 +69,10 @@ public class IoTDBArithmeticTableIT {
     "insert into table1(device, time, s1, s2, s3, s4, s5, s6, s7, s8) values ('d1', 1, 1, 1, 1.0, 1.0, '2024-01-01', 10, true, 'test')",
     "insert into table1(device, time, s1, s2, s3, s4, s5, s6, s7, s8) values ('d1', 2, 2, 2, 2.0, 2.0, '2024-02-01', 20, true, 'test')",
     "insert into table1(device, time, s1, s2, s3, s4, s5, s6, s7, s8) values ('d1', 3, 3, 3, 3.0, 3.0, '2024-03-01', 30, true, 'test')",
+    "CREATE TABLE table2 (device STRING ID, int32 INT32 MEASUREMENT, int64 INT64 MEASUREMENT, date DATE MEASUREMENT)",
+    "insert into table2(device, time, int32, int64, date) values ('d1', 1, 2147483647, 9223372036854775807, '9999-12-31')",
+    "insert into table2(device, time, int32, int64, date) values ('d1', 2, -2147483648, -9223372036854775808, '1000-01-01')",
+    "insert into table2(device, time, int32, date) values ('d1', 3, 86400000, '9999-12-31')",
   };
 
   @BeforeClass
@@ -291,6 +295,8 @@ public class IoTDBArithmeticTableIT {
         String.format("select s6-(%d) from table1", Long.MIN_VALUE),
         "750: long Subtraction overflow",
         "test");
+
+    tableAssertTestFail("select date + int32 from table2 where time = 1", "752", "test");
   }
 
   @Test

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TSStatusCode.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TSStatusCode.java
@@ -136,6 +136,7 @@ public enum TSStatusCode {
   // Arithmetic
   NUMERIC_VALUE_OUT_OF_RANGE(750),
   DIVISION_BY_ZERO(751),
+  DATE_OUT_OF_RANGE(752),
 
   // Authentication
   INIT_AUTH_ERROR(800),

--- a/iotdb-core/datanode/src/main/codegen/templates/ArithmeticBinaryColumnTransformer.ftl
+++ b/iotdb-core/datanode/src/main/codegen/templates/ArithmeticBinaryColumnTransformer.ftl
@@ -147,6 +147,11 @@ public class ${className} extends BinaryColumnTransformer {
           String.format("long ${operator.name} overflow: %s - %s", left, right),
           NUMERIC_VALUE_OUT_OF_RANGE.getStatusCode(),
           true);
+    }catch (DateTimeParseException e) {
+      throw new IoTDBRuntimeException(
+          "Year must be between 1000 and 9999.",
+          DATE_OUT_OF_RANGE.getStatusCode(),
+          true);
     }
     <#else>
     <#--Timestamp - int || Timestamp - long-->

--- a/iotdb-core/datanode/src/main/codegen/templates/ArithmeticBinaryColumnTransformer.ftl
+++ b/iotdb-core/datanode/src/main/codegen/templates/ArithmeticBinaryColumnTransformer.ftl
@@ -42,6 +42,11 @@ import org.apache.tsfile.utils.DateUtils;
 
 import java.time.ZoneId;
 
+<#if first.instance == "DATE">
+import java.time.format.DateTimeParseException;
+
+import static org.apache.iotdb.rpc.TSStatusCode.DATE_OUT_OF_RANGE;
+</#if>
 <#if first.dataType == "int" || second.dataType == "int" || first.dataType == "long" || second.dataType == "long">
 import static org.apache.iotdb.rpc.TSStatusCode.NUMERIC_VALUE_OUT_OF_RANGE;
 </#if>
@@ -103,10 +108,21 @@ public class ${className} extends BinaryColumnTransformer {
     <#if first.instance == "DATE">
     <#--Date + int || Date + long-->
     try{
-      long timestamp = Math.addExact(DateTimeUtils.correctPrecision(DateUtils.parseIntToTimestamp(left,zoneId)), right);
-      return DateUtils.parseDateExpressionToInt(DateTimeUtils.convertToLocalDate(timestamp, zoneId));
+      long timestamp =
+          Math.addExact(
+              DateTimeUtils.correctPrecision(DateUtils.parseIntToTimestamp(left,zoneId)), right);
+      return DateUtils.parseDateExpressionToInt(
+          DateTimeUtils.convertToLocalDate(timestamp, zoneId));
     }catch (ArithmeticException e){
-      throw new IoTDBRuntimeException(String.format("long ${operator.name} overflow: %s + %s", left, right),NUMERIC_VALUE_OUT_OF_RANGE.getStatusCode(),true);
+      throw new IoTDBRuntimeException(
+          String.format("long ${operator.name} overflow: %s + %s", left, right),
+          NUMERIC_VALUE_OUT_OF_RANGE.getStatusCode(),
+          true);
+    }catch (DateTimeParseException e) {
+      throw new IoTDBRuntimeException(
+          "Year must be between 1000 and 9999.",
+          DATE_OUT_OF_RANGE.getStatusCode(),
+          true);
     }
     <#else>
     <#--Timestamp + int || Timestamp + long-->
@@ -121,17 +137,26 @@ public class ${className} extends BinaryColumnTransformer {
     <#if first.instance == "DATE">
     <#--Date - int || Date - long-->
     try{
-      long timestamp = Math.subtractExact(DateTimeUtils.correctPrecision(DateUtils.parseIntToTimestamp(left, zoneId)), right);
-      return DateUtils.parseDateExpressionToInt(DateTimeUtils.convertToLocalDate(timestamp, zoneId));
+      long timestamp =
+          Math.subtractExact(
+              DateTimeUtils.correctPrecision(DateUtils.parseIntToTimestamp(left, zoneId)), right);
+      return DateUtils.parseDateExpressionToInt(
+          DateTimeUtils.convertToLocalDate(timestamp, zoneId));
     }catch (ArithmeticException e){
-      throw new IoTDBRuntimeException(String.format("long ${operator.name} overflow: %s - %s", left, right),NUMERIC_VALUE_OUT_OF_RANGE.getStatusCode(),true);
+      throw new IoTDBRuntimeException(
+          String.format("long ${operator.name} overflow: %s - %s", left, right),
+          NUMERIC_VALUE_OUT_OF_RANGE.getStatusCode(),
+          true);
     }
     <#else>
     <#--Timestamp - int || Timestamp - long-->
     try{
       return Math.subtractExact(left, right);
     }catch (ArithmeticException e){
-      throw new IoTDBRuntimeException(String.format("long ${operator.name} overflow: %s - %s", left, right),NUMERIC_VALUE_OUT_OF_RANGE.getStatusCode(),true);
+      throw new IoTDBRuntimeException(
+          String.format("long ${operator.name} overflow: %s - %s", left, right),
+          NUMERIC_VALUE_OUT_OF_RANGE.getStatusCode(),
+          true);
     }
     </#if>
     <#break>
@@ -217,13 +242,19 @@ public class ${className} extends BinaryColumnTransformer {
       long timestamp = Math.addExact(left,DateTimeUtils.correctPrecision(DateUtils.parseIntToTimestamp(right, zoneId)));
       return DateUtils.parseDateExpressionToInt(DateTimeUtils.convertToLocalDate(timestamp, zoneId));
     }catch (ArithmeticException e){
-      throw new IoTDBRuntimeException(String.format("long ${operator.name} overflow: %s + %s", left, right),NUMERIC_VALUE_OUT_OF_RANGE.getStatusCode(),true);
+      throw new IoTDBRuntimeException(
+          String.format("long ${operator.name} overflow: %s + %s", left, right),
+          NUMERIC_VALUE_OUT_OF_RANGE.getStatusCode(),
+          true);
     }
     <#else>
     try{
       return Math.addExact(left, right);
     }catch (ArithmeticException e){
-      throw new IoTDBRuntimeException(String.format("long ${operator.name} overflow: %s + %s", left, right),NUMERIC_VALUE_OUT_OF_RANGE.getStatusCode(),true);
+      throw new IoTDBRuntimeException(
+          String.format("long ${operator.name} overflow: %s + %s", left, right),
+          NUMERIC_VALUE_OUT_OF_RANGE.getStatusCode(),
+          true);
     }
     </#if>
   }
@@ -314,27 +345,39 @@ public class ${className} extends BinaryColumnTransformer {
     try{
       return Math.addExact(left, right);
     }catch (ArithmeticException e){
-      throw new IoTDBRuntimeException(String.format("${resultType} ${operator.name} overflow: %s + %s", left, right),NUMERIC_VALUE_OUT_OF_RANGE.getStatusCode(),false);
+      throw new IoTDBRuntimeException(
+          String.format("${resultType} ${operator.name} overflow: %s + %s", left, right),
+          NUMERIC_VALUE_OUT_OF_RANGE.getStatusCode(),
+          false);
     }
     <#break>
     <#case "Subtraction">
     try{
       return Math.subtractExact(left, right);
     }catch (ArithmeticException e){
-      throw new IoTDBRuntimeException(String.format("${resultType} ${operator.name} overflow: %s - %s", left, right),NUMERIC_VALUE_OUT_OF_RANGE.getStatusCode(),false);
+      throw new IoTDBRuntimeException(
+          String.format("${resultType} ${operator.name} overflow: %s - %s", left, right),
+          NUMERIC_VALUE_OUT_OF_RANGE.getStatusCode(),
+          false);
     }
     <#break>
     <#case "Multiplication">
     try{
       return Math.multiplyExact(left, right);
     }catch (ArithmeticException e){
-      throw new IoTDBRuntimeException(String.format("${resultType} ${operator.name} overflow: %s * %s", left, right),NUMERIC_VALUE_OUT_OF_RANGE.getStatusCode(),true);
+      throw new IoTDBRuntimeException(
+          String.format("${resultType} ${operator.name} overflow: %s * %s", left, right),
+          NUMERIC_VALUE_OUT_OF_RANGE.getStatusCode(),
+          true);
     }
     <#break>
     <#case "Division">
     try{
       if (left == <#if first.dataType == "int">Integer.MIN_VALUE<#elseif first.dataType == "long">Long.MIN_VALUE</#if> && right == -1) {
-        throw new IoTDBRuntimeException(String.format("${resultType} overflow: %s / %s", left, right),NUMERIC_VALUE_OUT_OF_RANGE.getStatusCode(),true);
+        throw new IoTDBRuntimeException(
+          String.format("${resultType} overflow: %s / %s", left, right),
+          NUMERIC_VALUE_OUT_OF_RANGE.getStatusCode(),
+          true);
       }
       return left / right;
     }catch (ArithmeticException e){

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/DateTimeUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/DateTimeUtils.java
@@ -76,7 +76,6 @@ public class DateTimeUtils {
           return millis;
       }
     } catch (ArithmeticException e) {
-      long temp = 1728574910450000000L;
       throw new IoTDBRuntimeException(
           String.format(
               "Timestamp overflow, Millisecond: %s , Timestamp precision: %s",

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/DateTimeUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/DateTimeUtils.java
@@ -19,6 +19,7 @@
 package org.apache.iotdb.db.utils;
 
 import org.apache.iotdb.commons.conf.CommonDescriptor;
+import org.apache.iotdb.commons.exception.IoTDBRuntimeException;
 import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.db.protocol.session.SessionManager;
 import org.apache.iotdb.db.qp.sql.IoTDBSqlParser;
@@ -49,6 +50,8 @@ import java.util.Calendar;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
+import static org.apache.iotdb.rpc.TSStatusCode.NUMERIC_VALUE_OUT_OF_RANGE;
+
 public class DateTimeUtils {
 
   private DateTimeUtils() {
@@ -59,17 +62,27 @@ public class DateTimeUtils {
       CommonDescriptor.getInstance().getConfig().getTimestampPrecision();
 
   public static long correctPrecision(long millis) {
-    switch (TIMESTAMP_PRECISION) {
-      case "us":
-      case "microsecond":
-        return millis * 1_000L;
-      case "ns":
-      case "nanosecond":
-        return millis * 1_000_000L;
-      case "ms":
-      case "millisecond":
-      default:
-        return millis;
+    try {
+      switch (TIMESTAMP_PRECISION) {
+        case "us":
+        case "microsecond":
+          return Math.multiplyExact(millis, 1_000L);
+        case "ns":
+        case "nanosecond":
+          return Math.multiplyExact(millis, 1_000_000L);
+        case "ms":
+        case "millisecond":
+        default:
+          return millis;
+      }
+    } catch (ArithmeticException e) {
+      long temp = 1728574910450000000L;
+      throw new IoTDBRuntimeException(
+          String.format(
+              "Timestamp overflow, Millisecond: %s , Timestamp precision: %s",
+              millis, TIMESTAMP_PRECISION),
+          NUMERIC_VALUE_OUT_OF_RANGE.getStatusCode(),
+          true);
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/ErrorHandlingUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/ErrorHandlingUtils.java
@@ -106,7 +106,8 @@ public class ErrorHandlingUtils {
             || status.getCode() == TSStatusCode.NO_PERMISSION.getStatusCode()
             || status.getCode() == TSStatusCode.ILLEGAL_PATH.getStatusCode()
             || status.getCode() == TSStatusCode.NUMERIC_VALUE_OUT_OF_RANGE.getStatusCode()
-            || status.getCode() == TSStatusCode.DIVISION_BY_ZERO.getStatusCode()) {
+            || status.getCode() == TSStatusCode.DIVISION_BY_ZERO.getStatusCode()
+            || status.getCode() == TSStatusCode.DATE_OUT_OF_RANGE.getStatusCode()) {
           LOGGER.warn(message);
         } else {
           LOGGER.warn(message, e);


### PR DESCRIPTION
This pull request introduces several changes to enhance arithmetic operations in the IoTDB project, particularly focusing on handling date arithmetic and overflow scenarios. The key updates include adding a new status code for date out-of-range errors, updating test cases to cover these scenarios, and refining the error handling logic.

### Enhancements to Arithmetic Operations:

* [`iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TSStatusCode.java`](diffhunk://#diff-02b6f3f950aa3c87eed0b5ec88c3f8724e2b5fbc2c92d897512986f620ec5bd7R139): Added a new status code `DATE_OUT_OF_RANGE` to handle date-related errors.

### Test Case Updates:

* [`integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/query/IoTDBArithmeticTableIT.java`](diffhunk://#diff-908fd9921b253d5bad61a0f1e2389379172b0031b3c541be95a08fe2645848f7R72-R75): Added new test cases for date arithmetic operations and overflow scenarios. [[1]](diffhunk://#diff-908fd9921b253d5bad61a0f1e2389379172b0031b3c541be95a08fe2645848f7R72-R75) [[2]](diffhunk://#diff-908fd9921b253d5bad61a0f1e2389379172b0031b3c541be95a08fe2645848f7R298-R299)

### Error Handling Improvements:

* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/ErrorHandlingUtils.java`](diffhunk://#diff-7f6166a8f1581ee65b7d661a090b3d223876333b1a5e7e70ee3df545c16f9809L109-R110): Updated the error handling logic to include the new `DATE_OUT_OF_RANGE` status code.

### Code Generation Templates:

* [`iotdb-core/datanode/src/main/codegen/templates/ArithmeticBinaryColumnTransformer.ftl`](diffhunk://#diff-9cd2377fe278d6e4ebe464a12c9b88e50281580fcc974a1fcae71319cd295a89R45-R49): Enhanced the arithmetic binary column transformer to handle date arithmetic and overflow scenarios more robustly, including catching `DateTimeParseException` and throwing a new `IoTDBRuntimeException` for date out-of-range errors.
