### PR TITLE
Perfect the aggregation queries when there is no devices or no data partitions.

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBMultiIDsWithAttributesTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBMultiIDsWithAttributesTableIT.java
@@ -899,14 +899,15 @@ public class IoTDBMultiIDsWithAttributesTableIT {
         };
 
     // TODO(beyyes) test below
-    //    sql = "select count(*) from (\n" +
-    //            "\tselect device, level, date_bin(1d, time) as bin, \n" +
-    //            "\tcount(num) as count_num, count(*) as count_star, count(device) as count_device,
-    // count(date) as count_date, count(attr1) as count_attr1, count(attr2) as count_attr2,
-    // count(time) as count_time, avg(num) as avg_num \n" +
-    //            "\tfrom table0 \n" +
-    //            "\tgroup by 3, device, level order by device, level, bin\n" +
-    //            ")\n";
+    //        sql = "select count(*) from (\n" +
+    //                "\tselect device, level, date_bin(1d, time) as bin, \n" +
+    //                "\tcount(num) as count_num, count(*) as count_star, count(device) as
+    // count_device,
+    //     count(date) as count_date, count(attr1) as count_attr1, count(attr2) as count_attr2,
+    //     count(time) as count_time, avg(num) as avg_num \n" +
+    //                "\tfrom table0 \n" +
+    //                "\tgroup by 3, device, level order by device, level, bin\n" +
+    //                ")\n";
   }
 
   @Test
@@ -1003,6 +1004,23 @@ public class IoTDBMultiIDsWithAttributesTableIT {
             + "count(device) as count_device, count(date) as count_date, "
             + "count(attr1) as count_attr1, count(attr2) as count_attr2, count(time) as count_time, sum(num) as sum_num,"
             + "avg(num) as avg_num from table0 where time=32 or time=1971-04-27T01:46:40.000+08:00 group by 3, device, level order by device, level";
+    tableResultSetEqualTest(sql, expectedHeader, retArray, DATABASE_NAME);
+
+    // not exist device test
+    expectedHeader = buildHeaders(3);
+    sql = "select count(*), count(num), sum(num) from table0 where device='d_not_exist'";
+    retArray = new String[] {"0,0,null,"};
+    tableResultSetEqualTest(sql, expectedHeader, retArray, DATABASE_NAME);
+
+    // not exist time range test
+    sql = "select count(*), count(num), sum(num) from table0 where time>2100-04-26T18:01:40.000";
+    retArray = new String[] {"0,0,null,"};
+    tableResultSetEqualTest(sql, expectedHeader, retArray, DATABASE_NAME);
+
+    // only one device in this time
+    expectedHeader = buildHeaders(2);
+    sql = "select count(num),sum(num) from table1 where time=0";
+    retArray = new String[] {"2,6.0,"};
     tableResultSetEqualTest(sql, expectedHeader, retArray, DATABASE_NAME);
   }
 
@@ -1150,6 +1168,11 @@ public class IoTDBMultiIDsWithAttributesTableIT {
           "1970-01-01T00:00:00.100Z,1970-01-01T00:00:00.100Z,1970-01-01T00:00:00.100Z,1971-01-01T00:00:00.000Z,1971-01-01T00:00:00.000Z,1970-01-01T00:00:00.100Z,1970-01-01T00:00:00.100Z,1970-01-01T00:00:00.100Z,1970-01-01T00:00:00.100Z,1970-01-01T00:00:00.100Z,1971-08-20T11:33:20.000Z,1971-01-01T00:01:40.000Z,1971-01-01T00:01:40.000Z,",
         };
     tableResultSetEqualTest(sql, expectedHeader1, retArray, DATABASE_NAME);
