### PR TITLE
Fix non deterministic test - RoleTest#testRole_InitAndSerialize

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/auth/entity/RoleTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/auth/entity/RoleTest.java
@@ -80,23 +80,29 @@ public class RoleTest {
         admin.toString());
   }
 
-  private void assertEqualsDeserializedRole(String expectedStr, String actualStr){
+  private void assertEqualsDeserializedRole(String expectedStr, String actualStr) {
     Assert.assertEquals(extractName(expectedStr), extractName(actualStr));
     List<String> expectedPathPrevilegeList = extractPathPrevilegeList(expectedStr);
     List<String> actualPathPrevilegeList = extractPathPrevilegeList(actualStr);
-    Assert.assertTrue(expectedPathPrevilegeList.size() == actualPathPrevilegeList.size() && expectedPathPrevilegeList.containsAll(actualPathPrevilegeList) && actualPathPrevilegeList.containsAll(expectedPathPrevilegeList));
+    Assert.assertTrue(
+        expectedPathPrevilegeList.size() == actualPathPrevilegeList.size()
+            && expectedPathPrevilegeList.containsAll(actualPathPrevilegeList)
+            && actualPathPrevilegeList.containsAll(expectedPathPrevilegeList));
     Set<String> expectedSystemPrivilegeSet = extractSystemPrivilegeSet(expectedStr);
     Set<String> actualSystemPrivilegeSet = extractSystemPrivilegeSet(actualStr);
-    Assert.assertTrue(expectedSystemPrivilegeSet.size() == actualSystemPrivilegeSet.size() && expectedSystemPrivilegeSet.containsAll(actualSystemPrivilegeSet) && actualSystemPrivilegeSet.containsAll(expectedSystemPrivilegeSet));
+    Assert.assertTrue(
+        expectedSystemPrivilegeSet.size() == actualSystemPrivilegeSet.size()
+            && expectedSystemPrivilegeSet.containsAll(actualSystemPrivilegeSet)
+            && actualSystemPrivilegeSet.containsAll(expectedSystemPrivilegeSet));
   }
 
-  private String extractName(String roleStr){
+  private String extractName(String roleStr) {
     Pattern namePattern = Pattern.compile("name='([^']+)'");
     Matcher nameMatcher = namePattern.matcher(roleStr);
-    return nameMatcher.find() ? nameMatcher.group(1): "";
+    return nameMatcher.find() ? nameMatcher.group(1) : "";
   }
 
-  private List<String> extractPathPrevilegeList(String roleStr){
+  private List<String> extractPathPrevilegeList(String roleStr) {
     Pattern pathPrivilegePattern = Pattern.compile("pathPrivilegeList=\\[([^]]+)\\]");
     Matcher pathPrivilegeMatcher = pathPrivilegePattern.matcher(roleStr);
     List<String> pathPrivilegeList = new ArrayList<>();
@@ -107,7 +113,7 @@ public class RoleTest {
     return pathPrivilegeList;
   }
 
-  private Set<String> extractSystemPrivilegeSet(String roleStr){
+  private Set<String> extractSystemPrivilegeSet(String roleStr) {
     Pattern systemPrivilegePattern = Pattern.compile("systemPrivilegeSet=\\[([^]]+)\\]");
     Matcher systemPrivilegeMatcher = systemPrivilegePattern.matcher(roleStr);
     Set<String> systemPrivilegeSet = new HashSet<>();


### PR DESCRIPTION
## Description
The test `org.apache.iotdb.db.auth.entity.RoleTest#testRole_InitAndSerialize` fails under [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool which detects non-deterministic nature of tests with when non-deterministic data structures are used. The failure behavior is defined by non-deterministic ordering of `pathPrivilegeList` and `systemPrivilegeSet`.

### How to Reproduce
```
mvn -pl iotdb-core/datanode edu.illinois:nondex-maven-plugin:2.1.7:nondex 
-Dtest=RoleTest#testRole_InitAndSerialize 
-DnondexRuns=10
```

### Error
```
[INFO] Running org.apache.iotdb.db.auth.entity.RoleTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.312 s <<< FAILURE! -- in org.apache.iotdb.db.auth.entity.RoleTest
[ERROR] org.apache.iotdb.db.auth.entity.RoleTest.testRole_InitAndSerialize -- Time elapsed: 0.267 s <<< FAILURE!
org.junit.ComparisonFailure: expected:<...legeList=[root.ln : [WRITE_DATA READ_SCHEMA_with_grant_option]], systemPrivilegeSe...> but was:<...legeList=[root.ln : [READ_SCHEMA_with_grant_option WRITE_DATA]], systemPrivilegeSe...>
	at org.junit.Assert.assertEquals(Assert.java:117)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at org.apache.iotdb.db.auth.entity.RoleTest.testRole_InitAndSerialize(RoleTest.java:48) ...
```

### Proposed Solution
Assert the role.toString by handling the above catch. Extract and assert the list and set instead of asserting string directly.
Please let me know if you have any questions or need any additional justification/changes from my side.
<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
