### PR TITLE
[remove datanode] GCR load balancing implement for removing datanode

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/region/GreedyRegionGroupAllocator.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/region/GreedyRegionGroupAllocator.java
@@ -82,6 +82,19 @@ public class GreedyRegionGroupAllocator implements IRegionGroupAllocator {
         weightList.stream().limit(replicationFactor).collect(Collectors.toList()));
   }
 
+  @Override
+  public TDataNodeConfiguration selectDestDataNode(
+      Map<Integer, TDataNodeConfiguration> availableDataNodeMap,
+      Map<Integer, Double> freeDiskSpaceMap,
+      List<TRegionReplicaSet> allocatedRegionGroups,
+      List<TRegionReplicaSet> databaseAllocatedRegionGroups,
+      int replicationFactor,
+      TConsensusGroupId consensusGroupId,
+      TRegionReplicaSet remainReplicaSet) {
+    // TODO: Implement this method
+    return null;
+  }
+
   private List<TDataNodeLocation> buildWeightList(
       Map<Integer, TDataNodeConfiguration> availableDataNodeMap,
       Map<Integer, Double> freeDiskSpaceMap,

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/region/GreedyRegionGroupAllocator.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/region/GreedyRegionGroupAllocator.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -91,7 +92,7 @@ public class GreedyRegionGroupAllocator implements IRegionGroupAllocator {
       Map<String, List<TRegionReplicaSet>> databaseAllocatedRegionGroupMap,
       Map<TConsensusGroupId, TRegionReplicaSet> remainReplicasMap) {
     // TODO: Implement this method
-    return null;
+    return Collections.emptyMap();
   }
 
   private List<TDataNodeLocation> buildWeightList(

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/region/GreedyRegionGroupAllocator.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/region/GreedyRegionGroupAllocator.java
@@ -83,14 +83,13 @@ public class GreedyRegionGroupAllocator implements IRegionGroupAllocator {
   }
 
   @Override
-  public TDataNodeConfiguration selectDestDataNode(
+  public Map<TConsensusGroupId, TDataNodeConfiguration> removeNodeReplicaSelect(
       Map<Integer, TDataNodeConfiguration> availableDataNodeMap,
       Map<Integer, Double> freeDiskSpaceMap,
       List<TRegionReplicaSet> allocatedRegionGroups,
-      List<TRegionReplicaSet> databaseAllocatedRegionGroups,
-      int replicationFactor,
-      TConsensusGroupId consensusGroupId,
-      TRegionReplicaSet remainReplicaSet) {
+      Map<TConsensusGroupId, String> regionDatabaseMap,
+      Map<String, List<TRegionReplicaSet>> databaseAllocatedRegionGroupMap,
+      Map<TConsensusGroupId, TRegionReplicaSet> remainReplicasMap) {
     // TODO: Implement this method
     return null;
   }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/region/GreedyRegionGroupAllocator.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/region/GreedyRegionGroupAllocator.java
@@ -25,7 +25,6 @@ import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -92,7 +91,8 @@ public class GreedyRegionGroupAllocator implements IRegionGroupAllocator {
       Map<String, List<TRegionReplicaSet>> databaseAllocatedRegionGroupMap,
       Map<TConsensusGroupId, TRegionReplicaSet> remainReplicasMap) {
     // TODO: Implement this method
-    return Collections.emptyMap();
+    throw new UnsupportedOperationException(
+        "The removeNodeReplicaSelect method of GreedyRegionGroupAllocator is yet to be implemented.");
   }
 
   private List<TDataNodeLocation> buildWeightList(

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/region/IRegionGroupAllocator.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/region/IRegionGroupAllocator.java
@@ -54,7 +54,8 @@ public interface IRegionGroupAllocator {
    * @param availableDataNodeMap DataNodes that can be used for allocation
    * @param freeDiskSpaceMap The free disk space of the DataNodes
    * @param allocatedRegionGroups Allocated RegionGroups
-   * @param regionDatabaseMap
+   * @param regionDatabaseMap A mapping from each region identifier to its corresponding database
+   *     name
    * @param databaseAllocatedRegionGroupMap Allocated RegionGroups within the same Database with the
    *     replica set
    * @param remainReplicasMap the remaining replica set excluding the removed DataNodes

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/region/IRegionGroupAllocator.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/region/IRegionGroupAllocator.java
@@ -47,4 +47,26 @@ public interface IRegionGroupAllocator {
       List<TRegionReplicaSet> databaseAllocatedRegionGroups,
       int replicationFactor,
       TConsensusGroupId consensusGroupId);
+
+  /**
+   * Select the optimal DataNode to place the new replica on along with the remaining replica set.
+   *
+   * @param availableDataNodeMap DataNodes that can be used for allocation
+   * @param freeDiskSpaceMap The free disk space of the DataNodes
+   * @param allocatedRegionGroups Allocated RegionGroups
+   * @param databaseAllocatedRegionGroups Allocated RegionGroups within the same Database with the
+   *     replica set
+   * @param replicationFactor Replication factor of the replica set
+   * @param consensusGroupId TConsensusGroupId of the replica set
+   * @param remainReplicaSet the remaining replica set excluding the removed DataNodes
+   * @return The optimal DataNode to place the new replica on along with the remaining replica set
+   */
+  TDataNodeConfiguration selectDestDataNode(
+      Map<Integer, TDataNodeConfiguration> availableDataNodeMap,
+      Map<Integer, Double> freeDiskSpaceMap,
+      List<TRegionReplicaSet> allocatedRegionGroups,
+      List<TRegionReplicaSet> databaseAllocatedRegionGroups,
+      int replicationFactor,
+      TConsensusGroupId consensusGroupId,
+      TRegionReplicaSet remainReplicaSet);
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/region/IRegionGroupAllocator.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/region/IRegionGroupAllocator.java
@@ -54,19 +54,17 @@ public interface IRegionGroupAllocator {
    * @param availableDataNodeMap DataNodes that can be used for allocation
    * @param freeDiskSpaceMap The free disk space of the DataNodes
    * @param allocatedRegionGroups Allocated RegionGroups
-   * @param databaseAllocatedRegionGroups Allocated RegionGroups within the same Database with the
+   * @param regionDatabaseMap
+   * @param databaseAllocatedRegionGroupMap Allocated RegionGroups within the same Database with the
    *     replica set
-   * @param replicationFactor Replication factor of the replica set
-   * @param consensusGroupId TConsensusGroupId of the replica set
-   * @param remainReplicaSet the remaining replica set excluding the removed DataNodes
-   * @return The optimal DataNode to place the new replica on along with the remaining replica set
+   * @param remainReplicasMap the remaining replica set excluding the removed DataNodes
+   * @return The optimal DataNode to place the new replica on along with the remaining replicas
    */
-  TDataNodeConfiguration selectDestDataNode(
+  Map<TConsensusGroupId, TDataNodeConfiguration> removeNodeReplicaSelect(
       Map<Integer, TDataNodeConfiguration> availableDataNodeMap,
       Map<Integer, Double> freeDiskSpaceMap,
       List<TRegionReplicaSet> allocatedRegionGroups,
-      List<TRegionReplicaSet> databaseAllocatedRegionGroups,
-      int replicationFactor,
-      TConsensusGroupId consensusGroupId,
-      TRegionReplicaSet remainReplicaSet);
+      Map<TConsensusGroupId, String> regionDatabaseMap,
+      Map<String, List<TRegionReplicaSet>> databaseAllocatedRegionGroupMap,
+      Map<TConsensusGroupId, TRegionReplicaSet> remainReplicasMap);
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/region/PartiteGraphPlacementRegionGroupAllocator.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/region/PartiteGraphPlacementRegionGroupAllocator.java
@@ -123,7 +123,7 @@ public class PartiteGraphPlacementRegionGroupAllocator implements IRegionGroupAl
       Map<String, List<TRegionReplicaSet>> databaseAllocatedRegionGroupMap,
       Map<TConsensusGroupId, TRegionReplicaSet> remainReplicasMap) {
     // TODO: Implement this method
-    return null;
+    return Collections.emptyMap();
   }
 
   private void prepare(

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/region/PartiteGraphPlacementRegionGroupAllocator.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/region/PartiteGraphPlacementRegionGroupAllocator.java
@@ -114,6 +114,19 @@ public class PartiteGraphPlacementRegionGroupAllocator implements IRegionGroupAl
     return result;
   }
 
+  @Override
+  public TDataNodeConfiguration selectDestDataNode(
+      Map<Integer, TDataNodeConfiguration> availableDataNodeMap,
+      Map<Integer, Double> freeDiskSpaceMap,
+      List<TRegionReplicaSet> allocatedRegionGroups,
+      List<TRegionReplicaSet> databaseAllocatedRegionGroups,
+      int replicationFactor,
+      TConsensusGroupId consensusGroupId,
+      TRegionReplicaSet remainReplicaSet) {
+    // TODO: Implement this method
+    return null;
+  }
+
   private void prepare(
       int replicationFactor,
       Map<Integer, TDataNodeConfiguration> availableDataNodeMap,

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/region/PartiteGraphPlacementRegionGroupAllocator.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/region/PartiteGraphPlacementRegionGroupAllocator.java
@@ -123,7 +123,8 @@ public class PartiteGraphPlacementRegionGroupAllocator implements IRegionGroupAl
       Map<String, List<TRegionReplicaSet>> databaseAllocatedRegionGroupMap,
       Map<TConsensusGroupId, TRegionReplicaSet> remainReplicasMap) {
     // TODO: Implement this method
-    return Collections.emptyMap();
+    throw new UnsupportedOperationException(
+        "The removeNodeReplicaSelect method of PartiteGraphPlacementRegionGroupAllocator is yet to be implemented.");
   }
 
   private void prepare(

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/region/PartiteGraphPlacementRegionGroupAllocator.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/region/PartiteGraphPlacementRegionGroupAllocator.java
@@ -115,14 +115,13 @@ public class PartiteGraphPlacementRegionGroupAllocator implements IRegionGroupAl
   }
 
   @Override
-  public TDataNodeConfiguration selectDestDataNode(
+  public Map<TConsensusGroupId, TDataNodeConfiguration> removeNodeReplicaSelect(
       Map<Integer, TDataNodeConfiguration> availableDataNodeMap,
       Map<Integer, Double> freeDiskSpaceMap,
       List<TRegionReplicaSet> allocatedRegionGroups,
-      List<TRegionReplicaSet> databaseAllocatedRegionGroups,
-      int replicationFactor,
-      TConsensusGroupId consensusGroupId,
-      TRegionReplicaSet remainReplicaSet) {
+      Map<TConsensusGroupId, String> regionDatabaseMap,
+      Map<String, List<TRegionReplicaSet>> databaseAllocatedRegionGroupMap,
+      Map<TConsensusGroupId, TRegionReplicaSet> remainReplicasMap) {
     // TODO: Implement this method
     return null;
   }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RemoveDataNodeHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RemoveDataNodeHandler.java
@@ -37,7 +37,6 @@ import org.apache.iotdb.confignode.conf.ConfigNodeConfig;
 import org.apache.iotdb.confignode.conf.ConfigNodeDescriptor;
 import org.apache.iotdb.confignode.consensus.request.write.datanode.RemoveDataNodePlan;
 import org.apache.iotdb.confignode.consensus.response.datanode.DataNodeToStatusResp;
-import org.apache.iotdb.confignode.exception.DatabaseNotExistsException;
 import org.apache.iotdb.confignode.manager.ConfigManager;
 import org.apache.iotdb.confignode.manager.load.balancer.region.GreedyCopySetRegionGroupAllocator;
 import org.apache.iotdb.confignode.manager.load.balancer.region.GreedyRegionGroupAllocator;
@@ -380,38 +379,6 @@ public class RemoveDataNodeHandler {
                     .getLoadManager()
                     .getFreeDiskSpace(dataNode.getLocation().getDataNodeId())));
     return freeDiskSpaceMap;
-  }
-
-  /**
-   * Retrieves the replication factor for the given database and consensus group type. If the
-   * database does not exist, a default value is returned.
-   */
-  private int getReplicationFactor(
-      String database, TConsensusGroupType consensusGroupType, TConsensusGroupId regionId) {
-    try {
-      return configManager
-          .getClusterSchemaManager()
-          .getReplicationFactor(database, consensusGroupType);
-    } catch (DatabaseNotExistsException e) {
-      LOGGER.warn(
-          "Region {}'s database: {} does not exist, using default value.", regionId, database, e);
-      return consensusGroupType.equals(TConsensusGroupType.DataRegion)
-          ? ConfigNodeDescriptor.getInstance().getConf().getDataReplicationFactor()
-          : ConfigNodeDescriptor.getInstance().getConf().getSchemaReplicationFactor();
-    }
-  }
-
-  /**
-   * Updates a single replica set by adding the new DataNode to its list and updating the
-   * allocatedReplicaSets.
-   */
-  private void updateReplicaSet(
-      List<TRegionReplicaSet> allocatedReplicaSets,
-      TRegionReplicaSet replicaSet,
-      TDataNodeLocation newDataNode) {
-    allocatedReplicaSets.remove(replicaSet);
-    replicaSet.getDataNodeLocations().add(newDataNode);
-    allocatedReplicaSets.add(replicaSet);
   }
 
   /**

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RemoveDataNodeHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RemoveDataNodeHandler.java
@@ -38,10 +38,8 @@ import org.apache.iotdb.confignode.conf.ConfigNodeDescriptor;
 import org.apache.iotdb.confignode.consensus.request.write.datanode.RemoveDataNodePlan;
 import org.apache.iotdb.confignode.consensus.response.datanode.DataNodeToStatusResp;
 import org.apache.iotdb.confignode.manager.ConfigManager;
-import org.apache.iotdb.confignode.manager.load.balancer.region.GreedyCopySetRegionGroupAllocator;
 import org.apache.iotdb.confignode.manager.load.balancer.region.GreedyRegionGroupAllocator;
 import org.apache.iotdb.confignode.manager.load.balancer.region.IRegionGroupAllocator;
-import org.apache.iotdb.confignode.manager.load.balancer.region.PartiteGraphPlacementRegionGroupAllocator;
 import org.apache.iotdb.confignode.manager.load.cache.node.NodeHeartbeatSample;
 import org.apache.iotdb.confignode.manager.load.cache.region.RegionHeartbeatSample;
 import org.apache.iotdb.confignode.manager.partition.PartitionMetrics;
@@ -88,11 +86,11 @@ public class RemoveDataNodeHandler {
         this.regionGroupAllocator = new GreedyRegionGroupAllocator();
         break;
       case PGR:
-        this.regionGroupAllocator = new PartiteGraphPlacementRegionGroupAllocator();
+        this.regionGroupAllocator = new GreedyRegionGroupAllocator();
         break;
       case GCR:
       default:
-        this.regionGroupAllocator = new GreedyCopySetRegionGroupAllocator();
+        this.regionGroupAllocator = new GreedyRegionGroupAllocator();
     }
   }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RemoveDataNodeHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RemoveDataNodeHandler.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.confignode.procedure.env;
 
 import org.apache.iotdb.common.rpc.thrift.TConsensusGroupId;
+import org.apache.iotdb.common.rpc.thrift.TConsensusGroupType;
 import org.apache.iotdb.common.rpc.thrift.TDataNodeConfiguration;
 import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
 import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
@@ -36,7 +37,12 @@ import org.apache.iotdb.confignode.conf.ConfigNodeConfig;
 import org.apache.iotdb.confignode.conf.ConfigNodeDescriptor;
 import org.apache.iotdb.confignode.consensus.request.write.datanode.RemoveDataNodePlan;
 import org.apache.iotdb.confignode.consensus.response.datanode.DataNodeToStatusResp;
+import org.apache.iotdb.confignode.exception.DatabaseNotExistsException;
 import org.apache.iotdb.confignode.manager.ConfigManager;
+import org.apache.iotdb.confignode.manager.load.balancer.region.GreedyCopySetRegionGroupAllocator;
+import org.apache.iotdb.confignode.manager.load.balancer.region.GreedyRegionGroupAllocator;
+import org.apache.iotdb.confignode.manager.load.balancer.region.IRegionGroupAllocator;
+import org.apache.iotdb.confignode.manager.load.balancer.region.PartiteGraphPlacementRegionGroupAllocator;
 import org.apache.iotdb.confignode.manager.load.cache.node.NodeHeartbeatSample;
 import org.apache.iotdb.confignode.manager.load.cache.region.RegionHeartbeatSample;
 import org.apache.iotdb.confignode.manager.partition.PartitionMetrics;
@@ -51,10 +57,13 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.iotdb.confignode.conf.ConfigNodeConstant.REMOVE_DATANODE_PROCESS;
@@ -70,8 +79,22 @@ public class RemoveDataNodeHandler {
 
   private final ConfigManager configManager;
 
+  private final IRegionGroupAllocator regionGroupAllocator;
+
   public RemoveDataNodeHandler(ConfigManager configManager) {
     this.configManager = configManager;
+
+    switch (ConfigNodeDescriptor.getInstance().getConf().getRegionGroupAllocatePolicy()) {
+      case GREEDY:
+        this.regionGroupAllocator = new GreedyRegionGroupAllocator();
+        break;
+      case PGR:
+        this.regionGroupAllocator = new PartiteGraphPlacementRegionGroupAllocator();
+        break;
+      case GCR:
+      default:
+        this.regionGroupAllocator = new GreedyCopySetRegionGroupAllocator();
+    }
   }
 
   /**
@@ -191,6 +214,199 @@ public class RemoveDataNodeHandler {
               .collect(Collectors.toList()));
     }
     return regionMigrationPlans;
+  }
+
+  /**
+   * Retrieves all region migration plans for the specified removed DataNodes and selects the
+   * destination.
+   *
+   * @param removedDataNodes the list of DataNodes from which to obtain migration plans
+   * @return a list of region migration plans associated with the removed DataNodes
+   */
+  public List<RegionMigrationPlan> selectedRegionMigrationPlans(
+      List<TDataNodeLocation> removedDataNodes) {
+
+    Set<Integer> removedDataNodesSet = new HashSet<>();
+    for (TDataNodeLocation removedDataNode : removedDataNodes) {
+      removedDataNodesSet.add(removedDataNode.dataNodeId);
+    }
+
+    final List<TDataNodeConfiguration> availableDataNodes =
+        configManager
+            .getNodeManager()
+            .filterDataNodeThroughStatus(NodeStatus.Running, NodeStatus.Unknown)
+            .stream()
+            .filter(node -> !removedDataNodesSet.contains(node.getLocation().getDataNodeId()))
+            .collect(Collectors.toList());
+
+    List<RegionMigrationPlan> regionMigrationPlans = new ArrayList<>();
+
+    regionMigrationPlans.addAll(
+        selectMigrationPlans(availableDataNodes, TConsensusGroupType.DataRegion, removedDataNodes));
+
+    regionMigrationPlans.addAll(
+        selectMigrationPlans(
+            availableDataNodes, TConsensusGroupType.SchemaRegion, removedDataNodes));
+
+    return regionMigrationPlans;
+  }
+
+  public List<RegionMigrationPlan> selectMigrationPlans(
+      List<TDataNodeConfiguration> availableDataNodes,
+      TConsensusGroupType consensusGroupType,
+      List<TDataNodeLocation> removedDataNodes) {
+
+    // Retrieve all allocated replica sets for the given consensus group type
+    List<TRegionReplicaSet> allocatedReplicaSets =
+        configManager.getPartitionManager().getAllReplicaSets(consensusGroupType);
+
+    // Step 1: Identify affected replica sets and record the removed DataNode for each replica set
+    Map<TConsensusGroupId, TDataNodeLocation> removedNodeMap = new HashMap<>();
+    Set<TRegionReplicaSet> affectedReplicaSets =
+        identifyAffectedReplicaSets(allocatedReplicaSets, removedDataNodes, removedNodeMap);
+
+    // Step 2: Update affected replica sets by removing the removed DataNode
+    updateReplicaSets(allocatedReplicaSets, affectedReplicaSets, removedNodeMap);
+
+    // Build a mapping of available DataNodes and their free disk space (computed only once)
+    Map<Integer, TDataNodeConfiguration> availableDataNodeMap =
+        buildAvailableDataNodeMap(availableDataNodes);
+    Map<Integer, Double> freeDiskSpaceMap = buildFreeDiskSpaceMap(availableDataNodes);
+
+    // Step 3: For each affected replica set, select a new destination DataNode and create a
+    // migration plan
+    List<RegionMigrationPlan> migrationPlans = new ArrayList<>();
+    for (TRegionReplicaSet replicaSet : affectedReplicaSets) {
+      String database =
+          configManager.getPartitionManager().getRegionDatabase(replicaSet.getRegionId());
+      List<TRegionReplicaSet> databaseAllocatedReplicaSets =
+          configManager.getPartitionManager().getAllReplicaSets(database, consensusGroupType);
+      int replicationFactor =
+          getReplicationFactor(database, consensusGroupType, replicaSet.getRegionId());
+
+      TDataNodeConfiguration selectedNode =
+          regionGroupAllocator.selectDestDataNode(
+              availableDataNodeMap,
+              freeDiskSpaceMap,
+              allocatedReplicaSets,
+              databaseAllocatedReplicaSets,
+              replicationFactor,
+              replicaSet.getRegionId(),
+              replicaSet);
+      LOGGER.info(
+          "Selected DataNode {} for Region {}",
+          selectedNode.getLocation().getDataNodeId(),
+          replicaSet.getRegionId());
+
+      // Update the replica set by adding the new DataNode
+      updateReplicaSet(allocatedReplicaSets, replicaSet, selectedNode.getLocation());
+
+      // Create the migration plan
+      RegionMigrationPlan plan =
+          RegionMigrationPlan.create(
+              replicaSet.getRegionId(), removedNodeMap.get(replicaSet.getRegionId()));
+      plan.setToDataNode(selectedNode.getLocation());
+      migrationPlans.add(plan);
+    }
+    return migrationPlans;
+  }
+
+  /**
+   * Identifies affected replica sets from allocatedReplicaSets that contain any DataNode in
+   * removedDataNodes, and records the removed DataNode for each replica set.
+   */
+  private Set<TRegionReplicaSet> identifyAffectedReplicaSets(
+      List<TRegionReplicaSet> allocatedReplicaSets,
+      List<TDataNodeLocation> removedDataNodes,
+      Map<TConsensusGroupId, TDataNodeLocation> removedNodeMap) {
+
+    Set<TRegionReplicaSet> affectedReplicaSets = new HashSet<>();
+    // Create a copy of allocatedReplicaSets to avoid concurrent modifications
+    List<TRegionReplicaSet> allocatedCopy = new ArrayList<>(allocatedReplicaSets);
+
+    for (TDataNodeLocation removedNode : removedDataNodes) {
+      allocatedCopy.stream()
+          .filter(replicaSet -> replicaSet.getDataNodeLocations().contains(removedNode))
+          .forEach(
+              replicaSet -> {
+                removedNodeMap.put(replicaSet.getRegionId(), removedNode);
+                affectedReplicaSets.add(replicaSet);
+              });
+    }
+    return affectedReplicaSets;
+  }
+
+  /**
+   * Updates each affected replica set by removing the removed DataNode from its list. The
+   * allocatedReplicaSets list is updated accordingly.
+   */
+  private void updateReplicaSets(
+      List<TRegionReplicaSet> allocatedReplicaSets,
+      Set<TRegionReplicaSet> affectedReplicaSets,
+      Map<TConsensusGroupId, TDataNodeLocation> removedNodeMap) {
+    for (TRegionReplicaSet replicaSet : affectedReplicaSets) {
+      // Remove the replica set, update its node list, then re-add it
+      allocatedReplicaSets.remove(replicaSet);
+      replicaSet.getDataNodeLocations().remove(removedNodeMap.get(replicaSet.getRegionId()));
+      allocatedReplicaSets.add(replicaSet);
+    }
+  }
+
+  /**
+   * Constructs a mapping from DataNodeId to TDataNodeConfiguration from the available DataNodes.
+   */
+  private Map<Integer, TDataNodeConfiguration> buildAvailableDataNodeMap(
+      List<TDataNodeConfiguration> availableDataNodes) {
+    return availableDataNodes.stream()
+        .collect(
+            Collectors.toMap(
+                dataNode -> dataNode.getLocation().getDataNodeId(), Function.identity()));
+  }
+
+  /** Constructs a mapping of free disk space for each DataNode. */
+  private Map<Integer, Double> buildFreeDiskSpaceMap(
+      List<TDataNodeConfiguration> availableDataNodes) {
+    Map<Integer, Double> freeDiskSpaceMap = new HashMap<>(availableDataNodes.size());
+    availableDataNodes.forEach(
+        dataNode ->
+            freeDiskSpaceMap.put(
+                dataNode.getLocation().getDataNodeId(),
+                configManager
+                    .getLoadManager()
+                    .getFreeDiskSpace(dataNode.getLocation().getDataNodeId())));
+    return freeDiskSpaceMap;
+  }
+
+  /**
+   * Retrieves the replication factor for the given database and consensus group type. If the
+   * database does not exist, a default value is returned.
+   */
+  private int getReplicationFactor(
+      String database, TConsensusGroupType consensusGroupType, TConsensusGroupId regionId) {
+    try {
+      return configManager
+          .getClusterSchemaManager()
+          .getReplicationFactor(database, consensusGroupType);
+    } catch (DatabaseNotExistsException e) {
+      LOGGER.warn(
+          "Region {}'s database: {} does not exist, using default value.", regionId, database, e);
+      return consensusGroupType.equals(TConsensusGroupType.DataRegion)
+          ? ConfigNodeDescriptor.getInstance().getConf().getDataReplicationFactor()
+          : ConfigNodeDescriptor.getInstance().getConf().getSchemaReplicationFactor();
+    }
+  }
+
+  /**
+   * Updates a single replica set by adding the new DataNode to its list and updating the
+   * allocatedReplicaSets.
+   */
+  private void updateReplicaSet(
+      List<TRegionReplicaSet> allocatedReplicaSets,
+      TRegionReplicaSet replicaSet,
+      TDataNodeLocation newDataNode) {
+    allocatedReplicaSets.remove(replicaSet);
+    replicaSet.getDataNodeLocations().add(newDataNode);
+    allocatedReplicaSets.add(replicaSet);
   }
 
   /**

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/node/RemoveDataNodesProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/node/RemoveDataNodesProcedure.java
@@ -121,7 +121,8 @@ public class RemoveDataNodesProcedure extends AbstractNodeProcedure<RemoveDataNo
           removedDataNodes.forEach(
               dataNode -> removedNodeStatusMap.put(dataNode.getDataNodeId(), NodeStatus.Removing));
           removeDataNodeHandler.changeDataNodeStatus(removedDataNodes, removedNodeStatusMap);
-          regionMigrationPlans = removeDataNodeHandler.getRegionMigrationPlans(removedDataNodes);
+          regionMigrationPlans =
+              removeDataNodeHandler.selectedRegionMigrationPlans(removedDataNodes);
           LOG.info(
               "{}, DataNode regions to be removed is {}",
               REMOVE_DATANODE_PROCESS,
@@ -165,8 +166,7 @@ public class RemoveDataNodesProcedure extends AbstractNodeProcedure<RemoveDataNo
         regionMigrationPlan -> {
           TConsensusGroupId regionId = regionMigrationPlan.getRegionId();
           TDataNodeLocation removedDataNode = regionMigrationPlan.getFromDataNode();
-          TDataNodeLocation destDataNode =
-              env.getRegionMaintainHandler().findDestDataNode(regionId);
+          TDataNodeLocation destDataNode = regionMigrationPlan.getToDataNode();
           // TODO: need to improve the coordinator selection method here, maybe through load
           // balancing and other means.
           final TDataNodeLocation coordinatorForAddPeer =

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/load/balancer/region/GreedyCopySetDestNodeSelectorTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/load/balancer/region/GreedyCopySetDestNodeSelectorTest.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.confignode.manager.load.balancer.region;
+
+import org.apache.iotdb.common.rpc.thrift.TConsensusGroupId;
+import org.apache.iotdb.common.rpc.thrift.TConsensusGroupType;
+import org.apache.iotdb.common.rpc.thrift.TDataNodeConfiguration;
+import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
+import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class GreedyCopySetDestNodeSelectorTest {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(GreedyCopySetDestNodeSelectorTest.class);
+
+  private static final IRegionGroupAllocator GCR_ALLOCATOR =
+      new GreedyCopySetRegionGroupAllocator();
+
+  private static final TDataNodeLocation REMOVE_DATANODE_LOCATION =
+      new TDataNodeLocation().setDataNodeId(5);
+
+  private static final int TEST_DATA_NODE_NUM = 5;
+
+  private static final int DATA_REGION_PER_DATA_NODE = 4;
+
+  private static final int DATA_REPLICATION_FACTOR = 2;
+
+  private static final Map<Integer, TDataNodeConfiguration> AVAILABLE_DATA_NODE_MAP =
+      new HashMap<>();
+
+  private static final Map<Integer, Double> FREE_SPACE_MAP = new HashMap<>();
+
+  @BeforeClass
+  public static void setUp() {
+    // Construct TEST_DATA_NODE_NUM DataNodes
+    for (int i = 1; i <= TEST_DATA_NODE_NUM; i++) {
+      AVAILABLE_DATA_NODE_MAP.put(
+          i, new TDataNodeConfiguration().setLocation(new TDataNodeLocation().setDataNodeId(i)));
+      FREE_SPACE_MAP.put(i, Math.random());
+    }
+  }
+
+  @Test
+  public void testSelectDestNode() {
+    final int dataRegionGroupNum =
+        DATA_REGION_PER_DATA_NODE * TEST_DATA_NODE_NUM / DATA_REPLICATION_FACTOR;
+
+    List<TRegionReplicaSet> allocateResult = new ArrayList<>();
+    for (int index = 0; index < dataRegionGroupNum; index++) {
+      allocateResult.add(
+          GCR_ALLOCATOR.generateOptimalRegionReplicasDistribution(
+              AVAILABLE_DATA_NODE_MAP,
+              FREE_SPACE_MAP,
+              allocateResult,
+              allocateResult,
+              DATA_REPLICATION_FACTOR,
+              new TConsensusGroupId(TConsensusGroupType.DataRegion, index)));
+    }
+
+    List<TRegionReplicaSet> migratedReplicas =
+        allocateResult.stream()
+            .filter(
+                replicaSet -> replicaSet.getDataNodeLocations().contains(REMOVE_DATANODE_LOCATION))
+            .collect(Collectors.toList());
+
+    AVAILABLE_DATA_NODE_MAP.remove(REMOVE_DATANODE_LOCATION.getDataNodeId());
+    FREE_SPACE_MAP.remove(REMOVE_DATANODE_LOCATION.getDataNodeId());
+
+    List<TRegionReplicaSet> remainReplicas = new ArrayList<>();
+    for (TRegionReplicaSet replicaSet : migratedReplicas) {
+      List<TDataNodeLocation> dataNodeLocations = replicaSet.getDataNodeLocations();
+      allocateResult.remove(replicaSet);
+      dataNodeLocations.remove(REMOVE_DATANODE_LOCATION);
+      allocateResult.add(replicaSet);
+      remainReplicas.add(replicaSet);
+    }
+
+    Map<Integer, Integer> randomRegionCounter = new HashMap<>();
+    Map<Integer, Integer> PGPRegionCounter = new HashMap<>();
+    Set<Integer> randomSelectedNodeIds = new HashSet<>();
+    Set<Integer> PGPSelectedNodeIds = new HashSet<>();
+
+    int randomMaxRegionCount = 0;
+    int randomMinRegionCount = Integer.MAX_VALUE;
+    int PGPMaxRegionCount = 0;
+    int PGPMinRegionCount = Integer.MAX_VALUE;
+
+    AVAILABLE_DATA_NODE_MAP
+        .keySet()
+        .forEach(
+            nodeId -> {
+              randomRegionCounter.put(nodeId, 0);
+              PGPRegionCounter.put(nodeId, 0);
+            });
+
+    for (TRegionReplicaSet remainReplicaSet : remainReplicas) {
+      TDataNodeLocation selectedNode =
+          randomSelectNodeForRegion(remainReplicaSet.getDataNodeLocations()).get();
+      LOGGER.info(
+          "Random Selected DataNode {} for Region {}",
+          selectedNode.getDataNodeId(),
+          remainReplicaSet.regionId);
+      randomSelectedNodeIds.add(selectedNode.getDataNodeId());
+      randomRegionCounter.put(
+          selectedNode.getDataNodeId(), randomRegionCounter.get(selectedNode.getDataNodeId()) + 1);
+    }
+
+    LOGGER.info("Remain Replicas... :");
+    for (TRegionReplicaSet remainReplicaSet : remainReplicas) {
+      LOGGER.info("Region Group Id: {}", remainReplicaSet.regionId.id);
+      List<TDataNodeLocation> dataNodeLocations = remainReplicaSet.getDataNodeLocations();
+      for (TDataNodeLocation dataNodeLocation : dataNodeLocations) {
+        LOGGER.info("DataNode: {}", dataNodeLocation.getDataNodeId());
+      }
+    }
+
+    for (TRegionReplicaSet remainReplicaSet : remainReplicas) {
+      TDataNodeConfiguration selectedNode =
+          GCR_ALLOCATOR.selectDestDataNode(
+              AVAILABLE_DATA_NODE_MAP,
+              FREE_SPACE_MAP,
+              allocateResult,
+              allocateResult,
+              DATA_REPLICATION_FACTOR,
+              remainReplicaSet.regionId,
+              remainReplicaSet);
+
+      LOGGER.info(
+          "GCR Selected DataNode {} for Region {}",
+          selectedNode.getLocation().getDataNodeId(),
+          remainReplicaSet.regionId);
+
+      allocateResult.remove(remainReplicaSet);
+      List<TDataNodeLocation> dataNodeLocations = remainReplicaSet.getDataNodeLocations();
+      dataNodeLocations.add(selectedNode.getLocation());
+      allocateResult.add(remainReplicaSet);
+      PGPSelectedNodeIds.add(selectedNode.getLocation().getDataNodeId());
+      PGPRegionCounter.put(
+          selectedNode.getLocation().getDataNodeId(),
+          PGPRegionCounter.get(selectedNode.getLocation().getDataNodeId()) + 1);
+    }
+
+    for (Integer i : randomRegionCounter.keySet()) {
+      Integer value = randomRegionCounter.get(i);
+      randomMaxRegionCount = Math.max(randomMaxRegionCount, value);
+      randomMinRegionCount = Math.min(randomMinRegionCount, value);
+    }
+
+    for (Integer i : PGPRegionCounter.keySet()) {
+      Integer value = PGPRegionCounter.get(i);
+      PGPMaxRegionCount = Math.max(PGPMaxRegionCount, value);
+      PGPMinRegionCount = Math.min(PGPMinRegionCount, value);
+    }
+
+//    Assert.assertEquals(TEST_DATA_NODE_NUM - 1, PGPSelectedNodeIds.size());
+    Assert.assertTrue(PGPSelectedNodeIds.size() >= randomSelectedNodeIds.size());
+    Assert.assertTrue(randomMaxRegionCount >= PGPMaxRegionCount);
+    Assert.assertTrue(randomMinRegionCount <= PGPMinRegionCount);
+  }
+
+  private Optional<TDataNodeLocation> randomSelectNodeForRegion(
+      List<TDataNodeLocation> regionReplicaNodes) {
+    List<TDataNodeConfiguration> dataNodeConfigurations =
+        new ArrayList<>(AVAILABLE_DATA_NODE_MAP.values());
+    // Randomly selected to ensure a basic load balancing
+    Collections.shuffle(dataNodeConfigurations);
+    return dataNodeConfigurations.stream()
+        .map(TDataNodeConfiguration::getLocation)
+        .filter(e -> !regionReplicaNodes.contains(e))
+        .findAny();
+  }
+}

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/load/balancer/region/GreedyCopySetRemoveNodeReplicaSelectTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/load/balancer/region/GreedyCopySetRemoveNodeReplicaSelectTest.java
@@ -147,12 +147,15 @@ public class GreedyCopySetRemoveNodeReplicaSelectTest {
       }
     }
     Map<TConsensusGroupId, TRegionReplicaSet> remainReplicasMap = new HashMap<>();
-    Map<TConsensusGroupId, String> regionDatabaseMap = new HashMap<>();
     Map<String, List<TRegionReplicaSet>> databaseAllocatedRegionGroupMap = new HashMap<>();
     databaseAllocatedRegionGroupMap.put("database", allocateResult);
 
     for (TRegionReplicaSet remainReplicaSet : remainReplicas) {
       remainReplicasMap.put(remainReplicaSet.getRegionId(), remainReplicaSet);
+    }
+    Map<TConsensusGroupId, String> regionDatabaseMap = new HashMap<>();
+    for (TRegionReplicaSet replicaSet : allocateResult) {
+      regionDatabaseMap.put(replicaSet.getRegionId(), "database");
     }
     Map<TConsensusGroupId, TDataNodeConfiguration> result =
         GCR_ALLOCATOR.removeNodeReplicaSelect(


### PR DESCRIPTION
## Description

Add region migration dest datanode selection algorithm for load balancing during removing datanode.

Please see https://apache-iotdb-project.feishu.cn/docx/G5aPdZJ4QozqmkxO9dsc7sEsnTe for detail design.
