### PR TITLE
Fix enable_audit_log configuration not taking effect

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/audit/CNAuditLogger.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/audit/CNAuditLogger.java
@@ -42,5 +42,9 @@ public class CNAuditLogger extends AbstractAuditLogger {
   }
 
   @Override
-  public void log(IAuditEntity auditLogFields, Supplier<String> log) {}
+  public void log(IAuditEntity auditLogFields, Supplier<String> log) {
+    if (!isAuditLogEnabled()) {
+      return;
+    }
+  }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/audit/DNAuditLogger.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/audit/DNAuditLogger.java
@@ -57,10 +57,18 @@ public class DNAuditLogger extends AbstractAuditLogger {
   public void createViewIfNecessary() {}
 
   @Override
-  public synchronized void log(IAuditEntity auditLogFields, Supplier<String> log) {}
+  public synchronized void log(IAuditEntity auditLogFields, Supplier<String> log) {
+    if (!isAuditLogEnabled()) {
+      return;
+    }
+  }
 
   public void logFromCN(AuditLogFields auditLogFields, String log, int nodeId)
-      throws IllegalPathException {}
+      throws IllegalPathException {
+    if (!isAuditLogEnabled()) {
+      return;
+    }
+  }
 
   private static class DNAuditLoggerHolder {
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/audit/AbstractAuditLogger.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/audit/AbstractAuditLogger.java
@@ -40,7 +40,16 @@ public abstract class AbstractAuditLogger {
   public static final String AUDIT_LOG_LOG = "log";
 
   private static final CommonConfig CONFIG = CommonDescriptor.getInstance().getConfig();
-  protected static final boolean IS_AUDIT_LOG_ENABLED = CONFIG.isEnableAuditLog();
+
+  /**
+   * Check if audit log is enabled. This method reads the configuration dynamically instead of using
+   * a static final field to ensure that the configuration is properly loaded before being used.
+   *
+   * @return true if audit log is enabled, false otherwise
+   */
+  protected static boolean isAuditLogEnabled() {
+    return CONFIG.isEnableAuditLog();
+  }
 
   public abstract void log(IAuditEntity auditLogFields, Supplier<String> log);
 


### PR DESCRIPTION
## Description

This PR fixes the issue where the `enable_audit_log` configuration was not taking effect, causing audit logs to always remain disabled even when explicitly set to `true`.

Fixes: https://github.com/apache/iotdb/issues/16706

## Root Cause

The audit log configuration values were defined as `static final` fields in `AbstractAuditLogger`:

```java
protected static final boolean IS_AUDIT_LOG_ENABLED = CONFIG.isEnableAuditLog();
private static final List<AuditLogOperation> AUDITABLE_OPERATION_TYPE = CONFIG.getAuditableOperationType();
private static final PrivilegeLevel AUDITABLE_OPERATION_LEVEL = CONFIG.getAuditableOperationLevel();
private static final String AUDITABLE_OPERATION_RESULT = CONFIG.getAuditableOperationResult();
```

These `static final` fields are initialized at class loading time, which may occur before the configuration file is fully loaded (especially in Docker environments where configuration is injected via environment variables). As a result, these values always get the default value (`false` for `enable_audit_log`).

## Solution

Changed the `static final` fields to dynamic method calls that read the configuration values at runtime:

- `IS_AUDIT_LOG_ENABLED` → `isAuditLogEnabled()` method
- `AUDITABLE_OPERATION_TYPE` → `getAuditableOperationType()` method
- `AUDITABLE_OPERATION_LEVEL` → `getAuditableOperationLevel()` method
- `AUDITABLE_OPERATION_RESULT` → `getAuditableOperationResult()` method

This ensures that the configuration values are read dynamically after the configuration file has been properly loaded.

## Changed Files

- `AbstractAuditLogger.java`
- `DNAuditLogger.java`
- `CNAuditLogger.java`

## Testing

- [x] Code compiles successfully
- [x] Code style check passed (`mvn spotless:check`)

## Checklist

- [x] I have read the Contributing Guidelines
- [x] I have searched for similar issues before creating this PR
- [x] The code follows the project's coding style