### PR TITLE
Harmonizing the case of reported error messages for aggregation 

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/AvgAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/AvgAccumulator.java
@@ -57,7 +57,7 @@ public class AvgAccumulator implements TableAccumulator {
 
   @Override
   public void addInput(Column[] arguments, AggregationMask mask) {
-    checkArgument(arguments.length == 1, "argument of Avg should be one column");
+    checkArgument(arguments.length == 1, "argument of AVG should be one column");
     switch (argumentDataType) {
       case INT32:
         addIntInput(arguments[0], mask);
@@ -85,7 +85,7 @@ public class AvgAccumulator implements TableAccumulator {
 
   @Override
   public void removeInput(Column[] arguments) {
-    checkArgument(arguments.length == 1, "argument of Avg should be one column");
+    checkArgument(arguments.length == 1, "argument of AVG should be one column");
     switch (argumentDataType) {
       case INT32:
         removeIntInput(arguments[0]);
@@ -117,7 +117,7 @@ public class AvgAccumulator implements TableAccumulator {
         argument instanceof BinaryColumn
             || (argument instanceof RunLengthEncodedColumn
                 && ((RunLengthEncodedColumn) argument).getValue() instanceof BinaryColumn),
-        "intermediate input and output of Avg should be BinaryColumn");
+        "intermediate input and output of AVG should be BinaryColumn");
 
     for (int i = 0; i < argument.getPositionCount(); i++) {
       if (argument.isNull(i)) {
@@ -136,7 +136,7 @@ public class AvgAccumulator implements TableAccumulator {
   public void evaluateIntermediate(ColumnBuilder columnBuilder) {
     checkArgument(
         columnBuilder instanceof BinaryColumnBuilder,
-        "intermediate input and output of Avg should be BinaryColumn");
+        "intermediate input and output of AVG should be BinaryColumn");
     if (!initResult) {
       columnBuilder.appendNull();
     } else {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/CountAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/CountAccumulator.java
@@ -42,7 +42,7 @@ public class CountAccumulator implements TableAccumulator {
 
   @Override
   public void addInput(Column[] arguments, AggregationMask mask) {
-    checkArgument(arguments.length == 1, "argument of Count should be one column");
+    checkArgument(arguments.length == 1, "argument of COUNT should be one column");
     int positionCount = mask.getSelectedPositionCount();
 
     if (mask.isSelectAll()) {
@@ -67,7 +67,7 @@ public class CountAccumulator implements TableAccumulator {
 
   @Override
   public void removeInput(Column[] arguments) {
-    checkArgument(arguments.length == 1, "argument of Count should be one column");
+    checkArgument(arguments.length == 1, "argument of COUNT should be one column");
     int count = arguments[0].getPositionCount();
     if (!arguments[0].mayHaveNull()) {
       countState -= count;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/CountAllAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/CountAllAccumulator.java
@@ -43,14 +43,14 @@ public class CountAllAccumulator implements TableAccumulator {
 
   @Override
   public void addInput(Column[] arguments, AggregationMask mask) {
-    checkArgument(arguments.length == 1, "argument of CountAll should be one column");
+    checkArgument(arguments.length == 1, "argument of COUNT should be one column");
     int count = mask.getSelectedPositionCount();
     countState += count;
   }
 
   @Override
   public void removeInput(Column[] arguments) {
-    checkArgument(arguments.length == 1, "argument of CountAll should be one column");
+    checkArgument(arguments.length == 1, "argument of COUNT should be one column");
     int count = arguments[0].getPositionCount();
     countState -= count;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/CountAllAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/CountAllAccumulator.java
@@ -43,14 +43,14 @@ public class CountAllAccumulator implements TableAccumulator {
 
   @Override
   public void addInput(Column[] arguments, AggregationMask mask) {
-    checkArgument(arguments.length == 1, "argument of COUNT should be one column");
+    checkArgument(arguments.length == 1, "argument of COUNT(*) should be one column");
     int count = mask.getSelectedPositionCount();
     countState += count;
   }
 
   @Override
   public void removeInput(Column[] arguments) {
-    checkArgument(arguments.length == 1, "argument of COUNT should be one column");
+    checkArgument(arguments.length == 1, "argument of COUNT(*) should be one column");
     int count = arguments[0].getPositionCount();
     countState -= count;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/ExtremeAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/ExtremeAccumulator.java
@@ -30,7 +30,7 @@ import org.apache.tsfile.write.UnSupportedDataTypeException;
 public class ExtremeAccumulator implements TableAccumulator {
   private static final long INSTANCE_SIZE =
       RamUsageEstimator.shallowSizeOfInstance(ExtremeAccumulator.class);
-  private static final String UNSUPPORTED_DATA_TYPE = "Unsupported data type in Extreme: %s";
+  private static final String UNSUPPORTED_DATA_TYPE = "Unsupported data type in EXTREME: %s";
   private final TSDataType seriesDataType;
   private final TsPrimitiveType extremeResult;
   private boolean initResult;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/FirstAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/FirstAccumulator.java
@@ -87,7 +87,7 @@ public class FirstAccumulator implements TableAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in First: %s", seriesDataType));
+            String.format("Unsupported data type in FIRST: %s", seriesDataType));
     }
   }
 
@@ -97,7 +97,7 @@ public class FirstAccumulator implements TableAccumulator {
         argument instanceof BinaryColumn
             || (argument instanceof RunLengthEncodedColumn
                 && ((RunLengthEncodedColumn) argument).getValue() instanceof BinaryColumn),
-        "intermediate input and output of First should be BinaryColumn");
+        "intermediate input and output of FIRST should be BinaryColumn");
 
     for (int i = 0; i < argument.getPositionCount(); i++) {
       if (argument.isNull(i)) {
@@ -141,7 +141,7 @@ public class FirstAccumulator implements TableAccumulator {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in First Aggregation: %s", seriesDataType));
+              String.format("Unsupported data type in FIRST Aggregation: %s", seriesDataType));
       }
     }
   }
@@ -150,7 +150,7 @@ public class FirstAccumulator implements TableAccumulator {
   public void evaluateIntermediate(ColumnBuilder columnBuilder) {
     checkArgument(
         columnBuilder instanceof BinaryColumnBuilder,
-        "intermediate input and output of First should be BinaryColumn");
+        "intermediate input and output of FIRST should be BinaryColumn");
     if (!initResult) {
       columnBuilder.appendNull();
     } else {
@@ -189,7 +189,7 @@ public class FirstAccumulator implements TableAccumulator {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in First aggregation: %s", seriesDataType));
+              String.format("Unsupported data type in FIRST aggregation: %s", seriesDataType));
       }
     }
   }
@@ -234,7 +234,7 @@ public class FirstAccumulator implements TableAccumulator {
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in First Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in FIRST Aggregation: %s", seriesDataType));
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/FirstByAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/FirstByAccumulator.java
@@ -76,7 +76,7 @@ public class FirstByAccumulator implements TableAccumulator {
 
   @Override
   public void addInput(Column[] arguments, AggregationMask mask) {
-    checkArgument(arguments.length == 3, "Length of input Column[] for FirstBy should be 3");
+    checkArgument(arguments.length == 3, "Length of input Column[] for FIRST_BY should be 3");
 
     // arguments[0] is x column, arguments[1] is y column, arguments[2] is time column
     switch (xDataType) {
@@ -104,7 +104,7 @@ public class FirstByAccumulator implements TableAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in FirstBy Aggregation: %s", yDataType));
+            String.format("Unsupported data type in FIRST_BY Aggregation: %s", yDataType));
     }
   }
 
@@ -114,7 +114,7 @@ public class FirstByAccumulator implements TableAccumulator {
         argument instanceof BinaryColumn
             || (argument instanceof RunLengthEncodedColumn
                 && ((RunLengthEncodedColumn) argument).getValue() instanceof BinaryColumn),
-        "intermediate input and output of FirstBy should be BinaryColumn");
+        "intermediate input and output of FIRST_BY should be BinaryColumn");
 
     for (int i = 0; i < argument.getPositionCount(); i++) {
       if (argument.isNull(i)) {
@@ -169,7 +169,7 @@ public class FirstByAccumulator implements TableAccumulator {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in FirstBy Aggregation: %s", yDataType));
+              String.format("Unsupported data type in FIRST_BY Aggregation: %s", yDataType));
       }
     }
   }
@@ -178,7 +178,7 @@ public class FirstByAccumulator implements TableAccumulator {
   public void evaluateIntermediate(ColumnBuilder columnBuilder) {
     checkArgument(
         columnBuilder instanceof BinaryColumnBuilder,
-        "intermediate input and output of FirstBy should be BinaryColumn");
+        "intermediate input and output of FIRST_BY should be BinaryColumn");
 
     if (!initResult) {
       columnBuilder.appendNull();
@@ -220,7 +220,7 @@ public class FirstByAccumulator implements TableAccumulator {
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in FirstBy Aggregation: %s", xDataType));
+            String.format("Unsupported data type in FIRST_BY Aggregation: %s", xDataType));
     }
   }
 
@@ -284,7 +284,7 @@ public class FirstByAccumulator implements TableAccumulator {
               break;
             default:
               throw new UnSupportedDataTypeException(
-                  String.format("Unsupported data type in FirstBy Aggregation: %s", yDataType));
+                  String.format("Unsupported data type in FIRST_BY Aggregation: %s", yDataType));
           }
         }
       }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/LastAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/LastAccumulator.java
@@ -105,7 +105,7 @@ public class LastAccumulator implements TableAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Last: %s", seriesDataType));
+            String.format("Unsupported data type in LAST: %s", seriesDataType));
     }
   }
 
@@ -115,7 +115,7 @@ public class LastAccumulator implements TableAccumulator {
         argument instanceof BinaryColumn
             || (argument instanceof RunLengthEncodedColumn
                 && ((RunLengthEncodedColumn) argument).getValue() instanceof BinaryColumn),
-        "intermediate input and output of Last should be BinaryColumn");
+        "intermediate input and output of LAST should be BinaryColumn");
 
     for (int i = 0; i < argument.getPositionCount(); i++) {
       if (argument.isNull(i)) {
@@ -159,7 +159,7 @@ public class LastAccumulator implements TableAccumulator {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in Last Aggregation: %s", seriesDataType));
+              String.format("Unsupported data type in LAST Aggregation: %s", seriesDataType));
       }
     }
   }
@@ -168,7 +168,7 @@ public class LastAccumulator implements TableAccumulator {
   public void evaluateIntermediate(ColumnBuilder columnBuilder) {
     checkArgument(
         columnBuilder instanceof BinaryColumnBuilder,
-        "intermediate input and output of Last should be BinaryColumn");
+        "intermediate input and output of LAST should be BinaryColumn");
 
     if (!initResult) {
       columnBuilder.appendNull();
@@ -207,7 +207,7 @@ public class LastAccumulator implements TableAccumulator {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in Last aggregation: %s", seriesDataType));
+              String.format("Unsupported data type in LAST aggregation: %s", seriesDataType));
       }
     }
   }
@@ -250,7 +250,7 @@ public class LastAccumulator implements TableAccumulator {
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Last Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in LAST Aggregation: %s", seriesDataType));
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/LastByAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/LastByAccumulator.java
@@ -35,7 +35,6 @@ import org.apache.tsfile.write.UnSupportedDataTypeException;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation.Utils.serializeTimeValue;
-import static org.apache.iotdb.db.utils.constant.SqlConstant.LAST_BY_AGGREGATION;
 
 public class LastByAccumulator implements TableAccumulator {
 
@@ -309,9 +308,7 @@ public class LastByAccumulator implements TableAccumulator {
               break;
             default:
               throw new UnSupportedDataTypeException(
-                  String.format(
-                      "Unsupported data type in LAST_BY Aggregation: %s",
-                      yDataType));
+                  String.format("Unsupported data type in LAST_BY Aggregation: %s", yDataType));
           }
         }
       }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/LastByAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/LastByAccumulator.java
@@ -101,7 +101,7 @@ public class LastByAccumulator implements TableAccumulator {
 
   @Override
   public void addInput(Column[] arguments, AggregationMask mask) {
-    checkArgument(arguments.length == 3, "Length of input Column[] for LastBy should be 3");
+    checkArgument(arguments.length == 3, "Length of input Column[] for LAST_BY should be 3");
 
     // arguments[0] is x column, arguments[1] is y column, arguments[2] is time column
     switch (xDataType) {
@@ -129,7 +129,7 @@ public class LastByAccumulator implements TableAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in LastBy Aggregation: %s", yDataType));
+            String.format("Unsupported data type in LAST_BY Aggregation: %s", yDataType));
     }
   }
 
@@ -139,7 +139,7 @@ public class LastByAccumulator implements TableAccumulator {
         argument instanceof BinaryColumn
             || (argument instanceof RunLengthEncodedColumn
                 && ((RunLengthEncodedColumn) argument).getValue() instanceof BinaryColumn),
-        "intermediate input and output of LastBy should be BinaryColumn");
+        "intermediate input and output of LAST_BY should be BinaryColumn");
 
     for (int i = 0; i < argument.getPositionCount(); i++) {
       if (argument.isNull(i)) {
@@ -194,7 +194,7 @@ public class LastByAccumulator implements TableAccumulator {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in LastBy Aggregation: %s", yDataType));
+              String.format("Unsupported data type in LAST_BY Aggregation: %s", yDataType));
       }
     }
   }
@@ -203,7 +203,7 @@ public class LastByAccumulator implements TableAccumulator {
   public void evaluateIntermediate(ColumnBuilder columnBuilder) {
     checkArgument(
         columnBuilder instanceof BinaryColumnBuilder,
-        "intermediate input and output of LastBy should be BinaryColumn");
+        "intermediate input and output of LAST_BY should be BinaryColumn");
 
     if (!initResult) {
       columnBuilder.appendNull();
@@ -245,7 +245,7 @@ public class LastByAccumulator implements TableAccumulator {
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in LastBy Aggregation: %s", xDataType));
+            String.format("Unsupported data type in LAST_BY Aggregation: %s", xDataType));
     }
   }
 
@@ -310,8 +310,8 @@ public class LastByAccumulator implements TableAccumulator {
             default:
               throw new UnSupportedDataTypeException(
                   String.format(
-                      "Unsupported data type: %s in Aggregation: %s",
-                      yDataType, LAST_BY_AGGREGATION));
+                      "Unsupported data type in LAST_BY Aggregation: %s",
+                      yDataType));
           }
         }
       }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/MaxAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/MaxAccumulator.java
