### PR TITLE
[To dev/1.3] Subscription: avoid the file reading when the memory is not enough for tsfile slicing & implement all-out effort global timeout control & support client resume from breakpoint for tsfile consumption (#13992)

### DIFF
--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/subscription/exception/SubscriptionPollTimeoutException.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/subscription/exception/SubscriptionPollTimeoutException.java
@@ -21,21 +21,21 @@ package org.apache.iotdb.rpc.subscription.exception;
 
 import java.util.Objects;
 
-public class SubscriptionPipeTimeoutException extends SubscriptionTimeoutException {
+public class SubscriptionPollTimeoutException extends SubscriptionTimeoutException {
 
-  public SubscriptionPipeTimeoutException(final String message) {
+  public SubscriptionPollTimeoutException(final String message) {
     super(message);
   }
 
-  public SubscriptionPipeTimeoutException(final String message, final Throwable cause) {
+  public SubscriptionPollTimeoutException(final String message, final Throwable cause) {
     super(message, cause);
   }
 
   @Override
   public boolean equals(final Object obj) {
-    return obj instanceof SubscriptionPipeTimeoutException
-        && Objects.equals(getMessage(), ((SubscriptionPipeTimeoutException) obj).getMessage())
-        && Objects.equals(getTimeStamp(), ((SubscriptionPipeTimeoutException) obj).getTimeStamp());
+    return obj instanceof SubscriptionPollTimeoutException
+        && Objects.equals(getMessage(), ((SubscriptionPollTimeoutException) obj).getMessage())
+        && Objects.equals(getTimeStamp(), ((SubscriptionPollTimeoutException) obj).getTimeStamp());
   }
 
   @Override

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/subscription/exception/SubscriptionTimeoutException.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/subscription/exception/SubscriptionTimeoutException.java
@@ -21,21 +21,23 @@ package org.apache.iotdb.rpc.subscription.exception;
 
 import java.util.Objects;
 
-public class SubscriptionPipeTimeoutException extends SubscriptionTimeoutException {
+public abstract class SubscriptionTimeoutException extends SubscriptionRuntimeNonCriticalException {
 
-  public SubscriptionPipeTimeoutException(final String message) {
+  public static String KEYWORD = "TimeoutException";
+
+  public SubscriptionTimeoutException(final String message) {
     super(message);
   }
 
-  public SubscriptionPipeTimeoutException(final String message, final Throwable cause) {
+  public SubscriptionTimeoutException(final String message, final Throwable cause) {
     super(message, cause);
   }
 
   @Override
   public boolean equals(final Object obj) {
-    return obj instanceof SubscriptionPipeTimeoutException
-        && Objects.equals(getMessage(), ((SubscriptionPipeTimeoutException) obj).getMessage())
-        && Objects.equals(getTimeStamp(), ((SubscriptionPipeTimeoutException) obj).getTimeStamp());
+    return obj instanceof SubscriptionTimeoutException
+        && Objects.equals(getMessage(), ((SubscriptionTimeoutException) obj).getMessage())
+        && Objects.equals(getTimeStamp(), ((SubscriptionTimeoutException) obj).getTimeStamp());
   }
 
   @Override

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/subscription/payload/poll/SubscriptionPollRequest.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/subscription/payload/poll/SubscriptionPollRequest.java
@@ -36,7 +36,7 @@ public class SubscriptionPollRequest {
 
   private final transient SubscriptionPollPayload payload;
 
-  private final transient long timeoutMs; // unused now
+  private final transient long timeoutMs;
 
   /** The maximum size, in bytes, for the response payload. */
   private final transient long maxBytes;

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/subscription/consumer/SubscriptionExecutorServiceManager.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/subscription/consumer/SubscriptionExecutorServiceManager.java
@@ -31,7 +31,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 public final class SubscriptionExecutorServiceManager {
@@ -285,10 +284,12 @@ public final class SubscriptionExecutorServiceManager {
       if (!isShutdown()) {
         synchronized (this) {
           if (!isShutdown()) {
-            return Math.max(
-                ((ThreadPoolExecutor) this.executor).getPoolSize()
-                    - ((ThreadPoolExecutor) this.executor).getActiveCount(),
-                0);
+            // TODO: temporarily disable multiple poll
+            return 0;
+            // return Math.max(
+            //    ((ThreadPoolExecutor) this.executor).getCorePoolSize()
+            //        - ((ThreadPoolExecutor) this.executor).getActiveCount(),
+            //    0);
           }
         }
       }

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/subscription/consumer/SubscriptionProvider.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/subscription/consumer/SubscriptionProvider.java
@@ -299,34 +299,35 @@ final class SubscriptionProvider extends SubscriptionSession {
     return unsubscribeResp.getTopics();
   }
 
-  List<SubscriptionPollResponse> poll(final Set<String> topicNames) throws SubscriptionException {
+  List<SubscriptionPollResponse> poll(final Set<String> topicNames, final long timeoutMs)
+      throws SubscriptionException {
     return poll(
         new SubscriptionPollRequest(
             SubscriptionPollRequestType.POLL.getType(),
             new PollPayload(topicNames),
-            0L,
+            timeoutMs,
             thriftMaxFrameSize));
   }
 
   List<SubscriptionPollResponse> pollFile(
-      final SubscriptionCommitContext commitContext, final long writingOffset)
+      final SubscriptionCommitContext commitContext, final long writingOffset, final long timeoutMs)
       throws SubscriptionException {
     return poll(
         new SubscriptionPollRequest(
             SubscriptionPollRequestType.POLL_FILE.getType(),
             new PollFilePayload(commitContext, writingOffset),
-            0L,
+            timeoutMs,
             thriftMaxFrameSize));
   }
 
   List<SubscriptionPollResponse> pollTablets(
-      final SubscriptionCommitContext commitContext, final int offset)
+      final SubscriptionCommitContext commitContext, final int offset, final long timeoutMs)
       throws SubscriptionException {
     return poll(
         new SubscriptionPollRequest(
             SubscriptionPollRequestType.POLL_TABLETS.getType(),
             new PollTabletsPayload(commitContext, offset),
-            0L,
+            timeoutMs,
             thriftMaxFrameSize));
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/processor/PipeProcessorSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/processor/PipeProcessorSubtask.java
@@ -47,7 +47,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class PipeProcessorSubtask extends PipeReportableSubtask {
@@ -96,7 +96,7 @@ public class PipeProcessorSubtask extends PipeReportableSubtask {
   @Override
   public void bindExecutors(
       final ListeningExecutorService subtaskWorkerThreadPoolExecutor,
-      final ExecutorService ignored,
+      final ScheduledExecutorService ignored,
       final PipeSubtaskScheduler subtaskScheduler) {
     this.subtaskWorkerThreadPoolExecutor = subtaskWorkerThreadPoolExecutor;
     this.subtaskScheduler = subtaskScheduler;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/payload/evolvable/batch/PipeTabletEventBatch.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/payload/evolvable/batch/PipeTabletEventBatch.java
@@ -25,7 +25,6 @@ import org.apache.iotdb.db.storageengine.dataregion.wal.exception.WALPipeExcepti
 import org.apache.iotdb.pipe.api.event.Event;
 import org.apache.iotdb.pipe.api.event.dml.insertion.TabletInsertionEvent;
 
-import org.apache.tsfile.exception.write.WriteProcessException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,7 +57,7 @@ public abstract class PipeTabletEventBatch implements AutoCloseable {
    * @return {@code true} if the batch can be transferred
    */
   public synchronized boolean onEvent(final TabletInsertionEvent event)
-      throws WALPipeException, IOException, WriteProcessException {
+      throws WALPipeException, IOException {
     if (isClosed || !(event instanceof EnrichedEvent)) {
       return false;
     }
@@ -94,7 +93,7 @@ public abstract class PipeTabletEventBatch implements AutoCloseable {
    *     exceptions and do not return {@code false} here.
    */
   protected abstract boolean constructBatch(final TabletInsertionEvent event)
-      throws WALPipeException, IOException, WriteProcessException;
+      throws WALPipeException, IOException;
 
   public boolean shouldEmit() {
     return totalBufferSize >= getMaxBatchSizeInBytes()

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEvent.java
@@ -396,14 +396,19 @@ public class PipeTsFileInsertionEvent extends EnrichedEvent implements TsFileIns
   /////////////////////////// TsFileInsertionEvent ///////////////////////////
 
   @Override
-  public Iterable<TabletInsertionEvent> toTabletInsertionEvents() {
+  public Iterable<TabletInsertionEvent> toTabletInsertionEvents() throws PipeException {
+    return toTabletInsertionEvents(Long.MAX_VALUE);
+  }
+
+  public Iterable<TabletInsertionEvent> toTabletInsertionEvents(final long timeoutMs)
+      throws PipeException {
     try {
       if (!waitForTsFileClose()) {
         LOGGER.warn(
             "Pipe skipping temporary TsFile's parsing which shouldn't be transferred: {}", tsFile);
         return Collections.emptyList();
       }
-      waitForResourceEnough4Parsing();
+      waitForResourceEnough4Parsing(timeoutMs);
       return initDataContainer().toTabletInsertionEvents();
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
@@ -417,31 +422,49 @@ public class PipeTsFileInsertionEvent extends EnrichedEvent implements TsFileIns
     }
   }
 
-  private void waitForResourceEnough4Parsing() throws InterruptedException {
+  private void waitForResourceEnough4Parsing(final long timeoutMs) throws InterruptedException {
     final PipeMemoryManager memoryManager = PipeDataNodeResourceManager.memory();
     if (memoryManager.isEnough4TabletParsing()) {
       return;
     }
 
+    final long startTime = System.currentTimeMillis();
+    long lastRecordTime = startTime;
+
     final long memoryCheckIntervalMs =
         PipeConfig.getInstance().getPipeTsFileParserCheckMemoryEnoughIntervalMs();
-    final long startTime = System.currentTimeMillis();
     while (!memoryManager.isEnough4TabletParsing()) {
       Thread.sleep(memoryCheckIntervalMs);
+
+      final long currentTime = System.currentTimeMillis();
+      final double elapsedRecordTimeSeconds = (currentTime - lastRecordTime) / 1000.0;
+      final double waitTimeSeconds = (currentTime - startTime) / 1000.0;
+      if (elapsedRecordTimeSeconds > 10.0) {
+        LOGGER.info(
+            "Wait for resource enough for parsing {} for {} seconds.",
+            resource != null ? resource.getTsFilePath() : "tsfile",
+            waitTimeSeconds);
+        lastRecordTime = currentTime;
+      } else if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug(
+            "Wait for resource enough for parsing {} for {} seconds.",
+            resource != null ? resource.getTsFilePath() : "tsfile",
+            waitTimeSeconds);
+      }
+
+      if (waitTimeSeconds * 1000 > timeoutMs) {
+        // should contain 'TimeoutException' in exception message
+        throw new InterruptedException(
+            String.format("TimeoutException: Waited %s seconds", waitTimeSeconds));
+      }
     }
 
-    final double waitTimeSeconds = (System.currentTimeMillis() - startTime) / 1000.0;
-    if (waitTimeSeconds > 1.0) {
-      LOGGER.info(
-          "Wait for resource enough for parsing {} for {} seconds.",
-          resource != null ? resource.getTsFilePath() : "tsfile",
-          waitTimeSeconds);
-    } else if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug(
-          "Wait for resource enough for parsing {} for {} seconds.",
-          resource != null ? resource.getTsFilePath() : "tsfile",
-          waitTimeSeconds);
-    }
+    final long currentTime = System.currentTimeMillis();
+    final double waitTimeSeconds = (currentTime - startTime) / 1000.0;
+    LOGGER.info(
+        "Wait for resource enough for parsing {} for {} seconds.",
+        resource != null ? resource.getTsFilePath() : "tsfile",
+        waitTimeSeconds);
   }
 
   /** The method is used to prevent circular replication in PipeConsensus */

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManager.java
@@ -59,6 +59,7 @@ public class PipeMemoryManager {
       PipeConfig.getInstance().getPipeDataStructureTabletMemoryBlockAllocationRejectThreshold();
   private volatile long usedMemorySizeInBytesOfTablets;
 
+  // Used to control the memory allocated for managing slice tsfile in subscription module.
   private static final double TS_FILE_MEMORY_REJECT_THRESHOLD =
       PipeConfig.getInstance().getPipeDataStructureTsFileMemoryBlockAllocationRejectThreshold();
   private volatile long usedMemorySizeInBytesOfTsFiles;
@@ -76,6 +77,11 @@ public class PipeMemoryManager {
   public boolean isEnough4TabletParsing() {
     return (double) usedMemorySizeInBytesOfTablets
         < 0.95 * TABLET_MEMORY_REJECT_THRESHOLD * TOTAL_MEMORY_SIZE_IN_BYTES;
+  }
+
+  public boolean isEnough4TsFileSlicing() {
+    return (double) usedMemorySizeInBytesOfTsFiles
+        < 0.95 * TS_FILE_MEMORY_REJECT_THRESHOLD * TOTAL_MEMORY_SIZE_IN_BYTES;
   }
 
   public synchronized PipeMemoryBlock forceAllocate(long sizeInBytes)

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/agent/SubscriptionReceiverAgent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/agent/SubscriptionReceiverAgent.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.subscription.agent;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
+import org.apache.iotdb.commons.subscription.config.SubscriptionConfig;
 import org.apache.iotdb.db.subscription.receiver.SubscriptionReceiver;
 import org.apache.iotdb.db.subscription.receiver.SubscriptionReceiverV1;
 import org.apache.iotdb.rpc.RpcUtils;
@@ -66,6 +67,18 @@ public class SubscriptionReceiverAgent {
           status,
           PipeSubscribeResponseVersion.VERSION_1.getVersion(),
           PipeSubscribeResponseType.ACK.getType());
+    }
+  }
+
+  public long remainingMs() {
+    return remainingMs(PipeSubscribeRequestVersion.VERSION_1.getVersion()); // default to VERSION_1
+  }
+
+  public long remainingMs(final byte reqVersion) {
+    if (RECEIVER_CONSTRUCTORS.containsKey(reqVersion)) {
+      return getReceiver(reqVersion).remainingMs();
+    } else {
+      return SubscriptionConfig.getInstance().getSubscriptionDefaultTimeoutInMs();
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingTabletQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingTabletQueue.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.subscription.broker;
 
 import org.apache.iotdb.commons.pipe.event.EnrichedEvent;
 import org.apache.iotdb.commons.subscription.config.SubscriptionConfig;
+import org.apache.iotdb.db.subscription.agent.SubscriptionAgent;
 import org.apache.iotdb.db.subscription.event.SubscriptionEvent;
 import org.apache.iotdb.pipe.api.event.dml.insertion.TsFileInsertionEvent;
 import org.apache.iotdb.rpc.subscription.payload.poll.SubscriptionCommitContext;
@@ -145,13 +146,22 @@ public class SubscriptionPrefetchingTabletQueue extends SubscriptionPrefetchingQ
 
           // 3. Poll next tablets
           try {
-            ev.fetchNextResponse();
-          } catch (final Exception ignored) {
-            // no exceptions will be thrown
+            executeReceiverSubtask(
+                () -> {
+                  ev.fetchNextResponse(offset);
+                  return null;
+                },
+                SubscriptionAgent.receiver().remainingMs());
+            ev.recordLastPolledTimestamp();
+            eventRef.set(ev);
+          } catch (final Exception e) {
+            final String errorMessage =
+                String.format(
+                    "exception occurred when fetching next response: %s, consumer id: %s, commit context: %s, offset: %s, prefetching queue: %s",
+                    e, consumerId, commitContext, offset, this);
+            LOGGER.warn(errorMessage);
+            eventRef.set(generateSubscriptionPollErrorResponse(errorMessage));
           }
-
-          ev.recordLastPolledTimestamp();
-          eventRef.set(ev);
 
           return ev;
         });

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingTsFileQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingTsFileQueue.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.subscription.broker;
 
 import org.apache.iotdb.commons.subscription.config.SubscriptionConfig;
 import org.apache.iotdb.db.pipe.event.common.tsfile.PipeTsFileInsertionEvent;
+import org.apache.iotdb.db.subscription.agent.SubscriptionAgent;
 import org.apache.iotdb.db.subscription.event.SubscriptionEvent;
 import org.apache.iotdb.db.subscription.event.pipe.SubscriptionPipeTsFilePlainEvent;
 import org.apache.iotdb.pipe.api.event.dml.insertion.TsFileInsertionEvent;
@@ -143,16 +144,7 @@ public class SubscriptionPrefetchingTsFileQueue extends SubscriptionPrefetchingQ
                 eventRef.set(generateSubscriptionPollErrorResponse(errorMessage));
                 return ev;
               }
-              // check offset
-              if (writingOffset != 0) {
-                final String errorMessage =
-                    String.format(
-                        "inconsistent offset, current: %s, incoming: %s, consumer: %s, file name: %s, prefetching queue: %s",
-                        0, writingOffset, consumerId, fileName, this);
-                LOGGER.warn(errorMessage);
-                eventRef.set(generateSubscriptionPollErrorResponse(errorMessage));
-                return ev;
-              }
+              // no need to check offset for resume from breakpoint
               break;
             case FILE_PIECE:
               // check file name
@@ -206,25 +198,22 @@ public class SubscriptionPrefetchingTsFileQueue extends SubscriptionPrefetchingQ
 
           // 3. Poll tsfile piece or tsfile seal
           try {
-            ev.fetchNextResponse();
+            executeReceiverSubtask(
+                () -> {
+                  ev.fetchNextResponse(writingOffset);
+                  return null;
+                },
+                SubscriptionAgent.receiver().remainingMs());
+            ev.recordLastPolledTimestamp();
+            eventRef.set(ev);
           } catch (final Exception e) {
-            LOGGER.warn(
-                "Exception occurred when SubscriptionPrefetchingTsFileQueue {} transferring file (with event {}) to consumer {}",
-                this,
-                ev,
-                consumerId,
-                e);
             final String errorMessage =
                 String.format(
-                    "Exception occurred when SubscriptionPrefetchingTsFileQueue %s transferring file (with event %s) to consumer %s: %s",
-                    this, ev, consumerId, e);
+                    "exception occurred when fetching next response: %s, consumer id: %s, commit context: %s, writing offset: %s, prefetching queue: %s",
+                    e, consumerId, commitContext, writingOffset, this);
             LOGGER.warn(errorMessage);
             eventRef.set(generateSubscriptionPollErrorResponse(errorMessage));
-            return ev;
           }
-
-          ev.recordLastPolledTimestamp();
-          eventRef.set(ev);
 
           return ev;
         });

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/SubscriptionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/SubscriptionEvent.java
@@ -220,12 +220,12 @@ public class SubscriptionEvent {
 
   //////////////////////////// prefetch & fetch ////////////////////////////
 
-  public void prefetchRemainingResponses() throws IOException {
+  public void prefetchRemainingResponses() throws Exception {
     response.prefetchRemainingResponses();
   }
 
-  public void fetchNextResponse() throws IOException {
-    response.fetchNextResponse();
+  public void fetchNextResponse(final long offset) throws Exception {
+    response.fetchNextResponse(offset);
   }
 
   //////////////////////////// byte buffer ////////////////////////////

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeEventBatch.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeEventBatch.java
@@ -94,7 +94,7 @@ public abstract class SubscriptionPipeEventBatch {
       final @NonNull EnrichedEvent event, final Consumer<SubscriptionEvent> consumer)
       throws Exception {
     if (event instanceof TabletInsertionEvent) {
-      onTabletInsertionEvent((TabletInsertionEvent) event); // no exceptions will be thrown
+      onTabletInsertionEvent((TabletInsertionEvent) event);
       enrichedEvents.add(event);
     } else if (event instanceof TsFileInsertionEvent) {
       onTsFileInsertionEvent((TsFileInsertionEvent) event);
@@ -108,9 +108,9 @@ public abstract class SubscriptionPipeEventBatch {
 
   /////////////////////////////// utility ///////////////////////////////
 
-  protected abstract void onTabletInsertionEvent(final TabletInsertionEvent event) throws Exception;
+  protected abstract void onTabletInsertionEvent(final TabletInsertionEvent event);
 
-  protected abstract void onTsFileInsertionEvent(final TsFileInsertionEvent event) throws Exception;
+  protected abstract void onTsFileInsertionEvent(final TsFileInsertionEvent event);
 
   protected abstract boolean shouldEmit();
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeTabletEventBatch.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeTabletEventBatch.java
@@ -22,7 +22,9 @@ package org.apache.iotdb.db.subscription.event.batch;
 import org.apache.iotdb.commons.pipe.event.EnrichedEvent;
 import org.apache.iotdb.db.pipe.event.common.tablet.PipeInsertNodeTabletInsertionEvent;
 import org.apache.iotdb.db.pipe.event.common.tablet.PipeRawTabletInsertionEvent;
+import org.apache.iotdb.db.pipe.event.common.tsfile.PipeTsFileInsertionEvent;
 import org.apache.iotdb.db.pipe.resource.memory.PipeMemoryWeightUtil;
+import org.apache.iotdb.db.subscription.agent.SubscriptionAgent;
 import org.apache.iotdb.db.subscription.broker.SubscriptionPrefetchingTabletQueue;
 import org.apache.iotdb.db.subscription.event.SubscriptionEvent;
 import org.apache.iotdb.pipe.api.event.dml.insertion.TabletInsertionEvent;
@@ -112,7 +114,9 @@ public class SubscriptionPipeTabletEventBatch extends SubscriptionPipeEventBatch
 
   @Override
   protected void onTsFileInsertionEvent(final TsFileInsertionEvent event) {
-    for (final TabletInsertionEvent tabletInsertionEvent : event.toTabletInsertionEvents()) {
+    for (final TabletInsertionEvent tabletInsertionEvent :
+        ((PipeTsFileInsertionEvent) event)
+            .toTabletInsertionEvents(SubscriptionAgent.receiver().remainingMs())) {
       onTabletInsertionEvent(tabletInsertionEvent);
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeTsFileEventBatch.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeTsFileEventBatch.java
@@ -68,8 +68,12 @@ public class SubscriptionPipeTsFileEventBatch extends SubscriptionPipeEventBatch
   /////////////////////////////// utility ///////////////////////////////
 
   @Override
-  protected void onTabletInsertionEvent(final TabletInsertionEvent event) throws Exception {
-    batch.onEvent(event); // no exceptions will be thrown
+  protected void onTabletInsertionEvent(final TabletInsertionEvent event) {
+    try {
+      batch.onEvent(event);
+    } catch (final Exception ignored) {
+      // no exceptions will be thrown
+    }
     ((EnrichedEvent) event)
         .decreaseReferenceCount(
             SubscriptionPipeTsFileEventBatch.class.getName(),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/response/SubscriptionEventExtendableResponse.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/response/SubscriptionEventExtendableResponse.java
@@ -58,16 +58,6 @@ public abstract class SubscriptionEventExtendableResponse
   }
 
   @Override
-  public void fetchNextResponse() throws IOException {
-    prefetchRemainingResponses();
-    if (Objects.isNull(poll())) {
-      LOGGER.warn(
-          "SubscriptionEventExtendableResponse {} is empty when fetching next response (broken invariant)",
-          this);
-    }
-  }
-
-  @Override
   public void trySerializeCurrentResponse() {
     SubscriptionPollResponseCache.getInstance().trySerialize(getCurrentResponse());
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/response/SubscriptionEventResponse.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/response/SubscriptionEventResponse.java
@@ -28,9 +28,9 @@ public interface SubscriptionEventResponse<E> {
 
   E getCurrentResponse();
 
-  void prefetchRemainingResponses() throws IOException;
+  void prefetchRemainingResponses() throws Exception;
 
-  void fetchNextResponse() throws IOException;
+  void fetchNextResponse(final long offset) throws Exception;
 
   /////////////////////////////// byte buffer ///////////////////////////////
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/response/SubscriptionEventSingleResponse.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/response/SubscriptionEventSingleResponse.java
@@ -65,7 +65,7 @@ public class SubscriptionEventSingleResponse
   }
 
   @Override
-  public void fetchNextResponse() {
+  public void fetchNextResponse(final long offset) {
     // do nothing
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/response/SubscriptionEventTabletResponse.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/response/SubscriptionEventTabletResponse.java
@@ -78,6 +78,16 @@ public class SubscriptionEventTabletResponse extends SubscriptionEventExtendable
   }
 
   @Override
+  public void fetchNextResponse(final long offset /* unused */) {
+    prefetchRemainingResponses();
+    if (Objects.isNull(poll())) {
+      LOGGER.warn(
+          "SubscriptionEventTabletResponse {} is empty when fetching next response (broken invariant)",
+          this);
+    }
+  }
+
+  @Override
   public synchronized void nack() {
     if (nextOffset.get() == 1) {
       // do nothing if with complete tablets

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/response/SubscriptionEventTsFileResponse.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/response/SubscriptionEventTsFileResponse.java
@@ -19,9 +19,12 @@
 
 package org.apache.iotdb.db.subscription.event.response;
 
+import org.apache.iotdb.commons.pipe.config.PipeConfig;
 import org.apache.iotdb.commons.subscription.config.SubscriptionConfig;
 import org.apache.iotdb.db.pipe.resource.PipeDataNodeResourceManager;
+import org.apache.iotdb.db.pipe.resource.memory.PipeMemoryManager;
 import org.apache.iotdb.db.pipe.resource.memory.PipeTsFileMemoryBlock;
+import org.apache.iotdb.db.subscription.agent.SubscriptionAgent;
 import org.apache.iotdb.db.subscription.event.cache.CachedSubscriptionPollResponse;
 import org.apache.iotdb.rpc.subscription.exception.SubscriptionException;
 import org.apache.iotdb.rpc.subscription.payload.poll.FileInitPayload;
@@ -67,12 +70,18 @@ public class SubscriptionEventTsFileResponse extends SubscriptionEventExtendable
   }
 
   @Override
-  public void prefetchRemainingResponses() throws IOException {
-    if (hasNoMore) {
-      return;
-    }
+  public void prefetchRemainingResponses() {
+    // do nothing
+  }
 
-    generateNextTsFileResponse().ifPresent(super::offer);
+  @Override
+  public void fetchNextResponse(final long offset) throws Exception {
+    generateNextTsFileResponse(offset).ifPresent(super::offer);
+    if (Objects.isNull(poll())) {
+      LOGGER.warn(
+          "SubscriptionEventTsFileResponse {} is empty when fetching next response (broken invariant)",
+          this);
+    }
   }
 
   @Override
@@ -103,8 +112,13 @@ public class SubscriptionEventTsFileResponse extends SubscriptionEventExtendable
             commitContext));
   }
 
+  private synchronized Optional<CachedSubscriptionPollResponse> generateNextTsFileResponse(
+      final long offset) throws SubscriptionException, IOException, InterruptedException {
+    return Optional.of(generateResponseWithPieceOrSealPayload(offset));
+  }
+
   private synchronized Optional<CachedSubscriptionPollResponse> generateNextTsFileResponse()
-      throws IOException {
+      throws SubscriptionException, IOException, InterruptedException {
     final SubscriptionPollResponse previousResponse = peekLast();
     if (Objects.isNull(previousResponse)) {
       LOGGER.warn(
@@ -137,7 +151,7 @@ public class SubscriptionEventTsFileResponse extends SubscriptionEventExtendable
   }
 
   private @NonNull CachedSubscriptionPollResponse generateResponseWithPieceOrSealPayload(
-      final long writingOffset) throws IOException {
+      final long writingOffset) throws SubscriptionException, IOException, InterruptedException {
     final long tsFileLength = tsFile.length();
     if (writingOffset >= tsFileLength) {
       // generate subscription poll response with seal payload
@@ -159,6 +173,7 @@ public class SubscriptionEventTsFileResponse extends SubscriptionEventExtendable
       bufferSize = readFileBufferSize;
     }
 
+    waitForResourceEnough4Slicing(SubscriptionAgent.receiver().remainingMs());
     try (final RandomAccessFile reader = new RandomAccessFile(tsFile, "r")) {
       reader.seek(writingOffset);
 
@@ -184,5 +199,49 @@ public class SubscriptionEventTsFileResponse extends SubscriptionEventExtendable
       response.setMemoryBlock(memoryBlock);
       return response;
     }
+  }
+
+  private void waitForResourceEnough4Slicing(final long timeoutMs) throws InterruptedException {
+    final PipeMemoryManager memoryManager = PipeDataNodeResourceManager.memory();
+    if (memoryManager.isEnough4TsFileSlicing()) {
+      return;
+    }
+
+    final long startTime = System.currentTimeMillis();
+    long lastRecordTime = startTime;
+
+    final long memoryCheckIntervalMs =
+        PipeConfig.getInstance().getPipeTsFileParserCheckMemoryEnoughIntervalMs();
+    while (!memoryManager.isEnough4TsFileSlicing()) {
+      Thread.sleep(memoryCheckIntervalMs);
+
+      final long currentTime = System.currentTimeMillis();
+      final double elapsedRecordTimeSeconds = (currentTime - lastRecordTime) / 1000.0;
+      final double waitTimeSeconds = (currentTime - startTime) / 1000.0;
+      if (elapsedRecordTimeSeconds > 10.0) {
+        LOGGER.info(
+            "Wait for resource enough for slicing tsfile {} for {} seconds.",
+            tsFile,
+            waitTimeSeconds);
+        lastRecordTime = currentTime;
+      } else if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug(
+            "Wait for resource enough for slicing tsfile {} for {} seconds.",
+            tsFile,
+            waitTimeSeconds);
+      }
+
+      if (waitTimeSeconds * 1000 > timeoutMs) {
+        // should contain 'TimeoutException' in exception message
+        // see org.apache.iotdb.rpc.subscription.exception.SubscriptionTimeoutException.KEYWORD
+        throw new InterruptedException(
+            String.format("TimeoutException: Waited %s seconds", waitTimeSeconds));
+      }
+    }
+
+    final long currentTime = System.currentTimeMillis();
+    final double waitTimeSeconds = (currentTime - startTime) / 1000.0;
+    LOGGER.info(
+        "Wait for resource enough for slicing tsfile {} for {} seconds.", tsFile, waitTimeSeconds);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/receiver/SubscriptionReceiver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/receiver/SubscriptionReceiver.java
@@ -30,4 +30,6 @@ public interface SubscriptionReceiver {
   PipeSubscribeRequestVersion getVersion();
 
   void handleExit();
+
+  long remainingMs();
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/receiver/SubscriptionReceiverV1.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/receiver/SubscriptionReceiverV1.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.client.IClientManager;
 import org.apache.iotdb.commons.client.exception.ClientManagerException;
 import org.apache.iotdb.commons.consensus.ConfigRegionId;
+import org.apache.iotdb.commons.subscription.config.SubscriptionConfig;
 import org.apache.iotdb.confignode.rpc.thrift.TCloseConsumerReq;
 import org.apache.iotdb.confignode.rpc.thrift.TCreateConsumerReq;
 import org.apache.iotdb.confignode.rpc.thrift.TSubscribeReq;
@@ -68,6 +69,7 @@ import org.apache.iotdb.rpc.subscription.payload.response.PipeSubscribeSubscribe
 import org.apache.iotdb.rpc.subscription.payload.response.PipeSubscribeUnsubscribeResp;
 import org.apache.iotdb.service.rpc.thrift.TPipeSubscribeReq;
 import org.apache.iotdb.service.rpc.thrift.TPipeSubscribeResp;
+import org.apache.iotdb.session.subscription.util.PollTimer;
 
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
@@ -101,23 +103,7 @@ public class SubscriptionReceiverV1 implements SubscriptionReceiver {
           PipeSubscribeResponseType.ACK.getType());
 
   private final ThreadLocal<ConsumerConfig> consumerConfigThreadLocal = new ThreadLocal<>();
-
-  @Override
-  public PipeSubscribeRequestVersion getVersion() {
-    return PipeSubscribeRequestVersion.VERSION_1;
-  }
-
-  @Override
-  public void handleExit() {
-    final ConsumerConfig consumerConfig = consumerConfigThreadLocal.get();
-    if (Objects.nonNull(consumerConfig)) {
-      LOGGER.info(
-          "Subscription: remove consumer config {} when handling exit",
-          consumerConfigThreadLocal.get());
-      // closeConsumer(consumerConfig);
-      consumerConfigThreadLocal.remove();
-    }
-  }
+  private final ThreadLocal<PollTimer> pollTimerThreadLocal = new ThreadLocal<>();
 
   @Override
   public final TPipeSubscribeResp handle(final TPipeSubscribeReq req) {
@@ -153,6 +139,32 @@ public class SubscriptionReceiverV1 implements SubscriptionReceiver {
         status,
         PipeSubscribeResponseVersion.VERSION_1.getVersion(),
         PipeSubscribeResponseType.ACK.getType());
+  }
+
+  @Override
+  public PipeSubscribeRequestVersion getVersion() {
+    return PipeSubscribeRequestVersion.VERSION_1;
+  }
+
+  @Override
+  public void handleExit() {
+    final ConsumerConfig consumerConfig = consumerConfigThreadLocal.get();
+    if (Objects.nonNull(consumerConfig)) {
+      LOGGER.info(
+          "Subscription: remove consumer config {} when handling exit",
+          consumerConfigThreadLocal.get());
+      // closeConsumer(consumerConfig);
+      consumerConfigThreadLocal.remove();
+    }
+  }
+
+  @Override
+  public long remainingMs() {
+    final PollTimer pollTimer = pollTimerThreadLocal.get();
+    if (Objects.isNull(pollTimer)) {
+      return SubscriptionConfig.getInstance().getSubscriptionDefaultTimeoutInMs();
+    }
+    return pollTimer.remainingMs();
   }
 
   private TPipeSubscribeResp handlePipeSubscribeHandshake(final PipeSubscribeHandshakeReq req) {
@@ -342,116 +354,8 @@ public class SubscriptionReceiverV1 implements SubscriptionReceiver {
   }
 
   private TPipeSubscribeResp handlePipeSubscribePoll(final PipeSubscribePollReq req) {
-    final ConsumerConfig consumerConfig = consumerConfigThreadLocal.get();
-    if (Objects.isNull(consumerConfig)) {
-      LOGGER.warn(
-          "Subscription: missing consumer config when handling PipeSubscribePollReq: {}", req);
-      return SUBSCRIPTION_MISSING_CUSTOMER_RESP;
-    }
-
-    final List<SubscriptionEvent> events;
-    final SubscriptionPollRequest request = req.getRequest();
-    final long maxBytes = (long) (request.getMaxBytes() * POLL_PAYLOAD_SIZE_EXCEED_THRESHOLD);
     try {
-      final short requestType = request.getRequestType();
-      if (SubscriptionPollRequestType.isValidatedRequestType(requestType)) {
-        switch (SubscriptionPollRequestType.valueOf(requestType)) {
-          case POLL:
-            events =
-                handlePipeSubscribePollInternal(
-                    consumerConfig, (PollPayload) request.getPayload(), maxBytes);
-            break;
-          case POLL_FILE:
-            events =
-                handlePipeSubscribePollTsFileInternal(
-                    consumerConfig, (PollFilePayload) request.getPayload());
-            break;
-          case POLL_TABLETS:
-            events =
-                handlePipeSubscribePollTabletsInternal(
-                    consumerConfig, (PollTabletsPayload) request.getPayload());
-            break;
-          default:
-            events = null;
-            break;
-        }
-      } else {
-        events = null;
-      }
-      if (Objects.isNull(events)) {
-        throw new SubscriptionException(String.format("unexpected request type: %s", requestType));
-      }
-
-      // generate response
-      final AtomicLong totalSize = new AtomicLong();
-      return PipeSubscribePollResp.toTPipeSubscribeResp(
-          RpcUtils.SUCCESS_STATUS,
-          events.stream()
-              .map(
-                  (event) -> {
-                    final SubscriptionCommitContext commitContext = event.getCommitContext();
-                    final SubscriptionPollResponse response = event.getCurrentResponse();
-                    if (Objects.isNull(response)) {
-                      LOGGER.warn(
-                          "Subscription: consumer {} poll null response for event {} with request: {}",
-                          consumerConfig,
-                          event,
-                          req.getRequest());
-                      // nack
-                      SubscriptionAgent.broker()
-                          .commit(consumerConfig, Collections.singletonList(commitContext), true);
-                      return null;
-                    }
-
-                    try {
-                      final ByteBuffer byteBuffer = event.getCurrentResponseByteBuffer();
-
-                      // payload size control
-                      final long size = event.getCurrentResponseSize();
-                      if (totalSize.get() + size > maxBytes) {
-                        throw new SubscriptionPayloadExceedException(
-                            String.format(
-                                "payload size %s byte(s) will exceed the threshold %s byte(s)",
-                                totalSize.get() + size, maxBytes));
-                      }
-                      totalSize.getAndAdd(size);
-
-                      SubscriptionPrefetchingQueueMetrics.getInstance()
-                          .mark(
-                              SubscriptionPrefetchingQueue.generatePrefetchingQueueId(
-                                  commitContext.getConsumerGroupId(), commitContext.getTopicName()),
-                              size);
-                      event.invalidateCurrentResponseByteBuffer();
-                      LOGGER.info(
-                          "Subscription: consumer {} poll {} successfully with request: {}",
-                          consumerConfig,
-                          response,
-                          req.getRequest());
-                      return byteBuffer;
-                    } catch (final Exception e) {
-                      if (e instanceof SubscriptionPayloadExceedException) {
-                        LOGGER.error(
-                            "Subscription: consumer {} poll excessive payload {} with request: {}, something unexpected happened with parameter configuration or payload control...",
-                            consumerConfig,
-                            response,
-                            req.getRequest(),
-                            e);
-                      } else {
-                        LOGGER.warn(
-                            "Subscription: consumer {} poll {} failed with request: {}",
-                            consumerConfig,
-                            response,
-                            req.getRequest(),
-                            e);
-                      }
-                      // nack
-                      SubscriptionAgent.broker()
-                          .commit(consumerConfig, Collections.singletonList(commitContext), true);
-                      return null;
-                    }
-                  })
-              .filter(Objects::nonNull)
-              .collect(Collectors.toList()));
+      return handlePipeSubscribePollInternal(req);
     } catch (final Exception e) {
       LOGGER.warn("Exception occurred when polling with request {}", req, e);
       final String exceptionMessage =
@@ -461,10 +365,129 @@ public class SubscriptionReceiverV1 implements SubscriptionReceiver {
       return PipeSubscribePollResp.toTPipeSubscribeResp(
           RpcUtils.getStatus(TSStatusCode.SUBSCRIPTION_POLL_ERROR, exceptionMessage),
           Collections.emptyList());
+    } finally {
+      pollTimerThreadLocal.remove();
     }
   }
 
-  private List<SubscriptionEvent> handlePipeSubscribePollInternal(
+  private TPipeSubscribeResp handlePipeSubscribePollInternal(final PipeSubscribePollReq req)
+      throws SubscriptionException {
+    final ConsumerConfig consumerConfig = consumerConfigThreadLocal.get();
+    if (Objects.isNull(consumerConfig)) {
+      LOGGER.warn(
+          "Subscription: missing consumer config when handling PipeSubscribePollReq: {}", req);
+      return SUBSCRIPTION_MISSING_CUSTOMER_RESP;
+    }
+
+    final List<SubscriptionEvent> events;
+    final SubscriptionPollRequest request = req.getRequest();
+
+    pollTimerThreadLocal.set(new PollTimer(System.currentTimeMillis(), request.getTimeoutMs()));
+
+    final long maxBytes = (long) (request.getMaxBytes() * POLL_PAYLOAD_SIZE_EXCEED_THRESHOLD);
+    final short requestType = request.getRequestType();
+    if (SubscriptionPollRequestType.isValidatedRequestType(requestType)) {
+      switch (SubscriptionPollRequestType.valueOf(requestType)) {
+        case POLL:
+          events =
+              handlePipeSubscribePollRequest(
+                  consumerConfig, (PollPayload) request.getPayload(), maxBytes);
+          break;
+        case POLL_FILE:
+          events =
+              handlePipeSubscribePollTsFileRequest(
+                  consumerConfig, (PollFilePayload) request.getPayload());
+          break;
+        case POLL_TABLETS:
+          events =
+              handlePipeSubscribePollTabletsRequest(
+                  consumerConfig, (PollTabletsPayload) request.getPayload());
+          break;
+        default:
+          events = null;
+          break;
+      }
+    } else {
+      events = null;
+    }
+
+    if (Objects.isNull(events)) {
+      throw new SubscriptionException(String.format("unexpected request type: %s", requestType));
+    }
+
+    // generate response
+    final AtomicLong totalSize = new AtomicLong();
+    return PipeSubscribePollResp.toTPipeSubscribeResp(
+        RpcUtils.SUCCESS_STATUS,
+        events.stream()
+            .map(
+                (event) -> {
+                  final SubscriptionCommitContext commitContext = event.getCommitContext();
+                  final SubscriptionPollResponse response = event.getCurrentResponse();
+                  if (Objects.isNull(response)) {
+                    LOGGER.warn(
+                        "Subscription: consumer {} poll null response for event {} with request: {}",
+                        consumerConfig,
+                        event,
+                        req.getRequest());
+                    // nack
+                    SubscriptionAgent.broker()
+                        .commit(consumerConfig, Collections.singletonList(commitContext), true);
+                    return null;
+                  }
+
+                  try {
+                    final ByteBuffer byteBuffer = event.getCurrentResponseByteBuffer();
+
+                    // payload size control
+                    final long size = event.getCurrentResponseSize();
+                    if (totalSize.get() + size > maxBytes) {
+                      throw new SubscriptionPayloadExceedException(
+                          String.format(
+                              "payload size %s byte(s) will exceed the threshold %s byte(s)",
+                              totalSize.get() + size, maxBytes));
+                    }
+                    totalSize.getAndAdd(size);
+
+                    SubscriptionPrefetchingQueueMetrics.getInstance()
+                        .mark(
+                            SubscriptionPrefetchingQueue.generatePrefetchingQueueId(
+                                commitContext.getConsumerGroupId(), commitContext.getTopicName()),
+                            size);
+                    event.invalidateCurrentResponseByteBuffer();
+                    LOGGER.info(
+                        "Subscription: consumer {} poll {} successfully with request: {}",
+                        consumerConfig,
+                        response,
+                        req.getRequest());
+                    return byteBuffer;
+                  } catch (final Exception e) {
+                    if (e instanceof SubscriptionPayloadExceedException) {
+                      LOGGER.error(
+                          "Subscription: consumer {} poll excessive payload {} with request: {}, something unexpected happened with parameter configuration or payload control...",
+                          consumerConfig,
+                          response,
+                          req.getRequest(),
+                          e);
+                    } else {
+                      LOGGER.warn(
+                          "Subscription: consumer {} poll {} failed with request: {}",
+                          consumerConfig,
+                          response,
+                          req.getRequest(),
+                          e);
+                    }
+                    // nack
+                    SubscriptionAgent.broker()
+                        .commit(consumerConfig, Collections.singletonList(commitContext), true);
+                    return null;
+                  }
+                })
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList()));
+  }
+
+  private List<SubscriptionEvent> handlePipeSubscribePollRequest(
       final ConsumerConfig consumerConfig, final PollPayload messagePayload, final long maxBytes) {
     final Set<String> subscribedTopicNames =
         SubscriptionAgent.consumer()
@@ -480,14 +503,14 @@ public class SubscriptionReceiverV1 implements SubscriptionReceiver {
     return SubscriptionAgent.broker().poll(consumerConfig, topicNames, maxBytes);
   }
 
-  private List<SubscriptionEvent> handlePipeSubscribePollTsFileInternal(
+  private List<SubscriptionEvent> handlePipeSubscribePollTsFileRequest(
       final ConsumerConfig consumerConfig, final PollFilePayload messagePayload) {
     return SubscriptionAgent.broker()
         .pollTsFile(
             consumerConfig, messagePayload.getCommitContext(), messagePayload.getWritingOffset());
   }
 
-  private List<SubscriptionEvent> handlePipeSubscribePollTabletsInternal(
+  private List<SubscriptionEvent> handlePipeSubscribePollTabletsRequest(
       final ConsumerConfig consumerConfig, final PollTabletsPayload messagePayload) {
     return SubscriptionAgent.broker()
         .pollTablets(consumerConfig, messagePayload.getCommitContext(), messagePayload.getOffset());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/task/execution/SubscriptionSubtaskExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/task/execution/SubscriptionSubtaskExecutor.java
@@ -20,14 +20,64 @@
 package org.apache.iotdb.db.subscription.task.execution;
 
 import org.apache.iotdb.commons.concurrent.ThreadName;
+import org.apache.iotdb.commons.pipe.agent.task.execution.PipeSubtaskExecutor;
+import org.apache.iotdb.commons.pipe.agent.task.execution.PipeSubtaskScheduler;
 import org.apache.iotdb.commons.subscription.config.SubscriptionConfig;
 import org.apache.iotdb.db.pipe.agent.task.execution.PipeConnectorSubtaskExecutor;
+import org.apache.iotdb.db.subscription.task.subtask.SubscriptionReceiverSubtask;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class SubscriptionSubtaskExecutor extends PipeConnectorSubtaskExecutor {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SubscriptionSubtaskExecutor.class);
+
+  private final AtomicLong submittedReceiverSubtasks = new AtomicLong(0);
 
   public SubscriptionSubtaskExecutor() {
     super(
         SubscriptionConfig.getInstance().getSubscriptionSubtaskExecutorMaxThreadNum(),
         ThreadName.SUBSCRIPTION_EXECUTOR_POOL);
+  }
+
+  @Override
+  protected PipeSubtaskScheduler schedulerSupplier(final PipeSubtaskExecutor executor) {
+    return new SubscriptionSubtaskScheduler((SubscriptionSubtaskExecutor) executor);
+  }
+
+  public void executeReceiverSubtask(
+      final SubscriptionReceiverSubtask subtask, final long timeoutMs) throws Exception {
+    if (!super.hasAvailableThread()) {
+      subtask.call(); // non-strict timeout
+      return;
+    }
+
+    submittedReceiverSubtasks.incrementAndGet();
+    try {
+      final Future<Void> future = subtaskWorkerThreadPoolExecutor.submit(subtask);
+      try {
+        future.get(timeoutMs, TimeUnit.MILLISECONDS); // strict timeout
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt(); // restore interrupted state
+        future.cancel(true);
+        throw e;
+      } catch (final ExecutionException | TimeoutException e) {
+        future.cancel(true);
+        throw e;
+      }
+    } finally {
+      submittedReceiverSubtasks.decrementAndGet();
+    }
+  }
+
+  public boolean hasSubmittedReceiverSubtasks() {
+    return submittedReceiverSubtasks.get() > 0;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/task/execution/SubscriptionSubtaskScheduler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/task/execution/SubscriptionSubtaskScheduler.java
@@ -17,29 +17,23 @@
  * under the License.
  */
 
-package org.apache.iotdb.rpc.subscription.exception;
+package org.apache.iotdb.db.subscription.task.execution;
 
-import java.util.Objects;
+import org.apache.iotdb.commons.pipe.agent.task.execution.PipeSubtaskScheduler;
 
-public class SubscriptionPipeTimeoutException extends SubscriptionTimeoutException {
+public class SubscriptionSubtaskScheduler extends PipeSubtaskScheduler {
 
-  public SubscriptionPipeTimeoutException(final String message) {
-    super(message);
-  }
+  private final SubscriptionSubtaskExecutor executor;
 
-  public SubscriptionPipeTimeoutException(final String message, final Throwable cause) {
-    super(message, cause);
-  }
+  public SubscriptionSubtaskScheduler(final SubscriptionSubtaskExecutor executor) {
+    super(executor);
 
-  @Override
-  public boolean equals(final Object obj) {
-    return obj instanceof SubscriptionPipeTimeoutException
-        && Objects.equals(getMessage(), ((SubscriptionPipeTimeoutException) obj).getMessage())
-        && Objects.equals(getTimeStamp(), ((SubscriptionPipeTimeoutException) obj).getTimeStamp());
+    this.executor = executor;
   }
 
   @Override
-  public int hashCode() {
-    return super.hashCode();
+  public boolean schedule() {
+    // prioritize executing SubscriptionReceiverSubtask over SubscriptionConnectorSubtask
+    return !executor.hasSubmittedReceiverSubtasks() && super.schedule();
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/task/subtask/SubscriptionConnectorSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/task/subtask/SubscriptionConnectorSubtask.java
@@ -20,13 +20,18 @@
 package org.apache.iotdb.db.subscription.task.subtask;
 
 import org.apache.iotdb.commons.pipe.agent.task.connection.UnboundedBlockingPendingQueue;
+import org.apache.iotdb.commons.subscription.config.SubscriptionConfig;
 import org.apache.iotdb.db.pipe.agent.task.subtask.connector.PipeConnectorSubtask;
 import org.apache.iotdb.db.subscription.agent.SubscriptionAgent;
 import org.apache.iotdb.pipe.api.PipeConnector;
 import org.apache.iotdb.pipe.api.event.Event;
 
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
 
 public class SubscriptionConnectorSubtask extends PipeConnectorSubtask {
 
@@ -55,15 +60,6 @@ public class SubscriptionConnectorSubtask extends PipeConnectorSubtask {
     this.consumerGroupId = consumerGroupId;
   }
 
-  @Override
-  protected boolean executeOnce() {
-    if (isClosed.get()) {
-      return false;
-    }
-
-    return SubscriptionAgent.broker().executePrefetch(consumerGroupId, topicName);
-  }
-
   public String getTopicName() {
     return topicName;
   }
@@ -74,6 +70,36 @@ public class SubscriptionConnectorSubtask extends PipeConnectorSubtask {
 
   public UnboundedBlockingPendingQueue<Event> getInputPendingQueue() {
     return inputPendingQueue;
+  }
+
+  //////////////////////////// execution & callback ////////////////////////////
+
+  @Override
+  protected void registerCallbackHookAfterSubmit(final ListenableFuture<Boolean> future) {
+    final ListenableFuture<Boolean> nextFuture =
+        Futures.withTimeout(
+            future,
+            Duration.ofSeconds(
+                SubscriptionConfig.getInstance().getSubscriptionDefaultTimeoutInMs()),
+            subtaskCallbackListeningExecutor);
+    Futures.addCallback(nextFuture, this, subtaskCallbackListeningExecutor);
+  }
+
+  @Override
+  public synchronized void onFailure(final Throwable throwable) {
+    isSubmitted = false;
+
+    // just resubmit
+    submitSelf();
+  }
+
+  @Override
+  protected boolean executeOnce() {
+    if (isClosed.get()) {
+      return false;
+    }
+
+    return SubscriptionAgent.broker().executePrefetch(consumerGroupId, topicName);
   }
 
   //////////////////////////// APIs provided for metric framework ////////////////////////////

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/task/subtask/SubscriptionReceiverSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/task/subtask/SubscriptionReceiverSubtask.java
@@ -17,29 +17,8 @@
  * under the License.
  */
 
-package org.apache.iotdb.rpc.subscription.exception;
+package org.apache.iotdb.db.subscription.task.subtask;
 
-import java.util.Objects;
+import java.util.concurrent.Callable;
 
-public class SubscriptionPipeTimeoutException extends SubscriptionTimeoutException {
-
-  public SubscriptionPipeTimeoutException(final String message) {
-    super(message);
-  }
-
-  public SubscriptionPipeTimeoutException(final String message, final Throwable cause) {
-    super(message, cause);
-  }
-
-  @Override
-  public boolean equals(final Object obj) {
-    return obj instanceof SubscriptionPipeTimeoutException
-        && Objects.equals(getMessage(), ((SubscriptionPipeTimeoutException) obj).getMessage())
-        && Objects.equals(getTimeStamp(), ((SubscriptionPipeTimeoutException) obj).getTimeStamp());
-  }
-
-  @Override
-  public int hashCode() {
-    return super.hashCode();
-  }
-}
+public interface SubscriptionReceiverSubtask extends Callable<Void> {}

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -285,12 +285,13 @@ public class CommonConfig {
   private int subscriptionPrefetchTsFileBatchMaxDelayInMs = 5000; // 5s
   private long subscriptionPrefetchTsFileBatchMaxSizeInBytes = 80 * MB;
   private int subscriptionPollMaxBlockingTimeMs = 500;
-  private int subscriptionSerializeMaxBlockingTimeMs = 100;
+  private int subscriptionDefaultTimeoutInMs = 10_000; // 10s
   private long subscriptionLaunchRetryIntervalMs = 1000;
   private int subscriptionRecycleUncommittedEventIntervalMs = 600000; // 600s
   private long subscriptionReadFileBufferSize = 8 * MB;
   private long subscriptionReadTabletBufferSize = 8 * MB;
   private long subscriptionTsFileDeduplicationWindowSeconds = 120; // 120s
+  private volatile long subscriptionTsFileSlicerCheckMemoryEnoughIntervalMs = 10L;
 
   private long subscriptionMetaSyncerInitialSyncDelayMinutes = 3;
   private long subscriptionMetaSyncerSyncIntervalMinutes = 3;
@@ -1283,13 +1284,12 @@ public class CommonConfig {
     this.subscriptionPollMaxBlockingTimeMs = subscriptionPollMaxBlockingTimeMs;
   }
 
-  public int getSubscriptionSerializeMaxBlockingTimeMs() {
-    return subscriptionSerializeMaxBlockingTimeMs;
+  public int getSubscriptionDefaultTimeoutInMs() {
+    return subscriptionDefaultTimeoutInMs;
   }
 
-  public void setSubscriptionSerializeMaxBlockingTimeMs(
-      int subscriptionSerializeMaxBlockingTimeMs) {
-    this.subscriptionSerializeMaxBlockingTimeMs = subscriptionSerializeMaxBlockingTimeMs;
+  public void setSubscriptionDefaultTimeoutInMs(final int subscriptionDefaultTimeoutInMs) {
+    this.subscriptionDefaultTimeoutInMs = subscriptionDefaultTimeoutInMs;
   }
 
   public long getSubscriptionLaunchRetryIntervalMs() {
@@ -1334,6 +1334,16 @@ public class CommonConfig {
       long subscriptionTsFileDeduplicationWindowSeconds) {
     this.subscriptionTsFileDeduplicationWindowSeconds =
         subscriptionTsFileDeduplicationWindowSeconds;
+  }
+
+  public long getSubscriptionTsFileSlicerCheckMemoryEnoughIntervalMs() {
+    return subscriptionTsFileSlicerCheckMemoryEnoughIntervalMs;
+  }
+
+  public void setSubscriptionTsFileSlicerCheckMemoryEnoughIntervalMs(
+      long subscriptionTsFileSlicerCheckMemoryEnoughIntervalMs) {
+    this.subscriptionTsFileSlicerCheckMemoryEnoughIntervalMs =
+        subscriptionTsFileSlicerCheckMemoryEnoughIntervalMs;
   }
 
   public long getSubscriptionMetaSyncerInitialSyncDelayMinutes() {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -662,11 +662,11 @@ public class CommonDescriptor {
             properties.getProperty(
                 "subscription_poll_max_blocking_time_ms",
                 String.valueOf(config.getSubscriptionPollMaxBlockingTimeMs()))));
-    config.setSubscriptionSerializeMaxBlockingTimeMs(
+    config.setSubscriptionDefaultTimeoutInMs(
         Integer.parseInt(
             properties.getProperty(
-                "subscription_serialize_max_blocking_time_ms",
-                String.valueOf(config.getSubscriptionSerializeMaxBlockingTimeMs()))));
+                "subscription_default_timeout_in_ms",
+                String.valueOf(config.getSubscriptionDefaultTimeoutInMs()))));
     config.setSubscriptionLaunchRetryIntervalMs(
         Long.parseLong(
             properties.getProperty(
@@ -692,6 +692,11 @@ public class CommonDescriptor {
             properties.getProperty(
                 "subscription_ts_file_deduplication_window_seconds",
                 String.valueOf(config.getSubscriptionTsFileDeduplicationWindowSeconds()))));
+    config.setSubscriptionTsFileSlicerCheckMemoryEnoughIntervalMs(
+        Long.parseLong(
+            properties.getProperty(
+                "subscription_ts_file_slicer_check_memory_enough_interval_ms",
+                String.valueOf(config.getSubscriptionTsFileSlicerCheckMemoryEnoughIntervalMs()))));
 
     config.setSubscriptionMetaSyncerInitialSyncDelayMinutes(
         Long.parseLong(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/subtask/PipeSubtask.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/subtask/PipeSubtask.java
@@ -29,7 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -65,7 +65,7 @@ public abstract class PipeSubtask
 
   public abstract void bindExecutors(
       ListeningExecutorService subtaskWorkerThreadPoolExecutor,
-      ExecutorService subtaskCallbackListeningExecutor,
+      ScheduledExecutorService subtaskCallbackListeningExecutor,
       PipeSubtaskScheduler subtaskScheduler);
 
   @Override

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/subscription/config/SubscriptionConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/subscription/config/SubscriptionConfig.java
@@ -57,8 +57,8 @@ public class SubscriptionConfig {
     return COMMON_CONFIG.getSubscriptionPollMaxBlockingTimeMs();
   }
 
-  public int getSubscriptionSerializeMaxBlockingTimeMs() {
-    return COMMON_CONFIG.getSubscriptionSerializeMaxBlockingTimeMs();
+  public int getSubscriptionDefaultTimeoutInMs() {
+    return COMMON_CONFIG.getSubscriptionDefaultTimeoutInMs();
   }
 
   public long getSubscriptionLaunchRetryIntervalMs() {
@@ -89,6 +89,10 @@ public class SubscriptionConfig {
     return COMMON_CONFIG.getSubscriptionMetaSyncerSyncIntervalMinutes();
   }
 
+  public long getSubscriptionTsFileSlicerCheckMemoryEnoughIntervalMs() {
+    return COMMON_CONFIG.getSubscriptionTsFileSlicerCheckMemoryEnoughIntervalMs();
+  }
+
   /////////////////////////////// Utils ///////////////////////////////
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SubscriptionConfig.class);
@@ -113,8 +117,7 @@ public class SubscriptionConfig {
         "SubscriptionPrefetchTsFileBatchMaxSizeInBytes: {}",
         getSubscriptionPrefetchTsFileBatchMaxSizeInBytes());
     LOGGER.info("SubscriptionPollMaxBlockingTimeMs: {}", getSubscriptionPollMaxBlockingTimeMs());
-    LOGGER.info(
-        "SubscriptionSerializeMaxBlockingTimeMs: {}", getSubscriptionSerializeMaxBlockingTimeMs());
+    LOGGER.info("SubscriptionDefaultTimeoutInMs: {}", getSubscriptionDefaultTimeoutInMs());
     LOGGER.info("SubscriptionLaunchRetryIntervalMs: {}", getSubscriptionLaunchRetryIntervalMs());
     LOGGER.info(
         "SubscriptionRecycleUncommittedEventIntervalMs: {}",
@@ -124,6 +127,9 @@ public class SubscriptionConfig {
     LOGGER.info(
         "SubscriptionTsFileDeduplicationWindowSeconds: {}",
         getSubscriptionTsFileDeduplicationWindowSeconds());
+    LOGGER.info(
+        "SubscriptionTsFileSlicerCheckMemoryEnoughIntervalMs: {}",
+        getSubscriptionTsFileSlicerCheckMemoryEnoughIntervalMs());
 
     LOGGER.info(
         "SubscriptionMetaSyncerInitialSyncDelayMinutes: {}",


### PR DESCRIPTION
cherry-pick #13992 to https://github.com/apache/iotdb/tree/dev/1.3