### PR TITLE
Fix timeout didn't pass to client bug

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceManager.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.commons.concurrent.threadpool.ScheduledExecutorUtil;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.exception.IoTDBException;
 import org.apache.iotdb.commons.exception.IoTDBRuntimeException;
+import org.apache.iotdb.commons.exception.QueryTimeoutException;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.queryengine.common.FragmentInstanceId;
 import org.apache.iotdb.db.queryengine.common.QueryId;
@@ -55,7 +56,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static java.util.Objects.requireNonNull;
@@ -412,8 +412,10 @@ public class FragmentInstanceManager {
             execution
                 .getStateMachine()
                 .failed(
-                    new TimeoutException(
-                        "Query has executed more than " + execution.getTimeoutInMs() + "ms"));
+                    new QueryTimeoutException(
+                        "Query has executed more than "
+                            + execution.getTimeoutInMs()
+                            + "ms, and now is in flushing state"));
           }
         });
   }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/exception/QueryTimeoutException.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/exception/QueryTimeoutException.java
@@ -27,4 +27,8 @@ public class QueryTimeoutException extends IoTDBRuntimeException {
   public QueryTimeoutException() {
     super("Query execution is time out", QUERY_TIMEOUT.getStatusCode(), true);
   }
+
+  public QueryTimeoutException(String message) {
+    super(message, QUERY_TIMEOUT.getStatusCode(), true);
+  }
 }


### PR DESCRIPTION
Sometimes, TimeoutException may be throw to client, it may mislead client to thinking that there is no more data in this query which may cause data missing.

The underlying bug is that `isFinished` method in LocalSourceHandle won't check the abort state, it will cause that return finished instead of throwing exception because if it's in aborted state, finished condition will also return true.