### PR TITLE
[remove datanode] Enhance remove message on environment with only ConfigNode

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/client/ConfigNodeInfo.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/client/ConfigNodeInfo.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.protocol.client;
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.commons.consensus.ConfigRegionId;
 import org.apache.iotdb.commons.exception.BadNodeUrlException;
+import org.apache.iotdb.commons.exception.StartupException;
 import org.apache.iotdb.commons.file.SystemPropertiesHandler;
 import org.apache.iotdb.commons.utils.NodeUrlUtils;
 import org.apache.iotdb.db.conf.DataNodeSystemPropertiesHandler;
@@ -109,7 +110,7 @@ public class ConfigNodeInfo {
         CONFIG_NODE_LIST, NodeUrlUtils.convertTEndPointUrls(new ArrayList<>(onlineConfigNodes)));
   }
 
-  public void loadConfigNodeList() {
+  public void loadConfigNodeList() throws StartupException {
     long startTime = System.currentTimeMillis();
     // properties contain CONFIG_NODE_LIST only when start as Data node
     configNodeInfoReadWriteLock.writeLock().lock();
@@ -120,6 +121,10 @@ public class ConfigNodeInfo {
         onlineConfigNodes.clear();
         onlineConfigNodes.addAll(
             NodeUrlUtils.parseTEndPointUrls(properties.getProperty(CONFIG_NODE_LIST)));
+      }
+      if (onlineConfigNodes.isEmpty()) {
+        throw new StartupException(
+            "No ConfigNode found in system.properties, please check if system.properties is configured correctly in DataNode system folder.");
       }
       long endTime = System.currentTimeMillis();
       logger.info(


### PR DESCRIPTION
## Description

The remove-datanode script only supports removing DataNodes in an environment where DataNode has been successfully started. If the remove script fails in an environment with only ConfigNode, a clear error message must be given.

![image](https://github.com/user-attachments/assets/cc1e52af-09d1-4b2f-8ac2-a362f608b000)
