### PR TITLE
Revert: cannot reuse time and column array in InsertTabletStatementGenerator

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/InsertTabletStatementGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/InsertTabletStatementGenerator.java
@@ -67,7 +67,7 @@ public abstract class InsertTabletStatementGenerator implements Accountable {
     this.rowLimit = rowLimit;
   }
 
-  public void initialize() {
+  public void reset() {
     this.rowCount = 0;
     this.times = new long[rowLimit];
     this.columns = new Object[this.measurements.length];
@@ -105,43 +105,6 @@ public abstract class InsertTabletStatementGenerator implements Accountable {
     for (int i = 0; i < this.bitMaps.length; ++i) {
       this.bitMaps[i] = new BitMap(rowLimit);
       this.bitMaps[i].markAll();
-    }
-  }
-
-  public void reset() {
-    this.rowCount = 0;
-    Arrays.fill(times, 0L);
-    for (int i = 0; i < this.measurements.length; i++) {
-      switch (dataTypes[i]) {
-        case BOOLEAN:
-          Arrays.fill((boolean[]) columns[i], false);
-          break;
-        case INT32:
-        case DATE:
-          Arrays.fill((int[]) columns[i], 0);
-          break;
-        case INT64:
-        case TIMESTAMP:
-          Arrays.fill((long[]) columns[i], 0L);
-          break;
-        case FLOAT:
-          Arrays.fill((float[]) columns[i], 0F);
-          break;
-        case DOUBLE:
-          Arrays.fill((double[]) columns[i], 0D);
-          break;
-        case TEXT:
-        case STRING:
-        case BLOB:
-          Arrays.fill((Binary[]) columns[i], Binary.EMPTY_VALUE);
-          break;
-        default:
-          throw new UnSupportedDataTypeException(
-              String.format("Data type %s is not supported.", dataTypes[i]));
-      }
-    }
-    for (BitMap bitMap : this.bitMaps) {
-      bitMap.markAll();
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/TableInsertTabletStatementGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/TableInsertTabletStatementGenerator.java
@@ -71,7 +71,7 @@ public class TableInsertTabletStatementGenerator extends InsertTabletStatementGe
     this.columnCategories = tsTableColumnCategories.toArray(new TsTableColumnCategory[0]);
     this.timeColumnIndex =
         measurementToInputLocationMap.get(TIME_COLUMN_NAME).getValueColumnIndex();
-    this.initialize();
+    this.reset();
   }
 
   public int processTsBlock(TsBlock tsBlock, int lastReadIndex) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/TreeInsertTabletStatementGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/TreeInsertTabletStatementGenerator.java
@@ -59,7 +59,7 @@ public class TreeInsertTabletStatementGenerator extends InsertTabletStatementGen
     for (String measurement : measurements) {
       writtenCounter.put(measurement, new AtomicLong(0));
     }
-    this.initialize();
+    this.reset();
   }
 
   public int processTsBlock(TsBlock tsBlock, int lastReadIndex) {


### PR DESCRIPTION
…nerator

## Description
Notice: times and columns in the InsertTabletStatementGenerator cannot be reused. When insertTabletStatements is constructed, we copy the times and columns from InsertTabletStatementGenerator. However serveral InsertTabletStatements may be held by WAL or PIPE. They're constructed concurrently and lead to problems. 

### Content1 ...

### Content2 ...

### Content3 ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