+
+    expectedHeader = buildHeaders(3);
+    sql = "select last_by(time,num+1),last_by(num+1,time),last_by(num+1,floatnum+1) from table0";
+    retArray = new String[] {"1971-08-20T11:33:20.000Z,16,16,"};
+    tableResultSetEqualTest(sql, expectedHeader, retArray, DATABASE_NAME);
   }
 
   @Test

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBMultiIDsWithAttributesTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBMultiIDsWithAttributesTableIT.java
@@ -1006,18 +1006,22 @@ public class IoTDBMultiIDsWithAttributesTableIT {
             + "avg(num) as avg_num from table0 where time=32 or time=1971-04-27T01:46:40.000+08:00 group by 3, device, level order by device, level";
     tableResultSetEqualTest(sql, expectedHeader, retArray, DATABASE_NAME);
 
-    // not exist device test
+    // queried device is not exist
     expectedHeader = buildHeaders(3);
     sql = "select count(*), count(num), sum(num) from table0 where device='d_not_exist'";
     retArray = new String[] {"0,0,null,"};
     tableResultSetEqualTest(sql, expectedHeader, retArray, DATABASE_NAME);
+    sql =
+        "select count(*), count(num), sum(num) from table0 where device='d_not_exist1' or device='d_not_exist2'";
+    retArray = new String[] {"0,0,null,"};
+    tableResultSetEqualTest(sql, expectedHeader, retArray, DATABASE_NAME);
 
-    // not exist time range test
+    // no data in given time range
     sql = "select count(*), count(num), sum(num) from table0 where time>2100-04-26T18:01:40.000";
     retArray = new String[] {"0,0,null,"};
     tableResultSetEqualTest(sql, expectedHeader, retArray, DATABASE_NAME);
 
-    // only one device in this time
+    // only one device has data in queried time
     expectedHeader = buildHeaders(2);
     sql = "select count(num),sum(num) from table1 where time=0";
     retArray = new String[] {"2,6.0,"};

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/TableAggregationTableScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/TableAggregationTableScanOperator.java
@@ -40,6 +40,7 @@ import org.apache.iotdb.db.storageengine.dataregion.read.QueryDataSource;
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnBuilder;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.file.metadata.StringArrayDeviceID;
 import org.apache.tsfile.file.metadata.statistics.Statistics;
 import org.apache.tsfile.file.metadata.statistics.StringStatistics;
 import org.apache.tsfile.read.common.TimeRange;
@@ -55,6 +56,7 @@ import org.apache.tsfile.write.schema.IMeasurementSchema;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -170,7 +172,7 @@ public class TableAggregationTableScanOperator extends AbstractSeriesAggregation
     this.maxReturnSize = maxReturnSize;
     this.maxTsBlockLineNum = maxTsBlockLineNum;
 
-    this.seriesScanUtil = constructAlignedSeriesScanUtil(deviceEntries.get(currentDeviceIndex));
+    constructAlignedSeriesScanUtil();
   }
 
   @Override
@@ -253,17 +255,28 @@ public class TableAggregationTableScanOperator extends AbstractSeriesAggregation
     return resultTsBlock;
   }
 
