### PR TITLE
Fix throw exception when compare with null

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/IoTDBFilterTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/IoTDBFilterTableIT.java
@@ -256,7 +256,7 @@ public class IoTDBFilterTableIT {
         new String[] {"null,", "null,"},
         DATABASE_NAME);
     tableResultSetEqualTest(
-        "select s2 - null from sg1",
+        "select s1 - null from sg1",
         new String[] {"_col0"},
         new String[] {"null,", "null,"},
         DATABASE_NAME);

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/IoTDBFilterTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/IoTDBFilterTableIT.java
@@ -237,4 +237,14 @@ public class IoTDBFilterTableIT {
       fail(throwable.getMessage());
     }
   }
+
+  @Test
+  public void testCompareWithNull() {
+    tableResultSetEqualTest(
+        "select s1 from sg1 where s1 != null", new String[] {"s1"}, new String[] {}, DATABASE_NAME);
+    tableResultSetEqualTest(
+        "select s1 from sg1 where s1 <> null", new String[] {"s1"}, new String[] {}, DATABASE_NAME);
+    tableResultSetEqualTest(
+        "select s1 from sg1 where s1 = null", new String[] {"s1"}, new String[] {}, DATABASE_NAME);
+  }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/IoTDBFilterTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/IoTDBFilterTableIT.java
@@ -247,4 +247,18 @@ public class IoTDBFilterTableIT {
     tableResultSetEqualTest(
         "select s1 from sg1 where s1 = null", new String[] {"s1"}, new String[] {}, DATABASE_NAME);
   }
+
+  @Test
+  public void testCalculateWithNull() {
+    tableResultSetEqualTest(
+        "select s1 + null from sg1",
+        new String[] {"_col0"},
+        new String[] {"null,", "null,"},
+        DATABASE_NAME);
+    tableResultSetEqualTest(
+        "select s2 - null from sg1",
+        new String[] {"_col0"},
+        new String[] {"null,", "null,"},
+        DATABASE_NAME);
+  }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/function/arithmetic/AdditionResolver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/function/arithmetic/AdditionResolver.java
@@ -28,6 +28,7 @@ import static org.apache.tsfile.read.common.type.FloatType.FLOAT;
 import static org.apache.tsfile.read.common.type.IntType.INT32;
 import static org.apache.tsfile.read.common.type.LongType.INT64;
 import static org.apache.tsfile.read.common.type.TimestampType.TIMESTAMP;
