### PR TITLE
[IoTConsensusV2] Fix NPE when transfer tsfile mods

### DIFF
--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/receiver/IoTDBFileReceiver.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/receiver/IoTDBFileReceiver.java
@@ -400,10 +400,10 @@ public abstract class IoTDBFileReceiver implements IoTDBReceiver {
     return writingFile != null && writingFile.exists() && writingFile.getName().equals(fileName);
   }
 
-  private void closeCurrentWritingFileWriter(final boolean fsyncAfterClose) {
+  private void closeCurrentWritingFileWriter(final boolean fsyncBeforeClose) {
     if (writingFileWriter != null) {
       try {
-        if (IS_FSYNC_ENABLED && fsyncAfterClose) {
+        if (IS_FSYNC_ENABLED && fsyncBeforeClose) {
           writingFileWriter.getFD().sync();
         }
         writingFileWriter.close();


### PR DESCRIPTION
After discussion, we decide to maintain both mods transfer and DAL transfer for DELETION replication.

This pr enhances the support for mods transfer.

As this image shows, when transfer mods may encounter npe.
<img width="872" alt="image" src="https://github.com/user-attachments/assets/89fac87c-73cd-4d70-8dff-a4a82c1870d6" />

This is caused by 2 bugs:
1. sync a file after close its handler(we should sync before close)
2. `handleTsFileSealWithMods` doesn't support mods transfer well, need some enhancement.
