### PR TITLE
fix tests in BatchedAlignedSeriesReadChunkCompactionTest

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/AbstractCompactionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/AbstractCompactionTest.java
@@ -81,9 +81,10 @@ import org.junit.Assert;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -844,7 +845,7 @@ public class AbstractCompactionTest {
 
   protected List<IFullPath> getPaths(List<TsFileResource> resources)
       throws IOException, IllegalPathException {
-    Set<IFullPath> paths = new HashSet<>();
+    Set<IFullPath> paths = new LinkedHashSet<>();
     try (MultiTsFileDeviceIterator deviceIterator = new MultiTsFileDeviceIterator(resources)) {
       while (deviceIterator.hasNextDevice()) {
         Pair<IDeviceID, Boolean> iDeviceIDBooleanPair = deviceIterator.nextDevice();
@@ -852,7 +853,10 @@ public class AbstractCompactionTest {
         boolean isAlign = iDeviceIDBooleanPair.getRight();
         Map<String, MeasurementSchema> schemaMap = deviceIterator.getAllSchemasOfCurrentDevice();
         IMeasurementSchema timeSchema = schemaMap.remove(TsFileConstant.TIME_COLUMN_ID);
-        List<IMeasurementSchema> measurementSchemas = new ArrayList<>(schemaMap.values());
+        List<IMeasurementSchema> measurementSchemas =
+            schemaMap.values().stream()
+                .sorted(Comparator.comparing(IMeasurementSchema::getMeasurementName))
+                .collect(Collectors.toList());
         if (measurementSchemas.isEmpty()) {
           continue;
         }


### PR DESCRIPTION
# Fix flaky tests in `BatchedAlignedSeriesReadChunkCompactionTest`

## Description

This PR fixes 12 flaky tests in `BatchedAlignedSeriesReadChunkCompactionTest` that were failing intermittently due to non-deterministic iteration order of collections.

## Root Cause

The `getPaths()` method in `AbstractCompactionTest.java` had two sources of non-determinism:

1. **`HashSet` usage**: The method used `HashSet<IFullPath>` which does not guarantee iteration order
2. **Unsorted `schemaMap.values()`**: The `measurementSchemas` list was created directly from `schemaMap.values()` without sorting, and since `schemaMap` is backed by a `ConcurrentHashMap`, the iteration order is non-deterministic

This caused `AlignedFullPath` objects to be created with measurements in different orders across test runs, leading to comparison failures when validating compaction results.

## Fix

1. Changed `HashSet` to `LinkedHashSet` to preserve insertion order
2. Sorted `measurementSchemas` by measurement name before creating the list

## Changes

**File:** `iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/AbstractCompactionTest.java`

```java
// Before (non-deterministic):
Set<IFullPath> paths = new HashSet<>();
// ...
List<IMeasurementSchema> measurementSchemas = new ArrayList<>(schemaMap.values());

// After (deterministic):
Set<IFullPath> paths = new LinkedHashSet<>();
// ...
List<IMeasurementSchema> measurementSchemas =
    schemaMap.values().stream()
        .sorted(Comparator.comparing(IMeasurementSchema::getMeasurementName))
        .collect(Collectors.toList());
```

## Tests Fixed

- `BatchedAlignedSeriesReadChunkCompactionTest#testCompactionWithDifferentCompressionTypeOrEncoding`
- `BatchedAlignedSeriesReadChunkCompactionTest#testCompactionWithEmptyBatch`
- `BatchedAlignedSeriesReadChunkCompactionTest#testSimpleCompactionByFlushChunk`
- `BatchedAlignedSeriesReadChunkCompactionTest#testSimpleCompactionByFlushPage`
- `BatchedAlignedSeriesReadChunkCompactionTest#testSimpleCompactionByWritePoint`
- `BatchedAlignedSeriesReadChunkCompactionTest#testSimpleCompactionWithAllDeletedColumnByFlushChunk`
- `BatchedAlignedSeriesReadChunkCompactionTest#testSimpleCompactionWithAllDeletedPageByFlushPage`
- `BatchedAlignedSeriesReadChunkCompactionTest#testSimpleCompactionWithNotExistColumnByFlushChunk`
- `BatchedAlignedSeriesReadChunkCompactionTest#testSimpleCompactionWithNullColumn`
- `BatchedAlignedSeriesReadChunkCompactionTest#testSimpleCompactionWithNullColumnByFlushChunk`
- `BatchedAlignedSeriesReadChunkCompactionTest#testSimpleCompactionWithPartialDeletedColumnByFlushChunk`
- `BatchedAlignedSeriesReadChunkCompactionTest#testSimpleCompactionWithPartialDeletedPageByWritePoint`

## Verification

Verified using NonDex with 3 different random seeds - all tests pass consistently.

