### PR TITLE
[IoTConsensus] More accurate statistics on IoTConsensus memory management 

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/LogDispatcher.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/LogDispatcher.java
@@ -567,7 +567,8 @@ public class LogDispatcher {
         data.buildSerializedRequests();
         // construct request from wal
         logBatches.addTLogEntry(
-            new TLogEntry(data.getSerializedRequests(), data.getSearchIndex(), true));
+            new TLogEntry(
+                data.getSerializedRequests(), data.getSearchIndex(), true, data.getMemorySize()));
       }
       // In the case of corrupt Data, we return true so that we can send a batch as soon as
       // possible, avoiding potential duplication
@@ -577,7 +578,11 @@ public class LogDispatcher {
     private void constructBatchIndexedFromConsensusRequest(
         IndexedConsensusRequest request, Batch logBatches) {
       logBatches.addTLogEntry(
-          new TLogEntry(request.getSerializedRequests(), request.getSearchIndex(), false));
+          new TLogEntry(
+              request.getSerializedRequests(),
+              request.getSearchIndex(),
+              false,
+              request.getMemorySize()));
     }
   }
 }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/SyncStatus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/logdispatcher/SyncStatus.java
@@ -45,7 +45,7 @@ public class SyncStatus {
    */
   public synchronized void addNextBatch(Batch batch) throws InterruptedException {
     while (pendingBatches.size() >= config.getReplication().getMaxPendingBatchesNum()
-        || !iotConsensusMemoryManager.reserve(batch.getSerializedSize(), false)) {
+        || !iotConsensusMemoryManager.reserve(batch.getMemorySize(), false)) {
       wait();
     }
     pendingBatches.add(batch);
@@ -64,7 +64,7 @@ public class SyncStatus {
       while (current.isSynced()) {
         controller.update(current.getEndIndex(), false);
         iterator.remove();
-        iotConsensusMemoryManager.free(current.getSerializedSize(), false);
+        iotConsensusMemoryManager.free(current.getMemorySize(), false);
         if (iterator.hasNext()) {
           current = iterator.next();
         } else {
@@ -79,7 +79,7 @@ public class SyncStatus {
   public synchronized void free() {
     long size = 0;
     for (Batch pendingBatch : pendingBatches) {
-      size += pendingBatch.getSerializedSize();
+      size += pendingBatch.getMemorySize();
     }
     pendingBatches.clear();
     controller.update(0L, true);

--- a/iotdb-protocol/thrift-consensus/src/main/thrift/iotconsensus.thrift
+++ b/iotdb-protocol/thrift-consensus/src/main/thrift/iotconsensus.thrift
@@ -26,6 +26,7 @@ struct TLogEntry {
   1: required list<binary> data
   2: required i64 searchIndex
   3: required bool fromWAL
+  4: required i64 memorySize
 }
 
 struct TSyncLogEntriesReq {


### PR DESCRIPTION
## Description

The actual memory occupied by IoTConsensus is 2-3 times larger than the statistical memory of memory management, so more detailed statistics of consensus memory are needed.

As shown in the figure, the statistical result of using getMemorySize is about twice the size of buffer, which makes the result more accurate.

<img width="1183" alt="image" src="https://github.com/user-attachments/assets/52f2fb50-89ac-4646-b1a6-4b90a9389120" />

