### PR TITLE
Fix memory leak in wal compressed buffer

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/consensus/deletion/persist/PageCacheDeletionBuffer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/consensus/deletion/persist/PageCacheDeletionBuffer.java
@@ -273,6 +273,7 @@ public class PageCacheDeletionBuffer implements DeletionBuffer {
     }
     // clean buffer
     MmapUtil.clean(serializeBuffer);
+    serializeBuffer = null;
   }
 
   private void waitUntilFlushAllDeletionsOrTimeOut() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/buffer/WALBuffer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/buffer/WALBuffer.java
@@ -178,11 +178,12 @@ public class WALBuffer extends AbstractWALBuffer {
     buffersLock.lock();
     try {
       MmapUtil.clean(workingBuffer);
-      MmapUtil.clean(workingBuffer);
+      MmapUtil.clean(idleBuffer);
       MmapUtil.clean(syncingBuffer);
       MmapUtil.clean(compressedByteBuffer);
       workingBuffer = ByteBuffer.allocateDirect(capacity);
       idleBuffer = ByteBuffer.allocateDirect(capacity);
+      syncingBuffer = null;
       compressedByteBuffer = ByteBuffer.allocateDirect(getCompressedByteBufferSize(capacity));
       currentWALFileWriter.setCompressedByteBuffer(compressedByteBuffer);
     } catch (OutOfMemoryError e) {
@@ -719,9 +720,13 @@ public class WALBuffer extends AbstractWALBuffer {
     checkpointManager.close();
 
     MmapUtil.clean(workingBuffer);
-    MmapUtil.clean(workingBuffer);
+    MmapUtil.clean(idleBuffer);
     MmapUtil.clean(syncingBuffer);
     MmapUtil.clean(compressedByteBuffer);
+    workingBuffer = null;
+    idleBuffer = null;
+    syncingBuffer = null;
+    compressedByteBuffer = null;
   }
 
   private void shutdownThread(ExecutorService thread, ThreadName threadName) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALInputStream.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALInputStream.java
@@ -173,6 +173,7 @@ public class WALInputStream extends InputStream implements AutoCloseable {
     MmapUtil.clean(dataBuffer);
     MmapUtil.clean(compressedBuffer);
     dataBuffer = null;
+    compressedBuffer = null;
   }
 
   @Override
@@ -306,6 +307,7 @@ public class WALInputStream extends InputStream implements AutoCloseable {
         dataBuffer = ByteBuffer.allocateDirect(segmentInfo.uncompressedSize);
         uncompressWALBuffer(compressedBuffer, dataBuffer, unCompressor);
         MmapUtil.clean(compressedBuffer);
+        compressedBuffer = null;
       } else {
         dataBuffer = ByteBuffer.allocateDirect(segmentInfo.dataInDiskSize);
         readWALBufferFromChannel(dataBuffer);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/compression/WALCompressionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/compression/WALCompressionTest.java
@@ -80,6 +80,7 @@ public class WALCompressionTest {
       FileUtils.delete(walFile);
     }
     originalMinCompressionSize = WALTestUtils.getMinCompressionSize();
+    WALTestUtils.setMinCompressionSize(0);
     if (new File(compressionDir).exists()) {
       FileUtils.forceDelete(new File(compressionDir));
     }
@@ -125,29 +126,33 @@ public class WALCompressionTest {
 
   public void testSkipToGivenPosition()
       throws QueryProcessException, IllegalPathException, IOException {
-    LogWriter writer = new WALWriter(walFile);
-    ByteBuffer buffer = ByteBuffer.allocate(1024 * 4);
-    List<Pair<Long, Integer>> positionAndEntryPairList = new ArrayList<>();
-    int memTableId = 0;
-    long fileOffset = 0;
-    for (int i = 0; i < 100; ) {
-      InsertRowNode insertRowNode = WALTestUtils.getInsertRowNode(devicePath + memTableId, i);
-      if (buffer.remaining() >= buffer.capacity() / 4) {
-        int pos = buffer.position();
-        insertRowNode.serialize(buffer);
-        int size = buffer.position() - pos;
-        positionAndEntryPairList.add(new Pair<>(fileOffset, size));
-        fileOffset += size;
-        i++;
-      } else {
+    List<Pair<Long, Integer>> positionAndEntryPairList;
+    int memTableId;
+    try (LogWriter writer = new WALWriter(walFile)) {
+      writer.setCompressedByteBuffer(
+          ByteBuffer.allocateDirect(WALBuffer.ONE_THIRD_WAL_BUFFER_SIZE));
+      ByteBuffer buffer = ByteBuffer.allocate(1024 * 4);
+      positionAndEntryPairList = new ArrayList<>();
+      memTableId = 0;
+      long fileOffset = 0;
+      for (int i = 0; i < 100; ) {
+        InsertRowNode insertRowNode = WALTestUtils.getInsertRowNode(devicePath + memTableId, i);
+        if (buffer.remaining() >= buffer.capacity() / 4) {
+          int pos = buffer.position();
+          insertRowNode.serialize(buffer);
+          int size = buffer.position() - pos;
+          positionAndEntryPairList.add(new Pair<>(fileOffset, size));
+          fileOffset += size;
+          i++;
+        } else {
+          writer.write(buffer);
+          buffer.clear();
+        }
+      }
+      if (buffer.position() != 0) {
         writer.write(buffer);
-        buffer.clear();
       }
     }
-    if (buffer.position() != 0) {
-      writer.write(buffer);
-    }
-    writer.close();
     try (WALInputStream stream = new WALInputStream(walFile)) {
       for (int i = 0; i < 100; ++i) {
         Pair<Long, Integer> positionAndNodePair = positionAndEntryPairList.get(i);


### PR DESCRIPTION
After calling `org.apache.iotdb.db.storageengine.dataregion.wal.io.WALInputStream#skipToGivenLogicalPosition`, the compressed buffer is cleaned but not nullified.
As a result, the succinct call of `org.apache.iotdb.db.storageengine.dataregion.wal.io.WALInputStream#loadNextSegmentV2` may use the cleaned buffer and cause memory issues.