@@ -54,7 +54,7 @@ public class MaxAccumulator implements TableAccumulator {
 
   @Override
   public void addInput(Column[] arguments, AggregationMask mask) {
-    checkArgument(arguments.length == 1, "argument of Max should be one column");
+    checkArgument(arguments.length == 1, "argument of MAX should be one column");
 
     switch (seriesDataType) {
       case INT32:
@@ -81,7 +81,7 @@ public class MaxAccumulator implements TableAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Max Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in MAX Aggregation: %s", seriesDataType));
     }
   }
 
@@ -117,7 +117,7 @@ public class MaxAccumulator implements TableAccumulator {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in Max Aggregation: %s", seriesDataType));
+              String.format("Unsupported data type in MAX Aggregation: %s", seriesDataType));
       }
     }
   }
@@ -154,7 +154,7 @@ public class MaxAccumulator implements TableAccumulator {
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Max Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in MAX Aggregation: %s", seriesDataType));
     }
   }
 
@@ -189,7 +189,7 @@ public class MaxAccumulator implements TableAccumulator {
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Max Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in MAX Aggregation: %s", seriesDataType));
     }
   }
 
@@ -230,7 +230,7 @@ public class MaxAccumulator implements TableAccumulator {
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Max Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in MAX Aggregation: %s", seriesDataType));
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/MinAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/MinAccumulator.java
@@ -54,7 +54,7 @@ public class MinAccumulator implements TableAccumulator {
 
   @Override
   public void addInput(Column[] arguments, AggregationMask mask) {
-    checkArgument(arguments.length == 1, "argument of Min should be one column");
+    checkArgument(arguments.length == 1, "argument of MIN should be one column");
 
     switch (seriesDataType) {
       case INT32:
@@ -81,7 +81,7 @@ public class MinAccumulator implements TableAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Min Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in MIN Aggregation: %s", seriesDataType));
     }
   }
 
@@ -117,7 +117,7 @@ public class MinAccumulator implements TableAccumulator {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in Min Aggregation: %s", seriesDataType));
+              String.format("Unsupported data type in MIN Aggregation: %s", seriesDataType));
       }
     }
   }
