### PR TITLE
Fix intermediate output of MaxMinByAccumulator in TableModel

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
@@ -1751,6 +1751,11 @@ public class IoTDBTableAggregationIT {
         expectedHeader,
         retArray,
         DATABASE_NAME);
+
+    expectedHeader = new String[] {"_col0"};
+    retArray = new String[] {"40,"};
+    tableResultSetEqualTest(
+        "select max_by(s1, s10) from table1 where s1=40", expectedHeader, retArray, DATABASE_NAME);
   }
 
   @Test
@@ -1934,11 +1939,6 @@ public class IoTDBTableAggregationIT {
         expectedHeader,
         retArray,
         DATABASE_NAME);
-
-    expectedHeader = new String[] {"_col0"};
-    retArray = new String[] {"40,"};
-    tableResultSetEqualTest(
-        "select max_by(s1, s10) from table1 where s1=40", expectedHeader, retArray, DATABASE_NAME);
   }
 
   @Test

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
@@ -1267,6 +1267,11 @@ public class IoTDBTableAggregationIT {
         expectedHeader,
         retArray,
         DATABASE_NAME);
+
+    expectedHeader = new String[] {"_col0"};
+    retArray = new String[] {"40,"};
+    tableResultSetEqualTest(
+        "select min_by(s1, s10) from table1 where s1=40", expectedHeader, retArray, DATABASE_NAME);
   }
 
   @Test
@@ -1929,6 +1934,11 @@ public class IoTDBTableAggregationIT {
         expectedHeader,
         retArray,
         DATABASE_NAME);
+
+    expectedHeader = new String[] {"_col0"};
+    retArray = new String[] {"40,"};
+    tableResultSetEqualTest(
+        "select max_by(s1, s10) from table1 where s1=40", expectedHeader, retArray, DATABASE_NAME);
   }
 
   @Test

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/TableMaxMinByBaseAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/TableMaxMinByBaseAccumulator.java
@@ -324,16 +324,16 @@ public abstract class TableMaxMinByBaseAccumulator implements TableAccumulator {
 
   private byte[] serialize() {
     byte[] valueBytes;
+    int yLength = calcTypeSize(yDataType, yExtremeValue);
     if (xNull) {
-      valueBytes = new byte[calcTypeSize(yDataType, yExtremeValue) + 1];
+      valueBytes = new byte[yLength + 1];
       serializeValue(yDataType, yExtremeValue, valueBytes, 0);
-      BytesUtils.boolToBytes(true, valueBytes, 8);
+      BytesUtils.boolToBytes(true, valueBytes, yLength);
     } else {
-      valueBytes =
-          new byte[calcTypeSize(yDataType, yExtremeValue) + 1 + calcTypeSize(xDataType, xResult)];
+      valueBytes = new byte[yLength + 1 + calcTypeSize(xDataType, xResult)];
       int offset = 0;
       serializeValue(yDataType, yExtremeValue, valueBytes, offset);
-      offset = calcTypeSize(yDataType, yExtremeValue);
+      offset = yLength;
 
       BytesUtils.boolToBytes(false, valueBytes, offset);
       offset += 1;


### PR DESCRIPTION
Cause: the offset is not correct, it should be determined by length of `yValue`
![image](https://github.com/user-attachments/assets/81272a76-3120-402d-90b4-0b1276d01cc9)
