### PR TITLE
[To dev/1.3] Subscription: [Bug] When using SubscriptionPullConsumer to consume data, an error is reported when configuring ConsumerConstant.NODE_URLS_KEY as the cluster address. (#15322)

### DIFF
--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/subscription/consumer/SubscriptionConsumer.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/subscription/consumer/SubscriptionConsumer.java
@@ -1402,7 +1402,7 @@ abstract class SubscriptionConsumer implements AutoCloseable {
       return this;
     }
 
-    public Builder port(final int port) {
+    public Builder port(final Integer port) {
       this.port = port;
       return this;
     }

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/subscription/consumer/SubscriptionConsumer.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/subscription/consumer/SubscriptionConsumer.java
@@ -188,12 +188,8 @@ abstract class SubscriptionConsumer implements AutoCloseable {
   protected SubscriptionConsumer(final Builder builder, final Properties properties) {
     this(
         builder
-            .host(
-                (String)
-                    properties.getOrDefault(ConsumerConstant.HOST_KEY, SessionConfig.DEFAULT_HOST))
-            .port(
-                (Integer)
-                    properties.getOrDefault(ConsumerConstant.PORT_KEY, SessionConfig.DEFAULT_PORT))
+            .host((String) properties.get(ConsumerConstant.HOST_KEY))
+            .port((Integer) properties.get(ConsumerConstant.PORT_KEY))
             .nodeUrls((List<String>) properties.get(ConsumerConstant.NODE_URLS_KEY))
             .username(
                 (String)

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/subscription/consumer/SubscriptionPullConsumer.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/subscription/consumer/SubscriptionPullConsumer.java
@@ -301,7 +301,7 @@ public class SubscriptionPullConsumer extends SubscriptionConsumer {
     }
 
     @Override
-    public Builder port(final int port) {
+    public Builder port(final Integer port) {
       super.port(port);
       return this;
     }

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/subscription/consumer/SubscriptionPushConsumer.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/subscription/consumer/SubscriptionPushConsumer.java
@@ -234,7 +234,7 @@ public class SubscriptionPushConsumer extends SubscriptionConsumer {
     }
 
     @Override
-    public Builder port(final int port) {
+    public Builder port(final Integer port) {
       super.port(port);
       return this;
     }


### PR DESCRIPTION
cherry-pick #15322 to https://github.com/apache/iotdb/tree/dev/1.3