### PR TITLE
Add more log and remove useless synchronize

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceContext.java
@@ -456,10 +456,6 @@ public class FragmentInstanceContext extends QueryContext {
     return dataNodeQueryContext;
   }
 
-  public void setDataNodeQueryContext(DataNodeQueryContext dataNodeQueryContext) {
-    this.dataNodeQueryContext = dataNodeQueryContext;
-  }
-
   public FragmentInstanceInfo getInstanceInfo() {
     FragmentInstanceState state = stateMachine.getState();
     long endTime = getEndTime();
@@ -949,7 +945,7 @@ public class FragmentInstanceContext extends QueryContext {
         .updatePageReaderMemoryUsage(getQueryStatistics().getPageReaderMaxUsedMemorySize().get());
   }
 
-  private synchronized void releaseDataNodeQueryContext() {
+  private void releaseDataNodeQueryContext() {
     if (dataNodeQueryContextMap == null) {
       // this process is in fetch schema, nothing need to release
       return;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AbstractWritableMemChunk.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AbstractWritableMemChunk.java
@@ -58,12 +58,18 @@ public abstract class AbstractWritableMemChunk implements IWritableMemChunk {
   protected void maybeReleaseTvList(TVList tvList) {
     long startTimeInMs = System.currentTimeMillis();
     boolean succeed = false;
+    int retryCount = 0;
     while (!succeed) {
       try {
         tryReleaseTvList(tvList);
         succeed = true;
       } catch (MemoryNotEnoughException ex) {
-        LOGGER.warn("Failed to transfer tvlist memory owner to query engine, {}", ex.getMessage());
+        // print log every 5 seconds
+        if (retryCount % 50 == 0) {
+          LOGGER.warn(
+              "Failed to transfer tvlist memory owner to query engine, {}", ex.getMessage());
+        }
+        retryCount++;
         long waitQueryInMs = System.currentTimeMillis() - startTimeInMs;
         if (waitQueryInMs > MAX_WAIT_QUERY_MS) {
           // Abort first query in the list. When all queries in the list have been aborted,

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AbstractWritableMemChunk.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AbstractWritableMemChunk.java
@@ -33,12 +33,16 @@ import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.BitMap;
 import org.apache.tsfile.write.chunk.IChunkWriter;
 import org.apache.tsfile.write.schema.IMeasurementSchema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 
 public abstract class AbstractWritableMemChunk implements IWritableMemChunk {
+  private static final Logger LOGGER = LoggerFactory.getLogger(AbstractWritableMemChunk.class);
+
   protected static long RETRY_INTERVAL_MS = 100L;
   protected static long MAX_WAIT_QUERY_MS = 60 * 1000L;
 
@@ -59,6 +63,7 @@ public abstract class AbstractWritableMemChunk implements IWritableMemChunk {
         tryReleaseTvList(tvList);
         succeed = true;
       } catch (MemoryNotEnoughException ex) {
+        LOGGER.warn("Failed to transfer tvlist memory owner to query engine, {}", ex.getMessage());
         long waitQueryInMs = System.currentTimeMillis() - startTimeInMs;
         if (waitQueryInMs > MAX_WAIT_QUERY_MS) {
           // Abort first query in the list. When all queries in the list have been aborted,


### PR DESCRIPTION
This pull request introduces improvements to logging and memory management in the `AbstractWritableMemChunk` class, and makes minor adjustments to the `FragmentInstanceContext` class to simplify method access and improve thread safety. The most notable changes are the addition of logging for memory transfer retries and the removal of an unnecessary setter method.

**Logging and Memory Management Enhancements:**

* Added a logger to `AbstractWritableMemChunk` and enhanced the `maybeReleaseTvList` method to log a warning every 5 seconds when memory transfer to the query engine fails, helping with debugging and monitoring memory issues. [[1]](diffhunk://#diff-5665962b46995ddf0bb0f8d18d45a7d47f88562fcaccd62767412010fe0c6f63R36-R45) [[2]](diffhunk://#diff-5665962b46995ddf0bb0f8d18d45a7d47f88562fcaccd62767412010fe0c6f63R61-R72)

**Thread Safety and Code Simplification:**

* Removed the `setDataNodeQueryContext` setter from `FragmentInstanceContext`, making the context immutable after construction and reducing the risk of accidental modification.
* Changed `releaseDataNodeQueryContext` in `FragmentInstanceContext` from a synchronized to a non-synchronized method, which may improve performance and reflects that synchronization is no longer needed in this context.