### PR TITLE
[AINode] Preliminary version of concurrent inference

### DIFF
--- a/iotdb-core/ainode/ainode/core/inference/request.py
+++ b/iotdb-core/ainode/ainode/core/inference/request.py
@@ -15,8 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-from typing import Callable, Optional, List, Dict, Any
+from typing import Any, Callable, Dict, List, Optional
+
 import torch
+
 
 class Request:
     def __init__(
@@ -25,32 +27,34 @@ class Request:
         all_input_ids: torch.Tensor,
         max_new_steps: int = 96,
         post_inference_fn: Optional[Callable] = None,
-        chunk_size: int = 96,                   # token size, how many time steps a token has
+        chunk_size: int = 96,  # token size, how many time steps a token has
         **model_kwargs,
-    ):      
+    ):
         if all_input_ids.ndim == 1:
             all_input_ids = all_input_ids.unsqueeze(0)
 
         self.id = id
         self.all_input_ids = all_input_ids
         self.model_kwargs = model_kwargs
-        self.max_new_steps = max_new_steps      # Number of time steps to generate
+        self.max_new_steps = max_new_steps  # Number of time steps to generate
         self.chunk_size = chunk_size
         self.post_inference_fn = post_inference_fn
 
         self.batch_size = all_input_ids.size(0)
-        self.state = 'waiting'
-        self.cur_step_idx = 0                  # Current write position in the output step index
+        self.state = "waiting"
+        self.cur_step_idx = 0  # Current write position in the output step index
 
         # Preallocate output buffer [batch_size, max_new_tokens]
         device = all_input_ids.device
-        self.output_tensor = torch.zeros(self.batch_size, max_new_steps, device=device) # shape: [self.batch_size, max_new_steps]
+        self.output_tensor = torch.zeros(
+            self.batch_size, max_new_steps, device=device
+        )  # shape: [self.batch_size, max_new_steps]
 
     def mark_running(self):
-        self.state = 'running'
+        self.state = "running"
 
     def mark_finished(self):
-        self.state = 'finished'
+        self.state = "finished"
 
     def is_finished(self) -> bool:
         return self.cur_step_idx >= self.max_new_steps
@@ -66,17 +70,19 @@ class Request:
 
         if end_idx > self.max_new_steps:
             # raise ValueError(f"write_step_output exceeds allocated output space: {end_idx} > {self.max_new_steps}")
-            self.output_tensor[:, self.cur_step_idx:] = step_output[:, :self.max_new_steps - self.cur_step_idx]
+            self.output_tensor[:, self.cur_step_idx :] = step_output[
+                :, : self.max_new_steps - self.cur_step_idx
+            ]
             self.cur_step_idx = self.max_new_steps
         else:
-            self.output_tensor[:, self.cur_step_idx:end_idx] = step_output
+            self.output_tensor[:, self.cur_step_idx : end_idx] = step_output
             self.cur_step_idx = end_idx
 
         if self.is_finished():
             self.mark_finished()
 
     def get_final_output(self) -> torch.Tensor:
-        return self.output_tensor[:, :self.cur_step_idx]
+        return self.output_tensor[:, : self.cur_step_idx]
 
     def run_post_inference_fn(self) -> Optional[torch.Tensor]:
         if self.post_inference_fn is not None:
@@ -84,7 +90,6 @@ class Request:
         return self.get_final_output()
 
     def reset(self):
-        self.state = 'waiting'
+        self.state = "waiting"
         self.cur_step_idx = 0
         self.output_tensor.zero_()
-        

--- a/iotdb-core/ainode/ainode/core/inference/requestPool.py
+++ b/iotdb-core/ainode/ainode/core/inference/requestPool.py
@@ -15,18 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-import torch
-from torch import nn
-import torch.nn.functional as F
-from typing import Optional, List, Dict, Any, Tuple
-import queue 
-import time
-import threading
 import gc
-from transformers.modeling_outputs import MoeModelOutputWithPast, MoeCausalLMOutputWithPast
-from safetensors.torch import load_file
-
 import logging
+import queue
+import threading
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from safetensors.torch import load_file
+from torch import nn
+from transformers.modeling_outputs import (
+    MoeCausalLMOutputWithPast,
+    MoeModelOutputWithPast,
+)
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
@@ -37,62 +41,76 @@ logger = logging.getLogger(__name__)
 from ainode.core.inference.request import Request
 from ainode.core.inference.utils import split_moe_output
 
