### PR TITLE
Adjust default wal_throttle_threshold_in_byte and region_migration_speed_limit_bytes_per_second

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -1064,7 +1064,7 @@ public class IoTDBConfig {
   private int driverTaskExecutionTimeSliceInMs = 200;
 
   /** Maximum size of wal buffer used in IoTConsensus. Unit: byte */
-  private long throttleThreshold = 50 * 1024 * 1024 * 1024L;
+  private long throttleThreshold = 200 * 1024 * 1024 * 1024L;
 
   /** Maximum wait time of write cache in IoTConsensus. Unit: ms */
   private long cacheWindowTimeInMs = 10 * 1000L;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -1144,7 +1144,7 @@ public class IoTDBConfig {
   private int maxSizePerBatch = 16 * 1024 * 1024;
   private int maxPendingBatchesNum = 5;
   private double maxMemoryRatioForQueue = 0.6;
-  private long regionMigrationSpeedLimitBytesPerSecond = 32 * 1024 * 1024L;
+  private long regionMigrationSpeedLimitBytesPerSecond = 48 * 1024 * 1024L;
 
   // IoTConsensusV2 Config
   private int iotConsensusV2PipelineSize = 5;

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
@@ -1457,10 +1457,10 @@ delete_wal_files_period_in_ms=20000
 
 # The minimum size of wal files when throttle down in IoTConsensus
 # If this value is not set, it will be carefully chosen according to the available disk space.
-# If this value is set smaller than 0, it will default to 50 * 1024 * 1024 * 1024 bytes (50GB).
+# If this value is set smaller than 0, it will default to 200 * 1024 * 1024 * 1024 bytes (200GB).
 # effectiveMode: hot_reload
 # Datatype: long
-wal_throttle_threshold_in_byte=53687091200
+wal_throttle_threshold_in_byte=214748364800
 
 # Maximum wait time of write cache in IoTConsensus
 # If this value is less than or equal to 0, use the default value 10 * 1000 ms (10s)

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
@@ -1504,7 +1504,7 @@ data_region_iot_max_memory_ratio_for_queue = 0.6
 # values less than or equal to 0 means no limit
 # effectiveMode: hot_reload
 # Datatype: long
-region_migration_speed_limit_bytes_per_second = 33554432
+region_migration_speed_limit_bytes_per_second = 50331648
 
 ####################
 ### Blob Allocator Configuration


### PR DESCRIPTION
- wal_throttle_threshold_in_byte: from 50GB to 200GB
- region_migration_speed_limit_bytes_per_second: from 32MB/s to 48MB/s