### PR TITLE
[RatisConsensus] prevent misuse of addRemotePeer

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -578,7 +578,16 @@ class RatisConsensus implements IConsensus {
 
     RaftPeer peerToAdd = Utils.fromPeerAndPriorityToRaftPeer(peer, DEFAULT_PRIORITY);
     // pre-condition: peer not in this group
-    if (group.getPeers().contains(peerToAdd)) {
+    if (group.getPeers().stream()
+        .anyMatch(
+            p ->
+                p.getId().equals(peerToAdd.getId())
+                    || p.getAddress().equals(peerToAdd.getAddress()))) {
+      logger.warn(
+          "{}: try to add a peer {} with conflicting id or address in {}",
+          this,
+          peerToAdd,
+          group.getPeers());
       throw new PeerAlreadyInConsensusGroupException(groupId, peer);
     }
 


### PR DESCRIPTION
We should forbid adding new peer having same id/address with existing peers.