### PR TITLE
fix cpp-client-gettimestamp

### DIFF
--- a/iotdb-client/client-cpp/src/main/IoTDBRpcDataSet.cpp
+++ b/iotdb-client/client-cpp/src/main/IoTDBRpcDataSet.cpp
@@ -462,18 +462,18 @@ std::string IoTDBRpcDataSet::getStringByTsBlockColumnIndexAndDataType(int32_t in
     }
 }
 
-int64_t IoTDBRpcDataSet::getTimestampByIndex(int32_t columnIndex) {
+boost::optional<int64_t> IoTDBRpcDataSet::getTimestampByIndex(int32_t columnIndex) {
     int32_t index = getTsBlockColumnIndexForColumnIndex(columnIndex);
     return getTimestampByTsBlockColumnIndex(index);
 }
 
-int64_t IoTDBRpcDataSet::getTimestamp(const std::string& columnName) {
+boost::optional<int64_t> IoTDBRpcDataSet::getTimestamp(const std::string& columnName) {
     int32_t index = getTsBlockColumnIndexForColumnName(columnName);
     return getTimestampByTsBlockColumnIndex(index);
 }
 
-int64_t IoTDBRpcDataSet::getTimestampByTsBlockColumnIndex(int32_t tsBlockColumnIndex) {
-    return getLongByTsBlockColumnIndex(tsBlockColumnIndex).value();
+boost::optional<int64_t> IoTDBRpcDataSet::getTimestampByTsBlockColumnIndex(int32_t tsBlockColumnIndex) {
+    return getLongByTsBlockColumnIndex(tsBlockColumnIndex);
 }
 
 boost::optional<boost::gregorian::date> IoTDBRpcDataSet::getDateByIndex(int32_t columnIndex) {

--- a/iotdb-client/client-cpp/src/main/IoTDBRpcDataSet.h
+++ b/iotdb-client/client-cpp/src/main/IoTDBRpcDataSet.h
@@ -83,8 +83,8 @@ public:
     std::shared_ptr<Binary> getBinary(const std::string& columnName);
     boost::optional<std::string> getStringByIndex(int32_t columnIndex);
     boost::optional<std::string> getString(const std::string& columnName);
-    int64_t getTimestampByIndex(int32_t columnIndex);
-    int64_t getTimestamp(const std::string& columnName);
+    boost::optional<int64_t> getTimestampByIndex(int32_t columnIndex);
+    boost::optional<int64_t> getTimestamp(const std::string& columnName);
     boost::optional<boost::gregorian::date> getDateByIndex(int32_t columnIndex);
     boost::optional<boost::gregorian::date> getDate(const std::string& columnName);
 
@@ -122,7 +122,7 @@ private:
     std::shared_ptr<Binary> getBinaryByTsBlockColumnIndex(int32_t tsBlockColumnIndex);
     boost::optional<std::string> getStringByTsBlockColumnIndex(int32_t tsBlockColumnIndex);
     boost::optional<boost::gregorian::date> getDateByTsBlockColumnIndex(int32_t tsBlockColumnIndex);
-    int64_t getTimestampByTsBlockColumnIndex(int32_t tsBlockColumnIndex);
+    boost::optional<int64_t> getTimestampByTsBlockColumnIndex(int32_t tsBlockColumnIndex);
 
     std::string sql_;
     bool isClosed_;

--- a/iotdb-client/client-cpp/src/test/cpp/sessionRelationalIT.cpp
+++ b/iotdb-client/client-cpp/src/test/cpp/sessionRelationalIT.cpp
@@ -199,7 +199,7 @@ TEST_CASE("Test RelationalTabletTsblockRead", "[testRelationalTabletTsblockRead]
             REQUIRE_FALSE(dataIter.getFloatByIndex(5).is_initialized());
             REQUIRE_FALSE(dataIter.getDoubleByIndex(6).is_initialized());
             REQUIRE_FALSE(dataIter.getStringByIndex(7).is_initialized());
-            REQUIRE_FALSE(dataIter.getLongByIndex(8).is_initialized());
+            REQUIRE_FALSE(dataIter.getTimestampByIndex(8).is_initialized());
             REQUIRE_FALSE(dataIter.getDateByIndex(9).is_initialized());
             REQUIRE_FALSE(dataIter.getStringByIndex(10).is_initialized());
             REQUIRE_FALSE(dataIter.getStringByIndex(11).is_initialized());
@@ -211,7 +211,7 @@ TEST_CASE("Test RelationalTabletTsblockRead", "[testRelationalTabletTsblockRead]
             REQUIRE(fabs(dataIter.getFloatByIndex(5).value() - rowNum * 1.1f) < 0.1f);
             REQUIRE(fabs(dataIter.getDoubleByIndex(6).value() - rowNum * 1.1f) < 0.1);
             REQUIRE(dataIter.getStringByIndex(7).value() == "text_" + to_string(rowNum));
-            REQUIRE(dataIter.getLongByIndex(8).value() == static_cast<int64_t>(timestamp));
+            REQUIRE(dataIter.getTimestampByIndex(8).value() == static_cast<int64_t>(timestamp));
             REQUIRE(dataIter.getDateByIndex(9).value() == boost::gregorian::date(2025, 5, 15));
             REQUIRE(dataIter.getStringByIndex(10).value() == "blob_" + to_string(rowNum));
             REQUIRE(dataIter.getStringByIndex(11).value() == "string_" + to_string(rowNum));


### PR DESCRIPTION
Fix getTimestampByIndex to use boost::optional for non-first-column timestamps 