### PR TITLE
Subscription: add parameter to the clean up method to distinguish the force close situation & fix reference count management for iteration snapshot

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingQueue.java
@@ -136,11 +136,11 @@ public abstract class SubscriptionPrefetchingQueue {
     batches.cleanUp();
 
     // clean up events in prefetchingQueue
-    prefetchingQueue.forEach(SubscriptionEvent::cleanUp);
+    prefetchingQueue.forEach(event -> event.cleanUp(true));
     prefetchingQueue.clear();
 
     // clean up events in inFlightEvents
-    inFlightEvents.values().forEach(SubscriptionEvent::cleanUp);
+    inFlightEvents.values().forEach(event -> event.cleanUp(true));
     inFlightEvents.clear();
 
     // no need to clean up events in inputPendingQueue, see
@@ -447,7 +447,7 @@ public abstract class SubscriptionPrefetchingQueue {
                 commitContext,
                 this);
             // clean up committed event
-            ev.cleanUp();
+            ev.cleanUp(false);
             return null; // remove this entry
           }
 
@@ -477,7 +477,7 @@ public abstract class SubscriptionPrefetchingQueue {
           acked.set(true);
 
           // clean up committed event
-          ev.cleanUp();
+          ev.cleanUp(false);
           return null; // remove this entry
         });
 
