### PR TITLE
Prevent the contents of log_datanode_sample_query.log and log_explain_ananlyze.log from being output to log_datanode_all.log

### DIFF
--- a/iotdb-core/datanode/src/assembly/resources/conf/logback-datanode.xml
+++ b/iotdb-core/datanode/src/assembly/resources/conf/logback-datanode.xml
@@ -257,7 +257,7 @@
     <logger level="info" name="QUERY_DEBUG">
         <appender-ref ref="QUERY_DEBUG"/>
     </logger>
-    <logger level="info" name="SLOW_SQL">
+    <logger level="info" name="SLOW_SQL" additivity="false">
         <appender-ref ref="SLOW_SQL"/>
     </logger>
     <logger level="info" name="SAMPLED_QUERIES" additivity="false">


### PR DESCRIPTION
## Description
Prevent the contents of log_datanode_sample_query.log and log_explain_ananlyze.log from being output to log_datanode_all.log