### PR TITLE
Fix BigArray NPE of some aggregation functions (first, last, sum, extreme) when groups are more than 1024 in aggregation query

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedExtremeAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedExtremeAccumulator.java
@@ -105,6 +105,7 @@ public class GroupedExtremeAccumulator implements GroupedAccumulator {
 
   @Override
   public void setGroupCount(long groupCount) {
+    inits.ensureCapacity(groupCount);
     switch (seriesDataType) {
       case INT32:
       case DATE:

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedFirstAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedFirstAccumulator.java
@@ -125,6 +125,7 @@ public class GroupedFirstAccumulator implements GroupedAccumulator {
 
   @Override
   public void setGroupCount(long groupCount) {
+    minTimes.ensureCapacity(groupCount);
     switch (seriesDataType) {
       case INT32:
       case DATE:

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedLastAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedLastAccumulator.java
@@ -125,6 +125,7 @@ public class GroupedLastAccumulator implements GroupedAccumulator {
 
   @Override
   public void setGroupCount(long groupCount) {
+    maxTimes.ensureCapacity(groupCount);
     switch (seriesDataType) {
       case INT32:
       case DATE:
@@ -439,9 +440,23 @@ public class GroupedLastAccumulator implements GroupedAccumulator {
 
   private void addFloatInput(
       int[] groupIds, Column valueColumn, Column timeColumn, AggregationMask mask) {
-    for (int i = 0; i < groupIds.length; i++) {
-      if (!valueColumn.isNull(i)) {
-        updateFloatValue(groupIds[i], valueColumn.getFloat(i), timeColumn.getLong(i));
+    int positionCount = mask.getSelectedPositionCount();
+
+    if (mask.isSelectAll()) {
+      for (int i = 0; i < positionCount; i++) {
+        if (!valueColumn.isNull(i)) {
+          updateFloatValue(groupIds[i], valueColumn.getFloat(i), timeColumn.getLong(i));
+        }
+      }
+    } else {
+      int[] selectedPositions = mask.getSelectedPositions();
+      int position;
+      for (int i = 0; i < positionCount; i++) {
+        position = selectedPositions[i];
+        if (!valueColumn.isNull(position)) {
+          updateFloatValue(
+              groupIds[position], valueColumn.getFloat(position), timeColumn.getLong(position));
+        }
       }
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedSumAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedSumAccumulator.java
@@ -48,6 +48,7 @@ public class GroupedSumAccumulator implements GroupedAccumulator {
 
   @Override
   public void setGroupCount(long groupCount) {
+    initResult.ensureCapacity(groupCount);
     sumValues.ensureCapacity(groupCount);
   }
 


### PR DESCRIPTION
As title.

Extra: this PR also fix some wrong in `GroupedFirstAccumulator`, it will not cause the incorrectness of query now, but if we introduce filter in AggFunction in later, it will cause.

