### PR TITLE
fix auth parser error with grant all on root.** from non-root user.

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBAuthIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBAuthIT.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.it.auth;
 
 import org.apache.iotdb.commons.auth.entity.PrivilegeType;
 import org.apache.iotdb.commons.schema.column.ColumnHeaderConstant;
+import org.apache.iotdb.db.it.utils.TestUtils;
 import org.apache.iotdb.it.env.EnvFactory;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.ClusterIT;
@@ -155,6 +156,30 @@ public class IoTDBAuthIT {
         Assert.assertThrows(
             SQLException.class,
             () -> userStmt.execute("GRANT USER tempuser PRIVILEGES WRITE_SCHEMA ON root.a"));
+
+        adminStmt.execute("GRANT ALL ON root.** TO USER tempuser WITH GRANT OPTION");
+        userStmt.execute("CREATE USER testuser 'password'");
+        userStmt.execute("GRANT ALL ON root.** TO USER testuser WITH GRANT OPTION");
+        ResultSet dataSet = userStmt.executeQuery("LIST PRIVILEGES OF USER testuser");
+
+        Set<String> ansSet =
+            new HashSet<>(
+                Arrays.asList(
+                    ",,MANAGE_USER,true,",
+                    ",,MANAGE_ROLE,true,",
+                    ",,USE_TRIGGER,true,",
+                    ",,USE_UDF,true,",
+                    ",,USE_CQ,true,",
+                    ",,USE_PIPE,true,",
+                    ",,USE_MODEL,true,",
+                    ",,EXTEND_TEMPLATE,true,",
+                    ",,MANAGE_DATABASE,true,",
+                    ",,MAINTAIN,true,",
+                    ",root.**,READ_DATA,true,",
+                    ",root.**,WRITE_DATA,true,",
+                    ",root.**,READ_SCHEMA,true,",
+                    ",root.**,WRITE_SCHEMA,true,"));
+        TestUtils.assertResultSetEqual(dataSet, "Role,Scope,Privileges,GrantOption,", ansSet);
       }
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/parser/ASTVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/parser/ASTVisitor.java
@@ -2518,6 +2518,9 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
         continue;
       } else if (priv.equalsIgnoreCase("ALL")) {
         for (PrivilegeType type : PrivilegeType.values()) {
+          if (type.isRelationalPrivilege()) {
+            continue;
+          }
           privSet.add(type.toString());
         }
         continue;

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/parser/StatementGeneratorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/parser/StatementGeneratorTest.java
@@ -783,6 +783,9 @@ public class StatementGeneratorTest {
     // 1. test complex privilege on single path :"root.**"
     Set<String> allPriv = new HashSet<>();
     for (PrivilegeType type : PrivilegeType.values()) {
+      if (type.isRelationalPrivilege()) {
+        continue;
+      }
       allPriv.add(type.toString());
     }
 


### PR DESCRIPTION
## Description
Fix bug "Not support Relation statement in tree sql_dialect " when a non-root user grant all on root.** to user other.
