### PR TITLE
When the queries aligned series has some inconsistent data types in memtable, the other column will also be ignored

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/view/recent/IoTDBTableViewQueryWithNotMatchedDataTypeIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/view/recent/IoTDBTableViewQueryWithNotMatchedDataTypeIT.java
@@ -94,7 +94,8 @@ public class IoTDBTableViewQueryWithNotMatchedDataTypeIT {
   public void test() throws IoTDBConnectionException, StatementExecutionException {
     try (ITableSession session = EnvFactory.getEnv().getTableSessionConnection()) {
       session.executeNonQueryStatement("USE " + DATABASE_NAME);
-      SessionDataSet sessionDataSet = session.executeQueryStatement("select * from view1");
+      SessionDataSet sessionDataSet =
+          session.executeQueryStatement("select * from view1 where current is not null");
       Assert.assertFalse(sessionDataSet.hasNext());
       sessionDataSet.close();
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/utils/ResourceByPathUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/utils/ResourceByPathUtils.java
@@ -66,7 +66,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -318,18 +317,6 @@ class AlignedResourceByPathUtils extends ResourceByPathUtils {
     }
     AlignedWritableMemChunk alignedMemChunk =
         ((AlignedWritableMemChunkGroup) memTableMap.get(deviceID)).getAlignedMemChunk();
-
-    // check If data type matches
-    Map<String, TSDataType> dataTypeMap = new HashMap<>(alignedMemChunk.getSchemaList().size());
-    for (IMeasurementSchema schema : alignedMemChunk.getSchemaList()) {
-      dataTypeMap.put(schema.getMeasurementName(), schema.getType());
-    }
-    for (IMeasurementSchema schema : alignedFullPath.getSchemaList()) {
-      TSDataType dataTypeInMemChunk = dataTypeMap.get(schema.getMeasurementName());
-      if (dataTypeInMemChunk != null && dataTypeInMemChunk != schema.getType()) {
-        return null;
-      }
-    }
     // only need to do this check for tree model
     if (context.isIgnoreAllNullRows()) {
       boolean containsMeasurement = false;
@@ -350,6 +337,7 @@ class AlignedResourceByPathUtils extends ResourceByPathUtils {
             context, alignedMemChunk, modsToMemtable == null, globalTimeFilter);
 
     // column index list for the query
+    // Columns with inconsistent types will be ignored and set -1
     List<Integer> columnIndexList =
         alignedMemChunk.buildColumnIndexList(alignedFullPath.getSchemaList());
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AlignedWritableMemChunk.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AlignedWritableMemChunk.java
@@ -834,9 +834,18 @@ public class AlignedWritableMemChunk extends AbstractWritableMemChunk {
 
   public List<Integer> buildColumnIndexList(List<IMeasurementSchema> schemaList) {
     List<Integer> columnIndexList = new ArrayList<>();
-    for (IMeasurementSchema measurementSchema : schemaList) {
+    for (IMeasurementSchema requiredMeasurementSchema : schemaList) {
+      Integer measurementIndex =
+          measurementIndexMap.get(requiredMeasurementSchema.getMeasurementName());
+      if (measurementIndex == null) {
+        columnIndexList.add(-1);
+        continue;
+      }
+      IMeasurementSchema schemaInMemChunk = this.schemaList.get(measurementIndex);
       columnIndexList.add(
-          measurementIndexMap.getOrDefault(measurementSchema.getMeasurementName(), -1));
+          schemaInMemChunk.getType() == requiredMeasurementSchema.getType()
+              ? measurementIndex
+              : -1);
     }
     return columnIndexList;
   }


### PR DESCRIPTION
## Description
When the queried aligned series has some inconsistent types in memtable, the other column will also be ignored.  Related previous PR is https://github.com/apache/iotdb/pull/15617.