### PR TITLE
Add APPROX_COUNT_DISTINCT Function

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
@@ -4120,6 +4120,42 @@ public class IoTDBTableAggregationIT {
         expectedHeader,
         retArray,
         DATABASE_NAME);
+
+    retArray =
+        new String[] {
+          "2024-09-24T06:15:30.000Z,beijing,2,2,",
+          "2024-09-24T06:15:30.000Z,shanghai,2,2,",
+          "2024-09-24T06:15:31.000Z,beijing,0,0,",
+          "2024-09-24T06:15:31.000Z,shanghai,0,0,",
+          "2024-09-24T06:15:35.000Z,beijing,2,2,",
+          "2024-09-24T06:15:35.000Z,shanghai,2,2,",
+          "2024-09-24T06:15:36.000Z,beijing,2,4,",
+          "2024-09-24T06:15:36.000Z,shanghai,2,4,",
+          "2024-09-24T06:15:40.000Z,beijing,0,4,",
+          "2024-09-24T06:15:40.000Z,shanghai,0,4,",
+          "2024-09-24T06:15:41.000Z,beijing,2,0,",
+          "2024-09-24T06:15:41.000Z,shanghai,2,0,",
+          "2024-09-24T06:15:46.000Z,beijing,0,2,",
+          "2024-09-24T06:15:46.000Z,shanghai,0,2,",
+          "2024-09-24T06:15:50.000Z,beijing,0,2,",
+          "2024-09-24T06:15:50.000Z,shanghai,0,2,",
+          "2024-09-24T06:15:51.000Z,beijing,2,0,",
+          "2024-09-24T06:15:51.000Z,shanghai,2,0,",
+          "2024-09-24T06:15:55.000Z,beijing,2,0,",
+          "2024-09-24T06:15:55.000Z,shanghai,2,0,",
+        };
+
+    tableResultSetEqualTest(
+        "select time,province,approx_count_distinct(s6),approx_count_distinct(s7) from table1 group by 1,2 order by time",
+        new String[] {"time", "province", "_col2", "_col3"},
+        retArray,
+        DATABASE_NAME);
+
+    tableResultSetEqualTest(
+        "select time,province,approx_count_distinct(s6,0.02),approx_count_distinct(s7,0.02) from table1 group by 1,2 order by time",
+        new String[] {"time", "province", "_col2", "_col3"},
+        retArray,
+        DATABASE_NAME);
   }
 
   @Test

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
@@ -4202,7 +4202,7 @@ public class IoTDBTableAggregationIT {
         DATABASE_NAME);
     tableAssertTestFail(
         "select approx_count_distinct(province, 'test') from table1",
-        "701: Second argument of Aggregate functions [approx_count_distinct] should be DOUBLE",
+        "701: Second argument of Aggregate functions [approx_count_distinct] should be numberic type and do not use expression",
         DATABASE_NAME);
   }
 

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
@@ -4106,6 +4106,23 @@ public class IoTDBTableAggregationIT {
   }
 
   @Test
