### PR TITLE
Invalidating partition cache for all datanodes except the unknown ones when deleting database

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
@@ -185,35 +185,35 @@ public class ConfigNodeProcedureEnv {
         }
       }
 
-      if (nodeStatus == NodeStatus.Running) {
-        // Always invalidate PartitionCache first
-        final TSStatus invalidatePartitionStatus =
-            (TSStatus)
-                SyncDataNodeClientPool.getInstance()
-                    .sendSyncRequestToDataNodeWithRetry(
-                        dataNodeConfiguration.getLocation().getInternalEndPoint(),
-                        invalidateCacheReq,
-                        CnToDnSyncRequestType.INVALIDATE_PARTITION_CACHE);
-
-        final TSStatus invalidateSchemaStatus =
-            (TSStatus)
-                SyncDataNodeClientPool.getInstance()
-                    .sendSyncRequestToDataNodeWithRetry(
-                        dataNodeConfiguration.getLocation().getInternalEndPoint(),
-                        invalidateCacheReq,
-                        CnToDnSyncRequestType.INVALIDATE_SCHEMA_CACHE);
-
-        if (!verifySucceed(invalidatePartitionStatus, invalidateSchemaStatus)) {
-          LOG.error(
-              "Invalidate cache failed, invalidate partition cache status is {}, invalidate schemaengine cache status is {}",
-              invalidatePartitionStatus,
-              invalidateSchemaStatus);
-          return false;
-        }
-      } else if (nodeStatus == NodeStatus.Unknown) {
+      if (nodeStatus == NodeStatus.Unknown) {
         LOG.warn(
             "Invalidate cache failed, because DataNode {} is Unknown",
             dataNodeConfiguration.getLocation().getInternalEndPoint());
+        return false;
+      }
+
+      // Always invalidate PartitionCache first
+      final TSStatus invalidatePartitionStatus =
+          (TSStatus)
+              SyncDataNodeClientPool.getInstance()
+                  .sendSyncRequestToDataNodeWithRetry(
+                      dataNodeConfiguration.getLocation().getInternalEndPoint(),
+                      invalidateCacheReq,
+                      CnToDnSyncRequestType.INVALIDATE_PARTITION_CACHE);
+
+      final TSStatus invalidateSchemaStatus =
+          (TSStatus)
+              SyncDataNodeClientPool.getInstance()
+                  .sendSyncRequestToDataNodeWithRetry(
+                      dataNodeConfiguration.getLocation().getInternalEndPoint(),
+                      invalidateCacheReq,
+                      CnToDnSyncRequestType.INVALIDATE_SCHEMA_CACHE);
+
+      if (!verifySucceed(invalidatePartitionStatus, invalidateSchemaStatus)) {
+        LOG.error(
+            "Invalidate cache failed, invalidate partition cache status is {}, invalidate schemaengine cache status is {}",
+            invalidatePartitionStatus,
+            invalidateSchemaStatus);
         return false;
       }
     }


### PR DESCRIPTION
We found that the partition cache is not invalidated for datanodes that are neither "Running" nor "Unknown" when deleting the database. As a result, those applications use the partition cache will eventually hit the dirty cache and incur further errors.
To address this bug, we should invalidate partition cache for all datanodes except the unknown ones when deleting database.