### PR TITLE
Change IT configuration to make CI more stable

### DIFF
--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppCommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppCommonConfig.java
@@ -539,6 +539,12 @@ public class MppCommonConfig extends MppBaseConfig implements CommonConfig {
   }
 
   @Override
+  public CommonConfig setDataNodeMemoryProportion(String dataNodeMemoryProportion) {
+    setProperty("datanode_memory_proportion", dataNodeMemoryProportion);
+    return this;
+  }
+
+  @Override
   public CommonConfig setSubscriptionPrefetchTsFileBatchMaxDelayInMs(
       int subscriptionPrefetchTsFileBatchMaxDelayInMs) {
     setProperty(

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppSharedCommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppSharedCommonConfig.java
@@ -556,6 +556,13 @@ public class MppSharedCommonConfig implements CommonConfig {
   }
 
   @Override
+  public CommonConfig setDataNodeMemoryProportion(String dataNodeMemoryProportion) {
+    dnConfig.setDataNodeMemoryProportion(dataNodeMemoryProportion);
+    cnConfig.setDataNodeMemoryProportion(dataNodeMemoryProportion);
+    return this;
+  }
+
+  @Override
   public CommonConfig setSubscriptionPrefetchTsFileBatchMaxDelayInMs(
       int subscriptionPrefetchTsFileBatchMaxDelayInMs) {
     dnConfig.setSubscriptionPrefetchTsFileBatchMaxDelayInMs(

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/remote/config/RemoteCommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/remote/config/RemoteCommonConfig.java
@@ -392,6 +392,11 @@ public class RemoteCommonConfig implements CommonConfig {
   }
 
   @Override
+  public CommonConfig setDataNodeMemoryProportion(String dataNodeMemoryProportion) {
+    return this;
+  }
+
+  @Override
   public CommonConfig setEnforceStrongPassword(boolean enforceStrongPassword) {
     return this;
   }

--- a/integration-test/src/main/java/org/apache/iotdb/itbase/env/CommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/itbase/env/CommonConfig.java
@@ -172,6 +172,8 @@ public interface CommonConfig {
 
   CommonConfig setQueryMemoryProportion(String queryMemoryProportion);
 
+  CommonConfig setDataNodeMemoryProportion(String dataNodeMemoryProportion);
+
   CommonConfig setSubscriptionPrefetchTsFileBatchMaxDelayInMs(
       int subscriptionPrefetchTsFileBatchMaxDelayInMs);
 

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/orderBy/IoTDBOrderByIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/orderBy/IoTDBOrderByIT.java
@@ -103,7 +103,8 @@ public class IoTDBOrderByIT {
     EnvFactory.getEnv()
         .getConfig()
         .getDataNodeCommonConfig()
-        .setQueryMemoryProportion("1:100:200:50:200:400:200:50");
+        .setDataNodeMemoryProportion("2:4:1:1:1:1")
+        .setQueryMemoryProportion("1:100:100:10:400:200:100:50");
     EnvFactory.getEnv().initClusterEnvironment();
     insertData();
   }

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBAsofJoinTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBAsofJoinTableIT.java
@@ -63,12 +63,15 @@ public class IoTDBAsofJoinTableIT {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    EnvFactory.getEnv().initClusterEnvironment();
     EnvFactory.getEnv()
         .getConfig()
         .getCommonConfig()
         .setMaxTsBlockLineNumber(2)
-        .setMaxNumberOfPointsInPage(5);
+        .setMaxNumberOfPointsInPage(5)
+        .setDataNodeMemoryProportion("2:4:1:1:1:1")
+        .setQueryMemoryProportion("1:100:100:10:400:200:100:50")
+        .setSortBufferSize(1024 * 1024);
+    EnvFactory.getEnv().initClusterEnvironment();
     insertData();
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/PlanGraphPrinter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/PlanGraphPrinter.java
@@ -86,9 +86,9 @@ import org.apache.iotdb.db.queryengine.plan.relational.planner.node.ValueFillNod
 import org.apache.iotdb.db.queryengine.plan.relational.planner.node.WindowNode;
 
 import com.google.common.base.Joiner;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.tsfile.utils.Pair;
-import org.eclipse.jetty.util.StringUtil;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -550,7 +550,7 @@ public class PlanGraphPrinter extends PlanVisitor<List<String>, PlanGraphPrinter
     boxValue.add(
         String.format(
             "Series: %s%s", node.getDevicePath().getIDeviceID(), node.getMeasurementSchemas()));
-    if (StringUtil.isNotBlank(node.getOutputViewPath())) {
+    if (StringUtils.isNotBlank(node.getOutputViewPath())) {
       boxValue.add(String.format("ViewPath: %s", node.getOutputViewPath()));
     }
     boxValue.add(printRegion(node.getRegionReplicaSet()));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/source/LastQueryScanNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/source/LastQueryScanNode.java
@@ -31,11 +31,11 @@ import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeUtil;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanVisitor;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 import org.apache.tsfile.write.schema.IMeasurementSchema;
-import org.eclipse.jetty.util.StringUtil;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -258,7 +258,7 @@ public class LastQueryScanNode extends LastSeriesSourceNode {
 
   @Override
   public String toString() {
-    if (StringUtil.isNotBlank(outputViewPath)) {
+    if (StringUtils.isNotBlank(outputViewPath)) {
       return String.format(
           "LastQueryScanNode-%s:[Device: %s, Aligned: %s, Measurements: %s, ViewPath: %s, DataRegion: %s]",
           this.getPlanNodeId(),


### PR DESCRIPTION
This pull request introduces a new configuration option for setting the DataNode memory proportion, updates related interfaces and test setups to use this option, and refines a utility import in the query engine code. The main changes add the new `setDataNodeMemoryProportion` method to configuration classes and update test classes to utilize this new setting, while also cleaning up a dependency in the `LastQueryScanNode` class.

Configuration enhancements:

* Added the `setDataNodeMemoryProportion` method to the `CommonConfig` interface and its implementations (`MppCommonConfig`, `MppSharedCommonConfig`, `RemoteCommonConfig`) to allow setting DataNode memory proportions programmatically. [[1]](diffhunk://#diff-adc438fd7a7c566e75afd7ed2abfb2d5ad8c2fc50be94494ecf3e08a48f52f29R175-R176) [[2]](diffhunk://#diff-23c2f46d3f95c9657dfdfea7a831bc188434ae54e1a27673ece516f9191465b9R541-R546) [[3]](diffhunk://#diff-b5a127ee0fa55d5aebb2f2273bf9bf5593fba6b976fbddf28d9cdd78792e5600R558-R564) [[4]](diffhunk://#diff-56cb005d9e09edb5ba3657ca3926c0eff3bed5cb7e93a617dbd242d867d0a1acR394-R398)

Test setup updates:

* Updated test classes (`IoTDBOrderByIT`, `IoTDBAsofJoinTableIT`) to use the new `setDataNodeMemoryProportion` method, ensuring that tests properly configure DataNode memory settings alongside existing query memory settings. [[1]](diffhunk://#diff-40758e0d92ca668db999b1be8c6215538a9e7de965497a11a478060b9913eabeL106-R107) [[2]](diffhunk://#diff-09ed468e95f2178f3c0847f0f1811b8cc02e1bd81d80f8ca774b2ce5ad644375L66-R74)

Dependency cleanup:

* Replaced usage of `StringUtil.isNotBlank` from Jetty with `StringUtils.isNotBlank` from Apache Commons Lang in `LastQueryScanNode`, and removed the unnecessary Jetty import. [[1]](diffhunk://#diff-011dc0dbdf4954592b058bec46c1053cbe3933734c8b60a64e338f49f7e0612cR34-L38) [[2]](diffhunk://#diff-011dc0dbdf4954592b058bec46c1053cbe3933734c8b60a64e338f49f7e0612cL261-R261)