### PR TITLE
Feature/node supplier

### DIFF
--- a/iotdb-client/client-cpp/pom.xml
+++ b/iotdb-client/client-cpp/pom.xml
@@ -176,6 +176,14 @@
                                     <destinationFile>${project.build.directory}/build/main/generated-sources-cpp/TableSessionBuilder.h</destinationFile>
                                 </fileSet>
                                 <fileSet>
+                                    <sourceFile>${project.basedir}/src/main/NodesSupplier.h</sourceFile>
+                                    <destinationFile>${project.build.directory}/build/main/generated-sources-cpp/NodesSupplier.h</destinationFile>
+                                </fileSet>
+                                <fileSet>
+                                    <sourceFile>${project.basedir}/src/main/ThriftConnection.h</sourceFile>
+                                    <destinationFile>${project.build.directory}/build/main/generated-sources-cpp/ThriftConnection.h</destinationFile>
+                                </fileSet>
+                                <fileSet>
                                     <sourceFile>${project.basedir}/src/main/AbstractSessionBuilder.h</sourceFile>
                                     <destinationFile>${project.build.directory}/build/main/generated-sources-cpp/AbstractSessionBuilder.h</destinationFile>
                                 </fileSet>

--- a/iotdb-client/client-cpp/pom.xml
+++ b/iotdb-client/client-cpp/pom.xml
@@ -180,8 +180,24 @@
                                     <destinationFile>${project.build.directory}/build/main/generated-sources-cpp/NodesSupplier.h</destinationFile>
                                 </fileSet>
                                 <fileSet>
+                                    <sourceFile>${project.basedir}/src/main/NodesSupplier.cpp</sourceFile>
+                                    <destinationFile>${project.build.directory}/build/main/generated-sources-cpp/NodesSupplier.cpp</destinationFile>
+                                </fileSet>
+                                <fileSet>
                                     <sourceFile>${project.basedir}/src/main/ThriftConnection.h</sourceFile>
                                     <destinationFile>${project.build.directory}/build/main/generated-sources-cpp/ThriftConnection.h</destinationFile>
+                                </fileSet>
+                                <fileSet>
+                                    <sourceFile>${project.basedir}/src/main/ThriftConnection.cpp</sourceFile>
+                                    <destinationFile>${project.build.directory}/build/main/generated-sources-cpp/ThriftConnection.cpp</destinationFile>
+                                </fileSet>
+                                <fileSet>
+                                    <sourceFile>${project.basedir}/src/main/SessionConnection.h</sourceFile>
+                                    <destinationFile>${project.build.directory}/build/main/generated-sources-cpp/SessionConnection.h</destinationFile>
+                                </fileSet>
+                                <fileSet>
+                                    <sourceFile>${project.basedir}/src/main/SessionConnection.cpp</sourceFile>
+                                    <destinationFile>${project.build.directory}/build/main/generated-sources-cpp/SessionConnection.cpp</destinationFile>
                                 </fileSet>
                                 <fileSet>
                                     <sourceFile>${project.basedir}/src/main/AbstractSessionBuilder.h</sourceFile>

--- a/iotdb-client/client-cpp/src/main/AbstractSessionBuilder.h
+++ b/iotdb-client/client-cpp/src/main/AbstractSessionBuilder.h
@@ -32,6 +32,8 @@ public:
     int fetchSize = 10000;
     std::string sqlDialect = "tree";
     std::string database = "";
+    bool enableAutoFetch = false;
+    bool enableRedirections = true;
 };
 
 #endif // IOTDB_ABSTRACTSESSIONBUILDER_H

--- a/iotdb-client/client-cpp/src/main/NodesSupplier.cpp
+++ b/iotdb-client/client-cpp/src/main/NodesSupplier.cpp
@@ -59,7 +59,11 @@ boost::optional<TEndPoint> DummyNodesSupplier::getQueryEndPoint() {
     }
 }
 
