### PR TITLE
Fix potential NPE in tryGetFLushLock

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -2160,6 +2160,21 @@ public class DataRegion implements IDataRegionForQuery {
           && tsFileResource.isSatisfied(singleDeviceId, globalTimeFilter, true, isDebug)) {
         TsFileProcessor tsFileProcessor = tsFileResource.getProcessor();
         try {
+          if (tsFileProcessor == null) {
+            // tsFileProcessor == null means this tsfile is being closed, here we try to busy loop
+            // until status in TsFileResource has been changed which is supposed to be the last step
+            // of closing
+            while (!tsFileResource.isClosed() && waitTimeInMs > 0) {
+              TimeUnit.MILLISECONDS.sleep(5);
+              waitTimeInMs -= 5;
+            }
+            if (tsFileResource.isClosed()) {
+              continue;
+            } else {
+              clearAlreadyLockedList(needToUnLockList);
+              return false;
+            }
+          }
           long startTime = System.nanoTime();
           if (tsFileProcessor.tryReadLock(waitTimeInMs)) {
             // minus already consumed time


### PR DESCRIPTION
This pull request improves the robustness of the `tryGetFLushLock` method in `DataRegion.java` by handling cases where a `TsFileProcessor` is null, which indicates the file is in the process of closing. The new logic introduces a busy-wait loop to check for the file's closed status before proceeding, ensuring thread safety and correctness during concurrent file operations.

**Concurrency and file closing handling:**

* Added a check for `tsFileProcessor == null` to detect if a tsfile is being closed, and implemented a busy-wait loop that waits for the file to finish closing before proceeding. If the file closes within the wait time, the loop continues; otherwise, it clears the lock list and returns `false` to prevent unsafe operations. (`iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java`)