### PR TITLE
IoTConsensusV2: Fix borrow tsfileWriter and delete tsfileWriter's file concurrency bug

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/pipeconsensus/PipeConsensusReceiver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/pipeconsensus/PipeConsensusReceiver.java
@@ -396,6 +396,7 @@ public class PipeConsensusReceiver {
     File writingFile = tsFileWriter.getWritingFile();
     RandomAccessFile writingFileWriter = tsFileWriter.getWritingFileWriter();
 
+    boolean isReturnTsFileWriter = false;
     try {
       if (isWritingFileNonAvailable(tsFileWriter)) {
         final TSStatus status =
@@ -445,7 +446,7 @@ public class PipeConsensusReceiver {
 
       if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         // if transfer success, disk buffer will be released.
-        tsFileWriter.returnSelf(consensusPipeName);
+        isReturnTsFileWriter = true;
         LOGGER.info(
             "PipeConsensus-PipeName-{}: Seal file {} successfully.",
             consensusPipeName,
@@ -458,7 +459,7 @@ public class PipeConsensusReceiver {
             status.getMessage());
       }
       return new TPipeConsensusTransferResp(status);
-    } catch (IOException | DiskSpaceInsufficientException e) {
+    } catch (IOException e) {
       LOGGER.warn(
           "PipeConsensus-PipeName-{}: Failed to seal file {} from req {}.",
           consensusPipeName,
@@ -486,6 +487,18 @@ public class PipeConsensusReceiver {
       // sender.
       closeCurrentWritingFileWriter(tsFileWriter, false);
       deleteCurrentWritingFile(tsFileWriter);
+      // must return tsfileWriter after deleting its file.
+      if (isReturnTsFileWriter) {
+        try {
+          tsFileWriter.returnSelf(consensusPipeName);
+        } catch (IOException | DiskSpaceInsufficientException e) {
+          LOGGER.warn(
+              "PipeConsensus-PipeName-{}: Failed to return tsFileWriter {}.",
+              consensusPipeName,
+              tsFileWriter,
+              e);
+        }
+      }
     }
   }
 
@@ -511,6 +524,7 @@ public class PipeConsensusReceiver {
         req.getFileNames().stream()
             .map(fileName -> new File(currentWritingDirPath, fileName))
             .collect(Collectors.toList());
+    boolean isReturnTsFileWriter = false;
     try {
       if (isWritingFileNonAvailable(tsFileWriter)) {
         final TSStatus status =
@@ -574,7 +588,7 @@ public class PipeConsensusReceiver {
 
       if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         // if transfer success, disk buffer will be released.
-        tsFileWriter.returnSelf(consensusPipeName);
+        isReturnTsFileWriter = true;
         LOGGER.info(
             "PipeConsensus-PipeName-{}: Seal file with mods {} successfully.",
             consensusPipeName,
@@ -606,6 +620,18 @@ public class PipeConsensusReceiver {
       // Clear the directory instead of only deleting the referenced files in seal request
       // to avoid previously undeleted file being redundant when transferring multi files
       IoTDBReceiverAgent.cleanPipeReceiverDir(currentWritingDirPath);
+      // must return tsfileWriter after deleting its file.
+      if (isReturnTsFileWriter) {
+        try {
+          tsFileWriter.returnSelf(consensusPipeName);
+        } catch (IOException | DiskSpaceInsufficientException e) {
+          LOGGER.warn(
+              "PipeConsensus-PipeName-{}: Failed to return tsFileWriter {}.",
+              consensusPipeName,
+              tsFileWriter,
+              e);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
There are two TsFile, naming TsFileA and TsFileB respectively.

**Time1:** TsFileB is going to finish replication as it's seal request is being handled by follower.

**Time2:** TsFileB's seal request is handled by follower successfully, and TsFileB returns its TsFileWriter which names TsFileWriterA to TsWriterPool.

**Time3:** TsFileA is being transferred to follower, and TsFileA borrows TsFileWriterA from TsWriterPool.

**Time4:** TsFileA binds its file to TsFileWriterA

**Time5:** TsFileB deletes TsFileWriterA's binding file, which is TsFileA's file.

**Time6:** Any further requests related to TsFileA will cause NPE, because TsFileA's file is deleted.


```txt
2025-03-11 16:57:06,717 [pool-70-IoTDB-PipeConsensusRPC-Processor-40] INFO  o.a.i.d.p.r.p.p.PipeConsensusReceiver$RequestExecutor:1347 - PipeConsensus-PipeName-__consensus.DataRegion[15]_3_4: start to receive no.TCommitId(replicateIndex:5748, dataNodeRebootTimes:0) event 
2025-03-11 16:57:07,000 [pool-70-IoTDB-PipeConsensusRPC-Processor-40] INFO  o.a.i.d.s.d.DataRegion:3087 - TsFile 1741683426979-1630-0-0.tsfile is successfully loaded in unsequence list. 
2025-03-11 16:57:07,000 [pool-70-IoTDB-PipeConsensusRPC-Processor-40] INFO  o.a.i.d.p.r.p.p.PipeConsensusReceiver$PipeConsensusTsFileWriter:1153 - PipeConsensus-PipeName-__consensus.DataRegion[15]_3_4: tsfileWriter-1 roll to writing path /data1/iotdb_data/v2021_rc1_0309_e90d59f_issue0102/data/datanode/system/pipe/consensus/receiver/__consensus.DataRegion[15]_3_4/1 
2025-03-11 16:57:07,742 [pool-70-IoTDB-PipeConsensusRPC-Processor-16] INFO  o.a.i.d.p.r.p.p.PipeConsensusReceiver:893 - PipeConsensus-PipeName-__consensus.DataRegion[15]_3_4: Writing file sequence-db2_g_0-15-1-1741680249522-1618-0-0.tsfile is not existed or name is not correct, try to create it. Current writing file is null. 
2025-03-11 16:57:07,821 [pool-70-IoTDB-PipeConsensusRPC-Processor-16] INFO  o.a.i.d.p.r.p.p.PipeConsensusReceiver:927 - PipeConsensus-PipeName-__consensus.DataRegion[15]_3_4: Writing file /data1/iotdb_data/v2021_rc1_0309_e90d59f_issue0102/data/datanode/system/pipe/consensus/receiver/__consensus.DataRegion[15]_3_4/1/sequence-db2_g_0-15-1-1741680249522-1618-0-0.tsfile was created. Ready to write file pieces. 
2025-03-11 16:57:07,847 [pool-70-IoTDB-PipeConsensusRPC-Processor-40] INFO  o.a.i.d.p.r.p.p.PipeConsensusReceiver$PipeConsensusTsFileWriter:1166 - PipeConsensus-PipeName-__consensus.DataRegion[15]_3_4: Origin receiver tsFileWriter-1 file dir /data1/iotdb_data/v2021_rc1_0309_e90d59f_issue0102/data/datanode/system/pipe/consensus/receiver/__consensus.DataRegion[15]_3_4/1 was deleted. 
2025-03-11 16:57:07,847 [pool-70-IoTDB-PipeConsensusRPC-Processor-40] INFO  o.a.i.d.p.r.p.p.PipeConsensusReceiver$PipeConsensusTsFileWriter:1230 - PipeConsensus-PipeName-__consensus.DataRegion[15]_3_4: tsFileWriter-1 returned self 
2025-03-11 16:57:07,847 [pool-70-IoTDB-PipeConsensusRPC-Processor-40] INFO  o.a.i.d.p.r.p.p.PipeConsensusReceiver:449 - PipeConsensus-PipeName-__consensus.DataRegion[15]_3_4: Seal file /data3/iotdb_data/v2021_rc1_0309_e90d59f_issue0102/data/datanode/system/pipe/consensus/receiver/__consensus.DataRegion[15]_3_4/1/sequence-db2_g_0-15-1-1741680208778-1613-0-0.tsfile successfully. 
2025-03-11 16:57:07,848 [pool-70-IoTDB-PipeConsensusRPC-Processor-40] INFO  o.a.i.d.p.r.p.p.PipeConsensusReceiver:820 - PipeConsensus-PipeName-__consensus.DataRegion[15]_3_4: Current writing file writer /data1/iotdb_data/v2021_rc1_0309_e90d59f_issue0102/data/datanode/system/pipe/consensus/receiver/__consensus.DataRegion[15]_3_4/1/sequence-db2_g_0-15-1-1741680249522-1618-0-0.tsfile was closed. 
```