-DummyNodesSupplier::~DummyNodesSupplier() {}
+std::vector<TEndPoint> DummyNodesSupplier::getEndPointList() {
+    return availableNodes_;
+}
+
+DummyNodesSupplier::~DummyNodesSupplier() = default;
 
 std::shared_ptr<NodesSupplier> NodesSupplier::create(
     std::vector<TEndPoint> endpoints,
@@ -67,8 +71,7 @@ std::shared_ptr<NodesSupplier> NodesSupplier::create(
     int32_t thriftDefaultBufferSize, int32_t thriftMaxFrameSize,
     int32_t connectionTimeoutInMs, bool useSSL, bool enableRPCCompression,
     std::string version, std::chrono::milliseconds refreshInterval,
-    NodeSelectionPolicy policy
-) {
+    NodeSelectionPolicy policy) {
     if (endpoints.empty()) {
         return nullptr;
     }
@@ -92,7 +95,7 @@ NodesSupplier::NodesSupplier(
     deduplicateEndpoints();
 }
 
-std::vector<TEndPoint> NodesSupplier::getCurrentEndpoints() {
+std::vector<TEndPoint> NodesSupplier::getEndPointList() {
     std::lock_guard<std::mutex> lock(mutex);
     return endpoints;
 }

--- a/iotdb-client/client-cpp/src/main/NodesSupplier.cpp
+++ b/iotdb-client/client-cpp/src/main/NodesSupplier.cpp
@@ -1,0 +1,218 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "NodesSupplier.h"
+#include "Session.h"
+#include <algorithm>
+#include <iostream>
+#include <utility>
+
+const std::string NodesSupplier::SHOW_DATA_NODES_COMMAND = "SHOW DATANODES";
+const std::string NodesSupplier::STATUS_COLUMN_NAME = "Status";
+const std::string NodesSupplier::IP_COLUMN_NAME = "RpcAddress";
+const std::string NodesSupplier::PORT_COLUMN_NAME = "RpcPort";
+const std::string NodesSupplier::REMOVING_STATUS = "Removing";
+
+const int64_t NodesSupplier::TIMEOUT_IN_MS = 60000;
+const int NodesSupplier::FETCH_SIZE = 10000;
+const int NodesSupplier::THRIFT_DEFAULT_BUFFER_SIZE = 4096;
+const int NodesSupplier::THRIFT_MAX_FRAME_SIZE = 1048576;
+const int NodesSupplier::CONNECTION_TIMEOUT_IN_MS = 1000;
+
+TEndPoint RoundRobinPolicy::select(const std::vector<TEndPoint>& nodes) {
+    static std::atomic_uint index{0};
+
+    if (nodes.empty()) {
+        throw IoTDBException("No available nodes");
+    }
+
+    return nodes[index++ % nodes.size()];
+}
+
+DummyNodesSupplier::DummyNodesSupplier(const std::vector<TEndPoint>& nodes,
+                                       NodeSelectionPolicy policy)
+    : availableNodes_(nodes), policy_(std::move(policy)) {}
+
+boost::optional<TEndPoint> DummyNodesSupplier::getQueryEndPoint() {
+    try {
+        if (availableNodes_.empty()) {
+            return boost::none;
+        }
+        return policy_(availableNodes_);
+    } catch (const IoTDBException& e) {
+        return boost::none;
+    }
+}
+
+DummyNodesSupplier::~DummyNodesSupplier() {}
+
+std::shared_ptr<NodesSupplier> NodesSupplier::create(
+    std::vector<TEndPoint> endpoints,
+    std::string userName, std::string password, std::string zoneId,
+    int32_t thriftDefaultBufferSize, int32_t thriftMaxFrameSize,
+    int32_t connectionTimeoutInMs, bool useSSL, bool enableRPCCompression,
+    std::string version, std::chrono::milliseconds refreshInterval,
+    NodeSelectionPolicy policy
+) {
+    if (endpoints.empty()) {
+        return nullptr;
+    }
+    auto supplier = std::make_shared<NodesSupplier>(
+        userName, password, zoneId, thriftDefaultBufferSize,
+        thriftMaxFrameSize, connectionTimeoutInMs, useSSL,
+        enableRPCCompression, version, std::move(endpoints), std::move(policy)
+    );
+    supplier->startBackgroundRefresh(refreshInterval);
+    return supplier;
+}
+
+NodesSupplier::NodesSupplier(
+    std::string userName, std::string password, const std::string& zoneId,
+    int32_t thriftDefaultBufferSize, int32_t thriftMaxFrameSize,
+    int32_t connectionTimeoutInMs, bool useSSL, bool enableRPCCompression,
+    std::string version, std::vector<TEndPoint> endpoints, NodeSelectionPolicy policy) : userName(std::move(userName)), password(std::move(password)), zoneId(zoneId),
+    thriftDefaultBufferSize(thriftDefaultBufferSize), thriftMaxFrameSize(thriftMaxFrameSize),
+    connectionTimeoutInMs(connectionTimeoutInMs), useSSL(useSSL), enableRPCCompression(enableRPCCompression), version(version), endpoints(std::move(endpoints)),
+    selectionPolicy(std::move(policy)) {
+    deduplicateEndpoints();
+}
+
+std::vector<TEndPoint> NodesSupplier::getCurrentEndpoints() {
+    std::lock_guard<std::mutex> lock(mutex);
+    return endpoints;
+}
+
+TEndPoint NodesSupplier::selectQueryEndpoint() {
+    std::lock_guard<std::mutex> lock(mutex);
+    try {
+        return selectionPolicy(endpoints);
+    } catch (const std::exception& e) {
+        log_error("NodesSupplier::selectQueryEndpoint exception: %s", e.what());
+        throw IoTDBException("NodesSupplier::selectQueryEndpoint exception, " + std::string(e.what()));
+    }
+}
+
+boost::optional<TEndPoint> NodesSupplier::getQueryEndPoint() {
+    try {
+        return selectQueryEndpoint();
+    } catch (const IoTDBException& e) {
+        return boost::none;
+    }
+}
+
+NodesSupplier::~NodesSupplier() {
+    stopBackgroundRefresh();
+    client->close();
+}
+
+void NodesSupplier::deduplicateEndpoints() {
+    std::vector<TEndPoint> uniqueEndpoints;
+    uniqueEndpoints.reserve(endpoints.size());
+    for (const auto& endpoint : endpoints) {
+        if (std::find(uniqueEndpoints.begin(), uniqueEndpoints.end(), endpoint) == uniqueEndpoints.end()) {
+            uniqueEndpoints.push_back(endpoint);
+        }
+    }
+    endpoints = std::move(uniqueEndpoints);
+}
+
+void NodesSupplier::startBackgroundRefresh(std::chrono::milliseconds interval) {
+    isRunning = true;
+    refreshThread = std::thread([this, interval] {
+        while (isRunning) {
+            refreshEndpointList();
+            std::unique_lock<std::mutex> cvLock(this->mutex);
+            refreshCondition.wait_for(cvLock, interval, [this]() {
+                return !isRunning.load();
+            });
+        }
+    });
+}
+
+std::vector<TEndPoint> NodesSupplier::fetchLatestEndpoints() {
+    try {
+        if (client == nullptr) {
+            client = std::make_shared<ThriftConnection>(selectionPolicy(endpoints));
+            client->init(userName, password, enableRPCCompression, zoneId, version);
+        }
+
+        auto sessionDataSet = client->executeQueryStatement(SHOW_DATA_NODES_COMMAND);
+
+        uint32_t columnAddrIdx = -1, columnPortIdx = -1, columnStatusIdx = -1;
+        auto columnNames = sessionDataSet->getColumnNames();
+        for (uint32_t i = 0; i < columnNames.size(); i++) {
+            if (columnNames[i] == IP_COLUMN_NAME) {
+                columnAddrIdx = i;
+            } else if (columnNames[i] == PORT_COLUMN_NAME) {
+                columnPortIdx = i;
+            } else if (columnNames[i] == STATUS_COLUMN_NAME) {
+                columnStatusIdx = i;
+            }
+        }
+
+        if (columnAddrIdx == -1 || columnPortIdx == -1 || columnStatusIdx == -1) {
+            throw IoTDBException("Required columns not found in query result.");
+        }
+
+        std::vector<TEndPoint> ret;
+        while (sessionDataSet->hasNext()) {
+            RowRecord* record = sessionDataSet->next();
+            std::string ip = record->fields.at(columnAddrIdx).stringV;
+            int32_t port = record->fields.at(columnPortIdx).intV;
+            std::string status = record->fields.at(columnStatusIdx).stringV;
+
+            if (ip == "0.0.0.0" || status == REMOVING_STATUS) {
+                log_warn("Skipping invalid node: " + ip + ":" + to_string(port));
+                continue;
+            }
+            TEndPoint endpoint;
+            endpoint.ip = ip;
+            endpoint.port = port;
+            ret.emplace_back(endpoint);
+        }
+
+        return ret;
+    } catch (const IoTDBException& e) {
+        client.reset();
+        throw IoTDBException(std::string("NodesSupplier::fetchLatestEndpoints failed: ") + e.what());
+    }
+}
+
+void NodesSupplier::refreshEndpointList() {
+    try {
+        auto newEndpoints = fetchLatestEndpoints();
+        if (newEndpoints.empty()) {
+            return;
+        }
+
+        std::lock_guard<std::mutex> lock(mutex);
+        endpoints.swap(newEndpoints);
+        deduplicateEndpoints();
+    } catch (const IoTDBException& e) {
+        log_error(std::string("NodesSupplier::refreshEndpointList failed: ") + e.what());
+    }
+}
+
+void NodesSupplier::stopBackgroundRefresh() noexcept {
+    if (isRunning.exchange(false)) {
+        refreshCondition.notify_all();
+        if (refreshThread.joinable()) {
+            refreshThread.join();
+        }
+    }
+}

--- a/iotdb-client/client-cpp/src/main/NodesSupplier.h
+++ b/iotdb-client/client-cpp/src/main/NodesSupplier.h
@@ -40,11 +40,11 @@ public:
     const std::string IP_COLUMN_NAME = "RpcAddress";
     const std::string PORT_COLUMN_NAME = "RpcPort";
     const std::string REMOVING_STATUS = "Removing";
-    static constexpr int64_t TIMEOUT_IN_MS = 60000;
+    const int64_t TIMEOUT_IN_MS = 60000;
     const int FETCH_SIZE = 10000;
-    static constexpr THRIFT_DEFAULT_BUFFER_SIZE = 4096;
-    static constexpr THRIFT_MAX_FRAME_SIZE = 1048576;
-    static constexpr CONNECTION_TIMEOUT_IN_MS = 1000;
+    const int THRIFT_DEFAULT_BUFFER_SIZE = 4096;
+    const int THRIFT_MAX_FRAME_SIZE = 1048576;
+    const int CONNECTION_TIMEOUT_IN_MS = 1000;
     std::shared_ptr<ThriftConnection> client;
 
     std::string userName;

--- a/iotdb-client/client-cpp/src/main/NodesSupplier.h
+++ b/iotdb-client/client-cpp/src/main/NodesSupplier.h
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#pragma once
+#include <vector>
+#include <atomic>
+#include <mutex>
+#include <chrono>
+#include <thread>
+#include <functional>
+#include <condition_variable>
+#include <algorithm>
+
+#include "Session.h"
+
+class TEndPoint;
+
+class NodesSupplier {
+public:
+    using NodeSelectionPolicy = std::function<TEndPoint(const std::vector<TEndPoint>&)>;
+    
+    static std::shared_ptr<NodesSupplier> create(
+        std::vector<TEndPoint> endpoints,
+        std::chrono::seconds refreshInterval = std::chrono::seconds(5),
+        NodeSelectionPolicy policy = roundRobinPolicy) {
+        auto supplier = std::make_shared<NodesSupplier>(std::move(endpoints), std::move(policy));
+        supplier->startBackgroundRefresh(refreshInterval);
+        return supplier;
+    }
+
+    NodesSupplier(std::vector<TEndPoint> endpoints, NodeSelectionPolicy policy)
+        : endpoints(std::move(endpoints)), selectionPolicy(std::move(policy)) 
+    {
+        deduplicateEndpoints();
+    }
+
+    std::vector<TEndPoint> getCurrentEndpoints() const {
+        std::lock_guard<std::mutex> lock(mutex);
+        return endpoints;
+    }
+
+    TEndPoint selectQueryEndpoint() {
+        std::lock_guard<std::mutex> lock(mutex);
+        return selectionPolicy(endpoints);
+    }
+
+    ~NodesSupplier() {
+        stopBackgroundRefresh();
+    }
+
+private:
+    mutable std::mutex mutex;
+    std::vector<TEndPoint> endpoints;
+    NodeSelectionPolicy selectionPolicy;
+    
+    std::atomic_bool isRunning{false};
+    std::thread refreshThread;
+    std::condition_variable refreshCondition;
+
+    std::shared_ptr<IClientRPCServiceIf> rpcClient;
+
+    void deduplicateEndpoints() {
+        std::sort(endpoints.begin(), endpoints.end());
+        endpoints.erase(std::unique(endpoints.begin(), endpoints.end()), endpoints.end());
+    }
+
+    void startBackgroundRefresh(std::chrono::seconds interval) {
+        isRunning = true;
+        refreshThread = std::thread([this, interval] {
+            while (isRunning) {
+                refreshEndpointList();
+                
+                std::unique_lock<std::mutex> lock(mutex);
+                refreshCondition.wait_for(lock, interval, [this] { 
+                    return !isRunning.load(); 
+                });
+            }
+        });
+    }
+
+    std::vector<TEndPoint> fetchLatestEndpoints() {
+        // 实际实现需要连接服务端获取
+        return std::vector<TEndPoint>();
+    }
+
+    void refreshEndpointList() {
+        auto newEndpoints = fetchLatestEndpoints();
+        
+        std::lock_guard<std::mutex> lock(mutex);
+        endpoints.swap(newEndpoints);
+        deduplicateEndpoints();
+    }
+
+    void stopBackgroundRefresh() noexcept {
+        if (isRunning.exchange(false)) {
+            refreshCondition.notify_all();
+            if (refreshThread.joinable()) {
+                refreshThread.join();
+            }
+        }
+    }
+
+    static TEndPoint roundRobinPolicy(const std::vector<TEndPoint>& nodes) {
+        static std::atomic_uint roundRobinIndex{0};
+        if (nodes.empty()) {
+            throw std::runtime_error("No available nodes");
+        }
+        return nodes[roundRobinIndex++ % nodes.size()];
+    }
+};

--- a/iotdb-client/client-cpp/src/main/NodesSupplier.h
+++ b/iotdb-client/client-cpp/src/main/NodesSupplier.h
@@ -29,22 +29,13 @@
 #include <condition_variable>
 #include <algorithm>
 
-#include "Session.h"
 #include "ThriftConnection.h"
 
 class TEndPoint;
 
 class RoundRobinPolicy {
 public:
-    static TEndPoint select(const std::vector<TEndPoint>& nodes) {
-        static std::atomic_uint index{0};
-
-        if (nodes.empty()) {
-            throw IoTDBException("No available nodes");
-        }
-
-        return nodes[index++ % nodes.size()];
-    }
+    static TEndPoint select(const std::vector<TEndPoint>& nodes);
 };
 
 class INodesSupplier {
@@ -58,21 +49,11 @@ public:
 class DummyNodesSupplier : public INodesSupplier {
 public:
     explicit DummyNodesSupplier(const std::vector<TEndPoint>& nodes, 
-                                NodeSelectionPolicy policy = RoundRobinPolicy::select) 
-        : availableNodes_(nodes), policy_(std::move(policy)) {}
+                                NodeSelectionPolicy policy = RoundRobinPolicy::select);
 
-    boost::optional<TEndPoint> getQueryEndPoint() override {
-        try {
-            if (availableNodes_.empty()) {
-                return boost::none;
-            }
-            return policy_(availableNodes_);
-        } catch (const IoTDBException& e) {
-            return boost::none;
-        }
-    }
+    boost::optional<TEndPoint> getQueryEndPoint() override;
 
-    ~DummyNodesSupplier() override {}
+    ~DummyNodesSupplier() override;
 
 private:
     const std::vector<TEndPoint> availableNodes_;
@@ -92,8 +73,35 @@ public:
     static const int THRIFT_DEFAULT_BUFFER_SIZE;
     static const int THRIFT_MAX_FRAME_SIZE;
     static const int CONNECTION_TIMEOUT_IN_MS;
-    std::shared_ptr<ThriftConnection> client;
 
+    static std::shared_ptr<NodesSupplier> create(
+        std::vector<TEndPoint> endpoints,
+        std::string userName, std::string password, std::string zoneId = "",
+        int32_t thriftDefaultBufferSize = ThriftConnection::THRIFT_DEFAULT_BUFFER_SIZE,
+        int32_t thriftMaxFrameSize = ThriftConnection::THRIFT_MAX_FRAME_SIZE,
+        int32_t connectionTimeoutInMs = ThriftConnection::CONNECTION_TIMEOUT_IN_MS,
+        bool useSSL = false, bool enableRPCCompression = false,
+        std::string version = "V_1_0",
+        std::chrono::milliseconds refreshInterval = std::chrono::milliseconds(TIMEOUT_IN_MS),
+        NodeSelectionPolicy policy = RoundRobinPolicy::select
+    );
+
+    NodesSupplier(
+        std::string userName, std::string password, const std::string& zoneId,
+        int32_t thriftDefaultBufferSize, int32_t thriftMaxFrameSize,
+        int32_t connectionTimeoutInMs, bool useSSL, bool enableRPCCompression,
+        std::string version, std::vector<TEndPoint> endpoints, NodeSelectionPolicy policy
+    );
+
+    std::vector<TEndPoint> getCurrentEndpoints();
+
+    TEndPoint selectQueryEndpoint();
+
+    boost::optional<TEndPoint> getQueryEndPoint() override;
+
+    ~NodesSupplier() override;
+
+private:
     std::string userName;
     std::string password;
     int32_t thriftDefaultBufferSize;
@@ -103,166 +111,26 @@ public:
     bool enableRPCCompression;
     std::string version;
     std::string zoneId;
-    
-    static std::shared_ptr<NodesSupplier> create(std::vector<TEndPoint> endpoints,
-        std::string userName, std::string password, std::string zoneId = "",
-        int32_t thriftDefaultBufferSize = ThriftConnection::THRIFT_DEFAULT_BUFFER_SIZE,
-        int32_t thriftMaxFrameSize = ThriftConnection::THRIFT_MAX_FRAME_SIZE,
-        int32_t connectionTimeoutInMs = ThriftConnection::CONNECTION_TIMEOUT_IN_MS,
-        bool useSSL = false, bool enableRPCCompression = false,
-        std::string version = "V_1_0",
-        std::chrono::milliseconds refreshInterval = std::chrono::milliseconds(TIMEOUT_IN_MS),
-        NodeSelectionPolicy policy = RoundRobinPolicy::select) {
-        if (endpoints.empty()) {
-            return nullptr;
-        }
-        auto supplier = std::make_shared<NodesSupplier>(userName, password, zoneId, thriftDefaultBufferSize,
-            thriftMaxFrameSize, connectionTimeoutInMs, useSSL, enableRPCCompression, version, std::move(endpoints), std::move(policy));
-        supplier->startBackgroundRefresh(refreshInterval);
-        return supplier;
-    }
 
-    NodesSupplier(std::string userName, std::string password, std::string zoneId, int32_t thriftDefaultBufferSize,
-        int32_t thriftMaxFrameSize, int32_t connectionTimeoutInMs, bool useSSL, bool enableRPCCompression,
-        std::string version, std::vector<TEndPoint> endpoints, NodeSelectionPolicy policy) : userName(userName),
-            password(password), zoneId(zoneId),
-            thriftDefaultBufferSize(thriftDefaultBufferSize),
-            thriftMaxFrameSize(thriftMaxFrameSize), connectionTimeoutInMs(connectionTimeoutInMs),
-            useSSL(useSSL), enableRPCCompression(enableRPCCompression),
-            version(version), endpoints(std::move(endpoints)),
-            selectionPolicy(std::move(policy)){
-        deduplicateEndpoints();
-    }
-
-    std::vector<TEndPoint> getCurrentEndpoints() {
-        std::lock_guard<std::mutex> lock(mutex);
-        return endpoints;
-    }
-
-    TEndPoint selectQueryEndpoint() {
-        std::lock_guard<std::mutex> lock(mutex);
-        return selectionPolicy(endpoints);
-    }
-
-    boost::optional<TEndPoint> getQueryEndPoint() override {
-        try {
-            return selectQueryEndpoint();
-        } catch (const IoTDBException& e) {
-            return boost::none;
-        } catch (...) {
-            return boost::none;
-        }
-    }
-
-    ~NodesSupplier() override {
-        stopBackgroundRefresh();
-    }
-
-private:
     std::mutex mutex;
     std::vector<TEndPoint> endpoints;
     NodeSelectionPolicy selectionPolicy;
-    
+
     std::atomic<bool> isRunning{false};
     std::thread refreshThread;
     std::condition_variable refreshCondition;
 
-    std::shared_ptr<IClientRPCServiceIf> rpcClient;
+    std::shared_ptr<ThriftConnection> client;
 
-    void deduplicateEndpoints() {
-        std::vector<TEndPoint> uniqueEndpoints;
-        uniqueEndpoints.reserve(endpoints.size());
-        for (const auto& endpoint : endpoints) {
-            if (std::find(uniqueEndpoints.begin(), uniqueEndpoints.end(), endpoint) == uniqueEndpoints.end()) {
-                uniqueEndpoints.push_back(endpoint);
-            }
-        }
-        endpoints = std::move(uniqueEndpoints);
-    }
+    void deduplicateEndpoints();
 
-    void startBackgroundRefresh(std::chrono::milliseconds interval) {
-        isRunning = true;
-        refreshThread = std::thread([this, interval] {
-            while (isRunning) {
-                refreshEndpointList();
-                std::unique_lock<std::mutex> cvLock(this->mutex);
-                refreshCondition.wait_for(cvLock, interval, [this]() {
-                    return !isRunning.load();
-                });
-            }
-        });
-    }
+    void startBackgroundRefresh(std::chrono::milliseconds interval);
 
-    std::vector<TEndPoint> fetchLatestEndpoints() {
-        if (client == nullptr) {
-            client = std::make_shared<ThriftConnection>(selectionPolicy(endpoints));
-            client->init(userName, password, enableRPCCompression, zoneId, version);
-        }
-        unique_ptr<SessionDataSet> sessionDataSet = client->executeQueryStatement(SHOW_DATA_NODES_COMMAND);
-        uint32_t columnAddrIdx = -1, columnPortIdx = -1, columnStatusIdx = -1;
-        auto columnNames = sessionDataSet->getColumnNames();
-        for (uint32_t i = 0; i < columnNames.size(); i++) {
-            if (columnNames[i] == IP_COLUMN_NAME) {
-                columnAddrIdx = i;
-            } else if (columnNames[i] == PORT_COLUMN_NAME) {
-                columnPortIdx = i;
-            } else if (columnNames[i] == STATUS_COLUMN_NAME) {
-                columnStatusIdx = i;
-            }
-        }
-        std::vector<TEndPoint> ret;
-        try {
-            while (sessionDataSet->hasNext()) {
-                RowRecord* record = sessionDataSet->next();
-                std::string ip = record->fields.at(columnAddrIdx).stringV;
-                int32_t port = record->fields.at(columnPortIdx).intV;
-                if (ip == "0.0.0.0" || REMOVING_STATUS == record->fields.at(columnStatusIdx).stringV) {
-                    std::cout << ip << ":" << port << std::endl;
-                    continue;
-                }
-                TEndPoint endpoint;
-                endpoint.ip = ip;
-                endpoint.port = port;
-                ret.emplace_back(endpoint);
-            }
-        }
-        catch (exception& e) {
-            client.reset();
-            throw IoTDBException(std::string("NodesSupplier::fetchLatestEndpoints") + e.what());
-        }
-        return ret;
-    }
+    std::vector<TEndPoint> fetchLatestEndpoints();
 
-    void refreshEndpointList() {
-        auto newEndpoints = fetchLatestEndpoints();
-        if (newEndpoints.empty()) {
-            return;
-        }
-        std::lock_guard<std::mutex> lock(mutex);
-        endpoints.swap(newEndpoints);
-        deduplicateEndpoints();
-    }
+    void refreshEndpointList();
 
-    void stopBackgroundRefresh() noexcept {
-        if (isRunning.exchange(false)) {
-            refreshCondition.notify_all();
-            if (refreshThread.joinable()) {
-                refreshThread.join();
-            }
-        }
-    }
+    void stopBackgroundRefresh() noexcept;
 };
-
-const std::string NodesSupplier::SHOW_DATA_NODES_COMMAND = "SHOW DATANODES";
-const std::string NodesSupplier::STATUS_COLUMN_NAME = "Status";
-const std::string NodesSupplier::IP_COLUMN_NAME = "RpcAddress";
-const std::string NodesSupplier::PORT_COLUMN_NAME = "RpcPort";
-const std::string NodesSupplier::REMOVING_STATUS = "Removing";
-
-const int64_t NodesSupplier::TIMEOUT_IN_MS = 60000;
-const int NodesSupplier::FETCH_SIZE = 10000;
-const int NodesSupplier::THRIFT_DEFAULT_BUFFER_SIZE = 4096;
-const int NodesSupplier::THRIFT_MAX_FRAME_SIZE = 1048576;
-const int NodesSupplier::CONNECTION_TIMEOUT_IN_MS = 1000;
 
 #endif

--- a/iotdb-client/client-cpp/src/main/NodesSupplier.h
+++ b/iotdb-client/client-cpp/src/main/NodesSupplier.h
@@ -40,11 +40,11 @@ public:
     const std::string IP_COLUMN_NAME = "RpcAddress";
     const std::string PORT_COLUMN_NAME = "RpcPort";
     const std::string REMOVING_STATUS = "Removing";
-    const static int64_t TIMEOUT_IN_MS = 60000;
+    static constexpr int64_t TIMEOUT_IN_MS = 60000;
     const int FETCH_SIZE = 10000;
-    const static int THRIFT_DEFAULT_BUFFER_SIZE = 4096;
-    const static int THRIFT_MAX_FRAME_SIZE = 1048576;
-    const static int CONNECTION_TIMEOUT_IN_MS = 1000;
+    static constexpr THRIFT_DEFAULT_BUFFER_SIZE = 4096;
+    static constexpr THRIFT_MAX_FRAME_SIZE = 1048576;
+    static constexpr CONNECTION_TIMEOUT_IN_MS = 1000;
     std::shared_ptr<ThriftConnection> client;
 
     std::string userName;

--- a/iotdb-client/client-cpp/src/main/NodesSupplier.h
+++ b/iotdb-client/client-cpp/src/main/NodesSupplier.h
@@ -42,7 +42,7 @@ class INodesSupplier {
 public:
     virtual ~INodesSupplier() = default;
     virtual boost::optional<TEndPoint> getQueryEndPoint() = 0;
-
+    virtual std::vector<TEndPoint> getEndPointList() = 0;
     using NodeSelectionPolicy = std::function<TEndPoint(const std::vector<TEndPoint>&)>;
 };
 
@@ -52,6 +52,8 @@ public:
                                 NodeSelectionPolicy policy = RoundRobinPolicy::select);
 
     boost::optional<TEndPoint> getQueryEndPoint() override;
+
+    std::vector<TEndPoint> getEndPointList() override;
 
     ~DummyNodesSupplier() override;
 
@@ -92,10 +94,7 @@ public:
         int32_t connectionTimeoutInMs, bool useSSL, bool enableRPCCompression,
         std::string version, std::vector<TEndPoint> endpoints, NodeSelectionPolicy policy
     );
-
-    std::vector<TEndPoint> getCurrentEndpoints();
-
-    TEndPoint selectQueryEndpoint();
+    std::vector<TEndPoint> getEndPointList() override;
 
     boost::optional<TEndPoint> getQueryEndPoint() override;
 
@@ -129,6 +128,8 @@ private:
     std::vector<TEndPoint> fetchLatestEndpoints();
 
     void refreshEndpointList();
+
+    TEndPoint selectQueryEndpoint();
 
     void stopBackgroundRefresh() noexcept;
 };

