### PR TITLE
Restruct procedure waiting strategy to fix NPE bug when completed procedures were cleaned before getting result

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
@@ -145,9 +145,7 @@ import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -234,7 +232,7 @@ public class ProcedureManager {
 
   public TSStatus deleteDatabases(
       final List<TDatabaseSchema> deleteSgSchemaList, final boolean isGeneratedByPipe) {
-    final List<Long> procedureIds = new ArrayList<>();
+    DeleteDatabaseProcedure procedure = null;
     final long startCheckTimeForProcedures = System.currentTimeMillis();
     for (final TDatabaseSchema databaseSchema : deleteSgSchemaList) {
       final String database = databaseSchema.getName();
@@ -248,9 +246,8 @@ public class ProcedureManager {
           hasOverlappedTask = procedureIdDuplicatePair.getRight();
 
           if (Boolean.FALSE.equals(procedureIdDuplicatePair.getRight())) {
-            final DeleteDatabaseProcedure deleteDatabaseProcedure =
-                new DeleteDatabaseProcedure(databaseSchema, isGeneratedByPipe);
-            procedureIds.add(this.executor.submitProcedure(deleteDatabaseProcedure));
+            procedure = new DeleteDatabaseProcedure(databaseSchema, isGeneratedByPipe);
+            this.executor.submitProcedure(procedure);
             break;
           }
           try {
@@ -268,33 +265,28 @@ public class ProcedureManager {
         }
       }
     }
-    final List<TSStatus> procedureStatus = new ArrayList<>();
-    final boolean isSucceed = waitingProcedureFinished(procedureIds, procedureStatus);
+    final TSStatus result = waitingProcedureFinishedV2(procedure);
     // Clear the previously deleted regions
     final PartitionManager partitionManager = getConfigManager().getPartitionManager();
     partitionManager.getRegionMaintainer().submit(partitionManager::maintainRegionReplicas);
-    if (isSucceed) {
-      return StatusUtils.OK;
-    } else {
-      return RpcUtils.getStatus(procedureStatus);
-    }
+    return result;
   }
 
   public TSStatus deleteTimeSeries(
       String queryId, PathPatternTree patternTree, boolean isGeneratedByPipe) {
-    long procedureId = -1;
+    DeleteTimeSeriesProcedure procedure = null;
     synchronized (this) {
       boolean hasOverlappedTask = false;
       ProcedureType type;
       DeleteTimeSeriesProcedure deleteTimeSeriesProcedure;
-      for (Procedure<?> procedure : executor.getProcedures().values()) {
-        type = ProcedureFactory.getProcedureType(procedure);
+      for (Procedure<?> runningProcedure : executor.getProcedures().values()) {
+        type = ProcedureFactory.getProcedureType(runningProcedure);
         if (type == null || !type.equals(ProcedureType.DELETE_TIMESERIES_PROCEDURE)) {
           continue;
         }
-        deleteTimeSeriesProcedure = ((DeleteTimeSeriesProcedure) procedure);
+        deleteTimeSeriesProcedure = ((DeleteTimeSeriesProcedure) runningProcedure);
         if (queryId.equals(deleteTimeSeriesProcedure.getQueryId())) {
-          procedureId = deleteTimeSeriesProcedure.getProcId();
+          procedure = deleteTimeSeriesProcedure;
           break;
         }
         if (patternTree.isOverlapWith(deleteTimeSeriesProcedure.getPatternTree())) {
@@ -303,44 +295,36 @@ public class ProcedureManager {
         }
       }
 
-      if (procedureId == -1) {
+      if (procedure == null) {
         if (hasOverlappedTask) {
           return RpcUtils.getStatus(
               TSStatusCode.OVERLAP_WITH_EXISTING_TASK,
               "Some other task is deleting some target timeseries.");
         }
-        procedureId =
-            this.executor.submitProcedure(
-                new DeleteTimeSeriesProcedure(queryId, patternTree, isGeneratedByPipe));
+        procedure = new DeleteTimeSeriesProcedure(queryId, patternTree, isGeneratedByPipe);
+        this.executor.submitProcedure(procedure);
       }
     }
-    List<TSStatus> procedureStatus = new ArrayList<>();
-    boolean isSucceed =
-        waitingProcedureFinished(Collections.singletonList(procedureId), procedureStatus);
-    if (isSucceed) {
-      return StatusUtils.OK;
-    } else {
-      return procedureStatus.get(0);
-    }
+    return waitingProcedureFinishedV2(procedure);
   }
 
   public TSStatus deleteLogicalView(TDeleteLogicalViewReq req) {
     String queryId = req.getQueryId();
     PathPatternTree patternTree =
         PathPatternTree.deserialize(ByteBuffer.wrap(req.getPathPatternTree()));
-    long procedureId = -1;
+    DeleteLogicalViewProcedure procedure = null;
     synchronized (this) {
       boolean hasOverlappedTask = false;
       ProcedureType type;
       DeleteLogicalViewProcedure deleteLogicalViewProcedure;
-      for (Procedure<?> procedure : executor.getProcedures().values()) {
-        type = ProcedureFactory.getProcedureType(procedure);
+      for (Procedure<?> runningProcedure : executor.getProcedures().values()) {
+        type = ProcedureFactory.getProcedureType(runningProcedure);
         if (type == null || !type.equals(ProcedureType.DELETE_LOGICAL_VIEW_PROCEDURE)) {
           continue;
         }
-        deleteLogicalViewProcedure = ((DeleteLogicalViewProcedure) procedure);
+        deleteLogicalViewProcedure = ((DeleteLogicalViewProcedure) runningProcedure);
         if (queryId.equals(deleteLogicalViewProcedure.getQueryId())) {
-          procedureId = deleteLogicalViewProcedure.getProcId();
+          procedure = deleteLogicalViewProcedure;
           break;
         }
         if (patternTree.isOverlapWith(deleteLogicalViewProcedure.getPatternTree())) {
@@ -349,28 +333,19 @@ public class ProcedureManager {
         }
       }
 
-      if (procedureId == -1) {
+      if (procedure == null) {
         if (hasOverlappedTask) {
           return RpcUtils.getStatus(
               TSStatusCode.OVERLAP_WITH_EXISTING_TASK,
               "Some other task is deleting some target views.");
         }
-        procedureId =
-            this.executor.submitProcedure(
-                new DeleteLogicalViewProcedure(
-                    queryId,
-                    patternTree,
-                    req.isSetIsGeneratedByPipe() && req.isIsGeneratedByPipe()));
+        procedure =
+            new DeleteLogicalViewProcedure(
+                queryId, patternTree, req.isSetIsGeneratedByPipe() && req.isIsGeneratedByPipe());
+        this.executor.submitProcedure(procedure);
       }
     }
-    List<TSStatus> procedureStatus = new ArrayList<>();
-    boolean isSucceed =
-        waitingProcedureFinished(Collections.singletonList(procedureId), procedureStatus);
-    if (isSucceed) {
-      return StatusUtils.OK;
-    } else {
-      return procedureStatus.get(0);
-    }
+    return waitingProcedureFinishedV2(procedure);
   }
 
   public TSStatus alterLogicalView(TAlterLogicalViewReq req) {
@@ -386,56 +361,49 @@ public class ProcedureManager {
       viewPathToSourceMap.put(path, viewExpression);
     }
 
-    long procedureId = -1;
+    AlterLogicalViewProcedure procedure = null;
     synchronized (this) {
       ProcedureType type;
       AlterLogicalViewProcedure alterLogicalViewProcedure;
-      for (Procedure<?> procedure : executor.getProcedures().values()) {
-        type = ProcedureFactory.getProcedureType(procedure);
+      for (Procedure<?> runningProcedure : executor.getProcedures().values()) {
+        type = ProcedureFactory.getProcedureType(runningProcedure);
         if (type == null || !type.equals(ProcedureType.ALTER_LOGICAL_VIEW_PROCEDURE)) {
           continue;
         }
-        alterLogicalViewProcedure = ((AlterLogicalViewProcedure) procedure);
+        alterLogicalViewProcedure = ((AlterLogicalViewProcedure) runningProcedure);
         if (queryId.equals(alterLogicalViewProcedure.getQueryId())) {
-          procedureId = alterLogicalViewProcedure.getProcId();
+          procedure = alterLogicalViewProcedure;
           break;
         }
       }
 
-      if (procedureId == -1) {
-        procedureId =
-            this.executor.submitProcedure(
-                new AlterLogicalViewProcedure(
-                    queryId,
-                    viewPathToSourceMap,
-                    req.isSetIsGeneratedByPipe() && req.isIsGeneratedByPipe()));
+      if (procedure == null) {
+        procedure =
+            new AlterLogicalViewProcedure(
+                queryId,
+                viewPathToSourceMap,
+                req.isSetIsGeneratedByPipe() && req.isIsGeneratedByPipe());
+        this.executor.submitProcedure(procedure);
       }
     }
-    List<TSStatus> procedureStatus = new ArrayList<>();
-    boolean isSucceed =
-        waitingProcedureFinished(Collections.singletonList(procedureId), procedureStatus);
-    if (isSucceed) {
-      return StatusUtils.OK;
-    } else {
-      return procedureStatus.get(0);
-    }
+    return waitingProcedureFinishedV2(procedure);
   }
 
   public TSStatus setSchemaTemplate(
       String queryId, String templateName, String templateSetPath, boolean isGeneratedByPipe) {
-    long procedureId = -1;
+    SetTemplateProcedure procedure = null;
     synchronized (this) {
       boolean hasOverlappedTask = false;
       ProcedureType type;
       SetTemplateProcedure setTemplateProcedure;
-      for (Procedure<?> procedure : executor.getProcedures().values()) {
-        type = ProcedureFactory.getProcedureType(procedure);
+      for (Procedure<?> runningProcedure : executor.getProcedures().values()) {
+        type = ProcedureFactory.getProcedureType(runningProcedure);
         if (type == null || !type.equals(ProcedureType.SET_TEMPLATE_PROCEDURE)) {
           continue;
         }
-        setTemplateProcedure = (SetTemplateProcedure) procedure;
+        setTemplateProcedure = (SetTemplateProcedure) runningProcedure;
         if (queryId.equals(setTemplateProcedure.getQueryId())) {
-          procedureId = setTemplateProcedure.getProcId();
+          procedure = setTemplateProcedure;
           break;
         }
         if (templateSetPath.equals(setTemplateProcedure.getTemplateSetPath())) {
@@ -444,43 +412,35 @@ public class ProcedureManager {
         }
       }
 
-      if (procedureId == -1) {
+      if (procedure == null) {
         if (hasOverlappedTask) {
           return RpcUtils.getStatus(
               TSStatusCode.OVERLAP_WITH_EXISTING_TASK,
               "Some other task is setting template on target path.");
         }
-        procedureId =
-            this.executor.submitProcedure(
-                new SetTemplateProcedure(
-                    queryId, templateName, templateSetPath, isGeneratedByPipe));
+        procedure =
+            new SetTemplateProcedure(queryId, templateName, templateSetPath, isGeneratedByPipe);
+        this.executor.submitProcedure(procedure);
       }
     }
-    List<TSStatus> procedureStatus = new ArrayList<>();
-    boolean isSucceed =
-        waitingProcedureFinished(Collections.singletonList(procedureId), procedureStatus);
-    if (isSucceed) {
-      return StatusUtils.OK;
-    } else {
-      return procedureStatus.get(0);
-    }
+    return waitingProcedureFinishedV2(procedure);
   }
 
   public TSStatus deactivateTemplate(
       String queryId, Map<PartialPath, List<Template>> templateSetInfo, boolean isGeneratedByPipe) {
-    long procedureId = -1;
+    DeactivateTemplateProcedure procedure = null;
     synchronized (this) {
       boolean hasOverlappedTask = false;
       ProcedureType type;
       DeactivateTemplateProcedure deactivateTemplateProcedure;
-      for (Procedure<?> procedure : executor.getProcedures().values()) {
-        type = ProcedureFactory.getProcedureType(procedure);
+      for (Procedure<?> runningProcedure : executor.getProcedures().values()) {
+        type = ProcedureFactory.getProcedureType(runningProcedure);
         if (type == null || !type.equals(ProcedureType.DEACTIVATE_TEMPLATE_PROCEDURE)) {
           continue;
         }
-        deactivateTemplateProcedure = (DeactivateTemplateProcedure) procedure;
+        deactivateTemplateProcedure = (DeactivateTemplateProcedure) runningProcedure;
         if (queryId.equals(deactivateTemplateProcedure.getQueryId())) {
-          procedureId = deactivateTemplateProcedure.getProcId();
+          procedure = deactivateTemplateProcedure;
           break;
         }
         for (PartialPath pattern : templateSetInfo.keySet()) {
@@ -500,42 +460,34 @@ public class ProcedureManager {
         }
       }
 
-      if (procedureId == -1) {
+      if (procedure == null) {
         if (hasOverlappedTask) {
           return RpcUtils.getStatus(
               TSStatusCode.OVERLAP_WITH_EXISTING_TASK,
               "Some other task is deactivating some target template from target path.");
         }
-        procedureId =
-            this.executor.submitProcedure(
-                new DeactivateTemplateProcedure(queryId, templateSetInfo, isGeneratedByPipe));
+        procedure = new DeactivateTemplateProcedure(queryId, templateSetInfo, isGeneratedByPipe);
+        this.executor.submitProcedure(procedure);
       }
     }
-    List<TSStatus> procedureStatus = new ArrayList<>();
-    boolean isSucceed =
-        waitingProcedureFinished(Collections.singletonList(procedureId), procedureStatus);
-    if (isSucceed) {
-      return StatusUtils.OK;
-    } else {
-      return procedureStatus.get(0);
-    }
+    return waitingProcedureFinishedV2(procedure);
   }
 
   public TSStatus unsetSchemaTemplate(
       String queryId, Template template, PartialPath path, boolean isGeneratedByPipe) {
-    long procedureId = -1;
+    UnsetTemplateProcedure procedure = null;
     synchronized (this) {
       boolean hasOverlappedTask = false;
       ProcedureType type;
       UnsetTemplateProcedure unsetTemplateProcedure;
-      for (Procedure<?> procedure : executor.getProcedures().values()) {
-        type = ProcedureFactory.getProcedureType(procedure);
+      for (Procedure<?> runningProcedure : executor.getProcedures().values()) {
+        type = ProcedureFactory.getProcedureType(runningProcedure);
         if (type == null || !type.equals(ProcedureType.UNSET_TEMPLATE_PROCEDURE)) {
           continue;
         }
-        unsetTemplateProcedure = (UnsetTemplateProcedure) procedure;
+        unsetTemplateProcedure = (UnsetTemplateProcedure) runningProcedure;
         if (queryId.equals(unsetTemplateProcedure.getQueryId())) {
-          procedureId = unsetTemplateProcedure.getProcId();
+          procedure = unsetTemplateProcedure;
           break;
         }
         if (template.getId() == unsetTemplateProcedure.getTemplateId()
@@ -545,26 +497,18 @@ public class ProcedureManager {
         }
       }
 
-      if (procedureId == -1) {
+      if (procedure == null) {
         if (hasOverlappedTask) {
           return RpcUtils.getStatus(
               TSStatusCode.OVERLAP_WITH_EXISTING_TASK,
               "Some other task is unsetting target template from target path "
                   + path.getFullPath());
         }
-        procedureId =
-            this.executor.submitProcedure(
-                new UnsetTemplateProcedure(queryId, template, path, isGeneratedByPipe));
+        procedure = new UnsetTemplateProcedure(queryId, template, path, isGeneratedByPipe);
+        this.executor.submitProcedure(procedure);
       }
     }
-    List<TSStatus> procedureStatus = new ArrayList<>();
-    boolean isSucceed =
-        waitingProcedureFinished(Collections.singletonList(procedureId), procedureStatus);
-    if (isSucceed) {
-      return StatusUtils.OK;
-    } else {
-      return procedureStatus.get(0);
-    }
+    return waitingProcedureFinishedV2(procedure);
   }
 
   /**
@@ -960,18 +904,10 @@ public class ProcedureManager {
    */
   public TSStatus createRegionGroups(
       TConsensusGroupType consensusGroupType, CreateRegionGroupsPlan createRegionGroupsPlan) {
-    final long procedureId =
-        executor.submitProcedure(
-            new CreateRegionGroupsProcedure(consensusGroupType, createRegionGroupsPlan));
-    final List<TSStatus> statusList = new ArrayList<>();
-    final boolean isSucceed =
-        waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-    if (isSucceed) {
-      return RpcUtils.SUCCESS_STATUS;
-    } else {
-      return new TSStatus(TSStatusCode.CREATE_REGION_ERROR.getStatusCode())
-          .setMessage(statusList.get(0).getMessage());
-    }
+    CreateRegionGroupsProcedure procedure =
+        new CreateRegionGroupsProcedure(consensusGroupType, createRegionGroupsPlan);
+    executor.submitProcedure(procedure);
+    return waitingProcedureFinishedV2(procedure);
   }
 
   /**
@@ -998,16 +934,8 @@ public class ProcedureManager {
           .setMessage(e.getMessage());
     }
 
-    final long procedureId = executor.submitProcedure(createTriggerProcedure);
-    final List<TSStatus> statusList = new ArrayList<>();
-    final boolean isSucceed =
-        waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-    if (isSucceed) {
-      return RpcUtils.SUCCESS_STATUS;
-    } else {
-      return new TSStatus(TSStatusCode.CREATE_TRIGGER_ERROR.getStatusCode())
-          .setMessage(statusList.get(0).getMessage());
-    }
+    executor.submitProcedure(createTriggerProcedure);
+    return waitingProcedureFinishedV2(createTriggerProcedure);
   }
 
   /**
@@ -1017,25 +945,15 @@ public class ProcedureManager {
    *     {@link TSStatusCode#DROP_TRIGGER_ERROR} otherwise
    */
   public TSStatus dropTrigger(String triggerName, boolean isGeneratedByPipe) {
-    long procedureId =
-        executor.submitProcedure(new DropTriggerProcedure(triggerName, isGeneratedByPipe));
-    final List<TSStatus> statusList = new ArrayList<>();
-    final boolean isSucceed =
-        waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-    if (isSucceed) {
-      return RpcUtils.SUCCESS_STATUS;
-    } else {
-      return new TSStatus(TSStatusCode.DROP_TRIGGER_ERROR.getStatusCode())
-          .setMessage(statusList.get(0).getMessage());
-    }
+    DropTriggerProcedure procedure = new DropTriggerProcedure(triggerName, isGeneratedByPipe);
+    executor.submitProcedure(procedure);
+    return waitingProcedureFinishedV2(procedure);
   }
 
   public TSStatus createCQ(TCreateCQReq req, ScheduledExecutorService scheduledExecutor) {
-    final long procedureId =
-        executor.submitProcedure(new CreateCQProcedure(req, scheduledExecutor));
-    final List<TSStatus> statusList = new ArrayList<>();
-    waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-    return statusList.get(0);
+    CreateCQProcedure procedure = new CreateCQProcedure(req, scheduledExecutor);
+    executor.submitProcedure(procedure);
+    return waitingProcedureFinishedV2(procedure);
   }
 
   public TSStatus createModel(String modelName, String uri) {
@@ -1045,16 +963,9 @@ public class ProcedureManager {
   }
 
   public TSStatus dropModel(String modelId) {
-    long procedureId = executor.submitProcedure(new DropModelProcedure(modelId));
-    List<TSStatus> statusList = new ArrayList<>();
-    boolean isSucceed =
-        waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-    if (isSucceed) {
-      return RpcUtils.SUCCESS_STATUS;
-    } else {
-      return new TSStatus(TSStatusCode.DROP_MODEL_ERROR.getStatusCode())
-          .setMessage(statusList.get(0).getMessage());
-    }
+    DropModelProcedure procedure = new DropModelProcedure(modelId);
+    executor.submitProcedure(procedure);
+    return waitingProcedureFinishedV2(procedure);
   }
 
   public TSStatus createPipePlugin(
@@ -1076,38 +987,23 @@ public class ProcedureManager {
           .setMessage(e.getMessage());
     }
 
-    final long procedureId = executor.submitProcedure(createPipePluginProcedure);
-    final List<TSStatus> statusList = new ArrayList<>();
-    final boolean isSucceed =
-        waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-    if (isSucceed) {
-      return RpcUtils.SUCCESS_STATUS;
-    } else {
-      return new TSStatus(TSStatusCode.CREATE_PIPE_PLUGIN_ERROR.getStatusCode())
-          .setMessage(statusList.get(0).getMessage());
-    }
+    executor.submitProcedure(createPipePluginProcedure);
+    return waitingProcedureFinishedV2(createPipePluginProcedure);
   }
 
   public TSStatus dropPipePlugin(TDropPipePluginReq req) {
-    final long procedureId =
-        executor.submitProcedure(
-            new DropPipePluginProcedure(
-                req.getPluginName(), req.isSetIfExistsCondition() && req.isIfExistsCondition()));
-    final List<TSStatus> statusList = new ArrayList<>();
-    final boolean isSucceed =
-        waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-    if (isSucceed) {
-      return RpcUtils.SUCCESS_STATUS;
-    } else {
-      return new TSStatus(TSStatusCode.DROP_PIPE_PLUGIN_ERROR.getStatusCode())
-          .setMessage(statusList.get(0).getMessage());
-    }
+    DropPipePluginProcedure procedure =
+        new DropPipePluginProcedure(
+            req.getPluginName(), req.isSetIfExistsCondition() && req.isIfExistsCondition());
+    executor.submitProcedure(procedure);
+    return waitingProcedureFinishedV2(procedure);
   }
 
   public TSStatus createConsensusPipe(TCreatePipeReq req) {
     try {
-      final long procedureId = executor.submitProcedure(new CreatePipeProcedureV2(req));
-      return handleConsensusPipeProcedure(procedureId);
+      CreatePipeProcedureV2 procedure = new CreatePipeProcedureV2(req);
+      executor.submitProcedure(procedure);
+      return handleConsensusPipeProcedure(procedure);
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
     }
@@ -1115,15 +1011,14 @@ public class ProcedureManager {
 
   public TSStatus createPipe(TCreatePipeReq req) {
     try {
-      final long procedureId = executor.submitProcedure(new CreatePipeProcedureV2(req));
-      final List<TSStatus> statusList = new ArrayList<>();
-      final boolean isSucceed =
-          waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-      if (isSucceed) {
-        return statusList.get(0);
+      CreatePipeProcedureV2 procedure = new CreatePipeProcedureV2(req);
+      executor.submitProcedure(procedure);
+      TSStatus status = waitingProcedureFinishedV2(procedure);
+      if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+        return status;
       } else {
         return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(statusList.get(0).getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
@@ -1132,15 +1027,14 @@ public class ProcedureManager {
 
   public TSStatus alterPipe(TAlterPipeReq req) {
     try {
-      final long procedureId = executor.submitProcedure(new AlterPipeProcedureV2(req));
-      final List<TSStatus> statusList = new ArrayList<>();
-      final boolean isSucceed =
-          waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-      if (isSucceed) {
-        return statusList.get(0);
+      AlterPipeProcedureV2 procedure = new AlterPipeProcedureV2(req);
+      executor.submitProcedure(procedure);
+      TSStatus status = waitingProcedureFinishedV2(procedure);
+      if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+        return status;
       } else {
         return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(statusList.get(0).getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
@@ -1149,8 +1043,9 @@ public class ProcedureManager {
 
   public TSStatus startConsensusPipe(String pipeName) {
     try {
-      final long procedureId = executor.submitProcedure(new StartPipeProcedureV2(pipeName));
-      return handleConsensusPipeProcedure(procedureId);
+      StartPipeProcedureV2 procedure = new StartPipeProcedureV2(pipeName);
+      executor.submitProcedure(procedure);
+      return handleConsensusPipeProcedure(procedure);
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
     }
@@ -1158,15 +1053,14 @@ public class ProcedureManager {
 
   public TSStatus startPipe(String pipeName) {
     try {
-      final long procedureId = executor.submitProcedure(new StartPipeProcedureV2(pipeName));
-      final List<TSStatus> statusList = new ArrayList<>();
-      final boolean isSucceed =
-          waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-      if (isSucceed) {
-        return statusList.get(0);
+      StartPipeProcedureV2 procedure = new StartPipeProcedureV2(pipeName);
+      executor.submitProcedure(procedure);
+      TSStatus status = waitingProcedureFinishedV2(procedure);
+      if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+        return status;
       } else {
         return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(statusList.get(0).getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
@@ -1175,8 +1069,9 @@ public class ProcedureManager {
 
   public TSStatus stopConsensusPipe(String pipeName) {
     try {
-      final long procedureId = executor.submitProcedure(new StopPipeProcedureV2(pipeName));
-      return handleConsensusPipeProcedure(procedureId);
+      StopPipeProcedureV2 procedure = new StopPipeProcedureV2(pipeName);
+      executor.submitProcedure(procedure);
+      return handleConsensusPipeProcedure(procedure);
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
     }
@@ -1184,15 +1079,14 @@ public class ProcedureManager {
 
   public TSStatus stopPipe(String pipeName) {
     try {
-      final long procedureId = executor.submitProcedure(new StopPipeProcedureV2(pipeName));
-      final List<TSStatus> statusList = new ArrayList<>();
-      final boolean isSucceed =
-          waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-      if (isSucceed) {
-        return statusList.get(0);
+      StopPipeProcedureV2 procedure = new StopPipeProcedureV2(pipeName);
+      executor.submitProcedure(procedure);
+      TSStatus status = waitingProcedureFinishedV2(procedure);
+      if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+        return status;
       } else {
         return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(statusList.get(0).getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
@@ -1201,8 +1095,9 @@ public class ProcedureManager {
 
   public TSStatus dropConsensusPipe(String pipeName) {
     try {
-      final long procedureId = executor.submitProcedure(new DropPipeProcedureV2(pipeName));
-      return handleConsensusPipeProcedure(procedureId);
+      DropPipeProcedureV2 procedure = new DropPipeProcedureV2(pipeName);
+      executor.submitProcedure(procedure);
+      return handleConsensusPipeProcedure(procedure);
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
     }
@@ -1210,35 +1105,32 @@ public class ProcedureManager {
 
   public TSStatus dropPipe(String pipeName) {
     try {
-      final long procedureId = executor.submitProcedure(new DropPipeProcedureV2(pipeName));
-      final List<TSStatus> statusList = new ArrayList<>();
-      final boolean isSucceed =
-          waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-      if (isSucceed) {
-        return statusList.get(0);
+      DropPipeProcedureV2 procedure = new DropPipeProcedureV2(pipeName);
+      executor.submitProcedure(procedure);
+      TSStatus status = waitingProcedureFinishedV2(procedure);
+      if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+        return status;
       } else {
         return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(statusList.get(0).getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
     }
   }
 
-  private TSStatus handleConsensusPipeProcedure(final long procedureId) {
-    final List<TSStatus> statusList = new ArrayList<>();
-    final boolean isSucceed =
-        waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-    if (isSucceed) {
-      return statusList.get(0);
+  private TSStatus handleConsensusPipeProcedure(Procedure<?> procedure) {
+    TSStatus status = waitingProcedureFinishedV2(procedure);
+    if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+      return status;
     } else {
       // if time out, optimistically believe that this procedure will execute successfully.
-      if (statusList.get(0).getMessage().equals(PROCEDURE_TIMEOUT_MESSAGE)) {
+      if (status.getMessage().equals(PROCEDURE_TIMEOUT_MESSAGE)) {
         return new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
       }
       // otherwise, some exceptions must have occurred, throw them.
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
-          .setMessage(wrapTimeoutMessageForPipeProcedure(statusList.get(0).getMessage()));
+          .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
     }
   }
 
@@ -1270,19 +1162,12 @@ public class ProcedureManager {
   public TSStatus pipeHandleMetaChangeWithBlock(
       boolean needWriteConsensusOnConfigNodes, boolean needPushPipeMetaToDataNodes) {
     try {
-      final long procedureId =
-          executor.submitProcedure(
-              new PipeHandleMetaChangeProcedure(
-                  needWriteConsensusOnConfigNodes, needPushPipeMetaToDataNodes));
-      final List<TSStatus> statusList = new ArrayList<>();
-      final boolean isSucceed =
-          waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-      if (isSucceed) {
-        return RpcUtils.SUCCESS_STATUS;
-      } else {
-        return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(statusList.get(0).getMessage()));
-      }
+      PipeHandleMetaChangeProcedure procedure =
+          new PipeHandleMetaChangeProcedure(
+              needWriteConsensusOnConfigNodes, needPushPipeMetaToDataNodes);
+
+      executor.submitProcedure(procedure);
+      return waitingProcedureFinishedV2(procedure);
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
     }
@@ -1290,15 +1175,14 @@ public class ProcedureManager {
 
   public TSStatus pipeMetaSync() {
     try {
-      final long procedureId = executor.submitProcedure(new PipeMetaSyncProcedure());
-      final List<TSStatus> statusList = new ArrayList<>();
-      final boolean isSucceed =
-          waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-      if (isSucceed) {
-        return RpcUtils.SUCCESS_STATUS;
+      PipeMetaSyncProcedure procedure = new PipeMetaSyncProcedure();
+      executor.submitProcedure(procedure);
+      TSStatus status = waitingProcedureFinishedV2(procedure);
+      if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+        return status;
       } else {
         return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(statusList.get(0).getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
@@ -1307,15 +1191,14 @@ public class ProcedureManager {
 
   public TSStatus createTopic(TCreateTopicReq req) {
     try {
-      final long procedureId = executor.submitProcedure(new CreateTopicProcedure(req));
-      final List<TSStatus> statusList = new ArrayList<>();
-      final boolean isSucceed =
-          waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-      if (isSucceed) {
-        return statusList.get(0);
+      CreateTopicProcedure procedure = new CreateTopicProcedure(req);
+      executor.submitProcedure(procedure);
+      TSStatus status = waitingProcedureFinishedV2(procedure);
+      if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+        return status;
       } else {
-        return new TSStatus(TSStatusCode.CREATE_TOPIC_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(statusList.get(0).getMessage()));
+        return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.CREATE_TOPIC_ERROR.getStatusCode())
@@ -1325,15 +1208,14 @@ public class ProcedureManager {
 
   public TSStatus dropTopic(String topicName) {
     try {
-      final long procedureId = executor.submitProcedure(new DropTopicProcedure(topicName));
-      final List<TSStatus> statusList = new ArrayList<>();
-      final boolean isSucceed =
-          waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-      if (isSucceed) {
-        return statusList.get(0);
+      DropTopicProcedure procedure = new DropTopicProcedure(topicName);
+      executor.submitProcedure(procedure);
+      TSStatus status = waitingProcedureFinishedV2(procedure);
+      if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+        return status;
       } else {
-        return new TSStatus(TSStatusCode.DROP_TOPIC_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(statusList.get(0).getMessage()));
+        return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.DROP_TOPIC_ERROR.getStatusCode()).setMessage(e.getMessage());
@@ -1342,15 +1224,14 @@ public class ProcedureManager {
 
   public TSStatus topicMetaSync() {
     try {
-      final long procedureId = executor.submitProcedure(new TopicMetaSyncProcedure());
-      final List<TSStatus> statusList = new ArrayList<>();
-      final boolean isSucceed =
-          waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-      if (isSucceed) {
-        return RpcUtils.SUCCESS_STATUS;
+      TopicMetaSyncProcedure procedure = new TopicMetaSyncProcedure();
+      executor.submitProcedure(procedure);
+      TSStatus status = waitingProcedureFinishedV2(procedure);
+      if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+        return status;
       } else {
-        return new TSStatus(TSStatusCode.TOPIC_PUSH_META_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(statusList.get(0).getMessage()));
+        return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.TOPIC_PUSH_META_ERROR.getStatusCode())
@@ -1360,15 +1241,14 @@ public class ProcedureManager {
 
   public TSStatus createConsumer(TCreateConsumerReq req) {
     try {
-      final long procedureId = executor.submitProcedure(new CreateConsumerProcedure(req));
-      final List<TSStatus> statusList = new ArrayList<>();
-      final boolean isSucceed =
-          waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-      if (isSucceed) {
-        return statusList.get(0);
+      CreateConsumerProcedure procedure = new CreateConsumerProcedure(req);
+      executor.submitProcedure(procedure);
+      TSStatus status = waitingProcedureFinishedV2(procedure);
+      if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+        return status;
       } else {
-        return new TSStatus(TSStatusCode.CREATE_CONSUMER_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(statusList.get(0).getMessage()));
+        return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.CREATE_CONSUMER_ERROR.getStatusCode())
@@ -1378,15 +1258,14 @@ public class ProcedureManager {
 
   public TSStatus dropConsumer(TCloseConsumerReq req) {
     try {
-      final long procedureId = executor.submitProcedure(new DropConsumerProcedure(req));
-      final List<TSStatus> statusList = new ArrayList<>();
-      final boolean isSucceed =
-          waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-      if (isSucceed) {
-        return statusList.get(0);
+      DropConsumerProcedure procedure = new DropConsumerProcedure(req);
+      executor.submitProcedure(procedure);
+      TSStatus status = waitingProcedureFinishedV2(procedure);
+      if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+        return status;
       } else {
-        return new TSStatus(TSStatusCode.DROP_CONSUMER_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(statusList.get(0).getMessage()));
+        return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.DROP_CONSUMER_ERROR.getStatusCode())
@@ -1396,15 +1275,14 @@ public class ProcedureManager {
 
   public TSStatus consumerGroupMetaSync() {
     try {
-      final long procedureId = executor.submitProcedure(new ConsumerGroupMetaSyncProcedure());
-      final List<TSStatus> statusList = new ArrayList<>();
-      final boolean isSucceed =
-          waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-      if (isSucceed) {
-        return RpcUtils.SUCCESS_STATUS;
+      ConsumerGroupMetaSyncProcedure procedure = new ConsumerGroupMetaSyncProcedure();
+      executor.submitProcedure(procedure);
+      TSStatus status = waitingProcedureFinishedV2(procedure);
+      if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+        return status;
       } else {
-        return new TSStatus(TSStatusCode.CONSUMER_PUSH_META_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(statusList.get(0).getMessage()));
+        return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.CONSUMER_PUSH_META_ERROR.getStatusCode())
@@ -1414,17 +1292,16 @@ public class ProcedureManager {
 
   public TSStatus createSubscription(TSubscribeReq req) {
     try {
-      final long procedureId = executor.submitProcedure(new CreateSubscriptionProcedure(req));
-      final List<TSStatus> statusList = new ArrayList<>();
-      final boolean isSucceed =
-          waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-      if (isSucceed) {
-        return statusList.get(0);
-      } else if (PROCEDURE_TIMEOUT_MESSAGE.equals(statusList.get(0).getMessage())) {
+      CreateSubscriptionProcedure procedure = new CreateSubscriptionProcedure(req);
+      executor.submitProcedure(procedure);
+      TSStatus status = waitingProcedureFinishedV2(procedure);
+      if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+        return status;
+      } else if (PROCEDURE_TIMEOUT_MESSAGE.equals(status.getMessage())) {
         // we assume that a timeout has occurred in the procedure related to the pipe in the
         // subscription procedure
         return new TSStatus(TSStatusCode.SUBSCRIPTION_PIPE_TIMEOUT_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(statusList.get(0).getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
       } else {
         return new TSStatus(TSStatusCode.SUBSCRIPTION_SUBSCRIBE_ERROR.getStatusCode());
       }
@@ -1436,19 +1313,18 @@ public class ProcedureManager {
 
   public TSStatus dropSubscription(TUnsubscribeReq req) {
     try {
-      final long procedureId = executor.submitProcedure(new DropSubscriptionProcedure(req));
-      final List<TSStatus> statusList = new ArrayList<>();
-      final boolean isSucceed =
-          waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-      if (isSucceed) {
-        return statusList.get(0);
-      } else if (PROCEDURE_TIMEOUT_MESSAGE.equals(statusList.get(0).getMessage())) {
+      DropSubscriptionProcedure procedure = new DropSubscriptionProcedure(req);
+      executor.submitProcedure(procedure);
+      TSStatus status = waitingProcedureFinishedV2(procedure);
+      if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+        return status;
+      } else if (PROCEDURE_TIMEOUT_MESSAGE.equals(status.getMessage())) {
         // we assume that a timeout has occurred in the procedure related to the pipe in the
         // subscription procedure
         return new TSStatus(TSStatusCode.SUBSCRIPTION_PIPE_TIMEOUT_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(statusList.get(0).getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
       } else {
-        return new TSStatus(TSStatusCode.SUBSCRIPTION_UNSUBSCRIBE_ERROR.getStatusCode());
+        return new TSStatus(TSStatusCode.SUBSCRIPTION_SUBSCRIBE_ERROR.getStatusCode());
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.SUBSCRIPTION_UNSUBSCRIBE_ERROR.getStatusCode())
@@ -1459,16 +1335,10 @@ public class ProcedureManager {
   public TSStatus operateAuthPlan(
       AuthorPlan authorPlan, List<TDataNodeConfiguration> dns, boolean isGeneratedByPipe) {
     try {
-      final long procedureId =
-          executor.submitProcedure(new AuthOperationProcedure(authorPlan, dns, isGeneratedByPipe));
-      final List<TSStatus> statusList = new ArrayList<>();
-      final boolean isSucceed =
-          waitingProcedureFinished(Collections.singletonList(procedureId), statusList);
-      if (isSucceed) {
-        return RpcUtils.SUCCESS_STATUS;
-      } else {
-        return new TSStatus(statusList.get(0).getCode()).setMessage(statusList.get(0).getMessage());
-      }
+      AuthOperationProcedure procedure =
+          new AuthOperationProcedure(authorPlan, dns, isGeneratedByPipe);
+      executor.submitProcedure(procedure);
+      return waitingProcedureFinishedV2(procedure);
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.AUTH_OPERATE_EXCEPTION.getStatusCode())
           .setMessage(e.getMessage());
@@ -1476,16 +1346,9 @@ public class ProcedureManager {
   }
 
   public TSStatus setTTL(SetTTLPlan setTTLPlan, final boolean isGeneratedByPipe) {
-    long procedureId = executor.submitProcedure(new SetTTLProcedure(setTTLPlan, isGeneratedByPipe));
-
-    List<TSStatus> procedureStatus = new ArrayList<>();
-    boolean isSucceed =
-        waitingProcedureFinished(Collections.singletonList(procedureId), procedureStatus);
-    if (isSucceed) {
-      return RpcUtils.SUCCESS_STATUS;
-    } else {
-      return procedureStatus.get(0);
-    }
+    SetTTLProcedure procedure = new SetTTLProcedure(setTTLPlan, isGeneratedByPipe);
+    executor.submitProcedure(procedure);
+    return waitingProcedureFinishedV2(procedure);
   }
 
   /**
@@ -1541,6 +1404,52 @@ public class ProcedureManager {
       }
     }
     return isSucceed;
+  }
+
+  /**
+   * Waiting until the specific procedure finished.
+   *
+   * @param procedure The specific procedure
+   * @return TSStatus the running result of this procedure
+   */
+  private TSStatus waitingProcedureFinishedV2(Procedure<?> procedure) {
+    if (procedure == null) {
+      LOGGER.error("Unexpected null procedure parameters for waitingProcedureFinished");
+      return RpcUtils.getStatus(TSStatusCode.INTERNAL_SERVER_ERROR);
+    }
+    TSStatus status;
+    final long startTimeForCurrentProcedure = System.currentTimeMillis();
+    while (executor.isRunning()
+        && !executor.isFinished(procedure.getProcId())
+        && System.currentTimeMillis() - startTimeForCurrentProcedure < PROCEDURE_WAIT_TIME_OUT) {
+      sleepWithoutInterrupt(PROCEDURE_WAIT_RETRY_TIMEOUT);
+    }
+    if (!procedure.isFinished()) {
+      // The procedure is still executing
+      status =
+          RpcUtils.getStatus(TSStatusCode.OVERLAP_WITH_EXISTING_TASK, PROCEDURE_TIMEOUT_MESSAGE);
+    } else {
+      if (procedure.isSuccess()) {
+        status =
+            RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS, Arrays.toString(procedure.getResult()));
+      } else {
+        if (procedure.getException().getCause() instanceof IoTDBException) {
+          final IoTDBException e = (IoTDBException) procedure.getException().getCause();
+          if (e instanceof BatchProcessException) {
+            status =
+                RpcUtils.getStatus(
+                    Arrays.stream(((BatchProcessException) e).getFailingStatus())
+                        .collect(Collectors.toList()));
+          } else {
+            status = RpcUtils.getStatus(e.getErrorCode(), e.getMessage());
+          }
+        } else {
+          status =
+              StatusUtils.EXECUTE_STATEMENT_ERROR.setMessage(procedure.getException().getMessage());
+        }
+      }
+    }
+    return status;
   }
 
   private static String wrapTimeoutMessageForPipeProcedure(String message) {
@@ -1667,19 +1576,18 @@ public class ProcedureManager {
                 req.getPatternInfo(),
                 req.getFilterInfo(),
                 req.getModInfo());
-        procedureId = this.executor.submitProcedure(procedure);
+        this.executor.submitProcedure(procedure);
       }
     }
-    executor.getResultOrProcedure(procedureId);
-    final List<TSStatus> procedureStatus = new ArrayList<>();
-    if (waitingProcedureFinished(Collections.singletonList(procedureId), procedureStatus)) {
-      if (Objects.isNull(procedure)) {
-        procedure = ((DeleteDevicesProcedure) executor.getResultOrProcedure(procedureId));
-      }
+    TSStatus status = waitingProcedureFinishedV2(procedure);
+    if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
       return new TDeleteTableDeviceResp(StatusUtils.OK)
-          .setDeletedNum(Objects.nonNull(procedure) ? procedure.getDeletedDevicesNum() : -1);
+          .setDeletedNum(
+              Optional.ofNullable(procedure)
+                  .map(DeleteDevicesProcedure::getDeletedDevicesNum)
+                  .orElse(-1L));
     } else {
-      return new TDeleteTableDeviceResp(procedureStatus.get(0));
+      return new TDeleteTableDeviceResp(status);
     }
   }
 
@@ -1702,13 +1610,9 @@ public class ProcedureManager {
               TSStatusCode.OVERLAP_WITH_EXISTING_TASK,
               "Some other task is operating table with same name.");
         }
-        procedureId = this.executor.submitProcedure(procedure);
       }
     }
-    final List<TSStatus> procedureStatus = new ArrayList<>();
-    return waitingProcedureFinished(Collections.singletonList(procedureId), procedureStatus)
-        ? StatusUtils.OK
-        : procedureStatus.get(0);
+    return waitingProcedureFinishedV2(procedure);
   }
 
   public Pair<Long, Boolean> checkDuplicateTableTask(

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
@@ -265,7 +265,7 @@ public class ProcedureManager {
         }
       }
     }
-    final TSStatus result = waitingProcedureFinishedV2(procedure);
+    final TSStatus result = waitingProcedureFinished(procedure);
     // Clear the previously deleted regions
     final PartitionManager partitionManager = getConfigManager().getPartitionManager();
     partitionManager.getRegionMaintainer().submit(partitionManager::maintainRegionReplicas);
@@ -305,7 +305,7 @@ public class ProcedureManager {
         this.executor.submitProcedure(procedure);
       }
     }
-    return waitingProcedureFinishedV2(procedure);
+    return waitingProcedureFinished(procedure);
   }
 
   public TSStatus deleteLogicalView(TDeleteLogicalViewReq req) {
@@ -345,7 +345,7 @@ public class ProcedureManager {
         this.executor.submitProcedure(procedure);
       }
     }
-    return waitingProcedureFinishedV2(procedure);
+    return waitingProcedureFinished(procedure);
   }
 
   public TSStatus alterLogicalView(TAlterLogicalViewReq req) {
@@ -386,7 +386,7 @@ public class ProcedureManager {
         this.executor.submitProcedure(procedure);
       }
     }
-    return waitingProcedureFinishedV2(procedure);
+    return waitingProcedureFinished(procedure);
   }
 
   public TSStatus setSchemaTemplate(
@@ -423,7 +423,7 @@ public class ProcedureManager {
         this.executor.submitProcedure(procedure);
       }
     }
-    return waitingProcedureFinishedV2(procedure);
+    return waitingProcedureFinished(procedure);
   }
 
   public TSStatus deactivateTemplate(
@@ -470,7 +470,7 @@ public class ProcedureManager {
         this.executor.submitProcedure(procedure);
       }
     }
-    return waitingProcedureFinishedV2(procedure);
+    return waitingProcedureFinished(procedure);
   }
 
   public TSStatus unsetSchemaTemplate(
@@ -508,7 +508,7 @@ public class ProcedureManager {
         this.executor.submitProcedure(procedure);
       }
     }
-    return waitingProcedureFinishedV2(procedure);
+    return waitingProcedureFinished(procedure);
   }
 
   /**
@@ -907,7 +907,7 @@ public class ProcedureManager {
     CreateRegionGroupsProcedure procedure =
         new CreateRegionGroupsProcedure(consensusGroupType, createRegionGroupsPlan);
     executor.submitProcedure(procedure);
-    return waitingProcedureFinishedV2(procedure);
+    return waitingProcedureFinished(procedure);
   }
 
   /**
@@ -935,7 +935,7 @@ public class ProcedureManager {
     }
 
     executor.submitProcedure(createTriggerProcedure);
-    return waitingProcedureFinishedV2(createTriggerProcedure);
+    return waitingProcedureFinished(createTriggerProcedure);
   }
 
   /**
@@ -947,13 +947,13 @@ public class ProcedureManager {
   public TSStatus dropTrigger(String triggerName, boolean isGeneratedByPipe) {
     DropTriggerProcedure procedure = new DropTriggerProcedure(triggerName, isGeneratedByPipe);
     executor.submitProcedure(procedure);
-    return waitingProcedureFinishedV2(procedure);
+    return waitingProcedureFinished(procedure);
   }
 
   public TSStatus createCQ(TCreateCQReq req, ScheduledExecutorService scheduledExecutor) {
     CreateCQProcedure procedure = new CreateCQProcedure(req, scheduledExecutor);
     executor.submitProcedure(procedure);
-    return waitingProcedureFinishedV2(procedure);
+    return waitingProcedureFinished(procedure);
   }
 
   public TSStatus createModel(String modelName, String uri) {
@@ -965,7 +965,7 @@ public class ProcedureManager {
   public TSStatus dropModel(String modelId) {
     DropModelProcedure procedure = new DropModelProcedure(modelId);
     executor.submitProcedure(procedure);
-    return waitingProcedureFinishedV2(procedure);
+    return waitingProcedureFinished(procedure);
   }
 
   public TSStatus createPipePlugin(
@@ -988,7 +988,7 @@ public class ProcedureManager {
     }
 
     executor.submitProcedure(createPipePluginProcedure);
-    return waitingProcedureFinishedV2(createPipePluginProcedure);
+    return waitingProcedureFinished(createPipePluginProcedure);
   }
 
   public TSStatus dropPipePlugin(TDropPipePluginReq req) {
@@ -996,7 +996,7 @@ public class ProcedureManager {
         new DropPipePluginProcedure(
             req.getPluginName(), req.isSetIfExistsCondition() && req.isIfExistsCondition());
     executor.submitProcedure(procedure);
-    return waitingProcedureFinishedV2(procedure);
+    return waitingProcedureFinished(procedure);
   }
 
   public TSStatus createConsensusPipe(TCreatePipeReq req) {
@@ -1013,7 +1013,7 @@ public class ProcedureManager {
     try {
       CreatePipeProcedureV2 procedure = new CreatePipeProcedureV2(req);
       executor.submitProcedure(procedure);
-      TSStatus status = waitingProcedureFinishedV2(procedure);
+      TSStatus status = waitingProcedureFinished(procedure);
       if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         return status;
       } else {
@@ -1029,7 +1029,7 @@ public class ProcedureManager {
     try {
       AlterPipeProcedureV2 procedure = new AlterPipeProcedureV2(req);
       executor.submitProcedure(procedure);
-      TSStatus status = waitingProcedureFinishedV2(procedure);
+      TSStatus status = waitingProcedureFinished(procedure);
       if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         return status;
       } else {
@@ -1055,7 +1055,7 @@ public class ProcedureManager {
     try {
       StartPipeProcedureV2 procedure = new StartPipeProcedureV2(pipeName);
       executor.submitProcedure(procedure);
-      TSStatus status = waitingProcedureFinishedV2(procedure);
+      TSStatus status = waitingProcedureFinished(procedure);
       if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         return status;
       } else {
@@ -1081,7 +1081,7 @@ public class ProcedureManager {
     try {
       StopPipeProcedureV2 procedure = new StopPipeProcedureV2(pipeName);
       executor.submitProcedure(procedure);
-      TSStatus status = waitingProcedureFinishedV2(procedure);
+      TSStatus status = waitingProcedureFinished(procedure);
       if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         return status;
       } else {
@@ -1107,7 +1107,7 @@ public class ProcedureManager {
     try {
       DropPipeProcedureV2 procedure = new DropPipeProcedureV2(pipeName);
       executor.submitProcedure(procedure);
-      TSStatus status = waitingProcedureFinishedV2(procedure);
+      TSStatus status = waitingProcedureFinished(procedure);
       if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         return status;
       } else {
@@ -1120,7 +1120,7 @@ public class ProcedureManager {
   }
 
   private TSStatus handleConsensusPipeProcedure(Procedure<?> procedure) {
-    TSStatus status = waitingProcedureFinishedV2(procedure);
+    TSStatus status = waitingProcedureFinished(procedure);
     if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
       return status;
     } else {
@@ -1167,7 +1167,7 @@ public class ProcedureManager {
               needWriteConsensusOnConfigNodes, needPushPipeMetaToDataNodes);
 
       executor.submitProcedure(procedure);
-      return waitingProcedureFinishedV2(procedure);
+      return waitingProcedureFinished(procedure);
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
     }
@@ -1177,7 +1177,7 @@ public class ProcedureManager {
     try {
       PipeMetaSyncProcedure procedure = new PipeMetaSyncProcedure();
       executor.submitProcedure(procedure);
-      TSStatus status = waitingProcedureFinishedV2(procedure);
+      TSStatus status = waitingProcedureFinished(procedure);
       if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         return status;
       } else {
@@ -1193,7 +1193,7 @@ public class ProcedureManager {
     try {
       CreateTopicProcedure procedure = new CreateTopicProcedure(req);
       executor.submitProcedure(procedure);
-      TSStatus status = waitingProcedureFinishedV2(procedure);
+      TSStatus status = waitingProcedureFinished(procedure);
       if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         return status;
       } else {
@@ -1210,7 +1210,7 @@ public class ProcedureManager {
     try {
       DropTopicProcedure procedure = new DropTopicProcedure(topicName);
       executor.submitProcedure(procedure);
-      TSStatus status = waitingProcedureFinishedV2(procedure);
+      TSStatus status = waitingProcedureFinished(procedure);
       if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         return status;
       } else {
@@ -1226,7 +1226,7 @@ public class ProcedureManager {
     try {
       TopicMetaSyncProcedure procedure = new TopicMetaSyncProcedure();
       executor.submitProcedure(procedure);
-      TSStatus status = waitingProcedureFinishedV2(procedure);
+      TSStatus status = waitingProcedureFinished(procedure);
       if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         return status;
       } else {
@@ -1243,7 +1243,7 @@ public class ProcedureManager {
     try {
       CreateConsumerProcedure procedure = new CreateConsumerProcedure(req);
       executor.submitProcedure(procedure);
-      TSStatus status = waitingProcedureFinishedV2(procedure);
+      TSStatus status = waitingProcedureFinished(procedure);
       if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         return status;
       } else {
@@ -1260,7 +1260,7 @@ public class ProcedureManager {
     try {
       DropConsumerProcedure procedure = new DropConsumerProcedure(req);
       executor.submitProcedure(procedure);
-      TSStatus status = waitingProcedureFinishedV2(procedure);
+      TSStatus status = waitingProcedureFinished(procedure);
       if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         return status;
       } else {
@@ -1277,7 +1277,7 @@ public class ProcedureManager {
     try {
       ConsumerGroupMetaSyncProcedure procedure = new ConsumerGroupMetaSyncProcedure();
       executor.submitProcedure(procedure);
-      TSStatus status = waitingProcedureFinishedV2(procedure);
+      TSStatus status = waitingProcedureFinished(procedure);
       if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         return status;
       } else {
@@ -1294,7 +1294,7 @@ public class ProcedureManager {
     try {
       CreateSubscriptionProcedure procedure = new CreateSubscriptionProcedure(req);
       executor.submitProcedure(procedure);
-      TSStatus status = waitingProcedureFinishedV2(procedure);
+      TSStatus status = waitingProcedureFinished(procedure);
       if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         return status;
       } else if (PROCEDURE_TIMEOUT_MESSAGE.equals(status.getMessage())) {
@@ -1315,7 +1315,7 @@ public class ProcedureManager {
     try {
       DropSubscriptionProcedure procedure = new DropSubscriptionProcedure(req);
       executor.submitProcedure(procedure);
-      TSStatus status = waitingProcedureFinishedV2(procedure);
+      TSStatus status = waitingProcedureFinished(procedure);
       if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         return status;
       } else if (PROCEDURE_TIMEOUT_MESSAGE.equals(status.getMessage())) {
@@ -1338,7 +1338,7 @@ public class ProcedureManager {
       AuthOperationProcedure procedure =
           new AuthOperationProcedure(authorPlan, dns, isGeneratedByPipe);
       executor.submitProcedure(procedure);
-      return waitingProcedureFinishedV2(procedure);
+      return waitingProcedureFinished(procedure);
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.AUTH_OPERATE_EXCEPTION.getStatusCode())
           .setMessage(e.getMessage());
@@ -1348,62 +1348,7 @@ public class ProcedureManager {
   public TSStatus setTTL(SetTTLPlan setTTLPlan, final boolean isGeneratedByPipe) {
     SetTTLProcedure procedure = new SetTTLProcedure(setTTLPlan, isGeneratedByPipe);
     executor.submitProcedure(procedure);
-    return waitingProcedureFinishedV2(procedure);
-  }
-
-  /**
-   * Waiting until the specific procedures finished.
-   *
-   * @param procedureIds The specific procedures' index
-   * @param statusList The corresponding running results of these procedures
-   * @return True if all Procedures finished successfully, false otherwise
-   */
-  private boolean waitingProcedureFinished(List<Long> procedureIds, List<TSStatus> statusList) {
-    boolean isSucceed = true;
-    for (long procedureId : procedureIds) {
-      final long startTimeForCurrentProcedure = System.currentTimeMillis();
-      while (executor.isRunning()
-          && !executor.isFinished(procedureId)
-          && System.currentTimeMillis() - startTimeForCurrentProcedure < PROCEDURE_WAIT_TIME_OUT) {
-        sleepWithoutInterrupt(PROCEDURE_WAIT_RETRY_TIMEOUT);
-      }
-      final Procedure<ConfigNodeProcedureEnv> finishedProcedure =
-          executor.getResultOrProcedure(procedureId);
-      if (!finishedProcedure.isFinished()) {
-        // The procedure is still executing
-        statusList.add(
-            RpcUtils.getStatus(TSStatusCode.OVERLAP_WITH_EXISTING_TASK, PROCEDURE_TIMEOUT_MESSAGE));
-        isSucceed = false;
-        continue;
-      }
-      if (finishedProcedure.isSuccess()) {
-        if (Objects.nonNull(finishedProcedure.getResult())) {
-          statusList.add(
-              RpcUtils.getStatus(
-                  TSStatusCode.SUCCESS_STATUS, Arrays.toString(finishedProcedure.getResult())));
-        } else {
-          statusList.add(StatusUtils.OK);
-        }
-      } else {
-        if (finishedProcedure.getException().getCause() instanceof IoTDBException) {
-          final IoTDBException e = (IoTDBException) finishedProcedure.getException().getCause();
-          if (e instanceof BatchProcessException) {
-            statusList.add(
-                RpcUtils.getStatus(
-                    Arrays.stream(((BatchProcessException) e).getFailingStatus())
-                        .collect(Collectors.toList())));
-          } else {
-            statusList.add(RpcUtils.getStatus(e.getErrorCode(), e.getMessage()));
-          }
-        } else {
-          statusList.add(
-              StatusUtils.EXECUTE_STATEMENT_ERROR.setMessage(
-                  finishedProcedure.getException().getMessage()));
-        }
-        isSucceed = false;
-      }
-    }
-    return isSucceed;
+    return waitingProcedureFinished(procedure);
   }
 
   /**
@@ -1412,7 +1357,7 @@ public class ProcedureManager {
    * @param procedure The specific procedure
    * @return TSStatus the running result of this procedure
    */
-  private TSStatus waitingProcedureFinishedV2(Procedure<?> procedure) {
+  private TSStatus waitingProcedureFinished(Procedure<?> procedure) {
     if (procedure == null) {
       LOGGER.error("Unexpected null procedure parameters for waitingProcedureFinished");
       return RpcUtils.getStatus(TSStatusCode.INTERNAL_SERVER_ERROR);
@@ -1579,7 +1524,7 @@ public class ProcedureManager {
         this.executor.submitProcedure(procedure);
       }
     }
-    TSStatus status = waitingProcedureFinishedV2(procedure);
+    TSStatus status = waitingProcedureFinished(procedure);
     if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
       return new TDeleteTableDeviceResp(StatusUtils.OK)
           .setDeletedNum(
@@ -1612,7 +1557,7 @@ public class ProcedureManager {
         }
       }
     }
-    return waitingProcedureFinishedV2(procedure);
+    return waitingProcedureFinished(procedure);
   }
 
   public Pair<Long, Boolean> checkDuplicateTableTask(

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
@@ -964,30 +964,6 @@ public class ProcedureExecutor<Env> {
     return abort(procId, true);
   }
 
-  public Procedure<Env> getResult(long procId) {
-    CompletedProcedureContainer retainer = completed.get(procId);
-    if (retainer == null) {
-      return null;
-    } else {
-      return retainer.getProcedure();
-    }
-  }
-
-  /**
-   * Query a procedure result.
-   *
-   * @param procId procedure id
-   * @return procedure or retainer
-   */
-  public Procedure<Env> getResultOrProcedure(long procId) {
-    CompletedProcedureContainer retainer = completed.get(procId);
-    if (retainer == null) {
-      return procedures.get(procId);
-    } else {
-      return retainer.getProcedure();
-    }
-  }
-
   public ProcedureScheduler getScheduler() {
     return scheduler;
   }


### PR DESCRIPTION
Currently, there is a bug in the way we use the procedure framework to track task statuses. The current process primarily involves three steps:
* Submit the task to the procedure.
* Retain the procedure ID.
* Use the procedure ID to retrieve the status of the procedure.

The second and third steps in the above process have issues due to the asynchronous nature of procedure completion and cleanup. There are two relevant characteristics here:

* When a procedure is completed, it transitions from the procedures map to the completed map.
A background thread periodically cleans up the completed map.
* As a result, for a procedure that has already been completed, there is a chance that it will be neither in the procedures map nor in the completed map. In this case, the procedure’s status can no longer be retrieved, potentially leading to other exceptions.

The corresponding solution is to use the procedure itself directly to get its status instead of relying on the procID. HBase has adopted a similar approach (refer to [this link](https://github.com/apache/hbase/blob/master/hbase-server/src/main/java/org/apache/hadoop/hbase/master/snapshot/EnabledTableSnapshotHandler.java#L96)).

By using this approach, even if there is a CN Leader switch, threads that depend on the status of the old procedure can still complete their tasks based on the old reference.

```Java
  private boolean waitingProcedureFinished(List<Long> procedureIds, List<TSStatus> statusList) {
    boolean isSucceed = true;
    for (long procedureId : procedureIds) {
      final long startTimeForCurrentProcedure = System.currentTimeMillis();
      while (executor.isRunning()
          && !executor.isFinished(procedureId)
          && System.currentTimeMillis() - startTimeForCurrentProcedure < PROCEDURE_WAIT_TIME_OUT) {
        sleepWithoutInterrupt(PROCEDURE_WAIT_RETRY_TIMEOUT);
      }
      final Procedure<ConfigNodeProcedureEnv> finishedProcedure =
          executor.getResultOrProcedure(procedureId);
      if (!finishedProcedure.isFinished()) {
        // The procedure is still executing
        statusList.add(
            RpcUtils.getStatus(TSStatusCode.OVERLAP_WITH_EXISTING_TASK, PROCEDURE_TIMEOUT_MESSAGE));
        isSucceed = false;
        continue;
      }
      if (finishedProcedure.isSuccess()) {
        if (Objects.nonNull(finishedProcedure.getResult())) {
          statusList.add(
              RpcUtils.getStatus(
                  TSStatusCode.SUCCESS_STATUS, Arrays.toString(finishedProcedure.getResult())));
        } else {
          statusList.add(StatusUtils.OK);
        }
      } else {
        if (finishedProcedure.getException().getCause() instanceof IoTDBException) {
          final IoTDBException e = (IoTDBException) finishedProcedure.getException().getCause();
          if (e instanceof BatchProcessException) {
            statusList.add(
                RpcUtils.getStatus(
                    Arrays.stream(((BatchProcessException) e).getFailingStatus())
                        .collect(Collectors.toList())));
          } else {
            statusList.add(RpcUtils.getStatus(e.getErrorCode(), e.getMessage()));
          }
        } else {
          statusList.add(
              StatusUtils.EXECUTE_STATEMENT_ERROR.setMessage(
                  finishedProcedure.getException().getMessage()));
        }
        isSucceed = false;
      }
    }
    return isSucceed;
  }

  public Procedure<Env> getResultOrProcedure(long procId) {
    CompletedProcedureContainer retainer = completed.get(procId);
    if (retainer == null) {
      return procedures.get(procId);
    } else {
      return retainer.getProcedure();
    }
  }
```