### PR TITLE
Pipe: avoid event accumulation in the stale sink pending queue & promptly clean up closed processor subtasks & close parser when releasing phantom reference of tsfile event

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/connector/PipeRealtimePriorityBlockingQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/connector/PipeRealtimePriorityBlockingQueue.java
@@ -51,6 +51,8 @@ public class PipeRealtimePriorityBlockingQueue extends UnboundedBlockingPendingQ
 
   @Override
   public boolean directOffer(final Event event) {
+    checkBeforeOffer(event);
+
     if (event instanceof TsFileInsertionEvent) {
       tsfileInsertEventDeque.add((TsFileInsertionEvent) event);
       return true;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/processor/PipeProcessorSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/processor/PipeProcessorSubtask.java
@@ -228,10 +228,9 @@ public class PipeProcessorSubtask extends PipeReportableSubtask {
     PipeProcessorMetrics.getInstance().deregister(taskID);
     try {
       isClosed.set(true);
-
-      // pipeProcessor closes first, then no more events will be added into outputEventCollector.
-      // only after that, outputEventCollector can be closed.
       pipeProcessor.close();
+      // It is important to note that even if the subtask and its corresponding processor are
+      // closed, the execution thread may still deliver events downstream.
     } catch (final Exception e) {
       LOGGER.info(
           "Exception occurred when closing pipe processor subtask {}, root cause: {}",

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/processor/PipeProcessorSubtaskWorker.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/processor/PipeProcessorSubtaskWorker.java
@@ -33,9 +33,6 @@ public class PipeProcessorSubtaskWorker extends WrappedRunnable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PipeProcessorSubtaskWorker.class);
 
-  private static final long CLOSED_SUBTASK_CLEANUP_ROUND_INTERVAL = 1000;
-  private long closedSubtaskCleanupRoundCounter = 0;
-
   private static final int SLEEP_INTERVAL_ADJUSTMENT_ROUND_INTERVAL = 100;
   private int totalRoundInAdjustmentInterval = 0;
   private int workingRoundInAdjustmentInterval = 0;
@@ -56,12 +53,10 @@ public class PipeProcessorSubtaskWorker extends WrappedRunnable {
   }
 
   private void cleanupClosedSubtasksIfNecessary() {
-    if (++closedSubtaskCleanupRoundCounter % CLOSED_SUBTASK_CLEANUP_ROUND_INTERVAL == 0) {
-      subtasks.stream()
-          .filter(PipeProcessorSubtask::isClosed)
-          .collect(Collectors.toList())
-          .forEach(subtasks::remove);
-    }
+    subtasks.stream()
+        .filter(PipeProcessorSubtask::isClosed)
+        .collect(Collectors.toList())
+        .forEach(subtasks::remove);
   }
 
   private boolean runSubtasks() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEvent.java
@@ -56,6 +56,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.tsfile.common.constant.TsFileConstant.PATH_ROOT;
 import static org.apache.tsfile.common.constant.TsFileConstant.PATH_SEPARATOR;
@@ -81,7 +82,7 @@ public class PipeTsFileInsertionEvent extends PipeInsertionEvent
   private final boolean isGeneratedByHistoricalExtractor;
 
   private final AtomicBoolean isClosed;
-  private TsFileInsertionEventParser eventParser;
+  private final AtomicReference<TsFileInsertionEventParser> eventParser;
 
   // The point count of the TsFile. Used for metrics on PipeConsensus' receiver side.
   // May be updated after it is flushed. Should be negative if not set.
@@ -188,6 +189,8 @@ public class PipeTsFileInsertionEvent extends PipeInsertionEvent
     // If the status is "closed", then the resource status is "closed", the tsFile won't be altered
     // and can be sent.
     isClosed.set(resource.isClosed());
+
+    this.eventParser = new AtomicReference<>(null);
   }
 
   /**
@@ -570,13 +573,12 @@ public class PipeTsFileInsertionEvent extends PipeInsertionEvent
 
   private TsFileInsertionEventParser initEventParser() {
     try {
-      if (eventParser == null) {
-        eventParser =
-            new TsFileInsertionEventParserProvider(
-                    tsFile, treePattern, tablePattern, startTime, endTime, pipeTaskMeta, this)
-                .provide();
-      }
-      return eventParser;
+      eventParser.compareAndSet(
+          null,
+          new TsFileInsertionEventParserProvider(
+                  tsFile, treePattern, tablePattern, startTime, endTime, pipeTaskMeta, this)
+              .provide());
+      return eventParser.get();
     } catch (final IOException e) {
       close();
 
@@ -613,10 +615,13 @@ public class PipeTsFileInsertionEvent extends PipeInsertionEvent
   /** Release the resource of {@link TsFileInsertionEventParser}. */
   @Override
   public void close() {
-    if (eventParser != null) {
-      eventParser.close();
-      eventParser = null;
-    }
+    eventParser.getAndUpdate(
+        parser -> {
+          if (Objects.nonNull(parser)) {
+            parser.close();
+          }
+          return null;
+        });
   }
 
   /////////////////////////// Object ///////////////////////////
@@ -654,7 +659,8 @@ public class PipeTsFileInsertionEvent extends PipeInsertionEvent
         this.tsFile,
         this.isWithMod,
         this.modFile,
-        this.sharedModFile);
+        this.sharedModFile,
+        this.eventParser);
   }
 
   private static class PipeTsFileInsertionEventResource extends PipeEventResource {
@@ -662,7 +668,8 @@ public class PipeTsFileInsertionEvent extends PipeInsertionEvent
     private final File tsFile;
     private final boolean isWithMod;
     private final File modFile;
-    private final File sharedModFile;
+    private final File sharedModFile; // unused now
+    private final AtomicReference<TsFileInsertionEventParser> eventParser;
 
     private PipeTsFileInsertionEventResource(
         final AtomicBoolean isReleased,
@@ -670,21 +677,33 @@ public class PipeTsFileInsertionEvent extends PipeInsertionEvent
         final File tsFile,
         final boolean isWithMod,
         final File modFile,
-        File sharedModFile) {
+        final File sharedModFile,
+        final AtomicReference<TsFileInsertionEventParser> eventParser) {
       super(isReleased, referenceCount);
       this.tsFile = tsFile;
       this.isWithMod = isWithMod;
       this.modFile = modFile;
       this.sharedModFile = sharedModFile;
+      this.eventParser = eventParser;
     }
 
     @Override
     protected void finalizeResource() {
       try {
+        // decrease reference count
         PipeDataNodeResourceManager.tsfile().decreaseFileReference(tsFile);
         if (isWithMod) {
           PipeDataNodeResourceManager.tsfile().decreaseFileReference(modFile);
         }
+
+        // close event parser
+        eventParser.getAndUpdate(
+            parser -> {
+              if (Objects.nonNull(parser)) {
+                parser.close();
+              }
+              return null;
+            });
       } catch (final Exception e) {
         LOGGER.warn(
             String.format("Decrease reference count for TsFile %s error.", tsFile.getPath()), e);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/response/SubscriptionEventTabletResponse.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/response/SubscriptionEventTabletResponse.java
@@ -116,6 +116,11 @@ public class SubscriptionEventTabletResponse extends SubscriptionEventExtendable
 
   @Override
   public synchronized void nack() {
+    if (nextOffset.get() == 1) {
+      // do nothing if with complete tablets
+      return;
+    }
+
     cleanUp();
 
     // should not reset the iterator of batch when init

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/response/SubscriptionEventTabletResponse.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/response/SubscriptionEventTabletResponse.java
@@ -116,11 +116,6 @@ public class SubscriptionEventTabletResponse extends SubscriptionEventExtendable
 
   @Override
   public synchronized void nack() {
-    if (nextOffset.get() == 1) {
-      // do nothing if with complete tablets
-      return;
-    }
-
     cleanUp();
 
     // should not reset the iterator of batch when init


### PR DESCRIPTION
As title.