### PR TITLE
Region operation "extend" and "remove" support multi regions in one SQL

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/IoTDBRegionGroupExpandAndShrinkForIoTV1IT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/IoTDBRegionGroupExpandAndShrinkForIoTV1IT.java
@@ -381,7 +381,7 @@ public class IoTDBRegionGroupExpandAndShrinkForIoTV1IT
       int targetDataNode)
       throws Exception {
     String command = buildMultiRegionCommand(MULTI_EXPAND_FORMAT, regionIds, targetDataNode);
-    
+
     Predicate<TShowRegionResp> expandPredicate =
         tShowRegionResp -> {
           Map<Integer, Set<Integer>> newRegionMap =
@@ -395,8 +395,14 @@ public class IoTDBRegionGroupExpandAndShrinkForIoTV1IT
         };
 
     executeMultiRegionOperation(
-        statement, client, command, regionIds, expandPredicate,
-        Optional.of(targetDataNode), Optional.empty(), "expand");
+        statement,
+        client,
+        command,
+        regionIds,
+        expandPredicate,
+        Optional.of(targetDataNode),
+        Optional.empty(),
+        "expand");
   }
 
   private void multiRegionGroupShrink(
@@ -406,7 +412,7 @@ public class IoTDBRegionGroupExpandAndShrinkForIoTV1IT
       int targetDataNode)
       throws Exception {
     String command = buildMultiRegionCommand(MULTI_SHRINK_FORMAT, regionIds, targetDataNode);
-    
+
     Predicate<TShowRegionResp> shrinkPredicate =
         tShowRegionResp -> {
           Map<Integer, Set<Integer>> newRegionMap =
@@ -420,11 +426,18 @@ public class IoTDBRegionGroupExpandAndShrinkForIoTV1IT
         };
 
     executeMultiRegionOperation(
-        statement, client, command, regionIds, shrinkPredicate,
-        Optional.empty(), Optional.of(targetDataNode), "shrink");
+        statement,
+        client,
+        command,
+        regionIds,
+        shrinkPredicate,
+        Optional.empty(),
+        Optional.of(targetDataNode),
+        "shrink");
   }
 
-  private String buildMultiRegionCommand(String format, List<Integer> regionIds, int targetDataNode) {
+  private String buildMultiRegionCommand(
+      String format, List<Integer> regionIds, int targetDataNode) {
     String regionIdStr = regionIds.stream().map(String::valueOf).collect(Collectors.joining(","));
     return String.format(format, regionIdStr, targetDataNode);
   }
@@ -438,7 +451,7 @@ public class IoTDBRegionGroupExpandAndShrinkForIoTV1IT
       Optional<Integer> expectedDataNode,
       Optional<Integer> notExpectedDataNode,
       String operationType) {
-    
+
     LOGGER.info("Executing multi-region {} command: {}", operationType, command);
 
     Awaitility.await()
@@ -456,28 +469,30 @@ public class IoTDBRegionGroupExpandAndShrinkForIoTV1IT
                 if (errorMessage != null
                     && errorMessage.contains("successfully submitted")
                     && errorMessage.contains("failed to submit")) {
-                  LOGGER.warn("Multi-region {} partially succeeded: {}", operationType, errorMessage);
+                  LOGGER.warn(
+                      "Multi-region {} partially succeeded: {}", operationType, errorMessage);
                   return true;
                 }
                 LOGGER.warn(
-                    "Multi-region {} command execution failed, retrying: {}", operationType, errorMessage);
+                    "Multi-region {} command execution failed, retrying: {}",
+                    operationType,
+                    errorMessage);
                 return false;
               }
             });
 
     // Use the first region for awaitUntilSuccess (framework limitation)
-    awaitUntilSuccess(
-        client,
-        regionIds.get(0),
-        predicate,
-        expectedDataNode,
-        notExpectedDataNode);
+    awaitUntilSuccess(client, regionIds.get(0), predicate, expectedDataNode, notExpectedDataNode);
 
