### PR TITLE
[To dev/1.3] Load: Consider isGeneratedByPipe mark when executing tsfile-tablet conversion in analysis stage (#14651)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
@@ -2983,6 +2983,12 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
   @Override
   public Analysis visitPipeEnrichedStatement(
       PipeEnrichedStatement pipeEnrichedStatement, MPPQueryContext context) {
+    // The LoadTsFileStatement is a special case, it needs isGeneratedByPipe information
+    // in the analyzer to execute the tsfile-tablet conversion in some cases.
+    if (pipeEnrichedStatement.getInnerStatement() instanceof LoadTsFileStatement) {
+      ((LoadTsFileStatement) pipeEnrichedStatement.getInnerStatement()).markIsGeneratedByPipe();
+    }
+
     Analysis analysis = pipeEnrichedStatement.getInnerStatement().accept(this, context);
 
     // statement may be changed because of logical view

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/LoadTsFileAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/LoadTsFileAnalyzer.java
@@ -229,7 +229,7 @@ public class LoadTsFileAnalyzer implements AutoCloseable {
   private void executeDataTypeConversionOnTypeMismatch(
       final Analysis analysis, final VerifyMetadataTypeMismatchException e) {
     final LoadTsFileDataTypeConverter loadTsFileDataTypeConverter =
-        new LoadTsFileDataTypeConverter();
+        new LoadTsFileDataTypeConverter(loadTsFileStatement.isGeneratedByPipe());
     final TSStatus status =
         loadTsFileStatement.isConvertOnTypeMismatch()
             ? loadTsFileDataTypeConverter.convertForTreeModel(loadTsFileStatement).orElse(null)

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/load/LoadTsFileScheduler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/load/LoadTsFileScheduler.java
@@ -525,7 +525,7 @@ public class LoadTsFileScheduler implements IScheduler {
 
   private void convertFailedTsFilesToTabletsAndRetry() {
     final LoadTsFileDataTypeConverter loadTsFileDataTypeConverter =
-        new LoadTsFileDataTypeConverter();
+        new LoadTsFileDataTypeConverter(isGeneratedByPipe);
 
     for (final int failedLoadTsFileIndex : failedTsFileNodeIndexes) {
       final LoadSingleTsFileNode failedNode = tsFileNodeList.get(failedLoadTsFileIndex);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/LoadTsFileStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/LoadTsFileStatement.java
@@ -47,6 +47,7 @@ public class LoadTsFileStatement extends Statement {
   private boolean deleteAfterLoad = false;
   private boolean convertOnTypeMismatch = true;
   private boolean autoCreateDatabase = true;
+  private boolean isGeneratedByPipe = false;
 
   private Map<String, String> loadAttributes;
 
@@ -166,6 +167,14 @@ public class LoadTsFileStatement extends Statement {
 
   public boolean isAutoCreateDatabase() {
     return autoCreateDatabase;
+  }
+
+  public void markIsGeneratedByPipe() {
+    isGeneratedByPipe = true;
+  }
+
+  public boolean isGeneratedByPipe() {
+    return isGeneratedByPipe;
   }
 
   public List<File> getTsFiles() {


### PR DESCRIPTION
(cherry picked from commit 90cdf3bbc94224723ba00b0f92b0007d38a84000)