### PR TITLE
Optimize first, last, first_by, last_by aggregation process in table model

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/FirstAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/FirstAccumulator.java
@@ -245,11 +245,11 @@ public class FirstAccumulator implements TableAccumulator {
     this.firstValue.reset();
   }
 
-  private void addIntInput(Column valueColumn, Column timeColumn) {
-    // TODO can add first position optimization if first position is null ?
+  protected void addIntInput(Column valueColumn, Column timeColumn) {
     for (int i = 0; i < valueColumn.getPositionCount(); i++) {
       if (!valueColumn.isNull(i)) {
         updateIntFirstValue(valueColumn.getInt(i), timeColumn.getLong(i));
+        return;
       }
     }
   }
@@ -262,10 +262,11 @@ public class FirstAccumulator implements TableAccumulator {
     }
   }
 
-  private void addLongInput(Column valueColumn, Column timeColumn) {
+  protected void addLongInput(Column valueColumn, Column timeColumn) {
     for (int i = 0; i < valueColumn.getPositionCount(); i++) {
       if (!valueColumn.isNull(i)) {
         updateLongFirstValue(valueColumn.getLong(i), timeColumn.getLong(i));
+        return;
       }
     }
   }
@@ -278,10 +279,11 @@ public class FirstAccumulator implements TableAccumulator {
     }
   }
 
-  private void addFloatInput(Column valueColumn, Column timeColumn) {
+  protected void addFloatInput(Column valueColumn, Column timeColumn) {
     for (int i = 0; i < valueColumn.getPositionCount(); i++) {
       if (!valueColumn.isNull(i)) {
         updateFloatFirstValue(valueColumn.getFloat(i), timeColumn.getLong(i));
+        return;
       }
     }
   }
@@ -294,10 +296,11 @@ public class FirstAccumulator implements TableAccumulator {
     }
   }
 
-  private void addDoubleInput(Column valueColumn, Column timeColumn) {
+  protected void addDoubleInput(Column valueColumn, Column timeColumn) {
     for (int i = 0; i < valueColumn.getPositionCount(); i++) {
       if (!valueColumn.isNull(i)) {
         updateDoubleFirstValue(valueColumn.getDouble(i), timeColumn.getLong(i));
+        return;
       }
     }
   }
@@ -310,10 +313,11 @@ public class FirstAccumulator implements TableAccumulator {
     }
   }
 
-  private void addBinaryInput(Column valueColumn, Column timeColumn) {
+  protected void addBinaryInput(Column valueColumn, Column timeColumn) {
     for (int i = 0; i < valueColumn.getPositionCount(); i++) {
       if (!valueColumn.isNull(i)) {
         updateBinaryFirstValue(valueColumn.getBinary(i), timeColumn.getLong(i));
+        return;
       }
     }
   }
@@ -326,10 +330,11 @@ public class FirstAccumulator implements TableAccumulator {
     }
   }
 
