### PR TITLE
Optimize insertRelationalTablet performance

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertTabletNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertTabletNode.java
@@ -70,7 +70,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
-import java.util.function.IntToLongFunction;
 
 import static org.apache.iotdb.db.utils.CommonUtils.isAlive;
 
@@ -1229,26 +1228,23 @@ public class InsertTabletNode extends InsertNode implements WALEntryValue {
 
   /**
    * @param results insertion result of each row
-   * @param rowTTLGetter the ttl associated with each row
+   * @param ttl the ttl
    * @return the position of the first alive row
    * @throws OutOfTTLException if all rows have expired the TTL
    */
-  public int checkTTL(TSStatus[] results, IntToLongFunction rowTTLGetter) throws OutOfTTLException {
-    return checkTTLInternal(results, rowTTLGetter, true);
+  public int checkTTL(TSStatus[] results, long ttl) throws OutOfTTLException {
+    return checkTTLInternal(results, ttl, true);
   }
 
-  protected int checkTTLInternal(
-      TSStatus[] results, IntToLongFunction rowTTLGetter, boolean breakOnFirstAlive)
+  protected int checkTTLInternal(TSStatus[] results, long ttl, boolean breakOnFirstAlive)
       throws OutOfTTLException {
 
     /*
      * assume that batch has been sorted by client
      */
     int loc = 0;
-    long ttl = 0;
     int firstAliveLoc = -1;
     while (loc < getRowCount()) {
-      ttl = rowTTLGetter.applyAsLong(loc);
       long currTime = getTimes()[loc];
       // skip points that do not satisfy TTL
       if (!isAlive(currTime, ttl)) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/RelationalInsertTabletNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/RelationalInsertTabletNode.java
@@ -50,7 +50,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.IntToLongFunction;
 
 public class RelationalInsertTabletNode extends InsertTabletNode {
 
@@ -334,8 +333,8 @@ public class RelationalInsertTabletNode extends InsertTabletNode {
   }
 
   @Override
-  public int checkTTL(TSStatus[] results, IntToLongFunction rowTTLGetter) throws OutOfTTLException {
-    return checkTTLInternal(results, rowTTLGetter, false);
+  public int checkTTL(TSStatus[] results, long ttl) throws OutOfTTLException {
+    return checkTTLInternal(results, ttl, false);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/RelationalInsertTabletNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/RelationalInsertTabletNode.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.schema.table.column.TsTableColumnCategory;
+import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.db.exception.query.OutOfTTLException;
 import org.apache.iotdb.db.queryengine.plan.analyze.IAnalysis;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
@@ -56,20 +57,7 @@ public class RelationalInsertTabletNode extends InsertTabletNode {
   // deviceId cache for Table-view insertion
   private IDeviceID[] deviceIDs;
 
-  public RelationalInsertTabletNode(
-      PlanNodeId id,
-      PartialPath devicePath,
-      boolean isAligned,
-      String[] measurements,
-      TSDataType[] dataTypes,
-      long[] times,
-      BitMap[] bitMaps,
-      Object[] columns,
-      int rowCount,
-      TsTableColumnCategory[] columnCategories) {
-    super(id, devicePath, isAligned, measurements, dataTypes, times, bitMaps, columns, rowCount);
-    setColumnCategories(columnCategories);
-  }
+  private boolean singleDevice;
 
   public RelationalInsertTabletNode(
       PlanNodeId id,
@@ -101,8 +89,46 @@ public class RelationalInsertTabletNode extends InsertTabletNode {
     super(id);
   }
 
+  @TestOnly
+  public RelationalInsertTabletNode(
+      PlanNodeId id,
+      PartialPath devicePath,
+      boolean isAligned,
+      String[] measurements,
+      TSDataType[] dataTypes,
+      long[] times,
+      BitMap[] bitMaps,
+      Object[] columns,
+      int rowCount,
+      TsTableColumnCategory[] columnCategories) {
+    super(id, devicePath, isAligned, measurements, dataTypes, times, bitMaps, columns, rowCount);
+    setColumnCategories(columnCategories);
+  }
+
+  public void setSingleDevice() {
+    this.singleDevice = true;
+  }
+
   @Override
   public IDeviceID getDeviceID(int rowIdx) {
+    if (singleDevice) {
+      if (deviceIDs == null) {
+        deviceIDs = new IDeviceID[1];
+      }
+      if (deviceIDs[0] == null) {
+        String[] deviceIdSegments = new String[idColumnIndices.size() + 1];
+        deviceIdSegments[0] = this.getTableName();
+        for (int i = 0; i < idColumnIndices.size(); i++) {
+          final Integer columnIndex = idColumnIndices.get(i);
+          Object idSeg = ((Object[]) columns[columnIndex])[0];
+          boolean isNull =
+              bitMaps != null && bitMaps[columnIndex] != null && bitMaps[columnIndex].isMarked(0);
+          deviceIdSegments[i + 1] = !isNull && idSeg != null ? idSeg.toString() : null;
+        }
+        deviceIDs[0] = Factory.DEFAULT_FACTORY.create(deviceIdSegments);
+      }
+      return deviceIDs[0];
+    }
     if (deviceIDs == null) {
       deviceIDs = new IDeviceID[rowCount];
     }
@@ -139,18 +165,23 @@ public class RelationalInsertTabletNode extends InsertTabletNode {
     long[] subTimes = new long[count];
     Object[] values = initTabletValues(dataTypes.length, count, dataTypes);
     BitMap[] newBitMaps = this.bitMaps == null ? null : initBitmaps(dataTypes.length, count);
-    return new RelationalInsertTabletNode(
-        getPlanNodeId(),
-        targetPath,
-        isAligned,
-        measurements,
-        dataTypes,
-        measurementSchemas,
-        subTimes,
-        newBitMaps,
-        values,
-        subTimes.length,
-        columnCategories);
+    RelationalInsertTabletNode split =
+        new RelationalInsertTabletNode(
+            getPlanNodeId(),
+            targetPath,
+            isAligned,
+            measurements,
+            dataTypes,
+            measurementSchemas,
+            subTimes,
+            newBitMaps,
+            values,
+            subTimes.length,
+            columnCategories);
+    if (singleDevice) {
+      split.setSingleDevice();
+    }
+    return split;
   }
 
   protected Map<TRegionReplicaSet, List<Integer>> splitByReplicaSet(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/RelationPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/RelationPlanner.java
@@ -654,6 +654,9 @@ public class RelationPlanner extends AstVisitor<RelationPlan, Void> {
             insertTabletStatement.getRowCount(),
             insertTabletStatement.getColumnCategories());
     insertNode.setFailedMeasurementNumber(insertTabletStatement.getFailedMeasurementNumber());
+    if (insertTabletStatement.isSingleDevice()) {
+      insertNode.setSingleDevice();
+    }
     return new RelationPlan(
         insertNode, analysis.getRootScope(), Collections.emptyList(), outerContext);
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/InsertTablet.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/InsertTablet.java
@@ -107,5 +107,8 @@ public class InsertTablet extends WrappedInsertStatement {
       IDeviceID deviceID = insertTabletStatement.getTableDeviceID(i);
       deviceID2LastIdxMap.put(deviceID, i);
     }
+    if (deviceID2LastIdxMap.size() == 1) {
+      insertTabletStatement.setSingleDevice();
+    }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertTabletStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertTabletStatement.java
@@ -71,6 +71,8 @@ public class InsertTabletStatement extends InsertBaseStatement implements ISchem
 
   private IDeviceID[] deviceIDs;
 
+  private boolean singleDevice;
+
   protected int rowCount = 0;
 
   /**
@@ -469,6 +471,14 @@ public class InsertTabletStatement extends InsertBaseStatement implements ISchem
     }
 
     return deviceIDs[rowIdx];
+  }
+
+  public void setSingleDevice() {
+    singleDevice = true;
+  }
+
+  public boolean isSingleDevice() {
+    return singleDevice;
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -1237,7 +1237,7 @@ public class DataRegion implements IDataRegionForQuery {
       InsertTabletNode insertTabletNode, TSStatus[] results, long[] infoForMetrics)
       throws OutOfTTLException {
     boolean noFailure;
-    int loc = insertTabletNode.checkTTL(results, i -> getTTL(insertTabletNode));
+    int loc = insertTabletNode.checkTTL(results, getTTL(insertTabletNode));
     noFailure = loc == 0;
     List<Pair<IDeviceID, Integer>> deviceEndOffsetPairs =
         insertTabletNode.splitByDevice(loc, insertTabletNode.getRowCount());


### PR DESCRIPTION
## Description

This PR is optimizing the insertRelationalTablet performance.
1. We don't need to checkTTL for each rows of the RelationalTabletNode.
2. If we can know a RelationalTablet only contains one device, we can optimize the implementation of getIDevices method in RelationalTabletNode.

<img width="615" alt="image" src="https://github.com/user-attachments/assets/979dd74f-bb16-41fe-9e04-af6158e5f4d2">

########### Data Mode ###########
GROUP_NUMBER=1
IoTDB_TABLE_NUMBER=1
DEVICE_NUMBER=4000
REAL_INSERT_RATE=1.0
SENSOR_NUMBER=50
IS_SENSOR_TS_ALIGNMENT=true
IS_OUT_OF_ORDER=false
OUT_OF_ORDER_RATIO=0.5
########### Data Amount ###########
OPERATION_PROPORTION=1:0:0:0:0:0:0:0:0:0:0:0
SCHEMA_CLIENT_NUMBER=20
DATA_CLIENT_NUMBER=20
LOOP=100
BATCH_SIZE_PER_WRITE=1000
DEVICE_NUM_PER_WRITE=1
START_TIME=2022-01-01T00:00:00+08:00
POINT_STEP=1000
OP_MIN_INTERVAL=0
OP_MIN_INTERVAL_RANDOM=false
INSERT_DATATYPE_PROPORTION=1:1:1:1:1:1:1:1:1:1
ENCODINGS=RLE/TS_2DIFF/TS_2DIFF/GORILLA/GORILLA/DICTIONARY/PLAIN/PLAIN/TS_2DIFF/TS_2DIFF
COMPRESSOR=LZ4

