### PR TITLE
Fix wrong status code of case when

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBCaseWhenThenTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBCaseWhenThenTableIT.java
@@ -159,6 +159,10 @@ public class IoTDBCaseWhenThenTableIT {
         "select case when s1<=0 then true else 22 end from table1",
         "701: All CASE results must be the same type or coercible to a common type. Cannot find common type between BOOLEAN and INT32, all types (without duplicates): [BOOLEAN, INT32]",
         DATABASE);
+    tableAssertTestFail(
+        "select case when s1<=0 then 0 when s1>1 then null end from table1",
+        "701: All result types must be the same:",
+        DATABASE);
 
     // TEXT and other types cannot exist at the same time
     retArray = new String[] {"good,", "bad,", "okok,", "okok,"};

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/IrTypeAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/IrTypeAnalyzer.java
@@ -241,7 +241,10 @@ public class IrTypeAnalyzer {
                   })
               .collect(Collectors.toSet());
 
-      checkArgument(resultTypes.size() == 1, "All result types must be the same: %s", resultTypes);
+      if (resultTypes.size() != 1) {
+        throw new SemanticException(
+            String.format("All result types must be the same: %s", resultTypes));
+      }
       Type resultType = resultTypes.iterator().next();
       node.getDefaultValue()
           .ifPresent(
@@ -275,7 +278,11 @@ public class IrTypeAnalyzer {
                   })
               .collect(Collectors.toSet());
 
-      checkArgument(resultTypes.size() == 1, "All result types must be the same: %s", resultTypes);
+      if (resultTypes.size() != 1) {
+        throw new SemanticException(
+            String.format("All result types must be the same: %s", resultTypes));
+      }
+
       Type resultType = resultTypes.iterator().next();
       node.getDefaultValue()
           .ifPresent(

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
         <thrift.version>0.14.1</thrift.version>
         <xz.version>1.9</xz.version>
         <zstd-jni.version>1.5.6-3</zstd-jni.version>
-        <tsfile.version>2.2.0-250722-SNAPSHOT</tsfile.version>
+        <tsfile.version>2.2.0-250730-SNAPSHOT</tsfile.version>
     </properties>
     <!--
     if we claim dependencies in dependencyManagement, then we do not claim


### PR DESCRIPTION
This pull request introduces improvements to error handling and testing for CASE expressions in the IoTDB query engine. The changes ensure stricter type validation for CASE expressions and enhance test coverage for edge cases.

### Enhancements to error handling:

* [`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/IrTypeAnalyzer.java`](diffhunk://#diff-13930271f6daa99066c9dfe57eb9ba951f2d76eadbefc9523851080ecbaca476L244-R247): Replaced `checkArgument` with a more descriptive `SemanticException` to provide clearer error messages when CASE expression result types are not consistent in both `visitSearchedCaseExpression` and `visitSimpleCaseExpression` methods. [[1]](diffhunk://#diff-13930271f6daa99066c9dfe57eb9ba951f2d76eadbefc9523851080ecbaca476L244-R247) [[2]](diffhunk://#diff-13930271f6daa99066c9dfe57eb9ba951f2d76eadbefc9523851080ecbaca476L278-R285)

### Improvements to test coverage:

* [`integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBCaseWhenThenTableIT.java`](diffhunk://#diff-ece4f2e10ca92124130f5ce046317e13ca4c2b78ebf0582d4f5c373d7efabf56R162-R165): Added a new test case to validate that CASE expressions with mixed types (e.g., `0` and `null`) correctly trigger an error about inconsistent result types.