### PR TITLE
Implememt auto release technique for Blob Allocator

### DIFF
--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/BinaryAllocator.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/BinaryAllocator.java
@@ -100,8 +100,9 @@ public class BinaryAllocator {
     sampleEvictor =
         new SampleEvictor(
             ThreadName.BINARY_ALLOCATOR_SAMPLE_EVICTOR.getName(),
-            allocatorConfig.durationShutdownTimeout);
-    sampleEvictor.start(allocatorConfig.durationBetweenEvictorRuns);
+            allocatorConfig.durationShutdownTimeout,
+            allocatorConfig.durationBetweenEvictorRuns);
+    sampleEvictor.start();
     autoReleaser =
         new AutoReleaser(
             ThreadName.BINARY_ALLOCATOR_AUTO_RELEASER.getName(),
@@ -272,8 +273,9 @@ public class BinaryAllocator {
 
   public class SampleEvictor extends Evictor {
 
-    public SampleEvictor(String name, Duration evictorShutdownTimeoutDuration) {
-      super(name, evictorShutdownTimeoutDuration);
+    public SampleEvictor(
+        String name, Duration evictorShutdownTimeoutDuration, Duration durationBetweenEvictorRuns) {
+      super(name, evictorShutdownTimeoutDuration, durationBetweenEvictorRuns);
     }
 
     @Override

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/BinaryAllocator.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/BinaryAllocator.java
@@ -304,7 +304,7 @@ public class BinaryAllocator {
           ref.slabRegion.deallocate(ref.byteArray);
         }
       } catch (InterruptedException e) {
-        LOGGER.info("{} exits due to interruptedException.", 1);
+        LOGGER.info("{} exits due to interruptedException.", name);
         Thread.currentThread().interrupt();
       }
     }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/PooledBinaryPhantomReference.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/PooledBinaryPhantomReference.java
@@ -1,0 +1,23 @@
+package org.apache.iotdb.commons.binaryallocator;
+
+import org.apache.iotdb.commons.binaryallocator.arena.Arena;
+
+import org.apache.tsfile.utils.PooledBinary;
+
+import java.lang.ref.PhantomReference;
+import java.lang.ref.ReferenceQueue;
+
+public class PooledBinaryPhantomReference extends PhantomReference<PooledBinary> {
+  public final byte[] byteArray;
+  public Arena.SlabRegion slabRegion;
+
+  public PooledBinaryPhantomReference(
+      PooledBinary referent,
+      ReferenceQueue<? super PooledBinary> q,
+      byte[] byteArray,
+      Arena.SlabRegion region) {
+    super(referent, q);
+    this.byteArray = byteArray;
+    this.slabRegion = region;
+  }
+}

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/PooledBinaryPhantomReference.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/PooledBinaryPhantomReference.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.iotdb.commons.binaryallocator;
 
 import org.apache.iotdb.commons.binaryallocator.arena.Arena;

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/autoreleaser/Releaser.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/autoreleaser/Releaser.java
@@ -17,58 +17,55 @@
  * under the License.
  */
 
-package org.apache.iotdb.commons.binaryallocator.evictor;
+package org.apache.iotdb.commons.binaryallocator.autoreleaser;
 
 import org.apache.iotdb.commons.concurrent.IoTDBThreadPoolFactory;
-import org.apache.iotdb.commons.concurrent.threadpool.ScheduledExecutorUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-public abstract class Evictor implements Runnable {
-  private static final Logger LOGGER = LoggerFactory.getLogger(Evictor.class);
+public abstract class Releaser implements Runnable {
+  private static final Logger LOGGER = LoggerFactory.getLogger(Releaser.class);
 
-  private ScheduledFuture<?> scheduledFuture;
+  private Future<?> future;
   private final String name;
   private final Duration shutdownTimeoutDuration;
 
-  private ScheduledExecutorService executor;
+  private ExecutorService executor;
 
-  public Evictor(String name, Duration shutdownTimeoutDuration) {
+  public Releaser(String name, Duration shutdownTimeoutDuration) {
     this.name = name;
     this.shutdownTimeoutDuration = shutdownTimeoutDuration;
   }
 
-  /** Cancels the scheduled future. */
+  /** Cancels the future. */
   void cancel() {
-    scheduledFuture.cancel(false);
+    future.cancel(false);
   }
 
   @Override
   public abstract void run();
 
-  void setScheduledFuture(final ScheduledFuture<?> scheduledFuture) {
-    this.scheduledFuture = scheduledFuture;
+  void setFuture(final Future<?> future) {
+    this.future = future;
   }
 
   @Override
   public String toString() {
-    return getClass().getName() + " [scheduledFuture=" + scheduledFuture + "]";
+    return getClass().getName() + " [future=" + future + "]";
   }
 
-  public void start(final Duration delay) {
+  public void start() {
     if (null == executor) {
-      executor = IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor(name);
+      executor = IoTDBThreadPoolFactory.newSingleThreadExecutor(name);
     }
-    final ScheduledFuture<?> scheduledFuture =
-        ScheduledExecutorUtil.safelyScheduleAtFixedRate(
-            executor, this, delay.toMillis(), delay.toMillis(), TimeUnit.MILLISECONDS);
-    this.setScheduledFuture(scheduledFuture);
+    final Future<?> future = executor.submit(this);
+    this.setFuture(future);
   }
 
   public void stop() {
@@ -84,7 +81,7 @@ public abstract class Evictor implements Runnable {
       boolean result =
           executor.awaitTermination(shutdownTimeoutDuration.toMillis(), TimeUnit.MILLISECONDS);
       if (!result) {
-        LOGGER.info("unable to stop evictor after {} ms", shutdownTimeoutDuration.toMillis());
+        LOGGER.info("unable to stop auto releaser after {} ms", shutdownTimeoutDuration.toMillis());
       }
     } catch (final InterruptedException ignored) {
       Thread.currentThread().interrupt();

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/autoreleaser/Releaser.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/autoreleaser/Releaser.java
@@ -33,7 +33,7 @@ public abstract class Releaser implements Runnable {
   private static final Logger LOGGER = LoggerFactory.getLogger(Releaser.class);
 
   private Future<?> future;
-  private final String name;
+  protected final String name;
   private final Duration shutdownTimeoutDuration;
 
   private ExecutorService executor;

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/config/AllocatorConfig.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/config/AllocatorConfig.java
@@ -37,8 +37,8 @@ public class AllocatorConfig {
   public boolean enableBinaryAllocator =
       CommonDescriptor.getInstance().getConfig().isEnableBinaryAllocator();
 
-  /** Maximum wait time in milliseconds when shutting down the evictor */
-  public Duration durationEvictorShutdownTimeout = Duration.ofMillis(1000L);
+  /** Maximum wait time in milliseconds when shutting down the evictor and autoReleaser */
+  public Duration durationShutdownTimeout = Duration.ofMillis(1000L);
 
   /** Time interval in milliseconds between two consecutive evictor runs */
   public Duration durationBetweenEvictorRuns = Duration.ofMillis(1000L);

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/evictor/Evictor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/binaryallocator/evictor/Evictor.java
@@ -36,12 +36,15 @@ public abstract class Evictor implements Runnable {
   private ScheduledFuture<?> scheduledFuture;
   private final String name;
   private final Duration shutdownTimeoutDuration;
+  private final Duration durationBetweenEvictorRuns;
 
   private ScheduledExecutorService executor;
 
-  public Evictor(String name, Duration shutdownTimeoutDuration) {
+  public Evictor(
+      String name, Duration shutdownTimeoutDuration, Duration durationBetweenEvictorRuns) {
     this.name = name;
     this.shutdownTimeoutDuration = shutdownTimeoutDuration;
+    this.durationBetweenEvictorRuns = durationBetweenEvictorRuns;
   }
 
   /** Cancels the scheduled future. */
@@ -61,13 +64,17 @@ public abstract class Evictor implements Runnable {
     return getClass().getName() + " [scheduledFuture=" + scheduledFuture + "]";
   }
 
-  public void start(final Duration delay) {
+  public void start() {
     if (null == executor) {
       executor = IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor(name);
     }
     final ScheduledFuture<?> scheduledFuture =
         ScheduledExecutorUtil.safelyScheduleAtFixedRate(
-            executor, this, delay.toMillis(), delay.toMillis(), TimeUnit.MILLISECONDS);
+            executor,
+            this,
+            durationBetweenEvictorRuns.toMillis(),
+            durationBetweenEvictorRuns.toMillis(),
+            TimeUnit.MILLISECONDS);
     this.setScheduledFuture(scheduledFuture);
   }
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/ThreadName.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/ThreadName.java
@@ -193,6 +193,7 @@ public enum ThreadName {
   STORAGE_ENGINE_RECOVER_TRIGGER("StorageEngine-RecoverTrigger"),
   FILE_TIME_INDEX_RECORD("FileTimeIndexRecord"),
   BINARY_ALLOCATOR_SAMPLE_EVICTOR("BinaryAllocator-SampleEvictor"),
+  BINARY_ALLOCATOR_AUTO_RELEASER("BinaryAllocator-Auto-Releaser"),
 
   // the unknown thread name is used for metrics
   UNKNOWN("UNKNOWN");

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/binaryallocator/BinaryAllocatorTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/binaryallocator/BinaryAllocatorTest.java
@@ -29,12 +29,15 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class BinaryAllocatorTest {
+
   @Test
   public void testAllocateBinary() {
     AllocatorConfig config = new AllocatorConfig();
@@ -154,7 +157,13 @@ public class BinaryAllocatorTest {
     // reference count is 0
     binary = null;
     System.gc();
-    Thread.sleep(100);
-    assertEquals(binaryAllocator.getTotalUsedMemory(), 4096);
+    long startTime = System.currentTimeMillis();
+    while (System.currentTimeMillis() - startTime <= TimeUnit.MINUTES.toMillis(1)) {
+      if (binaryAllocator.getTotalUsedMemory() == 4096) {
+        return;
+      }
+      Thread.sleep(100);
+    }
+    fail("Can not auto release PoolBinary in binary allocator");
   }
 }


### PR DESCRIPTION
# Description
It's often challenging to properly manage PooledBinary object lifecycles, which can lead to resource leaks or logic errors.
Implemented auto-release mechanism using PhantomReference to automatically return the byte array in PooledBinary to the pool when they become unreachable.

# Detail
Method changed:
* BinaryAllocator::allocate(int reqCapacity) -> BinaryAllocator::allocate(int reqCapacity, boolean autoRelease)