@@ -154,7 +154,7 @@ public class MinAccumulator implements TableAccumulator {
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Min Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in MIN Aggregation: %s", seriesDataType));
     }
   }
 
@@ -189,7 +189,7 @@ public class MinAccumulator implements TableAccumulator {
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Min Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in MIN Aggregation: %s", seriesDataType));
     }
   }
 
@@ -230,7 +230,7 @@ public class MinAccumulator implements TableAccumulator {
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Min Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in MIN Aggregation: %s", seriesDataType));
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/SumAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/SumAccumulator.java
@@ -51,7 +51,7 @@ public class SumAccumulator implements TableAccumulator {
 
   @Override
   public void addInput(Column[] arguments, AggregationMask mask) {
-    checkArgument(arguments.length == 1, "argument of Sum should be one column");
+    checkArgument(arguments.length == 1, "argument of SUM should be one column");
     switch (argumentDataType) {
       case INT32:
         addIntInput(arguments[0], mask);
@@ -73,13 +73,13 @@ public class SumAccumulator implements TableAccumulator {
       case TIMESTAMP:
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Sum Aggregation: %s", argumentDataType));
+            String.format("Unsupported data type in SUM Aggregation: %s", argumentDataType));
     }
   }
 
   @Override
   public void removeInput(Column[] arguments) {
-    checkArgument(arguments.length == 1, "argument of Sum should be one column");
+    checkArgument(arguments.length == 1, "argument of SUM should be one column");
     switch (argumentDataType) {
       case INT32:
         removeIntInput(arguments[0]);
@@ -101,7 +101,7 @@ public class SumAccumulator implements TableAccumulator {
       case TIMESTAMP:
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Sum Aggregation: %s", argumentDataType));
+            String.format("Unsupported data type in SUM Aggregation: %s", argumentDataType));
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/TableMaxMinByBaseAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/TableMaxMinByBaseAccumulator.java
@@ -53,7 +53,8 @@ public abstract class TableMaxMinByBaseAccumulator implements TableAccumulator {
 
   private boolean initResult;
 
-  public static final String UNSUPPORTED_TYPE_MESSAGE = "Unsupported data type in MaxBy/MinBy: %s";
+  public static final String UNSUPPORTED_TYPE_MESSAGE =
+      "Unsupported data type in MAX_BY/MIN_BY: %s";
 
   protected TableMaxMinByBaseAccumulator(TSDataType xDataType, TSDataType yDataType) {
     this.xDataType = xDataType;
@@ -65,7 +66,7 @@ public abstract class TableMaxMinByBaseAccumulator implements TableAccumulator {
   // Column should be like: | x | y |
   @Override
   public void addInput(Column[] arguments, AggregationMask mask) {
-    checkArgument(arguments.length == 2, "Length of input Column[] for MaxBy/MinBy should be 2");
+    checkArgument(arguments.length == 2, "Length of input Column[] for MAX_BY/MIN_BY should be 2");
     switch (yDataType) {
       case INT32:
       case DATE:
@@ -100,7 +101,7 @@ public abstract class TableMaxMinByBaseAccumulator implements TableAccumulator {
         argument instanceof BinaryColumn
             || (argument instanceof RunLengthEncodedColumn
                 && ((RunLengthEncodedColumn) argument).getValue() instanceof BinaryColumn),
-        "intermediate input and output of max_by/min_by should be BinaryColumn");
+        "intermediate input and output of MAX_BY/MIN_BY should be BinaryColumn");
 
     for (int i = 0; i < argument.getPositionCount(); i++) {
       if (argument.isNull(i)) {
@@ -121,7 +122,7 @@ public abstract class TableMaxMinByBaseAccumulator implements TableAccumulator {
   public void evaluateIntermediate(ColumnBuilder columnBuilder) {
     checkArgument(
         columnBuilder instanceof BinaryColumnBuilder,
-        "intermediate input and output of Max_By/Min_By should be BinaryColumn");
+        "intermediate input and output of MAX_BY/MIN_BY should be BinaryColumn");
 
     if (!initResult) {
       columnBuilder.appendNull();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/TableVarianceAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/TableVarianceAccumulator.java
@@ -85,7 +85,7 @@ public class TableVarianceAccumulator implements TableAccumulator {
       case TIMESTAMP:
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Variance Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in VARIANCE Aggregation: %s", seriesDataType));
     }
   }
 
@@ -112,7 +112,7 @@ public class TableVarianceAccumulator implements TableAccumulator {
       case TIMESTAMP:
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Variance Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in VARIANCE Aggregation: %s", seriesDataType));
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedAvgAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedAvgAccumulator.java
@@ -61,7 +61,7 @@ public class GroupedAvgAccumulator implements GroupedAccumulator {
 
   @Override
   public void addInput(int[] groupIds, Column[] arguments, AggregationMask mask) {
-    checkArgument(arguments.length == 1, "argument of Avg should be one column");
+    checkArgument(arguments.length == 1, "argument of AVG should be one column");
     switch (argumentDataType) {
       case INT32:
         addIntInput(groupIds, arguments[0], mask);
@@ -93,7 +93,7 @@ public class GroupedAvgAccumulator implements GroupedAccumulator {
         argument instanceof BinaryColumn
             || (argument instanceof RunLengthEncodedColumn
                 && ((RunLengthEncodedColumn) argument).getValue() instanceof BinaryColumn),
-        "intermediate input and output of Avg should be BinaryColumn");
+        "intermediate input and output of AVG should be BinaryColumn");
 
     for (int i = 0; i < groupIds.length; i++) {
       if (!argument.isNull(i)) {
@@ -106,7 +106,7 @@ public class GroupedAvgAccumulator implements GroupedAccumulator {
   public void evaluateIntermediate(int groupId, ColumnBuilder columnBuilder) {
     checkArgument(
         columnBuilder instanceof BinaryColumnBuilder,
-        "intermediate input and output of Avg should be BinaryColumn");
+        "intermediate input and output of AVG should be BinaryColumn");
     if (countValues.get(groupId) == 0) {
       columnBuilder.appendNull();
     } else {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedExtremeAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedExtremeAccumulator.java
@@ -67,7 +67,7 @@ public class GroupedExtremeAccumulator implements GroupedAccumulator {
       case TIMESTAMP:
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type Extreme Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type EXTREME Aggregation: %s", seriesDataType));
     }
   }
 
@@ -97,7 +97,7 @@ public class GroupedExtremeAccumulator implements GroupedAccumulator {
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Extreme Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in EXTREME Aggregation: %s", seriesDataType));
     }
 
     return INSTANCE_SIZE + valuesSize;
@@ -127,7 +127,7 @@ public class GroupedExtremeAccumulator implements GroupedAccumulator {
       case BOOLEAN:
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Extreme Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in EXTREME Aggregation: %s", seriesDataType));
     }
   }
 
@@ -155,7 +155,7 @@ public class GroupedExtremeAccumulator implements GroupedAccumulator {
       case TIMESTAMP:
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type Extreme Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type EXTREME Aggregation: %s", seriesDataType));
     }
   }
 
@@ -188,7 +188,7 @@ public class GroupedExtremeAccumulator implements GroupedAccumulator {
         case TIMESTAMP:
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in Extreme Aggregation: %s", seriesDataType));
+              String.format("Unsupported data type in EXTREME Aggregation: %s", seriesDataType));
       }
     }
   }
@@ -219,7 +219,7 @@ public class GroupedExtremeAccumulator implements GroupedAccumulator {
         case TIMESTAMP:
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in Extreme Aggregation: %s", seriesDataType));
+              String.format("Unsupported data type in EXTREME Aggregation: %s", seriesDataType));
       }
     }
   }
@@ -250,7 +250,7 @@ public class GroupedExtremeAccumulator implements GroupedAccumulator {
         case TIMESTAMP:
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in Extreme Aggregation: %s", seriesDataType));
+              String.format("Unsupported data type in EXTREME Aggregation: %s", seriesDataType));
       }
     }
   }
@@ -282,7 +282,7 @@ public class GroupedExtremeAccumulator implements GroupedAccumulator {
       case TIMESTAMP:
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Extreme Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in EXTREME Aggregation: %s", seriesDataType));
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedFirstAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedFirstAccumulator.java
@@ -85,7 +85,7 @@ public class GroupedFirstAccumulator implements GroupedAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in First Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in FIRST Aggregation: %s", seriesDataType));
     }
   }
 
@@ -117,7 +117,7 @@ public class GroupedFirstAccumulator implements GroupedAccumulator {
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in First Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in FIRST Aggregation: %s", seriesDataType));
     }
 
     return INSTANCE_SIZE + valuesSize;
@@ -151,7 +151,7 @@ public class GroupedFirstAccumulator implements GroupedAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in First Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in FIRST Aggregation: %s", seriesDataType));
     }
   }
 
@@ -183,7 +183,7 @@ public class GroupedFirstAccumulator implements GroupedAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in First Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in FIRST Aggregation: %s", seriesDataType));
     }
   }
 
@@ -193,7 +193,7 @@ public class GroupedFirstAccumulator implements GroupedAccumulator {
         argument instanceof BinaryColumn
             || (argument instanceof RunLengthEncodedColumn
                 && ((RunLengthEncodedColumn) argument).getValue() instanceof BinaryColumn),
-        "intermediate input and output of First should be BinaryColumn");
+        "intermediate input and output of FIRST should be BinaryColumn");
 
     for (int i = 0; i < groupIds.length; i++) {
       if (argument.isNull(i)) {
@@ -237,7 +237,7 @@ public class GroupedFirstAccumulator implements GroupedAccumulator {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in First Aggregation: %s", seriesDataType));
+              String.format("Unsupported data type in FIRST Aggregation: %s", seriesDataType));
       }
     }
   }
