### PR TITLE
Fix exception when casewhen function meets two conditions

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/query/IoTDBCaseWhenThenIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/query/IoTDBCaseWhenThenIT.java
@@ -887,4 +887,24 @@ public class IoTDBCaseWhenThenIT {
         };
     resultSetEqualTest(sql, expectedHeader, retArray);
   }
+
+  @Test
+  public void testMultipleSatisfyCase() {
+    // Test the result when two when clause are satisfied
+    String sql =
+        "select case when s3 < 20 or s4 > 60 then \"just so so~~~\" when s3 > 20 or s4 < 60 then \"very well~~~\" end from root.sg.d2";
+    String[] expectedHeader =
+        new String[] {
+          TIMESTAMP_STR,
+          "CASE WHEN root.sg.d2.s3 < 20 | root.sg.d2.s4 > 60 THEN \"just so so~~~\" WHEN root.sg.d2.s3 > 20 | root.sg.d2.s4 < 60 THEN \"very well~~~\" END"
+        };
+    String[] retArray =
+        new String[] {
+          "0,just so so~~~,",
+          "1000000,just so so~~~,",
+          "20000000,just so so~~~,",
+          "210000000,just so so~~~,",
+        };
+    resultSetEqualTest(sql, expectedHeader, retArray);
+  }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/builtinfunction/scalar/IoTDBCastFunctionTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/builtinfunction/scalar/IoTDBCastFunctionTableIT.java
@@ -35,6 +35,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+import static org.apache.iotdb.db.it.utils.TestUtils.tableAssertTestFail;
 import static org.apache.iotdb.db.it.utils.TestUtils.tableResultSetEqualTest;
 import static org.apache.iotdb.itbase.constant.TestConstant.TIMESTAMP_STR;
 import static org.junit.Assert.fail;
@@ -93,6 +94,12 @@ public class IoTDBCastFunctionTableIT {
         "INSERT INTO special(Time, device_id ,s6) values(2, 'd1', '1.1')",
         "INSERT INTO special(Time, device_id ,s6) values(3, 'd1', '4e60')",
         "INSERT INTO special(Time, device_id ,s6) values(4, 'd1', '4e60000')",
+        "flush",
+
+        // special cases for date and timestamp
+        "create table dateType(device_id STRING ID, s1 DATE MEASUREMENT, s2 TIMESTAMP MEASUREMENT)",
+        "INSERT INTO dateType(Time,device_id, s1, s2) values(1,'d1', '9999-12-31', 253402300800)",
+        "INSERT INTO dateType(Time,device_id, s1, s2) values(1,'d1', '1000-01-01', -30610310400)",
       };
 
   @BeforeClass
@@ -774,6 +781,13 @@ public class IoTDBCastFunctionTableIT {
       e.printStackTrace();
       fail();
     }
+  }
+
+  @Test
+  public void testDateOutOfRange() {
+    tableAssertTestFail("select CAST(s1 + AS TIMESTAMP) from dateType", "752", DATABASE_NAME);
+
+    tableAssertTestFail("select CAST(s2 AS DATE) from dateType", "752", DATABASE_NAME);
   }
 
   // endregion

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/builtinfunction/scalar/IoTDBCastFunctionTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/builtinfunction/scalar/IoTDBCastFunctionTableIT.java
@@ -35,7 +35,6 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-import static org.apache.iotdb.db.it.utils.TestUtils.tableAssertTestFail;
 import static org.apache.iotdb.db.it.utils.TestUtils.tableResultSetEqualTest;
 import static org.apache.iotdb.itbase.constant.TestConstant.TIMESTAMP_STR;
 import static org.junit.Assert.fail;
@@ -94,12 +93,6 @@ public class IoTDBCastFunctionTableIT {
         "INSERT INTO special(Time, device_id ,s6) values(2, 'd1', '1.1')",
         "INSERT INTO special(Time, device_id ,s6) values(3, 'd1', '4e60')",
         "INSERT INTO special(Time, device_id ,s6) values(4, 'd1', '4e60000')",
-        "flush",
-
-        // special cases for date and timestamp
-        "create table dateType(device_id STRING ID, s1 DATE MEASUREMENT, s2 TIMESTAMP MEASUREMENT)",
-        "INSERT INTO dateType(Time,device_id, s1, s2) values(1,'d1', '9999-12-31', 253402300800)",
-        "INSERT INTO dateType(Time,device_id, s1, s2) values(1,'d1', '1000-01-01', -30610310400)",
       };
 
   @BeforeClass
@@ -781,13 +774,6 @@ public class IoTDBCastFunctionTableIT {
       e.printStackTrace();
       fail();
     }
