### PR TITLE
Optimize table cache leader implement 2

### DIFF
--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -2729,6 +2729,9 @@ public class Session implements ISession {
    */
   public void insertRelationalTablet(Tablet tablet)
       throws IoTDBConnectionException, StatementExecutionException {
+    if (tablet.getRowSize() == 0) {
+      return;
+    }
     if (enableRedirection) {
       insertRelationalTabletWithLeaderCache(tablet);
     } else {
@@ -2750,6 +2753,8 @@ public class Session implements ISession {
     Map<SessionConnection, Tablet> relationalTabletGroup = new HashMap<>();
     if (tableModelDeviceIdToEndpoint.isEmpty()) {
       relationalTabletGroup.put(defaultSessionConnection, tablet);
+    } else if (SessionUtils.isTabletContainsSingleDevice(tablet)) {
+      relationalTabletGroup.put(getSessionConnection(tablet.getDeviceID(0)), tablet);
     } else {
       for (int i = 0; i < tablet.getRowSize(); i++) {
         IDeviceID iDeviceID = tablet.getDeviceID(i);

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/util/SessionUtils.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/util/SessionUtils.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.rpc.UrlUtils;
 
 import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.BitMap;
 import org.apache.tsfile.utils.BytesUtils;
@@ -342,6 +343,20 @@ public class SessionUtils {
         throw new UnSupportedDataTypeException(
             String.format("Data type %s is not supported.", dataType));
     }
+  }
+
+  /* Used for table model insert only. */
+  public static boolean isTabletContainsSingleDevice(Tablet tablet) {
+    if (tablet.getRowSize() == 1) {
+      return true;
+    }
+    IDeviceID firstDeviceId = tablet.getDeviceID(0);
+    for (int i = 1; i < tablet.getRowSize(); ++i) {
+      if (!firstDeviceId.equals(tablet.getDeviceID(i))) {
+        return false;
+      }
+    }
+    return true;
   }
 
   public static List<TEndPoint> parseSeedNodeUrls(List<String> nodeUrls) {


### PR DESCRIPTION
## Description

Subsequent pr of #13989 
When a Table model tablet contains only single device, we don't need to create a new Tablet and setValue for it. 