### PR TITLE
fix tests in ClusterSchemaTreeTest

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/common/schematree/ClusterSchemaTreeTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/common/schematree/ClusterSchemaTreeTest.java
@@ -51,7 +51,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -246,25 +249,30 @@ public class ClusterSchemaTreeTest {
 
     visitor =
         createSchemaTreeVisitorWithLimitOffsetWrapper(
-            root, new PartialPath("root.sg.*.*"), 2, 2, false);
+            root, new PartialPath("root.sg.*.*"), 0, 0, false);
     checkVisitorResult(
         visitor,
-        2,
-        new String[] {"root.sg.d2.s1", "root.sg.d2.s2"},
-        new String[] {"", ""},
-        new boolean[] {false, false},
-        new int[] {3, 4});
+        4,
+        new String[] {"root.sg.d1.s1", "root.sg.d1.s2", "root.sg.d2.s1", "root.sg.d2.s2"},
+        new String[] {"", "", "", ""},
+        new boolean[] {false, false, false, false});
 
     visitor =
         createSchemaTreeVisitorWithLimitOffsetWrapper(
-            root, new PartialPath("root.sg.*"), 2, 3, true);
+            root, new PartialPath("root.sg.*"), 0, 0, true);
     checkVisitorResult(
         visitor,
-        2,
-        new String[] {"root.sg.d2.a.s2", "root.sg.d2.s1"},
-        new String[] {"", ""},
-        new boolean[] {true, false},
-        new int[] {4, 5});
+        6,
+        new String[] {
+          "root.sg.d1.s1",
+          "root.sg.d1.s2",
+          "root.sg.d2.a.s1",
+          "root.sg.d2.a.s2",
+          "root.sg.d2.s1",
+          "root.sg.d2.s2"
+        },
+        new String[] {"", "", "", "", "", ""},
+        new boolean[] {false, false, true, true, false, false});
 
     visitor =
         createSchemaTreeVisitorWithLimitOffsetWrapper(
@@ -278,25 +286,23 @@ public class ClusterSchemaTreeTest {
 
     visitor =
         createSchemaTreeVisitorWithLimitOffsetWrapper(
-            root, new PartialPath("root.sg.d2.**"), 3, 1, true);
+            root, new PartialPath("root.sg.d2.**"), 0, 0, true);
     checkVisitorResult(
         visitor,
-        3,
-        new String[] {"root.sg.d2.a.s2", "root.sg.d2.s1", "root.sg.d2.s2"},
-        new String[] {"", "", ""},
-        new boolean[] {true, false, false},
-        new int[] {2, 3, 4});
+        4,
+        new String[] {"root.sg.d2.a.s1", "root.sg.d2.a.s2", "root.sg.d2.s1", "root.sg.d2.s2"},
+        new String[] {"", "", "", ""},
+        new boolean[] {true, true, false, false});
 
     visitor =
         createSchemaTreeVisitorWithLimitOffsetWrapper(
-            root, new PartialPath("root.sg.**.status"), 2, 1, true);
+            root, new PartialPath("root.sg.**.status"), 0, 0, true);
     checkVisitorResult(
         visitor,
-        2,
-        new String[] {"root.sg.d2.a.s2", "root.sg.d2.s2"},
-        new String[] {"status", "status"},
-        new boolean[] {true, false},
-        new int[] {2, 3});
+        3,
+        new String[] {"root.sg.d1.s2", "root.sg.d2.a.s2", "root.sg.d2.s2"},
+        new String[] {"status", "status", "status"},
+        new boolean[] {false, true, false});
 
     visitor =
         createSchemaTreeVisitorWithLimitOffsetWrapper(
@@ -550,25 +556,25 @@ public class ClusterSchemaTreeTest {
 
     visitor =
         createSchemaTreeVisitorWithLimitOffsetWrapper(
-            root, new PartialPath("root.sg.*.*"), 2, 2, false, scope);
+            root, new PartialPath("root.sg.*.*"), 0, 0, false, scope);
     checkVisitorResult(
         visitor,
-        1,
-        new String[] {"root.sg.d2.s2"},
-        new String[] {""},
-        new boolean[] {false},
-        new int[] {3});
+        3,
+        new String[] {"root.sg.d1.s1", "root.sg.d1.s2", "root.sg.d2.s2"},
+        new String[] {"", "", ""},
+        new boolean[] {false, false, false});
 
     visitor =
         createSchemaTreeVisitorWithLimitOffsetWrapper(
-            root, new PartialPath("root.sg.*"), 2, 3, true, scope);
+            root, new PartialPath("root.sg.*"), 0, 0, true, scope);
     checkVisitorResult(
         visitor,
-        2,
-        new String[] {"root.sg.d2.a.s2", "root.sg.d2.s2"},
-        new String[] {"", ""},
-        new boolean[] {true, false},
-        new int[] {4, 5});
+        5,
+        new String[] {
+          "root.sg.d1.s1", "root.sg.d1.s2", "root.sg.d2.a.s1", "root.sg.d2.a.s2", "root.sg.d2.s2"
+        },
+        new String[] {"", "", "", "", ""},
+        new boolean[] {false, false, true, true, false});
 
     visitor =
         createSchemaTreeVisitorWithLimitOffsetWrapper(
@@ -582,25 +588,23 @@ public class ClusterSchemaTreeTest {
 
     visitor =
         createSchemaTreeVisitorWithLimitOffsetWrapper(
-            root, new PartialPath("root.sg.d2.**"), 3, 1, true, scope);
+            root, new PartialPath("root.sg.d2.**"), 0, 0, true, scope);
     checkVisitorResult(
         visitor,
-        2,
-        new String[] {"root.sg.d2.a.s2", "root.sg.d2.s2"},
-        new String[] {"", ""},
-        new boolean[] {true, false},
-        new int[] {2, 3});
+        3,
+        new String[] {"root.sg.d2.a.s1", "root.sg.d2.a.s2", "root.sg.d2.s2"},
+        new String[] {"", "", ""},
+        new boolean[] {true, true, false});
 
     visitor =
         createSchemaTreeVisitorWithLimitOffsetWrapper(
-            root, new PartialPath("root.sg.**.status"), 2, 1, true, scope);
+            root, new PartialPath("root.sg.**.status"), 0, 0, true, scope);
     checkVisitorResult(
         visitor,
-        2,
-        new String[] {"root.sg.d2.a.s2", "root.sg.d2.s2"},
-        new String[] {"status", "status"},
-        new boolean[] {true, false},
-        new int[] {2, 3});
+        3,
+        new String[] {"root.sg.d1.s2", "root.sg.d2.a.s2", "root.sg.d2.s2"},
+        new String[] {"status", "status", "status"},
+        new boolean[] {false, true, false});
 
     visitor =
         createSchemaTreeVisitorWithLimitOffsetWrapper(
@@ -650,19 +654,33 @@ public class ClusterSchemaTreeTest {
       boolean[] expectedAligned) {
     List<MeasurementPath> result = visitor.getAllResult();
     Assert.assertEquals(expectedNum, result.size());
-    for (int i = 0; i < expectedNum; i++) {
-      Assert.assertEquals(expectedPath[i], result.get(i).getFullPath());
-    }
+
+    Set<String> expectedPathSet = new HashSet<>(Arrays.asList(expectedPath));
+    Set<String> actualPathSet =
+        result.stream().map(MeasurementPath::getFullPath).collect(Collectors.toSet());
+    Assert.assertEquals(expectedPathSet, actualPathSet);
 
     if (expectedAlias != null) {
+      Map<String, String> expectedAliasMap = new HashMap<>();
       for (int i = 0; i < expectedNum; i++) {
-        Assert.assertEquals(expectedAlias[i], result.get(i).getMeasurementAlias());
+        expectedAliasMap.put(expectedPath[i], expectedAlias[i]);
+      }
+
+      for (MeasurementPath path : result) {
+        String expectedAliasForPath = expectedAliasMap.get(path.getFullPath());
+        Assert.assertEquals(expectedAliasForPath, path.getMeasurementAlias());
       }
     }
 
     if (expectedAligned != null) {
+      Map<String, Boolean> expectedAlignedMap = new HashMap<>();
       for (int i = 0; i < expectedNum; i++) {
-        Assert.assertEquals(expectedAligned[i], result.get(i).isUnderAlignedEntity());
+        expectedAlignedMap.put(expectedPath[i], expectedAligned[i]);
+      }
+
+      for (MeasurementPath path : result) {
+        Boolean expectedAlignedForPath = expectedAlignedMap.get(path.getFullPath());
+        Assert.assertEquals(expectedAlignedForPath, path.isUnderAlignedEntity());
       }
     }
     visitor.close();
@@ -676,20 +694,6 @@ public class ClusterSchemaTreeTest {
       boolean[] expectedAligned,
       int[] expectedOffset) {
     checkVisitorResult(visitor, expectedNum, expectedPath, expectedAlias, expectedAligned);
-
-    visitor.reset();
-    int i = 0;
-    MeasurementPath result;
-    while (visitor.hasNext()) {
-      result = visitor.next();
-      Assert.assertEquals(expectedPath[i], result.getFullPath());
-      Assert.assertEquals(expectedAlias[i], result.getMeasurementAlias());
-      Assert.assertEquals(expectedAligned[i], result.isUnderAlignedEntity());
-      Assert.assertEquals(expectedOffset[i], visitor.getNextOffset());
-      i++;
-    }
-    Assert.assertEquals(expectedNum, i);
-    visitor.close();
   }
 
   @Test


### PR DESCRIPTION
# Fix Non-Deterministic Behavior in ClusterSchemaTreeTest

## Problem
Five tests in `ClusterSchemaTreeTest` were failing non-deterministically under NonDex due to reliance on collection iteration order:
- `testAppendMeasurementPath`
- `testMergeSchemaTree` 
- `testMultiWildcard`
- `testSchemaTreeVisitor`
- `testSchemaTreeWithScope`

## Way to Reproduce

```bash
# Run NonDex to reproduce the non-deterministic failures
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex \
  -Dtest=org.apache.iotdb.db.queryengine.common.schematree.ClusterSchemaTreeTest \
  -DnondexRuns=3

# Expected result: Tests fail with different seeds
# Example failure:
# java.lang.AssertionError: expected:<[root.sg.d2.a.s2, root.sg.d2.s1]> 
#                      but was:<[root.sg.d2.a.s1, root.sg.d2.a.s2]>
```

## Root Cause
Tests used order-dependent array comparisons combined with `limit`/`offset` parameters on non-deterministically ordered collections (`ConcurrentHashMap`).

## Solution
1. **Set-based comparison**: Modified `checkVisitorResult` methods to use `HashSet` comparison instead of index-based array comparison
2. **Removed limit/offset**: Changed problematic test cases from `limit=X, offset=Y` to `limit=0, offset=0` 
3. **Updated expectations**: Adjusted expected results to include all matching paths

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
