### PR TITLE
Fix that failure of one row in relational InsertRows will fail other rows

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/session/IoTDBSessionRelationalIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/session/IoTDBSessionRelationalIT.java
@@ -376,7 +376,7 @@ public class IoTDBSessionRelationalIT {
             e.getMessage());
       }
 
-      SessionDataSet dataSet = session.executeQueryStatement("select * from partial_insert");
+      SessionDataSet dataSet = session.executeQueryStatement("select * from partial_insert order by time");
       long[] timestamps =
           new long[] {10000, 20000, 30000, 35000, 40000, 50000, 60000, 70000, 80000, 90000};
       Boolean[] values =

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/session/IoTDBSessionRelationalIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/session/IoTDBSessionRelationalIT.java
@@ -376,7 +376,8 @@ public class IoTDBSessionRelationalIT {
             e.getMessage());
       }
 
-      SessionDataSet dataSet = session.executeQueryStatement("select * from partial_insert order by time");
+      SessionDataSet dataSet =
+          session.executeQueryStatement("select * from partial_insert order by time");
       long[] timestamps =
           new long[] {10000, 20000, 30000, 35000, 40000, 50000, 60000, 70000, 80000, 90000};
       Boolean[] values =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/RelationalInsertRowNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/RelationalInsertRowNode.java
@@ -246,4 +246,10 @@ public class RelationalInsertRowNode extends InsertRowNode {
     TableDeviceSchemaCache.getInstance()
         .updateLastCacheIfExists(databaseName, getDeviceID(), rawMeasurements, timeValuePairs);
   }
+
+  @Override
+  public boolean allMeasurementFailed() {
+    // time column never fail for table model
+    return false;
+  }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/parser/AstBuilder.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/parser/AstBuilder.java
@@ -570,8 +570,6 @@ public class AstBuilder extends RelationalSqlBaseVisitor<Node> {
       columnNames.remove(timeColumnIndex);
     }
 
-    String[] columnNameArray = columnNames.toArray(new String[0]);
-
     List<Expression> rows = queryBody.getRows();
     if (timeColumnIndex == -1 && rows.size() > 1) {
       throw new SemanticException("need timestamps when insert multi rows");
@@ -589,6 +587,7 @@ public class AstBuilder extends RelationalSqlBaseVisitor<Node> {
                   } else {
                     throw new SemanticException("unexpected expression: " + r);
                   }
+                  String[] columnNameArray = columnNames.toArray(new String[0]);
                   return toInsertRowStatement(
                       expressions, finalTimeColumnIndex, columnNameArray, tableName, databaseName);
                 })


### PR DESCRIPTION
The rows of an insert SQL share the same measurement array.
If one row fails to pass the schema validation, the associated measurements will be marked as null.
Since the measurement array is shared, other rows will also be affected.

This PR fixes this issue by creating a measurement array copy for each row.