+
 class RequestPool:
     def __init__(self, model, config, total_memory_availble):
         super().__init__()
         self.model = model
         self.config = config
-        self.total_memory_availble = total_memory_availble      # MB
-            
+        self.total_memory_availble = total_memory_availble  # MB
+
         self.waiting_list = queue.Queue()
         self.running_list = queue.Queue()
 
         self.results_queue = queue.Queue()
-        
-    # TODO introduce pipeline
-    def add_request(self, req_id, x, max_new_steps: int = 96, post_inference_fn = None, **model_kwargs):
+
+    def add_request(
+        self, req_id, x, max_new_steps: int = 96, post_inference_fn=None, **model_kwargs
+    ):
         if len(x.shape) == 2:
             batch_size, cur_len = x.shape
             if cur_len < self.config.input_token_len:
                 raise ValueError(
-                    f"Input length must be at least {self.config.input_token_len}")
+                    f"Input length must be at least {self.config.input_token_len}"
+                )
             elif cur_len % self.config.input_token_len != 0:
-                new_len = (cur_len // self.config.input_token_len) * \
-                    self.config.input_token_len
+                new_len = (
+                    cur_len // self.config.input_token_len
+                ) * self.config.input_token_len
                 x = x[:, -new_len:]
         else:
-            raise ValueError('Input shape must be: [batch_size, seq_len]')
-        
+            raise ValueError("Input shape must be: [batch_size, seq_len]")
+
         x = x.to(self.model.device)
         model_kwargs["attention_mask"] = self.prepare_attention_mask_for_generation(x)
-        
+
         batch_size, cur_len = x.shape
-        
-        model_kwargs["unfinished_sequences"] = torch.ones(batch_size, dtype=torch.long, device=x.device)
+
+        model_kwargs["unfinished_sequences"] = torch.ones(
+            batch_size, dtype=torch.long, device=x.device
+        )
         model_kwargs["cache_position"] = torch.arange(cur_len, device=x.device)
         true_seq_len = cur_len // self.config.input_token_len
-        model_kwargs["attention_mask"] = model_kwargs["attention_mask"][:, -true_seq_len:]
+        model_kwargs["attention_mask"] = model_kwargs["attention_mask"][
+            :, -true_seq_len:
+        ]
         model_kwargs["past_key_values"] = None
         model_kwargs["position_ids"] = None
-        model_kwargs["is_encoder_decoder"] = getattr(self.config, "is_encoder_decoder", False)
-        
+        model_kwargs["is_encoder_decoder"] = getattr(
+            self.config, "is_encoder_decoder", False
+        )
+
         req = Request(req_id, x, max_new_steps, post_inference_fn, 96, **model_kwargs)
         self.waiting_list.put(req)
 
-        logger.info(f"Enqueued req={req_id}  batch={batch_size}  "
-                f"seq={cur_len}  target={max_new_steps} chunk_size={req.chunk_size}")
-        
+        logger.info(
+            f"Enqueued req={req_id}  batch={batch_size}  "
+            f"seq={cur_len}  target={max_new_steps} chunk_size={req.chunk_size}"
+        )
+
     def memory_is_availble(self, request):
-        # TODO test with several rounds of dummy data
+        # need test with several rounds of dummy data
         pass
-        
+
     def step(self):
         while not self.waiting_list.empty():
             request = self.waiting_list.queue[0]
-            all_not_running = all(item.state != 'running' for item in list(self.running_list.queue))
+            all_not_running = all(
+                item.state != "running" for item in list(self.running_list.queue)
+            )
             if self.memory_is_availble(request) and all_not_running:
                 request = self.waiting_list.get()
-                request.state = 'ready'
+                request.state = "ready"
                 self.running_list.put(request)
                 logger.debug(f"Request {request.id} moved to running_list")
             else:
@@ -106,27 +124,27 @@ class RequestPool:
         while not self.running_list.empty():
             request = self.running_list.get()
             running_reqs.append(request)
-            
+
         model_inputs = self.prepare_model_inputs(running_reqs)
 
-        logger.info(f"Running batch: {len(running_reqs)} reqs | "
-            f"total_samples={sum(r.batch_size for r in running_reqs)}")
+        logger.info(
+            f"Running batch: {len(running_reqs)} reqs | "
+            f"total_samples={sum(r.batch_size for r in running_reqs)}"
+        )
         with torch.no_grad():
             # Uniformly generate 96 steps; crop inside request.write_step_output if it exceeds max length
-            batch_output = self.model(
-                **model_inputs, max_output_length=96
-            )
-            
+            batch_output = self.model(**model_inputs, max_output_length=96)
+
         results = []
         # print(f'type:{type(batch_output)}')
         if type(batch_output) == torch.Tensor:
-            offset = 0  
+            offset = 0
             for request in running_reqs:
                 b = request.batch_size
-                output_i = batch_output[offset : offset + b]   # [B_i, chunk]
+                output_i = batch_output[offset : offset + b]  # [B_i, chunk]
                 offset += b
 
-                next_tokens = output_i                        # [B_i, chunk]
+                next_tokens = output_i  # [B_i, chunk]
                 request.all_input_ids = torch.cat(
                     [request.all_input_ids, next_tokens], dim=-1
                 )
@@ -139,7 +157,7 @@ class RequestPool:
                     horizon_length=horizon_length,
                     is_encoder_decoder=self.config.is_encoder_decoder,
                 )
