### PR TITLE
[Py-client] Fix dataset contains null value contract error 

### DIFF
--- a/.github/workflows/multi-language-client.yml
+++ b/.github/workflows/multi-language-client.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - master
       - "rc/*"
-      - fix_py_query
     paths:
       - 'pom.xml'
       - 'iotdb-client/pom.xml'

--- a/.github/workflows/multi-language-client.yml
+++ b/.github/workflows/multi-language-client.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - "rc/*"
+      - fix_py_query
     paths:
       - 'pom.xml'
       - 'iotdb-client/pom.xml'

--- a/iotdb-client/client-py/iotdb/utils/IoTDBRpcDataSet.py
+++ b/iotdb-client/client-py/iotdb/utils/IoTDBRpcDataSet.py
@@ -216,17 +216,7 @@ class IoTDBRpcDataSet(object):
                     data_array.dtype.newbyteorder("<")
                 )
             if len(data_array) < total_length:
-                # INT32, INT64, BOOLEAN, TIMESTAMP, DATE
-                if (
-                    data_type == 0
-                    or data_type == 1
-                    or data_type == 2
-                    or data_type == 8
-                    or data_type == 9
-                ):
-                    tmp_array = np.full(total_length, np.nan, np.float32)
-                else:
-                    tmp_array = np.full(total_length, None, dtype=object)
+                tmp_array = np.full(total_length, None, dtype=object)
 
                 bitmap_buffer = self.__query_data_set.bitmapList[location]
                 buffer = _to_bitbuffer(bitmap_buffer)

--- a/iotdb-client/client-py/iotdb/utils/IoTDBRpcDataSet.py
+++ b/iotdb-client/client-py/iotdb/utils/IoTDBRpcDataSet.py
@@ -216,17 +216,8 @@ class IoTDBRpcDataSet(object):
                     data_array.dtype.newbyteorder("<")
                 )
             if len(data_array) < total_length:
-                # INT32, INT64, BOOLEAN, TIMESTAMP, DATE
-                if (
-                    data_type == 0
-                    or data_type == 1
-                    or data_type == 2
-                    or data_type == 8
-                    or data_type == 9
-                ):
-                    tmp_array = np.full(total_length, np.nan, np.float32)
-                else:
-                    tmp_array = np.full(total_length, None, dtype=object)
+
+                tmp_array = np.full(total_length, None, dtype=object)
 
                 bitmap_buffer = self.__query_data_set.bitmapList[location]
                 buffer = _to_bitbuffer(bitmap_buffer)

--- a/iotdb-client/client-py/iotdb/utils/IoTDBRpcDataSet.py
+++ b/iotdb-client/client-py/iotdb/utils/IoTDBRpcDataSet.py
@@ -216,8 +216,17 @@ class IoTDBRpcDataSet(object):
                     data_array.dtype.newbyteorder("<")
                 )
             if len(data_array) < total_length:
-
-                tmp_array = np.full(total_length, None, dtype=object)
+                # INT32, INT64, BOOLEAN, TIMESTAMP, DATE
+                if (
+                    data_type == 0
+                    or data_type == 1
+                    or data_type == 2
+                    or data_type == 8
+                    or data_type == 9
+                ):
+                    tmp_array = np.full(total_length, np.nan, np.float32)
+                else:
+                    tmp_array = np.full(total_length, None, dtype=object)
 
                 bitmap_buffer = self.__query_data_set.bitmapList[location]
                 buffer = _to_bitbuffer(bitmap_buffer)

--- a/iotdb-client/client-py/tests/integration/test_new_data_types.py
+++ b/iotdb-client/client-py/tests/integration/test_new_data_types.py
@@ -155,11 +155,12 @@ def session_test(use_session_pool=False):
 
         session.insert_records(
             [device_id],
-            [11],
+            [11, 12],
             [measurements_new_type],
             [data_types_new_type],
             [
                 [date(1971, 1, 1), 11, b"\x12\x34", "test11"],
+                [None, 12, b"\x12\x34", "test12"],
             ],
         )
 
@@ -170,7 +171,7 @@ def session_test(use_session_pool=False):
             while dataset.has_next():
                 cnt += 1
                 print(dataset.next())
-            assert cnt == 1
+            assert cnt == 2
 
         # close session connection.
         session.close()

--- a/iotdb-client/client-py/tests/integration/test_new_data_types.py
+++ b/iotdb-client/client-py/tests/integration/test_new_data_types.py
@@ -156,11 +156,18 @@ def session_test(use_session_pool=False):
         session.insert_records(
             [device_id, device_id],
             [11, 12],
-            [measurements_new_type, measurements_new_type],
-            [data_types_new_type, data_types_new_type],
+            [measurements_new_type, ["s_02", "s_03", "s_04"]],
+            [
+                data_types_new_type,
+                [
+                    TSDataType.TIMESTAMP,
+                    TSDataType.BLOB,
+                    TSDataType.STRING,
+                ],
+            ],
             [
                 [date(1971, 1, 1), 11, b"\x12\x34", "test11"],
-                [None, 12, b"\x12\x34", "test12"],
+                [12, b"\x12\x34", "test12"],
             ],
         )
 

