### PR TITLE
pref: Set the maximum number of history records in the history file / memory to 1,000 lines.

### DIFF
--- a/iotdb-client/cli/src/main/java/org/apache/iotdb/cli/utils/JlineUtils.java
+++ b/iotdb-client/cli/src/main/java/org/apache/iotdb/cli/utils/JlineUtils.java
@@ -97,6 +97,10 @@ public class JlineUtils {
               + "-"
               + username.hashCode();
       builder.variable(LineReader.HISTORY_FILE, new File(historyFilePath));
+      // Set the maximum number of history records in the history file to 1,000 lines.
+      builder.variable(LineReader.HISTORY_FILE_SIZE, 1_000);
+      // Set the maximum number of history records in memory to 1,000 lines.
+      builder.variable(LineReader.HISTORY_SIZE, 1_000);
     }
 
     // TODO: since the lexer doesn't produce tokens for quotation marks, disable the highlighter to


### PR DESCRIPTION
see title