### PR TITLE
Fix cache invalidation failure and add retry

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionSimpleIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionSimpleIT.java
@@ -1900,7 +1900,8 @@ public class IoTDBSessionSimpleIT {
   }
 
   @Test
-  public void testWriteRestartAndDeleteDB() throws IoTDBConnectionException, StatementExecutionException {
+  public void testWriteRestartAndDeleteDB()
+      throws IoTDBConnectionException, StatementExecutionException {
     try (ISession session = EnvFactory.getEnv().getSessionConnection()) {
       session.insertRecord("root.sg1.d1", 1, Arrays.asList("s3"), Arrays.asList("1"));
 

--- a/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionSimpleIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionSimpleIT.java
@@ -1898,4 +1898,26 @@ public class IoTDBSessionSimpleIT {
       e.printStackTrace();
     }
   }
+
+  @Test
+  public void testWriteRestartAndDeleteDB() throws IoTDBConnectionException, StatementExecutionException {
+    try (ISession session = EnvFactory.getEnv().getSessionConnection()) {
+      session.insertRecord("root.sg1.d1", 1, Arrays.asList("s3"), Arrays.asList("1"));
+
+      TestUtils.stopForciblyAndRestartDataNodes();
+
+      SessionDataSet dataSet = session.executeQueryStatement("select s3 from root.sg1.d1");
+      dataSet.next();
+      dataSet.close();
+
+      session.executeNonQueryStatement("DELETE DATABASE root.sg1");
+
+      session.insertRecord(
+          "root.sg1.d1", 1, Arrays.asList("s1", "s2", "s3"), Arrays.asList("1", "1", "1"));
+
+      dataSet = session.executeQueryStatement("SELECT * FROM root.sg1.d1");
+      RowRecord record = dataSet.next();
+      assertEquals(3, record.getFields().size());
+    }
+  }
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
@@ -59,7 +59,6 @@ import org.apache.iotdb.confignode.procedure.scheduler.ProcedureScheduler;
 import org.apache.iotdb.confignode.rpc.thrift.TAddConsensusGroupReq;
 import org.apache.iotdb.confignode.rpc.thrift.TNodeVersionInfo;
 import org.apache.iotdb.consensus.exception.ConsensusException;
-import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.mpp.rpc.thrift.TActiveTriggerInstanceReq;
 import org.apache.iotdb.mpp.rpc.thrift.TCreateDataRegionReq;
 import org.apache.iotdb.mpp.rpc.thrift.TCreatePipePluginInstanceReq;


### PR DESCRIPTION
When executing DELETE DATABASE right after the restart of a data node, cache inconsistency will occur due to:
1. the node status remains UNKNOWN during the execution of DELETE DATABASE;
2. nodes with status UNKNOWN are skipped when invalidating the cache.



'1.' is fixed by adding more retries when finding a node with UNKNOWN status;

 '2.'  is fixed by aborting the DELETE DATABASE procedure if any node is UNKNOWN.