### PR TITLE
RegionMigrateProcedure and RegionReconstructProcedure no longer acquire lock

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
@@ -831,10 +831,6 @@ public class ConfigNodeProcedureEnv {
     return scheduler;
   }
 
-  public LockQueue getRegionMigrateLock() {
-    return regionMaintainHandler.getRegionMigrateLock();
-  }
-
   public ReentrantLock getSchedulerLock() {
     return schedulerLock;
   }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RegionMaintainHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RegionMaintainHandler.java
@@ -45,7 +45,6 @@ import org.apache.iotdb.confignode.consensus.request.write.partition.RemoveRegio
 import org.apache.iotdb.confignode.manager.ConfigManager;
 import org.apache.iotdb.confignode.manager.load.cache.consensus.ConsensusGroupHeartbeatSample;
 import org.apache.iotdb.confignode.procedure.exception.ProcedureException;
-import org.apache.iotdb.confignode.procedure.scheduler.LockQueue;
 import org.apache.iotdb.mpp.rpc.thrift.TCreatePeerReq;
 import org.apache.iotdb.mpp.rpc.thrift.TMaintainPeerReq;
 import org.apache.iotdb.mpp.rpc.thrift.TRegionLeaderChangeResp;
@@ -77,9 +76,6 @@ public class RegionMaintainHandler {
   private static final ConfigNodeConfig CONF = ConfigNodeDescriptor.getInstance().getConf();
 
   private final ConfigManager configManager;
-
-  /** region migrate lock */
-  private final LockQueue regionMigrateLock = new LockQueue();
 
   private final IClientManager<TEndPoint, SyncDataNodeInternalServiceClient> dataNodeClientManager;
 
@@ -447,10 +443,6 @@ public class RegionMaintainHandler {
 
   public boolean isFailed(TSStatus status) {
     return !isSucceed(status);
-  }
-
-  public LockQueue getRegionMigrateLock() {
-    return regionMigrateLock;
   }
 
   /**

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/region/RegionMigrateProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/region/RegionMigrateProcedure.java
@@ -27,7 +27,6 @@ import org.apache.iotdb.commons.utils.ThriftCommonsSerDeUtils;
 import org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv;
 import org.apache.iotdb.confignode.procedure.env.RegionMaintainHandler;
 import org.apache.iotdb.confignode.procedure.exception.ProcedureException;
-import org.apache.iotdb.confignode.procedure.state.ProcedureLockState;
 import org.apache.iotdb.confignode.procedure.state.RegionTransitionState;
 import org.apache.iotdb.confignode.procedure.store.ProcedureType;
 import org.apache.iotdb.db.utils.DateTimeUtils;
@@ -141,38 +140,6 @@ public class RegionMigrateProcedure extends RegionOperationProcedure<RegionTrans
   @Override
   protected void rollbackState(ConfigNodeProcedureEnv env, RegionTransitionState state)
       throws IOException, InterruptedException, ProcedureException {}
-
-  @Override
-  protected ProcedureLockState acquireLock(ConfigNodeProcedureEnv configNodeProcedureEnv) {
-    configNodeProcedureEnv.getSchedulerLock().lock();
-    try {
-      if (configNodeProcedureEnv.getRegionMigrateLock().tryLock(this)) {
-        LOGGER.info("procedureId {} acquire lock.", getProcId());
-        return ProcedureLockState.LOCK_ACQUIRED;
-      }
-      configNodeProcedureEnv.getRegionMigrateLock().waitProcedure(this);
-
-      LOGGER.info("procedureId {} wait for lock.", getProcId());
-      return ProcedureLockState.LOCK_EVENT_WAIT;
-    } finally {
-      configNodeProcedureEnv.getSchedulerLock().unlock();
-    }
-  }
-
-  @Override
-  protected void releaseLock(ConfigNodeProcedureEnv configNodeProcedureEnv) {
-    configNodeProcedureEnv.getSchedulerLock().lock();
-    try {
-      LOGGER.info("procedureId {} release lock.", getProcId());
-      if (configNodeProcedureEnv.getRegionMigrateLock().releaseLock(this)) {
-        configNodeProcedureEnv
-            .getRegionMigrateLock()
-            .wakeWaitingProcedures(configNodeProcedureEnv.getScheduler());
-      }
-    } finally {
-      configNodeProcedureEnv.getSchedulerLock().unlock();
-    }
-  }
 
   @Override
   protected RegionTransitionState getState(int stateId) {


### PR DESCRIPTION
There are two reasons:
- The concurrency control for region migration and reconstruction has already been handled at a higher level, see ProcedureManager.regionOperationCommonCheck).
- This part of the code conflicts with the unified lock management implemented at the Dec of 2024 (#14250), which may lead to one procedure being executed by multiple threads simultaneously.