### PR TITLE
Subscription: retain tsfile events in tsfile batch to avoid premature commit

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeTsFileEventBatch.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeTsFileEventBatch.java
@@ -69,6 +69,11 @@ public class SubscriptionPipeTsFileEventBatch extends SubscriptionPipeEventBatch
   public synchronized void cleanUp(final boolean force) {
     // close batch, it includes clearing the reference count of events
     batch.close();
+
+    // clear the reference count of events
+    for (final EnrichedEvent enrichedEvent : enrichedEvents) {
+      enrichedEvent.clearReferenceCount(this.getClass().getName());
+    }
     enrichedEvents.clear();
   }
 


### PR DESCRIPTION
As title.

Consider the historical data export snapshot scenario

1. The events delivered upstream are, in order, the tsfile event and the termination event.  
2. The tsfile event is parsed into multiple tablet events, and then the reference count of the tsfile event is set to 0 (should report as false).  
3. Assuming that for some reason the tablet events were not sent to the peer in time, the reference count of the transfer termination event is set to 0 (should report as true).  
4. At this point, because the tablet events were not enriched with a commit id (see #15524), the termination event successfully marks the corresponding DR complete, which in turn leads to data loss.