### PR TITLE
[RTO/RPO] Phi logging/concurrency Improvement

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/detector/PhiAccrualDetector.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/detector/PhiAccrualDetector.java
@@ -71,7 +71,7 @@ public class PhiAccrualDetector implements IFailureDetector {
     }
     final PhiAccrual phiAccrual = create(history);
     final boolean isAvailable = phiAccrual.phi() < (double) this.threshold;
-    if (!isAvailable) {
+    if (!isAvailable && LOGGER.isDebugEnabled()) {
       // log the status change and dump the heartbeat history for analysis use
       final StringBuilder builder = new StringBuilder();
       builder.append("[");
@@ -81,7 +81,7 @@ public class PhiAccrualDetector implements IFailureDetector {
       }
       builder.append(phiAccrual.timeElapsedSinceLastHeartbeat / 1000_000);
       builder.append("]");
-      LOGGER.info(String.format("Node Down, heartbeat history (ms): %s", builder));
+      LOGGER.debug(String.format("Node Down, heartbeat history (ms): %s", builder));
     }
 
     return isAvailable;

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/node/AINodeHeartbeatCache.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/node/AINodeHeartbeatCache.java
@@ -40,28 +40,27 @@ public class AINodeHeartbeatCache extends BaseNodeCache {
   public void updateCurrentStatistics(boolean forceUpdate) {
     NodeHeartbeatSample lastSample;
     final List<AbstractHeartbeatSample> heartbeatHistory;
-    synchronized (slidingWindow) {
-      lastSample = (NodeHeartbeatSample) getLastSample();
-      heartbeatHistory = Collections.unmodifiableList(slidingWindow);
-    }
-
-    /* Update load sample */
-    if (lastSample != null && lastSample.isSetLoadSample()) {
-      latestLoadSample.set((lastSample.getLoadSample()));
-    }
-
     /* Update Node status */
     NodeStatus status = null;
     String statusReason = null;
     long currentNanoTime = System.nanoTime();
-    if (lastSample != null && NodeStatus.Removing.equals(lastSample.getStatus())) {
-      status = NodeStatus.Removing;
-    } else if (!failureDetector.isAvailable(heartbeatHistory)) {
-      /* Failure detector decides that this AINode is UNKNOWN */
-      status = NodeStatus.Unknown;
-    } else if (lastSample != null) {
-      status = lastSample.getStatus();
-      statusReason = lastSample.getStatusReason();
+    synchronized (slidingWindow) {
+      lastSample = (NodeHeartbeatSample) getLastSample();
+      heartbeatHistory = Collections.unmodifiableList(slidingWindow);
+      /* Update load sample */
+      if (lastSample != null && lastSample.isSetLoadSample()) {
+        latestLoadSample.set((lastSample.getLoadSample()));
+      }
+
+      if (lastSample != null && NodeStatus.Removing.equals(lastSample.getStatus())) {
+        status = NodeStatus.Removing;
+      } else if (!failureDetector.isAvailable(heartbeatHistory)) {
+        /* Failure detector decides that this AINode is UNKNOWN */
+        status = NodeStatus.Unknown;
+      } else if (lastSample != null) {
+        status = lastSample.getStatus();
+        statusReason = lastSample.getStatusReason();
+      }
     }
 
     long loadScore = NodeStatus.isNormalStatus(status) ? 0 : Long.MAX_VALUE;

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/node/ConfigNodeHeartbeatCache.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/node/ConfigNodeHeartbeatCache.java
@@ -55,23 +55,23 @@ public class ConfigNodeHeartbeatCache extends BaseNodeCache {
     }
 
     NodeHeartbeatSample lastSample;
+    // Update Node status
+    NodeStatus status;
+    long currentNanoTime = System.nanoTime();
     final List<AbstractHeartbeatSample> heartbeatHistory;
     synchronized (slidingWindow) {
       lastSample = (NodeHeartbeatSample) getLastSample();
       heartbeatHistory = Collections.unmodifiableList(slidingWindow);
-    }
 
-    // Update Node status
-    NodeStatus status;
-    long currentNanoTime = System.nanoTime();
-    if (lastSample == null) {
-      /* First heartbeat not received from this ConfigNode, status is UNKNOWN */
-      status = NodeStatus.Unknown;
-    } else if (!failureDetector.isAvailable(heartbeatHistory)) {
-      /* Failure detector decides that this ConfigNode is UNKNOWN */
-      status = NodeStatus.Unknown;
-    } else {
-      status = lastSample.getStatus();
+      if (lastSample == null) {
+        /* First heartbeat not received from this ConfigNode, status is UNKNOWN */
+        status = NodeStatus.Unknown;
+      } else if (!failureDetector.isAvailable(heartbeatHistory)) {
+        /* Failure detector decides that this ConfigNode is UNKNOWN */
+        status = NodeStatus.Unknown;
+      } else {
+        status = lastSample.getStatus();
+      }
     }
 
     /* Update loadScore */

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/node/DataNodeHeartbeatCache.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/node/DataNodeHeartbeatCache.java
@@ -53,29 +53,28 @@ public class DataNodeHeartbeatCache extends BaseNodeCache {
 
     NodeHeartbeatSample lastSample;
     final List<AbstractHeartbeatSample> heartbeatHistory;
-    synchronized (slidingWindow) {
-      lastSample = (NodeHeartbeatSample) getLastSample();
-      heartbeatHistory = Collections.unmodifiableList(slidingWindow);
-    }
-
-    /* Update load sample */
-    if (lastSample != null && lastSample.isSetLoadSample()) {
-      latestLoadSample.set(lastSample.getLoadSample());
-    }
-
     /* Update Node status */
     NodeStatus status;
     String statusReason = null;
     long currentNanoTime = System.nanoTime();
-    if (lastSample == null) {
-      /* First heartbeat not received from this DataNode, status is UNKNOWN */
-      status = NodeStatus.Unknown;
-    } else if (!failureDetector.isAvailable(heartbeatHistory)) {
-      /* Failure detector decides that this DataNode is UNKNOWN */
-      status = NodeStatus.Unknown;
-    } else {
-      status = lastSample.getStatus();
-      statusReason = lastSample.getStatusReason();
+    synchronized (slidingWindow) {
+      lastSample = (NodeHeartbeatSample) getLastSample();
+      heartbeatHistory = Collections.unmodifiableList(slidingWindow);
+      /* Update load sample */
+      if (lastSample != null && lastSample.isSetLoadSample()) {
+        latestLoadSample.set(lastSample.getLoadSample());
+      }
+
+      if (lastSample == null) {
+        /* First heartbeat not received from this DataNode, status is UNKNOWN */
+        status = NodeStatus.Unknown;
+      } else if (!failureDetector.isAvailable(heartbeatHistory)) {
+        /* Failure detector decides that this DataNode is UNKNOWN */
+        status = NodeStatus.Unknown;
+      } else {
+        status = lastSample.getStatus();
+        statusReason = lastSample.getStatusReason();
+      }
     }
 
     /* Update loadScore */

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/region/RegionCache.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/region/RegionCache.java
@@ -44,20 +44,20 @@ public class RegionCache extends AbstractLoadCache {
     synchronized (slidingWindow) {
       lastSample = (RegionHeartbeatSample) getLastSample();
       history = Collections.unmodifiableList(slidingWindow);
-    }
 
-    RegionStatus status;
-    long currentNanoTime = System.nanoTime();
-    if (lastSample == null) {
-      /* First heartbeat not received from this region, status is UNKNOWN */
-      status = RegionStatus.Unknown;
-    } else if (!failureDetector.isAvailable(history)) {
-      /* Failure detector decides that this region is UNKNOWN */
-      status = RegionStatus.Unknown;
-    } else {
-      status = lastSample.getStatus();
+      RegionStatus status;
+      long currentNanoTime = System.nanoTime();
+      if (lastSample == null) {
+        /* First heartbeat not received from this region, status is UNKNOWN */
+        status = RegionStatus.Unknown;
+      } else if (!failureDetector.isAvailable(history)) {
+        /* Failure detector decides that this region is UNKNOWN */
+        status = RegionStatus.Unknown;
+      } else {
+        status = lastSample.getStatus();
+      }
+      this.currentStatistics.set(new RegionStatistics(currentNanoTime, status));
     }
-    this.currentStatistics.set(new RegionStatistics(currentNanoTime, status));
   }
 
   public RegionStatistics getCurrentStatistics() {


### PR DESCRIPTION
1. Use debug level log for history dump (workaround)
2. Use copy of history to avoid concurrency issue (workaround also)