### PR TITLE
IoTV2: Fix NPE as tsFileWriter is regarded as a zombie writer and cleaned by mistake.

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/pipeconsensus/PipeConsensusReceiver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/pipeconsensus/PipeConsensusReceiver.java
@@ -1139,7 +1139,7 @@ public class PipeConsensusReceiver {
         }
       }
 
-      return tsFileWriter.get();
+      return tsFileWriter.get().refreshLastUsedTs();
     }
 
     private void checkZombieTsFileWriter() {
@@ -1309,9 +1309,13 @@ public class PipeConsensusReceiver {
 
     public void setUsed(boolean used) {
       isUsed = used;
+    }
+
+    public PipeConsensusTsFileWriter refreshLastUsedTs() {
       if (isUsed) {
         lastUsedTs = System.currentTimeMillis();
       }
+      return this;
     }
 
     public void returnSelf(ConsensusPipeName consensusPipeName)


### PR DESCRIPTION
as title.

we should update tsFileWriter's lastUsedTime every time it is borrowed.