### PR TITLE
perf: Optimize TypeManager allocation in StatementAnalyzer

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/TableConfigTaskVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/TableConfigTaskVisitor.java
@@ -219,6 +219,7 @@ import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Use;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.ViewFieldDefinition;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.rewrite.StatementRewrite;
 import org.apache.iotdb.db.queryengine.plan.relational.type.AuthorRType;
+import org.apache.iotdb.db.queryengine.plan.relational.type.TypeManager;
 import org.apache.iotdb.db.queryengine.plan.relational.type.TypeNotFoundException;
 import org.apache.iotdb.db.queryengine.plan.statement.metadata.DatabaseSchemaStatement;
 import org.apache.iotdb.db.queryengine.plan.statement.metadata.RemoveAINodeStatement;
@@ -281,13 +282,17 @@ public class TableConfigTaskVisitor extends AstVisitor<IConfigTask, MPPQueryCont
 
   private final AccessControl accessControl;
 
+  private final TypeManager typeManager;
+
   public TableConfigTaskVisitor(
       final IClientSession clientSession,
       final Metadata metadata,
-      final AccessControl accessControl) {
+      final AccessControl accessControl,
+      final TypeManager typeManager) {
     this.clientSession = clientSession;
     this.metadata = metadata;
     this.accessControl = accessControl;
+    this.typeManager = typeManager;
   }
 
   @Override
