### PR TITLE
Fix DN does not exit due to exception handling failure

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBCustomizedClusterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBCustomizedClusterIT.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.DailyIT;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.StatementExecutionException;
+import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.session.Session;
 
 import org.junit.Test;
@@ -41,6 +42,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -267,5 +269,23 @@ public class IoTDBCustomizedClusterIT {
     } finally {
       simpleEnv.cleanClusterEnvironment();
     }
+  }
+
+  @Test
+  public void testStartWithWrongConfig() throws InterruptedException {
+    SimpleEnv simpleEnv = new SimpleEnv();
+    simpleEnv
+        .getConfig()
+        .getCommonConfig()
+        .setDataRegionConsensusProtocolClass("org.apache.iotdb.consensus.iot.IoTConsensusV1");
+    try {
+      simpleEnv.initClusterEnvironment(1, 1);
+    } catch (AssertionError e) {
+      // ignore
+    }
+    simpleEnv.getDataNodeWrapper(0).getInstance().waitFor(20, TimeUnit.SECONDS);
+    assertEquals(
+        TSStatusCode.ILLEGAL_PARAMETER.getStatusCode(),
+        simpleEnv.getDataNodeWrapper(0).getInstance().exitValue());
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/StatusUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/StatusUtils.java
@@ -25,8 +25,6 @@ import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.rpc.RpcUtils;
 import org.apache.iotdb.rpc.TSStatusCode;
 
-import org.apache.ratis.util.ExitUtils;
-
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
@@ -251,13 +249,19 @@ public class StatusUtils {
   }
 
   public static int retrieveExitStatusCode(Throwable e) {
-    if (e instanceof ExitUtils.ExitException && e.getCause() != null) {
+    while (e.getCause() != null) {
       e = e.getCause();
     }
-    if (e.getMessage().contains("because Could not create ServerSocket")
-        || e.getMessage().contains("Failed to bind to address")
-        || e.getMessage().contains("Address already in use: bind")) {
-      return TSStatusCode.PORT_OCCUPIED.getStatusCode();
+    if (e.getMessage() != null) {
+      if (e.getMessage().contains("because Could not create ServerSocket")
+          || e.getMessage().contains("Failed to bind to address")
+          || e.getMessage().contains("Address already in use: bind")) {
+        return TSStatusCode.PORT_OCCUPIED.getStatusCode();
+      }
+
+      if (e instanceof ClassNotFoundException || e instanceof IllegalArgumentException) {
+        return TSStatusCode.ILLEGAL_PARAMETER.getStatusCode();
+      }
     }
     return -1;
   }


### PR DESCRIPTION
The exception with no message will trigger an NPE in the shutdown process, which prevents the DN process from exiting normally.