### PR TITLE
Fix: Null value settings not applying correctly in tablet.

### DIFF
--- a/iotdb-client/client-cpp/src/main/Session.cpp
+++ b/iotdb-client/client-cpp/src/main/Session.cpp
@@ -274,7 +274,7 @@ string SessionUtils::getValue(const Tablet &tablet) {
                         valueBuffer.putInt(valueBuf[index]);
                     }
                     else {
-                        valueBuffer.putInt((numeric_limits<int>::min)());
+                        valueBuffer.putInt((numeric_limits<int32_t>::min)());
                     }
                 }
                 break;
@@ -318,7 +318,11 @@ string SessionUtils::getValue(const Tablet &tablet) {
             case TSDataType::TEXT: {
                 string* valueBuf = (string*)(tablet.values[i]);
                 for (size_t index = 0; index < tablet.rowSize; index++) {
-                    valueBuffer.putString(valueBuf[index]);
+                    if (!bitMap.isMarked(index)) {
+                        valueBuffer.putString(valueBuf[index]);
+                    } else {
+                        valueBuffer.putString("");
+                    }
                 }
                 break;
             }
@@ -332,8 +336,8 @@ string SessionUtils::getValue(const Tablet &tablet) {
         valueBuffer.putChar(columnHasNull ? (char) 1 : (char) 0);
         if (columnHasNull) {
             const vector<char>& bytes = bitMap.getByteArray();
-            for (const char byte: bytes) {
-                valueBuffer.putChar(byte);
+            for (size_t index = 0; index < tablet.rowSize / 8 + 1; index++) {
+                valueBuffer.putChar(bytes[index]);
             }
         }
     }


### PR DESCRIPTION
## Description

Fixed an issue where tablet bitmap processing failed to handle null values correctly.


### Implementation Details
- **The tablet's bitmap is serialized according to tablet.rowSize, not the full byte length.**

### Testing
- Verified fix in test environment

<hr>

This PR has:
• [x] been self-reviewed.
- table model
```cpp
      
#include "TableSession.h"
#include "TableSessionBuilder.h"
#include <iostream>
#include <ostream>

using namespace std;

TableSession *session;

int main() {
    try {
        session = (new TableSessionBuilder())->build();
        try {
            session->executeNonQueryStatement("CREATE DATABASE test_insert_db1");
            session->executeNonQueryStatement("use test_insert_db1");
            session->executeNonQueryStatement("CREATE TABLE t1 (tag1 STRING TAG,attr1 STRING ATTRIBUTE,s1 BOOLEAN FIELD,s2 INT32 FIELD,s3 INT64 FIELD,s4 FLOAT FIELD,s5 DOUBLE FIELD,s6 TEXT FIELD)");
            // 构建Tablet
            vector<pair<string, TSDataType::TSDataType>> schemaList {
                make_pair("tag1", TSDataType::TEXT),
                make_pair("attr1", TSDataType::TEXT),
                make_pair("s1", TSDataType::BOOLEAN),
                make_pair("s2", TSDataType::INT32),
                make_pair("s3", TSDataType::INT64),
                make_pair("s4", TSDataType::FLOAT),
                make_pair("s5", TSDataType::DOUBLE),
                make_pair("s6", TSDataType::TEXT)
            };
            vector<ColumnCategory> columnTypes = {
                ColumnCategory::TAG,
                ColumnCategory::ATTRIBUTE,
                ColumnCategory::FIELD,
                ColumnCategory::FIELD,
                ColumnCategory::FIELD,
                ColumnCategory::FIELD,
                ColumnCategory::FIELD,
                ColumnCategory::FIELD
            };
            Tablet tablet("t1", schemaList, columnTypes, 100);

            // 写入包含时间戳的空值
            int64_t time = 0;
            for (int row = 0; row < 10; row++) {
                int rowIndex = tablet.rowSize++;
                tablet.timestamps[rowIndex] = time++;
                tablet.addValue("tag1", rowIndex, "tag1");
                tablet.addValue("attr1", rowIndex, "attr1");
                tablet.addValue("s1", rowIndex, true);
                tablet.addValue("s2", rowIndex, row);
                tablet.addValue("s3", rowIndex, int64_t(row));
                tablet.addValue("s4", rowIndex, 111.1F);
                tablet.addValue("s5", rowIndex, 111.1);
                tablet.addValue("s6", rowIndex, "test");
                if (row % 2 == 0) {
                    tablet.bitMaps[0].mark(row);
                    tablet.bitMaps[1].mark(row);
                    tablet.bitMaps[2].mark(row);
                    tablet.bitMaps[3].mark(row);
                    tablet.bitMaps[4].mark(row);
                    tablet.bitMaps[5].mark(row);
                    tablet.bitMaps[6].mark(row);
                    tablet.bitMaps[7].mark(row);
            }
            }
            session->insert(tablet);
        } catch (IoTDBException &e) {
            cout << e.what() << endl;
        }

        session->close();
    } catch (IoTDBConnectionException &e) {
        cout << e.what() << endl;
    }
    return 0;
}

    
```
![image](https://github.com/user-attachments/assets/3ec03ed2-04a5-42fe-a42d-e92b316245d6)
- tree model
```cpp
      
#include "Session.h"
#include <cstdint>

using namespace std;
Session *session;

int main() {
    session = new Session("127.0.0.1", 6667, "root", "root");
    session->open(false);
    session->createDatabase("root.test_db1");

    // 创建对齐时间序列
    vector<std::string> measurements;
    measurements.push_back("s1");
    measurements.push_back("s2");
    measurements.push_back("s3");
    measurements.push_back("s4");
    measurements.push_back("s5");
    measurements.push_back("s6");
    vector<TSDataType::TSDataType> dataTypes;
    dataTypes.push_back(TSDataType::BOOLEAN);
    dataTypes.push_back(TSDataType::INT32);
    dataTypes.push_back(TSDataType::INT64);
    dataTypes.push_back(TSDataType::FLOAT);
    dataTypes.push_back(TSDataType::DOUBLE);
    dataTypes.push_back(TSDataType::TEXT);
    vector<TSEncoding::TSEncoding> encodings;
    encodings.push_back(TSEncoding::PLAIN);
    encodings.push_back(TSEncoding::PLAIN);
    encodings.push_back(TSEncoding::PLAIN);
    encodings.push_back(TSEncoding::PLAIN);
    encodings.push_back(TSEncoding::PLAIN);
    encodings.push_back(TSEncoding::PLAIN);
    vector<CompressionType::CompressionType> compressors;
    compressors.push_back(CompressionType::LZ4);
    compressors.push_back(CompressionType::LZ4);
    compressors.push_back(CompressionType::LZ4);
    compressors.push_back(CompressionType::LZ4);
    compressors.push_back(CompressionType::LZ4);
    compressors.push_back(CompressionType::LZ4);
    // session->createAlignedTimeseries("root.test_db1.d1", measurements, dataTypes, encodings, compressors);

    // 创建非对齐时间序列
    vector<string> paths;
    paths.emplace_back("root.test_db1.d1.s1");
    paths.emplace_back("root.test_db1.d1.s2");
    paths.emplace_back("root.test_db1.d1.s3");
    paths.emplace_back("root.test_db1.d1.s4");
    paths.emplace_back("root.test_db1.d1.s5");
    paths.emplace_back("root.test_db1.d1.s6");
    vector<TSDataType::TSDataType> tsDataTypes;
    tsDataTypes.push_back(TSDataType::BOOLEAN);
    tsDataTypes.push_back(TSDataType::INT32);
    tsDataTypes.push_back(TSDataType::INT64);
    tsDataTypes.push_back(TSDataType::FLOAT);
    tsDataTypes.push_back(TSDataType::DOUBLE);
    tsDataTypes.push_back(TSDataType::TEXT);
    vector<TSEncoding::TSEncoding> tsEncodings;
    tsEncodings.push_back(TSEncoding::PLAIN);
    tsEncodings.push_back(TSEncoding::PLAIN);
    tsEncodings.push_back(TSEncoding::PLAIN);
    tsEncodings.push_back(TSEncoding::PLAIN);
    tsEncodings.push_back(TSEncoding::PLAIN);
    tsEncodings.push_back(TSEncoding::PLAIN);
    vector<CompressionType::CompressionType> compressionTypes;
    compressionTypes.push_back(CompressionType::LZ4);
    compressionTypes.push_back(CompressionType::LZ4);
    compressionTypes.push_back(CompressionType::LZ4);
    compressionTypes.push_back(CompressionType::LZ4);
    compressionTypes.push_back(CompressionType::LZ4);
    compressionTypes.push_back(CompressionType::LZ4);
    session->createMultiTimeseries(paths, dataTypes, encodings, compressors, nullptr, nullptr, nullptr, nullptr);

    // 构建tablet
    pair<string, TSDataType::TSDataType> pairA("s1", TSDataType::BOOLEAN);
    pair<string, TSDataType::TSDataType> pairB("s2", TSDataType::INT32);
    pair<string, TSDataType::TSDataType> pairC("s3", TSDataType::INT64);
    pair<string, TSDataType::TSDataType> pairD("s4", TSDataType::FLOAT);
    pair<string, TSDataType::TSDataType> pairE("s5", TSDataType::DOUBLE);
    pair<string, TSDataType::TSDataType> pairF("s6", TSDataType::TEXT);
    vector<pair<string, TSDataType::TSDataType>> schemas;
    schemas.push_back(pairA);
    schemas.push_back(pairB);
    schemas.push_back(pairC);
    schemas.push_back(pairD);
    schemas.push_back(pairE);
    schemas.push_back(pairF);
    Tablet tablet("root.test_db1.d1", schemas, 30);

    // 写入数据
    int64_t time = 0;
    for (int row = 0; row < 10; row++) {
        int rowIndex = tablet.rowSize++;
        tablet.timestamps[rowIndex] = time++;
        tablet.addValue("s1", rowIndex, true);
        tablet.addValue("s2", rowIndex, row);
        tablet.addValue("s3", rowIndex, int64_t(row));
        tablet.addValue("s4", rowIndex, 111.1F);
        tablet.addValue("s5", rowIndex, 111.1);
        tablet.addValue("s6", rowIndex, "text");
        // 标记空值
        if (row % 2 == 0) {
            tablet.bitMaps[0].mark(row);
            tablet.bitMaps[1].mark(row);
            tablet.bitMaps[2].mark(row);
            tablet.bitMaps[3].mark(row);
            tablet.bitMaps[4].mark(row);
            tablet.bitMaps[5].mark(row);
        }
    }

    // session->insertAlignedTablet(tablet, true);
    session->insertTablet(tablet, true);

    session->close();
}

    
```
![image](https://github.com/user-attachments/assets/f7d9c565-2995-4441-bd08-7ba60831a190)


<hr>

##### Key changed/added classes
- Tablet
- Tablet Serialize