### PR TITLE
Compaction task memory is incorrect when compaction_max_aligned_series_num_in_one_batch <= 0

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/exception/CompactionSourceFileDeletedException.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/exception/CompactionSourceFileDeletedException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.storageengine.dataregion.compaction.execute.exception;
+
+public class CompactionSourceFileDeletedException extends RuntimeException {
+
+  public CompactionSourceFileDeletedException(String message) {
+    super(message);
+  }
+
+  @Override
+  public Throwable fillInStackTrace() {
+    return this;
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.db.service.metrics.CompactionMetrics;
 import org.apache.iotdb.db.service.metrics.FileMetrics;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.constant.CompactionTaskType;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.exception.CompactionRecoverException;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.exception.CompactionSourceFileDeletedException;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.performer.ICompactionPerformer;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.performer.impl.FastCompactionPerformer;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.performer.impl.ReadChunkCompactionPerformer;
@@ -680,10 +681,13 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
             innerSpaceEstimator.roughEstimateInnerCompactionMemory(
                 filesView.sourceFilesInCompactionPerformer);
         memoryCost =
-            CompactionEstimateUtils.shouldAccurateEstimate(roughEstimatedMemoryCost)
+            CompactionEstimateUtils.shouldUseRoughEstimateResult(roughEstimatedMemoryCost)
                 ? roughEstimatedMemoryCost
                 : innerSpaceEstimator.estimateInnerCompactionMemory(
                     filesView.sourceFilesInCompactionPerformer);
+      } catch (CompactionSourceFileDeletedException e) {
+        innerSpaceEstimator.cleanup();
+        return -1;
       } catch (Exception e) {
         if (e instanceof StopReadTsFileByInterruptException || Thread.interrupted()) {
           Thread.currentThread().interrupt();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
@@ -681,7 +681,7 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
             innerSpaceEstimator.roughEstimateInnerCompactionMemory(
                 filesView.sourceFilesInCompactionPerformer);
         memoryCost =
-            CompactionEstimateUtils.shouldUseRoughEstimateResult(roughEstimatedMemoryCost)
+            CompactionEstimateUtils.shouldUseRoughEstimatedResult(roughEstimatedMemoryCost)
                 ? roughEstimatedMemoryCost
                 : innerSpaceEstimator.estimateInnerCompactionMemory(
                     filesView.sourceFilesInCompactionPerformer);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/AbstractCrossSpaceEstimator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/AbstractCrossSpaceEstimator.java
@@ -45,15 +45,10 @@ public abstract class AbstractCrossSpaceEstimator extends AbstractCompactionEsti
     List<TsFileResource> resources = new ArrayList<>(seqResources.size() + unseqResources.size());
     resources.addAll(seqResources);
     resources.addAll(unseqResources);
-    if (!CompactionEstimateUtils.addReadLock(resources)) {
-      return -1L;
-    }
+    CompactionEstimateUtils.addReadLock(resources);
 
     long cost = 0;
     try {
-      if (!isAllSourceFileExist(resources)) {
-        return -1L;
-      }
       CompactionTaskInfo taskInfo = calculatingCompactionTaskInfo(resources);
       cost += calculatingMetadataMemoryCost(taskInfo);
       cost += calculatingDataMemoryCost(taskInfo);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/AbstractInnerSpaceEstimator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/AbstractInnerSpaceEstimator.java
@@ -45,15 +45,9 @@ public abstract class AbstractInnerSpaceEstimator extends AbstractCompactionEsti
   }
 
   public long estimateInnerCompactionMemory(List<TsFileResource> resources) throws IOException {
-    if (!CompactionEstimateUtils.addReadLock(resources)) {
-      return -1L;
-    }
+    CompactionEstimateUtils.addReadLock(resources);
     long cost;
     try {
-      if (!isAllSourceFileExist(resources)) {
-        return -1L;
-      }
-
       CompactionTaskInfo taskInfo = calculatingCompactionTaskInfo(resources);
       cost = calculatingMetadataMemoryCost(taskInfo);
       cost += calculatingDataMemoryCost(taskInfo);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/CompactionEstimateUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/CompactionEstimateUtils.java
@@ -129,7 +129,7 @@ public class CompactionEstimateUtils {
     }
   }
 
-  public static Map<IDeviceID, Long> getDeviceMetadataSizeMapAndCollectMetadataInfo(
+  static Map<IDeviceID, Long> getDeviceMetadataSizeMapAndCollectMetadataInfo(
       CompactionTsFileReader reader, MetadataInfo metadataInfo) throws IOException {
     Map<IDeviceID, Long> deviceMetadataSizeMap = new HashMap<>();
     TsFileDeviceIterator deviceIterator = reader.getAllDevicesIteratorWithIsAligned();
@@ -137,9 +137,7 @@ public class CompactionEstimateUtils {
       Pair<IDeviceID, Boolean> deviceAlignedPair = deviceIterator.next();
       IDeviceID deviceID = deviceAlignedPair.getLeft();
       boolean isAligned = deviceAlignedPair.getRight();
-      if (isAligned) {
-        metadataInfo.hasAlignedSeries = true;
-      }
+      metadataInfo.hasAlignedSeries |= isAligned;
       MetadataIndexNode firstMeasurementNodeOfCurrentDevice =
           deviceIterator.getFirstMeasurementNodeOfCurrentDevice();
       long totalTimeseriesMetadataSizeOfCurrentDevice = 0;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/CompactionEstimateUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/CompactionEstimateUtils.java
@@ -149,7 +149,7 @@ public class CompactionEstimateUtils {
     return deviceMetadataSizeMap;
   }
 
-  public static boolean shouldUseRoughEstimateResult(long roughEstimatedMemCost) {
+  public static boolean shouldUseRoughEstimatedResult(long roughEstimatedMemCost) {
     return roughEstimatedMemCost > 0
         && IoTDBDescriptor.getInstance().getConfig().getCompactionThreadCount()
                 * roughEstimatedMemCost

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/CompactionEstimateUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/CompactionEstimateUtils.java
@@ -182,22 +182,3 @@ public class CompactionEstimateUtils {
     resources.forEach(TsFileResource::readUnlock);
   }
 }
-
-class MetadataInfo {
-  public long metadataMemCost;
-  public int maxConcurrentAlignedSeriesNum;
-
-  public int getMaxConcurrentSeriesNum() {
-    int compactionMaxAlignedSeriesNumInOneBatch =
-        IoTDBDescriptor.getInstance().getConfig().getCompactionMaxAlignedSeriesNumInOneBatch();
-    compactionMaxAlignedSeriesNumInOneBatch =
-        Math.min(
-            compactionMaxAlignedSeriesNumInOneBatch <= 0
-                ? Integer.MAX_VALUE
-                : compactionMaxAlignedSeriesNumInOneBatch,
-            maxConcurrentAlignedSeriesNum);
-    return Math.max(
-        compactionMaxAlignedSeriesNumInOneBatch,
-        IoTDBDescriptor.getInstance().getConfig().getSubCompactionTaskNum());
-  }
-}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/FastCompactionInnerCompactionEstimator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/FastCompactionInnerCompactionEstimator.java
@@ -82,6 +82,9 @@ public class FastCompactionInnerCompactionEstimator extends AbstractInnerSpaceEs
   @Override
   public long roughEstimateInnerCompactionMemory(List<TsFileResource> resources)
       throws IOException {
+    if (config.getCompactionMaxAlignedSeriesNumInOneBatch() <= 0) {
+      return -1L;
+    }
     Optional<MetadataInfo> metadataInfo =
         CompactionEstimateUtils.collectMetadataInfo(
             resources,

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/FastCompactionInnerCompactionEstimator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/FastCompactionInnerCompactionEstimator.java
@@ -24,7 +24,6 @@ import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 
 public class FastCompactionInnerCompactionEstimator extends AbstractInnerSpaceEstimator {
 
@@ -85,16 +84,13 @@ public class FastCompactionInnerCompactionEstimator extends AbstractInnerSpaceEs
     if (config.getCompactionMaxAlignedSeriesNumInOneBatch() <= 0) {
       return -1L;
     }
-    Optional<MetadataInfo> metadataInfo =
+    MetadataInfo metadataInfo =
         CompactionEstimateUtils.collectMetadataInfo(
             resources,
             resources.get(0).isSeq()
                 ? CompactionType.INNER_SEQ_COMPACTION
                 : CompactionType.INNER_UNSEQ_COMPACTION);
-    if (!metadataInfo.isPresent()) {
-      return -1L;
-    }
-    int maxConcurrentSeriesNum = metadataInfo.get().getMaxConcurrentSeriesNum();
+    int maxConcurrentSeriesNum = metadataInfo.getMaxConcurrentSeriesNum();
     long maxChunkSize = config.getTargetChunkSize();
     long maxPageSize = tsFileConfig.getPageSizeInByte();
     int maxOverlapFileNum = calculatingMaxOverlapFileNumInSubCompactionTask(resources);
@@ -102,6 +98,6 @@ public class FastCompactionInnerCompactionEstimator extends AbstractInnerSpaceEs
     // target file (chunk + unsealed page writer)
     return (maxOverlapFileNum + 1) * maxConcurrentSeriesNum * (maxChunkSize + maxPageSize)
         + fixedMemoryBudget
-        + metadataInfo.get().metadataMemCost;
+        + metadataInfo.metadataMemCost;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/FastCrossSpaceCompactionEstimator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/FastCrossSpaceCompactionEstimator.java
@@ -25,7 +25,6 @@ import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 public class FastCrossSpaceCompactionEstimator extends AbstractCrossSpaceEstimator {
 
@@ -91,13 +90,10 @@ public class FastCrossSpaceCompactionEstimator extends AbstractCrossSpaceEstimat
     sourceFiles.addAll(seqResources);
     sourceFiles.addAll(unseqResources);
 
-    Optional<MetadataInfo> metadataInfo =
+    MetadataInfo metadataInfo =
         CompactionEstimateUtils.collectMetadataInfo(sourceFiles, CompactionType.CROSS_COMPACTION);
-    if (!metadataInfo.isPresent()) {
-      return -1L;
-    }
 
-    int maxConcurrentSeriesNum = metadataInfo.get().getMaxConcurrentSeriesNum();
+    int maxConcurrentSeriesNum = metadataInfo.getMaxConcurrentSeriesNum();
     long maxChunkSize = config.getTargetChunkSize();
     long maxPageSize = tsFileConfig.getPageSizeInByte();
     int maxOverlapFileNum = calculatingMaxOverlapFileNumInSubCompactionTask(sourceFiles);
@@ -105,6 +101,6 @@ public class FastCrossSpaceCompactionEstimator extends AbstractCrossSpaceEstimat
     // target files (chunk + unsealed page writer)
     return (maxOverlapFileNum + 1) * maxConcurrentSeriesNum * (maxChunkSize + maxPageSize)
         + fixedMemoryBudget
-        + metadataInfo.get().metadataMemCost;
+        + metadataInfo.metadataMemCost;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/FastCrossSpaceCompactionEstimator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/FastCrossSpaceCompactionEstimator.java
@@ -84,6 +84,9 @@ public class FastCrossSpaceCompactionEstimator extends AbstractCrossSpaceEstimat
   @Override
   public long roughEstimateCrossCompactionMemory(
       List<TsFileResource> seqResources, List<TsFileResource> unseqResources) throws IOException {
+    if (config.getCompactionMaxAlignedSeriesNumInOneBatch() <= 0) {
+      return -1L;
+    }
     List<TsFileResource> sourceFiles = new ArrayList<>(seqResources.size() + unseqResources.size());
     sourceFiles.addAll(seqResources);
     sourceFiles.addAll(unseqResources);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/MetadataInfo.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/MetadataInfo.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.storageengine.dataregion.compaction.selector.estimator;
+
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+
+class MetadataInfo {
+  public long metadataMemCost;
+  public int maxConcurrentAlignedSeriesNum;
+
+  public int getMaxConcurrentSeriesNum() {
+    int compactionMaxAlignedSeriesNumInOneBatch =
+        IoTDBDescriptor.getInstance().getConfig().getCompactionMaxAlignedSeriesNumInOneBatch();
+    compactionMaxAlignedSeriesNumInOneBatch =
+        Math.min(
+            compactionMaxAlignedSeriesNumInOneBatch <= 0
+                ? Integer.MAX_VALUE
+                : compactionMaxAlignedSeriesNumInOneBatch,
+            maxConcurrentAlignedSeriesNum);
+    return Math.max(
+        compactionMaxAlignedSeriesNumInOneBatch,
+        IoTDBDescriptor.getInstance().getConfig().getSubCompactionTaskNum());
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/MetadataInfo.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/MetadataInfo.java
@@ -23,8 +23,12 @@ import org.apache.iotdb.db.conf.IoTDBDescriptor;
 
 class MetadataInfo {
   public long metadataMemCost;
+  public boolean hasAlignedSeries;
 
   public int getMaxConcurrentSeriesNum() {
+    if (!hasAlignedSeries) {
+      return IoTDBDescriptor.getInstance().getConfig().getSubCompactionTaskNum();
+    }
     int compactionMaxAlignedSeriesNumInOneBatch =
         IoTDBDescriptor.getInstance().getConfig().getCompactionMaxAlignedSeriesNumInOneBatch();
     compactionMaxAlignedSeriesNumInOneBatch =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/MetadataInfo.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/MetadataInfo.java
@@ -23,17 +23,14 @@ import org.apache.iotdb.db.conf.IoTDBDescriptor;
 
 class MetadataInfo {
   public long metadataMemCost;
-  public int maxConcurrentAlignedSeriesNum;
 
   public int getMaxConcurrentSeriesNum() {
     int compactionMaxAlignedSeriesNumInOneBatch =
         IoTDBDescriptor.getInstance().getConfig().getCompactionMaxAlignedSeriesNumInOneBatch();
     compactionMaxAlignedSeriesNumInOneBatch =
-        Math.min(
-            compactionMaxAlignedSeriesNumInOneBatch <= 0
-                ? Integer.MAX_VALUE
-                : compactionMaxAlignedSeriesNumInOneBatch,
-            maxConcurrentAlignedSeriesNum);
+        compactionMaxAlignedSeriesNumInOneBatch <= 0
+            ? Integer.MAX_VALUE
+            : compactionMaxAlignedSeriesNumInOneBatch;
     return Math.max(
         compactionMaxAlignedSeriesNumInOneBatch,
         IoTDBDescriptor.getInstance().getConfig().getSubCompactionTaskNum());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/ReadChunkInnerCompactionEstimator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/ReadChunkInnerCompactionEstimator.java
@@ -24,7 +24,6 @@ import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 
 public class ReadChunkInnerCompactionEstimator extends AbstractInnerSpaceEstimator {
 
@@ -79,18 +78,15 @@ public class ReadChunkInnerCompactionEstimator extends AbstractInnerSpaceEstimat
     if (config.getCompactionMaxAlignedSeriesNumInOneBatch() <= 0) {
       return -1L;
     }
-    Optional<MetadataInfo> metadataInfo =
+    MetadataInfo metadataInfo =
         CompactionEstimateUtils.collectMetadataInfo(resources, CompactionType.INNER_SEQ_COMPACTION);
-    if (!metadataInfo.isPresent()) {
-      return -1L;
-    }
-    int maxConcurrentSeriesNum = metadataInfo.get().getMaxConcurrentSeriesNum();
+    int maxConcurrentSeriesNum = metadataInfo.getMaxConcurrentSeriesNum();
     long maxChunkSize = config.getTargetChunkSize();
     long maxPageSize = tsFileConfig.getPageSizeInByte();
     // source files (chunk + uncompressed page)
     // target file (chunk + unsealed page writer)
     return 2 * maxConcurrentSeriesNum * (maxChunkSize + maxPageSize)
         + fixedMemoryBudget
-        + metadataInfo.get().metadataMemCost;
+        + metadataInfo.metadataMemCost;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/ReadChunkInnerCompactionEstimator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/estimator/ReadChunkInnerCompactionEstimator.java
@@ -76,6 +76,9 @@ public class ReadChunkInnerCompactionEstimator extends AbstractInnerSpaceEstimat
   @Override
   public long roughEstimateInnerCompactionMemory(List<TsFileResource> resources)
       throws IOException {
+    if (config.getCompactionMaxAlignedSeriesNumInOneBatch() <= 0) {
+      return -1L;
+    }
     Optional<MetadataInfo> metadataInfo =
         CompactionEstimateUtils.collectMetadataInfo(resources, CompactionType.INNER_SEQ_COMPACTION);
     if (!metadataInfo.isPresent()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/impl/RewriteCrossSpaceCompactionSelector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/impl/RewriteCrossSpaceCompactionSelector.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.MergeException;
 import org.apache.iotdb.db.service.metrics.CompactionMetrics;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.constant.CompactionTaskType;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.exception.CompactionSourceFileDeletedException;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.utils.CompactionUtils;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.schedule.CompactionScheduleContext;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.schedule.CompactionTaskManager;
@@ -139,6 +140,8 @@ public class RewriteCrossSpaceCompactionSelector implements ICrossSpaceSelector 
           candidate.getUnseqFiles().size());
 
       return executeTaskResourceSelection(candidate);
+    } catch (CompactionSourceFileDeletedException e) {
+      return new CrossCompactionTaskResource();
     } catch (Exception e) {
       if (e instanceof StopReadTsFileByInterruptException || Thread.interrupted()) {
         Thread.currentThread().interrupt();
@@ -226,7 +229,7 @@ public class RewriteCrossSpaceCompactionSelector implements ICrossSpaceSelector 
           compactionEstimator.roughEstimateCrossCompactionMemory(
               newSelectedSeqResources, newSelectedUnseqResources);
       long memoryCost =
-          CompactionEstimateUtils.shouldAccurateEstimate(roughEstimatedMemoryCost)
+          CompactionEstimateUtils.shouldUseRoughEstimateResult(roughEstimatedMemoryCost)
               ? roughEstimatedMemoryCost
               : compactionEstimator.estimateCrossCompactionMemory(
                   newSelectedSeqResources, newSelectedUnseqResources);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/impl/RewriteCrossSpaceCompactionSelector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/impl/RewriteCrossSpaceCompactionSelector.java
@@ -229,7 +229,7 @@ public class RewriteCrossSpaceCompactionSelector implements ICrossSpaceSelector 
           compactionEstimator.roughEstimateCrossCompactionMemory(
               newSelectedSeqResources, newSelectedUnseqResources);
       long memoryCost =
-          CompactionEstimateUtils.shouldUseRoughEstimateResult(roughEstimatedMemoryCost)
+          CompactionEstimateUtils.shouldUseRoughEstimatedResult(roughEstimatedMemoryCost)
               ? roughEstimatedMemoryCost
               : compactionEstimator.estimateCrossCompactionMemory(
                   newSelectedSeqResources, newSelectedUnseqResources);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/cross/CrossSpaceCompactionSelectorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/cross/CrossSpaceCompactionSelectorTest.java
@@ -349,56 +349,7 @@ public class CrossSpaceCompactionSelectorTest extends AbstractCompactionTest {
                 cd2.await();
                 CrossCompactionTaskResource crossCompactionTaskResource =
                     selector.selectOneTaskResources(candidate);
-                if (!crossCompactionTaskResource.isValid()) {
-                  throw new RuntimeException("compaction task resource is not valid");
-                }
-                if (crossCompactionTaskResource.getSeqFiles().size() != 1) {
-                  throw new RuntimeException("selected seq file should be 1");
-                }
-                if (crossCompactionTaskResource.getUnseqFiles().size() != 1) {
-                  throw new RuntimeException("selected unseq file num should be 1");
-                }
-
-                CrossSpaceCompactionTask crossSpaceCompactionTask =
-                    new CrossSpaceCompactionTask(
-                        0,
-                        tsFileManager,
-                        crossCompactionTaskResource.getSeqFiles(),
-                        crossCompactionTaskResource.getUnseqFiles(),
-                        IoTDBDescriptor.getInstance()
-                            .getConfig()
-                            .getCrossCompactionPerformer()
-                            .createInstance(),
-                        crossCompactionTaskResource.getTotalMemoryCost(),
-                        tsFileManager.getNextCompactionTaskId());
-                // set file status to COMPACTION_CANDIDATE
-                if (!crossSpaceCompactionTask.setSourceFilesToCompactionCandidate()) {
-                  throw new RuntimeException("set status should be true");
-                }
-                for (int i = 0; i < seqResources.size(); i++) {
-                  TsFileResource resource = seqResources.get(i);
-                  if (i < 1) {
-                    if (resource.getStatus() != TsFileResourceStatus.COMPACTION_CANDIDATE) {
-                      throw new RuntimeException("status should be COMPACTION_CANDIDATE");
-                    }
-                  } else if (i == 1) {
-                    if (resource.getStatus() != TsFileResourceStatus.DELETED) {
-                      throw new RuntimeException("status should be DELETED");
-                    }
-                  } else if (resource.getStatus() != TsFileResourceStatus.NORMAL) {
-                    throw new RuntimeException("status should be NORMAL");
-                  }
-                }
-                for (int i = 0; i < unseqResources.size(); i++) {
-                  TsFileResource resource = unseqResources.get(i);
-                  if (i < 1) {
-                    if (resource.getStatus() != TsFileResourceStatus.COMPACTION_CANDIDATE) {
-                      throw new RuntimeException("status should be COMPACTION_CANDIDATE");
-                    }
-                  } else if (resource.getStatus() != TsFileResourceStatus.NORMAL) {
-                    throw new RuntimeException("status should be NORMAL");
-                  }
-                }
+                Assert.assertFalse(crossCompactionTaskResource.isValid());
               } catch (Exception e) {
                 fail.set(true);
                 e.printStackTrace();
@@ -1181,56 +1132,7 @@ public class CrossSpaceCompactionSelectorTest extends AbstractCompactionTest {
 
                 CrossCompactionTaskResource crossCompactionTaskResource =
                     selector.selectOneTaskResources(candidate);
-                if (!crossCompactionTaskResource.isValid()) {
-                  throw new RuntimeException("compaction task resource is not valid");
-                }
-                if (crossCompactionTaskResource.getSeqFiles().size() != 1) {
-                  throw new RuntimeException("selected seq file num is not 1");
-                }
-                if (crossCompactionTaskResource.getUnseqFiles().size() != 1) {
-                  throw new RuntimeException("selected unseq file num is not 1");
-                }
-
-                CrossSpaceCompactionTask crossSpaceCompactionTask =
-                    new CrossSpaceCompactionTask(
-                        0,
-                        tsFileManager,
-                        crossCompactionTaskResource.getSeqFiles(),
-                        crossCompactionTaskResource.getUnseqFiles(),
-                        IoTDBDescriptor.getInstance()
-                            .getConfig()
-                            .getCrossCompactionPerformer()
-                            .createInstance(),
-                        crossCompactionTaskResource.getTotalMemoryCost(),
-                        tsFileManager.getNextCompactionTaskId());
-                // set file status to COMPACTION_CANDIDATE
-                if (!crossSpaceCompactionTask.setSourceFilesToCompactionCandidate()) {
-                  throw new RuntimeException("set status should be true");
-                }
-                for (int i = 0; i < unseqResources.size(); i++) {
-                  TsFileResource resource = unseqResources.get(i);
-                  if (i < 1) {
-                    if (resource.getStatus() != TsFileResourceStatus.COMPACTION_CANDIDATE) {
-                      throw new RuntimeException("status should be COMPACTION_CANDIDATE");
-                    }
-                  } else if (i == 1) {
-                    if (resource.getStatus() != TsFileResourceStatus.DELETED) {
-                      throw new RuntimeException("status should be DELETED");
-                    }
-                  } else if (resource.getStatus() != TsFileResourceStatus.NORMAL) {
-                    throw new RuntimeException("status should be NORMAL");
-                  }
-                }
-                for (int i = 0; i < seqResources.size(); i++) {
-                  TsFileResource resource = seqResources.get(i);
-                  if (i < 1) {
-                    if (resource.getStatus() != TsFileResourceStatus.COMPACTION_CANDIDATE) {
-                      throw new RuntimeException("status should be COMPACTION_CANDIDATE");
-                    }
-                  } else if (resource.getStatus() != TsFileResourceStatus.NORMAL) {
-                    throw new RuntimeException("status should be NORMAL");
-                  }
-                }
+                Assert.assertFalse(crossCompactionTaskResource.isValid());
               } catch (Exception e) {
                 fail.set(true);
                 e.printStackTrace();

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/utils/CompactionTaskMemCostEstimatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/utils/CompactionTaskMemCostEstimatorTest.java
@@ -130,6 +130,16 @@ public class CompactionTaskMemCostEstimatorTest extends AbstractCompactionTest {
           TSEncoding.PLAIN,
           CompressionType.UNCOMPRESSED);
       writer.endChunkGroup();
+
+      writer.startChunkGroup("d2");
+      for (int i = 0; i < 10; i++) {
+        writer.generateSimpleNonAlignedSeriesToCurrentDevice(
+            "s" + i,
+            new TimeRange[] {new TimeRange(0, 10000)},
+            TSEncoding.PLAIN,
+            CompressionType.UNCOMPRESSED);
+      }
+      writer.endChunkGroup();
       writer.endFile();
     }
     seqResources.add(resource);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/utils/CompactionTaskMemCostEstimatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/utils/CompactionTaskMemCostEstimatorTest.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.storageengine.dataregion.compaction.utils;
 
 import org.apache.iotdb.commons.exception.MetadataException;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.AbstractCompactionTest;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.selector.estimator.FastCompactionInnerCompactionEstimator;
@@ -28,15 +29,22 @@ import org.apache.iotdb.db.storageengine.dataregion.compaction.selector.estimato
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 
 import org.apache.tsfile.exception.write.WriteProcessException;
+import org.apache.tsfile.file.metadata.enums.CompressionType;
+import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.read.common.TimeRange;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 public class CompactionTaskMemCostEstimatorTest extends AbstractCompactionTest {
+
+  int compactionBatchSize =
+      IoTDBDescriptor.getInstance().getConfig().getCompactionMaxAlignedSeriesNumInOneBatch();
 
   @Before
   public void setUp()
@@ -46,6 +54,9 @@ public class CompactionTaskMemCostEstimatorTest extends AbstractCompactionTest {
 
   @After
   public void tearDown() throws IOException, StorageEngineException {
+    IoTDBDescriptor.getInstance()
+        .getConfig()
+        .setCompactionMaxAlignedSeriesNumInOneBatch(compactionBatchSize);
     super.tearDown();
   }
 
@@ -102,5 +113,31 @@ public class CompactionTaskMemCostEstimatorTest extends AbstractCompactionTest {
         new FastCrossSpaceCompactionEstimator()
             .estimateCrossCompactionMemory(seqResources, unseqResources);
     Assert.assertTrue(cost > 0);
+  }
+
+  @Test
+  public void testEstimateWithNegativeBatchSize() throws IOException {
+    TsFileResource resource = createEmptyFileAndResource(true);
+    try (CompactionTestFileWriter writer = new CompactionTestFileWriter(resource)) {
+      writer.startChunkGroup("d1");
+      List<String> measurements = new ArrayList<>();
+      for (int i = 0; i < 10; i++) {
+        measurements.add("s" + i);
+      }
+      writer.generateSimpleAlignedSeriesToCurrentDevice(
+          measurements,
+          new TimeRange[] {new TimeRange(0, 10000)},
+          TSEncoding.PLAIN,
+          CompressionType.UNCOMPRESSED);
+      writer.endChunkGroup();
+      writer.endFile();
+    }
+    seqResources.add(resource);
+    IoTDBDescriptor.getInstance().getConfig().setCompactionMaxAlignedSeriesNumInOneBatch(-1);
+    ReadChunkInnerCompactionEstimator estimator = new ReadChunkInnerCompactionEstimator();
+    long v1 = estimator.roughEstimateInnerCompactionMemory(seqResources);
+    IoTDBDescriptor.getInstance().getConfig().setCompactionReadOperationPerSec(100);
+    long v2 = estimator.roughEstimateInnerCompactionMemory(seqResources);
+    Assert.assertEquals(v1, v2);
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/utils/CompactionTaskMemCostEstimatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/utils/CompactionTaskMemCostEstimatorTest.java
@@ -136,8 +136,9 @@ public class CompactionTaskMemCostEstimatorTest extends AbstractCompactionTest {
     IoTDBDescriptor.getInstance().getConfig().setCompactionMaxAlignedSeriesNumInOneBatch(-1);
     ReadChunkInnerCompactionEstimator estimator = new ReadChunkInnerCompactionEstimator();
     long v1 = estimator.roughEstimateInnerCompactionMemory(seqResources);
-    IoTDBDescriptor.getInstance().getConfig().setCompactionReadOperationPerSec(100);
+    Assert.assertTrue(v1 < 0);
+    IoTDBDescriptor.getInstance().getConfig().setCompactionMaxAlignedSeriesNumInOneBatch(10);
     long v2 = estimator.roughEstimateInnerCompactionMemory(seqResources);
-    Assert.assertEquals(v1, v2);
+    Assert.assertTrue(v2 > 0);
   }
 }


### PR DESCRIPTION
## Description
Compaction task memory is incorrect when compaction_max_aligned_series_num_in_one_batch <= 0