### PR TITLE
[To dev/1.3] Pipe: bind memory block for PipeTransferTsFileHandler and PipeInsertNodeTabletInsertionEvent & unify the memory threshold judgment for tablet and tsfile block & close data container when internally decrease reference count of PipeTsFileInsertionEvent (#14873)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/processor/PipeProcessorSubtaskWorker.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/processor/PipeProcessorSubtaskWorker.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 public class PipeProcessorSubtaskWorker extends WrappedRunnable {
 
@@ -53,10 +52,7 @@ public class PipeProcessorSubtaskWorker extends WrappedRunnable {
   }
 
   private void cleanupClosedSubtasksIfNecessary() {
-    subtasks.stream()
-        .filter(PipeProcessorSubtask::isClosed)
-        .collect(Collectors.toList())
-        .forEach(subtasks::remove);
+    subtasks.removeIf(PipeProcessorSubtask::isClosed);
   }
 
   private boolean runSubtasks() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTrackableHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTrackableHandler.java
@@ -28,7 +28,7 @@ import org.apache.thrift.TException;
 import org.apache.thrift.async.AsyncMethodCallback;
 
 public abstract class PipeTransferTrackableHandler
-    implements AsyncMethodCallback<TPipeTransferResp> {
+    implements AsyncMethodCallback<TPipeTransferResp>, AutoCloseable {
 
   protected final IoTDBDataRegionAsyncConnector connector;
 
@@ -38,25 +38,30 @@ public abstract class PipeTransferTrackableHandler
 
   @Override
   public void onComplete(final TPipeTransferResp response) {
-    if (!connector.isClosed()) {
-      if (onCompleteInternal(response)) {
-        // eliminate handler only when all transmissions corresponding to the handler have been
-        // completed
-        connector.eliminateHandler(this);
-      }
-    } else {
+    if (connector.isClosed()) {
       clearEventsReferenceCount();
+      connector.eliminateHandler(this);
+      return;
+    }
+
+    if (onCompleteInternal(response)) {
+      // eliminate handler only when all transmissions corresponding to the handler have been
+      // completed
+      // NOTE: We should not clear the reference count of events, as this would cause the
+      // `org.apache.iotdb.pipe.it.dual.tablemodel.manual.basic.IoTDBPipeDataSinkIT#testSinkTsFileFormat3` test to fail.
       connector.eliminateHandler(this);
     }
   }
 
   @Override
   public void onError(final Exception exception) {
-    if (!connector.isClosed()) {
-      onErrorInternal(exception);
-    } else {
+    if (connector.isClosed()) {
       clearEventsReferenceCount();
+      connector.eliminateHandler(this);
+      return;
     }
+
+    onErrorInternal(exception);
     connector.eliminateHandler(this);
   }
 
@@ -76,6 +81,7 @@ public abstract class PipeTransferTrackableHandler
     connector.trackHandler(this);
     if (connector.isClosed()) {
       clearEventsReferenceCount();
+      connector.eliminateHandler(this);
       return false;
     }
     doTransfer(client, req);
@@ -95,4 +101,9 @@ public abstract class PipeTransferTrackableHandler
       throws TException;
 
   public abstract void clearEventsReferenceCount();
+
+  @Override
+  public void close() {
+    // do nothing
+  }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTsFileHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTsFileHandler.java
@@ -33,6 +33,10 @@ import org.apache.iotdb.db.pipe.connector.payload.evolvable.request.PipeTransfer
 import org.apache.iotdb.db.pipe.connector.payload.evolvable.request.PipeTransferTsFileSealWithModReq;
 import org.apache.iotdb.db.pipe.connector.protocol.thrift.async.IoTDBDataRegionAsyncConnector;
 import org.apache.iotdb.db.pipe.event.common.tsfile.PipeTsFileInsertionEvent;
+import org.apache.iotdb.db.pipe.resource.PipeDataNodeResourceManager;
+import org.apache.iotdb.db.pipe.resource.memory.PipeMemoryManager;
+import org.apache.iotdb.db.pipe.resource.memory.PipeTsFileMemoryBlock;
+import org.apache.iotdb.pipe.api.exception.PipeException;
 import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.service.rpc.thrift.TPipeTransferReq;
 import org.apache.iotdb.service.rpc.thrift.TPipeTransferResp;
@@ -75,6 +79,7 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
   private final boolean transferMod;
 
   private final int readFileBufferSize;
+  private final PipeTsFileMemoryBlock memoryBlock;
   private final byte[] readBuffer;
   private long position;
 
@@ -94,7 +99,7 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
       final File tsFile,
       final File modFile,
       final boolean transferMod)
-      throws FileNotFoundException {
+      throws FileNotFoundException, InterruptedException {
     super(connector);
 
     this.pipeName2WeightMap = pipeName2WeightMap;
@@ -108,7 +113,14 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
     this.transferMod = transferMod;
     currentFile = transferMod ? modFile : tsFile;
 
-    readFileBufferSize = PipeConfig.getInstance().getPipeConnectorReadFileBufferSize();
+    waitForResourceEnough4Slicing(Integer.MAX_VALUE);
+    readFileBufferSize =
+        (int)
+            Math.min(
+                PipeConfig.getInstance().getPipeConnectorReadFileBufferSize(),
+                transferMod ? Math.max(tsFile.length(), modFile.length()) : tsFile.length());
+    memoryBlock =
+        PipeDataNodeResourceManager.memory().forceAllocateForTsFileWithRetry(readFileBufferSize);
     readBuffer = new byte[readFileBufferSize];
     position = 0;
 
@@ -267,6 +279,7 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
           client.returnSelf();
         }
       }
+
       return true;
     }
 
@@ -370,5 +383,54 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
   @Override
   public void clearEventsReferenceCount() {
     events.forEach(event -> event.clearReferenceCount(PipeTransferTsFileHandler.class.getName()));
+  }
+
+  @Override
+  public void close() {
+    super.close();
+    memoryBlock.close();
+  }
+
+  private void waitForResourceEnough4Slicing(final long timeoutMs) throws InterruptedException {
+    final PipeMemoryManager memoryManager = PipeDataNodeResourceManager.memory();
+    if (memoryManager.isEnough4TsFileSlicing()) {
+      return;
+    }
+
+    final long startTime = System.currentTimeMillis();
+    long lastRecordTime = startTime;
+
+    final long memoryCheckIntervalMs =
+        PipeConfig.getInstance().getPipeCheckMemoryEnoughIntervalMs();
+    while (!memoryManager.isEnough4TsFileSlicing()) {
+      Thread.sleep(memoryCheckIntervalMs);
+
+      final long currentTime = System.currentTimeMillis();
+      final double elapsedRecordTimeSeconds = (currentTime - lastRecordTime) / 1000.0;
+      final double waitTimeSeconds = (currentTime - startTime) / 1000.0;
+      if (elapsedRecordTimeSeconds > 10.0) {
+        LOGGER.info(
+            "Wait for resource enough for slicing tsfile {} for {} seconds.",
+            tsFile,
+            waitTimeSeconds);
+        lastRecordTime = currentTime;
+      } else if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug(
+            "Wait for resource enough for slicing tsfile {} for {} seconds.",
+            tsFile,
+            waitTimeSeconds);
+      }
+
+      if (waitTimeSeconds * 1000 > timeoutMs) {
+        // should contain 'TimeoutException' in exception message
+        throw new PipeException(
+            String.format("TimeoutException: Waited %s seconds", waitTimeSeconds));
+      }
+    }
+
+    final long currentTime = System.currentTimeMillis();
+    final double waitTimeSeconds = (currentTime - startTime) / 1000.0;
+    LOGGER.info(
+        "Wait for resource enough for slicing tsfile {} for {} seconds.", tsFile, waitTimeSeconds);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEvent.java
@@ -254,10 +254,6 @@ public class PipeTsFileInsertionEvent extends EnrichedEvent
       if (isWithMod) {
         modFile = PipeDataNodeResourceManager.tsfile().increaseFileReference(modFile, false, null);
       }
-      if (Objects.nonNull(pipeName)) {
-        PipeDataNodeRemainingEventAndTimeMetrics.getInstance()
-            .increaseTsFileEventCount(pipeName, creationTime);
-      }
       return true;
     } catch (final Exception e) {
       LOGGER.warn(
@@ -266,6 +262,11 @@ public class PipeTsFileInsertionEvent extends EnrichedEvent
               tsFile, modFile, holderMessage),
           e);
       return false;
+    } finally {
+      if (Objects.nonNull(pipeName)) {
+        PipeDataNodeRemainingEventAndTimeMetrics.getInstance()
+            .increaseTsFileEventCount(pipeName, creationTime);
+      }
     }
   }
 
