### PR TITLE
IoTV2: Use global singleton ClientManager to avoid too many thrift threads which leads to Direct Memory OOM.

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/pipe/PipeConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/pipe/PipeConsensus.java
@@ -120,8 +120,10 @@ public class PipeConsensus implements IConsensus {
             config.getPipeConsensusConfig().getReplicateMode());
     this.consensusPipeGuardian =
         config.getPipeConsensusConfig().getPipe().getConsensusPipeGuardian();
-    this.asyncClientManager = PipeConsensusClientMgrContainer.getInstance().newAsyncClientManager();
-    this.syncClientManager = PipeConsensusClientMgrContainer.getInstance().newSyncClientManager();
+    this.asyncClientManager =
+        PipeConsensusClientMgrContainer.getInstance().getGlobalAsyncClientManager();
+    this.syncClientManager =
+        PipeConsensusClientMgrContainer.getInstance().getGlobalSyncClientManager();
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/pipeconsensus/PipeConsensusAsyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/pipeconsensus/PipeConsensusAsyncConnector.java
@@ -147,7 +147,7 @@ public class PipeConsensusAsyncConnector extends IoTDBConnector implements Conse
             nodeUrls, consensusGroupId, thisDataNodeId, pipeConsensusConnectorMetrics);
     retryConnector.customize(parameters, configuration);
     asyncTransferClientManager =
-        PipeConsensusClientMgrContainer.getInstance().newAsyncClientManager();
+        PipeConsensusClientMgrContainer.getInstance().getGlobalAsyncClientManager();
 
     if (isTabletBatchModeEnabled) {
       tabletBatchBuilder =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/pipeconsensus/PipeConsensusSyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/pipeconsensus/PipeConsensusSyncConnector.java
@@ -97,7 +97,7 @@ public class PipeConsensusSyncConnector extends IoTDBConnector {
     this.consensusGroupId = consensusGroupId;
     this.thisDataNodeId = thisDataNodeId;
     this.syncRetryClientManager =
-        PipeConsensusClientMgrContainer.getInstance().newSyncClientManager();
+        PipeConsensusClientMgrContainer.getInstance().getGlobalSyncClientManager();
     this.pipeConsensusConnectorMetrics = pipeConsensusConnectorMetrics;
   }
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/container/PipeConsensusClientMgrContainer.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/container/PipeConsensusClientMgrContainer.java
@@ -40,6 +40,8 @@ import org.apache.iotdb.commons.conf.CommonDescriptor;
 public class PipeConsensusClientMgrContainer {
   private static final CommonConfig CONF = CommonDescriptor.getInstance().getConfig();
   private final PipeConsensusClientProperty config;
+  private final IClientManager<TEndPoint, AsyncPipeConsensusServiceClient> asyncClientManager;
+  private final IClientManager<TEndPoint, SyncPipeConsensusServiceClient> syncClientManager;
 
   private PipeConsensusClientMgrContainer() {
     // load rpc client config
@@ -49,16 +51,20 @@ public class PipeConsensusClientMgrContainer {
             .setMaxClientNumForEachNode(CONF.getMaxClientNumForEachNode())
             .setSelectorNumOfClientManager(CONF.getSelectorNumOfClientManager())
             .build();
+    this.asyncClientManager =
+        new IClientManager.Factory<TEndPoint, AsyncPipeConsensusServiceClient>()
+            .createClientManager(new AsyncPipeConsensusServiceClientPoolFactory(config));
+    this.syncClientManager =
+        new IClientManager.Factory<TEndPoint, SyncPipeConsensusServiceClient>()
+            .createClientManager(new SyncPipeConsensusServiceClientPoolFactory(config));
   }
 
-  public IClientManager<TEndPoint, AsyncPipeConsensusServiceClient> newAsyncClientManager() {
-    return new IClientManager.Factory<TEndPoint, AsyncPipeConsensusServiceClient>()
-        .createClientManager(new AsyncPipeConsensusServiceClientPoolFactory(config));
+  public IClientManager<TEndPoint, AsyncPipeConsensusServiceClient> getGlobalAsyncClientManager() {
+    return this.asyncClientManager;
   }
 
-  public IClientManager<TEndPoint, SyncPipeConsensusServiceClient> newSyncClientManager() {
-    return new IClientManager.Factory<TEndPoint, SyncPipeConsensusServiceClient>()
-        .createClientManager(new SyncPipeConsensusServiceClientPoolFactory(config));
+  public IClientManager<TEndPoint, SyncPipeConsensusServiceClient> getGlobalSyncClientManager() {
+    return this.syncClientManager;
   }
 
   private static class PipeConsensusClientMgrContainerHolder {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/container/PipeConsensusClientMgrContainer.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/container/PipeConsensusClientMgrContainer.java
@@ -49,7 +49,7 @@ public class PipeConsensusClientMgrContainer {
         PipeConsensusClientProperty.newBuilder()
             .setIsRpcThriftCompressionEnabled(CONF.isRpcThriftCompressionEnabled())
             .setMaxClientNumForEachNode(CONF.getMaxClientNumForEachNode())
-            .setSelectorNumOfClientManager(CONF.getSelectorNumOfClientManager())
+            .setSelectorNumOfClientManager(Math.max(3, CONF.getSelectorNumOfClientManager()))
             .build();
     this.asyncClientManager =
         new IClientManager.Factory<TEndPoint, AsyncPipeConsensusServiceClient>()


### PR DESCRIPTION
as title.

I also set selector num max(3, conf), considering all pipe connectors and pipeConsensus use a single client manager.