### PR TITLE
[AINode] IoTDBTreeModelDataset bug fix

### DIFF
--- a/iotdb-core/ainode/ainode/core/ingress/iotdb.py
+++ b/iotdb-core/ainode/ainode/core/ingress/iotdb.py
@@ -223,6 +223,7 @@ class IoTDBTreeModelDataset(BasicDatabaseForecastDataset):
             + self.seq_len
             + self.output_token_len
         ]
+        result = torch.tensor(result)
         return (
             result[0 : self.seq_len],
             result[self.input_token_len : self.seq_len + self.output_token_len],


### PR DESCRIPTION
Fix a small bug that the tree model dataset does not convert the result into torch.tensor when first invoked