@@ -868,7 +873,7 @@ public class TableConfigTaskVisitor extends AstVisitor<IConfigTask, MPPQueryCont
     new Analyzer(
             context,
             context.getSession(),
-            new StatementAnalyzerFactory(metadata, null, accessControl),
+            new StatementAnalyzerFactory(metadata, null, accessControl, typeManager),
             Collections.emptyList(),
             Collections.emptyMap(),
             StatementRewrite.NOOP,

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzer.java
@@ -192,7 +192,6 @@ import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.With;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.WithQuery;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.WrappedInsertStatement;
 import org.apache.iotdb.db.queryengine.plan.relational.type.CompatibleResolver;
-import org.apache.iotdb.db.queryengine.plan.relational.type.InternalTypeManager;
 import org.apache.iotdb.db.queryengine.plan.relational.type.TypeManager;
 import org.apache.iotdb.db.queryengine.plan.statement.component.FillPolicy;
 import org.apache.iotdb.db.queryengine.plan.statement.crud.InsertBaseStatement;
@@ -293,8 +292,6 @@ import static org.apache.tsfile.read.common.type.BooleanType.BOOLEAN;
 
 public class StatementAnalyzer {
 
-  private static final TypeManager TYPE_MANAGER = new InternalTypeManager();
-
   private final StatementAnalyzerFactory statementAnalyzerFactory;
 
   private final Analysis analysis;
@@ -312,6 +309,8 @@ public class StatementAnalyzer {
 
   private final CorrelationSupport correlationSupport;
 
+  private final TypeManager typeManager;
+
   public StatementAnalyzer(
       StatementAnalyzerFactory statementAnalyzerFactory,
       Analysis analysis,
@@ -320,7 +319,8 @@ public class StatementAnalyzer {
       WarningCollector warningCollector,
       SessionInfo sessionContext,
       Metadata metadata,
-      CorrelationSupport correlationSupport) {
+      CorrelationSupport correlationSupport,
+      TypeManager typeManager) {
     this.statementAnalyzerFactory = statementAnalyzerFactory;
     this.analysis = analysis;
     this.queryContext = queryContext;
@@ -329,6 +329,7 @@ public class StatementAnalyzer {
     this.sessionContext = sessionContext;
     this.metadata = metadata;
     this.correlationSupport = correlationSupport;
+    this.typeManager = typeManager;
   }
 
   public Scope analyze(Node node) {
@@ -5186,7 +5187,7 @@ public class StatementAnalyzer {
       // currently, only constant arguments are supported
       Object constantValue =
           IrExpressionInterpreter.evaluateConstantExpression(
-              expression, new PlannerContext(metadata, TYPE_MANAGER), sessionContext);
+              expression, new PlannerContext(metadata, typeManager), sessionContext);
       if (!argumentSpecification.getType().checkObjectType(constantValue)) {
         if ((argumentSpecification.getType().equals(org.apache.iotdb.udf.api.type.Type.STRING)
                 || argumentSpecification.getType().equals(org.apache.iotdb.udf.api.type.Type.TEXT))

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzerFactory.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzerFactory.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.db.queryengine.execution.warnings.WarningCollector;
 import org.apache.iotdb.db.queryengine.plan.relational.metadata.Metadata;
 import org.apache.iotdb.db.queryengine.plan.relational.security.AccessControl;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.parser.SqlParser;
+import org.apache.iotdb.db.queryengine.plan.relational.type.TypeManager;
 
 import static java.util.Objects.requireNonNull;
 
@@ -33,16 +34,21 @@ public class StatementAnalyzerFactory {
   private final Metadata metadata;
   private final SqlParser sqlParser;
   private final AccessControl accessControl;
+  private final TypeManager typeManager;
 
   public StatementAnalyzerFactory(
-      final Metadata metadata, final SqlParser sqlParser, final AccessControl accessControl) {
+      final Metadata metadata,
+      final SqlParser sqlParser,
+      final AccessControl accessControl,
+      final TypeManager typeManager) {
     this.metadata = requireNonNull(metadata, "plannerContext is null");
     this.sqlParser = sqlParser;
     this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    this.typeManager = requireNonNull(typeManager, "typeManager is null");
   }
 
   public StatementAnalyzerFactory withSpecializedAccessControl(AccessControl accessControl) {
-    return new StatementAnalyzerFactory(metadata, sqlParser, accessControl);
+    return new StatementAnalyzerFactory(metadata, sqlParser, accessControl, typeManager);
   }
 
   public StatementAnalyzer createStatementAnalyzer(
@@ -59,12 +65,13 @@ public class StatementAnalyzerFactory {
         warningCollector,
         session,
         metadata,
-        correlationSupport);
+        correlationSupport,
+        typeManager);
   }
 
   public static StatementAnalyzerFactory createTestingStatementAnalyzerFactory(
-      Metadata metadata, AccessControl accessControl) {
-    return new StatementAnalyzerFactory(metadata, new SqlParser(), accessControl);
+      Metadata metadata, AccessControl accessControl, TypeManager typeManager) {
+    return new StatementAnalyzerFactory(metadata, new SqlParser(), accessControl, typeManager);
   }
 
   public AccessControl getAccessControl() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/TableModelPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/TableModelPlanner.java
@@ -47,6 +47,7 @@ import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Statement;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.WrappedInsertStatement;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.parser.SqlParser;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.rewrite.StatementRewrite;
+import org.apache.iotdb.db.queryengine.plan.relational.type.TypeManager;
 import org.apache.iotdb.db.queryengine.plan.scheduler.ClusterScheduler;
 import org.apache.iotdb.db.queryengine.plan.scheduler.IScheduler;
 import org.apache.iotdb.db.queryengine.plan.scheduler.load.LoadTsFileScheduler;
@@ -87,6 +88,8 @@ public class TableModelPlanner implements IPlanner {
 
   private final DataNodeLocationSupplierFactory.DataNodeLocationSupplier dataNodeLocationSupplier;
 
+  private final TypeManager typeManager;
+
   public TableModelPlanner(
       final Statement statement,
       final SqlParser sqlParser,
@@ -100,7 +103,8 @@ public class TableModelPlanner implements IPlanner {
       final List<PlanOptimizer> logicalPlanOptimizers,
       final List<PlanOptimizer> distributionPlanOptimizers,
       final AccessControl accessControl,
-      final DataNodeLocationSupplierFactory.DataNodeLocationSupplier dataNodeLocationSupplier) {
+      final DataNodeLocationSupplierFactory.DataNodeLocationSupplier dataNodeLocationSupplier,
+      final TypeManager typeManager) {
     this.statement = statement;
     this.sqlParser = sqlParser;
     this.metadata = metadata;
@@ -112,6 +116,7 @@ public class TableModelPlanner implements IPlanner {
     this.distributionPlanOptimizers = distributionPlanOptimizers;
     this.accessControl = accessControl;
     this.dataNodeLocationSupplier = dataNodeLocationSupplier;
+    this.typeManager = typeManager;
   }
 
   @Override
@@ -119,7 +124,7 @@ public class TableModelPlanner implements IPlanner {
     return new Analyzer(
             context,
             context.getSession(),
-            new StatementAnalyzerFactory(metadata, sqlParser, accessControl),
+            new StatementAnalyzerFactory(metadata, sqlParser, accessControl, typeManager),
             Collections.emptyList(),
             Collections.emptyMap(),
             statementRewrite,

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/AnalyzerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/AnalyzerTest.java
@@ -72,6 +72,7 @@ import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.LogicalExpression
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Statement;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.parser.SqlParser;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.rewrite.StatementRewriteFactory;
+import org.apache.iotdb.db.queryengine.plan.relational.type.InternalTypeManager;
 import org.apache.iotdb.db.queryengine.plan.statement.StatementTestUtils;
 import org.apache.iotdb.db.queryengine.plan.statement.crud.InsertRowStatement;
 import org.apache.iotdb.db.queryengine.plan.statement.crud.InsertTabletStatement;
@@ -1261,7 +1262,8 @@ public class AnalyzerTest {
       final SessionInfo session) {
     try {
       final StatementAnalyzerFactory statementAnalyzerFactory =
-          new StatementAnalyzerFactory(metadata, sqlParser, nopAccessControl);
+          new StatementAnalyzerFactory(
+              metadata, sqlParser, nopAccessControl, new InternalTypeManager());
 
       Analyzer analyzer =
           new Analyzer(
@@ -1285,7 +1287,8 @@ public class AnalyzerTest {
       final SqlParser sqlParser,
       final SessionInfo session) {
     final StatementAnalyzerFactory statementAnalyzerFactory =
-        new StatementAnalyzerFactory(metadata, sqlParser, nopAccessControl);
+        new StatementAnalyzerFactory(
+            metadata, sqlParser, nopAccessControl, new InternalTypeManager());
     Analyzer analyzer =
         new Analyzer(
             context,

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/AuthTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/AuthTest.java
@@ -32,6 +32,7 @@ import org.apache.iotdb.db.queryengine.plan.relational.security.TreeAccessCheckV
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Statement;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.parser.SqlParser;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.rewrite.StatementRewrite;
+import org.apache.iotdb.db.queryengine.plan.relational.type.InternalTypeManager;
 
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -224,7 +225,8 @@ public class AuthTest {
         new StatementAnalyzerFactory(
             TEST_MATADATA,
             sqlParser,
-            new AccessControlImpl(authChecker, new TreeAccessCheckVisitor()));
+            new AccessControlImpl(authChecker, new TreeAccessCheckVisitor()),
+            new InternalTypeManager());
     MPPQueryContext context = new MPPQueryContext(sql, QUERY_ID, 0, session, null, null);
     Analyzer analyzer =
         new Analyzer(
@@ -251,7 +253,8 @@ public class AuthTest {
         new TableConfigTaskVisitor(
             Mockito.mock(IClientSession.class),
             TEST_MATADATA,
-            new AccessControlImpl(authChecker, new TreeAccessCheckVisitor())),
+            new AccessControlImpl(authChecker, new TreeAccessCheckVisitor()),
+            new InternalTypeManager()),
         context);
   }
 
@@ -266,7 +269,8 @@ public class AuthTest {
         new TableConfigTaskVisitor(
             clientSession,
             TEST_MATADATA,
-            new AccessControlImpl(authChecker, new TreeAccessCheckVisitor())),
+            new AccessControlImpl(authChecker, new TreeAccessCheckVisitor()),
+            new InternalTypeManager()),
         context);
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/RowPatternRecognitionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/RowPatternRecognitionTest.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.db.queryengine.plan.relational.security.AllowAllAccessCo
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Statement;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.parser.SqlParser;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.rewrite.StatementRewriteFactory;
+import org.apache.iotdb.db.queryengine.plan.relational.type.InternalTypeManager;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -475,7 +476,8 @@ public class RowPatternRecognitionTest {
       final SqlParser sqlParser,
       final SessionInfo session) {
     final StatementAnalyzerFactory statementAnalyzerFactory =
-        new StatementAnalyzerFactory(metadata, sqlParser, nopAccessControl);
+        new StatementAnalyzerFactory(
+            metadata, sqlParser, nopAccessControl, new InternalTypeManager());
 
     Analyzer analyzer =
         new Analyzer(

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/planner/PlanTester.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/planner/PlanTester.java
@@ -43,6 +43,7 @@ import org.apache.iotdb.db.queryengine.plan.relational.security.AllowAllAccessCo
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Statement;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.parser.SqlParser;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.rewrite.StatementRewriteFactory;
+import org.apache.iotdb.db.queryengine.plan.relational.type.InternalTypeManager;
 
 import com.google.common.collect.ImmutableList;
 import org.mockito.Mockito;
@@ -170,7 +171,8 @@ public class PlanTester {
       SessionInfo session) {
     try {
       StatementAnalyzerFactory statementAnalyzerFactory =
-          new StatementAnalyzerFactory(metadata, sqlParser, new AllowAllAccessControl());
+          new StatementAnalyzerFactory(
+              metadata, sqlParser, new AllowAllAccessControl(), new InternalTypeManager());
 
       Analyzer analyzer =
           new Analyzer(


### PR DESCRIPTION
## Description
The initialization cost of the TypeManager in StatementAnalyzer is too high. The TypeManager can be placed in the Coordinator to reduce unnecessary object creation.
![img_v3_02sm_830657ac-e4fc-446f-a77f-13a7596c404g](https://github.com/user-attachments/assets/60cb9747-1bc5-490d-9ea2-d1b8ec833ee5)
![img_v3_02sm_ad3fc8e6-93d3-4127-ab49-f15ca2aa977g](https://github.com/user-attachments/assets/31635bfb-e254-4e0f-9440-dbbd37e14886)


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
