### PR TITLE
Fix that place-holder tag column are not Binary[]

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/session/IoTDBSessionRelationalIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/session/IoTDBSessionRelationalIT.java
@@ -801,7 +801,7 @@ public class IoTDBSessionRelationalIT {
 
   @Test
   @Category({LocalStandaloneIT.class, ClusterIT.class})
-  public void autoCreatetagColumnTest()
+  public void autoCreateTagColumnTest()
       throws IoTDBConnectionException, StatementExecutionException {
     try (ITableSession session = EnvFactory.getEnv().getTableSessionConnection()) {
       session.executeNonQueryStatement("USE \"db1\"");
@@ -824,52 +824,54 @@ public class IoTDBSessionRelationalIT {
               columnTypes,
               15);
 
-      for (long row = 0; row < 15; row++) {
-        int rowIndex = tablet.getRowSize();
-        tablet.addTimestamp(rowIndex, timestamp + row);
-        tablet.addValue("tag2", rowIndex, "tag:" + row);
-        tablet.addValue("attr1", rowIndex, "attr:" + row);
-        tablet.addValue("m1", rowIndex, row * 1.0);
-        if (tablet.getRowSize() == tablet.getMaxRowNumber()) {
-          session.insert(tablet);
-          tablet.reset();
-        }
+      for (int row = 0; row < 15; row++) {
+        tablet.addTimestamp(row, timestamp);
+        tablet.addValue("tag2", row, "tag:" + timestamp);
+        tablet.addValue("attr1", row, "attr:" + timestamp);
+        tablet.addValue("m1", row, timestamp * 1.0);
+        timestamp ++;
       }
 
-      if (tablet.getRowSize() != 0) {
-        session.insert(tablet);
-        tablet.reset();
-      }
-
-      session.executeNonQueryStatement("FLush");
-
-      for (long row = 15; row < 30; row++) {
-        int rowIndex = tablet.getRowSize();
-        tablet.addTimestamp(rowIndex, timestamp + row);
-        tablet.addValue("tag2", rowIndex, "tag:" + row);
-        tablet.addValue("attr1", rowIndex, "attr:" + row);
-        tablet.addValue("m1", rowIndex, row * 1.0);
-        if (tablet.getRowSize() == tablet.getMaxRowNumber()) {
-          session.insert(tablet);
-          tablet.reset();
-        }
-      }
-
-      if (tablet.getRowSize() != 0) {
-        session.insert(tablet);
-        tablet.reset();
-      }
+      session.insert(tablet);
+      tablet.reset();
 
       SessionDataSet dataSet = session.executeQueryStatement("select * from table8 order by time");
       int cnt = 0;
       while (dataSet.hasNext()) {
         RowRecord rowRecord = dataSet.next();
-        timestamp = rowRecord.getFields().get(0).getLongV();
+        long t = rowRecord.getFields().get(0).getLongV();
         // tag 1 should be null
         assertNull(rowRecord.getFields().get(1).getDataType());
-        assertEquals("tag:" + timestamp, rowRecord.getFields().get(2).getBinaryV().toString());
-        assertEquals("attr:" + timestamp, rowRecord.getFields().get(3).getBinaryV().toString());
-        assertEquals(timestamp * 1.0, rowRecord.getFields().get(4).getDoubleV(), 0.0001);
+        assertEquals("tag:" + t, rowRecord.getFields().get(2).getBinaryV().toString());
+        assertEquals("attr:" + t, rowRecord.getFields().get(3).getBinaryV().toString());
+        assertEquals(t * 1.0, rowRecord.getFields().get(4).getDoubleV(), 0.0001);
+        cnt++;
+      }
+      assertEquals(15, cnt);
+
+      session.executeNonQueryStatement("FLush");
+
+      for (int row = 0; row < 15; row++) {
+        tablet.addTimestamp(row, timestamp);
+        tablet.addValue("tag2", row, "tag:" + timestamp);
+        tablet.addValue("attr1", row, "attr:" + timestamp);
+        tablet.addValue("m1", row, timestamp * 1.0);
+        timestamp ++;
+      }
+
+      session.insert(tablet);
+      tablet.reset();
+
+      dataSet = session.executeQueryStatement("select * from table8 order by time");
+      cnt = 0;
+      while (dataSet.hasNext()) {
+        RowRecord rowRecord = dataSet.next();
+        long t = rowRecord.getFields().get(0).getLongV();
+        // tag 1 should be null
+        assertNull(rowRecord.getFields().get(1).getDataType());
+        assertEquals("tag:" + t, rowRecord.getFields().get(2).getBinaryV().toString());
+        assertEquals("attr:" + t, rowRecord.getFields().get(3).getBinaryV().toString());
+        assertEquals(t * 1.0, rowRecord.getFields().get(4).getDoubleV(), 0.0001);
         cnt++;
       }
       assertEquals(30, cnt);
@@ -878,7 +880,7 @@ public class IoTDBSessionRelationalIT {
 
   @Test
   @Category({LocalStandaloneIT.class, ClusterIT.class})
-  public void autoAdjusttagTest() throws IoTDBConnectionException, StatementExecutionException {
+  public void autoAdjustTagTest() throws IoTDBConnectionException, StatementExecutionException {
     try (ITableSession session = EnvFactory.getEnv().getTableSessionConnection()) {
       session.executeNonQueryStatement("USE \"db1\"");
       // the tag order in the table is (tag1, tag2)
@@ -1462,6 +1464,85 @@ public class IoTDBSessionRelationalIT {
 
     try (ISession session = EnvFactory.getEnv().getSessionConnection()) {
       session.executeNonQueryStatement("SET CONFIGURATION \"enable_partial_insert\"=\"true\"");
+    }
+  }
+
+  @Test
+  @Category({LocalStandaloneIT.class, ClusterIT.class})
+  public void autoCreateTagColumnTest2()
+      throws IoTDBConnectionException, StatementExecutionException {
+    int testNum = 17;
+    try (ITableSession session = EnvFactory.getEnv().getTableSessionConnection()) {
+      session.executeNonQueryStatement("USE \"db1\"");
+      // only one column in this table, and others should be auto-created
+      session.executeNonQueryStatement("CREATE TABLE table" + testNum + " (tag1 string tag, s1 text field)");
+
+      List<IMeasurementSchema> schemaList = new ArrayList<>();
+      schemaList.add(new MeasurementSchema("tag2", TSDataType.STRING));
+      schemaList.add(new MeasurementSchema("s2", TSDataType.INT64));
+      final List<ColumnCategory> columnTypes =
+          Arrays.asList(ColumnCategory.TAG, ColumnCategory.FIELD);
+
+      long timestamp = 0;
+      Tablet tablet =
+          new Tablet(
+              "table" + testNum,
+              IMeasurementSchema.getMeasurementNameList(schemaList),
+              IMeasurementSchema.getDataTypeList(schemaList),
+              columnTypes,
+              15);
+
+      for (int row = 0; row < 15; row++) {
+        tablet.addTimestamp(row, timestamp);
+        tablet.addValue("tag2", row, "tag:" + timestamp);
+        tablet.addValue("s2", row, timestamp);
+        timestamp ++;
+      }
+
+      session.insert(tablet);
+      tablet.reset();
+
+      SessionDataSet dataSet = session.executeQueryStatement("select * from table" + testNum + " order by time");
+      int cnt = 0;
+      while (dataSet.hasNext()) {
+        RowRecord rowRecord = dataSet.next();
+        long t = rowRecord.getFields().get(0).getLongV();
+        // tag 1 should be null
+        assertNull(rowRecord.getFields().get(1).getDataType());
+        // s1 should be null
+        assertNull(rowRecord.getFields().get(2).getDataType());
+        assertEquals("tag:" + t, rowRecord.getFields().get(3).getBinaryV().toString());
+        assertEquals(t, rowRecord.getFields().get(4).getLongV());
+        cnt++;
+      }
+      assertEquals(15, cnt);
+
+      session.executeNonQueryStatement("FLush");
+
+      for (int row = 0; row < 15; row++) {
+        tablet.addTimestamp(row, timestamp);
+        tablet.addValue("tag2", row, "tag:" + timestamp);
+        tablet.addValue("s2", row, timestamp);
+        timestamp ++;
+      }
+
+      session.insert(tablet);
+      tablet.reset();
+
+      dataSet = session.executeQueryStatement("select * from table" + testNum + " order by time");
+      cnt = 0;
+      while (dataSet.hasNext()) {
+        RowRecord rowRecord = dataSet.next();
+        long t = rowRecord.getFields().get(0).getLongV();
+        // tag 1 should be null
+        assertNull(rowRecord.getFields().get(1).getDataType());
+        // s1 should be null
+        assertNull(rowRecord.getFields().get(2).getDataType());
+        assertEquals("tag:" + t, rowRecord.getFields().get(3).getBinaryV().toString());
+        assertEquals(t, rowRecord.getFields().get(4).getLongV());
+        cnt++;
+      }
+      assertEquals(30, cnt);
     }
   }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/session/IoTDBSessionRelationalIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/session/IoTDBSessionRelationalIT.java
@@ -25,6 +25,8 @@ import org.apache.iotdb.it.env.EnvFactory;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
+import org.apache.iotdb.itbase.category.TableClusterIT;
+import org.apache.iotdb.itbase.category.TableLocalStandaloneIT;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.StatementExecutionException;
 
@@ -59,6 +61,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 @RunWith(IoTDBTestRunner.class)
+@Category({TableLocalStandaloneIT.class, TableClusterIT.class})
 public class IoTDBSessionRelationalIT {
 
   @BeforeClass
@@ -1471,7 +1474,7 @@ public class IoTDBSessionRelationalIT {
   @Category({LocalStandaloneIT.class, ClusterIT.class})
   public void autoCreateTagColumnTest2()
       throws IoTDBConnectionException, StatementExecutionException {
-    int testNum = 17;
+    int testNum = 18;
     try (ITableSession session = EnvFactory.getEnv().getTableSessionConnection()) {
       session.executeNonQueryStatement("USE \"db1\"");
       // only one column in this table, and others should be auto-created
@@ -1513,7 +1516,7 @@ public class IoTDBSessionRelationalIT {
         assertNull(rowRecord.getFields().get(1).getDataType());
         // s1 should be null
         assertNull(rowRecord.getFields().get(2).getDataType());
-        assertEquals("tag:" + t, rowRecord.getFields().get(3).getBinaryV().toString());
+        assertEquals("string", rowRecord.getFields().get(3).getBinaryV().toString());
         assertEquals(t, rowRecord.getFields().get(4).getLongV());
         cnt++;
       }
@@ -1523,7 +1526,7 @@ public class IoTDBSessionRelationalIT {
 
       for (int row = 0; row < 15; row++) {
         tablet.addTimestamp(row, timestamp);
-        tablet.addValue("tag2", row, "tag:" + timestamp);
+        tablet.addValue("tag2", row, "string");
         tablet.addValue("s2", row, timestamp);
         timestamp++;
       }
@@ -1540,7 +1543,7 @@ public class IoTDBSessionRelationalIT {
         assertNull(rowRecord.getFields().get(1).getDataType());
         // s1 should be null
         assertNull(rowRecord.getFields().get(2).getDataType());
-        assertEquals("tag:" + t, rowRecord.getFields().get(3).getBinaryV().toString());
+        assertEquals("string", rowRecord.getFields().get(3).getBinaryV().toString());
         assertEquals(t, rowRecord.getFields().get(4).getLongV());
         cnt++;
       }

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/session/IoTDBSessionRelationalIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/session/IoTDBSessionRelationalIT.java
@@ -1494,7 +1494,7 @@ public class IoTDBSessionRelationalIT {
 
       for (int row = 0; row < 15; row++) {
         tablet.addTimestamp(row, timestamp);
-        tablet.addValue("tag2", row, "tag:" + timestamp);
+        tablet.addValue("tag2", row, "string");
         tablet.addValue("s2", row, timestamp);
         timestamp ++;
       }

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/session/IoTDBSessionRelationalIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/session/IoTDBSessionRelationalIT.java
@@ -829,7 +829,7 @@ public class IoTDBSessionRelationalIT {
         tablet.addValue("tag2", row, "tag:" + timestamp);
         tablet.addValue("attr1", row, "attr:" + timestamp);
         tablet.addValue("m1", row, timestamp * 1.0);
-        timestamp ++;
+        timestamp++;
       }
 
       session.insert(tablet);
@@ -856,7 +856,7 @@ public class IoTDBSessionRelationalIT {
         tablet.addValue("tag2", row, "tag:" + timestamp);
         tablet.addValue("attr1", row, "attr:" + timestamp);
         tablet.addValue("m1", row, timestamp * 1.0);
-        timestamp ++;
+        timestamp++;
       }
 
       session.insert(tablet);
@@ -1475,7 +1475,8 @@ public class IoTDBSessionRelationalIT {
     try (ITableSession session = EnvFactory.getEnv().getTableSessionConnection()) {
       session.executeNonQueryStatement("USE \"db1\"");
       // only one column in this table, and others should be auto-created
-      session.executeNonQueryStatement("CREATE TABLE table" + testNum + " (tag1 string tag, s1 text field)");
+      session.executeNonQueryStatement(
+          "CREATE TABLE table" + testNum + " (tag1 string tag, s1 text field)");
 
       List<IMeasurementSchema> schemaList = new ArrayList<>();
       schemaList.add(new MeasurementSchema("tag2", TSDataType.STRING));
@@ -1496,13 +1497,14 @@ public class IoTDBSessionRelationalIT {
         tablet.addTimestamp(row, timestamp);
         tablet.addValue("tag2", row, "string");
         tablet.addValue("s2", row, timestamp);
-        timestamp ++;
+        timestamp++;
       }
 
       session.insert(tablet);
       tablet.reset();
 
-      SessionDataSet dataSet = session.executeQueryStatement("select * from table" + testNum + " order by time");
+      SessionDataSet dataSet =
+          session.executeQueryStatement("select * from table" + testNum + " order by time");
       int cnt = 0;
       while (dataSet.hasNext()) {
         RowRecord rowRecord = dataSet.next();
@@ -1523,7 +1525,7 @@ public class IoTDBSessionRelationalIT {
         tablet.addTimestamp(row, timestamp);
         tablet.addValue("tag2", row, "tag:" + timestamp);
         tablet.addValue("s2", row, timestamp);
-        timestamp ++;
+        timestamp++;
       }
 
       session.insert(tablet);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/CommonUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/CommonUtils.java
@@ -379,12 +379,6 @@ public class CommonUtils {
         break;
       case TEXT:
       case STRING:
-        if (columnCategory.equals(TsTableColumnCategory.FIELD)) {
-          valueColumn = new Binary[rowNum];
-        } else {
-          valueColumn = new String[rowNum];
-        }
-        break;
       case BLOB:
         valueColumn = new Binary[rowNum];
         break;


### PR DESCRIPTION
If the incoming tablet does not contain all tag columns, missing ones will be added as place holders. 
However, they are mistakenly initialized as String[] instead of Binary[], which may cause serialization error. 