### PR TITLE
[To dev/1.3] Subscription: close memory block for previous tsfile response (#14909)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/response/SubscriptionEventTsFileResponse.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/response/SubscriptionEventTsFileResponse.java
@@ -81,10 +81,15 @@ public class SubscriptionEventTsFileResponse extends SubscriptionEventExtendable
   @Override
   public void fetchNextResponse(final long offset) throws Exception {
     generateNextTsFileResponse(offset).ifPresent(super::offer);
-    if (Objects.isNull(poll())) {
+
+    // poll and clean previous response
+    final CachedSubscriptionPollResponse previousResponse;
+    if (Objects.isNull(previousResponse = poll())) {
       LOGGER.warn(
           "SubscriptionEventTsFileResponse {} is empty when fetching next response (broken invariant)",
           this);
+    } else {
+      previousResponse.closeMemoryBlock();
     }
   }
 


### PR DESCRIPTION
cherry-pick #14909 to https://github.com/apache/iotdb/tree/dev/1.3