### PR TITLE
Compatibility modification for LikeViewExpression deserialization

### DIFF
--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/schema/view/viewExpression/unary/LikeViewExpression.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/schema/view/viewExpression/unary/LikeViewExpression.java
@@ -57,7 +57,6 @@ public class LikeViewExpression extends UnaryViewExpression {
   public LikeViewExpression(ByteBuffer byteBuffer) {
     super(ViewExpression.deserialize(byteBuffer));
     pattern = ReadWriteIOUtils.readString(byteBuffer);
-    // 先读一个byte
     byte judge = ReadWriteIOUtils.readByte(byteBuffer);
     switch (judge){
       case -1:

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/schema/view/viewExpression/unary/LikeViewExpression.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/schema/view/viewExpression/unary/LikeViewExpression.java
@@ -28,7 +28,6 @@ import org.apache.tsfile.utils.ReadWriteIOUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 
@@ -58,7 +57,7 @@ public class LikeViewExpression extends UnaryViewExpression {
     super(ViewExpression.deserialize(byteBuffer));
     pattern = ReadWriteIOUtils.readString(byteBuffer);
     byte judge = ReadWriteIOUtils.readByte(byteBuffer);
-    switch (judge){
+    switch (judge) {
       case -1:
       case 0:
         isNot = false;
@@ -85,7 +84,7 @@ public class LikeViewExpression extends UnaryViewExpression {
     try {
       pattern = ReadWriteIOUtils.readString(inputStream);
       byte judge = ReadWriteIOUtils.readByte(inputStream);
-      switch (judge){
+      switch (judge) {
         case -1:
         case 0:
           escape = Optional.empty();
@@ -97,9 +96,9 @@ public class LikeViewExpression extends UnaryViewExpression {
           break;
         case 2:
           if (ReadWriteIOUtils.readBool(inputStream)) {
-              escape = Optional.of(ReadWriteIOUtils.readString(inputStream).charAt(0));
+            escape = Optional.of(ReadWriteIOUtils.readString(inputStream).charAt(0));
           } else {
-              escape = Optional.empty();
+            escape = Optional.empty();
           }
           isNot = ReadWriteIOUtils.readBool(inputStream);
           break;


### PR DESCRIPTION
When adding escape functionality to LIKE, the serialization and deserialization methods of LikeViewExpression were modified, which led to compatibility issues during version upgrades. The old Raft logs would cause errors when processed with the new deserialization function. The compatibility issue has now been resolved.