### PR TITLE
fix an encrypt_key_import bug

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -961,15 +961,6 @@ public class IoTDBDescriptor {
         .setKerberosPrincipal(
             properties.getProperty("kerberos_principal", conf.getKerberosPrincipal()));
     TSFileDescriptor.getInstance().getConfig().setBatchSize(conf.getBatchSize());
-    TSFileDescriptor.getInstance()
-        .getConfig()
-        .setEncryptFlag(properties.getProperty("encrypt_flag", "false"));
-    TSFileDescriptor.getInstance()
-        .getConfig()
-        .setEncryptType(properties.getProperty("encrypt_type", "UNENCRYPTED"));
-    TSFileDescriptor.getInstance()
-        .getConfig()
-        .setEncryptKeyFromPath(properties.getProperty("encrypt_key_from_path", ""));
 
     conf.setCoordinatorReadExecutorSize(
         Integer.parseInt(
@@ -1795,6 +1786,15 @@ public class IoTDBDescriptor {
                     "max_tsblock_line_number",
                     ConfigurationFileUtils.getConfigurationDefaultValue(
                         "max_tsblock_line_number"))));
+    TSFileDescriptor.getInstance()
+        .getConfig()
+        .setEncryptFlag(properties.getProperty("encrypt_flag", "false"));
+    TSFileDescriptor.getInstance()
+        .getConfig()
+        .setEncryptType(properties.getProperty("encrypt_type", "UNENCRYPTED"));
+    TSFileDescriptor.getInstance()
+        .getConfig()
+        .setEncryptKeyFromPath(properties.getProperty("encrypt_key_path", ""));
   }
 
   // Mqtt related


### PR DESCRIPTION
fix an encrypt_key_import bug(the parameter's name is wrong and lead to import useless). Correct it and move the set-parameter part to a more proper place.