### PR TITLE
AINode: add retry logic in model status check in AINode IT

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/ainode/it/AINodeBasicIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/ainode/it/AINodeBasicIT.java
@@ -135,12 +135,12 @@ public class AINodeBasicIT {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
       boolean loading = true;
+      int count = 0;
       while (loading) {
         statement.execute(registerSql);
         try (ResultSet resultSet = statement.executeQuery(showSql)) {
           ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
           checkHeader(resultSetMetaData, "ModelId,ModelType,State,Configs,Notes");
-          int count = 0;
           while (resultSet.next()) {
             String modelName = resultSet.getString(1);
             String modelType = resultSet.getString(2);
@@ -150,21 +150,21 @@ public class AINodeBasicIT {
             assertEquals("USER_DEFINED", modelType);
             if (status.equals("ACTIVE")) {
               loading = false;
+              count++;
             } else if (status.equals("LOADING")) {
-              continue;
+              break;
             } else {
               fail("Unexpected status of model: " + status);
             }
-            count++;
           }
-          assertEquals(1, count);
         }
       }
+      assertEquals(1, count);
       statement.execute(dropSql);
       try (ResultSet resultSet = statement.executeQuery(showSql)) {
         ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
         checkHeader(resultSetMetaData, "ModelId,ModelType,State,Configs,Notes");
-        int count = 0;
+        count = 0;
         while (resultSet.next()) {
           count++;
         }

--- a/integration-test/src/test/java/org/apache/iotdb/ainode/it/AINodeBasicIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/ainode/it/AINodeBasicIT.java
@@ -135,7 +135,7 @@ public class AINodeBasicIT {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
       boolean loading = true;
-      while(loading){
+      while (loading) {
         statement.execute(registerSql);
         try (ResultSet resultSet = statement.executeQuery(showSql)) {
           ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
@@ -148,11 +148,11 @@ public class AINodeBasicIT {
 
             assertEquals("operationTest", modelName);
             assertEquals("USER_DEFINED", modelType);
-            if(status.equals("ACTIVE")){
+            if (status.equals("ACTIVE")) {
               loading = false;
-            } else if(status.equals("LOADING")){
+            } else if (status.equals("LOADING")) {
               continue;
-            }else {
+            } else {
               fail("Unexpected status of model: " + status);
             }
             count++;

--- a/integration-test/src/test/java/org/apache/iotdb/ainode/it/AINodeBasicIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/ainode/it/AINodeBasicIT.java
@@ -134,10 +134,10 @@ public class AINodeBasicIT {
     String dropSql = "DROP MODEL operationTest";
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
+      statement.execute(registerSql);
       boolean loading = true;
       int count = 0;
       while (loading) {
-        statement.execute(registerSql);
         try (ResultSet resultSet = statement.executeQuery(showSql)) {
           ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
           checkHeader(resultSetMetaData, "ModelId,ModelType,State,Configs,Notes");


### PR DESCRIPTION
Optimization for AINode IT: The model registration of AINode is an asynchronous operation. Sometimes, due to the delay in model registration, the model status is not updated in time, which can cause IT errors. This PR adds retry logic in IT. If it is found that the model status has not been updated, it will continue to retry, avoiding unnecessary IT errors.