### PR TITLE
Fix ConfignNode LoadManager NPE when removing datanodes

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/LoadCache.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/LoadCache.java
@@ -248,11 +248,11 @@ public class LoadCache {
     nodeCacheMap
         .computeIfAbsent(nodeId, empty -> new AINodeHeartbeatCache(nodeId))
         .cacheHeartbeatSample(sample);
-    heartbeatProcessingMap.get(nodeId).set(false);
+    Optional.ofNullable(heartbeatProcessingMap.get(nodeId)).ifPresent(node -> node.set(false));
   }
 
   public void resetHeartbeatProcessing(int nodeId) {
-    heartbeatProcessingMap.get(nodeId).set(false);
+    Optional.ofNullable(heartbeatProcessingMap.get(nodeId)).ifPresent(node -> node.set(false));
   }
 
   /**
@@ -469,8 +469,9 @@ public class LoadCache {
    * @return NodeStatus of the specified Node. Unknown if cache doesn't exist.
    */
   public NodeStatus getNodeStatus(int nodeId) {
-    BaseNodeCache nodeCache = nodeCacheMap.get(nodeId);
-    return nodeCache == null ? NodeStatus.Unknown : nodeCache.getNodeStatus();
+    return Optional.ofNullable(nodeCacheMap.get(nodeId))
+        .map(BaseNodeCache::getNodeStatus)
+        .orElse(NodeStatus.Unknown);
   }
 
   /**
@@ -480,10 +481,9 @@ public class LoadCache {
    * @return The specified Node's current status if the nodeCache contains it, Unknown otherwise
    */
   public String getNodeStatusWithReason(int nodeId) {
-    BaseNodeCache nodeCache = nodeCacheMap.get(nodeId);
-    return nodeCache == null
-        ? NodeStatus.Unknown.getStatus() + "(NoHeartbeat)"
-        : nodeCache.getNodeStatusWithReason();
+    return Optional.ofNullable(nodeCacheMap.get(nodeId))
+        .map(BaseNodeCache::getNodeStatusWithReason)
+        .orElseGet(() -> NodeStatus.Unknown.getStatus() + "(NoHeartbeat)");
   }
 
   /**
@@ -537,9 +537,9 @@ public class LoadCache {
    * @return The free disk space that sample through heartbeat, 0 if no heartbeat received
    */
   public double getFreeDiskSpace(int dataNodeId) {
-    DataNodeHeartbeatCache dataNodeHeartbeatCache =
-        (DataNodeHeartbeatCache) nodeCacheMap.get(dataNodeId);
-    return dataNodeHeartbeatCache == null ? 0d : dataNodeHeartbeatCache.getFreeDiskSpace();
+    return Optional.ofNullable((DataNodeHeartbeatCache) nodeCacheMap.get(dataNodeId))
+        .map(DataNodeHeartbeatCache::getFreeDiskSpace)
+        .orElse(0d);
   }
 
   /**
@@ -594,12 +594,9 @@ public class LoadCache {
    * @return Corresponding RegionStatus if cache exists, Unknown otherwise
    */
   public RegionStatus getRegionStatus(TConsensusGroupId consensusGroupId, int dataNodeId) {
-    return regionGroupCacheMap.containsKey(consensusGroupId)
-        ? regionGroupCacheMap
-            .get(consensusGroupId)
-            .getCurrentStatistics()
-            .getRegionStatus(dataNodeId)
-        : RegionStatus.Unknown;
+    return Optional.ofNullable(regionGroupCacheMap.get(consensusGroupId))
+        .map(x -> x.getCurrentStatistics().getRegionStatus(dataNodeId))
+        .orElse(RegionStatus.Unknown);
   }
 
   /**
@@ -609,9 +606,9 @@ public class LoadCache {
    * @return Corresponding RegionGroupStatus if cache exists, Disabled otherwise
    */
   public RegionGroupStatus getRegionGroupStatus(TConsensusGroupId consensusGroupId) {
-    return regionGroupCacheMap.containsKey(consensusGroupId)
-        ? regionGroupCacheMap.get(consensusGroupId).getCurrentStatistics().getRegionGroupStatus()
-        : RegionGroupStatus.Disabled;
+    return Optional.ofNullable(regionGroupCacheMap.get(consensusGroupId))
+        .map(x -> x.getCurrentStatistics().getRegionGroupStatus())
+        .orElse(RegionGroupStatus.Disabled);
   }
 
   /**


### PR DESCRIPTION
When Datanodes are currently removed, the deletion of some maps of cn loadmanager and the callback of asynchronous rpc may have some concurrency conflicts. In this case, some robustness needs to be improved