### PR TITLE
[AINode] Fix: remove venv out of the target directory. 

### DIFF
--- a/distribution/src/assembly/ainode.xml
+++ b/distribution/src/assembly/ainode.xml
@@ -30,20 +30,48 @@
         <fileSet>
             <directory>${project.basedir}/../iotdb-core/ainode/target/apache-iotdb-ainode-${project.version}/apache-iotdb-ainode-${project.version}/conf</directory>
             <outputDirectory>${file.separator}/conf</outputDirectory>
+            <excludes>
+                <exclude>venv/**</exclude>
+                <exclude>.venv/**</exclude>
+                <exclude>target/**</exclude>
+                <exclude>**/__pycache__/**</exclude>
+                <exclude>**/*.pyc</exclude>
+            </excludes>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/../iotdb-core/ainode/target/apache-iotdb-ainode-${project.version}/apache-iotdb-ainode-${project.version}/sbin</directory>
             <outputDirectory>${file.separator}/sbin</outputDirectory>
             <fileMode>0755</fileMode>
+            <excludes>
+                <exclude>venv/**</exclude>
+                <exclude>.venv/**</exclude>
+                <exclude>target/**</exclude>
+                <exclude>**/__pycache__/**</exclude>
+                <exclude>**/*.pyc</exclude>
+            </excludes>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/../iotdb-core/ainode/target/apache-iotdb-ainode-${project.version}/apache-iotdb-ainode-${project.version}/lib</directory>
             <outputDirectory>${file.separator}/lib</outputDirectory>
+            <excludes>
+                <exclude>venv/**</exclude>
+                <exclude>.venv/**</exclude>
+                <exclude>target/**</exclude>
+                <exclude>**/__pycache__/**</exclude>
+                <exclude>**/*.pyc</exclude>
+            </excludes>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/../iotdb-core/ainode/target/apache-iotdb-ainode-${project.version}/apache-iotdb-ainode-${project.version}/tools</directory>
             <outputDirectory>${file.separator}/tools</outputDirectory>
             <fileMode>0755</fileMode>
+            <excludes>
+                <exclude>venv/**</exclude>
+                <exclude>.venv/**</exclude>
+                <exclude>target/**</exclude>
+                <exclude>**/__pycache__/**</exclude>
+                <exclude>**/*.pyc</exclude>
+            </excludes>
         </fileSet>
     </fileSets>
     <componentDescriptors>

--- a/distribution/src/assembly/ainode.xml
+++ b/distribution/src/assembly/ainode.xml
@@ -30,48 +30,20 @@
         <fileSet>
             <directory>${project.basedir}/../iotdb-core/ainode/target/apache-iotdb-ainode-${project.version}/apache-iotdb-ainode-${project.version}/conf</directory>
             <outputDirectory>${file.separator}/conf</outputDirectory>
-            <excludes>
-                <exclude>venv/**</exclude>
-                <exclude>.venv/**</exclude>
-                <exclude>target/**</exclude>
-                <exclude>**/__pycache__/**</exclude>
-                <exclude>**/*.pyc</exclude>
-            </excludes>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/../iotdb-core/ainode/target/apache-iotdb-ainode-${project.version}/apache-iotdb-ainode-${project.version}/sbin</directory>
             <outputDirectory>${file.separator}/sbin</outputDirectory>
             <fileMode>0755</fileMode>
-            <excludes>
-                <exclude>venv/**</exclude>
-                <exclude>.venv/**</exclude>
-                <exclude>target/**</exclude>
-                <exclude>**/__pycache__/**</exclude>
-                <exclude>**/*.pyc</exclude>
-            </excludes>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/../iotdb-core/ainode/target/apache-iotdb-ainode-${project.version}/apache-iotdb-ainode-${project.version}/lib</directory>
             <outputDirectory>${file.separator}/lib</outputDirectory>
-            <excludes>
-                <exclude>venv/**</exclude>
-                <exclude>.venv/**</exclude>
-                <exclude>target/**</exclude>
-                <exclude>**/__pycache__/**</exclude>
-                <exclude>**/*.pyc</exclude>
-            </excludes>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/../iotdb-core/ainode/target/apache-iotdb-ainode-${project.version}/apache-iotdb-ainode-${project.version}/tools</directory>
             <outputDirectory>${file.separator}/tools</outputDirectory>
             <fileMode>0755</fileMode>
-            <excludes>
-                <exclude>venv/**</exclude>
-                <exclude>.venv/**</exclude>
-                <exclude>target/**</exclude>
-                <exclude>**/__pycache__/**</exclude>
-                <exclude>**/*.pyc</exclude>
-            </excludes>
         </fileSet>
     </fileSets>
     <componentDescriptors>

