### PR TITLE
Fix select-distinct when there is no order by and select items contains expression

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
@@ -4159,6 +4159,14 @@ public class IoTDBTableAggregationIT {
         expectedHeader,
         retArray,
         DATABASE_NAME);
+
+    expectedHeader = new String[] {"_col0"};
+    retArray = new String[] {"false,"};
+    tableResultSetEqualTest(
+        "select distinct s1 < 0 from table1 where s1 is not null",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
   }
 
   @Test

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/QueryPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/QueryPlanner.java
@@ -256,7 +256,7 @@ public class QueryPlanner {
     }
 
     List<Expression> orderBy = analysis.getOrderByExpressions(node);
-    if (!orderBy.isEmpty()) {
+    if (!orderBy.isEmpty() || node.getSelect().isDistinct()) {
       builder =
           builder.appendProjections(
               Iterables.concat(orderBy, outputs), symbolAllocator, queryContext);


### PR DESCRIPTION
cause: now only appendProjections when there is order-by, but maybe there is projection before distinct too.
![image](https://github.com/user-attachments/assets/71c5a8f7-f031-462a-97d7-a0390cd5bf65)
