### PR TITLE
Fix null pointer exception casued by measurements values and measureSchemas values are not consistent

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/RelationPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/RelationPlanner.java
@@ -95,6 +95,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.tsfile.read.common.type.Type;
+import org.apache.tsfile.write.schema.MeasurementSchema;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -759,14 +760,19 @@ public class RelationPlanner extends AstVisitor<RelationPlan, Void> {
   @Override
   protected RelationPlan visitInsertTablet(InsertTablet node, Void context) {
     final InsertTabletStatement insertTabletStatement = node.getInnerTreeStatement();
+
+    String[] measurements = insertTabletStatement.getMeasurements();
+    MeasurementSchema[] measurementSchemas = insertTabletStatement.getMeasurementSchemas();
+    stayConsistent(measurements, measurementSchemas);
+
     RelationalInsertTabletNode insertNode =
         new RelationalInsertTabletNode(
             idAllocator.genPlanNodeId(),
             insertTabletStatement.getDevicePath(),
             insertTabletStatement.isAligned(),
-            insertTabletStatement.getMeasurements(),
+            measurements,
             insertTabletStatement.getDataTypes(),
-            insertTabletStatement.getMeasurementSchemas(),
+            measurementSchemas,
             insertTabletStatement.getTimes(),
             insertTabletStatement.getBitMaps(),
             insertTabletStatement.getColumns(),
@@ -790,19 +796,24 @@ public class RelationPlanner extends AstVisitor<RelationPlan, Void> {
 
   protected RelationalInsertRowNode fromInsertRowStatement(
       final InsertRowStatement insertRowStatement) {
+
+    String[] measurements = insertRowStatement.getMeasurements();
+    MeasurementSchema[] measurementSchemas = insertRowStatement.getMeasurementSchemas();
+    stayConsistent(measurements, measurementSchemas);
+
     final RelationalInsertRowNode insertNode =
         new RelationalInsertRowNode(
             idAllocator.genPlanNodeId(),
             insertRowStatement.getDevicePath(),
             insertRowStatement.isAligned(),
-            insertRowStatement.getMeasurements(),
+            measurements,
             insertRowStatement.getDataTypes(),
+            measurementSchemas,
             insertRowStatement.getTime(),
             insertRowStatement.getValues(),
             insertRowStatement.isNeedInferType(),
             insertRowStatement.getColumnCategories());
     insertNode.setFailedMeasurementNumber(insertRowStatement.getFailedMeasurementNumber());
-    insertNode.setMeasurementSchemas(insertRowStatement.getMeasurementSchemas());
     return insertNode;
   }
 
@@ -1001,5 +1012,16 @@ public class RelationPlanner extends AstVisitor<RelationPlan, Void> {
             sourceProperties.build());
 
     return new RelationPlan(root, analysis.getScope(node), outputSymbols.build(), outerContext);
+  }
+
+  private static void stayConsistent(
+      String[] measurements, MeasurementSchema[] measurementSchemas) {
+    int minLength = Math.min(measurements.length, measurementSchemas.length);
+    for (int j = 0; j < minLength; j++) {
+      if (measurements[j] == null || measurementSchemas[j] == null) {
+        measurements[j] = null;
+        measurementSchemas[j] = null;
+      }
+    }
   }
 }


### PR DESCRIPTION
Fix the problem of null pointer below: 
sql覆盖 IoTV2 3副本 DN
NullPointerException: Cannot invoke "org.apache.tsfile.write.schema.MeasurementSchema.serializeTo(java.io.OutputStream)" because "this.measurementSchemas[i]" is null

`
2025-05-06 13:19:02,468 [pool-35-IoTDB-into-operation-executor-2] ERROR o.a.i.d.u.ErrorHandlingUtils:67 - Status code: EXECUTE_STATEMENT_ERROR(301), operation: insertTablets failed
java.lang.NullPointerException: Cannot invoke "org.apache.tsfile.write.schema.MeasurementSchema.serializeTo(java.io.OutputStream)" because "this.measurementSchemas[i]" is null
        at org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertTabletNode.writeMeasurementsOrSchemas(InsertTabletNode.java:502)
        at org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertTabletNode.subSerialize(InsertTabletNode.java:463)
        at org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertMultiTabletsNode.serializeAttributes(InsertMultiTabletsNode.java:246)
        at org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNode.serialize(PlanNode.java:148)
        at org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNode.serializeToByteBuffer(PlanNode.java:184)
        at org.apache.iotdb.db.queryengine.plan.scheduler.AsyncPlanNodeSender.<init>(AsyncPlanNodeSender.java:77)
        at org.apache.iotdb.db.queryengine.plan.scheduler.FragmentInstanceDispatcherImpl.dispatchWriteAsync(FragmentInstanceDispatcherImpl.java:220)
        at org.apache.iotdb.db.queryengine.plan.scheduler.FragmentInstanceDispatcherImpl.dispatch(FragmentInstanceDispatcherImpl.java:123)
        at org.apache.iotdb.db.queryengine.plan.scheduler.ClusterScheduler.start(ClusterScheduler.java:117)
        at org.apache.iotdb.db.queryengine.plan.planner.TreeModelPlanner.doSchedule(TreeModelPlanner.java:158)
        at org.apache.iotdb.db.queryengine.plan.execution.QueryExecution.schedule(QueryExecution.java:270)
        at org.apache.iotdb.db.queryengine.plan.execution.QueryExecution.start(QueryExecution.java:192)
        at org.apache.iotdb.db.queryengine.plan.Coordinator.execution(Coordinator.java:234)
        at org.apache.iotdb.db.queryengine.plan.Coordinator.executeForTreeModel(Coordinator.java:270)
        at org.apache.iotdb.db.queryengine.plan.Coordinator.executeForTreeModel(Coordinator.java:257)
        at org.apache.iotdb.db.protocol.client.DataNodeInternalClient.insertTablets(DataNodeInternalClient.java:87)
        at org.apache.iotdb.db.queryengine.execution.operator.process.AbstractIntoOperator.lambda$executeInsertMultiTabletsStatement$0(AbstractIntoOperator.java:286)
        at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:131)
        at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:75)
        at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:82)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)
2025-05-06 13:19:02,469 [Query-Worker-Thread-0$20250506_051902_60084_3.1.0.0] INFO  o.a.i.d.q.e.s.DriverScheduler$Scheduler:581 - The task 20250506_051902_60084_3.1.0.0 is aborted. All other tasks in the same query will be cancelled
2025-05-06 13:19:02,469 [pool-30-IoTDB-DataNodeInternalRPC-Processor-54] WARN  o.a.i.d.u.ErrorHandlingUtils:121 - Status code: 301, Query Statement: "SELECT max_value(x01)     INTO root.view.v1(y1)   FROM root.db.d2         WHERE Time >= xx & Time < xx      GROUP BY TIME ([xx, xx), 1s) ;". executeStatement failed because Error occurred while inserting tablets in SELECT INTO: [EXECUTE_STATEMENT_ERROR(301)] Exception occurred: insertTablets failed. Cannot invoke "org.apache.tsfile.write.schema.MeasurementSchema.serializeTo(java.io.OutputStream)" because "this.measurementSchemas[i]" is null
org.apache.iotdb.commons.exception.IoTDBException: Error occurred while inserting tablets in SELECT INTO: [EXECUTE_STATEMENT_ERROR(301)] Exception occurred: insertTablets failed. Cannot invoke "org.apache.tsfile.write.schema.MeasurementSchema.serializeTo(java.io.OutputStream)" because "this.measurementSchemas[i]" is null
        at org.apache.iotdb.db.queryengine.plan.execution.QueryExecution.dealWithException(QueryExecution.java:467)
        at org.apache.iotdb.db.queryengine.plan.execution.QueryExecution.getResult(QueryExecution.java:452)
        at org.apache.iotdb.db.queryengine.plan.execution.QueryExecution.getBatchResult(QueryExecution.java:487)
        at org.apache.iotdb.db.protocol.thrift.impl.DataNodeInternalRPCServiceImpl.executeCQ(DataNodeInternalRPCServiceImpl.java:1513)
        at org.apache.iotdb.mpp.rpc.thrift.IDataNodeRPCService$Processor$executeCQ.getResult(IDataNodeRPCService.java:8224)
        at org.apache.iotdb.mpp.rpc.thrift.IDataNodeRPCService$Processor$executeCQ.getResult(IDataNodeRPCService.java:8204)
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38)
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:38)
        at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:248)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)`