### PR TITLE
Fix database hint of CLI when change sql_dialect back to table

### DIFF
--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBConnection.java
@@ -644,8 +644,11 @@ public class IoTDBConnection implements Connection {
     params.setDb(database);
   }
 
-  protected void changeDefaultSqlDialect(String sqlDialect) {
-    params.setSqlDialect(sqlDialect);
+  protected void mayChangeDefaultSqlDialect(String sqlDialect) {
+    if (!sqlDialect.equals(params.getSqlDialect())) {
+      params.setSqlDialect(sqlDialect);
+      params.setDb(null);
+    }
   }
 
   public int getTimeFactor() {

--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
@@ -330,7 +330,7 @@ public class IoTDBStatement implements Statement {
     }
 
     if (execResp.isSetTableModel()) {
-      connection.changeDefaultSqlDialect(execResp.tableModel ? TABLE : TREE);
+      connection.mayChangeDefaultSqlDialect(execResp.tableModel ? TABLE : TREE);
     }
 
     if (execResp.isSetColumns()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/session/IClientSession.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/session/IClientSession.java
@@ -153,6 +153,13 @@ public abstract class IClientSession {
 
   public void setSqlDialect(SqlDialect sqlDialect) {
     this.sqlDialect = sqlDialect;
+    this.databaseName = null;
+  }
+
+  public void setSqlDialectAndClean(SqlDialect sqlDialect) {
+    this.sqlDialect = sqlDialect;
+    // clean database to avoid misuse of it between different SqlDialect
+    this.databaseName = null;
   }
 
   public void setSqlDialectAndClean(SqlDialect sqlDialect) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/session/IClientSession.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/session/IClientSession.java
@@ -153,7 +153,6 @@ public abstract class IClientSession {
 
   public void setSqlDialect(SqlDialect sqlDialect) {
     this.sqlDialect = sqlDialect;
-    this.databaseName = null;
   }
 
   public void setSqlDialectAndClean(SqlDialect sqlDialect) {


### PR DESCRIPTION
Cause: CLI get the current db from JDBC client, we don't clean db in it when change sql_dialect.
Fix: clean databaseName in JDBC client when change sql_dialect
Verify: 
<img width="866" alt="image" src="https://github.com/user-attachments/assets/3cdf8541-2b2e-43c8-a1c7-24bdd0dc50b4" />
