### PR TITLE
[To dev/1.3] Pipe: GC device2Measurements in PipeRealtimeEvent in time to avoid OOM when insertion is in high load (#14018)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/realtime/PipeRealtimeEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/realtime/PipeRealtimeEvent.java
@@ -171,7 +171,9 @@ public class PipeRealtimeEvent extends EnrichedEvent {
         event.shallowCopySelfAndBindPipeTaskMetaForProgressReport(
             pipeName, creationTime, pipeTaskMeta, pattern, startTime, endTime),
         this.tsFileEpoch,
-        this.device2Measurements,
+        // device2Measurements is not used anymore, so it is not copied.
+        // If null is not passed, the field will not be GCed and may cause OOM.
+        null,
         pipeTaskMeta,
         pattern,
         startTime,


### PR DESCRIPTION
(cherry picked from commit caac607464359cb194b07bd1fa6c985bb745826e)