### PR TITLE
Load: Fix Load validation failure when the datapoint's timestamp is at Long's extreme value

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/timeindex/ArrayDeviceTimeIndex.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/timeindex/ArrayDeviceTimeIndex.java
@@ -319,7 +319,7 @@ public class ArrayDeviceTimeIndex implements ITimeIndex {
   @Override
   public void updateStartTime(IDeviceID deviceId, long time) {
     long startTime = getStartTime(deviceId);
-    if (time < startTime) {
+    if (time <= startTime) {
       int index = getDeviceIndex(deviceId);
       startTimes[index] = time;
     }
@@ -329,7 +329,7 @@ public class ArrayDeviceTimeIndex implements ITimeIndex {
   @Override
   public void updateEndTime(IDeviceID deviceId, long time) {
     long endTime = getEndTime(deviceId);
-    if (time > endTime) {
+    if (time >= endTime) {
       int index = getDeviceIndex(deviceId);
       endTimes[index] = time;
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/utils/TsFileResourceUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/utils/TsFileResourceUtils.java
@@ -94,24 +94,6 @@ public class TsFileResourceUtils {
       for (IDeviceID device : devices) {
         long startTime = timeIndex.getStartTime(device);
         long endTime = timeIndex.getEndTime(device);
-        if (startTime == Long.MAX_VALUE) {
-          logger.error(
-              "{} {} the start time of {} is {}",
-              resource.getTsFilePath(),
-              VALIDATE_FAILED,
-              device,
-              Long.MAX_VALUE);
-          return false;
-        }
-        if (endTime == Long.MIN_VALUE) {
-          logger.error(
-              "{} {} the end time of {} is {}",
-              resource.getTsFilePath(),
-              VALIDATE_FAILED,
-              device,
-              Long.MIN_VALUE);
-          return false;
-        }
         if (startTime > endTime) {
           logger.error(
               "{} {} the start time of {} is greater than end time",

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/TsFileValidationCorrectnessTests.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/TsFileValidationCorrectnessTests.java
@@ -182,8 +182,8 @@ public class TsFileValidationCorrectnessTests {
       writer.endChunkGroup();
       writer.endFile();
     }
-    tsFileResource.updateStartTime(IDeviceID.Factory.DEFAULT_FACTORY.create("d1"), 1);
-    tsFileResource.updateEndTime(IDeviceID.Factory.DEFAULT_FACTORY.create("d1"), 3);
+    tsFileResource.updateStartTime(IDeviceID.Factory.DEFAULT_FACTORY.create("root.testsg.d1"), 1);
+    tsFileResource.updateEndTime(IDeviceID.Factory.DEFAULT_FACTORY.create("root.testsg.d1"), 3);
     tsFileResource.serialize();
     boolean success = TsFileValidator.getInstance().validateTsFile(tsFileResource);
     Assert.assertTrue(success);
@@ -200,8 +200,8 @@ public class TsFileValidationCorrectnessTests {
         TSEncoding.PLAIN,
         CompressionType.SNAPPY,
         path);
-    tsFileResource.updateStartTime(IDeviceID.Factory.DEFAULT_FACTORY.create("d1"), 1);
-    tsFileResource.updateEndTime(IDeviceID.Factory.DEFAULT_FACTORY.create("d1"), 100);
+    tsFileResource.updateStartTime(IDeviceID.Factory.DEFAULT_FACTORY.create("root.testsg.d1"), 1);
+    tsFileResource.updateEndTime(IDeviceID.Factory.DEFAULT_FACTORY.create("root.testsg.d1"), 100);
     tsFileResource.serialize();
     boolean success = TsFileValidator.getInstance().validateTsFile(tsFileResource);
     Assert.assertTrue(success);
@@ -218,8 +218,8 @@ public class TsFileValidationCorrectnessTests {
         TSEncoding.PLAIN,
         CompressionType.SNAPPY,
         path);
-    tsFileResource.updateStartTime(IDeviceID.Factory.DEFAULT_FACTORY.create("d1"), 1);
-    tsFileResource.updateEndTime(IDeviceID.Factory.DEFAULT_FACTORY.create("d1"), 110);
+    tsFileResource.updateStartTime(IDeviceID.Factory.DEFAULT_FACTORY.create("root.testsg.d1"), 1);
+    tsFileResource.updateEndTime(IDeviceID.Factory.DEFAULT_FACTORY.create("root.testsg.d1"), 110);
     tsFileResource.serialize();
     boolean success = TsFileValidator.getInstance().validateTsFile(tsFileResource);
     Assert.assertTrue(success);
@@ -289,8 +289,8 @@ public class TsFileValidationCorrectnessTests {
       writer.endChunkGroup();
       writer.endFile();
     }
-    tsFileResource.updateStartTime(IDeviceID.Factory.DEFAULT_FACTORY.create("d1"), 1);
-    tsFileResource.updateEndTime(IDeviceID.Factory.DEFAULT_FACTORY.create("d1"), 3);
+    tsFileResource.updateStartTime(IDeviceID.Factory.DEFAULT_FACTORY.create("root.testsg.d1"), 1);
+    tsFileResource.updateEndTime(IDeviceID.Factory.DEFAULT_FACTORY.create("root.testsg.d1"), 3);
     tsFileResource.serialize();
     boolean success = TsFileValidator.getInstance().validateTsFile(tsFileResource);
     Assert.assertTrue(success);
@@ -317,8 +317,8 @@ public class TsFileValidationCorrectnessTests {
       writer.endChunkGroup();
       writer.endFile();
     }
-    tsFileResource.updateStartTime(IDeviceID.Factory.DEFAULT_FACTORY.create("d1"), 1);
-    tsFileResource.updateEndTime(IDeviceID.Factory.DEFAULT_FACTORY.create("d1"), 3);
+    tsFileResource.updateStartTime(IDeviceID.Factory.DEFAULT_FACTORY.create("root.testsg.d1"), 1);
+    tsFileResource.updateEndTime(IDeviceID.Factory.DEFAULT_FACTORY.create("root.testsg.d1"), 3);
     tsFileResource.serialize();
     tsFileResource.remove();
     Assert.assertTrue(TsFileValidator.getInstance().validateTsFile(tsFileResource));


### PR DESCRIPTION
## Description
Remove the validation check for `startTime` and `endTime` against `Long.MAX_VALUE/MIN_VALUE` during the validation phase