### PR TITLE
IoTV2: Reset receiver's metric when clear receiver's buffer

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/pipeconsensus/PipeConsensusReceiver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/pipeconsensus/PipeConsensusReceiver.java
@@ -1655,6 +1655,8 @@ public class PipeConsensusReceiver {
       try {
         this.reqExecutionOrderBuffer.clear();
         this.tsFileWriterPool.releaseAllWriters(consensusPipeName);
+        this.tsFileEventCount.set(0);
+        this.WALEventCount.set(0);
         if (resetSyncIndex) {
           this.onSyncedReplicateIndex = 0;
         }


### PR DESCRIPTION
as title. 

In one case, we found that one region receiver's pending tsFileEvent num has reached an unexpected `66` value, which is far greater than receiver's buffer len `5`.

This case is caused by buffer reset. We need to reset event counter as well when we clear buffer

<img width="440" alt="image" src="https://github.com/user-attachments/assets/d12f84f7-1b4d-41dd-ba4b-1c61a0ee8253" />
