### PR TITLE
Fix column length may be 0 when using cache fetch

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/query/IoTDBCaseWhenThenIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/query/IoTDBCaseWhenThenIT.java
@@ -889,6 +889,18 @@ public class IoTDBCaseWhenThenIT {
   }
 
   @Test
+  public void testKind1Logic() {
+    String sql =
+        "select case when s3 >= 0 and s3 < 20 and s4 >= 50 and s4 < 60 then 'just so so~~~' when s3 >= 20 and s3 < 40 and s4 >= 70 and s4 < 80 then 'very well~~~' end as result from root.sg.d2";
+    String[] expectedHeader = new String[] {TIMESTAMP_STR, "result"};
+    String[] retArray =
+        new String[] {
+          "0,null,", "1000000,just so so~~~,", "20000000,null,", "210000000,very well~~~,",
+        };
+    resultSetEqualTest(sql, expectedHeader, retArray);
+  }
+
+  @Test
   public void testMultipleSatisfyCase() {
     // Test the result when two when clause are satisfied
     String sql =

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBCaseWhenThenTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBCaseWhenThenTableIT.java
@@ -660,4 +660,12 @@ public class IoTDBCaseWhenThenTableIT {
         };
     tableResultSetEqualTest(sql, expectedHeader, retArray, DATABASE);
   }
+
+  @Test
+  public void testKind1Logic() {
+    String sql =
+        "select case when s3 >= 0 and s3 < 20 and s4 >= 50 and s4 < 60 then 'just so so~~~' when s3 >= 20 and s3 < 40 and s4 >= 70 and s4 < 80 then 'very well~~~' end from table2";
+    String[] retArray = new String[] {"null,", "just so so~~~,", "null,", "very well~~~,"};
+    tableResultSetEqualTest(sql, expectedHeader, retArray, DATABASE);
+  }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/binary/LogicAndColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/binary/LogicAndColumnTransformer.java
@@ -36,8 +36,8 @@ public class LogicAndColumnTransformer extends LogicBinaryColumnTransformer {
     boolean[] selectionCopy = selection.clone();
 
     leftTransformer.evaluateWithSelection(selectionCopy);
-    Column leftColumn = leftTransformer.getColumn();
     int positionCount = leftTransformer.getColumnCachePositionCount();
+    Column leftColumn = leftTransformer.getColumn();
 
     for (int i = 0; i < positionCount; i++) {
       if (!leftColumn.isNull(i) && !leftColumn.getBoolean(i)) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/binary/LogicOrColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/binary/LogicOrColumnTransformer.java
@@ -36,8 +36,8 @@ public class LogicOrColumnTransformer extends LogicBinaryColumnTransformer {
     boolean[] selectionCopy = selection.clone();
 
     leftTransformer.evaluateWithSelection(selectionCopy);
-    Column leftColumn = leftTransformer.getColumn();
     int positionCount = leftTransformer.getColumnCachePositionCount();
+    Column leftColumn = leftTransformer.getColumn();
 
     for (int i = 0; i < positionCount; i++) {
       if (!leftColumn.isNull(i) && leftColumn.getBoolean(i)) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/multi/LogicalAndMultiColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/multi/LogicalAndMultiColumnTransformer.java
@@ -54,7 +54,7 @@ public class LogicalAndMultiColumnTransformer extends LogicalMultiColumnTransfor
       }
     }
 
-    int positionCount = columnTransformerList.get(0).getColumnCachePositionCount();
+    int positionCount = childrenColumns.get(0).getPositionCount();
     ColumnBuilder builder = returnType.createColumnBuilder(positionCount);
     for (int i = 0; i < positionCount; i++) {
       if (selection[i]) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/multi/LogicalOrMultiColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/multi/LogicalOrMultiColumnTransformer.java
@@ -54,7 +54,7 @@ public class LogicalOrMultiColumnTransformer extends LogicalMultiColumnTransform
       }
     }
 
-    int positionCount = columnTransformerList.get(0).getColumnCachePositionCount();
+    int positionCount = childColumns.get(0).getPositionCount();
     ColumnBuilder builder = returnType.createColumnBuilder(positionCount);
 
     for (int i = 0; i < positionCount; i++) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/multi/MappableUDFColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/multi/MappableUDFColumnTransformer.java
@@ -67,7 +67,7 @@ public class MappableUDFColumnTransformer extends ColumnTransformer {
       columns[i] = inputColumnTransformers[i].getColumn();
     }
     // construct input TsBlock with columns
-    int positionCount = inputColumnTransformers[0].getColumnCachePositionCount();
+    int positionCount = columns[0].getPositionCount();
     ColumnBuilder builder = returnType.createColumnBuilder(positionCount);
     // executor UDF and cache result
     executor.execute(columns, builder);


### PR DESCRIPTION
This pull request includes several changes to the `evaluateWithSelection` and `doTransform` methods across multiple transformer classes in the `iotdb-core` module. The changes primarily focus on improving the consistency and correctness of how the position count is obtained from columns.

### Consistency Improvements:

* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/binary/LogicAndColumnTransformer.java`](diffhunk://#diff-c54acc8c312ac148943810046c419a58e13d57402c8e4dd40dd2d53595a8d01aL39-R40): Moved the assignment of `leftColumn` to ensure it is consistently placed after obtaining the position count.
* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/binary/LogicOrColumnTransformer.java`](diffhunk://#diff-f8664105db52e335df7b40037af2198f4cd1d8364b59edf6cb73d7315b39e2edL39-R40): Similar adjustment as in `LogicAndColumnTransformer` to ensure consistent placement of `leftColumn` assignment.

### Correctness Improvements:

* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/multi/LogicalAndMultiColumnTransformer.java`](diffhunk://#diff-1240f14b88650a14753736ebe01b9a1ccc6e8c5182e2b2e9b21eece67d6810c1L57-R57): Changed the source of `positionCount` from `columnTransformerList` to `childrenColumns` to correctly reflect the position count.
* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/multi/LogicalOrMultiColumnTransformer.java`](diffhunk://#diff-f812c4f0a951360a720a54b57b19333fa909757d53aa60d914238002240bf2d1L57-R57): Updated the source of `positionCount` from `columnTransformerList` to `childColumns` for accuracy.
* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/multi/MappableUDFColumnTransformer.java`](diffhunk://#diff-179f6b7a999c6e7c3157697928c54e7a589275ed4ffdee940e2fec9ef9bd3bd0L70-R70): Corrected the source of `positionCount` from `inputColumnTransformers` to `columns` to ensure the correct position count is used.