### PR TITLE
Load: Memory Allocation and Release Mismatch in LoadTsFileDataCacheMemoryBlock

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LocalExecutionPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LocalExecutionPlanner.java
@@ -295,6 +295,19 @@ public class LocalExecutionPlanner {
 
   public synchronized void releaseToFreeMemoryForOperators(final long memoryInBytes) {
     freeMemoryForOperators += memoryInBytes;
+
+    if (freeMemoryForOperators > ALLOCATE_MEMORY_FOR_OPERATORS) {
+      LOGGER.error(
+          "The free memory released is more than allocated memory, free memory:{} released memory: {},allocated memory:{}",
+          freeMemoryForOperators,
+          memoryInBytes,
+          ALLOCATE_MEMORY_FOR_OPERATORS);
+
+      throw new MemoryNotEnoughException(
+          String.format(
+              "The memory released is more than allocated memory, released memory: %d, allocated memory: %d",
+              memoryInBytes, ALLOCATE_MEMORY_FOR_OPERATORS));
+    }
   }
 
   public long getAllocateMemoryForOperators() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/load/memory/LoadTsFileAnalyzeSchemaMemoryBlock.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/load/memory/LoadTsFileAnalyzeSchemaMemoryBlock.java
@@ -51,7 +51,9 @@ public class LoadTsFileAnalyzeSchemaMemoryBlock extends LoadTsFileAbstractMemory
 
   @Override
   public synchronized void addMemoryUsage(long memoryInBytes) {
-    memoryUsageInBytes.addAndGet(memoryInBytes);
+    if (memoryUsageInBytes.addAndGet(memoryInBytes) > totalMemorySizeInBytes) {
+      LOGGER.warn("{} has exceed total memory size", this);
+    }
 
     MetricService.getInstance()
         .getOrCreateGauge(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/load/memory/LoadTsFileDataCacheMemoryBlock.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/load/memory/LoadTsFileDataCacheMemoryBlock.java
@@ -28,14 +28,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class LoadTsFileDataCacheMemoryBlock extends LoadTsFileAbstractMemoryBlock {
+
   private static final Logger LOGGER =
       LoggerFactory.getLogger(LoadTsFileDataCacheMemoryBlock.class);
   private static final long MINIMUM_MEMORY_SIZE_IN_BYTES = 1024 * 1024L; // 1 MB
-  private static final int MAX_ASK_FOR_MEMORY_COUNT = 256; // must be a power of 2
-  private static final long EACH_ASK_MEMORY_SIZE_IN_BYTES =
-      Math.max(
-          MINIMUM_MEMORY_SIZE_IN_BYTES,
-          LoadTsFileMemoryManager.MEMORY_TOTAL_SIZE_FROM_QUERY_IN_BYTES >> 4);
 
   private final AtomicLong limitedMemorySizeInBytes;
   private final AtomicLong memoryUsageInBytes;
@@ -64,33 +60,21 @@ public class LoadTsFileDataCacheMemoryBlock extends LoadTsFileAbstractMemoryBloc
   }
 
   @Override
-  public void addMemoryUsage(long memoryInBytes) {
-    memoryUsageInBytes.addAndGet(memoryInBytes);
-
-    askForMemoryCount.getAndUpdate(
-        count -> {
-          if ((count & (count - 1)) == 0) {
-            // count is a power of 2
-            long actuallyAllocateMemorySizeInBytes =
-                MEMORY_MANAGER.tryAllocateFromQuery(EACH_ASK_MEMORY_SIZE_IN_BYTES);
-            limitedMemorySizeInBytes.addAndGet(actuallyAllocateMemorySizeInBytes);
-            if (actuallyAllocateMemorySizeInBytes < EACH_ASK_MEMORY_SIZE_IN_BYTES) {
-              return (count & (MAX_ASK_FOR_MEMORY_COUNT - 1)) + 1;
-            } else {
-              return 1;
-            }
-          }
-          return (count & (MAX_ASK_FOR_MEMORY_COUNT - 1)) + 1;
-        });
+  public synchronized void addMemoryUsage(long memoryInBytes) {
+    if (memoryUsageInBytes.addAndGet(memoryInBytes) > limitedMemorySizeInBytes.get()) {
+      LOGGER.warn("{} has exceed total memory size", this);
+    }
   }
 
   @Override
-  public void reduceMemoryUsage(long memoryInBytes) {
-    memoryUsageInBytes.addAndGet(-memoryInBytes);
+  public synchronized void reduceMemoryUsage(long memoryInBytes) {
+    if (memoryUsageInBytes.addAndGet(-memoryInBytes) < 0) {
+      LOGGER.warn("{} has reduce memory usage to negative", this);
+    }
   }
 
   @Override
-  public void forceResize(long newSizeInBytes) {
+  public synchronized void forceResize(long newSizeInBytes) {
     throw new UnsupportedOperationException(
         "resize is not supported for LoadTsFileDataCacheMemoryBlock");
   }
@@ -119,6 +103,7 @@ public class LoadTsFileDataCacheMemoryBlock extends LoadTsFileAbstractMemoryBloc
       return false;
     }
 
+    MEMORY_MANAGER.releaseToQuery(shrinkMemoryInBytes);
     limitedMemorySizeInBytes.addAndGet(-shrinkMemoryInBytes);
     return true;
   }


### PR DESCRIPTION
## Description
Removed askForMemoryCount.getAndUpdate to prevent memory over-release
