### PR TITLE
[AINode] Alter the authority of ainode folders

### DIFF
--- a/iotdb-core/ainode/ainode/core/ainode.py
+++ b/iotdb-core/ainode/ainode/core/ainode.py
@@ -64,7 +64,6 @@ def _check_path_permission():
     if not os.path.exists(system_path):
         try:
             os.makedirs(system_path)
-            os.chmod(system_path, 0o777)
         except PermissionError as e:
             logger.error(e)
             raise e

--- a/iotdb-core/ainode/ainode/core/log.py
+++ b/iotdb-core/ainode/ainode/core/log.py
@@ -98,13 +98,11 @@ class Logger:
             file_levels = AINODE_LOG_FILE_LEVELS
             if not os.path.exists(log_dir):
                 os.makedirs(log_dir)
-                os.chmod(log_dir, 0o777)
             for file_name in file_names:
                 log_path = log_dir + "/" + file_name
                 if not os.path.exists(log_path):
                     f = open(log_path, mode="w", encoding="utf-8")
                     f.close()
-                    os.chmod(log_path, 0o777)
             self.file_handlers = []
             for l in range(len(file_names)):
                 self.file_handlers.append(


### PR DESCRIPTION
In this PR, we alter the authority of the `logs` and `data` folders of the AINode.