### PR TITLE
Add eviction metrics in binary allocator

### DIFF
--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/BinaryAllocator.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/BinaryAllocator.java
@@ -155,10 +155,12 @@ public class BinaryAllocator {
     return metrics;
   }
 
-  private void evict(double ratio) {
+  private int evict(double ratio) {
+    int evictedSize = 0;
     for (Arena arena : heapArenas) {
-      arena.evict(ratio);
+      evictedSize += arena.evict(ratio);
     }
+    return evictedSize;
   }
 
   public static BinaryAllocator getInstance() {
@@ -231,17 +233,19 @@ public class BinaryAllocator {
       return;
     }
 
+    int evictedSize = 0;
     if (curGcTimePercent > SHUTDOWN_GC_TIME_PERCENTAGE) {
       LOGGER.info(
           "Binary allocator is shutting down because of high GC time percentage {}%.",
           curGcTimePercent);
-      evict(1.0);
+      evictedSize = evict(1.0);
       close(false);
     } else if (curGcTimePercent > HALF_GC_TIME_PERCENTAGE) {
-      evict(0.5);
+      evictedSize = evict(0.5);
     } else if (curGcTimePercent > WARNING_GC_TIME_PERCENTAGE) {
-      evict(0.2);
+      evictedSize = evict(0.2);
     }
+    metrics.updateGcEvictionCounter(evictedSize);
   }
 
   public class SampleEvictor extends Evictor {
@@ -252,9 +256,11 @@ public class BinaryAllocator {
 
     @Override
     public void run() {
+      int evictedSize = 0;
       for (Arena arena : heapArenas) {
-        arena.runSampleEviction();
+        evictedSize += arena.runSampleEviction();
       }
+      metrics.updateSampleEvictionCounter(evictedSize);
     }
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/BinaryAllocator.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/BinaryAllocator.java
@@ -155,8 +155,8 @@ public class BinaryAllocator {
     return metrics;
   }
 
-  private int evict(double ratio) {
-    int evictedSize = 0;
+  private long evict(double ratio) {
+    long evictedSize = 0;
     for (Arena arena : heapArenas) {
       evictedSize += arena.evict(ratio);
     }
@@ -233,7 +233,7 @@ public class BinaryAllocator {
       return;
     }
 
-    int evictedSize = 0;
+    long evictedSize = 0;
     if (curGcTimePercent > SHUTDOWN_GC_TIME_PERCENTAGE) {
       LOGGER.info(
           "Binary allocator is shutting down because of high GC time percentage {}%.",
@@ -256,7 +256,7 @@ public class BinaryAllocator {
 
     @Override
     public void run() {
-      int evictedSize = 0;
+      long evictedSize = 0;
       for (Arena arena : heapArenas) {
         evictedSize += arena.runSampleEviction();
       }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/arena/Arena.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/arena/Arena.java
@@ -201,7 +201,7 @@ public class Arena {
     }
 
     private long evict(int num) {
-      int evicted = 0;
+      long evicted = 0;
       while (num > 0 && !queue.isEmpty()) {
         queue.poll();
         evictions.incrementAndGet();

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/metric/BinaryAllocatorMetrics.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/metric/BinaryAllocatorMetrics.java
@@ -123,16 +123,16 @@ public class BinaryAllocatorMetrics implements IMetricSet {
         EVICTED_BY_GC_EVICTION);
   }
 
-  public void updateAllocationCounter(int allocateFromSlabDelta, int allocateFromJVMDelta) {
+  public void updateAllocationCounter(long allocateFromSlabDelta, long allocateFromJVMDelta) {
     allocateFromSlab.inc(allocateFromSlabDelta);
     allocateFromJVM.inc(allocateFromJVMDelta);
   }
 
-  public void updateGcEvictionCounter(int evictedByGcEvictionDelta) {
+  public void updateGcEvictionCounter(long evictedByGcEvictionDelta) {
     evictedByGcEviction.inc(evictedByGcEvictionDelta);
   }
 
-  public void updateSampleEvictionCounter(int evictedBySampleEvictionDelta) {
+  public void updateSampleEvictionCounter(long evictedBySampleEvictionDelta) {
     evictedBySampleEviction.inc(evictedBySampleEvictionDelta);
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/metric/BinaryAllocatorMetrics.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/metric/BinaryAllocatorMetrics.java
@@ -34,10 +34,14 @@ public class BinaryAllocatorMetrics implements IMetricSet {
   private static final String ALLOCATE_FROM_SLAB = "allocate-from-slab";
   private static final String ALLOCATE_FROM_JVM = "allocate-from-jvm";
   private static final String ACTIVE_MEMORY = "active-memory";
+  private static final String EVICTED_BY_SAMPLE_EVICTION = "evicted-by-sample-eviction";
+  private static final String EVICTED_BY_GC_EVICTION = "evicted-by-gc-eviction";
 
   private final BinaryAllocator binaryAllocator;
   private Counter allocateFromSlab;
   private Counter allocateFromJVM;
+  private Counter evictedBySampleEviction;
+  private Counter evictedByGcEviction;
 
   public BinaryAllocatorMetrics(final BinaryAllocator binaryAllocator) {
     this.binaryAllocator = binaryAllocator;
@@ -71,6 +75,18 @@ public class BinaryAllocatorMetrics implements IMetricSet {
             MetricLevel.IMPORTANT,
             Tag.NAME.toString(),
             ALLOCATE_FROM_JVM);
+    evictedBySampleEviction =
+        metricService.getOrCreateCounter(
+            Metric.BINARY_ALLOCATOR.toString(),
+            MetricLevel.IMPORTANT,
+            Tag.NAME.toString(),
+            EVICTED_BY_SAMPLE_EVICTION);
+    evictedByGcEviction =
+        metricService.getOrCreateCounter(
+            Metric.BINARY_ALLOCATOR.toString(),
+            MetricLevel.IMPORTANT,
+            Tag.NAME.toString(),
+            EVICTED_BY_GC_EVICTION);
   }
 
   @Override
@@ -95,10 +111,28 @@ public class BinaryAllocatorMetrics implements IMetricSet {
         Metric.BINARY_ALLOCATOR.toString(),
         Tag.NAME.toString(),
         ALLOCATE_FROM_JVM);
+    metricService.remove(
+        MetricType.COUNTER,
+        Metric.BINARY_ALLOCATOR.toString(),
+        Tag.NAME.toString(),
+        EVICTED_BY_SAMPLE_EVICTION);
+    metricService.remove(
+        MetricType.COUNTER,
+        Metric.BINARY_ALLOCATOR.toString(),
+        Tag.NAME.toString(),
+        EVICTED_BY_GC_EVICTION);
   }
 
-  public void updateCounter(int allocateFromSlabDelta, int allocateFromJVMDelta) {
+  public void updateAllocationCounter(int allocateFromSlabDelta, int allocateFromJVMDelta) {
     allocateFromSlab.inc(allocateFromSlabDelta);
     allocateFromJVM.inc(allocateFromJVMDelta);
+  }
+
+  public void updateGcEvictionCounter(int evictedByGcEvictionDelta) {
+    evictedByGcEviction.inc(evictedByGcEvictionDelta);
+  }
+
+  public void updateSampleEvictionCounter(int evictedBySampleEvictionDelta) {
+    evictedBySampleEviction.inc(evictedBySampleEvictionDelta);
   }
 }


### PR DESCRIPTION
## Description
This PR introduces new metrics to track memory eviction statistics in the Binary Allocator component. The allocator implements two distinct eviction strategies:

Sample-based eviction: Periodically samples memory regions to identify eviction candidates
GC-based eviction: Leverages garbage collection cycles to reclaim unused memory

The primary enhancement is the addition of metrics that monitor the cumulative size of evicted memory through both strategies. These metrics provide visibility into the allocator's memory reclamation behavior and efficiency.