### PR TITLE
[to dev/1.3] When the config node can not find the configuration file, the set configuration command does not update other nodes' configuration

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBSetConfigurationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBSetConfigurationIT.java
@@ -57,28 +57,35 @@ public class IoTDBSetConfigurationIT {
 
   @Test
   public void testSetConfigurationWithUndefinedConfigKey() {
+    String expectedExceptionMsg =
+        "301: ignored config items: [a] because they are immutable or undefined.";
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      executeAndExpectException(statement, "set configuration \"a\"=\"false\"");
+      executeAndExpectException(
+          statement, "set configuration \"a\"=\"false\"", expectedExceptionMsg);
       int configNodeNum = EnvFactory.getEnv().getConfigNodeWrapperList().size();
       int dataNodeNum = EnvFactory.getEnv().getDataNodeWrapperList().size();
 
       for (int i = 0; i < configNodeNum; i++) {
-        executeAndExpectException(statement, "set configuration \"a\"=\"false\" on " + i);
+        executeAndExpectException(
+            statement, "set configuration \"a\"=\"false\" on " + i, expectedExceptionMsg);
       }
       for (int i = 0; i < dataNodeNum; i++) {
         int dnId = configNodeNum + i;
-        executeAndExpectException(statement, "set configuration \"a\"=\"false\" on " + dnId);
+        executeAndExpectException(
+            statement, "set configuration \"a\"=\"false\" on " + dnId, expectedExceptionMsg);
       }
     } catch (Exception e) {
       Assert.fail(e.getMessage());
     }
   }
 
