### PR TITLE
[To dev/1.3] Bump org.apache.commons:commons-lang3 from 3.13.0 to 3.18.0 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <commons-csv.version>1.10.0</commons-csv.version>
         <commons-io.version>2.14.0</commons-io.version>
         <commons-jexl3.version>3.3</commons-jexl3.version>
-        <commons-lang3.version>3.13.0</commons-lang3.version>
+        <commons-lang3.version>3.18.0</commons-lang3.version>
         <commons-math3.version>3.6.1</commons-math3.version>
         <commons-pool2.version>2.11.1</commons-pool2.version>
         <commons.collections4.version>4.4</commons.collections4.version>


### PR DESCRIPTION
Bumps org.apache.commons:commons-lang3 from 3.13.0 to 3.18.0.

Fixing CVE-2025-48924