-  }
-
-  @Test
-  public void testDateOutOfRange() {
-    tableAssertTestFail("select CAST(s1 + AS TIMESTAMP) from dateType", "752", DATABASE_NAME);
-
-    tableAssertTestFail("select CAST(s2 AS DATE) from dateType", "752", DATABASE_NAME);
   }
 
   // endregion

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/AbstractCaseWhenThenColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/AbstractCaseWhenThenColumnTransformer.java
@@ -55,15 +55,92 @@ public abstract class AbstractCaseWhenThenColumnTransformer extends ColumnTransf
 
   @Override
   public void evaluate() {
-    int[] branchIndexForEachRow = new int[elseTransformer.getColumnCachePositionCount()];
+
+    List<Column> thenColumnList = new ArrayList<>();
+
+    // region evaluate first when
+    ColumnTransformer firstWhenColumnTransformer = whenThenTransformers.get(0).left;
+    firstWhenColumnTransformer.evaluate();
+    Column firstWhenColumn = firstWhenColumnTransformer.getColumn();
+
+    int positionCount = firstWhenColumn.getPositionCount();
+    boolean[] selection = new boolean[positionCount];
+    Arrays.fill(selection, true);
+
+    int[] branchIndexForEachRow = new int[positionCount];
     Arrays.fill(branchIndexForEachRow, -1);
 
-    doTransform(branchIndexForEachRow);
+    boolean[] selectionForThen = selection.clone();
+
+    // 根据第一个 whenColumn更新 branchIndexForEachRow
+    for (int i = 0; i < positionCount; i++) {
+      // 当前行没有匹配的 whenTransformer 时，才更新 selectionForThen 和 branchIndexForEachRow
+      if (branchIndexForEachRow[i] == -1) {
+        if (!firstWhenColumn.isNull(i) && firstWhenColumn.getBoolean(i)) {
+          branchIndexForEachRow[i] = 0;
+          selectionForThen[i] = true;
+        } else {
+          selectionForThen[i] = false;
+        }
+      }
+    }
+
+    ColumnTransformer firstThenColumnTransformer = whenThenTransformers.get(0).right;
+    firstThenColumnTransformer.evaluateWithSelection(selectionForThen);
+    Column firstThenColumn = firstThenColumnTransformer.getColumn();
+    thenColumnList.add(firstThenColumn);
+
+    // endregion
+
+    // when and then columns
+    for (int i = 1; i < whenThenTransformers.size(); i++) {
+      ColumnTransformer whenColumnTransformer = whenThenTransformers.get(i).left;
+      whenColumnTransformer.evaluateWithSelection(selection);
+      Column whenColumn = whenColumnTransformer.getColumn();
+
+      selectionForThen = selection.clone();
+
+      // 初始化 selectionForThen
+      for (int j = 0; j < positionCount; j++) {
+        if (branchIndexForEachRow[j] == -1
+            || branchIndexForEachRow[j] == whenThenTransformers.size()) {
+          selectionForThen[j] = false;
+        }
+      }
+
+      // 根据第一个 whenColumn更新 branchIndexForEachRow
+      for (int j = 0; j < positionCount; j++) {
+        // 当前行没有匹配的 whenTransformer 时，才更新 selectionForThen 和 branchIndexForEachRow
+        if (branchIndexForEachRow[j] == -1) {
+          if (!whenColumn.isNull(j) && whenColumn.getBoolean(j)) {
+            branchIndexForEachRow[j] = i;
+            selectionForThen[j] = true;
+          } else {
+            selectionForThen[j] = false;
+          }
+        }
+      }
+
+      ColumnTransformer thenColumnTransformer = whenThenTransformers.get(i).right;
+      thenColumnTransformer.evaluateWithSelection(selectionForThen);
+      Column thenColumn = thenColumnTransformer.getColumn();
+      thenColumnList.add(thenColumn);
+    }
+
+    // elseColumn
+    doTransform(branchIndexForEachRow, positionCount, thenColumnList);
   }
 
   @Override
   public void evaluateWithSelection(boolean[] selection) {
+
+    // region initialize branchIndexForEachRow.
+    // branchIndexForEachRow indicates the index of the WhenTransformer matched by each row.
     int[] branchIndexForEachRow = new int[selection.length];
+    // positionCount indicates the length of column
+    int positionCount = selection.length;
+
+    // 赋值为-1表示需要进行求值，否则表示不需要进行求值
     for (int i = 0; i < selection.length; i++) {
       if (selection[i]) {
         branchIndexForEachRow[i] = -1;
@@ -71,93 +148,91 @@ public abstract class AbstractCaseWhenThenColumnTransformer extends ColumnTransf
         branchIndexForEachRow[i] = whenThenTransformers.size();
       }
     }
-    doTransform(branchIndexForEachRow);
-  }
+    // endregion
 
