### PR TITLE
Fix NPE in Procedure's log

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
@@ -803,17 +803,18 @@ public class ProcedureExecutor<Env> {
       // Check if any of the worker is stuck
       int runningCount = 0, stuckCount = 0;
       for (WorkerThread worker : workerThreads) {
-        if (worker.activeProcedure.get() == null) {
+        final Procedure<?> proc = worker.activeProcedure.get();
+        if (proc == null) {
           continue;
         }
         runningCount++;
         // WARN the worker is stuck
-        if (worker.getCurrentRunTime() < DEFAULT_WORKER_STUCK_THRESHOLD) {
+        if (worker.getCurrentRunTime() > DEFAULT_WORKER_STUCK_THRESHOLD) {
           stuckCount++;
           LOG.warn(
               "Worker stuck {}({}), run time {} ms",
               worker,
-              worker.activeProcedure.get().getProcType(),
+              proc.getProcType(),
               worker.getCurrentRunTime());
         }
         LOG.info(


### PR DESCRIPTION
We found an error use case of the AtomicReference, which will cause NPE in extreme concurrent test. Specifically, in the original version, the AtomicReference is not null in the first check does not mean it remains exist at the second time. This scenario actually got worse when employ the AtomicReference.