### PR TITLE
Support fetch the device's leader through corresponding database and time

### DIFF
--- a/example/session/src/main/java/org/apache/iotdb/TableModelSessionPoolExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/TableModelSessionPoolExample.java
@@ -134,6 +134,21 @@ public class TableModelSessionPoolExample {
         tablet.reset();
       }
 
+      // query device leader
+      String correctURL =
+          session.getDeviceLeaderURL("test2", Arrays.asList("test1", "1", "5", "3"), 66);
+      System.out.println("Correct device leader URL: " + correctURL);
+      String errorDbURL =
+          session.getDeviceLeaderURL("test3", Arrays.asList("test1", "1", "5", "3"), 66);
+      System.out.println("Error dbName device leader URL: " + errorDbURL);
+      String errorDeviceURL =
+          session.getDeviceLeaderURL("test2", Arrays.asList("test1", "1", "5"), 66);
+      System.out.println("Error deviceId device leader URL: " + errorDeviceURL);
+      String errorTimeURL =
+          session.getDeviceLeaderURL(
+              "test2", Arrays.asList("test1", "1", "5", "3"), 6666666666666666L);
+      System.out.println("Error time device leader URL: " + errorTimeURL);
+
       // query table data
       try (SessionDataSet dataSet =
           session.executeQueryStatement(

--- a/iotdb-client/isession/src/main/java/org/apache/iotdb/isession/ITableSession.java
+++ b/iotdb-client/isession/src/main/java/org/apache/iotdb/isession/ITableSession.java
@@ -24,6 +24,8 @@ import org.apache.iotdb.rpc.StatementExecutionException;
 
 import org.apache.tsfile.write.record.Tablet;
 
+import java.util.List;
+
 /**
  * This interface defines a session for interacting with IoTDB tables. It supports operations such
  * as data insertion, executing queries, and closing the session. Implementations of this interface
@@ -45,6 +47,17 @@ public interface ITableSession extends AutoCloseable {
    * @throws IoTDBConnectionException if there is an issue with the IoTDB connection.
    */
   void insert(Tablet tablet) throws StatementExecutionException, IoTDBConnectionException;
+
+  /**
+   * Retrieves the DataNode URL of the device leader for a given database and a deviceID.
+   *
+   * @param dbName the name of the database.
+   * @param deviceId a list of string for constructing the specified deviceID.
+   * @param time the time at which partition the device leader is queried.
+   * @return the DataNode URL <ip:port> of the device leader as a String.
+   */
+  String getDeviceLeaderURL(String dbName, List<String> deviceId, long time)
+      throws IoTDBConnectionException, StatementExecutionException;
 
   /**
    * Executes a non-query SQL statement, such as a DDL or DML command.

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -56,6 +56,8 @@ import org.apache.iotdb.service.rpc.thrift.TSQueryTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSQueryTemplateResp;
 import org.apache.iotdb.service.rpc.thrift.TSSetSchemaTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSUnsetSchemaTemplateReq;
+import org.apache.iotdb.service.rpc.thrift.TTableDeviceLeaderReq;
+import org.apache.iotdb.service.rpc.thrift.TTableDeviceLeaderResp;
 import org.apache.iotdb.session.template.MeasurementNode;
 import org.apache.iotdb.session.template.TemplateQueryType;
 import org.apache.iotdb.session.util.SessionUtils;
@@ -2776,6 +2778,12 @@ public class Session implements ISession {
       } catch (RedirectException ignored) {
       }
     }
+  }
+
+  public TTableDeviceLeaderResp fetchDeviceLeader(String dbName, List<String> deviceId, long time)
+      throws IoTDBConnectionException, StatementExecutionException {
+    TTableDeviceLeaderReq req = new TTableDeviceLeaderReq(dbName, deviceId, time);
+    return getDefaultSessionConnection().fetchDeviceLeader(req);
   }
 
   private void insertRelationalTabletWithLeaderCache(Tablet tablet)

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -65,6 +65,8 @@ import org.apache.iotdb.service.rpc.thrift.TSRawDataQueryReq;
 import org.apache.iotdb.service.rpc.thrift.TSSetSchemaTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSSetTimeZoneReq;
 import org.apache.iotdb.service.rpc.thrift.TSUnsetSchemaTemplateReq;
+import org.apache.iotdb.service.rpc.thrift.TTableDeviceLeaderReq;
+import org.apache.iotdb.service.rpc.thrift.TTableDeviceLeaderResp;
 import org.apache.iotdb.session.util.SessionUtils;
 
 import org.apache.thrift.TException;
@@ -1223,6 +1225,16 @@ public class SessionConnection {
             .getResult();
     RpcUtils.verifySuccess(execResp.getStatus());
     return execResp;
+  }
+
+  protected TTableDeviceLeaderResp fetchDeviceLeader(TTableDeviceLeaderReq req)
+      throws StatementExecutionException {
+    final TTableDeviceLeaderResp resp =
+        callWithRetryAndReconnect(
+                () -> client.fetchDeviceLeader(req), TTableDeviceLeaderResp::getStatus)
+            .getResult();
+    RpcUtils.verifySuccess(resp.getStatus());
+    return resp;
   }
 
   private <T> RetryResult<T> callWithReconnect(TFunction<T> supplier)

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/TableSession.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/TableSession.java
@@ -23,8 +23,11 @@ import org.apache.iotdb.isession.ITableSession;
 import org.apache.iotdb.isession.SessionDataSet;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.StatementExecutionException;
+import org.apache.iotdb.service.rpc.thrift.TTableDeviceLeaderResp;
 
 import org.apache.tsfile.write.record.Tablet;
+
+import java.util.List;
 
 public class TableSession implements ITableSession {
 
@@ -37,6 +40,13 @@ public class TableSession implements ITableSession {
   @Override
   public void insert(Tablet tablet) throws StatementExecutionException, IoTDBConnectionException {
     session.insertRelationalTablet(tablet);
+  }
+
+  @Override
+  public String getDeviceLeaderURL(String dbName, List<String> deviceId, long time)
+      throws IoTDBConnectionException, StatementExecutionException {
+    TTableDeviceLeaderResp resp = session.fetchDeviceLeader(dbName, deviceId, time);
+    return resp.getIp() + ":" + resp.getPort();
   }
 
   @Override

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/pool/TableSessionWrapper.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/pool/TableSessionWrapper.java
@@ -23,12 +23,14 @@ import org.apache.iotdb.isession.ITableSession;
 import org.apache.iotdb.isession.SessionDataSet;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.StatementExecutionException;
+import org.apache.iotdb.service.rpc.thrift.TTableDeviceLeaderResp;
 import org.apache.iotdb.session.Session;
 
 import org.apache.tsfile.write.record.Tablet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -65,6 +67,13 @@ public class TableSessionWrapper implements ITableSession {
       session = null;
       throw e;
     }
+  }
+
+  @Override
+  public String getDeviceLeaderURL(String dbName, List<String> deviceId, long time)
+      throws IoTDBConnectionException, StatementExecutionException {
+    TTableDeviceLeaderResp resp = session.fetchDeviceLeader(dbName, deviceId, time);
+    return resp.getIp() + ":" + resp.getPort();
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/ClientRPCServiceImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/ClientRPCServiceImpl.java
@@ -181,6 +181,8 @@ import org.apache.iotdb.service.rpc.thrift.TSSetTimeZoneReq;
 import org.apache.iotdb.service.rpc.thrift.TSUnsetSchemaTemplateReq;
 import org.apache.iotdb.service.rpc.thrift.TSyncIdentityInfo;
 import org.apache.iotdb.service.rpc.thrift.TSyncTransportMetaInfo;
+import org.apache.iotdb.service.rpc.thrift.TTableDeviceLeaderReq;
+import org.apache.iotdb.service.rpc.thrift.TTableDeviceLeaderResp;
 
 import io.airlift.units.Duration;
 import io.jsonwebtoken.lang.Strings;
@@ -3090,6 +3092,35 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
   @Override
   public TSStatus testConnectionEmptyRPC() throws TException {
     return new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
+  }
+
+  @Override
+  public TTableDeviceLeaderResp fetchDeviceLeader(TTableDeviceLeaderReq req) throws TException {
+    IDeviceID deviceID =
+        Factory.DEFAULT_FACTORY.create(
+            req.getDeviceId().toArray(new String[req.getDeviceIdSize()]));
+    TTimePartitionSlot timePartitionSlot = TimePartitionUtils.getTimePartitionSlot(req.getTime());
+    DataPartitionQueryParam queryParam =
+        new DataPartitionQueryParam(deviceID, Collections.singletonList(timePartitionSlot));
+    DataPartition dataPartition =
+        partitionFetcher.getDataPartition(
+            Collections.singletonMap(req.getDbName(), Collections.singletonList(queryParam)));
+    TRegionReplicaSet targetRegionReplicaSet =
+        dataPartition.getAllReplicaSets().stream().findFirst().orElse(null);
+    TEndPoint targetEndPoint =
+        targetRegionReplicaSet != null
+            ? targetRegionReplicaSet.getDataNodeLocations().get(0).getClientRpcEndPoint()
+            : null;
+    TTableDeviceLeaderResp resp = new TTableDeviceLeaderResp();
+    resp.setStatus(new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode()));
+    if (targetEndPoint != null) {
+      resp.setIp(targetEndPoint.getIp());
+      resp.setPort(String.valueOf(targetEndPoint.getPort()));
+    } else {
+      resp.setIp("");
+      resp.setPort("");
+    }
+    return resp;
   }
 
   @Override

--- a/iotdb-protocol/thrift-datanode/src/main/thrift/client.thrift
+++ b/iotdb-protocol/thrift-datanode/src/main/thrift/client.thrift
@@ -548,6 +548,17 @@ struct TSConnectionInfoResp {
   1: required list<TSConnectionInfo> connectionInfoList
 }
 
+struct TTableDeviceLeaderReq {
+  1:required string dbName
+  2:required list<string> deviceId
+  3:required i64 time
+}
+
+struct TTableDeviceLeaderResp {
+  1:required string ip
+  2:required string port
+}
+
 service IClientRPCService {
 
   TSExecuteStatementResp executeQueryStatementV2(1:TSExecuteStatementReq req);
@@ -683,5 +694,7 @@ service IClientRPCService {
   TSConnectionInfoResp fetchAllConnectionsInfo();
 
   /** For other node's call */
-  common.TSStatus testConnectionEmptyRPC()
+  common.TSStatus testConnectionEmptyRPC();
+
+  TTableDeviceLeaderResp fetchDeviceLeader(TTableDeviceLeaderReq req);
 }

--- a/iotdb-protocol/thrift-datanode/src/main/thrift/client.thrift
+++ b/iotdb-protocol/thrift-datanode/src/main/thrift/client.thrift
@@ -549,14 +549,15 @@ struct TSConnectionInfoResp {
 }
 
 struct TTableDeviceLeaderReq {
-  1:required string dbName
-  2:required list<string> deviceId
-  3:required i64 time
+  1: required string dbName
+  2: required list<string> deviceId
+  3: required i64 time
 }
 
 struct TTableDeviceLeaderResp {
-  1:required string ip
-  2:required string port
+  1: required common.TSStatus status
+  2: required string ip
+  3: required string port
 }
 
 service IClientRPCService {


### PR DESCRIPTION
In this PR, we create a new session interface `fetchDeviceLeader`. The user can get the device leader's DataNode client RPC location through inputing `databaseName, deviceName, time`. This interface is self-tested, we left the test codes in TableModelSessionPoolExample. You can find following results after executing the test codes:

Correct device leader URL: 0.0.0.0:6667
Error dbName device leader URL: :
Error deviceId device leader URL: :
Error time device leader URL: :
