### PR TITLE
Fix duplicated time in result set bug

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBDeletionTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBDeletionTableIT.java
@@ -24,8 +24,6 @@ import org.apache.iotdb.isession.ITableSession;
 import org.apache.iotdb.isession.SessionDataSet;
 import org.apache.iotdb.it.env.EnvFactory;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
-import org.apache.iotdb.itbase.category.ClusterIT;
-import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 import org.apache.iotdb.itbase.category.ManualIT;
 import org.apache.iotdb.itbase.category.TableClusterIT;
 import org.apache.iotdb.itbase.category.TableLocalStandaloneIT;
@@ -1647,7 +1645,6 @@ public class IoTDBDeletionTableIT {
   }
 
   @Test
-  @Category({LocalStandaloneIT.class, ClusterIT.class})
   public void deleteTableOfTheSameNameTest()
       throws IoTDBConnectionException, StatementExecutionException {
     int testNum = 24;

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBNullValueIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBNullValueIT.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.relational.it.query.recent;
+
+import org.apache.iotdb.it.env.EnvFactory;
+import org.apache.iotdb.it.framework.IoTDBTestRunner;
+import org.apache.iotdb.itbase.category.TableClusterIT;
+import org.apache.iotdb.itbase.category.TableLocalStandaloneIT;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.apache.iotdb.db.it.utils.TestUtils.prepareTableData;
+import static org.apache.iotdb.db.it.utils.TestUtils.tableResultSetEqualTest;
+
+@RunWith(IoTDBTestRunner.class)
+@Category({TableLocalStandaloneIT.class, TableClusterIT.class})
+public class IoTDBNullValueIT {
+  private static final String DATABASE_NAME = "test";
+
+  private static final String[] createSqls =
+      new String[] {
+        "CREATE DATABASE " + DATABASE_NAME,
+        "USE " + DATABASE_NAME,
+        "create table table1(id1 tag, s1 string)",
+        "insert into table1 values(0, 'd1', null), (1,'d1', 1)",
+        "flush",
+        "insert into table1 values(0, 'd1', 0)",
+        "flush"
+      };
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    EnvFactory.getEnv().getConfig().getCommonConfig().setEnableCrossSpaceCompaction(false);
+    EnvFactory.getEnv().initClusterEnvironment();
+    prepareTableData(createSqls);
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  @Test
+  public void nullTest() {
+
+    // case 1: all without time filter using previous fill without timeDuration
+    String[] expectedHeader = new String[] {"time", "id1", "s1"};
+    String[] retArray =
+        new String[] {
+          "1970-01-01T00:00:00.000Z,d1,0,", "1970-01-01T00:00:00.001Z,d1,1,",
+        };
+    tableResultSetEqualTest("select * from table1", expectedHeader, retArray, DATABASE_NAME);
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/FileLoaderUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/FileLoaderUtils.java
@@ -41,7 +41,7 @@ import org.apache.tsfile.file.metadata.AlignedTimeSeriesMetadata;
 import org.apache.tsfile.file.metadata.IChunkMetadata;
 import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.file.metadata.ITimeSeriesMetadata;
-import org.apache.tsfile.file.metadata.TableDeviceMetadata;
+import org.apache.tsfile.file.metadata.TableDeviceTimeSeriesMetadata;
 import org.apache.tsfile.file.metadata.TimeseriesMetadata;
 import org.apache.tsfile.read.controller.IChunkLoader;
 import org.apache.tsfile.read.filter.basic.Filter;
@@ -395,7 +395,7 @@ public class FileLoaderUtils {
     AbstractAlignedTimeSeriesMetadata alignedTimeSeriesMetadata =
         ignoreAllNullRows
             ? new AlignedTimeSeriesMetadata(timeColumnMetadata, valueColumnMetadataList)
-            : new TableDeviceMetadata(timeColumnMetadata, valueColumnMetadataList);
+            : new TableDeviceTimeSeriesMetadata(timeColumnMetadata, valueColumnMetadataList);
 
     alignedTimeSeriesMetadata.setChunkMetadataLoader(
         new DiskAlignedChunkMetadataLoader(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/performer/impl/ReadChunkCompactionPerformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/performer/impl/ReadChunkCompactionPerformer.java
@@ -36,7 +36,7 @@ import org.apache.iotdb.db.storageengine.rescon.memory.SystemInfo;
 
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.exception.write.PageException;
-import org.apache.tsfile.file.metadata.AlignedChunkMetadata;
+import org.apache.tsfile.file.metadata.AbstractAlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.ChunkMetadata;
 import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.read.TsFileSequenceReader;
@@ -179,8 +179,9 @@ public class ReadChunkCompactionPerformer implements ISeqCompactionPerformer {
       MultiTsFileDeviceIterator deviceIterator)
       throws IOException, InterruptedException, IllegalPathException, PageException {
     checkThreadInterrupted();
-    LinkedList<Pair<TsFileSequenceReader, List<AlignedChunkMetadata>>> readerAndChunkMetadataList =
-        deviceIterator.getReaderAndChunkMetadataForCurrentAlignedSeries();
+    LinkedList<Pair<TsFileSequenceReader, List<AbstractAlignedChunkMetadata>>>
+        readerAndChunkMetadataList =
+            deviceIterator.getReaderAndChunkMetadataForCurrentAlignedSeries();
     if (!checkAlignedSeriesExists(readerAndChunkMetadataList)) {
       return;
     }
@@ -212,9 +213,9 @@ public class ReadChunkCompactionPerformer implements ISeqCompactionPerformer {
   }
 
   private boolean checkAlignedSeriesExists(
-      LinkedList<Pair<TsFileSequenceReader, List<AlignedChunkMetadata>>>
+      LinkedList<Pair<TsFileSequenceReader, List<AbstractAlignedChunkMetadata>>>
           readerAndChunkMetadataList) {
-    for (Pair<TsFileSequenceReader, List<AlignedChunkMetadata>> readerListPair :
+    for (Pair<TsFileSequenceReader, List<AbstractAlignedChunkMetadata>> readerListPair :
         readerAndChunkMetadataList) {
       if (!readerListPair.right.isEmpty()) {
         return true;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/MultiTsFileDeviceIterator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/MultiTsFileDeviceIterator.java
@@ -34,7 +34,7 @@ import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.utils.ModificationUtils;
 
 import org.apache.tsfile.enums.TSDataType;
-import org.apache.tsfile.file.metadata.AlignedChunkMetadata;
+import org.apache.tsfile.file.metadata.AbstractAlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.ChunkMetadata;
 import org.apache.tsfile.file.metadata.IChunkMetadata;
 import org.apache.tsfile.file.metadata.IDeviceID;
@@ -384,14 +384,14 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
    * @throws IOException if io errors occurred
    */
   @SuppressWarnings({"squid:S1319", "squid:S135"})
-  public LinkedList<Pair<TsFileSequenceReader, List<AlignedChunkMetadata>>>
+  public LinkedList<Pair<TsFileSequenceReader, List<AbstractAlignedChunkMetadata>>>
       getReaderAndChunkMetadataForCurrentAlignedSeries() throws IOException, IllegalPathException {
     if (currentDevice == null || !currentDevice.right) {
       return new LinkedList<>();
     }
 
-    LinkedList<Pair<TsFileSequenceReader, List<AlignedChunkMetadata>>> readerAndChunkMetadataList =
-        new LinkedList<>();
+    LinkedList<Pair<TsFileSequenceReader, List<AbstractAlignedChunkMetadata>>>
+        readerAndChunkMetadataList = new LinkedList<>();
     for (TsFileResource tsFileResource : tsFileResourcesSortedByAsc) {
       if (!deviceIteratorMap.containsKey(tsFileResource)) {
         continue;
@@ -403,7 +403,7 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
       MetadataIndexNode firstMeasurementNodeOfCurrentDevice =
           iterator.getFirstMeasurementNodeOfCurrentDevice();
       TsFileSequenceReader reader = readerMap.get(tsFileResource);
-      List<AlignedChunkMetadata> alignedChunkMetadataList =
+      List<AbstractAlignedChunkMetadata> alignedChunkMetadataList =
           reader.getAlignedChunkMetadataByMetadataIndexNode(
               currentDevice.left, firstMeasurementNodeOfCurrentDevice, ignoreAllNullRows);
       applyModificationForAlignedChunkMetadataList(tsFileResource, alignedChunkMetadataList);
@@ -420,7 +420,7 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
    * @param alignedChunkMetadataList list of aligned chunk metadata
    */
   private void applyModificationForAlignedChunkMetadataList(
-      TsFileResource tsFileResource, List<AlignedChunkMetadata> alignedChunkMetadataList)
+      TsFileResource tsFileResource, List<AbstractAlignedChunkMetadata> alignedChunkMetadataList)
       throws IllegalPathException {
     if (alignedChunkMetadataList.isEmpty()) {
       // all the value chunks is empty chunk
@@ -437,7 +437,7 @@ public class MultiTsFileDeviceIterator implements AutoCloseable {
             tsFileResource, r -> new ArrayList<>(tsFileResource.getAllModEntries()));
 
     // construct the input params List<List<Modification>> for QueryUtils.modifyAlignedChunkMetaData
-    AlignedChunkMetadata alignedChunkMetadata = alignedChunkMetadataList.get(0);
+    AbstractAlignedChunkMetadata alignedChunkMetadata = alignedChunkMetadataList.get(0);
     List<IChunkMetadata> valueChunkMetadataList = alignedChunkMetadata.getValueChunkMetadataList();
 
     // match time column modifications

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/batch/BatchedFastAlignedSeriesCompactionExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/batch/BatchedFastAlignedSeriesCompactionExecutor.java
@@ -43,7 +43,7 @@ import org.apache.iotdb.db.utils.datastructure.PatternTreeMapFactory;
 
 import org.apache.tsfile.common.constant.TsFileConstant;
 import org.apache.tsfile.exception.write.PageException;
-import org.apache.tsfile.file.metadata.AlignedChunkMetadata;
+import org.apache.tsfile.file.metadata.AbstractAlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.ChunkMetadata;
 import org.apache.tsfile.file.metadata.IChunkMetadata;
 import org.apache.tsfile.file.metadata.IDeviceID;
@@ -72,7 +72,7 @@ public class BatchedFastAlignedSeriesCompactionExecutor
   private final List<IMeasurementSchema> valueMeasurementSchemas;
   private final List<TsFileResource> sortedSourceFiles;
 
-  private final Map<TsFileResource, List<AlignedChunkMetadata>> alignedChunkMetadataCache;
+  private final Map<TsFileResource, List<AbstractAlignedChunkMetadata>> alignedChunkMetadataCache;
   private final BatchCompactionPlan batchCompactionPlan;
   private final int batchSize =
       IoTDBDescriptor.getInstance().getConfig().getCompactionMaxAlignedSeriesNumInOneBatch();
@@ -110,11 +110,11 @@ public class BatchedFastAlignedSeriesCompactionExecutor
     this.batchCompactionPlan = new BatchCompactionPlan();
   }
 
-  private List<AlignedChunkMetadata> getAlignedChunkMetadataListBySelectedValueColumn(
+  private List<AbstractAlignedChunkMetadata> getAlignedChunkMetadataListBySelectedValueColumn(
       TsFileResource tsFileResource, List<IMeasurementSchema> selectedValueMeasurementSchemas)
       throws IOException, IllegalPathException {
     // 1. get Full AlignedChunkMetadata from cache
-    List<AlignedChunkMetadata> alignedChunkMetadataList = null;
+    List<AbstractAlignedChunkMetadata> alignedChunkMetadataList = null;
     if (alignedChunkMetadataCache.containsKey(tsFileResource)) {
       alignedChunkMetadataList = alignedChunkMetadataCache.get(tsFileResource);
     } else {
@@ -124,8 +124,8 @@ public class BatchedFastAlignedSeriesCompactionExecutor
     }
     // 2. generate AlignedChunkMetadata list by selected value columns
 
-    List<AlignedChunkMetadata> filteredAlignedChunkMetadataList = new ArrayList<>();
-    for (AlignedChunkMetadata alignedChunkMetadata : alignedChunkMetadataList) {
+    List<AbstractAlignedChunkMetadata> filteredAlignedChunkMetadataList = new ArrayList<>();
+    for (AbstractAlignedChunkMetadata alignedChunkMetadata : alignedChunkMetadataList) {
       filteredAlignedChunkMetadataList.add(
           AlignedSeriesBatchCompactionUtils.filterAlignedChunkMetadataByIndex(
               alignedChunkMetadata, batchColumnSelection.getSelectedColumnIndexList()));
@@ -264,8 +264,8 @@ public class BatchedFastAlignedSeriesCompactionExecutor
     }
 
     @Override
-    protected List<AlignedChunkMetadata> getAlignedChunkMetadataList(TsFileResource resource)
-        throws IOException, IllegalPathException {
+    protected List<AbstractAlignedChunkMetadata> getAlignedChunkMetadataList(
+        TsFileResource resource) throws IOException, IllegalPathException {
       return getAlignedChunkMetadataListBySelectedValueColumn(resource, measurementSchemas);
     }
 
@@ -301,10 +301,10 @@ public class BatchedFastAlignedSeriesCompactionExecutor
       IChunkMetadata batchedAlignedChunkMetadata =
           alignedPageElement.getChunkMetadataElement().chunkMetadata;
       TsFileResource resource = alignedPageElement.getChunkMetadataElement().fileElement.resource;
-      List<AlignedChunkMetadata> alignedChunkMetadataListOfFile =
+      List<AbstractAlignedChunkMetadata> alignedChunkMetadataListOfFile =
           alignedChunkMetadataCache.get(resource);
-      AlignedChunkMetadata originAlignedChunkMetadata = null;
-      for (AlignedChunkMetadata alignedChunkMetadata : alignedChunkMetadataListOfFile) {
+      AbstractAlignedChunkMetadata originAlignedChunkMetadata = null;
+      for (AbstractAlignedChunkMetadata alignedChunkMetadata : alignedChunkMetadataListOfFile) {
         if (alignedChunkMetadata.getOffsetOfChunkHeader()
             == batchedAlignedChunkMetadata.getOffsetOfChunkHeader()) {
           originAlignedChunkMetadata = alignedChunkMetadata;
@@ -383,8 +383,8 @@ public class BatchedFastAlignedSeriesCompactionExecutor
     }
 
     @Override
-    protected List<AlignedChunkMetadata> getAlignedChunkMetadataList(TsFileResource resource)
-        throws IOException, IllegalPathException {
+    protected List<AbstractAlignedChunkMetadata> getAlignedChunkMetadataList(
+        TsFileResource resource) throws IOException, IllegalPathException {
       return getAlignedChunkMetadataListBySelectedValueColumn(resource, measurementSchemas);
     }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/batch/BatchedReadChunkAlignedSeriesCompactionExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/batch/BatchedReadChunkAlignedSeriesCompactionExecutor.java
@@ -38,7 +38,7 @@ import org.apache.iotdb.db.storageengine.dataregion.compaction.io.CompactionTsFi
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 
 import org.apache.tsfile.exception.write.PageException;
-import org.apache.tsfile.file.metadata.AlignedChunkMetadata;
+import org.apache.tsfile.file.metadata.AbstractAlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.ChunkMetadata;
 import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.file.metadata.statistics.Statistics;
@@ -67,13 +67,14 @@ public class BatchedReadChunkAlignedSeriesCompactionExecutor
   private final int batchSize =
       IoTDBDescriptor.getInstance().getConfig().getCompactionMaxAlignedSeriesNumInOneBatch();
   private final AlignedSeriesBatchCompactionUtils.BatchColumnSelection batchColumnSelection;
-  private final LinkedList<Pair<TsFileSequenceReader, List<AlignedChunkMetadata>>>
+  private final LinkedList<Pair<TsFileSequenceReader, List<AbstractAlignedChunkMetadata>>>
       originReaderAndChunkMetadataList;
 
   public BatchedReadChunkAlignedSeriesCompactionExecutor(
       IDeviceID device,
       TsFileResource targetResource,
-      LinkedList<Pair<TsFileSequenceReader, List<AlignedChunkMetadata>>> readerAndChunkMetadataList,
+      LinkedList<Pair<TsFileSequenceReader, List<AbstractAlignedChunkMetadata>>>
+          readerAndChunkMetadataList,
       CompactionTsFileWriter writer,
       CompactionTaskSummary summary,
       boolean ignoreAllNullRows)
@@ -113,7 +114,7 @@ public class BatchedReadChunkAlignedSeriesCompactionExecutor
       selectedColumnSchemaList = batchColumnSelection.getCurrentSelectedColumnSchemaList();
     }
 
-    LinkedList<Pair<TsFileSequenceReader, List<AlignedChunkMetadata>>>
+    LinkedList<Pair<TsFileSequenceReader, List<AbstractAlignedChunkMetadata>>>
         batchedReaderAndChunkMetadataList =
             filterAlignedChunkMetadataList(readerAndChunkMetadataList, selectedColumnIndexList);
 
@@ -137,7 +138,7 @@ public class BatchedReadChunkAlignedSeriesCompactionExecutor
   private void compactLeftBatches() throws PageException, IOException {
     while (batchColumnSelection.hasNext()) {
       batchColumnSelection.next();
-      LinkedList<Pair<TsFileSequenceReader, List<AlignedChunkMetadata>>>
+      LinkedList<Pair<TsFileSequenceReader, List<AbstractAlignedChunkMetadata>>>
           groupReaderAndChunkMetadataList =
               filterAlignedChunkMetadataList(
                   readerAndChunkMetadataList, batchColumnSelection.getSelectedColumnIndexList());
@@ -155,16 +156,19 @@ public class BatchedReadChunkAlignedSeriesCompactionExecutor
     }
   }
 
-  private LinkedList<Pair<TsFileSequenceReader, List<AlignedChunkMetadata>>>
+  private LinkedList<Pair<TsFileSequenceReader, List<AbstractAlignedChunkMetadata>>>
       filterAlignedChunkMetadataList(
-          List<Pair<TsFileSequenceReader, List<AlignedChunkMetadata>>> readerAndChunkMetadataList,
+          List<Pair<TsFileSequenceReader, List<AbstractAlignedChunkMetadata>>>
+              readerAndChunkMetadataList,
           List<Integer> selectedMeasurementIndexs) {
-    LinkedList<Pair<TsFileSequenceReader, List<AlignedChunkMetadata>>>
+    LinkedList<Pair<TsFileSequenceReader, List<AbstractAlignedChunkMetadata>>>
         groupReaderAndChunkMetadataList = new LinkedList<>();
-    for (Pair<TsFileSequenceReader, List<AlignedChunkMetadata>> pair : readerAndChunkMetadataList) {
-      List<AlignedChunkMetadata> alignedChunkMetadataList = pair.getRight();
-      List<AlignedChunkMetadata> selectedColumnAlignedChunkMetadataList = new LinkedList<>();
-      for (AlignedChunkMetadata alignedChunkMetadata : alignedChunkMetadataList) {
+    for (Pair<TsFileSequenceReader, List<AbstractAlignedChunkMetadata>> pair :
+        readerAndChunkMetadataList) {
+      List<AbstractAlignedChunkMetadata> alignedChunkMetadataList = pair.getRight();
+      List<AbstractAlignedChunkMetadata> selectedColumnAlignedChunkMetadataList =
+          new LinkedList<>();
+      for (AbstractAlignedChunkMetadata alignedChunkMetadata : alignedChunkMetadataList) {
         selectedColumnAlignedChunkMetadataList.add(
             AlignedSeriesBatchCompactionUtils.filterAlignedChunkMetadataByIndex(
                 alignedChunkMetadata, selectedMeasurementIndexs));
@@ -181,7 +185,7 @@ public class BatchedReadChunkAlignedSeriesCompactionExecutor
     public FirstBatchedReadChunkAlignedSeriesCompactionExecutor(
         IDeviceID device,
         TsFileResource targetResource,
-        LinkedList<Pair<TsFileSequenceReader, List<AlignedChunkMetadata>>>
+        LinkedList<Pair<TsFileSequenceReader, List<AbstractAlignedChunkMetadata>>>
             readerAndChunkMetadataList,
         CompactionTsFileWriter writer,
         CompactionTaskSummary summary,
@@ -224,8 +228,8 @@ public class BatchedReadChunkAlignedSeriesCompactionExecutor
       String file = timePage.getFile();
       ChunkMetadata timeChunkMetadata = timePage.getChunkMetadata();
 
-      List<AlignedChunkMetadata> alignedChunkMetadataList = Collections.emptyList();
-      for (Pair<TsFileSequenceReader, List<AlignedChunkMetadata>> pair :
+      List<AbstractAlignedChunkMetadata> alignedChunkMetadataList = Collections.emptyList();
+      for (Pair<TsFileSequenceReader, List<AbstractAlignedChunkMetadata>> pair :
           originReaderAndChunkMetadataList) {
         TsFileSequenceReader reader = pair.getLeft();
         if (reader.getFileName().equals(file)) {
@@ -234,8 +238,8 @@ public class BatchedReadChunkAlignedSeriesCompactionExecutor
         }
       }
 
-      AlignedChunkMetadata originAlignedChunkMetadata = null;
-      for (AlignedChunkMetadata alignedChunkMetadata : alignedChunkMetadataList) {
+      AbstractAlignedChunkMetadata originAlignedChunkMetadata = null;
+      for (AbstractAlignedChunkMetadata alignedChunkMetadata : alignedChunkMetadataList) {
         if (alignedChunkMetadata.getOffsetOfChunkHeader()
             == timeChunkMetadata.getOffsetOfChunkHeader()) {
           originAlignedChunkMetadata = alignedChunkMetadata;
@@ -303,7 +307,7 @@ public class BatchedReadChunkAlignedSeriesCompactionExecutor
     public FollowingBatchedReadChunkAlignedSeriesGroupCompactionExecutor(
         IDeviceID device,
         TsFileResource targetResource,
-        LinkedList<Pair<TsFileSequenceReader, List<AlignedChunkMetadata>>>
+        LinkedList<Pair<TsFileSequenceReader, List<AbstractAlignedChunkMetadata>>>
             readerAndChunkMetadataList,
         CompactionTsFileWriter writer,
         CompactionTaskSummary summary,

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/batch/utils/AlignedSeriesBatchCompactionUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/batch/utils/AlignedSeriesBatchCompactionUtils.java
@@ -21,7 +21,7 @@ package org.apache.iotdb.db.storageengine.dataregion.compaction.execute.utils.ex
 
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.utils.executor.ModifiedStatus;
 
-import org.apache.tsfile.file.metadata.AlignedChunkMetadata;
+import org.apache.tsfile.file.metadata.AbstractAlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.ChunkMetadata;
 import org.apache.tsfile.file.metadata.IChunkMetadata;
 import org.apache.tsfile.read.TsFileSequenceReader;
@@ -43,17 +43,18 @@ public class AlignedSeriesBatchCompactionUtils {
   private AlignedSeriesBatchCompactionUtils() {}
 
   public static void markAlignedChunkHasDeletion(
-      LinkedList<Pair<TsFileSequenceReader, List<AlignedChunkMetadata>>>
+      LinkedList<Pair<TsFileSequenceReader, List<AbstractAlignedChunkMetadata>>>
           readerAndChunkMetadataList) {
-    for (Pair<TsFileSequenceReader, List<AlignedChunkMetadata>> pair : readerAndChunkMetadataList) {
-      List<AlignedChunkMetadata> alignedChunkMetadataList = pair.getRight();
+    for (Pair<TsFileSequenceReader, List<AbstractAlignedChunkMetadata>> pair :
+        readerAndChunkMetadataList) {
+      List<AbstractAlignedChunkMetadata> alignedChunkMetadataList = pair.getRight();
       markAlignedChunkHasDeletion(alignedChunkMetadataList);
     }
   }
 
   public static void markAlignedChunkHasDeletion(
-      List<AlignedChunkMetadata> alignedChunkMetadataList) {
-    for (AlignedChunkMetadata alignedChunkMetadata : alignedChunkMetadataList) {
+      List<AbstractAlignedChunkMetadata> alignedChunkMetadataList) {
+    for (AbstractAlignedChunkMetadata alignedChunkMetadata : alignedChunkMetadataList) {
       IChunkMetadata timeChunkMetadata = alignedChunkMetadata.getTimeChunkMetadata();
       for (IChunkMetadata iChunkMetadata : alignedChunkMetadata.getValueChunkMetadataList()) {
         if (iChunkMetadata != null && iChunkMetadata.isModified()) {
@@ -68,8 +69,8 @@ public class AlignedSeriesBatchCompactionUtils {
     return chunkMetadata.getMeasurementUid().isEmpty();
   }
 
-  public static AlignedChunkMetadata filterAlignedChunkMetadataByIndex(
-      AlignedChunkMetadata alignedChunkMetadata, List<Integer> selectedMeasurements) {
+  public static AbstractAlignedChunkMetadata filterAlignedChunkMetadataByIndex(
+      AbstractAlignedChunkMetadata alignedChunkMetadata, List<Integer> selectedMeasurements) {
     IChunkMetadata[] valueChunkMetadataArr = new IChunkMetadata[selectedMeasurements.size()];
     List<IChunkMetadata> originValueChunkMetadataList =
         alignedChunkMetadata.getValueChunkMetadataList();
@@ -77,12 +78,13 @@ public class AlignedSeriesBatchCompactionUtils {
       int columnIndex = selectedMeasurements.get(i);
       valueChunkMetadataArr[i] = originValueChunkMetadataList.get(columnIndex);
     }
-    return new AlignedChunkMetadata(
+    return alignedChunkMetadata.createNewChunkMetadata(
         alignedChunkMetadata.getTimeChunkMetadata(), Arrays.asList(valueChunkMetadataArr));
   }
 
-  public static AlignedChunkMetadata fillAlignedChunkMetadataBySchemaList(
-      AlignedChunkMetadata originAlignedChunkMetadata, List<IMeasurementSchema> schemaList) {
+  public static AbstractAlignedChunkMetadata fillAlignedChunkMetadataBySchemaList(
+      AbstractAlignedChunkMetadata originAlignedChunkMetadata,
+      List<IMeasurementSchema> schemaList) {
     List<IChunkMetadata> originValueChunkMetadataList =
         originAlignedChunkMetadata.getValueChunkMetadataList();
     IChunkMetadata[] newValueChunkMetadataArr = new IChunkMetadata[schemaList.size()];
@@ -109,14 +111,14 @@ public class AlignedSeriesBatchCompactionUtils {
         currentValueChunkMetadataIndex++;
       }
     }
-    return new AlignedChunkMetadata(
+    return originAlignedChunkMetadata.createNewChunkMetadata(
         originAlignedChunkMetadata.getTimeChunkMetadata(), Arrays.asList(newValueChunkMetadataArr));
   }
 
   public static ModifiedStatus calculateAlignedPageModifiedStatus(
       long startTime,
       long endTime,
-      AlignedChunkMetadata originAlignedChunkMetadata,
+      AbstractAlignedChunkMetadata originAlignedChunkMetadata,
       boolean ignoreAllNullRows) {
     ModifiedStatus timePageModifiedStatus =
         checkIsModified(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/SeriesCompactionExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/fast/SeriesCompactionExecutor.java
@@ -36,7 +36,7 @@ import org.apache.iotdb.db.utils.ModificationUtils;
 import org.apache.iotdb.db.utils.datastructure.PatternTreeMapFactory;
 
 import org.apache.tsfile.exception.write.PageException;
-import org.apache.tsfile.file.metadata.AlignedChunkMetadata;
+import org.apache.tsfile.file.metadata.AbstractAlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.IChunkMetadata;
 import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.read.TimeValuePair;
@@ -495,14 +495,14 @@ public abstract class SeriesCompactionExecutor {
       case READ_IN:
         summary.increaseProcessChunkNum(
             isAligned
-                ? ((AlignedChunkMetadata) chunkMetadataElement.chunkMetadata)
+                ? ((AbstractAlignedChunkMetadata) chunkMetadataElement.chunkMetadata)
                         .getValueChunkMetadataList()
                         .size()
                     + 1
                 : 1);
         if (isAligned) {
           for (IChunkMetadata valueChunkMetadata :
-              ((AlignedChunkMetadata) chunkMetadataElement.chunkMetadata)
+              ((AbstractAlignedChunkMetadata) chunkMetadataElement.chunkMetadata)
                   .getValueChunkMetadataList()) {
             if (valueChunkMetadata == null) {
               continue;
@@ -517,7 +517,7 @@ public abstract class SeriesCompactionExecutor {
       case DIRECTORY_FLUSH:
         if (isAligned) {
           summary.increaseDirectlyFlushChunkNum(
-              ((AlignedChunkMetadata) (chunkMetadataElement.chunkMetadata))
+              ((AbstractAlignedChunkMetadata) (chunkMetadataElement.chunkMetadata))
                       .getValueChunkMetadataList()
                       .size()
                   + 1);
@@ -528,7 +528,7 @@ public abstract class SeriesCompactionExecutor {
       case DESERIALIZE_CHUNK:
         if (isAligned) {
           summary.increaseDeserializedChunkNum(
-              ((AlignedChunkMetadata) (chunkMetadataElement.chunkMetadata))
+              ((AbstractAlignedChunkMetadata) (chunkMetadataElement.chunkMetadata))
                       .getValueChunkMetadataList()
                       .size()
                   + 1);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/readchunk/ReadChunkAlignedSeriesCompactionExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/executor/readchunk/ReadChunkAlignedSeriesCompactionExecutor.java
@@ -39,7 +39,7 @@ import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.exception.write.PageException;
 import org.apache.tsfile.file.header.ChunkHeader;
 import org.apache.tsfile.file.header.PageHeader;
-import org.apache.tsfile.file.metadata.AlignedChunkMetadata;
+import org.apache.tsfile.file.metadata.AbstractAlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.ChunkMetadata;
 import org.apache.tsfile.file.metadata.IChunkMetadata;
 import org.apache.tsfile.file.metadata.IDeviceID;
@@ -68,7 +68,7 @@ import java.util.stream.Collectors;
 public class ReadChunkAlignedSeriesCompactionExecutor {
 
   protected final IDeviceID device;
-  protected final LinkedList<Pair<TsFileSequenceReader, List<AlignedChunkMetadata>>>
+  protected final LinkedList<Pair<TsFileSequenceReader, List<AbstractAlignedChunkMetadata>>>
       readerAndChunkMetadataList;
   protected final TsFileResource targetResource;
   protected final CompactionTsFileWriter writer;
@@ -85,7 +85,8 @@ public class ReadChunkAlignedSeriesCompactionExecutor {
   public ReadChunkAlignedSeriesCompactionExecutor(
       IDeviceID device,
       TsFileResource targetResource,
-      LinkedList<Pair<TsFileSequenceReader, List<AlignedChunkMetadata>>> readerAndChunkMetadataList,
+      LinkedList<Pair<TsFileSequenceReader, List<AbstractAlignedChunkMetadata>>>
+          readerAndChunkMetadataList,
       CompactionTsFileWriter writer,
       CompactionTaskSummary summary,
       boolean ignoreAllNullRows)
@@ -108,7 +109,8 @@ public class ReadChunkAlignedSeriesCompactionExecutor {
   public ReadChunkAlignedSeriesCompactionExecutor(
       IDeviceID device,
       TsFileResource targetResource,
-      LinkedList<Pair<TsFileSequenceReader, List<AlignedChunkMetadata>>> readerAndChunkMetadataList,
+      LinkedList<Pair<TsFileSequenceReader, List<AbstractAlignedChunkMetadata>>>
+          readerAndChunkMetadataList,
       CompactionTsFileWriter writer,
       CompactionTaskSummary summary,
       IMeasurementSchema timeSchema,
@@ -131,11 +133,11 @@ public class ReadChunkAlignedSeriesCompactionExecutor {
   private void collectValueColumnSchemaList() throws IOException {
     Map<String, IMeasurementSchema> measurementSchemaMap = new HashMap<>();
     for (int i = this.readerAndChunkMetadataList.size() - 1; i >= 0; i--) {
-      Pair<TsFileSequenceReader, List<AlignedChunkMetadata>> pair =
+      Pair<TsFileSequenceReader, List<AbstractAlignedChunkMetadata>> pair =
           this.readerAndChunkMetadataList.get(i);
       CompactionTsFileReader reader = (CompactionTsFileReader) pair.getLeft();
-      List<AlignedChunkMetadata> alignedChunkMetadataList = pair.getRight();
-      for (AlignedChunkMetadata alignedChunkMetadata : alignedChunkMetadataList) {
+      List<AbstractAlignedChunkMetadata> alignedChunkMetadataList = pair.getRight();
+      for (AbstractAlignedChunkMetadata alignedChunkMetadata : alignedChunkMetadataList) {
         if (alignedChunkMetadata == null) {
           continue;
         }
@@ -176,10 +178,11 @@ public class ReadChunkAlignedSeriesCompactionExecutor {
   }
 
   private void fillAlignedChunkMetadataToMatchSchemaList() {
-    for (Pair<TsFileSequenceReader, List<AlignedChunkMetadata>> pair : readerAndChunkMetadataList) {
-      List<AlignedChunkMetadata> alignedChunkMetadataList = pair.getRight();
+    for (Pair<TsFileSequenceReader, List<AbstractAlignedChunkMetadata>> pair :
+        readerAndChunkMetadataList) {
+      List<AbstractAlignedChunkMetadata> alignedChunkMetadataList = pair.getRight();
       for (int i = 0; i < alignedChunkMetadataList.size(); i++) {
-        AlignedChunkMetadata alignedChunkMetadata = alignedChunkMetadataList.get(i);
+        AbstractAlignedChunkMetadata alignedChunkMetadata = alignedChunkMetadataList.get(i);
         alignedChunkMetadataList.set(
             i,
             AlignedSeriesBatchCompactionUtils.fillAlignedChunkMetadataBySchemaList(
@@ -193,15 +196,15 @@ public class ReadChunkAlignedSeriesCompactionExecutor {
   }
 
   public void execute() throws IOException, PageException {
-    for (Pair<TsFileSequenceReader, List<AlignedChunkMetadata>> readerListPair :
+    for (Pair<TsFileSequenceReader, List<AbstractAlignedChunkMetadata>> readerListPair :
         readerAndChunkMetadataList) {
       TsFileSequenceReader reader = readerListPair.left;
-      List<AlignedChunkMetadata> alignedChunkMetadataList = readerListPair.right;
+      List<AbstractAlignedChunkMetadata> alignedChunkMetadataList = readerListPair.right;
 
       if (reader instanceof CompactionTsFileReader) {
         ((CompactionTsFileReader) reader).markStartOfAlignedSeries();
       }
-      for (AlignedChunkMetadata alignedChunkMetadata : alignedChunkMetadataList) {
+      for (AbstractAlignedChunkMetadata alignedChunkMetadata : alignedChunkMetadataList) {
         compactWithAlignedChunk(reader, alignedChunkMetadata);
       }
       if (reader instanceof CompactionTsFileReader) {
@@ -215,7 +218,7 @@ public class ReadChunkAlignedSeriesCompactionExecutor {
   }
 
   private void compactWithAlignedChunk(
-      TsFileSequenceReader reader, AlignedChunkMetadata alignedChunkMetadata)
+      TsFileSequenceReader reader, AbstractAlignedChunkMetadata alignedChunkMetadata)
       throws IOException, PageException {
     ChunkLoader timeChunk =
         getChunkLoader(reader, (ChunkMetadata) alignedChunkMetadata.getTimeChunkMetadata());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/writer/FastCrossCompactionWriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/writer/FastCrossCompactionWriter.java
@@ -26,7 +26,7 @@ import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 
 import org.apache.tsfile.exception.write.PageException;
 import org.apache.tsfile.file.header.PageHeader;
-import org.apache.tsfile.file.metadata.AlignedChunkMetadata;
+import org.apache.tsfile.file.metadata.AbstractAlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.ChunkMetadata;
 import org.apache.tsfile.file.metadata.IChunkMetadata;
 import org.apache.tsfile.read.TsFileSequenceReader;
@@ -97,8 +97,8 @@ public class FastCrossCompactionWriter extends AbstractCrossCompactionWriter {
   @Override
   public boolean flushAlignedChunk(ChunkMetadataElement chunkMetadataElement, int subTaskId)
       throws IOException {
-    AlignedChunkMetadata alignedChunkMetadata =
-        (AlignedChunkMetadata) chunkMetadataElement.chunkMetadata;
+    AbstractAlignedChunkMetadata alignedChunkMetadata =
+        (AbstractAlignedChunkMetadata) chunkMetadataElement.chunkMetadata;
     IChunkMetadata timeChunkMetadata = alignedChunkMetadata.getTimeChunkMetadata();
     List<IChunkMetadata> valueChunkMetadatas = alignedChunkMetadata.getValueChunkMetadataList();
     Chunk timeChunk = chunkMetadataElement.chunk;
@@ -132,8 +132,8 @@ public class FastCrossCompactionWriter extends AbstractCrossCompactionWriter {
       int subTaskId,
       AbstractCompactionFlushController flushController)
       throws IOException {
-    AlignedChunkMetadata alignedChunkMetadata =
-        (AlignedChunkMetadata) chunkMetadataElement.chunkMetadata;
+    AbstractAlignedChunkMetadata alignedChunkMetadata =
+        (AbstractAlignedChunkMetadata) chunkMetadataElement.chunkMetadata;
     IChunkMetadata timeChunkMetadata = alignedChunkMetadata.getTimeChunkMetadata();
     List<IChunkMetadata> valueChunkMetadatas = alignedChunkMetadata.getValueChunkMetadataList();
     List<Chunk> valueChunks = chunkMetadataElement.valueChunks;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/writer/FastInnerCompactionWriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/utils/writer/FastInnerCompactionWriter.java
@@ -26,7 +26,7 @@ import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 
 import org.apache.tsfile.exception.write.PageException;
 import org.apache.tsfile.file.header.PageHeader;
-import org.apache.tsfile.file.metadata.AlignedChunkMetadata;
+import org.apache.tsfile.file.metadata.AbstractAlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.ChunkMetadata;
 import org.apache.tsfile.file.metadata.IChunkMetadata;
 import org.apache.tsfile.read.common.Chunk;
@@ -89,8 +89,8 @@ public class FastInnerCompactionWriter extends AbstractInnerCompactionWriter {
   @Override
   public boolean flushAlignedChunk(ChunkMetadataElement chunkMetadataElement, int subTaskId)
       throws IOException {
-    AlignedChunkMetadata alignedChunkMetadata =
-        (AlignedChunkMetadata) chunkMetadataElement.chunkMetadata;
+    AbstractAlignedChunkMetadata alignedChunkMetadata =
+        (AbstractAlignedChunkMetadata) chunkMetadataElement.chunkMetadata;
     IChunkMetadata timeChunkMetadata = alignedChunkMetadata.getTimeChunkMetadata();
     List<IChunkMetadata> valueChunkMetadatas = alignedChunkMetadata.getValueChunkMetadataList();
     Chunk timeChunk = chunkMetadataElement.chunk;
@@ -121,8 +121,8 @@ public class FastInnerCompactionWriter extends AbstractInnerCompactionWriter {
       int subTaskId,
       AbstractCompactionFlushController flushController)
       throws IOException {
-    AlignedChunkMetadata alignedChunkMetadata =
-        (AlignedChunkMetadata) chunkMetadataElement.chunkMetadata;
+    AbstractAlignedChunkMetadata alignedChunkMetadata =
+        (AbstractAlignedChunkMetadata) chunkMetadataElement.chunkMetadata;
     IChunkMetadata timeChunkMetadata = alignedChunkMetadata.getTimeChunkMetadata();
     List<IChunkMetadata> valueChunkMetadatas = alignedChunkMetadata.getValueChunkMetadataList();
     List<Chunk> valueChunks = chunkMetadataElement.valueChunks;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AlignedReadOnlyMemChunk.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AlignedReadOnlyMemChunk.java
@@ -30,6 +30,7 @@ import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.file.metadata.AlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.ChunkMetadata;
 import org.apache.tsfile.file.metadata.IChunkMetadata;
+import org.apache.tsfile.file.metadata.TableDeviceChunkMetadata;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.tsfile.file.metadata.statistics.Statistics;
 import org.apache.tsfile.read.common.TimeRange;
@@ -75,10 +76,11 @@ public class AlignedReadOnlyMemChunk extends ReadOnlyMemChunk {
                 timeColumnDeletion,
                 valueColumnsDeletionList,
                 context.isIgnoreAllNullRows());
-    initAlignedChunkMetaFromTsBlock();
+    initAlignedChunkMetaFromTsBlock(context.isIgnoreAllNullRows());
   }
 
-  private void initAlignedChunkMetaFromTsBlock() throws QueryProcessException {
+  private void initAlignedChunkMetaFromTsBlock(boolean ignoreAllNullRows)
+      throws QueryProcessException {
     // Time chunk
     Statistics timeStatistics = Statistics.getStatsByType(TSDataType.VECTOR);
     IChunkMetadata timeChunkMetadata =
@@ -160,7 +162,9 @@ public class AlignedReadOnlyMemChunk extends ReadOnlyMemChunk {
       }
     }
     IChunkMetadata alignedChunkMetadata =
-        new AlignedChunkMetadata(timeChunkMetadata, valueChunkMetadataList);
+        ignoreAllNullRows
+            ? new AlignedChunkMetadata(timeChunkMetadata, valueChunkMetadataList)
+            : new TableDeviceChunkMetadata(timeChunkMetadata, valueChunkMetadataList);
     alignedChunkMetadata.setChunkLoader(new MemAlignedChunkLoader(context, this));
     alignedChunkMetadata.setVersion(Long.MAX_VALUE);
     cachedMetaData = alignedChunkMetadata;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/TsFileProcessor.java
@@ -80,6 +80,7 @@ import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.file.metadata.AbstractAlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.AlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.ChunkMetadata;
 import org.apache.tsfile.file.metadata.IChunkMetadata;
@@ -1788,7 +1789,7 @@ public class TsFileProcessor {
 
   private void processAlignedChunkMetaDataFromFlushedMemTable(
       IDeviceID deviceID,
-      AlignedChunkMetadata alignedChunkMetadata,
+      AbstractAlignedChunkMetadata alignedChunkMetadata,
       Map<String, List<IChunkMetadata>> measurementToChunkMetaMap,
       Map<String, List<IChunkHandle>> measurementToChunkHandleMap,
       String filePath) {
@@ -1841,10 +1842,10 @@ public class TsFileProcessor {
       Map<String, List<IChunkMetadata>> measurementToChunkMetaList,
       Map<String, List<IChunkHandle>> measurementToChunkHandleList) {
     for (IChunkMetadata chunkMetadata : chunkMetadataList) {
-      if (chunkMetadata instanceof AlignedChunkMetadata) {
+      if (chunkMetadata instanceof AbstractAlignedChunkMetadata) {
         processAlignedChunkMetaDataFromFlushedMemTable(
             deviceID,
-            (AlignedChunkMetadata) chunkMetadata,
+            (AbstractAlignedChunkMetadata) chunkMetadata,
             measurementToChunkMetaList,
             measurementToChunkHandleList,
             this.tsFileResource.getTsFilePath());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/DiskAlignedChunkLoader.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/DiskAlignedChunkLoader.java
@@ -26,7 +26,6 @@ import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileID;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 
 import org.apache.tsfile.file.metadata.AbstractAlignedChunkMetadata;
-import org.apache.tsfile.file.metadata.AlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.ChunkMetadata;
 import org.apache.tsfile.file.metadata.IChunkMetadata;
 import org.apache.tsfile.read.common.Chunk;
@@ -77,7 +76,8 @@ public class DiskAlignedChunkLoader implements IChunkLoader {
       throws IOException {
     long t1 = System.nanoTime();
     try {
-      AbstractAlignedChunkMetadata alignedChunkMetadata = (AbstractAlignedChunkMetadata) chunkMetaData;
+      AbstractAlignedChunkMetadata alignedChunkMetadata =
+          (AbstractAlignedChunkMetadata) chunkMetaData;
       ChunkMetadata timeChunkMetadata = (ChunkMetadata) alignedChunkMetadata.getTimeChunkMetadata();
       Chunk timeChunk =
           ChunkCache.getInstance()

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/DiskAlignedChunkLoader.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/DiskAlignedChunkLoader.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.storageengine.buffer.ChunkCache;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileID;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 
+import org.apache.tsfile.file.metadata.AbstractAlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.AlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.ChunkMetadata;
 import org.apache.tsfile.file.metadata.IChunkMetadata;
@@ -76,7 +77,7 @@ public class DiskAlignedChunkLoader implements IChunkLoader {
       throws IOException {
     long t1 = System.nanoTime();
     try {
-      AlignedChunkMetadata alignedChunkMetadata = (AlignedChunkMetadata) chunkMetaData;
+      AbstractAlignedChunkMetadata alignedChunkMetadata = (AbstractAlignedChunkMetadata) chunkMetaData;
       ChunkMetadata timeChunkMetadata = (ChunkMetadata) alignedChunkMetadata.getTimeChunkMetadata();
       Chunk timeChunk =
           ChunkCache.getInstance()

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/MemAlignedChunkReader.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/MemAlignedChunkReader.java
@@ -21,7 +21,7 @@ package org.apache.iotdb.db.storageengine.dataregion.read.reader.chunk;
 
 import org.apache.iotdb.db.storageengine.dataregion.memtable.AlignedReadOnlyMemChunk;
 
-import org.apache.tsfile.file.metadata.AlignedChunkMetadata;
+import org.apache.tsfile.file.metadata.AbstractAlignedChunkMetadata;
 import org.apache.tsfile.read.common.BatchData;
 import org.apache.tsfile.read.filter.basic.Filter;
 import org.apache.tsfile.read.reader.IChunkReader;
@@ -42,7 +42,7 @@ public class MemAlignedChunkReader implements IChunkReader {
         Collections.singletonList(
             new MemAlignedPageReader(
                 readableChunk.getTsBlock(),
-                (AlignedChunkMetadata) readableChunk.getChunkMetaData(),
+                (AbstractAlignedChunkMetadata) readableChunk.getChunkMetaData(),
                 globalTimeFilter));
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/MemAlignedPageReader.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/MemAlignedPageReader.java
@@ -22,7 +22,7 @@ package org.apache.iotdb.db.storageengine.dataregion.read.reader.chunk;
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnBuilder;
 import org.apache.tsfile.enums.TSDataType;
-import org.apache.tsfile.file.metadata.AlignedChunkMetadata;
+import org.apache.tsfile.file.metadata.AbstractAlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.statistics.Statistics;
 import org.apache.tsfile.read.common.BatchData;
 import org.apache.tsfile.read.common.BatchDataFactory;
@@ -45,7 +45,7 @@ import static org.apache.tsfile.read.reader.series.PaginationController.UNLIMITE
 public class MemAlignedPageReader implements IPageReader {
 
   private final TsBlock tsBlock;
-  private final AlignedChunkMetadata chunkMetadata;
+  private final AbstractAlignedChunkMetadata chunkMetadata;
 
   private Filter recordFilter;
   private PaginationController paginationController = UNLIMITED_PAGINATION_CONTROLLER;
@@ -53,7 +53,7 @@ public class MemAlignedPageReader implements IPageReader {
   private TsBlockBuilder builder;
 
   public MemAlignedPageReader(
-      TsBlock tsBlock, AlignedChunkMetadata chunkMetadata, Filter recordFilter) {
+      TsBlock tsBlock, AbstractAlignedChunkMetadata chunkMetadata, Filter recordFilter) {
     this.tsBlock = tsBlock;
     this.chunkMetadata = chunkMetadata;
     this.recordFilter = recordFilter;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/metadata/DiskAlignedChunkMetadataLoader.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/metadata/DiskAlignedChunkMetadataLoader.java
@@ -26,8 +26,8 @@ import org.apache.iotdb.db.storageengine.dataregion.read.reader.chunk.DiskAligne
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.utils.ModificationUtils;
 
+import org.apache.tsfile.file.metadata.AbstractAlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.AbstractAlignedTimeSeriesMetadata;
-import org.apache.tsfile.file.metadata.AlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.IChunkMetadata;
 import org.apache.tsfile.file.metadata.ITimeSeriesMetadata;
 import org.apache.tsfile.read.controller.IChunkMetadataLoader;
@@ -83,7 +83,7 @@ public class DiskAlignedChunkMetadataLoader implements IChunkMetadataLoader {
   public List<IChunkMetadata> loadChunkMetadataList(ITimeSeriesMetadata timeSeriesMetadata) {
     final long t1 = System.nanoTime();
     try {
-      List<AlignedChunkMetadata> alignedChunkMetadataList =
+      List<AbstractAlignedChunkMetadata> alignedChunkMetadataList =
           ((AbstractAlignedTimeSeriesMetadata) timeSeriesMetadata).getCopiedChunkMetadataList();
 
       // when alignedChunkMetadataList.size() == 1, it means that the chunk statistics is same as

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/ErrorHandlingUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/ErrorHandlingUtils.java
@@ -106,7 +106,11 @@ public class ErrorHandlingUtils {
             || status.getCode() == TSStatusCode.ILLEGAL_PATH.getStatusCode()
             || status.getCode() == TSStatusCode.NUMERIC_VALUE_OUT_OF_RANGE.getStatusCode()
             || status.getCode() == TSStatusCode.DIVISION_BY_ZERO.getStatusCode()
-            || status.getCode() == TSStatusCode.DATE_OUT_OF_RANGE.getStatusCode()) {
+            || status.getCode() == TSStatusCode.DATE_OUT_OF_RANGE.getStatusCode()
+            || status.getCode() == TSStatusCode.TABLE_NOT_EXISTS.getStatusCode()
+            || status.getCode() == TSStatusCode.TABLE_ALREADY_EXISTS.getStatusCode()
+            || status.getCode() == TSStatusCode.COLUMN_NOT_EXISTS.getStatusCode()
+            || status.getCode() == TSStatusCode.COLUMN_ALREADY_EXISTS.getStatusCode()) {
           LOGGER.info(message);
         } else {
           LOGGER.warn(message, e);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/ModificationUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/ModificationUtils.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.storageengine.dataregion.modification.ModEntry;
 import org.apache.iotdb.db.storageengine.dataregion.modification.TableDeletionEntry;
 import org.apache.iotdb.db.storageengine.dataregion.modification.TreeDeletionEntry;
 
+import org.apache.tsfile.file.metadata.AbstractAlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.AlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.IChunkMetadata;
 import org.apache.tsfile.file.metadata.IDeviceID;
@@ -101,7 +102,7 @@ public class ModificationUtils {
   }
 
   private static void modifyValueColumns(
-      AlignedChunkMetadata metaData, List<List<ModEntry>> valueColumnsModifications) {
+      AbstractAlignedChunkMetadata metaData, List<List<ModEntry>> valueColumnsModifications) {
     List<IChunkMetadata> valueChunkMetadataList = metaData.getValueChunkMetadataList();
     // deal with each sub sensor
     for (int j = 0; j < valueChunkMetadataList.size(); j++) {
@@ -116,7 +117,7 @@ public class ModificationUtils {
   }
 
   private static boolean areAllValueColumnsDeleted(
-      AlignedChunkMetadata alignedChunkMetadata, boolean modified) {
+      AbstractAlignedChunkMetadata alignedChunkMetadata, boolean modified) {
 
     // the whole aligned path need to be removed, only set to be true if all the sub sensors
     // are deleted and ignoreAllNullRows is true
@@ -156,11 +157,11 @@ public class ModificationUtils {
   }
 
   public static void modifyAlignedChunkMetaData(
-      List<AlignedChunkMetadata> chunkMetaData,
+      List<? extends AbstractAlignedChunkMetadata> chunkMetaData,
       List<ModEntry> timeColumnModifications,
       List<List<ModEntry>> valueColumnsModifications,
       boolean ignoreAllNullRows) {
-    for (AlignedChunkMetadata metaData : chunkMetaData) {
+    for (AbstractAlignedChunkMetadata metaData : chunkMetaData) {
       IChunkMetadata timeColumnChunkMetadata = metaData.getTimeChunkMetadata();
 
       for (ModEntry modification : timeColumnModifications) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/FastCompactionPerformerWithInconsistentCompressionTypeAndEncodingTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/FastCompactionPerformerWithInconsistentCompressionTypeAndEncodingTest.java
@@ -32,7 +32,7 @@ import org.apache.tsfile.exception.write.WriteProcessException;
 import org.apache.tsfile.file.MetaMarker;
 import org.apache.tsfile.file.header.ChunkHeader;
 import org.apache.tsfile.file.header.PageHeader;
-import org.apache.tsfile.file.metadata.AlignedChunkMetadata;
+import org.apache.tsfile.file.metadata.AbstractAlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.ChunkMetadata;
 import org.apache.tsfile.file.metadata.IChunkMetadata;
 import org.apache.tsfile.file.metadata.IDeviceID;
@@ -622,9 +622,9 @@ public class FastCompactionPerformerWithInconsistentCompressionTypeAndEncodingTe
       throws IOException {
     Map<String, CompressionType> compressionTypeMap = new HashMap<>();
     for (IDeviceID device : reader.getAllDevices()) {
-      List<AlignedChunkMetadata> alignedChunkMetadataList =
+      List<AbstractAlignedChunkMetadata> alignedChunkMetadataList =
           reader.getAlignedChunkMetadata(device, true);
-      for (AlignedChunkMetadata alignedChunkMetadata : alignedChunkMetadataList) {
+      for (AbstractAlignedChunkMetadata alignedChunkMetadata : alignedChunkMetadataList) {
         IChunkMetadata timeChunkMetadata = alignedChunkMetadata.getTimeChunkMetadata();
         List<IChunkMetadata> valueChunkMetadataList =
             alignedChunkMetadata.getValueChunkMetadataList();

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/FastInnerCompactionPerformerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/FastInnerCompactionPerformerTest.java
@@ -39,7 +39,7 @@ import org.apache.iotdb.db.utils.EnvironmentUtils;
 import org.apache.tsfile.common.conf.TSFileDescriptor;
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.exception.write.WriteProcessException;
-import org.apache.tsfile.file.metadata.AlignedChunkMetadata;
+import org.apache.tsfile.file.metadata.AbstractAlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.ChunkMetadata;
 import org.apache.tsfile.file.metadata.IChunkMetadata;
 import org.apache.tsfile.file.metadata.IDeviceID;
@@ -2047,10 +2047,10 @@ public class FastInnerCompactionPerformerTest extends AbstractCompactionTest {
 
     TsFileResource targetResource = tsFileManager.getTsFileList(false).get(0);
     try (TsFileSequenceReader reader = new TsFileSequenceReader(targetResource.getTsFilePath())) {
-      List<AlignedChunkMetadata> chunkMetadataList =
+      List<AbstractAlignedChunkMetadata> chunkMetadataList =
           reader.getAlignedChunkMetadata(
               IDeviceID.Factory.DEFAULT_FACTORY.create("root.testsg.d1"), true);
-      for (AlignedChunkMetadata alignedChunkMetadata : chunkMetadataList) {
+      for (AbstractAlignedChunkMetadata alignedChunkMetadata : chunkMetadataList) {
         ChunkMetadata timeChunkMetadata =
             (ChunkMetadata) alignedChunkMetadata.getTimeChunkMetadata();
         Chunk timeChunk = reader.readMemChunk(timeChunkMetadata);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/repair/RepairUnsortedFileCompactionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/repair/RepairUnsortedFileCompactionTest.java
@@ -46,7 +46,7 @@ import org.apache.iotdb.db.storageengine.dataregion.tsfile.timeindex.ITimeIndex;
 import org.apache.iotdb.db.storageengine.dataregion.utils.TsFileResourceUtils;
 
 import org.apache.tsfile.exception.write.WriteProcessException;
-import org.apache.tsfile.file.metadata.AlignedChunkMetadata;
+import org.apache.tsfile.file.metadata.AbstractAlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.ChunkMetadata;
 import org.apache.tsfile.file.metadata.IChunkMetadata;
 import org.apache.tsfile.file.metadata.IDeviceID;
@@ -682,10 +682,10 @@ public class RepairUnsortedFileCompactionTest extends AbstractRepairDataTest {
     Assert.assertTrue(task.start());
     TsFileResource target = tsFileManager.getTsFileList(false).get(0);
     try (TsFileSequenceReader reader = new TsFileSequenceReader(target.getTsFilePath())) {
-      List<AlignedChunkMetadata> chunkMetadataList =
+      List<AbstractAlignedChunkMetadata> chunkMetadataList =
           reader.getAlignedChunkMetadata(
               IDeviceID.Factory.DEFAULT_FACTORY.create("root.testsg.d1"), true);
-      for (AlignedChunkMetadata alignedChunkMetadata : chunkMetadataList) {
+      for (AbstractAlignedChunkMetadata alignedChunkMetadata : chunkMetadataList) {
         ChunkMetadata timeChunkMetadata =
             (ChunkMetadata) alignedChunkMetadata.getTimeChunkMetadata();
         Chunk timeChunk = reader.readMemChunk(timeChunkMetadata);
@@ -796,7 +796,7 @@ public class RepairUnsortedFileCompactionTest extends AbstractRepairDataTest {
     Assert.assertTrue(task.start());
     TsFileResource target = tsFileManager.getTsFileList(false).get(0);
     try (TsFileSequenceReader reader = new TsFileSequenceReader(target.getTsFilePath())) {
-      List<AlignedChunkMetadata> chunkMetadataList =
+      List<AbstractAlignedChunkMetadata> chunkMetadataList =
           reader.getAlignedChunkMetadata(
               IDeviceID.Factory.DEFAULT_FACTORY.create("root.testsg.d1"), true);
       Assert.assertEquals(3, chunkMetadataList.size());

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/utils/BatchCompactionUtilsTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/utils/BatchCompactionUtilsTest.java
@@ -34,6 +34,7 @@ import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.exception.write.PageException;
 import org.apache.tsfile.exception.write.WriteProcessException;
 import org.apache.tsfile.file.header.PageHeader;
+import org.apache.tsfile.file.metadata.AbstractAlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.AlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.ChunkMetadata;
 import org.apache.tsfile.file.metadata.IChunkMetadata;
@@ -107,7 +108,7 @@ public class BatchCompactionUtilsTest extends AbstractCompactionTest {
             true);
     try (TsFileSequenceReader reader =
         new TsFileSequenceReader(seqResource1.getTsFile().getAbsolutePath())) {
-      AlignedChunkMetadata alignedChunkMetadata =
+      AbstractAlignedChunkMetadata alignedChunkMetadata =
           reader
               .getAlignedChunkMetadata(
                   IDeviceID.Factory.DEFAULT_FACTORY.create("root.testsg.d0"), true)
@@ -311,14 +312,14 @@ public class BatchCompactionUtilsTest extends AbstractCompactionTest {
             new MeasurementSchema("s1", TSDataType.INT32),
             new MeasurementSchema("s2", TSDataType.INT32),
             new MeasurementSchema("s4", TSDataType.INT32));
-    AlignedChunkMetadata newAlignedChunkMetadata =
+    AbstractAlignedChunkMetadata newAlignedChunkMetadata =
         AlignedSeriesBatchCompactionUtils.fillAlignedChunkMetadataBySchemaList(
             alignedChunkMetadata, measurementSchemas);
     Assert.assertEquals(
+        Arrays.asList("s0", "s1", "s2", "s4"),
         newAlignedChunkMetadata.getValueChunkMetadataList().stream()
             .map(IChunkMetadata::getMeasurementUid)
-            .collect(Collectors.toList()),
-        Arrays.asList("s0", "s1", "s2", "s4"));
+            .collect(Collectors.toList()));
   }
 
   @Test
@@ -333,14 +334,14 @@ public class BatchCompactionUtilsTest extends AbstractCompactionTest {
         Arrays.asList(
             new MeasurementSchema("s0", TSDataType.INT32),
             new MeasurementSchema("s4", TSDataType.INT32));
-    AlignedChunkMetadata newAlignedChunkMetadata =
+    AbstractAlignedChunkMetadata newAlignedChunkMetadata =
         AlignedSeriesBatchCompactionUtils.fillAlignedChunkMetadataBySchemaList(
             alignedChunkMetadata, measurementSchemas);
     Assert.assertEquals(
+        Arrays.asList(null, "s4"),
         newAlignedChunkMetadata.getValueChunkMetadataList().stream()
             .map(chunkMetadata -> chunkMetadata == null ? null : chunkMetadata.getMeasurementUid())
-            .collect(Collectors.toList()),
-        Arrays.asList(null, "s4"));
+            .collect(Collectors.toList()));
   }
 
   @Test
@@ -368,23 +369,23 @@ public class BatchCompactionUtilsTest extends AbstractCompactionTest {
             new MeasurementSchema("s2", TSDataType.INT32),
             new MeasurementSchema("s3", TSDataType.INT32),
             new MeasurementSchema("s4", TSDataType.INT32));
-    AlignedChunkMetadata newAlignedChunkMetadata1 =
+    AbstractAlignedChunkMetadata newAlignedChunkMetadata1 =
         AlignedSeriesBatchCompactionUtils.fillAlignedChunkMetadataBySchemaList(
             alignedChunkMetadata1, measurementSchemas);
     Assert.assertEquals(
+        Arrays.asList("s0", "s1", "s2", null, null),
         newAlignedChunkMetadata1.getValueChunkMetadataList().stream()
             .map(chunkMetadata -> chunkMetadata == null ? null : chunkMetadata.getMeasurementUid())
-            .collect(Collectors.toList()),
-        Arrays.asList("s0", "s1", "s2", null, null));
+            .collect(Collectors.toList()));
 
-    AlignedChunkMetadata newAlignedChunkMetadata2 =
+    AbstractAlignedChunkMetadata newAlignedChunkMetadata2 =
         AlignedSeriesBatchCompactionUtils.fillAlignedChunkMetadataBySchemaList(
             alignedChunkMetadata2, measurementSchemas);
     Assert.assertEquals(
+        Arrays.asList(null, null, null, "s3", "s4"),
         newAlignedChunkMetadata2.getValueChunkMetadataList().stream()
             .map(chunkMetadata -> chunkMetadata == null ? null : chunkMetadata.getMeasurementUid())
-            .collect(Collectors.toList()),
-        Arrays.asList(null, null, null, "s3", "s4"));
+            .collect(Collectors.toList()));
   }
 
   @Test
@@ -411,22 +412,22 @@ public class BatchCompactionUtilsTest extends AbstractCompactionTest {
         Arrays.asList(
             new MeasurementSchema("s2", TSDataType.INT32),
             new MeasurementSchema("s4", TSDataType.INT32));
-    AlignedChunkMetadata newAlignedChunkMetadata1 =
+    AbstractAlignedChunkMetadata newAlignedChunkMetadata1 =
         AlignedSeriesBatchCompactionUtils.fillAlignedChunkMetadataBySchemaList(
             alignedChunkMetadata1, measurementSchemas);
     Assert.assertEquals(
+        Arrays.asList("s2", null),
         newAlignedChunkMetadata1.getValueChunkMetadataList().stream()
             .map(chunkMetadata -> chunkMetadata == null ? null : chunkMetadata.getMeasurementUid())
-            .collect(Collectors.toList()),
-        Arrays.asList("s2", null));
+            .collect(Collectors.toList()));
 
-    AlignedChunkMetadata newAlignedChunkMetadata2 =
+    AbstractAlignedChunkMetadata newAlignedChunkMetadata2 =
         AlignedSeriesBatchCompactionUtils.fillAlignedChunkMetadataBySchemaList(
             alignedChunkMetadata2, measurementSchemas);
     Assert.assertEquals(
+        Arrays.asList(null, "s4"),
         newAlignedChunkMetadata2.getValueChunkMetadataList().stream()
             .map(chunkMetadata -> chunkMetadata == null ? null : chunkMetadata.getMeasurementUid())
-            .collect(Collectors.toList()),
-        Arrays.asList(null, "s4"));
+            .collect(Collectors.toList()));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
         <thrift.version>0.14.1</thrift.version>
         <xz.version>1.9</xz.version>
         <zstd-jni.version>1.5.6-3</zstd-jni.version>
-        <tsfile.version>2.1.0-250126-SNAPSHOT</tsfile.version>
+        <tsfile.version>2.1.0-250206-SNAPSHOT</tsfile.version>
     </properties>
     <!--
     if we claim dependencies in dependencyManagement, then we do not claim

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
         <thrift.version>0.14.1</thrift.version>
         <xz.version>1.9</xz.version>
         <zstd-jni.version>1.5.6-3</zstd-jni.version>
-        <tsfile.version>2.1.0-SNAPSHOT</tsfile.version>
+        <tsfile.version>2.1.0-250126-SNAPSHOT</tsfile.version>
     </properties>
     <!--
     if we claim dependencies in dependencyManagement, then we do not claim

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
         <thrift.version>0.14.1</thrift.version>
         <xz.version>1.9</xz.version>
         <zstd-jni.version>1.5.6-3</zstd-jni.version>
-        <tsfile.version>2.0.0-250118-SNAPSHOT</tsfile.version>
+        <tsfile.version>2.1.0-SNAPSHOT</tsfile.version>
     </properties>
     <!--
     if we claim dependencies in dependencyManagement, then we do not claim


### PR DESCRIPTION
To replay you can use the following sqls (remember to disable cross_space_compaction)
```
create database db;
use db;
create table table1(id1 tag, s1 string);
insert into table1 values(0, 'd1', null), (1,'d1', 1);
flush;
insert into table1 values(0, 'd1', 0);
flush;
select * from table1;
```

previously, you will get duplicate timestamp 0
```
+-----------------------------+---+----+
|                         time|id1|  s1|
+-----------------------------+---+----+
|1970-01-01T08:00:00.000+08:00| d1|   0|
|1970-01-01T08:00:00.000+08:00| d1|null|
|1970-01-01T08:00:00.001+08:00| d1|   1|
+-----------------------------+---+----+
```