### PR TITLE
[To dev/1.3] Pipe: fix the issues of excessive stale PipeEventCommitter logs and missing PipeDataNodeRemainingEventAndTimeMetrics (#14284)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/IoTDBDataRegionExtractor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/IoTDBDataRegionExtractor.java
@@ -34,6 +34,7 @@ import org.apache.iotdb.db.pipe.extractor.dataregion.realtime.PipeRealtimeDataRe
 import org.apache.iotdb.db.pipe.extractor.dataregion.realtime.PipeRealtimeDataRegionHybridExtractor;
 import org.apache.iotdb.db.pipe.extractor.dataregion.realtime.PipeRealtimeDataRegionLogExtractor;
 import org.apache.iotdb.db.pipe.extractor.dataregion.realtime.PipeRealtimeDataRegionTsFileExtractor;
+import org.apache.iotdb.db.pipe.metric.PipeDataNodeRemainingEventAndTimeMetrics;
 import org.apache.iotdb.db.pipe.metric.PipeDataRegionExtractorMetrics;
 import org.apache.iotdb.db.storageengine.StorageEngine;
 import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALMode;
@@ -342,6 +343,7 @@ public class IoTDBDataRegionExtractor extends IoTDBExtractor {
 
     // register metric after generating taskID
     PipeDataRegionExtractorMetrics.getInstance().register(this);
+    PipeDataNodeRemainingEventAndTimeMetrics.getInstance().register(this);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/metric/PipeDataNodeRemainingEventAndTimeMetrics.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/metric/PipeDataNodeRemainingEventAndTimeMetrics.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.pipe.metric;
 import org.apache.iotdb.commons.pipe.agent.task.progress.PipeEventCommitManager;
 import org.apache.iotdb.commons.service.metric.enums.Metric;
 import org.apache.iotdb.commons.service.metric.enums.Tag;
+import org.apache.iotdb.db.pipe.extractor.dataregion.IoTDBDataRegionExtractor;
 import org.apache.iotdb.db.pipe.extractor.schemaregion.IoTDBSchemaRegionExtractor;
 import org.apache.iotdb.metrics.AbstractMetricService;
 import org.apache.iotdb.metrics.metricsets.IMetricSet;
@@ -117,6 +118,19 @@ public class PipeDataNodeRemainingEventAndTimeMetrics implements IMetricSet {
   }
 
   //////////////////////////// register & deregister (pipe integration) ////////////////////////////
+
+  public void register(final IoTDBDataRegionExtractor extractor) {
+    // The metric is global thus the regionId is omitted
+    final String pipeID = extractor.getPipeName() + "_" + extractor.getCreationTime();
+    remainingEventAndTimeOperatorMap.computeIfAbsent(
+        pipeID,
+        k ->
+            new PipeDataNodeRemainingEventAndTimeOperator(
+                extractor.getPipeName(), extractor.getCreationTime()));
+    if (Objects.nonNull(metricService)) {
+      createMetrics(pipeID);
+    }
+  }
 
   public void register(final IoTDBSchemaRegionExtractor extractor) {
     // The metric is global thus the regionId is omitted

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/progress/PipeEventCommitManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/progress/PipeEventCommitManager.java
@@ -127,18 +127,20 @@ public class PipeEventCommitManager {
       final int currentRestartTimes =
           eventCommitterRestartTimesMap.computeIfAbsent(
               generateCommitterRestartTimesKey(committerKey), k -> 0);
-      if (committerKey.getRestartTimes() < currentRestartTimes) {
-        LOGGER.warn(
-            "stale PipeEventCommitter({}) when commit event: {}, current restart times {}",
-            committerKey,
-            event.coreReportMessage(),
-            currentRestartTimes);
-      } else if (LOGGER.isDebugEnabled()) {
-        LOGGER.debug(
-            "missing PipeEventCommitter({}) when commit event: {}, stack trace: {}",
-            committerKey,
-            event.coreReportMessage(),
-            Thread.currentThread().getStackTrace());
+      if (LOGGER.isDebugEnabled()) {
+        if (committerKey.getRestartTimes() < currentRestartTimes) {
+          LOGGER.debug(
+              "stale PipeEventCommitter({}) when commit event: {}, current restart times {}",
+              committerKey,
+              event.coreReportMessage(),
+              currentRestartTimes);
+        } else {
+          LOGGER.debug(
+              "missing PipeEventCommitter({}) when commit event: {}, stack trace: {}",
+              committerKey,
+              event.coreReportMessage(),
+              Thread.currentThread().getStackTrace());
+        }
       }
       return;
     }


### PR DESCRIPTION
cherry-pick #14284 to https://github.com/apache/iotdb/tree/dev/1.3

