### PR TITLE
Resolve IndexOutOfPartitionBound and symbol not found in window functions.

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBWindowFunctionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBWindowFunctionIT.java
@@ -72,6 +72,21 @@ public class IoTDBWindowFunctionIT {
         "FLUSH",
         "CLEAR ATTRIBUTE CACHE",
       };
+  private static final String[] normalSqls =
+      new String[] {
+        "create table demo3 (Device string tag, t2 string tag, t3 string tag, a1 string attribute, Flow int64 field, f2 int32 field, f3 double field,f4 float field, date date field, timestamp timestamp field, string string field)",
+        "insert into demo3 values (1970-01-01T08:00:00.000+08:00, 'd0', 'd0', 'd0', 'd0', 3, 3, 3.0, 3.0, '1970-01-01', 3, '3')",
+        "insert into demo3 values (1970-01-01T08:00:00.001+08:00, 'd0', 'd0', 'd0', 'd0', 5, 5, 5.0, 5.0, '1970-01-01', 5, '5')",
+        "insert into demo3 values (1970-01-01T08:00:00.002+08:00, 'd0', 'd0', 'd0', 'd0', 3, 3, 3.0, 3.0, '1970-01-01', 3, '3')",
+        "insert into demo3 values (1970-01-01T08:00:00.003+08:00, 'd0', 'd0', 'd0', 'd0', 1, 1, 1.0, 1.0, '1970-01-01', 1, '1')",
+        "insert into demo3 values (1970-01-01T08:00:00.004+08:00, 'd0', 'd0', 'd0', 'd0', null, null, null, null, null, null, null)",
+        "FLUSH",
+        "insert into demo3 values (1970-01-01T08:00:00.005+08:00, 'd1', 'd1', 'd1', 'd1', 2, 2, 2.0, 2.0, '1970-01-01', 2, '2')",
+        "insert into demo3 values (1970-01-01T08:00:00.006+08:00, 'd1', 'd1', 'd1', 'd1', null, null, null, null, null, null, null)",
+        "insert into demo3 values (1970-01-01T08:00:00.007+08:00, 'd1', 'd1', 'd1', 'd1', 4, 4, 4.0, 4.0, '1970-01-01', 4, '4')",
+        "insert into demo3 values (1970-01-01T08:00:00.008+08:00,  null, null, null, null, null, null, null, null, null, null, null)",
+        "CLEAR ATTRIBUTE CACHE",
+      };
 
   private static void insertData() {
     try (Connection connection = EnvFactory.getEnv().getTableConnection();
@@ -80,6 +95,9 @@ public class IoTDBWindowFunctionIT {
         statement.execute(sql);
       }
       for (String sql : sqlsWithNulls) {
+        statement.execute(sql);
+      }
+      for (String sql : normalSqls) {
         statement.execute(sql);
       }
     } catch (Exception e) {
@@ -574,6 +592,51 @@ public class IoTDBWindowFunctionIT {
     tableAssertTestFail(
         "SELECT *, count(value) OVER (PARTITION BY device ORDER BY time GROUPS BETWEEN 1 PRECEDING AND -1 FOLLOWING) AS cnt FROM demo",
         "Window frame offset value must not be negative or null",
+        DATABASE_NAME);
+  }
+
+  @Test
+  public void testMultiPartitions() {
+    String[] expectedHeader = new String[] {"time", "device", "flow", "cnt"};
+    String[] retArray =
+        new String[] {
+          "1970-01-01T00:00:00.000Z,d0,3,4,",
+          "1970-01-01T00:00:00.001Z,d0,5,4,",
+          "1970-01-01T00:00:00.002Z,d0,3,4,",
+          "1970-01-01T00:00:00.003Z,d0,1,4,",
+          "1970-01-01T00:00:00.004Z,d0,null,4,",
+          "1970-01-01T00:00:00.005Z,d1,2,2,",
+          "1970-01-01T00:00:00.006Z,d1,null,2,",
+          "1970-01-01T00:00:00.007Z,d1,4,2,",
+          "1970-01-01T00:00:00.008Z,null,null,0,",
+        };
+    tableResultSetEqualTest(
+        "SELECT time, device, flow, count(flow) OVER(PARTITION BY device ORDER BY flow ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS cnt FROM demo3 ORDER BY time",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+  }
+
+  @Test
+  public void testComplexQuery() {
+    String[] expectedHeader = new String[] {"flow", "_col1"};
+    String[] retArray =
+        new String[] {
+          "1,null,",
+          "3,1970-01-01T00:00:00.003Z,",
+          "5,1970-01-01T00:00:00.002Z,",
+          "null,1970-01-01T00:00:00.001Z,",
+        };
+    tableResultSetEqualTest(
+        " SELECT flow, \n"
+            + "           lag(last(time)) OVER (order by flow)\n"
+            + "    FROM VARIATION(\n"
+            + "        DATA => (SELECT time, flow FROM demo3 WHERE device = 'd0'),\n"
+            + "        COL => 'flow',\n"
+            + "        DELTA => 0.0)\n"
+            + "    GROUP BY flow",
+        expectedHeader,
+        retArray,
         DATABASE_NAME);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/window/TableWindowOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/window/TableWindowOperator.java
@@ -99,8 +99,8 @@ public class TableWindowOperator implements ProcessOperator {
     this.tsBlockBuilder = new TsBlockBuilder(outputDataTypes);
 
     // Basic information part
-    this.windowFunctions = windowFunctions;
-    this.frameInfoList = frameInfoList;
+    this.windowFunctions = ImmutableList.copyOf(windowFunctions);
+    this.frameInfoList = ImmutableList.copyOf(frameInfoList);
 
     // Partition Part
     this.partitionChannels = ImmutableList.copyOf(partitionChannels);
@@ -313,6 +313,8 @@ public class TableWindowOperator implements ProcessOperator {
   private TsBlock transform(long startTime) {
     while (!cachedPartitionExecutors.isEmpty()) {
       PartitionExecutor partitionExecutor = cachedPartitionExecutors.getFirst();
+      // Reset window functions for new partition
+      partitionExecutor.resetWindowFunctions();
 
       while (System.nanoTime() - startTime < maxRuntime
           && !tsBlockBuilder.isFull()

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/window/partition/PartitionExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/window/partition/PartitionExecutor.java
@@ -88,11 +88,6 @@ public final class PartitionExecutor {
     peerGroupComparator = new RowComparator(sortDataTypes);
     sortedColumns = partition.getSortedColumnList(sortChannels);
 
-    // Reset functions for new partition
-    for (WindowFunction windowFunction : windowFunctions) {
-      windowFunction.reset();
-    }
-
     currentPosition = partitionStart;
     needPeerGroup =
         windowFunctions.stream().anyMatch(WindowFunction::needPeerGroup)
@@ -196,6 +191,12 @@ public final class PartitionExecutor {
         && peerGroupComparator.equalColumnLists(
             sortedColumns, peerGroupStart - partitionStart, peerGroupEnd - partitionStart)) {
       peerGroupEnd++;
+    }
+  }
+
+  public void resetWindowFunctions() {
+    for (WindowFunction windowFunction : windowFunctions) {
+      windowFunction.reset();
     }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/optimizations/SymbolMapper.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/optimizations/SymbolMapper.java
@@ -268,13 +268,13 @@ public class SymbolMapper {
         node.getSpecification().getPartitionBy().stream().map(this::map).collect(toImmutableList());
     Optional<OrderingScheme> newOrderingScheme =
         node.getSpecification().getOrderingScheme().map(this::map);
-    DataOrganizationSpecification specification =
+    DataOrganizationSpecification newSpecification =
         new DataOrganizationSpecification(newPartitionBy, newOrderingScheme);
 
     return new WindowNode(
         node.getPlanNodeId(),
         source,
-        specification,
+        newSpecification,
         newFunctions.buildOrThrow(),
         node.getHashSymbol().map(this::map),
         node.getPrePartitionedInputs().stream().map(this::map).collect(toImmutableSet()),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/optimizations/SymbolMapper.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/optimizations/SymbolMapper.java
@@ -51,6 +51,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -263,10 +264,14 @@ public class SymbolMapper {
                       function.isIgnoreNulls()));
             });
 
+    ImmutableList<Symbol> newPartitionBy = node.getSpecification().getPartitionBy().stream().map(this::map).collect(toImmutableList());
+    Optional<OrderingScheme> newOrderingScheme = node.getSpecification().getOrderingScheme().map(this::map);
+    DataOrganizationSpecification specification = new DataOrganizationSpecification(newPartitionBy, newOrderingScheme);
+
     return new WindowNode(
         node.getPlanNodeId(),
         source,
-        node.getSpecification(),
+        specification,
         newFunctions.buildOrThrow(),
         node.getHashSymbol().map(this::map),
         node.getPrePartitionedInputs().stream().map(this::map).collect(toImmutableSet()),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/optimizations/SymbolMapper.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/optimizations/SymbolMapper.java
@@ -264,9 +264,12 @@ public class SymbolMapper {
                       function.isIgnoreNulls()));
             });
 
-    ImmutableList<Symbol> newPartitionBy = node.getSpecification().getPartitionBy().stream().map(this::map).collect(toImmutableList());
-    Optional<OrderingScheme> newOrderingScheme = node.getSpecification().getOrderingScheme().map(this::map);
-    DataOrganizationSpecification specification = new DataOrganizationSpecification(newPartitionBy, newOrderingScheme);
+    ImmutableList<Symbol> newPartitionBy =
+        node.getSpecification().getPartitionBy().stream().map(this::map).collect(toImmutableList());
+    Optional<OrderingScheme> newOrderingScheme =
+        node.getSpecification().getOrderingScheme().map(this::map);
+    DataOrganizationSpecification specification =
+        new DataOrganizationSpecification(newPartitionBy, newOrderingScheme);
 
     return new WindowNode(
         node.getPlanNodeId(),


### PR DESCRIPTION
## Description

This PR fix two bugs in window function:
- *Index out of partition bound*: this is caused by multiple partitions sharing the same window function instance, as well as their frames states. For efficiency purpose, frames do not re-caclulate for each iteration. They may remove some data if the frame shrinks, which may cause IndexOutOfPartitionBoundError.
- *Symbol not found*: window functions need OrderBy channels. The OrderBy symbols are added at QueryPlan stage, and would be looked up their channel by child operator's outputs' layout in OperatorGenerate stage. However, the symbols generate by child operator would be optimized by UnaliasSymbolReferences pass, and the window functions do not optimized their symbols in this pass.
