### PR TITLE
[To dev/1.3] Correct error messages when encountered IllegalPathException

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBSetConfigurationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBSetConfigurationIT.java
@@ -263,8 +263,8 @@ public class IoTDBSetConfigurationIT {
         statement.execute("CREATE TIMESERIES root.db1.s3 WITH datatype=INT32");
       } catch (SQLException e) {
         assertEquals(
-                "509: An error occurred when executing getDeviceToDatabase():root.db1 is not a legal path, because it is no longer than default sg level: 3",
-                e.getMessage());
+            "509: An error occurred when executing getDeviceToDatabase():root.db1 is not a legal path, because it is no longer than default sg level: 3",
+            e.getMessage());
       }
     }
   }

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBSetConfigurationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBSetConfigurationIT.java
@@ -225,7 +225,7 @@ public class IoTDBSetConfigurationIT {
         statement.execute("INSERT INTO root.fail(timestamp, s1) VALUES (1, 1)");
       } catch (SQLException e) {
         assertEquals(
-            "509: root.fail is not a legal path, because it is no longer than default sg level: 3",
+            "509: An error occurred when executing getDeviceToDatabase():root.fail is not a legal path, because it is no longer than default sg level: 3",
             e.getMessage());
       }
 
@@ -257,6 +257,15 @@ public class IoTDBSetConfigurationIT {
       // the default value should take effect
       Assert.assertEquals("root.a", databases.getString(1));
       assertFalse(databases.next());
+
+      // create timeseries with an illegal path
+      try {
+        statement.execute("CREATE TIMESERIES root.db1.s3 WITH datatype=INT32");
+      } catch (SQLException e) {
+        assertEquals(
+                "509: An error occurred when executing getDeviceToDatabase():root.db1 is not a legal path, because it is no longer than default sg level: 3",
+                e.getMessage());
+      }
     }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/partition/PartitionCache.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/partition/PartitionCache.java
@@ -29,6 +29,7 @@ import org.apache.iotdb.commons.client.IClientManager;
 import org.apache.iotdb.commons.client.exception.ClientManagerException;
 import org.apache.iotdb.commons.consensus.ConfigRegionId;
 import org.apache.iotdb.commons.exception.IoTDBException;
+import org.apache.iotdb.commons.exception.IoTDBRuntimeException;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.partition.DataPartition;
 import org.apache.iotdb.commons.partition.DataPartitionQueryParam;
@@ -382,7 +383,11 @@ public class PartitionCache {
             throw new StatementAnalyzeException("Failed to get database Map");
           }
         }
-      } catch (TException | MetadataException | ClientManagerException e) {
+      } catch (MetadataException e) {
+        throw new IoTDBRuntimeException(
+            "An error occurred when executing getDeviceToDatabase():" + e.getMessage(),
+            e.getErrorCode());
+      } catch (TException | ClientManagerException e) {
         throw new StatementAnalyzeException(
             "An error occurred when executing getDeviceToDatabase():" + e.getMessage(), e);
       }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/ErrorHandlingUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/ErrorHandlingUtils.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.utils;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.exception.IoTDBException;
+import org.apache.iotdb.commons.exception.IoTDBRuntimeException;
 import org.apache.iotdb.db.exception.BatchProcessException;
 import org.apache.iotdb.db.exception.QueryInBatchStatementException;
 import org.apache.iotdb.db.exception.StorageGroupNotReadyException;
@@ -145,6 +146,8 @@ public class ErrorHandlingUtils {
           TSStatusCode.QUERY_NOT_ALLOWED, INFO_NOT_ALLOWED_IN_BATCH_ERROR + rootCause.getMessage());
     } else if (t instanceof IoTDBException) {
       return RpcUtils.getStatus(((IoTDBException) t).getErrorCode(), rootCause.getMessage());
+    } else if (t instanceof IoTDBRuntimeException) {
+      return RpcUtils.getStatus(((IoTDBRuntimeException) t).getErrorCode(), rootCause.getMessage());
     } else if (t instanceof TsFileRuntimeException) {
       return RpcUtils.getStatus(TSStatusCode.TSFILE_PROCESSOR_ERROR, rootCause.getMessage());
     } else if (t instanceof SemanticException) {


### PR DESCRIPTION
In the conf/iotdb-system.properties files, add these configs below

default_storage_group_level=2 
enable_audit_log=true 

Start up 1C1D, enter CLI
```
Starting IoTDB Cli
---------------------
 _____       _________  ______   ______    
|_   _|     |  _   _  ||_   _ `.|_   _ \   
  | |   .--.|_/ | | \_|  | | `. \ | |_) |  
  | | / .'`\ \  | |      | |  | | |  __'.  
 _| |_| \__. | _| |_    _| |_.' /_| |__) | 
|_____|'.__.' |_____|  |______.'|_______/  version 1.3.3-SNAPSHOT (Build: 16c2856)
                                           Successfully login at 127.0.0.1:6667
IoTDB> create timeseries root.db.s1 with datatype=INT32;
Msg: org.apache.iotdb.jdbc.IoTDBSQLException: 305: [INTERNAL_SERVER_ERROR(305)] Exception occurred: "create timeseries root.db.s1 with datatype=INT32". executeStatement failed. An error occurred when executing getDeviceToStorageGroup():root.db is not a legal path
```
Hope don't appear the error code of 305, but display number 509. After code is changed, the content will be becomed as follow :
`Msg: org.apache.iotdb.jdbc.IoTDBSQLException: 509: An error occurred when executing getDeviceToDatabase():root.fail is not a legal path`
