### PR TITLE
Fix DataNodeWrapper didn't set Timezone

### DIFF
--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/node/DataNodeWrapper.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/node/DataNodeWrapper.java
@@ -168,6 +168,7 @@ public class DataNodeWrapper extends AbstractNodeWrapper {
         .setMaxHeapSize(EnvUtils.getIntFromSysVar(DATANODE_MAX_HEAP_SIZE, 256, clusterIndex))
         .setMaxDirectMemorySize(
             EnvUtils.getIntFromSysVar(DATANODE_MAX_DIRECT_MEMORY_SIZE, 256, clusterIndex))
+        .setTimezone("Asia/Shanghai")
         .build();
   }
 


### PR DESCRIPTION
## Description

ConfigNodeWrapper set Timezone but not in DataNodeWrapper.

https://github.com/apache/iotdb/blob/a5e7d7b30c993c0657566f817e84f767656b4c23/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/node/ConfigNodeWrapper.java#L108-L116