### PR TITLE
fix: Failed to remove unwritable directories when creating tsfile

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/generator/TsFileNameGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/generator/TsFileNameGenerator.java
@@ -108,8 +108,13 @@ public class TsFileNameGenerator {
                     + File.separator
                     + timePartitionId;
             File targetDir = fsFactory.getFile(tsFileDir);
-            if (!(targetDir.exists() || targetDir.mkdirs())) {
-              throw new IOException(tsFileDir + " directory creation failure");
+            if (!targetDir.exists()) {
+              if (!targetDir.mkdirs() && !targetDir.exists()) {
+                throw new IOException(
+                    "Directory creation failed: "
+                        + tsFileDir
+                        + " (Permission denied or parent not writable)");
+              }
             }
             return tsFileDir
                 + File.separator

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/generator/TsFileNameGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/generator/TsFileNameGenerator.java
@@ -107,7 +107,9 @@ public class TsFileNameGenerator {
                     + virtualStorageGroup
                     + File.separator
                     + timePartitionId;
-            fsFactory.getFile(tsFileDir).mkdirs();
+            if (!fsFactory.getFile(tsFileDir).mkdirs()) {
+              throw new IOException(tsFileDir + " directory creation failure");
+            }
             return tsFileDir
                 + File.separator
                 + generateNewTsFileName(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/generator/TsFileNameGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/generator/TsFileNameGenerator.java
@@ -107,7 +107,8 @@ public class TsFileNameGenerator {
                     + virtualStorageGroup
                     + File.separator
                     + timePartitionId;
-            if (!fsFactory.getFile(tsFileDir).mkdirs()) {
+            File targetDir = fsFactory.getFile(tsFileDir);
+            if (!(targetDir.exists() || targetDir.mkdirs())) {
               throw new IOException(tsFileDir + " directory creation failure");
             }
             return tsFileDir

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/rescon/disk/FolderManagerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/rescon/disk/FolderManagerTest.java
@@ -85,7 +85,8 @@ public class FolderManagerTest {
                     File.separator + "virtualSG" +
                     File.separator + "1";
 
-            if (!fsFactory.getFile(tsFileDir).mkdirs()) {
+            File targetDir = fsFactory.getFile(tsFileDir);
+            if (!(targetDir.exists() || targetDir.mkdirs())) {
                 throw new IOException(tsFileDir + " directory creation failure");
             }
 
@@ -117,7 +118,8 @@ public class FolderManagerTest {
                     File.separator + "virtualSG" +
                     File.separator + "1";
 
-            if (!fsFactory.getFile(tsFileDir).mkdirs()) {
+            File targetDir = fsFactory.getFile(tsFileDir);
+            if (!(targetDir.exists() || targetDir.mkdirs())) {
                 throw new IOException(tsFileDir + " directory creation failure");
             }
 
@@ -138,7 +140,8 @@ public class FolderManagerTest {
             String tsFileDir = baseDir + File.separator + "logicalSG" +
                     File.separator + "virtualSG" +
                     File.separator + "1";
-            if (!fsFactory.getFile(tsFileDir).mkdirs()) {
+            File targetDir = fsFactory.getFile(tsFileDir);
+            if (!(targetDir.exists() || targetDir.mkdirs())) {
                 throw new IOException(tsFileDir + " directory creation failure");
             }
             return tsFileDir + File.separator + "immutable_test.tsfile";

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/rescon/disk/FolderManagerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/rescon/disk/FolderManagerTest.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.storageengine.rescon.disk;
 
 import org.apache.iotdb.db.exception.DiskSpaceInsufficientException;
 import org.apache.iotdb.db.storageengine.rescon.disk.strategy.DirectoryStrategyType;
+
 import org.apache.tsfile.fileSystem.FSFactoryProducer;
 import org.apache.tsfile.fileSystem.fsFactory.FSFactory;
 import org.junit.Before;
@@ -37,135 +38,151 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
-import static org.junit.Assert.assertNotEquals;
 
 @RunWith(Parameterized.class)
 public class FolderManagerTest {
 
-    @Rule
-    public TemporaryFolder tempFolder = new TemporaryFolder();
+  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
 
-    private final DirectoryStrategyType strategyType;
-    private FolderManager folderManager;
-    private List<String> testFolders;
-    private static FSFactory fsFactory = FSFactoryProducer.getFSFactory();
+  private final DirectoryStrategyType strategyType;
+  private FolderManager folderManager;
+  private List<String> testFolders;
+  private static FSFactory fsFactory = FSFactoryProducer.getFSFactory();
 
-    public FolderManagerTest(DirectoryStrategyType strategyType) {
-        this.strategyType = strategyType;
-    }
+  public FolderManagerTest(DirectoryStrategyType strategyType) {
+    this.strategyType = strategyType;
+  }
 
-    @Parameterized.Parameters
-    public static Collection<DirectoryStrategyType> strategyTypes() {
-        return Arrays.asList(DirectoryStrategyType.values());
-    }
+  @Parameterized.Parameters
+  public static Collection<DirectoryStrategyType> strategyTypes() {
+    return Arrays.asList(DirectoryStrategyType.values());
+  }
 
-    @Before
-    public void setUp() throws Exception {
-        File folder1 = tempFolder.newFolder("folder1");
-        File folder2 = tempFolder.newFolder("folder2");
-        File folder3 = tempFolder.newFolder("folder3");
+  @Before
+  public void setUp() throws Exception {
+    File folder1 = tempFolder.newFolder("folder1");
+    File folder2 = tempFolder.newFolder("folder2");
+    File folder3 = tempFolder.newFolder("folder3");
 
-        testFolders = Arrays.asList(
-                folder1.getAbsolutePath(),
-                folder2.getAbsolutePath(),
-                folder3.getAbsolutePath()
-        );
+    testFolders =
+        Arrays.asList(
+            folder1.getAbsolutePath(), folder2.getAbsolutePath(), folder3.getAbsolutePath());
 
-        folderManager = new FolderManager(testFolders, strategyType);
-    }
+    folderManager = new FolderManager(testFolders, strategyType);
+  }
 
-    @Test
-    public void testSuccessfulDirectoryCreation() throws Exception {
-        String result = folderManager.getNextWithRetry(baseDir -> {
-            String tsFileDir = baseDir + File.separator + "logicalSG" +
-                    File.separator + "virtualSG" +
-                    File.separator + "1";
+  @Test
+  public void testSuccessfulDirectoryCreation() throws Exception {
+    String result =
+        folderManager.getNextWithRetry(
+            baseDir -> {
+              String tsFileDir =
+                  baseDir
+                      + File.separator
+                      + "logicalSG"
+                      + File.separator
+                      + "virtualSG"
+                      + File.separator
+                      + "1";
 
-            File targetDir = fsFactory.getFile(tsFileDir);
-            if (!(targetDir.exists() || targetDir.mkdirs())) {
+              File targetDir = fsFactory.getFile(tsFileDir);
+              if (!(targetDir.exists() || targetDir.mkdirs())) {
                 throw new IOException(tsFileDir + " directory creation failure");
-            }
+              }
 
-            return tsFileDir + File.separator + "test.tsfile";
-        });
+              return tsFileDir + File.separator + "test.tsfile";
+            });
 
-        assertNotNull(result);
-        assertTrue(result.endsWith("test.tsfile"));
-        assertTrue(new File(result).getParentFile().exists());
-    }
+    assertNotNull(result);
+    assertTrue(result.endsWith("test.tsfile"));
+    assertTrue(new File(result).getParentFile().exists());
+  }
 
-    @Test
-    public void testRetryAfterFailure() throws Exception {
-        // Array elements can be modified in lambdas despite final reference
-        final boolean[] firstAttempt = {true};
-        final String[] firstFolder = {null};
+  @Test
+  public void testRetryAfterFailure() throws Exception {
+    // Array elements can be modified in lambdas despite final reference
+    final boolean[] firstAttempt = {true};
+    final String[] firstFolder = {null};
 
-        String result = folderManager.getNextWithRetry(baseDir -> {
-            if (firstAttempt[0]) {
+    String result =
+        folderManager.getNextWithRetry(
+            baseDir -> {
+              if (firstAttempt[0]) {
                 firstAttempt[0] = false;
                 firstFolder[0] = baseDir;
                 throw new IOException("Simulated directory creation failure");
-            }
+              }
 
-            // Verify we got a different folder on retry
-            assertNotEquals(firstFolder[0], baseDir);
+              // Verify we got a different folder on retry
+              assertNotEquals(firstFolder[0], baseDir);
 
-            String tsFileDir = baseDir + File.separator + "logicalSG" +
-                    File.separator + "virtualSG" +
-                    File.separator + "1";
+              String tsFileDir =
+                  baseDir
+                      + File.separator
+                      + "logicalSG"
+                      + File.separator
+                      + "virtualSG"
+                      + File.separator
+                      + "1";
 
-            File targetDir = fsFactory.getFile(tsFileDir);
-            if (!(targetDir.exists() || targetDir.mkdirs())) {
+              File targetDir = fsFactory.getFile(tsFileDir);
+              if (!(targetDir.exists() || targetDir.mkdirs())) {
                 throw new IOException(tsFileDir + " directory creation failure");
-            }
+              }
 
-            return tsFileDir + File.separator + "retry.tsfile";
-        });
-
-        assertNotNull(result);
-        assertTrue(result.endsWith("retry.tsfile"));
-        assertTrue(new File(result).getParentFile().exists());
-    }
-
-    @Ignore("Test requires manual setup: directory must be set as immutable")
-    @Test
-    public void testImmutableBaseDir() throws Exception {
-        // Requires manual setup: directory must be set as immutable
-        String immutableFolder = testFolders.get(0);
-        String result = folderManager.getNextWithRetry(baseDir -> {
-            String tsFileDir = baseDir + File.separator + "logicalSG" +
-                    File.separator + "virtualSG" +
-                    File.separator + "1";
-            File targetDir = fsFactory.getFile(tsFileDir);
-            if (!(targetDir.exists() || targetDir.mkdirs())) {
-                throw new IOException(tsFileDir + " directory creation failure");
-            }
-            return tsFileDir + File.separator + "immutable_test.tsfile";
-        });
-
-        assertNotNull("Result path should not be null", result);
-        assertTrue("File should end with correct suffix",
-                result.endsWith("immutable_test.tsfile"));
-        assertTrue("Parent directory should exist",
-                new File(result).getParentFile().exists());
-    }
-
-    @Test
-    public void testEventuallyThrowsDiskFullAfterRetries() {
-        try {
-            folderManager.getNextWithRetry(baseDir -> {
-                throw new IOException("Persistent failure");
+              return tsFileDir + File.separator + "retry.tsfile";
             });
-            fail("Expected DiskSpaceInsufficientException");
-        } catch (DiskSpaceInsufficientException e) {
-            // Expected after all retries fail
-            assertTrue(e.getMessage().contains("Can't get next folder"));
-        } catch (Exception e) {
-            fail("Should have thrown DiskSpaceInsufficientException");
-        }
+
+    assertNotNull(result);
+    assertTrue(result.endsWith("retry.tsfile"));
+    assertTrue(new File(result).getParentFile().exists());
+  }
+
+  @Ignore("Test requires manual setup: directory must be set as immutable")
+  @Test
+  public void testImmutableBaseDir() throws Exception {
+    // Requires manual setup: directory must be set as immutable
+    String immutableFolder = testFolders.get(0);
+    String result =
+        folderManager.getNextWithRetry(
+            baseDir -> {
+              String tsFileDir =
+                  baseDir
+                      + File.separator
+                      + "logicalSG"
+                      + File.separator
+                      + "virtualSG"
+                      + File.separator
+                      + "1";
+              File targetDir = fsFactory.getFile(tsFileDir);
+              if (!(targetDir.exists() || targetDir.mkdirs())) {
+                throw new IOException(tsFileDir + " directory creation failure");
+              }
+              return tsFileDir + File.separator + "immutable_test.tsfile";
+            });
+
+    assertNotNull("Result path should not be null", result);
+    assertTrue("File should end with correct suffix", result.endsWith("immutable_test.tsfile"));
+    assertTrue("Parent directory should exist", new File(result).getParentFile().exists());
+  }
+
+  @Test
+  public void testEventuallyThrowsDiskFullAfterRetries() {
+    try {
+      folderManager.getNextWithRetry(
+          baseDir -> {
+            throw new IOException("Persistent failure");
+          });
+      fail("Expected DiskSpaceInsufficientException");
+    } catch (DiskSpaceInsufficientException e) {
+      // Expected after all retries fail
+      assertTrue(e.getMessage().contains("Can't get next folder"));
+    } catch (Exception e) {
+      fail("Should have thrown DiskSpaceInsufficientException");
     }
+  }
 }


### PR DESCRIPTION
The issue occurs because mkdirs() fails silently - it returns false rather than throwing an IOException when unable to create directories.
```
try {
      return folderManager.getNextWithRetry(
          baseDir -> {
            String tsFileDir =
                baseDir
                    + File.separator
                    + logicalStorageGroup
                    + File.separator
                    + virtualStorageGroup
                    + File.separator
                    + timePartitionId;
            fsFactory.getFile(tsFileDir).mkdirs();
            return tsFileDir
                + File.separator
                + generateNewTsFileName(
                    time,
                    version,
                    innerSpaceCompactionCount,
                    crossSpaceCompactionCount,
                    customSuffix);
          });
    } catch (DiskSpaceInsufficientException e) {
      LOGGER.error("All disks are full, cannot create tsfile directory", e);
      throw new IOException("Disk space insufficient", e);
    } catch (Exception e) {
      LOGGER.warn("Failed to create tsfile directory after retries", e);
      throw new IOException("Failed to create directory after retries", e);
    }
```
