### PR TITLE
[to dev/1.3] Subscription: The usage of bitmap in SubscriptionSessionDataSet may cause npe

### DIFF
--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/subscription/payload/SubscriptionSessionDataSet.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/subscription/payload/SubscriptionSessionDataSet.java
@@ -105,7 +105,9 @@ public class SubscriptionSessionDataSet implements ISessionDataSet {
 
     for (int columnIndex = 0; columnIndex < columnSize; ++columnIndex) {
       final Field field;
-      if (tablet.bitMaps[columnIndex].isMarked(rowIndex)) {
+      if (tablet.bitMaps != null
+          && tablet.bitMaps[columnIndex] != null
+          && tablet.bitMaps[columnIndex].isMarked(rowIndex)) {
         field = new Field(null);
       } else {
         final TSDataType dataType = tablet.getSchemas().get(columnIndex).getType();


### PR DESCRIPTION
## Description
The usage of bitmap in SubscriptionSessionDataSet may cause npe
master branch: https://github.com/apache/iotdb/pull/14124