### PR TITLE
【remember to add Hu and Peng to co-arthor and delete this bracket before merge】IoTConsensus and IoTConsensusV2 no longer stores the peer list locally on the DataNode

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/common/Peer.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/common/Peer.java
@@ -35,14 +35,15 @@ import org.slf4j.LoggerFactory;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Comparator;
 import java.util.Objects;
 
-public class Peer {
+public class Peer implements Comparable<Peer> {
 
   private final Logger logger = LoggerFactory.getLogger(Peer.class);
   private final ConsensusGroupId groupId;
-  private final TEndPoint endpoint;
   private final int nodeId;
+  private final TEndPoint endpoint;
 
   public Peer(ConsensusGroupId groupId, int nodeId, TEndPoint endpoint) {
     this.groupId = groupId;
@@ -103,6 +104,14 @@ public class Peer {
   @Override
   public String toString() {
     return "Peer{" + "groupId=" + groupId + ", endpoint=" + endpoint + ", nodeId=" + nodeId + '}';
+  }
+
+  @Override
+  public int compareTo(Peer peer) {
+    return Comparator.comparing(Peer::getGroupId)
+        .thenComparingInt(Peer::getNodeId)
+        .thenComparing(Peer::getEndpoint)
+        .compare(this, peer);
   }
 
   public static Peer valueOf(

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensus.java
@@ -497,7 +497,7 @@ public class IoTConsensus implements IConsensus {
     Peer localPeer = new Peer(groupId, thisNodeId, thisNode);
     if (!correctPeers.contains(localPeer)) {
       logger.info(
-          "[RESET PEER LIST] Local peer is not in the correct configuration, delete local peer {}",
+          "[RESET PEER LIST] {} Local peer is not in the correct configuration, delete it.",
           groupId);
       deleteLocalPeer(groupId);
       return;
@@ -510,9 +510,9 @@ public class IoTConsensus implements IConsensus {
       for (Peer peer : currentMembers) {
         if (!correctPeers.contains(peer)) {
           if (!impl.removeSyncLogChannel(peer)) {
-            logger.error("[RESET PEER LIST] Failed to remove sync channel with: {}", peer);
+            logger.error("[RESET PEER LIST] {} Failed to remove sync channel with: {}", groupId, peer);
           } else {
-            logger.info("[RESET PEER LIST] Remove sync channel with: {}", peer);
+            logger.info("[RESET PEER LIST] {} Remove sync channel with: {}", groupId, peer);
           }
         }
       }
@@ -520,19 +520,20 @@ public class IoTConsensus implements IConsensus {
       for (Peer peer : correctPeers) {
         if (!impl.getConfiguration().contains(peer)) {
           impl.buildSyncLogChannel(peer);
-          logger.info("[RESET PEER LIST] Build sync channel with: {}", peer);
+          logger.info("[RESET PEER LIST] {} Build sync channel with: {}", groupId, peer);
         }
       }
       // show result
       String newPeerListStr = impl.getConfiguration().toString();
       if (!previousPeerListStr.equals(newPeerListStr)) {
         logger.info(
-            "[RESET PEER LIST] Local peer list has been reset: {} -> {}",
+            "[RESET PEER LIST] {} Local peer list has been reset: {} -> {}", groupId,
             previousPeerListStr,
             newPeerListStr);
       } else {
         logger.info(
-            "[RESET PEER LIST] The current peer list is correct, nothing need to be reset: {}",
+            "[RESET PEER LIST] {} The current peer list is correct, nothing need to be reset: {}",
+                groupId,
             previousPeerListStr);
       }
     }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensus.java
@@ -510,7 +510,8 @@ public class IoTConsensus implements IConsensus {
       for (Peer peer : currentMembers) {
         if (!correctPeers.contains(peer)) {
           if (!impl.removeSyncLogChannel(peer)) {
-            logger.error("[RESET PEER LIST] {} Failed to remove sync channel with: {}", groupId, peer);
+            logger.error(
+                "[RESET PEER LIST] {} Failed to remove sync channel with: {}", groupId, peer);
           } else {
             logger.info("[RESET PEER LIST] {} Remove sync channel with: {}", groupId, peer);
           }
@@ -527,13 +528,14 @@ public class IoTConsensus implements IConsensus {
       String newPeerListStr = impl.getConfiguration().toString();
       if (!previousPeerListStr.equals(newPeerListStr)) {
         logger.info(
-            "[RESET PEER LIST] {} Local peer list has been reset: {} -> {}", groupId,
+            "[RESET PEER LIST] {} Local peer list has been reset: {} -> {}",
+            groupId,
             previousPeerListStr,
             newPeerListStr);
       } else {
         logger.info(
             "[RESET PEER LIST] {} The current peer list is correct, nothing need to be reset: {}",
-                groupId,
+            groupId,
             previousPeerListStr);
       }
     }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensus.java
@@ -189,7 +189,7 @@ public class IoTConsensus implements IConsensus {
       BiConsumer<ConsensusGroupId, List<Peer>> resetPeerListWithoutThrow =
           (consensusGroupId, peers) -> {
             try {
-              resetPeerList(consensusGroupId, peers);
+              resetPeerListImpl(consensusGroupId, peers, false);
             } catch (ConsensusGroupNotExistException ignore) {
 
             } catch (Exception e) {
@@ -491,6 +491,12 @@ public class IoTConsensus implements IConsensus {
   @Override
   public void resetPeerList(ConsensusGroupId groupId, List<Peer> correctPeers)
       throws ConsensusException {
+    resetPeerListImpl(groupId, correctPeers, true);
+  }
+
+  private void resetPeerListImpl(
+      ConsensusGroupId groupId, List<Peer> correctPeers, boolean startNow)
+      throws ConsensusException {
     IoTConsensusServerImpl impl =
         Optional.ofNullable(stateMachineMap.get(groupId))
             .orElseThrow(() -> new ConsensusGroupNotExistException(groupId));
@@ -521,7 +527,7 @@ public class IoTConsensus implements IConsensus {
       // add correct peer
       for (Peer peer : correctPeers) {
         if (!impl.getConfiguration().contains(peer)) {
-          impl.buildSyncLogChannel(peer);
+          impl.buildSyncLogChannel(peer, startNow);
           logger.info("[RESET PEER LIST] {} Build sync channel with: {}", groupId, peer);
         }
       }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensus.java
@@ -75,6 +75,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -174,7 +175,7 @@ public class IoTConsensus implements IConsensus {
               new IoTConsensusServerImpl(
                   path.toString(),
                   new Peer(consensusGroupId, thisNodeId, thisNode),
-                  new ArrayList<>(),
+                  new TreeSet<>(),
                   registry.apply(consensusGroupId),
                   backgroundTaskService,
                   clientManager,
@@ -281,7 +282,7 @@ public class IoTConsensus implements IConsensus {
                       new IoTConsensusServerImpl(
                           path,
                           new Peer(groupId, thisNodeId, thisNode),
-                          peers,
+                          new TreeSet<>(peers),
                           registry.apply(groupId),
                           backgroundTaskService,
                           clientManager,

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -486,7 +486,7 @@ public class IoTConsensusServerImpl {
       if (peer.equals(thisNode)) {
         // use searchIndex for thisNode as the initialSyncIndex because targetPeer will load the
         // snapshot produced by thisNode
-        buildSyncLogChannel(targetPeer);
+        buildSyncLogChannel(targetPeer, true);
       } else {
         // use RPC to tell other peers to build sync log channel to target peer
         try (SyncIoTConsensusServiceClient client =
@@ -634,21 +634,22 @@ public class IoTConsensusServerImpl {
   }
 
   /** build SyncLog channel with safeIndex as the default initial sync index. */
-  public void buildSyncLogChannel(Peer targetPeer) {
-    buildSyncLogChannel(targetPeer, getMinSyncIndex());
+  public void buildSyncLogChannel(Peer targetPeer, boolean startNow) {
+    buildSyncLogChannel(targetPeer, getMinSyncIndex(), startNow);
   }
 
-  public void buildSyncLogChannel(Peer targetPeer, long initialSyncIndex) {
+  public void buildSyncLogChannel(Peer targetPeer, long initialSyncIndex, boolean startNow) {
     KillPoint.setKillPoint(DataNodeKillPoints.ORIGINAL_ADD_PEER_DONE);
     configuration.add(targetPeer);
     if (Objects.equals(targetPeer, thisNode)) {
       return;
     }
-    logDispatcher.addLogDispatcherThread(targetPeer, initialSyncIndex);
+    logDispatcher.addLogDispatcherThread(targetPeer, initialSyncIndex, startNow);
     logger.info(
-        "[IoTConsensus] Successfully build sync log channel to {} with initialSyncIndex {}",
+        "[IoTConsensus] Successfully build sync log channel to {} with initialSyncIndex {}. {}",
         targetPeer,
-        initialSyncIndex);
+        initialSyncIndex,
+        startNow ? "Sync log channel has started." : "Sync log channel maybe start later.");
   }
 
   /**

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -639,11 +639,13 @@ public class IoTConsensusServerImpl {
   public void buildSyncLogChannel(Peer targetPeer, long initialSyncIndex) {
     KillPoint.setKillPoint(DataNodeKillPoints.ORIGINAL_ADD_PEER_DONE);
     // step 1, build sync channel in LogDispatcher
-    logger.info(
-        "[IoTConsensus] build sync log channel to {} with initialSyncIndex {}",
-        targetPeer,
-        initialSyncIndex);
-    logDispatcher.addLogDispatcherThread(targetPeer, initialSyncIndex);
+    if (!targetPeer.equals(thisNode)) {
+      logger.info(
+              "[IoTConsensus] build sync log channel to {} with initialSyncIndex {}",
+              targetPeer,
+              initialSyncIndex);
+      logDispatcher.addLogDispatcherThread(targetPeer, initialSyncIndex);
+    }
     // step 2, update configuration
     configuration.add(targetPeer);
     logger.info("[IoTConsensus Configuration] persist new configuration: {}", configuration);

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/service/IoTConsensusRPCServiceProcessor.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/service/IoTConsensusRPCServiceProcessor.java
@@ -189,7 +189,7 @@ public class IoTConsensusRPCServiceProcessor implements IoTConsensusIService.Ifa
       return new TBuildSyncLogChannelRes(status);
     }
     TSStatus responseStatus;
-    impl.buildSyncLogChannel(new Peer(groupId, req.nodeId, req.endPoint));
+    impl.buildSyncLogChannel(new Peer(groupId, req.nodeId, req.endPoint), true);
     responseStatus = new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
     return new TBuildSyncLogChannelRes(responseStatus);
   }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/pipe/PipeConsensusPeerManager.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/pipe/PipeConsensusPeerManager.java
@@ -19,37 +19,24 @@
 
 package org.apache.iotdb.consensus.pipe;
 
-import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.consensus.common.Peer;
 
 import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.DataOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Stream;
 
 public class PipeConsensusPeerManager {
 
-  private static final String CONFIGURATION_FILE_NAME = "configuration.dat";
   private static final Logger LOGGER = LoggerFactory.getLogger(PipeConsensusPeerManager.class);
 
-  private final String storageDir;
   private final Set<Peer> peers;
 
-  public PipeConsensusPeerManager(String storageDir, List<Peer> peers) {
-    this.storageDir = storageDir;
+  public PipeConsensusPeerManager(List<Peer> peers) {
     this.peers = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     this.peers.addAll(peers);
@@ -58,63 +45,15 @@ public class PipeConsensusPeerManager {
     }
   }
 
-  public void recover() throws IOException {
-    try (Stream<Path> pathStream = Files.walk(Paths.get(storageDir), 1)) {
-      Path[] configurationPaths =
-          pathStream
-              .filter(Files::isRegularFile)
-              .filter(path -> path.getFileName().toString().endsWith(CONFIGURATION_FILE_NAME))
-              .toArray(Path[]::new);
-      ByteBuffer readBuffer;
-      for (Path path : configurationPaths) {
-        readBuffer = ByteBuffer.wrap(Files.readAllBytes(path));
-        peers.add(Peer.deserialize(readBuffer));
-      }
-    }
-  }
-
-  private void persist(Peer peer) throws IOException {
-    File configurationFile = new File(storageDir, generateConfigurationFileName(peer));
-    if (configurationFile.exists()) {
-      LOGGER.warn("Configuration file {} already exists, delete it.", configurationFile);
-      FileUtils.deleteFileOrDirectory(configurationFile);
-    }
-
-    try (FileOutputStream fileOutputStream = new FileOutputStream(configurationFile)) {
-      try (DataOutputStream dataOutputStream = new DataOutputStream(fileOutputStream)) {
-        peer.serialize(dataOutputStream);
-      } finally {
-        try {
-          fileOutputStream.flush();
-          fileOutputStream.getFD().sync();
-        } catch (IOException ignore) {
-          // ignore sync exception
-        }
-      }
-    }
-  }
-
-  private String generateConfigurationFileName(Peer peer) {
-    return peer.getNodeId() + "_" + CONFIGURATION_FILE_NAME;
-  }
-
-  public void persistAll() throws IOException {
-    for (Peer peer : peers) {
-      persist(peer);
-    }
-  }
-
   public boolean contains(Peer peer) {
     return peers.contains(peer);
   }
 
-  public void addAndPersist(Peer peer) throws IOException {
+  public void addPeer(Peer peer) {
     peers.add(peer);
-    persist(peer);
   }
 
-  public void removeAndPersist(Peer peer) throws IOException {
-    Files.deleteIfExists(Paths.get(storageDir, generateConfigurationFileName(peer)));
+  public void removePeer(Peer peer) {
     peers.remove(peer);
   }
 
@@ -128,27 +67,7 @@ public class PipeConsensusPeerManager {
     return ImmutableList.copyOf(peers);
   }
 
-  public void deleteAllFiles() throws IOException {
-    IOException exception = null;
-    for (Peer peer : peers) {
-      try {
-        Files.deleteIfExists(Paths.get(storageDir, generateConfigurationFileName(peer)));
-      } catch (IOException e) {
-        LOGGER.error("Failed to delete configuration file for peer {}", peer, e);
-        if (exception == null) {
-          exception = e;
-        } else {
-          exception.addSuppressed(e);
-        }
-      }
-    }
-    if (exception != null) {
-      throw exception;
-    }
-  }
-
-  public void clear() throws IOException {
-    deleteAllFiles();
+  public void clear() {
     peers.clear();
   }
 }

--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/ReplicateTest.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/ReplicateTest.java
@@ -48,8 +48,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class ReplicateTest {
@@ -117,6 +115,8 @@ public class ReplicateTest {
                                     ConsensusFactory.CONSTRUCT_FAILED_MSG,
                                     ConsensusFactory.IOT_CONSENSUS))));
         servers.get(i).recordCorrectPeerListBeforeStarting(Collections.singletonMap(gid, peers));
+      }
+      for (int i = 0; i < peers.size(); i++) {
         servers.get(i).start();
       }
     } catch (IOException e) {

--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/ReplicateTest.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/ReplicateTest.java
@@ -46,7 +46,9 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -56,12 +58,6 @@ public class ReplicateTest {
   private final Logger logger = LoggerFactory.getLogger(ReplicateTest.class);
 
   private final ConsensusGroupId gid = new DataRegionId(1);
-
-  private static final long timeout = TimeUnit.SECONDS.toMillis(300);
-
-  private static final String CONFIGURATION_FILE_NAME = "configuration.dat";
-
-  private static final String CONFIGURATION_TMP_FILE_NAME = "configuration.dat.tmp";
 
   private int basePort = 9000;
 
@@ -73,9 +69,9 @@ public class ReplicateTest {
 
   private final List<File> peersStorage =
       Arrays.asList(
-          new File("target" + java.io.File.separator + "1"),
-          new File("target" + java.io.File.separator + "2"),
-          new File("target" + java.io.File.separator + "3"));
+          new File("target" + File.separator + "1"),
+          new File("target" + File.separator + "2"),
+          new File("target" + File.separator + "3"));
 
   private final ConsensusGroup group = new ConsensusGroup(gid, peers);
   private final List<IoTConsensus> servers = new ArrayList<>();
@@ -120,6 +116,7 @@ public class ReplicateTest {
                                 String.format(
                                     ConsensusFactory.CONSTRUCT_FAILED_MSG,
                                     ConsensusFactory.IOT_CONSENSUS))));
+        servers.get(i).recordCorrectPeerListBeforeStarting(Collections.singletonMap(gid, peers));
         servers.get(i).start();
       }
     } catch (IOException e) {
@@ -299,6 +296,10 @@ public class ReplicateTest {
           Thread.sleep(100);
         }
       }
+
+      System.out.println(stateMachines.get(0).getRequestSet().size());
+      System.out.println(stateMachines.get(1).getRequestSet().size());
+      System.out.println(stateMachines.get(2).getRequestSet().size());
 
       Assert.assertEquals(CHECK_POINT_GAP * 2, stateMachines.get(0).getRequestSet().size());
       Assert.assertEquals(CHECK_POINT_GAP * 2, stateMachines.get(1).getRequestSet().size());

--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/ReplicateTest.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/iot/ReplicateTest.java
@@ -184,23 +184,9 @@ public class ReplicateTest {
       stopServer();
       initServer();
 
-      Assert.assertEquals(
-          peers.stream().map(Peer::getNodeId).collect(Collectors.toSet()),
-          servers.get(0).getImpl(gid).getConfiguration().stream()
-              .map(Peer::getNodeId)
-              .collect(Collectors.toSet()));
-
-      Assert.assertEquals(
-          peers.stream().map(Peer::getNodeId).collect(Collectors.toSet()),
-          servers.get(1).getImpl(gid).getConfiguration().stream()
-              .map(Peer::getNodeId)
-              .collect(Collectors.toSet()));
-
-      Assert.assertEquals(
-          peers.stream().map(Peer::getNodeId).collect(Collectors.toSet()),
-          servers.get(2).getImpl(gid).getConfiguration().stream()
-              .map(Peer::getNodeId)
-              .collect(Collectors.toSet()));
+      checkPeerList(servers.get(0).getImpl(gid));
+      checkPeerList(servers.get(1).getImpl(gid));
+      checkPeerList(servers.get(2).getImpl(gid));
 
       Assert.assertEquals(CHECK_POINT_GAP, servers.get(0).getImpl(gid).getSearchIndex());
       Assert.assertEquals(CHECK_POINT_GAP, servers.get(1).getImpl(gid).getSearchIndex());
@@ -261,23 +247,9 @@ public class ReplicateTest {
       initServer();
 
       servers.get(2).createLocalPeer(group.getGroupId(), group.getPeers());
-      Assert.assertEquals(
-          peers.stream().map(Peer::getNodeId).collect(Collectors.toSet()),
-          servers.get(0).getImpl(gid).getConfiguration().stream()
-              .map(Peer::getNodeId)
-              .collect(Collectors.toSet()));
-
-      Assert.assertEquals(
-          peers.stream().map(Peer::getNodeId).collect(Collectors.toSet()),
-          servers.get(1).getImpl(gid).getConfiguration().stream()
-              .map(Peer::getNodeId)
-              .collect(Collectors.toSet()));
-
-      Assert.assertEquals(
-          peers.stream().map(Peer::getNodeId).collect(Collectors.toSet()),
-          servers.get(2).getImpl(gid).getConfiguration().stream()
-              .map(Peer::getNodeId)
-              .collect(Collectors.toSet()));
+      checkPeerList(servers.get(0).getImpl(gid));
+      checkPeerList(servers.get(1).getImpl(gid));
+      checkPeerList(servers.get(2).getImpl(gid));
 
       Assert.assertEquals(CHECK_POINT_GAP, servers.get(0).getImpl(gid).getSearchIndex());
       Assert.assertEquals(CHECK_POINT_GAP, servers.get(1).getImpl(gid).getSearchIndex());
@@ -296,10 +268,6 @@ public class ReplicateTest {
           Thread.sleep(100);
         }
       }
-
-      System.out.println(stateMachines.get(0).getRequestSet().size());
-      System.out.println(stateMachines.get(1).getRequestSet().size());
-      System.out.println(stateMachines.get(2).getRequestSet().size());
 
       Assert.assertEquals(CHECK_POINT_GAP * 2, stateMachines.get(0).getRequestSet().size());
       Assert.assertEquals(CHECK_POINT_GAP * 2, stateMachines.get(1).getRequestSet().size());
@@ -345,5 +313,11 @@ public class ReplicateTest {
       }
     }
     return true;
+  }
+
+  private void checkPeerList(IoTConsensusServerImpl iotServerImpl) {
+    Assert.assertEquals(
+        peers.stream().map(Peer::getNodeId).collect(Collectors.toSet()),
+        iotServerImpl.getConfiguration().stream().map(Peer::getNodeId).collect(Collectors.toSet()));
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/ConsensusGroupId.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/ConsensusGroupId.java
@@ -25,7 +25,7 @@ import org.apache.iotdb.common.rpc.thrift.TConsensusGroupType;
 import java.util.Objects;
 
 /** We abstract this class to hide word `ConsensusGroup` for IoTDB StorageEngine/SchemaEngine. */
-public abstract class ConsensusGroupId {
+public abstract class ConsensusGroupId implements Comparable<ConsensusGroupId> {
 
   protected int id;
 
@@ -125,5 +125,10 @@ public abstract class ConsensusGroupId {
         TConsensusGroupId tConsensusGroupId) {
       return create(tConsensusGroupId.getType().getValue(), tConsensusGroupId.getId());
     }
+  }
+
+  @Override
+  public int compareTo(ConsensusGroupId o) {
+    return Integer.compare(id, o.id);
   }
 }


### PR DESCRIPTION
The new `resetPeerList` interface is super powerful. 

Now, IoTConsensus member management can be fully handled by ConfigNode, and DataNode can simply obtain the peer list from ConfigNode during startup (through `resetPeerList` interface).