-  private void doTransform(int[] branch) {
-    int[] branchIndexForEachRow = null;
     List<Column> thenColumnList = new ArrayList<>();
 
     // when and then columns
     for (int i = 0; i < whenThenTransformers.size(); i++) {
       ColumnTransformer whenColumnTransformer = whenThenTransformers.get(i).left;
-      whenColumnTransformer.tryEvaluate();
+      whenColumnTransformer.evaluateWithSelection(selection);
       Column whenColumn = whenColumnTransformer.getColumn();
 
-      int positionCount = whenColumn.getPositionCount();
-      boolean[] selection = new boolean[positionCount];
+      boolean[] selectionForThen = selection.clone();
 
-      if (branchIndexForEachRow == null) {
-        // init branchIndexForEachRow if it is null
-        branchIndexForEachRow = new int[positionCount];
-        Arrays.fill(branchIndexForEachRow, -1);
-      } else {
-        // update selection with branchIndexForEachRow
-        for (int j = 0; j < branchIndexForEachRow.length; j++) {
-          if (branchIndexForEachRow[j] != -1) {
-            selection[j] = true;
-          }
+      // 初始化 selectionForThen
+      for (int j = 0; j < positionCount; j++) {
+        if (branchIndexForEachRow[j] == -1
+            || branchIndexForEachRow[j] == whenThenTransformers.size()) {
+          selectionForThen[j] = false;
         }
       }
 
+      // 根据第一个 whenColumn更新 branchIndexForEachRow
       for (int j = 0; j < positionCount; j++) {
+        // 当前行没有匹配的 whenTransformer 时，才更新 selectionForThen 和 branchIndexForEachRow
         if (branchIndexForEachRow[j] == -1) {
+          // 满足第 i 个 when 条件
           if (!whenColumn.isNull(j) && whenColumn.getBoolean(j)) {
             branchIndexForEachRow[j] = i;
-            selection[j] = true;
+            selectionForThen[j] = true;
           } else {
-            selection[j] = false;
+            selectionForThen[j] = false;
           }
         }
       }
 
       ColumnTransformer thenColumnTransformer = whenThenTransformers.get(i).right;
-      thenColumnTransformer.evaluateWithSelection(selection);
+      thenColumnTransformer.evaluateWithSelection(selectionForThen);
       Column thenColumn = thenColumnTransformer.getColumn();
       thenColumnList.add(thenColumn);
     }
 
     // elseColumn
-    if (branchIndexForEachRow != null) {
-      int positionCount = branchIndexForEachRow.length;
-      boolean[] selectionForElse = new boolean[positionCount];
-      for (int i = 0; i < branchIndexForEachRow.length; i++) {
-        if (branchIndexForEachRow[i] == -1) {
-          selectionForElse[i] = true;
-        }
+    // when selectionForElse[i] is false represent the rows that do not need to evaluate
+    doTransform(branchIndexForEachRow, positionCount, thenColumnList);
+  }
+
+  private void doTransform(
+      int[] branchIndexForEachRow, int positionCount, List<Column> thenColumnList) {
+    boolean[] selectionForElse = new boolean[positionCount];
+    for (int i = 0; i < branchIndexForEachRow.length; i++) {
+      if (branchIndexForEachRow[i] == -1) {
+        selectionForElse[i] = true;
       }
-      elseTransformer.evaluateWithSelection(selectionForElse);
+    }
+    elseTransformer.evaluateWithSelection(selectionForElse);
 
-      ColumnBuilder builder = returnType.createColumnBuilder(positionCount);
-      Column elseColumn = elseTransformer.getColumn();
+    ColumnBuilder builder = returnType.createColumnBuilder(positionCount);
+    Column elseColumn = elseTransformer.getColumn();
 
-      for (int i = 0; i < positionCount; i++) {
-        Column resultColumn = null;
-        if (branchIndexForEachRow[i] == -1) {
-          resultColumn = elseColumn;
-        } else if (branchIndexForEachRow[i] < whenThenTransformers.size()) {
-          resultColumn = thenColumnList.get(branchIndexForEachRow[i]);
-        }
-
-        if (resultColumn == null || resultColumn.isNull(i)) {
-          builder.appendNull();
-        } else {
-          writeToColumnBuilder(
-              branchIndexForEachRow[i] == -1
-                  ? elseTransformer.getType()
-                  : whenThenTransformers.get(branchIndexForEachRow[i]).right.getType(),
-              resultColumn,
-              i,
-              builder);
-        }
+    for (int i = 0; i < positionCount; i++) {
+      Column resultColumn = null;
+      if (branchIndexForEachRow[i] == -1) {
+        resultColumn = elseColumn;
+      } else if (branchIndexForEachRow[i] < whenThenTransformers.size()) {
+        resultColumn = thenColumnList.get(branchIndexForEachRow[i]);
       }
 
-      initializeColumnCache(builder.build());
-      for (Pair<ColumnTransformer, ColumnTransformer> whenThenColumnTransformer :
-          whenThenTransformers) {
-        whenThenColumnTransformer.left.clearCache();
-        whenThenColumnTransformer.right.clearCache();
+      if (resultColumn == null || resultColumn.isNull(i)) {
+        builder.appendNull();
+      } else {
+        writeToColumnBuilder(
+            branchIndexForEachRow[i] == -1
+                ? elseTransformer.getType()
+                : whenThenTransformers.get(branchIndexForEachRow[i]).right.getType(),
+            resultColumn,
+            i,
+            builder);
       }
+    }
+
+    initializeColumnCache(builder.build());
+    for (Pair<ColumnTransformer, ColumnTransformer> whenThenColumnTransformer :
+        whenThenTransformers) {
+      whenThenColumnTransformer.left.clearCache();
+      whenThenColumnTransformer.right.clearCache();
+      elseTransformer.clearCache();
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/AbstractCaseWhenThenColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/AbstractCaseWhenThenColumnTransformer.java
@@ -72,9 +72,10 @@ public abstract class AbstractCaseWhenThenColumnTransformer extends ColumnTransf
 
     boolean[] selectionForThen = selection.clone();
 
-    // 根据第一个 whenColumn更新 branchIndexForEachRow
+    // Update branchIndexForEachRow based on first whenColumn
     for (int i = 0; i < positionCount; i++) {
-      // 当前行没有匹配的 whenTransformer 时，才更新 selectionForThen 和 branchIndexForEachRow
+      // Update selectionForThen and branchIndexForEachRow when there is no matching whenTransformer
+      // for the current row.
       if (branchIndexForEachRow[i] == -1) {
         if (!firstWhenColumn.isNull(i) && firstWhenColumn.getBoolean(i)) {
           branchIndexForEachRow[i] = 0;
@@ -132,7 +133,8 @@ public abstract class AbstractCaseWhenThenColumnTransformer extends ColumnTransf
     int positionCount = selection.length;
     boolean[] selectionForWhen = selection.clone();
 
-    // 赋值为-1表示需要进行求值，否则表示不需要进行求值
+    // An assignment of -1 means that evaluation is required, otherwise it means that evaluation is
+    // not required.
     for (int i = 0; i < selection.length; i++) {
       if (selection[i]) {
         branchIndexForEachRow[i] = -1;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/AbstractCaseWhenThenColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/AbstractCaseWhenThenColumnTransformer.java
@@ -101,11 +101,13 @@ public abstract class AbstractCaseWhenThenColumnTransformer extends ColumnTransf
       }
 
       for (int j = 0; j < positionCount; j++) {
-        if (!whenColumn.isNull(j) && whenColumn.getBoolean(j)) {
-          branchIndexForEachRow[j] = i;
-          selection[j] = true;
-        } else {
-          selection[j] = false;
+        if (branchIndexForEachRow[j] == -1) {
+          if (!whenColumn.isNull(j) && whenColumn.getBoolean(j)) {
+            branchIndexForEachRow[j] = i;
+            selection[j] = true;
+          } else {
+            selection[j] = false;
+          }
         }
       }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/leaf/TimeColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/leaf/TimeColumnTransformer.java
@@ -46,5 +46,6 @@ public class TimeColumnTransformer extends LeafColumnTransformer {
         builder.write(timeColumn, i);
       }
     }
+    initializeColumnCache(builder.build());
   }
 }


### PR DESCRIPTION
This pull request introduces a new test case and improves the logic for handling `CASE WHEN` transformations. The most important changes include adding a new test to verify multiple `WHEN` clause satisfaction and enhancing the transformation logic to handle uninitialized branches.

### New Test Case:
* [`integration-test/src/test/java/org/apache/iotdb/db/it/query/IoTDBCaseWhenThenIT.java`](diffhunk://#diff-17d68169af2e9f080b744801580ee66a28ac479b71c49a745460b932f0af5464R890-R909): Added a new test method `testMultipleSatisfyCase` to verify the behavior when multiple `WHEN` clauses are satisfied.

### Transformation Logic Improvement:
* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/AbstractCaseWhenThenColumnTransformer.java`](diffhunk://#diff-1cea02ca1c6972693f34174ef72701635fa40779c9ec54c328924d5ca4ef95b3R104-R112): Updated the `doTransform` method to include a check for uninitialized branches (`branchIndexForEachRow[j] == -1`).