### PR TITLE
[AINode] Add cluster_ingress_port for AINodeWrapper

### DIFF
--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/env/AbstractEnv.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/env/AbstractEnv.java
@@ -258,7 +258,7 @@ public abstract class AbstractEnv implements BaseEnv {
 
     if (addAINode) {
       this.aiNodeWrapperList = new ArrayList<>();
-      startAINode(seedConfigNode, testClassName);
+      startAINode(seedConfigNode, this.dataNodeWrapperList.get(0).getPort(), testClassName);
     }
 
     checkClusterStatusWithoutUnknown();
@@ -307,11 +307,13 @@ public abstract class AbstractEnv implements BaseEnv {
     return dataNodeWrapper;
   }
 
-  private void startAINode(final String seedConfigNode, final String testClassName) {
+  private void startAINode(
+      final String seedConfigNode, final int clusterIngressPort, final String testClassName) {
     final String aiNodeEndPoint;
     final AINodeWrapper aiNodeWrapper =
         new AINodeWrapper(
             seedConfigNode,
+            clusterIngressPort,
             testClassName,
             testMethodName,
             index,

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/node/AINodeWrapper.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/node/AINodeWrapper.java
@@ -43,6 +43,7 @@ public class AINodeWrapper extends AbstractNodeWrapper {
   private static final Logger logger = IoTDBTestLogger.logger;
   private final long startTime;
   private final String seedConfigNode;
+  private final int clusterIngressPort;
 
   private static final String SCRIPT_FILE = "start-ainode.sh";
 
@@ -67,6 +68,7 @@ public class AINodeWrapper extends AbstractNodeWrapper {
 
   public AINodeWrapper(
       String seedConfigNode,
+      int clusterIngressPort,
       String testClassName,
       String testMethodName,
       int clusterIndex,
@@ -74,6 +76,7 @@ public class AINodeWrapper extends AbstractNodeWrapper {
       long startTime) {
     super(testClassName, testMethodName, port, clusterIndex, false, startTime);
     this.seedConfigNode = seedConfigNode;
+    this.clusterIngressPort = clusterIngressPort;
     this.startTime = startTime;
   }
 
@@ -105,8 +108,12 @@ public class AINodeWrapper extends AbstractNodeWrapper {
 
       // set attribute
       replaceAttribute(
-          new String[] {"ain_seed_config_node", "ain_rpc_port"},
-          new String[] {this.seedConfigNode, Integer.toString(getPort())},
+          new String[] {"ain_seed_config_node", "ain_rpc_port", "ain_cluster_ingress_port"},
+          new String[] {
+            this.seedConfigNode,
+            Integer.toString(getPort()),
+            Integer.toString(this.clusterIngressPort)
+          },
           propertiesFile);
 
       // start AINode


### PR DESCRIPTION
We add cluster_ingress_port to AINodeWrapper, so that the AINode can fetch data from DataNode in the CI environment