### PR TITLE
Fix frozen IoTConsensus sync lag

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/buffer/IWALBuffer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/buffer/IWALBuffer.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.storageengine.dataregion.wal.buffer;
 
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 /**
  * This class serializes and flushes {@link WALEntry}. If search is enabled, the order of search
@@ -51,6 +52,14 @@ public interface IWALBuffer extends AutoCloseable {
    * @throws InterruptedException when interrupted by the flush thread
    */
   void waitForFlush() throws InterruptedException;
+
+  /**
+   * Wait for next flush operation done, if the predicate == true after entering a locked environment.
+   * Otherwise, return directly.
+   * @param waitPredicate the condition which should be satisfied before waiting.
+   * @throws InterruptedException when interrupted by the flush thread
+   */
+  public void waitForFlush(Predicate<WALBuffer> waitPredicate) throws InterruptedException;
 
   /**
    * Wait for next flush operation done.

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/buffer/WALBuffer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/buffer/WALBuffer.java
@@ -64,6 +64,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Predicate;
 
 import static org.apache.iotdb.db.storageengine.dataregion.wal.node.WALNode.DEFAULT_SEARCH_INDEX;
 
@@ -661,6 +662,18 @@ public class WALBuffer extends AbstractWALBuffer {
     buffersLock.lock();
     try {
       idleBufferReadyCondition.await();
+    } finally {
+      buffersLock.unlock();
+    }
+  }
+
+  @Override
+  public void waitForFlush(Predicate<WALBuffer> waitPredicate) throws InterruptedException {
+    buffersLock.lock();
+    try {
+      if (waitPredicate.test(this)) {
+        idleBufferReadyCondition.await();
+      }
     } finally {
       buffersLock.unlock();
     }


### PR DESCRIPTION
If the IoTConsensus dispatcher is about to wait right after the last WAL flush, it cannot be woken up as long as there is no further insertion.
The result is that the dispatcher cannot sense the WALs of the last WAL flush, and the sync lag is frozen.

To avoid this, the dispatcher should double-check the search index before waiting.