### PR TITLE
Pipe: Modify MaxAllowedPinnedMemTableCount to adapt to changes in the number of DRs & Modify the implementation of the poll method in PipeRealtimePriorityBlockingQueue to reduce commit queue backlog & Adjust the default thread count related to Pipe for better performance & Significantly reduce pipeMemoryAllocateRetryIntervalMs & Provide a switch for memory control of ConnectorReadFileBuffer

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTaskAgent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTaskAgent.java
@@ -662,7 +662,9 @@ public class PipeDataNodeTaskAgent extends PipeTaskAgent {
 
   private boolean mayMemTablePinnedCountReachDangerousThreshold() {
     return PipeDataNodeResourceManager.wal().getPinnedWalCount()
-        >= 10 * PipeConfig.getInstance().getPipeMaxAllowedPinnedMemTableCount();
+        >= 5
+            * PipeConfig.getInstance().getPipeMaxAllowedPinnedMemTableCount()
+            * StorageEngine.getInstance().getDataRegionNumber();
   }
 
   private boolean mayWalSizeReachThrottleThreshold() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/connector/PipeRealtimePriorityBlockingQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/connector/PipeRealtimePriorityBlockingQueue.java
@@ -86,9 +86,10 @@ public class PipeRealtimePriorityBlockingQueue extends UnboundedBlockingPendingQ
       eventCount.set(0);
     }
     if (Objects.isNull(event)) {
+      // Sequentially poll the first offered non-TsFileInsertionEvent
       event = super.directPoll();
       if (Objects.isNull(event)) {
-        event = tsfileInsertEventDeque.pollLast();
+        event = tsfileInsertEventDeque.pollFirst();
       }
       if (event != null) {
         eventCount.incrementAndGet();
@@ -120,8 +121,7 @@ public class PipeRealtimePriorityBlockingQueue extends UnboundedBlockingPendingQ
       // Sequentially poll the first offered non-TsFileInsertionEvent
       event = super.directPoll();
       if (event == null && !tsfileInsertEventDeque.isEmpty()) {
-        // Always poll the last offered event
-        event = tsfileInsertEventDeque.pollLast();
+        event = tsfileInsertEventDeque.pollFirst();
       }
       if (event != null) {
         eventCount.incrementAndGet();
@@ -132,7 +132,7 @@ public class PipeRealtimePriorityBlockingQueue extends UnboundedBlockingPendingQ
     if (Objects.isNull(event)) {
       event = super.waitedPoll();
       if (Objects.isNull(event)) {
-        event = tsfileInsertEventDeque.pollLast();
+        event = tsfileInsertEventDeque.pollFirst();
       }
       if (event != null) {
         eventCount.incrementAndGet();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTsFileHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTsFileHandler.java
@@ -123,7 +123,11 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
                 PipeConfig.getInstance().getPipeConnectorReadFileBufferSize(),
                 transferMod ? Math.max(tsFile.length(), modFile.length()) : tsFile.length());
     memoryBlock =
-        PipeDataNodeResourceManager.memory().forceAllocateForTsFileWithRetry(readFileBufferSize);
+        PipeDataNodeResourceManager.memory()
+            .forceAllocateForTsFileWithRetry(
+                PipeConfig.getInstance().isPipeConnectorReadFileBufferMemoryControlEnabled()
+                    ? readFileBufferSize
+                    : 0);
     readBuffer = new byte[readFileBufferSize];
     position = 0;
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/realtime/PipeRealtimeDataRegionHybridExtractor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/realtime/PipeRealtimeDataRegionHybridExtractor.java
@@ -32,6 +32,7 @@ import org.apache.iotdb.db.pipe.extractor.dataregion.IoTDBDataRegionExtractor;
 import org.apache.iotdb.db.pipe.extractor.dataregion.realtime.epoch.TsFileEpoch;
 import org.apache.iotdb.db.pipe.metric.PipeDataRegionExtractorMetrics;
 import org.apache.iotdb.db.pipe.resource.PipeDataNodeResourceManager;
+import org.apache.iotdb.db.storageengine.StorageEngine;
 import org.apache.iotdb.db.storageengine.dataregion.wal.WALManager;
 import org.apache.iotdb.pipe.api.event.Event;
 import org.apache.iotdb.pipe.api.event.dml.insertion.TabletInsertionEvent;
@@ -251,14 +252,16 @@ public class PipeRealtimeDataRegionHybridExtractor extends PipeRealtimeDataRegio
   private boolean mayMemTablePinnedCountReachDangerousThreshold(final PipeRealtimeEvent event) {
     final boolean mayMemTablePinnedCountReachDangerousThreshold =
         PipeDataNodeResourceManager.wal().getPinnedWalCount()
-            >= PipeConfig.getInstance().getPipeMaxAllowedPinnedMemTableCount();
+            >= PipeConfig.getInstance().getPipeMaxAllowedPinnedMemTableCount()
+                * StorageEngine.getInstance().getDataRegionNumber();
     if (mayMemTablePinnedCountReachDangerousThreshold && event.mayExtractorUseTablets(this)) {
       LOGGER.info(
           "Pipe task {}@{} canNotUseTabletAnyMore3: The number of pinned memtables {} has reached the dangerous threshold {}",
           pipeName,
           dataRegionId,
           PipeDataNodeResourceManager.wal().getPinnedWalCount(),
-          PipeConfig.getInstance().getPipeMaxAllowedPinnedMemTableCount());
+          PipeConfig.getInstance().getPipeMaxAllowedPinnedMemTableCount()
+              * StorageEngine.getInstance().getDataRegionNumber());
     }
     return mayMemTablePinnedCountReachDangerousThreshold;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/StorageEngine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/StorageEngine.java
@@ -863,6 +863,10 @@ public class StorageEngine implements IService {
     return new ArrayList<>(dataRegionMap.keySet());
   }
 
+  public int getDataRegionNumber() {
+    return dataRegionMap.size();
+  }
+
   /** This method is not thread-safe */
   public void setDataRegion(DataRegionId regionId, DataRegion newRegion) {
     if (dataRegionMap.containsKey(regionId)) {

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
@@ -1730,7 +1730,7 @@ continuous_query_min_every_interval_in_ms=1000
 pipe_lib_dir=ext/pipe
 
 # The maximum number of threads that can be used to execute the pipe subtasks in PipeSubtaskExecutor.
-# When <= 0, use max(5, CPU core number).
+# When <= 0, use max(5, CPU core number / 2).
 # effectiveMode: restart
 # Datatype: int
 pipe_subtask_executor_max_thread_num=0
@@ -1742,13 +1742,13 @@ pipe_sink_timeout_ms=900000
 
 # The maximum number of selectors that can be used in the sink.
 # Recommend to set this value to less than or equal to pipe_sink_max_client_number.
-# When <= 0, use max(4, CPU core number).
+# When <= 0, use max(4, CPU core number / 2).
 # effectiveMode: restart
 # Datatype: int
 pipe_sink_selector_number=0
 
 # The maximum number of clients that can be used in the sink.
-# When <= 0, use max(16, CPU core number).
+# When <= 0, use max(16, CPU core number / 2).
 # effectiveMode: restart
 # Datatype: int
 pipe_sink_max_client_number=0

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -229,6 +229,7 @@ public class CommonConfig {
   private int pipeConnectorHandshakeTimeoutMs = 10 * 1000; // 10 seconds
   private int pipeConnectorTransferTimeoutMs = 15 * 60 * 1000; // 15 minutes
   private int pipeConnectorReadFileBufferSize = 8388608;
+  private boolean isPipeConnectorReadFileBufferMemoryControlEnabled = true;
   private long pipeConnectorRetryIntervalMs = 1000L;
   private boolean pipeConnectorRPCThriftCompressionEnabled = false;
 
@@ -272,7 +273,7 @@ public class CommonConfig {
   private int pipeWalPinMaxLogIntervalRounds = 90;
 
   private boolean pipeMemoryManagementEnabled = true;
-  private long pipeMemoryAllocateRetryIntervalMs = 1000;
+  private long pipeMemoryAllocateRetryIntervalMs = 50;
   private int pipeMemoryAllocateMaxRetries = 10;
   private long pipeMemoryAllocateMinSizeInBytes = 32;
   private long pipeMemoryAllocateForTsFileSequenceReaderInBytes = (long) 2 * 1024 * 1024; // 2MB
@@ -831,6 +832,16 @@ public class CommonConfig {
 
   public void setPipeConnectorReadFileBufferSize(int pipeConnectorReadFileBufferSize) {
     this.pipeConnectorReadFileBufferSize = pipeConnectorReadFileBufferSize;
+  }
+
+  public boolean isPipeConnectorReadFileBufferMemoryControlEnabled() {
+    return isPipeConnectorReadFileBufferMemoryControlEnabled;
+  }
+
+  public void setIsPipeConnectorReadFileBufferMemoryControlEnabled(
+      boolean isPipeConnectorReadFileBufferMemoryControlEnabled) {
+    this.isPipeConnectorReadFileBufferMemoryControlEnabled =
+        isPipeConnectorReadFileBufferMemoryControlEnabled;
   }
 
   public void setPipeConnectorRPCThriftCompressionEnabled(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -207,7 +207,7 @@ public class CommonConfig {
 
   /** The maximum number of threads that can be used to execute subtasks in PipeSubtaskExecutor. */
   private int pipeSubtaskExecutorMaxThreadNum =
-      Math.max(5, Runtime.getRuntime().availableProcessors());
+      Math.max(5, Runtime.getRuntime().availableProcessors() / 2);
 
   private int pipeNonForwardingEventsProgressReportInterval = 100;
 
@@ -234,9 +234,9 @@ public class CommonConfig {
   private boolean pipeConnectorRPCThriftCompressionEnabled = false;
 
   private int pipeAsyncConnectorSelectorNumber =
-      Math.max(4, Runtime.getRuntime().availableProcessors());
+      Math.max(4, Runtime.getRuntime().availableProcessors() / 2);
   private int pipeAsyncConnectorMaxClientNumber =
-      Math.max(16, Runtime.getRuntime().availableProcessors());
+      Math.max(16, Runtime.getRuntime().availableProcessors() / 2);
 
   private double pipeAllSinksRateLimitBytesPerSecond = -1;
   private int rateLimiterHotReloadCheckIntervalMs = 1000;

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -257,7 +257,7 @@ public class CommonConfig {
 
   private int pipeMaxAllowedHistoricalTsFilePerDataRegion = 100;
   private int pipeMaxAllowedPendingTsFileEpochPerDataRegion = 10;
-  private int pipeMaxAllowedPinnedMemTableCount = 1000;
+  private int pipeMaxAllowedPinnedMemTableCount = 10; // per data region
   private long pipeMaxAllowedLinkedTsFileCount = 300;
   private float pipeMaxAllowedLinkedDeletedTsFileDiskUsagePercentage = 0.1F;
   private long pipeStuckRestartIntervalSeconds = 120;

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonConfig.java
@@ -229,7 +229,7 @@ public class CommonConfig {
   private int pipeConnectorHandshakeTimeoutMs = 10 * 1000; // 10 seconds
   private int pipeConnectorTransferTimeoutMs = 15 * 60 * 1000; // 15 minutes
   private int pipeConnectorReadFileBufferSize = 8388608;
-  private boolean isPipeConnectorReadFileBufferMemoryControlEnabled = true;
+  private boolean isPipeConnectorReadFileBufferMemoryControlEnabled = false;
   private long pipeConnectorRetryIntervalMs = 1000L;
   private boolean pipeConnectorRPCThriftCompressionEnabled = false;
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -391,6 +391,14 @@ public class CommonDescriptor {
                     properties.getProperty(
                         "pipe_connector_read_file_buffer_size",
                         String.valueOf(config.getPipeConnectorReadFileBufferSize())))));
+    config.setIsPipeConnectorReadFileBufferMemoryControlEnabled(
+        Boolean.parseBoolean(
+            Optional.ofNullable(properties.getProperty("pipe_sink_read_file_buffer_memory_control"))
+                .orElse(
+                    properties.getProperty(
+                        "pipe_connector_read_file_buffer_memory_control",
+                        String.valueOf(
+                            config.isPipeConnectorReadFileBufferMemoryControlEnabled())))));
     config.setPipeConnectorRetryIntervalMs(
         Long.parseLong(
             Optional.ofNullable(properties.getProperty("pipe_sink_retry_interval_ms"))

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeConfig.java
@@ -136,6 +136,10 @@ public class PipeConfig {
     return COMMON_CONFIG.getPipeConnectorReadFileBufferSize();
   }
 
+  public boolean isPipeConnectorReadFileBufferMemoryControlEnabled() {
+    return COMMON_CONFIG.isPipeConnectorReadFileBufferMemoryControlEnabled();
+  }
+
   public long getPipeConnectorRetryIntervalMs() {
     return COMMON_CONFIG.getPipeConnectorRetryIntervalMs();
   }
@@ -399,6 +403,9 @@ public class PipeConfig {
     LOGGER.info("PipeConnectorHandshakeTimeoutMs: {}", getPipeConnectorHandshakeTimeoutMs());
     LOGGER.info("PipeConnectorTransferTimeoutMs: {}", getPipeConnectorTransferTimeoutMs());
     LOGGER.info("PipeConnectorReadFileBufferSize: {}", getPipeConnectorReadFileBufferSize());
+    LOGGER.info(
+        "PipeConnectorReadFileBufferMemoryControlEnabled: {}",
+        isPipeConnectorReadFileBufferMemoryControlEnabled());
     LOGGER.info("PipeConnectorRetryIntervalMs: {}", getPipeConnectorRetryIntervalMs());
     LOGGER.info(
         "PipeConnectorRPCThriftCompressionEnabled: {}",


### PR DESCRIPTION
As title.