### PR TITLE
Subscription: fix `hasNext` method in tablet batch to support multiple tsfile in the same batch

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeTabletEventBatch.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeTabletEventBatch.java
@@ -216,7 +216,7 @@ public class SubscriptionPipeTabletEventBatch extends SubscriptionPipeEventBatch
         // reset
         currentTabletInsertionEventsIterator = null;
         currentTsFileInsertionEvent = null;
-        return false;
+        return hasNext();
       }
     }
 


### PR DESCRIPTION
fixup #14101