### PR TITLE
Detect singular frame lengths in TElasticFramedTransport

### DIFF
--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TElasticFramedTransport.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TElasticFramedTransport.java
@@ -130,9 +130,15 @@ public class TElasticFramedTransport extends TTransport {
 
     if (size > thriftMaxFrameSize) {
       close();
-      throw new TTransportException(
-          TTransportException.CORRUPTED_DATA,
-          "Frame size (" + size + ") larger than protect max size (" + thriftMaxFrameSize + ")!");
+      if (size == 1195725856L || size == 1347375956L) {
+        // if someone sends HTTP GET/POST to this port, the size will be read as the following
+        throw new TTransportException(TTransportException.CORRUPTED_DATA,
+            "Singular frame size (" + size + ") detected, you may be sending HTTP GET/POST requests to the Thrift-RPC port, please confirm that you are using the right port");
+      } else {
+        throw new TTransportException(
+            TTransportException.CORRUPTED_DATA,
+            "Frame size (" + size + ") larger than protect max size (" + thriftMaxFrameSize + ")!");
+      }
     }
     readBuffer.fill(underlying, size);
   }

--- a/iotdb-client/service-rpc/src/test/java/org/apache/iotdb/rpc/TElasticFramedTransportTest.java
+++ b/iotdb-client/service-rpc/src/test/java/org/apache/iotdb/rpc/TElasticFramedTransportTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.rpc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import org.apache.thrift.transport.TByteBuffer;
+import org.apache.thrift.transport.TTransportException;
+import org.junit.Test;
+
+public class TElasticFramedTransportTest {
+
+  @Test
+  public void testSingularSize() {
+
+    try {
+      TElasticFramedTransport transport = new TElasticFramedTransport(
+          new TByteBuffer(ByteBuffer.wrap("GET 127.0.0.1 HTTP/1.1".getBytes(
+              StandardCharsets.UTF_8))), 128 * 1024 * 1024, 512 * 1024 * 1024, false);
+      transport.open();
+      transport.read(ByteBuffer.allocate(4096));
+      fail("Exception expected");
+    } catch (TTransportException e) {
+      assertEquals(
+          "Singular frame size (1195725856) detected, you may be sending HTTP GET/POST requests to the Thrift-RPC port, please confirm that you are using the right port",
+          e.getMessage());
+    }
+
+    try {
+      TElasticFramedTransport transport = new TElasticFramedTransport(
+          new TByteBuffer(ByteBuffer.wrap("POST 127.0.0.1 HTTP/1.1".getBytes(
+              StandardCharsets.UTF_8))), 128 * 1024 * 1024, 512 * 1024 * 1024, false);
+      transport.open();
+      transport.read(ByteBuffer.allocate(4096));
+      fail("Exception expected");
+    } catch (TTransportException e) {
+      assertEquals(
+          "Singular frame size (1347375956) detected, you may be sending HTTP GET/POST requests to the Thrift-RPC port, please confirm that you are using the right port",
+          e.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
If someone mistakenly send HTTP requests to the Thrift-RPC port, the error message is now more clear.