### PR TITLE
Reduce default value of rpcMaxConcurrentClientNum

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
@@ -121,7 +121,7 @@ public class ConfigNodeConfig {
       RegionBalancer.RegionGroupAllocatePolicy.GCR;
 
   /** Max concurrent client number. */
-  private int rpcMaxConcurrentClientNum = 65535;
+  private int rpcMaxConcurrentClientNum = 3000;
 
   /** just for test wait for 60 second by default. */
   private int thriftServerAwaitTimeForStopService = 60;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -149,7 +149,7 @@ public class IoTDBConfig {
   private int rpcMinConcurrentClientNum = Runtime.getRuntime().availableProcessors();
 
   /** Max concurrent client number */
-  private int rpcMaxConcurrentClientNum = 65535;
+  private int rpcMaxConcurrentClientNum = 1000;
 
   private long allocateMemoryForRead = Runtime.getRuntime().maxMemory() * 3 / 10;
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -746,7 +746,7 @@ public class IoTDBDescriptor {
                 "dn_rpc_max_concurrent_client_num",
                 Integer.toString(conf.getRpcMaxConcurrentClientNum())));
     if (maxConcurrentClientNum <= 0) {
-      maxConcurrentClientNum = 65535;
+      maxConcurrentClientNum = 1000;
     }
 
     conf.setRpcMaxConcurrentClientNum(maxConcurrentClientNum);

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
@@ -460,7 +460,7 @@ cn_rpc_thrift_compression_enable=false
 # The maximum number of concurrent clients that can be connected to the configNode.
 # effectiveMode: restart
 # Datatype: int
-cn_rpc_max_concurrent_client_num=65535
+cn_rpc_max_concurrent_client_num=3000
 
 # Thrift socket and connection timeout between raft nodes, in milliseconds.
 # effectiveMode: restart
@@ -510,7 +510,7 @@ dn_rpc_min_concurrent_client_num=1
 # The maximum number of concurrent clients that can be connected to the dataNode.
 # effectiveMode: restart
 # Datatype: int
-dn_rpc_max_concurrent_client_num=65535
+dn_rpc_max_concurrent_client_num=1000
 
 # thrift max frame size, 512MB by default
 # effectiveMode: restart


### PR DESCRIPTION
## Description

The default value of rpcMaxConcurrentClientNum 65535 is too large. Reducing the default number of allowed client connections can enhance the self-protection mechanism of the database.

This PR changes the default cn_rpc_max_concurrent_client_num to 3000, changes the default dn_rpc_max_concurrent_client_num to 1000.