### PR TITLE
[IOTDB-6357] Fix Bugs in AlignByDeviceOrderByLimitOffsetTest

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/AlignByDeviceOrderByLimitOffsetTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/AlignByDeviceOrderByLimitOffsetTest.java
@@ -177,8 +177,12 @@ public class AlignByDeviceOrderByLimitOffsetTest {
     assertTrue(firstFiRoot.getChildren().get(0) instanceof LimitNode);
     mergeSortNode = ((LimitNode) firstFiRoot.getChildren().get(0)).getChild();
     assertTrue(mergeSortNode instanceof MergeSortNode);
-    assertTrue(mergeSortNode.getChildren().get(0) instanceof DeviceViewNode);
-    assertTrue(mergeSortNode.getChildren().get(0).getChildren().get(0) instanceof SortNode);
+    assertTrue(
+        "MergeSort subtree should contain at least one DeviceViewNode",
+        containsNodeType(mergeSortNode, DeviceViewNode.class));
+    assertTrue(
+        "There should be a SortNode somewhere under the MergeSort subtree",
+        containsNodeType(mergeSortNode, SortNode.class));
     assertScanNodeLimitValue(
         plan.getInstances().get(0).getFragment().getPlanNodeTree(), LIMIT_VALUE);
     assertScanNodeLimitValue(

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/AlignByDeviceOrderByLimitOffsetTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/AlignByDeviceOrderByLimitOffsetTest.java
@@ -233,11 +233,10 @@ public class AlignByDeviceOrderByLimitOffsetTest {
     assertTrue(firstFiRoot.getChildren().get(0) instanceof LimitNode);
     PlanNode transformNode = ((LimitNode) firstFiRoot.getChildren().get(0)).getChild();
     assertTrue(transformNode instanceof TransformNode);
-    assertTrue(transformNode.getChildren().get(0) instanceof MergeSortNode);
-    assertTrue(transformNode.getChildren().get(0).getChildren().get(0) instanceof DeviceViewNode);
-    assertTrue(
-        transformNode.getChildren().get(0).getChildren().get(0).getChildren().get(0)
-            instanceof SortNode);
+    PlanNode mergeSortNode = transformNode.getChildren().get(0);
+    assertTrue(mergeSortNode instanceof MergeSortNode);
+    assertTrue(containsNodeType(mergeSortNode, DeviceViewNode.class));
+    assertTrue(containsNodeType(mergeSortNode, SortNode.class));
   }
 
   /*

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/AlignByDeviceOrderByLimitOffsetTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/AlignByDeviceOrderByLimitOffsetTest.java
@@ -281,16 +281,17 @@ public class AlignByDeviceOrderByLimitOffsetTest {
     assertTrue(firstFiRoot.getChildren().get(0) instanceof LimitNode);
     PlanNode filterNode = ((LimitNode) firstFiRoot.getChildren().get(0)).getChild();
     assertTrue(filterNode instanceof FilterNode);
-    assertTrue(filterNode.getChildren().get(0) instanceof AggregationMergeSortNode);
-    assertTrue(filterNode.getChildren().get(0).getChildren().get(0) instanceof DeviceViewNode);
+    PlanNode aggMergeNode = filterNode.getChildren().get(0);
+    assertTrue(aggMergeNode instanceof AggregationMergeSortNode);
     assertTrue(
-        filterNode.getChildren().get(0).getChildren().get(0).getChildren().get(0)
-            instanceof RawDataAggregationNode);
+        containsNodeType(aggMergeNode, DeviceViewNode.class)
+            || containsNodeType(aggMergeNode, SingleDeviceViewNode.class));
+    assertTrue(containsNodeType(aggMergeNode, RawDataAggregationNode.class));
     PlanNode thirdFiRoot = plan.getInstances().get(2).getFragment().getPlanNodeTree();
     assertTrue(thirdFiRoot instanceof IdentitySinkNode);
-    assertTrue(thirdFiRoot.getChildren().get(0) instanceof DeviceViewNode);
-    assertTrue(
-        thirdFiRoot.getChildren().get(0).getChildren().get(0) instanceof RawDataAggregationNode);
+    PlanNode deviceRoot = thirdFiRoot.getChildren().get(0);
+    assertTrue(deviceRoot instanceof DeviceViewNode || deviceRoot instanceof SingleDeviceViewNode);
+    assertTrue(containsNodeType(deviceRoot, RawDataAggregationNode.class));
   }
 
   /*

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/AlignByDeviceOrderByLimitOffsetTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/AlignByDeviceOrderByLimitOffsetTest.java
@@ -103,10 +103,12 @@ public class AlignByDeviceOrderByLimitOffsetTest {
     assertTrue(firstFiRoot.getChildren().get(0) instanceof LimitNode);
     mergeSortNode = ((LimitNode) firstFiRoot.getChildren().get(0)).getChild();
     assertTrue(mergeSortNode instanceof MergeSortNode);
-    assertTrue(mergeSortNode.getChildren().get(0) instanceof DeviceViewNode);
     assertTrue(
-        mergeSortNode.getChildren().get(0).getChildren().get(0) instanceof FullOuterTimeJoinNode);
-
+        "MergeSort subtree should contain at least one DeviceViewNode",
+        containsNodeType(mergeSortNode, DeviceViewNode.class));
+    assertTrue(
+        "DeviceViewNode subtree should contain a FullOuterTimeJoinNode",
+        containsNodeType(mergeSortNode, FullOuterTimeJoinNode.class));
     // order by device, time
     sql =
         "select * from root.sg.d1, root.sg.d22 order by device asc, time desc LIMIT 10 align by device";
@@ -120,9 +122,12 @@ public class AlignByDeviceOrderByLimitOffsetTest {
     assertTrue(firstFiRoot.getChildren().get(0) instanceof LimitNode);
     mergeSortNode = ((LimitNode) firstFiRoot.getChildren().get(0)).getChild();
     assertTrue(mergeSortNode instanceof MergeSortNode);
-    assertTrue(mergeSortNode.getChildren().get(0) instanceof DeviceViewNode);
     assertTrue(
-        mergeSortNode.getChildren().get(0).getChildren().get(0) instanceof FullOuterTimeJoinNode);
+        "MergeSort subtree should contain at least one DeviceViewNode",
+        containsNodeType(mergeSortNode, DeviceViewNode.class));
+    assertTrue(
+        "DeviceViewNode subtree should contain a FullOuterTimeJoinNode",
+        containsNodeType(mergeSortNode, FullOuterTimeJoinNode.class));
     assertScanNodeLimitValue(
         plan.getInstances().get(0).getFragment().getPlanNodeTree(), LIMIT_VALUE);
     assertScanNodeLimitValue(
@@ -1120,5 +1125,17 @@ public class AlignByDeviceOrderByLimitOffsetTest {
         assertScanNodeLimitValue(node, limitValue);
       }
     }
+  }
+
+  private static boolean containsNodeType(PlanNode root, Class<?> clazz) {
+    if (clazz.isInstance(root)) {
+      return true;
+    }
+    for (PlanNode child : root.getChildren()) {
+      if (containsNodeType(child, clazz)) {
+        return true;
+      }
+    }
+    return false;
   }
 }


### PR DESCRIPTION
## Description
I report the problem in the issue #16593 

### Solutions
1. Walk the subtree instead instead of pinning to indices. Added helper `containsNodeType(PlanNode, Class<?>)` that recursively checks for a given node class.
2. Accept either `DeviceViewNode` or `SingleDeviceViewNode`. Assertions now allow both legitimate alternatives.
3. Reused the helper across all four tests, so they tolerate harmless structural differences and stay reliable under random seeds shuffling.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
