### PR TITLE
Fix mods file metrics

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/metrics/FileMetrics.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/metrics/FileMetrics.java
@@ -92,6 +92,16 @@ public class FileMetrics implements IMetricSet {
     MODS_FILE_METRICS.decreaseModFileSize(size);
   }
 
+  @TestOnly
+  public int getModFileNum() {
+    return MODS_FILE_METRICS.getModFileNum();
+  }
+
+  @TestOnly
+  public long getModFileSize() {
+    return MODS_FILE_METRICS.getModFileSize();
+  }
+
   // endregion
 
   public Map<Integer, Long> getRegionSizeMap() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/metrics/file/ModsFileMetrics.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/metrics/file/ModsFileMetrics.java
@@ -60,11 +60,11 @@ public class ModsFileMetrics implements IMetricSet {
         MetricType.AUTO_GAUGE, Metric.FILE_COUNT.toString(), Tag.NAME.toString(), MODS);
   }
 
-  private int getModFileNum() {
+  public int getModFileNum() {
     return modFileNum.get();
   }
 
-  private long getModFileSize() {
+  public long getModFileSize() {
     return modFileSize.get();
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
@@ -734,7 +734,6 @@ public class TsFileResource implements PersistentResource {
   public void closeWithoutSettingStatus() throws IOException {
     if (exclusiveModFile != null) {
       exclusiveModFile.close();
-      exclusiveModFile = null;
     }
     if (compactionModFile != null) {
       compactionModFile.close();


### PR DESCRIPTION
## Description
Fix mods file metrics.
<img width="642" alt="截屏2025-04-07 14 24 22" src="https://github.com/user-attachments/assets/9a02c893-7eb3-42f9-b0d7-2f666dc858a5" />
<img width="892" alt="截屏2025-04-07 14 24 40" src="https://github.com/user-attachments/assets/a8524f98-a83e-49fa-b98c-806969867a0c" />
The 'closeWithoutSettingStatus' method sets exclusiveModFile to null, and the mods file metric will be updated again when other modules call getExclusiveModFile.
