### PR TITLE
fix cpp session mem leak

### DIFF
--- a/example/client-cpp-example/src/TableModelSessionExample.cpp
+++ b/example/client-cpp-example/src/TableModelSessionExample.cpp
@@ -22,7 +22,7 @@
 
 using namespace std;
 
-TableSession *session;
+shared_ptr<TableSession> session;
 
 void insertRelationalTablet() {
 
@@ -202,8 +202,6 @@ int main() {
 
         cout << "session close\n" << endl;
         session->close();
-
-        delete session;
 
         cout << "finished!\n" << endl;
     } catch (IoTDBConnectionException &e) {

--- a/iotdb-client/client-cpp/src/main/SessionBuilder.h
+++ b/iotdb-client/client-cpp/src/main/SessionBuilder.h
@@ -79,12 +79,12 @@ public:
         return this;
     }
 
-    Session* build() {
+   std::shared_ptr<Session> build() {
         sqlDialect = "tree";
-        Session* newSession = new Session(this);
+        auto newSession = std::make_shared<Session>(this);
         newSession->open(false);
         return newSession;
-    }
+   }
 };
 
 #endif // IOTDB_SESSION_BUILDER_H

--- a/iotdb-client/client-cpp/src/main/TableSession.h
+++ b/iotdb-client/client-cpp/src/main/TableSession.h
@@ -26,18 +26,14 @@
 
 class TableSession {
 private:
-    Session* session_;
+    std::shared_ptr<Session> session_;
     string getDatabase();
 public:
-    TableSession(Session* session) {
+    TableSession(std::shared_ptr<Session> session) {
         this->session_ = session;
     }
-    ~TableSession() {
-        if (session_) {
-            delete session_;
-            session_ = nullptr;
-        }
-    }
+    ~TableSession() {}
+
     void insert(Tablet& tablet, bool sorted = false);
     void executeNonQueryStatement(const std::string& sql);
     unique_ptr<SessionDataSet> executeQueryStatement(const std::string& sql);

--- a/iotdb-client/client-cpp/src/main/TableSessionBuilder.h
+++ b/iotdb-client/client-cpp/src/main/TableSessionBuilder.h
@@ -69,11 +69,11 @@ public:
         AbstractSessionBuilder::nodeUrls = nodeUrls;
         return this;
     }
-    TableSession* build() {
+    std::shared_ptr<TableSession> build() {
         sqlDialect = "table";
-        Session* newSession = new Session(this);
+        auto newSession = std::make_shared<Session>(this);
         newSession->open(false);
-        return new TableSession(newSession);
+        return std::make_shared<TableSession>(newSession);
     }
 };
 


### PR DESCRIPTION
## Description


### Content1
fix cpp sesssion builder memory leak

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [√] been tested
```
        try {
            auto builder = std::make_shared<TableSessionBuilder>();
            auto session = std::shared_ptr<TableSession>(builder->username("root")
                    ->password("root")
                    ->nodeUrls(node_urls)
                    ->build());
            session->executeNonQueryStatement("show timeseries");
            session->close();
        }
        catch (const exception &e) {
            printf("exception: %s\n", e.what());
        }
```
```
$ valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes ./iotdbapp 
==95960== Memcheck, a memory error detector
==95960== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==95960== Using Valgrind-3.22.0 and LibVEX; rerun with -h for copyright info
==95960== Command: ./iotdbapp
==95960== 
Thrift: Fri Sep 19 10:37:16 2025 TSocket::open() timed out <Host: 127.0.0.1 Port: 6667>
[WARN]  /home/hongzhi/target/build/main/generated-sources-cpp/NodesSupplier.cpp:209 (fetchLatestEndpoints) - Failed to fetch endpoints from 127.0.0.1:6667 , error=open() timed out
[ERROR] /home/hongzhi/target/build/main/generated-sources-cpp/NodesSupplier.cpp:229 (refreshEndpointList) - NodesSupplier::refreshEndpointList failed: NodesSupplier::fetchLatestEndpoints failed: all nodes unreachable.
Thrift: Fri Sep 19 10:37:17 2025 TSocket::open() timed out <Host: 127.0.0.1 Port: 6667>
[WARN]  /home/hongzhi/target/build/main/generated-sources-cpp/NodesSupplier.cpp:209 (fetchLatestEndpoints) - Failed to fetch endpoints from 127.0.0.1:6667 , error=open() timed out
[ERROR] /home/hongzhi/target/build/main/generated-sources-cpp/NodesSupplier.cpp:229 (refreshEndpointList) - NodesSupplier::refreshEndpointList failed: NodesSupplier::fetchLatestEndpoints failed: all nodes unreachable.
Thrift: Fri Sep 19 10:37:19 2025 TSocket::open() timed out <Host: 127.0.0.1 Port: 6667>
[DEBUG] /home/hongzhi/target/build/main/generated-sources-cpp/SessionConnection.cpp:110 (init) - open() timed out
[DEBUG] /home/hongzhi/target/build/main/generated-sources-cpp/Session.cpp:795 (initDefaultSessionConnection) - open() timed out
[DEBUG] /home/hongzhi/target/build/main/generated-sources-cpp/Session.cpp:950 (open) - open() timed out
exception: open() timed out
==95960== 
==95960== HEAP SUMMARY:
==95960==     in use at exit: 0 bytes in 0 blocks
==95960==   total heap usage: 349 allocs, 349 frees, 106,622 bytes allocated
==95960== 
==95960== All heap blocks were freed -- no leaks are possible
==95960== 
==95960== For lists of detected and suppressed errors, rerun with: -s
==95960== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
Modified SessionBuilder to use smart pointers.
