### PR TITLE
Make show-queries can execute on more status node

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -1755,12 +1755,12 @@ public class ConfigManager implements IManager {
   }
 
   @Override
-  public TGetDataNodeLocationsResp getRunningDataNodeLocations() {
+  public TGetDataNodeLocationsResp getReadableDataNodeLocations() {
     TSStatus status = confirmLeader();
     return status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()
         ? new TGetDataNodeLocationsResp(
             new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode()),
-            nodeManager.filterDataNodeThroughStatus(NodeStatus.Running).stream()
+            nodeManager.filterDataNodeThroughStatus(NodeStatus::isReadable).stream()
                 .map(TDataNodeConfiguration::getLocation)
                 .collect(Collectors.toList()))
         : new TGetDataNodeLocationsResp(status, Collections.emptyList());

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/IManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/IManager.java
@@ -589,7 +589,7 @@ public interface IManager {
 
   TSStatus killQuery(String queryId, int dataNodeId);
 
-  TGetDataNodeLocationsResp getRunningDataNodeLocations();
+  TGetDataNodeLocationsResp getReadableDataNodeLocations();
 
   /**
    * Get the latest RegionRouteMap.

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/LoadManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/LoadManager.java
@@ -50,6 +50,7 @@ import org.apache.iotdb.confignode.rpc.thrift.TTimeSlotList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 /**
  * The {@link LoadManager} at ConfigNodeGroup-Leader is active. It proactively implements the
@@ -207,6 +208,16 @@ public class LoadManager {
    */
   public List<Integer> filterDataNodeThroughStatus(NodeStatus... status) {
     return loadCache.filterDataNodeThroughStatus(status);
+  }
+
+  /**
+   * Filter DataNodes through the NodeStatus predicate.
+   *
+   * @param statusPredicate The NodeStatus predicate
+   * @return Filtered DataNodes with the predicate
+   */
+  public List<Integer> filterDataNodeThroughStatus(Function<NodeStatus, Boolean> statusPredicate) {
+    return loadCache.filterDataNodeThroughStatus(statusPredicate);
   }
 
   /**

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/LoadCache.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/LoadCache.java
@@ -63,6 +63,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /** Maintain all kinds of heartbeat samples and statistics. */
@@ -537,6 +538,22 @@ public class LoadCache {
                 nodeCacheEntry.getValue() instanceof DataNodeHeartbeatCache
                     && Arrays.stream(status)
                         .anyMatch(s -> s.equals(nodeCacheEntry.getValue().getNodeStatus())))
+        .map(Map.Entry::getKey)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Filter DataNodes through the NodeStatus predicate.
+   *
+   * @param statusPredicate The NodeStatus predicate
+   * @return Filtered DataNodes with the predicate
+   */
+  public List<Integer> filterDataNodeThroughStatus(Function<NodeStatus, Boolean> statusPredicate) {
+    return nodeCacheMap.entrySet().stream()
+        .filter(
+            nodeCacheEntry ->
+                nodeCacheEntry.getValue() instanceof DataNodeHeartbeatCache
+                    && statusPredicate.apply(nodeCacheEntry.getValue().getNodeStatus()))
         .map(Map.Entry::getKey)
         .collect(Collectors.toList());
   }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/node/NodeManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/node/NodeManager.java
@@ -112,6 +112,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /** {@link NodeManager} manages cluster node addition and removal requests. */
@@ -1079,6 +1080,18 @@ public class NodeManager {
    */
   public List<TDataNodeConfiguration> filterDataNodeThroughStatus(NodeStatus... status) {
     return nodeInfo.getRegisteredDataNodes(getLoadManager().filterDataNodeThroughStatus(status));
+  }
+
+  /**
+   * Filter DataNodes through the NodeStatus predicate.
+   *
+   * @param statusPredicate The NodeStatus predicate
+   * @return Filtered DataNodes with the predicate
+   */
+  public List<TDataNodeConfiguration> filterDataNodeThroughStatus(
+      Function<NodeStatus, Boolean> statusPredicate) {
+    return nodeInfo.getRegisteredDataNodes(
+        getLoadManager().filterDataNodeThroughStatus(statusPredicate));
   }
 
   /**

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/service/thrift/ConfigNodeRPCServiceProcessor.java
@@ -979,8 +979,8 @@ public class ConfigNodeRPCServiceProcessor implements IConfigNodeRPCService.Ifac
   }
 
   @Override
-  public TGetDataNodeLocationsResp getRunningDataNodeLocations() {
-    return configManager.getRunningDataNodeLocations();
+  public TGetDataNodeLocationsResp getReadableDataNodeLocations() {
+    return configManager.getReadableDataNodeLocations();
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/client/ConfigNodeClient.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/client/ConfigNodeClient.java
@@ -807,9 +807,9 @@ public class ConfigNodeClient implements IConfigNodeRPCService.Iface, ThriftClie
   }
 
   @Override
-  public TGetDataNodeLocationsResp getRunningDataNodeLocations() throws TException {
+  public TGetDataNodeLocationsResp getReadableDataNodeLocations() throws TException {
     return executeRemoteCallWithRetry(
-        () -> client.getRunningDataNodeLocations(), resp -> !updateConfigNodeLeader(resp.status));
+        () -> client.getReadableDataNodeLocations(), resp -> !updateConfigNodeLeader(resp.status));
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/Analysis.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/Analysis.java
@@ -286,7 +286,7 @@ public class Analysis implements IAnalysis {
   /////////////////////////////////////////////////////////////////////////////////////////////////
 
   // extra message from config node, queries wll be sent to these Running DataNodes
-  private List<TDataNodeLocation> runningDataNodeLocations;
+  private List<TDataNodeLocation> readableDataNodeLocations;
 
   // used for limit and offset push down optimizer, if we select all columns from aligned device, we
   // can use statistics to skip
@@ -805,12 +805,12 @@ public class Analysis implements IAnalysis {
     this.tagValuesToGroupedTimeseriesOperands = tagValuesToGroupedTimeseriesOperands;
   }
 
-  public List<TDataNodeLocation> getRunningDataNodeLocations() {
-    return runningDataNodeLocations;
+  public List<TDataNodeLocation> getReadableDataNodeLocations() {
+    return readableDataNodeLocations;
   }
 
-  public void setRunningDataNodeLocations(List<TDataNodeLocation> runningDataNodeLocations) {
-    this.runningDataNodeLocations = runningDataNodeLocations;
+  public void setReadableDataNodeLocations(List<TDataNodeLocation> readableDataNodeLocations) {
+    this.readableDataNodeLocations = readableDataNodeLocations;
   }
 
   public boolean isVirtualSource() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LogicalPlanBuilder.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LogicalPlanBuilder.java
@@ -1271,7 +1271,7 @@ public class LogicalPlanBuilder {
   }
 
   public LogicalPlanBuilder planShowQueries(Analysis analysis) {
-    List<TDataNodeLocation> dataNodeLocations = analysis.getRunningDataNodeLocations();
+    List<TDataNodeLocation> dataNodeLocations = analysis.getReadableDataNodeLocations();
     if (dataNodeLocations.size() == 1) {
       this.root =
           planSingleShowQueries(dataNodeLocations.get(0))

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/cluster/NodeStatus.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/cluster/NodeStatus.java
@@ -57,4 +57,17 @@ public enum NodeStatus {
     // Currently, the only normal status is Running
     return status != null && status.equals(NodeStatus.Running);
   }
+
+  public static boolean isReadable(NodeStatus status) {
+    switch (status) {
+      case Running:
+      case Removing:
+      case ReadOnly:
+        return true;
+      case Unknown:
+        return false;
+      default:
+        throw new UnsupportedOperationException(String.format("Unknown NodeStatus %s.", status));
+    }
+  }
 }

--- a/iotdb-protocol/thrift-confignode/src/main/thrift/confignode.thrift
+++ b/iotdb-protocol/thrift-confignode/src/main/thrift/confignode.thrift
@@ -1550,8 +1550,8 @@ service IConfigNodeRPCService {
   /** Kill query */
   common.TSStatus killQuery(string queryId, i32 dataNodeId)
 
-  /** Get all DataNodeLocations of Running DataNodes */
-  TGetDataNodeLocationsResp getRunningDataNodeLocations()
+  /** Get all DataNodeLocations of Readable DataNodes */
+  TGetDataNodeLocationsResp getReadableDataNodeLocations()
 
   // ======================================================
   // Cluster Tools


### PR DESCRIPTION
In the past, show-queries can execute only on `Running` status node. 
But now, more status of node have  been introduced, show-queries can execute on node which is readable (status is `Running`, `Removing` or `ReadOnly`).

Additionally, this PR implements the switch-case judge method of readable to ensure it will be checked if someone introduces more status of node.