### PR TITLE
[To rc/1.3.3] Fix division by zero when querying only ID and attribute columns in table model

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/AbstractOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/AbstractOperator.java
@@ -40,9 +40,12 @@ public abstract class AbstractOperator implements Operator {
     if (maxTupleSizeOfTsBlock != -1) {
       return;
     }
+    // oneTupleSize should be greater than 0 to avoid division by zero
     long oneTupleSize =
-        (tsBlock.getRetainedSizeInBytes() - tsBlock.getTotalInstanceSize())
-            / tsBlock.getPositionCount();
+        Math.max(
+            1,
+            (tsBlock.getRetainedSizeInBytes() - tsBlock.getTotalInstanceSize())
+                / tsBlock.getPositionCount());
     if (oneTupleSize > maxReturnSize) {
       // make sure at least one-tuple-at-a-time
       this.maxTupleSizeOfTsBlock = 1;


### PR DESCRIPTION
cp from https://github.com/apache/iotdb/pull/13707