### PR TITLE
[Refactor] Reduce redundancy by introducing consistent functional interface in SessionConnection

### DIFF
--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -63,6 +63,7 @@ import org.apache.iotdb.service.rpc.thrift.TSRawDataQueryReq;
 import org.apache.iotdb.service.rpc.thrift.TSSetSchemaTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSSetTimeZoneReq;
 import org.apache.iotdb.service.rpc.thrift.TSUnsetSchemaTemplateReq;
+import org.apache.iotdb.session.util.CheckedSupplier;
 import org.apache.iotdb.session.util.SessionUtils;
 
 import org.apache.thrift.TException;
@@ -1477,172 +1478,96 @@ public class SessionConnection {
 
   protected void createSchemaTemplate(TSCreateSchemaTemplateReq request)
       throws IoTDBConnectionException, StatementExecutionException {
-    request.setSessionId(sessionId);
-    try {
+    doOperation(() -> {
+      request.setSessionId(sessionId);
       RpcUtils.verifySuccess(client.createSchemaTemplate(request));
-    } catch (TException e) {
-      if (reconnect()) {
-        try {
-          request.setSessionId(sessionId);
-          RpcUtils.verifySuccess(client.createSchemaTemplate(request));
-        } catch (TException tException) {
-          throw new IoTDBConnectionException(tException);
-        }
-      } else {
-        throw new IoTDBConnectionException(logForReconnectionFailure());
-      }
-    }
+      return null;
+    });
   }
 
   protected void appendSchemaTemplate(TSAppendSchemaTemplateReq request)
       throws IoTDBConnectionException, StatementExecutionException {
-    request.setSessionId(sessionId);
-    try {
+    doOperation(() -> {
+      request.setSessionId(sessionId);
       RpcUtils.verifySuccess(client.appendSchemaTemplate(request));
-    } catch (TException e) {
-      if (reconnect()) {
-        try {
-          request.setSessionId(sessionId);
-          RpcUtils.verifySuccess(client.appendSchemaTemplate(request));
-        } catch (TException tException) {
-          throw new IoTDBConnectionException(tException);
-        }
-      } else {
-        throw new IoTDBConnectionException(logForReconnectionFailure());
-      }
-    }
+      return null;
+    });
   }
 
   protected void pruneSchemaTemplate(TSPruneSchemaTemplateReq request)
       throws IoTDBConnectionException, StatementExecutionException {
-    request.setSessionId(sessionId);
-    try {
+    doOperation(() -> {
+      request.setSessionId(sessionId);
       RpcUtils.verifySuccess(client.pruneSchemaTemplate(request));
-    } catch (TException e) {
-      if (reconnect()) {
-        try {
-          request.setSessionId(sessionId);
-          RpcUtils.verifySuccess(client.pruneSchemaTemplate(request));
-        } catch (TException tException) {
-          throw new IoTDBConnectionException(tException);
-        }
-      } else {
-        throw new IoTDBConnectionException(logForReconnectionFailure());
-      }
-    }
+      return null;
+    });
   }
 
   protected TSQueryTemplateResp querySchemaTemplate(TSQueryTemplateReq req)
       throws StatementExecutionException, IoTDBConnectionException {
-    TSQueryTemplateResp execResp;
-    req.setSessionId(sessionId);
-    try {
-      execResp = client.querySchemaTemplate(req);
+    return doOperation(() -> {
+      req.setSessionId(sessionId);
+      TSQueryTemplateResp execResp = client.querySchemaTemplate(req);
       RpcUtils.verifySuccess(execResp.getStatus());
-    } catch (TException e) {
-      if (reconnect()) {
-        try {
-          execResp = client.querySchemaTemplate(req);
-        } catch (TException tException) {
-          throw new IoTDBConnectionException(tException);
-        }
-      } else {
-        throw new IoTDBConnectionException(logForReconnectionFailure());
-      }
-    }
-
-    RpcUtils.verifySuccess(execResp.getStatus());
-    return execResp;
+      return execResp;
+    });
   }
 
   protected void setSchemaTemplate(TSSetSchemaTemplateReq request)
       throws IoTDBConnectionException, StatementExecutionException {
-    request.setSessionId(sessionId);
-    try {
+    doOperation(() -> {
+      request.setSessionId(sessionId);
       RpcUtils.verifySuccess(client.setSchemaTemplate(request));
-    } catch (TException e) {
-      if (reconnect()) {
-        try {
-          request.setSessionId(sessionId);
-          RpcUtils.verifySuccess(client.setSchemaTemplate(request));
-        } catch (TException tException) {
-          throw new IoTDBConnectionException(tException);
-        }
-      } else {
-        throw new IoTDBConnectionException(logForReconnectionFailure());
-      }
-    }
+      return null;
+    });
   }
 
   protected void unsetSchemaTemplate(TSUnsetSchemaTemplateReq request)
       throws IoTDBConnectionException, StatementExecutionException {
-    request.setSessionId(sessionId);
-    try {
+    doOperation(() -> {
+      request.setSessionId(sessionId);
       RpcUtils.verifySuccess(client.unsetSchemaTemplate(request));
-    } catch (TException e) {
-      if (reconnect()) {
-        try {
-          request.setSessionId(sessionId);
-          RpcUtils.verifySuccess(client.unsetSchemaTemplate(request));
-        } catch (TException tException) {
-          throw new IoTDBConnectionException(tException);
-        }
-      } else {
-        throw new IoTDBConnectionException(logForReconnectionFailure());
-      }
-    }
+      return null;
+    });
   }
 
   protected void dropSchemaTemplate(TSDropSchemaTemplateReq request)
       throws IoTDBConnectionException, StatementExecutionException {
-    request.setSessionId(sessionId);
-    try {
+    doOperation(() -> {
+      request.setSessionId(sessionId);
       RpcUtils.verifySuccess(client.dropSchemaTemplate(request));
-    } catch (TException e) {
-      if (reconnect()) {
-        try {
-          request.setSessionId(sessionId);
-          RpcUtils.verifySuccess(client.dropSchemaTemplate(request));
-        } catch (TException tException) {
-          throw new IoTDBConnectionException(tException);
-        }
-      } else {
-        throw new IoTDBConnectionException(logForReconnectionFailure());
-      }
-    }
+      return null;
+    });
   }
 
   protected void createTimeseriesUsingSchemaTemplate(
       TCreateTimeseriesUsingSchemaTemplateReq request)
       throws IoTDBConnectionException, StatementExecutionException {
-    request.setSessionId(sessionId);
-    try {
+    doOperation(() -> {
+      request.setSessionId(sessionId);
       RpcUtils.verifySuccess(client.createTimeseriesUsingSchemaTemplate(request));
-    } catch (TException e) {
-      if (reconnect()) {
-        try {
-          request.setSessionId(sessionId);
-          RpcUtils.verifySuccess(client.createTimeseriesUsingSchemaTemplate(request));
-        } catch (TException tException) {
-          throw new IoTDBConnectionException(tException);
-        }
-      } else {
-        throw new IoTDBConnectionException(MSG_RECONNECTION_FAIL);
-      }
-    }
+      return null;
+    });
   }
 
   protected TSBackupConfigurationResp getBackupConfiguration()
       throws IoTDBConnectionException, StatementExecutionException {
-    TSBackupConfigurationResp execResp;
-    try {
-      execResp = client.getBackupConfiguration();
+    return doOperation(() -> {
+      TSBackupConfigurationResp execResp = client.getBackupConfiguration();
       RpcUtils.verifySuccess(execResp.getStatus());
+      return execResp;
+    });
+  }
+
+  private <RETURN> RETURN doOperation(CheckedSupplier<RETURN, TException> supplier)
+  throws IoTDBConnectionException, StatementExecutionException {
+    RETURN ret;
+    try {
+      ret = supplier.get();
     } catch (TException e) {
       if (reconnect()) {
         try {
-          execResp = client.getBackupConfiguration();
-          RpcUtils.verifySuccess(execResp.getStatus());
+          ret = supplier.get();
         } catch (TException tException) {
           throw new IoTDBConnectionException(tException);
         }
@@ -1650,7 +1575,7 @@ public class SessionConnection {
         throw new IoTDBConnectionException(logForReconnectionFailure());
       }
     }
-    return execResp;
+    return ret;
   }
 
   public TSConnectionInfoResp fetchAllConnections() throws IoTDBConnectionException {

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/util/CheckedSupplier.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/util/CheckedSupplier.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.session.util;
+
+import org.apache.iotdb.rpc.StatementExecutionException;
+
+/** Supplier with a throws-clause. */
+@FunctionalInterface
+public interface CheckedSupplier<OUTPUT, THROWABLE extends Throwable> {
+  /**
+   * The same as {@link java.util.function.Supplier#get()}
+   * except that this method is declared with a throws-clause.
+   */
+  OUTPUT get() throws THROWABLE, StatementExecutionException;
+}


### PR DESCRIPTION
The SessionConnection has 26 times of redundant control clauses.
We can unify them by introducing a CheckedSupplier.