### PR TITLE
Support null tag for device fetch leader interface

### DIFF
--- a/example/session/src/main/java/org/apache/iotdb/TableModelSessionPoolExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/TableModelSessionPoolExample.java
@@ -119,7 +119,7 @@ public class TableModelSessionPoolExample {
         int rowIndex = tablet.getRowSize();
         tablet.addTimestamp(rowIndex, timestamp);
         tablet.addValue("region_id", rowIndex, "1");
-        tablet.addValue("plant_id", rowIndex, "5");
+        tablet.addValue("plant_id", rowIndex, null);
         tablet.addValue("device_id", rowIndex, "3");
         tablet.addValue("model", rowIndex, "A");
         tablet.addValue("temperature", rowIndex, 37.6F);
@@ -135,18 +135,23 @@ public class TableModelSessionPoolExample {
       }
 
       // query device leader
+      List<Boolean> isSetTag = Arrays.asList(true, true, false, true);
       String correctURL =
-          session.getDeviceLeaderURL("test2", Arrays.asList("test1", "1", "5", "3"), 66);
+          session.getDeviceLeaderURL("test2", Arrays.asList("test1", "1", "3"), isSetTag, 66);
       System.out.println("Correct device leader URL: " + correctURL);
       String errorDbURL =
-          session.getDeviceLeaderURL("test3", Arrays.asList("test1", "1", "5", "3"), 66);
+          session.getDeviceLeaderURL("test3", Arrays.asList("test1", "1", "3"), isSetTag, 66);
       System.out.println("Error dbName device leader URL: " + errorDbURL);
       String errorDeviceURL =
-          session.getDeviceLeaderURL("test2", Arrays.asList("test1", "1", "5"), 66);
+          session.getDeviceLeaderURL("test2", Arrays.asList("test1", "3", "1"), isSetTag, 66);
       System.out.println("Error deviceId device leader URL: " + errorDeviceURL);
+      List<Boolean> falseTagList = Arrays.asList(false, true, true, true);
+      String errorTagURL =
+          session.getDeviceLeaderURL("test2", Arrays.asList("test1", "1", "3"), falseTagList, 66);
+      System.out.println("Error tag device leader URL: " + errorTagURL);
       String errorTimeURL =
           session.getDeviceLeaderURL(
-              "test2", Arrays.asList("test1", "1", "5", "3"), 6666666666666666L);
+              "test2", Arrays.asList("test1", "1", "3"), isSetTag, 6666666666666666L);
       System.out.println("Error time device leader URL: " + errorTimeURL);
 
       // query table data

--- a/iotdb-client/isession/src/main/java/org/apache/iotdb/isession/ITableSession.java
+++ b/iotdb-client/isession/src/main/java/org/apache/iotdb/isession/ITableSession.java
@@ -53,10 +53,11 @@ public interface ITableSession extends AutoCloseable {
    *
    * @param dbName the name of the database.
    * @param deviceId a list of string for constructing the specified deviceID.
+   * @param isSetTag a true indicating the deviceID is set, false otherwise.
    * @param time the time at which partition the device leader is queried.
    * @return the DataNode URL <ip:port> of the device leader as a String.
    */
-  String getDeviceLeaderURL(String dbName, List<String> deviceId, long time)
+  String getDeviceLeaderURL(String dbName, List<String> deviceId, List<Boolean> isSetTag, long time)
       throws IoTDBConnectionException, StatementExecutionException;
 
   /**

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -2780,9 +2780,10 @@ public class Session implements ISession {
     }
   }
 
-  public TTableDeviceLeaderResp fetchDeviceLeader(String dbName, List<String> deviceId, long time)
+  public TTableDeviceLeaderResp fetchDeviceLeader(
+      String dbName, List<String> deviceId, List<Boolean> isSetTag, long time)
       throws IoTDBConnectionException, StatementExecutionException {
-    TTableDeviceLeaderReq req = new TTableDeviceLeaderReq(dbName, deviceId, time);
+    TTableDeviceLeaderReq req = new TTableDeviceLeaderReq(dbName, deviceId, isSetTag, time);
     return getDefaultSessionConnection().fetchDeviceLeader(req);
   }
 

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/TableSession.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/TableSession.java
@@ -43,9 +43,10 @@ public class TableSession implements ITableSession {
   }
 
   @Override
-  public String getDeviceLeaderURL(String dbName, List<String> deviceId, long time)
+  public String getDeviceLeaderURL(
+      String dbName, List<String> deviceId, List<Boolean> isSetTag, long time)
       throws IoTDBConnectionException, StatementExecutionException {
-    TTableDeviceLeaderResp resp = session.fetchDeviceLeader(dbName, deviceId, time);
+    TTableDeviceLeaderResp resp = session.fetchDeviceLeader(dbName, deviceId, isSetTag, time);
     return resp.getIp() + ":" + resp.getPort();
   }
 

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/pool/TableSessionWrapper.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/pool/TableSessionWrapper.java
@@ -70,9 +70,10 @@ public class TableSessionWrapper implements ITableSession {
   }
 
   @Override
-  public String getDeviceLeaderURL(String dbName, List<String> deviceId, long time)
+  public String getDeviceLeaderURL(
+      String dbName, List<String> deviceId, List<Boolean> isSetTag, long time)
       throws IoTDBConnectionException, StatementExecutionException {
-    TTableDeviceLeaderResp resp = session.fetchDeviceLeader(dbName, deviceId, time);
+    TTableDeviceLeaderResp resp = session.fetchDeviceLeader(dbName, deviceId, isSetTag, time);
     return resp.getIp() + ":" + resp.getPort();
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/ClientRPCServiceImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/ClientRPCServiceImpl.java
@@ -3096,9 +3096,12 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
 
   @Override
   public TTableDeviceLeaderResp fetchDeviceLeader(TTableDeviceLeaderReq req) throws TException {
-    IDeviceID deviceID =
-        Factory.DEFAULT_FACTORY.create(
-            req.getDeviceId().toArray(new String[req.getDeviceIdSize()]));
+    int start_index = 0;
+    String[] trueSegments = new String[req.getIsSetTagSize()];
+    for (int i = 0; i < req.getIsSetTagSize(); i++) {
+      trueSegments[i] = req.getIsSetTag().get(i) ? req.getDeviceId().get(start_index++) : null;
+    }
+    IDeviceID deviceID = Factory.DEFAULT_FACTORY.create(trueSegments);
     TTimePartitionSlot timePartitionSlot = TimePartitionUtils.getTimePartitionSlot(req.getTime());
     DataPartitionQueryParam queryParam =
         new DataPartitionQueryParam(deviceID, Collections.singletonList(timePartitionSlot));

--- a/iotdb-protocol/thrift-datanode/src/main/thrift/client.thrift
+++ b/iotdb-protocol/thrift-datanode/src/main/thrift/client.thrift
@@ -551,7 +551,8 @@ struct TSConnectionInfoResp {
 struct TTableDeviceLeaderReq {
   1: required string dbName
   2: required list<string> deviceId
-  3: required i64 time
+  3: required list<bool> isSetTag
+  4: required i64 time
 }
 
 struct TTableDeviceLeaderResp {


### PR DESCRIPTION
Plz refer the usage from `TableModelSessionPoolExample`:

Correct device leader URL: 0.0.0.0:6667
Error dbName device leader URL: :
Error deviceId device leader URL: :
Error tag device leader URL: :
Error time device leader URL: :