### PR TITLE
Optimize partition cache getRegionReplicaSet interface performance by batching

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/ClusterPartitionFetcher.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/ClusterPartitionFetcher.java
@@ -60,7 +60,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -493,12 +493,16 @@ public class ClusterPartitionFetcher implements IPartitionFetcher {
       String database = entry1.getKey();
       final Map<TSeriesPartitionSlot, TRegionReplicaSet> result1 =
           regionReplicaMap.computeIfAbsent(database, k -> new HashMap<>());
+
+      Map<TSeriesPartitionSlot, TConsensusGroupId> orderedMap =
+          new LinkedHashMap<>(entry1.getValue());
+      List<TConsensusGroupId> orderedGroupIds = new ArrayList<>(orderedMap.values());
       List<TRegionReplicaSet> regionReplicaSets =
-          partitionCache.getRegionReplicaSet(new ArrayList<>(entry1.getValue().values()));
-      Iterator<TRegionReplicaSet> iterator = regionReplicaSets.iterator();
-      for (final Map.Entry<TSeriesPartitionSlot, TConsensusGroupId> entry2 :
-          entry1.getValue().entrySet()) {
-        result1.put(entry2.getKey(), iterator.next());
+          partitionCache.getRegionReplicaSet(orderedGroupIds);
+
+      int index = 0;
+      for (Map.Entry<TSeriesPartitionSlot, TConsensusGroupId> entry2 : orderedMap.entrySet()) {
+        result1.put(entry2.getKey(), regionReplicaSets.get(index++));
       }
     }
     return new SchemaPartition(
@@ -518,6 +522,29 @@ public class ClusterPartitionFetcher implements IPartitionFetcher {
 
   private DataPartition parseDataPartitionResp(
       final TDataPartitionTableResp dataPartitionTableResp) {
+    final Set<TConsensusGroupId> uniqueConsensusGroupIds = new HashSet<>();
+    for (final Map<
+            String, Map<TSeriesPartitionSlot, Map<TTimePartitionSlot, List<TConsensusGroupId>>>>
+        partitionTable : Collections.singleton(dataPartitionTableResp.getDataPartitionTable())) {
+      for (final Map<TSeriesPartitionSlot, Map<TTimePartitionSlot, List<TConsensusGroupId>>>
+          seriesPartitionMap : partitionTable.values()) {
+        for (final Map<TTimePartitionSlot, List<TConsensusGroupId>> timePartitionMap :
+            seriesPartitionMap.values()) {
+          for (final List<TConsensusGroupId> consensusGroupIds : timePartitionMap.values()) {
+            uniqueConsensusGroupIds.addAll(consensusGroupIds);
+          }
+        }
+      }
+    }
+
+    final List<TRegionReplicaSet> allRegionReplicaSets =
+        partitionCache.getRegionReplicaSet(new ArrayList<>(uniqueConsensusGroupIds));
+    final Map<TConsensusGroupId, TRegionReplicaSet> regionReplicaSetMap = new HashMap<>();
+    for (int i = 0; i < allRegionReplicaSets.size(); i++) {
+      regionReplicaSetMap.put(
+          new ArrayList<>(uniqueConsensusGroupIds).get(i), allRegionReplicaSets.get(i));
+    }
+
     final Map<String, Map<TSeriesPartitionSlot, Map<TTimePartitionSlot, List<TRegionReplicaSet>>>>
         regionReplicaSet = new HashMap<>();
     for (final Map.Entry<
@@ -531,8 +558,10 @@ public class ClusterPartitionFetcher implements IPartitionFetcher {
             result1.computeIfAbsent(entry2.getKey(), k -> new HashMap<>());
         for (final Map.Entry<TTimePartitionSlot, List<TConsensusGroupId>> entry3 :
             entry2.getValue().entrySet()) {
-          final List<TRegionReplicaSet> regionReplicaSets =
-              partitionCache.getRegionReplicaSet(entry3.getValue());
+          final List<TRegionReplicaSet> regionReplicaSets = new ArrayList<>();
+          for (TConsensusGroupId groupId : entry3.getValue()) {
+            regionReplicaSets.add(regionReplicaSetMap.get(groupId));
+          }
           result2.put(entry3.getKey(), regionReplicaSets);
         }
       }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/ClusterPartitionFetcher.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/ClusterPartitionFetcher.java
@@ -539,10 +539,10 @@ public class ClusterPartitionFetcher implements IPartitionFetcher {
 
     final List<TRegionReplicaSet> allRegionReplicaSets =
         partitionCache.getRegionReplicaSet(new ArrayList<>(uniqueConsensusGroupIds));
+    final List<TConsensusGroupId> consensusGroupIds = new ArrayList<>(uniqueConsensusGroupIds);
     final Map<TConsensusGroupId, TRegionReplicaSet> regionReplicaSetMap = new HashMap<>();
     for (int i = 0; i < allRegionReplicaSets.size(); i++) {
-      regionReplicaSetMap.put(
-          new ArrayList<>(uniqueConsensusGroupIds).get(i), allRegionReplicaSets.get(i));
+      regionReplicaSetMap.put(consensusGroupIds.get(i), allRegionReplicaSets.get(i));
     }
 
     final Map<String, Map<TSeriesPartitionSlot, Map<TTimePartitionSlot, List<TRegionReplicaSet>>>>

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/partition/PartitionCache.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/partition/PartitionCache.java
@@ -897,11 +897,11 @@ public class PartitionCache {
         }
       }
 
-      final List<TRegionReplicaSet> allRegionReplicaSets =
-          getRegionReplicaSet(new ArrayList<>(allConsensusGroupIds));
+      final List<TConsensusGroupId> consensusGroupIds = new ArrayList<>(allConsensusGroupIds);
+      final List<TRegionReplicaSet> allRegionReplicaSets = getRegionReplicaSet(consensusGroupIds);
 
       for (int i = 0; i < allRegionReplicaSets.size(); i++) {
-        TConsensusGroupId groupId = new ArrayList<>(allConsensusGroupIds).get(i);
+        TConsensusGroupId groupId = consensusGroupIds.get(i);
         TRegionReplicaSet replicaSet = allRegionReplicaSets.get(i);
 
         for (TimeSlotRegionInfo info : consensusGroupToTimeSlotMap.get(groupId)) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/partition/PartitionCache.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/partition/PartitionCache.java
@@ -838,7 +838,9 @@ public class PartitionCache {
 
         Map<TSeriesPartitionSlot, SeriesPartitionTable> cachedDatabasePartitionMap =
             dataPartitionTable.getDataPartitionMap();
-        dataPartitionMap.put(databaseName, new HashMap<>());
+        Map<TSeriesPartitionSlot, Map<TTimePartitionSlot, List<TRegionReplicaSet>>>
+            seriesSlotToTimePartitionMap =
+                dataPartitionMap.computeIfAbsent(databaseName, k -> new HashMap<>());
 
         for (DataPartitionQueryParam param : params) {
           TSeriesPartitionSlot seriesPartitionSlot;
@@ -863,6 +865,8 @@ public class PartitionCache {
 
           Map<TTimePartitionSlot, List<TConsensusGroupId>> cachedTimePartitionSlot =
               cachedSeriesPartitionTable.getSeriesPartitionMap();
+          seriesSlotToTimePartitionMap.computeIfAbsent(seriesPartitionSlot, k -> new HashMap<>());
+
           if (param.getTimePartitionSlotList().isEmpty()) {
             return null;
           }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/partition/PartitionCache.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/partition/PartitionCache.java
@@ -75,6 +75,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -810,7 +811,7 @@ public class PartitionCache {
       }
 
       final Set<TConsensusGroupId> allConsensusGroupIds = new HashSet<>();
-      final Map<TConsensusGroupId, List<TimeSlotRegionInfo>> consensusGroupToTimeSlotMap =
+      final Map<TConsensusGroupId, HashSet<TimeSlotRegionInfo>> consensusGroupToTimeSlotMap =
           new HashMap<>();
 
       Map<String, Map<TSeriesPartitionSlot, Map<TTimePartitionSlot, List<TRegionReplicaSet>>>>
@@ -888,7 +889,7 @@ public class PartitionCache {
             for (TConsensusGroupId groupId : cacheConsensusGroupIds) {
               allConsensusGroupIds.add(groupId);
               consensusGroupToTimeSlotMap
-                  .computeIfAbsent(groupId, k -> new ArrayList<>())
+                  .computeIfAbsent(groupId, k -> new HashSet<>())
                   .add(
                       new TimeSlotRegionInfo(databaseName, seriesPartitionSlot, timePartitionSlot));
             }
@@ -932,6 +933,26 @@ public class PartitionCache {
       this.databaseName = databaseName;
       this.seriesPartitionSlot = seriesPartitionSlot;
       this.timePartitionSlot = timePartitionSlot;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      TimeSlotRegionInfo that = (TimeSlotRegionInfo) o;
+      return Objects.equals(databaseName, that.databaseName)
+          && Objects.equals(seriesPartitionSlot, that.seriesPartitionSlot)
+          && Objects.equals(timePartitionSlot, that.timePartitionSlot);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = Objects.hashCode(databaseName);
+      result = 31 * result + Objects.hashCode(seriesPartitionSlot);
+      result = 31 * result + Objects.hashCode(timePartitionSlot);
+      return result;
     }
   }
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/PartitionCacheTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/PartitionCacheTest.java
@@ -276,7 +276,10 @@ public class PartitionCacheTest {
 
   private void checkRegionReplicaSet(TConsensusGroupId consensusGroupId) {
     try {
-      assertNotNull(partitionCache.getRegionReplicaSet(consensusGroupId));
+      List<TRegionReplicaSet> regionReplicaSets =
+          partitionCache.getRegionReplicaSet(Collections.singletonList(consensusGroupId));
+      assertEquals(1, regionReplicaSets.size());
+      assertNotNull(regionReplicaSets.get(0));
     } catch (Exception e) {
       fail(e.getMessage());
     }


### PR DESCRIPTION
# Motivation

We found that on physical machines with good configuration, if there are a large number of regions and devices, and each write operation writes only one row of data per device, the PartitionCache's regionLock becomes a bottleneck. Although all operations are using read locks, on a machine with 96 cores and 192 threads, high-concurrency read operations involving CAS (Compare-And-Swap) on a read lock still turn into a bottleneck.

To address this, we batched the logic, reducing the number of times each thread needs to acquire a read lock from region num to just once overall. This eliminated the read lock bottleneck.

# Configuration
## Machine：
* 96C 192 Thread 768GB Memory
## IoTDB Server：1C1D
* data_region_group_extension_policy=CUSTOM
* default_data_region_group_num_per_database=192
## Benchmark：
* LOOP=100
* DEVICE_NUMBER=4500000
* SENSOR_NUMBER=2
* DATA_CLIENT_NUMBER=150
* POINT_STEP=1000
* OP_MIN_INTERVAL=-1
* INSERT_DATATYPE_PROPORTION=0:1:0:1:0:0:0:0:0:0
* BATCH_SIZE_PER_WRITE=1
* DEVICE_NUM_PER_WRITE=30000
* IS_OUT_OF_ORDER=false

# Test result
## Before
```
Create schema cost 3.48 second
Test elapsed time (not include schema creation): 360.23 second
----------------------------------------------------------Result Matrix----------------------------------------------------------
Operation                okOperation              okPoint                  failOperation            failPoint                throughput(point/s)
INGESTION                15000                    900000000                0                        0                        2498376.56
PRECISE_POINT            0                        0                        0                        0                        0.00
TIME_RANGE               0                        0                        0                        0                        0.00
VALUE_RANGE              0                        0                        0                        0                        0.00
AGG_RANGE                0                        0                        0                        0                        0.00
AGG_VALUE                0                        0                        0                        0                        0.00
AGG_RANGE_VALUE          0                        0                        0                        0                        0.00
GROUP_BY                 0                        0                        0                        0                        0.00
LATEST_POINT             0                        0                        0                        0                        0.00
RANGE_QUERY_DESC         0                        0                        0                        0                        0.00
VALUE_RANGE_QUERY_DESC   0                        0                        0                        0                        0.00
GROUP_BY_DESC            0                        0                        0                        0                        0.00
---------------------------------------------------------------------------------------------------------------------------------

--------------------------------------------------------------------------Latency (ms) Matrix--------------------------------------------------------------------------
Operation                AVG         MIN         P10         P25         MEDIAN      P75         P90         P95         P99         P999        MAX         SLOWEST_THREAD
INGESTION                3419.17     307.01      2434.31     2908.19     3326.67     3678.20     3991.60     4208.49     13318.90    20724.98    21227.74    351047.16
PRECISE_POINT            0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00
TIME_RANGE               0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00
VALUE_RANGE              0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00
AGG_RANGE                0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00
AGG_VALUE                0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00
AGG_RANGE_VALUE          0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00
GROUP_BY                 0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00
LATEST_POINT             0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00
RANGE_QUERY_DESC         0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00
VALUE_RANGE_QUERY_DESC   0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00
GROUP_BY_DESC            0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

<img width="1695" alt="image" src="https://github.com/user-attachments/assets/d80d2138-b72e-4eea-b52c-e9751e131f86" />

## After
```
Create schema cost 2.69 second
Test elapsed time (not include schema creation): 165.53 second
----------------------------------------------------------Result Matrix----------------------------------------------------------
Operation                okOperation              okPoint                  failOperation            failPoint                throughput(point/s)
INGESTION                15000                    900000000                0                        0                        5437068.69
PRECISE_POINT            0                        0                        0                        0                        0.00
TIME_RANGE               0                        0                        0                        0                        0.00
VALUE_RANGE              0                        0                        0                        0                        0.00
AGG_RANGE                0                        0                        0                        0                        0.00
AGG_VALUE                0                        0                        0                        0                        0.00
AGG_RANGE_VALUE          0                        0                        0                        0                        0.00
GROUP_BY                 0                        0                        0                        0                        0.00
LATEST_POINT             0                        0                        0                        0                        0.00
RANGE_QUERY_DESC         0                        0                        0                        0                        0.00
VALUE_RANGE_QUERY_DESC   0                        0                        0                        0                        0.00
GROUP_BY_DESC            0                        0                        0                        0                        0.00
---------------------------------------------------------------------------------------------------------------------------------

--------------------------------------------------------------------------Latency (ms) Matrix--------------------------------------------------------------------------
Operation                AVG         MIN         P10         P25         MEDIAN      P75         P90         P95         P99         P999        MAX         SLOWEST_THREAD
INGESTION                1424.66     294.88      848.60      1029.60     1214.31     1397.61     1566.03     1684.30     10181.36    18736.46    19026.30    151111.42
PRECISE_POINT            0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00
TIME_RANGE               0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00
VALUE_RANGE              0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00
AGG_RANGE                0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00
AGG_VALUE                0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00
AGG_RANGE_VALUE          0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00
GROUP_BY                 0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00
LATEST_POINT             0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00
RANGE_QUERY_DESC         0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00
VALUE_RANGE_QUERY_DESC   0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00
GROUP_BY_DESC            0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00        0.00
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

<img width="1635" alt="image" src="https://github.com/user-attachments/assets/3611db4a-ee32-4d65-81c5-724fbbb85836" />


# Conclusion

With this batch optimization, we removed the regionLock bottleneck, improving write performance by 112% in this case.

BTW, We also checked all locks on PartitionCache to ensure that no other locks would have similar workload-dependent bindings and become bottlenecked.

# Future Optimization

We may optimize write performance in this case by futher optimizing validateDeviceSchemaInCache