--- a/iotdb-client/client-cpp/src/main/NodesSupplier.h
+++ b/iotdb-client/client-cpp/src/main/NodesSupplier.h
@@ -40,7 +40,7 @@ public:
     const std::string IP_COLUMN_NAME = "RpcAddress";
     const std::string PORT_COLUMN_NAME = "RpcPort";
     const std::string REMOVING_STATUS = "Removing";
-    const static int64_t TIMEOUT_IN_MS = 6000;
+    const static int64_t TIMEOUT_IN_MS = 60000;
     const int FETCH_SIZE = 10000;
     const static int THRIFT_DEFAULT_BUFFER_SIZE = 4096;
     const static int THRIFT_MAX_FRAME_SIZE = 1048576;

--- a/iotdb-client/client-cpp/src/main/NodesSupplier.h
+++ b/iotdb-client/client-cpp/src/main/NodesSupplier.h
@@ -35,16 +35,17 @@ class TEndPoint;
 
 class NodesSupplier {
 public:
-    const std::string SHOW_DATA_NODES_COMMAND = "SHOW DATANODES";
-    const std::string STATUS_COLUMN_NAME = "Status";
-    const std::string IP_COLUMN_NAME = "RpcAddress";
-    const std::string PORT_COLUMN_NAME = "RpcPort";
-    const std::string REMOVING_STATUS = "Removing";
-    const int64_t TIMEOUT_IN_MS = 60000;
-    const int FETCH_SIZE = 10000;
-    const int THRIFT_DEFAULT_BUFFER_SIZE = 4096;
-    const int THRIFT_MAX_FRAME_SIZE = 1048576;
-    const int CONNECTION_TIMEOUT_IN_MS = 1000;
+    static const std::string SHOW_DATA_NODES_COMMAND;
+    static const std::string STATUS_COLUMN_NAME;
+    static const std::string IP_COLUMN_NAME;
+    static const std::string PORT_COLUMN_NAME;
+    static const std::string REMOVING_STATUS;
+
+    static const int64_t TIMEOUT_IN_MS;
+    static const int FETCH_SIZE;
+    static const int THRIFT_DEFAULT_BUFFER_SIZE;
+    static const int THRIFT_MAX_FRAME_SIZE;
+    static const int CONNECTION_TIMEOUT_IN_MS;
     std::shared_ptr<ThriftConnection> client;
 
     std::string userName;
@@ -205,5 +206,17 @@ private:
         return nodes[roundRobinIndex++ % nodes.size()];
     }
 };
