### PR TITLE
docker: support configuring JVM memory environment variables in docke…

### DIFF
--- a/docker/src/main/DockerCompose/docker-compose-host-3c3d.yml
+++ b/docker/src/main/DockerCompose/docker-compose-host-3c3d.yml
@@ -29,6 +29,7 @@ services:
       - schema_replication_factor=3
       - schema_region_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus
       - config_node_consensus_protocol_class=org.apache.iotdb.consensus.ratis.RatisConsensus
+      - CONFIGNODE_JMX_OPTS=-Xms1G -Xmx1G -XX:MaxDirectMemorySize=256M 
     volumes:
       - /etc/hosts:/etc/hosts:ro
       - ./data/confignode:/iotdb/data
@@ -48,6 +49,7 @@ services:
       - dn_data_region_consensus_port=10760
       - data_replication_factor=3
       - data_region_consensus_protocol_class=org.apache.iotdb.consensus.iot.IoTConsensus
+      - IOTDB_JMX_OPTS=-Xms4G -Xmx4G -XX:MaxDirectMemorySize=1G
     volumes:
       - /etc/hosts:/etc/hosts:ro
       - ./data/datanode:/iotdb/data/

--- a/docker/src/main/DockerCompose/docker-compose-standalone.yml
+++ b/docker/src/main/DockerCompose/docker-compose-standalone.yml
@@ -36,7 +36,9 @@ services:
       - dn_schema_region_consensus_port=10750
       - dn_data_region_consensus_port=10760
       - dn_seed_config_node=iotdb-service:10710
-    volumes:
+      - IOTDB_JMX_OPTS=-Xms4G -Xmx4G -XX:MaxDirectMemorySize=1G
+      - CONFIGNODE_JMX_OPTS=-Xms1G -Xmx1G -XX:MaxDirectMemorySize=256M
+     volumes:
         - ./data:/iotdb/data
         - ./logs:/iotdb/logs
     networks:

--- a/docker/src/main/DockerCompose/replace-conf-from-env.sh
+++ b/docker/src/main/DockerCompose/replace-conf-from-env.sh
@@ -34,17 +34,18 @@ function process_single(){
     if [[ "${content:0:1}" != "#" ]]; then
       sed -i "${line_no}d" ${filename}
     fi
-    sed -i "${line_no} i${key_value}" ${filename}
+    sed -i "${line_no}a${key_value}" ${filename}
   else
-    echo "append  $key $filename"
-    line_no=$(wc -l $filename)
-    sed -i "${line_no} a${key_value}" ${filename}
+    echo "append $key $filename"
+    line_no=$(wc -l $filename|cut -d ' ' -f1)
+    sed -i "${line_no}a${key_value}" ${filename}
 	fi
 }
 
 function replace_configs(){
   for v in $(env); do
-    if [[ "${v}" =~ "=" && "${v}" =~ "_" && ! "${v}" =~ "JAVA_" ]]; then
+    key_name="${v%%=*}"
+    if [[ "${key_name}" == "${key_name,,}" && ! 2w$key_name =~ ^_ ]]; then
 #      echo "###### $v ####"
       for f in ${target_files}; do
           process_single $v ${conf_path}/$f


### PR DESCRIPTION
docker: support configuring JVM memory environment variables in docker compose file:IOTDB_JMX_OPTS for datanode,CONFIGNODE_JMX_OPTS for confignode

## Description
configure JVM memory with environment variables in docker compose file  
```
#docker-compose file
    environment:
      # for datanode
      - IOTDB_JMX_OPTS=-Xms4G -Xmx4G -XX:MaxDirectMemorySize=1G
      # for confignode
      - CONFIGNODE_JMX_OPTS=-Xms1G -Xmx1G -XX:MaxDirectMemorySize=256M
```

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [x] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
