### PR TITLE
Fix that the row deletion mark is mistakenly use

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBDeletionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBDeletionIT.java
@@ -437,6 +437,37 @@ public class IoTDBDeletionIT {
     }
   }
 
+  @Test
+  public void testDelAfterUpdate() throws SQLException {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute(
+          "CREATE ALIGNED TIMESERIES root.ln12.d1 (status int32)");
+      statement.execute("INSERT INTO root.ln12.d1(timestamp, status) VALUES(1, 1)");
+      statement.execute("INSERT INTO root.ln12.d1(timestamp, status) VALUES(2, 2)");
+      statement.execute("INSERT INTO root.ln12.d1(timestamp, status) VALUES(3, 3)");
+      statement.execute("INSERT INTO root.ln12.d1(timestamp, status) VALUES(2, 2)");
+
+      try (ResultSet resultSet = statement.executeQuery("select status from root.ln12.d1")) {
+        int cnt = 0;
+        while (resultSet.next()) {
+          cnt++;
+        }
+        Assert.assertEquals(3, cnt);
+      }
+
+      statement.execute("DELETE FROM root.ln12.d1.* WHERE time <= 2");
+
+      try (ResultSet resultSet = statement.executeQuery("select status from root.ln12.d1")) {
+        int cnt = 0;
+        while (resultSet.next()) {
+          cnt++;
+        }
+        Assert.assertEquals(1, cnt);
+      }
+    }
+  }
+
   private static void prepareSeries() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBDeletionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBDeletionIT.java
@@ -388,7 +388,7 @@ public class IoTDBDeletionIT {
       statement.execute(
           "DELETE FROM root.ln10.wf01.wt01.status,root.sg.wf01.wt01.status WHERE time >2022-10-11 10:20:50;");
 
-      try (ResultSet resultSet = statement.executeQuery("select ** from root")) {
+      try (ResultSet resultSet = statement.executeQuery("select ** from root.ln10")) {
         int cnt = 0;
         while (resultSet.next()) {
           cnt++;

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBDeletionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBDeletionIT.java
@@ -441,8 +441,7 @@ public class IoTDBDeletionIT {
   public void testDelAfterUpdate() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute(
-          "CREATE ALIGNED TIMESERIES root.ln12.d1 (status int32)");
+      statement.execute("CREATE ALIGNED TIMESERIES root.ln12.d1 (status int32)");
       statement.execute("INSERT INTO root.ln12.d1(timestamp, status) VALUES(1, 1)");
       statement.execute("INSERT INTO root.ln12.d1(timestamp, status) VALUES(2, 2)");
       statement.execute("INSERT INTO root.ln12.d1(timestamp, status) VALUES(3, 3)");

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
@@ -493,30 +493,28 @@ public abstract class AlignedTVList extends TVList {
   /**
    * Get whether value is null at the given position in AlignedTvList.
    *
-   * @param rowIndex value index inside this column
+   * @param unsortedRowIndex value index inside this column
    * @param columnIndex index of the column
    * @return boolean
    */
-  public boolean isNullValue(int rowIndex, int columnIndex) {
-    if (rowIndex >= rowCount) {
+  public boolean isNullValue(int unsortedRowIndex, int columnIndex) {
+    if (unsortedRowIndex >= rowCount) {
       return false;
     }
-    if (allValueColDeletedMap != null && allValueColDeletedMap.isMarked(rowIndex)) {
+    if (allValueColDeletedMap != null && allValueColDeletedMap.isMarked(unsortedRowIndex)) {
       return true;
     }
-    if (isTimeDeleted(rowIndex)) {
-      return true;
-    }
+
     if (values.get(columnIndex) == null) {
       return true;
     }
     if (bitMaps == null
         || bitMaps.get(columnIndex) == null
-        || bitMaps.get(columnIndex).get(rowIndex / ARRAY_SIZE) == null) {
+        || bitMaps.get(columnIndex).get(unsortedRowIndex / ARRAY_SIZE) == null) {
       return false;
     }
-    int arrayIndex = rowIndex / ARRAY_SIZE;
-    int elementIndex = rowIndex % ARRAY_SIZE;
+    int arrayIndex = unsortedRowIndex / ARRAY_SIZE;
+    int elementIndex = unsortedRowIndex % ARRAY_SIZE;
     List<BitMap> columnBitMaps = bitMaps.get(columnIndex);
     return columnBitMaps.get(arrayIndex).isMarked(elementIndex);
   }
@@ -1424,6 +1422,9 @@ public abstract class AlignedTVList extends TVList {
     return timeColDeletedMap;
   }
 
+  /**
+   * @param rowIndex should be the sorted index.
+   */
   public boolean isTimeDeleted(int rowIndex) {
     int bitmapIndex = getValueIndex(rowIndex);
     if (timeColDeletedMap == null || timeColDeletedMap.getSize() <= bitmapIndex) {


### PR DESCRIPTION
The row deletion mark is mistakenly used to judge the deletion of a value column, which is fixed in this PR.