### PR TITLE
Add some supplementary logs during partition allocation

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/DeleteDatabaseProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/DeleteDatabaseProcedure.java
@@ -197,7 +197,9 @@ public class DeleteDatabaseProcedure
           env.getConfigManager()
               .getLoadManager()
               .clearDataPartitionPolicyTable(deleteDatabaseSchema.getName());
-          LOG.info("data partition policy table cleared.");
+          LOG.info(
+              "[DeleteDatabaseProcedure] The data partition policy table of database: {} is cleared.",
+              deleteDatabaseSchema.getName());
 
           // Delete Database metrics
           PartitionMetrics.unbindDatabaseRelatedMetricsWhenUpdate(


### PR DESCRIPTION
The process of creating partitions might throw some NPEs when the corresponding database is deleted logically. Thus, we add some logs for clearing the bug suspicion.