### PR TITLE
Fix the issue where string filtering cannot be used in the DEFINE clause

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBPatternAggregationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBPatternAggregationIT.java
@@ -557,11 +557,15 @@ public class IoTDBPatternAggregationIT {
             + "        AND A.time = CAST('2025-06-01 00:00:00' AS TIMESTAMP) "
             + "        AND A.number = CAST('100' AS INT64) "
             + "        AND A.quantity = CAST('5' AS INT32) "
-            // + "        AND A.discount = CAST('0.95' AS DOUBLE) "
+            + "        AND A.quantity = CAST('5' AS INT64) "
+            + "        AND A.discount = 0.95 "
+            + "        AND A.discount = CAST('0.95' AS FLOAT) "
+            + "        AND A.discount = CAST('0.95' AS DOUBLE) "
             + "        AND A.totalprice = CAST('55000.5' AS DOUBLE) "
             + "        AND A.status = CAST('true' AS BOOLEAN) "
             + "        AND A.receipt = CAST(X'526563656970743130305F3230323530363031' AS BLOB) "
             + "        AND CAST(A.quantity AS INT64) = CAST('5' AS INT64) "
+            + "        AND CAST(A.quantity AS INT64) = CAST(5 AS INT64) "
             + ") AS m ",
         expectedHeader,
         retArray,

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBPatternAggregationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBPatternAggregationIT.java
@@ -508,16 +508,17 @@ public class IoTDBPatternAggregationIT {
   @Test
   public void testDifferentTypes() {
     String[] expectedHeader = new String[] {"match", "count_total"};
-    String[] retArray = new String[] {"1,10,"};
+    String[] retArray = new String[] {"1,12,"};
     tableResultSetEqualTest(
         "SELECT m.match, m.count_total FROM orders "
             + "MATCH_RECOGNIZE ( "
             + "    ORDER BY time "
             + "    MEASURES "
             + "        MATCH_NUMBER() AS match, "
-            + "        COUNT(totalprice) AS count_total "
+            + "        COUNT(totalprice) AS count_total, "
+            + "        L.time AS time "
             + "    ONE ROW PER MATCH "
-            + "    PATTERN (A B C D E F G H I J) "
+            + "    PATTERN (A B C D E F G H I J K L) "
             + "    DEFINE "
             + "        A AS A.customer_id = '100', "
             + "        B AS B.region = 'beijing', "
@@ -528,7 +529,39 @@ public class IoTDBPatternAggregationIT {
             + "        G AS G.totalprice = 667849.9, "
             + "        H AS H.quantity = 6, "
             + "        I AS I.discount = 1.00, "
-            + "        J AS J.receipt = X'526563656970743130305F3230323530363033' "
+            + "        J AS J.receipt = X'526563656970743130305F3230323530363033', "
+            + "        K AS K.time = 1748923300000, "
+            + "        L AS L.time = CAST('2025-06-03 04:18:20' AS TIMESTAMP) "
+            + ") AS m ",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+  }
+
+  @Test
+  public void testDifferentCast() {
+    String[] expectedHeader = new String[] {"match", "cnt"};
+    String[] retArray = new String[] {"1,1,"};
+    tableResultSetEqualTest(
+        "SELECT m.match, m.cnt FROM orders "
+            + "MATCH_RECOGNIZE ( "
+            + "    ORDER BY time "
+            + "    MEASURES "
+            + "        MATCH_NUMBER() AS match, "
+            + "        COUNT(*) AS cnt "
+            + "    ONE ROW PER MATCH "
+            + "    PATTERN (A) "
+            + "    DEFINE "
+            + "        A AS "
+            + "            A.order_date = CAST('2025-06-01' AS DATE) "
+            + "        AND A.time = CAST('2025-06-01 00:00:00' AS TIMESTAMP) "
+            + "        AND A.number = CAST('100' AS INT64) "
+            + "        AND A.quantity = CAST('5' AS INT32) "
+            // + "        AND A.discount = CAST('0.95' AS DOUBLE) "
+            + "        AND A.totalprice = CAST('55000.5' AS DOUBLE) "
+            + "        AND A.status = CAST('true' AS BOOLEAN) "
+            + "        AND A.receipt = CAST(X'526563656970743130305F3230323530363031' AS BLOB) "
+            + "        AND CAST(A.quantity AS INT64) = CAST('5' AS INT64) "
             + ") AS m ",
         expectedHeader,
         retArray,

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBPatternAggregationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBPatternAggregationIT.java
@@ -93,6 +93,21 @@ public class IoTDBPatternAggregationIT {
         "INSERT INTO t3 VALUES (2025-01-01T00:03:00, 7)",
         "INSERT INTO t3 VALUES (2025-01-01T00:04:00, 7)",
         "INSERT INTO t3 VALUES (2025-01-01T00:05:00, -8)",
+
+        // TABLE: orders
+        "create table orders (customer_id TAG, region ATTRIBUTE, order_date DATE, product TEXT, status BOOLEAN, number INT64, totalprice DOUBLE, quantity INT32, discount FLOAT, receipt BLOB)",
+        "insert into orders values(1748736000000, '100', 'beijing', '2025-06-01', 'table', true, 100, 55000.5, 5, 0.95, X'526563656970743130305F3230323530363031')",
+        "insert into orders values(1748736600000, '100', 'beijing', '2025-06-01', 'table', true, 255, 13200.3, 10, 0.90, X'526563656970743130305F3230323530363031')",
+        "insert into orders values(1748737200000, '100', 'beijing', '2025-06-01', 'table', true, 888, 12400, 20, 0.85, X'526563656970743130305F3230323530363031')",
+        "insert into orders values(1748737800000, '100', 'beijing', '2025-06-01', 'table', true, 55, 9998.3, 2, 1.00, X'526563656970743130305F3230323530363031')",
+        "insert into orders values(1748739600000, '100', 'beijing', '2025-06-01', 'table', true, 666, 9998.3, 15, 0.92, X'526563656970743130305F3230323530363031')",
+        "insert into orders values(1748822400000, '101', 'shanghai', '2025-06-02', 'door', false, 608, 12350.5, 8, 0.88, X'526563656970743130315F3230323530363032')",
+        "insert into orders values(1748826000000, '101', 'shanghai', '2025-06-02', 'door', true, 1000, 667849.9, 12, 0.80, X'526563656970743130315F3230323530363032')",
+        "insert into orders values(1748831400000, '101', 'shanghai', '2025-06-02', 'door', true, 360, 33920.5, 6, 0.85, X'526563656970743130315F3230323530363032')",
+        "insert into orders values(1748835000000, '101', 'shanghai', '2025-06-02', 'door', true, 150, 33920.5, 3, 1.00, X'526563656970743130315F3230323530363032')",
+        "insert into orders values(1748923200000, '100', 'beijing', '2025-06-03', 'table', true, 150, 11230.4, 4, 0.97, X'526563656970743130305F3230323530363033')",
+        "insert into orders values(1748923300000, '101', 'beijing', '2025-06-04', 'table', true, 50, 55000.00, 2, 0.90, X'526563656970743130315F3230323530363034')",
+        "insert into orders values(1748924300000, '102', 'beijing', '2025-06-05', 'table', true, 50, 65000.00, 1, 0.85, X'526563656970743130325F3230323530363035')",
       };
 
   private static void insertData() {
@@ -484,6 +499,36 @@ public class IoTDBPatternAggregationIT {
             + "    PATTERN ((A | B)*) "
             + "    DEFINE "
             + "        A AS AVG(totalprice) = 5 "
+            + ") AS m ",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+  }
+
+  @Test
+  public void testDifferentTypes() {
+    String[] expectedHeader = new String[] {"match", "count_total"};
+    String[] retArray = new String[] {"1,10,"};
+    tableResultSetEqualTest(
+        "SELECT m.match, m.count_total FROM orders "
+            + "MATCH_RECOGNIZE ( "
+            + "    ORDER BY time "
+            + "    MEASURES "
+            + "        MATCH_NUMBER() AS match, "
+            + "        COUNT(totalprice) AS count_total "
+            + "    ONE ROW PER MATCH "
+            + "    PATTERN (A B C D E F G H I J) "
+            + "    DEFINE "
+            + "        A AS A.customer_id = '100', "
+            + "        B AS B.region = 'beijing', "
+            + "        C AS C.order_date = CAST('2025-06-01' AS DATE), "
+            + "        D AS D.product = 'table', "
+            + "        E AS E.status = true, "
+            + "        F AS F.number = 608, "
+            + "        G AS G.totalprice = 667849.9, "
+            + "        H AS H.quantity = 6, "
+            + "        I AS I.discount = 1.00, "
+            + "        J AS J.receipt = X'526563656970743130305F3230323530363033' "
             + ") AS m ",
         expectedHeader,
         retArray,

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/rowpattern/expression/CastComputation.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/rowpattern/expression/CastComputation.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.execution.operator.process.rowpattern.expression;
+
+import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.DataType;
+import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.GenericDataType;
+
+import java.util.List;
+
+public class CastComputation extends Computation {
+  private final Computation inner;
+  private final DataType targetType;
+
+  public CastComputation(Computation inner, DataType targetType) {
+    this.inner = inner;
+    this.targetType = targetType;
+  }
+
+  @Override
+  public Object evaluate(List<Object> values) {
+    Object value = inner.evaluate(values);
+    if (value == null) {
+      return null;
+    }
+
+    if (targetType instanceof GenericDataType) {
+      String typeName = ((GenericDataType) targetType).getName().getValue().toUpperCase();
+
+      switch (typeName) {
+        case "INT32":
+          if (value instanceof Number) {
+            return ((Number) value).intValue();
+          }
+          return Integer.parseInt(value.toString());
+        case "INT64":
+          if (value instanceof Number) {
+            return ((Number) value).longValue();
+          }
+          return Long.parseLong(value.toString());
+        case "FLOAT":
+          if (value instanceof Number) {
+            return ((Number) value).floatValue();
+          }
+          return Float.parseFloat(value.toString());
+        case "DOUBLE":
+          if (value instanceof Number) {
+            return ((Number) value).doubleValue();
+          }
+          return Double.parseDouble(value.toString());
+        case "STRING":
+          return value.toString();
+        case "BOOLEAN":
+          if (value instanceof Boolean) {
+            return value;
+          }
+          return Boolean.parseBoolean(value.toString());
+        default:
+          throw new UnsupportedOperationException("Unsupported cast to type: " + typeName);
+      }
+    } else {
+      throw new UnsupportedOperationException(
+          "Target type is not a GenericDataType: " + targetType);
+    }
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/rowpattern/expression/ComparisonOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/rowpattern/expression/ComparisonOperator.java
@@ -86,12 +86,30 @@ public enum ComparisonOperator implements BinaryOperator {
     NormalizedValue normLeft = normalize(left);
     NormalizedValue normRight = normalize(right);
 
+    // float/double mixed comparison: convert to double and compare with tolerance
+    if (normLeft.type == NormalizedValue.Type.DOUBLE
+        && normRight.type == NormalizedValue.Type.DOUBLE) {
+      double d1 = (Double) normLeft.value;
+      double d2 = (Double) normRight.value;
+      if (almostEqual(d1, d2)) {
+        return 0;
+      }
+      return Double.compare(d1, d2);
+    }
+
     if (normLeft.type != normRight.type) {
       throw new SemanticException(
           "Cannot compare values of different types: " + normLeft.type + " vs. " + normRight.type);
     }
 
     return normLeft.compareTo(normRight);
+  }
+
+  private static final double EPSILON = 1e-7;
+
+  private static boolean almostEqual(double a, double b) {
+    double diff = Math.abs(a - b);
+    return diff <= EPSILON;
   }
 
   /** provide a unified comparison logic */

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/rowpattern/expression/ComparisonOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/rowpattern/expression/ComparisonOperator.java
@@ -140,6 +140,8 @@ public enum ComparisonOperator implements BinaryOperator {
       return new NormalizedValue(NormalizedValue.Type.BOOLEAN, obj);
     } else if (obj instanceof Binary) {
       return new NormalizedValue(NormalizedValue.Type.BINARY, obj);
+    } else if (obj instanceof byte[]) {
+      return new NormalizedValue(NormalizedValue.Type.BINARY, new Binary((byte[]) obj));
     } else {
       throw new SemanticException("Unsupported type: " + obj.getClass());
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/rowpattern/expression/Computation.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/rowpattern/expression/Computation.java
@@ -23,10 +23,12 @@ import org.apache.iotdb.db.exception.sql.SemanticException;
 import org.apache.iotdb.db.queryengine.plan.relational.planner.rowpattern.ExpressionAndValuePointers;
 import org.apache.iotdb.db.queryengine.plan.relational.planner.rowpattern.ExpressionAndValuePointers.Assignment;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.ArithmeticBinaryExpression;
+import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.BinaryLiteral;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.BooleanLiteral;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.ComparisonExpression;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.DoubleLiteral;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Expression;
+import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.GenericLiteral;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.LogicalExpression;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.LongLiteral;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.StringLiteral;
@@ -129,6 +131,20 @@ public abstract class Computation {
         // undefined pattern variable is 'true'
         BooleanLiteral constExpr = (BooleanLiteral) expression;
         return new ConstantComputation(constExpr.getValue());
+      } else if (expression instanceof BinaryLiteral) {
+        BinaryLiteral constExpr = (BinaryLiteral) expression;
+        return new ConstantComputation(constExpr.getValue());
+      } else if (expression instanceof GenericLiteral) {
+        GenericLiteral constExpr = (GenericLiteral) expression;
+        String type = constExpr.getType();
+
+        if ("DATE".equalsIgnoreCase(type)) {
+          String dateStr = constExpr.getValue();
+          int dateInt = Integer.parseInt(dateStr);
+          return new ConstantComputation(dateInt);
+        } else {
+          return new ConstantComputation(constExpr.getValue());
+        }
       } else {
         throw new SemanticException(
             "Unsupported expression type: " + expression.getClass().getName());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/rowpattern/expression/PatternExpressionComputation.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/rowpattern/expression/PatternExpressionComputation.java
@@ -28,6 +28,7 @@ import org.apache.iotdb.db.queryengine.execution.operator.process.rowpattern.mat
 import org.apache.iotdb.db.queryengine.execution.operator.process.window.partition.Partition;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.read.common.type.BinaryType;
 import org.apache.tsfile.read.common.type.BooleanType;
 import org.apache.tsfile.read.common.type.DoubleType;
 import org.apache.tsfile.read.common.type.FloatType;
@@ -161,7 +162,7 @@ public class PatternExpressionComputation {
       return partition.getFloat(channel, position);
     } else if (type instanceof DoubleType) {
       return partition.getDouble(channel, position);
-    } else if (type instanceof StringType) {
+    } else if (type instanceof StringType || type instanceof BinaryType) {
       return partition.getBinary(channel, position);
     } else {
       throw new SemanticException("Unsupported type: " + type.getClass().getSimpleName());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/rowpattern/expression/PatternExpressionComputation.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/rowpattern/expression/PatternExpressionComputation.java
@@ -28,14 +28,13 @@ import org.apache.iotdb.db.queryengine.execution.operator.process.rowpattern.mat
 import org.apache.iotdb.db.queryengine.execution.operator.process.window.partition.Partition;
 
 import org.apache.tsfile.enums.TSDataType;
-import org.apache.tsfile.read.common.type.BinaryType;
+import org.apache.tsfile.read.common.type.AbstractIntType;
+import org.apache.tsfile.read.common.type.AbstractLongType;
+import org.apache.tsfile.read.common.type.AbstractVarcharType;
+import org.apache.tsfile.read.common.type.BlobType;
 import org.apache.tsfile.read.common.type.BooleanType;
 import org.apache.tsfile.read.common.type.DoubleType;
 import org.apache.tsfile.read.common.type.FloatType;
-import org.apache.tsfile.read.common.type.IntType;
-import org.apache.tsfile.read.common.type.LongType;
-import org.apache.tsfile.read.common.type.StringType;
-import org.apache.tsfile.read.common.type.TimestampType;
 import org.apache.tsfile.read.common.type.Type;
 
 import java.util.ArrayList;
@@ -154,15 +153,15 @@ public class PatternExpressionComputation {
 
     if (type instanceof BooleanType) {
       return partition.getBoolean(channel, position);
-    } else if (type instanceof IntType) {
+    } else if (type instanceof AbstractIntType) {
       return partition.getInt(channel, position);
-    } else if (type instanceof LongType || type instanceof TimestampType) {
+    } else if (type instanceof AbstractLongType) {
       return partition.getLong(channel, position);
     } else if (type instanceof FloatType) {
       return partition.getFloat(channel, position);
     } else if (type instanceof DoubleType) {
       return partition.getDouble(channel, position);
-    } else if (type instanceof StringType || type instanceof BinaryType) {
+    } else if (type instanceof AbstractVarcharType || type instanceof BlobType) {
       return partition.getBinary(channel, position);
     } else {
       throw new SemanticException("Unsupported type: " + type.getClass().getSimpleName());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/LiteralEncoder.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/LiteralEncoder.java
@@ -93,8 +93,7 @@ public final class LiteralEncoder {
     }
 
     if (type.equals(FLOAT) || type.equals(DOUBLE)) {
-      Double value = (Double) object;
-      return new DoubleLiteral(value);
+      return new DoubleLiteral(((Number) object).doubleValue());
     }
 
     if (isBool(type)) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/process/rowpattern/PatternExpressionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/process/rowpattern/PatternExpressionTest.java
@@ -50,4 +50,13 @@ public class PatternExpressionTest {
     values = Arrays.asList(6, 5, 10); // 6 + 5 < 10 -> false
     assertEquals(false, fullExpression.evaluate(values));
   }
+
+  @Test
+  public void testStringExpression() {
+    Computation expr =
+        new BinaryComputation(
+            new ReferenceComputation(0), new ReferenceComputation(1), ComparisonOperator.EQUAL);
+    List<Object> values = Arrays.asList("hello", "hello");
+    assertEquals(true, expr.evaluate(values));
+  }
 }


### PR DESCRIPTION
Fix the issue where string & date & blob filtering cannot be used in the DEFINE clause