-  private AlignedSeriesScanUtil constructAlignedSeriesScanUtil(DeviceEntry deviceEntry) {
+  private void constructAlignedSeriesScanUtil() {
+    DeviceEntry deviceEntry;
+
+    if (this.deviceEntries.size() <= this.currentDeviceIndex
+        || this.deviceEntries.get(this.currentDeviceIndex) == null) {
+      // for device which not exist
+      deviceEntry = new DeviceEntry(new StringArrayDeviceID(""), Collections.emptyList());
+    } else {
+      deviceEntry = this.deviceEntries.get(this.currentDeviceIndex);
+    }
+
     AlignedFullPath alignedPath =
         constructAlignedPath(deviceEntry, measurementColumnNames, measurementSchemas);
 
-    return new AlignedSeriesScanUtil(
-        alignedPath,
-        scanOrder,
-        seriesScanOptions,
-        operatorContext.getInstanceContext(),
-        true,
-        measurementColumnTSDataTypes);
+    this.seriesScanUtil =
+        new AlignedSeriesScanUtil(
+            alignedPath,
+            scanOrder,
+            seriesScanOptions,
+            operatorContext.getInstanceContext(),
+            true,
+            measurementColumnTSDataTypes);
   }
 
   /** Return true if we have the result of this timeRange. */
@@ -313,7 +326,7 @@ public class TableAggregationTableScanOperator extends AbstractSeriesAggregation
 
       if (currentDeviceIndex < deviceCount) {
         // construct AlignedSeriesScanUtil for next device
-        this.seriesScanUtil = constructAlignedSeriesScanUtil(deviceEntries.get(currentDeviceIndex));
+        constructAlignedSeriesScanUtil();
         queryDataSource.reset();
         this.seriesScanUtil.initQueryDataSource(queryDataSource);
       }
@@ -790,8 +803,7 @@ public class TableAggregationTableScanOperator extends AbstractSeriesAggregation
 
         if (currentDeviceIndex < deviceCount) {
           // construct AlignedSeriesScanUtil for next device
-          this.seriesScanUtil =
-              constructAlignedSeriesScanUtil(deviceEntries.get(currentDeviceIndex));
+          constructAlignedSeriesScanUtil();
           queryDataSource.reset();
           this.seriesScanUtil.initQueryDataSource(queryDataSource);
         }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/TableAggregationTableScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/TableAggregationTableScanOperator.java
@@ -258,9 +258,8 @@ public class TableAggregationTableScanOperator extends AbstractSeriesAggregation
   private void constructAlignedSeriesScanUtil() {
     DeviceEntry deviceEntry;
 
-    if (this.deviceEntries.size() <= this.currentDeviceIndex
-        || this.deviceEntries.get(this.currentDeviceIndex) == null) {
-      // for device which not exist
+    if (this.deviceEntries.isEmpty() || this.deviceEntries.get(this.currentDeviceIndex) == null) {
+      // for device which is not exist
       deviceEntry = new DeviceEntry(new StringArrayDeviceID(""), Collections.emptyList());
     } else {
       deviceEntry = this.deviceEntries.get(this.currentDeviceIndex);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/memory/TableModelStatementMemorySourceVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/memory/TableModelStatementMemorySourceVisitor.java
@@ -75,9 +75,9 @@ public class TableModelStatementMemorySourceVisitor
                 symbolAllocator,
                 NOOP)
             .plan(context.getAnalysis());
-    if (context.getAnalysis().isEmptyDataSource()) {
-      return new StatementMemorySource(new TsBlock(0), header);
-    }
+    //    if (context.getAnalysis().isEmptyDataSource()) {
+    //      return new StatementMemorySource(new TsBlock(0), header);
+    //    }
 
     // Generate table model distributed plan
     final TableDistributedPlanGenerator.PlanContext planContext =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/OperatorTreeGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/OperatorTreeGenerator.java
@@ -671,7 +671,7 @@ public class OperatorTreeGenerator extends PlanVisitor<Operator, LocalExecutionP
     boolean canUseStatistics =
         !TSDataType.BLOB.equals(node.getSeriesPath().getSeriesType())
             || (aggregationDescriptors.stream()
-                .noneMatch(o -> !judgeCanUseStatistics(o.getAggregationType(), TSDataType.BLOB)));
+                .allMatch(o -> judgeCanUseStatistics(o.getAggregationType(), TSDataType.BLOB)));
     SeriesAggregationScanOperator aggregateScanOperator =
         new SeriesAggregationScanOperator(
             node.getPlanNodeId(),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/PlanGraphPrinter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/PlanGraphPrinter.java
@@ -696,7 +696,7 @@ public class PlanGraphPrinter extends PlanVisitor<List<String>, PlanGraphPrinter
         String.format(
             "RegionId: %s",
             node.getRegionReplicaSet() == null || node.getRegionReplicaSet().getRegionId() == null
-                ? ""
+                ? "Not Assigned"
                 : node.getRegionReplicaSet().getRegionId().getId()));
     return render(node, boxValue, context);
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/Analysis.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/Analysis.java
@@ -335,8 +335,9 @@ public class Analysis implements IAnalysis {
     return aggregates.get(NodeRef.of(query));
   }
 
-  public boolean hasAggregates() {
-    return !aggregates.isEmpty();
+  public boolean noAggregates() {
+    return aggregates.isEmpty()
+        || (aggregates.size() == 1 && aggregates.entrySet().iterator().next().getValue().isEmpty());
   }
 
   public void setOrderByAggregates(OrderBy node, List<Expression> aggregates) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/Analysis.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/Analysis.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.queryengine.plan.relational.analyzer;
 
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
+import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.partition.DataPartition;
 import org.apache.iotdb.commons.partition.SchemaPartition;
@@ -68,8 +69,10 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Streams;
 import com.google.errorprone.annotations.Immutable;
+import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.read.common.block.TsBlock;
 import org.apache.tsfile.read.common.type.Type;
+import org.apache.tsfile.read.filter.basic.Filter;
 import org.apache.tsfile.utils.TimeDuration;
 
 import javax.annotation.Nullable;
@@ -807,6 +810,15 @@ public class Analysis implements IAnalysis {
       redirectNodeList = new ArrayList<>();
     }
     redirectNodeList.add(endPoint);
+  }
+
+  public List<TRegionReplicaSet> getDataRegionReplicaSetWithTimeFilter(
+      String database, IDeviceID deviceId, Filter timeFilter) {
+    if (dataPartition == null) {
+      return Collections.singletonList(new TRegionReplicaSet());
+    } else {
+      return dataPartition.getDataRegionReplicaSetWithTimeFilter(database, deviceId, timeFilter);
+    }
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/distribute/TableDistributedPlanGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/distribute/TableDistributedPlanGenerator.java
@@ -566,7 +566,6 @@ public class TableDistributedPlanGenerator
   public List<PlanNode> visitAggregationTableScan(
       AggregationTableScanNode node, PlanContext context) {
 
-    Map<TRegionReplicaSet, AggregationTableScanNode> tableScanNodeMap = new HashMap<>();
     boolean needSplit = false;
     List<List<TRegionReplicaSet>> regionReplicaSetsList = new ArrayList<>();
     for (DeviceEntry deviceEntry : node.getDeviceEntries()) {
@@ -586,6 +585,7 @@ public class TableDistributedPlanGenerator
           Collections.singletonList(Collections.singletonList(new TRegionReplicaSet()));
     }
 
+    Map<TRegionReplicaSet, AggregationTableScanNode> regionNodeMap = new HashMap<>();
     // Step is SINGLE, has date_bin(time) and device data in more than one region, we need to split
     // this node into two-stage Aggregation
     needSplit = needSplit && node.getProjection() != null && node.getStep() == SINGLE;
@@ -595,82 +595,15 @@ public class TableDistributedPlanGenerator
           split(node, symbolAllocator, queryId);
       finalAggregation = splitResult.left;
       AggregationTableScanNode partialAggregation = splitResult.right;
-      for (int i = 0; i < regionReplicaSetsList.size(); i++) {
-        for (TRegionReplicaSet regionReplicaSet : regionReplicaSetsList.get(i)) {
-          AggregationTableScanNode aggregationTableScanNode =
-              tableScanNodeMap.computeIfAbsent(
-                  regionReplicaSet,
-                  k -> {
-                    AggregationTableScanNode scanNode =
-                        new AggregationTableScanNode(
-                            queryId.genPlanNodeId(),
-                            partialAggregation.getQualifiedObjectName(),
-                            partialAggregation.getOutputSymbols(),
-                            partialAggregation.getAssignments(),
-                            new ArrayList<>(),
-                            partialAggregation.getIdAndAttributeIndexMap(),
-                            partialAggregation.getScanOrder(),
-                            partialAggregation.getTimePredicate().orElse(null),
-                            partialAggregation.getPushDownPredicate(),
-                            partialAggregation.getPushDownLimit(),
-                            partialAggregation.getPushDownOffset(),
-                            partialAggregation.isPushLimitToEachDevice(),
-                            partialAggregation.getProjection(),
-                            partialAggregation.getAggregations(),
-                            partialAggregation.getGroupingSets(),
-                            partialAggregation.getPreGroupedSymbols(),
-                            partialAggregation.getStep(),
-                            partialAggregation.getGroupIdSymbol());
-                    scanNode.setRegionReplicaSet(regionReplicaSet);
-                    return scanNode;
-                  });
-          if (node.getDeviceEntries().get(i) != null) {
-            aggregationTableScanNode.appendDeviceEntry(node.getDeviceEntries().get(i));
-          }
-        }
-      }
+      buildRegionNodeMap(node, regionReplicaSetsList, regionNodeMap, partialAggregation);
     } else {
-      for (int i = 0; i < regionReplicaSetsList.size(); i++) {
-        for (TRegionReplicaSet regionReplicaSet : regionReplicaSetsList.get(i)) {
-          AggregationTableScanNode aggregationTableScanNode =
-              tableScanNodeMap.computeIfAbsent(
-                  regionReplicaSet,
-                  k -> {
-                    AggregationTableScanNode scanNode =
-                        new AggregationTableScanNode(
-                            queryId.genPlanNodeId(),
-                            node.getQualifiedObjectName(),
-                            node.getOutputSymbols(),
-                            node.getAssignments(),
-                            new ArrayList<>(),
-                            node.getIdAndAttributeIndexMap(),
-                            node.getScanOrder(),
-                            node.getTimePredicate().orElse(null),
-                            node.getPushDownPredicate(),
-                            node.getPushDownLimit(),
-                            node.getPushDownOffset(),
-                            node.isPushLimitToEachDevice(),
-                            node.getProjection(),
-                            node.getAggregations(),
-                            node.getGroupingSets(),
-                            node.getPreGroupedSymbols(),
-                            node.getStep(),
-                            node.getGroupIdSymbol());
-                    scanNode.setRegionReplicaSet(regionReplicaSet);
-                    return scanNode;
-                  });
-          if (node.getDeviceEntries().size() > i && node.getDeviceEntries().get(i) != null) {
-            aggregationTableScanNode.appendDeviceEntry(node.getDeviceEntries().get(i));
-          }
-        }
-      }
+      buildRegionNodeMap(node, regionReplicaSetsList, regionNodeMap, node);
     }
 
     List<PlanNode> resultTableScanNodeList = new ArrayList<>();
     TRegionReplicaSet mostUsedDataRegion = null;
     int maxDeviceEntrySizeOfTableScan = 0;
-    for (Map.Entry<TRegionReplicaSet, AggregationTableScanNode> entry :
-        tableScanNodeMap.entrySet()) {
+    for (Map.Entry<TRegionReplicaSet, AggregationTableScanNode> entry : regionNodeMap.entrySet()) {
       TRegionReplicaSet regionReplicaSet = entry.getKey();
       TableScanNode subTableScanNode = entry.getValue();
       subTableScanNode.setPlanNodeId(queryId.genPlanNodeId());
@@ -704,6 +637,49 @@ public class TableDistributedPlanGenerator
     }
 
     return resultTableScanNodeList;
+  }
+
+  private void buildRegionNodeMap(
+      AggregationTableScanNode originalAggTableScanNode,
+      List<List<TRegionReplicaSet>> regionReplicaSetsList,
+      Map<TRegionReplicaSet, AggregationTableScanNode> regionNodeMap,
+      AggregationTableScanNode partialAggTableScanNode) {
+    for (int i = 0; i < regionReplicaSetsList.size(); i++) {
+      for (TRegionReplicaSet regionReplicaSet : regionReplicaSetsList.get(i)) {
+        AggregationTableScanNode aggregationTableScanNode =
+            regionNodeMap.computeIfAbsent(
+                regionReplicaSet,
+                k -> {
+                  AggregationTableScanNode scanNode =
+                      new AggregationTableScanNode(
+                          queryId.genPlanNodeId(),
+                          partialAggTableScanNode.getQualifiedObjectName(),
+                          partialAggTableScanNode.getOutputSymbols(),
+                          partialAggTableScanNode.getAssignments(),
+                          new ArrayList<>(),
+                          partialAggTableScanNode.getIdAndAttributeIndexMap(),
+                          partialAggTableScanNode.getScanOrder(),
+                          partialAggTableScanNode.getTimePredicate().orElse(null),
+                          partialAggTableScanNode.getPushDownPredicate(),
+                          partialAggTableScanNode.getPushDownLimit(),
+                          partialAggTableScanNode.getPushDownOffset(),
+                          partialAggTableScanNode.isPushLimitToEachDevice(),
+                          partialAggTableScanNode.getProjection(),
+                          partialAggTableScanNode.getAggregations(),
+                          partialAggTableScanNode.getGroupingSets(),
+                          partialAggTableScanNode.getPreGroupedSymbols(),
+                          partialAggTableScanNode.getStep(),
+                          partialAggTableScanNode.getGroupIdSymbol());
+                  scanNode.setRegionReplicaSet(regionReplicaSet);
+                  return scanNode;
+                });
+        if (originalAggTableScanNode.getDeviceEntries().size() > i
+            && originalAggTableScanNode.getDeviceEntries().get(i) != null) {
+          aggregationTableScanNode.appendDeviceEntry(
+              originalAggTableScanNode.getDeviceEntries().get(i));
+        }
+      }
+    }
   }
 
   private static OrderingScheme constructOrderingSchema(List<Symbol> symbols) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/optimizations/PushAggregationIntoTableScan.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/optimizations/PushAggregationIntoTableScan.java
@@ -56,7 +56,7 @@ public class PushAggregationIntoTableScan implements PlanOptimizer {
   @Override
   public PlanNode optimize(PlanNode plan, PlanOptimizer.Context context) {
     if (!(context.getAnalysis().getStatement() instanceof Query)
-        || !context.getAnalysis().hasAggregates()) {
+        || context.getAnalysis().noAggregates()) {
       return plan;
     }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/optimizations/PushPredicateIntoTableScan.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/optimizations/PushPredicateIntoTableScan.java
@@ -483,7 +483,7 @@ public class PushPredicateIntoTableScan implements PlanOptimizer {
           .recordPlanCost(TABLE_TYPE, SCHEMA_FETCHER, System.nanoTime() - startTime);
 
       if (deviceEntries.isEmpty()) {
-        if (!analysis.hasAggregates()) {
+        if (analysis.noAggregates()) {
           // no device entries, queries(except aggregation) can be finished
           analysis.setFinishQueryAfterAnalyze();
         }
@@ -509,7 +509,7 @@ public class PushPredicateIntoTableScan implements PlanOptimizer {
         }
 
         if (dataPartition.getDataPartitionMap().isEmpty()) {
-          if (!analysis.hasAggregates()) {
+          if (analysis.noAggregates()) {
             // no data partitions, queries(except aggregation) can be finished
             analysis.setFinishQueryAfterAnalyze();
           }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/optimizations/PushPredicateIntoTableScan.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/optimizations/PushPredicateIntoTableScan.java
@@ -484,6 +484,7 @@ public class PushPredicateIntoTableScan implements PlanOptimizer {
 
       if (deviceEntries.isEmpty()) {
         if (!analysis.hasAggregates()) {
+          // no device entries, queries(except aggregation) can be finished
           analysis.setFinishQueryAfterAnalyze();
         }
         analysis.setEmptyDataSource(true);
@@ -509,6 +510,7 @@ public class PushPredicateIntoTableScan implements PlanOptimizer {
 
         if (dataPartition.getDataPartitionMap().isEmpty()) {
           if (!analysis.hasAggregates()) {
+            // no data partitions, queries(except aggregation) can be finished
             analysis.setFinishQueryAfterAnalyze();
           }
           analysis.setEmptyDataSource(true);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/optimizations/PushPredicateIntoTableScan.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/optimizations/PushPredicateIntoTableScan.java
@@ -483,7 +483,9 @@ public class PushPredicateIntoTableScan implements PlanOptimizer {
           .recordPlanCost(TABLE_TYPE, SCHEMA_FETCHER, System.nanoTime() - startTime);
 
       if (deviceEntries.isEmpty()) {
-        analysis.setFinishQueryAfterAnalyze();
+        if (!analysis.hasAggregates()) {
+          analysis.setFinishQueryAfterAnalyze();
+        }
         analysis.setEmptyDataSource(true);
       } else {
         Filter timeFilter =
@@ -506,7 +508,9 @@ public class PushPredicateIntoTableScan implements PlanOptimizer {
         }
 
         if (dataPartition.getDataPartitionMap().isEmpty()) {
-          analysis.setFinishQueryAfterAnalyze();
+          if (!analysis.hasAggregates()) {
+            analysis.setFinishQueryAfterAnalyze();
+          }
           analysis.setEmptyDataSource(true);
         } else {
           analysis.upsertDataPartition(dataPartition);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/optimizations/TransformAggregationToStreamable.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/optimizations/TransformAggregationToStreamable.java
@@ -50,7 +50,7 @@ public class TransformAggregationToStreamable implements PlanOptimizer {
   @Override
   public PlanNode optimize(PlanNode plan, PlanOptimizer.Context context) {
     if (!(context.getAnalysis().getStatement() instanceof Query)
-        || !context.getAnalysis().hasAggregates()) {
+        || context.getAnalysis().noAggregates()) {
       return plan;
     }
 


### PR DESCRIPTION
## Description

As the title.

Before this pr, `select count(*), count(num), sum(num) from table0 where device='d_not_exist'` or `select count(*), count(num), sum(num) from table0 where time>now()` will return empty. In this pr, the sql will return `0,0,null`

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [x] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
