### PR TITLE
Pipe: atomically publish segment lock to avoid uninitialized volatile variable

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/tsfile/PipeTsFileResourceSegmentLock.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/tsfile/PipeTsFileResourceSegmentLock.java
@@ -51,13 +51,13 @@ public class PipeTsFileResourceSegmentLock {
           lockSegmentSize = Math.min(SEGMENT_LOCK_MAX_SIZE, lockSegmentSize);
           lockSegmentSize = Math.max(SEGMENT_LOCK_MIN_SIZE, lockSegmentSize);
 
-          final ReentrantLock[] newLocks = new ReentrantLock[lockSegmentSize];
-          for (int i = 0; i < newLocks.length; i++) {
-            newLocks[i] = new ReentrantLock();
+          final ReentrantLock[] tmpLocks = new ReentrantLock[lockSegmentSize];
+          for (int i = 0; i < tmpLocks.length; i++) {
+            tmpLocks[i] = new ReentrantLock();
           }
 
           // publish this variable
-          locks = newLocks;
+          locks = tmpLocks;
         }
       }
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/tsfile/PipeTsFileResourceSegmentLock.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/tsfile/PipeTsFileResourceSegmentLock.java
@@ -51,10 +51,13 @@ public class PipeTsFileResourceSegmentLock {
           lockSegmentSize = Math.min(SEGMENT_LOCK_MAX_SIZE, lockSegmentSize);
           lockSegmentSize = Math.max(SEGMENT_LOCK_MIN_SIZE, lockSegmentSize);
 
-          locks = new ReentrantLock[lockSegmentSize];
-          for (int i = 0; i < locks.length; i++) {
-            locks[i] = new ReentrantLock();
+          final ReentrantLock[] newLocks = new ReentrantLock[lockSegmentSize];
+          for (int i = 0; i < newLocks.length; i++) {
+            newLocks[i] = new ReentrantLock();
           }
+
+          // publish this variable
+          locks = newLocks;
         }
       }
     }


### PR DESCRIPTION
fixup #13915