### PR TITLE
[to rc/1.3.3] Fix the issue that tasks with negative estimated memory are executed

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/schedule/CompactionTaskQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/schedule/CompactionTaskQueue.java
@@ -84,6 +84,7 @@ public class CompactionTaskQueue extends FixedPriorityBlockingQueue<AbstractComp
     return task.isCompactionAllowed()
         && task.getCompactionConfigVersion()
             >= CompactionTaskManager.getInstance().getCurrentCompactionConfigVersion()
+        && task.getEstimatedMemoryCost() >= 0
         && task.getEstimatedMemoryCost() <= SystemInfo.getInstance().getMemorySizeForCompaction()
         && task.getProcessedFileNum() <= SystemInfo.getInstance().getTotalFileLimitForCompaction();
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/schedule/CompactionTaskQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/schedule/CompactionTaskQueue.java
@@ -84,6 +84,8 @@ public class CompactionTaskQueue extends FixedPriorityBlockingQueue<AbstractComp
     return task.isCompactionAllowed()
         && task.getCompactionConfigVersion()
             >= CompactionTaskManager.getInstance().getCurrentCompactionConfigVersion()
+        // The estimated memory cost being less than 0 indicates that an exception occurred during
+        // the process of estimating the memory for the compaction task.
         && task.getEstimatedMemoryCost() >= 0
         && task.getEstimatedMemoryCost() <= SystemInfo.getInstance().getMemorySizeForCompaction()
         && task.getProcessedFileNum() <= SystemInfo.getInstance().getTotalFileLimitForCompaction();


### PR DESCRIPTION
## Description
Fix the issue that tasks with negative estimated memory are executed
https://github.com/apache/iotdb/pull/13856