@@ -246,7 +246,7 @@ public class GroupedFirstAccumulator implements GroupedAccumulator {
   public void evaluateIntermediate(int groupId, ColumnBuilder columnBuilder) {
     checkArgument(
         columnBuilder instanceof BinaryColumnBuilder,
-        "intermediate input and output of First should be BinaryColumn");
+        "intermediate input and output of FIRST should be BinaryColumn");
     if (minTimes.get(groupId) == Long.MAX_VALUE) {
       columnBuilder.appendNull();
     } else {
@@ -284,7 +284,7 @@ public class GroupedFirstAccumulator implements GroupedAccumulator {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in First Aggregation: %s", seriesDataType));
+              String.format("Unsupported data type in FIRST Aggregation: %s", seriesDataType));
       }
     }
   }
@@ -320,7 +320,7 @@ public class GroupedFirstAccumulator implements GroupedAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in First Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in FIRST Aggregation: %s", seriesDataType));
     }
   }
 
@@ -372,7 +372,7 @@ public class GroupedFirstAccumulator implements GroupedAccumulator {
         return bytes;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in First Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in FIRST Aggregation: %s", seriesDataType));
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedFirstByAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedFirstByAccumulator.java
@@ -95,7 +95,7 @@ public class GroupedFirstByAccumulator implements GroupedAccumulator {
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in FirstBy Aggregation: %s", xDataType));
+            String.format("Unsupported data type in FIRST_BY Aggregation: %s", xDataType));
     }
   }
 
@@ -127,7 +127,7 @@ public class GroupedFirstByAccumulator implements GroupedAccumulator {
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in FirstBy Aggregation: %s", xDataType));
+            String.format("Unsupported data type in FIRST_BY Aggregation: %s", xDataType));
     }
 
     return INSTANCE_SIZE + valuesSize + yFirstTimes.sizeOf() + inits.sizeOf() + xNulls.sizeOf();
