### PR TITLE
Fix ratis byte limit configuration too small

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/utils/Utils.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/utils/Utils.java
@@ -310,7 +310,8 @@ public class Utils {
         properties, RaftServerConfigKeys.Log.CorruptionPolicy.WARN_AND_RETURN);
 
     RaftServerConfigKeys.Write.setByteLimit(
-        properties, config.getLeaderLogAppender().getBufferByteLimit());
+        properties,
+        SizeInBytes.valueOf(config.getLeaderLogAppender().getBufferByteLimit().getSize() * 10));
 
     RaftServerConfigKeys.Log.setQueueByteLimit(
         properties, config.getLeaderLogAppender().getBufferByteLimit());


### PR DESCRIPTION
The current default speed limit for Ratis writes is 16MB, which is the same size as the bytebuffer, which is unreasonable. We should make it ten times bigger