### PR TITLE
[To dev/1.3] Fixed the bug that internalCreate(Multi)TimeSeries may write empty device when measurements are all trimmed (#14827)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/executor/RegionWriteExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/executor/RegionWriteExecutor.java
@@ -458,11 +458,11 @@ public class RegionWriteExecutor {
             measurementGroupMap.remove(emptyDevice);
           }
 
-          final RegionExecutionResult failingResult =
+          final RegionExecutionResult executionResult =
               registerTimeSeries(measurementGroupMap, node, context, failingStatus);
 
-          if (failingResult != null) {
-            return failingResult;
+          if (executionResult != null) {
+            return executionResult;
           }
 
           final TSStatus status = RpcUtils.getStatus(failingStatus);
@@ -589,7 +589,12 @@ public class RegionWriteExecutor {
           measurementGroup.removeMeasurements(failingMeasurementMap.keySet());
 
           return processExecutionResultOfInternalCreateSchema(
-              super.visitInternalCreateTimeSeries(node, context),
+              !measurementGroup.isEmpty()
+                  ? super.visitInternalCreateTimeSeries(node, context)
+                  : RegionExecutionResult.create(
+                      true,
+                      "Execute successfully",
+                      RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS, "Execute successfully")),
               failingStatus,
               alreadyExistingStatus);
         } finally {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/executor/RegionWriteExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/executor/RegionWriteExecutor.java
@@ -80,6 +80,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -633,8 +634,13 @@ public class RegionWriteExecutor {
           MeasurementGroup measurementGroup;
           Map<Integer, MetadataException> failingMeasurementMap;
           MetadataException metadataException;
-          for (final Map.Entry<PartialPath, Pair<Boolean, MeasurementGroup>> deviceEntry :
-              node.getDeviceMap().entrySet()) {
+
+          final Iterator<Map.Entry<PartialPath, Pair<Boolean, MeasurementGroup>>> iterator =
+              node.getDeviceMap().entrySet().iterator();
+
+          while (iterator.hasNext()) {
+            final Map.Entry<PartialPath, Pair<Boolean, MeasurementGroup>> deviceEntry =
+                iterator.next();
             measurementGroup = deviceEntry.getValue().right;
             failingMeasurementMap =
                 schemaRegion.checkMeasurementExistence(
@@ -662,10 +668,18 @@ public class RegionWriteExecutor {
               }
             }
             measurementGroup.removeMeasurements(failingMeasurementMap.keySet());
+            if (measurementGroup.isEmpty()) {
+              iterator.remove();
+            }
           }
 
           return processExecutionResultOfInternalCreateSchema(
-              super.visitInternalCreateMultiTimeSeries(node, context),
+              !node.getDeviceMap().isEmpty()
+                  ? super.visitInternalCreateMultiTimeSeries(node, context)
+                  : RegionExecutionResult.create(
+                      true,
+                      "Execute successfully",
+                      RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS, "Execute successfully")),
               failingStatus,
               alreadyExistingStatus);
         } finally {


### PR DESCRIPTION
## Description
As the title said.
Original PR: https://github.com/apache/iotdb/pull/14827

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
