### PR TITLE
Fix division by zero error when flush memtable

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
@@ -1481,12 +1481,15 @@ public abstract class AlignedTVList extends TVList {
     if (largestBinaryChunkSize == 0) {
       return largestPrimitivePointSize;
     }
-    int avgPointSizeOfLargestBinaryColumn =
-        (int) largestBinaryChunkSize / getColumnValueCnt(largestBinaryColumnIndex);
+    int columnValueCnt = getColumnValueCnt(largestBinaryColumnIndex);
+    if (columnValueCnt == 0) {
+      return largestPrimitivePointSize;
+    }
+    int avgPointSizeOfLargestBinaryColumn = (int) largestBinaryChunkSize / columnValueCnt;
     return Math.max(avgPointSizeOfLargestBinaryColumn, largestPrimitivePointSize);
   }
 
-  public int getColumnValueCnt(int columnIndex) {
+  private int getColumnValueCnt(int columnIndex) {
     int pointNum = 0;
     if (bitMaps == null || bitMaps.get(columnIndex) == null) {
       pointNum = rowCount;


### PR DESCRIPTION
## Description
![image](https://github.com/user-attachments/assets/f7a6566d-84c0-4397-aecc-e21278331d32)


To reproduce, execute the following sqls.

```sql
create database db1
use db1
create table t2(s1 text field, s2 text field)
insert into t2(time,s2) values(2,'t1')
alter table t2 drop column s2
flush
```