### PR TITLE
Improve argument validation for approx_most_frequent function

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBTableAggregationIT.java
@@ -4262,7 +4262,15 @@ public class IoTDBTableAggregationIT {
         DATABASE_NAME);
     tableAssertTestFail(
         "select approx_most_frequent(province, 'test', 100) from table1",
-        "701: The second and third argument of 'approx_most_frequent' function must be numeric literal",
+        "701: The second and third argument of 'approx_most_frequent' function must be positive integer literal",
+        DATABASE_NAME);
+    tableAssertTestFail(
+        "select approx_most_frequent(province, 1.5, 100) from table1",
+        "701: The second and third argument of 'approx_most_frequent' function must be positive integer literal",
+        DATABASE_NAME);
+    tableAssertTestFail(
+        "select approx_most_frequent() from table1",
+        "701: Aggregation functions [approx_most_frequent] should only have three arguments",
         DATABASE_NAME);
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/parser/AstBuilder.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/parser/AstBuilder.java
@@ -3264,17 +3264,15 @@ public class AstBuilder extends RelationalSqlBaseVisitor<Node> {
             "The second argument of 'approx_count_distinct' function must be a literal");
       }
     } else if (name.toString().equalsIgnoreCase(APPROX_MOST_FREQUENT)) {
-      if (!isNumericLiteral(arguments.get(1)) || !isNumericLiteral(arguments.get(2))) {
+      if (arguments.size() == 3
+          && (!(arguments.get(1) instanceof LongLiteral)
+              || !(arguments.get(2) instanceof LongLiteral))) {
         throw new SemanticException(
-            "The second and third argument of 'approx_most_frequent' function must be numeric literal");
+            "The second and third argument of 'approx_most_frequent' function must be positive integer literal");
       }
     }
 
     return new FunctionCall(getLocation(ctx), name, window, nulls, distinct, mode, arguments);
-  }
-
-  public boolean isNumericLiteral(Expression expression) {
-    return expression instanceof LongLiteral || expression instanceof DoubleLiteral;
   }
 
   @Override


### PR DESCRIPTION
This pull request refines the validation logic for the `approx_most_frequent` function in the SQL parser. The primary change ensures that the second and third arguments are explicitly validated as positive integer literals, improving clarity and correctness.

### Validation improvements for function arguments:
* In `AstBuilder.java`, updated the validation logic for the `approx_most_frequent` function to check that the second and third arguments are positive integer literals (`LongLiteral`) when three arguments are provided. This replaces the previous generic numeric literal check.

* Removed the `isNumericLiteral` helper method, as it is no longer used following the updated validation logic.