### PR TITLE
Datanode cannot start when metaDataCacheEnable=false

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/DataNodeMemoryConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/DataNodeMemoryConfig.java
@@ -473,9 +473,7 @@ public class DataNodeMemoryConfig {
     // metadata cache is disabled, we need to move all their allocated memory to other parts
     if (!isMetaDataCacheEnable()) {
       long sum =
-          bloomFilterCacheMemoryManager.getTotalMemorySizeInBytes()
-              + chunkCacheMemoryManager.getTotalMemorySizeInBytes()
-              + timeSeriesMetaDataCacheMemoryManager.getTotalMemorySizeInBytes();
+          bloomFilterCacheMemorySize + chunkCacheMemorySize + timeSeriesMetaDataCacheMemorySize;
       bloomFilterCacheMemorySize = 0;
       chunkCacheMemorySize = 0;
       timeSeriesMetaDataCacheMemorySize = 0;


### PR DESCRIPTION
## Description
Datanode cannot start when metaDataCacheEnable=false
```
java.lang.NullPointerException: null
	at org.apache.iotdb.db.conf.DataNodeMemoryConfig.initQueryEngineMemoryAllocate(DataNodeMemoryConfig.java:476)
	at org.apache.iotdb.db.conf.DataNodeMemoryConfig.init(DataNodeMemoryConfig.java:219)
	at org.apache.iotdb.db.conf.IoTDBDescriptor.loadProperties(IoTDBDescriptor.java:311)
	at org.apache.iotdb.db.conf.IoTDBDescriptor.loadProps(IoTDBDescriptor.java:229)
	at org.apache.iotdb.db.conf.IoTDBDescriptor.<init>(IoTDBDescriptor.java:134)
	at org.apache.iotdb.db.conf.IoTDBDescriptor$IoTDBDescriptorHolder.<clinit>(IoTDBDescriptor.java:2648)
	at org.apache.iotdb.db.conf.IoTDBDescriptor.getInstance(IoTDBDescriptor.java:166)
	at org.apache.iotdb.db.service.DataNode.<clinit>(DataNode.java:142)
```