--- a/iotdb-client/client-py/tests/integration/test_new_data_types.py
+++ b/iotdb-client/client-py/tests/integration/test_new_data_types.py
@@ -153,5 +153,23 @@ def session_test(use_session_pool=False):
             assert rows == 10
             assert columns == 5
 
+        session.insert_records(
+            [device_id],
+            [11],
+            [measurements_new_type],
+            [data_types_new_type],
+            [
+                [date(1970, 1, 1), 11, b"\x12\x34", "test11"],
+            ],
+        )
+
+        with session.execute_query_statement(
+            "select s_01,s_02,s_03,s_04 from root.sg_test_01.d_04 where time > 10"
+        ) as dataset:
+            cnt = 0
+            while dataset.has_next():
+                print(dataset.next())
+            assert cnt == 1
+
         # close session connection.
         session.close()

--- a/iotdb-client/client-py/tests/integration/test_new_data_types.py
+++ b/iotdb-client/client-py/tests/integration/test_new_data_types.py
@@ -168,6 +168,7 @@ def session_test(use_session_pool=False):
         ) as dataset:
             cnt = 0
             while dataset.has_next():
+                cnt += 1
                 print(dataset.next())
             assert cnt == 1
 

--- a/iotdb-client/client-py/tests/integration/test_new_data_types.py
+++ b/iotdb-client/client-py/tests/integration/test_new_data_types.py
@@ -154,10 +154,10 @@ def session_test(use_session_pool=False):
             assert columns == 5
 
         session.insert_records(
-            [device_id],
+            [device_id, device_id],
             [11, 12],
-            [measurements_new_type],
-            [data_types_new_type],
+            [measurements_new_type, measurements_new_type],
+            [data_types_new_type, measurements_new_type],
             [
                 [date(1971, 1, 1), 11, b"\x12\x34", "test11"],
                 [None, 12, b"\x12\x34", "test12"],

--- a/iotdb-client/client-py/tests/integration/test_new_data_types.py
+++ b/iotdb-client/client-py/tests/integration/test_new_data_types.py
@@ -157,7 +157,7 @@ def session_test(use_session_pool=False):
             [device_id, device_id],
             [11, 12],
             [measurements_new_type, measurements_new_type],
-            [data_types_new_type, measurements_new_type],
+            [data_types_new_type, data_types_new_type],
             [
                 [date(1971, 1, 1), 11, b"\x12\x34", "test11"],
                 [None, 12, b"\x12\x34", "test12"],

--- a/iotdb-client/client-py/tests/integration/test_new_data_types.py
+++ b/iotdb-client/client-py/tests/integration/test_new_data_types.py
@@ -159,7 +159,7 @@ def session_test(use_session_pool=False):
             [measurements_new_type],
             [data_types_new_type],
             [
-                [date(1970, 1, 1), 11, b"\x12\x34", "test11"],
+                [date(1971, 1, 1), 11, b"\x12\x34", "test11"],
             ],
         )
 


### PR DESCRIPTION
## Description

To reproduce:
1. execute the following sql

```sql
create database root.ln

CREATE ALIGNED TIMESERIES root.ln.g1.d1(BOOLEAN BOOLEAN encoding=PLAIN compressor=SNAPPY, INT32 INT32 encoding=PLAIN compressor=SNAPPY, INT64 INT64 encoding=PLAIN compressor=SNAPPY, FLOAT FLOAT encoding=PLAIN compressor=SNAPPY, DOUBLE DOUBLE encoding=PLAIN compressor=SNAPPY, TEXT TEXT encoding=PLAIN compressor=SNAPPY, TS TIMESTAMP encoding=PLAIN compressor=SNAPPY, DATE DATE encoding=PLAIN compressor=SNAPPY, BLOB BLOB encoding=PLAIN compressor=SNAPPY, STRING STRING encoding=PLAIN compressor=SNAPPY)

insert into root.ln.g1.d1(timestamp, BOOLEAN, INT32, INT64, FLOAT, DOUBLE, TEXT, TS, DATE, BLOB, STRING) aligned values(1, true, 1, 1, 1.0, 1.0, '1', 1, '1971-01-01', X'', '1')
insert into root.ln.g1.d1(timestamp, STRING) aligned values(2, 'None')
```

2. execute the following python script
```py
from iotdb.Session import Session

session = Session("127.0.0.1", "6667", "root", "root", 1024, "UTC+8", False)
 
session.open(False)
 
with session.execute_query_statement(
        "select * from root.**"
    ) as session_data_set:
        session_data_set.set_fetch_size(1024)
        while session_data_set.has_next():
            print(session_data_set.next())
 
session.close()
```

You will see an error.
![image](https://github.com/user-attachments/assets/ae5531ff-bba4-43f1-a69c-3eabdc0d1bc0)

