### PR TITLE
IoTV2: Fix global client manager close by mistake when running

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/pipeconsensus/PipeConsensusSyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/pipeconsensus/PipeConsensusSyncConnector.java
@@ -524,9 +524,6 @@ public class PipeConsensusSyncConnector extends IoTDBConnector {
   @Override
   public synchronized void close() {
     super.close();
-    if (syncRetryClientManager != null) {
-      syncRetryClientManager.close();
-    }
 
     if (tabletBatchBuilder != null) {
       tabletBatchBuilder.close();


### PR DESCRIPTION
as title.

All global client managers should only be closed in `PipeConsensus`
<img width="829" alt="image" src="https://github.com/user-attachments/assets/c6313a31-7c8c-48df-b33b-71b4a6f03549" />
