### PR TITLE
Procedure: Fix the concurrency error during StateMachineProcedure snapshot

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/StateMachineProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/StateMachineProcedure.java
@@ -32,8 +32,8 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 /**
  * Procedure described by a series of steps.
@@ -51,7 +51,7 @@ public abstract class StateMachineProcedure<Env, TState> extends Procedure<Env> 
   private static final int EOF_STATE = Integer.MIN_VALUE;
 
   private Flow stateFlow = Flow.HAS_MORE_STATE;
-  private final LinkedList<Integer> states = new LinkedList<>();
+  private final ConcurrentLinkedDeque<Integer> states = new ConcurrentLinkedDeque<>();
 
   private final List<Procedure<?>> subProcList = new ArrayList<>();
 
@@ -271,8 +271,11 @@ public abstract class StateMachineProcedure<Env, TState> extends Procedure<Env> 
   @Override
   public void serialize(DataOutputStream stream) throws IOException {
     super.serialize(stream);
-    stream.writeInt(states.size());
-    for (int state : states) {
+
+    // Ensure that the Size does not differ from the actual length during the reading process
+    final ArrayList<Integer> copyStates = new ArrayList<>(states);
+    stream.writeInt(copyStates.size());
+    for (int state : copyStates) {
       stream.writeInt(state);
     }
   }


### PR DESCRIPTION
## Description
If the status list is updated during the snapshot process, it will cause parallel read and write errors. This will cause the State Machine Server to showdown.

![image](https://github.com/user-attachments/assets/ef88b134-914e-4e8d-9f19-9d8c71e107b9)


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
