### PR TITLE
Subscription: return immediately when unsubscribe empty complete topics

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/receiver/SubscriptionReceiverV1.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/receiver/SubscriptionReceiverV1.java
@@ -705,6 +705,12 @@ public class SubscriptionReceiverV1 implements SubscriptionReceiver {
     final List<String> topicNamesToUnsubscribe =
         SubscriptionAgent.broker().fetchTopicNamesToUnsubscribe(consumerConfig, topics.keySet());
 
+    // If it is empty, it could be that the consumer has been closed, or there are no completed
+    // topics. In this case, it should immediately return.
+    if (topicNamesToUnsubscribe.isEmpty()) {
+      return;
+    }
+
     unsubscribe(consumerConfig, new HashSet<>(topicNamesToUnsubscribe));
     LOGGER.info(
         "Subscription: consumer {} unsubscribe {} (completed topics) successfully",


### PR DESCRIPTION
As title.

Fix https://github.com/apache/iotdb/actions/runs/15676401234/job/44157650384?pr=15726:

```text
2025-06-16 17:54:25,997 [pool-33-IoTDB-ClientRPC-Processor-2] ERROR o.a.i.c.c.t.WrappedThreadPoolExecutor:132 - Exception in thread pool org.apache.iotdb.threadpool:type=ClientRPC-Processor 
org.apache.iotdb.rpc.subscription.exception.SubscriptionException: Subscription: Failed to unsubscribe topics [] for consumer {consumer-id=device_accurate_dataset_push_snapshot, group-id=loose_range_all, password=******, sql-dialect=tree, username=root} in config node, status is TSStatus(code:1908, message:ProcedureId 34: Fail to DROP_SUBSCRIPTION because Failed to unsubscribe because the consumer device_accurate_dataset_push_snapshot in consumer group loose_range_all does not exist).
	at org.apache.iotdb.db.subscription.receiver.SubscriptionReceiverV1.unsubscribe(SubscriptionReceiverV1.java:845)
	at org.apache.iotdb.db.subscription.receiver.SubscriptionReceiverV1.unsubscribeCompleteTopics(SubscriptionReceiverV1.java:708)
	at org.apache.iotdb.db.subscription.receiver.SubscriptionReceiverV1.handleExit(SubscriptionReceiverV1.java:171)
	at org.apache.iotdb.db.subscription.agent.SubscriptionReceiverAgent.handleClientExit(SubscriptionReceiverAgent.java:117)
	at org.apache.iotdb.db.protocol.thrift.impl.ClientRPCServiceImpl.handleClientExit(ClientRPCServiceImpl.java:3188)
	at org.apache.iotdb.db.protocol.thrift.handler.RPCServiceThriftHandler.deleteContext(RPCServiceThriftHandler.java:51)
	at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:262)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
2025-06-16 17:54:26,001 [pool-33-IoTDB-ClientRPC-Processor-2] ERROR o.a.i.c.c.IoTDBDefaultThreadExceptionHandler:31 - Exception in thread pool-33-IoTDB-ClientRPC-Processor-2-182 
org.apache.iotdb.rpc.subscription.exception.SubscriptionException: Subscription: Failed to unsubscribe topics [] for consumer {consumer-id=device_accurate_dataset_push_snapshot, group-id=loose_range_all, password=******, sql-dialect=tree, username=root} in config node, status is TSStatus(code:1908, message:ProcedureId 34: Fail to DROP_SUBSCRIPTION because Failed to unsubscribe because the consumer device_accurate_dataset_push_snapshot in consumer group loose_range_all does not exist).
	at org.apache.iotdb.db.subscription.receiver.SubscriptionReceiverV1.unsubscribe(SubscriptionReceiverV1.java:845)
	at org.apache.iotdb.db.subscription.receiver.SubscriptionReceiverV1.unsubscribeCompleteTopics(SubscriptionReceiverV1.java:708)
	at org.apache.iotdb.db.subscription.receiver.SubscriptionReceiverV1.handleExit(SubscriptionReceiverV1.java:171)
	at org.apache.iotdb.db.subscription.agent.SubscriptionReceiverAgent.handleClientExit(SubscriptionReceiverAgent.java:117)
	at org.apache.iotdb.db.protocol.thrift.impl.ClientRPCServiceImpl.handleClientExit(ClientRPCServiceImpl.java:3188)
	at org.apache.iotdb.db.protocol.thrift.handler.RPCServiceThriftHandler.deleteContext(RPCServiceThriftHandler.java:51)
	at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:262)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
```