### PR TITLE
fix: Boundary checks for maxStandardError in APPROX_COUNT_DISTINCT.

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
@@ -4157,6 +4157,12 @@ public class IoTDBTableAggregationIT {
         new String[] {"time", "province", "_col2", "_col3"},
         retArray,
         DATABASE_NAME);
+
+    tableResultSetEqualTest(
+        "select approx_count_distinct(time,0.0040625),approx_count_distinct(time,0.26) from table1",
+        new String[] {"_col0", "_col1"},
+        new String[] {"10,11,"},
+        DATABASE_NAME);
   }
 
   @Test

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/HyperLogLog.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/HyperLogLog.java
@@ -105,8 +105,8 @@ public class HyperLogLog {
   }
 
   private static int standardErrorToBuckets(double maxStandardError) {
-    if (maxStandardError <= LOWEST_MAX_STANDARD_ERROR
-        || maxStandardError >= HIGHEST_MAX_STANDARD_ERROR) {
+    if (maxStandardError < LOWEST_MAX_STANDARD_ERROR
+        || maxStandardError > HIGHEST_MAX_STANDARD_ERROR) {
       throw new IoTDBRuntimeException(
           String.format(
               "Max Standard Error must be in [%s, %s]: %s",


### PR DESCRIPTION
This pull request includes a minor but important fix to the `HyperLogLog` class in the `iotdb-core` module. The change ensures that the bounds check for `maxStandardError` is inclusive of the lowest and highest allowed values.

* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/HyperLogLog.java`](diffhunk://#diff-e386b0d69ef98e3c9b262715f258c19fb22e033a82364a7143bfdf3285f1e3b3L108-R109): Adjusted the conditional check in the `standardErrorToBuckets` method to use inclusive bounds for `LOWEST_MAX_STANDARD_ERROR` and `HIGHEST_MAX_STANDARD_ERROR`, ensuring correct validation of `maxStandardError`.