### PR TITLE
Feature/retry on disk failure

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/receiver/protocol/IoTDBConfigNodeReceiver.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/receiver/protocol/IoTDBConfigNodeReceiver.java
@@ -994,6 +994,9 @@ public class IoTDBConfigNodeReceiver extends IoTDBFileReceiver {
   }
 
   @Override
+  protected void markFileBaseDirStateAbnormal(String dir) {}
+
+  @Override
   protected String getSenderHost() {
     final IClientSession session = SESSION_MANAGER.getCurrSession();
     return session != null ? session.getClientAddress() : "unknown";

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/exception/load/LoadFileException.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/exception/load/LoadFileException.java
@@ -31,4 +31,8 @@ public class LoadFileException extends IoTDBException {
   public LoadFileException(Exception exception) {
     super(exception, TSStatusCode.LOAD_FILE_ERROR.getStatusCode());
   }
+
+  public LoadFileException(String message, Exception exception) {
+    super(message, exception, TSStatusCode.LOAD_FILE_ERROR.getStatusCode());
+  }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/pipeconsensus/PipeConsensusReceiver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/pipeconsensus/PipeConsensusReceiver.java
@@ -1234,44 +1234,39 @@ public class PipeConsensusReceiver {
     }
 
     public void rollToNextWritingPath() throws IOException, DiskSpaceInsufficientException {
-      String receiverBasePath;
-      try {
-        receiverBasePath = getReceiverFileBaseDir();
-      } catch (Exception e) {
-        LOGGER.warn(
-            "Failed to init pipeConsensus receiver file folder manager because all disks of folders are full.",
-            e);
-        throw e;
-      }
-      if (Objects.isNull(receiverBasePath)) {
-        LOGGER.warn(
-            "PipeConsensus-PipeName-{}: Failed to get pipeConsensus receiver file base directory, because folderManager is null. May because the disk is full.",
-            consensusPipeName.toString());
-        throw new DiskSpaceInsufficientException(receiveDirs);
+      for (int retryTimes = 0; retryTimes <= 1; retryTimes++) {
+        String receiverBasePath;
+        try {
+          receiverBasePath = getReceiverFileBaseDir();
+          if (Objects.isNull(receiverBasePath)) {
+            LOGGER.warn("PipeConsensus-PipeName-{}: Failed to get base directory", consensusPipeName);
+            throw new DiskSpaceInsufficientException(receiveDirs);
+          }
+        } catch (Exception e) {
+          LOGGER.warn("Failed to init pipeConsensus receiver file folder manager", e);
+          throw e;
+        }
+
+        try {
+          this.localWritingDir = new File(receiverBasePath + File.separator + index);
+          deleteFileOrDirectoryIfExists(this.localWritingDir,
+                  String.format("TsFileWriter-%s roll to new dir and delete last writing dir", index));
+
+          if (this.localWritingDir.mkdirs()) {
+            LOGGER.info("PipeConsensus-PipeName-{}: tsfileWriter-{} roll to writing path {}",
+                    consensusPipeName, index, this.localWritingDir.getPath());
+            return;
+          }
+        } catch (Exception ignored) {
+        }
+        LOGGER.warn("PipeConsensus-PipeName-{}: Failed to create receiver tsFileWriter-{} file dir {} (retryTimes={})",
+                consensusPipeName, index, this.localWritingDir.getPath(), retryTimes);
+        folderManager.updateFolderState(receiverBasePath, FolderManager.FolderState.ABNORMAL);
       }
 
-      String localWritingDirPath = receiverBasePath + File.separator + index;
-      this.localWritingDir = new File(localWritingDirPath);
-      // Remove exists dir
-      deleteFileOrDirectoryIfExists(
-          this.localWritingDir,
-          String.format("TsFileWriter-%s roll to new dir and delete last writing dir", index));
-      if (!this.localWritingDir.mkdirs()) {
-        LOGGER.warn(
-            "PipeConsensus-PipeName-{}: Failed to create receiver tsFileWriter-{} file dir {}. May because authority or dir already exists etc.",
-            consensusPipeName,
-            index,
-            this.localWritingDir.getPath());
-        throw new IOException(
-            String.format(
-                "PipeConsensus-PipeName-%s: Failed to create tsFileWriter-%d receiver file dir %s. May because authority or dir already exists etc.",
-                consensusPipeName, index, this.localWritingDir.getPath()));
-      }
-      LOGGER.info(
-          "PipeConsensus-PipeName-{}: tsfileWriter-{} roll to writing path {}",
-          consensusPipeName,
-          index,
-          localWritingDirPath);
+      throw new IOException(String.format(
+              "PipeConsensus-PipeName-%s: Failed to create tsFileWriter-%d receiver file dir %s",
+              consensusPipeName, index, this.localWritingDir.getPath()));
     }
 
     public File getLocalWritingDir() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/thrift/IoTDBDataNodeReceiver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/thrift/IoTDBDataNodeReceiver.java
@@ -509,6 +509,11 @@ public class IoTDBDataNodeReceiver extends IoTDBFileReceiver {
   }
 
   @Override
+  protected void markFileBaseDirStateAbnormal(String dir) {
+    folderManager.updateFolderState(dir, FolderManager.FolderState.ABNORMAL);
+  }
+
+  @Override
   protected String getSenderHost() {
     final IClientSession session = SESSION_MANAGER.getCurrSession();
     return session != null ? session.getClientAddress() : "unknown";

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/snapshot/SnapshotLoader.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/snapshot/SnapshotLoader.java
@@ -312,6 +312,7 @@ public class SnapshotLoader {
         } catch (Exception e) {
           LOGGER.warn("Failed to process file {}: {}", file.getName(), e.getMessage(), e);
           folderManager.updateFolderState(dataDir, FolderManager.FolderState.ABNORMAL);
+          dataDir = null;
           continue;
         }
         fileTarget.put(fileKey, dataDir);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/allocation/AbstractNodeAllocationStrategy.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/allocation/AbstractNodeAllocationStrategy.java
@@ -68,7 +68,7 @@ public abstract class AbstractNodeAllocationStrategy implements NodeAllocationSt
       // create new wal node
       try {
         return new WALNode(identifier, folder + File.separator + identifier);
-      } catch (IOException e) {
+      } catch (Exception e) {
         logger.error("Meet exception when creating wal node", e);
         folderManager.updateFolderState(folder, FolderManager.FolderState.ABNORMAL);
       }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/allocation/AbstractNodeAllocationStrategy.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/allocation/AbstractNodeAllocationStrategy.java
@@ -69,7 +69,7 @@ public abstract class AbstractNodeAllocationStrategy implements NodeAllocationSt
       try {
         return new WALNode(identifier, folder + File.separator + identifier);
       } catch (Exception e) {
-        logger.error("Meet exception when creating wal node", e);
+        logger.warn("Meet exception when creating wal node", e);
         folderManager.updateFolderState(folder, FolderManager.FolderState.ABNORMAL);
       }
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/load/LoadTsFileManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/load/LoadTsFileManager.java
@@ -208,17 +208,24 @@ public class LoadTsFileManager {
     cleanupTask.ifPresent(CleanupTask::markLoadTaskRunning);
     try {
       final AtomicReference<Exception> exception = new AtomicReference<>();
-      final TsFileWriterManager writerManager =
-          uuid2WriterManager.computeIfAbsent(
-              uuid,
-              o -> {
-                try {
-                  return new TsFileWriterManager(new File(getNextFolder(), uuid));
-                } catch (DiskSpaceInsufficientException e) {
-                  exception.set(e);
-                  return null;
-                }
-              });
+      final TsFileWriterManager writerManager = uuid2WriterManager.computeIfAbsent(uuid, o -> {
+        String folder = null;
+        for (int retryTimes = 0; retryTimes <= 1; retryTimes++) {
+          try {
+            folder = getNextFolder();
+            return new TsFileWriterManager(new File(folder, uuid));
+          } catch (DiskSpaceInsufficientException e) {
+            exception.set(e);
+            return null;
+          } catch (Exception ignored) {
+            synchronized (FOLDER_MANAGER) {
+              FOLDER_MANAGER.get().updateFolderState(folder, FolderManager.FolderState.ABNORMAL);
+            }
+          }
+        }
+        return null;
+      });
+
       if (exception.get() != null || writerManager == null) {
         throw new IOException(
             "Failed to create TsFileWriterManager for uuid "

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/load/disk/ILoadDiskSelector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/load/disk/ILoadDiskSelector.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.storageengine.load.disk;
 
 import org.apache.iotdb.db.exception.DiskSpaceInsufficientException;
+import org.apache.iotdb.db.exception.load.LoadFileException;
 
 import java.io.File;
 
@@ -32,7 +33,7 @@ public interface ILoadDiskSelector {
       long filePartitionId,
       String tsfileName,
       int tierLevel)
-      throws DiskSpaceInsufficientException;
+          throws DiskSpaceInsufficientException, LoadFileException;
 
   enum LoadDiskSelectorType {
     MIN_IO_FIRST("MIN_IO_FIRST"),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/load/disk/InheritSystemMultiDisksStrategySelector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/load/disk/InheritSystemMultiDisksStrategySelector.java
@@ -20,16 +20,22 @@
 package org.apache.iotdb.db.storageengine.load.disk;
 
 import org.apache.iotdb.db.exception.DiskSpaceInsufficientException;
+import org.apache.iotdb.db.exception.load.LoadFileException;
+import org.apache.iotdb.db.storageengine.rescon.disk.FolderManager;
 import org.apache.iotdb.db.storageengine.rescon.disk.TierManager;
 
 import org.apache.tsfile.fileSystem.FSFactoryProducer;
 import org.apache.tsfile.fileSystem.fsFactory.FSFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.util.Collections;
 
 public class InheritSystemMultiDisksStrategySelector implements ILoadDiskSelector {
 
   protected final FSFactory fsFactory = FSFactoryProducer.getFSFactory();
+  private static final Logger logger = LoggerFactory.getLogger(InheritSystemMultiDisksStrategySelector.class);
 
   public InheritSystemMultiDisksStrategySelector() {
     // empty body
@@ -43,16 +49,34 @@ public class InheritSystemMultiDisksStrategySelector implements ILoadDiskSelecto
       long filePartitionId,
       String tsfileName,
       int tierLevel)
-      throws DiskSpaceInsufficientException {
+          throws DiskSpaceInsufficientException, LoadFileException {
     // inherit system multi-disks select strategy, see configuration `dn_multi_dir_strategy`
-    return fsFactory.getFile(
-        TierManager.getInstance().getNextFolderForTsFile(tierLevel, false),
-        databaseName
-            + File.separatorChar
-            + dataRegionId
-            + File.separatorChar
-            + filePartitionId
-            + File.separator
-            + tsfileName);
+    Exception lastException = null;
+    for (int retryTimes = 0; retryTimes <= 1; retryTimes++) {
+      String folder = TierManager.getInstance().getNextFolderForTsFile(tierLevel, false);
+      try {
+        return fsFactory.getFile(folder, databaseName
+                        + File.separatorChar
+                        + dataRegionId
+                        + File.separatorChar
+                        + filePartitionId
+                        + File.separator
+                        + tsfileName);
+      } catch (Exception e) {
+        TierManager.getInstance().getFolderManager(tierLevel, false).updateFolderState(
+                folder, FolderManager.FolderState.ABNORMAL);
+        lastException = e;
+        logger.error(
+                "Failed to get target file [{}] for database={}, region={}, partition={}, tier={} at retry {}: {}",
+                tsfileName, databaseName, dataRegionId, filePartitionId,
+                tierLevel, retryTimes, e.getMessage(), e
+        );
+      }
+    }
+    throw new LoadFileException(
+            String.format("Storage allocation failed for %s/%s/%s (tier %d)",
+                    databaseName, dataRegionId, filePartitionId, tierLevel),
+            lastException
+    );
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/load/disk/MinIOSelector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/load/disk/MinIOSelector.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.DiskSpaceInsufficientException;
+import org.apache.iotdb.db.exception.load.LoadFileException;
 import org.apache.iotdb.metrics.utils.FileStoreUtils;
 
 import org.slf4j.Logger;
@@ -76,7 +77,7 @@ public class MinIOSelector extends InheritSystemMultiDisksStrategySelector {
       long filePartitionId,
       String tsfileName,
       int tierLevel)
-      throws DiskSpaceInsufficientException {
+          throws DiskSpaceInsufficientException, LoadFileException {
     File targetFile;
     String fileDirRoot = null;
     try {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/FolderManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/FolderManager.java
@@ -32,17 +32,40 @@ import org.apache.iotdb.db.storageengine.rescon.disk.strategy.SequenceStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class FolderManager {
   private static final Logger logger = LoggerFactory.getLogger(FolderManager.class);
+  /**
+   * Represents the operational states of a data folder.
+   */
+  public enum FolderState {
+    /**
+     * Indicates the folder is functioning normally with no issues.
+     */
+    HEALTHY,
+    /**
+     * Indicates the folder has operational problems requiring attention.
+     */
+    ABNORMAL
+  }
+
 
   private final List<String> folders;
+  /**
+   * Map storing the state of each folder (HEALTHY/ABNORMAL).
+   * Key: folder path as String
+   * Value: corresponding FolderState enum value
+   */
+  private final Map<String, FolderState> foldersStates = new HashMap<>();
   private final DirectoryStrategy selectStrategy;
 
   public FolderManager(List<String> folders, DirectoryStrategyType type)
       throws DiskSpaceInsufficientException {
     this.folders = folders;
+    folders.forEach(dir -> foldersStates.put(dir, FolderState.HEALTHY));
     switch (type) {
       case SEQUENCE_STRATEGY:
         this.selectStrategy = new SequenceStrategy();
@@ -61,12 +84,18 @@ public class FolderManager {
     }
     try {
       this.selectStrategy.setFolders(folders);
+      this.selectStrategy.setFoldersStates(foldersStates);
     } catch (DiskSpaceInsufficientException e) {
       logger.error("All folders are full, change system mode to read-only.", e);
       CommonDescriptor.getInstance().getConfig().setNodeStatus(NodeStatus.ReadOnly);
       CommonDescriptor.getInstance().getConfig().setStatusReason(NodeStatus.DISK_FULL);
       throw e;
     }
+  }
+
+  public void updateFolderState(String folder, FolderState state) {
+    foldersStates.replace(folder, state);
+    selectStrategy.updateFolderState(folder, state);
   }
 
   public String getNextFolder() throws DiskSpaceInsufficientException {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/TierManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/TierManager.java
@@ -190,6 +190,10 @@ public class TierManager {
         : unSeqTiers.get(tierLevel).getNextFolder();
   }
 
+  public FolderManager getFolderManager(int tierLevel, boolean sequence) {
+    return sequence ? seqTiers.get(tierLevel) : unSeqTiers.get(tierLevel);
+  }
+
   public List<String> getAllFilesFolders() {
     List<String> folders = new ArrayList<>(seqDir2TierLevel.keySet());
     folders.addAll(unSeqDir2TierLevel.keySet());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/strategy/DirectoryStrategy.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/strategy/DirectoryStrategy.java
@@ -23,11 +23,16 @@ import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.utils.JVMCommonUtils;
 import org.apache.iotdb.db.exception.DiskSpaceInsufficientException;
 
+import org.apache.iotdb.db.storageengine.rescon.disk.FolderManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
+import static org.apache.iotdb.db.storageengine.rescon.disk.FolderManager.FolderState.HEALTHY;
 
 /**
  * The basic class of all the strategies of multiple directories. If a user wants to define his own
@@ -61,6 +66,36 @@ public abstract class DirectoryStrategy {
     }
 
     this.folders = folders;
+  }
+
+  /**
+   * Map storing the state of each folder (HEALTHY/ABNORMAL).
+   * Key: folder path as String
+   * Value: corresponding FolderState enum value
+   */
+  Map<String, FolderManager.FolderState> foldersStates = new HashMap<>();
+
+  /**
+   * Replaces the entire folder states mapping with a new one.
+   *
+   * @param foldersStates new mapping of folder paths to their states
+   */
+  public void setFoldersStates(Map<String, FolderManager.FolderState> foldersStates) {
+    this.foldersStates = foldersStates;
+  }
+
+  /**
+   * Updates the state of a specific folder if it exists in the mapping.
+   *
+   * @param folder path of the folder to update
+   * @param state new state to set for the folder
+   */
+  public void updateFolderState(String folder, FolderManager.FolderState state) {
+    foldersStates.replace(folder, state);
+  }
+
+  public boolean isUnavailableFolder(String dir) {
+    return (foldersStates.getOrDefault(dir, HEALTHY) != HEALTHY);
   }
 
   /**

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/strategy/MaxDiskUsableSpaceFirstStrategy.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/strategy/MaxDiskUsableSpaceFirstStrategy.java
@@ -35,6 +35,9 @@ public class MaxDiskUsableSpaceFirstStrategy extends DirectoryStrategy {
 
     for (int i = 0; i < folders.size(); i++) {
       String folder = folders.get(i);
+      if (isUnavailableFolder(folder)) {
+        continue;
+      }
       if (!JVMCommonUtils.hasSpace(folder)) {
         continue;
       }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/strategy/MinFolderOccupiedSpaceFirstStrategy.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/strategy/MinFolderOccupiedSpaceFirstStrategy.java
@@ -36,6 +36,9 @@ public class MinFolderOccupiedSpaceFirstStrategy extends DirectoryStrategy {
 
     for (int i = 0; i < folders.size(); i++) {
       String folder = folders.get(i);
+      if (isUnavailableFolder(folder)) {
+        continue;
+      }
       if (!JVMCommonUtils.hasSpace(folder)) {
         continue;
       }
@@ -45,6 +48,7 @@ public class MinFolderOccupiedSpaceFirstStrategy extends DirectoryStrategy {
         space = JVMCommonUtils.getOccupiedSpace(folder);
       } catch (IOException e) {
         LOGGER.error("Cannot calculate occupied space for path {}.", folder, e);
+        continue;
       }
       if (space < minSpace) {
         minSpace = space;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/strategy/RandomOnDiskUsableSpaceStrategy.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/strategy/RandomOnDiskUsableSpaceStrategy.java
@@ -58,6 +58,10 @@ public class RandomOnDiskUsableSpaceStrategy extends DirectoryStrategy {
     List<Long> spaceList = new ArrayList<>();
     for (int i = 0; i < folders.size(); i++) {
       String folder = folders.get(i);
+      if (isUnavailableFolder(folder)) {
+        spaceList.add(0L);
+        continue;
+      }
       spaceList.add(JVMCommonUtils.getUsableSpace(folder));
     }
     return spaceList;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/strategy/SequenceStrategy.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/strategy/SequenceStrategy.java
@@ -68,10 +68,10 @@ public class SequenceStrategy extends DirectoryStrategy {
         long freeSpace = dirFile.getFreeSpace();
         long totalSpace = dirFile.getTotalSpace();
         LOGGER.warn(
-            "{} is above the warning threshold, free space {}, total space{}",
-            dir,
-            freeSpace,
-            totalSpace);
+                "{} is above the warning threshold, or not accessible, free space {}, total space {}",
+                dir,
+                freeSpace,
+                totalSpace);
         dirLastPrintTimeMap.put(index, System.currentTimeMillis());
       }
       if (index == start) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/strategy/SequenceStrategy.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/strategy/SequenceStrategy.java
@@ -60,7 +60,7 @@ public class SequenceStrategy extends DirectoryStrategy {
   private int tryGetNextIndex(int start) throws DiskSpaceInsufficientException {
     int index = (start + 1) % folders.size();
     String dir = folders.get(index);
-    while (!JVMCommonUtils.hasSpace(dir)) {
+    while (isUnavailableFolder(dir) || !JVMCommonUtils.hasSpace(dir)) {
       File dirFile = FSFactoryProducer.getFSFactory().getFile(dir);
 
       Long lastPrintTime = dirLastPrintTimeMap.computeIfAbsent(index, i -> -1L);

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/receiver/IoTDBFileReceiver.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/receiver/IoTDBFileReceiver.java
@@ -156,47 +156,50 @@ public abstract class IoTDBFileReceiver implements IoTDBReceiver {
       }
     }
 
-    final String receiverFileBaseDir;
-    try {
-      receiverFileBaseDir = getReceiverFileBaseDir();
-      if (Objects.isNull(receiverFileBaseDir)) {
+    String receiverFileBaseDir;
+    File newReceiverDir = null;
+    for (int retryTimes = 0; retryTimes <= 1; retryTimes++) {
+      try {
+        receiverFileBaseDir = getReceiverFileBaseDir();
+        if (Objects.isNull(receiverFileBaseDir)) {
+          LOGGER.warn(
+                  "Receiver id = {}: Failed to init pipe receiver file folder manager because all disks of folders are full.",
+                  receiverId.get());
+          return new TPipeTransferResp(StatusUtils.getStatus(TSStatusCode.DISK_SPACE_INSUFFICIENT));
+        }
+      } catch (Exception e) {
         LOGGER.warn(
-            "Receiver id = {}: Failed to init pipe receiver file folder manager because all disks of folders are full.",
-            receiverId.get());
+                "Receiver id = {}: Failed to create pipe receiver file folder because all disks of folders are full.",
+                receiverId.get(),
+                e);
         return new TPipeTransferResp(StatusUtils.getStatus(TSStatusCode.DISK_SPACE_INSUFFICIENT));
       }
-    } catch (Exception e) {
-      LOGGER.warn(
-          "Receiver id = {}: Failed to create pipe receiver file folder because all disks of folders are full.",
-          receiverId.get(),
-          e);
-      return new TPipeTransferResp(StatusUtils.getStatus(TSStatusCode.DISK_SPACE_INSUFFICIENT));
-    }
 
-    // Create a new receiver file dir
-    final File newReceiverDir = new File(receiverFileBaseDir, Long.toString(receiverId.get()));
-    if (!newReceiverDir.exists() && !newReceiverDir.mkdirs()) {
-      LOGGER.warn(
-          "Receiver id = {}: Failed to create receiver file dir {}.",
-          receiverId.get(),
-          newReceiverDir.getPath());
-      return new TPipeTransferResp(
-          RpcUtils.getStatus(
-              TSStatusCode.PIPE_HANDSHAKE_ERROR,
-              String.format("Failed to create receiver file dir %s.", newReceiverDir.getPath())));
+      try {
+        // Create a new receiver file dir
+        newReceiverDir = new File(receiverFileBaseDir, Long.toString(receiverId.get()));
+        if (newReceiverDir.exists() || newReceiverDir.mkdirs()) {
+          receiverFileDirWithIdSuffix.set(newReceiverDir);
+          LOGGER.info(
+                  "Receiver id = {}: Handshake successfully! Sender's host = {}, port = {}. Receiver's file dir = {}.",
+                  receiverId.get(),
+                  getSenderHost(),
+                  getSenderPort(),
+                  newReceiverDir.getPath());
+          return new TPipeTransferResp(RpcUtils.SUCCESS_STATUS);
+        }
+      } catch (Exception ignored) {
+      }
+      LOGGER.warn("Receiver id = {}: Failed to create receiver file dir {}.", receiverId.get(), newReceiverDir.getPath());
+      markFileBaseDirStateAbnormal(receiverFileBaseDir);
     }
-    receiverFileDirWithIdSuffix.set(newReceiverDir);
-
-    LOGGER.info(
-        "Receiver id = {}: Handshake successfully! Sender's host = {}, port = {}. Receiver's file dir = {}.",
-        receiverId.get(),
-        getSenderHost(),
-        getSenderPort(),
-        newReceiverDir.getPath());
-    return new TPipeTransferResp(RpcUtils.SUCCESS_STATUS);
+    return new TPipeTransferResp(RpcUtils.getStatus(TSStatusCode.PIPE_HANDSHAKE_ERROR,
+            String.format("Failed to create receiver file dir %s.", newReceiverDir.getPath())));
   }
 
   protected abstract String getReceiverFileBaseDir() throws Exception;
+
+  protected abstract void markFileBaseDirStateAbnormal(String dir);
 
   protected abstract String getSenderHost();
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/JVMCommonUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/JVMCommonUtils.java
@@ -65,32 +65,42 @@ public class JVMCommonUtils {
    * @return
    */
   public static long getUsableSpace(String dir) {
-    File dirFile = FSFactoryProducer.getFSFactory().getFile(dir);
-    dirFile.mkdirs();
-    return IOUtils.retryNoException(5, 2000L, dirFile::getFreeSpace, space -> space > 0).orElse(0L);
+    try {
+      File dirFile = FSFactoryProducer.getFSFactory().getFile(dir);
+      dirFile.mkdirs();
+      return IOUtils.retryNoException(5, 2000L, dirFile::getFreeSpace, space -> space > 0).orElse(0L);
+    } catch (Exception e) {
+      LOGGER.error("Unexpected error checking disk space for directory: {}", dir, e);
+      return 0L;
+    }
   }
 
   public static double getDiskFreeRatio(String dir) {
-    File dirFile = FSFactoryProducer.getFSFactory().getFile(dir);
-    if (!dirFile.mkdirs()) {
-      // This may solve getFreeSpace() == 0?
-      dirFile = new File(dir);
+    try {
+      File dirFile = FSFactoryProducer.getFSFactory().getFile(dir);
+      if (!dirFile.mkdirs()) {
+        // This may solve getFreeSpace() == 0?
+        dirFile = new File(dir);
+      }
+      long freeSpace =
+              IOUtils.retryNoException(5, 2000L, dirFile::getFreeSpace, space -> space > 0).orElse(0L);
+      if (freeSpace == 0) {
+        LOGGER.warn("Cannot get free space for {} after retries, please check the disk status", dir);
+      }
+      long totalSpace = dirFile.getTotalSpace();
+      double ratio = 1.0 * freeSpace / totalSpace;
+      if (ratio <= diskSpaceWarningThreshold) {
+        LOGGER.warn(
+                "{} is above the warning threshold, free space {}, total space {}",
+                dir,
+                freeSpace,
+                totalSpace);
+      }
+      return ratio;
+    } catch (Exception e) {
+      LOGGER.error("Unexpected error checking disk space for {}", dir, e);
+      return 0;
     }
-    long freeSpace =
-        IOUtils.retryNoException(5, 2000L, dirFile::getFreeSpace, space -> space > 0).orElse(0L);
-    if (freeSpace == 0) {
-      LOGGER.warn("Cannot get free space for {} after retries, please check the disk status", dir);
-    }
-    long totalSpace = dirFile.getTotalSpace();
-    double ratio = 1.0 * freeSpace / totalSpace;
-    if (ratio <= diskSpaceWarningThreshold) {
-      LOGGER.warn(
-          "{} is above the warning threshold, free space {}, total space {}",
-          dir,
-          freeSpace,
-          totalSpace);
-    }
-    return ratio;
   }
 
   public static boolean hasSpace(String dir) {


### PR DESCRIPTION
## Description  

### Key Changes  
- **Added disk directory failure detection and recovery**:  
  - When a disk directory is found to be inaccessible during initial access, the system now reports the directory as abnormal and automatically attempts to fetch a new available directory.  
  - This resolves the issue of single-disk directory failures in multi-disk environments.  

### Verification  
- **Tested in a 3N3C environment** (refer to [Feishu Doc](https://timechor.feishu.cn/docx/Cgi1dMLhfovBs9xqK0dc1P0VnVe)).  
- **Behavior**:  
  - IoTDB now logs directory access failures (see example logs below) and successfully retries with a healthy directory.  

### Example Log Output  
```plaintext
（Now changed to warning-level logging）2025-06-09 10:13:34,500 [pool-33-IoTDB-DataNodeInternalRPC-Processor-24] ERROR  o.a.i.d.s.d.w.a.AbstractNodeAllocationStrategy:72 - Meet exception when creating wal node 
java.io.FileNotFoundException: /root/apache-iotdb-2.0.4-SNAPSHOT-all-bin/data/datanode/wal3/root.db1.g_0-7/_0.checkpoint (No such file or directory)
        at java.io.FileOutputStream.open0(Native Method)
        at java.io.FileOutputStream.open(FileOutputStream.java:270)
        at java.io.FileOutputStream.<init>(FileOutputStream.java:213)
        at org.apache.iotdb.db.storageengine.dataregion.wal.io.LogWriter.<init>(LogWriter.java:70)
        at org.apache.iotdb.db.storageengine.dataregion.wal.io.CheckpointWriter.<init>(CheckpointWriter.java:30)
        at org.apache.iotdb.db.storageengine.dataregion.wal.checkpoint.CheckpointManager.<init>(CheckpointManager.java:90)
        at org.apache.iotdb.db.storageengine.dataregion.wal.node.WALNode.<init>(WALNode.java:129)
        at org.apache.iotdb.db.storageengine.dataregion.wal.node.WALNode.<init>(WALNode.java:118)
        at org.apache.iotdb.db.storageengine.dataregion.wal.allocation.AbstractNodeAllocationStrategy.createWALNode(AbstractNodeAllocationStrategy.java:70)
        at org.apache.iotdb.db.storageengine.dataregion.wal.allocation.FirstCreateStrategy.applyForWALNode(FirstCreateStrategy.java:56)
        at org.apache.iotdb.db.storageengine.dataregion.wal.WALManager.applyForWALNode(WALManager.java:100)
        at org.apache.iotdb.db.storageengine.dataregion.DataRegion.getWALNode(DataRegion.java:3840)
        at org.apache.iotdb.db.consensus.statemachine.dataregion.DataRegionStateMachine.read(DataRegionStateMachine.java:242)
        at org.apache.iotdb.consensus.iot.IoTConsensusServerImpl.<init>(IoTConsensusServerImpl.java:150)
        at org.apache.iotdb.consensus.iot.IoTConsensus.lambda$createLocalPeer$8(IoTConsensus.java:286)
        at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1660)
        at org.apache.iotdb.consensus.iot.IoTConsensus.createLocalPeer(IoTConsensus.java:269)
        at org.apache.iotdb.db.protocol.thrift.impl.DataNodeRegionManager.createDataRegion(DataNodeRegionManager.java:157)
        at org.apache.iotdb.db.protocol.thrift.impl.DataNodeInternalRPCServiceImpl.createDataRegion(DataNodeInternalRPCServiceImpl.java:562)
        at org.apache.iotdb.mpp.rpc.thrift.IDataNodeRPCService$Processor$createDataRegion.getResult(IDataNodeRPCService.java:6511)
        at org.apache.iotdb.mpp.rpc.thrift.IDataNodeRPCService$Processor$createDataRegion.getResult(IDataNodeRPCService.java:6491)
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38)
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:38)
        at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:248)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
2025-06-09 10:13:34,735 [pool-33-IoTDB-DataNodeInternalRPC-Processor-12] WARN  o.a.i.d.s.d.t.g.TsFileNameGenerator:120 - Failed to process folder [tierLevel=0, sequence=true, baseDir=/root/apache-iotdb-2.0.4-SNAPSHOT-all-bin/data/datanode/data3/sequence], state set to ABNORMAL 
2025-06-09 10:13:34,735 [pool-33-IoTDB-DataNodeInternalRPC-Processor-13] WARN  o.a.i.d.s.d.t.g.TsFileNameGenerator:120 - Failed to process folder [tierLevel=0, sequence=true, baseDir=/root/apache-iotdb-2.0.4-SNAPSHOT-all-bin/data/datanode/data3/sequence], state set to ABNORMAL 
2025-06-09 10:13:34,735 [pool-33-IoTDB-DataNodeInternalRPC-Processor-7] WARN  o.a.i.d.s.d.t.g.TsFileNameGenerator:120 - Failed to process folder [tierLevel=0, sequence=true, baseDir=/root/apache-iotdb-2.0.4-SNAPSHOT-all-bin/data/datanode/data3/sequence], state set to ABNORMAL 
（​Now adjusted to: {} is above the warning threshold, or not accessible, free space {}, total space {}）2025-06-09 10:13:35,215 [pool-24-IoTDB-IoTConsensusRPC-Processor-2] WARN  o.a.i.d.s.r.d.s.SequenceStrategy:70 - /root/apache-iotdb-2.0.4-SNAPSHOT-all-bin/data/datanode/data3/sequence is above the warning threshold, free space 118933000192, total space243640324096 
2025-06-09 10:13:55,833 [pool-24-IoTDB-IoTConsensusRPC-Processor-7] WARN  o.a.i.d.s.d.t.g.TsFileNameGenerator:120 - Failed to process folder [tierLevel=0, sequence=false, baseDir=/root/apache-iotdb-2.0.4-SNAPSHOT-all-bin/data/datanode/data3/unsequence], state set to ABNORMAL
```  

---  

### Key Changed Classes/Packages  
- `FolderManager` (core logic for directory failover)  
- Also includes the relevant code that calls `org.apache.iotdb.db.storageengine.rescon.disk.FolderManager#getNextFolder`

---  