### PR TITLE
[To dev/1.3] Pipe: atomically publish segment lock to avoid uninitialized volatile variable (#14064)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/tsfile/PipeTsFileResourceSegmentLock.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/tsfile/PipeTsFileResourceSegmentLock.java
@@ -51,10 +51,13 @@ public class PipeTsFileResourceSegmentLock {
           lockSegmentSize = Math.min(SEGMENT_LOCK_MAX_SIZE, lockSegmentSize);
           lockSegmentSize = Math.max(SEGMENT_LOCK_MIN_SIZE, lockSegmentSize);
 
-          locks = new ReentrantLock[lockSegmentSize];
-          for (int i = 0; i < locks.length; i++) {
-            locks[i] = new ReentrantLock();
+          final ReentrantLock[] tmpLocks = new ReentrantLock[lockSegmentSize];
+          for (int i = 0; i < tmpLocks.length; i++) {
+            tmpLocks[i] = new ReentrantLock();
           }
+
+          // publish this variable
+          locks = tmpLocks;
         }
       }
     }


### PR DESCRIPTION
cherry-pick #14064 to https://github.com/apache/iotdb/tree/dev/1.3