### PR TITLE
Fix NodeSupplier connection leaky while encountering exception

### DIFF
--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/ThriftConnection.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/ThriftConnection.java
@@ -193,6 +193,7 @@ public class ThriftConnection {
         }
       } catch (TException e) {
         LOGGER.warn("Closing Session-{} with {} failed.", sessionId, endPoint);
+      } finally {
         if (transport.isOpen()) {
           transport.close();
         }


### PR DESCRIPTION
This pull request makes a small but important change to the `ThriftConnection` class to ensure resources are properly released. The change moves the transport closing logic into a `finally` block, guaranteeing that the transport is closed even if an exception occurs during session closing.

- Resource management improvement:
  * Ensured that `transport.close()` is always called by moving it into a `finally` block in the `close()` method of `ThriftConnection`, improving reliability and preventing potential resource leaks.