### PR TITLE
Fix Memory NPE when use IDEA to debug

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -130,8 +130,10 @@ public class IoTDBDescriptor {
     loadProps();
     ServiceLoader<IPropertiesLoader> propertiesLoaderServiceLoader =
         ServiceLoader.load(IPropertiesLoader.class);
+    boolean hasProperties = false;
     for (IPropertiesLoader loader : propertiesLoaderServiceLoader) {
       LOGGER.info("Will reload properties from {} ", loader.getClass().getName());
+      hasProperties = true;
       Properties properties = loader.loadProperties();
       TrimProperties trimProperties = new TrimProperties();
       trimProperties.putAll(properties);
@@ -149,6 +151,10 @@ public class IoTDBDescriptor {
       TSFileDescriptor.getInstance()
           .getConfig()
           .setCustomizedProperties(loader.getCustomizedProperties());
+    }
+    // if there are no properties, we need to init memory config
+    if (!hasProperties) {
+      memoryConfig.init(new TrimProperties());
     }
   }
 


### PR DESCRIPTION
Fix Memory NPE when use IDEA to debug. This is mainly because when there are no properties, init method in DataNodeMemoryConfig will never be called.