### PR TITLE
Pipe: reduce pipe phantom reference logging frequency by omitting printing if count unchanged

### DIFF
--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/resource/ref/PipePhantomReferenceManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/resource/ref/PipePhantomReferenceManager.java
@@ -86,10 +86,10 @@ public abstract class PipePhantomReferenceManager {
           System.currentTimeMillis() - startTime,
           getPhantomReferenceCount());
     } else {
-      final long currentCount = getPhantomReferenceCount();
-      if (currentCount != lastPhantomReferenceCount) {
-        LOGGER.info("Remaining pipe phantom reference count: {}", currentCount);
-        lastPhantomReferenceCount = currentCount;
+      final long currentPhantomReferenceCount = getPhantomReferenceCount();
+      if (currentPhantomReferenceCount != lastPhantomReferenceCount) {
+        LOGGER.info("Remaining pipe phantom reference count: {}", currentPhantomReferenceCount);
+        lastPhantomReferenceCount = currentPhantomReferenceCount;
       }
     }
   }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/resource/ref/PipePhantomReferenceManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/resource/ref/PipePhantomReferenceManager.java
@@ -42,6 +42,8 @@ public abstract class PipePhantomReferenceManager {
 
   private static final ReferenceQueue<EnrichedEvent> REFERENCE_QUEUE = new ReferenceQueue<>();
 
+  private volatile long lastPhantomReferenceCount = -1;
+
   public PipePhantomReferenceManager() {
     // Do nothing now.
   }
@@ -77,12 +79,18 @@ public abstract class PipePhantomReferenceManager {
       // Nowhere to really log this.
     }
 
-    if (maxCount != 0 || getPhantomReferenceCount() != 0) {
+    if (count != 0) {
       LOGGER.info(
           "Clean {} pipe phantom reference(s) successfully within {} ms, remaining reference count: {}",
           count,
           System.currentTimeMillis() - startTime,
           getPhantomReferenceCount());
+    } else {
+      final long currentCount = getPhantomReferenceCount();
+      if (currentCount != lastPhantomReferenceCount) {
+        LOGGER.info("Remaining pipe phantom reference count: {}", currentCount);
+        lastPhantomReferenceCount = currentCount;
+      }
     }
   }
 


### PR DESCRIPTION
As title.