### PR TITLE
Fix format IT

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/builtinfunction/scalar/IoTDBFormatFunctionTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/builtinfunction/scalar/IoTDBFormatFunctionTableIT.java
@@ -36,14 +36,13 @@ import static java.lang.String.format;
 import static org.apache.iotdb.db.it.utils.TestUtils.tableAssertTestFail;
 import static org.apache.iotdb.db.it.utils.TestUtils.tableResultSetEqualTest;
 
-// @Ignore
 @RunWith(IoTDBTestRunner.class)
 @Category({TableLocalStandaloneIT.class, TableClusterIT.class})
 public class IoTDBFormatFunctionTableIT {
 
   private static final String DATABASE_NAME = "db";
 
-  private final ZoneId zoneId = ZoneId.of("Z");
+  private static final ZoneId zoneId = ZoneId.of("Z");
 
   private static final String[] SQLs =
       new String[] {

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/builtinfunction/scalar/IoTDBFormatFunctionTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/builtinfunction/scalar/IoTDBFormatFunctionTableIT.java
@@ -14,6 +14,7 @@
 
 package org.apache.iotdb.relational.it.query.old.builtinfunction.scalar;
 
+import org.apache.iotdb.db.utils.DateTimeUtils;
 import org.apache.iotdb.it.env.EnvFactory;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.TableClusterIT;
@@ -22,23 +23,27 @@ import org.apache.iotdb.itbase.env.BaseEnv;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.sql.Connection;
 import java.sql.Statement;
+import java.time.LocalDate;
+import java.time.ZoneId;
 
+import static java.lang.String.format;
 import static org.apache.iotdb.db.it.utils.TestUtils.tableAssertTestFail;
 import static org.apache.iotdb.db.it.utils.TestUtils.tableResultSetEqualTest;
 
-@Ignore
+// @Ignore
 @RunWith(IoTDBTestRunner.class)
 @Category({TableLocalStandaloneIT.class, TableClusterIT.class})
 public class IoTDBFormatFunctionTableIT {
 
   private static final String DATABASE_NAME = "db";
+
+  private final ZoneId zoneId = ZoneId.of("Z");
 
   private static final String[] SQLs =
       new String[] {
@@ -152,7 +157,10 @@ public class IoTDBFormatFunctionTableIT {
     tableResultSetEqualTest(
         "SELECT FORMAT('%tc', s1) FROM timestamp_table",
         new String[] {"_col0"},
-        new String[] {"周四 1月 01 00:00:00 Z 1970,", "周四 1月 01 00:00:00 Z 1970,"},
+        new String[] {
+          format("%tc,", DateTimeUtils.convertToZonedDateTime(10, zoneId)),
+          format("%tc,", DateTimeUtils.convertToZonedDateTime(20, zoneId)),
+        },
         DATABASE_NAME);
   }
 
@@ -161,7 +169,10 @@ public class IoTDBFormatFunctionTableIT {
     tableResultSetEqualTest(
         "SELECT FORMAT('%1$tA, %1$tB %1$te, %1$tY', s1) FROM date_table",
         new String[] {"_col0"},
-        new String[] {"星期一, 一月 1, 2024,", "星期二, 七月 4, 2006,"},
+        new String[] {
+          format("%1$tA, %1$tB %1$te, %1$tY,", LocalDate.of(2024, 1, 1)),
+          format("%1$tA, %1$tB %1$te, %1$tY,", LocalDate.of(2006, 7, 4))
+        },
         DATABASE_NAME);
 
     tableResultSetEqualTest(


### PR DESCRIPTION
This pull request includes updates to the `IoTDBFormatFunctionTableIT` test class to improve date and time formatting in test cases. The changes primarily involve importing necessary utilities and updating test assertions to use dynamic date and time values.

Key changes include:

### Imports and Dependencies:
* Added imports for `DateTimeUtils`, `LocalDate`, `ZoneId`, and `format` to support new date and time formatting functionality. [[1]](diffhunk://#diff-81d6991cc3a2bfadf2a2b018b43dd2101d495ebed67050183b355ce578d14a55R17) [[2]](diffhunk://#diff-81d6991cc3a2bfadf2a2b018b43dd2101d495ebed67050183b355ce578d14a55L25-R46)

### Test Enhancements:
* Removed the `@Ignore` annotation to enable the test class for execution.
* Added a `ZoneId` constant to specify the time zone for formatting.
* Updated the `testTimestampFormat` method to use `DateTimeUtils.convertToZonedDateTime` for dynamic timestamp formatting in assertions.
* Updated the `testDateFormat` method to use `LocalDate` for dynamic date formatting in assertions.