### PR TITLE
fix test in InnerUnseqCompactionWithReadPointPerformerTest

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/inner/InnerUnseqCompactionWithReadPointPerformerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/inner/InnerUnseqCompactionWithReadPointPerformerTest.java
@@ -50,8 +50,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -127,7 +127,7 @@ public class InnerUnseqCompactionWithReadPointPerformerTest {
             for (CompactionOverlapType compactionOverlapType : compactionOverlapTypes) {
               List<TsFileResource> toMergeResources = new ArrayList<>();
               for (int i = 0; i < toMergeFileNum; i++) {
-                Set<String> fullPath = new HashSet<>();
+                Set<String> fullPath = new LinkedHashSet<>();
                 if (compactionTimeseriesType == CompactionTimeseriesType.ALL_SAME) {
                   fullPath.add(fullPaths[0]);
                   fullPath.add(fullPaths[1]);
@@ -309,7 +309,7 @@ public class InnerUnseqCompactionWithReadPointPerformerTest {
                 toMergeResources.add(tsFileResource);
                 // has mods files before compaction
                 if (compactionBeforeHasMod) {
-                  Map<String, Pair<Long, Long>> toDeleteTimeseriesAndTime = new HashMap<>();
+                  Map<String, Pair<Long, Long>> toDeleteTimeseriesAndTime = new LinkedHashMap<>();
                   if (compactionTimeseriesType == CompactionTimeseriesType.ALL_SAME) {
                     toDeleteTimeseriesAndTime.put(
                         fullPaths[i], new Pair<>(i * 600L + 250L, i * 600L + 300L));
@@ -352,7 +352,7 @@ public class InnerUnseqCompactionWithReadPointPerformerTest {
               Map<String, List<TimeValuePair>> sourceData =
                   CompactionCheckerUtils.readFiles(toMergeResources);
               if (compactionHasMod) {
-                Map<String, Pair<Long, Long>> toDeleteTimeseriesAndTime = new HashMap<>();
+                Map<String, Pair<Long, Long>> toDeleteTimeseriesAndTime = new LinkedHashMap<>();
                 toDeleteTimeseriesAndTime.put(fullPaths[1], new Pair<>(250L, 300L));
                 CompactionFileGeneratorUtils.generateMods(
                     toDeleteTimeseriesAndTime, toMergeResources.get(0), true);
@@ -379,7 +379,7 @@ public class InnerUnseqCompactionWithReadPointPerformerTest {
               List<TsFileResource> targetTsFileResources = new ArrayList<>();
               targetTsFileResources.add(targetTsFileResource);
               CompactionCheckerUtils.checkDataAndResource(sourceData, targetTsFileResources);
-              Map<String, List<List<Long>>> chunkPagePointsNumMerged = new HashMap<>();
+              Map<String, List<List<Long>>> chunkPagePointsNumMerged = new LinkedHashMap<>();
               if (compactionTimeseriesType == CompactionTimeseriesType.ALL_SAME) {
                 if (toMergeFileNum == 2) {
                   if (compactionBeforeHasMod) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/utils/CompactionFileGeneratorUtils.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/utils/CompactionFileGeneratorUtils.java
@@ -45,7 +45,7 @@ import org.apache.tsfile.write.writer.RestorableTsFileIOWriter;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -166,7 +166,7 @@ public class CompactionFileGeneratorUtils {
       newTsFileResource.getTsFile().getParentFile().mkdirs();
     }
     RestorableTsFileIOWriter writer = new RestorableTsFileIOWriter(newTsFileResource.getTsFile());
-    Map<IDeviceID, List<String>> deviceMeasurementMap = new HashMap<>();
+    Map<IDeviceID, List<String>> deviceMeasurementMap = new LinkedHashMap<>();
     for (String fullPath : fullPaths) {
       PartialPath partialPath = new MeasurementPath(fullPath);
       List<String> sensors =
@@ -224,7 +224,7 @@ public class CompactionFileGeneratorUtils {
     TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(Integer.MAX_VALUE);
 
     RestorableTsFileIOWriter writer = new RestorableTsFileIOWriter(newTsFileResource.getTsFile());
-    Map<IDeviceID, List<String>> deviceMeasurementMap = new HashMap<>();
+    Map<IDeviceID, List<String>> deviceMeasurementMap = new LinkedHashMap<>();
     for (String fullPath : fullPaths) {
       PartialPath partialPath = new MeasurementPath(fullPath);
       List<String> sensors =
@@ -313,7 +313,7 @@ public class CompactionFileGeneratorUtils {
       newTsFileResource.getTsFile().getParentFile().mkdirs();
     }
     RestorableTsFileIOWriter writer = new RestorableTsFileIOWriter(newTsFileResource.getTsFile());
-    Map<IDeviceID, List<String>> deviceMeasurementMap = new HashMap<>();
+    Map<IDeviceID, List<String>> deviceMeasurementMap = new LinkedHashMap<>();
     for (String fullPath : fullPaths) {
       PartialPath partialPath = new PartialPath(fullPath);
       List<String> sensors =


### PR DESCRIPTION
# Fix Non-Deterministic Behavior in InnerUnseqCompactionWithReadPointPerformerTest

## Problem

`InnerUnseqCompactionWithReadPointPerformerTest.test` was failing non-deterministically under NonDex with 100% failure rate (10/10 runs) due to reliance on HashMap/HashSet iteration order in test setup and file generation.

## Way to Reproduce

```bash
cd iotdb-core/datanode
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex \
  -Dtest=InnerUnseqCompactionWithReadPointPerformerTest#test \
  -DnondexRuns=10 -Drat.skip=true
# Result: 10/10 failures with varying expected/actual values
# Example: expected:<1149> but was:<2949>
```

## Root Cause

Multiple HashMap/HashSet usages caused non-deterministic iteration order:
1. **Test expectations map** (`chunkPagePointsNumMerged`): HashMap iteration affected assertion order
2. **Measurement paths set** (`fullPath`): HashSet iteration determined TsFile write order
3. **Modification maps** (`toDeleteTimeseriesAndTime`): HashMap affected deletion ordering
4. **Device-measurement grouping** in `CompactionFileGeneratorUtils`: HashMap caused non-deterministic device ordering in generated TsFiles

When NonDex shuffled collection order, measurements/devices were written in different sequences, causing expected chunk/page point counts to mismatch actual values.

## Solution

**InnerUnseqCompactionWithReadPointPerformerTest.java:**
- Changed `Set<String> fullPath` from HashSet to LinkedHashSet (line 130)
- Changed `toDeleteTimeseriesAndTime` maps from HashMap to LinkedHashMap (lines 313, 356)
- Changed `chunkPagePointsNumMerged` from HashMap to LinkedHashMap (line 383)

**CompactionFileGeneratorUtils.java:**
- Changed `deviceMeasurementMap` from HashMap to LinkedHashMap in `writeChunkToTsFileWithTimeRange()` method

## Verification

```bash
cd iotdb-core/datanode
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex \
  -Dtest=InnerUnseqCompactionWithReadPointPerformerTest#test \
  -DnondexRuns=20 -Drat.skip=true
# Result: 20/20 passes (100% success rate)
```

---

**Key changed classes:**
- `InnerUnseqCompactionWithReadPointPerformerTest` (test changes only)
- `CompactionFileGeneratorUtils` (test utility changes only)