### PR TITLE
[remove datanode] Do not disable the entire region group for one removing region

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/RegionGroupStatus.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/RegionGroupStatus.java
@@ -24,24 +24,22 @@ public enum RegionGroupStatus {
   Running("Running", 1),
 
   /**
-   * All Regions in RegionGroup are in the Running or Unknown status, and the number of Regions in
-   * the Unknown status is less than half
+   * All Regions in RegionGroup are in the Running or Unknown or Removing status, and the number of
+   * Regions in the Unknown or Removing status is less than half
    */
   Available("Available", 2),
 
   /**
    * All Regions in RegionGroup are in the Running, Unknown or ReadOnly status, and at least 1 node
-   * is in ReadOnly status, the number of Regions in the Unknown or ReadOnly status is less than
-   * half
+   * is in ReadOnly status, the number of Regions in the Unknown or ReadOnly or Removing status is
+   * less than half
    */
   Discouraged("Discouraged", 3),
 
   /**
    * The following cases will lead to Disabled RegionGroup:
    *
-   * <p>1. There is a Region in Removing status
-   *
-   * <p>2. More than half of the Regions are in Unknown or ReadOnly status
+   * <p>1. More than half of the Regions are in Unknown or ReadOnly or Removing status
    */
   Disabled("Disabled", 4);
 

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/load/LoadManagerTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/load/LoadManagerTest.java
@@ -188,7 +188,7 @@ public class LoadManagerTest {
     Assert.assertEquals(
         new Pair<>(
             new RegionGroupStatistics(RegionGroupStatus.Running, allRunningRegionStatisticsMap),
-            new RegionGroupStatistics(RegionGroupStatus.Disabled, oneRemovingRegionStatisticsMap)),
+            new RegionGroupStatistics(RegionGroupStatus.Available, oneRemovingRegionStatisticsMap)),
         differentRegionGroupStatisticsMap.get(regionGroupId));
     // Add and mark Region 3 as Adding
     int addDataNodeId = 3;
@@ -203,8 +203,8 @@ public class LoadManagerTest {
     oneAddingRegionStatisticsMap.put(addDataNodeId, new RegionStatistics(RegionStatus.Adding));
     Assert.assertEquals(
         new Pair<>(
-            new RegionGroupStatistics(RegionGroupStatus.Disabled, oneRemovingRegionStatisticsMap),
-            new RegionGroupStatistics(RegionGroupStatus.Disabled, oneAddingRegionStatisticsMap)),
+            new RegionGroupStatistics(RegionGroupStatus.Available, oneRemovingRegionStatisticsMap),
+            new RegionGroupStatistics(RegionGroupStatus.Available, oneAddingRegionStatisticsMap)),
         differentRegionGroupStatisticsMap.get(regionGroupId));
     // Both Region 0 and 3 can't be updated
     LOAD_CACHE.cacheRegionHeartbeatSample(
@@ -226,8 +226,8 @@ public class LoadManagerTest {
     oneRemovingRegionStatisticsMap.put(addDataNodeId, new RegionStatistics(RegionStatus.Running));
     Assert.assertEquals(
         new Pair<>(
-            new RegionGroupStatistics(RegionGroupStatus.Disabled, oneAddingRegionStatisticsMap),
-            new RegionGroupStatistics(RegionGroupStatus.Disabled, oneRemovingRegionStatisticsMap)),
+            new RegionGroupStatistics(RegionGroupStatus.Available, oneAddingRegionStatisticsMap),
+            new RegionGroupStatistics(RegionGroupStatus.Available, oneRemovingRegionStatisticsMap)),
         differentRegionGroupStatisticsMap.get(regionGroupId));
     // Removing process completed
     LOAD_MANAGER.removeRegionCache(regionGroupId, removeDataNodeId);
@@ -237,7 +237,7 @@ public class LoadManagerTest {
     allRunningRegionStatisticsMap.put(addDataNodeId, new RegionStatistics(RegionStatus.Running));
     Assert.assertEquals(
         new Pair<>(
-            new RegionGroupStatistics(RegionGroupStatus.Disabled, oneRemovingRegionStatisticsMap),
+            new RegionGroupStatistics(RegionGroupStatus.Available, oneRemovingRegionStatisticsMap),
             new RegionGroupStatistics(RegionGroupStatus.Running, allRunningRegionStatisticsMap)),
         differentRegionGroupStatisticsMap.get(regionGroupId));
   }

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/load/cache/RegionGroupCacheTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/load/cache/RegionGroupCacheTest.java
@@ -123,7 +123,7 @@ public class RegionGroupCacheTest {
         2, new RegionHeartbeatSample(currentTime, RegionStatus.Removing));
     disabledRegionGroup2.updateCurrentStatistics();
     Assert.assertEquals(
-        RegionGroupStatus.Disabled,
+        RegionGroupStatus.Available,
         disabledRegionGroup2.getCurrentStatistics().getRegionGroupStatus());
   }
 }


### PR DESCRIPTION
## Description

With enhancements to region migration and datanode removal processes, it’s increasingly common for regions to enter the "Removing" status. However, a region in this status disables the entire consensus group design, potentially leading to a significant number of consensus groups becoming unavailable. This, in turn, can impact the overall stability of the system.