### PR TITLE
Add comments in docker-compose for startup hang

### DIFF
--- a/docker/src/main/DockerCompose/docker-compose-ainode.yml
+++ b/docker/src/main/DockerCompose/docker-compose-ainode.yml
@@ -44,9 +44,9 @@ services:
       - ainode-data:/ainode/data
       - ./logs/ainode:/ainode/logs
       # - ./lib/ainode:/ainode/lib  # Uncomment for rolling upgrade
-    # Kylin V10: Container nofile limit is very high (~2^30 = 1073741824). This may cause
-    # the startup step "Checking whether the ports are already occupied..." to hang (lsof too slow).
-    # If you get stuck there, lower the container nofile limit by uncommenting below:
+    # Note: Some environments set an extremely high container nofile limit (~2^30 = 1073741824).
+    # This can make the startup step "Checking whether the ports are already occupied..." appear to hang (lsof slow).
+    # If you see that line for a long time, lower the nofile limit by uncommenting below:
     # ulimits:
     #   nofile:
     #     soft: 1048576

--- a/docker/src/main/DockerCompose/docker-compose-ainode.yml
+++ b/docker/src/main/DockerCompose/docker-compose-ainode.yml
@@ -44,3 +44,10 @@ services:
       - ainode-data:/ainode/data
       - ./logs/ainode:/ainode/logs
       # - ./lib/ainode:/ainode/lib  # Uncomment for rolling upgrade
+    # Kylin V10: Container nofile limit is very high (~2^30 = 1073741824). This may cause
+    # the startup step "Checking whether the ports are already occupied..." to hang (lsof too slow).
+    # If you get stuck there, lower the container nofile limit by uncommenting below:
+    # ulimits:
+    #   nofile:
+    #     soft: 1048576
+    #     hard: 1048576

--- a/docker/src/main/DockerCompose/docker-compose-cluster-1c1d1a.yml
+++ b/docker/src/main/DockerCompose/docker-compose-cluster-1c1d1a.yml
@@ -41,9 +41,9 @@ services:
     volumes:
         - ./data/iotdb:/iotdb/data
         - ./logs/iotdb:/iotdb/logs
-    # Kylin V10: Container nofile limit is very high (~2^30 = 1073741824). This may cause
-    # the startup step "Checking whether the ports are already occupied..." to hang (lsof too slow).
-    # If you get stuck there, lower the container nofile limit by uncommenting below:
+    # Note: Some environments set an extremely high container nofile limit (~2^30 = 1073741824).
+    # This can make the startup step "Checking whether the ports are already occupied..." appear to hang (lsof slow).
+    # If you see that line for a long time, lower the nofile limit by uncommenting below:
     # ulimits:
     #   nofile:
     #     soft: 1048576
@@ -64,9 +64,9 @@ services:
     networks:
       iotdb:
     #     ipv4_address: 127.0.0.1
-    # Kylin V10: Container nofile limit is very high (~2^30 = 1073741824). This may cause
-    # the startup step "Checking whether the ports are already occupied..." to hang (lsof too slow).
-    # If you get stuck there, lower the container nofile limit by uncommenting below:
+    # Note: Some environments set an extremely high container nofile limit (~2^30 = 1073741824).
+    # This can make the startup step "Checking whether the ports are already occupied..." appear to hang (lsof slow).
+    # If you see that line for a long time, lower the nofile limit by uncommenting below:
     # ulimits:
     #   nofile:
     #     soft: 1048576

--- a/docker/src/main/DockerCompose/docker-compose-cluster-1c1d1a.yml
+++ b/docker/src/main/DockerCompose/docker-compose-cluster-1c1d1a.yml
@@ -41,11 +41,13 @@ services:
     volumes:
         - ./data/iotdb:/iotdb/data
         - ./logs/iotdb:/iotdb/logs
-    # Enable this configuration for kylinOS
+    # Kylin V10: Container nofile limit is very high (~2^30 = 1073741824). This may cause
+    # the startup step "Checking whether the ports are already occupied..." to hang (lsof too slow).
+    # If you get stuck there, lower the container nofile limit by uncommenting below:
     # ulimits:
     #   nofile:
-    #     soft: 20000
-    #     hard: 20000
+    #     soft: 1048576
+    #     hard: 1048576
     networks:
       iotdb:
         # ipv4_address: 127.0.0.1
@@ -62,6 +64,13 @@ services:
     networks:
       iotdb:
     #     ipv4_address: 127.0.0.1
