### PR TITLE
Fix null timestamp

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/session/IoTDBSessionRelationalIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/session/IoTDBSessionRelationalIT.java
@@ -267,25 +267,19 @@ public class IoTDBSessionRelationalIT {
         session.executeNonQueryStatement("insert into wrong_time values(1+1,'bb','cc','dd')");
         fail("No exception thrown");
       } catch (StatementExecutionException e) {
-        assertEquals(
-            "701: Unsupported expression: (1 + 1)",
-            e.getMessage());
+        assertEquals("701: Unsupported expression: (1 + 1)", e.getMessage());
       }
       try {
         session.executeNonQueryStatement("insert into wrong_time values(1.0,'bb','cc','dd')");
         fail("No exception thrown");
       } catch (StatementExecutionException e) {
-        assertEquals(
-            "701: Unsupported expression: 1E0",
-            e.getMessage());
+        assertEquals("701: Unsupported expression: 1E0", e.getMessage());
       }
       try {
         session.executeNonQueryStatement("insert into wrong_time values(true,'bb','cc','dd')");
         fail("No exception thrown");
       } catch (StatementExecutionException e) {
-        assertEquals(
-            "701: Unsupported expression: true",
-            e.getMessage());
+        assertEquals("701: Unsupported expression: true", e.getMessage());
       }
       session.executeNonQueryStatement("drop table wrong_time");
     }

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/session/IoTDBSessionRelationalIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/session/IoTDBSessionRelationalIT.java
@@ -233,6 +233,65 @@ public class IoTDBSessionRelationalIT {
   }
 
   @Test
+  public void insertAllNullSqlTest() throws IoTDBConnectionException, StatementExecutionException {
+    try (ITableSession session = EnvFactory.getEnv().getTableSessionConnection()) {
+      session.executeNonQueryStatement("USE \"db1\"");
+      session.executeNonQueryStatement(
+          "create table all_null(color string tag, device_id string tag,city string attribute)");
+      try {
+        session.executeNonQueryStatement("insert into all_null values(null,null,null,null)");
+        fail("No exception thrown");
+      } catch (StatementExecutionException e) {
+        assertEquals("701: Timestamp cannot be null", e.getMessage());
+      }
+      session.executeNonQueryStatement("drop table all_null");
+    }
+  }
+
+  @Test
+  public void insertWrongTimeSqlTest()
+      throws IoTDBConnectionException, StatementExecutionException {
+    try (ITableSession session = EnvFactory.getEnv().getTableSessionConnection()) {
+      session.executeNonQueryStatement("USE \"db1\"");
+      session.executeNonQueryStatement(
+          "create table wrong_time(color string tag, device_id string tag,city string attribute)");
+      try {
+        session.executeNonQueryStatement("insert into wrong_time values('aa','bb','cc','dd')");
+        fail("No exception thrown");
+      } catch (StatementExecutionException e) {
+        assertEquals(
+            "701: Input time format aa error. Input like yyyy-MM-dd HH:mm:ss, yyyy-MM-ddTHH:mm:ss or refer to user document for more info.",
+            e.getMessage());
+      }
+      try {
+        session.executeNonQueryStatement("insert into wrong_time values(1+1,'bb','cc','dd')");
+        fail("No exception thrown");
+      } catch (StatementExecutionException e) {
+        assertEquals(
+            "701: Unsupported expression: (1 + 1)",
+            e.getMessage());
+      }
+      try {
+        session.executeNonQueryStatement("insert into wrong_time values(1.0,'bb','cc','dd')");
+        fail("No exception thrown");
+      } catch (StatementExecutionException e) {
+        assertEquals(
+            "701: Unsupported expression: 1E0",
+            e.getMessage());
+      }
+      try {
+        session.executeNonQueryStatement("insert into wrong_time values(true,'bb','cc','dd')");
+        fail("No exception thrown");
+      } catch (StatementExecutionException e) {
+        assertEquals(
+            "701: Unsupported expression: true",
+            e.getMessage());
+      }
+      session.executeNonQueryStatement("drop table wrong_time");
+    }
+  }
+
+  @Test
   public void insertRelationalSqlTest()
       throws IoTDBConnectionException, StatementExecutionException {
     try (ITableSession session = EnvFactory.getEnv().getTableSessionConnection()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/parser/AstBuilder.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/parser/AstBuilder.java
@@ -657,15 +657,7 @@ public class AstBuilder extends RelationalSqlBaseVisitor<Node> {
       Expression expression = expressions.get(i);
 
       if (columnSchema.getColumnCategory().equals(TIME)) {
-        if (expression instanceof LongLiteral) {
-          timestamp = ((LongLiteral) expression).getParsedValue();
-        } else {
-          timestamp =
-              parseDateTimeFormat(
-                  ((StringLiteral) expression).getValue(),
-                  CommonDateTimeUtils.currentTime(),
-                  zoneId);
-        }
+        timestamp = AstUtil.expressionToTimestamp(expression, zoneId);
       } else {
         Object value = AstUtil.expressionToTsValue(expression);
         nonTimeValues[nonTimeColumnIndex] = value;


### PR DESCRIPTION
Inserting a null timestamp via SQL will throw an unrecognizable exception.

It now throws a more clear semantic exception.