### PR TITLE
Remove use of canUseStatistics when judge aggregation push-down level in TableModel

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/Metadata.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/Metadata.java
@@ -183,10 +183,4 @@ public interface Metadata {
    */
   DataPartition getDataPartitionWithUnclosedTimeRange(
       final String database, final List<DataPartitionQueryParam> sgNameToQueryParamsMap);
-
-  /**
-   * @param withTime some function with time can also use Statistics, like first_by, last_by
-   * @return if the Aggregation can use statistics to optimize
-   */
-  boolean canUseStatistics(final String name, boolean withTime);
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableBuiltinAggregationFunction.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableBuiltinAggregationFunction.java
@@ -75,39 +75,6 @@ public enum TableBuiltinAggregationFunction {
     return NATIVE_FUNCTION_NAMES;
   }
 
-  /**
-   * @return if the Aggregation can use statistics to optimize
-   */
-  public static boolean canUseStatistics(String name, boolean withTime) {
-    final String functionName = name.toLowerCase();
-    switch (functionName) {
-      case "sum":
-      case "count":
-      case "avg":
-      case "extreme":
-      case "max":
-      case "min":
-      case "first":
-      case "last":
-        return true;
-      case "first_by":
-      case "last_by":
-        return withTime;
-      case "mode":
-      case "max_by":
-      case "min_by":
-      case "stddev":
-      case "stddev_pop":
-      case "stddev_samp":
-      case "variance":
-      case "var_pop":
-      case "var_samp":
-        return false;
-      default:
-        throw new IllegalArgumentException("Invalid Aggregation function: " + name);
-    }
-  }
-
   public static List<Type> getIntermediateTypes(String name, List<Type> originalArgumentTypes) {
     if (COUNT.functionName.equalsIgnoreCase(name)) {
       return ImmutableList.of(INT64);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableMetadataImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableMetadataImpl.java
@@ -711,11 +711,6 @@ public class TableMetadataImpl implements Metadata {
         Collections.singletonMap(database, sgNameToQueryParamsMap));
   }
 
-  @Override
-  public boolean canUseStatistics(String functionName, boolean withTime) {
-    return TableBuiltinAggregationFunction.canUseStatistics(functionName, withTime);
-  }
-
   public static boolean isTwoNumericType(List<? extends Type> argumentTypes) {
     return argumentTypes.size() == 2
         && isNumericType(argumentTypes.get(0))

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/optimizations/PushAggregationIntoTableScan.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/optimizations/PushAggregationIntoTableScan.java
@@ -137,17 +137,7 @@ public class PushAggregationIntoTableScan implements PlanOptimizer {
           hasProject ? projectNode.getAssignments().getMap() : null;
       // calculate Function part
       for (AggregationNode.Aggregation aggregation : values) {
-        // if the function cannot make use of Statistics, we don't push down
-        if (!metadata.canUseStatistics(
-            aggregation.getResolvedFunction().getSignature().getName(),
-            aggregation.getArguments().stream()
-                .anyMatch(
-                    v ->
-                        ((SymbolReference) v)
-                            .getName()
-                            .equalsIgnoreCase(TimestampOperand.TIMESTAMP_EXPRESSION_STRING)))) {
-          return PushDownLevel.NOOP;
-        }
+        // all the functions can be pre-agg in AggTableScanNode
 
         // if expr appears in arguments of Aggregation, we don't push down
         if (hasProject

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/AggregationTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/AggregationTest.java
@@ -264,25 +264,6 @@ public class AggregationTest {
                                 ImmutableList.of("tag1", "s1", "s2"),
                                 ImmutableSet.of("tag1", "s2", "s1"))))))));
 
-    // AggFunction cannot be push down
-    // Output - Project - Aggregation - TableScan
-    logicalQueryPlan = planTester.createPlan("SELECT mode(s2) FROM table1 group by tag1");
-    assertPlan(
-        logicalQueryPlan,
-        output(
-            project(
-                aggregation(
-                    singleGroupingSet("tag1"),
-                    ImmutableMap.of(
-                        Optional.empty(), aggregationFunction("mode", ImmutableList.of("s2"))),
-                    ImmutableList.of("tag1"), // Streamable
-                    Optional.empty(),
-                    SINGLE,
-                    tableScan(
-                        "testdb.table1",
-                        ImmutableList.of("tag1", "s2"),
-                        ImmutableSet.of("tag1", "s2"))))));
-
     // Expr appears in arguments of AggFunction
     // Output - Project - Aggregation - Project - TableScan
     logicalQueryPlan = planTester.createPlan("SELECT count(s2+1) FROM table1 group by tag1");

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/TSBSMetadata.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/TSBSMetadata.java
@@ -32,7 +32,6 @@ import org.apache.iotdb.db.queryengine.plan.relational.metadata.ITableDeviceSche
 import org.apache.iotdb.db.queryengine.plan.relational.metadata.Metadata;
 import org.apache.iotdb.db.queryengine.plan.relational.metadata.OperatorNotFoundException;
 import org.apache.iotdb.db.queryengine.plan.relational.metadata.QualifiedObjectName;
-import org.apache.iotdb.db.queryengine.plan.relational.metadata.TableBuiltinAggregationFunction;
 import org.apache.iotdb.db.queryengine.plan.relational.metadata.TableSchema;
 import org.apache.iotdb.db.queryengine.plan.relational.security.AccessControl;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Expression;
@@ -362,11 +361,6 @@ public class TSBSMetadata implements Metadata {
   public DataPartition getDataPartitionWithUnclosedTimeRange(
       String database, List<DataPartitionQueryParam> sgNameToQueryParamsMap) {
     return DATA_PARTITION;
-  }
-
-  @Override
-  public boolean canUseStatistics(String name, boolean withTime) {
-    return TableBuiltinAggregationFunction.canUseStatistics(name, withTime);
   }
 
   private static final DataPartition DATA_PARTITION =

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/TestMatadata.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/TestMatadata.java
@@ -32,7 +32,6 @@ import org.apache.iotdb.db.queryengine.plan.relational.metadata.ITableDeviceSche
 import org.apache.iotdb.db.queryengine.plan.relational.metadata.Metadata;
 import org.apache.iotdb.db.queryengine.plan.relational.metadata.OperatorNotFoundException;
 import org.apache.iotdb.db.queryengine.plan.relational.metadata.QualifiedObjectName;
-import org.apache.iotdb.db.queryengine.plan.relational.metadata.TableBuiltinAggregationFunction;
 import org.apache.iotdb.db.queryengine.plan.relational.metadata.TableSchema;
 import org.apache.iotdb.db.queryengine.plan.relational.security.AccessControl;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.ComparisonExpression;
@@ -309,11 +308,6 @@ public class TestMatadata implements Metadata {
   public DataPartition getDataPartitionWithUnclosedTimeRange(
       String database, List<DataPartitionQueryParam> sgNameToQueryParamsMap) {
     return DATA_PARTITION;
-  }
-
-  @Override
-  public boolean canUseStatistics(String name, boolean withTime) {
-    return TableBuiltinAggregationFunction.canUseStatistics(name, withTime);
   }
 
   private static final DataPartition DATA_PARTITION =


### PR DESCRIPTION
We think all functions can be pre-agg in AggTableScan.