-    String targetDescription = expectedDataNode.isPresent() ? 
-        "to DataNode " + expectedDataNode.get() : 
-        "from DataNode " + notExpectedDataNode.get();
-    LOGGER.info("Regions {} have {} {}", regionIds, 
-        operationType.equals("expand") ? "expanded" : "shrunk", targetDescription);
+    String targetDescription =
+        expectedDataNode.isPresent()
+            ? "to DataNode " + expectedDataNode.get()
+            : "from DataNode " + notExpectedDataNode.get();
+    LOGGER.info(
+        "Regions {} have {} {}",
+        regionIds,
+        operationType.equals("expand") ? "expanded" : "shrunk",
+        targetDescription);
   }
 
   private int findDataNodeNotContainsAnyRegion(

--- a/iotdb-core/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IoTDBSqlParser.g4
+++ b/iotdb-core/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IoTDBSqlParser.g4
@@ -541,11 +541,11 @@ reconstructRegion
     ;
 
 extendRegion
-    : EXTEND REGION regionId=INTEGER_LITERAL TO targetDataNodeId=INTEGER_LITERAL
+    : EXTEND REGION regionIds+=INTEGER_LITERAL (COMMA regionIds+=INTEGER_LITERAL)* TO targetDataNodeId=INTEGER_LITERAL
     ;
 
 removeRegion
-    : REMOVE REGION regionId=INTEGER_LITERAL FROM targetDataNodeId=INTEGER_LITERAL
+    : REMOVE REGION regionIds+=INTEGER_LITERAL (COMMA regionIds+=INTEGER_LITERAL)* FROM targetDataNodeId=INTEGER_LITERAL
     ;
 
 verifyConnection

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -2489,7 +2489,7 @@ public class ConfigManager implements IManager {
   public TSStatus extendRegion(TExtendRegionReq req) {
     TSStatus status = confirmLeader();
     return status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()
-        ? procedureManager.extendRegion(req)
+        ? procedureManager.extendRegions(req)
         : status;
   }
 
@@ -2497,7 +2497,7 @@ public class ConfigManager implements IManager {
   public TSStatus removeRegion(TRemoveRegionReq req) {
     TSStatus status = confirmLeader();
     return status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()
-        ? procedureManager.removeRegion(req)
+        ? procedureManager.removeRegions(req)
         : status;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/executor/ClusterConfigTaskExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/executor/ClusterConfigTaskExecutor.java
@@ -3213,7 +3213,7 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
         CONFIG_NODE_CLIENT_MANAGER.borrowClient(ConfigNodeInfo.CONFIG_REGION_ID)) {
       final TExtendRegionReq req =
           new TExtendRegionReq(
-              extendRegionTask.getStatement().getRegionId(),
+              extendRegionTask.getStatement().getRegionIds(),
               extendRegionTask.getStatement().getDataNodeId(),
               extendRegionTask.getModel());
       final TSStatus status = configNodeClient.extendRegion(req);
@@ -3236,7 +3236,7 @@ public class ClusterConfigTaskExecutor implements IConfigTaskExecutor {
         CONFIG_NODE_CLIENT_MANAGER.borrowClient(ConfigNodeInfo.CONFIG_REGION_ID)) {
       final TRemoveRegionReq req =
           new TRemoveRegionReq(
-              removeRegionTask.getStatement().getRegionId(),
+              removeRegionTask.getStatement().getRegionIds(),
               removeRegionTask.getStatement().getDataNodeId(),
               removeRegionTask.getModel());
       final TSStatus status = configNodeClient.removeRegion(req);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/metadata/region/ExtendRegionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/metadata/region/ExtendRegionTask.java
@@ -40,7 +40,7 @@ public class ExtendRegionTask implements IConfigTask {
 
   public ExtendRegionTask(ExtendRegion extendRegion) {
     this.statement =
-        new ExtendRegionStatement(extendRegion.getRegionId(), extendRegion.getDataNodeId());
+        new ExtendRegionStatement(extendRegion.getRegionIds(), extendRegion.getDataNodeId());
     this.model = Model.TABLE;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/metadata/region/RemoveRegionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/metadata/region/RemoveRegionTask.java
@@ -40,7 +40,7 @@ public class RemoveRegionTask implements IConfigTask {
 
   public RemoveRegionTask(RemoveRegion removeRegion) {
     this.statement =
-        new RemoveRegionStatement(removeRegion.getRegionId(), removeRegion.getDataNodeId());
+        new RemoveRegionStatement(removeRegion.getRegionIds(), removeRegion.getDataNodeId());
     this.model = Model.TABLE;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/parser/ASTVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/parser/ASTVisitor.java
@@ -289,6 +289,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.stream.Collectors.toList;
 import static org.apache.iotdb.commons.schema.SchemaConstant.ALL_RESULT_NODES;
 import static org.apache.iotdb.commons.schema.table.column.TsTableColumnCategory.FIELD;
 import static org.apache.iotdb.commons.schema.table.column.TsTableColumnCategory.TAG;
@@ -4277,14 +4278,16 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
 
   @Override
   public Statement visitExtendRegion(IoTDBSqlParser.ExtendRegionContext ctx) {
-    return new ExtendRegionStatement(
-        Integer.parseInt(ctx.regionId.getText()), Integer.parseInt(ctx.targetDataNodeId.getText()));
+    List<Integer> regionIds =
+        ctx.regionIds.stream().map(token -> Integer.parseInt(token.getText())).collect(toList());
+    return new ExtendRegionStatement(regionIds, Integer.parseInt(ctx.targetDataNodeId.getText()));
   }
 
   @Override
   public Statement visitRemoveRegion(IoTDBSqlParser.RemoveRegionContext ctx) {
-    return new RemoveRegionStatement(
-        Integer.parseInt(ctx.regionId.getText()), Integer.parseInt(ctx.targetDataNodeId.getText()));
+    List<Integer> regionIds =
+        ctx.regionIds.stream().map(token -> Integer.parseInt(token.getText())).collect(toList());
+    return new RemoveRegionStatement(regionIds, Integer.parseInt(ctx.targetDataNodeId.getText()));
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/ExtendRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/ExtendRegion.java
@@ -54,7 +54,7 @@ public class ExtendRegion extends Statement {
       return false;
     }
     ExtendRegion another = (ExtendRegion) obj;
-    return regionIds == another.regionIds && dataNodeId == another.dataNodeId;
+    return regionIds.equals(another.regionIds) && dataNodeId == another.dataNodeId;
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/ExtendRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/ExtendRegion.java
@@ -26,12 +26,12 @@ import java.util.Objects;
 
 public class ExtendRegion extends Statement {
 
-  private final int regionId;
+  private final List<Integer> regionIds;
   private final int dataNodeId;
 
-  public ExtendRegion(int regionId, int dataNodeId) {
+  public ExtendRegion(List<Integer> regionIds, int dataNodeId) {
     super(null);
-    this.regionId = regionId;
+    this.regionIds = regionIds;
     this.dataNodeId = dataNodeId;
   }
 
@@ -42,7 +42,7 @@ public class ExtendRegion extends Statement {
 
   @Override
   public int hashCode() {
-    return Objects.hash(ExtendRegion.class, regionId, dataNodeId);
+    return Objects.hash(ExtendRegion.class, regionIds, dataNodeId);
   }
 
   @Override
@@ -54,12 +54,12 @@ public class ExtendRegion extends Statement {
       return false;
     }
     ExtendRegion another = (ExtendRegion) obj;
-    return regionId == another.regionId && dataNodeId == another.dataNodeId;
+    return regionIds == another.regionIds && dataNodeId == another.dataNodeId;
   }
 
   @Override
   public String toString() {
-    return String.format("extend region %d to datanode %d", regionId, dataNodeId);
+    return String.format("extend region %s to datanode %d", regionIds, dataNodeId);
   }
 
   @Override
@@ -67,8 +67,8 @@ public class ExtendRegion extends Statement {
     return visitor.visitExtendRegion(this, context);
   }
 
-  public int getRegionId() {
-    return regionId;
+  public List<Integer> getRegionIds() {
+    return regionIds;
   }
 
   public int getDataNodeId() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/RemoveRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/RemoveRegion.java
@@ -59,7 +59,7 @@ public class RemoveRegion extends Statement {
 
   @Override
   public String toString() {
-    return String.format("remove region %d from %d", regionIds, dataNodeId);
+    return String.format("remove region %s from %d", regionIds, dataNodeId);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/RemoveRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/RemoveRegion.java
@@ -54,7 +54,7 @@ public class RemoveRegion extends Statement {
       return false;
     }
     RemoveRegion another = (RemoveRegion) obj;
-    return regionIds == another.regionIds && dataNodeId == another.dataNodeId;
+    return regionIds.equals(another.regionIds) && dataNodeId == another.dataNodeId;
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/RemoveRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/RemoveRegion.java
@@ -26,12 +26,12 @@ import java.util.Objects;
 
 public class RemoveRegion extends Statement {
 
-  private final int regionId;
+  private final List<Integer> regionIds;
   private final int dataNodeId;
 
-  public RemoveRegion(int regionId, int dataNodeId) {
+  public RemoveRegion(List<Integer> regionId, int dataNodeId) {
     super(null);
-    this.regionId = regionId;
+    this.regionIds = regionId;
     this.dataNodeId = dataNodeId;
   }
 
@@ -42,7 +42,7 @@ public class RemoveRegion extends Statement {
 
   @Override
   public int hashCode() {
-    return Objects.hash(RemoveRegion.class, regionId, dataNodeId);
+    return Objects.hash(RemoveRegion.class, regionIds, dataNodeId);
   }
 
   @Override
@@ -54,12 +54,12 @@ public class RemoveRegion extends Statement {
       return false;
     }
     RemoveRegion another = (RemoveRegion) obj;
-    return regionId == another.regionId && dataNodeId == another.dataNodeId;
+    return regionIds == another.regionIds && dataNodeId == another.dataNodeId;
   }
 
   @Override
   public String toString() {
-    return String.format("remove region %d from %d", regionId, dataNodeId);
+    return String.format("remove region %d from %d", regionIds, dataNodeId);
   }
 
   @Override
@@ -67,8 +67,8 @@ public class RemoveRegion extends Statement {
     return visitor.visitRemoveRegion(this, context);
   }
 
-  public int getRegionId() {
-    return regionId;
+  public List<Integer> getRegionIds() {
+    return regionIds;
   }
 
   public int getDataNodeId() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/parser/AstBuilder.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/parser/AstBuilder.java
@@ -1438,14 +1438,16 @@ public class AstBuilder extends RelationalSqlBaseVisitor<Node> {
 
   @Override
   public Node visitExtendRegionStatement(RelationalSqlParser.ExtendRegionStatementContext ctx) {
-    return new ExtendRegion(
-        Integer.parseInt(ctx.regionId.getText()), Integer.parseInt(ctx.targetDataNodeId.getText()));
+    List<Integer> regionIds =
+        ctx.regionIds.stream().map(token -> Integer.parseInt(token.getText())).collect(toList());
+    return new ExtendRegion(regionIds, Integer.parseInt(ctx.targetDataNodeId.getText()));
   }
 
   @Override
   public Node visitRemoveRegionStatement(RelationalSqlParser.RemoveRegionStatementContext ctx) {
-    return new RemoveRegion(
-        Integer.parseInt(ctx.regionId.getText()), Integer.parseInt(ctx.targetDataNodeId.getText()));
+    List<Integer> regionIds =
+        ctx.regionIds.stream().map(token -> Integer.parseInt(token.getText())).collect(toList());
+    return new RemoveRegion(regionIds, Integer.parseInt(ctx.targetDataNodeId.getText()));
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/metadata/region/ExtendRegionStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/metadata/region/ExtendRegionStatement.java
@@ -32,17 +32,17 @@ import java.util.List;
 
 public class ExtendRegionStatement extends Statement implements IConfigStatement {
 
-  private final int regionId;
+  private final List<Integer> regionIds;
   private final int dataNodeId;
 
-  public ExtendRegionStatement(int regionId, int dataNodeId) {
+  public ExtendRegionStatement(List<Integer> regionIds, int dataNodeId) {
     super();
-    this.regionId = regionId;
+    this.regionIds = regionIds;
     this.dataNodeId = dataNodeId;
   }
 
-  public int getRegionId() {
-    return regionId;
+  public List<Integer> getRegionIds() {
+    return regionIds;
   }
 
   public int getDataNodeId() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/metadata/region/RemoveRegionStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/metadata/region/RemoveRegionStatement.java
@@ -32,17 +32,17 @@ import java.util.List;
 
 public class RemoveRegionStatement extends Statement implements IConfigStatement {
 
-  private final int regionId;
+  private final List<Integer> regionIds;
   private final int dataNodeId;
 
-  public RemoveRegionStatement(int regionId, int dataNodeId) {
+  public RemoveRegionStatement(List<Integer> regionIds, int dataNodeId) {
     super();
-    this.regionId = regionId;
+    this.regionIds = regionIds;
     this.dataNodeId = dataNodeId;
   }
 
-  public int getRegionId() {
-    return regionId;
+  public List<Integer> getRegionIds() {
+    return regionIds;
   }
 
   public int getDataNodeId() {

--- a/iotdb-core/relational-grammar/src/main/antlr4/org/apache/iotdb/db/relational/grammar/sql/RelationalSql.g4
+++ b/iotdb-core/relational-grammar/src/main/antlr4/org/apache/iotdb/db/relational/grammar/sql/RelationalSql.g4
@@ -577,11 +577,11 @@ reconstructRegionStatement
     ;
 
 extendRegionStatement
-    : EXTEND REGION regionId=INTEGER_VALUE TO targetDataNodeId=INTEGER_VALUE
+    : EXTEND REGION regionIds+=INTEGER_VALUE (COMMA regionIds+=INTEGER_VALUE)* TO targetDataNodeId=INTEGER_VALUE
     ;
 
 removeRegionStatement
-    : REMOVE REGION regionId=INTEGER_VALUE FROM targetDataNodeId=INTEGER_VALUE
+    : REMOVE REGION regionIds+=INTEGER_VALUE (COMMA regionIds+=INTEGER_VALUE)* FROM targetDataNodeId=INTEGER_VALUE
     ;
 
 removeDataNodeStatement

--- a/iotdb-core/relational-grammar/src/main/antlr4/org/apache/iotdb/db/relational/grammar/sql/RelationalSql.g4
+++ b/iotdb-core/relational-grammar/src/main/antlr4/org/apache/iotdb/db/relational/grammar/sql/RelationalSql.g4
@@ -573,15 +573,15 @@ migrateRegionStatement
     ;
 
 reconstructRegionStatement
-    : RECONSTRUCT REGION regionIds+=INTEGER_VALUE (COMMA regionIds+=INTEGER_VALUE)* ON targetDataNodeId=INTEGER_VALUE
+    : RECONSTRUCT REGION regionIds+=INTEGER_VALUE (',' regionIds+=INTEGER_VALUE)* ON targetDataNodeId=INTEGER_VALUE
     ;
 
 extendRegionStatement
-    : EXTEND REGION regionIds+=INTEGER_VALUE (COMMA regionIds+=INTEGER_VALUE)* TO targetDataNodeId=INTEGER_VALUE
+    : EXTEND REGION regionIds+=INTEGER_VALUE (',' regionIds+=INTEGER_VALUE)* TO targetDataNodeId=INTEGER_VALUE
     ;
 
 removeRegionStatement
-    : REMOVE REGION regionIds+=INTEGER_VALUE (COMMA regionIds+=INTEGER_VALUE)* FROM targetDataNodeId=INTEGER_VALUE
+    : REMOVE REGION regionIds+=INTEGER_VALUE (',' regionIds+=INTEGER_VALUE)* FROM targetDataNodeId=INTEGER_VALUE
     ;
 
 removeDataNodeStatement

--- a/iotdb-protocol/thrift-confignode/src/main/thrift/confignode.thrift
+++ b/iotdb-protocol/thrift-confignode/src/main/thrift/confignode.thrift
@@ -322,13 +322,13 @@ struct TReconstructRegionReq {
 }
 
 struct TExtendRegionReq {
-    1: required i32 regionId
+    1: required list<i32> regionId
     2: required i32 dataNodeId
     3: required common.Model model
 }
 
 struct TRemoveRegionReq {
-    1: required i32 regionId
+    1: required list<i32> regionId
     2: required i32 dataNodeId
     3: required common.Model model
 }


### PR DESCRIPTION
```
IoTDB> extend region 1,2,3 to 3
Msg: org.apache.iotdb.jdbc.IoTDBSQLException: 909: Total regions: 3, successfully submitted: 2, failed to submit: 1
region 1: Successfully submitted
region 2: Successfully submitted
region 3: Target DataNode 3 already contains region TConsensusGroupId(type:DataRegion, id:3)
```