### PR TITLE
Modify the error message for when parameters do not match

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/builtinfunction/scalar/IoTDBFormatFunctionTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/builtinfunction/scalar/IoTDBFormatFunctionTableIT.java
@@ -211,7 +211,7 @@ public class IoTDBFormatFunctionTableIT {
 
     tableAssertTestFail(
         "SELECT FORMAT('%s') FROM string_table",
-        "701: Scalar function format must have at least two arguments, and first argument must be char type.",
+        "701: Scalar function format must have at least two arguments, and first argument pattern must be TEXT or STRING type.",
         DATABASE_NAME);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableMetadataImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableMetadataImpl.java
@@ -540,7 +540,7 @@ public class TableMetadataImpl implements Metadata {
         throw new SemanticException(
             "Scalar function "
                 + functionName.toLowerCase(Locale.ENGLISH)
-                + " must have at least two arguments, and first argument must be char type.");
+                + " must have at least two arguments, and first argument pattern must be TEXT or STRING type.");
       }
       return STRING;
     } else if (TableBuiltinScalarFunction.GREATEST.getFunctionName().equalsIgnoreCase(functionName)


### PR DESCRIPTION
This pull request includes a small but important change to the `iotdb-core/datanode` module. The change updates the error message for a scalar function to provide more accurate information about the required argument types.

* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableMetadataImpl.java`](diffhunk://#diff-5420ab45f1bfb25708b0cd843b2770256e0671bc180acb7abf7f8a89888a3aa0L543-R543): Updated the error message to specify that the first argument pattern must be of type TEXT or STRING instead of just char type.