### PR TITLE
Fix nodeUrls shuffle error

### DIFF
--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -433,7 +433,7 @@ public class Session implements ISession {
     if (nodeUrls.isEmpty()) {
       throw new IllegalArgumentException("nodeUrls shouldn't be empty.");
     }
-    Collections.shuffle(nodeUrls);
+    nodeUrls = shuffleNodeUrls(nodeUrls);
     this.nodeUrls = nodeUrls;
     this.username = username;
     this.password = password;
@@ -450,7 +450,7 @@ public class Session implements ISession {
       if (builder.nodeUrls.isEmpty()) {
         throw new IllegalArgumentException("nodeUrls shouldn't be empty.");
       }
-      Collections.shuffle(builder.nodeUrls);
+      builder.nodeUrls = shuffleNodeUrls(builder.nodeUrls);
       this.nodeUrls = builder.nodeUrls;
       this.enableQueryRedirection = true;
     } else {
@@ -576,6 +576,16 @@ public class Session implements ISession {
               }
               return t;
             });
+  }
+
+  private static List<String> shuffleNodeUrls(List<String> endPoints) {
+    try {
+      Collections.shuffle(endPoints);
+    } catch (UnsupportedOperationException e) {
+      endPoints = new ArrayList<>(endPoints);
+      Collections.shuffle(endPoints);
+    }
+    return endPoints;
   }
 
   private List<TEndPoint> getNodeUrls() {

--- a/iotdb-client/session/src/test/java/org/apache/iotdb/session/SessionTest.java
+++ b/iotdb-client/session/src/test/java/org/apache/iotdb/session/SessionTest.java
@@ -107,6 +107,18 @@ public class SessionTest {
             .build();
     session1 =
         new Session.Builder()
+            .nodeUrls(Collections.nCopies(2, "host:port"))
+            .username("username")
+            .password("pwd")
+            .build();
+    session1 =
+        new Session.Builder()
+            .nodeUrls(Collections.unmodifiableList(Arrays.asList("host:port1", "host:port2")))
+            .username("username")
+            .password("pwd")
+            .build();
+    session1 =
+        new Session.Builder()
             .host("host")
             .port(12)
             .username("username")


### PR DESCRIPTION
NodeUrls may be an unmodifiable List, shuffle it directly may throw an exception. 