### PR TITLE
[AINode] Fix maven verify bug

### DIFF
--- a/.github/workflows/cluster-it-1c1d1a.yml
+++ b/.github/workflows/cluster-it-1c1d1a.yml
@@ -48,10 +48,10 @@ jobs:
         shell: bash
         run: |
           mvn clean verify \
-          -P with-integration-tests \
+          -P with-integration-tests,with-ainode \
           -DskipUTs \
           -DintegrationTest.forkCount=1 \
-          -pl integration-test \
+          -pl integration-test,iotdb-core/ainode \
           -am \
           -PAIClusterIT
       - name: Upload Artifact

--- a/iotdb-core/ainode/pom.xml
+++ b/iotdb-core/ainode/pom.xml
@@ -38,6 +38,24 @@
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
+            <artifactId>iotdb-thrift-confignode</artifactId>
+            <version>2.0.6-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.iotdb</groupId>
+            <artifactId>iotdb-thrift-commons</artifactId>
+            <version>2.0.6-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.iotdb</groupId>
+            <artifactId>iotdb-thrift-ainode</artifactId>
+            <version>2.0.6-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-python-api</artifactId>
             <version>2.0.6-SNAPSHOT</version>
             <scope>provided</scope>
@@ -329,6 +347,9 @@
                                 <usedDependency>org.apache.iotdb:iotdb-thrift-confignode</usedDependency>
                                 <usedDependency>org.apache.iotdb:iotdb-thrift-ainode</usedDependency>
                             </usedDependencies>
+                            <ignoredUnusedDeclaredDependencies>
+                                <ignoredUnusedDeclaredDependency>org.apache.iotdb:iotdb-python-api</ignoredUnusedDeclaredDependency>
+                            </ignoredUnusedDeclaredDependencies>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Since the AINode now relies on iotdb-python-api module, while this python dependencies cannot be detected by maven, we should ignore the corresponding verify check.