### PR TITLE
Use reference time position for PartitionTableAutoCleaner

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/partition/IoTDBPartitionTableAutoCleanUSIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/partition/IoTDBPartitionTableAutoCleanUSIT.java
@@ -43,22 +43,23 @@ import java.util.concurrent.TimeUnit;
 
 @RunWith(IoTDBTestRunner.class)
 @Category({ClusterIT.class})
-public class IoTDBPartitionTableAutoCleanIT {
+public class IoTDBPartitionTableAutoCleanUSIT {
 
   private static final String TREE_DATABASE_PREFIX = "root.db.g_";
   private static final String TABLE_DATABASE_PREFIX = "database_";
 
   private static final int TEST_REPLICATION_FACTOR = 1;
-  private static final long TEST_TIME_PARTITION_INTERVAL = 604800000;
+  private static final long TEST_TIME_PARTITION_INTERVAL_IN_MS = 604800_000;
   private static final long TEST_TTL_CHECK_INTERVAL = 5_000;
 
   private static final TTimePartitionSlot TEST_CURRENT_TIME_SLOT =
       new TTimePartitionSlot()
           .setStartTime(
               System.currentTimeMillis()
-                  / TEST_TIME_PARTITION_INTERVAL
-                  * TEST_TIME_PARTITION_INTERVAL);
-  private static final long TEST_TTL = 7 * TEST_TIME_PARTITION_INTERVAL;
+                  * 1000L
+                  / TEST_TIME_PARTITION_INTERVAL_IN_MS
+                  * TEST_TIME_PARTITION_INTERVAL_IN_MS);
+  private static final long TEST_TTL_IN_MS = 7 * TEST_TIME_PARTITION_INTERVAL_IN_MS;
 
   @Before
   public void setUp() throws Exception {
@@ -67,8 +68,10 @@ public class IoTDBPartitionTableAutoCleanIT {
         .getCommonConfig()
         .setSchemaReplicationFactor(TEST_REPLICATION_FACTOR)
         .setDataReplicationFactor(TEST_REPLICATION_FACTOR)
-        .setTimePartitionInterval(TEST_TIME_PARTITION_INTERVAL)
-        .setTTLCheckInterval(TEST_TTL_CHECK_INTERVAL);
+        .setTimePartitionInterval(TEST_TIME_PARTITION_INTERVAL_IN_MS)
+        .setTTLCheckInterval(TEST_TTL_CHECK_INTERVAL)
+        // Note that the time precision of IoTDB is us in this IT
+        .setTimestampPrecision("us");
 
     // Init 1C1D environment
     EnvFactory.getEnv().initClusterEnvironment(1, 1);
@@ -94,7 +97,7 @@ public class IoTDBPartitionTableAutoCleanIT {
         statement.execute(
             String.format(
                 "INSERT INTO %s(timestamp, s) VALUES (%d, %d)",
-                databaseName, TEST_CURRENT_TIME_SLOT.getStartTime() - TEST_TTL * 2, -1));
+                databaseName, TEST_CURRENT_TIME_SLOT.getStartTime() - TEST_TTL_IN_MS * 2000, -1));
         // Insert existed data
         statement.execute(
             String.format(
@@ -102,15 +105,15 @@ public class IoTDBPartitionTableAutoCleanIT {
                 databaseName, TEST_CURRENT_TIME_SLOT.getStartTime(), 1));
       }
       // Let db0.TTL > device.TTL, the valid TTL should be the bigger one
-      statement.execute(String.format("SET TTL TO %s0 %d", TREE_DATABASE_PREFIX, TEST_TTL));
+      statement.execute(String.format("SET TTL TO %s0 %d", TREE_DATABASE_PREFIX, TEST_TTL_IN_MS));
       statement.execute(String.format("SET TTL TO %s0.s %d", TREE_DATABASE_PREFIX, 10));
       // Let db1.TTL < device.TTL, the valid TTL should be the bigger one
       statement.execute(String.format("SET TTL TO %s1 %d", TREE_DATABASE_PREFIX, 10));
-      statement.execute(String.format("SET TTL TO %s1.s %d", TREE_DATABASE_PREFIX, TEST_TTL));
+      statement.execute(String.format("SET TTL TO %s1.s %d", TREE_DATABASE_PREFIX, TEST_TTL_IN_MS));
       // Set TTL to path db2.**
-      statement.execute(String.format("SET TTL TO %s2.** %d", TREE_DATABASE_PREFIX, TEST_TTL));
+      statement.execute(
+          String.format("SET TTL TO %s2.** %d", TREE_DATABASE_PREFIX, TEST_TTL_IN_MS));
     }
-
     TDataPartitionReq req = new TDataPartitionReq();
     for (int i = 0; i < 3; i++) {
       req.putToPartitionSlotsMap(String.format("%s%d", TREE_DATABASE_PREFIX, i), new TreeMap<>());
@@ -149,13 +152,13 @@ public class IoTDBPartitionTableAutoCleanIT {
       statement.execute(
           String.format(
               "INSERT INTO tb(time, s) VALUES (%d, %d)",
-              TEST_CURRENT_TIME_SLOT.getStartTime() - TEST_TTL * 2, -1));
+              TEST_CURRENT_TIME_SLOT.getStartTime() - TEST_TTL_IN_MS * 2000, -1));
       // Insert existed data
       statement.execute(
           String.format(
               "INSERT INTO tb(time, s) VALUES (%d, %d)", TEST_CURRENT_TIME_SLOT.getStartTime(), 1));
       statement.execute(String.format("USE %s", TABLE_DATABASE_PREFIX));
-      statement.execute(String.format("ALTER TABLE tb SET PROPERTIES TTL=%d", TEST_TTL));
+      statement.execute(String.format("ALTER TABLE tb SET PROPERTIES TTL=%d", TEST_TTL_IN_MS));
     }
 
     TDataPartitionReq req = new TDataPartitionReq();

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/PartitionTableAutoCleaner.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/PartitionTableAutoCleaner.java
@@ -23,7 +23,6 @@ import org.apache.iotdb.common.rpc.thrift.TTimePartitionSlot;
 import org.apache.iotdb.commons.conf.CommonConfig;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.utils.PathUtils;
