### PR TITLE
[remove datanode] Fix concurrent modification when removing fails and rollback

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensus.java
@@ -61,6 +61,7 @@ import org.apache.iotdb.consensus.iot.snapshot.IoTConsensusRateLimiter;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
 
+import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -492,8 +493,9 @@ public class IoTConsensus implements IConsensus {
       deleteLocalPeer(groupId);
       return;
     }
-    String previousPeerListStr = impl.getConfiguration().toString();
-    for (Peer peer : impl.getConfiguration()) {
+    ImmutableList<Peer> currentMembers = ImmutableList.copyOf(impl.getConfiguration());
+    String previousPeerListStr = currentMembers.toString();
+    for (Peer peer : currentMembers) {
       if (!correctPeers.contains(peer)) {
         if (!impl.removeSyncLogChannel(peer)) {
           logger.error(


### PR DESCRIPTION
## Description
When removing fails and rollback occurs, both ConfigNode and DataNode may modify the configuration file simultaneously.

![img_v3_02h8_2f1b5b22-f434-4281-a53c-e248cb4eb65g](https://github.com/user-attachments/assets/e15e9e2b-aed2-4cbe-a8b3-a88f5488661d)