-                
+
                 request.write_step_output(output_i)
 
                 logger.debug(
@@ -149,19 +167,21 @@ class RequestPool:
                 )
 
                 if not request.is_finished():
-                    request.state = 'running'
+                    request.state = "running"
                     self.running_list.put(request)
                 else:
                     results.append((request.id, request.run_post_inference_fn()))
-        elif type(batch_output) == MoeModelOutputWithPast or type(batch_output) == MoeCausalLMOutputWithPast or type(batch_output) == tuple:
+        elif (
+            type(batch_output) == MoeModelOutputWithPast
+            or type(batch_output) == MoeCausalLMOutputWithPast
+            or type(batch_output) == tuple
+        ):
             split_sizes = [req.batch_size for req in running_reqs]
             outs_per_req = split_moe_output(batch_output, split_sizes)
 
             for req, out_i in zip(running_reqs, outs_per_req):
-                pred_tokens = out_i.logits               # shape [B_i, chunk]
-                req.all_input_ids = torch.cat(
-                    [req.all_input_ids, pred_tokens], dim=-1
-                )
+                pred_tokens = out_i.logits  # shape [B_i, chunk]
+                req.all_input_ids = torch.cat([req.all_input_ids, pred_tokens], dim=-1)
 
                 # print(f"chunksize:{req.chunk_size}, token_len:{self.config.input_token_len}")
                 horizon_len = req.chunk_size // self.config.input_token_len
@@ -182,7 +202,7 @@ class RequestPool:
                 )
 
                 if not req.is_finished():
-                    request.state = 'running'
+                    request.state = "running"
                     self.running_list.put(req)
                 else:
                     results.append((req.id, req.run_post_inference_fn()))
@@ -193,7 +213,7 @@ class RequestPool:
             self.results_queue.put(r)
         # return results
         logger.debug(f"Pushed {len(results)} finished results to results_queue")
-    
+
     def run_inference(self):
         while True:
             time.sleep(15)  # Check every 15ms
@@ -203,27 +223,39 @@ class RequestPool:
         model_inputs = []
 
         for req in running_reqs:
-            # TODO call preprocessing pipeline
-            
             single_req_model_inputs = self.prepare_model_inputs_for_single_req(req)
             model_inputs.append(single_req_model_inputs)
-        
+
         # Left pad with zeros
         def pad_and_merge_model_inputs(list_model_inputs: List[Dict]):
             batched_model_inputs = {}
-            keys_to_batch = ['input_ids', 'attention_mask', 'position_ids', 'past_key_values']
-            other_keys = [k for k in list_model_inputs[0].keys()
-                    if k not in keys_to_batch]
-    
+            keys_to_batch = [
+                "input_ids",
+                "attention_mask",
+                "position_ids",
+                "past_key_values",
+            ]
+            other_keys = [
+                k for k in list_model_inputs[0].keys() if k not in keys_to_batch
+            ]
+
             # start merge
             for k in other_keys:
                 batched_model_inputs[k] = list_model_inputs[0][k]
-                
+
             for k in ["input_ids", "attention_mask", "position_ids"]:
                 max_len = max(inp[k].size(-1) for inp in list_model_inputs)