@@ -163,7 +163,7 @@ public class GroupedFirstByAccumulator implements GroupedAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in FirstBy Aggregation: %s", xDataType));
+            String.format("Unsupported data type in FIRST_BY Aggregation: %s", xDataType));
     }
   }
 
@@ -200,7 +200,7 @@ public class GroupedFirstByAccumulator implements GroupedAccumulator {
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in FirstBy Aggregation: %s", xDataType));
+            String.format("Unsupported data type in FIRST_BY Aggregation: %s", xDataType));
     }
   }
 
@@ -234,7 +234,7 @@ public class GroupedFirstByAccumulator implements GroupedAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in FirstBy Aggregation: %s", xDataType));
+            String.format("Unsupported data type in FIRST_BY Aggregation: %s", xDataType));
     }
   }
 
@@ -244,7 +244,7 @@ public class GroupedFirstByAccumulator implements GroupedAccumulator {
         argument instanceof BinaryColumn
             || (argument instanceof RunLengthEncodedColumn
                 && ((RunLengthEncodedColumn) argument).getValue() instanceof BinaryColumn),
-        "intermediate input and output of FirstBy should be BinaryColumn");
+        "intermediate input and output of FIRST_BY should be BinaryColumn");
 
     for (int i = 0; i < argument.getPositionCount(); i++) {
       if (argument.isNull(i)) {
@@ -300,7 +300,7 @@ public class GroupedFirstByAccumulator implements GroupedAccumulator {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in FirstBy Aggregation: %s", xDataType));
+              String.format("Unsupported data type in FIRST_BY Aggregation: %s", xDataType));
       }
     }
   }
@@ -309,7 +309,7 @@ public class GroupedFirstByAccumulator implements GroupedAccumulator {
   public void evaluateIntermediate(int groupId, ColumnBuilder columnBuilder) {
     checkArgument(
         columnBuilder instanceof BinaryColumnBuilder,
-        "intermediate input and output of FirstBy should be BinaryColumn");
+        "intermediate input and output of FIRST_BY should be BinaryColumn");
 
     if (!inits.get(groupId)) {
       columnBuilder.appendNull();
@@ -353,7 +353,7 @@ public class GroupedFirstByAccumulator implements GroupedAccumulator {
           return bytes;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in FirstBy Aggregation: %s", xDataType));
+              String.format("Unsupported data type in FIRST_BY Aggregation: %s", xDataType));
       }
     }
     return bytes;
@@ -379,7 +379,7 @@ public class GroupedFirstByAccumulator implements GroupedAccumulator {
         return 1;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in FirstBy Aggregation: %s", xDataType));
+            String.format("Unsupported data type in FIRST_BY Aggregation: %s", xDataType));
     }
   }
 
@@ -415,7 +415,7 @@ public class GroupedFirstByAccumulator implements GroupedAccumulator {
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in FirstBy Aggregation: %s", xDataType));
+            String.format("Unsupported data type in FIRST_BY Aggregation: %s", xDataType));
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedLastAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedLastAccumulator.java
@@ -85,7 +85,7 @@ public class GroupedLastAccumulator implements GroupedAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Last Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in LAST Aggregation: %s", seriesDataType));
     }
   }
 
@@ -117,7 +117,7 @@ public class GroupedLastAccumulator implements GroupedAccumulator {
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Last Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in LAST Aggregation: %s", seriesDataType));
     }
 
     return INSTANCE_SIZE + valuesSize;
@@ -151,7 +151,7 @@ public class GroupedLastAccumulator implements GroupedAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Last Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in LAST Aggregation: %s", seriesDataType));
     }
   }
 
@@ -183,7 +183,7 @@ public class GroupedLastAccumulator implements GroupedAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Last Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in LAST Aggregation: %s", seriesDataType));
     }
   }
 
@@ -193,7 +193,7 @@ public class GroupedLastAccumulator implements GroupedAccumulator {
         argument instanceof BinaryColumn
             || (argument instanceof RunLengthEncodedColumn
                 && ((RunLengthEncodedColumn) argument).getValue() instanceof BinaryColumn),
-        "intermediate input and output of Last should be BinaryColumn");
+        "intermediate input and output of LAST should be BinaryColumn");
 
     for (int i = 0; i < groupIds.length; i++) {
       if (argument.isNull(i)) {
@@ -237,7 +237,7 @@ public class GroupedLastAccumulator implements GroupedAccumulator {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in Last Aggregation: %s", seriesDataType));
+              String.format("Unsupported data type in LAST Aggregation: %s", seriesDataType));
       }
     }
   }
@@ -246,7 +246,7 @@ public class GroupedLastAccumulator implements GroupedAccumulator {
   public void evaluateIntermediate(int groupId, ColumnBuilder columnBuilder) {
     checkArgument(
         columnBuilder instanceof BinaryColumnBuilder,
-        "intermediate input and output of Last should be BinaryColumn");
+        "intermediate input and output of LAST should be BinaryColumn");
     if (maxTimes.get(groupId) == Long.MIN_VALUE) {
       columnBuilder.appendNull();
     } else {
@@ -284,7 +284,7 @@ public class GroupedLastAccumulator implements GroupedAccumulator {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in Last Aggregation: %s", seriesDataType));
+              String.format("Unsupported data type in LAST Aggregation: %s", seriesDataType));
       }
     }
   }
@@ -320,7 +320,7 @@ public class GroupedLastAccumulator implements GroupedAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Last Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in LAST Aggregation: %s", seriesDataType));
     }
   }
 
@@ -372,7 +372,7 @@ public class GroupedLastAccumulator implements GroupedAccumulator {
         return bytes;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Last Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in LAST Aggregation: %s", seriesDataType));
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedLastByAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedLastByAccumulator.java
@@ -95,7 +95,7 @@ public class GroupedLastByAccumulator implements GroupedAccumulator {
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in LastBy Aggregation: %s", xDataType));
+            String.format("Unsupported data type in LAST_BY Aggregation: %s", xDataType));
     }
   }
 
@@ -127,7 +127,7 @@ public class GroupedLastByAccumulator implements GroupedAccumulator {
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in LastBy Aggregation: %s", xDataType));
+            String.format("Unsupported data type in LAST_BY Aggregation: %s", xDataType));
     }
 
     return INSTANCE_SIZE + valuesSize + yLastTimes.sizeOf() + inits.sizeOf() + xNulls.sizeOf();
@@ -163,7 +163,7 @@ public class GroupedLastByAccumulator implements GroupedAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in LastBy Aggregation: %s", xDataType));
+            String.format("Unsupported data type in LAST_BY Aggregation: %s", xDataType));
     }
   }
 
@@ -200,13 +200,13 @@ public class GroupedLastByAccumulator implements GroupedAccumulator {
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in LastBy Aggregation: %s", xDataType));
+            String.format("Unsupported data type in LAST_BY Aggregation: %s", xDataType));
     }
   }
 
   @Override
   public void addInput(int[] groupIds, Column[] arguments, AggregationMask mask) {
-    checkArgument(arguments.length == 3, "Length of input Column[] for LastBy/LastBy should be 3");
+    checkArgument(arguments.length == 3, "Length of input Column[] for LAST_BY should be 3");
 
     // arguments[0] is x column, arguments[1] is y column, arguments[2] is time column
     switch (xDataType) {
@@ -234,7 +234,7 @@ public class GroupedLastByAccumulator implements GroupedAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in LastBy Aggregation: %s", yDataType));
+            String.format("Unsupported data type in LAST_BY Aggregation: %s", yDataType));
     }
   }
 
