### PR TITLE
Region Migration: Fix migration failed when there are unknown nodes

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/pipe/PipeConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/pipe/PipeConsensusServerImpl.java
@@ -521,9 +521,9 @@ public class PipeConsensusServerImpl {
         consensusPipeManager.updateConsensusPipe(
             new ConsensusPipeName(peer, targetPeer), PipeStatus.RUNNING);
       } catch (Exception e) {
+        // just warn but not throw exceptions. Because there may exist unknown nodes in consensus
+        // group
         LOGGER.warn("{} cannot start consensus pipe to {}", peer, targetPeer, e);
-        throw new ConsensusGroupModifyPeerException(
-            String.format("%s cannot start consensus pipe to %s", peer, targetPeer), e);
       }
     }
   }


### PR DESCRIPTION
Considering cluster may have unknown nodes when migrate regions, all action related to migration should not panic exceptons. Instead, we just need to log a warn log