### PR TITLE
[To dev/1.3] Subscription: poll heartbeat event when there are no consumers (#15307)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/connector/PipeRealtimePriorityBlockingQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/connector/PipeRealtimePriorityBlockingQueue.java
@@ -162,6 +162,15 @@ public class PipeRealtimePriorityBlockingQueue extends UnboundedBlockingPendingQ
   }
 
   @Override
+  public Event peek() {
+    final Event event = pendingQueue.peek();
+    if (Objects.nonNull(event)) {
+      return event;
+    }
+    return tsfileInsertEventDeque.peek();
+  }
+
+  @Override
   public void clear() {
     super.clear();
     tsfileInsertEventDeque.clear();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionBlockingPendingQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionBlockingPendingQueue.java
@@ -33,6 +33,10 @@ public abstract class SubscriptionBlockingPendingQueue {
 
   public abstract Event waitedPoll();
 
+  public abstract Event peek();
+
+  public abstract void directOffer(final Event event);
+
   public int size() {
     return inputPendingQueue.size();
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/TsFileDeduplicationBlockingPendingQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/TsFileDeduplicationBlockingPendingQueue.java
@@ -58,6 +58,16 @@ public class TsFileDeduplicationBlockingPendingQueue extends SubscriptionBlockin
     return filter(inputPendingQueue.waitedPoll());
   }
 
+  @Override
+  public Event peek() {
+    return inputPendingQueue.peek();
+  }
+
+  @Override
+  public void directOffer(final Event event) {
+    inputPendingQueue.directOffer(event);
+  }
+
   private synchronized Event filter(final Event event) { // make it synchronized
     if (Objects.isNull(event)) {
       return null;

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/connection/BlockingPendingQueue.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/connection/BlockingPendingQueue.java
@@ -107,6 +107,10 @@ public abstract class BlockingPendingQueue<E extends Event> {
     return event;
   }
 
+  public E peek() {
+    return pendingQueue.peek();
+  }
+
   public void clear() {
     isClosed.set(true);
     pendingQueue.clear();


### PR DESCRIPTION
cherry-pick #15307 to https://github.com/apache/iotdb/tree/dev/1.3