+
+const std::string NodesSupplier::SHOW_DATA_NODES_COMMAND = "SHOW DATANODES";
+const std::string NodesSupplier::STATUS_COLUMN_NAME = "Status";
+const std::string NodesSupplier::IP_COLUMN_NAME = "RpcAddress";
+const std::string NodesSupplier::PORT_COLUMN_NAME = "RpcPort";
+const std::string NodesSupplier::REMOVING_STATUS = "Removing";
+
+const int64_t NodesSupplier::TIMEOUT_IN_MS = 60000;
+const int NodesSupplier::FETCH_SIZE = 10000;
+const int NodesSupplier::THRIFT_DEFAULT_BUFFER_SIZE = 4096;
+const int NodesSupplier::THRIFT_MAX_FRAME_SIZE = 1048576;
+const int NodesSupplier::CONNECTION_TIMEOUT_IN_MS = 1000;
 
 #endif

--- a/iotdb-client/client-cpp/src/main/Session.h
+++ b/iotdb-client/client-cpp/src/main/Session.h
@@ -1080,13 +1080,12 @@ private:
 };
 
 class Session {
-public:
-    static const TSProtocolVersion::type protocolVersion = TSProtocolVersion::IOTDB_SERVICE_PROTOCOL_V3;
 private:
     std::string host;
     int rpcPort;
     std::string username;
     std::string password;
+    const TSProtocolVersion::type protocolVersion = TSProtocolVersion::IOTDB_SERVICE_PROTOCOL_V3;
     std::shared_ptr<IClientRPCServiceIf> client;
     std::shared_ptr<TTransport> transport;
     bool isClosed = true;

--- a/iotdb-client/client-cpp/src/main/Session.h
+++ b/iotdb-client/client-cpp/src/main/Session.h
@@ -1080,12 +1080,13 @@ private:
 };
 
 class Session {
+public:
+    static const TSProtocolVersion::type protocolVersion = TSProtocolVersion::IOTDB_SERVICE_PROTOCOL_V3;
 private:
     std::string host;
     int rpcPort;
     std::string username;
     std::string password;
-    const TSProtocolVersion::type protocolVersion = TSProtocolVersion::IOTDB_SERVICE_PROTOCOL_V3;
     std::shared_ptr<IClientRPCServiceIf> client;
     std::shared_ptr<TTransport> transport;
     bool isClosed = true;

--- a/iotdb-client/client-cpp/src/main/SessionConnection.cpp
+++ b/iotdb-client/client-cpp/src/main/SessionConnection.cpp
@@ -1,0 +1,212 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "SessionConnection.h"
+#include "Session.h"
+#include "common_types.h"
+#include <thrift/protocol/TCompactProtocol.h>
+
+using namespace apache::thrift;
+using namespace apache::thrift::protocol;
+using namespace apache::thrift::transport;
+
+SessionConnection::SessionConnection(const TEndPoint& endpoint,
+                     const std::string& zoneId,
+                     std::function<std::vector<TEndPoint>()> nodeSupplier,
+                     int maxRetries,
+                     int64_t retryInterval,
+                     std::string dialect,
+                     std::string db,
+                     std::string version,
+                     std::string username,
+                     std::string password,
+                     TSProtocolVersion::type protocolVersion)
+    : zoneId(zoneId),
+      endPoint(endpoint),
+      availableNodes(std::move(nodeSupplier)),
+      maxRetryCount(maxRetries),
+      retryIntervalMs(retryInterval),
+      sqlDialect(dialect),
+      database(db),
+      version(version),
+      userName(username),
+      password(password),
+      protocolVersion(protocolVersion){
+    this->zoneId = zoneId.empty() ? getSystemDefaultZoneId() : zoneId;
+    endPointList.push_back(endpoint);
+}
+
+void SessionConnection::close() {
+    bool needThrowException = false;
+    string errMsg;
+    try {
+        TSCloseSessionReq req;
+        req.__set_sessionId(sessionId);
+        TSStatus tsStatus;
+        client->closeSession(tsStatus, req);
+    } catch (const TTransportException &e) {
+        log_debug(e.what());
+        throw IoTDBConnectionException(e.what());
+    } catch (const exception &e) {
+        log_debug(e.what());
+        errMsg = errMsg + "Session::close() client->closeSession() error, maybe remote server is down. " + e.what() + "\n" ;
+        needThrowException = true;
+    }
+
+    try {
+        if (transport->isOpen()) {
+            transport->close();
+        }
+    }
+    catch (const exception &e) {
+        log_debug(e.what());
+        errMsg = errMsg + "Session::close() transport->close() error. " + e.what() + "\n" ;
+        needThrowException = true;
+    }
+
+    if (needThrowException) {
+        throw IoTDBException(errMsg);
+    }
+}
+
+SessionConnection::~SessionConnection() {
+    try {
+        close();
+    } catch (const exception &e) {
+        log_debug(e.what());
+    }
+}
+
+void SessionConnection::init(const TEndPoint& endpoint) {
+    shared_ptr<TSocket> socket(new TSocket(endpoint.ip, endpoint.port));
+    transport = std::make_shared<TFramedTransport>(socket);
+    socket->setConnTimeout(connectionTimeoutInMs);
+    if (!transport->isOpen()) {
+        try {
+            transport->open();
+        }
+        catch (TTransportException &e) {
+            log_debug(e.what());
+            throw IoTDBConnectionException(e.what());
+        }
+    }
+    if (enableRPCCompression) {
+        shared_ptr<TCompactProtocol> protocol(new TCompactProtocol(transport));
+        client = std::make_shared<IClientRPCServiceClient>(protocol);
+    } else {
+        shared_ptr<TBinaryProtocol> protocol(new TBinaryProtocol(transport));
+        client = std::make_shared<IClientRPCServiceClient>(protocol);
+    }
+
+    std::map<std::string, std::string> configuration;
+    configuration["version"] = version;
+    // configuration["sql_dialect"] = sqlDialect;
+    // if (database != "") {
+    //     configuration["db"] = database;
+    // }
+
+    TSOpenSessionReq openReq;
+    openReq.__set_username(userName);
+    openReq.__set_password(password);
+    openReq.__set_zoneId(zoneId);
+    openReq.__set_configuration(configuration);
+    std::cout << endPoint << " " << userName << " " << password << " " << zoneId << std::endl;
+    try {
+        TSOpenSessionResp openResp;
+        client->openSession(openResp, openReq);
+        RpcUtils::verifySuccess(openResp.status);
+        if (protocolVersion != openResp.serverProtocolVersion) {
+            if (openResp.serverProtocolVersion == 0) {// less than 0.10
+                throw logic_error(string("Protocol not supported, Client version is ") + to_string(protocolVersion) +
+                                  ", but Server version is " + to_string(openResp.serverProtocolVersion));
+            }
+        }
+
+        sessionId = openResp.sessionId;
+        statementId = client->requestStatementId(sessionId);
+
+        if (!zoneId.empty()) {
+            setTimeZone(zoneId);
+        }
+        inited = true;
+    } catch (const TTransportException &e) {
+        log_debug(e.what());
+        transport->close();
+        throw IoTDBConnectionException(e.what());
+    } catch (const IoTDBException &e) {
+        log_debug(e.what());
+        transport->close();
+        throw;
+    } catch (const exception &e) {
+        log_debug(e.what());
+        transport->close();
+        throw IoTDBException(e.what());
+    }
+}
+
+std::unique_ptr<SessionDataSet> SessionConnection::executeQueryStatement(const std::string& sql, int64_t timeoutInMs) {
+    TSExecuteStatementReq req;
+    req.__set_sessionId(sessionId);
+    req.__set_statementId(statementId);
+    req.__set_statement(sql);
+    req.__set_timeout(timeoutInMs);
+    req.__set_enableRedirectQuery(true);
+    TSExecuteStatementResp resp;
+    try {
+        client->executeStatement(resp, req);
+        RpcUtils::verifySuccessWithRedirection(resp.status);
+    } catch (const TException &e) {
+        throw IoTDBConnectionException(e.what());
+    }
+
+    std::shared_ptr<TSQueryDataSet> queryDataSet(new TSQueryDataSet(resp.queryDataSet));
+    return std::unique_ptr<SessionDataSet>(new SessionDataSet(
+            sql, resp.columns, resp.dataTypeList, resp.columnNameIndexMap, resp.ignoreTimeStamp, resp.queryId,
+            statementId, client, sessionId, queryDataSet));
+}
+
+const TEndPoint& SessionConnection::getEndPoint() {
+    return endPoint;
+}
+
+void SessionConnection::setTimeZone(const std::string& newZoneId) {
+    TSSetTimeZoneReq req;
+    req.__set_sessionId(sessionId);
+    req.__set_timeZone(newZoneId);
+
+    try {
+        TSStatus tsStatus;
+        client->setTimeZone(tsStatus, req);
+        zoneId = newZoneId;
+    } catch (const TException& e) {
+        throw IoTDBConnectionException(e.what());
+    }
+}
+
+std::string SessionConnection::getSystemDefaultZoneId() {
+    time_t ts = 0;
+    struct tm tmv{};
+#if defined(_WIN64) || defined (WIN32) || defined (_WIN32)
+    localtime_s(&tmv, &ts);
+#else
+    localtime_r(&ts, &tmv);
+#endif
+    char zoneStr[32];
+    strftime(zoneStr, sizeof(zoneStr), "%z", &tmv);
+    return zoneStr;
+}

--- a/iotdb-client/client-cpp/src/main/SessionConnection.h
+++ b/iotdb-client/client-cpp/src/main/SessionConnection.h
@@ -1,0 +1,132 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef IOTDB_SESSIONCONNECTION_H
+#define IOTDB_SESSIONCONNECTION_H
+
+#include <memory>
+#include <vector>
+#include <string>
+#include <functional>
+#include <thrift/transport/TTransport.h>
+#include "IClientRPCService.h"
+#include "common_types.h"
+
+class SessionDataSet;
+class Session;
+
+class SessionConnection {
+public:
+    SessionConnection() = default;
+
+    SessionConnection(const TEndPoint& endpoint,
+                     const std::string& zoneId,
+                     std::function<std::vector<TEndPoint>()> nodeSupplier,
+                     int maxRetries = 60,
+                     int64_t retryInterval = 500,
+                     std::string dialect = "tree",
+                     std::string db = "",
+                     std::string version = "V_1_0",
+                     std::string username = "root",
+                     std::string password = "root",
+                     TSProtocolVersion::type protocolVersion = TSProtocolVersion::IOTDB_SERVICE_PROTOCOL_V3);
+
+    ~SessionConnection();
+
+    void setTimeZone(const std::string& newZoneId);
+
+    void setEndpoint(const TEndPoint& endpoint) {
+        this->endPoint = endpoint;
+    }
+
+    void setZoneId(const std::string& zoneId) {
+        this->zoneId = zoneId;
+    }
+
+    void setNodeSupplier(std::function<std::vector<TEndPoint>()> nodeSupplier) {
+        this->availableNodes = nodeSupplier;
+    }
+
+    void setMaxRetries(int maxRetries) {
+        this->maxRetryCount = maxRetries;
+    }
+
+    void setRetryInterval(int64_t retryInterval) {
+        this->retryIntervalMs = retryInterval;
+    }
+
+    void setDialect(const std::string& dialect) {
+        this->sqlDialect = dialect;
+    }
+
+    void setDb(const std::string& db) {
+        this->database = db;
+    }
+
+    void setVersion(const std::string& version) {
+        this->version = version;
+    }
+
+    void setUsername(const std::string& username) {
+        this->userName = username;
+    }
+
+    void setPassword(const std::string& password) {
+        this->password = password;
+    }
+
+    void setProtocolVersion(const TSProtocolVersion::type& protocolVersion) {
+        this->protocolVersion = protocolVersion;
+    }
+
+    const TEndPoint& getEndPoint();
+
+    void init(const TEndPoint& endpoint);
+
+    bool isInitialized() const {
+        return inited;
+    }
+
+    std::unique_ptr<SessionDataSet> executeQueryStatement(const std::string& sql, int64_t timeoutInMs = -1);
+
+private:
+    void close();
+    std::string getSystemDefaultZoneId();
+
+    std::shared_ptr<apache::thrift::transport::TTransport> transport;
+    std::shared_ptr<IClientRPCServiceClient> client;
+    int64_t sessionId;
+    int64_t statementId;
+    int64_t connectionTimeoutInMs;
+    bool enableRPCCompression;
+    std::string zoneId;
+    TEndPoint endPoint;
+    std::vector<TEndPoint> endPointList;
+    std::function<std::vector<TEndPoint>()> availableNodes;
+    int maxRetryCount;
+    int64_t retryIntervalMs;
+    std::string sqlDialect;
+    std::string database;
+    std::string version;
+    std::string userName;
+    std::string password;
+    TSProtocolVersion::type protocolVersion;
+    bool inited = false;
+};
+
+#endif

--- a/iotdb-client/client-cpp/src/main/ThriftConnection.cpp
+++ b/iotdb-client/client-cpp/src/main/ThriftConnection.cpp
@@ -1,0 +1,158 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "ThriftConnection.h"
+#include <ctime>
+#include <iostream>
+#include <thrift/transport/TSocket.h>
+
+#include "Session.h"
+
+const int ThriftConnection::THRIFT_DEFAULT_BUFFER_SIZE = 4096;
+const int ThriftConnection::THRIFT_MAX_FRAME_SIZE = 1048576;
+const int ThriftConnection::CONNECTION_TIMEOUT_IN_MS = 1000;
+
+ThriftConnection::ThriftConnection(const TEndPoint& endPoint,
+                                   int thriftDefaultBufferSize,
+                                   int thriftMaxFrameSize,
+                                   int connectionTimeoutInMs)
+    : endPoint(endPoint),
+      thriftDefaultBufferSize(thriftDefaultBufferSize),
+      thriftMaxFrameSize(thriftMaxFrameSize),
+      connectionTimeoutInMs(connectionTimeoutInMs) {}
+
+ThriftConnection::~ThriftConnection() = default;
+
+void ThriftConnection::initZoneId() {
+    if (!zoneId.empty()) {
+        return;
+    }
+
+    time_t ts = 0;
+    struct tm tmv{};
+#if defined(_WIN64) || defined (WIN32) || defined (_WIN32)
+    localtime_s(&tmv, &ts);
+#else
+    localtime_r(&ts, &tmv);
+#endif
+
+    char zoneStr[32];
+    strftime(zoneStr, sizeof(zoneStr), "%z", &tmv);
+    zoneId = zoneStr;
+}
+
+void ThriftConnection::init(const std::string& username,
+                            const std::string& password,
+                            bool enableRPCCompression,
+                            const std::string& zoneId,
+                            const std::string& version) {
+    std::shared_ptr<TSocket> socket(new TSocket(endPoint.ip, endPoint.port));
+    socket->setConnTimeout(connectionTimeoutInMs);
+    transport = std::make_shared<TFramedTransport>(socket);
+    if (!transport->isOpen()) {
+        try {
+            transport->open();
+        }
+        catch (TTransportException &e) {
+            throw IoTDBConnectionException(e.what());
+        }
+    }
+    if (zoneId.empty()) {
+        initZoneId();
+    } else {
+        this->zoneId = zoneId;
+    }
+
+    if (enableRPCCompression) {
+        std::shared_ptr<TCompactProtocol> protocol(new TCompactProtocol(transport));
+        client = std::make_shared<IClientRPCServiceClient>(protocol);
+    } else {
+        std::shared_ptr<TBinaryProtocol> protocol(new TBinaryProtocol(transport));
+        client = std::make_shared<IClientRPCServiceClient>(protocol);
+    }
+
+    std::map<std::string, std::string> configuration;
+    configuration["version"] = version;
+    TSOpenSessionReq openReq;
+    openReq.__set_username(username);
+    openReq.__set_password(password);
+    openReq.__set_zoneId(this->zoneId);
+    openReq.__set_configuration(configuration);
+    try {
+        TSOpenSessionResp openResp;
+        client->openSession(openResp, openReq);
+        RpcUtils::verifySuccess(openResp.status);
+        sessionId = openResp.sessionId;
+        statementId = client->requestStatementId(sessionId);
+    } catch (const TTransportException &e) {
+        transport->close();
+        throw IoTDBConnectionException(e.what());
+    } catch (const IoTDBException &e) {
+        transport->close();
+        throw IoTDBException(e.what());
+    } catch (const std::exception &e) {
+        transport->close();
+        throw IoTDBException(e.what());
+    }
+}
+
+std::unique_ptr<SessionDataSet> ThriftConnection::executeQueryStatement(const std::string& sql, int64_t timeoutInMs) {
+    TSExecuteStatementReq req;
+    req.__set_sessionId(sessionId);
+    req.__set_statementId(statementId);
+    req.__set_statement(sql);
+    req.__set_timeout(timeoutInMs);
+    TSExecuteStatementResp resp;
+    try {
+        client->executeStatement(resp, req);
+        RpcUtils::verifySuccess(resp.status);
+    } catch (const TTransportException &e) {
+        throw IoTDBConnectionException(e.what());
+    } catch (const IoTDBException &e) {
+        throw IoTDBConnectionException(e.what());
+    } catch (const std::exception &e) {
+        throw IoTDBException(e.what());
+    }
+    std::shared_ptr<TSQueryDataSet> queryDataSet(new TSQueryDataSet(resp.queryDataSet));
+    return std::unique_ptr<SessionDataSet>(new SessionDataSet(
+            sql, resp.columns, resp.dataTypeList, resp.columnNameIndexMap, resp.ignoreTimeStamp, resp.queryId,
+            statementId, client, sessionId, queryDataSet));
+}
+
+void ThriftConnection::close() {
+    try {
+        if (client) {
+            TSCloseSessionReq req;
+            req.__set_sessionId(sessionId);
+            TSStatus tsStatus;
+            client->closeSession(tsStatus, req);
+        }
+    } catch (const TTransportException &e) {
+        throw IoTDBConnectionException(e.what());
+    } catch (const std::exception &e) {
+        throw IoTDBConnectionException(e.what());
+    }
+
+    try {
+        if (transport->isOpen()) {
+            transport->close();
+        }
+    } catch (const std::exception &e) {
+        throw IoTDBConnectionException(e.what());
+    }
+}

--- a/iotdb-client/client-cpp/src/main/ThriftConnection.h
+++ b/iotdb-client/client-cpp/src/main/ThriftConnection.h
@@ -28,9 +28,9 @@
 
 class ThriftConnection {
 public:
-    const static int THRIFT_DEFAULT_BUFFER_SIZE = 4096;
-    const static int THRIFT_MAX_FRAME_SIZE = 1048576;
-    const static int CONNECTION_TIMEOUT_IN_MS = 1000;
+    static constexpr int THRIFT_DEFAULT_BUFFER_SIZE = 4096;
+    static constexpr int THRIFT_MAX_FRAME_SIZE = 1048576;
+    static constexpr int CONNECTION_TIMEOUT_IN_MS = 1000;
 private:
     TEndPoint endPoint;
 

--- a/iotdb-client/client-cpp/src/main/ThriftConnection.h
+++ b/iotdb-client/client-cpp/src/main/ThriftConnection.h
@@ -28,9 +28,9 @@
 
 class ThriftConnection {
 public:
-    constexpr int THRIFT_DEFAULT_BUFFER_SIZE = 4096;
-    constexpr int THRIFT_MAX_FRAME_SIZE = 1048576;
-    constexpr int CONNECTION_TIMEOUT_IN_MS = 1000;
+    static constexpr int THRIFT_DEFAULT_BUFFER_SIZE;
+    static constexpr int THRIFT_MAX_FRAME_SIZE;
+    static constexpr int CONNECTION_TIMEOUT_IN_MS;
 private:
     TEndPoint endPoint;
 
@@ -187,5 +187,9 @@ public:
         }
     }
 };
