### PR TITLE
Pipe: make exception message more friendly when creating data sync pipe failed

### DIFF
--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/connector/client/IoTDBSyncClientManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/connector/client/IoTDBSyncClientManager.java
@@ -180,6 +180,7 @@ public abstract class IoTDBSyncClientManager extends IoTDBClientManager implemen
               trustStorePath,
               trustStorePwd));
     } catch (Exception e) {
+      endPoint2HandshakeErrorMessage.put(endPoint, e.getMessage());
       throw new PipeConnectionException(
           String.format(
               PipeConnectionException.CONNECTION_ERROR_FORMATTER,

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/connector/client/IoTDBSyncClientManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/connector/client/IoTDBSyncClientManager.java
@@ -127,7 +127,7 @@ public abstract class IoTDBSyncClientManager extends IoTDBClientManager implemen
     }
     final StringBuilder errorMessage =
         new StringBuilder(
-            "All target servers are not available. Handshake errors with Target server:[");
+            "All target servers are not available. Handshake errors with target servers:[");
     for (final Map.Entry<TEndPoint, String> entry : failedEndPointsMessage.entrySet()) {
       errorMessage
           .append(" ip: ")
@@ -218,9 +218,10 @@ public abstract class IoTDBSyncClientManager extends IoTDBClientManager implemen
 
       if (resp.getStatus().getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         LOGGER.warn(
-            String.format(
-                "Handshake error with target server ip: %s, port: %s, because: %s.",
-                client.getIpAddress(), client.getPort(), resp.getStatus()));
+            "Handshake error with target server ip: {}, port: {}, because: {}.",
+            client.getIpAddress(),
+            client.getPort(),
+            resp.getStatus());
         failedEndPointsMessage.put(client.getEndPoint(), resp.getStatus().getMessage());
       } else {
         clientAndStatus.setRight(true);


### PR DESCRIPTION
## Description
will print the warning message in sendHandshakeReq when handshake failed 

now the message looks like this:

![screenshot](https://github.com/user-attachments/assets/bc1a34c6-1e46-41ef-973f-abfa98bb2c19)

