### PR TITLE
IoTV2: Fix file corrupt due to RandomAccessFile is lost.

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/pipeconsensus/PipeConsensusReceiver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/pipeconsensus/PipeConsensusReceiver.java
@@ -918,15 +918,18 @@ public class PipeConsensusReceiver {
   }
 
   private void deleteCurrentWritingFile(PipeConsensusTsFileWriter tsFileWriter) {
-    if (tsFileWriter.getWritingFile() != null) {
-      deleteFileOrDirectoryIfExists(
-          tsFileWriter.getWritingFile(),
-          String.format("TsFileWriter-%s delete current writing file", tsFileWriter.index));
-    } else {
-      if (LOGGER.isDebugEnabled()) {
-        LOGGER.debug(
-            "PipeConsensus-PipeName-{}: Current writing file is null. No need to delete.",
-            consensusPipeName.toString());
+    if (tsFileWriter.getLocalWritingDir() != null) {
+      try {
+        // There may be multiple files such as mods and tsfile pieces in the dir. Here we clean the
+        // dir instead of deleting it to avoid repeatedly deleting and creating the base dir for
+        // tsfile writer
+        FileUtils.cleanDirectory(tsFileWriter.getLocalWritingDir());
+      } catch (IOException e) {
+        LOGGER.warn(
+            "PipeConsensus-PipeName-{}: Failed to clean current writing file dir {}.",
+            consensusPipeName,
+            tsFileWriter.getLocalWritingDir().getPath(),
+            e);
       }
     }
   }


### PR DESCRIPTION
The problem can be abstracted as:

1. Write file A with RandomFileWriterA, write 0~x bytes.
2. Re-new RandomFileWriterB on file 
3. Use RandomFileWriterB to write file A and write x~end bytes
4. It is expected to directly override file A into x~end bytes

So every time we new RandomAccessFile, we should point its pointer to the end of the file, keeping the append semantics.
In addition, when the follower fails the precheck due to read-only or other reasons, the corresponding RandomAccessFile needs to be recycled.