### PR TITLE
Revert "Fix process of last query if intermediate state of last cache is read when query concurrently

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/LastQueryAggTableScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/LastQueryAggTableScanOperator.java
@@ -252,8 +252,14 @@ public class LastQueryAggTableScanOperator extends AbstractAggTableScanOperator 
               hitCachedResults.get(currentHitCacheIndex).getRight()[measurementIdx];
           long lastByTime = hitCachedResults.get(currentHitCacheIndex).getLeft().getAsLong();
           if (tsPrimitiveType == EMPTY_PRIMITIVE_TYPE) {
-            throw new IllegalStateException(
-                "If the read value is [EMPTY_PRIMITIVE_TYPE], we should never reach here");
+            // there is no data for this time series
+            if (aggregator.getStep().isOutputPartial()) {
+              columnBuilder.writeBinary(
+                  new Binary(
+                      serializeTimeValue(getTSDataType(schema.getType()), lastByTime, true, null)));
+            } else {
+              columnBuilder.appendNull();
+            }
           } else {
             if (aggregator.getStep().isOutputPartial()) {
               columnBuilder.writeBinary(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/TableOperatorGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/TableOperatorGenerator.java
@@ -305,7 +305,6 @@ import static org.apache.iotdb.db.queryengine.plan.planner.OperatorTreeGenerator
 import static org.apache.iotdb.db.queryengine.plan.planner.OperatorTreeGenerator.getLinearFill;
 import static org.apache.iotdb.db.queryengine.plan.planner.OperatorTreeGenerator.getPreviousFill;
 import static org.apache.iotdb.db.queryengine.plan.planner.plan.parameter.SeriesScanOptions.updateFilterUsingTTL;
-import static org.apache.iotdb.db.queryengine.plan.relational.metadata.fetcher.cache.TableDeviceLastCache.EMPTY_PRIMITIVE_TYPE;
 import static org.apache.iotdb.db.queryengine.plan.relational.planner.SortOrder.ASC_NULLS_FIRST;
 import static org.apache.iotdb.db.queryengine.plan.relational.planner.SortOrder.ASC_NULLS_LAST;
 import static org.apache.iotdb.db.queryengine.plan.relational.planner.SortOrder.DESC_NULLS_FIRST;
@@ -2985,7 +2984,6 @@ public class TableOperatorGenerator extends PlanVisitor<Operator, LocalExecution
         for (int j = 0; j < lastByResult.get().getRight().length; j++) {
           TsPrimitiveType tsPrimitiveType = lastByResult.get().getRight()[j];
           if (tsPrimitiveType == null
-              || tsPrimitiveType == EMPTY_PRIMITIVE_TYPE
               || (updateTimeFilter != null
                   && !LastQueryUtil.satisfyFilter(
                       updateTimeFilter,


### PR DESCRIPTION
let last cache hit, even if any sensor of one device is null in last row