### PR TITLE
Keep the order of times after spliting RelationalInsertTabletNode

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBInsertTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBInsertTableIT.java
@@ -955,7 +955,7 @@ public class IoTDBInsertTableIT {
         Assert.assertTrue(record.getFields().get(0).getLongV() > timeLowerBound);
         count++;
       }
-      Assert.assertTrue(count > 0 && count < 4);
+      Assert.assertEquals(2, count);
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertTabletNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertTabletNode.java
@@ -65,6 +65,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -219,7 +220,7 @@ public class InsertTabletNode extends InsertNode implements WALEntryValue {
     int startLoc = 0; // included
     IDeviceID currDeviceId = getDeviceID(0);
 
-    Map<IDeviceID, PartitionSplitInfo> deviceIDSplitInfoMap = new HashMap<>();
+    Map<IDeviceID, PartitionSplitInfo> deviceIDSplitInfoMap = new LinkedHashMap<>();
 
     for (int i = 1; i < times.length; i++) { // times are sorted in session API.
       IDeviceID nextDeviceId = getDeviceID(i);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -1232,7 +1232,7 @@ public class DataRegion implements IDataRegionForQuery {
       split(insertTabletNode, start, end, splitInfo);
       start = end;
     }
-    noFailure = noFailure && doInsert(insertTabletNode, splitInfo, results, costsForMetrics);
+    noFailure = doInsert(insertTabletNode, splitInfo, results, costsForMetrics) && noFailure;
 
     if (CommonDescriptor.getInstance().getConfig().isLastCacheEnable()
         && !insertTabletNode.isGeneratedByRemoteConsensusLeader()) {


### PR DESCRIPTION
## Description

As title.
When calculate TTL, RelationalInsertTabletNode should make sure the times are sorted.
