### PR TITLE
Address NPE cause by topology service

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/LoadCache.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/LoadCache.java
@@ -780,10 +780,25 @@ public class LoadCache {
 
   public void updateTopology(Map<Integer, Set<Integer>> latestTopology) {
     if (!latestTopology.equals(topologyGraph)) {
-      LOGGER.info("[Topology Service] Cluster topology changed, latest: {}", latestTopology);
+      LOGGER.info("[Topology] Cluster topology changed, latest: {}", latestTopology);
+      for (int fromId : latestTopology.keySet()) {
+        for (int toId : latestTopology.keySet()) {
+          boolean originReachable =
+              latestTopology.getOrDefault(fromId, Collections.emptySet()).contains(toId);
+          boolean newReachable =
+              latestTopology.getOrDefault(fromId, Collections.emptySet()).contains(toId);
+          if (originReachable != newReachable) {
+            LOGGER.info(
+                "[Topology] Topology of DataNode {} is now {} to DataNode {}",
+                fromId,
+                newReachable ? "reachable" : "unreachable",
+                toId);
+          }
+        }
+      }
+      topologyGraph = latestTopology;
+      topologyUpdated.set(true);
     }
-    topologyGraph = latestTopology;
-    topologyUpdated.set(true);
   }
 
   @Nullable

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/AbstractFragmentParallelPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/AbstractFragmentParallelPlanner.java
@@ -71,7 +71,7 @@ public abstract class AbstractFragmentParallelPlanner implements IFragmentParall
         && !CollectionUtils.isEmpty(regionReplicaSet.getDataNodeLocations())) {
       regionReplicaSet = validator.apply(regionReplicaSet);
       if (regionReplicaSet.getDataNodeLocations().isEmpty()) {
-        throw new ReplicaSetUnreachableException(fragment.getTargetRegionForTreeModel());
+        throw new ReplicaSetUnreachableException(replicaSetProvider.get());
       }
     }
     // Set ExecutorType and target host for the instance


### PR DESCRIPTION
We found that the topology service will throw a NPE at AbstractFragmentParallelPlanner, when the query target region replica set is unreachable. The reason leads to this issue is passing the wrong replica set. This PR fixes this NPE, while appending more logs for cluster topology service. As a result, log will be recorded to each node as long as the topology status changed.