### PR TITLE
Optimize query execution in easy count(*) cases

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceContext.java
@@ -68,6 +68,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.iotdb.db.queryengine.metric.DriverSchedulerMetricSet.BLOCK_QUEUED_TIME;
 import static org.apache.iotdb.db.queryengine.metric.DriverSchedulerMetricSet.READY_QUEUED_TIME;
+import static org.apache.iotdb.db.storageengine.dataregion.VirtualDataRegion.EMPTY_QUERY_DATA_SOURCE;
 import static org.apache.iotdb.db.utils.ErrorHandlingUtils.getRootCause;
 import static org.apache.iotdb.rpc.TSStatusCode.DATE_OUT_OF_RANGE;
 
@@ -452,6 +453,7 @@ public class FragmentInstanceContext extends QueryContext {
   public void initQueryDataSource(List<IFullPath> sourcePaths) throws QueryProcessException {
     long startTime = System.nanoTime();
     if (sourcePaths == null || sourcePaths.isEmpty()) {
+      this.sharedQueryDataSource = EMPTY_QUERY_DATA_SOURCE;
       return;
     }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/buffer/TimeSeriesMetadataCache.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/buffer/TimeSeriesMetadataCache.java
@@ -126,8 +126,8 @@ public class TimeSeriesMetadataCache {
         queryContext.getQueryStatistics().getLoadBloomFilterActualIOSize()::addAndGet;
     boolean cacheHit = true;
     try {
-      String deviceStringFormat = key.device.toString();
       if (!CACHE_ENABLE) {
+        String deviceStringFormat = key.device.toString();
         cacheHit = false;
 
         // bloom filter part
@@ -158,6 +158,7 @@ public class TimeSeriesMetadataCache {
           DEBUG_LOGGER.info("Cache miss: {}.{} in file: {}", key.device, key.measurement, filePath);
           DEBUG_LOGGER.info("Device: {}, all sensors: {}", key.device, allSensors);
         }
+        String deviceStringFormat = key.device.toString();
         // allow for the parallelism of different devices
         synchronized (
             devices.computeIfAbsent(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/VirtualDataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/VirtualDataRegion.java
@@ -41,7 +41,7 @@ public class VirtualDataRegion implements IDataRegionForQuery {
 
   private static final String VIRTUAL_DB_NAME = "root.__virtual";
 
-  private static final QueryDataSource EMPTY_QUERY_DATA_SOURCE =
+  public static final QueryDataSource EMPTY_QUERY_DATA_SOURCE =
       new QueryDataSource(Collections.emptyList(), Collections.emptyList());
 
   private static final QueryDataSourceForRegionScan EMPTY_REGION_QUERY_DATA_SOURCE =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
@@ -634,10 +634,10 @@ public class TsFileResource implements PersistentResource {
 
   // cannot use FileTimeIndex
   public long getOrderTimeForSeq(IDeviceID deviceId, boolean ascending) {
-    if (timeIndex instanceof ArrayDeviceTimeIndex && !definitelyNotContains(deviceId)) {
-      // checked above
-      //noinspection OptionalGetWithoutIsPresent
-      return ascending ? getStartTime(deviceId).get() : getEndTime(deviceId).get();
+    if (timeIndex instanceof ArrayDeviceTimeIndex) {
+      return ascending
+          ? timeIndex.getStartTime(deviceId).orElse(Long.MIN_VALUE)
+          : timeIndex.getEndTime(deviceId).orElse(Long.MAX_VALUE);
     } else {
       return ascending ? Long.MIN_VALUE : Long.MAX_VALUE;
     }
@@ -645,12 +645,15 @@ public class TsFileResource implements PersistentResource {
 
   // can use FileTimeIndex
   public long getOrderTimeForUnseq(IDeviceID deviceId, boolean ascending) {
-    if (!definitelyNotContains(deviceId)) {
-      // checked above
-      //noinspection OptionalGetWithoutIsPresent
-      return ascending ? getStartTime(deviceId).get() : getEndTime(deviceId).get();
+    if (timeIndex instanceof ArrayDeviceTimeIndex) {
+      if (ascending) {
+        return timeIndex.getStartTime(deviceId).orElse(Long.MIN_VALUE);
+      } else {
+        return timeIndex.getEndTime(deviceId).orElse(Long.MAX_VALUE);
+      }
     } else {
-      return ascending ? Long.MIN_VALUE : Long.MAX_VALUE;
+      // FileTimeIndex
+      return ascending ? getFileStartTime() : getFileEndTime();
     }
   }
 
@@ -1000,21 +1003,22 @@ public class TsFileResource implements PersistentResource {
       return false;
     }
 
-    // check above
-    long startTime = getStartTime(deviceId).get();
-    long endTime = isClosed() || !isSeq ? getEndTime(deviceId).get() : Long.MAX_VALUE;
-    if (startTime > endTime) {
-      // startTime > endTime indicates that there is something wrong with this TsFile. Return false
-      // directly, or it may lead to infinite loop in GroupByMonthFilter#getTimePointPosition.
-      LOGGER.warn(
-          "startTime[{}] of TsFileResource[{}] is greater than its endTime[{}]",
-          startTime,
-          this,
-          endTime);
-      return false;
-    }
-
     if (timeFilter != null) {
+      // check above
+      long startTime = getStartTime(deviceId).get();
+      long endTime = isClosed() || !isSeq ? getEndTime(deviceId).get() : Long.MAX_VALUE;
+      if (startTime > endTime) {
+        // startTime > endTime indicates that there is something wrong with this TsFile. Return
+        // false
+        // directly, or it may lead to infinite loop in GroupByMonthFilter#getTimePointPosition.
+        LOGGER.warn(
+            "startTime[{}] of TsFileResource[{}] is greater than its endTime[{}]",
+            startTime,
+            this,
+            endTime);
+        return false;
+      }
+
       boolean res = timeFilter.satisfyStartEndTime(startTime, endTime);
       if (debug && !res) {
         DEBUG_LOGGER.info(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/timeindex/ArrayDeviceTimeIndex.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/timeindex/ArrayDeviceTimeIndex.java
@@ -375,18 +375,22 @@ public class ArrayDeviceTimeIndex implements ITimeIndex {
 
   @Override
   public Optional<Long> getStartTime(IDeviceID deviceId) {
-    if (!deviceToIndex.containsKey(deviceId)) {
+    Integer index = deviceToIndex.get(deviceId);
+    if (index == null) {
       return Optional.empty();
+    } else {
+      return Optional.of(startTimes[index]);
     }
-    return Optional.of(startTimes[deviceToIndex.get(deviceId)]);
   }
 
   @Override
   public Optional<Long> getEndTime(IDeviceID deviceId) {
-    if (!deviceToIndex.containsKey(deviceId)) {
+    Integer index = deviceToIndex.get(deviceId);
+    if (index == null) {
       return Optional.empty();
+    } else {
+      return Optional.of(endTimes[index]);
     }
-    return Optional.of(endTimes[deviceToIndex.get(deviceId)]);
   }
 
   @Override


### PR DESCRIPTION
If all seq data, and compaction is well done, we will only need to get one TimeSeriesMetadata to calcuate count for each device. However, according to the profiler result, we found a lot of overhead in SeriesScanUtil, in this pr we will try to save the useless code execution.
1. needless set in initQueryDatasource in some cases
2. save device.toString() if cache hit in TimeSeriesMetadataCache
3. use result of map.get() to judge whether a key exists instead of using map,containsKey before calling map.get

![image](https://github.com/user-attachments/assets/ea1b56d1-a943-4d2b-af89-5070fabc05ad)