-import org.apache.iotdb.commons.utils.TimePartitionUtils;
 import org.apache.iotdb.confignode.consensus.request.write.partition.AutoCleanPartitionTablePlan;
 import org.apache.iotdb.confignode.manager.ConfigManager;
 import org.apache.iotdb.consensus.exception.ConsensusException;
@@ -43,6 +42,10 @@ public class PartitionTableAutoCleaner<Env> extends InternalProcedure<Env> {
   private static final Logger LOGGER = LoggerFactory.getLogger(PartitionTableAutoCleaner.class);
 
   private static final CommonConfig COMMON_CONFIG = CommonDescriptor.getInstance().getConfig();
+
+  private static final String timestampPrecision =
+      CommonDescriptor.getInstance().getConfig().getTimestampPrecision();
+
   private final ConfigManager configManager;
 
   public PartitionTableAutoCleaner(ConfigManager configManager) {
@@ -81,8 +84,7 @@ public class PartitionTableAutoCleaner<Env> extends InternalProcedure<Env> {
           "[PartitionTableCleaner] Periodically activate PartitionTableAutoCleaner for: {}",
           databaseTTLMap);
       // Only clean the partition table when necessary
-      TTimePartitionSlot currentTimePartitionSlot =
-          TimePartitionUtils.getCurrentTimePartitionSlot();
+      TTimePartitionSlot currentTimePartitionSlot = getCurrentTimePartitionSlot();
       try {
         configManager
             .getConsensusManager()
@@ -90,6 +92,21 @@ public class PartitionTableAutoCleaner<Env> extends InternalProcedure<Env> {
       } catch (ConsensusException e) {
         LOGGER.warn(CONSENSUS_WRITE_ERROR, e);
       }
+    }
+  }
+
+  /**
+   * @return The time partition slot corresponding to current timestamp. Note that we do not shift
+   *     the start time to the correct starting point, since this interface only constructs a time
+   *     reference position for the partition table cleaner.
+   */
+  private static TTimePartitionSlot getCurrentTimePartitionSlot() {
+    if ("ms".equals(timestampPrecision)) {
+      return new TTimePartitionSlot(System.currentTimeMillis());
+    } else if ("us".equals(timestampPrecision)) {
+      return new TTimePartitionSlot(System.currentTimeMillis() * 1000);
+    } else {
+      return new TTimePartitionSlot(System.currentTimeMillis() * 1000_000);
     }
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/TimePartitionUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/TimePartitionUtils.java
@@ -34,9 +34,6 @@ public class TimePartitionUtils {
   private static long timePartitionOrigin =
       CommonDescriptor.getInstance().getConfig().getTimePartitionOrigin();
 
-  private static String timestampPrecision =
-      CommonDescriptor.getInstance().getConfig().getTimestampPrecision();
-
   /** Time range for dividing database, the time unit is the same with IoTDB's TimestampPrecision */
   private static long timePartitionInterval =
       CommonDescriptor.getInstance().getConfig().getTimePartitionInterval();
@@ -71,16 +68,6 @@ public class TimePartitionUtils {
           maxPartitionEndTime.subtract(bigTimePartitionInterval).longValue();
     } else {
       timePartitionUpperBoundWithoutOverflow = maxPartitionEndTime.longValue();
-    }
-  }
-
-  public static TTimePartitionSlot getCurrentTimePartitionSlot() {
-    if ("ms".equals(timestampPrecision)) {
-      return getTimePartitionSlot(System.currentTimeMillis());
-    } else if ("us".equals(timestampPrecision)) {
-      return getTimePartitionSlot(System.currentTimeMillis() * 1000);
-    } else {
-      return getTimePartitionSlot(System.currentTimeMillis() * 1000_000);
     }
   }
 


### PR DESCRIPTION
Currently, the PartitionTableAutoCleaner uses an absolute time position to judge whether a data partition is expired. However, as the time partition interval stored in the ConfigNode can be only configured to "ms" precision, the calculation of the absolute time position is not correct. As a result, we should employ the reference time position.