### PR TITLE
Fix the handling of empty value chunk when load splitting time partitions

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/load/splitter/TsFileSplitter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/load/splitter/TsFileSplitter.java
@@ -521,6 +521,9 @@ public class TsFileSplitter {
           alignedChunkData.addValueChunk(header);
           if (!isTimeChunkNeedDecode) {
             alignedChunkData.writeEntireChunk(ByteBuffer.allocate(0), chunkMetadata);
+          } else {
+            alignedChunkData.writeEntirePage(
+                new PageHeader(0, 0, chunkMetadata.getStatistics()), ByteBuffer.allocate(0));
           }
           allChunkData.add(alignedChunkData);
         }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/BatchedCompactionWithTsFileSplitterTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/BatchedCompactionWithTsFileSplitterTest.java
@@ -71,7 +71,7 @@ public class BatchedCompactionWithTsFileSplitterTest extends AbstractCompactionT
     super.setUp();
     originMaxConcurrentAlignedSeriesInCompaction =
         IoTDBDescriptor.getInstance().getConfig().getCompactionMaxAlignedSeriesNumInOneBatch();
-    IoTDBDescriptor.getInstance().getConfig().setCompactionMaxAlignedSeriesNumInOneBatch(2);
+    IoTDBDescriptor.getInstance().getConfig().setCompactionMaxAlignedSeriesNumInOneBatch(6);
   }
 
   @After
@@ -222,7 +222,7 @@ public class BatchedCompactionWithTsFileSplitterTest extends AbstractCompactionT
             },
             TSEncoding.PLAIN,
             CompressionType.LZ4,
-            Arrays.asList(false, false, false, false, false),
+            Arrays.asList(false, false, false, true, false),
             true);
     seqResources.add(seqResource2);
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/BatchedCompactionWithTsFileSplitterTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/BatchedCompactionWithTsFileSplitterTest.java
@@ -71,7 +71,7 @@ public class BatchedCompactionWithTsFileSplitterTest extends AbstractCompactionT
     super.setUp();
     originMaxConcurrentAlignedSeriesInCompaction =
         IoTDBDescriptor.getInstance().getConfig().getCompactionMaxAlignedSeriesNumInOneBatch();
-    IoTDBDescriptor.getInstance().getConfig().setCompactionMaxAlignedSeriesNumInOneBatch(6);
+    IoTDBDescriptor.getInstance().getConfig().setCompactionMaxAlignedSeriesNumInOneBatch(2);
   }
 
   @After


### PR DESCRIPTION
## Description
Fix the handling of empty value chunk when load splitting time partitions