@@ -244,7 +244,7 @@ public class GroupedLastByAccumulator implements GroupedAccumulator {
         argument instanceof BinaryColumn
             || (argument instanceof RunLengthEncodedColumn
                 && ((RunLengthEncodedColumn) argument).getValue() instanceof BinaryColumn),
-        "intermediate input and output of LastBy should be BinaryColumn");
+        "intermediate input and output of LAST_BY should be BinaryColumn");
 
     for (int i = 0; i < argument.getPositionCount(); i++) {
       if (argument.isNull(i)) {
@@ -300,7 +300,7 @@ public class GroupedLastByAccumulator implements GroupedAccumulator {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in LastBy Aggregation: %s", yDataType));
+              String.format("Unsupported data type in LAST_BY Aggregation: %s", yDataType));
       }
     }
   }
@@ -309,7 +309,7 @@ public class GroupedLastByAccumulator implements GroupedAccumulator {
   public void evaluateIntermediate(int groupId, ColumnBuilder columnBuilder) {
     checkArgument(
         columnBuilder instanceof BinaryColumnBuilder,
-        "intermediate input and output of LastBy should be BinaryColumn");
+        "intermediate input and output of LAST_BY should be BinaryColumn");
 
     if (!inits.get(groupId)) {
       columnBuilder.appendNull();
@@ -353,7 +353,7 @@ public class GroupedLastByAccumulator implements GroupedAccumulator {
           return bytes;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in LastBy Aggregation: %s", yDataType));
+              String.format("Unsupported data type in LAST_BY Aggregation: %s", yDataType));
       }
     }
     return bytes;
@@ -379,7 +379,7 @@ public class GroupedLastByAccumulator implements GroupedAccumulator {
         return 1;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in LastBy Aggregation: %s", xDataType));
+            String.format("Unsupported data type in LAST_BY Aggregation: %s", xDataType));
     }
   }
 
@@ -415,7 +415,7 @@ public class GroupedLastByAccumulator implements GroupedAccumulator {
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in LastBy Aggregation: %s", xDataType));
+            String.format("Unsupported data type in LAST_BY Aggregation: %s", xDataType));
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedMaxAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedMaxAccumulator.java
@@ -76,7 +76,7 @@ public class GroupedMaxAccumulator implements GroupedAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Max Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in MAX Aggregation: %s", seriesDataType));
     }
   }
 
@@ -108,7 +108,7 @@ public class GroupedMaxAccumulator implements GroupedAccumulator {
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Max Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in MAX Aggregation: %s", seriesDataType));
     }
 
     return INSTANCE_SIZE + valuesSize + inits.sizeOf();
@@ -142,7 +142,7 @@ public class GroupedMaxAccumulator implements GroupedAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Max Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in MAX Aggregation: %s", seriesDataType));
     }
   }
 
@@ -174,7 +174,7 @@ public class GroupedMaxAccumulator implements GroupedAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Max Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in MAX Aggregation: %s", seriesDataType));
     }
   }
 
@@ -211,7 +211,7 @@ public class GroupedMaxAccumulator implements GroupedAccumulator {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in Max Aggregation: %s", seriesDataType));
+              String.format("Unsupported data type in MAX Aggregation: %s", seriesDataType));
       }
     }
   }
@@ -247,7 +247,7 @@ public class GroupedMaxAccumulator implements GroupedAccumulator {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in Max Aggregation: %s", seriesDataType));
+              String.format("Unsupported data type in MAX Aggregation: %s", seriesDataType));
       }
     }
   }
@@ -282,7 +282,7 @@ public class GroupedMaxAccumulator implements GroupedAccumulator {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in Max Aggregation: %s", seriesDataType));
+              String.format("Unsupported data type in MAX Aggregation: %s", seriesDataType));
       }
     }
   }
@@ -318,7 +318,7 @@ public class GroupedMaxAccumulator implements GroupedAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Max Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in MAX Aggregation: %s", seriesDataType));
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedMaxMinByBaseAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedMaxMinByBaseAccumulator.java
@@ -104,7 +104,7 @@ public abstract class GroupedMaxMinByBaseAccumulator implements GroupedAccumulat
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in MaxBy/MinBy Aggregation: %s", xDataType));
+            String.format("Unsupported data type in MAX_BY/MIN_BY Aggregation: %s", xDataType));
     }
 
     switch (yDataType) {
@@ -132,7 +132,7 @@ public abstract class GroupedMaxMinByBaseAccumulator implements GroupedAccumulat
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in MaxBy/MinBy Aggregation: %s", yDataType));
+            String.format("Unsupported data type in MAX_BY/MIN_BY Aggregation: %s", yDataType));
     }
   }
 
@@ -164,7 +164,7 @@ public abstract class GroupedMaxMinByBaseAccumulator implements GroupedAccumulat
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in MaxBy/MinBy Aggregation: %s", xDataType));
+            String.format("Unsupported data type in MAX_BY/MIN_BY Aggregation: %s", xDataType));
     }
 
     switch (yDataType) {
@@ -192,7 +192,7 @@ public abstract class GroupedMaxMinByBaseAccumulator implements GroupedAccumulat
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in MaxBy/MinBy Aggregation: %s", xDataType));
+            String.format("Unsupported data type in MAX_BY/MIN_BY Aggregation: %s", xDataType));
     }
 
     return INSTANCE_SIZE + valuesSize + inits.sizeOf() + xNulls.sizeOf();
@@ -227,7 +227,7 @@ public abstract class GroupedMaxMinByBaseAccumulator implements GroupedAccumulat
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in MaxBy/MinBy Aggregation: %s", xDataType));
+            String.format("Unsupported data type in MAX_BY/MIN_BY Aggregation: %s", xDataType));
     }
     switch (yDataType) {
       case INT32:
@@ -254,7 +254,7 @@ public abstract class GroupedMaxMinByBaseAccumulator implements GroupedAccumulat
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in MaxBy/MinBy Aggregation: %s", xDataType));
+            String.format("Unsupported data type in MAX_BY/MIN_BY Aggregation: %s", xDataType));
     }
   }
 
@@ -290,7 +290,7 @@ public abstract class GroupedMaxMinByBaseAccumulator implements GroupedAccumulat
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in MaxBy/MinBy Aggregation: %s", xDataType));
+            String.format("Unsupported data type in MAX_BY/MIN_BY Aggregation: %s", xDataType));
     }
 
     switch (yDataType) {
@@ -318,7 +318,7 @@ public abstract class GroupedMaxMinByBaseAccumulator implements GroupedAccumulat
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in MaxBy/MinBy Aggregation: %s", yDataType));
+            String.format("Unsupported data type in MAX_BY/MIN_BY Aggregation: %s", yDataType));
     }
   }
 
