### PR TITLE
Change LogicalOptimizer and DistributionOptimizer to singleton

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/memory/TableModelStatementMemorySourceVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/memory/TableModelStatementMemorySourceVisitor.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.queryengine.plan.execution.memory;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.db.queryengine.common.header.ColumnHeader;
 import org.apache.iotdb.db.queryengine.common.header.DatasetHeader;
+import org.apache.iotdb.db.queryengine.plan.Coordinator;
 import org.apache.iotdb.db.queryengine.plan.planner.LocalExecutionPlanner;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.LogicalQueryPlan;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanGraphPrinter;
@@ -73,7 +74,8 @@ public class TableModelStatementMemorySourceVisitor
                 LocalExecutionPlanner.getInstance().metadata,
                 context.getQueryContext().getSession(),
                 symbolAllocator,
-                NOOP)
+                NOOP,
+                Coordinator.getInstance().getLogicalPlanOptimizers())
             .plan(context.getAnalysis());
     //    if (context.getAnalysis().isEmptyDataSource()) {
     //      return new StatementMemorySource(new TsBlock(0), header);
@@ -87,7 +89,8 @@ public class TableModelStatementMemorySourceVisitor
                 context.getAnalysis(),
                 symbolAllocator,
                 logicalPlan,
-                LocalExecutionPlanner.getInstance().metadata)
+                LocalExecutionPlanner.getInstance().metadata,
+                Coordinator.getInstance().getDistributionPlanOptimizers())
             .generateDistributedPlanWithOptimize(planContext);
 
     final List<String> lines =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/TableOperatorGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/TableOperatorGenerator.java
@@ -66,7 +66,6 @@ import org.apache.iotdb.db.queryengine.execution.operator.schema.SchemaQueryScan
 import org.apache.iotdb.db.queryengine.execution.operator.schema.source.DevicePredicateFilter;
 import org.apache.iotdb.db.queryengine.execution.operator.schema.source.SchemaSourceFactory;
 import org.apache.iotdb.db.queryengine.execution.operator.sink.IdentitySinkOperator;
-import org.apache.iotdb.db.queryengine.execution.operator.source.AlignedSeriesScanOperator;
 import org.apache.iotdb.db.queryengine.execution.operator.source.ExchangeOperator;
 import org.apache.iotdb.db.queryengine.execution.operator.source.relational.TableAggregationTableScanOperator;
 import org.apache.iotdb.db.queryengine.execution.operator.source.relational.TableFullOuterJoinOperator;
@@ -384,7 +383,7 @@ public class TableOperatorGenerator extends PlanVisitor<Operator, LocalExecution
             .addOperatorContext(
                 context.getNextOperatorId(),
                 node.getPlanNodeId(),
-                AlignedSeriesScanOperator.class.getSimpleName());
+                TableScanNode.class.getSimpleName());
 
     int maxTsBlockLineNum = TSFileDescriptor.getInstance().getConfig().getMaxTsBlockLineNumber();
     if (context.getTypeProvider().getTemplatedInfo() != null) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/TableLogicalPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/TableLogicalPlanner.java
@@ -86,23 +86,23 @@ public class TableLogicalPlanner {
   private final Metadata metadata;
   private final WarningCollector warningCollector;
 
+  @TestOnly
   public TableLogicalPlanner(
       MPPQueryContext queryContext,
       Metadata metadata,
       SessionInfo sessionInfo,
       SymbolAllocator symbolAllocator,
       WarningCollector warningCollector) {
-    this.queryContext = queryContext;
-    this.metadata = metadata;
-    this.sessionInfo = requireNonNull(sessionInfo, "session is null");
-    this.symbolAllocator = requireNonNull(symbolAllocator, "symbolAllocator is null");
-    this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
-    this.planOptimizers =
+    this(
+        queryContext,
+        metadata,
+        sessionInfo,
+        symbolAllocator,
+        warningCollector,
         new LogicalOptimizeFactory(new PlannerContext(metadata, new InternalTypeManager()))
-            .getPlanOptimizers();
+            .getPlanOptimizers());
   }
 
-  @TestOnly
   public TableLogicalPlanner(
       MPPQueryContext queryContext,
       Metadata metadata,

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/distribute/TableDistributedPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/distribute/TableDistributedPlanner.java
@@ -14,6 +14,7 @@
 package org.apache.iotdb.db.queryengine.plan.relational.planner.distribute;
 
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
+import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.db.queryengine.common.MPPQueryContext;
 import org.apache.iotdb.db.queryengine.execution.exchange.sink.DownStreamChannelLocation;
 import org.apache.iotdb.db.queryengine.metric.QueryPlanCostMetricSet;
@@ -58,18 +59,32 @@ public class TableDistributedPlanner {
   private final List<PlanOptimizer> optimizers;
   private final Metadata metadata;
 
+  @TestOnly
   public TableDistributedPlanner(
       Analysis analysis,
       SymbolAllocator symbolAllocator,
       LogicalQueryPlan logicalQueryPlan,
       Metadata metadata) {
+    this(
+        analysis,
+        symbolAllocator,
+        logicalQueryPlan,
+        metadata,
+        new DistributedOptimizeFactory(new PlannerContext(metadata, new InternalTypeManager()))
+            .getPlanOptimizers());
+  }
+
+  public TableDistributedPlanner(
+      Analysis analysis,
+      SymbolAllocator symbolAllocator,
+      LogicalQueryPlan logicalQueryPlan,
+      Metadata metadata,
+      List<PlanOptimizer> distributedOptimizers) {
     this.analysis = analysis;
     this.symbolAllocator = requireNonNull(symbolAllocator, "symbolAllocator is null");
     this.logicalQueryPlan = logicalQueryPlan;
     this.mppQueryContext = logicalQueryPlan.getContext();
-    this.optimizers =
-        new DistributedOptimizeFactory(new PlannerContext(metadata, new InternalTypeManager()))
-            .getPlanOptimizers();
+    this.optimizers = distributedOptimizers;
     this.metadata = metadata;
   }
 


### PR DESCRIPTION
Optimizers are designed to be stateless, so we can share them among different queries. All stateful fields should be saved in Context instead of optimizer itself.