### PR TITLE
[IOTDB-6355] Fix query scan will return duplicated timestamp or unordered timestamp while TsFileResource degrading

### DIFF
--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppCommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppCommonConfig.java
@@ -508,6 +508,12 @@ public class MppCommonConfig extends MppBaseConfig implements CommonConfig {
     return this;
   }
 
+  @Override
+  public CommonConfig setQueryMemoryProportion(String queryMemoryProportion) {
+    setProperty("chunk_timeseriesmeta_free_memory_proportion", queryMemoryProportion);
+    return this;
+  }
+
   // For part of the log directory
   public String getClusterConfigStr() {
     return fromConsensusFullNameToAbbr(properties.getProperty(CONFIG_NODE_CONSENSUS_PROTOCOL_CLASS))

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppSharedCommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppSharedCommonConfig.java
@@ -519,4 +519,11 @@ public class MppSharedCommonConfig implements CommonConfig {
     cnConfig.setPipeConnectorRequestSliceThresholdBytes(pipeConnectorRequestSliceThresholdBytes);
     return this;
   }
+
+  @Override
+  public CommonConfig setQueryMemoryProportion(String queryMemoryProportion) {
+    dnConfig.setQueryMemoryProportion(queryMemoryProportion);
+    cnConfig.setQueryMemoryProportion(queryMemoryProportion);
+    return this;
+  }
 }

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/remote/config/RemoteCommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/remote/config/RemoteCommonConfig.java
@@ -365,4 +365,9 @@ public class RemoteCommonConfig implements CommonConfig {
       int pipeConnectorRequestSliceThresholdBytes) {
     return this;
   }
+
+  @Override
+  public CommonConfig setQueryMemoryProportion(String queryMemoryProportion) {
+    return this;
+  }
 }

--- a/integration-test/src/main/java/org/apache/iotdb/itbase/env/CommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/itbase/env/CommonConfig.java
@@ -161,4 +161,6 @@ public interface CommonConfig {
 
   CommonConfig setPipeConnectorRequestSliceThresholdBytes(
       int pipeConnectorRequestSliceThresholdBytes);
+
+  CommonConfig setQueryMemoryProportion(String queryMemoryProportion);
 }

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBFileTimeIndexIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBFileTimeIndexIT.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.it;
+
+import org.apache.iotdb.it.env.EnvFactory;
+import org.apache.iotdb.it.framework.IoTDBTestRunner;
+import org.apache.iotdb.itbase.category.ClusterIT;
+import org.apache.iotdb.itbase.category.LocalStandaloneIT;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@RunWith(IoTDBTestRunner.class)
+@Category({LocalStandaloneIT.class, ClusterIT.class})
+public class IoTDBFileTimeIndexIT {
+
+  private static final String[] sqls =
+      new String[] {
+        "insert into root.db.d1(time,s1) values(2,2)",
+        "insert into root.db.d1(time,s1) values(3,3)",
+        "flush",
+        "insert into root.db.d2(time,s1) values(5,5)",
+        "flush",
+        "insert into root.db.d1(time,s1) values(4,4)",
+        "flush",
+        "insert into root.db.d2(time,s1) values(1,1)",
+        "insert into root.db.d1(time,s1) values(3,30)",
+        "insert into root.db.d1(time,s1) values(4,40)",
+        "flush",
+        "insert into root.db.d2(time,s1) values(2,2)",
+        "insert into root.db.d1(time,s1) values(4,400)",
+        "flush",
+      };
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    Locale.setDefault(Locale.ENGLISH);
+
+    EnvFactory.getEnv()
+        .getConfig()
+        .getCommonConfig()
+        .setDataRegionGroupExtensionPolicy("CUSTOM")
+        .setDefaultDataRegionGroupNumPerDatabase(1)
+        .setEnableSeqSpaceCompaction(false)
+        .setEnableUnseqSpaceCompaction(false)
+        .setEnableCrossSpaceCompaction(false)
+        .setQueryMemoryProportion("1:100:200:50:200:200:0:250");
+    // Adjust memstable threshold size to make it flush automatically
+    EnvFactory.getEnv().initClusterEnvironment();
+    prepareData();
+  }
+
+  private static void prepareData() {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+
+      for (String sql : sqls) {
+        statement.addBatch(sql);
+      }
+      statement.executeBatch();
+    } catch (Exception e) {
+      fail(e.getMessage());
+    }
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  @Test
+  public void testQuery() throws SQLException {
+    long[] time = {2L, 3L, 4L};
+    double[] value = {2.0f, 30.0f, 400.0f};
+
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery("select s1 from root.db.d1")) {
+      int cnt = 0;
+      while (resultSet.next()) {
+        assertEquals(time[cnt], resultSet.getLong(1));
+        assertEquals(value[cnt], resultSet.getDouble(2), 0.00001);
+        cnt++;
+      }
+      assertEquals(time.length, cnt);
+    }
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
@@ -601,7 +601,17 @@ public class TsFileResource implements PersistentResource {
     }
   }
 
-  public long getOrderTime(IDeviceID deviceId, boolean ascending) {
+  // cannot use FileTimeIndex
+  public long getOrderTimeForSeq(IDeviceID deviceId, boolean ascending) {
+    if (timeIndex instanceof ArrayDeviceTimeIndex) {
+      return ascending ? getStartTime(deviceId) : getEndTime(deviceId);
+    } else {
+      return ascending ? Long.MIN_VALUE : Long.MAX_VALUE;
+    }
+  }
+
+  // can use FileTimeIndex
+  public long getOrderTimeForUnseq(IDeviceID deviceId, boolean ascending) {
     return ascending ? getStartTime(deviceId) : getEndTime(deviceId);
   }
 


### PR DESCRIPTION
Assuming that we have the following file distribution, and all the files shown have been degraded to FileTimeIndex:
![image](https://github.com/user-attachments/assets/97485e4a-9d53-4c31-88cb-dd6b9a140a6d)

While we do scanning, we will firstly unpack the frist seq file and the first and second unseq file, then while we merge on read, we will continue to get timestamp 4, then we using startTime of the second seq time which is 5 to judge whether it's overlapped with timestamp 4. 5 is larger than 4, so we think that the second seq tsfile isn't overlapped with timestamp 4, and as it's in seq space, so we mistakenly assumend that none of the subsequent files would overlap with timestamp 4.

The above processing is correct while there doesn't exist degraded resource in seq space, however while exsiting degraded resource in seq space, if current seq tsfile's startTime is larger than the current timestamp, we cannot conclude that the startTime of subsequent seq tsfiles are all larger than current timestamp.

The solution is that we will return Long.MIN_VALUE for FileTimeIndex in seq space which means that all the degraded seq resources will be unpacked anyway. And then we can use the TimeSeriesMetadata to further precisely judge we need to stop searching:
```
asc: if timeseries metadata of current seq tsfile's endTime >= endpointTime, we don't need to continue
desc: if timeseries metadata of current seq tsfile's startTime <= endpointTime, we don't need to continue
```