### PR TITLE
[region migration] Retry WRITE_PROCESS_REJECT status code

### DIFF
--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/StatusUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/StatusUtils.java
@@ -54,6 +54,7 @@ public class StatusUtils {
     NEED_RETRY.add(TSStatusCode.SYSTEM_READ_ONLY.getStatusCode());
     NEED_RETRY.add(TSStatusCode.STORAGE_ENGINE_NOT_READY.getStatusCode());
     NEED_RETRY.add(TSStatusCode.WRITE_PROCESS_ERROR.getStatusCode());
+    NEED_RETRY.add(TSStatusCode.WRITE_PROCESS_REJECT.getStatusCode());
     NEED_RETRY.add(TSStatusCode.WAL_ERROR.getStatusCode());
     NEED_RETRY.add(TSStatusCode.DISK_SPACE_INSUFFICIENT.getStatusCode());
     NEED_RETRY.add(TSStatusCode.QUERY_PROCESS_ERROR.getStatusCode());


### PR DESCRIPTION
## Description

When the region is inactive, the status code returned by write is `WRITE_PROCESS_REJECT`. To enable retries in this situation, the mpp retry policy should also retry on this status code.

![img_v3_02g0_c20fe30d-7392-4005-bc4e-3bfc4886d88g](https://github.com/user-attachments/assets/910fdb16-13e9-46ec-a68d-14ebbc19ee41)
