### PR TITLE
Using join to query views of non-aligned series may throw NullPointerException

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/view/recent/IoTDBTableViewQueryIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/view/recent/IoTDBTableViewQueryIT.java
@@ -351,6 +351,11 @@ public class IoTDBTableViewQueryIT {
           "select * from (select time, battery as device1 from view1 where battery = 'b1') as t1 full outer join (select time, battery as device2 from view2 where battery = 'b') as t2 using(time)",
           "select * from (select time, battery as device1 from table1 where battery = 'b1') as t1 full outer join (select time, battery as device2 from table1 where battery = 'b') as t2 using(time)",
           true);
+      compareQueryResults(
+          session,
+          "select * from (select * from view1 where battery = 'b1') join (select * from view1 where battery = 'b1' and (voltage > 0 or current > 0)) using(time)",
+          "select * from (select * from table1 where battery = 'b1') join (select * from table1 where battery = 'b1' and (voltage > 0 or current > 0)) using(time)",
+          true);
     }
   }
 


### PR DESCRIPTION
## Description
Using join to query views of non-aligned series may throw NullPointerException
```
2025-06-04 17:35:38,451 [pool-33-IoTDB-DataNodeInternalRPC-Processor-128$20250604_093526_10262_6.6.0] WARN  o.a.i.d.q.e.f.FragmentInstanceManager:202 - error when create FragmentInstanceExecution.
java.lang.NullPointerException: Cannot invoke "java.util.List.get(int)" because the return value of "java.util.Map.get(Object)" is null
        at org.apache.iotdb.db.queryengine.execution.relational.ColumnTransformerBuilder.lambda$visitSymbolReference$17(ColumnTransformerBuilder.java:1280)
        at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1220)
        at org.apache.iotdb.db.queryengine.execution.relational.ColumnTransformerBuilder.visitSymbolReference(ColumnTransformerBuilder.java:1276)
        at org.apache.iotdb.db.queryengine.execution.relational.ColumnTransformerBuilder.visitSymbolReference(ColumnTransformerBuilder.java:204)
        at org.apache.iotdb.db.queryengine.plan.relational.sql.ast.SymbolReference.accept(SymbolReference.java:46)
        at org.apache.iotdb.db.queryengine.plan.relational.sql.ast.AstVisitor.process(AstVisitor.java:33)
        at org.apache.iotdb.db.queryengine.plan.planner.TableOperatorGenerator.constructFilterAndProjectOperator(TableOperatorGenerator.java:1296)
        at org.apache.iotdb.db.queryengine.plan.planner.TableOperatorGenerator.access$100(TableOperatorGenerator.java:331)
        at org.apache.iotdb.db.queryengine.plan.planner.TableOperatorGenerator$1.getFilterAndProjectOperator(TableOperatorGenerator.java:825)
        at org.apache.iotdb.db.queryengine.plan.planner.TableOperatorGenerator$1.generateCurrentDeviceOperatorTree(TableOperatorGenerator.java:552)
        at org.apache.iotdb.db.queryengine.execution.operator.source.relational.DeviceIteratorScanOperator.constructCurrentDeviceOperatorTree(DeviceIteratorScanOperator.java:117)
        at org.apache.iotdb.db.queryengine.execution.operator.source.relational.DeviceIteratorScanOperator.<init>(DeviceIteratorScanOperator.java:68)
        at org.apache.iotdb.db.queryengine.plan.planner.TableOperatorGenerator.visitTreeNonAlignedDeviceViewScan(TableOperatorGenerator.java:470)
        at org.apache.iotdb.db.queryengine.plan.planner.TableOperatorGenerator.visitTreeNonAlignedDeviceViewScan(TableOperatorGenerator.java:331)
        at org.apache.iotdb.db.queryengine.plan.relational.planner.node.TreeNonAlignedDeviceViewScanNode.accept(TreeNonAlignedDeviceViewScanNode.java:78)
        at org.apache.iotdb.db.queryengine.plan.planner.TableOperatorGenerator.visitIdentitySink(TableOperatorGenerator.java:374)
        at org.apache.iotdb.db.queryengine.plan.planner.TableOperatorGenerator.visitIdentitySink(TableOperatorGenerator.java:331)
        at org.apache.iotdb.db.queryengine.plan.planner.plan.node.sink.IdentitySinkNode.accept(IdentitySinkNode.java:75)
        at org.apache.iotdb.db.queryengine.plan.planner.LocalExecutionPlanner.generateOperator(LocalExecutionPlanner.java:185)
        at org.apache.iotdb.db.queryengine.plan.planner.LocalExecutionPlanner.plan(LocalExecutionPlanner.java:112)
        at org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceManager.lambda$execDataQueryFragmentInstance$3(FragmentInstanceManager.java:162)
        at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708)
        at org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceManager.execDataQueryFragmentInstance(FragmentInstanceManager.java:138)
        at org.apache.iotdb.db.consensus.statemachine.dataregion.DataRegionStateMachine.read(DataRegionStateMachine.java:251)
        at org.apache.iotdb.consensus.iot.IoTConsensusServerImpl.read(IoTConsensusServerImpl.java:258)
        at org.apache.iotdb.consensus.iot.IoTConsensus.read(IoTConsensus.java:253)
        at org.apache.iotdb.db.queryengine.execution.executor.RegionReadExecutor.execute(RegionReadExecutor.java:84)
        at org.apache.iotdb.db.protocol.thrift.impl.DataNodeInternalRPCServiceImpl.sendFragmentInstance(DataNodeInternalRPCServiceImpl.java:422)
        at org.apache.iotdb.mpp.rpc.thrift.IDataNodeRPCService$Processor$sendFragmentInstance.getResult(IDataNodeRPCService.java:6364)
        at org.apache.iotdb.mpp.rpc.thrift.IDataNodeRPCService$Processor$sendFragmentInstance.getResult(IDataNodeRPCService.java:6344)
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38)
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:38)
        at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:248)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
```