### PR TITLE
[RatisConsensus] enforce the newly added peer have different endpoint

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -555,6 +555,13 @@ class RatisConsensus implements IConsensus {
       throw new PeerAlreadyInConsensusGroupException(groupId, peer);
     }
 
+    // pre-condition: peer should not have same ip address with any member already in the group
+    if (group.getPeers().stream()
+        .anyMatch(
+            p -> Utils.fromRaftPeerAddressToTEndPoint(p.getAddress()).equals(peer.getEndpoint()))) {
+      throw new PeerAlreadyInConsensusGroupException(groupId, peer);
+    }
+
     List<RaftPeer> newConfig = new ArrayList<>(group.getPeers());
     newConfig.add(peerToAdd);
 


### PR DESCRIPTION
Enforce the user to use RatisConsensus correctly.