### PR TITLE
Separate fully dirty files by partially dirty files task

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/schedule/CompactionScheduler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/schedule/CompactionScheduler.java
@@ -160,9 +160,7 @@ public class CompactionScheduler {
     long startTime = System.currentTimeMillis();
     List<InnerSpaceCompactionTask> innerSpaceTaskList =
         innerSpaceCompactionSelector.selectInnerSpaceTask(
-            sequence
-                ? tsFileManager.getOrCreateSequenceListByTimePartition(timePartition)
-                : tsFileManager.getOrCreateUnsequenceListByTimePartition(timePartition));
+            tsFileManager.getTsFileListSnapshot(timePartition, sequence));
     CompactionMetrics.getInstance()
         .updateCompactionTaskSelectionTimeCost(
             sequence ? CompactionTaskType.INNER_SEQ : CompactionTaskType.INNER_UNSEQ,
@@ -245,8 +243,8 @@ public class CompactionScheduler {
 
     List<CrossCompactionTaskResource> selectedTasks =
         selector.selectInsertionCrossSpaceTask(
-            tsFileManager.getOrCreateSequenceListByTimePartition(timePartition),
-            tsFileManager.getOrCreateUnsequenceListByTimePartition(timePartition));
+            tsFileManager.getTsFileListSnapshot(timePartition, true),
+            tsFileManager.getTsFileListSnapshot(timePartition, false));
     if (selectedTasks.isEmpty()) {
       return 0;
     }
@@ -287,8 +285,8 @@ public class CompactionScheduler {
 
     List<CrossCompactionTaskResource> taskList =
         crossSpaceCompactionSelector.selectCrossSpaceTask(
-            tsFileManager.getOrCreateSequenceListByTimePartition(timePartition),
-            tsFileManager.getOrCreateUnsequenceListByTimePartition(timePartition));
+            tsFileManager.getTsFileListSnapshot(timePartition, true),
+            tsFileManager.getTsFileListSnapshot(timePartition, false));
     List<Long> memoryCost =
         taskList.stream()
             .map(CrossCompactionTaskResource::getTotalMemoryCost)
@@ -337,12 +335,12 @@ public class CompactionScheduler {
     if (config.isEnableSeqSpaceCompaction()) {
       taskList.addAll(
           settleSelector.selectSettleTask(
-              tsFileManager.getOrCreateSequenceListByTimePartition(timePartition)));
+              tsFileManager.getTsFileListSnapshot(timePartition, true)));
     }
     if (config.isEnableUnseqSpaceCompaction()) {
       taskList.addAll(
           settleSelector.selectSettleTask(
-              tsFileManager.getOrCreateUnsequenceListByTimePartition(timePartition)));
+              tsFileManager.getTsFileListSnapshot(timePartition, false)));
     }
     CompactionMetrics.getInstance()
         .updateCompactionTaskSelectionTimeCost(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/impl/SettleSelectorImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/selector/impl/SettleSelectorImpl.java
@@ -97,24 +97,38 @@ public class SettleSelectorImpl implements ISettleSelector {
     }
   }
 
