### PR TITLE
Change all query example into iterator style

### DIFF
--- a/example/session/src/main/java/org/apache/iotdb/SessionPoolExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/SessionPoolExample.java
@@ -74,7 +74,6 @@ public class SessionPoolExample {
 
     service = Executors.newFixedThreadPool(10);
     insertRecord();
-    queryByRowRecord();
     Thread.sleep(1000);
     queryByIterator();
     sessionPool.close();
@@ -99,28 +98,6 @@ public class SessionPoolExample {
       values.add(2L);
       values.add(3L);
       sessionPool.insertRecord(deviceId, time, measurements, types, values);
-    }
-  }
-
-  private static void queryByRowRecord() {
-    for (int i = 0; i < 1; i++) {
-      service.submit(
-          () -> {
-            SessionDataSetWrapper wrapper = null;
-            try {
-              wrapper = sessionPool.executeQueryStatement("select * from root.sg1.d1");
-              System.out.println(wrapper.getColumnNames());
-              System.out.println(wrapper.getColumnTypes());
-              while (wrapper.hasNext()) {
-                System.out.println(wrapper.next());
-              }
-            } catch (IoTDBConnectionException | StatementExecutionException e) {
-              LOGGER.error("Query by row record error", e);
-            } finally {
-              // remember to close data set finally!
-              sessionPool.closeResultSet(wrapper);
-            }
-          });
     }
   }
 

