### PR TITLE
Fix aggregation dealing logic in no data situation

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBMultiIDsWithAttributesTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBMultiIDsWithAttributesTableIT.java
@@ -633,11 +633,34 @@ public class IoTDBMultiIDsWithAttributesTableIT {
           "d2,l4,3,3,3,0,0,0,3,27.0,",
           "d2,l5,3,3,3,1,0,0,3,30.0,",
         };
-    String sql =
+    sql =
         "select device, level, "
             + "count(num) as count_num, count(*) as count_star, count(device) as count_device, count(date) as count_date, "
             + "count(attr1) as count_attr1, count(attr2) as count_attr2, count(time) as count_time, sum(num) as sum_num "
             + "from table0 group by device,level order by device, level";
+    tableResultSetEqualTest(sql, expectedHeader, retArray, DATABASE_NAME);
+
+    expectedHeader =
+        new String[] {
+          "device",
+          "count_num",
+          "count_star",
+          "count_device",
+          "count_date",
+          "count_attr1",
+          "count_attr2",
+          "count_time",
+          "sum_num"
+        };
+    retArray =
+        new String[] {
+          "d1,3,3,3,0,3,3,3,20.0,",
+        };
+    sql =
+        "select device, "
+            + "count(num) as count_num, count(*) as count_star, count(device) as count_device, count(date) as count_date, "
+            + "count(attr1) as count_attr1, count(attr2) as count_attr2, count(time) as count_time, sum(num) as sum_num "
+            + "from table0 where device='d1' and level='l1' group by device order by device";
     tableResultSetEqualTest(sql, expectedHeader, retArray, DATABASE_NAME);
   }
 
@@ -776,7 +799,106 @@ public class IoTDBMultiIDsWithAttributesTableIT {
     //            ")\n";
   }
 
+  @Test
+  public void aggregationNoDataTest() {
+    expectedHeader =
+        new String[] {
+          "count_num",
+          "count_star",
+          "count_device",
+          "count_date",
+          "count_attr1",
+          "count_attr2",
+          "count_time",
+          "sum_num",
+          "avg_num"
+        };
+
+    retArray =
+        new String[] {
+          "0,0,0,0,0,0,0,null,null,",
+        };
+    sql =
+        "select count(num) as count_num, count(*) as count_star, count(device) as count_device, count(date) as count_date, "
+            + "count(attr1) as count_attr1, count(attr2) as count_attr2, count(time) as count_time, sum(num) as sum_num,"
+            + "avg(num) as avg_num from table0 where time=32";
+    tableResultSetEqualTest(sql, expectedHeader, retArray, DATABASE_NAME);
+
+    retArray =
+        new String[] {
+          "2,2,2,0,2,1,2,24.0,12.0,",
+        };
+    sql =
+        "select count(num) as count_num, count(*) as count_star, count(device) as count_device, count(date) as count_date, "
+            + "count(attr1) as count_attr1, count(attr2) as count_attr2, count(time) as count_time, sum(num) as sum_num,"
+            + "avg(num) as avg_num from table0 where time=32 or time=1971-04-27T01:46:40.000+08:00";
+    tableResultSetEqualTest(sql, expectedHeader, retArray, DATABASE_NAME);
+
+    expectedHeader =
+        new String[] {
+          "device",
+          "level",
+          "count_num",
+          "count_star",
+          "count_device",
+          "count_date",
+          "count_attr1",
+          "count_attr2",
+          "count_time",
+          "sum_num",
+          "avg_num"
+        };
+    retArray = new String[] {};
+    sql =
+        "select device, level, count(num) as count_num, count(*) as count_star, count(device) as count_device, count(date) as count_date, "
+            + "count(attr1) as count_attr1, count(attr2) as count_attr2, count(time) as count_time, sum(num) as sum_num,"
+            + "avg(num) as avg_num from table0 where time=32 group by device, level";
+    tableResultSetEqualTest(sql, expectedHeader, retArray, DATABASE_NAME);
+    retArray = new String[] {"d1,l2,1,1,1,0,1,1,1,12.0,12.0,", "d2,l2,1,1,1,0,1,0,1,12.0,12.0,"};
+    sql =
+        "select device, level, count(num) as count_num, count(*) as count_star, count(device) as count_device, count(date) as count_date, "
+            + "count(attr1) as count_attr1, count(attr2) as count_attr2, count(time) as count_time, sum(num) as sum_num,"
+            + "avg(num) as avg_num from table0 where time=32 or time=1971-04-27T01:46:40.000+08:00 group by device, level";
+    tableResultSetEqualTest(sql, expectedHeader, retArray, DATABASE_NAME);
+
+    expectedHeader =
+        new String[] {
+          "device",
+          "level",
+          "bin",
+          "count_num",
+          "count_star",
+          "count_device",
+          "count_date",
+          "count_attr1",
+          "count_attr2",
+          "count_time",
+          "sum_num",
+          "avg_num"
+        };
+    retArray = new String[] {};
+    sql =
+        "select device, level, date_bin(1d, time) as bin, count(num) as count_num, count(*) as count_star, "
+            + "count(device) as count_device, count(date) as count_date, "
+            + "count(attr1) as count_attr1, count(attr2) as count_attr2, count(time) as count_time, sum(num) as sum_num,"
+            + "avg(num) as avg_num from table0 where time=32 group by 3, device, level";
+    tableResultSetEqualTest(sql, expectedHeader, retArray, DATABASE_NAME);
+    retArray =
+        new String[] {
+          "d1,l2,1971-04-26T00:00:00.000Z,1,1,1,0,1,1,1,12.0,12.0,",
+          "d2,l2,1971-04-26T00:00:00.000Z,1,1,1,0,1,0,1,12.0,12.0,"
+        };
+    sql =
+        "select device, level, date_bin(1d, time) as bin, count(num) as count_num, count(*) as count_star, "
+            + "count(device) as count_device, count(date) as count_date, "
+            + "count(attr1) as count_attr1, count(attr2) as count_attr2, count(time) as count_time, sum(num) as sum_num,"
+            + "avg(num) as avg_num from table0 where time=32 or time=1971-04-27T01:46:40.000+08:00 group by 3, device, level";
+    tableResultSetEqualTest(sql, expectedHeader, retArray, DATABASE_NAME);
+  }
+
+  // ==================================================================
   // ============================ Join Test ===========================
