### PR TITLE
Subscription: improve event consistency by operating within the `compute` method

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingQueue.java
@@ -48,6 +48,7 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -404,50 +405,60 @@ public abstract class SubscriptionPrefetchingQueue {
    */
   private boolean ackInternal(
       final String consumerId, final SubscriptionCommitContext commitContext) {
-    final SubscriptionEvent event = inFlightEvents.get(new Pair<>(consumerId, commitContext));
-    if (Objects.isNull(event)) {
-      LOGGER.warn(
-          "Subscription: subscription commit context {} does not exist, it may have been committed or something unexpected happened, prefetching queue: {}",
-          commitContext,
-          this);
-      return false;
-    }
+    final AtomicBoolean acked = new AtomicBoolean(false);
+    inFlightEvents.compute(
+        new Pair<>(consumerId, commitContext),
+        (key, ev) -> {
+          if (Objects.isNull(ev)) {
+            LOGGER.warn(
+                "Subscription: subscription commit context {} does not exist, it may have been committed or something unexpected happened, prefetching queue: {}",
+                commitContext,
+                this);
+            return null;
+          }
 
-    if (event.isCommitted()) {
-      LOGGER.warn(
-          "Subscription: subscription event {} is committed, subscription commit context {}, prefetching queue: {}",
-          event,
-          commitContext,
-          this);
-      return false;
-    }
+          if (ev.isCommitted()) {
+            LOGGER.warn(
+                "Subscription: subscription event {} is committed, subscription commit context {}, prefetching queue: {}",
+                ev,
+                commitContext,
+                this);
+            return ev;
+          }
 
-    if (!event.isCommittable()) {
-      LOGGER.warn(
-          "Subscription: subscription event {} is not committable, subscription commit context {}, prefetching queue: {}",
-          event,
-          commitContext,
-          this);
-      return false;
-    }
+          if (ev.isCommitted()) {
+            LOGGER.warn(
+                "Subscription: subscription event {} is committed, subscription commit context {}, prefetching queue: {}",
+                ev,
+                commitContext,
+                this);
+            // clean up committed event
+            ev.cleanUp();
+            return null; // remove this entry
+          }
 
-    // check if a consumer acks event from another consumer group...
-    final String consumerGroupId = commitContext.getConsumerGroupId();
-    if (!Objects.equals(consumerGroupId, brokerId)) {
-      LOGGER.warn(
-          "inconsistent consumer group when acking event, current: {}, incoming: {}, consumer id: {}, event commit context: {}, prefetching queue: {}, commit it anyway...",
-          brokerId,
-          consumerGroupId,
-          consumerId,
-          commitContext,
-          this);
-    }
+          // check if a consumer acks event from another consumer group...
+          final String consumerGroupId = commitContext.getConsumerGroupId();
+          if (!Objects.equals(consumerGroupId, brokerId)) {
+            LOGGER.warn(
+                "inconsistent consumer group when acking event, current: {}, incoming: {}, consumer id: {}, event commit context: {}, prefetching queue: {}, commit it anyway...",
+                brokerId,
+                consumerGroupId,
+                consumerId,
+                commitContext,
+                this);
+          }
 
-    event.ack();
-    event.recordCommittedTimestamp(); // now committed
+          ev.ack();
+          ev.recordCommittedTimestamp(); // now committed
+          acked.set(true);
 
-    // no need to update inFlightEvents
-    return true;
+          // clean up committed event
+          ev.cleanUp();
+          return null; // remove this entry
+        });
+
+    return acked.get();
   }
 
   /**
@@ -467,31 +478,38 @@ public abstract class SubscriptionPrefetchingQueue {
    */
   public boolean nackInternal(
       final String consumerId, final SubscriptionCommitContext commitContext) {
-    final SubscriptionEvent event = inFlightEvents.get(new Pair<>(consumerId, commitContext));
-    if (Objects.isNull(event)) {
-      LOGGER.warn(
-          "Subscription: subscription commit context [{}] does not exist, it may have been committed or something unexpected happened, prefetching queue: {}",
-          commitContext,
-          this);
-      return false;
-    }
+    final AtomicBoolean nacked = new AtomicBoolean(false);
+    inFlightEvents.compute(
+        new Pair<>(consumerId, commitContext),
+        (key, ev) -> {
+          if (Objects.isNull(ev)) {
+            LOGGER.warn(
+                "Subscription: subscription commit context [{}] does not exist, it may have been committed or something unexpected happened, prefetching queue: {}",
+                commitContext,
+                this);
+            return null;
+          }
 
-    // check if a consumer nacks event from another consumer group...
-    final String consumerGroupId = commitContext.getConsumerGroupId();
-    if (!Objects.equals(consumerGroupId, brokerId)) {
-      LOGGER.warn(
-          "inconsistent consumer group when nacking event, current: {}, incoming: {}, consumer id: {}, event commit context: {}, prefetching queue: {}, commit it anyway...",
-          brokerId,
-          consumerGroupId,
-          consumerId,
-          commitContext,
-          this);
-    }
+          // check if a consumer nacks event from another consumer group...
+          final String consumerGroupId = commitContext.getConsumerGroupId();
+          if (!Objects.equals(consumerGroupId, brokerId)) {
+            LOGGER.warn(
+                "inconsistent consumer group when nacking event, current: {}, incoming: {}, consumer id: {}, event commit context: {}, prefetching queue: {}, commit it anyway...",
+                brokerId,
+                consumerGroupId,
+                consumerId,
+                commitContext,
+                this);
+          }
 
-    event.nack(); // now pollable
+          ev.nack(); // now pollable
+          nacked.set(true);
 
-    // no need to update inFlightEvents and prefetchingQueue
-    return true;
+          // no need to update inFlightEvents and prefetchingQueue
+          return ev;
+        });
+
+    return nacked.get();
   }
 
   public SubscriptionCommitContext generateSubscriptionCommitContext() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingQueue.java
@@ -83,6 +83,12 @@ public abstract class SubscriptionPrefetchingQueue {
    * SubscriptionPrefetchingQueue#ack}, etc. However, it does not enforce mutual exclusion among the
    * other operations themselves.
    *
+   * <p>Under the premise of obtaining this lock, to avoid inconsistencies, updates to the {@link
+   * SubscriptionEvent} in both {@link SubscriptionPrefetchingQueue#prefetchingQueue} and {@link
+   * SubscriptionPrefetchingQueue#inFlightEvents} MUST be performed within the {@link
+   * ConcurrentHashMap#compute} method of inFlightEvents in the {@link
+   * SubscriptionPrefetchingQueue}.
+   *
    * <p>This lock is created with fairness set to true, which means threads acquire the lock in the
    * order they requested it, to avoid thread starvation.
    */

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingQueue.java
@@ -569,7 +569,7 @@ public abstract class SubscriptionPrefetchingQueue {
             .map(SubscriptionEvent::getPipeEventCount)
             .reduce(Integer::sum)
             .orElse(0)
-        + +inFlightEvents.values().stream()
+        + inFlightEvents.values().stream()
             .map(SubscriptionEvent::getPipeEventCount)
             .reduce(Integer::sum)
             .orElse(0);


### PR DESCRIPTION
To ensure consistency while holding this lock in prefetching queue (although it does not enforce mutual exclusion among the other operations themselves.), updates to the SubscriptionEvent in both SubscriptionPrefetchingQueue#prefetchingQueue and SubscriptionPrefetchingQueue#inFlightEvents must be performed within the ConcurrentHashMap#compute method of inFlightEvents in the SubscriptionPrefetchingQueue.