### PR TITLE
Support a new read_consistency_level

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
@@ -359,7 +359,9 @@ public class ConfigNodeDescriptor {
 
     String readConsistencyLevel =
         properties.getProperty("read_consistency_level", conf.getReadConsistencyLevel());
-    if (readConsistencyLevel.equals("strong") || readConsistencyLevel.equals("weak")) {
+    if (readConsistencyLevel.equalsIgnoreCase("strong")
+        || readConsistencyLevel.equalsIgnoreCase("weak")
+        || readConsistencyLevel.equalsIgnoreCase("follower_read")) {
       conf.setReadConsistencyLevel(readConsistencyLevel);
     } else {
       throw new IOException(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -3342,8 +3342,13 @@ public class IoTDBConfig {
   public void setReadConsistencyLevel(String readConsistencyLevel) {
     if ("weak".equalsIgnoreCase(readConsistencyLevel)) {
       this.readConsistencyLevel = ReadConsistencyLevel.WEAK;
-    } else {
+    } else if ("strong".equalsIgnoreCase(readConsistencyLevel)) {
       this.readConsistencyLevel = ReadConsistencyLevel.STRONG;
+    } else if ("follower_read".equalsIgnoreCase(readConsistencyLevel)) {
+      this.readConsistencyLevel = ReadConsistencyLevel.FOLLOWER_READ;
+    } else {
+      throw new IllegalArgumentException(
+          String.format("Unknown readConsistencyLevel %s", readConsistencyLevel));
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/AbstractFragmentParallelPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/AbstractFragmentParallelPlanner.java
@@ -137,6 +137,11 @@ public abstract class AbstractFragmentParallelPlanner implements IFragmentParall
   }
 
   private int getTargetIndex(List<TDataNodeLocation> availableDataNodes) {
+    // if only one node is available, just return 0
+    if (availableDataNodes.size() == 1) {
+      return 0;
+    }
+
     int targetIndex;
     if (ReadConsistencyLevel.STRONG == this.readConsistencyLevel
         || queryContext.getSession() == null) {

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
@@ -1026,6 +1026,7 @@ text_compressor=LZ4
 # These consistency levels are currently supported:
 # 1. strong(Default, read from the leader replica)
 # 2. weak(Read from a random replica)
+# 3. follower_read(If there are available follower replicas, select one from any of the follower replicas.)
 # effectiveMode: restart
 # Datatype: string
 read_consistency_level=strong

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/enums/ReadConsistencyLevel.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/enums/ReadConsistencyLevel.java
@@ -21,5 +21,6 @@ package org.apache.iotdb.commons.enums;
 
 public enum ReadConsistencyLevel {
   STRONG,
-  WEAK
+  WEAK,
+  FOLLOWER_READ
 }


### PR DESCRIPTION
This pull request introduces support for a new read consistency level, `follower_read`, across the IoTDB codebase. The changes ensure that configuration, logic, and documentation now recognize and correctly handle this new option alongside the existing `strong` and `weak` levels.

**Read Consistency Level Enhancements:**

* Added `FOLLOWER_READ` to the `ReadConsistencyLevel` enum in `ReadConsistencyLevel.java`, allowing the system to use follower replicas for read operations.
* Updated the configuration logic in `ConfigNodeDescriptor.java` and `IoTDBConfig.java` to accept and validate the new `follower_read` value, throwing exceptions for unknown values. [[1]](diffhunk://#diff-3ed021394fbf9a40c9ad48c24dfb3ba90ebb20aba5bdcf9a7763ebe0cca5e70dL362-R364) [[2]](diffhunk://#diff-30d3dc10c256a0068e3b87dd128011b653b4a8ecd0f0bf1149979022b5d92ea7L3345-R3351)
* Enhanced the planner logic in `AbstractFragmentParallelPlanner.java` to select follower replicas when `FOLLOWER_READ` is specified, ensuring the leader is skipped and a follower is chosen based on session ID.
* Updated the configuration template in `iotdb-system.properties.template` to document the new `follower_read` option for users.

**Refactoring and Logic Separation:**

* Refactored the data node selection logic in `AbstractFragmentParallelPlanner.java` by extracting target index determination into a separate method, improving readability and maintainability.


Supposing we have a 3C3D cluster and data replica number is set to 3, we execute the following sqls to prepare data:

```
create database test;
use test;
create table t1(device_id STRING TAG, s1 float);
insert into t1 values(now(),'d1', 1.0); 
```

Before this pr, if we do `select * from t1;` query, the query will always be routed to leader:
<img width="2900" height="1800" alt="f374fca129e9c9da5bb8f5e86e53384f" src="https://github.com/user-attachments/assets/cbad4ec8-3486-4c6c-afbe-cbe571ac1043" />

After this pr, if we set `read_consistency_level=follower_read` and then restart the cluster, then the above query will always be routed to any follower:
<img width="2748" height="1468" alt="edcf2ad9bdf44cb525d6ef196c171704" src="https://github.com/user-attachments/assets/34106086-bd3a-4b9d-8497-de701bc06de0" />