### PR TITLE
RestAPI remove getCurrSessionAndUpdateIdleTime

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/rest/table/v1/impl/RestApiServiceImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/rest/table/v1/impl/RestApiServiceImpl.java
@@ -123,7 +123,7 @@ public class RestApiServiceImpl extends RestApiService {
     Statement statement = null;
     long startTime = System.nanoTime();
     try {
-      IClientSession clientSession = SESSION_MANAGER.getCurrSessionAndUpdateIdleTime();
+      IClientSession clientSession = SESSION_MANAGER.getCurrSession();
       statement = createStatement(sql, clientSession, relationSqlParser);
       Response resp = validateStatement(statement, true);
       if (resp != null) {
@@ -154,7 +154,7 @@ public class RestApiServiceImpl extends RestApiService {
       RequestValidationHandler.validateInsertTabletRequest(insertTabletRequest);
       insertTabletStatement =
           StatementConstructionHandler.constructInsertTabletStatement(insertTabletRequest);
-      IClientSession clientSession = SESSION_MANAGER.getCurrSessionAndUpdateIdleTime();
+      IClientSession clientSession = SESSION_MANAGER.getCurrSession();
       clientSession.setDatabaseName(insertTabletRequest.getDatabase());
       clientSession.setSqlDialect(IClientSession.SqlDialect.TABLE);
       queryId = SESSION_MANAGER.requestQueryId();
@@ -196,7 +196,7 @@ public class RestApiServiceImpl extends RestApiService {
     Statement statement = null;
     long startTime = System.nanoTime();
     try {
-      IClientSession clientSession = SESSION_MANAGER.getCurrSessionAndUpdateIdleTime();
+      IClientSession clientSession = SESSION_MANAGER.getCurrSession();
       statement = createStatement(sql, clientSession, relationSqlParser);
       Response resp = validateStatement(statement, false);
       if (resp != null) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/rest/v1/impl/RestApiServiceImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/rest/v1/impl/RestApiServiceImpl.java
@@ -112,7 +112,7 @@ public class RestApiServiceImpl extends RestApiService {
             COORDINATOR.executeForTableModel(
                 ((CreateTableViewStatement) statement).getCreateTableView(),
                 new SqlParser(),
-                SESSION_MANAGER.getCurrSessionAndUpdateIdleTime(),
+                SESSION_MANAGER.getCurrSession(),
                 queryId,
                 SESSION_MANAGER.getSessionInfo(SESSION_MANAGER.getCurrSession()),
                 sql.getSql(),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/rest/v2/impl/RestApiServiceImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/rest/v2/impl/RestApiServiceImpl.java
@@ -129,7 +129,7 @@ public class RestApiServiceImpl extends RestApiService {
       }
       // Check cache first
       if (!TableDeviceSchemaCache.getInstance().getLastCache(resultMap)) {
-        IClientSession clientSession = SESSION_MANAGER.getCurrSessionAndUpdateIdleTime();
+        IClientSession clientSession = SESSION_MANAGER.getCurrSession();
         TSLastDataQueryReq tsLastDataQueryReq =
             FastLastHandler.createTSLastDataQueryReq(clientSession, prefixPathList);
         statement = StatementGenerator.createStatement(tsLastDataQueryReq);


### PR DESCRIPTION
RestAPI remove getCurrSessionAndUpdateIdleTime, because RestAPI is not a long connection