@@ -349,7 +349,7 @@ public abstract class GroupedMaxMinByBaseAccumulator implements GroupedAccumulat
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in MaxBy/MinBy Aggregation: %s", yDataType));
+            String.format("Unsupported data type in MAX_BY/MIN_BY Aggregation: %s", yDataType));
     }
   }
 
@@ -359,7 +359,7 @@ public abstract class GroupedMaxMinByBaseAccumulator implements GroupedAccumulat
         argument instanceof BinaryColumn
             || (argument instanceof RunLengthEncodedColumn
                 && ((RunLengthEncodedColumn) argument).getValue() instanceof BinaryColumn),
-        "intermediate input and output of MaxBy or MinBy should be BinaryColumn");
+        "intermediate input and output of MAX_BY/MIN_BY should be BinaryColumn");
 
     for (int i = 0; i < groupIds.length; i++) {
       if (argument.isNull(i)) {
@@ -375,7 +375,7 @@ public abstract class GroupedMaxMinByBaseAccumulator implements GroupedAccumulat
   public void evaluateIntermediate(int groupId, ColumnBuilder columnBuilder) {
     checkArgument(
         columnBuilder instanceof BinaryColumnBuilder,
-        "intermediate input and output of Mode should be BinaryColumn");
+        "intermediate input and output of MAX_BY/MIN_BY should be BinaryColumn");
 
     if (!inits.get(groupId)) {
       columnBuilder.appendNull();
@@ -603,7 +603,7 @@ public abstract class GroupedMaxMinByBaseAccumulator implements GroupedAccumulat
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in MaxBy/MinBy Aggregation: %s", xDataType));
+            String.format("Unsupported data type in MAX_BY/MIN_BY Aggregation: %s", xDataType));
     }
   }
 
@@ -636,7 +636,7 @@ public abstract class GroupedMaxMinByBaseAccumulator implements GroupedAccumulat
           xBooleanValues.set(groupId, xColumn.getBoolean(xIndex));
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in MaxBy/MinBy Aggregation: %s", xDataType));
+              String.format("Unsupported data type in MAX_BY/MIN_BY Aggregation: %s", xDataType));
       }
     }
   }
@@ -707,7 +707,7 @@ public abstract class GroupedMaxMinByBaseAccumulator implements GroupedAccumulat
 
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in MaxBy/MinBy Aggregation: %s", dataType));
+            String.format("Unsupported data type in MAX_BY/MIN_BY Aggregation: %s", dataType));
     }
   }
 
@@ -734,7 +734,7 @@ public abstract class GroupedMaxMinByBaseAccumulator implements GroupedAccumulat
         return 1;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in MaxBy/MinBy Aggregation: %s", dataType));
+            String.format("Unsupported data type in MAX_BY/MIN_BY Aggregation: %s", dataType));
     }
   }
 
@@ -789,7 +789,7 @@ public abstract class GroupedMaxMinByBaseAccumulator implements GroupedAccumulat
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in MaxBy/MinBy Aggregation: %s", yDataType));
+            String.format("Unsupported data type in MAX_BY/MIN_BY Aggregation: %s", yDataType));
     }
   }
 
@@ -827,7 +827,7 @@ public abstract class GroupedMaxMinByBaseAccumulator implements GroupedAccumulat
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in MaxBy/MinBy Aggregation: %s", xDataType));
+              String.format("Unsupported data type in MAX_BY/MIN_BY Aggregation: %s", xDataType));
       }
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedMinAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedMinAccumulator.java
@@ -76,7 +76,7 @@ public class GroupedMinAccumulator implements GroupedAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Min Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in MIN Aggregation: %s", seriesDataType));
     }
   }
 
@@ -108,7 +108,7 @@ public class GroupedMinAccumulator implements GroupedAccumulator {
         break;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Min Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in MIN Aggregation: %s", seriesDataType));
     }
 
     return INSTANCE_SIZE + valuesSize + inits.sizeOf();
@@ -142,7 +142,7 @@ public class GroupedMinAccumulator implements GroupedAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Min Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in MIN Aggregation: %s", seriesDataType));
     }
   }
 
@@ -174,7 +174,7 @@ public class GroupedMinAccumulator implements GroupedAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Min Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in MIN Aggregation: %s", seriesDataType));
     }
   }
 
@@ -211,7 +211,7 @@ public class GroupedMinAccumulator implements GroupedAccumulator {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in Min Aggregation: %s", seriesDataType));
+              String.format("Unsupported data type in MIN Aggregation: %s", seriesDataType));
       }
     }
   }
@@ -247,7 +247,7 @@ public class GroupedMinAccumulator implements GroupedAccumulator {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in Min Aggregation: %s", seriesDataType));
+              String.format("Unsupported data type in MIN Aggregation: %s", seriesDataType));
       }
     }
   }
@@ -282,7 +282,7 @@ public class GroupedMinAccumulator implements GroupedAccumulator {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Unsupported data type in Min Aggregation: %s", seriesDataType));
+              String.format("Unsupported data type in MIN Aggregation: %s", seriesDataType));
       }
     }
   }
