### PR TITLE
Fix process of last query if intermediate state of last cache is read when query concurrently

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/LastQueryAggTableScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/LastQueryAggTableScanOperator.java
@@ -249,14 +249,8 @@ public class LastQueryAggTableScanOperator extends AbstractAggTableScanOperator 
               hitCachedResults.get(currentHitCacheIndex).getRight()[measurementIdx];
           long lastByTime = hitCachedResults.get(currentHitCacheIndex).getLeft().getAsLong();
           if (tsPrimitiveType == EMPTY_PRIMITIVE_TYPE) {
-            // there is no data for this time series
-            if (aggregator.getStep().isOutputPartial()) {
-              columnBuilder.writeBinary(
-                  new Binary(
-                      serializeTimeValue(getTSDataType(schema.getType()), lastByTime, true, null)));
-            } else {
-              columnBuilder.appendNull();
-            }
+            throw new IllegalStateException(
+                "If the read value is [EMPTY_PRIMITIVE_TYPE], we should never reach here");
           } else {
             if (aggregator.getStep().isOutputPartial()) {
               columnBuilder.writeBinary(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/TableOperatorGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/TableOperatorGenerator.java
@@ -250,6 +250,7 @@ import static org.apache.iotdb.db.queryengine.plan.planner.OperatorTreeGenerator
 import static org.apache.iotdb.db.queryengine.plan.planner.OperatorTreeGenerator.getLinearFill;
 import static org.apache.iotdb.db.queryengine.plan.planner.OperatorTreeGenerator.getPreviousFill;
 import static org.apache.iotdb.db.queryengine.plan.planner.plan.parameter.SeriesScanOptions.updateFilterUsingTTL;
+import static org.apache.iotdb.db.queryengine.plan.relational.metadata.fetcher.cache.TableDeviceLastCache.EMPTY_PRIMITIVE_TYPE;
 import static org.apache.iotdb.db.queryengine.plan.relational.planner.SortOrder.ASC_NULLS_LAST;
 import static org.apache.iotdb.db.queryengine.plan.relational.planner.ir.GlobalTimePredicateExtractVisitor.isTimeColumn;
 import static org.apache.iotdb.db.queryengine.plan.relational.sql.ast.BooleanLiteral.TRUE_LITERAL;
@@ -2317,6 +2318,7 @@ public class TableOperatorGenerator extends PlanVisitor<Operator, LocalExecution
         for (int j = 0; j < lastByResult.get().getRight().length; j++) {
           TsPrimitiveType tsPrimitiveType = lastByResult.get().getRight()[j];
           if (tsPrimitiveType == null
+              || tsPrimitiveType == EMPTY_PRIMITIVE_TYPE
               || (updateTimeFilter != null
                   && !LastQueryUtil.satisfyFilter(
                       updateTimeFilter,


### PR DESCRIPTION
cause: 
The first last query failed to hit the last cache. And this placeholder `EMPTY_PRIMITIVE_TYPE` will be marked in the last cache, and then the last cache will be updated after the subsequent queries read the disk. 
However, before the last cache was updated in the previous query, a new query (with the same content as the previous one) read this placeholder.
Before this fix, we think the last cache is hit when the placeholder is read, it is not correct.