### PR TITLE
Add branches name pattern that will trigger CI

### DIFF
--- a/.github/workflows/cluster-it-1c1d.yml
+++ b/.github/workflows/cluster-it-1c1d.yml
@@ -6,6 +6,7 @@ on:
       - master
       - 'rel/1.*'
       - 'rc/1.*'
+      - 'force_ci/**'
     paths-ignore:
       - 'docs/**'
       - 'site/**'

--- a/.github/workflows/cluster-it-1c1d1a.yml
+++ b/.github/workflows/cluster-it-1c1d1a.yml
@@ -6,6 +6,7 @@ on:
       - master
       - 'rel/1.*'
       - 'rc/1.*'
+      - 'force_ci/**'
     paths-ignore:
       - 'docs/**'
       - 'site/**'
@@ -14,6 +15,7 @@ on:
       - master
       - 'rel/1.*'
       - 'rc/1.*'
+      - 'force_ci/**'
     paths-ignore:
       - 'docs/**'
       - 'site/**'

--- a/.github/workflows/cluster-it-1c3d.yml
+++ b/.github/workflows/cluster-it-1c3d.yml
@@ -6,6 +6,7 @@ on:
       - master
       - 'rel/1.*'
       - 'rc/1.*'
+      - 'force_ci/**'
     paths-ignore:
       - 'docs/**'
       - 'site/**'
@@ -14,6 +15,7 @@ on:
       - master
       - 'rel/1.*'
       - 'rc/1.*'
+      - 'force_ci/**'
     paths-ignore:
       - 'docs/**'
       - 'site/**'

--- a/.github/workflows/compile-check.yml
+++ b/.github/workflows/compile-check.yml
@@ -8,6 +8,7 @@ on:
       - master
       - 'rel/1.*'
       - 'rc/1.*'
+      - 'force_ci/**'
     paths-ignore:
       - 'docs/**'
       - 'site/**'
@@ -16,6 +17,7 @@ on:
       - master
       - 'rel/1.*'
       - 'rc/1.*'
+      - 'force_ci/**'
     paths-ignore:
       - 'docs/**'
       - 'site/**'

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -8,6 +8,7 @@ on:
       - master
       - 'rel/*'
       - "rc/*"
+      - 'force_ci/**'
     paths-ignore:
       - 'docs/**'
       - 'site/**'
@@ -16,6 +17,7 @@ on:
       - master
       - 'rel/*'
       - "rc/*"
+      - 'force_ci/**'
     paths-ignore:
       - 'docs/**'
       - 'site/**'

--- a/.github/workflows/multi-language-client.yml
+++ b/.github/workflows/multi-language-client.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - "rc/*"
+      - 'force_ci/**'
     paths:
       - 'pom.xml'
       - 'iotdb-client/pom.xml'
@@ -17,6 +18,7 @@ on:
     branches:
       - master
       - "rc/*"
+      - 'force_ci/**'
     paths:
       - 'pom.xml'
       - 'iotdb-client/pom.xml'

--- a/.github/workflows/pipe-it-2cluster.yml
+++ b/.github/workflows/pipe-it-2cluster.yml
@@ -6,6 +6,7 @@ on:
       - master
       - 'rel/1.*'
       - 'rc/1.*'
+      - 'force_ci/**'
     paths-ignore:
       - 'docs/**'
       - 'site/**'
@@ -15,6 +16,7 @@ on:
       - master
       - 'rel/1.*'
       - 'rc/1.*'
+      - 'force_ci/**'
     paths-ignore:
       - 'docs/**'
       - 'site/**'

--- a/.github/workflows/sonar-codecov.yml
+++ b/.github/workflows/sonar-codecov.yml
@@ -9,6 +9,7 @@ on:
       - master
       - "rel/*"
       - "rc/*"
+      - 'force_ci/**'
     paths-ignore:
       - "docs/**"
       - 'site/**'
@@ -18,6 +19,7 @@ on:
       - "rel/*"
       - "new_*"
       - "rc/*"
+      - 'force_ci/**'
     paths-ignore:
       - "docs/**"
       - 'site/**'

--- a/.github/workflows/table-cluster-it-1c1d.yml
+++ b/.github/workflows/table-cluster-it-1c1d.yml
@@ -6,6 +6,7 @@ on:
       - master
       - 'rel/1.*'
       - 'rc/1.*'
+      - 'force_ci/**'
     paths-ignore:
       - 'docs/**'
       - 'site/**'
@@ -14,6 +15,7 @@ on:
       - master
       - 'rel/1.*'
       - 'rc/1.*'
+      - 'force_ci/**'
     paths-ignore:
       - 'docs/**'
       - 'site/**'

--- a/.github/workflows/table-cluster-it-1c3d.yml
+++ b/.github/workflows/table-cluster-it-1c3d.yml
@@ -6,6 +6,7 @@ on:
       - master
       - 'rel/1.*'
       - 'rc/1.*'
+      - 'force_ci/**'
     paths-ignore:
       - 'docs/**'
       - 'site/**'
@@ -14,6 +15,7 @@ on:
       - master
       - 'rel/1.*'
       - 'rc/1.*'
+      - 'force_ci/**'
     paths-ignore:
       - 'docs/**'
       - 'site/**'

--- a/.github/workflows/todos-check.yml
+++ b/.github/workflows/todos-check.yml
@@ -6,6 +6,7 @@ on:
       - master
       - 'rel/*'
       - "rc/*"
+      - 'force_ci/**'
     paths-ignore:
       - 'docs/**'
       - 'site/**'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -9,6 +9,7 @@ on:
       - master
       - 'rel/*'
       - "rc/*"
+      - 'force_ci/**'
     paths-ignore:
       - 'docs/**'
       - 'site/**'
@@ -17,6 +18,7 @@ on:
       - master
       - 'rel/*'
       - "rc/*"
+      - 'force_ci/**'
     paths-ignore:
       - 'docs/**'
       - 'site/**'


### PR DESCRIPTION
After this PR, if you want to create branches that will trigger GitHub CI, you may create them under the "force_ci/" path.

The typical scenario is a massive development involving many people, and they work on a temporary branch before each of their work can be merged into the master branch. By creating the temporary branch under "force_ci/," one does not need to modify the yml file and revert it.