+
+constexpr int ThriftConnection::THRIFT_DEFAULT_BUFFER_SIZE = 4096;
+constexpr int ThriftConnection::THRIFT_MAX_FRAME_SIZE = 1048576;
+constexpr int ThriftConnection::CONNECTION_TIMEOUT_IN_MS = 1000;
 
 #endif

--- a/iotdb-client/client-cpp/src/main/ThriftConnection.h
+++ b/iotdb-client/client-cpp/src/main/ThriftConnection.h
@@ -28,9 +28,9 @@
 
 class ThriftConnection {
 public:
-    static constexpr int THRIFT_DEFAULT_BUFFER_SIZE;
-    static constexpr int THRIFT_MAX_FRAME_SIZE;
-    static constexpr int CONNECTION_TIMEOUT_IN_MS;
+    static const int THRIFT_DEFAULT_BUFFER_SIZE;
+    static const int THRIFT_MAX_FRAME_SIZE;
+    static const int CONNECTION_TIMEOUT_IN_MS;
 private:
     TEndPoint endPoint;
 
@@ -188,8 +188,8 @@ public:
     }
 };
 
-constexpr int ThriftConnection::THRIFT_DEFAULT_BUFFER_SIZE = 4096;
-constexpr int ThriftConnection::THRIFT_MAX_FRAME_SIZE = 1048576;
-constexpr int ThriftConnection::CONNECTION_TIMEOUT_IN_MS = 1000;
+const int ThriftConnection::THRIFT_DEFAULT_BUFFER_SIZE = 4096;
+const int ThriftConnection::THRIFT_MAX_FRAME_SIZE = 1048576;
+const int ThriftConnection::CONNECTION_TIMEOUT_IN_MS = 1000;
 
 #endif