+    # Kylin V10: Container nofile limit is very high (~2^30 = 1073741824). This may cause
+    # the startup step "Checking whether the ports are already occupied..." to hang (lsof too slow).
+    # If you get stuck there, lower the container nofile limit by uncommenting below:
+    # ulimits:
+    #   nofile:
+    #     soft: 1048576
+    #     hard: 1048576
 
 networks:
   iotdb:

--- a/docker/src/main/DockerCompose/docker-compose-cluster-1c2d.yml
+++ b/docker/src/main/DockerCompose/docker-compose-cluster-1c2d.yml
@@ -34,9 +34,9 @@ services:
     networks:
       iotdb:
         ipv4_address: 172.18.0.2
-    # Kylin V10: Container nofile limit is very high (~2^30 = 1073741824). This may cause
-    # the startup step "Checking whether the ports are already occupied..." to hang (lsof too slow).
-    # If you get stuck there, lower the container nofile limit by uncommenting below:
+    # Note: Some environments set an extremely high container nofile limit (~2^30 = 1073741824).
+    # This can make the startup step "Checking whether the ports are already occupied..." appear to hang (lsof slow).
+    # If you see that line for a long time, lower the nofile limit by uncommenting below:
     # ulimits:
     #   nofile:
     #     soft: 1048576
@@ -63,9 +63,9 @@ services:
     networks:
       iotdb:
         ipv4_address: 172.18.0.3
-    # Kylin V10: Container nofile limit is very high (~2^30 = 1073741824). This may cause
-    # the startup step "Checking whether the ports are already occupied..." to hang (lsof too slow).
-    # If you get stuck there, lower the container nofile limit by uncommenting below:
+    # Note: Some environments set an extremely high container nofile limit (~2^30 = 1073741824).
+    # This can make the startup step "Checking whether the ports are already occupied..." appear to hang (lsof slow).
+    # If you see that line for a long time, lower the nofile limit by uncommenting below:
     # ulimits:
     #   nofile:
     #     soft: 1048576
@@ -90,9 +90,9 @@ services:
     networks:
       iotdb:
         ipv4_address: 172.18.0.4
-    # Kylin V10: Container nofile limit is very high (~2^30 = 1073741824). This may cause
-    # the startup step "Checking whether the ports are already occupied..." to hang (lsof too slow).
-    # If you get stuck there, lower the container nofile limit by uncommenting below:
+    # Note: Some environments set an extremely high container nofile limit (~2^30 = 1073741824).
+    # This can make the startup step "Checking whether the ports are already occupied..." appear to hang (lsof slow).
+    # If you see that line for a long time, lower the nofile limit by uncommenting below:
     # ulimits:
     #   nofile:
     #     soft: 1048576

--- a/docker/src/main/DockerCompose/docker-compose-cluster-1c2d.yml
+++ b/docker/src/main/DockerCompose/docker-compose-cluster-1c2d.yml
@@ -34,6 +34,13 @@ services:
     networks:
       iotdb:
         ipv4_address: 172.18.0.2
+    # Kylin V10: Container nofile limit is very high (~2^30 = 1073741824). This may cause
+    # the startup step "Checking whether the ports are already occupied..." to hang (lsof too slow).
+    # If you get stuck there, lower the container nofile limit by uncommenting below:
+    # ulimits:
+    #   nofile:
+    #     soft: 1048576
+    #     hard: 1048576
 
   iotdb-datanode1:
     image: apache/iotdb:1.1.0-datanode
@@ -56,6 +63,13 @@ services:
     networks:
       iotdb:
         ipv4_address: 172.18.0.3
+    # Kylin V10: Container nofile limit is very high (~2^30 = 1073741824). This may cause
+    # the startup step "Checking whether the ports are already occupied..." to hang (lsof too slow).
+    # If you get stuck there, lower the container nofile limit by uncommenting below:
+    # ulimits:
+    #   nofile:
+    #     soft: 1048576
+    #     hard: 1048576
 
   iotdb-datanode2:
     image: apache/iotdb:1.1.0-datanode
@@ -76,6 +90,13 @@ services:
     networks:
       iotdb:
         ipv4_address: 172.18.0.4
+    # Kylin V10: Container nofile limit is very high (~2^30 = 1073741824). This may cause
+    # the startup step "Checking whether the ports are already occupied..." to hang (lsof too slow).
+    # If you get stuck there, lower the container nofile limit by uncommenting below:
+    # ulimits:
+    #   nofile:
+    #     soft: 1048576
+    #     hard: 1048576
 
 networks:
   iotdb:

--- a/docker/src/main/DockerCompose/docker-compose-host-3c3d.yml
+++ b/docker/src/main/DockerCompose/docker-compose-host-3c3d.yml
@@ -35,6 +35,13 @@ services:
       - ./data/confignode:/iotdb/data
       - ./logs/confignode:/iotdb/logs
     network_mode: "host"
