### PR TITLE
[To dev/1.3] Pipe: avoid supply event with failed tsfile resource pin & apply double-checked locking for exists-and-mkdirs operation (#13998)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/historical/PipeHistoricalDataRegionTsFileExtractor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/historical/PipeHistoricalDataRegionTsFileExtractor.java
@@ -465,15 +465,17 @@ public class PipeHistoricalDataRegionTsFileExtractor implements PipeHistoricalDa
                 .collect(Collectors.toList());
         resourceList.addAll(unsequenceTsFileResources);
 
-        resourceList.forEach(
+        resourceList.removeIf(
             resource -> {
               // Pin the resource, in case the file is removed by compaction or anything.
               // Will unpin it after the PipeTsFileInsertionEvent is created and pinned.
               try {
                 PipeDataNodeResourceManager.tsfile()
                     .pinTsFileResource(resource, shouldTransferModFile);
+                return false;
               } catch (final IOException e) {
-                LOGGER.warn("Pipe: failed to pin TsFileResource {}", resource.getTsFilePath());
+                LOGGER.warn("Pipe: failed to pin TsFileResource {}", resource.getTsFilePath(), e);
+                return true;
               }
             });
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/wal/hardlink/PipeWALHardlinkResourceManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/wal/hardlink/PipeWALHardlinkResourceManager.java
@@ -21,15 +21,14 @@ package org.apache.iotdb.db.pipe.resource.wal.hardlink;
 
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.pipe.config.PipeConfig;
+import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.db.pipe.resource.wal.PipeWALResourceManager;
 import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALEntryHandler;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -80,7 +79,7 @@ public class PipeWALHardlinkResourceManager extends PipeWALResourceManager {
     // if the file is a wal, and there is no related hardlink in pipe dir, create a hardlink to pipe
     // dir, maintain a reference count for the hardlink, and return the hardlink.
     hardlinkToReferenceMap.put(hardlink.getPath(), 1);
-    return createHardlink(file, hardlink);
+    return FileUtils.createHardLink(file, hardlink);
   }
 
   private boolean increaseReferenceIfExists(final String path) {
@@ -126,21 +125,6 @@ public class PipeWALHardlinkResourceManager extends PipeWALResourceManager {
               .append(builder);
     }
     return builder.toString();
-  }
-
-  private static File createHardlink(final File sourceFile, final File hardlink)
-      throws IOException {
-    if (!hardlink.getParentFile().exists() && !hardlink.getParentFile().mkdirs()) {
-      throw new IOException(
-          String.format(
-              "failed to create hardlink %s for file %s: failed to create parent dir %s",
-              hardlink.getPath(), sourceFile.getPath(), hardlink.getParentFile().getPath()));
-    }
-
-    final Path sourcePath = FileSystems.getDefault().getPath(sourceFile.getAbsolutePath());
-    final Path linkPath = FileSystems.getDefault().getPath(hardlink.getAbsolutePath());
-    Files.createLink(linkPath, sourcePath);
-    return hardlink;
   }
 
   /**

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/FileUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/FileUtils.java
@@ -105,12 +105,14 @@ public class FileUtils {
           sourceDir.getAbsolutePath());
       return false;
     }
-    if (!targetDir.exists()) {
-      if (!targetDir.mkdirs()) {
-        LOGGER.error(
-            "Failed to copy folder, because failed to create target folder[{}].",
-            targetDir.getAbsolutePath());
-        return false;
+    if (!targetDir.exists() && !targetDir.mkdirs()) {
+      synchronized (FileUtils.class) {
+        if (!targetDir.exists() && !targetDir.mkdirs()) {
+          LOGGER.error(
+              "Failed to copy folder, because failed to create target folder[{}].",
+              targetDir.getAbsolutePath());
+          return false;
+        }
       }
     } else if (!targetDir.isDirectory()) {
       LOGGER.error(
@@ -280,10 +282,14 @@ public class FileUtils {
 
   public static File createHardLink(File sourceFile, File hardlink) throws IOException {
     if (!hardlink.getParentFile().exists() && !hardlink.getParentFile().mkdirs()) {
-      throw new IOException(
-          String.format(
-              "failed to create hardlink %s for file %s: failed to create parent dir %s",
-              hardlink.getPath(), sourceFile.getPath(), hardlink.getParentFile().getPath()));
+      synchronized (FileUtils.class) {
+        if (!hardlink.getParentFile().exists() && !hardlink.getParentFile().mkdirs()) {
+          throw new IOException(
+              String.format(
+                  "failed to create hardlink %s for file %s: failed to create parent dir %s",
+                  hardlink.getPath(), sourceFile.getPath(), hardlink.getParentFile().getPath()));
+        }
+      }
     }
 
     final Path sourcePath = FileSystems.getDefault().getPath(sourceFile.getAbsolutePath());
@@ -294,10 +300,16 @@ public class FileUtils {
 
   public static File copyFile(File sourceFile, File targetFile) throws IOException {
     if (!targetFile.getParentFile().exists() && !targetFile.getParentFile().mkdirs()) {
-      throw new IOException(
-          String.format(
-              "failed to copy file %s to %s: failed to create parent dir %s",
-              sourceFile.getPath(), targetFile.getPath(), targetFile.getParentFile().getPath()));
+      synchronized (FileUtils.class) {
+        if (!targetFile.getParentFile().exists() && !targetFile.getParentFile().mkdirs()) {
+          throw new IOException(
+              String.format(
+                  "failed to copy file %s to %s: failed to create parent dir %s",
+                  sourceFile.getPath(),
+                  targetFile.getPath(),
+                  targetFile.getParentFile().getPath()));
+        }
+      }
     }
 
     Files.copy(sourceFile.toPath(), targetFile.toPath());


### PR DESCRIPTION
cherry-pick #13998 to https://github.com/apache/iotdb/tree/dev/1.3