### PR TITLE
Allocate less sort memory for IoTDBWindowTVFIT to avoid CI failed occationally

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBWindowTVFIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBWindowTVFIT.java
@@ -78,6 +78,7 @@ public class IoTDBWindowTVFIT {
 
   @BeforeClass
   public static void setUp() throws Exception {
+    EnvFactory.getEnv().getConfig().getCommonConfig().setSortBufferSize(1024 * 1024);
     EnvFactory.getEnv().initClusterEnvironment();
     insertData();
   }

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBWindowTVFIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBWindowTVFIT.java
@@ -78,7 +78,7 @@ public class IoTDBWindowTVFIT {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    EnvFactory.getEnv().getConfig().getCommonConfig().setSortBufferSize(1024 * 1024);
+    EnvFactory.getEnv().getConfig().getCommonConfig().setSortBufferSize(512 * 1024);
     EnvFactory.getEnv().initClusterEnvironment();
     insertData();
   }


### PR DESCRIPTION
This pull request makes a small change to the `integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBWindowTVFIT.java` file. The change sets the sort buffer size to `512 * 1024` in the `setUp` method to configure the environment before running tests.