### PR TITLE
fix: Ensure correct evaluation order in BinaryColumnTransformer and a…

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/query/IoTDBCaseWhenThenIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/query/IoTDBCaseWhenThenIT.java
@@ -919,4 +919,13 @@ public class IoTDBCaseWhenThenIT {
         };
     resultSetEqualTest(sql, expectedHeader, retArray);
   }
+
+  @Test
+  public void testThenWithBinarySameConstant() {
+    String sql = "SELECT CASE WHEN true THEN 200 + (s1 - 200) END AS result FROM root.sg.d1";
+    String[] expectedHeader = new String[] {TIMESTAMP_STR, "result"};
+    String[] retArray =
+        new String[] {"0,0.0,", "1000000,11.0,", "20000000,22.0,", "210000000,33.0,"};
+    resultSetEqualTest(sql, expectedHeader, retArray);
+  }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBCaseWhenThenTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBCaseWhenThenTableIT.java
@@ -38,7 +38,6 @@ import static org.apache.iotdb.db.it.utils.TestUtils.prepareTableData;
 import static org.apache.iotdb.db.it.utils.TestUtils.resultSetEqualTest;
 import static org.apache.iotdb.db.it.utils.TestUtils.tableAssertTestFail;
 import static org.apache.iotdb.db.it.utils.TestUtils.tableResultSetEqualTest;
-import static org.apache.iotdb.itbase.constant.TestConstant.TIMESTAMP_STR;
 
 // TODO:fix the different type exception
 @RunWith(IoTDBTestRunner.class)

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBCaseWhenThenTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBCaseWhenThenTableIT.java
@@ -38,6 +38,7 @@ import static org.apache.iotdb.db.it.utils.TestUtils.prepareTableData;
 import static org.apache.iotdb.db.it.utils.TestUtils.resultSetEqualTest;
 import static org.apache.iotdb.db.it.utils.TestUtils.tableAssertTestFail;
 import static org.apache.iotdb.db.it.utils.TestUtils.tableResultSetEqualTest;
+import static org.apache.iotdb.itbase.constant.TestConstant.TIMESTAMP_STR;
 
 // TODO:fix the different type exception
 @RunWith(IoTDBTestRunner.class)
@@ -671,6 +672,14 @@ public class IoTDBCaseWhenThenTableIT {
     String sql =
         "select case when s3 >= 0 and s3 < 20 and s4 >= 50 and s4 < 60 then 'just so so~~~' when s3 >= 20 and s3 < 40 and s4 >= 70 and s4 < 80 then 'very well~~~' end from table2";
     String[] retArray = new String[] {"null,", "just so so~~~,", "null,", "very well~~~,"};
+    tableResultSetEqualTest(sql, expectedHeader, retArray, DATABASE);
+  }
+
+  @Test
+  public void testThenWithBinarySameConstant() {
+    String sql = "SELECT CASE WHEN true THEN 200 + (s1 - 200) END AS result FROM table1";
+    String[] expectedHeader = new String[] {"result"};
+    String[] retArray = new String[] {"0,", "11,", "22,", "33,"};
     tableResultSetEqualTest(sql, expectedHeader, retArray, DATABASE);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/binary/BinaryColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/binary/BinaryColumnTransformer.java
@@ -56,10 +56,12 @@ public abstract class BinaryColumnTransformer extends ColumnTransformer {
   @Override
   public void evaluateWithSelection(boolean[] selection) {
     leftTransformer.evaluateWithSelection(selection);
-    rightTransformer.evaluateWithSelection(selection);
     // attention: get positionCount before calling getColumn
     int positionCount = leftTransformer.getColumnCachePositionCount();
     Column leftColumn = leftTransformer.getColumn();
+    // When the rightTransformer has the same constant as the leftTransformer, the leftTransformer's
+    // cache will be cleared, so need to getColumn before evaluate rightTransformer.
+    rightTransformer.evaluateWithSelection(selection);
     Column rightColumn = rightTransformer.getColumn();
 
     ColumnBuilder builder = returnType.createColumnBuilder(positionCount);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/multi/MultiColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/multi/MultiColumnTransformer.java
@@ -25,6 +25,7 @@ import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnBuilder;
 import org.apache.tsfile.read.common.type.Type;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -60,20 +61,17 @@ public abstract class MultiColumnTransformer extends ColumnTransformer {
 
   @Override
   public void evaluateWithSelection(boolean[] selection) {
+    List<Column> childrenColumns = new ArrayList<>();
+
     for (ColumnTransformer child : columnTransformerList) {
       child.evaluateWithSelection(selection);
+      childrenColumns.add(child.getColumn());
     }
 
     int positionCount = columnTransformerList.get(0).getColumnCachePositionCount();
 
     ColumnBuilder builder = returnType.createColumnBuilder(positionCount);
-    doTransform(
-        columnTransformerList.stream()
-            .map(ColumnTransformer::getColumn)
-            .collect(Collectors.toList()),
-        builder,
-        positionCount,
-        selection);
+    doTransform(childrenColumns, builder, positionCount, selection);
     initializeColumnCache(builder.build());
 
     for (ColumnTransformer child : columnTransformerList) {


### PR DESCRIPTION
This pull request introduces new test cases for SQL queries involving binary operations with constants, along with updates to column transformer logic to handle caching issues and improve performance. Below is a breakdown of the most important changes:

### New Test Cases for SQL Queries
* Added `testThenWithBinarySameConstant` in `IoTDBCaseWhenThenIT.java` to validate SQL queries with binary operations involving constants in a `CASE WHEN` statement.
* Added `testThenWithBinarySameConstant` in `IoTDBCaseWhenThenTableIT.java` to test similar functionality for table-based queries.
* Included a missing import for `TIMESTAMP_STR` in `IoTDBCaseWhenThenTableIT.java`.

### Updates to Column Transformer Logic
* Modified `BinaryColumnTransformer` to ensure the right transformer is evaluated after fetching the left transformer’s column, addressing a cache-clearing issue when both transformers share the same constant.
* Refactored `MultiColumnTransformer` to use a `List` for storing child columns during evaluation, improving clarity and performance by avoiding repeated stream operations. [[1]](diffhunk://#diff-373ebcf216981407554cdf0d4e3d79bce246bffd19f08e612ad8515c669cfb19R64-R74) [[2]](diffhunk://#diff-373ebcf216981407554cdf0d4e3d79bce246bffd19f08e612ad8515c669cfb19R28)