### PR TITLE
Fix error of non-mappable udtf query in align by device while existing any devices' data cross region

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/Analysis.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/Analysis.java
@@ -193,7 +193,7 @@ public class Analysis implements IAnalysis {
 
   // indicates whether DeviceView need special process when rewriteSource in DistributionPlan,
   // you can see SourceRewriter#visitDeviceView to get more information
-  // deviceViewSpecialProcess equals true when all Aggregation Functions and DIFF
+  // deviceViewSpecialProcess equals true when all Aggregation Functions and UDTF and DIFF
   private boolean deviceViewSpecialProcess;
 
   /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/Analysis.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/Analysis.java
@@ -193,7 +193,8 @@ public class Analysis implements IAnalysis {
 
   // indicates whether DeviceView need special process when rewriteSource in DistributionPlan,
   // you can see SourceRewriter#visitDeviceView to get more information
-  // deviceViewSpecialProcess equals true when all Aggregation Functions and UDTF and DIFF
+  // deviceViewSpecialProcess equals true when all Aggregation Functions and non-mappable UDTF and
+  // DIFF
   private boolean deviceViewSpecialProcess;
 
   /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/SourceRewriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/SourceRewriter.java
@@ -35,6 +35,7 @@ import org.apache.iotdb.db.queryengine.plan.analyze.Analysis;
 import org.apache.iotdb.db.queryengine.plan.expression.Expression;
 import org.apache.iotdb.db.queryengine.plan.expression.leaf.TimeSeriesOperand;
 import org.apache.iotdb.db.queryengine.plan.expression.multi.FunctionExpression;
+import org.apache.iotdb.db.queryengine.plan.expression.multi.FunctionType;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.BaseSourceRewriter;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
@@ -217,7 +218,7 @@ public class SourceRewriter extends BaseSourceRewriter<DistributionPlanContext> 
                   analysis.getPartitionInfo(outputDevice, context.getPartitionTimeFilter()));
       if (regionReplicaSets.size() > 1 && !existDeviceCrossRegion) {
         existDeviceCrossRegion = true;
-        if (analysis.isDeviceViewSpecialProcess() && aggregationCannotUseMergeSort()) {
+        if (analysis.isDeviceViewSpecialProcess() && cannotUseAggMergeSort()) {
           return processSpecialDeviceView(node, context);
         }
       }
@@ -387,10 +388,12 @@ public class SourceRewriter extends BaseSourceRewriter<DistributionPlanContext> 
   }
 
   /**
-   * aggregation align by device, and aggregation is `count_if` or `diff`, or aggregation used with
-   * group by parameter (session, variation, count), use the old aggregation logic
+   * 1. aggregation align by device, and aggregation is `count_if` or `diff`, or aggregation used
+   * with 2. group by parameter (session, variation, count), use the old aggregation logic 3.
+   * non-mappable UDTF, we just need to check UDTF in this method, because caller has already
+   * checked analysis.isDeviceViewSpecialProcess()
    */
-  private boolean aggregationCannotUseMergeSort() {
+  private boolean cannotUseAggMergeSort() {
     if (analysis.hasGroupByParameter()) {
       return true;
     }
@@ -398,7 +401,9 @@ public class SourceRewriter extends BaseSourceRewriter<DistributionPlanContext> 
     for (Expression expression : analysis.getDeviceViewOutputExpressions()) {
       if (expression instanceof FunctionExpression) {
         String functionName = ((FunctionExpression) expression).getFunctionName();
-        if (COUNT_IF.equalsIgnoreCase(functionName) || DIFF.equalsIgnoreCase(functionName)) {
+        if (((FunctionExpression) expression).getFunctionType() == FunctionType.UDTF
+            || COUNT_IF.equalsIgnoreCase(functionName)
+            || DIFF.equalsIgnoreCase(functionName)) {
           return true;
         }
       }


### PR DESCRIPTION
This pull request updates the device view aggregation logic in the query engine to better handle User-Defined Table Functions (UDTFs) and clarifies when special processing is needed. The main changes involve extending the special-case handling to include UDTFs and refactoring related method names for clarity.

**Device view aggregation logic improvements:**

* Updated the comment in `Analysis.java` to clarify that `deviceViewSpecialProcess` applies when all Aggregation Functions, UDTFs, and DIFF are present, not just Aggregation Functions and DIFF.
* Modified the logic in `SourceRewriter.java` so that special processing for device views is triggered when UDTFs are present, in addition to existing conditions. This is achieved by checking for the UDTF function type in the relevant method.
* Added `FunctionType` import in `SourceRewriter.java` to support the new UDTF check.

**Code clarity and maintainability:**

* Renamed the method `aggregationCannotUseMergeSort()` to `cannotUseAggMergeSort()` in `SourceRewriter.java` for improved readability and accuracy. [[1]](diffhunk://#diff-aeb97b321b306b0b926b350f5b29cd7e9d7673c211ba12825aeeb8a52ae9bb07L390-R406) [[2]](diffhunk://#diff-aeb97b321b306b0b926b350f5b29cd7e9d7673c211ba12825aeeb8a52ae9bb07L220-R221)
* Updated all method calls and logic to use the new method name and signature.