### PR TITLE
[AINode] Fix built-in model inference & support user parameters

### DIFF
--- a/iotdb-core/ainode/ainode/core/manager/model_manager.py
+++ b/iotdb-core/ainode/ainode/core/manager/model_manager.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-from typing import Callable
+from typing import Callable, Dict
 
 from torch import nn
 from yaml import YAMLError
@@ -97,13 +97,17 @@ class ModelManager:
             logger.warning(e)
             return get_status(TSStatusCode.AINODE_INTERNAL_ERROR, str(e))
 
-    def load_model(self, model_id: str, acceleration: bool = False) -> Callable:
+    def load_model(
+        self, model_id: str, inference_attrs: Dict[str, str], acceleration: bool = False
+    ) -> Callable:
         """
         Load the model with the given model_id.
         """
         logger.info(f"Load model {model_id}")
         try:
-            model = self.model_storage.load_model(model_id, acceleration)
+            model = self.model_storage.load_model(
+                model_id, inference_attrs, acceleration
+            )
             logger.info(f"Model {model_id} loaded")
             return model
         except Exception as e:

--- a/iotdb-core/ainode/ainode/core/model/built_in_model_factory.py
+++ b/iotdb-core/ainode/ainode/core/model/built_in_model_factory.py
@@ -123,7 +123,9 @@ def get_model_attributes(model_type: BuiltInModelType):
     return attribute_map
 
 
-def fetch_built_in_model(model_type: BuiltInModelType, model_dir) -> Callable:
+def fetch_built_in_model(
+    model_type: BuiltInModelType, model_dir, inference_attrs: Dict[str, str]
+) -> Callable:
     """
     Fetch the built-in model according to its id and directory, not that this directory only contains model weights and config.
     Args:
@@ -132,7 +134,9 @@ def fetch_built_in_model(model_type: BuiltInModelType, model_dir) -> Callable:
     Returns:
         model: the built-in model
     """
-    attributes = get_model_attributes(model_type)
+    default_attributes = get_model_attributes(model_type)
+    # parse the attributes from inference_attrs
+    attributes = parse_attribute(inference_attrs, default_attributes)
 
     # build the built-in model
     if model_type == BuiltInModelType.ARIMA:

--- a/iotdb-core/ainode/ainode/core/model/model_storage.py
+++ b/iotdb-core/ainode/ainode/core/model/model_storage.py
@@ -262,7 +262,9 @@ class ModelStorage(object):
             or self._model_info_map[model_id].category == ModelCategory.FINE_TUNED
         )
 
-    def load_model(self, model_id: str, acceleration: bool) -> Callable:
+    def load_model(
+        self, model_id: str, inference_attrs: Dict[str, str], acceleration: bool
+    ) -> Callable:
         """
         Load a model with automatic detection of .safetensors or .pt format
 
@@ -275,6 +277,7 @@ class ModelStorage(object):
                 return fetch_built_in_model(
                     get_built_in_model_type(self._model_info_map[model_id].model_type),
                     model_dir,
+                    inference_attrs,
                 )
             else:
                 # load the user-defined model


### PR DESCRIPTION
## Description

Fix built-in model inference & support user parameters

+ Fix bug where built-in models could not be invoked via call inference(...).

+ Support user-specified parameters (e.g. k=5, order="(1,1,0)") in inference calls.

+ Improve attribute parsing and error logging.
![1](https://github.com/user-attachments/assets/53b98976-7ccb-4f34-840c-7e510ba07591)
