### PR TITLE
[IoTConsensus] More accurate statistics on IoTConsensus memory management

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/common/request/IConsensusRequest.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/common/request/IConsensusRequest.java
@@ -36,6 +36,8 @@ public interface IConsensusRequest {
    */
   ByteBuffer serializeToByteBuffer();
 
+  // TODO: getMemorySize
+
   default void markAsGeneratedByRemoteConsensusLeader() {
     // do nothing by default
   }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/common/request/IConsensusRequest.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/common/request/IConsensusRequest.java
@@ -36,7 +36,10 @@ public interface IConsensusRequest {
    */
   ByteBuffer serializeToByteBuffer();
 
-  // TODO: getMemorySize
+  default long getMemorySize() {
+    // return 0 by default
+    return 0;
+  }
 
   default void markAsGeneratedByRemoteConsensusLeader() {
     // do nothing by default

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/common/request/IndexedConsensusRequest.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/common/request/IndexedConsensusRequest.java
@@ -53,6 +53,7 @@ public class IndexedConsensusRequest implements IConsensusRequest {
   public void buildSerializedRequests() {
     this.requests.forEach(
         r -> {
+          // max(buffer, getSize)
           ByteBuffer buffer = r.serializeToByteBuffer();
           this.serializedRequests.add(buffer);
           this.serializedSize += buffer.capacity();
@@ -72,6 +73,7 @@ public class IndexedConsensusRequest implements IConsensusRequest {
     return serializedRequests;
   }
 
+  // rename memorySize
   public long getSerializedSize() {
     return serializedSize;
   }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/common/request/IndexedConsensusRequest.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/common/request/IndexedConsensusRequest.java
@@ -33,7 +33,7 @@ public class IndexedConsensusRequest implements IConsensusRequest {
   private final long syncIndex;
   private final List<IConsensusRequest> requests;
   private final List<ByteBuffer> serializedRequests;
-  private long serializedSize = 0;
+  private long memorySize = 0;
 
   public IndexedConsensusRequest(long searchIndex, List<IConsensusRequest> requests) {
     this.searchIndex = searchIndex;
@@ -53,10 +53,9 @@ public class IndexedConsensusRequest implements IConsensusRequest {
   public void buildSerializedRequests() {
     this.requests.forEach(
         r -> {
-          // max(buffer, getSize)
           ByteBuffer buffer = r.serializeToByteBuffer();
           this.serializedRequests.add(buffer);
-          this.serializedSize += buffer.capacity();
+          this.memorySize += Long.max(buffer.capacity(), r.getMemorySize());
         });
   }
 
@@ -73,9 +72,8 @@ public class IndexedConsensusRequest implements IConsensusRequest {
     return serializedRequests;
   }
 
-  // rename memorySize
-  public long getSerializedSize() {
-    return serializedSize;
+  public long getMemorySize() {
+    return memorySize;
   }
 
   public long getSearchIndex() {

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/LogDispatcher.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/LogDispatcher.java
@@ -280,7 +280,7 @@ public class LogDispatcher {
 
     /** try to offer a request into queue with memory control. */
     public boolean offer(IndexedConsensusRequest indexedConsensusRequest) {
-      if (!iotConsensusMemoryManager.reserve(indexedConsensusRequest.getSerializedSize(), true)) {
+      if (!iotConsensusMemoryManager.reserve(indexedConsensusRequest.getMemorySize(), true)) {
         return false;
       }
       boolean success;
@@ -288,19 +288,19 @@ public class LogDispatcher {
         success = pendingEntries.offer(indexedConsensusRequest);
       } catch (Throwable t) {
         // If exception occurs during request offer, the reserved memory should be released
-        iotConsensusMemoryManager.free(indexedConsensusRequest.getSerializedSize(), true);
+        iotConsensusMemoryManager.free(indexedConsensusRequest.getMemorySize(), true);
         throw t;
       }
       if (!success) {
         // If offer failed, the reserved memory should be released
-        iotConsensusMemoryManager.free(indexedConsensusRequest.getSerializedSize(), true);
+        iotConsensusMemoryManager.free(indexedConsensusRequest.getMemorySize(), true);
       }
       return success;
     }
 
     /** try to remove a request from queue with memory control. */
     private void releaseReservedMemory(IndexedConsensusRequest indexedConsensusRequest) {
-      iotConsensusMemoryManager.free(indexedConsensusRequest.getSerializedSize(), true);
+      iotConsensusMemoryManager.free(indexedConsensusRequest.getMemorySize(), true);
     }
 
     public void stop() {
@@ -322,13 +322,13 @@ public class LogDispatcher {
       }
       long requestSize = 0;
       for (IndexedConsensusRequest indexedConsensusRequest : pendingEntries) {
-        requestSize += indexedConsensusRequest.getSerializedSize();
+        requestSize += indexedConsensusRequest.getMemorySize();
       }
       pendingEntries.clear();
       iotConsensusMemoryManager.free(requestSize, true);
       requestSize = 0;
       for (IndexedConsensusRequest indexedConsensusRequest : bufferedEntries) {
-        requestSize += indexedConsensusRequest.getSerializedSize();
+        requestSize += indexedConsensusRequest.getMemorySize();
       }
       iotConsensusMemoryManager.free(requestSize, true);
       syncStatus.free();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertNode.java
@@ -443,6 +443,7 @@ public abstract class InsertNode extends SearchNode {
         .getPartialPath(ReadWriteIOUtils.readString(stream));
   }
 
+  @Override
   public long getMemorySize() {
     if (memorySize == 0) {
       memorySize = InsertNodeMemoryEstimator.sizeOf(this);


### PR DESCRIPTION
## Description

The actual memory occupied by IoTConsensus is 2-3 times larger than the statistical memory of memory management, so more detailed statistics of consensus memory are needed.

As shown in the figure, the statistical result of using `getMemorySize` is about twice the size of `buffer`, which makes the result more accurate.

<img width="1053" alt="image" src="https://github.com/user-attachments/assets/2d89e2ea-30a2-43e1-b2a5-34d584031547" />
