### PR TITLE
[Region Migration] Each component uses an independent ClientManager && Filter out the consensus pipe when judging resource release

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/pipe/PipeConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/pipe/PipeConsensusServerImpl.java
@@ -530,6 +530,7 @@ public class PipeConsensusServerImpl {
 
         final List<String> consensusPipeNames =
             peerManager.getPeers().stream()
+                .filter(peer -> !peer.equals(targetPeer))
                 .map(peer -> new ConsensusPipeName(targetPeer, peer).toString())
                 .collect(Collectors.toList());
         isTransmissionCompleted =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/pipeconsensus/PipeConsensusAsyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/pipeconsensus/PipeConsensusAsyncConnector.java
@@ -142,7 +142,7 @@ public class PipeConsensusAsyncConnector extends IoTDBConnector implements Conse
             nodeUrls, consensusGroupId, thisDataNodeId, pipeConsensusConnectorMetrics);
     retryConnector.customize(parameters, configuration);
     asyncTransferClientManager =
-        PipeConsensusClientMgrContainer.getInstance().getAsyncClientManager();
+        PipeConsensusClientMgrContainer.getInstance().newAsyncClientManager();
 
     if (isTabletBatchModeEnabled) {
       tabletBatchBuilder =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/pipeconsensus/PipeConsensusSyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/pipeconsensus/PipeConsensusSyncConnector.java
@@ -93,7 +93,7 @@ public class PipeConsensusSyncConnector extends IoTDBConnector {
     this.consensusGroupId = consensusGroupId;
     this.thisDataNodeId = thisDataNodeId;
     this.syncRetryClientManager =
-        PipeConsensusClientMgrContainer.getInstance().getSyncClientManager();
+        PipeConsensusClientMgrContainer.getInstance().newSyncClientManager();
     this.pipeConsensusConnectorMetrics = pipeConsensusConnectorMetrics;
   }
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/container/PipeConsensusClientMgrContainer.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/container/PipeConsensusClientMgrContainer.java
@@ -39,32 +39,26 @@ import org.apache.iotdb.commons.conf.CommonDescriptor;
  */
 public class PipeConsensusClientMgrContainer {
   private static final CommonConfig CONF = CommonDescriptor.getInstance().getConfig();
-  private final IClientManager<TEndPoint, AsyncPipeConsensusServiceClient> asyncClientManager;
-  private final IClientManager<TEndPoint, SyncPipeConsensusServiceClient> syncClientManager;
+  private final PipeConsensusClientProperty config;
 
   private PipeConsensusClientMgrContainer() {
     // load rpc client config
-    PipeConsensusClientProperty config =
+    this.config =
         PipeConsensusClientProperty.newBuilder()
             .setIsRpcThriftCompressionEnabled(CONF.isRpcThriftCompressionEnabled())
             .setMaxClientNumForEachNode(CONF.getMaxClientNumForEachNode())
             .setSelectorNumOfClientManager(CONF.getSelectorNumOfClientManager())
             .build();
-
-    this.asyncClientManager =
-        new IClientManager.Factory<TEndPoint, AsyncPipeConsensusServiceClient>()
-            .createClientManager(new AsyncPipeConsensusServiceClientPoolFactory(config));
-    this.syncClientManager =
-        new IClientManager.Factory<TEndPoint, SyncPipeConsensusServiceClient>()
-            .createClientManager(new SyncPipeConsensusServiceClientPoolFactory(config));
   }
 
-  public IClientManager<TEndPoint, AsyncPipeConsensusServiceClient> getAsyncClientManager() {
-    return asyncClientManager;
+  public IClientManager<TEndPoint, AsyncPipeConsensusServiceClient> newAsyncClientManager() {
+    return new IClientManager.Factory<TEndPoint, AsyncPipeConsensusServiceClient>()
+        .createClientManager(new AsyncPipeConsensusServiceClientPoolFactory(config));
   }
 
-  public IClientManager<TEndPoint, SyncPipeConsensusServiceClient> getSyncClientManager() {
-    return syncClientManager;
+  public IClientManager<TEndPoint, SyncPipeConsensusServiceClient> newSyncClientManager() {
+    return new IClientManager.Factory<TEndPoint, SyncPipeConsensusServiceClient>()
+        .createClientManager(new SyncPipeConsensusServiceClientPoolFactory(config));
   }
 
   private static class PipeConsensusClientMgrContainerHolder {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/PipeTaskManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/PipeTaskManager.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.commons.pipe.agent.task;
 
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeStaticMeta;
+import org.apache.iotdb.commons.pipe.agent.task.meta.PipeType;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -115,9 +116,9 @@ public class PipeTaskManager {
    *     otherwise
    */
   public synchronized boolean hasPipeTaskInConsensusGroup(final int consensusGroupId) {
-    return pipeMap.values().stream()
-        .anyMatch(
-            consensusGroupId2PipeTask -> consensusGroupId2PipeTask.containsKey(consensusGroupId));
+    return pipeMap.entrySet().stream()
+        .filter(entry -> entry.getKey().getPipeType() != PipeType.CONSENSUS)
+        .anyMatch(entry -> entry.getValue().containsKey(consensusGroupId));
   }
 
   /**


### PR DESCRIPTION
as title.