### PR TITLE
fix wrong status code of case when 

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/IrTypeAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/IrTypeAnalyzer.java
@@ -233,10 +233,10 @@ public class IrTypeAnalyzer {
               .map(
                   clause -> {
                     Type operandType = process(clause.getOperand(), context);
-                    checkArgument(
-                        operandType.equals(BOOLEAN),
-                        "When clause operand must be boolean: %s",
-                        operandType);
+                    if (!operandType.equals(BOOLEAN)) {
+                      throw new SemanticException(
+                          String.format("When clause operand must be boolean: %s", operandType));
+                    }
                     return setExpressionType(clause, process(clause.getResult(), context));
                   })
               .collect(Collectors.toCollection(LinkedHashSet::new));
@@ -250,11 +250,12 @@ public class IrTypeAnalyzer {
           .ifPresent(
               defaultValue -> {
                 Type defaultType = process(defaultValue, context);
-                checkArgument(
-                    defaultType.equals(resultType),
-                    "Default result type must be the same as WHEN result types: %s vs %s",
-                    defaultType,
-                    resultType);
+                if (!defaultType.equals(resultType)) {
+                  throw new SemanticException(
+                      String.format(
+                          "Default result type must be the same as WHEN result types: %s vs %s",
+                          defaultType, resultType));
+                }
               });
 
       return setExpressionType(node, resultType);
@@ -269,11 +270,12 @@ public class IrTypeAnalyzer {
               .map(
                   clause -> {
                     Type clauseOperandType = process(clause.getOperand(), context);
-                    checkArgument(
-                        clauseOperandType.equals(operandType),
-                        "WHEN clause operand type must match CASE operand type: %s vs %s",
-                        clauseOperandType,
-                        operandType);
+                    if (!clauseOperandType.equals(operandType)) {
+                      throw new SemanticException(
+                          String.format(
+                              "WHEN clause operand type must match CASE operand type: %s vs %s",
+                              clauseOperandType, operandType));
+                    }
                     return setExpressionType(clause, process(clause.getResult(), context));
                   })
               .collect(Collectors.toCollection(LinkedHashSet::new));
@@ -288,11 +290,12 @@ public class IrTypeAnalyzer {
           .ifPresent(
               defaultValue -> {
                 Type defaultType = process(defaultValue, context);
-                checkArgument(
-                    defaultType.equals(resultType),
-                    "Default result type must be the same as WHEN result types: %s vs %s",
-                    defaultType,
-                    resultType);
+                if (!defaultType.equals(resultType)) {
+                  throw new SemanticException(
+                      String.format(
+                          "Default result type must be the same as WHEN result types: %s vs %s",
+                          defaultType, resultType));
+                }
               });
 
       return setExpressionType(node, resultType);


### PR DESCRIPTION
This pull request refactors the error handling in the `IrTypeAnalyzer` class to improve clarity and replace the use of `checkArgument` with explicit exception handling. The changes ensure that semantic validation errors are consistently reported using `SemanticException`.

### Refactoring of error handling:

* Replaced `checkArgument` with explicit `if` conditions and `SemanticException` for validating that `WHEN` clause operands in `SearchedCaseExpression` are of type `BOOLEAN`. (`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/IrTypeAnalyzer.java`, [iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/IrTypeAnalyzer.javaL236-R239](diffhunk://#diff-13930271f6daa99066c9dfe57eb9ba951f2d76eadbefc9523851080ecbaca476L236-R239))
* Replaced `checkArgument` with explicit `if` conditions and `SemanticException` for ensuring the default result type matches the `WHEN` result types in `SearchedCaseExpression`. (`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/IrTypeAnalyzer.java`, [iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/IrTypeAnalyzer.javaL253-R258](diffhunk://#diff-13930271f6daa99066c9dfe57eb9ba951f2d76eadbefc9523851080ecbaca476L253-R258))
* Updated `SimpleCaseExpression` to throw `SemanticException` when `WHEN` clause operand types do not match the `CASE` operand type, replacing `checkArgument`. (`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/IrTypeAnalyzer.java`, [iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/IrTypeAnalyzer.javaL272-R278](diffhunk://#diff-13930271f6daa99066c9dfe57eb9ba951f2d76eadbefc9523851080ecbaca476L272-R278))
* Changed the validation of default result types in `SimpleCaseExpression` to use `SemanticException` instead of `checkArgument` for type mismatch errors. (`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/IrTypeAnalyzer.java`, [iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/IrTypeAnalyzer.javaL291-R298](diffhunk://#diff-13930271f6daa99066c9dfe57eb9ba951f2d76eadbefc9523851080ecbaca476L291-R298))