### PR TITLE
with_clause feature

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBCteIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBCteIT.java
@@ -257,7 +257,7 @@ public class IoTDBCteIT {
             + " SELECT n+1 FROM t WHERE n < 100)"
             + " SELECT sum(n) FROM t";
 
-    tableAssertTestFail(sql, "Union is not supported in current version", DATABASE_NAME);
+    tableAssertTestFail(sql, "701: recursive cte is not supported yet", DATABASE_NAME);
   }
 
   @Test
@@ -267,37 +267,37 @@ public class IoTDBCteIT {
     try {
       adminStmt.execute("CREATE USER tmpuser 'tmppw123456789'");
       adminStmt.execute("USE testdb");
-      adminStmt.execute("CREATE TABLE IF NOT EXISTS testtb1(deviceid STRING TAG, voltage FLOAT FIELD)");
+      adminStmt.execute(
+          "CREATE TABLE IF NOT EXISTS testtb1(deviceid STRING TAG, voltage FLOAT FIELD)");
       adminStmt.execute("GRANT SELECT ON testdb.testtb TO USER tmpuser");
 
       try (Connection connection =
-                   EnvFactory.getEnv()
-                           .getConnection("tmpuser", "tmppw123456789", BaseEnv.TABLE_SQL_DIALECT);
-           Statement statement = connection.createStatement()) {
+              EnvFactory.getEnv()
+                  .getConnection("tmpuser", "tmppw123456789", BaseEnv.TABLE_SQL_DIALECT);
+          Statement statement = connection.createStatement()) {
         statement.execute("USE testdb");
         statement.execute("with cte as (select * from testtb) select * from cte");
       }
 
       try (Connection connection =
-                   EnvFactory.getEnv()
-                           .getConnection("tmpuser", "tmppw123456789", BaseEnv.TABLE_SQL_DIALECT);
-           Statement statement = connection.createStatement()) {
+              EnvFactory.getEnv()
+                  .getConnection("tmpuser", "tmppw123456789", BaseEnv.TABLE_SQL_DIALECT);
+          Statement statement = connection.createStatement()) {
         statement.execute("USE testdb");
         statement.execute("with cte as (select * from testtb1) select * from testtb");
         fail("No exception!");
       } catch (Exception e) {
         Assert.assertTrue(
-                e.getMessage(),
-                e.getMessage()
-                        .contains(
-                                "803: Access Denied: No permissions for this operation, please add privilege SELECT ON testdb.testtb1"));
+            e.getMessage(),
+            e.getMessage()
+                .contains(
+                    "803: Access Denied: No permissions for this operation, please add privilege SELECT ON testdb.testtb1"));
       }
     } finally {
       adminStmt.execute("DROP USER tmpuser");
       adminStmt.execute("DROP TABLE IF EXISTS testtb1");
     }
   }
-
 
   private static void prepareData() {
     try (Connection connection = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBCteIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBCteIT.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.iotdb.relational.it.query.recent;
 
 import org.apache.iotdb.isession.ITableSession;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzer.java
@@ -898,20 +898,7 @@ public class StatementAnalyzer {
 
         boolean isRecursive = false;
         if (with.isRecursive()) {
-          // cannot nest pattern recognition within recursive query
-
-          isRecursive = tryProcessRecursiveQuery(withQuery, name, withScopeBuilder);
-          // WITH query is not shaped accordingly to the rules for expandable query and will be
-          // processed like a plain WITH query.
-          // Since RECURSIVE is specified, any reference to WITH query name is considered a
-          // recursive reference and is not allowed.
-          if (!isRecursive) {
-            List<Node> recursiveReferences =
-                findReferences(withQuery.getQuery(), withQuery.getName());
-            if (!recursiveReferences.isEmpty()) {
-              throw new SemanticException("recursive reference not allowed in this context");
-            }
-          }
+          throw new SemanticException("recursive cte is not supported yet.");
         }
 
         if (!isRecursive) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/RelationPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/RelationPlanner.java
@@ -243,15 +243,7 @@ public class RelationPlanner extends AstVisitor<RelationPlan, Void> {
       RelationPlan subPlan;
       if (analysis.isExpandableQuery(namedQuery)) {
         // recursive cte
-        subPlan =
-            new QueryPlanner(
-                    analysis,
-                    symbolAllocator,
-                    queryContext,
-                    outerContext,
-                    sessionInfo,
-                    recursiveSubqueries)
-                .plan(namedQuery);
+        throw new SemanticException("unexpected recursive cte");
       } else {
         subPlan = process(namedQuery, null);
       }


### PR DESCRIPTION
This pull request introduces a new integration test suite for Common Table Expressions (CTEs) and adds support for implicit type coercion when resolving CTEs in query planning. The main focus is to ensure correct CTE handling, including type mismatches between CTE definitions and their usage, and to improve test coverage for CTE-related features.

**CTE Testing and Type Coercion Improvements:**

* Added a comprehensive integration test class `IoTDBCteIT` to verify CTE functionality, including basic queries, partial column aliasing, nested and multi-reference CTEs, privilege checks, JDBC/session compatibility, and error scenarios.
* In `RelationPlanner.java`, updated the logic for visiting a table to detect and process named queries (CTEs), including handling recursive CTEs and applying implicit type coercion when the output types of a CTE do not match the declared types.
* Introduced a new static method `coerce` in `QueryPlanner.java` to perform type coercion for CTE outputs, automatically adding projection and cast nodes as needed to align types.