### PR TITLE
Pipe: Fix connection leak caused by clients not closed after task dropped (2 situations)

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/connector/protocol/IoTDBConfigRegionConnector.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/connector/protocol/IoTDBConfigRegionConnector.java
@@ -149,7 +149,7 @@ public class IoTDBConfigRegionConnector extends IoTDBSslSyncConnector {
 
   private void doTransfer(final PipeConfigRegionWritePlanEvent pipeConfigRegionWritePlanEvent)
       throws PipeException {
-    final Pair<IoTDBSyncClient, Boolean> clientAndStatus = clientManager.getClient();
+    final Pair<IoTDBSyncClient, Boolean> clientAndStatus = getClientManager().getClient();
 
     final TPipeTransferResp resp;
     try {
@@ -175,7 +175,7 @@ public class IoTDBConfigRegionConnector extends IoTDBSslSyncConnector {
     final TSStatus status = resp.getStatus();
     // Send handshake req and then re-transfer the event
     if (status.getCode() == TSStatusCode.PIPE_CONFIG_RECEIVER_HANDSHAKE_NEEDED.getStatusCode()) {
-      clientManager.sendHandshakeReq(clientAndStatus);
+      getClientManager().sendHandshakeReq(clientAndStatus);
     }
     // Only handle the failed statuses to avoid string format performance overhead
     if (status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()
@@ -214,7 +214,7 @@ public class IoTDBConfigRegionConnector extends IoTDBSslSyncConnector {
     final long creationTime = snapshotEvent.getCreationTime();
     final File snapshotFile = snapshotEvent.getSnapshotFile();
     final File templateFile = snapshotEvent.getTemplateFile();
-    final Pair<IoTDBSyncClient, Boolean> clientAndStatus = clientManager.getClient();
+    final Pair<IoTDBSyncClient, Boolean> clientAndStatus = getClientManager().getClient();
 
     // 1. Transfer snapshotFile, and template File if exists
     transferFilePieces(
@@ -265,7 +265,7 @@ public class IoTDBConfigRegionConnector extends IoTDBSslSyncConnector {
     final TSStatus status = resp.getStatus();
     // Send handshake req and then re-transfer the event
     if (status.getCode() == TSStatusCode.PIPE_CONFIG_RECEIVER_HANDSHAKE_NEEDED.getStatusCode()) {
-      clientManager.sendHandshakeReq(clientAndStatus);
+      getClientManager().sendHandshakeReq(clientAndStatus);
     }
     // Only handle the failed statuses to avoid string format performance overhead
     if (status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/connector/PipeConnectorSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/connector/PipeConnectorSubtask.java
@@ -164,6 +164,11 @@ public class PipeConnectorSubtask extends PipeAbstractConnectorSubtask {
   }
 
   private void transferHeartbeatEvent(final PipeHeartbeatEvent event) {
+    // DO NOT call heartbeat or transfer after closed, or will cause connection leak
+    if (isClosed.get()) {
+      return;
+    }
+
     try {
       outputPipeConnector.heartbeat();
       outputPipeConnector.transfer(event);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/client/IoTDBDataNodeAsyncClientManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/client/IoTDBDataNodeAsyncClientManager.java
@@ -299,15 +299,19 @@ public class IoTDBDataNodeAsyncClientManager extends IoTDBClientManager
       client.resetMethodStateIfStopped();
       throw e;
     } finally {
-      client.setShouldReturnSelf(true);
       if (isClosed) {
         try {
           client.close();
           client.invalidateAll();
         } catch (final Exception e) {
-          LOGGER.warn("111");
+          LOGGER.warn(
+              "Failed to close client {}:{} after handshake failure when the manager is closed.",
+              targetNodeUrl.getIp(),
+              targetNodeUrl.getPort(),
+              e);
         }
       }
+      client.setShouldReturnSelf(true);
       client.returnSelf();
     }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/client/IoTDBDataNodeAsyncClientManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/client/IoTDBDataNodeAsyncClientManager.java
@@ -347,7 +347,9 @@ public class IoTDBDataNodeAsyncClientManager extends IoTDBClientManager
                   ASYNC_PIPE_DATA_TRANSFER_CLIENT_MANAGER_HOLDER.remove(receiverAttributes);
               if (clientManager != null) {
                 try {
+                  LOGGER.warn("AsyncPipeDataTransferServiceClient closed. 1", new Exception());
                   clientManager.close();
+                  LOGGER.warn("AsyncPipeDataTransferServiceClient closed. 2", new Exception());
                 } catch (final Exception e) {
                   LOGGER.warn("Failed to close client manager.", e);
                 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/client/IoTDBDataNodeAsyncClientManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/client/IoTDBDataNodeAsyncClientManager.java
@@ -300,6 +300,14 @@ public class IoTDBDataNodeAsyncClientManager extends IoTDBClientManager
       throw e;
     } finally {
       client.setShouldReturnSelf(true);
+      if (isClosed) {
+        try {
+          client.close();
+          client.invalidateAll();
+        } catch (final Exception e) {
+          LOGGER.warn("111");
+        }
+      }
       client.returnSelf();
     }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/client/IoTDBDataNodeAsyncClientManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/client/IoTDBDataNodeAsyncClientManager.java
@@ -359,11 +359,15 @@ public class IoTDBDataNodeAsyncClientManager extends IoTDBClientManager
                   ASYNC_PIPE_DATA_TRANSFER_CLIENT_MANAGER_HOLDER.remove(receiverAttributes);
               if (clientManager != null) {
                 try {
-                  LOGGER.warn("AsyncPipeDataTransferServiceClient closed. 1", new Exception());
                   clientManager.close();
-                  LOGGER.warn("AsyncPipeDataTransferServiceClient closed. 2", new Exception());
+                  LOGGER.info(
+                      "Closed AsyncPipeDataTransferServiceClientManager for receiver attributes: {}",
+                      receiverAttributes);
                 } catch (final Exception e) {
-                  LOGGER.warn("Failed to close client manager.", e);
+                  LOGGER.warn(
+                      "Failed to close AsyncPipeDataTransferServiceClientManager for receiver attributes: {}",
+                      receiverAttributes,
+                      e);
                 }
               }
               return null;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBDataRegionAsyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBDataRegionAsyncConnector.java
@@ -198,7 +198,9 @@ public class IoTDBDataRegionAsyncConnector extends IoTDBConnector {
 
   @Override
   public void heartbeat() throws Exception {
-    syncConnector.heartbeat();
+    if (!isClosed()) {
+      syncConnector.heartbeat();
+    }
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBDataRegionAsyncConnector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBDataRegionAsyncConnector.java
@@ -74,7 +74,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -432,34 +431,15 @@ public class IoTDBDataRegionAsyncConnector extends IoTDBConnector {
   private void transfer(final PipeTransferTsFileHandler pipeTransferTsFileHandler)
       throws Exception {
     transferTsFileCounter.incrementAndGet();
-    CompletableFuture<Void> completableFuture =
-        CompletableFuture.supplyAsync(
-            () -> {
-              AsyncPipeDataTransferServiceClient client = null;
-              try {
-                client = transferTsFileClientManager.borrowClient();
-                pipeTransferTsFileHandler.transfer(transferTsFileClientManager, client);
-              } catch (final Exception ex) {
-                logOnClientException(client, ex);
-                pipeTransferTsFileHandler.onError(ex);
-              } finally {
-                transferTsFileCounter.decrementAndGet();
-              }
-              return null;
-            },
-            executor);
-
-    if (PipeConfig.getInstance().isTransferTsFileSync()) {
-      try {
-        completableFuture.get();
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        LOGGER.error("Transfer tsfile event asynchronously was interrupted.", e);
-        throw new PipeException("Transfer tsfile event asynchronously was interrupted.", e);
-      } catch (Exception e) {
-        LOGGER.error("Failed to transfer tsfile event asynchronously.", e);
-        throw e;
-      }
+    AsyncPipeDataTransferServiceClient client = null;
+    try {
+      client = transferTsFileClientManager.borrowClient();
+      pipeTransferTsFileHandler.transfer(transferTsFileClientManager, client);
+    } catch (final Exception ex) {
+      logOnClientException(client, ex);
+      pipeTransferTsFileHandler.onError(ex);
+    } finally {
+      transferTsFileCounter.decrementAndGet();
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTrackableHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTrackableHandler.java
@@ -82,6 +82,7 @@ public abstract class PipeTransferTrackableHandler
     if (connector.isClosed()) {
       clearEventsReferenceCount();
       connector.eliminateHandler(this);
+      client.returnSelf();
       return false;
     }
     doTransfer(client, req);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTrackableHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTrackableHandler.java
@@ -82,6 +82,7 @@ public abstract class PipeTransferTrackableHandler
     if (connector.isClosed()) {
       clearEventsReferenceCount();
       connector.eliminateHandler(this);
+      client.setShouldReturnSelf(true);
       client.returnSelf();
       return false;
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTsFileHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTsFileHandler.java
@@ -222,6 +222,7 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
             : PipeTransferTsFilePieceReq.toTPipeTransferReq(
                 currentFile.getName(), position, payload);
     final TPipeTransferReq req = connector.compressIfNeeded(uncompressedReq);
+
     pipeName2WeightMap.forEach(
         (pipePair, weight) ->
             connector.rateLimitIfNeeded(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTsFileHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTsFileHandler.java
@@ -429,6 +429,14 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
   private void returnClientIfNecessary() {
     if (client != null) {
       client.setShouldReturnSelf(true);
+      if (connector.isClosed()) {
+        try {
+          client.close();
+          client.invalidateAll();
+        } catch (final Exception e) {
+          LOGGER.warn("111");
+        }
+      }
       client.returnSelf();
       client = null;
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTsFileHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTsFileHandler.java
@@ -206,6 +206,7 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
 
         try {
           Thread.sleep(20000);
+          LOGGER.error("sleep out 22", new Throwable());
         } catch (InterruptedException e) {
         }
 
@@ -229,6 +230,7 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
     final TPipeTransferReq req = connector.compressIfNeeded(uncompressedReq);
     try {
       Thread.sleep(20000);
+      LOGGER.error("sleep out 33", new Throwable());
     } catch (InterruptedException e) {
     }
     pipeName2WeightMap.forEach(
@@ -250,6 +252,7 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
   public void onComplete(final TPipeTransferResp response) {
     try {
       Thread.sleep(20000);
+      LOGGER.error("sleep out 44", new Throwable());
     } catch (InterruptedException e) {
     }
     try {
@@ -363,6 +366,7 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
   public void onError(final Exception exception) {
     try {
       Thread.sleep(20000);
+      LOGGER.error("onError sleep out 1", new Throwable());
     } catch (InterruptedException e) {
     }
     try {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTsFileHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTsFileHandler.java
@@ -204,12 +204,6 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
                     client.getEndPoint(),
                     (long) (req.getBody().length * weight)));
 
-        try {
-          Thread.sleep(20000);
-          LOGGER.error("sleep out 22", new Throwable());
-        } catch (InterruptedException e) {
-        }
-
         if (!tryTransfer(client, req)) {
           return;
         }
@@ -228,11 +222,6 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
             : PipeTransferTsFilePieceReq.toTPipeTransferReq(
                 currentFile.getName(), position, payload);
     final TPipeTransferReq req = connector.compressIfNeeded(uncompressedReq);
-    try {
-      Thread.sleep(20000);
-      LOGGER.error("sleep out 33", new Throwable());
-    } catch (InterruptedException e) {
-    }
     pipeName2WeightMap.forEach(
         (pipePair, weight) ->
             connector.rateLimitIfNeeded(
@@ -250,11 +239,6 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
 
   @Override
   public void onComplete(final TPipeTransferResp response) {
-    try {
-      Thread.sleep(20000);
-      LOGGER.error("sleep out 44", new Throwable());
-    } catch (InterruptedException e) {
-    }
     try {
       super.onComplete(response);
     } finally {
@@ -364,11 +348,6 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
 
   @Override
   public void onError(final Exception exception) {
-    try {
-      Thread.sleep(20000);
-      LOGGER.error("onError sleep out 1", new Throwable());
-    } catch (InterruptedException e) {
-    }
     try {
       super.onError(exception);
     } finally {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTsFileHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTsFileHandler.java
@@ -431,19 +431,25 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
   }
 
   private void returnClientIfNecessary() {
-    if (client != null) {
-      client.setShouldReturnSelf(true);
-      if (connector.isClosed()) {
-        try {
-          client.close();
-          client.invalidateAll();
-        } catch (final Exception e) {
-          LOGGER.warn("111");
-        }
-      }
-      client.returnSelf();
-      client = null;
+    if (client == null) {
+      return;
     }
+
+    if (connector.isClosed()) {
+      try {
+        client.close();
+        client.invalidateAll();
+      } catch (final Exception e) {
+        LOGGER.warn(
+            "Failed to close or invalidate client when connector is closed. Client: {}, Exception: {}",
+            client,
+            e.getMessage(),
+            e);
+      }
+    }
+    client.setShouldReturnSelf(true);
+    client.returnSelf();
+    client = null;
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTsFileHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTsFileHandler.java
@@ -204,6 +204,11 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
                     client.getEndPoint(),
                     (long) (req.getBody().length * weight)));
 
+        try {
+          Thread.sleep(20000);
+        } catch (InterruptedException e) {
+        }
+
         if (!tryTransfer(client, req)) {
           return;
         }
@@ -222,7 +227,10 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
             : PipeTransferTsFilePieceReq.toTPipeTransferReq(
                 currentFile.getName(), position, payload);
     final TPipeTransferReq req = connector.compressIfNeeded(uncompressedReq);
-
+    try {
+      Thread.sleep(20000);
+    } catch (InterruptedException e) {
+    }
     pipeName2WeightMap.forEach(
         (pipePair, weight) ->
             connector.rateLimitIfNeeded(
@@ -240,6 +248,10 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
 
   @Override
   public void onComplete(final TPipeTransferResp response) {
+    try {
+      Thread.sleep(20000);
+    } catch (InterruptedException e) {
+    }
     try {
       super.onComplete(response);
     } finally {
@@ -349,6 +361,10 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
 
   @Override
   public void onError(final Exception exception) {
+    try {
+      Thread.sleep(20000);
+    } catch (InterruptedException e) {
+    }
     try {
       super.onError(exception);
     } finally {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/ClientManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/ClientManager.java
@@ -64,6 +64,9 @@ public class ClientManager<K, V> implements IClientManager<K, V> {
    * return of a client is automatic whenever a particular client is used.
    */
   public void returnClient(K node, V client) {
+    if (node == null) {
+      LOGGER.error("{} CAN NOT BE RETURNED", client, new Exception());
+    }
     Optional.ofNullable(node)
         .ifPresent(
             x -> {
@@ -73,6 +76,16 @@ public class ClientManager<K, V> implements IClientManager<K, V> {
                 LOGGER.warn("Return client {} for node {} to pool failed.", client, node, e);
               }
             });
+    if (node != null) {
+      try {
+        pool.returnObject(node, client);
+      } catch (Exception e) {
+        LOGGER.warn("Return client {} for node {} to pool failed.", client, node, e);
+      }
+    } else if (client instanceof ThriftClient) {
+      ((ThriftClient) client).invalidateAll();
+      LOGGER.info("Client {} returned thrift client.", client);
+    }
   }
 
   @Override

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/ClientManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/ClientManager.java
@@ -67,15 +67,6 @@ public class ClientManager<K, V> implements IClientManager<K, V> {
     if (node == null) {
       LOGGER.error("{} CAN NOT BE RETURNED", client, new Exception());
     }
-    Optional.ofNullable(node)
-        .ifPresent(
-            x -> {
-              try {
-                pool.returnObject(node, client);
-              } catch (Exception e) {
-                LOGGER.warn("Return client {} for node {} to pool failed.", client, node, e);
-              }
-            });
     if (node != null) {
       try {
         pool.returnObject(node, client);

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncPipeDataTransferServiceClient.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncPipeDataTransferServiceClient.java
@@ -125,7 +125,6 @@ public class AsyncPipeDataTransferServiceClient extends IClientRPCService.AsyncC
       setTimeout(timeout);
       LOGGER.error("Failed to set timeout dynamically, set it statically", e);
     }
-    LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, timeout dynamically", id);
   }
 
   public void close() {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncPipeDataTransferServiceClient.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncPipeDataTransferServiceClient.java
@@ -136,7 +136,7 @@ public class AsyncPipeDataTransferServiceClient extends IClientRPCService.AsyncC
     LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, timeout dynamically", id);
   }
 
-  private void close() {
+  public void close() {
     ___transport.close();
     ___currentMethod = null;
     LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, closed", id);

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncPipeDataTransferServiceClient.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncPipeDataTransferServiceClient.java
@@ -72,12 +72,14 @@ public class AsyncPipeDataTransferServiceClient extends IClientRPCService.AsyncC
     this.printLogWhenEncounterException = property.isPrintLogWhenEncounterException();
     this.endpoint = endpoint;
     this.clientManager = clientManager;
+    LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, constructor", id);
   }
 
   @Override
   public void onComplete() {
     super.onComplete();
     returnSelf();
+    LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, onComplete", id);
   }
 
   @Override
@@ -85,18 +87,22 @@ public class AsyncPipeDataTransferServiceClient extends IClientRPCService.AsyncC
     super.onError(e);
     ThriftClient.resolveException(e, this);
     returnSelf();
+    LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, onError", id, e);
   }
 
   @Override
   public void invalidate() {
     if (!hasError()) {
       super.onError(new Exception(String.format("This client %d has been invalidated", id)));
+      LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, invalidate 1", id);
     }
+    LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, invalidate 2", id, new Exception());
   }
 
   @Override
   public void invalidateAll() {
     clientManager.clear(endpoint);
+    LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, invalidateAll", id, new Exception());
   }
 
   @Override
@@ -111,7 +117,9 @@ public class AsyncPipeDataTransferServiceClient extends IClientRPCService.AsyncC
   public void returnSelf() {
     if (shouldReturnSelf.get()) {
       clientManager.returnClient(endpoint, this);
+      LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, returnSelf 1", id);
     }
+    LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, returnSelf 2", id);
   }
 
   public void setShouldReturnSelf(final boolean shouldReturnSelf) {
@@ -125,11 +133,13 @@ public class AsyncPipeDataTransferServiceClient extends IClientRPCService.AsyncC
       setTimeout(timeout);
       LOGGER.error("Failed to set timeout dynamically, set it statically", e);
     }
+    LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, timeout dynamically", id);
   }
 
   private void close() {
     ___transport.close();
     ___currentMethod = null;
+    LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, closed", id);
   }
 
   private boolean isReady() {
@@ -165,10 +175,13 @@ public class AsyncPipeDataTransferServiceClient extends IClientRPCService.AsyncC
       if (___transport != null && ___transport.isOpen()) {
         ___transport.close();
         LOGGER.warn("Manually closing transport to prevent resource leakage.");
+        LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, resetMethodState 1", id);
       }
       ___currentMethod = null;
       LOGGER.info("Method state has been reset due to manager not running.");
+      LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, resetMethodState 2", id);
     }
+    LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, resetMethodState 3", id);
   }
 
   public String getIp() {
@@ -203,11 +216,14 @@ public class AsyncPipeDataTransferServiceClient extends IClientRPCService.AsyncC
         final TEndPoint endPoint,
         final PooledObject<AsyncPipeDataTransferServiceClient> pooledObject) {
       pooledObject.getObject().close();
+      LOGGER.warn(
+          "AsyncPipeDataTransferServiceClient#Factory endpoint = {}, destroyObject", endPoint);
     }
 
     @Override
     public PooledObject<AsyncPipeDataTransferServiceClient> makeObject(final TEndPoint endPoint)
         throws Exception {
+      LOGGER.warn("AsyncPipeDataTransferServiceClient#Factory endpoint = {}, makeObject", endPoint);
       return new DefaultPooledObject<>(
           new AsyncPipeDataTransferServiceClient(
               thriftClientProperty,
@@ -220,6 +236,8 @@ public class AsyncPipeDataTransferServiceClient extends IClientRPCService.AsyncC
     public boolean validateObject(
         final TEndPoint endPoint,
         final PooledObject<AsyncPipeDataTransferServiceClient> pooledObject) {
+      LOGGER.warn(
+          "AsyncPipeDataTransferServiceClient#Factory endpoint = {},   validateObject", endPoint);
       return pooledObject.getObject().isReady();
     }
   }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncPipeDataTransferServiceClient.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncPipeDataTransferServiceClient.java
@@ -72,14 +72,12 @@ public class AsyncPipeDataTransferServiceClient extends IClientRPCService.AsyncC
     this.printLogWhenEncounterException = property.isPrintLogWhenEncounterException();
     this.endpoint = endpoint;
     this.clientManager = clientManager;
-    LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, constructor", id);
   }
 
   @Override
   public void onComplete() {
     super.onComplete();
     returnSelf();
-    LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, onComplete", id);
   }
 
   @Override
@@ -87,22 +85,18 @@ public class AsyncPipeDataTransferServiceClient extends IClientRPCService.AsyncC
     super.onError(e);
     ThriftClient.resolveException(e, this);
     returnSelf();
-    LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, onError", id, e);
   }
 
   @Override
   public void invalidate() {
     if (!hasError()) {
       super.onError(new Exception(String.format("This client %d has been invalidated", id)));
-      LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, invalidate 1", id);
     }
-    LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, invalidate 2", id, new Exception());
   }
 
   @Override
   public void invalidateAll() {
     clientManager.clear(endpoint);
-    LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, invalidateAll", id, new Exception());
   }
 
   @Override
@@ -116,14 +110,8 @@ public class AsyncPipeDataTransferServiceClient extends IClientRPCService.AsyncC
    */
   public void returnSelf() {
     if (shouldReturnSelf.get()) {
-      if (clientManager.isClosed()) {
-        this.close();
-        this.invalidateAll();
-      }
       clientManager.returnClient(endpoint, this);
-      LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, returnSelf 1", id);
     }
-    LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, returnSelf 2", id);
   }
 
   public void setShouldReturnSelf(final boolean shouldReturnSelf) {
@@ -179,13 +167,10 @@ public class AsyncPipeDataTransferServiceClient extends IClientRPCService.AsyncC
       if (___transport != null && ___transport.isOpen()) {
         ___transport.close();
         LOGGER.warn("Manually closing transport to prevent resource leakage.");
-        LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, resetMethodState 1", id);
       }
       ___currentMethod = null;
       LOGGER.info("Method state has been reset due to manager not running.");
-      LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, resetMethodState 2", id);
     }
-    LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, resetMethodState 3", id);
   }
 
   public String getIp() {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncPipeDataTransferServiceClient.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncPipeDataTransferServiceClient.java
@@ -116,6 +116,10 @@ public class AsyncPipeDataTransferServiceClient extends IClientRPCService.AsyncC
    */
   public void returnSelf() {
     if (shouldReturnSelf.get()) {
+      if (clientManager.isClosed()) {
+        this.close();
+        this.invalidateAll();
+      }
       clientManager.returnClient(endpoint, this);
       LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, returnSelf 1", id);
     }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncPipeDataTransferServiceClient.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncPipeDataTransferServiceClient.java
@@ -131,7 +131,6 @@ public class AsyncPipeDataTransferServiceClient extends IClientRPCService.AsyncC
   public void close() {
     ___transport.close();
     ___currentMethod = null;
-    LOGGER.warn("AsyncPipeDataTransferServiceClient id = {}, closed", id);
   }
 
   private boolean isReady() {
@@ -205,14 +204,11 @@ public class AsyncPipeDataTransferServiceClient extends IClientRPCService.AsyncC
         final TEndPoint endPoint,
         final PooledObject<AsyncPipeDataTransferServiceClient> pooledObject) {
       pooledObject.getObject().close();
-      LOGGER.warn(
-          "AsyncPipeDataTransferServiceClient#Factory endpoint = {}, destroyObject", endPoint);
     }
 
     @Override
     public PooledObject<AsyncPipeDataTransferServiceClient> makeObject(final TEndPoint endPoint)
         throws Exception {
-      LOGGER.warn("AsyncPipeDataTransferServiceClient#Factory endpoint = {}, makeObject", endPoint);
       return new DefaultPooledObject<>(
           new AsyncPipeDataTransferServiceClient(
               thriftClientProperty,
@@ -225,8 +221,6 @@ public class AsyncPipeDataTransferServiceClient extends IClientRPCService.AsyncC
     public boolean validateObject(
         final TEndPoint endPoint,
         final PooledObject<AsyncPipeDataTransferServiceClient> pooledObject) {
-      LOGGER.warn(
-          "AsyncPipeDataTransferServiceClient#Factory endpoint = {},   validateObject", endPoint);
       return pooledObject.getObject().isReady();
     }
   }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/connector/client/IoTDBSyncClientManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/connector/client/IoTDBSyncClientManager.java
@@ -252,7 +252,8 @@ public abstract class IoTDBSyncClientManager extends IoTDBClientManager implemen
         LOGGER.info(
             "Handshake success. Target server ip: {}, port: {}",
             client.getIpAddress(),
-            client.getPort());
+            client.getPort(),
+            new Exception("FIND ME HERE"));
       }
     } catch (Exception e) {
       LOGGER.warn(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/connector/client/IoTDBSyncClientManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/connector/client/IoTDBSyncClientManager.java
@@ -252,8 +252,7 @@ public abstract class IoTDBSyncClientManager extends IoTDBClientManager implemen
         LOGGER.info(
             "Handshake success. Target server ip: {}, port: {}",
             client.getIpAddress(),
-            client.getPort(),
-            new Exception("FIND ME HERE"));
+            client.getPort());
       }
     } catch (Exception e) {
       LOGGER.warn(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/connector/protocol/IoTDBSslSyncConnector.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/connector/protocol/IoTDBSslSyncConnector.java
@@ -66,7 +66,7 @@ public abstract class IoTDBSslSyncConnector extends IoTDBConnector {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IoTDBSslSyncConnector.class);
 
-  protected volatile IoTDBSyncClientManager clientManager;
+  private volatile IoTDBSyncClientManager clientManager;
 
   protected IoTDBSyncClientManager getClientManager() {
     if (clientManager == null) {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/connector/protocol/IoTDBSslSyncConnector.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/connector/protocol/IoTDBSslSyncConnector.java
@@ -66,7 +66,14 @@ public abstract class IoTDBSslSyncConnector extends IoTDBConnector {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IoTDBSslSyncConnector.class);
 
-  protected IoTDBSyncClientManager clientManager;
+  protected volatile IoTDBSyncClientManager clientManager;
+
+  protected IoTDBSyncClientManager getClientManager() {
+    if (clientManager == null) {
+      throw new IllegalStateException("IoTDB sync client manager has been closed");
+    }
+    return clientManager;
+  }
 
   @Override
   public void validate(final PipeParameterValidator validator) throws Exception {
@@ -153,7 +160,7 @@ public abstract class IoTDBSslSyncConnector extends IoTDBConnector {
 
   @Override
   public void handshake() throws Exception {
-    clientManager.checkClientStatusAndTryReconstructIfNecessary();
+    getClientManager().checkClientStatusAndTryReconstructIfNecessary();
   }
 
   @Override
@@ -229,7 +236,7 @@ public abstract class IoTDBSslSyncConnector extends IoTDBConnector {
         // Send handshake req and then re-transfer the event
         if (status.getCode()
             == TSStatusCode.PIPE_CONFIG_RECEIVER_HANDSHAKE_NEEDED.getStatusCode()) {
-          clientManager.sendHandshakeReq(clientAndStatus);
+          getClientManager().sendHandshakeReq(clientAndStatus);
         }
         // Only handle the failed statuses to avoid string format performance overhead
         if (status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()
@@ -255,6 +262,7 @@ public abstract class IoTDBSslSyncConnector extends IoTDBConnector {
   public void close() {
     if (clientManager != null) {
       clientManager.close();
+      clientManager = null;
     }
 
     super.close();


### PR DESCRIPTION
This pull request introduces several changes across multiple files to improve connection management, enhance error handling, and ensure proper resource cleanup. The most notable updates include replacing direct `clientManager` calls with a `getClientManager()` method for safer access, adding checks to prevent operations after closure, and improving logging for debugging purposes.

### Connection Management Improvements:
* [`iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/connector/protocol/IoTDBSslSyncConnector.java`](diffhunk://#diff-571e6f3b28edec52b9532e699c7564cf00f1700f3178264b7d94b2fd63b4ce67L69-R76): Replaced direct `clientManager` access with a `getClientManager()` method that throws an exception if the client manager is closed, ensuring safer access.
* [`iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/connector/protocol/IoTDBSslSyncConnector.java`](diffhunk://#diff-571e6f3b28edec52b9532e699c7564cf00f1700f3178264b7d94b2fd63b4ce67L156-R163): Updated methods like `handshake` and `sendHandshakeReq` to use `getClientManager()` instead of directly accessing `clientManager`. [[1]](diffhunk://#diff-571e6f3b28edec52b9532e699c7564cf00f1700f3178264b7d94b2fd63b4ce67L156-R163) [[2]](diffhunk://#diff-571e6f3b28edec52b9532e699c7564cf00f1700f3178264b7d94b2fd63b4ce67L232-R239)

### Resource Cleanup Enhancements:
* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/client/IoTDBDataNodeAsyncClientManager.java`](diffhunk://#diff-bb503254743b53b16890f1a498805b6470d043cb6bffb4c44879fc4193822857R302-R313): Added logic to close clients and invalidate resources in cases where the manager is closed, preventing connection leaks. [[1]](diffhunk://#diff-bb503254743b53b16890f1a498805b6470d043cb6bffb4c44879fc4193822857R302-R313) [[2]](diffhunk://#diff-bb503254743b53b16890f1a498805b6470d043cb6bffb4c44879fc4193822857R363-R370)
* [`iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/ClientManager.java`](diffhunk://#diff-8f9d7d4eb2bbd220de459c5360944ade50c75332839003779f37bc06b9e92baeL67-R79): Enhanced the `returnClient` method to handle cases where the node is null, invalidating resources to prevent leaks.

### Error Handling Improvements:
* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/handler/PipeTransferTsFileHandler.java`](diffhunk://#diff-6a5277095c6319b2136b794048ee409b0fdc5a1140c83a52b6a3815c5b49f1d6L414-L419): Improved error handling and resource cleanup when the connector is closed, with detailed logging for debugging.
* [`iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/async/AsyncPipeDataTransferServiceClient.java`](diffhunk://#diff-863ff139022237e9b92d155447ad12560814709b8bef199d3ad9ec6501b718daL130-R130): Made the `close` method public for better resource management.

### Operational Safety Enhancements:
* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/connector/PipeConnectorSubtask.java`](diffhunk://#diff-04c726850fc21145882c7cae2fb323de5d84ae9530e88b78251bc7f67dd8d529R167-R171): Added a check to prevent heartbeat or transfer operations after the connector is closed.
* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/connector/protocol/thrift/async/IoTDBDataRegionAsyncConnector.java`](diffhunk://#diff-f05a94fe36be68e63bb4db6d39a8ce502854ea3dd5cf789e938a6c2b1281b22fR201-R204): Updated the `heartbeat` method to ensure it does not execute if the connector is closed.

These changes collectively enhance the robustness of the system by ensuring safer client management, preventing resource leaks, and improving error handling and operational safety.