### PR TITLE
[To dev/1.3] Subscription: Prevent IllegalArgumentException in SubscriptionLogStatus by validating bounds for nextLong (#16447)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/resource/log/SubscriptionLogStatus.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/resource/log/SubscriptionLogStatus.java
@@ -68,7 +68,7 @@ class SubscriptionLogStatus {
                         now
                             // introduce randomness
                             - BASE_INTERVAL_IN_MS
-                                * ThreadLocalRandom.current().nextLong(1, count + 1))));
+                                * ThreadLocalRandom.current().nextLong(Math.max(count, 1)))));
     final long last = lastTime.get();
     if (now - last >= allowedInterval) {
       // Use compareAndSet to ensure that only one thread updates at a time,


### PR DESCRIPTION
cherry-pick #16447 to https://github.com/apache/iotdb/tree/dev/1.3