### PR TITLE
Fix query resource clear async thread stuck bug

### DIFF
--- a/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDAFMedian.java
+++ b/library-udf/src/main/java/org/apache/iotdb/library/dprofile/UDAFMedian.java
@@ -31,6 +31,8 @@ import org.apache.iotdb.udf.api.customizer.parameter.UDFParameters;
 import org.apache.iotdb.udf.api.customizer.strategy.RowByRowAccessStrategy;
 import org.apache.iotdb.udf.api.type.Type;
 
+import java.util.NoSuchElementException;
+
 /** calculate the exact or approximate median. */
 public class UDAFMedian implements UDTF {
 
@@ -73,10 +75,14 @@ public class UDAFMedian implements UDTF {
 
   @Override
   public void terminate(PointCollector collector) throws Exception {
-    if (exact) {
-      collector.putDouble(0, statistics.getMedian());
-    } else {
-      collector.putDouble(0, sketch.query(0.5));
+    try {
+      if (exact) {
+        collector.putDouble(0, statistics.getMedian());
+      } else {
+        collector.putDouble(0, sketch.query(0.5));
+      }
+    } catch (NoSuchElementException e) {
+      // just ignore it
     }
   }
 }


### PR DESCRIPTION
Due to a race condition in Driver#tryWithLock there was a chance an operator might have end up not being properly closed upon completion.(here is the UDF throw NoSuchElementException)

- Driver#process executes an operator under the Driver#exclusiveLock
- An operator throws an exception and triggers a task failure
- A FIStateMachine listener closes all drivers calling Driver#close
- Driver#close is not able to acquire the Driver#exclusiveLock and assumes the driver will be terminated by the lock owner
- The lock owner throws an exception and never runs `destroyIfNecessary` in Driver#tryWithLock that was expected to close the operators
- Query resource clear async thread stuck to wait for driver to close