### PR TITLE
Add extra info for TableScanOperator and AggTableScanOperator in Explain Analyze

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/OperatorContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/OperatorContext.java
@@ -34,6 +34,7 @@ import org.apache.tsfile.utils.RamUsageEstimator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -165,7 +166,8 @@ public class OperatorContext implements Accountable {
 
   public void recordSpecifiedInfo(String key, String value) {
     if (specifiedInfo == null) {
-      specifiedInfo = new HashMap<>();
+      // explain analyze operator fetching and current operator updating may be concurrently
+      specifiedInfo = new ConcurrentHashMap<>();
     }
     specifiedInfo.put(key, value);
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/TableScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/TableScanOperator.java
@@ -54,11 +54,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.apache.iotdb.db.queryengine.execution.operator.source.AlignedSeriesScanOperator.appendDataIntoBuilder;
+import static org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanGraphPrinter.DEVICE_NUMBER;
 import static org.apache.iotdb.db.queryengine.plan.relational.type.InternalTypeManager.getTSDataType;
 
 public class TableScanOperator extends AbstractSeriesScanOperator {
   private static final long INSTANCE_SIZE =
       RamUsageEstimator.shallowSizeOfInstance(TableScanOperator.class);
+
+  public static final String CURRENT_DEVICE_INDEX_STRING = "CurrentDeviceIndex";
 
   public static final LongColumn TIME_COLUMN_TEMPLATE =
       new LongColumn(1, Optional.empty(), new long[] {0});
@@ -106,6 +109,7 @@ public class TableScanOperator extends AbstractSeriesScanOperator {
       int maxTsBlockLineNum) {
     this.sourceId = sourceId;
     this.operatorContext = context;
+    this.operatorContext.recordSpecifiedInfo(DEVICE_NUMBER, Integer.toString(deviceEntries.size()));
     this.columnSchemas = columnSchemas;
     this.columnsIndexArray = columnsIndexArray;
     this.deviceEntries = deviceEntries;
@@ -118,6 +122,7 @@ public class TableScanOperator extends AbstractSeriesScanOperator {
     this.measurementColumnTSDataTypes =
         measurementSchemas.stream().map(IMeasurementSchema::getType).collect(Collectors.toList());
     this.currentDeviceIndex = 0;
+    this.operatorContext.recordSpecifiedInfo(CURRENT_DEVICE_INDEX_STRING, Integer.toString(0));
 
     this.maxReturnSize =
         Math.min(
@@ -297,6 +302,8 @@ public class TableScanOperator extends AbstractSeriesScanOperator {
       // reset QueryDataSource
       queryDataSource.reset();
       this.seriesScanUtil.initQueryDataSource(queryDataSource);
+      this.operatorContext.recordSpecifiedInfo(
+          CURRENT_DEVICE_INDEX_STRING, Integer.toString(currentDeviceIndex));
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/PlanGraphPrinter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/PlanGraphPrinter.java
@@ -102,6 +102,8 @@ public class PlanGraphPrinter extends PlanVisitor<List<String>, PlanGraphPrinter
   private static final int BOX_MARGIN = 1;
   private static final int CONNECTION_LINE_HEIGHT = 2;
 
+  public static final String DEVICE_NUMBER = "DeviceNumber";
+
   @Override
   public List<String> visitPlan(PlanNode node, GraphContext context) {
     List<String> boxValue = new ArrayList<>();
@@ -616,7 +618,7 @@ public class PlanGraphPrinter extends PlanVisitor<List<String>, PlanGraphPrinter
     boxValue.add(String.format("TableScan-%s", node.getPlanNodeId().getId()));
     boxValue.add(String.format("QualifiedTableName: %s", node.getQualifiedObjectName().toString()));
     boxValue.add(String.format("OutputSymbols: %s", node.getOutputSymbols()));
-    boxValue.add(String.format("DeviceEntriesSize: %s", node.getDeviceEntries().size()));
+    boxValue.add(String.format("DeviceNumber: %s", node.getDeviceEntries().size()));
     boxValue.add(String.format("ScanOrder: %s", node.getScanOrder()));
     if (node.getTimePredicate().isPresent()) {
       boxValue.add(String.format("TimePredicate: %s", node.getTimePredicate().get()));
@@ -684,7 +686,7 @@ public class PlanGraphPrinter extends PlanVisitor<List<String>, PlanGraphPrinter
           String.format("Project-Expressions: %s", node.getProjection().getMap().values()));
     }
 
-    boxValue.add(String.format("DeviceEntriesSize: %s", node.getDeviceEntries().size()));
+    boxValue.add(String.format("DeviceNumber: %s", node.getDeviceEntries().size()));
     boxValue.add(String.format("ScanOrder: %s", node.getScanOrder()));
     if (node.getPushDownPredicate() != null) {
       boxValue.add(String.format("PushDownPredicate: %s", node.getPushDownPredicate()));


### PR DESCRIPTION
1. fix potential concurrent exception in Explain Analyze caused by using HashMap in OperatorContext
2. Add `DeviceNumber` and `CurrentDeviceIndex` for `TableScanOperator` and `TableAggregationTableScanOperator`
3. Change `DeviceEntriesSize` to `DeviceNumber` for `TableScanOperator` and `TableAggregationTableScanOperator` in explain statement