--- a/example/session/src/main/java/org/apache/iotdb/TableModelSessionExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/TableModelSessionExample.java
@@ -34,6 +34,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.iotdb.SessionExample.printDataSet;
+
 public class TableModelSessionExample {
 
   private static final String LOCAL_URL = "127.0.0.1:6667";
@@ -71,10 +73,7 @@ public class TableModelSessionExample {
       // show tables by specifying another database
       // using SHOW tables FROM
       try (SessionDataSet dataSet = session.executeQueryStatement("SHOW TABLES FROM test1")) {
-        System.out.println(dataSet.getColumnNames());
-        while (dataSet.hasNext()) {
-          System.out.println(dataSet.next());
-        }
+        printDataSet(dataSet);
       }
 
       // insert table data by tablet
@@ -122,11 +121,7 @@ public class TableModelSessionExample {
           session.executeQueryStatement(
               "select * from test1 "
                   + "where region_id = '1' and plant_id in ('3', '5') and device_id = '3'")) {
-        System.out.println(dataSet.getColumnNames());
-        System.out.println(dataSet.getColumnTypes());
-        while (dataSet.hasNext()) {
-          System.out.println(dataSet.next());
-        }
+        printDataSet(dataSet);
       }
 
     } catch (IoTDBConnectionException e) {
@@ -146,10 +141,7 @@ public class TableModelSessionExample {
 
       // show tables from current database
       try (SessionDataSet dataSet = session.executeQueryStatement("SHOW TABLES")) {
-        System.out.println(dataSet.getColumnNames());
-        while (dataSet.hasNext()) {
-          System.out.println(dataSet.next());
-        }
+        printDataSet(dataSet);
       }
 
       // change database to test2
@@ -158,10 +150,7 @@ public class TableModelSessionExample {
       // show tables by specifying another database
       // using SHOW tables FROM
       try (SessionDataSet dataSet = session.executeQueryStatement("SHOW TABLES")) {
-        System.out.println(dataSet.getColumnNames());
-        while (dataSet.hasNext()) {
-          System.out.println(dataSet.next());
-        }
+        printDataSet(dataSet);
       }
 
     } catch (IoTDBConnectionException e) {

--- a/example/session/src/main/java/org/apache/iotdb/TableModelSessionPoolExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/TableModelSessionPoolExample.java
@@ -35,6 +35,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.iotdb.SessionExample.printDataSet;
+
 public class TableModelSessionPoolExample {
 
   private static final String LOCAL_URL = "127.0.0.1:6667";
@@ -77,21 +79,13 @@ public class TableModelSessionPoolExample {
 
       // show tables from current database
       try (SessionDataSet dataSet = session.executeQueryStatement("SHOW TABLES")) {
-        System.out.println(dataSet.getColumnNames());
-        System.out.println(dataSet.getColumnTypes());
-        while (dataSet.hasNext()) {
-          System.out.println(dataSet.next());
-        }
+        printDataSet(dataSet);
       }
 
       // show tables by specifying another database
       // using SHOW tables FROM
       try (SessionDataSet dataSet = session.executeQueryStatement("SHOW TABLES FROM test1")) {
-        System.out.println(dataSet.getColumnNames());
-        System.out.println(dataSet.getColumnTypes());
-        while (dataSet.hasNext()) {
-          System.out.println(dataSet.next());
-        }
+        printDataSet(dataSet);
       }
 
       // insert table data by tablet
@@ -139,11 +133,7 @@ public class TableModelSessionPoolExample {
           session.executeQueryStatement(
               "select * from test1 "
                   + "where region_id = '1' and plant_id in ('3', '5') and device_id = '3'")) {
-        System.out.println(dataSet.getColumnNames());
-        System.out.println(dataSet.getColumnTypes());
-        while (dataSet.hasNext()) {
-          System.out.println(dataSet.next());
-        }
+        printDataSet(dataSet);
       }
 
     } catch (IoTDBConnectionException e) {
@@ -168,11 +158,7 @@ public class TableModelSessionPoolExample {
 
       // show tables from current database
       try (SessionDataSet dataSet = session.executeQueryStatement("SHOW TABLES")) {
-        System.out.println(dataSet.getColumnNames());
-        System.out.println(dataSet.getColumnTypes());
-        while (dataSet.hasNext()) {
-          System.out.println(dataSet.next());
-        }
+        printDataSet(dataSet);
       }
 
       // change database to test2
@@ -181,11 +167,7 @@ public class TableModelSessionPoolExample {
       // show tables by specifying another database
       // using SHOW tables FROM
       try (SessionDataSet dataSet = session.executeQueryStatement("SHOW TABLES")) {
-        System.out.println(dataSet.getColumnNames());
-        System.out.println(dataSet.getColumnTypes());
-        while (dataSet.hasNext()) {
-          System.out.println(dataSet.next());
-        }
+        printDataSet(dataSet);
       }
 
     } catch (IoTDBConnectionException e) {
@@ -198,11 +180,7 @@ public class TableModelSessionPoolExample {
 
       // show tables from default database test1
       try (SessionDataSet dataSet = session.executeQueryStatement("SHOW TABLES")) {
-        System.out.println(dataSet.getColumnNames());
-        System.out.println(dataSet.getColumnTypes());
-        while (dataSet.hasNext()) {
-          System.out.println(dataSet.next());
-        }
+        printDataSet(dataSet);
       }
 
     } catch (IoTDBConnectionException e) {


### PR DESCRIPTION
This pull request refactors the IoTDB Java session examples to improve code reuse and consistency in how query results are printed. The main enhancement is the introduction of a shared `printDataSet` utility method, which standardizes the output of query results across multiple example classes. Additionally, some redundant or outdated query methods are removed for clarity.

Key changes:

**Code reuse and consistency improvements:**

* Introduced a new `printDataSet(SessionDataSet dataSet)` method in `SessionExample.java` to handle printing of query results, including column names, types, and handling of null values. This method is now used throughout the example code to ensure consistent output formatting. (Fc9e8d42L812R812)
* Updated `TableModelSessionExample.java` and `TableModelSessionPoolExample.java` to use the shared `printDataSet` method for displaying query results, replacing previous ad-hoc printing logic. [[1]](diffhunk://#diff-2149ed73aebb9dd2786837799d1eb00b887c6d65d71e08e1b0e8f9fdbd695bc7R37-R38) [[2]](diffhunk://#diff-2149ed73aebb9dd2786837799d1eb00b887c6d65d71e08e1b0e8f9fdbd695bc7L74-R76) [[3]](diffhunk://#diff-2149ed73aebb9dd2786837799d1eb00b887c6d65d71e08e1b0e8f9fdbd695bc7L125-R124) [[4]](diffhunk://#diff-2149ed73aebb9dd2786837799d1eb00b887c6d65d71e08e1b0e8f9fdbd695bc7L149-R144) [[5]](diffhunk://#diff-2149ed73aebb9dd2786837799d1eb00b887c6d65d71e08e1b0e8f9fdbd695bc7L161-R153) [[6]](diffhunk://#diff-73c1a845a4b1bf00559d67b35dd7cbcf1538ce371b4ce486cb1a6202d2e891a6R38-R39) [[7]](diffhunk://#diff-73c1a845a4b1bf00559d67b35dd7cbcf1538ce371b4ce486cb1a6202d2e891a6L80-R88) [[8]](diffhunk://#diff-73c1a845a4b1bf00559d67b35dd7cbcf1538ce371b4ce486cb1a6202d2e891a6L142-R136)

**Code cleanup and simplification:**

* Removed the `queryByRowRecord` method from `SessionPoolExample.java`, as well as its invocation, to streamline the example and focus on the iterator-based approach. [[1]](diffhunk://#diff-f3e4f5e22236cf146d0639080651dfba76236a97cab0f0aca490f457c3d81c3fL77) [[2]](diffhunk://#diff-f3e4f5e22236cf146d0639080651dfba76236a97cab0f0aca490f457c3d81c3fL105-L126)
* Replaced multiple manual loops for printing `SessionDataSet` results in `SessionExample.java` with calls to `printDataSet`, including in methods like `query4Redirect`, `queryWithTimeout`, `rawDataQuery`, `lastDataQuery`, `fastLastDataQueryForOneDevice`, `fastLastDataQueryForOnePrefix`, `aggregationQuery`, and `groupByQuery`. [[1]](diffhunk://#diff-3a3fa624df531223227483a40128d766ef46cfdc7c3199e054763f9366bfb315L693-R699) [[2]](diffhunk://#diff-3a3fa624df531223227483a40128d766ef46cfdc7c3199e054763f9366bfb315L723-R708) [[3]](diffhunk://#diff-3a3fa624df531223227483a40128d766ef46cfdc7c3199e054763f9366bfb315L736-R717) [[4]](diffhunk://#diff-3a3fa624df531223227483a40128d766ef46cfdc7c3199e054763f9366bfb315L752-R737) [[5]](diffhunk://#diff-3a3fa624df531223227483a40128d766ef46cfdc7c3199e054763f9366bfb315L782-R751) [[6]](diffhunk://#diff-3a3fa624df531223227483a40128d766ef46cfdc7c3199e054763f9366bfb315L796-R761) [[7]](diffhunk://#diff-3a3fa624df531223227483a40128d766ef46cfdc7c3199e054763f9366bfb315L812-R785) [[8]](diffhunk://#diff-3a3fa624df531223227483a40128d766ef46cfdc7c3199e054763f9366bfb315L848-R801) [[9]](diffhunk://#diff-3a3fa624df531223227483a40128d766ef46cfdc7c3199e054763f9366bfb315L867-R836)

**Minor improvements:**

* Standardized the random number generator by making the `Random` instance in `SessionExample.java` static and final, and updating all usages accordingly. [[1]](diffhunk://#diff-3a3fa624df531223227483a40128d766ef46cfdc7c3199e054763f9366bfb315L67-R67) [[2]](diffhunk://#diff-3a3fa624df531223227483a40128d766ef46cfdc7c3199e054763f9366bfb315L459-R458) [[3]](diffhunk://#diff-3a3fa624df531223227483a40128d766ef46cfdc7c3199e054763f9366bfb315L500-R499) [[4]](diffhunk://#diff-3a3fa624df531223227483a40128d766ef46cfdc7c3199e054763f9366bfb315L561-R560) [[5]](diffhunk://#diff-3a3fa624df531223227483a40128d766ef46cfdc7c3199e054763f9366bfb315L605-R604)
* Changed the default query method called in `main` from `query()` to `queryByIterator()` in `SessionExample.java`, and removed the now-unused `query()` method. [[1]](diffhunk://#diff-3a3fa624df531223227483a40128d766ef46cfdc7c3199e054763f9366bfb315L105-L111) [[2]](diffhunk://#diff-3a3fa624df531223227483a40128d766ef46cfdc7c3199e054763f9366bfb315L693-R699)
* Removed redundant calls to `setFetchSize` where no longer necessary due to the new printing logic.

These changes make the example code easier to read, maintain, and extend, while ensuring all query outputs are handled in a unified way.