### PR TITLE
Fix overflow when using format in ns timestamp precision

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/builtinfunction/scalar/IoTDBFormatFunctionTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/builtinfunction/scalar/IoTDBFormatFunctionTableIT.java
@@ -74,6 +74,9 @@ public class IoTDBFormatFunctionTableIT {
         // data for date series
         "INSERT INTO date_table(time, device_id, s1) VALUES (10, 'd1', '2024-01-01')",
         "INSERT INTO date_table(time, device_id, s1) VALUES (20, 'd1', '2006-07-04')",
+        "INSERT INTO date_table(time, device_id, s1) VALUES (30, 'd2', '1970-01-01')",
+        "INSERT INTO date_table(time, device_id, s1) VALUES (40, 'd2', '9999-12-31')",
+        "INSERT INTO date_table(time, device_id, s1) VALUES (50, 'd2', '1900-01-01')",
 
         // data for special series
         "INSERT INTO null_table(time, device_id) VALUES (10, 'd1')",
@@ -81,6 +84,7 @@ public class IoTDBFormatFunctionTableIT {
 
   @BeforeClass
   public static void setUp() throws Exception {
+    EnvFactory.getEnv().getConfig().getCommonConfig().setTimestampPrecision("ns");
     EnvFactory.getEnv().initClusterEnvironment();
     insertData();
   }
@@ -150,7 +154,7 @@ public class IoTDBFormatFunctionTableIT {
     tableResultSetEqualTest(
         "SELECT FORMAT('%1$tF %1$tT.%1tL', s1) FROM timestamp_table",
         new String[] {"_col0"},
-        new String[] {"1970-01-01 00:00:00.010,", "1970-01-01 00:00:00.020,"},
+        new String[] {"1970-01-01 00:00:00.000,", "1970-01-01 00:00:00.000,"},
         DATABASE_NAME);
 
     tableResultSetEqualTest(
@@ -166,7 +170,7 @@ public class IoTDBFormatFunctionTableIT {
   @Test
   public void testDateFormat() {
     tableResultSetEqualTest(
-        "SELECT FORMAT('%1$tA, %1$tB %1$te, %1$tY', s1) FROM date_table",
+        "SELECT FORMAT('%1$tA, %1$tB %1$te, %1$tY', s1) FROM date_table where device_id = 'd1'",
         new String[] {"_col0"},
         new String[] {
           format("%1$tA, %1$tB %1$te, %1$tY,", LocalDate.of(2024, 1, 1)),
@@ -175,10 +179,14 @@ public class IoTDBFormatFunctionTableIT {
         DATABASE_NAME);
 
     tableResultSetEqualTest(
-        "SELECT FORMAT('%1$s %1$tF %1$tY-%1$tm-%1$td', s1) FROM date_table",
+        "SELECT FORMAT('%1$s %1$tF %1$tY-%1$tm-%1$td', s1) FROM date_table where device_id = 'd1'",
         new String[] {"_col0"},
         new String[] {"2024-01-01 2024-01-01 2024-01-01,", "2006-07-04 2006-07-04 2006-07-04,"},
         DATABASE_NAME);
+
+    tableResultSetEqualTest(
+        "SELECT FORMAT('%1$tY', s1) FROM date_table where device_id = 'd2'",
+        new String[] {"_col0"}, new String[] {"1970,", "9999,", "1900,"}, DATABASE_NAME);
   }
 
   @Test

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/unary/scalar/FormatColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/unary/scalar/FormatColumnTransformer.java
@@ -101,9 +101,7 @@ public class FormatColumnTransformer extends MultiColumnTransformer {
       case BLOB:
         return column.getObject(i);
       case DATE:
-        long timestamp =
-            DateTimeUtils.correctPrecision(DateUtils.parseIntToTimestamp(column.getInt(i), zoneId));
-        return DateTimeUtils.convertToLocalDate(timestamp, zoneId);
+        return DateUtils.parseIntToLocalDate(column.getInt(i));
       case TIMESTAMP:
         return DateTimeUtils.convertToZonedDateTime(column.getLong(i), zoneId);
       default:


### PR DESCRIPTION
This pull request includes a change to the `FormatColumnTransformer` class in the `iotdb-core` module, specifically to the `valueConverter` method. The change simplifies the conversion of `DATE` type values by using a more direct method.

Simplification of date conversion:

* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/unary/scalar/FormatColumnTransformer.java`](diffhunk://#diff-8d2fa9c31ebb1c81d04af40540bd7eb8fcc7acef2283b5d09920c59c8674ce8fL104-R104): Simplified the conversion of `DATE` type values by using `DateUtils.parseIntToLocalDate` instead of a multi-step process involving `DateTimeUtils.correctPrecision` and `DateTimeUtils.convertToLocalDate`.