### PR TITLE
[To rc/1.3.3] Pipe: Remove already deleted tsfile resource from historical extraction list to prevent FileNotFoundException (#13869)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/historical/PipeHistoricalDataRegionTsFileExtractor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/historical/PipeHistoricalDataRegionTsFileExtractor.java
@@ -435,13 +435,16 @@ public class PipeHistoricalDataRegionTsFileExtractor implements PipeHistoricalDa
             tsFileManager.getTsFileList(true).stream()
                 .filter(
                     resource ->
-                        // Some resource may not be closed due to the control of
-                        // PIPE_MIN_FLUSH_INTERVAL_IN_MS. We simply ignore them.
-                        !resource.isClosed()
-                            || mayTsFileContainUnprocessedData(resource)
-                                && isTsFileResourceOverlappedWithTimeRange(resource)
-                                && isTsFileGeneratedAfterExtractionTimeLowerBound(resource)
-                                && mayTsFileResourceOverlappedWithPattern(resource))
+                        // Some resource is marked as deleted but not removed from the list.
+                        !resource.isDeleted()
+                            && (
+                            // Some resource may not be closed due to the control of
+                            // PIPE_MIN_FLUSH_INTERVAL_IN_MS. We simply ignore them.
+                            !resource.isClosed()
+                                || mayTsFileContainUnprocessedData(resource)
+                                    && isTsFileResourceOverlappedWithTimeRange(resource)
+                                    && isTsFileGeneratedAfterExtractionTimeLowerBound(resource)
+                                    && mayTsFileResourceOverlappedWithPattern(resource)))
                 .collect(Collectors.toList());
         resourceList.addAll(sequenceTsFileResources);
 
@@ -449,13 +452,16 @@ public class PipeHistoricalDataRegionTsFileExtractor implements PipeHistoricalDa
             tsFileManager.getTsFileList(false).stream()
                 .filter(
                     resource ->
-                        // Some resource may not be closed due to the control of
-                        // PIPE_MIN_FLUSH_INTERVAL_IN_MS. We simply ignore them.
-                        !resource.isClosed()
-                            || mayTsFileContainUnprocessedData(resource)
-                                && isTsFileResourceOverlappedWithTimeRange(resource)
-                                && isTsFileGeneratedAfterExtractionTimeLowerBound(resource)
-                                && mayTsFileResourceOverlappedWithPattern(resource))
+                        // Some resource is marked as deleted but not removed from the list.
+                        !resource.isDeleted()
+                            && (
+                            // Some resource may not be closed due to the control of
+                            // PIPE_MIN_FLUSH_INTERVAL_IN_MS. We simply ignore them.
+                            !resource.isClosed()
+                                || mayTsFileContainUnprocessedData(resource)
+                                    && isTsFileResourceOverlappedWithTimeRange(resource)
+                                    && isTsFileGeneratedAfterExtractionTimeLowerBound(resource)
+                                    && mayTsFileResourceOverlappedWithPattern(resource)))
                 .collect(Collectors.toList());
         resourceList.addAll(unsequenceTsFileResources);
 


### PR DESCRIPTION
(cherry picked from commit ce53f9c160e49cebf747151bd6e7b65c53185953)