### PR TITLE
fix tests in ColumnInjectionPushDownTest

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/optimization/ColumnInjectionPushDownTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/optimization/ColumnInjectionPushDownTest.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -295,7 +294,7 @@ public class ColumnInjectionPushDownTest {
 
     List<String> outputColumnNames = Arrays.asList("Device", "__endTime", "count(s1)");
     List<String> devices = Arrays.asList("root.sg.d1", "root.sg.d2.a");
-    Map<String, List<Integer>> deviceToMeasurementIndexesMap = new HashMap<>();
+    Map<String, List<Integer>> deviceToMeasurementIndexesMap = new LinkedHashMap<>();
     deviceToMeasurementIndexesMap.put("root.sg.d1", Arrays.asList(1, 2));
     deviceToMeasurementIndexesMap.put("root.sg.d2.a", Arrays.asList(1, 2));
 
@@ -373,7 +372,7 @@ public class ColumnInjectionPushDownTest {
 
     List<String> outputColumnNames = Arrays.asList("Device", "__endTime", "count(s1)");
     List<String> devices = Arrays.asList("root.sg.d1", "root.sg.d2.a");
-    Map<String, List<Integer>> deviceToMeasurementIndexesMap = new HashMap<>();
+    Map<String, List<Integer>> deviceToMeasurementIndexesMap = new LinkedHashMap<>();
     deviceToMeasurementIndexesMap.put("root.sg.d1", Arrays.asList(1, 2));
     deviceToMeasurementIndexesMap.put("root.sg.d2.a", Arrays.asList(1, 2));
 
@@ -453,7 +452,7 @@ public class ColumnInjectionPushDownTest {
 
     List<String> outputColumnNames = Arrays.asList("Device", "__endTime", "count(s1)");
     List<String> devices = Arrays.asList("root.sg.d1", "root.sg.d2.a");
-    Map<String, List<Integer>> deviceToMeasurementIndexesMap = new HashMap<>();
+    Map<String, List<Integer>> deviceToMeasurementIndexesMap = new LinkedHashMap<>();
     deviceToMeasurementIndexesMap.put("root.sg.d1", Arrays.asList(1, 2));
     deviceToMeasurementIndexesMap.put("root.sg.d2.a", Arrays.asList(1, 2));
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/optimization/OptimizationTestUtil.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/optimization/OptimizationTestUtil.java
@@ -44,7 +44,7 @@ import org.junit.Assert;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -54,7 +54,7 @@ public class OptimizationTestUtil {
     // util class
   }
 
-  public static final Map<String, PartialPath> schemaMap = new HashMap<>();
+  public static final Map<String, PartialPath> schemaMap = new LinkedHashMap<>();
 
   static {
     try {
@@ -159,6 +159,6 @@ public class OptimizationTestUtil {
         TAggregationType.COUNT.name().toLowerCase(),
         step,
         Collections.singletonList(new TimeSeriesOperand(schemaMap.get(path))),
-        new HashMap<>());
+        new LinkedHashMap<>());
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/optimization/TestPlanBuilder.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/optimization/TestPlanBuilder.java
@@ -62,7 +62,7 @@ import org.apache.tsfile.file.metadata.IDeviceID;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -353,7 +353,7 @@ public class TestPlanBuilder {
 
   public TestPlanBuilder singleDeviceView(String id, String device, String measurement) {
     IDeviceID deviceID = IDeviceID.Factory.DEFAULT_FACTORY.create(device);
-    Map<IDeviceID, List<Integer>> deviceToMeasurementIndexesMap = new HashMap<>();
+    Map<IDeviceID, List<Integer>> deviceToMeasurementIndexesMap = new LinkedHashMap<>();
     deviceToMeasurementIndexesMap.put(deviceID, Collections.singletonList(1));
     DeviceViewNode deviceViewNode =
         new DeviceViewNode(
@@ -389,7 +389,7 @@ public class TestPlanBuilder {
   public TestPlanBuilder singleOrderedDeviceView(
       String id, String device, OrderByParameter orderByParameter, String... measurement) {
     IDeviceID deviceID = IDeviceID.Factory.DEFAULT_FACTORY.create(device);
-    Map<IDeviceID, List<Integer>> deviceToMeasurementIndexesMap = new HashMap<>();
+    Map<IDeviceID, List<Integer>> deviceToMeasurementIndexesMap = new LinkedHashMap<>();
     deviceToMeasurementIndexesMap.put(
         deviceID, measurement.length == 1 ? Collections.singletonList(1) : Arrays.asList(1, 2));
     DeviceViewNode deviceViewNode =
@@ -456,7 +456,7 @@ public class TestPlanBuilder {
       List<String> devices,
       Map<String, List<Integer>> deviceToMeasurementIndexesMap,
       List<PlanNode> children) {
-    Map<IDeviceID, List<Integer>> map = new HashMap<>();
+    Map<IDeviceID, List<Integer>> map = new LinkedHashMap<>();
     deviceToMeasurementIndexesMap.forEach(
         (key, value) -> map.put(IDeviceID.Factory.DEFAULT_FACTORY.create(key), value));
     DeviceViewNode deviceViewNode =


### PR DESCRIPTION
# Fix Non-Deterministic Behavior in ColumnInjectionPushDownTest

## Problem
Two tests were failing non-deterministically under NonDex with ~50% failure rate:
- `testCannotPushDownTimeJoinAlignByTime`
- `testPartialPushDownTimeJoinAlignByDevice`

## Reproduce
```bash
cd iotdb-core/datanode
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex \
  -Dtest=ColumnInjectionPushDownTest#testCannotPushDownTimeJoinAlignByTime \
  -DnondexRuns=4
```

**Failure example:**
java.lang.AssertionError: expected:<ColumnInjectNode@79d58e5b> but was:<ColumnInjectNode@d7938b9b>


## Root Cause
1. **HashMap in test utilities** - Non-deterministic iteration order caused plan nodes to be constructed differently across runs
2. **Order-sensitive comparison in FullOuterTimeJoinNode** - Children were compared as ordered lists, but join order doesn't affect semantic meaning

## Solution
1. **Test utilities**: Replaced `HashMap` with `LinkedHashMap` to preserve insertion order
   - `OptimizationTestUtil.schemaMap`
   - `OptimizationTestUtil.getAggregationDescriptor()`
   - All `deviceToMeasurementIndexesMap` in tests
   
2. **Production code**: Implemented order-independent `equals()` in `FullOuterTimeJoinNode`
   - Children are now compared as sets rather than ordered lists
   - Semantically correct since full outer time join order doesn't matter

## Key Changed Classes
- `OptimizationTestUtil` - HashMap → LinkedHashMap
- `ColumnInjectionPushDownTest` - HashMap → LinkedHashMap  
- `TestPlanBuilder` - HashMap → LinkedHashMap
- `FullOuterTimeJoinNode` - Order-independent equals()

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
