### PR TITLE
Fix aggregation query of TableModel when there are numerous regions in one device

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/Analysis.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/Analysis.java
@@ -101,6 +101,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.Objects.requireNonNull;
+import static org.apache.iotdb.commons.partition.DataPartition.NOT_ASSIGNED;
 
 public class Analysis implements IAnalysis {
 
@@ -820,7 +821,7 @@ public class Analysis implements IAnalysis {
   public List<TRegionReplicaSet> getDataRegionReplicaSetWithTimeFilter(
       String database, IDeviceID deviceId, Filter timeFilter) {
     if (dataPartition == null) {
-      return Collections.singletonList(new TRegionReplicaSet());
+      return Collections.singletonList(NOT_ASSIGNED);
     } else {
       return dataPartition.getDataRegionReplicaSetWithTimeFilter(database, deviceId, timeFilter);
     }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/TestMatadata.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/TestMatadata.java
@@ -240,6 +240,17 @@ public class TestMatadata implements Metadata {
             new DeviceEntry(new StringArrayDeviceID(DEVICE_6.split("\\.")), DEVICE_6_ATTRIBUTES),
             new DeviceEntry(new StringArrayDeviceID(DEVICE_5.split("\\.")), DEVICE_5_ATTRIBUTES));
       }
+      if (compareNotEqualsMatch(expressionList.get(0), "tag1", "shenzhen")) {
+        return Arrays.asList(
+            new DeviceEntry(new StringArrayDeviceID(DEVICE_4.split("\\.")), DEVICE_4_ATTRIBUTES),
+            new DeviceEntry(new StringArrayDeviceID(DEVICE_1.split("\\.")), DEVICE_1_ATTRIBUTES),
+            new DeviceEntry(new StringArrayDeviceID(DEVICE_3.split("\\.")), DEVICE_3_ATTRIBUTES),
+            new DeviceEntry(new StringArrayDeviceID(DEVICE_2.split("\\.")), DEVICE_2_ATTRIBUTES));
+      }
+      if (compareEqualsMatch(expressionList.get(0), "tag2", "B2")) {
+        return Collections.singletonList(
+            new DeviceEntry(new StringArrayDeviceID(DEVICE_5.split("\\.")), DEVICE_5_ATTRIBUTES));
+      }
     }
 
     return Arrays.asList(
@@ -255,6 +266,25 @@ public class TestMatadata implements Metadata {
     if (expression instanceof ComparisonExpression
         && ((ComparisonExpression) expression).getOperator()
             == ComparisonExpression.Operator.EQUAL) {
+      Expression leftExpression = ((ComparisonExpression) expression).getLeft();
+      Expression rightExpression = ((ComparisonExpression) expression).getRight();
+      if (leftExpression instanceof SymbolReference && rightExpression instanceof StringLiteral) {
+        return ((SymbolReference) leftExpression).getName().equalsIgnoreCase(idOrAttr)
+            && ((StringLiteral) rightExpression).getValue().equalsIgnoreCase(value);
+      } else if (leftExpression instanceof StringLiteral
+          && rightExpression instanceof SymbolReference) {
+        return ((SymbolReference) rightExpression).getName().equalsIgnoreCase(idOrAttr)
+            && ((StringLiteral) leftExpression).getValue().equalsIgnoreCase(value);
+      }
+    }
+
+    return false;
+  }
+
+  private boolean compareNotEqualsMatch(Expression expression, String idOrAttr, String value) {
+    if (expression instanceof ComparisonExpression
+        && ((ComparisonExpression) expression).getOperator()
+            == ComparisonExpression.Operator.NOT_EQUAL) {
       Expression leftExpression = ((ComparisonExpression) expression).getLeft();
       Expression rightExpression = ((ComparisonExpression) expression).getRight();
       if (leftExpression instanceof SymbolReference && rightExpression instanceof StringLiteral) {


### PR DESCRIPTION
When find more than one region in one device and AggStep is `SINGLE` when process `AggTableScan`, we need to split it and set sort property.