### PR TITLE
Fix Greatest's looping logic bug in Boolean types.

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/query/IoTDBGreatestLeastTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/query/IoTDBGreatestLeastTableIT.java
@@ -52,6 +52,8 @@ public class IoTDBGreatestLeastTableIT {
         "INSERT INTO number_table(time, device_id, int1, int2, long1, long2, float1, float2, double1, double2) VALUES (10, 'd1', 1000000, 2000000, 1000000, 2000000, 10.1, 20.2, 10.1, 20.2)",
         "INSERT INTO string_table(time, device_id, string1, string2, text1, text2) VALUES(10, 'd1', 'aaa', 'bbb', 'aaa', 'bbb')",
         "INSERT INTO boolean_table(time, device_id, bool1, bool2) VALUES(10, 'd1', true, false)",
+        "INSERT INTO boolean_table(time, device_id, bool1, bool2) VALUES(20, 'd1', false, true)",
+        "INSERT INTO boolean_table(time, device_id, bool1, bool2) VALUES(30, 'd1', true, true)",
         "INSERT INTO mix_type_table(time, device_id, s1, s2, s3, s4, s5, s6, s7) VALUES(10, 'd1', 1, 1, 1.0, 1.0, true, 'a', 'a')",
         "INSERT INTO null_table(time, device_id, string1, string2) VALUES(10, 'd1', null, null)",
         "INSERT INTO any_null_table(time, device_id, string2, int2, double2, timestamp2) VALUES(10, 'd1', 'test', 10, 10.0, 10)",
@@ -170,7 +172,7 @@ public class IoTDBGreatestLeastTableIT {
     tableResultSetEqualTest(
         "SELECT GREATEST(bool1, bool2) FROM boolean_table",
         new String[] {"_col0"},
-        new String[] {"true,"},
+        new String[] {"true,", "true,", "true,"},
         DATABASE_NAME);
   }
 
@@ -179,7 +181,7 @@ public class IoTDBGreatestLeastTableIT {
     tableResultSetEqualTest(
         "SELECT LEAST(bool1, bool2) FROM boolean_table",
         new String[] {"_col0"},
-        new String[] {"false,"},
+        new String[] {"false,", "false,", "true,"},
         DATABASE_NAME);
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/multi/BooleanGreatestColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/multi/BooleanGreatestColumnTransformer.java
@@ -37,7 +37,7 @@ public class BooleanGreatestColumnTransformer extends AbstractGreatestLeastColum
         if (column.getBoolean(index)) {
           // find max value true
           returnType.writeBoolean(builder, true);
-          break;
+          return;
         }
       }
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/multi/BooleanLeastColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/multi/BooleanLeastColumnTransformer.java
@@ -36,7 +36,7 @@ public class BooleanLeastColumnTransformer extends AbstractGreatestLeastColumnTr
         allNull = false;
         if (!column.getBoolean(index)) {
           returnType.writeBoolean(builder, false);
-          break;
+          return;
         }
       }
     }


### PR DESCRIPTION
This pull request includes changes to the `IoTDBGreatestLeastTableIT` integration test and improvements to the `BooleanGreatestColumnTransformer` and `BooleanLeastColumnTransformer` classes. The most important changes are the addition of new test cases and improvements to the boolean transformation logic.

Improvements to integration tests:

* [`integration-test/src/test/java/org/apache/iotdb/relational/it/query/old/query/IoTDBGreatestLeastTableIT.java`](diffhunk://#diff-3ebb39862466df9835f4759c18ce131c3bf343a81bc3f07102b35dc25e7d1472R55-R56): Added new boolean values to the `boolean_table` and updated the expected results in the `testBooleanTypeGreatestFunction` and `testBooleanTypeLeastFunction` methods to reflect these changes. [[1]](diffhunk://#diff-3ebb39862466df9835f4759c18ce131c3bf343a81bc3f07102b35dc25e7d1472R55-R56) [[2]](diffhunk://#diff-3ebb39862466df9835f4759c18ce131c3bf343a81bc3f07102b35dc25e7d1472L173-R175) [[3]](diffhunk://#diff-3ebb39862466df9835f4759c18ce131c3bf343a81bc3f07102b35dc25e7d1472L182-R184)

Codebase simplification:

* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/multi/BooleanGreatestColumnTransformer.java`](diffhunk://#diff-a69fd35004e490dd715a8edbc2324720ab48e31e5c06f0763e0330f39bcf4c03L40-R40): Replaced `break` with `return` to improve the boolean transformation logic.
* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/multi/BooleanLeastColumnTransformer.java`](diffhunk://#diff-cc0b0519ca19e7c38c1594a7edef2e3c07706bbb5ed975ab1a9550afec7acd67L39-R39): Replaced `break` with `return` to improve the boolean transformation logic.[Copilot is generating a summary...]