### PR TITLE
Fix wal node memory leak when using simple consensus

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/WALManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/WALManager.java
@@ -79,13 +79,13 @@ public class WALManager implements IService {
     }
   }
 
-  public static String getApplicantUniqueId(String storageGroupName, boolean sequence) {
+  public static String getApplicantUniqueId(String dataRegionName, boolean sequence) {
     return config.getDataRegionConsensusProtocolClass().equals(ConsensusFactory.IOT_CONSENSUS)
             || config
                 .getDataRegionConsensusProtocolClass()
                 .equals(ConsensusFactory.IOT_CONSENSUS_V2)
-        ? storageGroupName
-        : storageGroupName
+        ? dataRegionName
+        : dataRegionName
             + IoTDBConstant.FILE_NAME_SEPARATOR
             + (sequence ? "sequence" : "unsequence");
   }
@@ -127,6 +127,15 @@ public class WALManager implements IService {
 
     ((FirstCreateStrategy) walNodesManager).deleteWALNode(applicantUniqueId);
     WritingMetrics.getInstance().removeWALNodeInfoMetrics(applicantUniqueId);
+  }
+
+  /** UniqueId will be removed only when using ElasticStrategy. */
+  public void removeUniqueIdInfo(String applicantUniqueId) {
+    if (config.getWalMode() == WALMode.DISABLE || !(walNodesManager instanceof ElasticStrategy)) {
+      return;
+    }
+
+    ((ElasticStrategy) walNodesManager).removeUniqueIdInfo(applicantUniqueId);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/allocation/ElasticStrategy.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/allocation/ElasticStrategy.java
@@ -78,6 +78,15 @@ public class ElasticStrategy extends AbstractNodeAllocationStrategy {
     }
   }
 
+  public void removeUniqueIdInfo(String applicantUniqueId) {
+    nodesLock.lock();
+    try {
+      uniqueId2Nodes.remove(applicantUniqueId);
+    } finally {
+      nodesLock.unlock();
+    }
+  }
+
   @Override
   public List<WALNode> getNodesSnapshot() {
     List<WALNode> snapshot;


### PR DESCRIPTION
## Description

When DataRegion uses simple consensus, if users create database, insert some data and drop database in a loop, the number of wal nodes will increase continually until out of memory.