### PR TITLE
Fix the issue of SQL conversion in export tool

### DIFF
--- a/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/data/ExportData.java
+++ b/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/data/ExportData.java
@@ -238,7 +238,10 @@ public class ExportData extends AbstractDataTool {
           exportData.exportBySql(values[i], i);
         }
       } else {
-        exportData.exportBySql(queryCommand, 0);
+        String[] values = queryCommand.trim().split(";");
+        for (int i = 0; i < values.length; i++) {
+          exportData.exportBySql(values[i], i);
+        }
       }
     } catch (IOException e) {
       ioTPrinter.println("Failed to operate on file, because " + e.getMessage());


### PR DESCRIPTION
## Description
export-data.sh execute a table model SQL statement, if SQL adds a semicolon, the execution will fail.
Fixed an issue where semicolonized insertion failed when inserting a table model.