@@ -318,7 +318,7 @@ public class GroupedMinAccumulator implements GroupedAccumulator {
         return;
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Min Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in MIN Aggregation: %s", seriesDataType));
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedModeAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedModeAccumulator.java
@@ -109,7 +109,7 @@ public class GroupedModeAccumulator implements GroupedAccumulator {
         argument instanceof BinaryColumn
             || (argument instanceof RunLengthEncodedColumn
                 && ((RunLengthEncodedColumn) argument).getValue() instanceof BinaryColumn),
-        "intermediate input and output of Mode should be BinaryColumn");
+        "intermediate input and output of MODE should be BinaryColumn");
 
     for (int i = 0; i < argument.getPositionCount(); i++) {
       if (argument.isNull(i)) {
@@ -125,7 +125,7 @@ public class GroupedModeAccumulator implements GroupedAccumulator {
   public void evaluateIntermediate(int groupId, ColumnBuilder columnBuilder) {
     checkArgument(
         columnBuilder instanceof BinaryColumnBuilder,
-        "intermediate input and output of Mode should be BinaryColumn");
+        "intermediate input and output of MODE should be BinaryColumn");
 
     columnBuilder.writeBinary(new Binary(serializeCountMap(groupId)));
   }
@@ -589,7 +589,7 @@ public class GroupedModeAccumulator implements GroupedAccumulator {
     if (size > MAP_SIZE_THRESHOLD) {
       throw new RuntimeException(
           String.format(
-              "distinct values has exceeded the threshold %s when calculate Mode in one group",
+              "distinct values has exceeded the threshold %s when calculate MODE in one group",
               MAP_SIZE_THRESHOLD));
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedSumAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedSumAccumulator.java
@@ -54,7 +54,7 @@ public class GroupedSumAccumulator implements GroupedAccumulator {
 
   @Override
   public void addInput(int[] groupIds, Column[] arguments, AggregationMask mask) {
-    checkArgument(arguments.length == 1, "argument of Sum should be one column");
+    checkArgument(arguments.length == 1, "argument of SUM should be one column");
     switch (argumentDataType) {
       case INT32:
         addIntInput(groupIds, arguments[0], mask);
@@ -76,7 +76,7 @@ public class GroupedSumAccumulator implements GroupedAccumulator {
       case TIMESTAMP:
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Sum Aggregation: %s", argumentDataType));
+            String.format("Unsupported data type in SUM Aggregation: %s", argumentDataType));
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedVarianceAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedVarianceAccumulator.java
@@ -89,7 +89,7 @@ public class GroupedVarianceAccumulator implements GroupedAccumulator {
       case TIMESTAMP:
       default:
         throw new UnSupportedDataTypeException(
-            String.format("Unsupported data type in Variance Aggregation: %s", seriesDataType));
+            String.format("Unsupported data type in VARIANCE Aggregation: %s", seriesDataType));
     }
   }
 


### PR DESCRIPTION
This pull request involves several changes to the `iotdb-core` module, specifically related to the naming conventions of aggregation functions in various accumulator classes. The primary change is the standardization of the function names to uppercase.

Standardization of function names:

* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/AvgAccumulator.java`](diffhunk://#diff-3157fa86a400bd42336a13dd196a918303865cde90f815178bcc8d00a3bc8365L60-R60): Changed "Avg" to "AVG" in error messages. [[1]](diffhunk://#diff-3157fa86a400bd42336a13dd196a918303865cde90f815178bcc8d00a3bc8365L60-R60) [[2]](diffhunk://#diff-3157fa86a400bd42336a13dd196a918303865cde90f815178bcc8d00a3bc8365L88-R88) [[3]](diffhunk://#diff-3157fa86a400bd42336a13dd196a918303865cde90f815178bcc8d00a3bc8365L120-R120) [[4]](diffhunk://#diff-3157fa86a400bd42336a13dd196a918303865cde90f815178bcc8d00a3bc8365L139-R139)
* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/CountAccumulator.java`](diffhunk://#diff-9c2cefd0af0dde674034e7a94928e64a51a14999bc7e5088765c0efc034d8d02L45-R45): Changed "Count" to "COUNT" in error messages. [[1]](diffhunk://#diff-9c2cefd0af0dde674034e7a94928e64a51a14999bc7e5088765c0efc034d8d02L45-R45) [[2]](diffhunk://#diff-9c2cefd0af0dde674034e7a94928e64a51a14999bc7e5088765c0efc034d8d02L70-R70)
* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/CountAllAccumulator.java`](diffhunk://#diff-ab1a955899e99e9fd127377787e46ea3cd983fb70b021b4e5076b7a8502e4803L46-R53): Changed "CountAll" to "COUNT" in error messages.
* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/ExtremeAccumulator.java`](diffhunk://#diff-52be06b59ff6839dd82bbdc26b4a0afd2def8de4bcd2fc72cdb66cec4dce1e49L33-R33): Changed "Extreme" to "EXTREME" in error messages.
* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/FirstAccumulator.java`](diffhunk://#diff-4ce11d84d435fd68bbff7646776a57ec426d29eca3defb33ccc622264863d78bL90-R90): Changed "First" to "FIRST" in error messages. [[1]](diffhunk://#diff-4ce11d84d435fd68bbff7646776a57ec426d29eca3defb33ccc622264863d78bL90-R90) [[2]](diffhunk://#diff-4ce11d84d435fd68bbff7646776a57ec426d29eca3defb33ccc622264863d78bL100-R100) [[3]](diffhunk://#diff-4ce11d84d435fd68bbff7646776a57ec426d29eca3defb33ccc622264863d78bL144-R144) [[4]](diffhunk://#diff-4ce11d84d435fd68bbff7646776a57ec426d29eca3defb33ccc622264863d78bL153-R153) [[5]](diffhunk://#diff-4ce11d84d435fd68bbff7646776a57ec426d29eca3defb33ccc622264863d78bL192-R192) [[6]](diffhunk://#diff-4ce11d84d435fd68bbff7646776a57ec426d29eca3defb33ccc622264863d78bL237-R237)
* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/FirstByAccumulator.java`](diffhunk://#diff-908e670d1e5d6f64092c4208c1049b4d31b1d887292ee759c2a5f64c05efdf2cL79-R79): Changed "FirstBy" to "FIRST_BY" in error messages. [[1]](diffhunk://#diff-908e670d1e5d6f64092c4208c1049b4d31b1d887292ee759c2a5f64c05efdf2cL79-R79) [[2]](diffhunk://#diff-908e670d1e5d6f64092c4208c1049b4d31b1d887292ee759c2a5f64c05efdf2cL107-R107) [[3]](diffhunk://#diff-908e670d1e5d6f64092c4208c1049b4d31b1d887292ee759c2a5f64c05efdf2cL117-R117) [[4]](diffhunk://#diff-908e670d1e5d6f64092c4208c1049b4d31b1d887292ee759c2a5f64c05efdf2cL172-R172) [[5]](diffhunk://#diff-908e670d1e5d6f64092c4208c1049b4d31b1d887292ee759c2a5f64c05efdf2cL181-R181) [[6]](diffhunk://#diff-908e670d1e5d6f64092c4208c1049b4d31b1d887292ee759c2a5f64c05efdf2cL223-R223) [[7]](diffhunk://#diff-908e670d1e5d6f64092c4208c1049b4d31b1d887292ee759c2a5f64c05efdf2cL287-R287)
* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/LastAccumulator.java`](diffhunk://#diff-ed4942b6ec8f5e54347b87d0bb06efe3413f580afbdc6fdea7aa453819013be5L108-R108): Changed "Last" to "LAST" in error messages. [[1]](diffhunk://#diff-ed4942b6ec8f5e54347b87d0bb06efe3413f580afbdc6fdea7aa453819013be5L108-R108) [[2]](diffhunk://#diff-ed4942b6ec8f5e54347b87d0bb06efe3413f580afbdc6fdea7aa453819013be5L118-R118) [[3]](diffhunk://#diff-ed4942b6ec8f5e54347b87d0bb06efe3413f580afbdc6fdea7aa453819013be5L162-R162) [[4]](diffhunk://#diff-ed4942b6ec8f5e54347b87d0bb06efe3413f580afbdc6fdea7aa453819013be5L171-R171) [[5]](diffhunk://#diff-ed4942b6ec8f5e54347b87d0bb06efe3413f580afbdc6fdea7aa453819013be5L210-R210) [[6]](diffhunk://#diff-ed4942b6ec8f5e54347b87d0bb06efe3413f580afbdc6fdea7aa453819013be5L253-R253)
* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/LastByAccumulator.java`](diffhunk://#diff-2dba4f7c3539cf481c64ff2e263385e19ecc6391698f2cd25148cd020b9f9738L38): Changed "LastBy" to "LAST_BY" in error messages and removed an unused import. [[1]](diffhunk://#diff-2dba4f7c3539cf481c64ff2e263385e19ecc6391698f2cd25148cd020b9f9738L38) [[2]](diffhunk://#diff-2dba4f7c3539cf481c64ff2e263385e19ecc6391698f2cd25148cd020b9f9738L104-R103)