### PR TITLE
IoTV2: Fix the issue of resend lots of replicated files when DN restarts.

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/historical/PipeHistoricalDataRegionTsFileAndDeletionExtractor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/extractor/dataregion/historical/PipeHistoricalDataRegionTsFileAndDeletionExtractor.java
@@ -447,8 +447,7 @@ public class PipeHistoricalDataRegionTsFileAndDeletionExtractor
     // 1. origin is RecoverProgressIndex
     if (origin instanceof RecoverProgressIndex) {
       RecoverProgressIndex toBeTransformed = (RecoverProgressIndex) origin;
-      ProgressIndex transformed = extractRecoverProgressIndex(toBeTransformed);
-      return transformed == null ? origin : transformed;
+      return extractRecoverProgressIndex(toBeTransformed);
     }
     // 2. origin is HybridProgressIndex
     else if (origin instanceof HybridProgressIndex) {
@@ -463,9 +462,7 @@ public class PipeHistoricalDataRegionTsFileAndDeletionExtractor
                 toBeTransformed
                     .getType2Index()
                     .get(ProgressIndexType.RECOVER_PROGRESS_INDEX.getType());
-
-        ProgressIndex transformed = extractRecoverProgressIndex(specificToBeTransformed);
-        return transformed == null ? origin : transformed;
+        return extractRecoverProgressIndex(specificToBeTransformed);
       }
       // if hybridProgressIndex doesn't contain recoverProgressIndex, which is not what we expected,
       // fallback.
@@ -483,14 +480,6 @@ public class PipeHistoricalDataRegionTsFileAndDeletionExtractor
   }
 
   private ProgressIndex extractRecoverProgressIndex(RecoverProgressIndex toBeTransformed) {
-    if (!toBeTransformed
-        .getDataNodeId2LocalIndex()
-        .containsKey(IoTDBDescriptor.getInstance().getConfig().getDataNodeId())) {
-      // if recoverProgressIndex doesn't contain local DataNodeId, return null directly to indicate
-      // there is no need to extract dedicated progressIndex.
-      return null;
-    }
-
     return new RecoverProgressIndex(
         toBeTransformed.getDataNodeId2LocalIndex().entrySet().stream()
             .filter(


### PR DESCRIPTION
IoTV2 use `RecoverProgressIndex` to represent the replicate progress of its consensus pipe.
the `RecoverProgressIndex` is consist of binary tuple, where key represents the source data node id of the writing data and value represents the operation sequence

for one leader, naming nodeA, it may contain both local write data(`RecoverProgress`'s key is local data node id) and data replicated from other old leader.(`RecoverProgress`'s key is old leader's data node id)

if nodeA is restarted, consensus pipe will try to flush and collect all tsFiles on it. Those tsFiles may be high-level which are compacted from local write 0-level tsFile and replicated 0-level tsFile. In that case, Those high-level tsFiles' `RecoverProgress` may contain both local data node id key and old leader's data node id key.

IoTV2 will only transfer tsFiles with progressIndex greater than `startIndex`, for those tsFiles are considered to contain unprocessed data and are necessary to be resent.

The problem is, the comparison of `RecoverProgressIndex` is quite strict (for more details please refer to  `RecoverProgressIndex` source code.), causing some high-level tsFiles that don't contain local writing data are still considered necessary to be resent.

So for IoTV2, we only need to consider local write data and its dedicated progressIndex for deciding whether tsFiles contain unprocessed data.

