### PR TITLE
[To dev/1.3]chore!: Bind real config address for Thrift and Raft services (#16717)

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -156,6 +156,7 @@ class RatisConsensus implements IConsensus {
     this.storageDir = new File(config.getStorageDir());
 
     RaftServerConfigKeys.setStorageDir(properties, Collections.singletonList(storageDir));
+    GrpcConfigKeys.Server.setHost(properties, config.getThisNodeEndPoint().getIp());
     GrpcConfigKeys.Server.setPort(properties, config.getThisNodeEndPoint().getPort());
 
     Utils.initRatisConfig(properties, config.getRatisConfig());

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/AbstractThriftServiceThread.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/service/AbstractThriftServiceThread.java
@@ -283,11 +283,19 @@ public abstract class AbstractThriftServiceThread extends Thread {
 
   @SuppressWarnings("java:S2259")
   private TServerTransport openTransport(String bindAddress, int port) throws TTransportException {
+    if (bindAddress == null) {
+      // bind any address
+      return new TServerSocket(new InetSocketAddress(port));
+    }
     return new TServerSocket(new InetSocketAddress(bindAddress, port));
   }
 
   private TServerTransport openNonblockingTransport(
       String bindAddress, int port, int connectionTimeoutInMS) throws TTransportException {
+    if (bindAddress == null) {
+      // bind any address
+      return new TNonblockingServerSocket(new InetSocketAddress(port), connectionTimeoutInMS);
+    }
     return new TNonblockingServerSocket(
         new InetSocketAddress(bindAddress, port), connectionTimeoutInMS);
   }


### PR DESCRIPTION
* chore: Bind real internal address for Thrift and Raft services

* keep ExternalRpcAddress use config value

* Update iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/ExternalRPCService.java
