### PR TITLE
Remove useless metrics in AggTableScan and make the TimeseriesMetadataCache get time as FI level

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceContext.java
@@ -766,7 +766,9 @@ public class FragmentInstanceContext extends QueryContext {
         .recordTimeSeriesMetadataMetrics(
             getQueryStatistics().getLoadTimeSeriesMetadataFromCacheCount().get(),
             getQueryStatistics().getLoadTimeSeriesMetadataFromDiskCount().get(),
-            getQueryStatistics().getLoadTimeSeriesMetadataActualIOSize().get());
+            getQueryStatistics().getLoadTimeSeriesMetadataActualIOSize().get(),
+            getQueryStatistics().getLoadTimeSeriesMetadataFromCacheTime().get(),
+            getQueryStatistics().getLoadTimeSeriesMetadataFromDiskTime().get());
 
     SeriesScanCostMetricSet.getInstance()
         .recordConstructChunkReadersCount(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryStatistics.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryStatistics.java
@@ -54,7 +54,9 @@ public class QueryStatistics {
   private final AtomicLong loadTimeSeriesMetadataAlignedMemUnSeqTime = new AtomicLong(0);
 
   private final AtomicLong loadTimeSeriesMetadataFromCacheCount = new AtomicLong(0);
+  private final AtomicLong loadTimeSeriesMetadataFromCacheTime = new AtomicLong(0);
   private final AtomicLong loadTimeSeriesMetadataFromDiskCount = new AtomicLong(0);
+  private final AtomicLong loadTimeSeriesMetadataFromDiskTime = new AtomicLong(0);
   private final AtomicLong loadTimeSeriesMetadataActualIOSize = new AtomicLong(0);
 
   // statistics for count and time of construct chunk readers(disk io and decompress)
@@ -274,8 +276,16 @@ public class QueryStatistics {
     return loadTimeSeriesMetadataFromCacheCount;
   }
 
+  public AtomicLong getLoadTimeSeriesMetadataFromCacheTime() {
+    return loadTimeSeriesMetadataFromCacheTime;
+  }
+
   public AtomicLong getLoadTimeSeriesMetadataFromDiskCount() {
     return loadTimeSeriesMetadataFromDiskCount;
+  }
+
+  public AtomicLong getLoadTimeSeriesMetadataFromDiskTime() {
+    return loadTimeSeriesMetadataFromDiskTime;
   }
 
   public TQueryStatistics toThrift() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/TableAggregator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/TableAggregator.java
@@ -37,7 +37,6 @@ import static java.util.Objects.requireNonNull;
 import static org.apache.iotdb.db.queryengine.execution.aggregation.TreeAggregator.QUERY_EXECUTION_METRICS;
 import static org.apache.iotdb.db.queryengine.execution.operator.source.relational.TableScanOperator.TIME_COLUMN_TEMPLATE;
 import static org.apache.iotdb.db.queryengine.metric.QueryExecutionMetricSet.AGGREGATION_FROM_RAW_DATA;
-import static org.apache.iotdb.db.queryengine.metric.QueryExecutionMetricSet.AGGREGATION_FROM_STATISTICS;
 
 public class TableAggregator {
   private final TableAccumulator accumulator;
@@ -106,13 +105,7 @@ public class TableAggregator {
   }
 
   public void processStatistics(Statistics[] statistics) {
-    long startTime = System.nanoTime();
-    try {
-      accumulator.addStatistics(statistics);
-    } finally {
-      QUERY_EXECUTION_METRICS.recordExecutionCost(
-          AGGREGATION_FROM_STATISTICS, System.nanoTime() - startTime);
-    }
+    accumulator.addStatistics(statistics);
   }
 
   public boolean hasFinalResult() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/metric/SeriesScanCostMetricSet.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/metric/SeriesScanCostMetricSet.java
@@ -416,7 +416,7 @@ public class SeriesScanCostMetricSet implements IMetricSet {
             TIMESERIES_METADATA);
     loadTimeSeriesMetadataFromCacheTimer =
         metricService.getOrCreateTimer(
-            Metric.METRIC_QUERY_CACHE.toString(),
+            Metric.METRIC_QUERY_CACHE_TIMER.toString(),
             MetricLevel.IMPORTANT,
             Tag.TYPE.toString(),
             TIMESERIES_METADATA,
@@ -424,7 +424,7 @@ public class SeriesScanCostMetricSet implements IMetricSet {
             CACHE);
     loadTimeSeriesMetadataFromDiskTimer =
         metricService.getOrCreateTimer(
-            Metric.METRIC_QUERY_CACHE.toString(),
+            Metric.METRIC_QUERY_CACHE_TIMER.toString(),
             MetricLevel.IMPORTANT,
             Tag.TYPE.toString(),
             TIMESERIES_METADATA,
@@ -460,14 +460,14 @@ public class SeriesScanCostMetricSet implements IMetricSet {
         TIMESERIES_METADATA);
     metricService.remove(
         MetricType.TIMER,
-        Metric.METRIC_QUERY_CACHE.toString(),
+        Metric.METRIC_QUERY_CACHE_TIMER.toString(),
         Tag.TYPE.toString(),
         TIMESERIES_METADATA,
         Tag.FROM.toString(),
         CACHE);
     metricService.remove(
         MetricType.TIMER,
-        Metric.METRIC_QUERY_CACHE.toString(),
+        Metric.METRIC_QUERY_CACHE_TIMER.toString(),
         Tag.TYPE.toString(),
         TIMESERIES_METADATA,
         Tag.FROM.toString(),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/buffer/TimeSeriesMetadataCache.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/buffer/TimeSeriesMetadataCache.java
@@ -241,7 +241,7 @@ public class TimeSeriesMetadataCache {
         queryContext
             .getQueryStatistics()
             .getLoadTimeSeriesMetadataFromCacheTime()
-            .getAndAdd(System.nanoTime() - startTime);
+            .getAndAdd(System.nanoTime() - startTime - loadBloomFilterTime);
       } else {
         queryContext
             .getQueryStatistics()
@@ -250,7 +250,7 @@ public class TimeSeriesMetadataCache {
         queryContext
             .getQueryStatistics()
             .getLoadTimeSeriesMetadataFromDiskTime()
-            .getAndAdd(System.nanoTime() - startTime);
+            .getAndAdd(System.nanoTime() - startTime - loadBloomFilterTime);
       }
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/buffer/TimeSeriesMetadataCache.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/buffer/TimeSeriesMetadataCache.java
@@ -27,7 +27,6 @@ import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.db.conf.DataNodeMemoryConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.queryengine.execution.fragment.QueryContext;
-import org.apache.iotdb.db.queryengine.metric.SeriesScanCostMetricSet;
 import org.apache.iotdb.db.queryengine.metric.TimeSeriesMetadataCacheMetrics;
 import org.apache.iotdb.db.storageengine.dataregion.read.control.FileReaderManager;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileID;
@@ -55,8 +54,6 @@ import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongConsumer;
 
-import static org.apache.iotdb.db.queryengine.metric.SeriesScanCostMetricSet.READ_TIMESERIES_METADATA_CACHE;
-import static org.apache.iotdb.db.queryengine.metric.SeriesScanCostMetricSet.READ_TIMESERIES_METADATA_FILE;
 import static org.apache.tsfile.utils.RamUsageEstimator.sizeOfCharArray;
 
 /**
@@ -72,9 +69,6 @@ public class TimeSeriesMetadataCache {
       IoTDBDescriptor.getInstance().getMemoryConfig();
   private static final IMemoryBlock CACHE_MEMORY_BLOCK;
   private static final boolean CACHE_ENABLE = memoryConfig.isMetaDataCacheEnable();
-
-  private static final SeriesScanCostMetricSet SERIES_SCAN_COST_METRIC_SET =
-      SeriesScanCostMetricSet.getInstance();
 
   private final Cache<TimeSeriesMetadataCacheKey, TimeseriesMetadata> lruCache;
 
@@ -244,17 +238,19 @@ public class TimeSeriesMetadataCache {
             .getQueryStatistics()
             .getLoadTimeSeriesMetadataFromCacheCount()
             .incrementAndGet();
-        // in metric panel, loading BloomFilter time is included in loading TimeSeriesMetadata
-        SERIES_SCAN_COST_METRIC_SET.recordSeriesScanCost(
-            READ_TIMESERIES_METADATA_CACHE, System.nanoTime() - startTime);
+        queryContext
+            .getQueryStatistics()
+            .getLoadTimeSeriesMetadataFromCacheTime()
+            .getAndAdd(System.nanoTime() - startTime);
       } else {
         queryContext
             .getQueryStatistics()
             .getLoadTimeSeriesMetadataFromDiskCount()
             .incrementAndGet();
-        // in metric panel, loading BloomFilter time is included in loading TimeSeriesMetadata
-        SERIES_SCAN_COST_METRIC_SET.recordSeriesScanCost(
-            READ_TIMESERIES_METADATA_FILE, System.nanoTime() - startTime);
+        queryContext
+            .getQueryStatistics()
+            .getLoadTimeSeriesMetadataFromDiskTime()
+            .getAndAdd(System.nanoTime() - startTime);
       }
     }
   }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/metric/enums/Metric.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/metric/enums/Metric.java
@@ -111,6 +111,7 @@ public enum Metric {
   MEMORY_USAGE_MONITOR("memory_usage_monitor"),
   METRIC_LOAD_TIME_SERIES_METADATA("metric_load_time_series_metadata"),
   METRIC_QUERY_CACHE("metric_query_cache"),
+  METRIC_QUERY_CACHE_TIMER("metric_query_cache_timer"),
   QUERY_METADATA_COST("query_metadata_cost"),
   DISPATCHER("dispatcher"),
   QUERY_EXECUTION("query_execution"),


### PR DESCRIPTION
## Description


### Content1 ...
1. Remove useless statistics metrics calc logic in AggTableScanOperator.
2. Make the TimeseriesMetadataCache get time as FI level.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [x] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
