### PR TITLE
Fix the output ordinal of AggTableScanOperator are not consistent with OutputSymbols of AggTableScanNode when do single input distinct optimize

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
@@ -5133,6 +5133,14 @@ public class IoTDBTableAggregationIT {
         retArray,
         DATABASE_NAME);
 
+    expectedHeader = new String[] {"_col0"};
+    retArray = new String[] {"16,"};
+    tableResultSetEqualTest(
+        "select count(distinct device_id) from table1 group by date_bin(1d,time) order by 1",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+
     expectedHeader = new String[] {"province", "city", "region", "_col3", "_col4"};
     retArray =
         new String[] {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/SymbolAllocator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/SymbolAllocator.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.queryengine.plan.relational.planner;
 
+import org.apache.iotdb.commons.udf.builtin.relational.TableBuiltinScalarFunction;
 import org.apache.iotdb.db.queryengine.plan.analyze.TypeProvider;
 import org.apache.iotdb.db.queryengine.plan.relational.analyzer.Field;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Expression;
@@ -39,6 +40,9 @@ public class SymbolAllocator {
   public static final String GROUP_KEY_SUFFIX = "gid";
 
   public static final String SEPARATOR = "$";
+
+  public static final String DATE_BIN_PREFIX =
+      TableBuiltinScalarFunction.DATE_BIN.getFunctionName() + SEPARATOR;
 
   private final Map<Symbol, Type> symbolMap;
   private int nextId;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/iterative/rule/SingleDistinctAggregationToGroupBy.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/iterative/rule/SingleDistinctAggregationToGroupBy.java
@@ -133,8 +133,9 @@ public class SingleDistinctAggregationToGroupBy implements Rule<AggregationNode>
                     ImmutableMap.of(),
                     singleGroupingSet(
                         ImmutableList.<Symbol>builder()
-                            .addAll(aggregation.getGroupingKeys())
+                            // make sure date_bin is in the last of GroupingKeys
                             .addAll(symbols)
+                            .addAll(aggregation.getGroupingKeys())
                             .build())))
             .setAggregations(
                 // remove DISTINCT flag from function calls

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/node/AggregationTableScanNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/node/AggregationTableScanNode.java
@@ -54,6 +54,7 @@ import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
+import static org.apache.iotdb.db.queryengine.plan.relational.planner.SymbolAllocator.DATE_BIN_PREFIX;
 import static org.apache.iotdb.db.utils.constant.SqlConstant.COUNT;
 import static org.apache.iotdb.db.utils.constant.SqlConstant.TABLE_TIME_COLUMN_NAME;
 
@@ -126,10 +127,16 @@ public class AggregationTableScanNode extends DeviceTableScanNode {
 
     this.step = step;
 
+    List<Symbol> groupingKeys = groupingSets.getGroupingKeys();
+    for (int i = 0; i < groupingKeys.size(); i++) {
+      if (groupingKeys.get(i).getName().startsWith(DATE_BIN_PREFIX)) {
+        checkArgument(
+            i == groupingKeys.size() - 1, "date_bin function must be the last GroupingKey");
+      }
+    }
     requireNonNull(preGroupedSymbols, "preGroupedSymbols is null");
     checkArgument(
-        preGroupedSymbols.isEmpty()
-            || groupingSets.getGroupingKeys().containsAll(preGroupedSymbols),
+        preGroupedSymbols.isEmpty() || groupingKeys.containsAll(preGroupedSymbols),
         "Pre-grouped symbols must be a subset of the grouping keys");
     this.preGroupedSymbols = ImmutableList.copyOf(preGroupedSymbols);
 


### PR DESCRIPTION
Cause: The `AggTableScanOperator` always append the date_bin result in the last of `groupingKeys`, but it is not always the same order with `outputSymbols` refined, typically when do single input distinct optimize.
Fix: Make sure the date_bin is the last of `groupingKeys`, and add argument check when init  `AggTableScanNode`.