### PR TITLE
Increase the default upper bound for ClientManager

### DIFF
--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
@@ -456,7 +456,7 @@ cn_selector_thread_nums_of_client_manager=1
 # for a while, then ClientManager will throw ClientManagerException if there are no clients after the block time.
 # effectiveMode: restart
 # Datatype: int
-cn_max_client_count_for_each_node_in_client_manager=300
+cn_max_client_count_for_each_node_in_client_manager=1000
 
 # The maximum session idle time. unit: ms
 # Idle sessions are the ones that performs neither query or non-query operations for a period of time
@@ -516,7 +516,7 @@ dn_selector_thread_count_of_client_manager=1
 # for a while, then ClientManager will throw ClientManagerException if there are no clients after the block time.
 # effectiveMode: restart
 # Datatype: int
-dn_max_client_count_for_each_node_in_client_manager=300
+dn_max_client_count_for_each_node_in_client_manager=1000
 
 ####################
 ### REST Service Configuration

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/property/ClientPoolProperty.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/property/ClientPoolProperty.java
@@ -101,9 +101,9 @@ public class ClientPoolProperty<V> {
 
     private DefaultProperty() {}
 
-    public static final long WAIT_CLIENT_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(10);
+    public static final long WAIT_CLIENT_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(30);
     public static final long MIN_IDLE_TIME_FOR_CLIENT_MS = TimeUnit.MINUTES.toMillis(1);
     public static final long TIME_BETWEEN_EVICTION_RUNS_MS = TimeUnit.MINUTES.toMillis(1);
-    public static final int MAX_CLIENT_NUM_FOR_EACH_NODE = 300;
+    public static final int MAX_CLIENT_NUM_FOR_EACH_NODE = 1000;
   }
 }


### PR DESCRIPTION
This error is reported under too many concurrent loads, so we increase the value appropriately to improve robustness
![img_v3_02h9_39823c9f-8933-4424-8c22-75378fae55bg](https://github.com/user-attachments/assets/dd97b523-bde8-4a6a-a3be-537b8e0dd997)
