### PR TITLE
[To dev/1.3] Pipe: strict check for synonym pipe parameters to avoid ambiguity (#14694)

### DIFF
--- a/iotdb-api/pipe-api/src/main/java/org/apache/iotdb/pipe/api/customizer/parameter/PipeParameterValidator.java
+++ b/iotdb-api/pipe-api/src/main/java/org/apache/iotdb/pipe/api/customizer/parameter/PipeParameterValidator.java
@@ -23,6 +23,10 @@ import org.apache.iotdb.pipe.api.exception.PipeAttributeNotProvidedException;
 import org.apache.iotdb.pipe.api.exception.PipeParameterNotValidException;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class PipeParameterValidator {
 
@@ -34,6 +38,40 @@ public class PipeParameterValidator {
 
   public PipeParameters getParameters() {
     return parameters;
+  }
+
+  /**
+   * Validates whether the attributes entered by the user contain at least one attribute from
+   * lhsAttributes or rhsAttributes (if required), but not both.
+   *
+   * @param lhsAttributes list of left-hand side synonym attributes
+   * @param rhsAttributes list of right-hand side synonym attributes
+   * @param isRequired specifies whether at least one attribute from lhsAttributes or rhsAttributes
+   *     must be provided
+   * @throws PipeParameterNotValidException if both lhsAttributes and rhsAttributes are provided
+   * @throws PipeAttributeNotProvidedException if isRequired is true and neither lhsAttributes nor
+   *     rhsAttributes are provided
+   * @return the instance of PipeParameterValidator for method chaining
+   */
+  public PipeParameterValidator validateSynonymAttributes(
+      final List<String> lhsAttributes,
+      final List<String> rhsAttributes,
+      final boolean isRequired) {
+    final boolean lhsExistence = lhsAttributes.stream().anyMatch(parameters::hasAttribute);
+    final boolean rhsExistence = rhsAttributes.stream().anyMatch(parameters::hasAttribute);
+    if (lhsExistence && rhsExistence) {
+      throw new PipeParameterNotValidException(
+          String.format(
+              "Cannot specify both %s and %s at the same time", lhsAttributes, rhsAttributes));
+    }
+    if (isRequired && !lhsExistence && !rhsExistence) {
+      throw new PipeAttributeNotProvidedException(
+          Stream.concat(lhsAttributes.stream(), rhsAttributes.stream())
+              .collect(
+                  Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList))
+              .toString());
+    }
+    return this;
   }
 
   /**
@@ -83,7 +121,7 @@ public class PipeParameterValidator {
    * @throws PipeParameterNotValidException if the given argument is not valid
    */
   public PipeParameterValidator validate(
-      final PipeParameterValidator.SingleObjectValidationRule validationRule,
+      final SingleObjectValidationRule validationRule,
       final String messageToThrow,
       final Object argument)
       throws PipeParameterNotValidException {
@@ -107,7 +145,7 @@ public class PipeParameterValidator {
    * @throws PipeParameterNotValidException if the given arguments are not valid
    */
   public PipeParameterValidator validate(
-      final PipeParameterValidator.MultipleObjectsValidationRule validationRule,
+      final MultipleObjectsValidationRule validationRule,
       final String messageToThrow,
       final Object... arguments)
       throws PipeParameterNotValidException {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/connector/protocol/IoTDBConnector.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/connector/protocol/IoTDBConnector.java
@@ -186,6 +186,12 @@ public abstract class IoTDBConnector implements PipeConnector {
             Arrays.asList(CONNECTOR_IOTDB_BATCH_SIZE_KEY, SINK_IOTDB_BATCH_SIZE_KEY),
             CONNECTOR_IOTDB_PLAIN_BATCH_SIZE_DEFAULT_VALUE));
 
+    // Check coexistence of user and username
+    validator.validateSynonymAttributes(
+        Arrays.asList(CONNECTOR_IOTDB_USER_KEY, SINK_IOTDB_USER_KEY),
+        Arrays.asList(CONNECTOR_IOTDB_USERNAME_KEY, SINK_IOTDB_USERNAME_KEY),
+        false);
+
     username =
         parameters.getStringOrDefault(
             Arrays.asList(


### PR DESCRIPTION
cherry-pick #14694 to https://github.com/apache/iotdb/tree/dev/1.3