--- a/iotdb-core/ainode/pyproject.toml
+++ b/iotdb-core/ainode/pyproject.toml
@@ -14,7 +14,7 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-#
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
@@ -34,25 +34,42 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 include = [
-    {path = "iotdb/*", format = "wheel"},
-    {path = "iotdb/dbapi/*", format = "wheel"},
-    {path = "iotdb/sqlalchemy/*", format = "wheel"},
-    {path = "iotdb/template/*", format = "wheel"},
-    {path = "iotdb/thrift/*", format = "wheel"},
-    {path = "iotdb/thrift/ainode/*", format = "wheel"},
-    {path = "iotdb/thrift/common/*", format = "wheel"},
-    {path = "iotdb/thrift/confignode/*", format = "wheel"},
-    {path = "iotdb/thrift/datanode/*", format = "wheel"},
-    {path = "iotdb/thrift/rpc/*", format = "wheel"},
-    {path = "iotdb/tsfile/*", format = "wheel"},
-    {path = "iotdb/tsfile/common/*", format = "wheel"},
-    {path = "iotdb/tsfile/common/constant/*", format = "wheel"},
-    {path = "iotdb/tsfile/utils/*", format = "wheel"},
-    {path = "iotdb/utils/*", format = "wheel"},
-    {path = "iotdb/ainode/conf/*", format = "wheel"},
+    { path = "iotdb/dbapi/*", format = "wheel" },
+    { path = "iotdb/sqlalchemy/*", format = "wheel" },
+    { path = "iotdb/template/*", format = "wheel" },
+    { path = "iotdb/thrift/*", format = "wheel" },
+    { path = "iotdb/thrift/ainode/*", format = "wheel" },
+    { path = "iotdb/thrift/common/*", format = "wheel" },
+    { path = "iotdb/thrift/confignode/*", format = "wheel" },
+    { path = "iotdb/thrift/datanode/*", format = "wheel" },
+    { path = "iotdb/thrift/rpc/*", format = "wheel" },
+    { path = "iotdb/tsfile/*", format = "wheel" },
+    { path = "iotdb/tsfile/common/*", format = "wheel" },
+    { path = "iotdb/tsfile/common/constant/*", format = "wheel" },
+    { path = "iotdb/tsfile/utils/*", format = "wheel" },
+    { path = "iotdb/utils/*", format = "wheel" },
+    { path = "iotdb/__init__.py", format = "wheel" },
+    { path = "iotdb/ainode/__init__.py", format = "wheel" },
+    { path = "iotdb/ainode/conf/*", format = "wheel" },
+    { path = "iotdb/ainode/script.py", format = "wheel" }
 ]
+
 packages = [
-    { include = "iotdb/ainode" }
+    { include = "iotdb/ainode/core" }
+]
+
+exclude = [
+    "**/__pycache__/**",
+    "**/*.pyc", "**/*.pyo",
+    "**/.DS_Store",
+    "**/*.log", "**/*.log.gz",
+    "venv/**", ".venv/**", "*/.venv/**",
+    "iotdb/ainode/core/data/**",
+    "iotdb/ainode/core/logs/**",
+    "iotdb/**/.cache/**",
+    "iotdb/**/download/**",
+    "iotdb/**/logs/**",
+    "iotdb/**/log-*.log*"
 ]
 
 [tool.poetry.dependencies]
@@ -100,6 +117,7 @@ black = "25.1.0"
 isort = "6.0.1"
 
 [tool.poetry.scripts]
+# 如果你的入口确实在 iotdb/ainode/core/script.py，请改回：
 ainode = "iotdb.ainode.core.script:main"
 
 [tool.isort]

--- a/iotdb-core/ainode/pyproject.toml
+++ b/iotdb-core/ainode/pyproject.toml
@@ -15,7 +15,6 @@
 #  specific language governing permissions and limitations
 #  under the License.
 #
-
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/iotdb-core/ainode/pyproject.toml
+++ b/iotdb-core/ainode/pyproject.toml
@@ -14,6 +14,7 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
+#
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
@@ -117,7 +118,6 @@ black = "25.1.0"
 isort = "6.0.1"
 
 [tool.poetry.scripts]
-# 如果你的入口确实在 iotdb/ainode/core/script.py，请改回：
 ainode = "iotdb.ainode.core.script:main"
 
 [tool.isort]


### PR DESCRIPTION
## Description

Make a hotfix to the bug that `venv` for ainode would be put in the distribution package in 2.0.6-SNAPSHOT. If this fix is applied, the size of ainode package will decrease to 346mb.
Since the pull request did not change any pom file, several fixes will be pushed in few days.
 
This PR has:
- [x] been self-reviewed.
    - [x] concurrent read
    - [x] concurrent write
    - [x] concurrent read and write 
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.
