### PR TITLE
some tools use getColumnDisplaySize, No exceptions should be thrown.

### DIFF
--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBResultMetadata.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBResultMetadata.java
@@ -175,8 +175,8 @@ public class IoTDBResultMetadata implements ResultSetMetaData {
   }
 
   @Override
-  public int getColumnDisplaySize(int arg0) throws SQLException {
-    throw new SQLException(Constant.METHOD_NOT_SUPPORTED);
+  public int getColumnDisplaySize(int column) throws SQLException {
+    return getPrecision(column);
   }
 
   @Override


### PR DESCRIPTION
use getPrecision substitution
Indicates the designated column's normal maximum width in characters.

