### PR TITLE
Pipe IT: enlarge timeout in `testLoadWhenIncomingIdColumnsArePrefixOfExisting`

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/tablemodel/manual/basic/IoTDBPipeWithLoadIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/tablemodel/manual/basic/IoTDBPipeWithLoadIT.java
@@ -377,7 +377,6 @@ public class IoTDBPipeWithLoadIT extends AbstractPipeTableModelDualManualIT {
           "select * from t1",
           "time,tag1,tag2,tag3,s3,s4,s1,s2,",
           expectedResSet,
-          10,
           "db",
           handleFailure);
     }


### PR DESCRIPTION
fixup #14341