+  // ==================================================================
   // no filter
   @Test
   public void innerJoinTest1() {

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBMultiIDsWithAttributesTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBMultiIDsWithAttributesTableIT.java
@@ -461,7 +461,9 @@ public class IoTDBMultiIDsWithAttributesTableIT {
         DATABASE_NAME);
   }
 
+  // =========================================================================
   // ============================ Aggregation Test ===========================
+  // =========================================================================
   @Test
   public void aggregationTest() {
     String[] expectedHeader =
@@ -786,6 +788,41 @@ public class IoTDBMultiIDsWithAttributesTableIT {
             + "count(num) as count_num, count(*) as count_star, count(device) as count_device, count(date) as count_date, "
             + "count(attr1) as count_attr1, count(attr2) as count_attr2, count(time) as count_time, avg(num) as avg_num "
             + "from table0 group by 3, device, level order by device, level, bin";
+    tableResultSetEqualTest(sql, expectedHeader, retArray, DATABASE_NAME);
+
+    // only group by date_bin
+    expectedHeader = new String[] {"bin"};
+    retArray =
+        new String[] {
+          "1970-01-01T00:00:00.000Z,", "1971-01-01T00:00:00.000Z,", "1971-04-26T00:00:00.000Z,"
+        };
+    sql =
+        "select date_bin(1d, time) as bin from table0 where device='d1' and level='l2' group by 1";
+    tableResultSetEqualTest(sql, expectedHeader, retArray, DATABASE_NAME);
+
+    expectedHeader =
+        new String[] {
+          "bin",
+          "count_num",
+          "count_star",
+          "count_device",
+          "count_date",
+          "count_attr1",
+          "count_attr2",
+          "count_time",
+          "avg_num"
+        };
+    sql =
+        "select date_bin(1s, time) as bin,"
+            + "count(num) as count_num, count(*) as count_star, count(device) as count_device, count(date) as count_date, "
+            + "count(attr1) as count_attr1, count(attr2) as count_attr2, count(time) as count_time, avg(num) as avg_num "
+            + "from table0 where device='d1' and level='l2' group by 1";
+    retArray =
+        new String[] {
+          "1970-01-01T00:00:00.000Z,1,1,1,0,1,1,1,2.0,",
+          "1971-01-01T00:00:00.000Z,1,1,1,0,1,1,1,10.0,",
+          "1971-04-26T17:46:40.000Z,1,1,1,0,1,1,1,12.0,"
+        };
     tableResultSetEqualTest(sql, expectedHeader, retArray, DATABASE_NAME);
 
     // TODO(beyyes) test below

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/timerangeiterator/TableSingleTimeWindowIterator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/timerangeiterator/TableSingleTimeWindowIterator.java
@@ -28,9 +28,11 @@ public class TableSingleTimeWindowIterator implements ITableTimeRangeIterator {
 
   private TimeRange curTimeRange;
 
-  public TableSingleTimeWindowIterator(long startTime, long endTime) {
-    curTimeRange = new TimeRange(startTime, endTime);
+  public TableSingleTimeWindowIterator(TimeRange curTimeRange) {
+    this.curTimeRange = curTimeRange;
   }
+
+  public TableSingleTimeWindowIterator() {}
 
   @Override
   public TimeIteratorType getType() {
@@ -59,12 +61,15 @@ public class TableSingleTimeWindowIterator implements ITableTimeRangeIterator {
 
   @Override
   public void resetCurTimeRange() {
-    // do nothing
+    this.curTimeRange = null;
   }
 
   @Override
   public void updateCurTimeRange(long startTime) {
-    // not used
+    // only meets real data, init the curTimeRange
+    if (curTimeRange == null) {
+      curTimeRange = new TimeRange(Long.MIN_VALUE, Long.MAX_VALUE);
+    }
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/TableAggregationTableScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/TableAggregationTableScanOperator.java
@@ -196,7 +196,9 @@ public class TableAggregationTableScanOperator extends AbstractSeriesAggregation
   public TsBlock next() throws Exception {
 
     // optimize for sql: select count(*) from (select count(s1), sum(s1) from table)
-    if (tableAggregators.isEmpty()) {
+    if (tableAggregators.isEmpty()
+        && timeIterator.getType()
+            == ITableTimeRangeIterator.TimeIteratorType.SINGLE_TIME_ITERATOR) {
       resultTsBlockBuilder.reset();
       currentDeviceIndex = deviceCount;
       timeIterator.setFinished();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/TableAggregationTableScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/TableAggregationTableScanOperator.java
@@ -639,7 +639,7 @@ public class TableAggregationTableScanOperator extends AbstractSeriesAggregation
   public void appendAggregationResult(
       TsBlockBuilder tsBlockBuilder, List<? extends TableAggregator> aggregators) {
 
-    // no date in current time range, just output empty
+    // no data in current time range, just output empty
     if (!timeIterator.hasCachedTimeRange()) {
       return;
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/TableAggregationTableScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/TableAggregationTableScanOperator.java
@@ -621,6 +621,7 @@ public class TableAggregationTableScanOperator extends AbstractSeriesAggregation
 
   private void updateCurTimeRange(long startTime) {
     if (timeIterator.getType() == ITableTimeRangeIterator.TimeIteratorType.SINGLE_TIME_ITERATOR) {
+      timeIterator.updateCurTimeRange(startTime);
       return;
     }
 
@@ -637,6 +638,12 @@ public class TableAggregationTableScanOperator extends AbstractSeriesAggregation
   /** Append a row of aggregation results to the result tsBlock. */
   public void appendAggregationResult(
       TsBlockBuilder tsBlockBuilder, List<? extends TableAggregator> aggregators) {
+
+    // no date in current time range, just output empty
+    if (!timeIterator.hasCachedTimeRange()) {
+      return;
+    }
+
     ColumnBuilder[] columnBuilders = tsBlockBuilder.getValueColumnBuilders();
 
     int groupKeySize = groupingKeySchemas == null ? 0 : groupingKeySchemas.size();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/AvgAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/AvgAccumulator.java
@@ -25,6 +25,7 @@ import org.apache.tsfile.file.metadata.statistics.IntegerStatistics;
 import org.apache.tsfile.file.metadata.statistics.Statistics;
 import org.apache.tsfile.read.common.block.column.BinaryColumn;
 import org.apache.tsfile.read.common.block.column.BinaryColumnBuilder;
+import org.apache.tsfile.read.common.block.column.RunLengthEncodedColumn;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.BytesUtils;
 import org.apache.tsfile.utils.RamUsageEstimator;
@@ -89,7 +90,7 @@ public class AvgAccumulator implements TableAccumulator {
   @Override
   public void addIntermediate(Column argument) {
     checkArgument(
-        argument instanceof BinaryColumn,
+        argument instanceof BinaryColumn || argument instanceof RunLengthEncodedColumn,
         "intermediate input and output of Avg should be BinaryColumn");
 
     for (int i = 0; i < argument.getPositionCount(); i++) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/TableOperatorGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/TableOperatorGenerator.java
@@ -137,6 +137,7 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.common.conf.TSFileDescriptor;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.read.common.TimeRange;
 import org.apache.tsfile.read.common.type.BlobType;
 import org.apache.tsfile.read.common.type.RowType;
 import org.apache.tsfile.read.common.type.Type;
@@ -1513,7 +1514,14 @@ public class TableOperatorGenerator extends PlanVisitor<Operator, LocalExecution
       }
     }
     if (timeRangeIterator == null) {
-      timeRangeIterator = new TableSingleTimeWindowIterator(Long.MIN_VALUE, Long.MAX_VALUE);
+      if (node.getGroupingKeys().isEmpty()) {
+        // global aggregation, has no group by, output init value if no data
+        timeRangeIterator =
+            new TableSingleTimeWindowIterator(new TimeRange(Long.MIN_VALUE, Long.MAX_VALUE));
+      } else {
+        // aggregation with group by, only has data the result will not be empty
+        timeRangeIterator = new TableSingleTimeWindowIterator();
+      }
     }
 
     final OperatorContext operatorContext =


### PR DESCRIPTION
## Description


### Content1 ...

For global aggregation, such as `select count(s1), sum(s1) from table0`, if there is no date in table0, the output result will be `0, null`; 
But for group by with aggregation, such as `select count(s1), sum(s1) from table0 group by id1, id2`, if there is no date in table0, the output result will be empty. 

Besides, this pr also fix the case when only group by date_bin.

![image](https://github.com/user-attachments/assets/57f051e4-1a32-4296-a394-fb6d41710030)


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [x] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [x] added integration tests.
- [x] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
