### PR TITLE
Fix null measurement name issue in insertTablet

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionInsertNullIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBSessionInsertNullIT.java
@@ -35,6 +35,7 @@ import org.apache.tsfile.read.common.RowRecord;
 import org.apache.tsfile.write.record.Tablet;
 import org.apache.tsfile.write.schema.MeasurementSchema;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -423,6 +424,63 @@ public class IoTDBSessionInsertNullIT {
     } catch (Exception e) {
       e.printStackTrace();
       fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void insertTabletNullMeasurementTest() {
+    try (ISession session = EnvFactory.getEnv().getSessionConnection()) {
+      String deviceId = "root.sg1.clsu.aligned_d1";
+      Tablet tablet =
+          new Tablet(
+              deviceId,
+              Arrays.asList(
+                  new MeasurementSchema("s1", TSDataType.BOOLEAN),
+                  new MeasurementSchema(null, TSDataType.INT32)),
+              1);
+      tablet.addTimestamp(0, 300);
+      tablet.addValue("s1", 0, true);
+      tablet.addValue(null, 0, 1);
+      session.insertAlignedTablet(tablet);
+      fail();
+    } catch (Exception e) {
+      Assert.assertEquals("measurement should be non null value", e.getMessage());
+    }
+
+    try (ISession session = EnvFactory.getEnv().getSessionConnection()) {
+      String deviceId = "root.sg1.clsu.aligned_d1";
+      Tablet tablet =
+          new Tablet(
+              deviceId,
+              Arrays.asList(
+                  new MeasurementSchema("s1", TSDataType.BOOLEAN),
+                  new MeasurementSchema(null, TSDataType.INT32)),
+              1);
+      tablet.addTimestamp(0, 300);
+      tablet.addValue(0, 0, true);
+      tablet.addValue(0, 1, 1);
+      session.insertAlignedTablet(tablet);
+      fail();
+    } catch (Exception e) {
+      Assert.assertEquals("measurement should be non null value", e.getMessage());
+    }
+
+    try (ISession session = EnvFactory.getEnv().getSessionConnection()) {
+      String deviceId = "root.sg1.clsu.aligned_d1";
+      Tablet tablet =
+          new Tablet(
+              deviceId,
+              Arrays.asList(
+                  new MeasurementSchema("s1", TSDataType.BOOLEAN),
+                  new MeasurementSchema(null, TSDataType.INT32)),
+              1);
+      tablet.addTimestamp(0, 300);
+      tablet.addValue("s1", 0, true);
+      // doesn't insert 2nd measurement
+      session.insertAlignedTablet(tablet);
+      fail();
+    } catch (Exception e) {
+      Assert.assertEquals("measurement should be non null value", e.getMessage());
     }
   }
 }

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -2960,6 +2960,9 @@ public class Session implements ISession {
     TSInsertTabletReq request = new TSInsertTabletReq();
 
     for (IMeasurementSchema measurementSchema : tablet.getSchemas()) {
+      if (measurementSchema.getMeasurementName() == null) {
+        throw new IllegalArgumentException("measurement should be non null value");
+      }
       request.addToMeasurements(measurementSchema.getMeasurementName());
       request.addToTypes(measurementSchema.getType().ordinal());
     }
@@ -3084,6 +3087,9 @@ public class Session implements ISession {
     List<Integer> dataTypes = new ArrayList<>();
     request.setIsAligned(isAligned);
     for (IMeasurementSchema measurementSchema : tablet.getSchemas()) {
+      if (measurementSchema.getMeasurementName() == null) {
+        throw new IllegalArgumentException("measurement should be non null value");
+      }
       measurements.add(measurementSchema.getMeasurementName());
       dataTypes.add(measurementSchema.getType().ordinal());
     }

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -1093,6 +1093,7 @@ public class SessionConnection {
     if (status != null) {
       RpcUtils.verifySuccess(status);
     } else if (lastTException != null) {
+      reconnect();
       throw new IoTDBConnectionException(lastTException);
     } else {
       throw new IoTDBConnectionException(logForReconnectionFailure());

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -1093,7 +1093,6 @@ public class SessionConnection {
     if (status != null) {
       RpcUtils.verifySuccess(status);
     } else if (lastTException != null) {
-      reconnect();
       throw new IoTDBConnectionException(lastTException);
     } else {
       throw new IoTDBConnectionException(logForReconnectionFailure());


### PR DESCRIPTION
## To reproduce

```
    public static void testInsertTablet_schemaListNullIn2() throws IoTDBConnectionException, StatementExecutionException {
        int insertCount = 1;
        String device="root.params.d_1";
        List<MeasurementSchema> schemas = new ArrayList<>(3);
        schemas.add(new MeasurementSchema("s_0", TSDataType.BOOLEAN));
        schemas.add(new MeasurementSchema("s_1", TSDataType.INT32));
        schemas.add(new MeasurementSchema(null, TSDataType.INT32));
        Tablet tablet = new Tablet(device, schemas, insertCount);
        int rowIndex = 0;
        long timestamp = 1635232143960L;
        for (int row = 0; row < insertCount; row++) {
            timestamp += 3600000;
            tablet.addTimestamp(rowIndex, timestamp);
            for (int i = 0; i < schemas.size() - 1; i++) {
                switch(schemas.get(i).getType()) {
                    case BOOLEAN:
                        tablet.addValue(schemas.get(i).getMeasurementId(), rowIndex, true);
                        break;
                    case INT32:
                        tablet.addValue(schemas.get(i).getMeasurementId(), rowIndex, 1);
                        break;
                   
                }
            }
        }
        session.insertTablet(tablet);
    }
    public static void main(String[] args) throws IoTDBConnectionException, StatementExecutionException {
        Session session = new Session.Builder()
                .host("127.0.0.1")
                .port(6667)
                .enableRedirection(false)
                .maxRetryCount(0)
                .build();
        session.open();
        try {
        testInsertTablet_schemaListNullIn2();
        } catch (IoTDBConnectionException e) {
          // there is error log in datanode after execute the query
          session.executeQueryStatement("count databases;");
        }
}
```

The error log in datanode side.
```
2024-05-21 16:08:35,422 [pool-28-IoTDB-ClientRPC-Processor-2] ERROR o.a.t.s.TThreadPoolServer$WorkerProcess:258 - Error occurred during processing of message. 
java.lang.StringIndexOutOfBoundsException: String index out of range: -2147418111
	at java.lang.String.checkBounds(String.java:381)
	at java.lang.String.<init>(String.java:462)
	at org.apache.thrift.protocol.TBinaryProtocol.readString(TBinaryProtocol.java:404)
	at org.apache.iotdb.service.rpc.thrift.TSInsertTabletReq$TSInsertTabletReqStandardScheme.read(TSInsertTabletReq.java:967)
	at org.apache.iotdb.service.rpc.thrift.TSInsertTabletReq$TSInsertTabletReqStandardScheme.read(TSInsertTabletReq.java:931)
	at org.apache.iotdb.service.rpc.thrift.TSInsertTabletReq.read(TSInsertTabletReq.java:816)
	at org.apache.iotdb.service.rpc.thrift.IClientRPCService$insertTablet_args$insertTablet_argsStandardScheme.read(IClientRPCService.java:32117)
	at org.apache.iotdb.service.rpc.thrift.IClientRPCService$insertTablet_args$insertTablet_argsStandardScheme.read(IClientRPCService.java:32102)
	at org.apache.iotdb.service.rpc.thrift.IClientRPCService$insertTablet_args.read(IClientRPCService.java:32049)
	at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:23)
	at org.apache.iotdb.db.protocol.thrift.ProcessorWithMetrics.process(ProcessorWithMetrics.java:64)
	at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:248)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
```