@@ -276,6 +277,7 @@ public class PipeTsFileInsertionEvent extends EnrichedEvent
       if (isWithMod) {
         PipeDataNodeResourceManager.tsfile().decreaseFileReference(modFile);
       }
+      close();
       return true;
     } catch (final Exception e) {
       LOGGER.warn(
@@ -446,7 +448,7 @@ public class PipeTsFileInsertionEvent extends EnrichedEvent
     long lastRecordTime = startTime;
 
     final long memoryCheckIntervalMs =
-        PipeConfig.getInstance().getPipeTsFileParserCheckMemoryEnoughIntervalMs();
+        PipeConfig.getInstance().getPipeCheckMemoryEnoughIntervalMs();
     while (!memoryManager.isEnough4TabletParsing()) {
       Thread.sleep(memoryCheckIntervalMs);
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManager.java
@@ -59,7 +59,7 @@ public class PipeMemoryManager {
       PipeConfig.getInstance().getPipeDataStructureTabletMemoryBlockAllocationRejectThreshold();
   private volatile long usedMemorySizeInBytesOfTablets;
 
-  // Used to control the memory allocated for managing slice tsfile in subscription module.
+  // Used to control the memory allocated for managing slice tsfile.
   private static final double TS_FILE_MEMORY_REJECT_THRESHOLD =
       PipeConfig.getInstance().getPipeDataStructureTsFileMemoryBlockAllocationRejectThreshold();
   private volatile long usedMemorySizeInBytesOfTsFiles;
@@ -74,14 +74,45 @@ public class PipeMemoryManager {
             PipeConfig.getInstance().getPipeMemoryExpanderIntervalSeconds());
   }
 
+  // NOTE: Here we unify the memory threshold judgment for tablet and tsfile memory block, because
+  // introducing too many heuristic rules not conducive to flexible dynamic adjustment of memory
+  // configuration.
+
+  // Proportion of Memory Occupied by Tablet Memory Block: [TABLET_MEMORY_REJECT_THRESHOLD / 2,
+  // TABLET_MEMORY_REJECT_THRESHOLD + TS_FILE_MEMORY_REJECT_THRESHOLD / 2]
+  // Proportion of Memory Occupied by TsFile Memory Block: [TS_FILE_MEMORY_REJECT_THRESHOLD / 2,
+  // TS_FILE_MEMORY_REJECT_THRESHOLD + TABLET_MEMORY_REJECT_THRESHOLD / 2]
+
   public boolean isEnough4TabletParsing() {
-    return (double) usedMemorySizeInBytesOfTablets
-        < 0.95 * TABLET_MEMORY_REJECT_THRESHOLD * TOTAL_MEMORY_SIZE_IN_BYTES;
+    return (double) usedMemorySizeInBytesOfTablets + (double) usedMemorySizeInBytesOfTsFiles
+            < 0.95 * TABLET_MEMORY_REJECT_THRESHOLD * TOTAL_MEMORY_SIZE_IN_BYTES
+                + 0.95 * TS_FILE_MEMORY_REJECT_THRESHOLD * TOTAL_MEMORY_SIZE_IN_BYTES
+        && (double) usedMemorySizeInBytesOfTablets
+            < 0.95 * TABLET_MEMORY_REJECT_THRESHOLD / 2 * TOTAL_MEMORY_SIZE_IN_BYTES;
+  }
+
+  private boolean isHardEnough4TabletParsing() {
+    return (double) usedMemorySizeInBytesOfTablets + (double) usedMemorySizeInBytesOfTsFiles
+            < TABLET_MEMORY_REJECT_THRESHOLD * TOTAL_MEMORY_SIZE_IN_BYTES
+                + TS_FILE_MEMORY_REJECT_THRESHOLD * TOTAL_MEMORY_SIZE_IN_BYTES
+        && (double) usedMemorySizeInBytesOfTablets
+            < TABLET_MEMORY_REJECT_THRESHOLD / 2 * TOTAL_MEMORY_SIZE_IN_BYTES;
   }
 
   public boolean isEnough4TsFileSlicing() {
-    return (double) usedMemorySizeInBytesOfTsFiles
-        < 0.95 * TS_FILE_MEMORY_REJECT_THRESHOLD * TOTAL_MEMORY_SIZE_IN_BYTES;
+    return (double) usedMemorySizeInBytesOfTablets + (double) usedMemorySizeInBytesOfTsFiles
+            < 0.95 * TABLET_MEMORY_REJECT_THRESHOLD * TOTAL_MEMORY_SIZE_IN_BYTES
+                + 0.95 * TS_FILE_MEMORY_REJECT_THRESHOLD * TOTAL_MEMORY_SIZE_IN_BYTES
+        && (double) usedMemorySizeInBytesOfTsFiles
+            < 0.95 * TS_FILE_MEMORY_REJECT_THRESHOLD / 2 * TOTAL_MEMORY_SIZE_IN_BYTES;
+  }
+
+  private boolean isHardEnough4TsFileSlicing() {
+    return (double) usedMemorySizeInBytesOfTablets + (double) usedMemorySizeInBytesOfTsFiles
+            < TABLET_MEMORY_REJECT_THRESHOLD * TOTAL_MEMORY_SIZE_IN_BYTES
+                + TS_FILE_MEMORY_REJECT_THRESHOLD * TOTAL_MEMORY_SIZE_IN_BYTES
+        && (double) usedMemorySizeInBytesOfTsFiles
+            < TS_FILE_MEMORY_REJECT_THRESHOLD / 2 * TOTAL_MEMORY_SIZE_IN_BYTES;
   }
 
   public synchronized PipeMemoryBlock forceAllocate(long sizeInBytes)
@@ -97,8 +128,7 @@ public class PipeMemoryManager {
     }
 
     for (int i = 1; i <= MEMORY_ALLOCATE_MAX_RETRIES; i++) {
-      if ((double) usedMemorySizeInBytesOfTablets / TOTAL_MEMORY_SIZE_IN_BYTES
-          < TABLET_MEMORY_REJECT_THRESHOLD) {
+      if (isHardEnough4TabletParsing()) {
         break;
       }
 
@@ -110,8 +140,7 @@ public class PipeMemoryManager {
       }
     }
 
-    if ((double) usedMemorySizeInBytesOfTablets / TOTAL_MEMORY_SIZE_IN_BYTES
-        >= TABLET_MEMORY_REJECT_THRESHOLD) {
+    if (!isHardEnough4TabletParsing()) {
       throw new PipeRuntimeOutOfMemoryCriticalException(
           String.format(
               "forceAllocateForTablet: failed to allocate because there's too much memory for tablets, "
@@ -134,8 +163,7 @@ public class PipeMemoryManager {
     }
 
     for (int i = 1; i <= MEMORY_ALLOCATE_MAX_RETRIES; i++) {
-      if ((double) usedMemorySizeInBytesOfTsFiles / TOTAL_MEMORY_SIZE_IN_BYTES
-          < TS_FILE_MEMORY_REJECT_THRESHOLD) {
+      if (isHardEnough4TsFileSlicing()) {
         break;
       }
 
@@ -147,8 +175,7 @@ public class PipeMemoryManager {
       }
     }
 
-    if ((double) usedMemorySizeInBytesOfTsFiles / TOTAL_MEMORY_SIZE_IN_BYTES
-        >= TS_FILE_MEMORY_REJECT_THRESHOLD) {
+    if (!isHardEnough4TsFileSlicing()) {
       throw new PipeRuntimeOutOfMemoryCriticalException(
           String.format(
               "forceAllocateForTsFile: failed to allocate because there's too much memory for tsfiles, "

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -277,7 +277,7 @@ public class CommonConfig {
   private long pipeMemoryAllocateMinSizeInBytes = 32;
   private long pipeMemoryAllocateForTsFileSequenceReaderInBytes = (long) 2 * 1024 * 1024; // 2MB
   private long pipeMemoryExpanderIntervalSeconds = (long) 3 * 60; // 3Min
-  private volatile long pipeTsFileParserCheckMemoryEnoughIntervalMs = 10L;
+  private volatile long pipeCheckMemoryEnoughIntervalMs = 10L;
   private float pipeLeaderCacheMemoryUsagePercentage = 0.1F;
   private long pipeListeningQueueTransferSnapshotThreshold = 1000;
   private int pipeSnapshotExecutionMaxBatchSize = 1000;
@@ -1152,13 +1152,12 @@ public class CommonConfig {
     this.pipeMemoryExpanderIntervalSeconds = pipeMemoryExpanderIntervalSeconds;
   }
 
-  public long getPipeTsFileParserCheckMemoryEnoughIntervalMs() {
-    return pipeTsFileParserCheckMemoryEnoughIntervalMs;
+  public long getPipeCheckMemoryEnoughIntervalMs() {
+    return pipeCheckMemoryEnoughIntervalMs;
   }
 
-  public void setPipeTsFileParserCheckMemoryEnoughIntervalMs(
-      long pipeTsFileParserCheckMemoryEnoughIntervalMs) {
-    this.pipeTsFileParserCheckMemoryEnoughIntervalMs = pipeTsFileParserCheckMemoryEnoughIntervalMs;
+  public void setPipeCheckMemoryEnoughIntervalMs(long pipeCheckMemoryEnoughIntervalMs) {
+    this.pipeCheckMemoryEnoughIntervalMs = pipeCheckMemoryEnoughIntervalMs;
   }
 
   public int getPipeMemoryAllocateMaxRetries() {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -591,11 +591,11 @@ public class CommonDescriptor {
             properties.getProperty(
                 "pipe_memory_expander_interval_seconds",
                 String.valueOf(config.getPipeMemoryExpanderIntervalSeconds()))));
-    config.setPipeTsFileParserCheckMemoryEnoughIntervalMs(
+    config.setPipeCheckMemoryEnoughIntervalMs(
         Long.parseLong(
             properties.getProperty(
-                "pipe_tsfile_parser_check_memory_enough_interval_ms",
-                String.valueOf(config.getPipeTsFileParserCheckMemoryEnoughIntervalMs()))));
+                "pipe_check_memory_enough_interval_ms",
+                String.valueOf(config.getPipeCheckMemoryEnoughIntervalMs()))));
     config.setPipeLeaderCacheMemoryUsagePercentage(
         Float.parseFloat(
             properties.getProperty(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeConfig.java
@@ -316,8 +316,8 @@ public class PipeConfig {
     return COMMON_CONFIG.getPipeMemoryExpanderIntervalSeconds();
   }
 
-  public long getPipeTsFileParserCheckMemoryEnoughIntervalMs() {
-    return COMMON_CONFIG.getPipeTsFileParserCheckMemoryEnoughIntervalMs();
+  public long getPipeCheckMemoryEnoughIntervalMs() {
+    return COMMON_CONFIG.getPipeCheckMemoryEnoughIntervalMs();
   }
 
   /////////////////////////////// TwoStage ///////////////////////////////
@@ -480,9 +480,7 @@ public class PipeConfig {
         "PipeMemoryAllocateForTsFileSequenceReaderInBytes: {}",
         getPipeMemoryAllocateForTsFileSequenceReaderInBytes());
     LOGGER.info("PipeMemoryExpanderIntervalSeconds: {}", getPipeMemoryExpanderIntervalSeconds());
-    LOGGER.info(
-        "PipeTsFileParserCheckMemoryEnoughIntervalMs: {}",
-        getPipeTsFileParserCheckMemoryEnoughIntervalMs());
+    LOGGER.info("PipeCheckMemoryEnoughIntervalMs: {}", getPipeCheckMemoryEnoughIntervalMs());
 
     LOGGER.info(
         "TwoStageAggregateMaxCombinerLiveTimeInMs: {}",


### PR DESCRIPTION
cherry-pick #14873 to https://github.com/apache/iotdb/tree/dev/1.3