### PR TITLE
CaseWhen :Optimize the code structure and add comments

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/AbstractCaseWhenThenColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/AbstractCaseWhenThenColumnTransformer.java
@@ -213,12 +213,14 @@ public abstract class AbstractCaseWhenThenColumnTransformer extends ColumnTransf
     }
 
     initializeColumnCache(builder.build());
+    // Because of short-circuit evaluation, CaseWhen does not calculate all Then phrases, so its
+    // calculation results cannot be reused.
     for (Pair<ColumnTransformer, ColumnTransformer> whenThenColumnTransformer :
         whenThenTransformers) {
       whenThenColumnTransformer.left.clearCache();
       whenThenColumnTransformer.right.clearCache();
-      elseTransformer.clearCache();
     }
+    elseTransformer.clearCache();
   }
 
   protected abstract void writeToColumnBuilder(


### PR DESCRIPTION
This pull request includes a minor change to the `doTransform` method in the `AbstractCaseWhenThenColumnTransformer` class. The change ensures proper cache clearing for the `elseTransformer` by moving its `clearCache` call outside the loop for better clarity and correctness.

* **Cache management improvement:**
  - [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/AbstractCaseWhenThenColumnTransformer.java`](diffhunk://#diff-1cea02ca1c6972693f34174ef72701635fa40779c9ec54c328924d5ca4ef95b3R216-R223): Added a comment explaining the short-circuit evaluation behavior of CaseWhen and adjusted the placement of `elseTransformer.clearCache()` to ensure it is executed after the loop for consistent cache clearing.