### PR TITLE
[To dev/1.3] Subscription: allow generate subsequent events with the same tablet batch to avoid large message & improve poll logic to avoid unnecessary nack (#14452)

### DIFF
--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/subscription/consumer/SubscriptionConsumer.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/subscription/consumer/SubscriptionConsumer.java
@@ -610,7 +610,8 @@ abstract class SubscriptionConsumer implements AutoCloseable {
                         LOGGER.warn("unexpected response type: {}", responseType);
                         return Optional.empty();
                       })
-                  .apply(response, timer)
+                  // TODO: reuse previous timer?
+                  .apply(response, new PollTimer(System.currentTimeMillis(), timeoutMs))
                   .ifPresent(currentMessages::add);
             } catch (final SubscriptionRuntimeNonCriticalException e) {
               LOGGER.warn(

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/subscription/consumer/SubscriptionPullConsumer.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/subscription/consumer/SubscriptionPullConsumer.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.session.subscription.consumer;
 import org.apache.iotdb.rpc.subscription.config.ConsumerConstant;
 import org.apache.iotdb.rpc.subscription.exception.SubscriptionException;
 import org.apache.iotdb.session.subscription.payload.SubscriptionMessage;
+import org.apache.iotdb.session.subscription.util.CollectionUtils;
 import org.apache.iotdb.session.subscription.util.IdentifierUtils;
 
 import org.slf4j.Logger;
@@ -180,7 +181,7 @@ public class SubscriptionPullConsumer extends SubscriptionConsumer {
       LOGGER.info(
           "SubscriptionPullConsumer {} poll empty message from topics {} after {} millisecond(s)",
           this,
-          parsedTopicNames,
+          CollectionUtils.getLimitedString(parsedTopicNames, 32),
           timeoutMs);
       return messages;
     }

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/subscription/consumer/SubscriptionPushConsumer.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/subscription/consumer/SubscriptionPushConsumer.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.session.subscription.consumer;
 import org.apache.iotdb.rpc.subscription.config.ConsumerConstant;
 import org.apache.iotdb.rpc.subscription.exception.SubscriptionException;
 import org.apache.iotdb.session.subscription.payload.SubscriptionMessage;
+import org.apache.iotdb.session.subscription.util.CollectionUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -178,7 +179,7 @@ public class SubscriptionPushConsumer extends SubscriptionConsumer {
           LOGGER.info(
               "SubscriptionPushConsumer {} poll empty message from topics {} after {} millisecond(s)",
               this,
-              subscribedTopics.keySet(),
+              CollectionUtils.getLimitedString(subscribedTopics.keySet(), 32),
               autoPollTimeoutMs);
           return;
         }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/connector/PipeConnectorSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/connector/PipeConnectorSubtask.java
@@ -202,7 +202,7 @@ public class PipeConnectorSubtask extends PipeAbstractConnectorSubtask {
       final long startTime = System.currentTimeMillis();
       outputPipeConnector.close();
       LOGGER.info(
-          "Pipe: connector subtask {} was closed {} within {} ms",
+          "Pipe: connector subtask {} ({}) was closed within {} ms",
           taskID,
           outputPipeConnector,
           System.currentTimeMillis() - startTime);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingQueue.java
@@ -26,7 +26,6 @@ import org.apache.iotdb.db.pipe.agent.PipeDataNodeAgent;
 import org.apache.iotdb.db.pipe.agent.task.execution.PipeSubtaskExecutorManager;
 import org.apache.iotdb.db.pipe.event.UserDefinedEnrichedEvent;
 import org.apache.iotdb.db.pipe.event.common.terminate.PipeTerminateEvent;
-import org.apache.iotdb.db.pipe.event.common.tsfile.PipeTsFileInsertionEvent;
 import org.apache.iotdb.db.subscription.agent.SubscriptionAgent;
 import org.apache.iotdb.db.subscription.event.SubscriptionEvent;
 import org.apache.iotdb.db.subscription.event.batch.SubscriptionPipeEventBatches;
@@ -343,8 +342,8 @@ public abstract class SubscriptionPrefetchingQueue {
         continue;
       }
 
-      if (event instanceof PipeTsFileInsertionEvent) {
-        if (onEvent((PipeTsFileInsertionEvent) event)) {
+      if (event instanceof TsFileInsertionEvent) {
+        if (onEvent((TsFileInsertionEvent) event)) {
           return;
         }
         continue;
@@ -448,7 +447,7 @@ public abstract class SubscriptionPrefetchingQueue {
                 this);
           }
 
-          ev.ack();
+          ev.ack(this::enqueueEventToPrefetchingQueue);
           ev.recordCommittedTimestamp(); // now committed
           acked.set(true);
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/SubscriptionCommitContextSupplier.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/SubscriptionCommitContextSupplier.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.subscription.event;
+
+import org.apache.iotdb.rpc.subscription.payload.poll.SubscriptionCommitContext;
+
+@FunctionalInterface
+public interface SubscriptionCommitContextSupplier {
+
+  SubscriptionCommitContext get();
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/response/SubscriptionEventExtendableResponse.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/response/SubscriptionEventExtendableResponse.java
@@ -22,9 +22,6 @@ package org.apache.iotdb.db.subscription.event.response;
 import org.apache.iotdb.db.subscription.event.cache.CachedSubscriptionPollResponse;
 import org.apache.iotdb.db.subscription.event.cache.SubscriptionPollResponseCache;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Deque;
@@ -41,9 +38,6 @@ import java.util.concurrent.ConcurrentLinkedDeque;
  */
 public abstract class SubscriptionEventExtendableResponse
     implements SubscriptionEventResponse<CachedSubscriptionPollResponse> {
-
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(SubscriptionEventTabletResponse.class);
 
   private final Deque<CachedSubscriptionPollResponse> responses;
   protected volatile boolean hasNoMore = false;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/response/SubscriptionEventResponse.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/response/SubscriptionEventResponse.java
@@ -19,8 +19,11 @@
 
 package org.apache.iotdb.db.subscription.event.response;
 
+import org.apache.iotdb.db.subscription.event.SubscriptionEvent;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.function.Consumer;
 
 public interface SubscriptionEventResponse<E> {
 
@@ -43,6 +46,10 @@ public interface SubscriptionEventResponse<E> {
   void invalidateCurrentResponseByteBuffer();
 
   /////////////////////////////// lifecycle ///////////////////////////////
+
+  default void ack(final Consumer<SubscriptionEvent> onCommittedHook) {
+    // do nothing
+  }
 
   void nack();
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/receiver/SubscriptionReceiverV1.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/receiver/SubscriptionReceiverV1.java
@@ -89,7 +89,7 @@ public class SubscriptionReceiverV1 implements SubscriptionReceiver {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SubscriptionReceiverV1.class);
 
-  private static final double POLL_PAYLOAD_SIZE_EXCEED_THRESHOLD = 0.95;
+  private static final double POLL_PAYLOAD_SIZE_EXCEED_THRESHOLD = 0.9;
 
   private static final IClientManager<ConfigRegionId, ConfigNodeClient> CONFIG_NODE_CLIENT_MANAGER =
       ConfigNodeClientManager.getInstance();


### PR DESCRIPTION
cherry-pick #14452 to https://github.com/apache/iotdb/tree/dev/1.3