### PR TITLE
Fix Non-determinstic Test SchemaFetchScanOperatorTest#testSchemaFetch…

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/schema/SchemaFetchScanOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/schema/SchemaFetchScanOperatorTest.java
@@ -97,9 +97,13 @@ public class SchemaFetchScanOperatorTest {
     Pair<List<MeasurementPath>, Integer> pair =
         schemaTree.searchMeasurementPaths(new PartialPath("root.sg.**.status"), 0, 0, false);
     Assert.assertEquals(3, pair.left.size());
-    Assert.assertEquals(
-        Arrays.asList("root.sg.d1.s2", "root.sg.d2.a.s2", "root.sg.d2.s2"),
-        pair.left.stream().map(MeasurementPath::getFullPath).collect(Collectors.toList()));
+    List<String> expectedPath = Arrays.asList("root.sg.d1.s2", "root.sg.d2.a.s2", "root.sg.d2.s2");
+    List<String> actualPath =
+        pair.left.stream().map(MeasurementPath::getFullPath).collect(Collectors.toList());
+    Assert.assertTrue(
+        expectedPath.size() == actualPath.size()
+            && expectedPath.containsAll(actualPath)
+            && actualPath.containsAll(expectedPath));
   }
 
   private ISchemaRegion mockSchemaRegion() throws Exception {


### PR DESCRIPTION
## Description
The test `org.apache.iotdb.db.queryengine.execution.operator.schema.SchemaFetchScanOperatorTest#testSchemaFetchResult` fails under [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool which detects non-deterministic nature of tests with when non-deterministic data structures are used. The failure here is observed because the results we get from ClusterSchemaTree are not always in determinstic order.

### How to Reproduce
```
mvn -pl iotdb-core/datanode edu.illinois:nondex-maven-plugin:2.1.7:nondex 
-Dtest=SchemaFetchScanOperatorTest#testSchemaFetchResult
-DnondexRuns=10
```

### Error
```
[ERROR] org.apache.iotdb.db.queryengine.execution.operator.schema.SchemaFetchScanOperatorTest.testSchemaFetchResult -- Time elapsed: 1.146 s <<< FAILURE!
java.lang.AssertionError: expected:<[root.sg.d1.s2, root.sg.d2.a.s2, root.sg.d2.s2]> but was:<[root.sg.d2.s2, root.sg.d2.a.s2, root.sg.d1.s2]>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:120)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at org.apache.iotdb.db.queryengine.execution.operator.schema.SchemaFetchScanOperatorTest.testSchemaFetchResult(SchemaFetchScanOperatorTest.java:100)...
```

### Proposed Solution
Instead of asserting the lists directly, assert the lists without considering the order.
Please let me know if you have any questions or need any additional justification/changes from my side.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
