### PR TITLE
Print Dataset is closed error msg if user continues to fetch from it

### DIFF
--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
@@ -254,6 +254,9 @@ public class IoTDBRpcDataSet {
   }
 
   public boolean fetchResults() throws StatementExecutionException, IoTDBConnectionException {
+    if (isClosed) {
+      throw new IoTDBConnectionException("This DataSet is already closed");
+    }
     TSFetchResultsReq req = new TSFetchResultsReq(sessionId, sql, fetchSize, queryId, true);
     req.setTimeout(timeout);
     try {


### PR DESCRIPTION
Print Dataset is closed error msg if user continues to fetch from it.

Previously, the error msg is:
<img width="1754" alt="image" src="https://github.com/user-attachments/assets/9855be15-a327-47ff-bc5a-81eb3e434655">

Currently, the error msg is:
<img width="955" alt="image" src="https://github.com/user-attachments/assets/3f3cf74e-fd19-4fd4-963a-9286a543eefd">