-                padded = [self.left_pad(item[k], max_len, pad_value=(0 if k != "position_ids" else 0)) if item[k] is not None else None
-                        for item in list_model_inputs]
-                batched_model_inputs[k] = torch.cat(padded, dim=0) if padded[0] is not None else None  # [B_total, max_len]
+                padded = [
+                    self.left_pad(
+                        item[k], max_len, pad_value=(0 if k != "position_ids" else 0)
+                    )
+                    if item[k] is not None
+                    else None
+                    for item in list_model_inputs
+                ]
+                batched_model_inputs[k] = (
+                    torch.cat(padded, dim=0) if padded[0] is not None else None
+                )  # [B_total, max_len]
 
             # ---- past_key_values ----
             # List[Tuple[k, v]]，len = num_layers
@@ -236,23 +268,36 @@ class RequestPool:
 
                     # 只计算有值的 max_len
                     max_k_len = max(
-                        (item["past_key_values"][layer][0].size(-2)
-                        for item in list_model_inputs if item["past_key_values"] is not None),
-                        default=0
+                        (
+                            item["past_key_values"][layer][0].size(-2)
+                            for item in list_model_inputs
+                            if item["past_key_values"] is not None
+                        ),
+                        default=0,
                     )
                     max_v_len = max(
-                        (item["past_key_values"][layer][1].size(-2)
-                        for item in list_model_inputs if item["past_key_values"] is not None),
-                        default=0
+                        (
+                            item["past_key_values"][layer][1].size(-2)
+                            for item in list_model_inputs
+                            if item["past_key_values"] is not None
+                        ),
+                        default=0,
                     )
 
                     for item in list_model_inputs:
                         if item["past_key_values"] is None:
                             # first iteration：empty k/v
                             B = item["input_ids"].shape[0]
-                            H, D = self.config.num_heads, self.config.hidden_size // self.config.num_heads
-                            empty_k = torch.zeros(B, H, max_k_len, D, device=item["input_ids"].device)
-                            empty_v = torch.zeros(B, H, max_v_len, D, device=item["input_ids"].device)
+                            H, D = (
+                                self.config.num_heads,
+                                self.config.hidden_size // self.config.num_heads,
+                            )
+                            empty_k = torch.zeros(
+                                B, H, max_k_len, D, device=item["input_ids"].device
+                            )
+                            empty_v = torch.zeros(
+                                B, H, max_v_len, D, device=item["input_ids"].device
+                            )
                             k_list.append(empty_k)
                             v_list.append(empty_v)
                         else:
@@ -269,22 +314,26 @@ class RequestPool:
                 batched_model_inputs["past_key_values"] = pkv_merged
             else:
                 batched_model_inputs["past_key_values"] = None
-            
+
             return batched_model_inputs
-        
+
         model_inputs = pad_and_merge_model_inputs(model_inputs)
         return model_inputs
-    
+
     @staticmethod
-    def left_pad(t: torch.Tensor, target_len: int, pad_value: int = 0, dim: int = -1) -> torch.Tensor:
+    def left_pad(
+        t: torch.Tensor, target_len: int, pad_value: int = 0, dim: int = -1
+    ) -> torch.Tensor:
         """Pad the last dimension with zeros or a constant to target_len on the left side"""
         if t is None:
             return None
-        dim = dim if dim >= 0 else t.dim() + dim  # Convert negative dim to positive index
+        dim = (
+            dim if dim >= 0 else t.dim() + dim
+        )  # Convert negative dim to positive index
         pad_len = target_len - t.size(dim)
         if pad_len <= 0:
             return t
-        
+
         # pad_sizes = [pad_len, 0]  # (last_dim_left, last_dim_right)
         pad_sizes = [0] * (2 * t.dim())  # PyTorch expects pad in reverse order
         pad_sizes[-(2 * dim + 2)] = pad_len  # pad left side of dimension `dim`
@@ -292,14 +341,16 @@ class RequestPool:
         return F.pad(t, pad_sizes, value=pad_value)
 
     def prepare_model_inputs_for_single_req(self, running_req: Request):
-        return self.model.prepare_inputs_for_generation(running_req.all_input_ids, **running_req.model_kwargs)
-    
+        return self.model.prepare_inputs_for_generation(
+            running_req.all_input_ids, **running_req.model_kwargs
+        )
+
     def prepare_attention_mask_for_generation(
         self,
         inputs: torch.Tensor,
     ) -> torch.LongTensor:
         return torch.ones(inputs.shape[:2], dtype=torch.long, device=inputs.device)