-  private void addBooleanInput(Column valueColumn, Column timeColumn) {
+  protected void addBooleanInput(Column valueColumn, Column timeColumn) {
     for (int i = 0; i < valueColumn.getPositionCount(); i++) {
       if (!valueColumn.isNull(i)) {
         updateBooleanFirstValue(valueColumn.getBoolean(i), timeColumn.getLong(i));
+        return;
       }
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/FirstByAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/FirstByAccumulator.java
@@ -310,11 +310,11 @@ public class FirstByAccumulator implements TableAccumulator {
     this.xResult.reset();
   }
 
-  // TODO can add first position optimization if first position is null ?
-  private void addIntInput(Column xColumn, Column yColumn, Column timeColumn) {
+  protected void addIntInput(Column xColumn, Column yColumn, Column timeColumn) {
     for (int i = 0; i < yColumn.getPositionCount(); i++) {
       if (!yColumn.isNull(i)) {
         updateIntFirstValue(xColumn, i, timeColumn.getLong(i));
+        return;
       }
     }
   }
@@ -341,10 +341,11 @@ public class FirstByAccumulator implements TableAccumulator {
     }
   }
 
-  private void addLongInput(Column xColumn, Column yColumn, Column timeColumn) {
+  protected void addLongInput(Column xColumn, Column yColumn, Column timeColumn) {
     for (int i = 0; i < yColumn.getPositionCount(); i++) {
       if (!yColumn.isNull(i)) {
         updateLongFirstValue(xColumn, i, timeColumn.getLong(i));
+        return;
       }
     }
   }
@@ -371,10 +372,11 @@ public class FirstByAccumulator implements TableAccumulator {
     }
   }
 
-  private void addFloatInput(Column xColumn, Column yColumn, Column timeColumn) {
+  protected void addFloatInput(Column xColumn, Column yColumn, Column timeColumn) {
     for (int i = 0; i < yColumn.getPositionCount(); i++) {
       if (!yColumn.isNull(i)) {
         updateFloatFirstValue(xColumn, i, timeColumn.getLong(i));
+        return;
       }
     }
   }
@@ -401,10 +403,11 @@ public class FirstByAccumulator implements TableAccumulator {
     }
   }
 
-  private void addDoubleInput(Column xColumn, Column yColumn, Column timeColumn) {
+  protected void addDoubleInput(Column xColumn, Column yColumn, Column timeColumn) {
     for (int i = 0; i < yColumn.getPositionCount(); i++) {
       if (!yColumn.isNull(i)) {
         updateDoubleFirstValue(xColumn, i, timeColumn.getLong(i));
+        return;
       }
     }
   }
@@ -431,10 +434,11 @@ public class FirstByAccumulator implements TableAccumulator {
     }
   }
 
-  private void addBinaryInput(Column xColumn, Column yColumn, Column timeColumn) {
+  protected void addBinaryInput(Column xColumn, Column yColumn, Column timeColumn) {
     for (int i = 0; i < yColumn.getPositionCount(); i++) {
       if (!yColumn.isNull(i)) {
         updateBinaryFirstValue(xColumn, i, timeColumn.getLong(i));
+        return;
       }
     }
   }
@@ -461,10 +465,11 @@ public class FirstByAccumulator implements TableAccumulator {
     }
   }
 
-  private void addBooleanInput(Column xColumn, Column yColumn, Column timeColumn) {
+  protected void addBooleanInput(Column xColumn, Column yColumn, Column timeColumn) {
     for (int i = 0; i < yColumn.getPositionCount(); i++) {
       if (!yColumn.isNull(i)) {
         updateBooleanFirstValue(xColumn, i, timeColumn.getLong(i));
+        return;
       }
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/FirstByDescAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/FirstByDescAccumulator.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation;
 
+import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.enums.TSDataType;
 
 public class FirstByDescAccumulator extends FirstByAccumulator {
@@ -31,5 +32,59 @@ public class FirstByDescAccumulator extends FirstByAccumulator {
   @Override
   public boolean hasFinalResult() {
     return false;
+  }
+
+  @Override
+  protected void addIntInput(Column xColumn, Column yColumn, Column timeColumn) {
+    for (int i = 0; i < yColumn.getPositionCount(); i++) {
+      if (!yColumn.isNull(i)) {
+        updateIntFirstValue(xColumn, i, timeColumn.getLong(i));
+      }
+    }
+  }
+
+  @Override
+  protected void addLongInput(Column xColumn, Column yColumn, Column timeColumn) {
+    for (int i = 0; i < yColumn.getPositionCount(); i++) {
+      if (!yColumn.isNull(i)) {
+        updateLongFirstValue(xColumn, i, timeColumn.getLong(i));
+      }
+    }
+  }
+
+  @Override
+  protected void addFloatInput(Column xColumn, Column yColumn, Column timeColumn) {
+    for (int i = 0; i < yColumn.getPositionCount(); i++) {
+      if (!yColumn.isNull(i)) {
+        updateFloatFirstValue(xColumn, i, timeColumn.getLong(i));
+      }
+    }
+  }
+
+  @Override
+  protected void addDoubleInput(Column xColumn, Column yColumn, Column timeColumn) {
+    for (int i = 0; i < yColumn.getPositionCount(); i++) {
+      if (!yColumn.isNull(i)) {
+        updateDoubleFirstValue(xColumn, i, timeColumn.getLong(i));
+      }
+    }
+  }
+
+  @Override
+  protected void addBinaryInput(Column xColumn, Column yColumn, Column timeColumn) {
+    for (int i = 0; i < yColumn.getPositionCount(); i++) {
+      if (!yColumn.isNull(i)) {
+        updateBinaryFirstValue(xColumn, i, timeColumn.getLong(i));
+      }
+    }
+  }
+
+  @Override
+  protected void addBooleanInput(Column xColumn, Column yColumn, Column timeColumn) {
+    for (int i = 0; i < yColumn.getPositionCount(); i++) {
+      if (!yColumn.isNull(i)) {
+        updateBooleanFirstValue(xColumn, i, timeColumn.getLong(i));
+      }
+    }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/FirstDescAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/FirstDescAccumulator.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation;
 
+import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.enums.TSDataType;
 
 public class FirstDescAccumulator extends FirstAccumulator {
@@ -30,5 +31,59 @@ public class FirstDescAccumulator extends FirstAccumulator {
   @Override
   public boolean hasFinalResult() {
     return false;
+  }
+
+  @Override
+  protected void addIntInput(Column valueColumn, Column timeColumn) {
+    for (int i = 0; i < valueColumn.getPositionCount(); i++) {
+      if (!valueColumn.isNull(i)) {
+        updateIntFirstValue(valueColumn.getInt(i), timeColumn.getLong(i));
+      }
+    }
+  }
+
+  @Override
+  protected void addLongInput(Column valueColumn, Column timeColumn) {
+    for (int i = 0; i < valueColumn.getPositionCount(); i++) {
+      if (!valueColumn.isNull(i)) {
+        updateLongFirstValue(valueColumn.getLong(i), timeColumn.getLong(i));
+      }
+    }
+  }
+
+  @Override
+  protected void addFloatInput(Column valueColumn, Column timeColumn) {
+    for (int i = 0; i < valueColumn.getPositionCount(); i++) {
+      if (!valueColumn.isNull(i)) {
+        updateFloatFirstValue(valueColumn.getFloat(i), timeColumn.getLong(i));
+      }
+    }
+  }
+
+  @Override
+  protected void addDoubleInput(Column valueColumn, Column timeColumn) {
+    for (int i = 0; i < valueColumn.getPositionCount(); i++) {
+      if (!valueColumn.isNull(i)) {
+        updateDoubleFirstValue(valueColumn.getDouble(i), timeColumn.getLong(i));
+      }
+    }
+  }
+
+  @Override
+  protected void addBinaryInput(Column valueColumn, Column timeColumn) {
+    for (int i = 0; i < valueColumn.getPositionCount(); i++) {
+      if (!valueColumn.isNull(i)) {
+        updateBinaryFirstValue(valueColumn.getBinary(i), timeColumn.getLong(i));
+      }
+    }
+  }
+
+  @Override
+  protected void addBooleanInput(Column valueColumn, Column timeColumn) {
+    for (int i = 0; i < valueColumn.getPositionCount(); i++) {
+      if (!valueColumn.isNull(i)) {
+        updateBooleanFirstValue(valueColumn.getBoolean(i), timeColumn.getLong(i));
+      }
+    }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/LastAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/LastAccumulator.java
@@ -243,8 +243,7 @@ public class LastAccumulator implements TableAccumulator {
     this.lastValue.reset();
   }
 
-  private void addIntInput(Column valueColumn, Column timeColumn) {
-    // TODO can add last position optimization if last position is null ?
+  protected void addIntInput(Column valueColumn, Column timeColumn) {
     for (int i = 0; i < valueColumn.getPositionCount(); i++) {
       if (!valueColumn.isNull(i)) {
         updateIntLastValue(valueColumn.getInt(i), timeColumn.getLong(i));
@@ -260,7 +259,7 @@ public class LastAccumulator implements TableAccumulator {
     }
   }
 
-  private void addLongInput(Column valueColumn, Column timeColumn) {
+  protected void addLongInput(Column valueColumn, Column timeColumn) {
     for (int i = 0; i < valueColumn.getPositionCount(); i++) {
       if (!valueColumn.isNull(i)) {
         updateLongLastValue(valueColumn.getLong(i), timeColumn.getLong(i));
@@ -276,7 +275,7 @@ public class LastAccumulator implements TableAccumulator {
     }
   }
 
-  private void addFloatInput(Column valueColumn, Column timeColumn) {
+  protected void addFloatInput(Column valueColumn, Column timeColumn) {
     for (int i = 0; i < valueColumn.getPositionCount(); i++) {
       if (!valueColumn.isNull(i)) {
         updateFloatLastValue(valueColumn.getFloat(i), timeColumn.getLong(i));
@@ -292,7 +291,7 @@ public class LastAccumulator implements TableAccumulator {
     }
   }
 
-  private void addDoubleInput(Column valueColumn, Column timeColumn) {
+  protected void addDoubleInput(Column valueColumn, Column timeColumn) {
     for (int i = 0; i < valueColumn.getPositionCount(); i++) {
       if (!valueColumn.isNull(i)) {
         updateDoubleLastValue(valueColumn.getDouble(i), timeColumn.getLong(i));
@@ -308,7 +307,7 @@ public class LastAccumulator implements TableAccumulator {
     }
   }
 
-  private void addBinaryInput(Column valueColumn, Column timeColumn) {
+  protected void addBinaryInput(Column valueColumn, Column timeColumn) {
     for (int i = 0; i < valueColumn.getPositionCount(); i++) {
       if (!valueColumn.isNull(i)) {
         updateBinaryLastValue(valueColumn.getBinary(i), timeColumn.getLong(i));
@@ -324,7 +323,7 @@ public class LastAccumulator implements TableAccumulator {
     }
   }
 
-  private void addBooleanInput(Column valueColumn, Column timeColumn) {
+  protected void addBooleanInput(Column valueColumn, Column timeColumn) {
     for (int i = 0; i < valueColumn.getPositionCount(); i++) {
       if (!valueColumn.isNull(i)) {
         updateBooleanLastValue(valueColumn.getBoolean(i), timeColumn.getLong(i));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/LastByAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/LastByAccumulator.java
@@ -42,8 +42,8 @@ public class LastByAccumulator implements TableAccumulator {
   private static final long INSTANCE_SIZE =
       RamUsageEstimator.shallowSizeOfInstance(LastByAccumulator.class);
 
-  private final TSDataType xDataType;
-  private final TSDataType yDataType;
+  protected final TSDataType xDataType;
+  protected final TSDataType yDataType;
 
   private final boolean xIsTimeColumn;
   private final boolean yIsTimeColumn;
@@ -311,7 +311,7 @@ public class LastByAccumulator implements TableAccumulator {
   }
 
   // TODO can add last position optimization if last position is null ?
-  private void addIntInput(Column xColumn, Column yColumn, Column timeColumn) {
+  protected void addIntInput(Column xColumn, Column yColumn, Column timeColumn) {
     for (int i = 0; i < yColumn.getPositionCount(); i++) {
       if (!yColumn.isNull(i)) {
         updateIntLastValue(xColumn, i, timeColumn.getLong(i));
@@ -341,7 +341,7 @@ public class LastByAccumulator implements TableAccumulator {
     }
   }
 
-  private void addLongInput(Column xColumn, Column yColumn, Column timeColumn) {
+  protected void addLongInput(Column xColumn, Column yColumn, Column timeColumn) {
     for (int i = 0; i < yColumn.getPositionCount(); i++) {
       if (!yColumn.isNull(i)) {
         updateLongLastValue(xColumn, i, timeColumn.getLong(i));
@@ -371,7 +371,7 @@ public class LastByAccumulator implements TableAccumulator {
     }
   }
 
-  private void addFloatInput(Column xColumn, Column yColumn, Column timeColumn) {
+  protected void addFloatInput(Column xColumn, Column yColumn, Column timeColumn) {
     for (int i = 0; i < yColumn.getPositionCount(); i++) {
       if (!yColumn.isNull(i)) {
         updateFloatLastValue(xColumn, i, timeColumn.getLong(i));
@@ -401,7 +401,7 @@ public class LastByAccumulator implements TableAccumulator {
     }
   }
 
-  private void addDoubleInput(Column xColumn, Column yColumn, Column timeColumn) {
+  protected void addDoubleInput(Column xColumn, Column yColumn, Column timeColumn) {
     for (int i = 0; i < yColumn.getPositionCount(); i++) {
       if (!yColumn.isNull(i)) {
         updateDoubleLastValue(xColumn, i, timeColumn.getLong(i));
@@ -431,7 +431,7 @@ public class LastByAccumulator implements TableAccumulator {
     }
   }
 
-  private void addBinaryInput(Column xColumn, Column yColumn, Column timeColumn) {
+  protected void addBinaryInput(Column xColumn, Column yColumn, Column timeColumn) {
     for (int i = 0; i < yColumn.getPositionCount(); i++) {
       if (!yColumn.isNull(i)) {
         updateBinaryLastValue(xColumn, i, timeColumn.getLong(i));
@@ -461,7 +461,7 @@ public class LastByAccumulator implements TableAccumulator {
     }
   }
 
-  private void addBooleanInput(Column xColumn, Column yColumn, Column timeColumn) {
+  protected void addBooleanInput(Column xColumn, Column yColumn, Column timeColumn) {
     for (int i = 0; i < yColumn.getPositionCount(); i++) {
       if (!yColumn.isNull(i)) {
         updateBooleanLastValue(xColumn, i, timeColumn.getLong(i));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/LastByDescAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/LastByDescAccumulator.java
@@ -19,9 +19,11 @@
 
 package org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation;
 
+import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.enums.TSDataType;
 
 public class LastByDescAccumulator extends LastByAccumulator {
+
   public LastByDescAccumulator(
       TSDataType xDataType, TSDataType yDataType, boolean xIsTimeColumn, boolean yIsTimeColumn) {
     super(xDataType, yDataType, xIsTimeColumn, yIsTimeColumn);
@@ -30,5 +32,65 @@ public class LastByDescAccumulator extends LastByAccumulator {
   @Override
   public boolean hasFinalResult() {
     return initResult;
+  }
+
+  @Override
+  protected void addIntInput(Column xColumn, Column yColumn, Column timeColumn) {
+    for (int i = 0; i < yColumn.getPositionCount(); i++) {
+      if (!yColumn.isNull(i)) {
+        updateIntLastValue(xColumn, i, timeColumn.getLong(i));
+        return;
+      }
+    }
+  }
+
+  @Override
+  protected void addLongInput(Column xColumn, Column yColumn, Column timeColumn) {
+    for (int i = 0; i < yColumn.getPositionCount(); i++) {
+      if (!yColumn.isNull(i)) {
+        updateLongLastValue(xColumn, i, timeColumn.getLong(i));
+        return;
+      }
+    }
+  }
+
+  @Override
+  protected void addFloatInput(Column xColumn, Column yColumn, Column timeColumn) {
+    for (int i = 0; i < yColumn.getPositionCount(); i++) {
+      if (!yColumn.isNull(i)) {
+        updateFloatLastValue(xColumn, i, timeColumn.getLong(i));
+        return;
+      }
+    }
+  }
+
+  @Override
+  protected void addDoubleInput(Column xColumn, Column yColumn, Column timeColumn) {
+    for (int i = 0; i < yColumn.getPositionCount(); i++) {
+      if (!yColumn.isNull(i)) {
+        updateDoubleLastValue(xColumn, i, timeColumn.getLong(i));
+        return;
+      }
+    }
+  }
+
+  @Override
+  protected void addBinaryInput(Column xColumn, Column yColumn, Column timeColumn) {
+    for (int i = 0; i < yColumn.getPositionCount(); i++) {
+      if (!yColumn.isNull(i)) {
+        updateBinaryLastValue(xColumn, i, timeColumn.getLong(i));
+        return;
+      }
+    }
+  }
+
+  @Override
+  protected void addBooleanInput(Column xColumn, Column yColumn, Column timeColumn) {
+    for (int i = 0; i < yColumn.getPositionCount(); i++) {
+      if (!yColumn.isNull(i)) {
+        updateBooleanLastValue(xColumn, i, timeColumn.getLong(i));
+        return;
+      }
+    }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/LastDescAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/LastDescAccumulator.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation;
 
+import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.enums.TSDataType;
 
 public class LastDescAccumulator extends LastAccumulator {
@@ -30,5 +31,65 @@ public class LastDescAccumulator extends LastAccumulator {
   @Override
   public boolean hasFinalResult() {
     return initResult;
+  }
+
+  @Override
+  protected void addIntInput(Column valueColumn, Column timeColumn) {
+    for (int i = 0; i < valueColumn.getPositionCount(); i++) {
+      if (!valueColumn.isNull(i)) {
+        updateIntLastValue(valueColumn.getInt(i), timeColumn.getLong(i));
+        return;
+      }
+    }
+  }
+
+  @Override
+  protected void addLongInput(Column valueColumn, Column timeColumn) {
+    for (int i = 0; i < valueColumn.getPositionCount(); i++) {
+      if (!valueColumn.isNull(i)) {
+        updateLongLastValue(valueColumn.getLong(i), timeColumn.getLong(i));
+        return;
+      }
+    }
+  }
+
+  @Override
+  protected void addFloatInput(Column valueColumn, Column timeColumn) {
+    for (int i = 0; i < valueColumn.getPositionCount(); i++) {
+      if (!valueColumn.isNull(i)) {
+        updateFloatLastValue(valueColumn.getFloat(i), timeColumn.getLong(i));
+        return;
+      }
+    }
+  }
+
+  @Override
+  protected void addDoubleInput(Column valueColumn, Column timeColumn) {
+    for (int i = 0; i < valueColumn.getPositionCount(); i++) {
+      if (!valueColumn.isNull(i)) {
+        updateDoubleLastValue(valueColumn.getDouble(i), timeColumn.getLong(i));
+        return;
+      }
+    }
+  }
+
+  @Override
+  protected void addBinaryInput(Column valueColumn, Column timeColumn) {
+    for (int i = 0; i < valueColumn.getPositionCount(); i++) {
+      if (!valueColumn.isNull(i)) {
+        updateBinaryLastValue(valueColumn.getBinary(i), timeColumn.getLong(i));
+        return;
+      }
+    }
+  }
+
+  @Override
+  protected void addBooleanInput(Column valueColumn, Column timeColumn) {
+    for (int i = 0; i < valueColumn.getPositionCount(); i++) {
+      if (!valueColumn.isNull(i)) {
+        updateBooleanLastValue(valueColumn.getBoolean(i), timeColumn.getLong(i));
+        return;
+      }
+    }
   }
 }


### PR DESCRIPTION
## Description

For first, first_by, last and last_by aggregations, actually we can only read the first value/statistics and then terminate the process.

There is no need to read all values.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [x] added integration tests.
- [x] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
