### PR TITLE
Add retry for inactivePeer of region migration

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensus.java
@@ -331,7 +331,7 @@ public class IoTConsensus implements IConsensus {
       try {
         // step 1: inactive new Peer to prepare for following steps
         logger.info("[IoTConsensus] inactivate new peer: {}", peer);
-        impl.inactivePeer(peer, false);
+        impl.inactivatePeer(peer, false);
 
         // step 2: notify all the other Peers to build the sync connection to newPeer
         logger.info("[IoTConsensus] notify current peers to build sync log...");
@@ -397,7 +397,7 @@ public class IoTConsensus implements IConsensus {
 
       try {
         // let target peer reject new write
-        impl.inactivePeer(peer, true);
+        impl.inactivatePeer(peer, true);
         KillPoint.setKillPoint(IoTConsensusRemovePeerCoordinatorKillPoints.AFTER_INACTIVE_PEER);
         // wait its SyncLog to complete
         impl.waitTargetPeerUntilSyncLogCompleted(peer);

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -413,7 +413,7 @@ public class IoTConsensusServerImpl {
     R apply(T t) throws Exception;
   }
 
-  public void inactivePeer(Peer peer, boolean forDeletionPurpose)
+  public void inactivatePeer(Peer peer, boolean forDeletionPurpose)
       throws ConsensusGroupModifyPeerException {
     ConsensusGroupModifyPeerException lastException = null;
     // In region migration, if the target node restarts before the “addRegionPeer” phase within 1
@@ -430,7 +430,7 @@ public class IoTConsensusServerImpl {
                   new TInactivatePeerReq(peer.getGroupId().convertToTConsensusGroupId())
                       .setForDeletionPurpose(forDeletionPurpose));
           if (isSuccess(res.status)) {
-            break;
+            return;
           }
           lastException =
               new ConsensusGroupModifyPeerException(
@@ -444,9 +444,7 @@ public class IoTConsensusServerImpl {
         lastException = new ConsensusGroupModifyPeerException(e);
       }
     }
-    if (lastException != null) {
-      throw lastException;
-    }
+    throw lastException;
   }
 
   public void triggerSnapshotLoad(Peer peer) throws ConsensusGroupModifyPeerException {


### PR DESCRIPTION
In region migration, if the target node restarts before the “addRegionPeer” phase within 1 minutes, the client in the ClientManager will become invalid.

This PR adds 1 retry at this point to ensure that region migration can still proceed correctly in such cases.