### PR TITLE
[To dev/1.3] Pipe: Fixed the bug that sorter may use wrong value when there are duplicated timestamps & Refactor (#15488)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/util/PipeTabletEventSorter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/util/PipeTabletEventSorter.java
@@ -94,6 +94,7 @@ public class PipeTabletEventSorter {
   }
 
   private void sortTimestamps() {
+    // Index is sorted stably because it is Integer[]
     Arrays.sort(index, Comparator.comparingLong(i -> tablet.timestamps[i]));
     Arrays.sort(tablet.timestamps, 0, tablet.rowSize);
   }
@@ -226,7 +227,7 @@ public class PipeTabletEventSorter {
       return index[deDuplicatedIndex[i]];
     }
     int lastNonnullIndex = deDuplicatedIndex[i];
-    int lastIndex = i > 0 ? deDuplicatedIndex[i - 1] : -1;
+    final int lastIndex = i > 0 ? deDuplicatedIndex[i - 1] : -1;
     while (originalBitMap.isMarked(index[lastNonnullIndex])) {
       --lastNonnullIndex;
       if (lastNonnullIndex == lastIndex) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/util/PipeTabletEventSorter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/util/PipeTabletEventSorter.java
@@ -160,9 +160,7 @@ public class PipeTabletEventSorter {
         final boolean[] deDuplicatedBoolValues = new boolean[boolValues.length];
         for (int i = 0; i < deDuplicatedSize; i++) {
           deDuplicatedBoolValues[i] =
-              boolValues[
-                  getLastNonnullIndex(
-                      i, index, deDuplicatedIndex, originalBitMap, deDuplicatedBitMap)];
+              boolValues[getLastNonnullIndex(i, originalBitMap, deDuplicatedBitMap)];
         }
         return deDuplicatedBoolValues;
       case INT32:
@@ -170,9 +168,7 @@ public class PipeTabletEventSorter {
         final int[] deDuplicatedIntValues = new int[intValues.length];
         for (int i = 0; i < deDuplicatedSize; i++) {
           deDuplicatedIntValues[i] =
-              intValues[
-                  getLastNonnullIndex(
-                      i, index, deDuplicatedIndex, originalBitMap, deDuplicatedBitMap)];
+              intValues[getLastNonnullIndex(i, originalBitMap, deDuplicatedBitMap)];
         }
         return deDuplicatedIntValues;
       case DATE:
@@ -180,9 +176,7 @@ public class PipeTabletEventSorter {
         final LocalDate[] deDuplicatedDateValues = new LocalDate[dateValues.length];
         for (int i = 0; i < deDuplicatedSize; i++) {
           deDuplicatedDateValues[i] =
-              dateValues[
-                  getLastNonnullIndex(
-                      i, index, deDuplicatedIndex, originalBitMap, deDuplicatedBitMap)];
+              dateValues[getLastNonnullIndex(i, originalBitMap, deDuplicatedBitMap)];
         }
         return deDuplicatedDateValues;
       case INT64:
@@ -191,9 +185,7 @@ public class PipeTabletEventSorter {
         final long[] deDuplicatedLongValues = new long[longValues.length];
         for (int i = 0; i < deDuplicatedSize; i++) {
           deDuplicatedLongValues[i] =
-              longValues[
-                  getLastNonnullIndex(
-                      i, index, deDuplicatedIndex, originalBitMap, deDuplicatedBitMap)];
+              longValues[getLastNonnullIndex(i, originalBitMap, deDuplicatedBitMap)];
         }
         return deDuplicatedLongValues;
       case FLOAT:
@@ -201,9 +193,7 @@ public class PipeTabletEventSorter {
         final float[] deDuplicatedFloatValues = new float[floatValues.length];
         for (int i = 0; i < deDuplicatedSize; i++) {
           deDuplicatedFloatValues[i] =
-              floatValues[
-                  getLastNonnullIndex(
-                      i, index, deDuplicatedIndex, originalBitMap, deDuplicatedBitMap)];
+              floatValues[getLastNonnullIndex(i, originalBitMap, deDuplicatedBitMap)];
         }
         return deDuplicatedFloatValues;
       case DOUBLE:
@@ -211,9 +201,7 @@ public class PipeTabletEventSorter {
         final double[] deDuplicatedDoubleValues = new double[doubleValues.length];
         for (int i = 0; i < deDuplicatedSize; i++) {
           deDuplicatedDoubleValues[i] =
-              doubleValues[
-                  getLastNonnullIndex(
-                      i, index, deDuplicatedIndex, originalBitMap, deDuplicatedBitMap)];
+              doubleValues[getLastNonnullIndex(i, originalBitMap, deDuplicatedBitMap)];
         }
         return deDuplicatedDoubleValues;
       case TEXT:

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/util/PipeTabletEventSorter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/util/PipeTabletEventSorter.java
@@ -223,9 +223,7 @@ public class PipeTabletEventSorter {
         final Binary[] deDuplicatedBinaryValues = new Binary[binaryValues.length];
         for (int i = 0; i < deDuplicatedSize; i++) {
           deDuplicatedBinaryValues[i] =
-              binaryValues[
-                  getLastNonnullIndex(
-                      i, index, deDuplicatedIndex, originalBitMap, deDuplicatedBitMap)];
+              binaryValues[getLastNonnullIndex(i, originalBitMap, deDuplicatedBitMap)];
         }
         return deDuplicatedBinaryValues;
       default:
@@ -234,18 +232,8 @@ public class PipeTabletEventSorter {
     }
   }
 
-  private static int getLastNonnullIndex(
-      final int i,
-      final Integer[] index,
-      final int[] deDuplicatedIndex,
-      final BitMap originalBitMap,
-      final BitMap deDuplicatedBitMap) {
-    if (deDuplicatedIndex == null) {
-      if (originalBitMap.isMarked(index[i])) {
-        deDuplicatedBitMap.mark(i);
-      }
-      return index[i];
-    }
+  private int getLastNonnullIndex(
+      final int i, final BitMap originalBitMap, final BitMap deDuplicatedBitMap) {
     if (originalBitMap == null) {
       return index[deDuplicatedIndex[i]];
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/util/PipeTabletEventSorter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/util/PipeTabletEventSorter.java
@@ -35,14 +35,15 @@ public class PipeTabletEventSorter {
   private final Tablet tablet;
 
   private boolean isSorted = true;
-  private boolean isDeduplicated = true;
+  private boolean isDeDuplicated = true;
 
   private Integer[] index;
-  private int deduplicatedSize;
+  private int[] deDuplicatedIndex;
+  private int deDuplicatedSize;
 
   public PipeTabletEventSorter(final Tablet tablet) {
     this.tablet = tablet;
-    deduplicatedSize = tablet == null ? 0 : tablet.rowSize;
+    deDuplicatedSize = tablet == null ? 0 : tablet.rowSize;
   }
 
   public void deduplicateAndSortTimestampsIfNecessary() {
@@ -58,19 +59,20 @@ public class PipeTabletEventSorter {
         isSorted = false;
       }
       if (currentTimestamp == previousTimestamp) {
-        isDeduplicated = false;
+        isDeDuplicated = false;
       }
 
-      if (!isSorted && !isDeduplicated) {
+      if (!isSorted && !isDeDuplicated) {
         break;
       }
     }
 
-    if (isSorted && isDeduplicated) {
+    if (isSorted && isDeDuplicated) {
       return;
     }
 
     index = new Integer[tablet.rowSize];
+    deDuplicatedIndex = new int[tablet.rowSize];
     for (int i = 0, size = tablet.rowSize; i < size; i++) {
       index[i] = i;
     }
@@ -79,16 +81,16 @@ public class PipeTabletEventSorter {
       sortTimestamps();
 
       // Do deduplicate anyway.
-      // isDeduplicated may be false positive when isSorted is false.
+      // isDeDuplicated may be false positive when isSorted is false.
       deduplicateTimestamps();
-      isDeduplicated = true;
+      isDeDuplicated = true;
     }
 
-    if (!isDeduplicated) {
+    if (!isDeDuplicated) {
       deduplicateTimestamps();
     }
 
-    sortAndDeduplicateValuesAndBitMaps();
+    sortAndMayDeduplicateValuesAndBitMaps();
   }
 
   private void sortTimestamps() {
@@ -97,106 +99,165 @@ public class PipeTabletEventSorter {
   }
 
   private void deduplicateTimestamps() {
-    deduplicatedSize = 1;
+    deDuplicatedSize = 0;
+    long[] timestamps = tablet.timestamps;
     for (int i = 1, size = tablet.rowSize; i < size; i++) {
-      if (tablet.timestamps[i] != tablet.timestamps[i - 1]) {
-        index[deduplicatedSize] = index[i];
-        tablet.timestamps[deduplicatedSize] = tablet.timestamps[i];
+      if (timestamps[i] != timestamps[i - 1]) {
+        deDuplicatedIndex[deDuplicatedSize] = i - 1;
+        timestamps[deDuplicatedSize] = timestamps[i - 1];
 
-        ++deduplicatedSize;
+        ++deDuplicatedSize;
       }
     }
-    tablet.rowSize = deduplicatedSize;
+
+    deDuplicatedIndex[deDuplicatedSize] = tablet.rowSize - 1;
+    timestamps[deDuplicatedSize] = timestamps[tablet.rowSize - 1];
+    tablet.rowSize = ++deDuplicatedSize;
   }
 
-  private void sortAndDeduplicateValuesAndBitMaps() {
+  // Input:
+  // Col: [1, null, 3, 6, null]
+  // Timestamp: [2, 1, 1, 1, 1]
+  // Intermediate:
+  // Index: [1, 2, 3, 4, 0]
+  // SortedTimestamp: [1, 2]
+  // DeduplicateIndex: [3, 4]
+  // Output:
+  // (Used index: [2(3), 4(0)])
+  // Col: [6, 1]
+  private void sortAndMayDeduplicateValuesAndBitMaps() {
     int columnIndex = 0;
     for (int i = 0, size = tablet.getSchemas().size(); i < size; i++) {
       final IMeasurementSchema schema = tablet.getSchemas().get(i);
       if (schema != null) {
-        tablet.values[columnIndex] =
-            reorderValueList(deduplicatedSize, tablet.values[columnIndex], schema.getType(), index);
+        BitMap deDuplicatedBitMap = null;
+        BitMap originalBitMap = null;
         if (tablet.bitMaps != null && tablet.bitMaps[columnIndex] != null) {
-          tablet.bitMaps[columnIndex] =
-              reorderBitMap(deduplicatedSize, tablet.bitMaps[columnIndex], index);
+          originalBitMap = tablet.bitMaps[columnIndex];
+          deDuplicatedBitMap = new BitMap(originalBitMap.getSize());
+        }
+
+        tablet.values[columnIndex] =
+            reorderValueListAndBitMap(
+                tablet.values[columnIndex], schema.getType(), originalBitMap, deDuplicatedBitMap);
+
+        if (tablet.bitMaps != null && tablet.bitMaps[columnIndex] != null) {
+          tablet.bitMaps[columnIndex] = deDuplicatedBitMap;
         }
         columnIndex++;
       }
     }
   }
 
-  private static Object reorderValueList(
-      int deduplicatedSize,
+  private Object reorderValueListAndBitMap(
       final Object valueList,
       final TSDataType dataType,
-      final Integer[] index) {
+      final BitMap originalBitMap,
+      final BitMap deDuplicatedBitMap) {
     switch (dataType) {
       case BOOLEAN:
         final boolean[] boolValues = (boolean[]) valueList;
-        final boolean[] deduplicatedBoolValues = new boolean[boolValues.length];
-        for (int i = 0; i < deduplicatedSize; i++) {
-          deduplicatedBoolValues[i] = boolValues[index[i]];
+        final boolean[] deDuplicatedBoolValues = new boolean[boolValues.length];
+        for (int i = 0; i < deDuplicatedSize; i++) {
+          deDuplicatedBoolValues[i] =
+              boolValues[
+                  getLastNonnullIndex(
+                      i, index, deDuplicatedIndex, originalBitMap, deDuplicatedBitMap)];
         }
-        return deduplicatedBoolValues;
+        return deDuplicatedBoolValues;
       case INT32:
         final int[] intValues = (int[]) valueList;
-        final int[] deduplicatedIntValues = new int[intValues.length];
-        for (int i = 0; i < deduplicatedSize; i++) {
-          deduplicatedIntValues[i] = intValues[index[i]];
+        final int[] deDuplicatedIntValues = new int[intValues.length];
+        for (int i = 0; i < deDuplicatedSize; i++) {
+          deDuplicatedIntValues[i] =
+              intValues[
+                  getLastNonnullIndex(
+                      i, index, deDuplicatedIndex, originalBitMap, deDuplicatedBitMap)];
         }
-        return deduplicatedIntValues;
+        return deDuplicatedIntValues;
       case DATE:
         final LocalDate[] dateValues = (LocalDate[]) valueList;
-        final LocalDate[] deduplicatedDateValues = new LocalDate[dateValues.length];
-        for (int i = 0; i < deduplicatedSize; i++) {
-          deduplicatedDateValues[i] = dateValues[index[i]];
+        final LocalDate[] deDuplicatedDateValues = new LocalDate[dateValues.length];
+        for (int i = 0; i < deDuplicatedSize; i++) {
+          deDuplicatedDateValues[i] =
+              dateValues[
+                  getLastNonnullIndex(
+                      i, index, deDuplicatedIndex, originalBitMap, deDuplicatedBitMap)];
         }
-        return deduplicatedDateValues;
+        return deDuplicatedDateValues;
       case INT64:
       case TIMESTAMP:
         final long[] longValues = (long[]) valueList;
-        final long[] deduplicatedLongValues = new long[longValues.length];
-        for (int i = 0; i < deduplicatedSize; i++) {
-          deduplicatedLongValues[i] = longValues[index[i]];
+        final long[] deDuplicatedLongValues = new long[longValues.length];
+        for (int i = 0; i < deDuplicatedSize; i++) {
+          deDuplicatedLongValues[i] =
+              longValues[
+                  getLastNonnullIndex(
+                      i, index, deDuplicatedIndex, originalBitMap, deDuplicatedBitMap)];
         }
-        return deduplicatedLongValues;
+        return deDuplicatedLongValues;
       case FLOAT:
         final float[] floatValues = (float[]) valueList;
-        final float[] deduplicatedFloatValues = new float[floatValues.length];
-        for (int i = 0; i < deduplicatedSize; i++) {
-          deduplicatedFloatValues[i] = floatValues[index[i]];
+        final float[] deDuplicatedFloatValues = new float[floatValues.length];
+        for (int i = 0; i < deDuplicatedSize; i++) {
+          deDuplicatedFloatValues[i] =
+              floatValues[
+                  getLastNonnullIndex(
+                      i, index, deDuplicatedIndex, originalBitMap, deDuplicatedBitMap)];
         }
-        return deduplicatedFloatValues;
+        return deDuplicatedFloatValues;
       case DOUBLE:
         final double[] doubleValues = (double[]) valueList;
-        final double[] deduplicatedDoubleValues = new double[doubleValues.length];
-        for (int i = 0; i < deduplicatedSize; i++) {
-          deduplicatedDoubleValues[i] = doubleValues[index[i]];
+        final double[] deDuplicatedDoubleValues = new double[doubleValues.length];
+        for (int i = 0; i < deDuplicatedSize; i++) {
+          deDuplicatedDoubleValues[i] =
+              doubleValues[
+                  getLastNonnullIndex(
+                      i, index, deDuplicatedIndex, originalBitMap, deDuplicatedBitMap)];
         }
-        return deduplicatedDoubleValues;
+        return deDuplicatedDoubleValues;
       case TEXT:
       case BLOB:
       case STRING:
         final Binary[] binaryValues = (Binary[]) valueList;
-        final Binary[] deduplicatedBinaryValues = new Binary[binaryValues.length];
-        for (int i = 0; i < deduplicatedSize; i++) {
-          deduplicatedBinaryValues[i] = binaryValues[index[i]];
+        final Binary[] deDuplicatedBinaryValues = new Binary[binaryValues.length];
+        for (int i = 0; i < deDuplicatedSize; i++) {
+          deDuplicatedBinaryValues[i] =
+              binaryValues[
+                  getLastNonnullIndex(
+                      i, index, deDuplicatedIndex, originalBitMap, deDuplicatedBitMap)];
         }
-        return deduplicatedBinaryValues;
+        return deDuplicatedBinaryValues;
       default:
         throw new UnSupportedDataTypeException(
             String.format("Data type %s is not supported.", dataType));
     }
   }
 
-  private static BitMap reorderBitMap(
-      int deduplicatedSize, final BitMap bitMap, final Integer[] index) {
-    final BitMap deduplicatedBitMap = new BitMap(bitMap.getSize());
-    for (int i = 0; i < deduplicatedSize; i++) {
-      if (bitMap.isMarked(index[i])) {
-        deduplicatedBitMap.mark(i);
+  private static int getLastNonnullIndex(
+      final int i,
+      final Integer[] index,
+      final int[] deDuplicatedIndex,
+      final BitMap originalBitMap,
+      final BitMap deDuplicatedBitMap) {
+    if (deDuplicatedIndex == null) {
+      if (originalBitMap.isMarked(index[i])) {
+        deDuplicatedBitMap.mark(i);
+      }
+      return index[i];
+    }
+    if (originalBitMap == null) {
+      return index[deDuplicatedIndex[i]];
+    }
+    int lastNonnullIndex = deDuplicatedIndex[i];
+    int lastIndex = i > 0 ? deDuplicatedIndex[i - 1] : -1;
+    while (originalBitMap.isMarked(index[lastNonnullIndex])) {
+      --lastNonnullIndex;
+      if (lastNonnullIndex == lastIndex) {
+        deDuplicatedBitMap.mark(i);
+        return index[lastNonnullIndex + 1];
       }
     }
-    return deduplicatedBitMap;
+    return index[lastNonnullIndex];
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/connector/PipeTabletEventSorterTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/connector/PipeTabletEventSorterTest.java
@@ -112,7 +112,7 @@ public class PipeTabletEventSorterTest {
 
     long timestamp = 300;
     for (long i = 0; i < 10; i++) {
-      final int rowIndex = tablet.rowSize;
+      final int rowIndex = tablet.rowSize++;
       tablet.addTimestamp(rowIndex, timestamp);
       for (int s = 0; s < 3; s++) {
         tablet.addValue(

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/connector/PipeTabletEventSorterTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/connector/PipeTabletEventSorterTest.java
@@ -136,16 +136,9 @@ public class PipeTabletEventSorterTest {
     Assert.assertEquals(indices.size(), tablet.rowSize);
 
     final long[] timestamps = Arrays.copyOfRange(tablet.timestamps, 0, tablet.rowSize);
-    for (int i = 0; i < 3; ++i) {
-      Assert.assertArrayEquals(
-          timestamps, Arrays.copyOfRange((long[]) tablet.values[0], 0, tablet.rowSize));
-    }
-
-    for (int i = 1; i < tablet.rowSize; ++i) {
-      Assert.assertTrue(timestamps[i] > timestamps[i - 1]);
-      for (int j = 0; j < 3; ++j) {
-        Assert.assertTrue(((long[]) tablet.values[j])[i] > ((long[]) tablet.values[j])[i - 1]);
-      }
+    Assert.assertEquals(timestamps[0] + 8, ((long[]) tablet.values[0])[0]);
+    for (int i = 1; i < 3; ++i) {
+      Assert.assertEquals(timestamps[0] + 9, ((long[]) tablet.values[i])[0]);
     }
   }
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/connector/PipeTabletEventSorterTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/connector/PipeTabletEventSorterTest.java
@@ -112,10 +112,13 @@ public class PipeTabletEventSorterTest {
 
     long timestamp = 300;
     for (long i = 0; i < 10; i++) {
-      int rowIndex = tablet.rowSize++;
+      final int rowIndex = tablet.rowSize;
       tablet.addTimestamp(rowIndex, timestamp);
       for (int s = 0; s < 3; s++) {
-        tablet.addValue(schemaList.get(s).getMeasurementId(), rowIndex, timestamp);
+        tablet.addValue(
+            schemaList.get(s).getMeasurementId(),
+            rowIndex,
+            (i + s) % 3 != 0 ? timestamp + i : null);
       }
     }
 


### PR DESCRIPTION
## Description
As the title said.
https://github.com/apache/iotdb/pull/15488

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [x] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
