### PR TITLE
Fix corner case of StreamAggOperator

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/StreamingAggregationOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/StreamingAggregationOperator.java
@@ -46,7 +46,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 public class StreamingAggregationOperator extends AbstractOperator {
@@ -127,10 +126,6 @@ public class StreamingAggregationOperator extends AbstractOperator {
       }
 
       processInput(block);
-
-      if (outputs.isEmpty()) {
-        return null;
-      }
     } else {
       // last evaluate
       if (currentGroup != null) {
@@ -139,7 +134,10 @@ public class StreamingAggregationOperator extends AbstractOperator {
       }
       finished = true;
     }
-    checkState(!outputs.isEmpty(), "outputs should always not be empty here");
+
+    if (outputs.isEmpty()) {
+      return null;
+    }
 
     resultTsBlock = outputs.removeFirst();
     return checkTsBlockSizeAndGetResult();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/StreamingHashAggregationOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/StreamingHashAggregationOperator.java
@@ -44,7 +44,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 import static org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation.grouped.UpdateMemory.NOOP;
 
@@ -160,10 +159,6 @@ public class StreamingHashAggregationOperator extends AbstractOperator {
       }
 
       processInput(block);
-
-      if (outputs.isEmpty()) {
-        return null;
-      }
     } else {
       // last evaluate
       if (currentGroup != null) {
@@ -173,7 +168,10 @@ public class StreamingHashAggregationOperator extends AbstractOperator {
       finished = true;
       closeAggregationBuilder();
     }
-    checkState(!outputs.isEmpty(), "outputs should always not be empty here");
+
+    if (outputs.isEmpty()) {
+      return null;
+    }
 
     resultTsBlock = outputs.removeFirst();
     return checkTsBlockSizeAndGetResult();


### PR DESCRIPTION
Corner case: method `next()` of child of StreamAggOperator always return null until its process finished.
Fix: return null when this case. 
Verify on test enviorment：
![image](https://github.com/user-attachments/assets/011990e5-8920-4506-8ff0-76b20fd32e0d)
