### PR TITLE
[remove datanode] Remove LoadScore sort to fix RegionPriority order

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/LoadManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/LoadManager.java
@@ -220,15 +220,6 @@ public class LoadManager {
   }
 
   /**
-   * Get the loadScore of each DataNode.
-   *
-   * @return Map<DataNodeId, loadScore>
-   */
-  public Map<Integer, Long> getAllDataNodeLoadScores() {
-    return loadCache.getAllDataNodeLoadScores();
-  }
-
-  /**
    * Get the lowest loadScore DataNode.
    *
    * @return The index of the lowest loadScore DataNode. -1 if no DataNode heartbeat received.

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/RouteBalancer.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/RouteBalancer.java
@@ -296,20 +296,17 @@ public class RouteBalancer implements IClusterStatusSubscriber {
         new TreeMap<>();
     try {
       Map<TConsensusGroupId, Integer> regionLeaderMap = getLoadManager().getRegionLeaderMap();
-      Map<Integer, Long> dataNodeLoadScoreMap = getLoadManager().getAllDataNodeLoadScores();
 
       // Balancing region priority in each SchemaRegionGroup
       Map<TConsensusGroupId, TRegionReplicaSet> optimalRegionPriorityMap =
           priorityRouter.generateOptimalRoutePriority(
               getPartitionManager().getAllReplicaSets(TConsensusGroupType.SchemaRegion),
-              regionLeaderMap,
-              dataNodeLoadScoreMap);
+              regionLeaderMap);
       // Balancing region priority in each DataRegionGroup
       optimalRegionPriorityMap.putAll(
           priorityRouter.generateOptimalRoutePriority(
               getPartitionManager().getAllReplicaSets(TConsensusGroupType.DataRegion),
-              regionLeaderMap,
-              dataNodeLoadScoreMap));
+              regionLeaderMap));
 
       optimalRegionPriorityMap.forEach(
           (regionGroupId, optimalRegionPriority) -> {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/router/priority/GreedyPriorityBalancer.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/router/priority/GreedyPriorityBalancer.java
@@ -39,17 +39,13 @@ public class GreedyPriorityBalancer implements IPriorityBalancer {
 
   @Override
   public Map<TConsensusGroupId, TRegionReplicaSet> generateOptimalRoutePriority(
-      List<TRegionReplicaSet> replicaSets,
-      Map<TConsensusGroupId, Integer> regionLeaderMap,
-      Map<Integer, Long> dataNodeLoadScoreMap) {
+      List<TRegionReplicaSet> replicaSets, Map<TConsensusGroupId, Integer> regionLeaderMap) {
 
     Map<TConsensusGroupId, TRegionReplicaSet> regionPriorityMap = new TreeMap<>();
 
     replicaSets.forEach(
         replicaSet -> {
-          TRegionReplicaSet sortedReplicaSet =
-              sortReplicasByLoadScore(replicaSet, dataNodeLoadScoreMap);
-          regionPriorityMap.put(sortedReplicaSet.getRegionId(), sortedReplicaSet);
+          regionPriorityMap.put(replicaSet.getRegionId(), replicaSet);
         });
 
     return regionPriorityMap;

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/router/priority/GreedyPriorityBalancer.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/router/priority/GreedyPriorityBalancer.java
@@ -19,16 +19,11 @@
 package org.apache.iotdb.confignode.manager.load.balancer.router.priority;
 
 import org.apache.iotdb.common.rpc.thrift.TConsensusGroupId;
-import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 
-import org.apache.tsfile.utils.Pair;
-
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.Vector;
 
 /** The GreedyPriorityBalancer always pick the Replica with the lowest loadScore */
 public class GreedyPriorityBalancer implements IPriorityBalancer {
@@ -49,34 +44,5 @@ public class GreedyPriorityBalancer implements IPriorityBalancer {
         });
 
     return regionPriorityMap;
