### PR TITLE
Int + Date and Long + Date do not check if the date exceeds the range

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/query/IoTDBArithmeticTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/query/IoTDBArithmeticTableIT.java
@@ -356,6 +356,18 @@ public class IoTDBArithmeticTableIT {
 
     tableAssertTestFail(
         String.format(
+            "select %s + date from table2 where time = 1",
+            DateTimeUtils.correctPrecision(MILLISECONDS_IN_DAY)),
+        "752: Year must be between 1000 and 9999.",
+        "test");
+
+    tableAssertTestFail(
+        String.format("select %s + date from table2 where time = 1", 86400000),
+        "752: Year must be between 1000 and 9999.",
+        "test");
+
+    tableAssertTestFail(
+        String.format(
             "select date - %s from table2 where time = 2",
             DateTimeUtils.correctPrecision(MILLISECONDS_IN_DAY)),
         "752: Year must be between 1000 and 9999.",

--- a/iotdb-core/datanode/src/main/codegen/templates/ArithmeticBinaryColumnTransformer.ftl
+++ b/iotdb-core/datanode/src/main/codegen/templates/ArithmeticBinaryColumnTransformer.ftl
@@ -184,8 +184,14 @@ import org.apache.tsfile.read.common.type.Type;
 import org.apache.tsfile.utils.DateUtils;
 
 import java.time.ZoneId;
+<#if second.instance == "DATE">
+import java.time.format.DateTimeParseException;
+</#if>
 
 <#if first.dataType == "int" || second.dataType == "int" || first.dataType == "long" || second.dataType == "long">
+<#if second.instance == "DATE">
+import static org.apache.iotdb.rpc.TSStatusCode.DATE_OUT_OF_RANGE;
+</#if>
 import static org.apache.iotdb.rpc.TSStatusCode.NUMERIC_VALUE_OUT_OF_RANGE;
 </#if>
 
@@ -249,6 +255,11 @@ public class ${className} extends BinaryColumnTransformer {
       throw new IoTDBRuntimeException(
           String.format("long ${operator.name} overflow: %s + %s", left, right),
           NUMERIC_VALUE_OUT_OF_RANGE.getStatusCode(),
+          true);
+    }catch (DateTimeParseException e) {
+      throw new IoTDBRuntimeException(
+          "Year must be between 1000 and 9999.",
+          DATE_OUT_OF_RANGE.getStatusCode(),
           true);
     }
     <#else>


### PR DESCRIPTION
This pull request includes changes to enhance date handling and error reporting in arithmetic operations within the IoTDB project. The most significant changes involve adding new test cases, importing necessary classes, and handling specific exceptions for date-related operations.

Enhancements to date handling and error reporting:

* [`integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/query/IoTDBArithmeticTableIT.java`](diffhunk://#diff-908fd9921b253d5bad61a0f1e2389379172b0031b3c541be95a08fe2645848f7R357-R368): Added new test cases in `testDateOutOfRange` to verify the correct handling of date arithmetic operations and ensure that the error message "Year must be between 1000 and 9999." is correctly triggered.

* `iotdb-core/datanode/src/main/codegen/templates/ArithmeticBinaryColumnTransformer.ftl`: 
  * Imported `DateTimeParseException` to handle date parsing errors and `DATE_OUT_OF_RANGE` status code for specific error reporting.
  * Added a catch block for `DateTimeParseException` in the class `${className} extends BinaryColumnTransformer` to throw an `IoTDBRuntimeException` with the message "Year must be between 1000 and 9999." and the appropriate status code.