### PR TITLE
[IOTDB-6353] replace cglib to byte-buddy

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -1,6 +1,6 @@
 {
     "dependencies": [
-        "cglib:cglib",
+        "net.bytebuddy:byte-buddy",
         "ch.qos.logback:logback-classic",
         "ch.qos.logback:logback-core",
         "ch.qos.reload4j:reload4j",

--- a/iotdb-core/node-commons/pom.xml
+++ b/iotdb-core/node-commons/pom.xml
@@ -140,8 +140,8 @@
             <artifactId>nimbus-jose-jwt</artifactId>
         </dependency>
         <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib</artifactId>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/sync/ByteBuddyEnhancer.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/sync/ByteBuddyEnhancer.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.commons.client.sync;
+
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import net.bytebuddy.implementation.MethodDelegation;
+import net.bytebuddy.implementation.bind.annotation.Origin;
+import net.bytebuddy.implementation.bind.annotation.RuntimeType;
+import net.bytebuddy.implementation.bind.annotation.SuperCall;
+import net.bytebuddy.implementation.bind.annotation.This;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.ElementMatchers;
+import org.apache.iotdb.commons.client.ThriftClient;
+import org.apache.thrift.TException;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.concurrent.Callable;
+
+public class ByteBuddyEnhancer {
+    public static <V> V createProxy(Class<V> targetClass, Constructor constructor, Object[] args) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+        ElementMatcher.Junction<MethodDescription> matcher = ElementMatchers.noneOf(Object.class.getDeclaredMethods());
+
+        return new ByteBuddy()
+                .subclass(targetClass)
+                .method(matcher)
+                .intercept(MethodDelegation.to(SyncThriftClientWithErrorHandler.class))
+                .make()
+                .load(targetClass.getClassLoader(), ClassLoadingStrategy.Default.CHILD_FIRST)
+                .getLoaded()
+                .getDeclaredConstructor(constructor.getParameterTypes())
+                .newInstance(args);
+    }
+
+    public static class SyncThriftClientWithErrorHandler{
+        @RuntimeType
+        public static Object intercept(@This Object targetObject, @SuperCall Callable<?> callable, @Origin Method method) throws TException {
+            try {
+                Object result = callable.call();
+                return result;
+            } catch (Throwable t) {
+                ThriftClient.resolveException(t, (ThriftClient) targetObject);
+                throw new TException(
+                        "Error in calling method " + method.getName() + ", because: " + t.getMessage(), t);
+            }
+        }
+    }
+}

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/sync/SyncThriftClientWithErrorHandler.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/sync/SyncThriftClientWithErrorHandler.java
@@ -21,15 +21,9 @@ package org.apache.iotdb.commons.client.sync;
 
 import org.apache.iotdb.commons.client.ThriftClient;
 
-import net.sf.cglib.proxy.Enhancer;
-import net.sf.cglib.proxy.MethodInterceptor;
-import net.sf.cglib.proxy.MethodProxy;
-import org.apache.thrift.TException;
-
 import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
 
-public class SyncThriftClientWithErrorHandler implements MethodInterceptor {
+public class SyncThriftClientWithErrorHandler {
 
   /**
    * Note: The caller needs to ensure that the constructor corresponds to the class, or the cast
@@ -37,25 +31,7 @@ public class SyncThriftClientWithErrorHandler implements MethodInterceptor {
    */
   @SuppressWarnings("unchecked")
   public static <V extends ThriftClient> V newErrorHandler(
-      Class<V> targetClass, Constructor<V> constructor, Object... args) {
-    Enhancer enhancer = new Enhancer();
-    enhancer.setSuperclass(targetClass);
-    enhancer.setCallback(new SyncThriftClientWithErrorHandler());
-    if (constructor == null) {
-      return (V) enhancer.create();
-    }
-    return (V) enhancer.create(constructor.getParameterTypes(), args);
-  }
-
-  @Override
-  public Object intercept(Object o, Method method, Object[] objects, MethodProxy methodProxy)
-      throws Throwable {
-    try {
-      return methodProxy.invokeSuper(o, objects);
-    } catch (Throwable t) {
-      ThriftClient.resolveException(t, (ThriftClient) o);
-      throw new TException(
-          "Error in calling method " + method.getName() + ", because: " + t.getMessage(), t);
-    }
+      Class<V> targetClass, Constructor<V> constructor, Object... args) throws Exception {
+    return ByteBuddyEnhancer.createProxy(targetClass, constructor, args);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <boost.include.dir/>
         <!-- This was the last version to support Java 8 -->
         <caffeine.version>2.9.3</caffeine.version>
-        <cglib.version>3.3.0</cglib.version>
+        <bytebuddy.version>1.14.19</bytebuddy.version>
         <checker-qual.version>3.38.0</checker-qual.version>
         <cmake.build.type>Release</cmake.build.type>
         <commons-cli.version>1.5.0</commons-cli.version>
@@ -475,9 +475,9 @@
                 <version>${nimbus-jose-jwt.version}</version>
             </dependency>
             <dependency>
-                <groupId>cglib</groupId>
-                <artifactId>cglib</artifactId>
-                <version>${cglib.version}</version>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${bytebuddy.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
The cglib has stopped evolution, The cglib community suggests byte-buddy instead, so we'll do

https://github.com/cglib/cglib

IMPORTANT NOTE: cglib is unmaintained and does not work well (or possibly at all?) in newer JDKs, particularly JDK17+. If you need to support newer JDKs, we will accept well-tested well-thought-out patches... but you'll probably have better luck migrating to something like [ByteBuddy](https://bytebuddy.net/).

_*[https://github.com/raphw/byte-buddy.gi](https://github.com/raphw/byte-buddy.git*_)