### PR TITLE
Trim port in stop scripts & data dir

### DIFF
--- a/iotdb-core/confignode/src/assembly/resources/sbin/stop-confignode.bat
+++ b/iotdb-core/confignode/src/assembly/resources/sbin/stop-confignode.bat
@@ -37,6 +37,18 @@ for /f  "eol=; tokens=2,2 delims==" %%i in ('findstr /i "^cn_internal_port"
 "%config_file%"') do (
   set cn_internal_port=%%i
 )
+@REM trim the port
+:delLeft1
+if "%cn_internal_port:~0,1%"==" " (
+    set "cn_internal_port=%cn_internal_port:~1%"
+    goto delLeft1
+)
+
+:delRight1
+if "%cn_internal_port:~-1%"==" " (
+    set "cn_internal_port=%cn_internal_port:~0,-1%"
+    goto delRight1
+)
 
 if not defined cn_internal_port (
   echo "WARNING: cn_internal_port not found in the configuration file. Using default value cn_internal_port = 10710"
@@ -45,17 +57,8 @@ if not defined cn_internal_port (
 
 echo "check whether the cn_internal_port is used..., port is %cn_internal_port%"
 
-for /f  "eol=; tokens=2,2 delims==" %%i in ('findstr /i "cn_internal_address"
-"%config_file%"') do (
-  set cn_internal_address=%%i
-)
-
-if not defined cn_internal_address (
-  echo "WARNING: cn_internal_address not found in the configuration file. Using default value cn_internal_address = 127.0.0.1"
-  set cn_internal_address=127.0.0.1
-)
-
-for /f "tokens=5" %%a in ('netstat /ano ^| findstr %cn_internal_address%:%cn_internal_port% ^| findstr LISTENING ') do (
+echo %cn_internal_address%:%cn_internal_port%;
+for /f "tokens=5" %%a in ('netstat /ano ^| findstr :%cn_internal_port% ^| findstr LISTENING ') do (
   taskkill /f /pid %%a
     echo "close ConfigNode, PID:" %%a
 )

--- a/iotdb-core/confignode/src/assembly/resources/sbin/stop-confignode.sh
+++ b/iotdb-core/confignode/src/assembly/resources/sbin/stop-confignode.sh
@@ -24,11 +24,11 @@ CONFIGNODE_CONF="$(dirname "$0")/../conf"
 if [ -f "${CONFIGNODE_CONF}/iotdb-system.properties" ]; then
     cn_internal_port=$(sed '/^cn_internal_port=/!d;s/.*=//' "${CONFIGNODE_CONF}"/iotdb-system.properties)
     # trim the port
-    cn_internal_port=$(echo "cn_internal_port" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+    cn_internal_port=$(echo "$cn_internal_port" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
 else
     cn_internal_port=$(sed '/^cn_internal_port=/!d;s/.*=//' "${CONFIGNODE_CONF}"/iotdb-confignode.properties)
     # trim the port
-    cn_internal_port=$(echo "cn_internal_port" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+    cn_internal_port=$(echo "$cn_internal_port" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
 fi
 
 if [ -z "$cn_internal_port" ]; then

--- a/iotdb-core/confignode/src/assembly/resources/sbin/stop-confignode.sh
+++ b/iotdb-core/confignode/src/assembly/resources/sbin/stop-confignode.sh
@@ -23,8 +23,12 @@ CONFIGNODE_CONF="$(dirname "$0")/../conf"
 
 if [ -f "${CONFIGNODE_CONF}/iotdb-system.properties" ]; then
     cn_internal_port=$(sed '/^cn_internal_port=/!d;s/.*=//' "${CONFIGNODE_CONF}"/iotdb-system.properties)
+    # trim the port
+    cn_internal_port=$(echo "cn_internal_port" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
 else
     cn_internal_port=$(sed '/^cn_internal_port=/!d;s/.*=//' "${CONFIGNODE_CONF}"/iotdb-confignode.properties)
+    # trim the port
+    cn_internal_port=$(echo "cn_internal_port" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
 fi
 
 if [ -z "$cn_internal_port" ]; then

--- a/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.sh
+++ b/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.sh
@@ -163,7 +163,7 @@ get_first_data_dir() {
     fi
 
     # trim the dir
-    data_dir_value=$(echo "data_dir_value" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+    data_dir_value=$(echo "$data_dir_value" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
 
     if [[ "$data_dir_value" == /* ]]; then
         echo "$data_dir_value"

--- a/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.sh
+++ b/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.sh
@@ -162,6 +162,9 @@ get_first_data_dir() {
         data_dir_value=$(echo "$data_dir_value" | cut -d',' -f1)
     fi
 
+    # trim the dir
+    data_dir_value=$(echo "data_dir_value" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+
     if [[ "$data_dir_value" == /* ]]; then
         echo "$data_dir_value"
     else

--- a/iotdb-core/datanode/src/assembly/resources/sbin/stop-datanode.bat
+++ b/iotdb-core/datanode/src/assembly/resources/sbin/stop-datanode.bat
@@ -42,6 +42,17 @@ for /f  "eol=# tokens=2 delims==" %%i in ('findstr /i "^dn_rpc_port"
 "%config_file%"') do (
   set dn_rpc_port=%%i
 )
+@REM trim the port
+:delLeft1
+if "%dn_rpc_port:~0,1%"==" " (
+    set "dn_rpc_port=%dn_rpc_port:~1%"
+    goto delLeft1
+)
+:delRight1
+if "%dn_rpc_port:~-1%"==" " (
+    set "dn_rpc_port=%dn_rpc_port:~0,-1%"
+    goto delRight1
+)
 
 if not defined dn_rpc_port (
   echo "WARNING: dn_rpc_port not found in the configuration file. Using default value dn_rpc_port = 6667"
@@ -50,17 +61,7 @@ if not defined dn_rpc_port (
 
 echo Check whether the rpc_port is used..., port is %dn_rpc_port%
 
-for /f  "eol=# tokens=2 delims==" %%i in ('findstr /i "dn_rpc_address"
-"%config_file%"') do (
-  set dn_rpc_address=%%i
-)
-
-if not defined dn_rpc_address (
-  echo "WARNING: dn_rpc_address not found in the configuration file. Using default value dn_rpc_address = 0.0.0.0"
-  set dn_rpc_address=0.0.0.0
-)
-
-for /f "tokens=5" %%a in ('netstat /ano ^| findstr %dn_rpc_address%:%dn_rpc_port%') do (
+for /f "tokens=5" %%a in ('netstat /ano ^| findstr :%dn_rpc_port% ') do (
   taskkill /f /pid %%a
   echo Close DataNode, PID: %%a
 )

--- a/iotdb-core/datanode/src/assembly/resources/sbin/stop-datanode.sh
+++ b/iotdb-core/datanode/src/assembly/resources/sbin/stop-datanode.sh
@@ -23,8 +23,12 @@ DATANODE_CONF="`dirname "$0"`/../conf"
 
 if [ -f "${DATANODE_CONF}/iotdb-system.properties" ]; then
     dn_rpc_port=`sed '/^dn_rpc_port=/!d;s/.*=//' ${DATANODE_CONF}/iotdb-system.properties`
+    # trim the port
+    dn_rpc_port=$(echo "$dn_rpc_port" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
 else
     dn_rpc_port=`sed '/^dn_rpc_port=/!d;s/.*=//' ${DATANODE_CONF}/iotdb-datanode.properties`
+    # trim the port
+    dn_rpc_port=$(echo "$dn_rpc_port" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
 fi
 
 if [ -z "$dn_rpc_port" ]; then

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -1893,6 +1893,9 @@ public class IoTDBDescriptor {
     String[][] tierDataDirs = new String[tiers.length][];
     for (int i = 0; i < tiers.length; ++i) {
       tierDataDirs[i] = tiers[i].split(",");
+      for (int j = 0; j < tierDataDirs[i].length; j++) {
+        tierDataDirs[i][j] = tierDataDirs[i][j].trim();
+      }
     }
     return tierDataDirs;
   }


### PR DESCRIPTION
The scripts of stopping data nodes and config nodes use port from the configuration file but do not trim it, 
which may cause a failure of matching the port in config and the port of the node.

The same occurs when datanode-env.sh tries to make the dir for heap dump.