-  static class PartiallyDirtyResource {
-    List<TsFileResource> resources = new ArrayList<>();
-    long totalFileSize = 0;
+  static class SettleTaskResource {
 
-    public boolean add(TsFileResource resource, long dirtyDataSize) {
-      resources.add(resource);
-      totalFileSize += resource.getTsFileSize();
-      totalFileSize -= dirtyDataSize;
+    List<TsFileResource> fullyDirtyResources = new ArrayList<>();
+    List<TsFileResource> partiallyDirtyResources = new ArrayList<>();
+    long totalPartiallyDirtyFileSize = 0;
+
+    public void addFullyDirtyResource(TsFileResource resource) {
+      fullyDirtyResources.add(resource);
+    }
+
+    public boolean addPartiallyDirtyResource(TsFileResource resource, long dirtyDataSize) {
+      partiallyDirtyResources.add(resource);
+      totalPartiallyDirtyFileSize += resource.getTsFileSize();
+      totalPartiallyDirtyFileSize -= dirtyDataSize;
       return checkHasReachedThreshold();
     }
 
-    public List<TsFileResource> getResources() {
-      return resources;
+    public List<TsFileResource> getFullyDirtyResources() {
+      return fullyDirtyResources;
+    }
+
+    public List<TsFileResource> getPartiallyDirtyResources() {
+      return partiallyDirtyResources;
     }
 
     public boolean checkHasReachedThreshold() {
-      return resources.size() >= config.getInnerCompactionCandidateFileNum()
-          || totalFileSize >= config.getTargetCompactionFileSize();
+      return partiallyDirtyResources.size() >= config.getInnerCompactionCandidateFileNum()
+          || totalPartiallyDirtyFileSize >= config.getTargetCompactionFileSize();
+    }
+
+    public boolean isEmpty() {
+      return fullyDirtyResources.isEmpty() && partiallyDirtyResources.isEmpty();
     }
   }
 
@@ -128,9 +142,8 @@ public class SettleSelectorImpl implements ISettleSelector {
   }
 
   private List<SettleCompactionTask> selectTasks(List<TsFileResource> resources) {
-    List<TsFileResource> fullyDirtyResource = new ArrayList<>();
-    List<PartiallyDirtyResource> partiallyDirtyResourceList = new ArrayList<>();
-    PartiallyDirtyResource partiallyDirtyResource = new PartiallyDirtyResource();
+    List<SettleTaskResource> partiallyDirtyResourceList = new ArrayList<>();
+    SettleTaskResource settleTaskResource = new SettleTaskResource();
     try {
       for (TsFileResource resource : resources) {
         boolean shouldStop = false;
@@ -148,21 +161,22 @@ public class SettleSelectorImpl implements ISettleSelector {
 
         switch (fileDirtyInfo.status) {
           case FULLY_DIRTY:
-            fullyDirtyResource.add(resource);
+            settleTaskResource.addFullyDirtyResource(resource);
             break;
           case PARTIALLY_DIRTY:
-            shouldStop = partiallyDirtyResource.add(resource, fileDirtyInfo.dirtyDataSize);
+            shouldStop =
+                settleTaskResource.addPartiallyDirtyResource(resource, fileDirtyInfo.dirtyDataSize);
             break;
           case NOT_SATISFIED:
-            shouldStop = !partiallyDirtyResource.getResources().isEmpty();
+            shouldStop = !settleTaskResource.getPartiallyDirtyResources().isEmpty();
             break;
           default:
             // do nothing
         }
 
         if (shouldStop) {
-          partiallyDirtyResourceList.add(partiallyDirtyResource);
-          partiallyDirtyResource = new PartiallyDirtyResource();
+          partiallyDirtyResourceList.add(settleTaskResource);
+          settleTaskResource = new SettleTaskResource();
           if (!heavySelect) {
             // Non-heavy selection is triggered more frequently. In order to avoid selecting too
             // many files containing mods for compaction when the disk is insufficient, the number
@@ -171,8 +185,8 @@ public class SettleSelectorImpl implements ISettleSelector {
           }
         }
       }
-      partiallyDirtyResourceList.add(partiallyDirtyResource);
-      return createTask(fullyDirtyResource, partiallyDirtyResourceList);
+      partiallyDirtyResourceList.add(settleTaskResource);
+      return createTask(partiallyDirtyResourceList);
     } catch (Exception e) {
       LOGGER.error(
           "{}-{} cannot select file for settle compaction", storageGroupName, dataRegionId, e);
@@ -275,39 +289,22 @@ public class SettleSelectorImpl implements ISettleSelector {
     return ModificationUtils.isAllDeletedByMods(modifications, device, startTime, endTime);
   }
 
-  private List<SettleCompactionTask> createTask(
-      List<TsFileResource> fullyDirtyResources,
-      List<PartiallyDirtyResource> partiallyDirtyResourceList) {
+  private List<SettleCompactionTask> createTask(List<SettleTaskResource> settleTaskResourceList) {
     List<SettleCompactionTask> tasks = new ArrayList<>();
-    for (int i = 0; i < partiallyDirtyResourceList.size(); i++) {
-      if (i == 0) {
-        if (fullyDirtyResources.isEmpty()
-            && partiallyDirtyResourceList.get(i).getResources().isEmpty()) {
-          continue;
-        }
-        tasks.add(
-            new SettleCompactionTask(
-                timePartition,
-                tsFileManager,
-                fullyDirtyResources,
-                partiallyDirtyResourceList.get(i).getResources(),
-                isSeq,
-                createCompactionPerformer(),
-                tsFileManager.getNextCompactionTaskId()));
-      } else {
-        if (partiallyDirtyResourceList.get(i).getResources().isEmpty()) {
-          continue;
-        }
-        tasks.add(
-            new SettleCompactionTask(
-                timePartition,
-                tsFileManager,
-                Collections.emptyList(),
-                partiallyDirtyResourceList.get(i).getResources(),
-                isSeq,
-                createCompactionPerformer(),
-                tsFileManager.getNextCompactionTaskId()));
+    for (SettleTaskResource settleTaskResource : settleTaskResourceList) {
+      if (settleTaskResource.isEmpty()) {
+        continue;
       }
+      SettleCompactionTask task =
+          new SettleCompactionTask(
+              timePartition,
+              tsFileManager,
+              settleTaskResource.getFullyDirtyResources(),
+              settleTaskResource.getPartiallyDirtyResources(),
+              isSeq,
+              createCompactionPerformer(),
+              tsFileManager.getNextCompactionTaskId());
+      tasks.add(task);
     }
     return tasks;
   }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/settle/SettleCompactionSelectorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/settle/SettleCompactionSelectorTest.java
@@ -450,14 +450,14 @@ public class SettleCompactionSelectorTest extends AbstractCompactionTest {
     }
     seqTasks = settleSelector.selectSettleTask(seqResources);
     Assert.assertEquals(2, seqTasks.size());
-    Assert.assertEquals(5, seqTasks.get(0).getFullyDirtyFiles().size());
+    Assert.assertEquals(3, seqTasks.get(0).getFullyDirtyFiles().size());
     Assert.assertEquals(3, seqTasks.get(0).getPartiallyDirtyFiles().size());
     Assert.assertEquals(seqResources.get(1), seqTasks.get(0).getPartiallyDirtyFiles().get(0));
     Assert.assertEquals(seqResources.get(3), seqTasks.get(0).getPartiallyDirtyFiles().get(1));
     Assert.assertEquals(seqResources.get(5), seqTasks.get(0).getPartiallyDirtyFiles().get(2));
     Assert.assertEquals(seqResources.get(7), seqTasks.get(1).getPartiallyDirtyFiles().get(0));
     Assert.assertEquals(seqResources.get(9), seqTasks.get(1).getPartiallyDirtyFiles().get(1));
-    Assert.assertEquals(0, seqTasks.get(1).getFullyDirtyFiles().size());
+    Assert.assertEquals(2, seqTasks.get(1).getFullyDirtyFiles().size());
     Assert.assertEquals(2, seqTasks.get(1).getPartiallyDirtyFiles().size());
     Assert.assertTrue(seqTasks.get(0).start());
     Assert.assertTrue(seqTasks.get(1).start());
@@ -578,15 +578,15 @@ public class SettleCompactionSelectorTest extends AbstractCompactionTest {
             true, COMPACTION_TEST_SG, "0", 0, tsFileManager, new CompactionScheduleContext());
     List<SettleCompactionTask> seqTasks = settleSelector.selectSettleTask(seqResources);
     Assert.assertEquals(3, seqTasks.size());
-    Assert.assertEquals(3, seqTasks.get(0).getFullyDirtyFiles().size());
+    Assert.assertEquals(0, seqTasks.get(0).getFullyDirtyFiles().size());
     Assert.assertEquals(1, seqTasks.get(0).getPartiallyDirtyFiles().size());
     Assert.assertEquals(seqResources.get(0), seqTasks.get(0).getPartiallyDirtyFiles().get(0));
 
-    Assert.assertEquals(0, seqTasks.get(1).getFullyDirtyFiles().size());
+    Assert.assertEquals(2, seqTasks.get(1).getFullyDirtyFiles().size());
     Assert.assertEquals(1, seqTasks.get(1).getPartiallyDirtyFiles().size());
     Assert.assertEquals(seqResources.get(4), seqTasks.get(1).getPartiallyDirtyFiles().get(0));
 
-    Assert.assertEquals(0, seqTasks.get(2).getFullyDirtyFiles().size());
+    Assert.assertEquals(1, seqTasks.get(2).getFullyDirtyFiles().size());
     Assert.assertEquals(2, seqTasks.get(2).getPartiallyDirtyFiles().size());
     Assert.assertEquals(seqResources.get(6), seqTasks.get(2).getPartiallyDirtyFiles().get(0));
     Assert.assertEquals(seqResources.get(8), seqTasks.get(2).getPartiallyDirtyFiles().get(1));
@@ -987,14 +987,14 @@ public class SettleCompactionSelectorTest extends AbstractCompactionTest {
     }
     seqTasks = settleSelector.selectSettleTask(seqResources);
     Assert.assertEquals(2, seqTasks.size());
-    Assert.assertEquals(5, seqTasks.get(0).getFullyDirtyFiles().size());
+    Assert.assertEquals(3, seqTasks.get(0).getFullyDirtyFiles().size());
     Assert.assertEquals(3, seqTasks.get(0).getPartiallyDirtyFiles().size());
     Assert.assertEquals(seqResources.get(1), seqTasks.get(0).getPartiallyDirtyFiles().get(0));
     Assert.assertEquals(seqResources.get(3), seqTasks.get(0).getPartiallyDirtyFiles().get(1));
     Assert.assertEquals(seqResources.get(5), seqTasks.get(0).getPartiallyDirtyFiles().get(2));
     Assert.assertEquals(seqResources.get(7), seqTasks.get(1).getPartiallyDirtyFiles().get(0));
     Assert.assertEquals(seqResources.get(9), seqTasks.get(1).getPartiallyDirtyFiles().get(1));
-    Assert.assertEquals(0, seqTasks.get(1).getFullyDirtyFiles().size());
+    Assert.assertEquals(2, seqTasks.get(1).getFullyDirtyFiles().size());
     Assert.assertEquals(2, seqTasks.get(1).getPartiallyDirtyFiles().size());
     Assert.assertTrue(seqTasks.get(0).start());
     Assert.assertTrue(seqTasks.get(1).start());
@@ -1117,15 +1117,15 @@ public class SettleCompactionSelectorTest extends AbstractCompactionTest {
             true, COMPACTION_TEST_SG, "0", 0, tsFileManager, new CompactionScheduleContext());
     List<SettleCompactionTask> seqTasks = settleSelector.selectSettleTask(seqResources);
     Assert.assertEquals(3, seqTasks.size());
-    Assert.assertEquals(3, seqTasks.get(0).getFullyDirtyFiles().size());
+    Assert.assertEquals(0, seqTasks.get(0).getFullyDirtyFiles().size());
     Assert.assertEquals(1, seqTasks.get(0).getPartiallyDirtyFiles().size());
     Assert.assertEquals(seqResources.get(0), seqTasks.get(0).getPartiallyDirtyFiles().get(0));
 
-    Assert.assertEquals(0, seqTasks.get(1).getFullyDirtyFiles().size());
+    Assert.assertEquals(2, seqTasks.get(1).getFullyDirtyFiles().size());
     Assert.assertEquals(1, seqTasks.get(1).getPartiallyDirtyFiles().size());
     Assert.assertEquals(seqResources.get(4), seqTasks.get(1).getPartiallyDirtyFiles().get(0));
 
-    Assert.assertEquals(0, seqTasks.get(2).getFullyDirtyFiles().size());
+    Assert.assertEquals(1, seqTasks.get(2).getFullyDirtyFiles().size());
     Assert.assertEquals(2, seqTasks.get(2).getPartiallyDirtyFiles().size());
     Assert.assertEquals(seqResources.get(6), seqTasks.get(2).getPartiallyDirtyFiles().get(0));
     Assert.assertEquals(seqResources.get(8), seqTasks.get(2).getPartiallyDirtyFiles().get(1));


### PR DESCRIPTION
## Description
Currently, during the settle phase of file selection, all files in a partition are traversed and categorized based on the amount of remaining data. Files are classified as either fully dirty or partial dirty. A fully dirty file is one from which all data can be deleted, while a partial dirty file contains only some deletable data. In the final compaction tasks, fully dirty files are expected to be deleted first, followed by the cleanup of partial dirty files through inner-space compaction tasks.

A large number of partial dirty files may be selected within a single partition. These files are not all submitted in one compaction task. Instead, they are split into multiple tasks based on their size and count. The current splitting strategy submits all fully dirty files along with the first group of partial dirty files as one task, and each subsequent group of partial dirty files is submitted as separate tasks.

This leads to a problem, as shown in the diagram: the second task contains File 5 and File 7, with a fully dirty File 6 in between. If the fully dirty File 6 has not yet been deleted by another task when Task 2 is executed, an overlap may occur between File 6 and the target files produced by the compaction, resulting in an error.
<img width="1127" alt="截屏2025-04-14 18 27 50" src="https://github.com/user-attachments/assets/c8fb4f9d-eae9-4949-9bcc-c539407010f8" />

This PR change the way to submit fully dirty files.
<img width="1101" alt="截屏2025-04-14 18 32 14" src="https://github.com/user-attachments/assets/0b9619a1-2a7e-45b1-b439-67a375ab1a71" />