-  }
-
-  protected static TRegionReplicaSet sortReplicasByLoadScore(
-      TRegionReplicaSet replicaSet, Map<Integer, Long> dataNodeLoadScoreMap) {
-    TRegionReplicaSet sortedReplicaSet = new TRegionReplicaSet();
-    sortedReplicaSet.setRegionId(replicaSet.getRegionId());
-
-    // List<Pair<loadScore, TDataNodeLocation>> for sorting
-    List<Pair<Long, TDataNodeLocation>> sortList = new Vector<>();
-    replicaSet
-        .getDataNodeLocations()
-        .forEach(
-            dataNodeLocation -> {
-              // The absenteeism of loadScoreMap means ConfigNode-leader doesn't receive any
-              // heartbeat from that DataNode.
-              // In this case we put a maximum loadScore into the sortList.
-              sortList.add(
-                  new Pair<>(
-                      dataNodeLoadScoreMap.computeIfAbsent(
-                          dataNodeLocation.getDataNodeId(), empty -> Long.MAX_VALUE),
-                      dataNodeLocation));
-            });
-
-    sortList.sort(Comparator.comparingLong(Pair::getLeft));
-    for (Pair<Long, TDataNodeLocation> entry : sortList) {
-      sortedReplicaSet.addToDataNodeLocations(entry.getRight());
-    }
-
-    return sortedReplicaSet;
   }
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/router/priority/IPriorityBalancer.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/router/priority/IPriorityBalancer.java
@@ -34,12 +34,9 @@ public interface IPriorityBalancer {
    *
    * @param replicaSets All RegionGroups
    * @param regionLeaderMap The current leader of each RegionGroup
-   * @param dataNodeLoadScoreMap The current load score of each DataNode
    * @return Map<TConsensusGroupId, TRegionReplicaSet>, The optimal route priority for each
    *     RegionGroup. The replica with higher sorting result have higher priority.
    */
   Map<TConsensusGroupId, TRegionReplicaSet> generateOptimalRoutePriority(
-      List<TRegionReplicaSet> replicaSets,
-      Map<TConsensusGroupId, Integer> regionLeaderMap,
-      Map<Integer, Long> dataNodeLoadScoreMap);
+      List<TRegionReplicaSet> replicaSets, Map<TConsensusGroupId, Integer> regionLeaderMap);
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/router/priority/LeaderPriorityBalancer.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/router/priority/LeaderPriorityBalancer.java
@@ -35,10 +35,7 @@ public class LeaderPriorityBalancer extends GreedyPriorityBalancer implements IP
 
   @Override
   public Map<TConsensusGroupId, TRegionReplicaSet> generateOptimalRoutePriority(
-      List<TRegionReplicaSet> replicaSets,
-      Map<TConsensusGroupId, Integer> regionLeaderMap,
-      Map<Integer, Long> dataNodeLoadScoreMap) {
-
+      List<TRegionReplicaSet> replicaSets, Map<TConsensusGroupId, Integer> regionLeaderMap) {
     Map<TConsensusGroupId, TRegionReplicaSet> regionPriorityMap = new TreeMap<>();
 
     replicaSets.forEach(

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/router/priority/LeaderPriorityBalancer.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/router/priority/LeaderPriorityBalancer.java
@@ -43,23 +43,19 @@ public class LeaderPriorityBalancer extends GreedyPriorityBalancer implements IP
 
     replicaSets.forEach(
         replicaSet -> {
-          /* 1. Sort replicaSet by loadScore */
-          TRegionReplicaSet sortedReplicaSet =
-              sortReplicasByLoadScore(replicaSet, dataNodeLoadScoreMap);
 
-          /* 2. Pick leader if leader exists and available */
+          /* 1. Pick leader if leader exists and available */
           int leaderId = regionLeaderMap.getOrDefault(replicaSet.getRegionId(), -1);
-          if (leaderId != -1
-              && dataNodeLoadScoreMap.getOrDefault(leaderId, Long.MAX_VALUE) < Long.MAX_VALUE) {
-            for (int i = 0; i < sortedReplicaSet.getDataNodeLocationsSize(); i++) {
-              if (sortedReplicaSet.getDataNodeLocations().get(i).getDataNodeId() == leaderId) {
-                Collections.swap(sortedReplicaSet.getDataNodeLocations(), 0, i);
+          if (leaderId != -1) {
+            for (int i = 0; i < replicaSet.getDataNodeLocationsSize(); i++) {
+              if (replicaSet.getDataNodeLocations().get(i).getDataNodeId() == leaderId) {
+                Collections.swap(replicaSet.getDataNodeLocations(), 0, i);
                 break;
               }
             }
           }
 
-          regionPriorityMap.put(sortedReplicaSet.getRegionId(), sortedReplicaSet);
+          regionPriorityMap.put(replicaSet.getRegionId(), replicaSet);
         });
 
     return regionPriorityMap;

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/LoadCache.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/LoadCache.java
@@ -551,22 +551,6 @@ public class LoadCache {
   }
 
   /**
-   * Get the loadScore of each DataNode.
-   *
-   * @return Map<DataNodeId, loadScore>
-   */
-  public Map<Integer, Long> getAllDataNodeLoadScores() {
-    Map<Integer, Long> result = new ConcurrentHashMap<>();
-    nodeCacheMap.forEach(
-        (dataNodeId, heartbeatCache) -> {
-          if (heartbeatCache instanceof DataNodeHeartbeatCache) {
-            result.put(dataNodeId, heartbeatCache.getLoadScore());
-          }
-        });
-    return result;
-  }
-
-  /**
    * Get the lowest loadScore DataNode.
    *
    * @return The index of the lowest loadScore DataNode. -1 if no DataNode heartbeat received.

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/load/balancer/router/priority/GreedyPriorityTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/load/balancer/router/priority/GreedyPriorityTest.java
@@ -90,7 +90,7 @@ public class GreedyPriorityTest {
     }
 
     TRegionReplicaSet result2 = result.get(groupId2);
-    for (int i = 3; i < 4; i++) {
+    for (int i = 2; i < 4; i++) {
       Assert.assertEquals(dataNodeLocations.get(i), result2.getDataNodeLocations().get(i - 2));
     }
   }

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/load/balancer/router/priority/GreedyPriorityTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/load/balancer/router/priority/GreedyPriorityTest.java
@@ -36,7 +36,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class GreedyPriorityTest {
 
@@ -68,17 +67,11 @@ public class GreedyPriorityTest {
     }
     nodeCacheMap.values().forEach(baseNodeCache -> baseNodeCache.updateCurrentStatistics(false));
 
-    /* Get the loadScoreMap */
-    Map<Integer, Long> loadScoreMap = new ConcurrentHashMap<>();
-    nodeCacheMap.forEach(
-        (dataNodeId, heartbeatCache) ->
-            loadScoreMap.put(dataNodeId, heartbeatCache.getLoadScore()));
-
     /* Build TRegionReplicaSet */
     TConsensusGroupId groupId1 = new TConsensusGroupId(TConsensusGroupType.SchemaRegion, 1);
     TRegionReplicaSet regionReplicaSet1 =
         new TRegionReplicaSet(
-            groupId1, Arrays.asList(dataNodeLocations.get(1), dataNodeLocations.get(0)));
+            groupId1, Arrays.asList(dataNodeLocations.get(0), dataNodeLocations.get(1)));
     TConsensusGroupId groupId2 = new TConsensusGroupId(TConsensusGroupType.DataRegion, 2);
     TRegionReplicaSet regionReplicaSet2 =
         new TRegionReplicaSet(
@@ -88,7 +81,7 @@ public class GreedyPriorityTest {
     Map<TConsensusGroupId, TRegionReplicaSet> result =
         new GreedyPriorityBalancer()
             .generateOptimalRoutePriority(
-                Arrays.asList(regionReplicaSet1, regionReplicaSet2), new HashMap<>(), loadScoreMap);
+                Arrays.asList(regionReplicaSet1, regionReplicaSet2), new HashMap<>());
     Assert.assertEquals(2, result.size());
 
     TRegionReplicaSet result1 = result.get(groupId1);

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/load/balancer/router/priority/LeaderPriorityBalancerTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/load/balancer/router/priority/LeaderPriorityBalancerTest.java
@@ -33,7 +33,6 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -74,13 +73,13 @@ public class LeaderPriorityBalancerTest {
         new TRegionReplicaSet(
             groupId1,
             Arrays.asList(
-                dataNodeLocations.get(2), dataNodeLocations.get(1), dataNodeLocations.get(0)));
+                dataNodeLocations.get(0), dataNodeLocations.get(1), dataNodeLocations.get(2)));
     TConsensusGroupId groupId2 = new TConsensusGroupId(TConsensusGroupType.DataRegion, 2);
     TRegionReplicaSet regionReplicaSet2 =
         new TRegionReplicaSet(
             groupId2,
             Arrays.asList(
-                dataNodeLocations.get(5), dataNodeLocations.get(4), dataNodeLocations.get(3)));
+                dataNodeLocations.get(3), dataNodeLocations.get(4), dataNodeLocations.get(5)));
     List<TRegionReplicaSet> regionReplicaSets = Arrays.asList(regionReplicaSet1, regionReplicaSet2);
 
     // Build leaderMap
@@ -94,52 +93,12 @@ public class LeaderPriorityBalancerTest {
     TRegionReplicaSet result1 = result.get(groupId1);
     // Leader first
     Assert.assertEquals(dataNodeLocations.get(1), result1.getDataNodeLocations().get(0));
-    Assert.assertEquals(dataNodeLocations.get(2), result1.getDataNodeLocations().get(1));
-    Assert.assertEquals(dataNodeLocations.get(0), result1.getDataNodeLocations().get(2));
+    Assert.assertEquals(dataNodeLocations.get(0), result1.getDataNodeLocations().get(1));
+    Assert.assertEquals(dataNodeLocations.get(2), result1.getDataNodeLocations().get(2));
     TRegionReplicaSet result2 = result.get(groupId2);
     // Leader first
     Assert.assertEquals(dataNodeLocations.get(4), result2.getDataNodeLocations().get(0));
-    Assert.assertEquals(dataNodeLocations.get(5), result2.getDataNodeLocations().get(1));
-    Assert.assertEquals(dataNodeLocations.get(3), result2.getDataNodeLocations().get(2));
-  }
-
-  @Test
-  public void testLeaderUnavailable() {
-    // Build TDataNodeLocations
-    List<TDataNodeLocation> dataNodeLocations = new ArrayList<>();
-    for (int i = 0; i < 3; i++) {
-      dataNodeLocations.add(
-          new TDataNodeLocation(
-              i,
-              new TEndPoint("0.0.0.0", 6667 + i),
-              new TEndPoint("0.0.0.0", 10730 + i),
-              new TEndPoint("0.0.0.0", 10740 + i),
-              new TEndPoint("0.0.0.0", 10760 + i),
-              new TEndPoint("0.0.0.0", 10750 + i)));
-    }
-
-    // Build TRegionReplicaSet
-    TConsensusGroupId groupId1 = new TConsensusGroupId(TConsensusGroupType.SchemaRegion, 1);
-    TRegionReplicaSet regionReplicaSet1 =
-        new TRegionReplicaSet(
-            groupId1,
-            Arrays.asList(
-                dataNodeLocations.get(2), dataNodeLocations.get(1), dataNodeLocations.get(0)));
-
-    // Build leaderMap
-    Map<TConsensusGroupId, Integer> leaderMap = new HashMap<>();
-    leaderMap.put(groupId1, 1);
-
-    // Check result
-    Map<TConsensusGroupId, TRegionReplicaSet> result =
-        new LeaderPriorityBalancer()
-            .generateOptimalRoutePriority(Collections.singletonList(regionReplicaSet1), leaderMap);
-    // Not sorted since the leader is unavailable
-    Assert.assertEquals(
-        dataNodeLocations.get(1), result.get(groupId1).getDataNodeLocations().get(0));
-    Assert.assertEquals(
-        dataNodeLocations.get(2), result.get(groupId1).getDataNodeLocations().get(1));
-    Assert.assertEquals(
-        dataNodeLocations.get(0), result.get(groupId1).getDataNodeLocations().get(2));
+    Assert.assertEquals(dataNodeLocations.get(3), result2.getDataNodeLocations().get(1));
+    Assert.assertEquals(dataNodeLocations.get(5), result2.getDataNodeLocations().get(2));
   }
 }

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/load/balancer/router/priority/LeaderPriorityBalancerTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/load/balancer/router/priority/LeaderPriorityBalancerTest.java
@@ -37,7 +37,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class LeaderPriorityBalancerTest {
 
@@ -69,12 +68,6 @@ public class LeaderPriorityBalancerTest {
     }
     nodeCacheMap.values().forEach(baseNodeCache -> baseNodeCache.updateCurrentStatistics(false));
 
-    // Get the loadScoreMap
-    Map<Integer, Long> loadScoreMap = new ConcurrentHashMap<>();
-    nodeCacheMap.forEach(
-        (dataNodeId, heartbeatCache) ->
-            loadScoreMap.put(dataNodeId, heartbeatCache.getLoadScore()));
-
     // Build TRegionReplicaSet
     TConsensusGroupId groupId1 = new TConsensusGroupId(TConsensusGroupType.SchemaRegion, 1);
     TRegionReplicaSet regionReplicaSet1 =
@@ -97,20 +90,17 @@ public class LeaderPriorityBalancerTest {
 
     // Check result
     Map<TConsensusGroupId, TRegionReplicaSet> result =
-        new LeaderPriorityBalancer()
-            .generateOptimalRoutePriority(regionReplicaSets, leaderMap, loadScoreMap);
+        new LeaderPriorityBalancer().generateOptimalRoutePriority(regionReplicaSets, leaderMap);
     TRegionReplicaSet result1 = result.get(groupId1);
     // Leader first
     Assert.assertEquals(dataNodeLocations.get(1), result1.getDataNodeLocations().get(0));
-    // The others will be sorted by loadScore
-    Assert.assertEquals(dataNodeLocations.get(0), result1.getDataNodeLocations().get(1));
-    Assert.assertEquals(dataNodeLocations.get(2), result1.getDataNodeLocations().get(2));
+    Assert.assertEquals(dataNodeLocations.get(2), result1.getDataNodeLocations().get(1));
+    Assert.assertEquals(dataNodeLocations.get(0), result1.getDataNodeLocations().get(2));
     TRegionReplicaSet result2 = result.get(groupId2);
     // Leader first
     Assert.assertEquals(dataNodeLocations.get(4), result2.getDataNodeLocations().get(0));
-    // The others will be sorted by loadScore
-    Assert.assertEquals(dataNodeLocations.get(3), result2.getDataNodeLocations().get(1));
-    Assert.assertEquals(dataNodeLocations.get(5), result2.getDataNodeLocations().get(2));
+    Assert.assertEquals(dataNodeLocations.get(5), result2.getDataNodeLocations().get(1));
+    Assert.assertEquals(dataNodeLocations.get(3), result2.getDataNodeLocations().get(2));
   }
 
   @Test
@@ -140,24 +130,16 @@ public class LeaderPriorityBalancerTest {
     Map<TConsensusGroupId, Integer> leaderMap = new HashMap<>();
     leaderMap.put(groupId1, 1);
 
-    // Build loadScoreMap
-    Map<Integer, Long> loadScoreMap = new ConcurrentHashMap<>();
-    loadScoreMap.put(0, 10L);
-    loadScoreMap.put(2, 20L);
-    // The leader is DataNode-1, but it's unavailable
-    loadScoreMap.put(1, Long.MAX_VALUE);
-
     // Check result
     Map<TConsensusGroupId, TRegionReplicaSet> result =
         new LeaderPriorityBalancer()
-            .generateOptimalRoutePriority(
-                Collections.singletonList(regionReplicaSet1), leaderMap, loadScoreMap);
-    // Only sorted by loadScore since the leader is unavailable
+            .generateOptimalRoutePriority(Collections.singletonList(regionReplicaSet1), leaderMap);
+    // Not sorted since the leader is unavailable
     Assert.assertEquals(
-        dataNodeLocations.get(0), result.get(groupId1).getDataNodeLocations().get(0));
+        dataNodeLocations.get(1), result.get(groupId1).getDataNodeLocations().get(0));
     Assert.assertEquals(
         dataNodeLocations.get(2), result.get(groupId1).getDataNodeLocations().get(1));
     Assert.assertEquals(
-        dataNodeLocations.get(1), result.get(groupId1).getDataNodeLocations().get(2));
+        dataNodeLocations.get(0), result.get(groupId1).getDataNodeLocations().get(2));
   }
 }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensus.java