@@ -668,7 +668,7 @@ public abstract class SubscriptionPrefetchingQueue {
   private final RemappingFunction<SubscriptionEvent> committedCleaner =
       (ev) -> {
         if (ev.isCommitted()) {
-          ev.cleanUp();
+          ev.cleanUp(false);
           return null; // remove this entry
         }
         return ev;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingTabletQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingTabletQueue.java
@@ -88,7 +88,7 @@ public class SubscriptionPrefetchingTabletQueue extends SubscriptionPrefetchingQ
           }
 
           if (ev.isCommitted()) {
-            ev.cleanUp();
+            ev.cleanUp(false);
             final String errorMessage =
                 String.format(
                     "outdated poll request after commit, consumer id: %s, commit context: %s, offset: %s, prefetching queue: %s",

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingTsFileQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingTsFileQueue.java
@@ -94,7 +94,7 @@ public class SubscriptionPrefetchingTsFileQueue extends SubscriptionPrefetchingQ
           }
 
           if (ev.isCommitted()) {
-            ev.cleanUp();
+            ev.cleanUp(false);
             final String errorMessage =
                 String.format(
                     "outdated poll request after commit, consumer id: %s, commit context: %s, writing offset: %s, prefetching queue: %s",

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/SubscriptionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/SubscriptionEvent.java
@@ -181,8 +181,8 @@ public class SubscriptionEvent implements Comparable<SubscriptionEvent> {
    * {@link ConcurrentHashMap#compute} method of inFlightEvents in {@link
    * SubscriptionPrefetchingQueue} or {@link SubscriptionPrefetchingQueue#cleanUp}.
    */
-  public void cleanUp() {
-    pipeEvents.cleanUp();
+  public void cleanUp(final boolean force) {
+    pipeEvents.cleanUp(force);
     response.cleanUp();
 
     // TODO: clean more fields

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeEventBatch.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeEventBatch.java
@@ -62,7 +62,7 @@ public abstract class SubscriptionPipeEventBatch {
 
   public abstract void ack();
 
-  public abstract void cleanUp();
+  public abstract void cleanUp(final boolean force);
 
   /////////////////////////////// APIs ///////////////////////////////
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeEventBatches.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeEventBatches.java
@@ -136,7 +136,7 @@ public class SubscriptionPipeEventBatches {
   }
 
   public void cleanUp() {
-    regionIdToBatch.values().forEach(SubscriptionPipeEventBatch::cleanUp);
+    regionIdToBatch.values().forEach(batch -> batch.cleanUp(true));
     regionIdToBatch.clear();
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeTabletEventBatch.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeTabletEventBatch.java
@@ -101,9 +101,9 @@ public class SubscriptionPipeTabletEventBatch extends SubscriptionPipeEventBatch
   }
 
   @Override
-  public synchronized void cleanUp() {
+  public synchronized void cleanUp(final boolean force) {
     // do nothing if it has next or still referenced by unacked response
-    if (hasNext() || referenceCount.get() != 0) {
+    if (!force && (hasNext() || referenceCount.get() != 0)) {
       return;
     }
 
@@ -226,7 +226,7 @@ public class SubscriptionPipeTabletEventBatch extends SubscriptionPipeEventBatch
     currentTsFileInsertionEvent = null;
 
     if (Objects.nonNull(iterationSnapshot)) {
-      iterationSnapshot.clear();
+      iterationSnapshot.clear(false);
     }
     iterationSnapshot = new SubscriptionPipeTabletIterationSnapshot();
     referenceCount.set(0);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeTabletEventBatch.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeTabletEventBatch.java
@@ -226,7 +226,7 @@ public class SubscriptionPipeTabletEventBatch extends SubscriptionPipeEventBatch
     currentTsFileInsertionEvent = null;
 
     if (Objects.nonNull(iterationSnapshot)) {
-      iterationSnapshot.clear(false);
+      iterationSnapshot.cleanUp();
     }
     iterationSnapshot = new SubscriptionPipeTabletIterationSnapshot();
     referenceCount.set(0);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeTabletIterationSnapshot.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeTabletIterationSnapshot.java
@@ -44,7 +44,7 @@ public class SubscriptionPipeTabletIterationSnapshot {
     parsedEnrichedEvents.add(enrichedEvent);
   }
 
-  public void clear() {
+  public void clear(final boolean shouldReport) {
     for (final EnrichedEvent enrichedEvent : iteratedEnrichedEvents) {
       if (enrichedEvent instanceof PipeTsFileInsertionEvent) {
         // close data container in tsfile event
@@ -55,7 +55,7 @@ public class SubscriptionPipeTabletIterationSnapshot {
     for (final EnrichedEvent enrichedEvent : parsedEnrichedEvents) {
       if (enrichedEvent instanceof PipeRawTabletInsertionEvent) {
         // decrease reference count in raw tablet event
-        enrichedEvent.decreaseReferenceCount(this.getClass().getName(), true);
+        enrichedEvent.decreaseReferenceCount(this.getClass().getName(), shouldReport);
       }
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeTabletIterationSnapshot.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeTabletIterationSnapshot.java
@@ -44,7 +44,7 @@ public class SubscriptionPipeTabletIterationSnapshot {
     parsedEnrichedEvents.add(enrichedEvent);
   }
 
-  public void clear(final boolean shouldReport) {
+  public void ack() {
     for (final EnrichedEvent enrichedEvent : iteratedEnrichedEvents) {
       if (enrichedEvent instanceof PipeTsFileInsertionEvent) {
         // close data container in tsfile event
@@ -55,7 +55,23 @@ public class SubscriptionPipeTabletIterationSnapshot {
     for (final EnrichedEvent enrichedEvent : parsedEnrichedEvents) {
       if (enrichedEvent instanceof PipeRawTabletInsertionEvent) {
         // decrease reference count in raw tablet event
-        enrichedEvent.decreaseReferenceCount(this.getClass().getName(), shouldReport);
+        enrichedEvent.decreaseReferenceCount(this.getClass().getName(), true);
+      }
+    }
+  }
+
+  public void cleanUp() {
+    for (final EnrichedEvent enrichedEvent : iteratedEnrichedEvents) {
+      if (enrichedEvent instanceof PipeTsFileInsertionEvent) {
+        // close data container in tsfile event
+        ((PipeTsFileInsertionEvent) enrichedEvent).close();
+      }
+    }
+
+    for (final EnrichedEvent enrichedEvent : parsedEnrichedEvents) {
+      if (enrichedEvent instanceof PipeRawTabletInsertionEvent) {
+        // clear reference count in raw tablet event
+        enrichedEvent.clearReferenceCount(this.getClass().getName());
       }
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeTsFileEventBatch.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeTsFileEventBatch.java
@@ -59,7 +59,7 @@ public class SubscriptionPipeTsFileEventBatch extends SubscriptionPipeEventBatch
   }
 
   @Override
-  public synchronized void cleanUp() {
+  public synchronized void cleanUp(final boolean force) {
     // close batch, it includes clearing the reference count of events
     batch.close();
     enrichedEvents.clear();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/pipe/SubscriptionPipeEmptyEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/pipe/SubscriptionPipeEmptyEvent.java
@@ -27,7 +27,7 @@ public class SubscriptionPipeEmptyEvent implements SubscriptionPipeEvents {
   public void ack() {}
 
   @Override
-  public void cleanUp() {}
+  public void cleanUp(final boolean force) {}
 
   /////////////////////////////// stringify ///////////////////////////////
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/pipe/SubscriptionPipeEvents.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/pipe/SubscriptionPipeEvents.java
@@ -23,7 +23,7 @@ public interface SubscriptionPipeEvents {
 
   void ack();
 
-  void cleanUp();
+  void cleanUp(final boolean force);
 
   //////////////////////////// APIs provided for metric framework ////////////////////////////
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/pipe/SubscriptionPipeTabletBatchEvents.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/pipe/SubscriptionPipeTabletBatchEvents.java
@@ -46,13 +46,17 @@ public class SubscriptionPipeTabletBatchEvents implements SubscriptionPipeEvents
   @Override
   public void ack() {
     batch.ack();
-    iterationSnapshot.clear(true);
+    if (Objects.nonNull(iterationSnapshot)) {
+      iterationSnapshot.ack();
+    }
   }
 
   @Override
   public void cleanUp(final boolean force) {
     batch.cleanUp(force);
-    iterationSnapshot.clear(false);
+    if (Objects.nonNull(iterationSnapshot)) {
+      iterationSnapshot.cleanUp();
+    }
   }
 
   /////////////////////////////// stringify ///////////////////////////////

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/pipe/SubscriptionPipeTabletBatchEvents.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/pipe/SubscriptionPipeTabletBatchEvents.java
@@ -46,12 +46,13 @@ public class SubscriptionPipeTabletBatchEvents implements SubscriptionPipeEvents
   @Override
   public void ack() {
     batch.ack();
-    iterationSnapshot.clear();
+    iterationSnapshot.clear(true);
   }
 
   @Override
-  public void cleanUp() {
-    batch.cleanUp();
+  public void cleanUp(final boolean force) {
+    batch.cleanUp(force);
+    iterationSnapshot.clear(false);
   }
 
   /////////////////////////////// stringify ///////////////////////////////

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/pipe/SubscriptionPipeTsFileBatchEvents.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/pipe/SubscriptionPipeTsFileBatchEvents.java
@@ -46,9 +46,9 @@ public class SubscriptionPipeTsFileBatchEvents implements SubscriptionPipeEvents
   }
 
   @Override
-  public void cleanUp() {
+  public void cleanUp(final boolean force) {
     if (referenceCount.decrementAndGet() == 0) {
-      batch.cleanUp();
+      batch.cleanUp(force);
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/pipe/SubscriptionPipeTsFilePlainEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/pipe/SubscriptionPipeTsFilePlainEvent.java
@@ -37,7 +37,7 @@ public class SubscriptionPipeTsFilePlainEvent implements SubscriptionPipeEvents 
   }
 
   @Override
-  public void cleanUp() {
+  public void cleanUp(final boolean force) {
     // close data container in tsfile event
     tsFileInsertionEvent.close();
     // clear the reference count of event


### PR DESCRIPTION
As title.

Can eliminate the phantom reference leaks of tsfile events and raw tablet events in the case of a restart.