### PR TITLE
[To dev/1.3] Pipe: Handle existing hardlink in createHardLink method (#15998)

### DIFF
--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/FileUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/FileUtils.java
@@ -34,6 +34,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.DirectoryNotEmptyException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -321,7 +322,34 @@ public class FileUtils {
 
     final Path sourcePath = FileSystems.getDefault().getPath(sourceFile.getAbsolutePath());
     final Path linkPath = FileSystems.getDefault().getPath(hardlink.getAbsolutePath());
-    Files.createLink(linkPath, sourcePath);
+    try {
+      Files.createLink(linkPath, sourcePath);
+    } catch (final FileAlreadyExistsException fileAlreadyExistsException) {
+      if (haveSameMD5(sourceFile, hardlink)) {
+        LOGGER.warn(
+            "Hardlink {} already exists, will not create it again. Source file: {}",
+            hardlink.getAbsolutePath(),
+            sourceFile.getAbsolutePath());
+      } else {
+        LOGGER.warn(
+            "Hardlink {} already exists but does not match source file {}, will try create it again.",
+            hardlink.getAbsolutePath(),
+            sourceFile.getAbsolutePath());
+        deleteFileIfExist(hardlink);
+        try {
+          Files.createLink(linkPath, sourcePath);
+        } catch (final Exception e) {
+          deleteFileIfExist(linkPath.toFile());
+          LOGGER.error(
+              "Failed to create hardlink {} for file {}: {}",
+              hardlink.getAbsolutePath(),
+              sourceFile.getAbsolutePath(),
+              e.getMessage(),
+              e);
+          throw e;
+        }
+      }
+    }
     return hardlink;
   }
 


### PR DESCRIPTION
Adds logic to check if a hardlink already exists when creating a hardlink. If the existing file matches the source (by MD5), a warning is logged and creation is skipped. If not, the existing file is deleted and creation is retried, with error handling and logging for failures.

(cherry picked from commit de05c67c51910e147bc3c52ccb3cb7a63fbaab88)