### PR TITLE
Fix error message when there is no argument in first, last, first_by and last_by

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
@@ -3676,5 +3676,21 @@ public class IoTDBTableAggregationIT {
         "select extreme() from table1",
         "701: Aggregate functions [extreme] should only have one argument",
         DATABASE_NAME);
+    tableAssertTestFail(
+        "select first() from table1",
+        "701: Aggregate functions [first] should only have two arguments",
+        DATABASE_NAME);
+    tableAssertTestFail(
+        "select first_by() from table1",
+        "701: Aggregate functions [first_by] should only have three arguments",
+        DATABASE_NAME);
+    tableAssertTestFail(
+        "select last() from table1",
+        "701: Aggregate functions [last] should only have two arguments",
+        DATABASE_NAME);
+    tableAssertTestFail(
+        "select last_by() from table1",
+        "701: Aggregate functions [last_by] should only have three arguments",
+        DATABASE_NAME);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/parser/AstBuilder.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/parser/AstBuilder.java
@@ -1934,6 +1934,8 @@ public class AstBuilder extends RelationalSqlBaseVisitor<Node> {
               new DereferenceExpression(getLocation(ctx.label), (Identifier) visit(ctx.label)));
     }
 
+    // Syntactic sugar: first(s1) => first(s1,time), first_by(s1,s2) => first_by(s1,s2,time)
+    // So do last and last_by.
     if (name.toString().equalsIgnoreCase(FIRST_AGGREGATION)
         || name.toString().equalsIgnoreCase(LAST_AGGREGATION)) {
       if (arguments.size() == 1) {
@@ -1948,8 +1950,6 @@ public class AstBuilder extends RelationalSqlBaseVisitor<Node> {
                 .equalsIgnoreCase(TimestampOperand.TIMESTAMP_EXPRESSION_STRING),
             "The second argument of 'first' or 'last' function must be 'time'",
             ctx);
-      } else {
-        throw parseError("Invalid number of arguments for 'first' or 'last' function", ctx);
       }
     } else if (name.toString().equalsIgnoreCase(FIRST_BY_AGGREGATION)
         || name.toString().equalsIgnoreCase(LAST_BY_AGGREGATION)) {
@@ -1965,8 +1965,6 @@ public class AstBuilder extends RelationalSqlBaseVisitor<Node> {
                 .equalsIgnoreCase(TimestampOperand.TIMESTAMP_EXPRESSION_STRING),
             "The third argument of 'first_by' or 'last_by' function must be 'time'",
             ctx);
-      } else {
-        throw parseError("Invalid number of arguments for 'first_by' or 'last_by' function", ctx);
       }
     }
 


### PR DESCRIPTION
Fix: Remove the argument check when process syntax sugar.