-    
+
     def _update_model_kwargs_for_generation(
         self,
         outputs,
@@ -312,12 +363,13 @@ class RequestPool:
         model_kwargs["past_key_values"] = outputs.past_key_values
         if getattr(outputs, "state", None) is not None:
             model_kwargs["state"] = outputs.state
-            
+
         # update token_type_ids with last value
         if "token_type_ids" in model_kwargs:
             token_type_ids = model_kwargs["token_type_ids"]
             model_kwargs["token_type_ids"] = torch.cat(
-                [token_type_ids, token_type_ids[:, -1].unsqueeze(-1)], dim=-1)
+                [token_type_ids, token_type_ids[:, -1].unsqueeze(-1)], dim=-1
+            )
 
         # update attention mask
         if not is_encoder_decoder:
@@ -325,31 +377,48 @@ class RequestPool:
             if "attention_mask" in model_kwargs:
                 attention_mask = model_kwargs["attention_mask"]
                 model_kwargs["attention_mask"] = torch.cat(
-                    [attention_mask, attention_mask.new_ones((attention_mask.shape[0], horizon_length))], dim=-1
+                    [
+                        attention_mask,
+                        attention_mask.new_ones(
+                            (attention_mask.shape[0], horizon_length)
+                        ),
+                    ],
+                    dim=-1,
                 )
         else:
             # update decoder attention mask
             if "decoder_attention_mask" in model_kwargs:
                 decoder_attention_mask = model_kwargs["decoder_attention_mask"]
                 model_kwargs["decoder_attention_mask"] = torch.cat(
-                    [decoder_attention_mask, decoder_attention_mask.new_ones(
-                        (decoder_attention_mask.shape[0], horizon_length))],
+                    [
+                        decoder_attention_mask,
+                        decoder_attention_mask.new_ones(
+                            (decoder_attention_mask.shape[0], horizon_length)
+                        ),
+                    ],
                     dim=-1,
                 )
 
-        if "cache_position" in model_kwargs and model_kwargs["cache_position"] is not None:
-            model_kwargs["cache_position"] = model_kwargs["cache_position"][-1:] + horizon_length
+        if (
+            "cache_position" in model_kwargs
+            and model_kwargs["cache_position"] is not None
+        ):
+            model_kwargs["cache_position"] = (
+                model_kwargs["cache_position"][-1:] + horizon_length
+            )
 
         return model_kwargs
-    
+
+
 def pool_worker(p, done_event):
     while not done_event.is_set():
         p.step()
         time.sleep(0.001)
 
-'''
+
+"""
 The following code is used to test the difference in inference speed and the difference in result values when using and not using requestpool
-'''
+"""
 # if __name__ == '__main__':
 #     config = TimerConfig()
 #     config.ckpt_path = '/data/mahaoke/AINode/ainode/TimerXL/model.safetensors'
@@ -372,7 +441,7 @@ The following code is used to test the difference in inference speed and the dif
 #         return True
 #     RequestPool.memory_is_availble = _always_true
 
-#     def prepare_inputs(model, x, max_new_steps: int = 96, **model_kwargs):  
+#     def prepare_inputs(model, x, max_new_steps: int = 96, **model_kwargs):
 #         model_inputs = model.prepare_inputs_for_generation(x, **model_kwargs)
 #         return model_inputs
 
@@ -382,9 +451,9 @@ The following code is used to test the difference in inference speed and the dif
 #         remain = max_steps
 
 #         model_kwargs["attention_mask"] = pool.prepare_attention_mask_for_generation(inp)
-        
+
 #         batch_size, cur_len = inp.shape
-        
+
 #         model_kwargs["unfinished_sequences"] = torch.ones(batch_size, dtype=torch.long, device=inp.device)
 #         model_kwargs["cache_position"] = torch.arange(cur_len, device=inp.device)
 #         true_seq_len = cur_len // config.input_token_len
@@ -413,7 +482,7 @@ The following code is used to test the difference in inference speed and the dif
 
 #             remain -= chunk
 #         return torch.cat(preds, dim=-1)            # [B, max_steps]
-    
+
 #     # warm up
 #     for i in range(3):
 #         base_res1 = baseline_generate(model, x1, 192)

--- a/iotdb-core/ainode/ainode/core/inference/utils.py
+++ b/iotdb-core/ainode/ainode/core/inference/utils.py
@@ -15,11 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-from transformers.modeling_outputs import MoeCausalLMOutputWithPast
 import torch
+from transformers.modeling_outputs import MoeCausalLMOutputWithPast
+
 
 def _slice_tensor(t, s, e):
     return None if t is None else t[s:e]
+
 
 def _slice_tuple_of_tensors(tup, s, e):
     """
