### PR TITLE
Avoid NPE while stop DN

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/SchemaEngine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/SchemaEngine.java
@@ -221,7 +221,7 @@ public class SchemaEngine {
     }
   }
 
-  public void clear() {
+  public synchronized void clear() {
     schemaRegionLoader.clear();
 
     // clearSchemaResource will shut down release and flush task in PBTree mode, which must be
@@ -261,7 +261,10 @@ public class SchemaEngine {
 
   public synchronized void createSchemaRegion(
       final String storageGroup, final SchemaRegionId schemaRegionId) throws MetadataException {
-    final ISchemaRegion schemaRegion = schemaRegionMap.get(schemaRegionId);
+    if (this.schemaRegionMap == null) {
+      throw new MetadataException("Peer is shutting down now.");
+    }
+    final ISchemaRegion schemaRegion = this.schemaRegionMap.get(schemaRegionId);
     if (schemaRegion != null) {
       if (schemaRegion.getDatabaseFullPath().equals(storageGroup)) {
         return;
@@ -273,7 +276,7 @@ public class SchemaEngine {
                 schemaRegionId, schemaRegion.getDatabaseFullPath(), storageGroup));
       }
     }
-    schemaRegionMap.put(
+    this.schemaRegionMap.put(
         schemaRegionId, createSchemaRegionWithoutExistenceCheck(storageGroup, schemaRegionId));
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/SchemaEngine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/SchemaEngine.java
@@ -239,6 +239,7 @@ public class SchemaEngine {
       }
       schemaRegionMap.clear();
       schemaRegionMap = null;
+      logger.info("clear schema region map.");
     }
     // SchemaMetric should be cleared lastly
     if (schemaMetricManager != null) {


### PR DESCRIPTION
We found that the schemaRegionMap in a DataNode might be null when it is shutting down while the cluster is migrating regions. This is because the schemaRegionMap is cleared and our cluster wants to create a new schema region in this DataNode. To avoid this NPE, we:
1. Synchronize the schema region creation and clear process.
2. Throw a `MetadataException` to indicate that the DataNode is closing.