### PR TITLE
Delete remove node logic in ServerCommandLine

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/service/ConfigNode.java
@@ -30,7 +30,6 @@ import org.apache.iotdb.commons.concurrent.ThreadPoolMetrics;
 import org.apache.iotdb.commons.conf.CommonConfig;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
-import org.apache.iotdb.commons.exception.BadNodeUrlException;
 import org.apache.iotdb.commons.exception.ConfigurationException;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.exception.IoTDBException;
@@ -47,7 +46,6 @@ import org.apache.iotdb.confignode.client.sync.SyncConfigNodeClientPool;
 import org.apache.iotdb.confignode.conf.ConfigNodeConfig;
 import org.apache.iotdb.confignode.conf.ConfigNodeConstant;
 import org.apache.iotdb.confignode.conf.ConfigNodeDescriptor;
-import org.apache.iotdb.confignode.conf.ConfigNodeRemoveCheck;
 import org.apache.iotdb.confignode.conf.ConfigNodeStartupCheck;
 import org.apache.iotdb.confignode.conf.SystemPropertiesUtils;
 import org.apache.iotdb.confignode.manager.ConfigManager;
@@ -146,45 +144,9 @@ public class ConfigNode extends ServerCommandLine implements ConfigNodeMBean {
 
   @Override
   protected void remove(Set<Integer> nodeIds) throws IoTDBException {
-    // If the nodeId was null, this is a shorthand for removing the current dataNode.
-    // In this case we need to find our nodeId.
-
-    int removeConfigNodeId = -1;
-    if (nodeIds == null) {
-      removeConfigNodeId = CONF.getConfigNodeId();
-    } else {
-      if (nodeIds.size() != 1) {
-        throw new IoTDBException(
-            "It is not allowed to remove multiple ConfigNodes at the same time.", -1);
-      }
-      removeConfigNodeId = nodeIds.iterator().next();
-    }
-
-    try {
-      LOGGER.info("Starting to remove ConfigNode with node-id {}", removeConfigNodeId);
-
-      try {
-        TConfigNodeLocation removeConfigNodeLocation =
-            ConfigNodeRemoveCheck.getInstance().removeCheck(Long.toString(removeConfigNodeId));
-        if (removeConfigNodeLocation == null) {
-          LOGGER.error(
-              "The ConfigNode to be removed is not in the cluster, or the input format is incorrect.");
-          return;
-        }
-
-        ConfigNodeRemoveCheck.getInstance().removeConfigNode(removeConfigNodeLocation);
-      } catch (BadNodeUrlException e) {
-        LOGGER.warn("No ConfigNodes need to be removed.", e);
-        return;
-      }
-
-      LOGGER.info(
-          "ConfigNode: {} is removed. If the confignode data directory is no longer needed, you can delete it manually.",
-          removeConfigNodeId);
-    } catch (IOException e) {
-      LOGGER.error("Meet error when doing remove ConfigNode", e);
-      throw new IoTDBException("Error removing", -1);
-    }
+    throw new IoTDBException(
+        "The remove-confignode script has been deprecated. Please connect to the CLI and use SQL: remove confignode [confignode_id].",
+        -1);
   }
 
   public void active() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -55,8 +55,6 @@ import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.commons.utils.PathUtils;
 import org.apache.iotdb.confignode.rpc.thrift.TDataNodeRegisterReq;
 import org.apache.iotdb.confignode.rpc.thrift.TDataNodeRegisterResp;
-import org.apache.iotdb.confignode.rpc.thrift.TDataNodeRemoveReq;
-import org.apache.iotdb.confignode.rpc.thrift.TDataNodeRemoveResp;
 import org.apache.iotdb.confignode.rpc.thrift.TDataNodeRestartReq;
 import org.apache.iotdb.confignode.rpc.thrift.TDataNodeRestartResp;
 import org.apache.iotdb.confignode.rpc.thrift.TGetJarInListReq;
@@ -128,7 +126,6 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -279,64 +276,9 @@ public class DataNode extends ServerCommandLine implements DataNodeMBean {
 
   @Override
   protected void remove(Set<Integer> nodeIds) throws IoTDBException {
-    // If the nodeIds was null, this is a shorthand for removing the current dataNode.
-    // In this case we need to find our nodeId.
-    if (nodeIds == null) {
-      nodeIds = Collections.singleton(config.getDataNodeId());
-    }
-
-    // Load ConfigNodeList from system.properties file
-    ConfigNodeInfo.getInstance().loadConfigNodeList();
-
-    try (ConfigNodeClient configNodeClient =
-        ConfigNodeClientManager.getInstance().borrowClient(ConfigNodeInfo.CONFIG_REGION_ID)) {
-      // Find a datanode location with the given node id.
-
-      Set<Integer> validNodeIds =
-          configNodeClient.getDataNodeConfiguration(-1).getDataNodeConfigurationMap().keySet();
-
-      Set<Integer> invalidNodeIds = new HashSet<>(nodeIds);
-      invalidNodeIds.removeAll(validNodeIds);
-
-      if (!invalidNodeIds.isEmpty()) {
-        logger.info("Cannot remove invalid nodeIds:{}", invalidNodeIds);
-        nodeIds.removeAll(invalidNodeIds);
-      }
-
-      logger.info("Starting to remove DataNode with nodeIds: {}", nodeIds);
-
-      final Set<Integer> finalNodeIds = nodeIds;
-      List<TDataNodeLocation> removeDataNodeLocations =
-          configNodeClient
-              .getDataNodeConfiguration(-1)
-              .getDataNodeConfigurationMap()
-              .values()
-              .stream()
-              .map(TDataNodeConfiguration::getLocation)
-              .filter(location -> finalNodeIds.contains(location.getDataNodeId()))
-              .collect(Collectors.toList());
-
-      if (removeDataNodeLocations.isEmpty()) {
-        throw new IoTDBException("Invalid node-id", -1);
-      }
-
-      logger.info(
-          "Start to remove datanode, removed DataNodes endpoint: {}", removeDataNodeLocations);
-      TDataNodeRemoveReq removeReq = new TDataNodeRemoveReq(removeDataNodeLocations);
-      TDataNodeRemoveResp removeResp = configNodeClient.removeDataNode(removeReq);
-      logger.info("Submit Remove DataNodes result {} ", removeResp);
-      if (removeResp.getStatus().getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
-        throw new IoTDBException(
-            removeResp.getStatus().toString(), removeResp.getStatus().getCode());
-      }
-      logger.info(
-          "Submit remove-datanode request successfully, but the process may fail. "
-              + "more details are shown in the logs of confignode-leader and removed-datanode, "
-              + "and after the process of removing datanode ends successfully, "
-              + "you are supposed to delete directory and data of the removed-datanode manually");
-    } catch (TException | ClientManagerException e) {
-      throw new IoTDBException("Failed removing datanode", e, -1);
-    }
+    throw new IoTDBException(
+        "The remove-datanode script has been deprecated. Please connect to the CLI and use SQL: remove datanode [datanode_id].",
+        -1);
   }
 
   /** Prepare cluster IoTDB-DataNode */


### PR DESCRIPTION
## Description

For the sake of cluster security, delete the remove-confignode/datanode logic in ServerCommandLine after adding the remove SQL.