@@ -33,13 +35,15 @@ def _slice_tuple_of_tensors(tup, s, e):
         sliced.append(_slice_tensor(x, s, e) if torch.is_tensor(x) else x)
     return tuple(sliced)
 
+
 def _slice_pkv(pkv, s, e):
     if pkv is None:
         return None
     out = []
-    for layer in pkv:                       # layer: Tuple[key, value, ...]
+    for layer in pkv:  # layer: Tuple[key, value, ...]
         out.append(tuple(x[s:e] for x in layer))
     return out
+
 
 def split_moe_output(batch_out: MoeCausalLMOutputWithPast, split_sizes):
     """
@@ -52,11 +56,13 @@ def split_moe_output(batch_out: MoeCausalLMOutputWithPast, split_sizes):
         end = start + bsz
         outs.append(
             MoeCausalLMOutputWithPast(
-                loss           = _slice_tensor(batch_out.loss, start, end),
-                logits         = batch_out.logits[start:end],
-                past_key_values= _slice_pkv(batch_out.past_key_values, start, end),
-                hidden_states  = _slice_tuple_of_tensors(batch_out.hidden_states, start, end),
-                attentions     = _slice_tuple_of_tensors(batch_out.attentions,  start, end),
+                loss=_slice_tensor(batch_out.loss, start, end),
+                logits=batch_out.logits[start:end],
+                past_key_values=_slice_pkv(batch_out.past_key_values, start, end),
+                hidden_states=_slice_tuple_of_tensors(
+                    batch_out.hidden_states, start, end
+                ),
+                attentions=_slice_tuple_of_tensors(batch_out.attentions, start, end),
             )
         )
         start = end

--- a/iotdb-core/ainode/ainode/core/ingress/iotdb.py
+++ b/iotdb-core/ainode/ainode/core/ingress/iotdb.py
@@ -371,7 +371,6 @@ def register_dataset(key: str, dataset: Dataset):
 
 @singleton
 class DatasetFactory(object):
-
     def __init__(self):
         self.dataset_list = {
             "iotdb.table": IoTDBTableModelDataset,

--- a/iotdb-core/ainode/ainode/core/manager/model_manager.py
+++ b/iotdb-core/ainode/ainode/core/manager/model_manager.py
@@ -21,10 +21,7 @@ from torch import nn
 from yaml import YAMLError
 
 from ainode.core.constant import TSStatusCode
-from ainode.core.exception import (
-    BadConfigValueError,
-    InvalidUriError,
-)
+from ainode.core.exception import BadConfigValueError, InvalidUriError
 from ainode.core.log import Logger
 from ainode.core.model.model_info import BuiltInModelType, ModelInfo, ModelStates
 from ainode.core.model.model_storage import ModelStorage

--- a/iotdb-core/ainode/ainode/core/model/timerxl/ts_generation_mixin.py
+++ b/iotdb-core/ainode/ainode/core/model/timerxl/ts_generation_mixin.py
@@ -33,7 +33,6 @@ from transformers.utils import ModelOutput
 
 
 class TSGenerationMixin(GenerationMixin):
-
     @torch.no_grad()
     def generate(
         self,


### PR DESCRIPTION
## Description
This PR adds an request–pooling engine for multi-request inference on time-series models such as TimerXL. The change set introduces three core Python modules—requestpool.py, request.py, and utils.py—plus a self-contained benchmark harness (guarded by if __name__ == "__main__":) to compare pooled vs. baseline generation speed and numerical fidelity.

### Design
<b>Overlap multiple user requests on one device: </b>RequestPool.step() batches all ready requests every 15 ms if there are no requests running, and feeds a single forward pass to the model.
<b>Handle variable sequence lengths: </b>Left-padding to max_len per tensor type; preserves causal semantics while enabling torch.cat.

### Behavior & configuration
RequestPool.add_request truncates inputs that are not an exact multiple of config.input_token_len, ensuring model state alignment;
Oversized write attempts are silently clipped to max_new_steps;

### Class & method organization
`RequestPool`
<b>Public API: </b>add_request, run_inference (starts loop), step (single scheduling + forward pass).
`Request`
id, chunk_size, …, state, cur_step_idx, output_tensor
write_step_output pre-allocates and in-place fills a fixed buffer—no Python-side reallocation after start.
`utils`
split_moe_output Slices Moe[Causal]LMOutputWithPast into per-request objects.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [x] added unit tests.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
`ainode.core.inference.requestpool.RequestPool`
`ainode.core.inference.request.Request`
`ainode.core.inference.utils.split_moe_output`