### PR TITLE
Fix first_by and last_by with group by in TableModel

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
@@ -2080,6 +2080,32 @@ public class IoTDBTableAggregationIT {
         expectedHeader,
         retArray,
         DATABASE_NAME);
+
+    expectedHeader = new String[] {"city", "region", "device_id", "_col3"};
+    retArray =
+        new String[] {
+          "beijing,chaoyang,d09,null,",
+          "beijing,chaoyang,d10,true,",
+          "beijing,chaoyang,d11,null,",
+          "beijing,chaoyang,d12,true,",
+          "beijing,haidian,d13,null,",
+          "beijing,haidian,d14,true,",
+          "beijing,haidian,d15,null,",
+          "beijing,haidian,d16,true,",
+          "shanghai,huangpu,d01,null,",
+          "shanghai,huangpu,d02,true,",
+          "shanghai,huangpu,d03,null,",
+          "shanghai,huangpu,d04,true,",
+          "shanghai,pudong,d05,null,",
+          "shanghai,pudong,d06,true,",
+          "shanghai,pudong,d07,null,",
+          "shanghai,pudong,d08,true,",
+        };
+    tableResultSetEqualTest(
+        "select city,region,device_id,first_by(s5,time,time) from table1 group by city,region,device_id order by 1,2,3",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
   }
 
   @Test
@@ -2401,6 +2427,32 @@ public class IoTDBTableAggregationIT {
         };
     tableResultSetEqualTest(
         "select province,city,region,device_id,last_by(time,s8),last(s8) from table1 group by 1,2,3,4 order by 1,2,3,4",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+
+    expectedHeader = new String[] {"city", "region", "device_id", "_col3"};
+    retArray =
+        new String[] {
+          "beijing,chaoyang,d09,null,",
+          "beijing,chaoyang,d10,null,",
+          "beijing,chaoyang,d11,null,",
+          "beijing,chaoyang,d12,null,",
+          "beijing,haidian,d13,null,",
+          "beijing,haidian,d14,null,",
+          "beijing,haidian,d15,null,",
+          "beijing,haidian,d16,null,",
+          "shanghai,huangpu,d01,null,",
+          "shanghai,huangpu,d02,null,",
+          "shanghai,huangpu,d03,null,",
+          "shanghai,huangpu,d04,null,",
+          "shanghai,pudong,d05,null,",
+          "shanghai,pudong,d06,null,",
+          "shanghai,pudong,d07,null,",
+          "shanghai,pudong,d08,null,",
+        };
+    tableResultSetEqualTest(
+        "select city,region,device_id,last_by(s5,time,time) from table1 group by city,region,device_id order by 1,2,3",
         expectedHeader,
         retArray,
         DATABASE_NAME);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedFirstByAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedFirstByAccumulator.java
@@ -91,6 +91,7 @@ public class GroupedFirstByAccumulator implements GroupedAccumulator {
         break;
       case BOOLEAN:
         xBooleanValues = new BooleanBigArray();
+        break;
       default:
         throw new UnSupportedDataTypeException(
             String.format("Unsupported data type : %s", xDataType));
@@ -195,6 +196,7 @@ public class GroupedFirstByAccumulator implements GroupedAccumulator {
         break;
       case BOOLEAN:
         xBooleanValues.reset();
+        break;
       default:
         throw new UnSupportedDataTypeException(
             String.format("Unsupported data type : %s", xDataType));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedLastByAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedLastByAccumulator.java
@@ -196,6 +196,7 @@ public class GroupedLastByAccumulator implements GroupedAccumulator {
         break;
       case BOOLEAN:
         xBooleanValues.reset();
+        break;
       default:
         throw new UnSupportedDataTypeException(
             String.format("Unsupported data type : %s", xDataType));


### PR DESCRIPTION
Bug: The query will be error if first argument is `BOOLEAN` type in first_by and last_by function with group by.
Fix: Add `break` in switch case.
