### PR TITLE
Fix mqtt java8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <google.java.format.version>1.22.0</google.java.format.version>
         <gson.version>2.10.1</gson.version>
         <guava.version>32.1.2-jre</guava.version>
-        <h2.version>2.3.232</h2.version>
+        <h2.version>2.2.224</h2.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
         <google.java.format.version>1.22.0</google.java.format.version>
         <gson.version>2.10.1</gson.version>
         <guava.version>32.1.2-jre</guava.version>
+        <!-- This was the last version to support Java 8 -->
         <h2.version>2.2.224</h2.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>


### PR DESCRIPTION
## Description

h2 v2.3.232 requires Java 11, change it to the latest version to support Java 8.

v2.2.224 can also avoid CVE-2022-45868.