### PR TITLE
Append TTL logs for PartitionTableAutoCleaner

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/PartitionTableAutoCleaner.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/PartitionTableAutoCleaner.java
@@ -63,6 +63,12 @@ public class PartitionTableAutoCleaner<Env> extends InternalProcedure<Env> {
               ? configManager.getClusterSchemaManager().getDatabaseMaxTTL(database)
               : configManager.getTTLManager().getDatabaseMaxTTL(database);
       databaseTTLMap.put(database, databaseTTL);
+    }
+    LOGGER.info(
+        "[PartitionTableCleaner] Periodically activate PartitionTableAutoCleaner, databaseTTL: {}",
+        databaseTTLMap);
+    for (String database : databases) {
+      long databaseTTL = databaseTTLMap.get(database);
       if (!configManager.getPartitionManager().isDatabaseExist(database)
           || databaseTTL < 0
           || databaseTTL == Long.MAX_VALUE) {


### PR DESCRIPTION
In integration-tests, we found the corresponding IT for the PartitionTableAutoCleaner fails frequently. To facilitate bug location, we append some logs for the PartitionTableAutoCleaner.