### PR TITLE
[remove datanode] Refuse to remove when there are any other unknown or readonly DataNodes in the consensus group

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RemoveDataNodeHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RemoveDataNodeHandler.java
@@ -481,4 +481,21 @@ public class RemoveDataNodeHandler {
         .map(TRegionReplicaSet::getRegionId)
         .collect(Collectors.toList());
   }
+
+  /**
+   * Retrieves all DataNodes related to the specified DataNode.
+   *
+   * @param removedDataNode the DataNode to be removed
+   * @return a set of TDataNodeLocation representing the DataNodes associated with the specified
+   *     DataNode
+   */
+  public Set<TDataNodeLocation> getRelatedDataNodeLocations(TDataNodeLocation removedDataNode) {
+    return configManager.getPartitionManager().getAllReplicaSets().stream()
+        .filter(
+            replicaSet ->
+                replicaSet.getDataNodeLocations().contains(removedDataNode)
+                    && replicaSet.regionId.getType() != TConsensusGroupType.ConfigRegion)
+        .flatMap(replicaSet -> replicaSet.getDataNodeLocations().stream())
+        .collect(Collectors.toSet());
+  }
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RemoveDataNodeHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RemoveDataNodeHandler.java
@@ -20,7 +20,6 @@
 package org.apache.iotdb.confignode.procedure.env;
 
 import org.apache.iotdb.common.rpc.thrift.TConsensusGroupId;
-import org.apache.iotdb.common.rpc.thrift.TConsensusGroupType;
 import org.apache.iotdb.common.rpc.thrift.TDataNodeConfiguration;
 import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
@@ -474,10 +473,7 @@ public class RemoveDataNodeHandler {
    */
   public List<TConsensusGroupId> getMigratedDataNodeRegions(TDataNodeLocation removedDataNode) {
     return configManager.getPartitionManager().getAllReplicaSets().stream()
-        .filter(
-            replicaSet ->
-                replicaSet.getDataNodeLocations().contains(removedDataNode)
-                    && replicaSet.regionId.getType() != TConsensusGroupType.ConfigRegion)
+        .filter(replicaSet -> replicaSet.getDataNodeLocations().contains(removedDataNode))
         .map(TRegionReplicaSet::getRegionId)
         .collect(Collectors.toList());
   }
@@ -491,10 +487,7 @@ public class RemoveDataNodeHandler {
    */
   public Set<TDataNodeLocation> getRelatedDataNodeLocations(TDataNodeLocation removedDataNode) {
     return configManager.getPartitionManager().getAllReplicaSets().stream()
-        .filter(
-            replicaSet ->
-                replicaSet.getDataNodeLocations().contains(removedDataNode)
-                    && replicaSet.regionId.getType() != TConsensusGroupType.ConfigRegion)
+        .filter(replicaSet -> replicaSet.getDataNodeLocations().contains(removedDataNode))
         .flatMap(replicaSet -> replicaSet.getDataNodeLocations().stream())
         .collect(Collectors.toSet());
   }


### PR DESCRIPTION
## Description

1. When there are other unknown or readonly DataNodes in the consensus group that are not the removed node, for security reasons, the current remove peer operation will wait for the unknown node to come online. To optimize this situation, we can check before and refuse to remove.
2. In the future, the two-stage operations of add and remove in region migration can be provided to users as separate instructions. Therefore, for the remove operation, we can consider adding the unsafe instruction to force deletion to avoid stuck situations.

![image](https://github.com/user-attachments/assets/05cb05dc-f489-4662-8c45-1831d572d6d8)
