### PR TITLE
[To dev/1.3] Pipe: adjust default pipeRealTimeQueuePollHistoryThreshold to reduce retransmission upon frequent rebooting

### DIFF
--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -203,7 +203,7 @@ public class CommonConfig {
 
   private boolean pipeFileReceiverFsyncEnabled = true;
 
-  private int pipeRealTimeQueuePollHistoryThreshold = 100;
+  private int pipeRealTimeQueuePollHistoryThreshold = 1;
 
   /** The maximum number of threads that can be used to execute subtasks in PipeSubtaskExecutor. */
   private int pipeSubtaskExecutorMaxThreadNum =


### PR DESCRIPTION
(cherry picked from commit 515991dc9f7c13a569bcd3ebedc8b01720bda35c)