--- a/iotdb-client/client-cpp/src/main/ThriftConnection.h
+++ b/iotdb-client/client-cpp/src/main/ThriftConnection.h
@@ -28,9 +28,9 @@
 
 class ThriftConnection {
 public:
-    static constexpr int THRIFT_DEFAULT_BUFFER_SIZE = 4096;
-    static constexpr int THRIFT_MAX_FRAME_SIZE = 1048576;
-    static constexpr int CONNECTION_TIMEOUT_IN_MS = 1000;
+    constexpr int THRIFT_DEFAULT_BUFFER_SIZE = 4096;
+    constexpr int THRIFT_MAX_FRAME_SIZE = 1048576;
+    constexpr int CONNECTION_TIMEOUT_IN_MS = 1000;
 private:
     TEndPoint endPoint;
 

--- a/iotdb-client/client-cpp/src/main/ThriftConnection.h
+++ b/iotdb-client/client-cpp/src/main/ThriftConnection.h
@@ -1,0 +1,186 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#pragma once
+#include <memory>
+#include <thrift/transport/TSocket.h>
+#include <thrift/transport/TBufferTransports.h>
+#include <thrift/protocol/TCompactProtocol.h>
+#include "IClientRPCService.h"
+#include "Session.h"
+
+class ThriftConnection {
+private:
+    TEndPoint endPoint;
+    int thriftDefaultBufferSize;
+    int thriftMaxFrameSize;
+    int connectionTimeoutInMs;
+
+    std::shared_ptr<TTransport> transport;
+    std::shared_ptr<IClientRPCServiceClient> client;
+    int64_t sessionId;
+    int64_t statementId;
+    std::string zoneId;
+    int timeFactor;
+
+    void initZoneId() {
+        if (!zoneId.empty()) {
+            return;
+        }
+
+        time_t ts = 0;
+        struct tm tmv;
+#if defined(_WIN64) || defined (WIN32) || defined (_WIN32)
+        localtime_s(&tmv, &ts);
+#else
+        localtime_r(&ts, &tmv);
+#endif
+
+        char zoneStr[32];
+        strftime(zoneStr, sizeof(zoneStr), "%z", &tmv);
+        zoneId = zoneStr;
+    }
+
+public:
+    ThriftConnection(const TEndPoint& endPoint,
+                    int thriftDefaultBufferSize = 4096,
+                    int thriftMaxFrameSize = 1048576,
+                    int connectionTimeoutInMs = 0)
+        : endPoint(endPoint),
+          thriftDefaultBufferSize(thriftDefaultBufferSize),
+          thriftMaxFrameSize(thriftMaxFrameSize),
+          connectionTimeoutInMs(connectionTimeoutInMs) {}
+
+    void init(const std::string& username,
+             const std::string& password,
+             bool enableRPCCompression,
+             const std::string& zoneId,
+             const std::string& version) {
+        std::shared_ptr<TSocket> socket(new TSocket(endPoint.ip, endPoint.port));
+        socket->setConnTimeout(connectionTimeoutInMs);
+        transport = std::make_shared<TFramedTransport>(socket);
+        if (!transport->isOpen()) {
+            try {
+                transport->open();
+            }
+            catch (TTransportException &e) {
+                log_debug(e.what());
+                throw IoTDBConnectionException(e.what());
+            }
+        }
+        if (zoneId.empty()) {
+            initZoneId();
+        } else {
+            this->zoneId = zoneId;
+        }
+
+        if (enableRPCCompression) {
+            shared_ptr<TCompactProtocol> protocol(new TCompactProtocol(transport));
+            client = std::make_shared<IClientRPCServiceClient>(protocol);
+        } else {
+            shared_ptr<TBinaryProtocol> protocol(new TBinaryProtocol(transport));
+            client = std::make_shared<IClientRPCServiceClient>(protocol);
+        }
+
+        std::map<std::string, std::string> configuration;
+        configuration["version"] = version;
+        TSOpenSessionReq openReq;
+        openReq.__set_username(username);
+        openReq.__set_password(password);
+        openReq.__set_zoneId(zoneId);
+        openReq.__set_configuration(configuration);
+
+        try {
+            TSOpenSessionResp openResp;
+            client->openSession(openResp, openReq);
+            RpcUtils::verifySuccess(openResp.status);
+            if (Session::protocolVersion != openResp.serverProtocolVersion) {
+                if (openResp.serverProtocolVersion == 0) {// less than 0.10
+                    throw logic_error(string("Protocol not supported, Client version is ") + to_string(Session::protocolVersion) +
+                                      ", but Server version is " + to_string(openResp.serverProtocolVersion));
+                }
+            }
+            sessionId = openResp.sessionId;
+            statementId = client->requestStatementId(sessionId);
+        } catch (const TTransportException &e) {
+            log_debug(e.what());
+            transport->close();
+            throw IoTDBConnectionException(e.what());
+        } catch (const IoTDBException &e) {
+            log_debug(e.what());
+            transport->close();
+            throw IoTDBException(e.what());
+        } catch (const exception &e) {
+            log_debug(e.what());
+            transport->close();
+            throw IoTDBException(e.what());
+        }
+    }
+
+    unique_ptr<SessionDataSet> executeQueryStatement(const string &sql, int64_t timeoutInMs = -1) {
+        TSExecuteStatementReq req;
+        req.__set_sessionId(sessionId);
+        req.__set_statementId(statementId);
+        req.__set_statement(sql);
+        req.__set_timeout(timeoutInMs);
+        TSExecuteStatementResp resp;
+        try {
+            client->executeStatement(resp, req);
+            RpcUtils::verifySuccess(resp.status);
+        } catch (const TTransportException &e) {
+            log_debug(e.what());
+            throw IoTDBConnectionException(e.what());
+        } catch (const IoTDBException &e) {
+            log_debug(e.what());
+            throw;
+        }  catch (const exception &e) {
+            throw IoTDBException(e.what());
+        }
+        shared_ptr<TSQueryDataSet> queryDataSet(new TSQueryDataSet(resp.queryDataSet));
+        return unique_ptr<SessionDataSet>(new SessionDataSet(
+                sql, resp.columns, resp.dataTypeList, resp.columnNameIndexMap, resp.ignoreTimeStamp, resp.queryId,
+                statementId, client, sessionId, queryDataSet));
+    }
+
+    void close() {
+        try {
+            if (client) {
+                TSCloseSessionReq req;
+                req.__set_sessionId(sessionId);
+                TSStatus tsStatus;
+                client->closeSession(tsStatus, req);
+            }
+        } catch (const TTransportException &e) {
+            log_debug(e.what());
+            throw IoTDBConnectionException(e.what());
+        } catch (const exception &e) {
+            log_debug(e.what());
+            throw logic_error(std::string("Session::close() client->closeSession() error, maybe remote server is down. ") + e.what() + "\n");
+        }
+
+        try {
+            if (transport->isOpen()) {
+                transport->close();
+            }
+        }
+        catch (const exception &e) {
+            log_debug(e.what());
+            throw logic_error(std::string("Session::close() transport->close() error. ") + e.what() + "\n");
+        }
+    }
+};

--- a/iotdb-client/client-cpp/src/main/ThriftConnection.h
+++ b/iotdb-client/client-cpp/src/main/ThriftConnection.h
@@ -118,12 +118,6 @@ public:
             TSOpenSessionResp openResp;
             client->openSession(openResp, openReq);
             RpcUtils::verifySuccess(openResp.status);
-            if (Session::protocolVersion != openResp.serverProtocolVersion) {
-                if (openResp.serverProtocolVersion == 0) {
-                    throw IoTDBException(string("Protocol not supported, Client version is ") + to_string(Session::protocolVersion) +
-                                      ", but Server version is " + to_string(openResp.serverProtocolVersion));
-                }
-            }
             sessionId = openResp.sessionId;
             statementId = client->requestStatementId(sessionId);
         } catch (const TTransportException &e) {


### PR DESCRIPTION
**Commit message:**  
`Add failover support in IoTDB CPP client (NodeSupplier + reconnect + redirect)`  

## Key Changes  
• Implemented `NodeSupplier` with background refresh  
• Added connection retry with available nodes  
• Supported query redirection via `executeQueryStatementMayRedirect()`  

## Test Status  
✔ Basic tests passed (VS2022)  
⚠ Pending: Memory leak check & cluster tests  