+    # Kylin V10: Container nofile limit is very high (~2^30 = 1073741824). This may cause
+    # the startup step "Checking whether the ports are already occupied..." to hang (lsof too slow).
+    # If you get stuck there, lower the container nofile limit by uncommenting below:
+    # ulimits:
+    #   nofile:
+    #     soft: 1048576
+    #     hard: 1048576
 
   iotdb-datanode:
     image: apache/iotdb:1.1.0-datanode
@@ -55,3 +62,10 @@ services:
       - ./data/datanode:/iotdb/data/
       - ./logs/datanode:/iotdb/logs/
     network_mode: "host"
+    # Kylin V10: Container nofile limit is very high (~2^30 = 1073741824). This may cause
+    # the startup step "Checking whether the ports are already occupied..." to hang (lsof too slow).
+    # If you get stuck there, lower the container nofile limit by uncommenting below:
+    # ulimits:
+    #   nofile:
+    #     soft: 1048576
+    #     hard: 1048576

--- a/docker/src/main/DockerCompose/docker-compose-host-3c3d.yml
+++ b/docker/src/main/DockerCompose/docker-compose-host-3c3d.yml
@@ -35,9 +35,9 @@ services:
       - ./data/confignode:/iotdb/data
       - ./logs/confignode:/iotdb/logs
     network_mode: "host"
-    # Kylin V10: Container nofile limit is very high (~2^30 = 1073741824). This may cause
-    # the startup step "Checking whether the ports are already occupied..." to hang (lsof too slow).
-    # If you get stuck there, lower the container nofile limit by uncommenting below:
+    # Note: Some environments set an extremely high container nofile limit (~2^30 = 1073741824).
+    # This can make the startup step "Checking whether the ports are already occupied..." appear to hang (lsof slow).
+    # If you see that line for a long time, lower the nofile limit by uncommenting below:
     # ulimits:
     #   nofile:
     #     soft: 1048576
@@ -62,9 +62,9 @@ services:
       - ./data/datanode:/iotdb/data/
       - ./logs/datanode:/iotdb/logs/
     network_mode: "host"
-    # Kylin V10: Container nofile limit is very high (~2^30 = 1073741824). This may cause
-    # the startup step "Checking whether the ports are already occupied..." to hang (lsof too slow).
-    # If you get stuck there, lower the container nofile limit by uncommenting below:
+    # Note: Some environments set an extremely high container nofile limit (~2^30 = 1073741824).
+    # This can make the startup step "Checking whether the ports are already occupied..." appear to hang (lsof slow).
+    # If you see that line for a long time, lower the nofile limit by uncommenting below:
     # ulimits:
     #   nofile:
     #     soft: 1048576

--- a/docker/src/main/DockerCompose/docker-compose-standalone.yml
+++ b/docker/src/main/DockerCompose/docker-compose-standalone.yml
@@ -44,6 +44,13 @@ services:
     networks:
       iotdb:
         ipv4_address: 172.18.0.6
+    # Kylin V10: Container nofile limit is very high (~2^30 = 1073741824). This may cause
+    # the startup step "Checking whether the ports are already occupied..." to hang (lsof too slow).
+    # If you get stuck there, lower the container nofile limit by uncommenting below:
+    # ulimits:
+    #   nofile:
+    #     soft: 1048576
+    #     hard: 1048576
 
 networks:
   iotdb:

--- a/docker/src/main/DockerCompose/docker-compose-standalone.yml
+++ b/docker/src/main/DockerCompose/docker-compose-standalone.yml
@@ -44,9 +44,9 @@ services:
     networks:
       iotdb:
         ipv4_address: 172.18.0.6
-    # Kylin V10: Container nofile limit is very high (~2^30 = 1073741824). This may cause
-    # the startup step "Checking whether the ports are already occupied..." to hang (lsof too slow).
-    # If you get stuck there, lower the container nofile limit by uncommenting below:
+    # Note: Some environments set an extremely high container nofile limit (~2^30 = 1073741824).
+    # This can make the startup step "Checking whether the ports are already occupied..." appear to hang (lsof slow).
+    # If you see that line for a long time, lower the nofile limit by uncommenting below:
     # ulimits:
     #   nofile:
     #     soft: 1048576


### PR DESCRIPTION
Note: Some environments set an extremely high container nofile limit (~2^30 = 1073741824).
This can make the startup step "Checking whether the ports are already occupied..." appear to hang (lsof slow).
If you see that line for a long time, lower the nofile limit by uncommenting below: