### PR TITLE
Avoid CN OOM by Pulling User/Roles to DN When Cache Misses.

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/auth/ClusterAuthorityFetcher.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/auth/ClusterAuthorityFetcher.java
@@ -186,7 +186,7 @@ public class ClusterAuthorityFetcher implements IAuthorityFetcher {
             checkRoleFromConfigNode(username, rolename);
             cachedRole = iAuthorCache.getRoleCache(rolename);
           }
-          if (cachedRole.checkPathPrivilege(path, permission)) {
+          if (cachedRole != null && cachedRole.checkPathPrivilege(path, permission)) {
             checkFromRole = true;
             break;
           }


### PR DESCRIPTION
When there is no User Cache on the DN side, the entire time series will be handed over to CN for authentication, which ultimately leads to CN OOM in some PIPE scenarios with a large number of time series. To solve this problem, it is necessary to prohibit passing all time series to CN during authentication, and instead pull the user and it's corresponding roles to dn when the user cache and role caches fail.