### PR TITLE
[remove datanode] Do not allow regions to inherit the Removing state from datanode

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/handlers/heartbeat/DataNodeHeartbeatHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/handlers/heartbeat/DataNodeHeartbeatHandler.java
@@ -98,12 +98,9 @@ public class DataNodeHeartbeatHandler implements AsyncMethodCallback<TDataNodeHe
               RegionStatus nextRegionStatus = regionStatus;
               if (nextRegionStatus == RegionStatus.Removing) {
                 nextRegionStatus =
-                    ((RegionHeartbeatSample)
-                            loadManager
-                                .getLoadCache()
-                                .getRegionCache(regionGroupId, nodeId)
-                                .getLastSample())
-                        .getStatus();
+                    loadManager
+                        .getLoadCache()
+                        .getRegionCacheLastSampleStatus(regionGroupId, nodeId);
               }
 
               // Update RegionGroupCache

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/AbstractLoadCache.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/AbstractLoadCache.java
@@ -71,7 +71,7 @@ public abstract class AbstractLoadCache {
    *
    * @return The latest heartbeat sample.
    */
-  protected AbstractHeartbeatSample getLastSample() {
+  public AbstractHeartbeatSample getLastSample() {
     return slidingWindow.isEmpty() ? null : slidingWindow.get(slidingWindow.size() - 1);
   }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/LoadCache.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/LoadCache.java
@@ -41,6 +41,7 @@ import org.apache.iotdb.confignode.manager.load.cache.node.ConfigNodeHeartbeatCa
 import org.apache.iotdb.confignode.manager.load.cache.node.DataNodeHeartbeatCache;
 import org.apache.iotdb.confignode.manager.load.cache.node.NodeHeartbeatSample;
 import org.apache.iotdb.confignode.manager.load.cache.node.NodeStatistics;
+import org.apache.iotdb.confignode.manager.load.cache.region.RegionCache;
 import org.apache.iotdb.confignode.manager.load.cache.region.RegionGroupCache;
 import org.apache.iotdb.confignode.manager.load.cache.region.RegionGroupStatistics;
 import org.apache.iotdb.confignode.manager.load.cache.region.RegionHeartbeatSample;
@@ -304,6 +305,10 @@ public class LoadCache {
     // Only cache sample when the corresponding loadCache exists
     Optional.ofNullable(regionGroupCacheMap.get(regionGroupId))
         .ifPresent(group -> group.cacheHeartbeatSample(nodeId, sample, overwrite));
+  }
+
+  public RegionCache getRegionCache(TConsensusGroupId regionGroupId, int nodeId) {
+    return regionGroupCacheMap.get(regionGroupId).getRegionCache(nodeId);
   }
 
   /**

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/LoadCache.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/LoadCache.java
@@ -41,7 +41,6 @@ import org.apache.iotdb.confignode.manager.load.cache.node.ConfigNodeHeartbeatCa
 import org.apache.iotdb.confignode.manager.load.cache.node.DataNodeHeartbeatCache;
 import org.apache.iotdb.confignode.manager.load.cache.node.NodeHeartbeatSample;
 import org.apache.iotdb.confignode.manager.load.cache.node.NodeStatistics;
-import org.apache.iotdb.confignode.manager.load.cache.region.RegionCache;
 import org.apache.iotdb.confignode.manager.load.cache.region.RegionGroupCache;
 import org.apache.iotdb.confignode.manager.load.cache.region.RegionGroupStatistics;
 import org.apache.iotdb.confignode.manager.load.cache.region.RegionHeartbeatSample;
@@ -307,8 +306,12 @@ public class LoadCache {
         .ifPresent(group -> group.cacheHeartbeatSample(nodeId, sample, overwrite));
   }
 
-  public RegionCache getRegionCache(TConsensusGroupId regionGroupId, int nodeId) {
-    return regionGroupCacheMap.get(regionGroupId).getRegionCache(nodeId);
+  public RegionStatus getRegionCacheLastSampleStatus(TConsensusGroupId regionGroupId, int nodeId) {
+    return Optional.ofNullable(regionGroupCacheMap.get(regionGroupId))
+        .map(regionGroupCache -> regionGroupCache.getRegionCache(nodeId))
+        .map(regionCache -> (RegionHeartbeatSample) regionCache.getLastSample())
+        .map(RegionHeartbeatSample::getStatus)
+        .orElse(RegionStatus.Unknown);
   }
 
   /**

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/region/RegionGroupCache.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/region/RegionGroupCache.java
@@ -153,4 +153,8 @@ public class RegionGroupCache {
   public Set<Integer> getRegionLocations() {
     return regionCacheMap.keySet();
   }
+
+  public RegionCache getRegionCache(int nodeId) {
+    return regionCacheMap.get(nodeId);
+  }
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RemoveDataNodeHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RemoveDataNodeHandler.java
@@ -156,20 +156,22 @@ public class RemoveDataNodeHandler {
           nodeStatus,
           currentTime);
 
-      Map<TConsensusGroupId, Map<Integer, RegionHeartbeatSample>> heartbeatSampleMap =
-          new TreeMap<>();
-
       // Force update RegionStatus
-      configManager
-          .getPartitionManager()
-          .getAllReplicaSets(dataNodeId)
-          .forEach(
-              replicaSet ->
-                  heartbeatSampleMap.put(
-                      replicaSet.getRegionId(),
-                      Collections.singletonMap(
-                          dataNodeId, new RegionHeartbeatSample(currentTime, regionStatus))));
-      configManager.getLoadManager().forceUpdateRegionGroupCache(heartbeatSampleMap);
+      if (regionStatus != RegionStatus.Removing) {
+        Map<TConsensusGroupId, Map<Integer, RegionHeartbeatSample>> heartbeatSampleMap =
+                new TreeMap<>();
+        configManager
+                .getPartitionManager()
+                .getAllReplicaSets(dataNodeId)
+                .forEach(
+                        replicaSet ->
+                                heartbeatSampleMap.put(
+                                        replicaSet.getRegionId(),
+                                        Collections.singletonMap(
+                                                dataNodeId, new RegionHeartbeatSample(currentTime, regionStatus))));
+        configManager.getLoadManager().forceUpdateRegionGroupCache(heartbeatSampleMap);
+      }
+
     }
   }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RemoveDataNodeHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RemoveDataNodeHandler.java
@@ -159,19 +159,18 @@ public class RemoveDataNodeHandler {
       // Force update RegionStatus
       if (regionStatus != RegionStatus.Removing) {
         Map<TConsensusGroupId, Map<Integer, RegionHeartbeatSample>> heartbeatSampleMap =
-                new TreeMap<>();
+            new TreeMap<>();
         configManager
-                .getPartitionManager()
-                .getAllReplicaSets(dataNodeId)
-                .forEach(
-                        replicaSet ->
-                                heartbeatSampleMap.put(
-                                        replicaSet.getRegionId(),
-                                        Collections.singletonMap(
-                                                dataNodeId, new RegionHeartbeatSample(currentTime, regionStatus))));
+            .getPartitionManager()
+            .getAllReplicaSets(dataNodeId)
+            .forEach(
+                replicaSet ->
+                    heartbeatSampleMap.put(
+                        replicaSet.getRegionId(),
+                        Collections.singletonMap(
+                            dataNodeId, new RegionHeartbeatSample(currentTime, regionStatus))));
         configManager.getLoadManager().forceUpdateRegionGroupCache(heartbeatSampleMap);
       }
-
     }
   }
 


### PR DESCRIPTION
## Description

When removing datanode, datanode status will be updated to Removing and then the region will inherit the datanode status in the heartbeat thread. Not allowing the region to inherit the Removing status can better observe the status of region migration.