### PR TITLE
Use getOrCreateDataPartition when executing FetchDeviceLeader

### DIFF
--- a/example/session/src/main/java/org/apache/iotdb/TableModelSessionPoolExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/TableModelSessionPoolExample.java
@@ -139,9 +139,13 @@ public class TableModelSessionPoolExample {
       String correctURL =
           session.getDeviceLeaderURL("test2", Arrays.asList("test1", "1", "3"), isSetTag, 66);
       System.out.println("Correct device leader URL: " + correctURL);
-      String errorDbURL =
-          session.getDeviceLeaderURL("test3", Arrays.asList("test1", "1", "3"), isSetTag, 66);
-      System.out.println("Error dbName device leader URL: " + errorDbURL);
+      try {
+        String errorDbURL =
+                session.getDeviceLeaderURL("test3", Arrays.asList("test1", "1", "3"), isSetTag, 66);
+        System.out.println("Error dbName device leader URL: " + errorDbURL);
+      } catch (StatementExecutionException e) {
+        System.out.println(e.getMessage());
+      }
       String errorDeviceURL =
           session.getDeviceLeaderURL("test2", Arrays.asList("test1", "3", "1"), isSetTag, 66);
       System.out.println("Error deviceId device leader URL: " + errorDeviceURL);


### PR DESCRIPTION
In this PR, we replace the `getDataPartition` with `getOrCreateDataPartition` when executing FetchDeviceLeader. As a result, the behavior of this interface is as follows:

1. Return the corresponding region leader when both database and data partition are existed. Correct device leader URL: 0.0.0.0:6667
2. Throw `StatementExecutionException` when database not existed. 301: Failed to fetch device leader: An error occurred when executing getOrCreateDataPartition():Create DataPartition failed because the database: test3 is not exists
3. Automatically create a new data partition when the specified deviceId does not exist. Error deviceId device leader URL: 0.0.0.0:6667
4. Automatically create a new data partition when the specified deviceId does not exist. Error tag device leader URL: 0.0.0.0:6667
5. Automatically create a new data partition when the specified time partition does not exist. Error time device leader URL: 0.0.0.0:6667

U can find detailed test cases in TableModelSessionPoolExample.java.