### PR TITLE
Add some supplementary logs during partition allocation

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
@@ -403,7 +403,7 @@ public class PartitionManager {
               new TSStatus(TSStatusCode.DATABASE_NOT_EXIST.getStatusCode())
                   .setMessage(
                       String.format(
-                          "Create DataPartition failed because the database: %s is not exists",
+                          "Create DataPartition failed because the database: %s does not exist",
                           database)),
               false,
               null);

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
@@ -250,6 +250,21 @@ public class PartitionManager {
         return resp;
       }
 
+      // Here we check if the related Databases exist again,
+      // due to we don't have a transaction mechanism.
+      for (final String database : req.getPartitionSlotsMap().keySet()) {
+        if (!isDatabaseExist(database)) {
+          return new SchemaPartitionResp(
+              new TSStatus(TSStatusCode.DATABASE_NOT_EXIST.getStatusCode())
+                  .setMessage(
+                      String.format(
+                          "Create SchemaPartition failed because the database: %s is not exists",
+                          database)),
+              false,
+              null);
+        }
+      }
+
       // Filter unassigned SchemaPartitionSlots
       final Map<String, List<TSeriesPartitionSlot>> unassignedSchemaPartitionSlotsMap =
           partitionInfo.filterUnassignedSchemaPartitionSlots(req.getPartitionSlotsMap());
@@ -378,6 +393,21 @@ public class PartitionManager {
       resp = getDataPartition(req);
       if (resp.isAllPartitionsExist()) {
         return resp;
+      }
+
+      // Here we check if the related Databases exist again,
+      // due to we don't have a transaction mechanism.
+      for (final String database : req.getPartitionSlotsMap().keySet()) {
+        if (!isDatabaseExist(database)) {
+          return new DataPartitionResp(
+              new TSStatus(TSStatusCode.DATABASE_NOT_EXIST.getStatusCode())
+                  .setMessage(
+                      String.format(
+                          "Create DataPartition failed because the database: %s is not exists",
+                          database)),
+              false,
+              null);
+        }
       }
 
       // Filter unassigned DataPartitionSlots

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/partition/PartitionManager.java
@@ -258,7 +258,7 @@ public class PartitionManager {
               new TSStatus(TSStatusCode.DATABASE_NOT_EXIST.getStatusCode())
                   .setMessage(
                       String.format(
-                          "Create SchemaPartition failed because the database: %s is not exists",
+                          "Create SchemaPartition failed because the database: %s does not exist",
                           database)),
               false,
               null);

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/DeleteDatabaseProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/DeleteDatabaseProcedure.java
@@ -197,7 +197,9 @@ public class DeleteDatabaseProcedure
           env.getConfigManager()
               .getLoadManager()
               .clearDataPartitionPolicyTable(deleteDatabaseSchema.getName());
-          LOG.info("data partition policy table cleared.");
+          LOG.info(
+              "[DeleteDatabaseProcedure] The data partition policy table of database: {} is cleared.",
+              deleteDatabaseSchema.getName());
 
           // Delete Database metrics
           PartitionMetrics.unbindDatabaseRelatedMetricsWhenUpdate(


### PR DESCRIPTION
The process of creating partitions might throw some NPEs when the corresponding database is deleted logically. Thus, we add some logs for clearing the bug suspicion.