### PR TITLE
Fixed a few non deterministic tests

### DIFF
--- a/iotdb-client/session/src/test/java/org/apache/iotdb/session/SessionCacheLeaderTest.java
+++ b/iotdb-client/session/src/test/java/org/apache/iotdb/session/SessionCacheLeaderTest.java
@@ -45,6 +45,7 @@ import org.junit.Test;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -878,7 +879,7 @@ public class SessionCacheLeaderTest {
     Tablet tablet2 = new Tablet(allDeviceIds.get(2), schemaList, 100);
     Tablet tablet3 = new Tablet(allDeviceIds.get(3), schemaList, 100);
 
-    Map<String, Tablet> tabletMap = new HashMap<>();
+    Map<String, Tablet> tabletMap = new LinkedHashMap<>();
     tabletMap.put(allDeviceIds.get(1), tablet1);
     tabletMap.put(allDeviceIds.get(2), tablet2);
     tabletMap.put(allDeviceIds.get(3), tablet3);

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/schema/ConfigMTreeTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/schema/ConfigMTreeTest.java
@@ -41,7 +41,9 @@ import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -139,16 +141,24 @@ public class ConfigMTreeTest {
       root.setStorageGroup(new PartialPath("root.laptop.d1"));
       root.setStorageGroup(new PartialPath("root.laptop.d2"));
 
-      final List<PartialPath> list = new ArrayList<>();
+      List<PartialPath> list1 = Collections.singletonList(new PartialPath("root.laptop.d1"));
+      assertEquals(
+          new HashSet<>(list1),
+          new HashSet<>(root.getBelongedDatabases(new PartialPath("root.laptop.d1.s1"))));
+      assertEquals(
+          new HashSet<>(list1),
+          new HashSet<>(root.getBelongedDatabases(new PartialPath("root.laptop.d1"))));
 
-      list.add(new PartialPath("root.laptop.d1"));
-      assertEquals(list, root.getBelongedDatabases(new PartialPath("root.laptop.d1.s1")));
-      assertEquals(list, root.getBelongedDatabases(new PartialPath("root.laptop.d1")));
+      List<PartialPath> list2 =
+          Arrays.asList(new PartialPath("root.laptop.d1"), new PartialPath("root.laptop.d2"));
+      assertEquals(
+          new HashSet<>(list2),
+          new HashSet<>(root.getBelongedDatabases(new PartialPath("root.laptop.**"))));
+      assertEquals(
+          new HashSet<>(list2),
+          new HashSet<>(root.getBelongedDatabases(new PartialPath("root.**"))));
 
-      list.add(new PartialPath("root.laptop.d2"));
-      assertEquals(list, root.getBelongedDatabases(new PartialPath("root.laptop.**")));
-      assertEquals(list, root.getBelongedDatabases(new PartialPath("root.**")));
-    } catch (final MetadataException e) {
+    } catch (MetadataException e) {
       e.printStackTrace();
       fail(e.getMessage());
     }

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/path/PathPatternTreeTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/path/PathPatternTreeTest.java
@@ -282,10 +282,11 @@ public class PathPatternTreeTest {
       patternTree.appendPathPattern(path);
     }
     patternTree.constructTree();
-
-    Assert.assertEquals(
-        Arrays.asList(new PartialPath("root.sg1.*.t1.s1"), new PartialPath("root.sg1.d1.t2.s2")),
-        patternTree.getAllPathPatterns());
+    List<PartialPath> expectedPaths =
+        Arrays.asList(new PartialPath("root.sg1.*.t1.s1"), new PartialPath("root.sg1.d1.t2.s2"));
+    List<PartialPath> actualPaths = patternTree.getAllPathPatterns();
+    Collections.sort(actualPaths);
+    Assert.assertEquals(expectedPaths, actualPaths);
   }
 
   @Test


### PR DESCRIPTION
## Description
This PR fixes three non deterministic tests :

- org.apache.iotdb.session.SessionCacheLeaderTest.testInsertTabletsWithSessionBroken
- org.apache.iotdb.commons.path.PathPatternTreeTest.testPathPatternTreeSplit
- org.apache.iotdb.confignode.persistence.schema.ConfigMTreeTest.testGetAllFileNamesByPath

These tests failed under [NonDex ](https://github.com/TestingResearchIllinois/NonDex) tool as explained in the issue [IOTDB-6352](https://issues.apache.org/jira/browse/IOTDB-6352) .

### Steps to Reproduce

To reproduce the problem, first build the module and then run the [nondex](https://github.com/TestingResearchIllinois/NonDex) command:

- For SessionCacheLeaderTest:
> mvn install -pl iotdb-client/session -am -DskipTests

> mvn -pl iotdb-client/session edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.apache.iotdb.session.SessionCacheLeaderTest#testInsertTabletsWithSessionBroken

The reason for the flakiness of this test is that HashMap does not guarantee the order of its entries. This unordered behaviour can lead to differences in the insertion or iteration order of the map. The fix involves replacing it with LinkedHashMap which guarantees the order.

- For PathPatternTreeTest:
> mvn install -pl iotdb-core/node-commons -am -DskipTests

> mvn -pl iotdb-core/node-commons edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.apache.iotdb.commons.path.PathPatternTreeTest#testPathPatternTreeSplit

The reason for the flakiness of this test is due to the order of the path returned by `getAllPathPatterns ` function which gives a non deterministic order. The simple fix for this is to sort the output of getAllPathPatterns which will give a deterministic output.

- For ConfigMTreeTest:
> mvn install -pl iotdb-core/confignode -am -DskipTests

> mvn -pl iotdb-core/confignode edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.apache.iotdb.confignode.persistence.schema.ConfigMTreeTest#testGetAllFileNamesByPath

The reason for the flakiness of this test is due to the path returned by `getBelongedDatabases` function which gives a non deterministic order. The fix involves converting both the list to HashSet which makes the comparisions order independent.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

Please let me know if you have any questions or need any additional justification/changes from my side.

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