+  public void approxCountDistinctTest() {
+    String[] expectedHeader = buildHeaders(17);
+    String[] retArray = new String[] {"10,2,2,4,16,2,2,5,5,5,5,2,24,32,5,10,1,"};
+    tableResultSetEqualTest(
+        "select approx_count_distinct(time), approx_count_distinct(province), approx_count_distinct(city), approx_count_distinct(region), approx_count_distinct(device_id), approx_count_distinct(color), approx_count_distinct(type), approx_count_distinct(s1), approx_count_distinct(s2), approx_count_distinct(s3), approx_count_distinct(s4), approx_count_distinct(s5), approx_count_distinct(s6), approx_count_distinct(s7), approx_count_distinct(s8), approx_count_distinct(s9), approx_count_distinct(s10) from table1",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+
+    tableResultSetEqualTest(
+        "select approx_count_distinct(time, 0.02), approx_count_distinct(province, 0.02), approx_count_distinct(city, 0.02), approx_count_distinct(region, 0.02), approx_count_distinct(device_id, 0.02), approx_count_distinct(color, 0.02), approx_count_distinct(type, 0.02), approx_count_distinct(s1, 0.02), approx_count_distinct(s2, 0.02), approx_count_distinct(s3, 0.02), approx_count_distinct(s4, 0.02), approx_count_distinct(s5, 0.02), approx_count_distinct(s6, 0.02), approx_count_distinct(s7, 0.02), approx_count_distinct(s8, 0.02), approx_count_distinct(s9, 0.02), approx_count_distinct(s10, 0.02) from table1",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+  }
+
+  @Test
   public void exceptionTest() {
     tableAssertTestFail(
         "select avg() from table1",
@@ -4134,6 +4151,22 @@ public class IoTDBTableAggregationIT {
     tableAssertTestFail(
         "select last_by() from table1",
         "701: Aggregate functions [last_by] should only have two or three arguments",
+        DATABASE_NAME);
+    tableAssertTestFail(
+        "select approx_count_distinct() from table1",
+        "701: Aggregate functions [approx_count_distinct] should only have two arguments",
+        DATABASE_NAME);
+    tableAssertTestFail(
+        "select approx_count_distinct(province, 0.3) from table1",
+        "750: Max Standard Error must be in [0.0040625, 0.26]: 0.3",
+        DATABASE_NAME);
+    tableAssertTestFail(
+        "select approx_count_distinct(province, 0.3) from table1",
+        "750: Max Standard Error must be in [0.0040625, 0.26]: 0.3",
+        DATABASE_NAME);
+    tableAssertTestFail(
+        "select approx_count_distinct(province, 'test') from table1",
+        "701: Second argument of Aggregate functions [approx_count_distinct] should be DOUBLE",
         DATABASE_NAME);
   }
 

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
@@ -4124,35 +4124,35 @@ public class IoTDBTableAggregationIT {
     retArray =
         new String[] {
           "2024-09-24T06:15:30.000Z,beijing,2,2,",
-          "2024-09-24T06:15:30.000Z,shanghai,2,2,",
           "2024-09-24T06:15:31.000Z,beijing,0,0,",
-          "2024-09-24T06:15:31.000Z,shanghai,0,0,",
           "2024-09-24T06:15:35.000Z,beijing,2,2,",
-          "2024-09-24T06:15:35.000Z,shanghai,2,2,",
           "2024-09-24T06:15:36.000Z,beijing,2,4,",
-          "2024-09-24T06:15:36.000Z,shanghai,2,4,",
           "2024-09-24T06:15:40.000Z,beijing,0,4,",
-          "2024-09-24T06:15:40.000Z,shanghai,0,4,",
           "2024-09-24T06:15:41.000Z,beijing,2,0,",
-          "2024-09-24T06:15:41.000Z,shanghai,2,0,",
           "2024-09-24T06:15:46.000Z,beijing,0,2,",
-          "2024-09-24T06:15:46.000Z,shanghai,0,2,",
           "2024-09-24T06:15:50.000Z,beijing,0,2,",
-          "2024-09-24T06:15:50.000Z,shanghai,0,2,",
           "2024-09-24T06:15:51.000Z,beijing,2,0,",
-          "2024-09-24T06:15:51.000Z,shanghai,2,0,",
           "2024-09-24T06:15:55.000Z,beijing,2,0,",
+          "2024-09-24T06:15:30.000Z,shanghai,2,2,",
+          "2024-09-24T06:15:31.000Z,shanghai,0,0,",
+          "2024-09-24T06:15:35.000Z,shanghai,2,2,",
+          "2024-09-24T06:15:36.000Z,shanghai,2,4,",
+          "2024-09-24T06:15:40.000Z,shanghai,0,4,",
+          "2024-09-24T06:15:41.000Z,shanghai,2,0,",
+          "2024-09-24T06:15:46.000Z,shanghai,0,2,",
+          "2024-09-24T06:15:50.000Z,shanghai,0,2,",
+          "2024-09-24T06:15:51.000Z,shanghai,2,0,",
           "2024-09-24T06:15:55.000Z,shanghai,2,0,",
         };
 
     tableResultSetEqualTest(
-        "select time,province,approx_count_distinct(s6),approx_count_distinct(s7) from table1 group by 1,2 order by time",
+        "select time,province,approx_count_distinct(s6),approx_count_distinct(s7) from table1 group by 1,2 order by 2,1",
         new String[] {"time", "province", "_col2", "_col3"},
         retArray,
         DATABASE_NAME);
 
     tableResultSetEqualTest(
-        "select time,province,approx_count_distinct(s6,0.02),approx_count_distinct(s7,0.02) from table1 group by 1,2 order by time",
+        "select time,province,approx_count_distinct(s6,0.02),approx_count_distinct(s7,0.02) from table1 group by 1,2 order by 2,1",
         new String[] {"time", "province", "_col2", "_col3"},
         retArray,
         DATABASE_NAME);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/AccumulatorFactory.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/AccumulatorFactory.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.commons.udf.utils.TableUDFUtils;
 import org.apache.iotdb.commons.udf.utils.UDFDataTypeTransformer;
 import org.apache.iotdb.db.queryengine.execution.aggregation.VarianceAccumulator;
 import org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation.grouped.GroupedAccumulator;
+import org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation.grouped.GroupedApproxCountDistinctAccumulator;
 import org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation.grouped.GroupedAvgAccumulator;
 import org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation.grouped.GroupedCountAccumulator;
 import org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation.grouped.GroupedCountIfAccumulator;
@@ -240,6 +241,8 @@ public class AccumulatorFactory {
       case VAR_POP:
         return new GroupedVarianceAccumulator(
             inputDataTypes.get(0), VarianceAccumulator.VarianceType.VAR_POP);
+      case APPROX_COUNT_DISTINCT:
+        return new GroupedApproxCountDistinctAccumulator(inputDataTypes.get(0));
       default:
         throw new IllegalArgumentException("Invalid Aggregation function: " + aggregationType);
     }
@@ -305,6 +308,8 @@ public class AccumulatorFactory {
       case VAR_POP:
         return new TableVarianceAccumulator(
             inputDataTypes.get(0), VarianceAccumulator.VarianceType.VAR_POP);
+      case APPROX_COUNT_DISTINCT:
+        return new ApproxCountDistinctAccumulator(inputDataTypes.get(0));
       default:
         throw new IllegalArgumentException("Invalid Aggregation function: " + aggregationType);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/ApproxCountDistinctAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/ApproxCountDistinctAccumulator.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation;
+
+import org.apache.tsfile.block.column.Column;
+import org.apache.tsfile.block.column.ColumnBuilder;
+import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.file.metadata.statistics.Statistics;
+import org.apache.tsfile.utils.RamUsageEstimator;
+import org.apache.tsfile.write.UnSupportedDataTypeException;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class ApproxCountDistinctAccumulator implements TableAccumulator {
+  private static final long INSTANCE_SIZE =
+      RamUsageEstimator.shallowSizeOfInstance(ApproxCountDistinctAccumulator.class);
+  private final TSDataType seriesDataType;
+
+  private final HyperLogLog hll;
+
+  public ApproxCountDistinctAccumulator(TSDataType seriesDataType) {
+    this.seriesDataType = seriesDataType;
+    this.hll = new HyperLogLog(10);
+  }
+
+  @Override
+  public long getEstimatedSize() {
+    return INSTANCE_SIZE;
+  }
+
+  @Override
+  public TableAccumulator copy() {
+    return new ApproxCountDistinctAccumulator(seriesDataType);
+  }
+
+  @Override
+  public void addInput(Column[] arguments, AggregationMask mask) {
+    checkArgument(arguments.length == 1, "argument of ApproxCountDistinct should be one column");
+
+    switch (seriesDataType) {
+      case INT32:
+      case DATE:
+        addIntInput(arguments[0], mask);
+        return;
+      case INT64:
+      case TIMESTAMP:
+        addLongInput(arguments[0], mask);
+        return;
+      case FLOAT:
+        addFloatInput(arguments[0], mask);
+        return;
+      case DOUBLE:
+        addDoubleInput(arguments[0], mask);
+        return;
+      case TEXT:
+      case STRING:
+      case BLOB:
+        addBinaryInput(arguments[0], mask);
+        return;
+      case BOOLEAN:
+        addBooleanInput(arguments[0], mask);
+        return;
+      default:
+        throw new UnSupportedDataTypeException(
+            String.format(
+                "Unsupported data type in Approx_count_distinct Aggregation: %s", seriesDataType));
+    }
+  }
+
+  @Override
+  public void addIntermediate(Column argument) {
+    for (int i = 0; i < argument.getPositionCount(); i++) {
+      if (argument.isNull(i)) {
+        continue;
+      }
+
+      switch (seriesDataType) {
+        case INT32:
+        case DATE:
+          hll.add(argument.getInt(i));
+          break;
+        case INT64:
+        case TIMESTAMP:
+          hll.add(argument.getLong(i));
+          break;
+        case FLOAT:
+          hll.add(argument.getFloat(i));
+          break;
+        case DOUBLE:
+          hll.add(argument.getDouble(i));
+          break;
+        case STRING:
+        case TEXT:
+        case BLOB:
+          hll.add(argument.getBinary(i));
+          break;
+        case BOOLEAN:
+          hll.add(argument.getBoolean(i));
+          break;
+        default:
+          throw new UnSupportedDataTypeException(
+              String.format(
+                  "Unsupported data type in Approx_count_distinct Aggregation: %s",
+                  seriesDataType));
+      }
+    }
+  }
+
+  @Override
+  public void evaluateIntermediate(ColumnBuilder columnBuilder) {
+    columnBuilder.writeLong(hll.cardinality());
+  }
+
+  @Override
+  public void evaluateFinal(ColumnBuilder columnBuilder) {
+    columnBuilder.writeLong(hll.cardinality());
+  }
+
+  @Override
+  public boolean hasFinalResult() {
+    return false;
+  }
+
+  @Override
+  public void removeInput(Column[] arguments) {}
+
+  @Override
+  public boolean removable() {
+    return false;
+  }
+
+  @Override
+  public void addStatistics(Statistics[] statistics) {
+    throw new UnsupportedOperationException(
+        "ApproxCountDistinctAccumulator does not support statistics");
+  }
+
+  @Override
+  public void reset() {
+    hll.reset();
+  }
+
+  public void addBooleanInput(Column valueColumn, AggregationMask mask) {
+    int positionCount = mask.getPositionCount();
+
+    if (mask.isSelectAll()) {
+      for (int i = 0; i < valueColumn.getPositionCount(); i++) {
+        if (!valueColumn.isNull(i)) {
+          hll.add(valueColumn.getBoolean(i));
+        }
+      }
+    } else {
+      int[] selectedPositions = mask.getSelectedPositions();
+      int position;
+      for (int i = 0; i < positionCount; i++) {
+        position = selectedPositions[i];
+        if (!valueColumn.isNull(position)) {
+          hll.add(valueColumn.getBoolean(position));
+        }
+      }
+    }
+  }
+
+  public void addIntInput(Column valueColumn, AggregationMask mask) {
+    int positionCount = mask.getPositionCount();
+
+    if (mask.isSelectAll()) {
+      for (int i = 0; i < valueColumn.getPositionCount(); i++) {
+        if (!valueColumn.isNull(i)) {
+          hll.add(valueColumn.getInt(i));
+        }
+      }
+    } else {
+      int[] selectedPositions = mask.getSelectedPositions();
+      int position;
+      for (int i = 0; i < positionCount; i++) {
+        position = selectedPositions[i];
+        if (!valueColumn.isNull(position)) {
+          hll.add(valueColumn.getInt(position));
+        }
+      }
+    }
+  }
+
+  public void addLongInput(Column valueColumn, AggregationMask mask) {
+    int positionCount = mask.getPositionCount();
+
+    if (mask.isSelectAll()) {
+      for (int i = 0; i < valueColumn.getPositionCount(); i++) {
+        if (!valueColumn.isNull(i)) {
+          hll.add(valueColumn.getLong(i));
+        }
+      }
+    } else {
+      int[] selectedPositions = mask.getSelectedPositions();
+      int position;
+      for (int i = 0; i < positionCount; i++) {
+        position = selectedPositions[i];
+        if (!valueColumn.isNull(position)) {
+          hll.add(valueColumn.getLong(position));
+        }
+      }
+    }
+  }
+
+  public void addFloatInput(Column valueColumn, AggregationMask mask) {
+    int positionCount = mask.getPositionCount();
+
+    if (mask.isSelectAll()) {
+      for (int i = 0; i < valueColumn.getPositionCount(); i++) {
+        if (!valueColumn.isNull(i)) {
+          hll.add(valueColumn.getFloat(i));
+        }
+      }
+    } else {
+      int[] selectedPositions = mask.getSelectedPositions();
+      int position;
+      for (int i = 0; i < positionCount; i++) {
+        position = selectedPositions[i];
+        if (!valueColumn.isNull(position)) {
+          hll.add(valueColumn.getFloat(position));
+        }
+      }
+    }
+  }
+
+  public void addDoubleInput(Column valueColumn, AggregationMask mask) {
+    int positionCount = mask.getPositionCount();
+
+    if (mask.isSelectAll()) {
+      for (int i = 0; i < valueColumn.getPositionCount(); i++) {
+        if (!valueColumn.isNull(i)) {
+          hll.add(valueColumn.getDouble(i));
+        }
+      }
+    } else {
+      int[] selectedPositions = mask.getSelectedPositions();
+      int position;
+      for (int i = 0; i < positionCount; i++) {
+        position = selectedPositions[i];
+        if (!valueColumn.isNull(position)) {
+          hll.add(valueColumn.getDouble(position));
+        }
+      }
+    }
+  }
+
+  public void addBinaryInput(Column valueColumn, AggregationMask mask) {
+    int positionCount = mask.getPositionCount();
+
+    if (mask.isSelectAll()) {
+      for (int i = 0; i < valueColumn.getPositionCount(); i++) {
+        if (!valueColumn.isNull(i)) {
+          hll.add(valueColumn.getBinary(i));
+        }
+      }
+    } else {
+      int[] selectedPositions = mask.getSelectedPositions();
+      int position;
+      for (int i = 0; i < positionCount; i++) {
+        position = selectedPositions[i];
+        if (!valueColumn.isNull(position)) {
+          hll.add(valueColumn.getBinary(position));
+        }
+      }
+    }
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/ApproxCountDistinctAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/ApproxCountDistinctAccumulator.java
@@ -97,6 +97,13 @@ public class ApproxCountDistinctAccumulator implements TableAccumulator {
 
   @Override
   public void addIntermediate(Column argument) {
+
+    for (int i = 0; i < argument.getPositionCount(); i++) {
+      if (!argument.isNull(i)) {
+        HyperLogLog current = new HyperLogLog(argument.getBinary(i).getValues());
+        state.merge(current);
+      }
+    }
     HyperLogLog merged = null;
     for (int i = 0; i < argument.getPositionCount(); i++) {
       if (!argument.isNull(i)) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/ApproxCountDistinctAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/ApproxCountDistinctAccumulator.java
@@ -47,7 +47,7 @@ public class ApproxCountDistinctAccumulator implements TableAccumulator {
 
   @Override
   public void addInput(Column[] arguments, AggregationMask mask) {
-    checkArgument(arguments.length == 1, "argument of ApproxCountDistinct should be one column");
+    checkArgument(arguments.length == 1, "argument of APPROX_COUNT_DISTINCT should be one column");
 
     switch (seriesDataType) {
       case INT32:
@@ -75,7 +75,7 @@ public class ApproxCountDistinctAccumulator implements TableAccumulator {
       default:
         throw new UnSupportedDataTypeException(
             String.format(
-                "Unsupported data type in Approx_count_distinct Aggregation: %s", seriesDataType));
+                "Unsupported data type in APPROX_COUNT_DISTINCT Aggregation: %s", seriesDataType));
     }
   }
 
@@ -112,7 +112,7 @@ public class ApproxCountDistinctAccumulator implements TableAccumulator {
         default:
           throw new UnSupportedDataTypeException(
               String.format(
-                  "Unsupported data type in Approx_count_distinct Aggregation: %s",
+                  "Unsupported data type in APPROX_COUNT_DISTINCT Aggregation: %s",
                   seriesDataType));
       }
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/ApproxCountDistinctAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/ApproxCountDistinctAccumulator.java
@@ -76,7 +76,6 @@ public class ApproxCountDistinctAccumulator implements TableAccumulator {
       case STRING:
       case BLOB:
         addBinaryInput(arguments[0], mask, hll);
-        System.out.println(hll.cardinality() + this.toString());
         return;
       case BOOLEAN:
         addBooleanInput(arguments[0], mask, hll);
@@ -125,8 +124,7 @@ public class ApproxCountDistinctAccumulator implements TableAccumulator {
 
   @Override
   public void reset() {
-    HyperLogLog hll = state.getHyperLogLog();
-    hll.reset();
+    state.getHyperLogLog().reset();
   }
 
   public void addBooleanInput(Column valueColumn, AggregationMask mask, HyperLogLog hll) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/ApproxCountDistinctAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/ApproxCountDistinctAccumulator.java
@@ -53,10 +53,9 @@ public class ApproxCountDistinctAccumulator implements TableAccumulator {
 
   @Override
   public void addInput(Column[] arguments, AggregationMask mask) {
-    HyperLogLog hll;
     double maxStandardError =
         arguments.length == 1 ? DEFAULT_STANDARD_ERROR : arguments[1].getDouble(0);
-    hll = getOrCreateHyperLogLog(state, maxStandardError);
+    HyperLogLog hll = getOrCreateHyperLogLog(state, maxStandardError);
 
     switch (seriesDataType) {
       case INT32:

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/HyperLogLog.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/HyperLogLog.java
@@ -214,7 +214,6 @@ public class HyperLogLog {
    * @throws IllegalArgumentException if the precision doesn't match
    */
   public void merge(HyperLogLog other) {
-    // not use currently
     if (this.m != other.m) {
       throw new IllegalArgumentException(
           "Cannot merge HyperLogLog instances with different precision");
@@ -235,6 +234,10 @@ public class HyperLogLog {
       ReadWriteIOUtils.write(registers[i], byteBuffer);
     }
     return byteBuffer.array();
+  }
+
+  public boolean equals(HyperLogLog hll) {
+    return this.serialize() == hll.serialize();
   }
 
   public long getEstimatedSize() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/HyperLogLog.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/HyperLogLog.java
@@ -237,7 +237,7 @@ public class HyperLogLog {
   }
 
   public boolean equals(HyperLogLog hll) {
-    return this.serialize() == hll.serialize();
+    return Arrays.equals(this.serialize(), hll.serialize());
   }
 
   public long getEstimatedSize() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/HyperLogLog.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/HyperLogLog.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation;
+
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
+import org.apache.tsfile.common.conf.TSFileConfig;
+import org.apache.tsfile.utils.Binary;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+public class HyperLogLog {
+  private final int[] registers;
+  // Number of registers
+  private final int m;
+  // Number of bits used for register indexing
+  private final int b;
+  // Alpha constant for bias correction
+  private final double alpha;
+
+  private static final HashFunction hashFunction = Hashing.murmur3_128();
+
+  /**
+   * Constructs a HyperLogLog with the given precision.
+   *
+   * @param precision The precision parameter (4 <= precision <= 16)
+   */
+  public HyperLogLog(int precision) {
+    if (precision < 4 || precision > 16) {
+      throw new IllegalArgumentException("Precision must be between 4 and 16");
+    }
+
+    this.b = precision;
+    // 桶数量
+    // m = 2^precision
+    this.m = 1 << precision;
+    this.registers = new int[m];
+
+    // 设置修正因子
+    // Set alpha based on precision
+    switch (precision) {
+      case 4:
+        this.alpha = 0.673;
+        break;
+      case 5:
+        this.alpha = 0.697;
+        break;
+      case 6:
+        this.alpha = 0.709;
+        break;
+      default:
+        this.alpha = 0.7213 / (1 + 1.079 / m);
+        break;
+    }
+  }
+
+  public void add(boolean value) {
+    offer(hashFunction.hashString(String.valueOf(value), StandardCharsets.UTF_8).asLong());
+  }
+
+  public void add(int value) {
+    offer(hashFunction.hashInt(value).asLong());
+  }
+
+  public void add(long value) {
+    offer(hashFunction.hashLong(value).asLong());
+  }
+
+  public void add(float value) {
+    offer(hashFunction.hashString(String.valueOf(value), StandardCharsets.UTF_8).asLong());
+  }
+
+  public void add(double value) {
+    offer(hashFunction.hashString(String.valueOf(value), StandardCharsets.UTF_8).asLong());
+  }
+
+  public void add(Binary value) {
+    offer(
+        hashFunction
+            .hashString(value.getStringValue(TSFileConfig.STRING_CHARSET), StandardCharsets.UTF_8)
+            .asLong());
+  }
+
+  /**
+   * Adds a value to the estimator.
+   *
+   * @param value The value to add
+   */
+  public void offer(long hash) {
+    // 计算哈希值
+    // Compute hash of the value
+
+    // 将哈希值的前 b 位用于分桶
+    // Extract the first b bits for the register index
+    int idx = (int) (hash & (m - 1));
+
+    // 统计剩余二进制串中前导零的最大数量 + 1
+    // Count the number of leading zeros in the remaining bits
+    // Add 1 to get the position of the leftmost 1
+
+    int leadingZeros = Long.numberOfTrailingZeros(hash >>> b) + 1;
+
+    // 更新桶中最大的前导零数量
+    // Update the register if the new value is larger
+    registers[idx] = Math.max(registers[idx], leadingZeros);
+  }
+
+  /**
+   * Returns the estimated cardinality of the data set.
+   *
+   * @return The estimated cardinality
+   */
+  public long cardinality() {
+    double sum = 0;
+    int zeros = 0;
+
+    // 计算所有桶的调和平均数
+    // Compute the harmonic mean of 2^register[i]
+    for (int i = 0; i < m; i++) {
+      sum += 1.0 / (1 << registers[i]);
+      if (registers[i] == 0) {
+        zeros++;
+      }
+    }
+
+    // 基数估计值
+    // Apply bias correction formula
+    double estimate = alpha * m * m / sum;
+
+    // 小基数修正
+    // Small range correction
+    if (estimate <= 2.5 * m) {
+      if (zeros > 0) {
+        // Linear counting for small cardinalities
+        return Math.round(m * Math.log((double) m / zeros));
+      }
+    }
+
+    // 大基数修正
+    // Large range correction (for values > 2^32 / 30)
+    double maxCardinality = (double) (1L << 32);
+    if (estimate > maxCardinality / 30) {
+      return Math.round(-maxCardinality * Math.log(1 - estimate / maxCardinality));
+    }
+
+    return Math.round(estimate);
+  }
+
+  /** Resets the estimator. */
+  public void reset() {
+    Arrays.fill(registers, 0);
+  }
+
+  /**
+   * Merges another HyperLogLog instance into this one.
+   *
+   * @param other The other HyperLogLog instance to merge
+   * @throws IllegalArgumentException if the precision doesn't match
+   */
+  public void merge(HyperLogLog other) {
+    if (this.m != other.m) {
+      throw new IllegalArgumentException(
+          "Cannot merge HyperLogLog instances with different precision");
+    }
+
+    for (int i = 0; i < m; i++) {
+      registers[i] = Math.max(registers[i], other.registers[i]);
+    }
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/HyperLogLog.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/HyperLogLog.java
@@ -50,7 +50,7 @@ public class HyperLogLog {
   /**
    * Constructs a HyperLogLog with the given precision.
    *
-   * @param precision The precision parameter (4 <= precision <= 16)
+   * <p>The precision parameter (4 <= precision <= 16)
    */
   public HyperLogLog(double maxStandardError) {
     int buckets = standardErrorToBuckets(maxStandardError);
@@ -148,7 +148,7 @@ public class HyperLogLog {
   /**
    * Adds a value to the estimator.
    *
-   * @param value The value to add
+   * <p>The value to add
    */
   public void offer(long hash) {
     // Compute hash of the value

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/HyperLogLogState.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/HyperLogLogState.java
@@ -1,0 +1,7 @@
+package org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation;
+
+public interface HyperLogLogState {
+  HyperLogLog getHyperLogLog();
+
+  void setHyperLogLog(HyperLogLog value);
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/HyperLogLogState.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/HyperLogLogState.java
@@ -1,7 +1,0 @@
-package org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation;
-
-public interface HyperLogLogState {
-  HyperLogLog getHyperLogLog();
-
-  void setHyperLogLog(HyperLogLog value);
-}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/HyperLogLogStateFactory.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/HyperLogLogStateFactory.java
@@ -19,7 +19,6 @@ import org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggr
 import org.apache.tsfile.utils.RamUsageEstimator;
 
 import static java.util.Objects.requireNonNull;
-import static org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation.HyperLogLog.DEFAULT_STANDARD_ERROR;
 
 public class HyperLogLogStateFactory {
   public static SingleHyperLogLogState createSingleState() {
@@ -28,27 +27,6 @@ public class HyperLogLogStateFactory {
 
   public static GroupedHyperLogLogState createGroupedState() {
     return new GroupedHyperLogLogState();
-  }
-
-  public static HyperLogLog getOrCreateHyperLogLog(SingleHyperLogLogState state) {
-    return getOrCreateHyperLogLog(state, DEFAULT_STANDARD_ERROR);
-  }
-
-  public static HyperLogLog getOrCreateHyperLogLog(
-      SingleHyperLogLogState state, double maxStandardError) {
-    HyperLogLog hll = state.getHyperLogLog();
-    if (hll == null) {
-      hll = new HyperLogLog(maxStandardError);
-      state.setHyperLogLog(hll);
-    }
-    return hll;
-  }
-
-  public static HyperLogLogBigArray getOrCreateHyperLogLog(GroupedHyperLogLogState state) {
-    if (state.isEmpty()) {
-      state.setHyperLogLogs(new HyperLogLogBigArray());
-    }
-    return state.getHyperLogLogs();
   }
 
   public static class SingleHyperLogLogState {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/HyperLogLogStateFactory.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/HyperLogLogStateFactory.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation;
+
+import org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation.grouped.array.ObjectBigArray;
+
+import org.apache.tsfile.utils.RamUsageEstimator;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation.HyperLogLog.DEFAULT_STANDARD_ERROR;
+
+public class HyperLogLogStateFactory {
+  public static SingleHyperLogLogState createSingleState() {
+    return new SingleHyperLogLogState();
+  }
+
+  public static GroupedHyperLogLogState createGroupedState() {
+    return new GroupedHyperLogLogState();
+  }
+
+  public static HyperLogLog getOrCreateHyperLogLog(SingleHyperLogLogState state) {
+    return getOrCreateHyperLogLog(state, DEFAULT_STANDARD_ERROR);
+  }
+
+  public static HyperLogLog getOrCreateHyperLogLog(
+      SingleHyperLogLogState state, double maxStandardError) {
+    HyperLogLog hll = state.getHyperLogLog();
+    if (hll == null) {
+      hll = new HyperLogLog(maxStandardError);
+      state.setHyperLogLog(hll);
+    }
+    return hll;
+  }
+
+  public static ObjectBigArray<HyperLogLog> getOrCreateHyperLogLog(GroupedHyperLogLogState state) {
+    return getOrCreateHyperLogLog(state, DEFAULT_STANDARD_ERROR);
+  }
+
+  public static ObjectBigArray<HyperLogLog> getOrCreateHyperLogLog(
+      GroupedHyperLogLogState state, double maxStandardError) {
+    ObjectBigArray<HyperLogLog> hlls = state.getHyperLogLogs();
+    if (hlls == null) {
+      hlls = new ObjectBigArray<>(new HyperLogLog(maxStandardError));
+      state.setHyperLogLogs(hlls);
+    }
+    return hlls;
+  }
+
+  public static class SingleHyperLogLogState {
+    private static final long INSTANCE_SIZE =
+        RamUsageEstimator.shallowSizeOfInstance(SingleHyperLogLogState.class);
+    private HyperLogLog hll;
+
+    public HyperLogLog getHyperLogLog() {
+      return hll;
+    }
+
+    public void setHyperLogLog(HyperLogLog value) {
+      hll = value;
+    }
+  }
+
+  public static class GroupedHyperLogLogState {
+    private static final long INSTANCE_SIZE =
+        RamUsageEstimator.shallowSizeOfInstance(GroupedHyperLogLogState.class);
+    private ObjectBigArray<HyperLogLog> hlls = new ObjectBigArray<>();
+
+    public ObjectBigArray<HyperLogLog> getHyperLogLogs() {
+      return hlls;
+    }
+
+    public void setHyperLogLogs(ObjectBigArray<HyperLogLog> value) {
+      requireNonNull(value, "value is null");
+      this.hlls = value;
+    }
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedApproxCountDistinctAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedApproxCountDistinctAccumulator.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation.grouped;
+
+import org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation.AggregationMask;
+
+import org.apache.tsfile.block.column.Column;
+import org.apache.tsfile.block.column.ColumnBuilder;
+import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.utils.RamUsageEstimator;
+
+public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator {
+  private static final long INSTANCE_SIZE =
+      RamUsageEstimator.shallowSizeOfInstance(GroupedApproxCountDistinctAccumulator.class);
+  private final TSDataType seriesDataType;
+
+  public GroupedApproxCountDistinctAccumulator(TSDataType seriesDataType) {
+    this.seriesDataType = seriesDataType;
+  }
+
+  @Override
+  public long getEstimatedSize() {
+    return INSTANCE_SIZE;
+  }
+
+  @Override
+  public void setGroupCount(long groupCount) {}
+
+  @Override
+  public void addInput(int[] groupIds, Column[] arguments, AggregationMask mask) {}
+
+  @Override
+  public void addIntermediate(int[] groupIds, Column argument) {}
+
+  @Override
+  public void evaluateIntermediate(int groupId, ColumnBuilder columnBuilder) {}
+
+  @Override
+  public void evaluateFinal(int groupId, ColumnBuilder columnBuilder) {}
+
+  @Override
+  public void prepareFinal() {}
+
+  @Override
+  public void reset() {}
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedApproxCountDistinctAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedApproxCountDistinctAccumulator.java
@@ -89,16 +89,10 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
 
   @Override
   public void addIntermediate(int[] groupIds, Column argument) {
-
-    if (groupIds.length == 0) {
-      return;
-    }
-
     for (int i = 0; i < groupIds.length; i++) {
       int groupId = groupIds[i];
       if (!argument.isNull(i)) {
         HyperLogLog current = new HyperLogLog(argument.getBinary(i).getValues());
-
         state.merge(groupId, current);
       }
     }
@@ -121,8 +115,7 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
 
   @Override
   public void reset() {
-    HyperLogLogBigArray hlls = state.getHyperLogLogs();
-    hlls.reset();
+    state.getHyperLogLogs().reset();
   }
 
   public void addBooleanInput(
@@ -136,9 +129,11 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
     if (mask.isSelectAll()) {
       for (int i = 0; i < positionCount; i++) {
         int groupId = groupIds[i];
-        hlls.setIfNull(groupId, maxStandardError);
         if (!column.isNull(i)) {
           hlls.get(groupId).add(column.getBoolean(i));
+        } else {
+          // init a hyperloglog if the groupId's position is null
+          hlls.get(groupId, maxStandardError);
         }
       }
     } else {
@@ -150,6 +145,8 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
         groupId = groupIds[position];
         if (!column.isNull(position)) {
           hlls.get(groupId, maxStandardError).add(column.getBoolean(i));
+        } else {
+          hlls.get(groupId, maxStandardError);
         }
       }
     }
@@ -166,9 +163,11 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
     if (mask.isSelectAll()) {
       for (int i = 0; i < positionCount; i++) {
         int groupId = groupIds[i];
-        hlls.setIfNull(groupId, maxStandardError);
         if (!column.isNull(i)) {
           hlls.get(groupId).add(column.getInt(i));
+        } else {
+          // init a hyperloglog if the groupId's position is null
+          hlls.get(groupId, maxStandardError);
         }
       }
     } else {
@@ -180,6 +179,8 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
         groupId = groupIds[position];
         if (!column.isNull(position)) {
           hlls.get(groupId, maxStandardError).add(column.getInt(i));
+        } else {
+          hlls.get(groupId, maxStandardError);
         }
       }
     }
@@ -196,9 +197,11 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
     if (mask.isSelectAll()) {
       for (int i = 0; i < positionCount; i++) {
         int groupId = groupIds[i];
-        hlls.setIfNull(groupId, maxStandardError);
         if (!column.isNull(i)) {
           hlls.get(groupId).add(column.getLong(i));
+        } else {
+          // init a hyperloglog if the groupId's position is null
+          hlls.get(groupId, maxStandardError);
         }
       }
     } else {
@@ -210,6 +213,8 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
         groupId = groupIds[position];
         if (!column.isNull(position)) {
           hlls.get(groupId, maxStandardError).add(column.getLong(i));
+        } else {
+          hlls.get(groupId, maxStandardError);
         }
       }
     }
@@ -226,9 +231,11 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
     if (mask.isSelectAll()) {
       for (int i = 0; i < positionCount; i++) {
         int groupId = groupIds[i];
-        hlls.setIfNull(groupId, maxStandardError);
         if (!column.isNull(i)) {
           hlls.get(groupId).add(column.getFloat(i));
+        } else {
+          // init a hyperloglog if the groupId's position is null
+          hlls.get(groupId, maxStandardError);
         }
       }
     } else {
@@ -240,6 +247,8 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
         groupId = groupIds[position];
         if (!column.isNull(position)) {
           hlls.get(groupId, maxStandardError).add(column.getFloat(i));
+        } else {
+          hlls.get(groupId, maxStandardError);
         }
       }
     }
@@ -256,9 +265,11 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
     if (mask.isSelectAll()) {
       for (int i = 0; i < positionCount; i++) {
         int groupId = groupIds[i];
-        hlls.setIfNull(groupId, maxStandardError);
         if (!column.isNull(i)) {
           hlls.get(groupId).add(column.getDouble(i));
+        } else {
+          // init a hyperloglog if the groupId's position is null
+          hlls.get(groupId, maxStandardError);
         }
       }
     } else {
@@ -270,6 +281,8 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
         groupId = groupIds[position];
         if (!column.isNull(position)) {
           hlls.get(groupId, maxStandardError).add(column.getDouble(i));
+        } else {
+          hlls.get(groupId, maxStandardError);
         }
       }
     }
@@ -286,9 +299,11 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
     if (mask.isSelectAll()) {
       for (int i = 0; i < positionCount; i++) {
         int groupId = groupIds[i];
-        hlls.setIfNull(groupId, maxStandardError);
         if (!column.isNull(i)) {
           hlls.get(groupId).add(column.getBinary(i));
+        } else {
+          // init a hyperloglog if the groupId's position is null
+          hlls.get(groupId, maxStandardError);
         }
       }
     } else {
@@ -300,6 +315,8 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
         groupId = groupIds[position];
         if (!column.isNull(position)) {
           hlls.get(groupId, maxStandardError).add(column.getBinary(i));
+        } else {
+          hlls.get(groupId, maxStandardError);
         }
       }
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedApproxCountDistinctAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedApproxCountDistinctAccumulator.java
@@ -55,7 +55,7 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
   public void addInput(int[] groupIds, Column[] arguments, AggregationMask mask) {
     double maxStandardError =
         arguments.length == 1 ? DEFAULT_STANDARD_ERROR : arguments[1].getDouble(0);
-    HyperLogLogBigArray hlls = HyperLogLogStateFactory.getOrCreateHyperLogLog(state);
+    HyperLogLogBigArray hlls = getOrCreateHyperLogLog(state);
 
     switch (seriesDataType) {
       case BOOLEAN:
@@ -303,5 +303,13 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
         }
       }
     }
+  }
+
+  public static HyperLogLogBigArray getOrCreateHyperLogLog(
+      HyperLogLogStateFactory.GroupedHyperLogLogState state) {
+    if (state.isEmpty()) {
+      state.setHyperLogLogs(new HyperLogLogBigArray());
+    }
+    return state.getHyperLogLogs();
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedApproxCountDistinctAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedApproxCountDistinctAccumulator.java
@@ -129,11 +129,9 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
     if (mask.isSelectAll()) {
       for (int i = 0; i < positionCount; i++) {
         int groupId = groupIds[i];
+        HyperLogLog hll = hlls.get(groupId, maxStandardError);
         if (!column.isNull(i)) {
-          hlls.get(groupId).add(column.getBoolean(i));
-        } else {
-          // init a hyperloglog if the groupId's position is null
-          hlls.get(groupId, maxStandardError);
+          hll.add(column.getBoolean(i));
         }
       }
     } else {
@@ -143,10 +141,9 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
       for (int i = 0; i < positionCount; i++) {
         position = selectedPositions[i];
         groupId = groupIds[position];
+        HyperLogLog hll = hlls.get(groupId, maxStandardError);
         if (!column.isNull(position)) {
-          hlls.get(groupId, maxStandardError).add(column.getBoolean(i));
-        } else {
-          hlls.get(groupId, maxStandardError);
+          hll.add(column.getBoolean(i));
         }
       }
     }
@@ -163,11 +160,9 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
     if (mask.isSelectAll()) {
       for (int i = 0; i < positionCount; i++) {
         int groupId = groupIds[i];
+        HyperLogLog hll = hlls.get(groupId, maxStandardError);
         if (!column.isNull(i)) {
-          hlls.get(groupId).add(column.getInt(i));
-        } else {
-          // init a hyperloglog if the groupId's position is null
-          hlls.get(groupId, maxStandardError);
+          hll.add(column.getInt(i));
         }
       }
     } else {
@@ -177,10 +172,9 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
       for (int i = 0; i < positionCount; i++) {
         position = selectedPositions[i];
         groupId = groupIds[position];
+        HyperLogLog hll = hlls.get(groupId, maxStandardError);
         if (!column.isNull(position)) {
-          hlls.get(groupId, maxStandardError).add(column.getInt(i));
-        } else {
-          hlls.get(groupId, maxStandardError);
+          hll.add(column.getInt(i));
         }
       }
     }
@@ -197,11 +191,9 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
     if (mask.isSelectAll()) {
       for (int i = 0; i < positionCount; i++) {
         int groupId = groupIds[i];
+        HyperLogLog hll = hlls.get(groupId, maxStandardError);
         if (!column.isNull(i)) {
-          hlls.get(groupId).add(column.getLong(i));
-        } else {
-          // init a hyperloglog if the groupId's position is null
-          hlls.get(groupId, maxStandardError);
+          hll.add(column.getLong(i));
         }
       }
     } else {
@@ -211,10 +203,9 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
       for (int i = 0; i < positionCount; i++) {
         position = selectedPositions[i];
         groupId = groupIds[position];
+        HyperLogLog hll = hlls.get(groupId, maxStandardError);
         if (!column.isNull(position)) {
-          hlls.get(groupId, maxStandardError).add(column.getLong(i));
-        } else {
-          hlls.get(groupId, maxStandardError);
+          hll.add(column.getLong(i));
         }
       }
     }
@@ -231,11 +222,9 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
     if (mask.isSelectAll()) {
       for (int i = 0; i < positionCount; i++) {
         int groupId = groupIds[i];
+        HyperLogLog hll = hlls.get(groupId, maxStandardError);
         if (!column.isNull(i)) {
-          hlls.get(groupId).add(column.getFloat(i));
-        } else {
-          // init a hyperloglog if the groupId's position is null
-          hlls.get(groupId, maxStandardError);
+          hll.add(column.getFloat(i));
         }
       }
     } else {
@@ -245,10 +234,9 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
       for (int i = 0; i < positionCount; i++) {
         position = selectedPositions[i];
         groupId = groupIds[position];
+        HyperLogLog hll = hlls.get(groupId, maxStandardError);
         if (!column.isNull(position)) {
-          hlls.get(groupId, maxStandardError).add(column.getFloat(i));
-        } else {
-          hlls.get(groupId, maxStandardError);
+          hll.add(column.getFloat(i));
         }
       }
     }
@@ -265,11 +253,9 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
     if (mask.isSelectAll()) {
       for (int i = 0; i < positionCount; i++) {
         int groupId = groupIds[i];
+        HyperLogLog hll = hlls.get(groupId, maxStandardError);
         if (!column.isNull(i)) {
-          hlls.get(groupId).add(column.getDouble(i));
-        } else {
-          // init a hyperloglog if the groupId's position is null
-          hlls.get(groupId, maxStandardError);
+          hll.add(column.getDouble(i));
         }
       }
     } else {
@@ -279,10 +265,9 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
       for (int i = 0; i < positionCount; i++) {
         position = selectedPositions[i];
         groupId = groupIds[position];
+        HyperLogLog hll = hlls.get(groupId, maxStandardError);
         if (!column.isNull(position)) {
-          hlls.get(groupId, maxStandardError).add(column.getDouble(i));
-        } else {
-          hlls.get(groupId, maxStandardError);
+          hll.add(column.getDouble(i));
         }
       }
     }
@@ -299,11 +284,9 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
     if (mask.isSelectAll()) {
       for (int i = 0; i < positionCount; i++) {
         int groupId = groupIds[i];
+        HyperLogLog hll = hlls.get(groupId, maxStandardError);
         if (!column.isNull(i)) {
-          hlls.get(groupId).add(column.getBinary(i));
-        } else {
-          // init a hyperloglog if the groupId's position is null
-          hlls.get(groupId, maxStandardError);
+          hll.add(column.getBinary(i));
         }
       }
     } else {
@@ -313,10 +296,9 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
       for (int i = 0; i < positionCount; i++) {
         position = selectedPositions[i];
         groupId = groupIds[position];
+        HyperLogLog hll = hlls.get(groupId, maxStandardError);
         if (!column.isNull(position)) {
-          hlls.get(groupId, maxStandardError).add(column.getBinary(i));
-        } else {
-          hlls.get(groupId, maxStandardError);
+          hll.add(column.getBinary(i));
         }
       }
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedApproxCountDistinctAccumulator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/GroupedApproxCountDistinctAccumulator.java
@@ -15,16 +15,23 @@
 package org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation.grouped;
 
 import org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation.AggregationMask;
+import org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation.HyperLogLog;
+import org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation.HyperLogLogStateFactory;
+import org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation.grouped.array.ObjectBigArray;
 
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnBuilder;
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.utils.RamUsageEstimator;
+import org.apache.tsfile.write.UnSupportedDataTypeException;
 
 public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator {
   private static final long INSTANCE_SIZE =
       RamUsageEstimator.shallowSizeOfInstance(GroupedApproxCountDistinctAccumulator.class);
   private final TSDataType seriesDataType;
+
+  private final HyperLogLogStateFactory.GroupedHyperLogLogState state =
+      HyperLogLogStateFactory.createGroupedState();
 
   public GroupedApproxCountDistinctAccumulator(TSDataType seriesDataType) {
     this.seriesDataType = seriesDataType;
@@ -32,27 +39,254 @@ public class GroupedApproxCountDistinctAccumulator implements GroupedAccumulator
 
   @Override
   public long getEstimatedSize() {
-    return INSTANCE_SIZE;
+    ObjectBigArray<HyperLogLog> hlls = state.getHyperLogLogs();
+    return INSTANCE_SIZE + hlls.sizeOf();
   }
 
   @Override
-  public void setGroupCount(long groupCount) {}
+  public void setGroupCount(long groupCount) {
+    ObjectBigArray<HyperLogLog> hlls = state.getHyperLogLogs();
+    hlls.ensureCapacity(groupCount);
+  }
 
   @Override
-  public void addInput(int[] groupIds, Column[] arguments, AggregationMask mask) {}
+  public void addInput(int[] groupIds, Column[] arguments, AggregationMask mask) {
+    ObjectBigArray<HyperLogLog> hlls;
+    if (arguments.length == 1) {
+      hlls = HyperLogLogStateFactory.getOrCreateHyperLogLog(state);
+    } else if (arguments.length == 2) {
+      double maxStandardError = arguments[1].getDouble(0);
+      hlls = HyperLogLogStateFactory.getOrCreateHyperLogLog(state, maxStandardError);
+    } else {
+      throw new IllegalArgumentException(
+          "argument of APPROX_COUNT_DISTINCT should be one column with Max Standard Error");
+    }
+    switch (seriesDataType) {
+      case BOOLEAN:
+        addBooleanInput(groupIds, arguments[0], mask, hlls);
+        return;
+      case INT32:
+      case DATE:
+        addIntInput(groupIds, arguments[0], mask, hlls);
+        return;
+      case INT64:
+      case TIMESTAMP:
+        addLongInput(groupIds, arguments[0], mask, hlls);
+        return;
+      case FLOAT:
+        addFloatInput(groupIds, arguments[0], mask, hlls);
+        return;
+      case DOUBLE:
+        addDoubleInput(groupIds, arguments[0], mask, hlls);
+        return;
+      case TEXT:
+      case STRING:
+      case BLOB:
+        addBinaryInput(groupIds, arguments[0], mask, hlls);
+        return;
+      default:
+        throw new UnSupportedDataTypeException(
+            String.format(
+                "Unsupported data type in APPROX_COUNT_DISTINCT Aggregation: %s", seriesDataType));
+    }
+  }
 
   @Override
-  public void addIntermediate(int[] groupIds, Column argument) {}
+  public void addIntermediate(int[] groupIds, Column argument) {
+    ObjectBigArray<HyperLogLog> hlls = HyperLogLogStateFactory.getOrCreateHyperLogLog(state);
+    for (int i = 0; i < groupIds.length; i++) {
+      if (argument.isNull(i)) {
+        continue;
+      }
+      switch (seriesDataType) {
+        case BOOLEAN:
+          hlls.get(groupIds[i]).add(argument.getBoolean(i));
+        case INT32:
+        case DATE:
+          hlls.get(groupIds[i]).add(argument.getInt(i));
+        case INT64:
+        case TIMESTAMP:
+          hlls.get(groupIds[i]).add(argument.getLong(i));
+        case FLOAT:
+          hlls.get(groupIds[i]).add(argument.getFloat(i));
+        case DOUBLE:
+          hlls.get(groupIds[i]).add(argument.getDouble(i));
+        case TEXT:
+        case STRING:
+        case BLOB:
+          hlls.get(groupIds[i]).add(argument.getBinary(i));
+        default:
+          throw new UnSupportedDataTypeException(
+              String.format(
+                  "Unsupported data type in APPROX_COUNT_DISTINCT Aggregation: %s",
+                  seriesDataType));
+      }
+    }
+  }
 
   @Override
-  public void evaluateIntermediate(int groupId, ColumnBuilder columnBuilder) {}
+  public void evaluateIntermediate(int groupId, ColumnBuilder columnBuilder) {
+    ObjectBigArray<HyperLogLog> hlls = state.getHyperLogLogs();
+    columnBuilder.writeLong(hlls.get(groupId).cardinality());
+  }
 
   @Override
-  public void evaluateFinal(int groupId, ColumnBuilder columnBuilder) {}
+  public void evaluateFinal(int groupId, ColumnBuilder columnBuilder) {
+    ObjectBigArray<HyperLogLog> hlls = state.getHyperLogLogs();
+    columnBuilder.writeLong(hlls.get(groupId).cardinality());
+  }
 
   @Override
   public void prepareFinal() {}
 
   @Override
-  public void reset() {}
+  public void reset() {
+    ObjectBigArray<HyperLogLog> hlls = state.getHyperLogLogs();
+    hlls.forEach(HyperLogLog::reset);
+    hlls.reset();
+  }
+
+  public void addBooleanInput(
+      int[] groupIds, Column column, AggregationMask mask, ObjectBigArray<HyperLogLog> hlls) {
+    int positionCount = mask.getPositionCount();
+
+    if (mask.isSelectAll()) {
+      for (int i = 0; i < positionCount; i++) {
+        if (!column.isNull(i)) {
+          hlls.get(groupIds[i]).add(column.getBoolean(i));
+        }
+      }
+    } else {
+      int[] selectedPositions = mask.getSelectedPositions();
+      int position;
+      int groupId;
+      for (int i = 0; i < positionCount; i++) {
+        position = selectedPositions[i];
+        groupId = groupIds[position];
+        if (!column.isNull(position)) {
+          hlls.get(groupId).add(column.getBoolean(i));
+        }
+      }
+    }
+  }
+
+  public void addIntInput(
+      int[] groupIds, Column column, AggregationMask mask, ObjectBigArray<HyperLogLog> hlls) {
+    int positionCount = mask.getPositionCount();
+
+    if (mask.isSelectAll()) {
+      for (int i = 0; i < positionCount; i++) {
+        if (!column.isNull(i)) {
+          hlls.get(groupIds[i]).add(column.getInt(i));
+        }
+      }
+    } else {
+      int[] selectedPositions = mask.getSelectedPositions();
+      int position;
+      int groupId;
+      for (int i = 0; i < positionCount; i++) {
+        position = selectedPositions[i];
+        groupId = groupIds[position];
+        if (!column.isNull(position)) {
+          hlls.get(groupId).add(column.getInt(i));
+        }
+      }
+    }
+  }
+
+  public void addLongInput(
+      int[] groupIds, Column column, AggregationMask mask, ObjectBigArray<HyperLogLog> hlls) {
+    int positionCount = mask.getPositionCount();
+
+    if (mask.isSelectAll()) {
+      for (int i = 0; i < positionCount; i++) {
+        if (!column.isNull(i)) {
+          hlls.get(groupIds[i]).add(column.getLong(i));
+        }
+      }
+    } else {
+      int[] selectedPositions = mask.getSelectedPositions();
+      int position;
+      int groupId;
+      for (int i = 0; i < positionCount; i++) {
+        position = selectedPositions[i];
+        groupId = groupIds[position];
+        if (!column.isNull(position)) {
+          hlls.get(groupId).add(column.getLong(i));
+        }
+      }
+    }
+  }
+
+  public void addFloatInput(
+      int[] groupIds, Column column, AggregationMask mask, ObjectBigArray<HyperLogLog> hlls) {
+    int positionCount = mask.getPositionCount();
+
+    if (mask.isSelectAll()) {
+      for (int i = 0; i < positionCount; i++) {
+        if (!column.isNull(i)) {
+          hlls.get(groupIds[i]).add(column.getFloat(i));
+        }
+      }
+    } else {
+      int[] selectedPositions = mask.getSelectedPositions();
+      int position;
+      int groupId;
+      for (int i = 0; i < positionCount; i++) {
+        position = selectedPositions[i];
+        groupId = groupIds[position];
+        if (!column.isNull(position)) {
+          hlls.get(groupId).add(column.getFloat(i));
+        }
+      }
+    }
+  }
+
+  public void addDoubleInput(
+      int[] groupIds, Column column, AggregationMask mask, ObjectBigArray<HyperLogLog> hlls) {
+    int positionCount = mask.getPositionCount();
+
+    if (mask.isSelectAll()) {
+      for (int i = 0; i < positionCount; i++) {
+        if (!column.isNull(i)) {
+          hlls.get(groupIds[i]).add(column.getDouble(i));
+        }
+      }
+    } else {
+      int[] selectedPositions = mask.getSelectedPositions();
+      int position;
+      int groupId;
+      for (int i = 0; i < positionCount; i++) {
+        position = selectedPositions[i];
+        groupId = groupIds[position];
+        if (!column.isNull(position)) {
+          hlls.get(groupId).add(column.getDouble(i));
+        }
+      }
+    }
+  }
+
+  public void addBinaryInput(
+      int[] groupIds, Column column, AggregationMask mask, ObjectBigArray<HyperLogLog> hlls) {
+    int positionCount = mask.getPositionCount();
+
+    if (mask.isSelectAll()) {
+      for (int i = 0; i < positionCount; i++) {
+        if (!column.isNull(i)) {
+          hlls.get(groupIds[i]).add(column.getBinary(i));
+        }
+      }
+    } else {
+      int[] selectedPositions = mask.getSelectedPositions();
+      int position;
+      int groupId;
+      for (int i = 0; i < positionCount; i++) {
+        position = selectedPositions[i];
+        groupId = groupIds[position];
+        if (!column.isNull(position)) {
+          hlls.get(groupId).add(column.getBinary(i));
+        }
+      }
+    }
+  }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/array/BinaryBigArray.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/array/BinaryBigArray.java
@@ -33,10 +33,6 @@ public final class BinaryBigArray {
     array = new ObjectBigArray<>();
   }
 
-  public BinaryBigArray(Binary slice) {
-    array = new ObjectBigArray<>(slice);
-  }
-
   /** Returns the size of this big array in bytes. */
   public long sizeOf() {
     return INSTANCE_SIZE + array.sizeOf() + sizeOfBinarys;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/array/HyperLogLogBigArray.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/array/HyperLogLogBigArray.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation.grouped.array;
+
+import org.apache.iotdb.db.queryengine.execution.operator.source.relational.aggregation.HyperLogLog;
+
+import static org.apache.tsfile.utils.RamUsageEstimator.shallowSizeOf;
+import static org.apache.tsfile.utils.RamUsageEstimator.shallowSizeOfInstance;
+
+public final class HyperLogLogBigArray {
+  private static final long INSTANCE_SIZE = shallowSizeOfInstance(HyperLogLogBigArray.class);
+  private final ObjectBigArray<HyperLogLog> array;
+  private long sizeOfHyperLogLog;
+
+  public HyperLogLogBigArray() {
+    array = new ObjectBigArray<>();
+  }
+
+  public long sizeOf() {
+    return INSTANCE_SIZE + shallowSizeOf(array) + sizeOfHyperLogLog;
+  }
+
+  public HyperLogLog get(long index) {
+    return array.get(index);
+  }
+
+  public HyperLogLog get(long index, double maxStandardError) {
+    HyperLogLog result = array.get(index);
+    if (result == null) {
+      HyperLogLog previous = new HyperLogLog(maxStandardError);
+      array.set(index, previous);
+      return previous;
+    }
+    return result;
+  }
+
+  public void set(long index, HyperLogLog hll) {
+    updateRetainedSize(index, hll);
+    array.set(index, hll);
+  }
+
+  public void setIfNull(long index, double maxStandardError) {
+    if (array.get(index) == null) {
+      HyperLogLog hll = new HyperLogLog(maxStandardError);
+      updateRetainedSize(index, hll);
+      array.set(index, hll);
+    }
+  }
+
+  public void ensureCapacity(long length) {
+    array.ensureCapacity(length);
+  }
+
+  public void updateRetainedSize(long index, HyperLogLog value) {
+    HyperLogLog hll = array.get(index);
+    if (hll != null) {
+      sizeOfHyperLogLog -= hll.getEstimatedSize();
+    }
+    if (value != null) {
+      sizeOfHyperLogLog += value.getEstimatedSize();
+    }
+  }
+
+  public void reset() {
+    array.forEach(
+        item -> {
+          if (item != null) {
+            item.reset();
+          }
+        });
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/array/HyperLogLogBigArray.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/array/HyperLogLogBigArray.java
@@ -33,6 +33,7 @@ public final class HyperLogLogBigArray {
   }
 
   public HyperLogLog get(long index) {
+    // Only use if certain that the object exists.
     return array.get(index);
   }
 
@@ -52,13 +53,6 @@ public final class HyperLogLogBigArray {
   public void set(long index, HyperLogLog hll) {
     updateRetainedSize(index, hll);
     array.set(index, hll);
-  }
-
-  public void setIfNull(long index, double maxStandardError) {
-    if (array.get(index) == null) {
-      HyperLogLog hll = new HyperLogLog(maxStandardError);
-      set(index, hll);
-    }
   }
 
   public boolean isEmpty() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/array/HyperLogLogBigArray.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/array/HyperLogLogBigArray.java
@@ -44,7 +44,7 @@ public final class HyperLogLogBigArray {
   public HyperLogLog get(long index, HyperLogLog hll) {
     HyperLogLog result = array.get(index);
     if (result == null) {
-      array.set(index, hll);
+      set(index, hll);
       return hll;
     }
     return result;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/array/HyperLogLogBigArray.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/array/HyperLogLogBigArray.java
@@ -37,11 +37,14 @@ public final class HyperLogLogBigArray {
   }
 
   public HyperLogLog get(long index, double maxStandardError) {
+    return get(index, new HyperLogLog(maxStandardError));
+  }
+
+  public HyperLogLog get(long index, HyperLogLog hll) {
     HyperLogLog result = array.get(index);
     if (result == null) {
-      HyperLogLog previous = new HyperLogLog(maxStandardError);
-      array.set(index, previous);
-      return previous;
+      array.set(index, hll);
+      return hll;
     }
     return result;
   }
@@ -54,9 +57,12 @@ public final class HyperLogLogBigArray {
   public void setIfNull(long index, double maxStandardError) {
     if (array.get(index) == null) {
       HyperLogLog hll = new HyperLogLog(maxStandardError);
-      updateRetainedSize(index, hll);
-      array.set(index, hll);
+      set(index, hll);
     }
+  }
+
+  public boolean isEmpty() {
+    return sizeOfHyperLogLog == 0;
   }
 
   public void ensureCapacity(long length) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/array/MapBigArray.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/array/MapBigArray.java
@@ -35,10 +35,6 @@ public final class MapBigArray {
     array = new ObjectBigArray<>();
   }
 
-  public MapBigArray(HashMap<TsPrimitiveType, Long> slice) {
-    array = new ObjectBigArray<>(slice);
-  }
-
   /** Returns the size of this big array in bytes. */
   public long sizeOf() {
     return INSTANCE_SIZE + array.sizeOf() + sizeOfMaps;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/array/ObjectBigArray.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/array/ObjectBigArray.java
@@ -36,8 +36,6 @@ public final class ObjectBigArray<T> {
   private static final long INSTANCE_SIZE = shallowSizeOfInstance(ObjectBigArray.class);
   private static final long SIZE_OF_SEGMENT = sizeOfObjectArray(SEGMENT_SIZE);
 
-  //  private final Object initialValue;
-
   private Object[][] array;
   private long capacity;
   private int segments;
@@ -116,7 +114,7 @@ public final class ObjectBigArray<T> {
   }
 
   public void reset() {
-    fill((T) null);
+    fill(null);
   }
 
   public void forEach(Consumer<T> action) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/array/ObjectBigArray.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/grouped/array/ObjectBigArray.java
@@ -36,7 +36,7 @@ public final class ObjectBigArray<T> {
   private static final long INSTANCE_SIZE = shallowSizeOfInstance(ObjectBigArray.class);
   private static final long SIZE_OF_SEGMENT = sizeOfObjectArray(SEGMENT_SIZE);
 
-  private final Object initialValue;
+  //  private final Object initialValue;
 
   private Object[][] array;
   private long capacity;
@@ -44,11 +44,6 @@ public final class ObjectBigArray<T> {
 
   /** Creates a new big array containing one initial segment */
   public ObjectBigArray() {
-    this(null);
-  }
-
-  public ObjectBigArray(Object initialValue) {
-    this.initialValue = initialValue;
     array = new Object[INITIAL_SEGMENTS][];
     allocateNewSegment();
   }
@@ -121,7 +116,7 @@ public final class ObjectBigArray<T> {
   }
 
   public void reset() {
-    fill((T) initialValue);
+    fill((T) null);
   }
 
   public void forEach(Consumer<T> action) {
@@ -185,9 +180,6 @@ public final class ObjectBigArray<T> {
 
   private void allocateNewSegment() {
     Object[] newSegment = new Object[SEGMENT_SIZE];
-    if (initialValue != null) {
-      Arrays.fill(newSegment, initialValue);
-    }
     array[segments] = newSegment;
     capacity += SEGMENT_SIZE;
     segments++;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableMetadataImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableMetadataImpl.java
@@ -641,6 +641,7 @@ public class TableMetadataImpl implements Metadata {
       case SqlConstant.COUNT:
       case SqlConstant.COUNT_ALL:
       case SqlConstant.COUNT_IF:
+      case SqlConstant.APPROX_COUNT_DISTINCT:
         return INT64;
       case SqlConstant.FIRST_AGGREGATION:
       case SqlConstant.LAST_AGGREGATION:

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableMetadataImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableMetadataImpl.java
@@ -582,7 +582,6 @@ public class TableMetadataImpl implements Metadata {
       case SqlConstant.MIN:
       case SqlConstant.MAX:
       case SqlConstant.MODE:
-      case SqlConstant.APPROX_COUNT_DISTINCT:
         if (argumentTypes.size() != 1) {
           throw new SemanticException(
               String.format(
@@ -631,6 +630,19 @@ public class TableMetadataImpl implements Metadata {
         }
 
         break;
+      case SqlConstant.APPROX_COUNT_DISTINCT:
+        if (argumentTypes.size() != 1 && argumentTypes.size() != 2) {
+          throw new SemanticException(
+              String.format(
+                  "Aggregate functions [%s] should only have two arguments", functionName));
+        }
+
+        if (argumentTypes.size() == 2 && !DOUBLE.equals(argumentTypes.get(1))) {
+          throw new SemanticException(
+              String.format(
+                  "Second argument of Aggregate functions [%s] should be DOUBLE", functionName));
+        }
+
       case SqlConstant.COUNT:
         break;
       default:

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableMetadataImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableMetadataImpl.java
@@ -582,6 +582,7 @@ public class TableMetadataImpl implements Metadata {
       case SqlConstant.MIN:
       case SqlConstant.MAX:
       case SqlConstant.MODE:
+      case SqlConstant.APPROX_COUNT_DISTINCT:
         if (argumentTypes.size() != 1) {
           throw new SemanticException(
               String.format(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableMetadataImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/TableMetadataImpl.java
@@ -637,10 +637,11 @@ public class TableMetadataImpl implements Metadata {
                   "Aggregate functions [%s] should only have two arguments", functionName));
         }
 
-        if (argumentTypes.size() == 2 && !DOUBLE.equals(argumentTypes.get(1))) {
+        if (argumentTypes.size() == 2 && !isSupportedMathNumericType(argumentTypes.get(1))) {
           throw new SemanticException(
               String.format(
-                  "Second argument of Aggregate functions [%s] should be DOUBLE", functionName));
+                  "Second argument of Aggregate functions [%s] should be numberic type and do not use expression",
+                  functionName));
         }
 
       case SqlConstant.COUNT:

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/parser/AstBuilder.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/parser/AstBuilder.java
@@ -265,6 +265,7 @@ import static org.apache.iotdb.db.queryengine.plan.relational.sql.ast.GroupingSe
 import static org.apache.iotdb.db.queryengine.plan.relational.sql.ast.GroupingSets.Type.ROLLUP;
 import static org.apache.iotdb.db.queryengine.plan.relational.sql.ast.QualifiedName.mapIdentifier;
 import static org.apache.iotdb.db.utils.TimestampPrecisionUtils.currPrecision;
+import static org.apache.iotdb.db.utils.constant.SqlConstant.APPROX_COUNT_DISTINCT;
 import static org.apache.iotdb.db.utils.constant.SqlConstant.FIRST_AGGREGATION;
 import static org.apache.iotdb.db.utils.constant.SqlConstant.FIRST_BY_AGGREGATION;
 import static org.apache.iotdb.db.utils.constant.SqlConstant.LAST_AGGREGATION;
@@ -2728,6 +2729,14 @@ public class AstBuilder extends RelationalSqlBaseVisitor<Node> {
                 .equalsIgnoreCase(TimestampOperand.TIMESTAMP_EXPRESSION_STRING),
             "The third argument of 'first_by' or 'last_by' function must be 'time'",
             ctx);
+      }
+    } else if (name.toString().equalsIgnoreCase(APPROX_COUNT_DISTINCT)) {
+      if (arguments.size() == 2
+          && !(arguments.get(1) instanceof DoubleLiteral
+              || arguments.get(1) instanceof LongLiteral
+              || arguments.get(1) instanceof StringLiteral)) {
+        throw new SemanticException(
+            "The second argument of 'approx_count_distinct' function must be a literal");
       }
     }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/constant/SqlConstant.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/constant/SqlConstant.java
@@ -78,6 +78,8 @@ public class SqlConstant {
   public static final String COUNT_TIME = "count_time";
   public static final String COUNT_TIME_HEADER = "count_time(*)";
 
+  public static final String APPROX_COUNT_DISTINCT = "approx_count_distinct";
+
   // names of scalar functions
   public static final String DIFF = "diff";
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/relational/TableBuiltinAggregationFunction.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/relational/TableBuiltinAggregationFunction.java
@@ -57,6 +57,7 @@ public enum TableBuiltinAggregationFunction {
   VARIANCE("variance"),
   VAR_POP("var_pop"),
   VAR_SAMP("var_samp"),
+  APPROX_COUNT_DISTINCT("approx_count_distinct"),
   ;
 
   private final String functionName;
@@ -85,6 +86,7 @@ public enum TableBuiltinAggregationFunction {
       case "count":
       case "count_all":
       case "count_if":
+      case "approx_count_distinct":
         return INT64;
       case "sum":
         return DOUBLE;

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/relational/TableBuiltinAggregationFunction.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/builtin/relational/TableBuiltinAggregationFunction.java
@@ -86,7 +86,6 @@ public enum TableBuiltinAggregationFunction {
       case "count":
       case "count_all":
       case "count_if":
-      case "approx_count_distinct":
         return INT64;
       case "sum":
         return DOUBLE;
@@ -104,6 +103,7 @@ public enum TableBuiltinAggregationFunction {
       case "variance":
       case "var_pop":
       case "var_samp":
+      case "approx_count_distinct":
         return RowType.anonymous(Collections.emptyList());
       case "extreme":
       case "max":

--- a/iotdb-protocol/thrift-commons/src/main/thrift/common.thrift
+++ b/iotdb-protocol/thrift-commons/src/main/thrift/common.thrift
@@ -284,7 +284,8 @@ enum TAggregationType {
   LAST_BY,
   MIN,
   MAX,
-  COUNT_ALL
+  COUNT_ALL,
+  APPROX_COUNT_DISTINCT
 }
 
 struct TShowConfigurationTemplateResp {


### PR DESCRIPTION
This pull request introduces the `ApproxCountDistinctAccumulator` and its associated classes to support the `APPROX_COUNT_DISTINCT` aggregation function in the IoTDB query engine. The changes include the addition of new classes and modifications to existing factory methods to incorporate the new accumulator.

### Key Changes:

**New Classes:**
* [`ApproxCountDistinctAccumulator`](diffhunk://#diff-24c6e2b1ec5522790e49b72c6a8fb6c2c7618905a685fa633552ee87709b1200R1-R262): Implements the logic for the `APPROX_COUNT_DISTINCT` aggregation function, including methods for adding input data, merging intermediate results, and evaluating the final result.
* [`HyperLogLog`](diffhunk://#diff-e386b0d69ef98e3c9b262715f258c19fb22e033a82364a7143bfdf3285f1e3b3R1-R265): A probabilistic data structure used by `ApproxCountDistinctAccumulator` to estimate the cardinality of a data set.
* [`HyperLogLogState`](diffhunk://#diff-94b57fed7afe58c5d62e6365e974c260803db68d9e30f933861aa9a79b52e77bR1-R7): An interface for managing the state of `HyperLogLog` instances.
* [`HyperLogLogStateFactory`](diffhunk://#diff-f6618410182b079e5cb6c44a2d31ecd55dcadf8a0cdc26c268765cf318bd5503R1-R89): Provides factory methods to create and manage `HyperLogLog` states, including single and grouped states.

**Factory Method Modifications:**
* [`AccumulatorFactory.java`](diffhunk://#diff-a72623b1eb8bac3f674e3b12529635a4ebd66a0c5763e40878249d13bd6e6068R244-R245): Updated to include cases for `APPROX_COUNT_DISTINCT` in the `createBuiltinGroupedAccumulator` and `createBuiltinAccumulator` methods. [[1]](diffhunk://#diff-a72623b1eb8bac3f674e3b12529635a4ebd66a0c5763e40878249d13bd6e6068R244-R245) [[2]](diffhunk://#diff-a72623b1eb8bac3f674e3b12529635a4ebd66a0c5763e40878249d13bd6e6068R311-R312)