-  private void executeAndExpectException(Statement statement, String sql) {
+  private void executeAndExpectException(
+      Statement statement, String sql, String expectedContentInExceptionMsg) {
     try {
       statement.execute(sql);
-    } catch (Exception ignored) {
+    } catch (Exception e) {
+      Assert.assertTrue(e.getMessage().contains(expectedContentInExceptionMsg));
       return;
     }
     Assert.fail();

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBSetConfigurationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBSetConfigurationIT.java
@@ -56,6 +56,35 @@ public class IoTDBSetConfigurationIT {
   }
 
   @Test
+  public void testSetConfigurationWithUndefinedConfigKey() {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      executeAndExpectException(statement, "set configuration \"a\"=\"false\"");
+      int configNodeNum = EnvFactory.getEnv().getConfigNodeWrapperList().size();
+      int dataNodeNum = EnvFactory.getEnv().getDataNodeWrapperList().size();
+
+      for (int i = 0; i < configNodeNum; i++) {
+        executeAndExpectException(statement, "set configuration \"a\"=\"false\" on " + i);
+      }
+      for (int i = 0; i < dataNodeNum; i++) {
+        int dnId = configNodeNum + i;
+        executeAndExpectException(statement, "set configuration \"a\"=\"false\" on " + dnId);
+      }
+    } catch (Exception e) {
+      Assert.fail(e.getMessage());
+    }
+  }
+
+  private void executeAndExpectException(Statement statement, String sql) {
+    try {
+      statement.execute(sql);
+    } catch (Exception ignored) {
+      return;
+    }
+    Assert.fail();
+  }
+
+  @Test
   public void testSetConfiguration() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -1573,25 +1573,36 @@ public class ConfigManager implements IManager {
   public TSStatus setConfiguration(TSetConfigurationReq req) {
     TSStatus tsStatus = new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
     int currentNodeId = CONF.getConfigNodeId();
-    if (req.getNodeId() < 0 || currentNodeId == req.getNodeId()) {
-      URL url = ConfigNodeDescriptor.getPropsUrl(CommonConfig.SYSTEM_CONFIG_NAME);
-      if (url == null || !new File(url.getFile()).exists()) {
-        return tsStatus;
-      }
-      File file = new File(url.getFile());
-      Properties properties = new Properties();
-      properties.putAll(req.getConfigs());
-      try {
-        ConfigurationFileUtils.updateConfigurationFile(file, properties);
-      } catch (Exception e) {
-        return RpcUtils.getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR, e.getMessage());
-      }
-      ConfigNodeDescriptor.getInstance().loadHotModifiedProps(properties);
-      if (CONF.getConfigNodeId() == req.getNodeId()) {
+    if (currentNodeId != req.getNodeId()) {
+      tsStatus = confirmLeader();
+      if (tsStatus.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         return tsStatus;
       }
     }
-    tsStatus = confirmLeader();
+    if (currentNodeId == req.getNodeId() || req.getNodeId() < 0) {
+      URL url = ConfigNodeDescriptor.getPropsUrl(CommonConfig.SYSTEM_CONFIG_NAME);
+      boolean configurationFileFound = (url != null && new File(url.getFile()).exists());
+      Properties properties = new Properties();
+      properties.putAll(req.getConfigs());
+
+      if (configurationFileFound) {
+        File file = new File(url.getFile());
+        try {
+          ConfigurationFileUtils.updateConfigurationFile(file, properties);
+        } catch (Exception e) {
+          tsStatus = RpcUtils.getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR, e.getMessage());
+        }
+      } else {
+        String msg =
+            "Unable to find the configuration file. Some modifications are made only in memory.";
+        tsStatus = RpcUtils.getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR, msg);
+        LOGGER.warn(msg);
+      }
+      ConfigNodeDescriptor.getInstance().loadHotModifiedProps(properties);
+      if (currentNodeId == req.getNodeId()) {
+        return tsStatus;
+      }
+    }
     return tsStatus.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()
         ? RpcUtils.squashResponseStatusList(nodeManager.setConfiguration(req))
         : tsStatus;

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -1603,9 +1603,11 @@ public class ConfigManager implements IManager {
         return tsStatus;
       }
     }
-    return tsStatus.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()
-        ? RpcUtils.squashResponseStatusList(nodeManager.setConfiguration(req))
-        : tsStatus;
+    List<TSStatus> statusListOfOtherNodes = nodeManager.setConfiguration(req);
+    List<TSStatus> statusList = new ArrayList<>(statusListOfOtherNodes.size() + 1);
+    statusList.add(tsStatus);
+    statusList.addAll(statusListOfOtherNodes);
+    return RpcUtils.squashResponseStatusList(statusList);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -2022,7 +2022,7 @@ public class IoTDBDescriptor {
     try (InputStream inputStream = url.openStream()) {
       LOGGER.info("Start to reload config file {}", url);
       commonProperties.load(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
-      ConfigurationFileUtils.getConfigurationDefaultValue();
+      ConfigurationFileUtils.loadConfigurationDefaultValueFromTemplate();
       loadHotModifiedProps(commonProperties);
     } catch (Exception e) {
       LOGGER.warn("Fail to reload config file {}", url, e);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/executor/ClusterConfigTaskExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/executor/ClusterConfigTaskExecutor.java
@@ -1061,11 +1061,14 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
 
     TSStatus tsStatus = new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
     List<String> ignoredConfigItems =
-        ConfigurationFileUtils.filterImmutableConfigItems(req.getConfigs());
+        ConfigurationFileUtils.filterInvalidConfigItems(req.getConfigs());
     TSStatus warningTsStatus = null;
     if (!ignoredConfigItems.isEmpty()) {
       warningTsStatus = new TSStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode());
-      warningTsStatus.setMessage("ignored config items: " + ignoredConfigItems);
+      warningTsStatus.setMessage(
+          "ignored config items: "
+              + ignoredConfigItems
+              + " because they are immutable or undefined.");
       if (req.getConfigs().isEmpty()) {
         future.setException(new IoTDBException(warningTsStatus.message, warningTsStatus.code));
         return future;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/StorageEngine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/StorageEngine.java
@@ -662,6 +662,10 @@ public class StorageEngine implements IService {
     URL configFileUrl = IoTDBDescriptor.getPropsUrl(CommonConfig.SYSTEM_CONFIG_NAME);
     if (configFileUrl == null || !(new File(configFileUrl.getFile()).exists())) {
       // configuration file not exist, update in mem
+      String msg =
+          "Unable to find the configuration file. Some modifications are made only in memory.";
+      tsStatus = RpcUtils.getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR, msg);
+      LOGGER.warn(msg);
       try {
         IoTDBDescriptor.getInstance().loadHotModifiedProps(properties);
         IoTDBDescriptor.getInstance().reloadMetricProperties(properties);


### PR DESCRIPTION
## Description
https://github.com/apache/iotdb/pull/14390
1. When the config node can not find the configuration file, the set configuration command does not update other nodes' configuration
```
IoTDB> set configuration "enable_seq_space_compaction"="true"
Msg: org.apache.iotdb.jdbc.IoTDBSQLException: 301: Unable to find the configuration file. Some modifications are made only in memory.

```
2. Ignore undefined configuration items.
```
IoTDB> set configuration "enable_seq_space_compaction1"="true" on 1
Msg: org.apache.iotdb.jdbc.IoTDBSQLException: 301: ignored config items: [enable_seq_space_compaction1] because they are immutable or undefined.

```
