### PR TITLE
[AINode] Fix bug that AINode cannot compile in Windows

### DIFF
--- a/iotdb-core/ainode/build_binary.py
+++ b/iotdb-core/ainode/build_binary.py
@@ -386,9 +386,7 @@ def install_dependencies(venv_python, venv_dir, script_dir):
             print("The symlink approach may not have worked. Please check the symlink.")
             sys.exit(1)
         else:
-            print(
-                f"Poetry is correctly using virtual environment: {poetry_venv_path}"
-            )
+            print(f"Poetry is correctly using virtual environment: {poetry_venv_path}")
     else:
         print("Warning: Could not verify poetry virtual environment path")
         print(


### PR DESCRIPTION
The gbk encoder cannot recognize some syntax in `build_binary.py`, we remove them accordingly.