### PR TITLE
DAL: Fix thread leak when DN exit.

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/consensus/deletion/persist/PageCacheDeletionBuffer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/consensus/deletion/persist/PageCacheDeletionBuffer.java
@@ -261,7 +261,15 @@ public class PageCacheDeletionBuffer implements DeletionBuffer {
     // first waiting serialize and sync tasks finished, then release all resources
     waitUntilFlushAllDeletionsOrTimeOut();
     if (persistThread != null) {
-      persistThread.shutdown();
+      persistThread.shutdownNow();
+      try {
+        if (!persistThread.awaitTermination(30, TimeUnit.SECONDS)) {
+          LOGGER.warn("persistThread did not terminate within {}s", 30);
+        }
+      } catch (InterruptedException e) {
+        LOGGER.warn("DAL Thread {} still doesn't exit after 30s", dataRegionId);
+        Thread.currentThread().interrupt();
+      }
     }
     // clean buffer
     MmapUtil.clean(serializeBuffer);
@@ -330,6 +338,7 @@ public class PageCacheDeletionBuffer implements DeletionBuffer {
         LOGGER.warn(
             "Interrupted when waiting for taking DeletionResource from blocking queue to serialize.");
         Thread.currentThread().interrupt();
+        return;
       }
 
       // For further deletion, we use non-blocking poll() method to persist existing deletion of


### PR DESCRIPTION
We should use `shutdownNow` instead of `shutdown` to send an interruption signal to thread.

Test has shown results as expected:
<img width="1619" alt="image" src="https://github.com/user-attachments/assets/474dbc61-8ef5-43bd-b4d5-cdafd9e822b0" />
