### PR TITLE
Fix Non-Deterministic Behavior in NewReadChunkCompactionPerformerWithAlignedSeriesTest

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/utils/CompactionCheckerUtils.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/utils/CompactionCheckerUtils.java
@@ -70,9 +70,10 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -532,7 +533,7 @@ public class CompactionCheckerUtils {
 
   public static List<IFullPath> getAllPathsOfResources(List<TsFileResource> resources)
       throws IOException, IllegalPathException {
-    Set<IFullPath> paths = new HashSet<>();
+    Set<IFullPath> paths = new LinkedHashSet<>();
     try (MultiTsFileDeviceIterator deviceIterator = new MultiTsFileDeviceIterator(resources)) {
       while (deviceIterator.hasNextDevice()) {
         Pair<IDeviceID, Boolean> iDeviceIDBooleanPair = deviceIterator.nextDevice();
@@ -540,7 +541,10 @@ public class CompactionCheckerUtils {
         boolean isAlign = iDeviceIDBooleanPair.getRight();
         Map<String, MeasurementSchema> schemaMap = deviceIterator.getAllSchemasOfCurrentDevice();
         IMeasurementSchema timeSchema = schemaMap.remove(TsFileConstant.TIME_COLUMN_ID);
-        List<IMeasurementSchema> measurementSchemas = new ArrayList<>(schemaMap.values());
+        List<IMeasurementSchema> measurementSchemas =
+            schemaMap.values().stream()
+                .sorted(Comparator.comparing(IMeasurementSchema::getMeasurementName))
+                .collect(Collectors.toList());
         if (measurementSchemas.isEmpty()) {
           continue;
         }


### PR DESCRIPTION
# Fix Non-Deterministic Behavior in NewReadChunkCompactionPerformerWithAlignedSeriesTest

## Problem

Thirteen tests in `NewReadChunkCompactionPerformerWithAlignedSeriesTest` were failing non-deterministically under NonDex due to order-dependent measurement schema comparisons:

- `testCompactionWithAllDeletion`
- `testCompactionWithDeletion`
- `testCompactionWithDeletionAndEmptyPage`
- `testCompactionWithPartialDeletion`
- `testCompactionWithPartialDeletionAndEmptyPage`
- `testSimpleCompaction`
- `testSimpleCompactionByFlushChunk`
- `testSimpleCompactionWithEmptyChunk`
- `testSimpleCompactionWithEmptyPage`
- `testSimpleCompactionWithNullValue`
- `testSimpleCompactionWithNullValueAndEmptyChunk`
- `testSimpleCompactionWithNullValueAndEmptyPage`
- `testSimpleCompactionWithSomeDeviceNotInTargetFile`

## Way to Reproduce

```bash
cd iotdb-core/datanode
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex \
  -Dtest=NewReadChunkCompactionPerformerWithAlignedSeriesTest \
  -DnondexRuns=3 -Drat.skip=true
# Result: Multiple failures due to non-deterministic measurement order
```

## Root Cause

The `CompactionCheckerUtils.getAllPathsOfResources()` method used `HashSet` for storing paths and did not sort measurement schemas before constructing `AlignedFullPath` objects:

```java
Set<IFullPath> paths = new HashSet<>();  // Non-deterministic iteration order
// ...
List<IMeasurementSchema> measurementSchemas = new ArrayList<>(schemaMap.values());  // Unsorted
// ...
seriesPath = new AlignedFullPath(deviceID, existedMeasurements, measurementSchemas);
```

The `schemaMap` is backed by `ConcurrentHashMap` which has non-deterministic iteration order. When NonDex shuffled collection order, measurements appeared in different positions within `AlignedFullPath`, causing data comparison assertions to fail even though the compaction results were semantically correct.

## Solution

Made measurement ordering **deterministic** by sorting schemas and using ordered collections.

### Changes Made

**Before (Order-Dependent):**
```java
Set<IFullPath> paths = new HashSet<>();
// ...
List<IMeasurementSchema> measurementSchemas = new ArrayList<>(schemaMap.values());
```

**After (Order-Independent):**
```java
Set<IFullPath> paths = new LinkedHashSet<>();
// ...
List<IMeasurementSchema> measurementSchemas =
    schemaMap.values().stream()
        .sorted(Comparator.comparing(IMeasurementSchema::getMeasurementName))
        .collect(Collectors.toList());
```

### Key Improvements

- Changed `HashSet` to `LinkedHashSet` to preserve insertion order for deterministic iteration
- Added sorting of measurement schemas by measurement name using `Comparator.comparing()`
- Ensures `AlignedFullPath` objects always have measurements in consistent alphabetical order
- Added `java.util.Comparator` import

## Verification

```bash
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex \
  -Dtest=NewReadChunkCompactionPerformerWithAlignedSeriesTest \
  -DnondexRuns=3 -Drat.skip=true
# Result: All 15 tests pass across 3 different random seeds (933178, 974622, 1016066)
```

## Key Changed Classes

- **CompactionCheckerUtils**: Modified `getAllPathsOfResources()` method (~10 lines), test utility changes only

