### PR TITLE
Fix Test MetaUtilsTest

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/MetaUtilsTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/MetaUtilsTest.java
@@ -191,6 +191,19 @@ public class MetaUtilsTest {
     props.putAll(sdtProps);
     Pair<String, String> res = MetaUtils.parseDeadbandInfo(props);
     Assert.assertEquals("SDT", res.left);
-    Assert.assertEquals(sdtProps.toString(), res.right);
+    Assert.assertEquals(sdtProps, parseHashMap(res.right));
+  }
+
+  private static Map<String, String> parseHashMap(String mapString) {
+    Map<String, String> map = new HashMap<>();
+    String content = mapString.substring(1, mapString.length() - 1);
+    String[] entries = content.split(", ");
+    for (String entry : entries) {
+      String[] keyValue = entry.split("=");
+      if (keyValue.length == 2) {
+        map.put(keyValue[0], keyValue[1]);
+      }
+    }
+    return map;
   }
 }


### PR DESCRIPTION
## Description
The test `org.apache.iotdb.db.metadata.MetaUtilsTest#testParseDeadbandInfo` fails under [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool which detects non-deterministic nature of tests with when non-deterministic data structures are used. The failure is because of hashmap.toString() being compared directly and hashmap doesn't gurantee ordering.

### How to Reproduce
mvn -pl iotdb-core/datanode edu.illinois:nondex-maven-plugin:2.1.7:nondex 
-Dtest=MetaUtilsTest#testParseDeadbandInfo
-DnondexRuns=10

### Error
[ERROR] org.apache.iotdb.db.metadata.MetaUtilsTest.testParseDeadbandInfo -- Time elapsed: 1.257 s <<< FAILURE!
org.junit.ComparisonFailure: expected:<{comp[mintime=2, compmaxtime=10, compdev=0.01]}> but was:<{comp[dev=0.01, compmintime=2, compmaxtime=10]}>
	at org.junit.Assert.assertEquals(Assert.java:117)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at org.apache.iotdb.db.metadata.MetaUtilsTest.testParseDeadbandInfo(MetaUtilsTest.java:194) ...

### Proposed Solution
Implement parseHashmap method to parse the string and convert it into hashmap, and then compare it with the expected hashmap.

Please let me know if you have any questions or need any additional justification/changes from my side.
<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
