### PR TITLE
fix mods file metrics & fix the issue of missing mods with concurrent deletion and compaction

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -501,7 +501,12 @@ public class DataRegion implements IDataRegionForQuery {
                     resource.getTsFile().length(),
                     true,
                     resource.getTsFile().getName());
-            resource.upgradeModFile(upgradeModFileThreadPool);
+            if (ModificationFile.getExclusiveMods(resource.getTsFile()).exists()) {
+              // update mods file metrics
+              resource.getExclusiveModFile();
+            } else {
+              resource.upgradeModFile(upgradeModFileThreadPool);
+            }
           }
         }
         while (!value.isEmpty()) {
@@ -530,7 +535,12 @@ public class DataRegion implements IDataRegionForQuery {
                     false,
                     resource.getTsFile().getName());
           }
-          resource.upgradeModFile(upgradeModFileThreadPool);
+          if (ModificationFile.getExclusiveMods(resource.getTsFile()).exists()) {
+            // update mods file metrics
+            resource.getExclusiveModFile();
+          } else {
+            resource.upgradeModFile(upgradeModFileThreadPool);
+          }
         }
         while (!value.isEmpty()) {
           TsFileResource tsFileResource = value.get(value.size() - 1);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/CompactionUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/CompactionUtils.java
@@ -148,7 +148,7 @@ public class CompactionUtils {
     Set<ModEntry> modifications = new HashSet<>();
     // get compaction mods from all source unseq files
     for (TsFileResource unseqFile : unseqResources) {
-      modifications.addAll(ModificationFile.getCompactionMods(unseqFile).getAllMods());
+      modifications.addAll(ModificationFile.readAllCompactionModifications(unseqFile.getTsFile()));
     }
 
     // write target mods file
@@ -158,7 +158,8 @@ public class CompactionUtils {
         continue;
       }
       Set<ModEntry> seqModifications =
-          new HashSet<>(ModificationFile.getCompactionMods(seqResources.get(i)).getAllMods());
+          new HashSet<>(
+              ModificationFile.readAllCompactionModifications(seqResources.get(i).getTsFile()));
       modifications.addAll(seqModifications);
       updateOneTargetMods(targetResource, modifications);
       modifications.removeAll(seqModifications);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/modification/ModificationFile.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/modification/ModificationFile.java
@@ -73,6 +73,7 @@ public class ModificationFile implements AutoCloseable {
   private boolean hasCompacted = false;
   private boolean fileExists = false;
   private final boolean updateMetrics;
+  private boolean removed = false;
 
   private Set<ModificationFile> cascadeFiles = null;
 
@@ -89,19 +90,29 @@ public class ModificationFile implements AutoCloseable {
     }
   }
 
+  public void writeLock() {
+    this.lock.writeLock().lock();
+  }
+
+  public void writeUnlock() {
+    this.lock.writeLock().unlock();
+  }
+
   @SuppressWarnings("java:S2093") // cannot use try-with-resource, should not close here
   public void write(ModEntry entry) throws IOException {
     int updateFileNum = 0;
     lock.writeLock().lock();
     long size = 0;
     try {
-      if (fileOutputStream == null) {
-        fileOutputStream =
-            new BufferedOutputStream(Files.newOutputStream(file.toPath(), CREATE, APPEND));
-        channel = FileChannel.open(file.toPath(), CREATE, APPEND);
+      if (!removed) {
+        if (fileOutputStream == null) {
+          fileOutputStream =
+              new BufferedOutputStream(Files.newOutputStream(file.toPath(), CREATE, APPEND));
+          channel = FileChannel.open(file.toPath(), CREATE, APPEND);
+        }
+        size += entry.serialize(fileOutputStream);
+        fileOutputStream.flush();
       }
-      size += entry.serialize(fileOutputStream);
-      fileOutputStream.flush();
 
       if (cascadeFiles != null) {
         for (ModificationFile cascadeFile : cascadeFiles) {
@@ -124,15 +135,17 @@ public class ModificationFile implements AutoCloseable {
     lock.writeLock().lock();
     long size = 0;
     try {
-      if (fileOutputStream == null) {
-        fileOutputStream =
-            new BufferedOutputStream(Files.newOutputStream(file.toPath(), CREATE, APPEND));
-        channel = FileChannel.open(file.toPath(), CREATE, APPEND);
+      if (!removed) {
+        if (fileOutputStream == null) {
+          fileOutputStream =
+              new BufferedOutputStream(Files.newOutputStream(file.toPath(), CREATE, APPEND));
+          channel = FileChannel.open(file.toPath(), CREATE, APPEND);
+        }
+        for (ModEntry entry : entries) {
+          size += entry.serialize(fileOutputStream);
+        }
+        fileOutputStream.flush();
       }
-      for (ModEntry entry : entries) {
-        size += entry.serialize(fileOutputStream);
-      }
-      fileOutputStream.flush();
 
       if (cascadeFiles != null) {
         for (ModificationFile cascadeFile : cascadeFiles) {
@@ -150,7 +163,7 @@ public class ModificationFile implements AutoCloseable {
   }
 
   private void updateModFileMetric(int num, long size) {
-    if (updateMetrics) {
+    if (!removed && updateMetrics) {
       FileMetrics.getInstance().increaseModFileNum(num);
       FileMetrics.getInstance().increaseModFileSize(size);
     }
@@ -212,6 +225,16 @@ public class ModificationFile implements AutoCloseable {
     long levelNum = Long.parseLong(split[0]);
     long modNum = Long.parseLong(split[1]);
     return new long[] {levelNum, modNum};
+  }
+
+  public static List<ModEntry> readAllCompactionModifications(File tsfile) throws IOException {
+    try (ModificationFile modificationFile =
+        new ModificationFile(ModificationFile.getCompactionMods(tsfile), false)) {
+      if (modificationFile.exists()) {
+        return modificationFile.getAllMods();
+      }
+    }
+    return Collections.emptyList();
   }
 
   public static List<ModEntry> readAllModifications(
@@ -319,6 +342,7 @@ public class ModificationFile implements AutoCloseable {
       updateModFileMetric(-1, -getFileLength());
     }
     fileExists = false;
+    removed = true;
   }
 
   public static ModificationFile getExclusiveMods(TsFileResource tsFileResource) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/modification/ModificationFile.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/modification/ModificationFile.java
@@ -346,7 +346,7 @@ public class ModificationFile implements AutoCloseable {
       fileExists = false;
       removed = true;
     } finally {
-    	lock.writeLock().unlock();
+      lock.writeLock().unlock();
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/modification/ModificationFile.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/modification/ModificationFile.java
@@ -336,13 +336,18 @@ public class ModificationFile implements AutoCloseable {
   }
 
   public void remove() throws IOException {
-    close();
-    FileUtils.deleteFileOrDirectory(file);
-    if (fileExists) {
-      updateModFileMetric(-1, -getFileLength());
+    lock.writeLock().lock();
+    try {
+      close();
+      FileUtils.deleteFileOrDirectory(file);
+      if (fileExists) {
+        updateModFileMetric(-1, -getFileLength());
+      }
+      fileExists = false;
+      removed = true;
+    } finally {
+    	lock.writeLock().unlock();
     }
-    fileExists = false;
-    removed = true;
   }
 
   public static ModificationFile getExclusiveMods(TsFileResource tsFileResource) {


### PR DESCRIPTION
## Description
1. update mods file metrics during DataRegion recovery
2. some read of compaction mods file may trigger metrics updates
3. when linking mod file, if the source file has no mods, also add the target file mods as cascadeFiles
4. add removed mark for ModifcationFile