### PR TITLE
Let the DataPartitionTable be automatically cleanable

### DIFF
--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppCommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppCommonConfig.java
@@ -255,6 +255,12 @@ public class MppCommonConfig extends MppBaseConfig implements CommonConfig {
   }
 
   @Override
+  public CommonConfig setTTLCheckInterval(long ttlCheckInterval) {
+    setProperty("ttl_check_interval", String.valueOf(ttlCheckInterval));
+    return this;
+  }
+
+  @Override
   public CommonConfig setTimePartitionOrigin(long timePartitionOrigin) {
     setProperty("time_partition_origin", String.valueOf(timePartitionOrigin));
     return this;
@@ -378,6 +384,12 @@ public class MppCommonConfig extends MppBaseConfig implements CommonConfig {
   @Override
   public CommonConfig setSeriesSlotNum(int seriesSlotNum) {
     setProperty("series_slot_num", String.valueOf(seriesSlotNum));
+    return this;
+  }
+
+  @Override
+  public CommonConfig setSeriesPartitionExecutorClass(String seriesPartitionExecutorClass) {
+    setProperty("series_partition_executor_class", seriesPartitionExecutorClass);
     return this;
   }
 

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppSharedCommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppSharedCommonConfig.java
@@ -259,6 +259,13 @@ public class MppSharedCommonConfig implements CommonConfig {
   }
 
   @Override
+  public CommonConfig setTTLCheckInterval(long ttlCheckInterval) {
+    cnConfig.setTTLCheckInterval(ttlCheckInterval);
+    dnConfig.setTTLCheckInterval(ttlCheckInterval);
+    return this;
+  }
+
+  @Override
   public CommonConfig setTimePartitionOrigin(long timePartitionOrigin) {
     cnConfig.setTimePartitionOrigin(timePartitionOrigin);
     dnConfig.setTimePartitionOrigin(timePartitionOrigin);
@@ -379,6 +386,13 @@ public class MppSharedCommonConfig implements CommonConfig {
   public CommonConfig setSeriesSlotNum(int seriesSlotNum) {
     cnConfig.setSeriesSlotNum(seriesSlotNum);
     dnConfig.setSeriesSlotNum(seriesSlotNum);
+    return this;
+  }
+
+  @Override
+  public CommonConfig setSeriesPartitionExecutorClass(String seriesPartitionExecutorClass) {
+    cnConfig.setSeriesPartitionExecutorClass(seriesPartitionExecutorClass);
+    dnConfig.setSeriesPartitionExecutorClass(seriesPartitionExecutorClass);
     return this;
   }
 

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/remote/config/RemoteCommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/remote/config/RemoteCommonConfig.java
@@ -186,6 +186,11 @@ public class RemoteCommonConfig implements CommonConfig {
   }
 
   @Override
+  public CommonConfig setTTLCheckInterval(long ttlCheckInterval) {
+    return this;
+  }
+
+  @Override
   public CommonConfig setTimePartitionOrigin(long timePartitionOrigin) {
     return this;
   }
@@ -266,6 +271,11 @@ public class RemoteCommonConfig implements CommonConfig {
 
   @Override
   public CommonConfig setSeriesSlotNum(int seriesSlotNum) {
+    return this;
+  }
+
+  @Override
+  public CommonConfig setSeriesPartitionExecutorClass(String seriesPartitionExecutorClass) {
     return this;
   }
 

--- a/integration-test/src/main/java/org/apache/iotdb/itbase/env/CommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/itbase/env/CommonConfig.java
@@ -88,6 +88,8 @@ public interface CommonConfig {
 
   CommonConfig setTimePartitionInterval(long timePartitionInterval);
 
+  CommonConfig setTTLCheckInterval(long ttlCheckInterval);
+
   CommonConfig setTimePartitionOrigin(long timePartitionOrigin);
 
   CommonConfig setTimestampPrecision(String timestampPrecision);
@@ -121,6 +123,8 @@ public interface CommonConfig {
   CommonConfig setDataRatisTriggerSnapshotThreshold(long threshold);
 
   CommonConfig setSeriesSlotNum(int seriesSlotNum);
+
+  CommonConfig setSeriesPartitionExecutorClass(String seriesPartitionExecutorClass);
 
   CommonConfig setSchemaMemoryAllocate(String schemaMemoryAllocate);
 

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/partition/IoTDBPartitionTableAutoCleanTest.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/partition/IoTDBPartitionTableAutoCleanTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.confignode.it.partition;
+
+import org.apache.iotdb.common.rpc.thrift.TConsensusGroupId;
+import org.apache.iotdb.common.rpc.thrift.TSeriesPartitionSlot;
+import org.apache.iotdb.common.rpc.thrift.TTimePartitionSlot;
+import org.apache.iotdb.commons.client.sync.SyncConfigNodeIServiceClient;
+import org.apache.iotdb.commons.utils.TimePartitionUtils;
+import org.apache.iotdb.confignode.rpc.thrift.TDataPartitionReq;
+import org.apache.iotdb.confignode.rpc.thrift.TDataPartitionTableResp;
+import org.apache.iotdb.it.env.EnvFactory;
+import org.apache.iotdb.it.framework.IoTDBTestRunner;
+import org.apache.iotdb.itbase.category.ClusterIT;
+import org.apache.iotdb.rpc.TSStatusCode;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+@RunWith(IoTDBTestRunner.class)
+@Category({ClusterIT.class})
+public class IoTDBPartitionTableAutoCleanTest {
+
+  private static final int TEST_REPLICATION_FACTOR = 1;
+  private static final long TEST_TIME_PARTITION_INTERVAL = 604800000;
+  private static final long TEST_TTL_CHECK_INTERVAL = 5_000;
+  //  private static final int TEST_SERIES_SLOT_NUM = 1000;
+  //  private static final String TEST_SERIES_EXECUTOR_CLASS =
+  // "org.apache.iotdb.commons.partition.executor.hash.BKDRHashExecutor";
+
+  //  private static final SeriesPartitionExecutor TEST_EXECUTOR =
+  //    SeriesPartitionExecutor.getSeriesPartitionExecutor(TEST_SERIES_EXECUTOR_CLASS,
+  // TEST_SERIES_SLOT_NUM);
+  private static final TTimePartitionSlot TEST_CURRENT_TIME_SLOT =
+      TimePartitionUtils.getCurrentTimePartitionSlot();
+  private static final long TEST_TTL = 7 * TEST_TIME_PARTITION_INTERVAL;
+
+  @Before
+  public void setUp() throws Exception {
+    EnvFactory.getEnv()
+        .getConfig()
+        .getCommonConfig()
+        //      .setSeriesSlotNum(TEST_SERIES_SLOT_NUM)
+        //      .setSeriesPartitionExecutorClass(TEST_SERIES_EXECUTOR_CLASS)
+        .setSchemaReplicationFactor(TEST_REPLICATION_FACTOR)
+        .setDataReplicationFactor(TEST_REPLICATION_FACTOR)
+        .setTimePartitionInterval(TEST_TIME_PARTITION_INTERVAL)
+        .setTTLCheckInterval(TEST_TTL_CHECK_INTERVAL);
+
+    // Init 1C1D environment
+    EnvFactory.getEnv().initClusterEnvironment(1, 1);
+  }
+
+  @After
+  public void tearDown() {
+    EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  @Test
+  public void testAutoCleanPartitionTable() throws Exception {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      // Create db1
+      statement.execute("CREATE DATABASE root.db1");
+      statement.execute("CREATE TIMESERIES root.db1.s WITH DATATYPE=INT64,ENCODING=PLAIN");
+      // Insert expired data
+      statement.execute(
+          String.format(
+              "INSERT INTO root.db1(timestamp, s) VALUES (%d, %d)",
+              TEST_CURRENT_TIME_SLOT.getStartTime() - TEST_TTL * 2, -1));
+      // Insert existed data
+      statement.execute(
+          String.format(
+              "INSERT INTO root.db1(timestamp, s) VALUES (%d, %d)",
+              TEST_CURRENT_TIME_SLOT.getStartTime(), 1));
+      // Let db.TTL > device.TTL, the valid TTL should be the bigger one
+      statement.execute("SET TTL TO root.db1 " + TEST_TTL);
+      statement.execute("SET TTL TO root.db1.s " + 10);
+      // Create db2
+      statement.execute("CREATE DATABASE root.db2");
+      statement.execute("CREATE TIMESERIES root.db2.s WITH DATATYPE=INT64,ENCODING=PLAIN");
+      // Insert expired data
+      statement.execute(
+          String.format(
+              "INSERT INTO root.db2(timestamp, s) VALUES (%d, %d)",
+              TEST_CURRENT_TIME_SLOT.getStartTime() - TEST_TTL * 2, -1));
+      // Insert existed data
+      statement.execute(
+          String.format(
+              "INSERT INTO root.db2(timestamp, s) VALUES (%d, %d)",
+              TEST_CURRENT_TIME_SLOT.getStartTime(), 1));
+      // Let db.TTL < device.TTL, the valid TTL should be the bigger one
+      statement.execute("SET TTL TO root.db2 " + 10);
+      statement.execute("SET TTL TO root.db2.s " + TEST_TTL);
+    }
+
+    TDataPartitionReq req = new TDataPartitionReq();
+    req.putToPartitionSlotsMap("root.db1", new TreeMap<>());
+    req.putToPartitionSlotsMap("root.db2", new TreeMap<>());
+    try (SyncConfigNodeIServiceClient client =
+        (SyncConfigNodeIServiceClient) EnvFactory.getEnv().getLeaderConfigNodeConnection()) {
+      for (int retry = 0; retry < 120; retry++) {
+        boolean partitionTableAutoCleaned = true;
+        TDataPartitionTableResp resp = client.getDataPartitionTable(req);
+        if (TSStatusCode.SUCCESS_STATUS.getStatusCode() == resp.getStatus().getCode()) {
+          Map<String, Map<TSeriesPartitionSlot, Map<TTimePartitionSlot, List<TConsensusGroupId>>>>
+              dataPartitionTable = resp.getDataPartitionTable();
+          for (Map.Entry<
+                  String,
+                  Map<TSeriesPartitionSlot, Map<TTimePartitionSlot, List<TConsensusGroupId>>>>
+              e1 : dataPartitionTable.entrySet()) {
+            for (Map.Entry<TSeriesPartitionSlot, Map<TTimePartitionSlot, List<TConsensusGroupId>>>
+                e2 : e1.getValue().entrySet()) {
+              if (e2.getValue().size() != 1) {
+                // The PartitionTable of each database should only contain 1 time partition slot
+                partitionTableAutoCleaned = false;
+                break;
+              }
+            }
+            if (!partitionTableAutoCleaned) {
+              break;
+            }
+          }
+        }
+        if (partitionTableAutoCleaned) {
+          return;
+        }
+        TimeUnit.SECONDS.sleep(1);
+      }
+    }
+    Assert.fail("The PartitionTable in the ConfigNode is not auto cleaned!");
+  }
+}

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlan.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlan.java
@@ -56,6 +56,7 @@ import org.apache.iotdb.confignode.consensus.request.write.model.DropModelInNode
 import org.apache.iotdb.confignode.consensus.request.write.model.DropModelPlan;
 import org.apache.iotdb.confignode.consensus.request.write.model.UpdateModelInfoPlan;
 import org.apache.iotdb.confignode.consensus.request.write.partition.AddRegionLocationPlan;
+import org.apache.iotdb.confignode.consensus.request.write.partition.AutoCleanPartitionTablePlan;
 import org.apache.iotdb.confignode.consensus.request.write.partition.CreateDataPartitionPlan;
 import org.apache.iotdb.confignode.consensus.request.write.partition.CreateSchemaPartitionPlan;
 import org.apache.iotdb.confignode.consensus.request.write.partition.RemoveRegionLocationPlan;
@@ -245,6 +246,9 @@ public abstract class ConfigPhysicalPlan implements IConsensusRequest {
           break;
         case CreateDataPartition:
           plan = new CreateDataPartitionPlan();
+          break;
+        case AutoCleanPartitionTable:
+          plan = new AutoCleanPartitionTablePlan();
           break;
         case DeleteProcedure:
           plan = new DeleteProcedurePlan();

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlanType.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlanType.java
@@ -80,6 +80,7 @@ public enum ConfigPhysicalPlanType {
   CreateDataPartition((short) 404),
   GetOrCreateDataPartition((short) 405),
   GetNodePathsPartition((short) 406),
+  AutoCleanPartitionTable((short) 407),
 
   /** Procedure. */
   UpdateProcedure((short) 500),

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/write/partition/AutoCleanPartitionTablePlan.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/write/partition/AutoCleanPartitionTablePlan.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.confignode.consensus.request.write.partition;
+
+import org.apache.iotdb.common.rpc.thrift.TTimePartitionSlot;
+import org.apache.iotdb.commons.utils.BasicStructureSerDeUtil;
+import org.apache.iotdb.commons.utils.ThriftCommonsSerDeUtils;
+import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlan;
+import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlanType;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+
+public class AutoCleanPartitionTablePlan extends ConfigPhysicalPlan {
+
+  Map<String, Long> databaseTTLMap;
+  TTimePartitionSlot currentTimeSlot;
+
+  public AutoCleanPartitionTablePlan() {
+    super(ConfigPhysicalPlanType.AutoCleanPartitionTable);
+  }
+
+  public AutoCleanPartitionTablePlan(
+      Map<String, Long> databaseTTLMap, TTimePartitionSlot currentTimeSlot) {
+    this();
+    this.databaseTTLMap = databaseTTLMap;
+    this.currentTimeSlot = currentTimeSlot;
+  }
+
+  public Map<String, Long> getDatabaseTTLMap() {
+    return databaseTTLMap;
+  }
+
+  public TTimePartitionSlot getCurrentTimeSlot() {
+    return currentTimeSlot;
+  }
+
+  @Override
+  protected void serializeImpl(DataOutputStream stream) throws IOException {
+    stream.writeShort(getType().getPlanType());
+    stream.writeInt(databaseTTLMap.size());
+    for (Map.Entry<String, Long> entry : databaseTTLMap.entrySet()) {
+      BasicStructureSerDeUtil.write(entry.getKey(), stream);
+      stream.writeLong(entry.getValue());
+    }
+    ThriftCommonsSerDeUtils.serializeTTimePartitionSlot(currentTimeSlot, stream);
+  }
+
+  @Override
+  protected void deserializeImpl(ByteBuffer buffer) throws IOException {
+    int size = buffer.getInt();
+    databaseTTLMap = new TreeMap<>();
+    for (int i = 0; i < size; i++) {
+      String key = BasicStructureSerDeUtil.readString(buffer);
+      long value = buffer.getLong();
+      databaseTTLMap.put(key, value);
+    }
+    currentTimeSlot = ThriftCommonsSerDeUtils.deserializeTTimePartitionSlot(buffer);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    AutoCleanPartitionTablePlan that = (AutoCleanPartitionTablePlan) o;
+    return Objects.equals(databaseTTLMap, that.databaseTTLMap)
+        && Objects.equals(currentTimeSlot, that.currentTimeSlot);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), databaseTTLMap, currentTimeSlot);
+  }
+}

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
@@ -260,6 +260,7 @@ public class ConfigRegionStateMachine implements IStateMachine, IStateMachine.Ev
     configManager.getProcedureManager().stopExecutor();
     configManager.getRetryFailedTasksThread().stopRetryFailedTasksService();
     configManager.getPartitionManager().stopRegionCleaner();
+    configManager.getPartitionManager().stopPartitionTableCleaner();
     configManager.getCQManager().stopCQScheduler();
     configManager.getClusterSchemaManager().clearSchemaQuotaCache();
     // Remove Metric after leader change
@@ -294,6 +295,7 @@ public class ConfigRegionStateMachine implements IStateMachine, IStateMachine.Ev
         () -> configManager.getProcedureManager().getStore().getProcedureInfo().upgrade());
     configManager.getRetryFailedTasksThread().startRetryFailedTasksService();
     configManager.getPartitionManager().startRegionCleaner();
+    configManager.getPartitionManager().startPartitionTableCleaner();
     configManager.checkUserPathPrivilege();
     // Add Metric after leader ready
     configManager.addMetrics();

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/statemachine/ConfigRegionStateMachine.java
@@ -260,7 +260,6 @@ public class ConfigRegionStateMachine implements IStateMachine, IStateMachine.Ev
     configManager.getProcedureManager().stopExecutor();
     configManager.getRetryFailedTasksThread().stopRetryFailedTasksService();
     configManager.getPartitionManager().stopRegionCleaner();
-    configManager.getPartitionManager().stopPartitionTableCleaner();
     configManager.getCQManager().stopCQScheduler();
     configManager.getClusterSchemaManager().clearSchemaQuotaCache();
     // Remove Metric after leader change
@@ -295,7 +294,6 @@ public class ConfigRegionStateMachine implements IStateMachine, IStateMachine.Ev
         () -> configManager.getProcedureManager().getStore().getProcedureInfo().upgrade());
     configManager.getRetryFailedTasksThread().startRetryFailedTasksService();
     configManager.getPartitionManager().startRegionCleaner();
-    configManager.getPartitionManager().startPartitionTableCleaner();
     configManager.checkUserPathPrivilege();
     // Add Metric after leader ready
     configManager.addMetrics();

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/TTLManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/TTLManager.java
@@ -129,6 +129,17 @@ public class TTLManager {
     return ttlInfo.getTTLCount();
   }
 
+  /**
+   * Get the maximum ttl of the subtree of the corresponding database.
+   *
+   * @param database the path of the database.
+   * @return the maximum ttl of the subtree of the corresponding database. return NULL_TTL if the
+   *     TTL is not set or the database does not exist.
+   */
+  public long getDatabaseMaxTTL(String database) {
+    return ttlInfo.getDatabaseMaxTTL(database);
+  }
+
   /** Only used for upgrading from old database-level ttl to device-level ttl. */
   public void setTTL(Map<String, Long> databaseTTLMap) throws IllegalPathException {
     ttlInfo.setTTL(databaseTTLMap);

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/TTLInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/TTLInfo.java
@@ -158,6 +158,22 @@ public class TTLInfo implements SnapshotProcessor {
     }
   }
 
+  /**
+   * Get the maximum ttl of the subtree of the corresponding database.
+   *
+   * @param database the path of the database.
+   * @return the maximum ttl of the subtree of the corresponding database. return NULL_TTL if the
+   *     TTL is not set or the database does not exist.
+   */
+  public long getDatabaseMaxTTL(String database) {
+    lock.readLock().lock();
+    try {
+      return ttlCache.getDatabaseMaxTTL(database);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
   @Override
   public boolean processTakeSnapshot(File snapshotDir) throws TException, IOException {
     File snapshotFile = new File(snapshotDir, SNAPSHOT_FILENAME);

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
@@ -90,6 +90,7 @@ import org.apache.iotdb.confignode.consensus.request.write.model.DropModelInNode
 import org.apache.iotdb.confignode.consensus.request.write.model.DropModelPlan;
 import org.apache.iotdb.confignode.consensus.request.write.model.UpdateModelInfoPlan;
 import org.apache.iotdb.confignode.consensus.request.write.partition.AddRegionLocationPlan;
+import org.apache.iotdb.confignode.consensus.request.write.partition.AutoCleanPartitionTablePlan;
 import org.apache.iotdb.confignode.consensus.request.write.partition.CreateDataPartitionPlan;
 import org.apache.iotdb.confignode.consensus.request.write.partition.CreateSchemaPartitionPlan;
 import org.apache.iotdb.confignode.consensus.request.write.partition.RemoveRegionLocationPlan;
@@ -442,6 +443,8 @@ public class ConfigPlanExecutor {
         return partitionInfo.createSchemaPartition((CreateSchemaPartitionPlan) physicalPlan);
       case CreateDataPartition:
         return partitionInfo.createDataPartition((CreateDataPartitionPlan) physicalPlan);
+      case AutoCleanPartitionTable:
+        return partitionInfo.autoCleanPartitionTable((AutoCleanPartitionTablePlan) physicalPlan);
       case UpdateProcedure:
         return procedureInfo.updateProcedure((UpdateProcedurePlan) physicalPlan);
       case DeleteProcedure:

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/DatabasePartitionTable.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/DatabasePartitionTable.java
@@ -610,6 +610,16 @@ public class DatabasePartitionTable {
     return dataPartitionTable.getLastDataAllotTable();
   }
 
+  /**
+   * Remove PartitionTable where the TimeSlot is expired.
+   *
+   * @param TTL The Time To Live
+   * @param currentTimeSlot The current TimeSlot
+   */
+  public void autoCleanPartitionTable(long TTL, TTimePartitionSlot currentTimeSlot) {
+    dataPartitionTable.autoCleanPartitionTable(TTL, currentTimeSlot);
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/partition/PartitionInfo.java
@@ -42,6 +42,7 @@ import org.apache.iotdb.confignode.consensus.request.write.database.DeleteDataba
 import org.apache.iotdb.confignode.consensus.request.write.database.PreDeleteDatabasePlan;
 import org.apache.iotdb.confignode.consensus.request.write.datanode.UpdateDataNodePlan;
 import org.apache.iotdb.confignode.consensus.request.write.partition.AddRegionLocationPlan;
+import org.apache.iotdb.confignode.consensus.request.write.partition.AutoCleanPartitionTablePlan;
 import org.apache.iotdb.confignode.consensus.request.write.partition.CreateDataPartitionPlan;
 import org.apache.iotdb.confignode.consensus.request.write.partition.CreateSchemaPartitionPlan;
 import org.apache.iotdb.confignode.consensus.request.write.partition.RemoveRegionLocationPlan;
@@ -498,6 +499,24 @@ public class PartitionInfo implements SnapshotProcessor {
               }
             });
 
+    return new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
+  }
+
+  /**
+   * Remove PartitionTable where the TimeSlot is expired.
+   *
+   * @param plan Including TTL and current TimeSlot
+   */
+  public TSStatus autoCleanPartitionTable(AutoCleanPartitionTablePlan plan) {
+    plan.getDatabaseTTLMap()
+        .forEach(
+            (database, ttl) -> {
+              if (isDatabaseExisted(database) && 0 < ttl && ttl < Long.MAX_VALUE) {
+                databasePartitionTables
+                    .get(database)
+                    .autoCleanPartitionTable(ttl, plan.getCurrentTimeSlot());
+              }
+            });
     return new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
   }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/PartitionTableAutoCleaner.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/PartitionTableAutoCleaner.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.confignode.procedure;
+
+import org.apache.iotdb.common.rpc.thrift.TTimePartitionSlot;
+import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
+import org.apache.iotdb.commons.utils.TimePartitionUtils;
+import org.apache.iotdb.confignode.consensus.request.write.partition.AutoCleanPartitionTablePlan;
+import org.apache.iotdb.confignode.manager.ConfigManager;
+import org.apache.iotdb.consensus.exception.ConsensusException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.iotdb.confignode.manager.partition.PartitionManager.CONSENSUS_WRITE_ERROR;
+
+/** A cleaner that automatically deletes the expired mapping within the partition table. */
+public class PartitionTableAutoCleaner<Env> extends InternalProcedure<Env> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PartitionTableAutoCleaner.class);
+
+  private static final CommonConfig COMMON_CONFIG = CommonDescriptor.getInstance().getConfig();
+  private final ConfigManager configManager;
+
+  public PartitionTableAutoCleaner(ConfigManager configManager) {
+    super(COMMON_CONFIG.getTTLCheckInterval());
+    this.configManager = configManager;
+  }
+
+  @Override
+  protected void periodicExecute(Env env) {
+    List<String> databases = configManager.getClusterSchemaManager().getDatabaseNames(null);
+    Map<String, Long> databaseTTLMap =
+        configManager.getClusterSchemaManager().getTTLInfoForUpgrading();
+    for (String database : databases) {
+      long subTreeMaxTTL = configManager.getTTLManager().getDatabaseMaxTTL(database);
+      databaseTTLMap.put(
+          database, Math.max(subTreeMaxTTL, databaseTTLMap.getOrDefault(database, -1L)));
+      long databaseTTL = databaseTTLMap.get(database);
+      if (!configManager.getPartitionManager().isDatabaseExist(database)
+          || databaseTTL < 0
+          || databaseTTL == Long.MAX_VALUE) {
+        // Remove the entry if the database or the TTL does not exist
+        databaseTTLMap.remove(database);
+      }
+    }
+    if (!databaseTTLMap.isEmpty()) {
+      // Only clean the partition table when necessary
+      TTimePartitionSlot currentTimePartitionSlot =
+          TimePartitionUtils.getCurrentTimePartitionSlot();
+      try {
+        configManager
+            .getConsensusManager()
+            .write(new AutoCleanPartitionTablePlan(databaseTTLMap, currentTimePartitionSlot));
+      } catch (ConsensusException e) {
+        LOGGER.warn(CONSENSUS_WRITE_ERROR, e);
+      }
+    }
+  }
+}

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
@@ -289,7 +289,7 @@ public class ProcedureExecutor<Env> {
         new CompletedProcedureRecycler(store, completed, cleanTimeInterval, cleanEvictTTL));
   }
 
-  private void addInternalProcedure(InternalProcedure interalProcedure) {
+  public void addInternalProcedure(InternalProcedure interalProcedure) {
     if (interalProcedure == null) {
       return;
     }

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlanSerDeTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlanSerDeTest.java
@@ -62,6 +62,7 @@ import org.apache.iotdb.commons.sync.TsFilePipeInfo;
 import org.apache.iotdb.commons.trigger.TriggerInformation;
 import org.apache.iotdb.commons.udf.UDFInformation;
 import org.apache.iotdb.commons.udf.UDFType;
+import org.apache.iotdb.commons.utils.TimePartitionUtils;
 import org.apache.iotdb.confignode.consensus.request.write.auth.AuthorPlan;
 import org.apache.iotdb.confignode.consensus.request.write.confignode.ApplyConfigNodePlan;
 import org.apache.iotdb.confignode.consensus.request.write.confignode.RemoveConfigNodePlan;
@@ -85,6 +86,7 @@ import org.apache.iotdb.confignode.consensus.request.write.function.DropTableMod
 import org.apache.iotdb.confignode.consensus.request.write.function.DropTreeModelFunctionPlan;
 import org.apache.iotdb.confignode.consensus.request.write.function.UpdateFunctionPlan;
 import org.apache.iotdb.confignode.consensus.request.write.partition.AddRegionLocationPlan;
+import org.apache.iotdb.confignode.consensus.request.write.partition.AutoCleanPartitionTablePlan;
 import org.apache.iotdb.confignode.consensus.request.write.partition.CreateDataPartitionPlan;
 import org.apache.iotdb.confignode.consensus.request.write.partition.CreateSchemaPartitionPlan;
 import org.apache.iotdb.confignode.consensus.request.write.partition.RemoveRegionLocationPlan;
@@ -179,6 +181,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -443,6 +446,22 @@ public class ConfigPhysicalPlanSerDeTest {
     req0.setAssignedDataPartition(assignedDataPartition);
     CreateDataPartitionPlan req1 =
         (CreateDataPartitionPlan) ConfigPhysicalPlan.Factory.create(req0.serializeToByteBuffer());
+    Assert.assertEquals(req0, req1);
+  }
+
+  @Test
+  public void AutoCleanPartitionTablePlan() throws IOException {
+    Map<String, Long> databaseTTLMap = new TreeMap<>();
+    databaseTTLMap.put("root.db1", -1L); // NULL_TTL
+    databaseTTLMap.put("root.db2", 3600L * 1000 * 24); // 1d_TTL
+    databaseTTLMap.put("root.db3", 3600L * 1000 * 24 * 30); // 1m_TTL
+    TTimePartitionSlot currentTimeSlot =
+        new TTimePartitionSlot(TimePartitionUtils.getTimePartitionSlot(System.currentTimeMillis()));
+    AutoCleanPartitionTablePlan req0 =
+        new AutoCleanPartitionTablePlan(databaseTTLMap, currentTimeSlot);
+    AutoCleanPartitionTablePlan req1 =
+        (AutoCleanPartitionTablePlan)
+            ConfigPhysicalPlan.Factory.create(req0.serializeToByteBuffer());
     Assert.assertEquals(req0, req1);
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -542,9 +542,6 @@ public class IoTDBConfig {
   /** The interval of compaction task schedulation in each virtual database. The unit is ms. */
   private long compactionScheduleIntervalInMs = 60_000L;
 
-  /** The interval of ttl check task in each database. The unit is ms. Default is 2 hours. */
-  private long ttlCheckInterval = 7_200_000L;
-
   /** The number of threads to be set up to check ttl. */
   private int ttlCheckerNum = 1;
 
@@ -3061,16 +3058,8 @@ public class IoTDBConfig {
     this.compactionScheduleIntervalInMs = compactionScheduleIntervalInMs;
   }
 
-  public long getTTlCheckInterval() {
-    return ttlCheckInterval;
-  }
-
   public int getTTlCheckerNum() {
     return ttlCheckerNum;
-  }
-
-  public void setTtlCheckInterval(long ttlCheckInterval) {
-    this.ttlCheckInterval = ttlCheckInterval;
   }
 
   public long getMaxExpiredTime() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -734,11 +734,6 @@ public class IoTDBDescriptor {
                 "inner_compaction_task_selection_mods_file_threshold",
                 Long.toString(conf.getInnerCompactionTaskSelectionModsFileThreshold()))));
 
-    conf.setTtlCheckInterval(
-        Long.parseLong(
-            properties.getProperty(
-                "ttl_check_interval", Long.toString(conf.getTTlCheckInterval()))));
-
     conf.setMaxExpiredTime(
         Long.parseLong(
             properties.getProperty("max_expired_time", Long.toString(conf.getMaxExpiredTime()))));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/schedule/TTLScheduleTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/schedule/TTLScheduleTask.java
@@ -19,8 +19,8 @@
 
 package org.apache.iotdb.db.storageengine.dataregion.compaction.schedule;
 
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
-import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.storageengine.StorageEngine;
 import org.apache.iotdb.db.storageengine.dataregion.DataRegion;
 
@@ -39,7 +39,7 @@ public class TTLScheduleTask implements Callable<Void> {
   private final int workerNum;
 
   private final long ttlCheckInterval =
-      IoTDBDescriptor.getInstance().getConfig().getTTlCheckInterval();
+      CommonDescriptor.getInstance().getConfig().getTTLCheckInterval();
 
   public TTLScheduleTask(List<DataRegion> dataRegionList, int workerId, int workerNum) {
     this.dataRegionList = dataRegionList;

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/ThreadName.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/ThreadName.java
@@ -90,8 +90,6 @@ public enum ThreadName {
   CONFIG_NODE_LOAD_PUBLISHER("Cluster-LoadStatistics-Publisher"),
   // -------------------------- ConfigNode-RegionManagement --------------------------
   CONFIG_NODE_REGION_MAINTAINER("IoTDB-Region-Maintainer"),
-  // -------------------------- ConfigNode-PartitionManagement --------------------------
-  CONFIG_NODE_PARTITION_CLEANER("IoTDB-Partition-Cleaner"),
   // -------------------------- ConfigNode-Recover --------------------------
   CONFIG_NODE_RECOVER("ConfigNode-Manager-Recovery"),
   // -------------------------- ConfigNode-Procedure ------------------------

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/ThreadName.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/ThreadName.java
@@ -90,6 +90,8 @@ public enum ThreadName {
   CONFIG_NODE_LOAD_PUBLISHER("Cluster-LoadStatistics-Publisher"),
   // -------------------------- ConfigNode-RegionManagement --------------------------
   CONFIG_NODE_REGION_MAINTAINER("IoTDB-Region-Maintainer"),
+  // -------------------------- ConfigNode-PartitionManagement --------------------------
+  CONFIG_NODE_PARTITION_CLEANER("IoTDB-Partition-Cleaner"),
   // -------------------------- ConfigNode-Recover --------------------------
   CONFIG_NODE_RECOVER("ConfigNode-Manager-Recovery"),
   // -------------------------- ConfigNode-Procedure ------------------------

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -133,6 +133,9 @@ public class CommonConfig {
   /** The maximum number of TTL rules stored in the system, the default is 1000. */
   private int ttlRuleCapacity = 1000;
 
+  /** The interval of ttl check task in each database. The unit is ms. Default is 2 hours. */
+  private long ttlCheckInterval = 7_200_000L;
+
   /** Thrift socket and connection timeout between data node and config node. */
   private int cnConnectionTimeoutInMS = (int) TimeUnit.SECONDS.toMillis(60);
 
@@ -502,6 +505,14 @@ public class CommonConfig {
 
   public void setTTlRuleCapacity(int ttlRuleCapacity) {
     this.ttlRuleCapacity = ttlRuleCapacity;
+  }
+
+  public long getTTLCheckInterval() {
+    return ttlCheckInterval;
+  }
+
+  public void setTTLCheckInterval(long ttlCheckInterval) {
+    this.ttlCheckInterval = ttlCheckInterval;
   }
 
   public int getCnConnectionTimeoutInMS() {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -104,6 +104,11 @@ public class CommonDescriptor {
     }
     config.setTierTTLInMs(tierTTL);
 
+    config.setTTLCheckInterval(
+        Long.parseLong(
+            properties.getProperty(
+                "ttl_check_interval", Long.toString(config.getTTLCheckInterval()))));
+
     config.setSyncDir(properties.getProperty("dn_sync_dir", config.getSyncDir()).trim());
 
     config.setWalDirs(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/partition/DataPartitionTable.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/partition/DataPartitionTable.java
@@ -264,6 +264,18 @@ public class DataPartitionTable {
     return result;
   }
 
+  /**
+   * Remove PartitionTable where the TimeSlot is expired.
+   *
+   * @param TTL The Time To Live
+   * @param currentTimeSlot The current TimeSlot
+   */
+  public void autoCleanPartitionTable(long TTL, TTimePartitionSlot currentTimeSlot) {
+    dataPartitionMap.forEach(
+        (seriesPartitionSlot, seriesPartitionTable) ->
+            seriesPartitionTable.autoCleanPartitionTable(TTL, currentTimeSlot));
+  }
+
   public void serialize(OutputStream outputStream, TProtocol protocol)
       throws IOException, TException {
     ReadWriteIOUtils.write(dataPartitionMap.size(), outputStream);

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/schema/ttl/TTLCache.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/schema/ttl/TTLCache.java
@@ -35,8 +35,10 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 
 /** TTL Cache Tree, which is a prefix B+ tree with each node storing TTL. */
 @NotThreadSafe
@@ -170,6 +172,31 @@ public class TTLCache {
       }
     }
     return node.ttl;
+  }
+
+  /**
+   * Get the maximum ttl of the subtree of the corresponding database.
+   *
+   * @param database the path of the database.
+   * @return the maximum ttl of the subtree of the corresponding database. return NULL_TTL if the
+   *     TTL is not set or the database does not exist.
+   */
+  public long getDatabaseMaxTTL(String database) {
+    CacheNode node = ttlCacheTree.getChild(database);
+    if (node == null) {
+      return NULL_TTL;
+    }
+    Queue<CacheNode> queue = new LinkedList<>();
+    queue.add(node);
+    long maxTTL = node.ttl;
+    while (!queue.isEmpty()) {
+      CacheNode current = queue.poll();
+      for (CacheNode child : current.getChildren().values()) {
+        queue.add(child);
+        maxTTL = Math.max(maxTTL, child.ttl);
+      }
+    }
+    return maxTTL;
   }
 
   /**

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/TimePartitionUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/TimePartitionUtils.java
@@ -34,6 +34,9 @@ public class TimePartitionUtils {
   private static long timePartitionOrigin =
       CommonDescriptor.getInstance().getConfig().getTimePartitionOrigin();
 
+  private static String timestampPrecision =
+      CommonDescriptor.getInstance().getConfig().getTimestampPrecision();
+
   /** Time range for dividing database, the time unit is the same with IoTDB's TimestampPrecision */
   private static long timePartitionInterval =
       CommonDescriptor.getInstance().getConfig().getTimePartitionInterval();
@@ -68,6 +71,16 @@ public class TimePartitionUtils {
           maxPartitionEndTime.subtract(bigTimePartitionInterval).longValue();
     } else {
       timePartitionUpperBoundWithoutOverflow = maxPartitionEndTime.longValue();
+    }
+  }
+
+  public static TTimePartitionSlot getCurrentTimePartitionSlot() {
+    if ("ms".equals(timestampPrecision)) {
+      return getTimePartitionSlot(System.currentTimeMillis());
+    } else if ("us".equals(timestampPrecision)) {
+      return getTimePartitionSlot(System.currentTimeMillis() * 1000);
+    } else {
+      return getTimePartitionSlot(System.currentTimeMillis() * 1000_000);
     }
   }
 


### PR DESCRIPTION
A data partition is not necessary to exist when all corresponding data are expired given the pre-configurated TTL. Hence, this PR added a thread to automatically clean these expired data partitions, making the cache size of the DataPartitionTable is always acceptable! Specifically, the main updates include:

1. In TTLManager, to retrieve the maximum TTL of a specific database, we implement getDatabaseMaxTTL().
2. In TimePartitionUtils, to locate the time partition slot of the current timestamp, we implement the getCurrentTimePartitionSlot().
3. In PartitionManager, we setup a periodically asynchronous thread, which combines the aforementioned interfaces to construct an "AutoCleanPartitionTablePlan." As a result, for each database, any data partition whose data are all expired will be deleted automatically by this independent thread.

Incidentally, the corresponding IT is available at "IoTDBPartitionTableAutoCleanTest."