### PR TITLE
Bump TsFile version to 2.0.0-250118-SNAPSHOT

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/MemAlignedChunkLoaderTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/MemAlignedChunkLoaderTest.java
@@ -82,7 +82,7 @@ public class MemAlignedChunkLoaderTest {
     Mockito.when(statistics6.hasNullValue(2)).thenReturn(true);
 
     Statistics timeStatistics = Mockito.mock(Statistics.class);
-    Mockito.when(timeStatistics.getCount()).thenReturn(2L);
+    Mockito.when(timeStatistics.getCount()).thenReturn(2);
 
     Mockito.when(chunkMetadata1.getStatistics()).thenReturn(timeStatistics);
     Mockito.when(chunkMetadata1.getTimeStatistics()).thenReturn(timeStatistics);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/MemChunkLoaderTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/MemChunkLoaderTest.java
@@ -67,7 +67,7 @@ public class MemChunkLoaderTest {
     Mockito.when(chunk.getChunkMetaData()).thenReturn(chunkMetadata1);
     Mockito.when(chunk.getPointReader()).thenReturn(null);
     Statistics statistics = Mockito.mock(Statistics.class);
-    Mockito.when(statistics.getCount()).thenReturn(2L);
+    Mockito.when(statistics.getCount()).thenReturn(2);
 
     Mockito.when(chunkMetadata1.getStatistics()).thenReturn(statistics);
     Mockito.when(chunkMetadata1.getDataType()).thenReturn(TSDataType.BOOLEAN);
@@ -135,7 +135,7 @@ public class MemChunkLoaderTest {
     Mockito.when(chunk.getChunkMetaData()).thenReturn(chunkMetadata1);
     Mockito.when(chunk.getPointReader()).thenReturn(null);
     Statistics statistics = Mockito.mock(Statistics.class);
-    Mockito.when(statistics.getCount()).thenReturn(2L);
+    Mockito.when(statistics.getCount()).thenReturn(2);
 
     Mockito.when(chunkMetadata1.getStatistics()).thenReturn(statistics);
     Mockito.when(chunkMetadata1.getDataType()).thenReturn(TSDataType.INT32);
@@ -203,7 +203,7 @@ public class MemChunkLoaderTest {
     Mockito.when(chunk.getChunkMetaData()).thenReturn(chunkMetadata1);
     Mockito.when(chunk.getPointReader()).thenReturn(null);
     Statistics statistics = Mockito.mock(Statistics.class);
-    Mockito.when(statistics.getCount()).thenReturn(2L);
+    Mockito.when(statistics.getCount()).thenReturn(2);
 
     Mockito.when(chunkMetadata1.getStatistics()).thenReturn(statistics);
     Mockito.when(chunkMetadata1.getDataType()).thenReturn(TSDataType.INT64);
@@ -271,7 +271,7 @@ public class MemChunkLoaderTest {
     Mockito.when(chunk.getChunkMetaData()).thenReturn(chunkMetadata1);
     Mockito.when(chunk.getPointReader()).thenReturn(null);
     Statistics statistics = Mockito.mock(Statistics.class);
-    Mockito.when(statistics.getCount()).thenReturn(2L);
+    Mockito.when(statistics.getCount()).thenReturn(2);
 
     Mockito.when(chunkMetadata1.getStatistics()).thenReturn(statistics);
     Mockito.when(chunkMetadata1.getDataType()).thenReturn(TSDataType.FLOAT);
@@ -339,7 +339,7 @@ public class MemChunkLoaderTest {
     Mockito.when(chunk.getChunkMetaData()).thenReturn(chunkMetadata1);
     Mockito.when(chunk.getPointReader()).thenReturn(null);
     Statistics statistics = Mockito.mock(Statistics.class);
-    Mockito.when(statistics.getCount()).thenReturn(2L);
+    Mockito.when(statistics.getCount()).thenReturn(2);
 
     Mockito.when(chunkMetadata1.getStatistics()).thenReturn(statistics);
     Mockito.when(chunkMetadata1.getDataType()).thenReturn(TSDataType.DOUBLE);
@@ -407,7 +407,7 @@ public class MemChunkLoaderTest {
     Mockito.when(chunk.getChunkMetaData()).thenReturn(chunkMetadata1);
     Mockito.when(chunk.getPointReader()).thenReturn(null);
     Statistics statistics = Mockito.mock(Statistics.class);
-    Mockito.when(statistics.getCount()).thenReturn(2L);
+    Mockito.when(statistics.getCount()).thenReturn(2);
 
     Mockito.when(chunkMetadata1.getStatistics()).thenReturn(statistics);
     Mockito.when(chunkMetadata1.getDataType()).thenReturn(TSDataType.TEXT);

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
         <thrift.version>0.14.1</thrift.version>
         <xz.version>1.9</xz.version>
         <zstd-jni.version>1.5.6-3</zstd-jni.version>
-        <tsfile.version>2.0.0-250113-SNAPSHOT</tsfile.version>
+        <tsfile.version>2.0.0-250118-SNAPSHOT</tsfile.version>
     </properties>
     <!--
     if we claim dependencies in dependencyManagement, then we do not claim


### PR DESCRIPTION
To revert a change in TsFile that will make the memory calculation of Binary too expensive.