### PR TITLE
Avoid connection reset error log printed

### DIFF
--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TElasticFramedTransport.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TElasticFramedTransport.java
@@ -31,6 +31,7 @@ import javax.net.ssl.SSLHandshakeException;
 
 import java.io.EOFException;
 import java.net.SocketAddress;
+import java.net.SocketException;
 import java.net.SocketTimeoutException;
 
 // https://github.com/apache/thrift/blob/master/doc/specs/thrift-rpc.md
@@ -125,6 +126,10 @@ public class TElasticFramedTransport extends TTransport {
       // Read another frame of data
       readFrame();
     } catch (TTransportException e) {
+      // Adding this workaround to avoid the Connection reset error log printed.
+      if (e.getCause() instanceof SocketException && e.getMessage().contains("Connection reset")) {
+        throw new TTransportException(TTransportException.END_OF_FILE, e.getCause());
+      }
       // There is a bug fixed in Thrift 0.15. Some unnecessary error logs may be printed.
       // See https://issues.apache.org/jira/browse/THRIFT-5411 and
       // https://github.com/apache/thrift/commit/be20ad7e08fab200391e3eab41acde9da2a4fd07


### PR DESCRIPTION
## Description

Avoid the error log below printed. 
```
2025-11-11 15:53:42,754 [pool-36-IoTDB-ClientRPC-Processor-7] ERROR o.a.t.s.TThreadPoolServer$WorkerProcess:258 - Thrift Error occurred during processing of message.
org.apache.thrift.transport.TTransportException: java.net.SocketException: Connection reset
        at org.apache.thrift.transport.TIOStreamTransport.read(TIOStreamTransport.java:178)
        at org.apache.thrift.transport.TTransport.readAll(TTransport.java:109)
        at org.apache.iotdb.rpc.TElasticFramedTransport.readFrame(TElasticFramedTransport.java:122)
        at org.apache.iotdb.rpc.TElasticFramedTransport.read(TElasticFramedTransport.java:117)
        at org.apache.thrift.transport.TTransport.readAll(TTransport.java:109)
        at org.apache.thrift.protocol.TBinaryProtocol.readAll(TBinaryProtocol.java:463)
        at org.apache.thrift.protocol.TBinaryProtocol.readI32(TBinaryProtocol.java:361)
        at org.apache.thrift.protocol.TBinaryProtocol.readMessageBegin(TBinaryProtocol.java:244)
        at org.apache.iotdb.db.protocol.thrift.ProcessorWithMetrics.process(ProcessorWithMetrics.java:50)
        at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:248)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.net.SocketException: Connection reset
        at java.base/sun.nio.ch.NioSocketImpl.implRead(NioSocketImpl.java:328)
        at java.base/sun.nio.ch.NioSocketImpl.read(NioSocketImpl.java:355)
        at java.base/sun.nio.ch.NioSocketImpl$1.read(NioSocketImpl.java:808)
        at java.base/java.net.Socket$SocketInputStream.read(Socket.java:976)
        at java.base/java.io.BufferedInputStream.fill(BufferedInputStream.java:244)
        at java.base/java.io.BufferedInputStream.read1(BufferedInputStream.java:284)
        at java.base/java.io.BufferedInputStream.read(BufferedInputStream.java:343)
        at org.apache.thrift.transport.TIOStreamTransport.read(TIOStreamTransport.java:176)
        ... 12 common frames omitted
```