@@ -209,9 +209,11 @@ public class IoTConsensus implements IConsensus {
     if (impl.isReadOnly()) {
       return StatusUtils.getStatus(TSStatusCode.SYSTEM_READ_ONLY);
     } else if (!impl.isActive()) {
-      return RpcUtils.getStatus(
-          TSStatusCode.WRITE_PROCESS_REJECT,
-          "peer is inactive and not ready to receive sync log request.");
+      String message =
+          String.format(
+              "Peer is inactive and not ready to write request, %s, DataNode Id: %s",
+              groupId.toString(), impl.getThisNode().getNodeId());
+      return RpcUtils.getStatus(TSStatusCode.WRITE_PROCESS_REJECT, message);
     } else {
       return impl.write(request);
     }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/service/IoTConsensusRPCServiceProcessor.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/service/IoTConsensusRPCServiceProcessor.java
@@ -97,8 +97,12 @@ public class IoTConsensusRPCServiceProcessor implements IoTConsensusIService.Ifa
       return new TSyncLogEntriesRes(Collections.singletonList(status));
     }
     if (!impl.isActive()) {
+      String message =
+          String.format(
+              "Peer is inactive and not ready to receive sync log request, %s, DataNode Id: %s",
+              groupId, impl.getThisNode().getNodeId());
       TSStatus status = new TSStatus(TSStatusCode.WRITE_PROCESS_REJECT.getStatusCode());
-      status.setMessage("peer is inactive and not ready to receive sync log request");
+      status.setMessage(message);
       return new TSyncLogEntriesRes(Collections.singletonList(status));
     }
     BatchIndexedConsensusRequest logEntriesInThisBatch =


### PR DESCRIPTION
## Description

After the introduction of DataNode removing, the region status is no longer bound to the Datanode, and the sorting of loadscore will cause the RegionPriority order to be wrong.