### PR TITLE
Make deserialize of AggregationDescriptor AttributesMap use LinkedHashMap

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/aggregation/IoTDBCountIfIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/aggregation/IoTDBCountIfIT.java
@@ -212,7 +212,7 @@ public class IoTDBCountIfIT {
   public void testMultiAttributes() {
     String[] expectedHeader =
         new String[] {
-          "Count_if(root.db.d1.s3, 1, \"attr1\"=\"1\",\"attr2\"=\"2\",\"attr3\"=\"3\")"
+          "Count_if(root.db.d1.s3, 1, \"attr1\"=\"1\", \"attr2\"=\"2\", \"attr3\"=\"3\")"
         };
     String[] retArray = new String[] {"1,"};
     resultSetEqualTest(

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/aggregation/IoTDBCountIfIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/aggregation/IoTDBCountIfIT.java
@@ -209,6 +209,19 @@ public class IoTDBCountIfIT {
   }
 
   @Test
+  public void testMultiAttributes() {
+    String[] expectedHeader =
+        new String[] {
+          "Count_if(root.db.d1.s3, 1, \"attr1\"=\"1\",\"attr2\"=\"2\",\"attr3\"=\"3\")"
+        };
+    String[] retArray = new String[] {"1,"};
+    resultSetEqualTest(
+        "select Count_if(s3, 1, \"attr1\"=\"1\",\"attr2\"=\"2\",\"attr3\"=\"3\") from root.db.d1",
+        expectedHeader,
+        retArray);
+  }
+
+  @Test
   public void testContIfWithGroupByLevel() {
     String[] expectedHeader = new String[] {"Count_if(root.db.*.s1 = 0 & root.db.*.s2 = 0, 3)"};
     String[] retArray = new String[] {"4,"};

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/parameter/AggregationDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/parameter/AggregationDescriptor.java
@@ -332,7 +332,7 @@ public class AggregationDescriptor {
       inputExpressions.add(Expression.deserialize(byteBuffer));
       inputExpressionsSize--;
     }
-    Map<String, String> inputAttributes = ReadWriteIOUtils.readMap(byteBuffer);
+    Map<String, String> inputAttributes = ReadWriteIOUtils.readLinkedHashMap(byteBuffer);
     return new AggregationDescriptor(aggregationFuncName, step, inputExpressions, inputAttributes);
   }
 


### PR DESCRIPTION
Before fix, if the attributes of AggregationFunction is more than one, the ordinal of attributes will miss, it causes the `OutputColumnName` is different from  from before serialization.