+import static org.apache.tsfile.read.common.type.UnknownType.UNKNOWN;
 
 public class AdditionResolver {
 
@@ -40,6 +41,7 @@ public class AdditionResolver {
     addCondition(INT32, DOUBLE, DOUBLE);
     addCondition(INT32, DATE, DATE);
     addCondition(INT32, TIMESTAMP, TIMESTAMP);
+    addCondition(INT32, UNKNOWN, INT32);
 
     addCondition(INT64, INT32, INT64);
     addCondition(INT64, INT64, INT64);
@@ -47,22 +49,34 @@ public class AdditionResolver {
     addCondition(INT64, DOUBLE, DOUBLE);
     addCondition(INT64, DATE, DATE);
     addCondition(INT64, TIMESTAMP, TIMESTAMP);
+    addCondition(INT64, UNKNOWN, INT64);
 
     addCondition(FLOAT, INT32, FLOAT);
     addCondition(FLOAT, INT64, FLOAT);
     addCondition(FLOAT, FLOAT, FLOAT);
     addCondition(FLOAT, DOUBLE, DOUBLE);
+    addCondition(FLOAT, UNKNOWN, FLOAT);
 
     addCondition(DOUBLE, INT32, DOUBLE);
     addCondition(DOUBLE, INT64, DOUBLE);
     addCondition(DOUBLE, FLOAT, DOUBLE);
     addCondition(DOUBLE, DOUBLE, DOUBLE);
+    addCondition(DOUBLE, UNKNOWN, DOUBLE);
 
     addCondition(DATE, INT32, DATE);
     addCondition(DATE, INT64, DATE);
+    addCondition(DATE, UNKNOWN, DATE);
 
     addCondition(TIMESTAMP, INT32, TIMESTAMP);
     addCondition(TIMESTAMP, INT64, TIMESTAMP);
+    addCondition(TIMESTAMP, UNKNOWN, TIMESTAMP);
+
+    addCondition(UNKNOWN, INT32, INT32);
+    addCondition(UNKNOWN, INT64, INT64);
+    addCondition(UNKNOWN, FLOAT, FLOAT);
+    addCondition(UNKNOWN, DOUBLE, DOUBLE);
+    addCondition(UNKNOWN, DATE, DATE);
+    addCondition(UNKNOWN, TIMESTAMP, TIMESTAMP);
   }
 
   private static void addCondition(Type condition1, Type condition2, Type result) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/function/arithmetic/DivisionResolver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/function/arithmetic/DivisionResolver.java
@@ -22,10 +22,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.apache.tsfile.read.common.type.DateType.DATE;
 import static org.apache.tsfile.read.common.type.DoubleType.DOUBLE;
 import static org.apache.tsfile.read.common.type.FloatType.FLOAT;
 import static org.apache.tsfile.read.common.type.IntType.INT32;
 import static org.apache.tsfile.read.common.type.LongType.INT64;
+import static org.apache.tsfile.read.common.type.TimestampType.TIMESTAMP;
+import static org.apache.tsfile.read.common.type.UnknownType.UNKNOWN;
 
 public class DivisionResolver {
 
@@ -36,21 +39,36 @@ public class DivisionResolver {
     addCondition(INT32, INT64, INT64);
     addCondition(INT32, FLOAT, FLOAT);
     addCondition(INT32, DOUBLE, DOUBLE);
+    addCondition(INT32, UNKNOWN, INT32);
 
     addCondition(INT64, INT32, INT64);
     addCondition(INT64, INT64, INT64);
     addCondition(INT64, FLOAT, FLOAT);
     addCondition(INT64, DOUBLE, DOUBLE);
+    addCondition(INT64, UNKNOWN, INT64);
 
     addCondition(FLOAT, INT32, FLOAT);
     addCondition(FLOAT, INT64, FLOAT);
     addCondition(FLOAT, FLOAT, FLOAT);
     addCondition(FLOAT, DOUBLE, DOUBLE);
+    addCondition(FLOAT, UNKNOWN, FLOAT);
 
     addCondition(DOUBLE, INT32, DOUBLE);
     addCondition(DOUBLE, INT64, DOUBLE);
     addCondition(DOUBLE, FLOAT, DOUBLE);
     addCondition(DOUBLE, DOUBLE, DOUBLE);
+    addCondition(DOUBLE, UNKNOWN, DOUBLE);
+
+    addCondition(DATE, UNKNOWN, DATE);
+
+    addCondition(TIMESTAMP, UNKNOWN, TIMESTAMP);
+
+    addCondition(UNKNOWN, INT32, INT32);
+    addCondition(UNKNOWN, INT64, INT64);
+    addCondition(UNKNOWN, FLOAT, FLOAT);
+    addCondition(UNKNOWN, DOUBLE, DOUBLE);
+    addCondition(UNKNOWN, DATE, DATE);
+    addCondition(UNKNOWN, TIMESTAMP, TIMESTAMP);
   }
 
   private static void addCondition(Type condition1, Type condition2, Type result) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/function/arithmetic/DivisionResolver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/function/arithmetic/DivisionResolver.java
@@ -22,12 +22,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.apache.tsfile.read.common.type.DateType.DATE;
 import static org.apache.tsfile.read.common.type.DoubleType.DOUBLE;
 import static org.apache.tsfile.read.common.type.FloatType.FLOAT;
 import static org.apache.tsfile.read.common.type.IntType.INT32;
 import static org.apache.tsfile.read.common.type.LongType.INT64;
-import static org.apache.tsfile.read.common.type.TimestampType.TIMESTAMP;
 import static org.apache.tsfile.read.common.type.UnknownType.UNKNOWN;
 
 public class DivisionResolver {
@@ -59,16 +57,10 @@ public class DivisionResolver {
     addCondition(DOUBLE, DOUBLE, DOUBLE);
     addCondition(DOUBLE, UNKNOWN, DOUBLE);
 
-    addCondition(DATE, UNKNOWN, DATE);
-
-    addCondition(TIMESTAMP, UNKNOWN, TIMESTAMP);
-
     addCondition(UNKNOWN, INT32, INT32);
     addCondition(UNKNOWN, INT64, INT64);
     addCondition(UNKNOWN, FLOAT, FLOAT);
     addCondition(UNKNOWN, DOUBLE, DOUBLE);
-    addCondition(UNKNOWN, DATE, DATE);
-    addCondition(UNKNOWN, TIMESTAMP, TIMESTAMP);
   }
 
   private static void addCondition(Type condition1, Type condition2, Type result) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/function/arithmetic/ModulusResolver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/function/arithmetic/ModulusResolver.java
@@ -22,10 +22,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.apache.tsfile.read.common.type.DateType.DATE;
 import static org.apache.tsfile.read.common.type.DoubleType.DOUBLE;
 import static org.apache.tsfile.read.common.type.FloatType.FLOAT;
 import static org.apache.tsfile.read.common.type.IntType.INT32;
 import static org.apache.tsfile.read.common.type.LongType.INT64;
+import static org.apache.tsfile.read.common.type.TimestampType.TIMESTAMP;
+import static org.apache.tsfile.read.common.type.UnknownType.UNKNOWN;
 
 public class ModulusResolver {
 
@@ -36,21 +39,36 @@ public class ModulusResolver {
     addCondition(INT32, INT64, INT64);
     addCondition(INT32, FLOAT, FLOAT);
     addCondition(INT32, DOUBLE, DOUBLE);
+    addCondition(INT32, UNKNOWN, INT32);
 
     addCondition(INT64, INT32, INT64);
     addCondition(INT64, INT64, INT64);
     addCondition(INT64, FLOAT, FLOAT);
     addCondition(INT64, DOUBLE, DOUBLE);
+    addCondition(INT64, UNKNOWN, INT64);
 
     addCondition(FLOAT, INT32, FLOAT);
     addCondition(FLOAT, INT64, FLOAT);
     addCondition(FLOAT, FLOAT, FLOAT);
     addCondition(FLOAT, DOUBLE, DOUBLE);
+    addCondition(FLOAT, UNKNOWN, FLOAT);
 
     addCondition(DOUBLE, INT32, DOUBLE);
     addCondition(DOUBLE, INT64, DOUBLE);
     addCondition(DOUBLE, FLOAT, DOUBLE);
     addCondition(DOUBLE, DOUBLE, DOUBLE);
+    addCondition(DOUBLE, UNKNOWN, DOUBLE);
+
+    addCondition(DATE, UNKNOWN, DATE);
+
+    addCondition(TIMESTAMP, UNKNOWN, TIMESTAMP);
+
+    addCondition(UNKNOWN, INT32, INT32);
+    addCondition(UNKNOWN, INT64, INT64);
+    addCondition(UNKNOWN, FLOAT, FLOAT);
+    addCondition(UNKNOWN, DOUBLE, DOUBLE);
+    addCondition(UNKNOWN, DATE, DATE);
+    addCondition(UNKNOWN, TIMESTAMP, TIMESTAMP);
   }
 
   private static void addCondition(Type condition1, Type condition2, Type result) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/function/arithmetic/ModulusResolver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/function/arithmetic/ModulusResolver.java
@@ -22,12 +22,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.apache.tsfile.read.common.type.DateType.DATE;
 import static org.apache.tsfile.read.common.type.DoubleType.DOUBLE;
 import static org.apache.tsfile.read.common.type.FloatType.FLOAT;
 import static org.apache.tsfile.read.common.type.IntType.INT32;
 import static org.apache.tsfile.read.common.type.LongType.INT64;
-import static org.apache.tsfile.read.common.type.TimestampType.TIMESTAMP;
 import static org.apache.tsfile.read.common.type.UnknownType.UNKNOWN;
 
 public class ModulusResolver {
@@ -59,16 +57,10 @@ public class ModulusResolver {
     addCondition(DOUBLE, DOUBLE, DOUBLE);
     addCondition(DOUBLE, UNKNOWN, DOUBLE);
 
-    addCondition(DATE, UNKNOWN, DATE);
-
-    addCondition(TIMESTAMP, UNKNOWN, TIMESTAMP);
-
     addCondition(UNKNOWN, INT32, INT32);
     addCondition(UNKNOWN, INT64, INT64);
     addCondition(UNKNOWN, FLOAT, FLOAT);
     addCondition(UNKNOWN, DOUBLE, DOUBLE);
-    addCondition(UNKNOWN, DATE, DATE);
-    addCondition(UNKNOWN, TIMESTAMP, TIMESTAMP);
   }
 
   private static void addCondition(Type condition1, Type condition2, Type result) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/function/arithmetic/MultiplicationResolver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/function/arithmetic/MultiplicationResolver.java
@@ -22,12 +22,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.apache.tsfile.read.common.type.DateType.DATE;
 import static org.apache.tsfile.read.common.type.DoubleType.DOUBLE;
 import static org.apache.tsfile.read.common.type.FloatType.FLOAT;
 import static org.apache.tsfile.read.common.type.IntType.INT32;
 import static org.apache.tsfile.read.common.type.LongType.INT64;
-import static org.apache.tsfile.read.common.type.TimestampType.TIMESTAMP;
 import static org.apache.tsfile.read.common.type.UnknownType.UNKNOWN;
 
 public class MultiplicationResolver {
@@ -59,16 +57,10 @@ public class MultiplicationResolver {
     addCondition(DOUBLE, DOUBLE, DOUBLE);
     addCondition(DOUBLE, UNKNOWN, DOUBLE);
 
-    addCondition(DATE, UNKNOWN, DATE);
-
-    addCondition(TIMESTAMP, UNKNOWN, TIMESTAMP);
-
     addCondition(UNKNOWN, INT32, INT32);
     addCondition(UNKNOWN, INT64, INT64);
     addCondition(UNKNOWN, FLOAT, FLOAT);
     addCondition(UNKNOWN, DOUBLE, DOUBLE);
-    addCondition(UNKNOWN, DATE, DATE);
-    addCondition(UNKNOWN, TIMESTAMP, TIMESTAMP);
   }
 
   private static void addCondition(Type condition1, Type condition2, Type result) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/function/arithmetic/MultiplicationResolver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/function/arithmetic/MultiplicationResolver.java
@@ -22,10 +22,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.apache.tsfile.read.common.type.DateType.DATE;
 import static org.apache.tsfile.read.common.type.DoubleType.DOUBLE;
 import static org.apache.tsfile.read.common.type.FloatType.FLOAT;
 import static org.apache.tsfile.read.common.type.IntType.INT32;
 import static org.apache.tsfile.read.common.type.LongType.INT64;
+import static org.apache.tsfile.read.common.type.TimestampType.TIMESTAMP;
+import static org.apache.tsfile.read.common.type.UnknownType.UNKNOWN;
 
 public class MultiplicationResolver {
 
@@ -36,21 +39,36 @@ public class MultiplicationResolver {
     addCondition(INT32, INT64, INT64);
     addCondition(INT32, FLOAT, FLOAT);
     addCondition(INT32, DOUBLE, DOUBLE);
+    addCondition(INT32, UNKNOWN, INT32);
 
     addCondition(INT64, INT32, INT64);
     addCondition(INT64, INT64, INT64);
     addCondition(INT64, FLOAT, FLOAT);
     addCondition(INT64, DOUBLE, DOUBLE);
+    addCondition(INT64, UNKNOWN, INT64);
 
     addCondition(FLOAT, INT32, FLOAT);
     addCondition(FLOAT, INT64, FLOAT);
     addCondition(FLOAT, FLOAT, FLOAT);
     addCondition(FLOAT, DOUBLE, DOUBLE);
+    addCondition(FLOAT, UNKNOWN, FLOAT);
 
     addCondition(DOUBLE, INT32, DOUBLE);
     addCondition(DOUBLE, INT64, DOUBLE);
     addCondition(DOUBLE, FLOAT, DOUBLE);
     addCondition(DOUBLE, DOUBLE, DOUBLE);
+    addCondition(DOUBLE, UNKNOWN, DOUBLE);
+
+    addCondition(DATE, UNKNOWN, DATE);
+
+    addCondition(TIMESTAMP, UNKNOWN, TIMESTAMP);
+
+    addCondition(UNKNOWN, INT32, INT32);
+    addCondition(UNKNOWN, INT64, INT64);
+    addCondition(UNKNOWN, FLOAT, FLOAT);
+    addCondition(UNKNOWN, DOUBLE, DOUBLE);
+    addCondition(UNKNOWN, DATE, DATE);
+    addCondition(UNKNOWN, TIMESTAMP, TIMESTAMP);
   }
 
   private static void addCondition(Type condition1, Type condition2, Type result) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/function/arithmetic/SubtractionResolver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/function/arithmetic/SubtractionResolver.java
@@ -61,18 +61,14 @@ public class SubtractionResolver {
 
     addCondition(DATE, INT32, DATE);
     addCondition(DATE, INT64, DATE);
-    addCondition(DATE, UNKNOWN, DATE);
 
     addCondition(TIMESTAMP, INT32, TIMESTAMP);
     addCondition(TIMESTAMP, INT64, TIMESTAMP);
-    addCondition(TIMESTAMP, UNKNOWN, TIMESTAMP);
 
     addCondition(UNKNOWN, INT32, INT32);
     addCondition(UNKNOWN, INT64, INT64);
     addCondition(UNKNOWN, FLOAT, FLOAT);
     addCondition(UNKNOWN, DOUBLE, DOUBLE);
-    addCondition(UNKNOWN, DATE, DATE);
-    addCondition(UNKNOWN, TIMESTAMP, TIMESTAMP);
   }
 
   private static void addCondition(Type condition1, Type condition2, Type result) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/function/arithmetic/SubtractionResolver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/function/arithmetic/SubtractionResolver.java
@@ -28,6 +28,7 @@ import static org.apache.tsfile.read.common.type.FloatType.FLOAT;
 import static org.apache.tsfile.read.common.type.IntType.INT32;
 import static org.apache.tsfile.read.common.type.LongType.INT64;
 import static org.apache.tsfile.read.common.type.TimestampType.TIMESTAMP;
+import static org.apache.tsfile.read.common.type.UnknownType.UNKNOWN;
 
 public class SubtractionResolver {
 
@@ -38,27 +39,40 @@ public class SubtractionResolver {
     addCondition(INT32, INT64, INT64);
     addCondition(INT32, FLOAT, FLOAT);
     addCondition(INT32, DOUBLE, DOUBLE);
+    addCondition(INT32, UNKNOWN, INT32);
 
     addCondition(INT64, INT32, INT64);
     addCondition(INT64, INT64, INT64);
     addCondition(INT64, FLOAT, FLOAT);
     addCondition(INT64, DOUBLE, DOUBLE);
+    addCondition(INT64, UNKNOWN, INT64);
 
     addCondition(FLOAT, INT32, FLOAT);
     addCondition(FLOAT, INT64, FLOAT);
     addCondition(FLOAT, FLOAT, FLOAT);
     addCondition(FLOAT, DOUBLE, DOUBLE);
+    addCondition(FLOAT, UNKNOWN, FLOAT);
 
     addCondition(DOUBLE, INT32, DOUBLE);
     addCondition(DOUBLE, INT64, DOUBLE);
     addCondition(DOUBLE, FLOAT, DOUBLE);
     addCondition(DOUBLE, DOUBLE, DOUBLE);
+    addCondition(DOUBLE, UNKNOWN, DOUBLE);
 
     addCondition(DATE, INT32, DATE);
     addCondition(DATE, INT64, DATE);
+    addCondition(DATE, UNKNOWN, DATE);
 
     addCondition(TIMESTAMP, INT32, TIMESTAMP);
     addCondition(TIMESTAMP, INT64, TIMESTAMP);
+    addCondition(TIMESTAMP, UNKNOWN, TIMESTAMP);
+
+    addCondition(UNKNOWN, INT32, INT32);
+    addCondition(UNKNOWN, INT64, INT64);
+    addCondition(UNKNOWN, FLOAT, FLOAT);
+    addCondition(UNKNOWN, DOUBLE, DOUBLE);
+    addCondition(UNKNOWN, DATE, DATE);
+    addCondition(UNKNOWN, TIMESTAMP, TIMESTAMP);
   }
 
   private static void addCondition(Type condition1, Type condition2, Type result) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableMetadataImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableMetadataImpl.java
@@ -112,13 +112,11 @@ public class TableMetadataImpl implements Metadata {
       throws OperatorNotFoundException {
 
     if (isCompareWithNull(argumentTypes)) {
-      if (operatorType.equals(EQUAL)
-          || operatorType.equals(LESS_THAN)
-          || operatorType.equals(LESS_THAN_OR_EQUAL)) {
-        return BOOLEAN;
-      }
+      return BOOLEAN;
+    } else if (isCalculateWithNull(argumentTypes)) {
       return argumentTypes.get(0);
     }
+
     switch (operatorType) {
       case ADD:
         if (!isTwoTypeCalculable(argumentTypes)

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableMetadataImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableMetadataImpl.java
@@ -110,13 +110,6 @@ public class TableMetadataImpl implements Metadata {
   @Override
   public Type getOperatorReturnType(OperatorType operatorType, List<? extends Type> argumentTypes)
       throws OperatorNotFoundException {
-
-    if (isCompareWithNull(argumentTypes)) {
-      return BOOLEAN;
-    } else if (isCalculateWithNull(argumentTypes)) {
-      return argumentTypes.get(0);
-    }
-
     switch (operatorType) {
       case ADD:
         if (!isTwoTypeCalculable(argumentTypes)
@@ -807,18 +800,11 @@ public class TableMetadataImpl implements Metadata {
     if (left.equals(right)) {
       return true;
     }
-
     // Boolean type and Binary Type can not be compared with other types
-    return (isNumericType(left) && isNumericType(right)) || (isCharType(left) && isCharType(right));
-  }
-
-  public static boolean isCompareWithNull(List<? extends Type> argumentTypes) {
-    if (argumentTypes.size() != 2) {
-      return false;
-    }
-    Type left = argumentTypes.get(0);
-    Type right = argumentTypes.get(1);
-    return isNumericType(left) || isCharType(left) && isUnknownType(right);
+    return (isNumericType(left) && isNumericType(right))
+        || (isCharType(left) && isCharType(right))
+        || (isUnknownType(left) && (isNumericType(right) || isCharType(right)))
+        || ((isNumericType(left) || isCharType(left)) && isUnknownType(right));
   }
 
   public static boolean isArithmeticType(Type type) {
@@ -836,6 +822,10 @@ public class TableMetadataImpl implements Metadata {
     }
     Type left = argumentTypes.get(0);
     Type right = argumentTypes.get(1);
+    if ((isUnknownType(left) && isArithmeticType(right))
+        || (isUnknownType(right) && isArithmeticType(left))) {
+      return true;
+    }
     return isArithmeticType(left) && isArithmeticType(right);
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableMetadataImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableMetadataImpl.java
@@ -110,6 +110,7 @@ public class TableMetadataImpl implements Metadata {
   @Override
   public Type getOperatorReturnType(OperatorType operatorType, List<? extends Type> argumentTypes)
       throws OperatorNotFoundException {
+
     switch (operatorType) {
       case ADD:
         if (!isTwoTypeCalculable(argumentTypes)
@@ -800,6 +801,7 @@ public class TableMetadataImpl implements Metadata {
     if (left.equals(right)) {
       return true;
     }
+
     // Boolean type and Binary Type can not be compared with other types
     return (isNumericType(left) && isNumericType(right))
         || (isCharType(left) && isCharType(right))
@@ -827,14 +829,5 @@ public class TableMetadataImpl implements Metadata {
       return true;
     }
     return isArithmeticType(left) && isArithmeticType(right);
-  }
-
-  public static boolean isCalculateWithNull(List<? extends Type> argumentTypes) {
-    if (argumentTypes.size() != 2) {
-      return false;
-    }
-    Type left = argumentTypes.get(0);
-    Type right = argumentTypes.get(1);
-    return isArithmeticType(left) && isUnknownType(right);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/leaf/NullColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/leaf/NullColumnTransformer.java
@@ -21,10 +21,12 @@ package org.apache.iotdb.db.queryengine.transformation.dag.column.leaf;
 
 import org.apache.tsfile.read.common.block.column.NullColumn;
 
+import static org.apache.tsfile.read.common.type.UnknownType.UNKNOWN;
+
 public class NullColumnTransformer extends LeafColumnTransformer {
 
   public NullColumnTransformer() {
-    super(null);
+    super(UNKNOWN);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/unary/scalar/AbstractCastFunctionColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/unary/scalar/AbstractCastFunctionColumnTransformer.java
@@ -49,18 +49,12 @@ public abstract class AbstractCastFunctionColumnTransformer extends UnaryColumnT
   @Override
   protected void doTransform(Column column, ColumnBuilder columnBuilder) {
     Type childType = childColumnTransformer.getType();
-    if (childType == null) {
-      for (int i = 0; i < column.getPositionCount(); i++) {
+    TypeEnum sourceType = childType.getTypeEnum();
+    for (int i = 0, n = column.getPositionCount(); i < n; i++) {
+      if (!column.isNull(i)) {
+        transform(column, columnBuilder, sourceType, childType, i);
+      } else {
         columnBuilder.appendNull();
-      }
-    } else {
-      TypeEnum sourceType = childType.getTypeEnum();
-      for (int i = 0, n = column.getPositionCount(); i < n; i++) {
-        if (!column.isNull(i)) {
-          transform(column, columnBuilder, sourceType, childType, i);
-        } else {
-          columnBuilder.appendNull();
-        }
       }
     }
   }
@@ -68,18 +62,12 @@ public abstract class AbstractCastFunctionColumnTransformer extends UnaryColumnT
   @Override
   protected void doTransform(Column column, ColumnBuilder columnBuilder, boolean[] selection) {
     Type childType = childColumnTransformer.getType();
-    if (childType == null) {
-      for (int i = 0; i < column.getPositionCount(); i++) {
+    TypeEnum sourceType = childType.getTypeEnum();
+    for (int i = 0, n = column.getPositionCount(); i < n; i++) {
+      if (selection[i] && !column.isNull(i)) {
+        transform(column, columnBuilder, sourceType, childType, i);
+      } else {
         columnBuilder.appendNull();
-      }
-    } else {
-      TypeEnum sourceType = childType.getTypeEnum();
-      for (int i = 0, n = column.getPositionCount(); i < n; i++) {
-        if (selection[i] && !column.isNull(i)) {
-          transform(column, columnBuilder, sourceType, childType, i);
-        } else {
-          columnBuilder.appendNull();
-        }
       }
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/unary/scalar/AbstractCastFunctionColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/unary/scalar/AbstractCastFunctionColumnTransformer.java
@@ -48,26 +48,38 @@ public abstract class AbstractCastFunctionColumnTransformer extends UnaryColumnT
 
   @Override
   protected void doTransform(Column column, ColumnBuilder columnBuilder) {
-    TypeEnum sourceType = childColumnTransformer.getType().getTypeEnum();
     Type childType = childColumnTransformer.getType();
-    for (int i = 0, n = column.getPositionCount(); i < n; i++) {
-      if (!column.isNull(i)) {
-        transform(column, columnBuilder, sourceType, childType, i);
-      } else {
+    if (childType == null) {
+      for (int i = 0; i < column.getPositionCount(); i++) {
         columnBuilder.appendNull();
+      }
+    } else {
+      TypeEnum sourceType = childType.getTypeEnum();
+      for (int i = 0, n = column.getPositionCount(); i < n; i++) {
+        if (!column.isNull(i)) {
+          transform(column, columnBuilder, sourceType, childType, i);
+        } else {
+          columnBuilder.appendNull();
+        }
       }
     }
   }
 
   @Override
   protected void doTransform(Column column, ColumnBuilder columnBuilder, boolean[] selection) {
-    TypeEnum sourceType = childColumnTransformer.getType().getTypeEnum();
     Type childType = childColumnTransformer.getType();
-    for (int i = 0, n = column.getPositionCount(); i < n; i++) {
-      if (selection[i] && !column.isNull(i)) {
-        transform(column, columnBuilder, sourceType, childType, i);
-      } else {
+    if (childType == null) {
+      for (int i = 0; i < column.getPositionCount(); i++) {
         columnBuilder.appendNull();
+      }
+    } else {
+      TypeEnum sourceType = childType.getTypeEnum();
+      for (int i = 0, n = column.getPositionCount(); i < n; i++) {
+        if (selection[i] && !column.isNull(i)) {
+          transform(column, columnBuilder, sourceType, childType, i);
+        } else {
+          columnBuilder.appendNull();
+        }
       }
     }
   }


### PR DESCRIPTION
This pull request primarily focuses on enhancing the handling of `null` values in the query engine and transformation logic, and includes several new test cases to validate these changes. The most important changes include new methods for detecting `null` values in comparisons and calculations, additional imports, and modifications to the transformation logic to handle `null` values correctly.

Enhancements for handling `null` values:

* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableMetadataImpl.java`](diffhunk://#diff-5420ab45f1bfb25708b0cd843b2770256e0671bc180acb7abf7f8a89888a3aa0R815-R823): Added methods `isCompareWithNull` and `isCalculateWithNull` to handle `null` values in comparisons and calculations. [[1]](diffhunk://#diff-5420ab45f1bfb25708b0cd843b2770256e0671bc180acb7abf7f8a89888a3aa0R815-R823) [[2]](diffhunk://#diff-5420ab45f1bfb25708b0cd843b2770256e0671bc180acb7abf7f8a89888a3aa0R841-R849)
* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableMetadataImpl.java`](diffhunk://#diff-5420ab45f1bfb25708b0cd843b2770256e0671bc180acb7abf7f8a89888a3aa0R114-R119): Modified `getOperatorReturnType` to return appropriate types when `null` values are involved.
* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableMetadataImpl.java`](diffhunk://#diff-5420ab45f1bfb25708b0cd843b2770256e0671bc180acb7abf7f8a89888a3aa0R793-R796): Added `isUnknownType` method to identify `null` values.

Additional imports:

* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableMetadataImpl.java`](diffhunk://#diff-5420ab45f1bfb25708b0cd843b2770256e0671bc180acb7abf7f8a89888a3aa0R64-R66): Added imports for `EQUAL`, `LESS_THAN`, `LESS_THAN_OR_EQUAL`, and `UNKNOWN` types. [[1]](diffhunk://#diff-5420ab45f1bfb25708b0cd843b2770256e0671bc180acb7abf7f8a89888a3aa0R64-R66) [[2]](diffhunk://#diff-5420ab45f1bfb25708b0cd843b2770256e0671bc180acb7abf7f8a89888a3aa0R76)

Transformation logic adjustments:

* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/unary/scalar/AbstractCastFunctionColumnTransformer.java`](diffhunk://#diff-636393e41f47a869fcf39890782f34edecdfedf1767c5d8944f302e471d7dd4eL51-R57): Updated transformation methods to handle columns with `null` values properly. [[1]](diffhunk://#diff-636393e41f47a869fcf39890782f34edecdfedf1767c5d8944f302e471d7dd4eL51-R57) [[2]](diffhunk://#diff-636393e41f47a869fcf39890782f34edecdfedf1767c5d8944f302e471d7dd4eR66-R76) [[3]](diffhunk://#diff-636393e41f47a869fcf39890782f34edecdfedf1767c5d8944f302e471d7dd4eR85)

New test cases:

* [`integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/IoTDBFilterTableIT.java`](diffhunk://#diff-bdebb6d06287163ea6039fef561b000c6bc4eb69d398cce4507fbb8354790031R240-R263): Added test cases `testCompareWithNull` and `testCalculateWithNull` to verify the new `null` handling logic.