### PR TITLE
Fix Remove static from variables in DateBin function.

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/unary/scalar/DateBinFunctionColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/unary/scalar/DateBinFunctionColumnTransformer.java
@@ -34,10 +34,10 @@ public class DateBinFunctionColumnTransformer extends UnaryColumnTransformer {
   private static final long NANOSECONDS_IN_MILLISECOND = 1_000_000;
   private static final long NANOSECONDS_IN_MICROSECOND = 1_000;
 
-  private static long monthDuration;
-  private static long nonMonthDuration;
-  private static long origin;
-  private static ZoneId zoneId;
+  private long monthDuration;
+  private long nonMonthDuration;
+  private long origin;
+  private ZoneId zoneId;
 
   public DateBinFunctionColumnTransformer(
       Type returnType,


### PR DESCRIPTION
This pull request includes changes to the `DateBinFunctionColumnTransformer` class to improve its design and functionality. The most important change is the modification of several static fields to instance fields, which enhances the flexibility and thread-safety of the class.

Design and functionality improvements:

* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/unary/scalar/DateBinFunctionColumnTransformer.java`](diffhunk://#diff-6305624a6309fe575824478b8010ec68c38ebb22f777661699ef252c89f378b0L37-R40): Changed `monthDuration`, `nonMonthDuration`, `origin`, and `zoneId` from static fields to instance fields.