### PR TITLE
[Region Migration] Fix Create ConsensusPipe On Coordinator Failed

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/pipe/consensuspipe/ConsensusPipeManager.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/pipe/consensuspipe/ConsensusPipeManager.java
@@ -99,9 +99,6 @@ public class ConsensusPipeManager {
                   EXTRACTOR_CONSENSUS_RECEIVER_DATANODE_ID_KEY,
                   String.valueOf(consensusPipeName.getReceiverDataNodeId()))
               .put(EXTRACTOR_REALTIME_MODE_KEY, replicateMode.getValue())
-              .put(
-                  EXTRACTOR_CONSENSUS_RESTORE_PROGRESS_PIPE_TASK_NAME_KEY,
-                  String.valueOf(new ConsensusPipeName(senderPeer, regionMigrationCoordinatorPeer)))
               .build();
     } else {
       extractorParams =
@@ -118,6 +115,9 @@ public class ConsensusPipeManager {
                   EXTRACTOR_CONSENSUS_RECEIVER_DATANODE_ID_KEY,
                   String.valueOf(consensusPipeName.getReceiverDataNodeId()))
               .put(EXTRACTOR_REALTIME_MODE_KEY, replicateMode.getValue())
+              .put(
+                  EXTRACTOR_CONSENSUS_RESTORE_PROGRESS_PIPE_TASK_NAME_KEY,
+                  String.valueOf(new ConsensusPipeName(senderPeer, regionMigrationCoordinatorPeer)))
               .build();
     }
     return new ImmutableTriple<>(


### PR DESCRIPTION
Currently create consensusPipe on coordinator will failed, because the pre-check detect a consensusPipe from coordinator pointing to coordinator, as this image shows:
<img width="1077" alt="image" src="https://github.com/user-attachments/assets/77c76f73-da76-4944-b8e9-44f87aa21d60">
Fix this bugs caused by minor mistake...