### PR TITLE
fixed the bug that caused incompatible behavior when comparing int64 or int32 column with double literals in query filter conditions

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/query/IoTDBPredicateConversionTreeIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/query/IoTDBPredicateConversionTreeIT.java
@@ -1,0 +1,293 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.it.query;
+
+import org.apache.iotdb.it.env.EnvFactory;
+import org.apache.iotdb.it.framework.IoTDBTestRunner;
+import org.apache.iotdb.itbase.category.ClusterIT;
+import org.apache.iotdb.itbase.category.LocalStandaloneIT;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.sql.Connection;
+import java.sql.Statement;
+
+import static org.apache.iotdb.db.it.utils.TestUtils.resultSetEqualTest;
+import static org.junit.Assert.fail;
+
+@RunWith(IoTDBTestRunner.class)
+@Category({LocalStandaloneIT.class, ClusterIT.class})
+public class IoTDBPredicateConversionTreeIT {
+
+  private static final String DATABASE_NAME = "root.test_pred";
+  private static final String DEVICE_ID = DATABASE_NAME + ".d1";
+
+  private static final String[] SQLs =
+      new String[] {
+        "CREATE DATABASE " + DATABASE_NAME,
+        "CREATE TIMESERIES " + DEVICE_ID + ".int32_col WITH DATATYPE=INT32, ENCODING=PLAIN",
+        "CREATE TIMESERIES " + DEVICE_ID + ".int64_col WITH DATATYPE=INT64, ENCODING=PLAIN",
+        "INSERT INTO " + DEVICE_ID + "(time, int32_col, int64_col) VALUES(1, 20, 20)",
+        "INSERT INTO " + DEVICE_ID + "(time, int32_col, int64_col) VALUES(2, 29, 29)",
+        "INSERT INTO " + DEVICE_ID + "(time, int32_col, int64_col) VALUES(3, 30, 30)",
+        "INSERT INTO " + DEVICE_ID + "(time, int32_col, int64_col) VALUES(4, 31, 31)",
+        "INSERT INTO " + DEVICE_ID + "(time, int64_col) VALUES(5, 35)",
+        "INSERT INTO " + DEVICE_ID + "(time, int32_col) VALUES(6, 35)",
+        "INSERT INTO " + DEVICE_ID + "(time, int32_col, int64_col) VALUES(7, null, null)",
+        "INSERT INTO " + DEVICE_ID + "(time, int32_col, int64_col) VALUES(8, 1000, 1000)",
+        "INSERT INTO " + DEVICE_ID + "(time, int32_col, int64_col) VALUES(9, -29, -29)",
+        "INSERT INTO " + DEVICE_ID + "(time, int32_col, int64_col) VALUES(10, -30, -30)"
+      };
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    EnvFactory.getEnv().initClusterEnvironment();
+
+    importData();
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  private static void importData() {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+
+      for (String sql : SQLs) {
+        statement.execute(sql);
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testDoubleLiteralAndInt32Column() {
+    // Common header definition for Tree Model
+    String expectedHeader = "Time," + DEVICE_ID + ".int32_col,";
+
+    // ----------------------------------------------------------------------
+    // Group 1: Positive boundary 29.1
+    // ----------------------------------------------------------------------
+
+    // TC-1: int32_col >= 29.1
+    // Logic: Ceil(29.1) = 30 -> int32_col >= 30
+    // Expected result: Row 3(30), Row 4(31), Row 6(35), Row 8(1000)
+    String[] retArrayGtEqPositive = {"3,30,", "4,31,", "6,35,", "8,1000,"};
+    resultSetEqualTest(
+        "SELECT int32_col FROM " + DEVICE_ID + " WHERE int32_col >= 29.1",
+        expectedHeader,
+        retArrayGtEqPositive);
+
+    // TC-2: int32_col > 29.1
+    // Logic: Floor(29.1) = 29 -> int32_col > 29 -> equivalent to int32_col >= 30
+    // Expected result: Same as above
+    resultSetEqualTest(
+        "SELECT int32_col FROM " + DEVICE_ID + " WHERE int32_col > 29.1",
+        expectedHeader,
+        retArrayGtEqPositive);
+
+    // TC-3: int32_col <= 29.1
+    // Logic: Floor(29.1) = 29 -> int32_col <= 29
+    // Expected result: Row 1(20), Row 2(29), Row 9(-29), Row 10(-30)
+    String[] retArrayLtEqPositive = {"1,20,", "2,29,", "9,-29,", "10,-30,"};
+    resultSetEqualTest(
+        "SELECT int32_col FROM " + DEVICE_ID + " WHERE int32_col <= 29.1",
+        expectedHeader,
+        retArrayLtEqPositive);
+
+    // TC-4: int32_col < 29.1
+    // Logic: Ceil(29.1) = 30 -> int32_col < 30 -> equivalent to int32_col <= 29
+    // Expected result: Same as above
+    resultSetEqualTest(
+        "SELECT int32_col FROM " + DEVICE_ID + " WHERE int32_col < 29.1",
+        expectedHeader,
+        retArrayLtEqPositive);
+
+    // TC-5: int32_col = 29.1
+    // Logic: Integer values can never equal a decimal fraction -> Empty result
+    String[] retArrayEmpty = {};
+    resultSetEqualTest(
+        "SELECT int32_col FROM " + DEVICE_ID + " WHERE int32_col = 29.1",
+        expectedHeader,
+        retArrayEmpty);
+
+    // TC-6: int32_col != 29.1
+    // Logic: Integer values are never equal to a decimal fraction -> Return all non-null rows
+    // Expected result: All rows with int32 data (Row 5 and Row 7 are null, excluded)
+    String[] retArrayNotEq = {
+      "1,20,", "2,29,", "3,30,", "4,31,", "6,35,", "8,1000,", "9,-29,", "10,-30,"
+    };
+    resultSetEqualTest(
+        "SELECT int32_col FROM " + DEVICE_ID + " WHERE int32_col != 29.1",
+        expectedHeader,
+        retArrayNotEq);
+  }
+
+  @Test
+  public void testDoubleLiteralAndInt64Column() {
+    // Common header definition for Tree Model
+    String expectedHeader = "Time," + DEVICE_ID + ".int64_col,";
+
+    // ----------------------------------------------------------------------
+    // Group 1: Positive boundary 29.1
+    // ----------------------------------------------------------------------
+
+    // TC-1: int64_col >= 29.1
+    // Logic: Ceil(29.1) = 30 -> int64_col >= 30
+    // Expected result: Row 3(30), Row 4(31), Row 5(35), Row 8(1000)
+    // Note: Row 5 (35) is included here (it is int64). Row 6 is excluded (it is int32).
+    String[] retArrayGtEqPositive = {"3,30,", "4,31,", "5,35,", "8,1000,"};
+    resultSetEqualTest(
+        "SELECT int64_col FROM " + DEVICE_ID + " WHERE int64_col >= 29.1",
+        expectedHeader,
+        retArrayGtEqPositive);
+
+    // TC-2: int64_col > 29.1
+    // Logic: Floor(29.1) = 29 -> int64_col > 29 -> equivalent to int64_col >= 30
+    // Expected result: Same as above
+    resultSetEqualTest(
+        "SELECT int64_col FROM " + DEVICE_ID + " WHERE int64_col > 29.1",
+        expectedHeader,
+        retArrayGtEqPositive);
+
+    // TC-3: int64_col <= 29.1
+    // Logic: Floor(29.1) = 29 -> int64_col <= 29
+    // Expected result: Row 1(20), Row 2(29), Row 9(-29), Row 10(-30)
+    String[] retArrayLtEqPositive = {"1,20,", "2,29,", "9,-29,", "10,-30,"};
+    resultSetEqualTest(
+        "SELECT int64_col FROM " + DEVICE_ID + " WHERE int64_col <= 29.1",
+        expectedHeader,
+        retArrayLtEqPositive);
+
+    // TC-4: int64_col < 29.1
+    // Logic: Ceil(29.1) = 30 -> int64_col < 30 -> equivalent to int64_col <= 29
+    // Expected result: Same as above
+    resultSetEqualTest(
+        "SELECT int64_col FROM " + DEVICE_ID + " WHERE int64_col < 29.1",
+        expectedHeader,
+        retArrayLtEqPositive);
+
+    // TC-5: int64_col = 29.1
+    // Logic: Long values can never equal a decimal fraction -> Empty result
+    String[] retArrayEmpty = {};
+    resultSetEqualTest(
+        "SELECT int64_col FROM " + DEVICE_ID + " WHERE int64_col = 29.1",
+        expectedHeader,
+        retArrayEmpty);
+
+    // TC-6: int64_col != 29.1
+    // Logic: Long values are never equal to a decimal fraction -> Return all non-null rows
+    // Expected result: All rows with int64 data (Row 6 and Row 7 are null, excluded)
+    String[] retArrayNotEq = {
+      "1,20,", "2,29,", "3,30,", "4,31,", "5,35,", "8,1000,", "9,-29,", "10,-30,"
+    };
+    resultSetEqualTest(
+        "SELECT int64_col FROM " + DEVICE_ID + " WHERE int64_col != 29.1",
+        expectedHeader,
+        retArrayNotEq);
+
+    // ----------------------------------------------------------------------
+    // Group 2: Negative boundary -29.1
+    // ----------------------------------------------------------------------
+
+    // TC-7: int64_col <= -29.1
+    // Logic: Floor(-29.1) = -30 -> int64_col <= -30
+    // Expected result: Row 10(-30)
+    String[] retArrayLtEqNegative = {"10,-30,"};
+    resultSetEqualTest(
+        "SELECT int64_col FROM " + DEVICE_ID + " WHERE int64_col <= -29.1",
+        expectedHeader,
+        retArrayLtEqNegative);
+
+    // TC-8: int64_col >= -29.1
+    // Logic: Ceil(-29.1) = -29 -> int64_col >= -29
+    // Expected result: Row 9(-29) and all larger positive numbers (20, 29, 30, 31, 35, 1000)
+    String[] retArrayGtEqNegative = {
+      "1,20,", "2,29,", "3,30,", "4,31,", "5,35,", "8,1000,", "9,-29,"
+    };
+    resultSetEqualTest(
+        "SELECT int64_col FROM " + DEVICE_ID + " WHERE int64_col >= -29.1",
+        expectedHeader,
+        retArrayGtEqNegative);
+  }
+
+  @Test
+  public void testDoubleLiteralOverflow() {
+    String expectedHeaderInt32 = "Time," + DEVICE_ID + ".int32_col,";
+    String expectedHeaderInt64 = "Time," + DEVICE_ID + ".int64_col,";
+    String[] emptyResult = {};
+
+    // ----------------------------------------------------------------------
+    // Part 1: INT32 Column vs Double > Integer.MAX_VALUE (~2.14E9)
+    // Literal: 3.0E9
+    // ----------------------------------------------------------------------
+
+    // TC-1: int32 >= 3.0E9
+    // Logic: Impossible for any INT32 value.
+    // Expected: Empty result.
+    resultSetEqualTest(
+        "SELECT int32_col FROM " + DEVICE_ID + " WHERE int32_col >= 3.0E9",
+        expectedHeaderInt32,
+        emptyResult);
+
+    // TC-2: int32 <= 3.0E9
+    // Logic: Always True for valid values. Must exclude NULLs.
+    // Expected: All rows where int32_col is not null (Row 5 and 7 are null).
+    String[] allInt32Rows = {
+      "1,20,", "2,29,", "3,30,", "4,31,", "6,35,", "8,1000,", "9,-29,", "10,-30,"
+    };
+    resultSetEqualTest(
+        "SELECT int32_col FROM " + DEVICE_ID + " WHERE int32_col <= 3.0E9",
+        expectedHeaderInt32,
+        allInt32Rows);
+
+    // ----------------------------------------------------------------------
+    // Part 2: INT64 Column vs Double > Long.MAX_VALUE (~9.22E18)
+    // Literal: 1.0E19
+    // ----------------------------------------------------------------------
+
+    // TC-3: int64 >= 1.0E19
+    // Logic: Impossible for any INT64 value.
+    // Expected: Empty result.
+    resultSetEqualTest(
+        "SELECT int64_col FROM " + DEVICE_ID + " WHERE int64_col >= 1.0E19",
+        expectedHeaderInt64,
+        emptyResult);
+
+    // TC-4: int64 <= 1.0E19
+    // Logic: Always True for valid values. Must exclude NULLs.
+    // Expected: All rows where int64_col is not null (Row 6 and 7 are null).
+    String[] allInt64Rows = {
+      "1,20,", "2,29,", "3,30,", "4,31,", "5,35,", "8,1000,", "9,-29,", "10,-30,"
+    };
+    resultSetEqualTest(
+        "SELECT int64_col FROM " + DEVICE_ID + " WHERE int64_col <= 1.0E19",
+        expectedHeaderInt64,
+        allInt64Rows);
+  }
+}

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBPredicateConversionTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBPredicateConversionTableIT.java
@@ -1,0 +1,379 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.relational.it.query.recent;
+
+import org.apache.iotdb.it.env.EnvFactory;
+import org.apache.iotdb.it.framework.IoTDBTestRunner;
+import org.apache.iotdb.itbase.category.TableClusterIT;
+import org.apache.iotdb.itbase.category.TableLocalStandaloneIT;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.apache.iotdb.db.it.utils.TestUtils.prepareTableData;
+import static org.apache.iotdb.db.it.utils.TestUtils.tableResultSetEqualTest;
+
+@RunWith(IoTDBTestRunner.class)
+@Category({TableLocalStandaloneIT.class, TableClusterIT.class})
+public class IoTDBPredicateConversionTableIT {
+
+  private static final String DATABASE_NAME = "test_predicate_conversion";
+
+  private static final String[] createSqls =
+      new String[] {
+        "CREATE DATABASE " + DATABASE_NAME,
+        "USE " + DATABASE_NAME,
+        "CREATE TABLE PredicateTestTable(" + "int32_col INT32, " + "int64_col INT64" + ")",
+        "INSERT INTO PredicateTestTable(time, int32_col, int64_col) VALUES(1, 20, 20)",
+        "INSERT INTO PredicateTestTable(time, int32_col, int64_col) VALUES(2, 29, 29)",
+        "INSERT INTO PredicateTestTable(time, int32_col, int64_col) VALUES(3, 30, 30)",
+        "INSERT INTO PredicateTestTable(time, int32_col, int64_col) VALUES(4, 31, 31)",
+        "INSERT INTO PredicateTestTable(time, int64_col) VALUES(5, 35)",
+        "INSERT INTO PredicateTestTable(time, int32_col) VALUES(6, 35)",
+        "INSERT INTO PredicateTestTable(time, int32_col, int64_col) VALUES(7, null, null)",
+        "INSERT INTO PredicateTestTable(time, int32_col, int64_col) VALUES(8, 1000, 1000)",
+        "INSERT INTO PredicateTestTable(time, int32_col, int64_col) VALUES(9, -29, -29)",
+        "INSERT INTO PredicateTestTable(time, int32_col, int64_col) VALUES(10, -30, -30)"
+      };
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    EnvFactory.getEnv().initClusterEnvironment();
+    prepareTableData(createSqls);
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  @Test
+  public void testDoubleLiteralAndInt32Column() {
+    // Common header definition
+    String[] expectedHeader = {"time", "int32_col"};
+
+    // ----------------------------------------------------------------------
+    // Group 1: Positive boundary 29.1
+    // ----------------------------------------------------------------------
+
+    // TC-1: int32_col >= 29.1
+    // Logic: Ceil(29.1) = 30 -> int32_col >= 30
+    // Expected result: Row 3(30), Row 4(31), Row 6(35), Row 8(1000)
+    String[] retArrayGtEqPositive = {
+      "1970-01-01T00:00:00.003Z,30,",
+      "1970-01-01T00:00:00.004Z,31,",
+      "1970-01-01T00:00:00.006Z,35,",
+      "1970-01-01T00:00:00.008Z,1000,"
+    };
+    tableResultSetEqualTest(
+        "SELECT time, int32_col FROM PredicateTestTable WHERE int32_col >= 29.1 ORDER BY time",
+        expectedHeader,
+        retArrayGtEqPositive,
+        DATABASE_NAME);
+
+    // TC-2: int32_col > 29.1
+    // Logic: Floor(29.1) = 29 -> int32_col > 29 -> equivalent to int32_col >= 30
+    // Expected result: Same as above
+    tableResultSetEqualTest(
+        "SELECT time, int32_col FROM PredicateTestTable WHERE int32_col > 29.1 ORDER BY time",
+        expectedHeader,
+        retArrayGtEqPositive,
+        DATABASE_NAME);
+
+    // TC-3: int32_col <= 29.1
+    // Logic: Floor(29.1) = 29 -> int32_col <= 29
+    // Expected result: Row 1(20), Row 2(29), Row 9(-29), Row 10(-30)
+    String[] retArrayLtEqPositive = {
+      "1970-01-01T00:00:00.001Z,20,",
+      "1970-01-01T00:00:00.002Z,29,",
+      "1970-01-01T00:00:00.009Z,-29,",
+      "1970-01-01T00:00:00.010Z,-30,"
+    };
+    tableResultSetEqualTest(
+        "SELECT time, int32_col FROM PredicateTestTable WHERE int32_col <= 29.1 ORDER BY time",
+        expectedHeader,
+        retArrayLtEqPositive,
+        DATABASE_NAME);
+
+    // TC-4: int32_col < 29.1
+    // Logic: Ceil(29.1) = 30 -> int32_col < 30 -> equivalent to int32_col <= 29
+    // Expected result: Same as above
+    tableResultSetEqualTest(
+        "SELECT time, int32_col FROM PredicateTestTable WHERE int32_col < 29.1 ORDER BY time",
+        expectedHeader,
+        retArrayLtEqPositive,
+        DATABASE_NAME);
+
+    // TC-5: int32_col = 29.1
+    // Logic: Integer values can never equal a decimal fraction -> Empty result
+    String[] retArrayEmpty = {};
+    tableResultSetEqualTest(
+        "SELECT time, int32_col FROM PredicateTestTable WHERE int32_col = 29.1 ORDER BY time",
+        expectedHeader,
+        retArrayEmpty,
+        DATABASE_NAME);
+
+    // TC-6: int32_col != 29.1
+    // Logic: Integer values are never equal to a decimal fraction -> Return all non-null rows
+    // Expected result: All rows with int32 data (Row 5 and Row 7 are null, excluded)
+    String[] retArrayNotEq = {
+      "1970-01-01T00:00:00.001Z,20,",
+      "1970-01-01T00:00:00.002Z,29,",
+      "1970-01-01T00:00:00.003Z,30,",
+      "1970-01-01T00:00:00.004Z,31,",
+      "1970-01-01T00:00:00.006Z,35,",
+      "1970-01-01T00:00:00.008Z,1000,",
+      "1970-01-01T00:00:00.009Z,-29,",
+      "1970-01-01T00:00:00.010Z,-30,"
+    };
+    tableResultSetEqualTest(
+        "SELECT time, int32_col FROM PredicateTestTable WHERE int32_col != 29.1 ORDER BY time",
+        expectedHeader,
+        retArrayNotEq,
+        DATABASE_NAME);
+
+    // ----------------------------------------------------------------------
+    // Group 2: Negative boundary -29.1
+    // ----------------------------------------------------------------------
+
+    // TC-7: int32_col <= -29.1
+    // Logic: Floor(-29.1) = -30 -> int32_col <= -30
+    // Expected result: Row 10(-30)
+    String[] retArrayLtEqNegative = {"1970-01-01T00:00:00.010Z,-30,"};
+    tableResultSetEqualTest(
+        "SELECT time, int32_col FROM PredicateTestTable WHERE int32_col <= -29.1 ORDER BY time",
+        expectedHeader,
+        retArrayLtEqNegative,
+        DATABASE_NAME);
+
+    // TC-8: int32_col >= -29.1
+    // Logic: Ceil(-29.1) = -29 -> int32_col >= -29
+    // Expected result: Row 9(-29) and all larger positive numbers (20, 29, 30, 31, 35, 1000)
+    String[] retArrayGtEqNegative = {
+      "1970-01-01T00:00:00.001Z,20,",
+      "1970-01-01T00:00:00.002Z,29,",
+      "1970-01-01T00:00:00.003Z,30,",
+      "1970-01-01T00:00:00.004Z,31,",
+      "1970-01-01T00:00:00.006Z,35,",
+      "1970-01-01T00:00:00.008Z,1000,",
+      "1970-01-01T00:00:00.009Z,-29,"
+    };
+    tableResultSetEqualTest(
+        "SELECT time, int32_col FROM PredicateTestTable WHERE int32_col >= -29.1 ORDER BY time",
+        expectedHeader,
+        retArrayGtEqNegative,
+        DATABASE_NAME);
+  }
+
+  @Test
+  public void testDoubleLiteralAndInt64Column() {
+    // Common header definition
+    String[] expectedHeader = {"time", "int64_col"};
+
+    // ----------------------------------------------------------------------
+    // Group 1: Positive boundary 29.1
+    // ----------------------------------------------------------------------
+
+    // TC-1: int64_col >= 29.1
+    // Logic: Ceil(29.1) = 30 -> int64_col >= 30
+    // Expected result: Row 3(30), Row 4(31), Row 5(35), Row 8(1000)
+    // Note: Row 5 (35) is included here.
+    String[] retArrayGtEqPositive = {
+      "1970-01-01T00:00:00.003Z,30,",
+      "1970-01-01T00:00:00.004Z,31,",
+      "1970-01-01T00:00:00.005Z,35,",
+      "1970-01-01T00:00:00.008Z,1000,"
+    };
+    tableResultSetEqualTest(
+        "SELECT time, int64_col FROM PredicateTestTable WHERE int64_col >= 29.1 ORDER BY time",
+        expectedHeader,
+        retArrayGtEqPositive,
+        DATABASE_NAME);
+
+    // TC-2: int64_col > 29.1
+    // Logic: Floor(29.1) = 29 -> int64_col > 29 -> equivalent to int64_col >= 30
+    // Expected result: Same as above
+    tableResultSetEqualTest(
+        "SELECT time, int64_col FROM PredicateTestTable WHERE int64_col > 29.1 ORDER BY time",
+        expectedHeader,
+        retArrayGtEqPositive,
+        DATABASE_NAME);
+
+    // TC-3: int64_col <= 29.1
+    // Logic: Floor(29.1) = 29 -> int64_col <= 29
+    // Expected result: Row 1(20), Row 2(29), Row 9(-29), Row 10(-30)
+    String[] retArrayLtEqPositive = {
+      "1970-01-01T00:00:00.001Z,20,",
+      "1970-01-01T00:00:00.002Z,29,",
+      "1970-01-01T00:00:00.009Z,-29,",
+      "1970-01-01T00:00:00.010Z,-30,"
+    };
+    tableResultSetEqualTest(
+        "SELECT time, int64_col FROM PredicateTestTable WHERE int64_col <= 29.1 ORDER BY time",
+        expectedHeader,
+        retArrayLtEqPositive,
+        DATABASE_NAME);
+
+    // TC-4: int64_col < 29.1
+    // Logic: Ceil(29.1) = 30 -> int64_col < 30 -> equivalent to int64_col <= 29
+    // Expected result: Same as above
+    tableResultSetEqualTest(
+        "SELECT time, int64_col FROM PredicateTestTable WHERE int64_col < 29.1 ORDER BY time",
+        expectedHeader,
+        retArrayLtEqPositive,
+        DATABASE_NAME);
+
+    // TC-5: int64_col = 29.1
+    // Logic: Long values can never equal a decimal fraction -> Empty result
+    String[] retArrayEmpty = {};
+    tableResultSetEqualTest(
+        "SELECT time, int64_col FROM PredicateTestTable WHERE int64_col = 29.1 ORDER BY time",
+        expectedHeader,
+        retArrayEmpty,
+        DATABASE_NAME);
+
+    // TC-6: int64_col != 29.1
+    // Logic: Long values are never equal to a decimal fraction -> Return all non-null rows
+    // Expected result: All rows with int64 data (Row 6 and Row 7 are null, excluded)
+    String[] retArrayNotEq = {
+      "1970-01-01T00:00:00.001Z,20,",
+      "1970-01-01T00:00:00.002Z,29,",
+      "1970-01-01T00:00:00.003Z,30,",
+      "1970-01-01T00:00:00.004Z,31,",
+      "1970-01-01T00:00:00.005Z,35,",
+      "1970-01-01T00:00:00.008Z,1000,",
+      "1970-01-01T00:00:00.009Z,-29,",
+      "1970-01-01T00:00:00.010Z,-30,"
+    };
+    tableResultSetEqualTest(
+        "SELECT time, int64_col FROM PredicateTestTable WHERE int64_col != 29.1 ORDER BY time",
+        expectedHeader,
+        retArrayNotEq,
+        DATABASE_NAME);
+
+    // ----------------------------------------------------------------------
+    // Group 2: Negative boundary -29.1
+    // ----------------------------------------------------------------------
+
+    // TC-7: int64_col <= -29.1
+    // Logic: Floor(-29.1) = -30 -> int64_col <= -30
+    // Expected result: Row 10(-30)
+    String[] retArrayLtEqNegative = {"1970-01-01T00:00:00.010Z,-30,"};
+    tableResultSetEqualTest(
+        "SELECT time, int64_col FROM PredicateTestTable WHERE int64_col <= -29.1 ORDER BY time",
+        expectedHeader,
+        retArrayLtEqNegative,
+        DATABASE_NAME);
+
+    // TC-8: int64_col >= -29.1
+    // Logic: Ceil(-29.1) = -29 -> int64_col >= -29
+    // Expected result: Row 9(-29) and all larger positive numbers (20, 29, 30, 31, 35, 1000)
+    String[] retArrayGtEqNegative = {
+      "1970-01-01T00:00:00.001Z,20,",
+      "1970-01-01T00:00:00.002Z,29,",
+      "1970-01-01T00:00:00.003Z,30,",
+      "1970-01-01T00:00:00.004Z,31,",
+      "1970-01-01T00:00:00.005Z,35,",
+      "1970-01-01T00:00:00.008Z,1000,",
+      "1970-01-01T00:00:00.009Z,-29,"
+    };
+    tableResultSetEqualTest(
+        "SELECT time, int64_col FROM PredicateTestTable WHERE int64_col >= -29.1 ORDER BY time",
+        expectedHeader,
+        retArrayGtEqNegative,
+        DATABASE_NAME);
+  }
+
+  @Test
+  public void testDoubleLiteralOverflow() {
+    String[] headerInt32 = {"time", "int32_col"};
+    String[] headerInt64 = {"time", "int64_col"};
+    String[] emptyResult = {};
+
+    // ----------------------------------------------------------------------
+    // Part 1: INT32 Column vs Double > Integer.MAX_VALUE (~2.14E9)
+    // Literal: 3.0E9
+    // ----------------------------------------------------------------------
+
+    // TC-1: int32 >= 3.0E9
+    // Logic: Impossible for any INT32 value.
+    // Expected: Empty result.
+    tableResultSetEqualTest(
+        "SELECT time, int32_col FROM PredicateTestTable WHERE int32_col >= 3.0E9 ORDER BY time",
+        headerInt32,
+        emptyResult,
+        DATABASE_NAME);
+
+    // TC-2: int32 <= 3.0E9
+    // Logic: Always True for valid values. Must exclude NULLs (Row 5 and 7).
+    // Expected: All rows where int32_col is not null.
+    String[] allInt32Rows = {
+      "1970-01-01T00:00:00.001Z,20,",
+      "1970-01-01T00:00:00.002Z,29,",
+      "1970-01-01T00:00:00.003Z,30,",
+      "1970-01-01T00:00:00.004Z,31,",
+      "1970-01-01T00:00:00.006Z,35,", // Row 6 has int32
+      "1970-01-01T00:00:00.008Z,1000,",
+      "1970-01-01T00:00:00.009Z,-29,",
+      "1970-01-01T00:00:00.010Z,-30,"
+    };
+    tableResultSetEqualTest(
+        "SELECT time, int32_col FROM PredicateTestTable WHERE int32_col <= 3.0E9 ORDER BY time",
+        headerInt32,
+        allInt32Rows,
+        DATABASE_NAME);
+
+    // ----------------------------------------------------------------------
+    // Part 2: INT64 Column vs Double > Long.MAX_VALUE (~9.22E18)
+    // Literal: 1.0E19
+    // ----------------------------------------------------------------------
+
+    // TC-3: int64 >= 1.0E19
+    // Logic: Impossible for any INT64 value.
+    // Expected: Empty result.
+    tableResultSetEqualTest(
+        "SELECT time, int64_col FROM PredicateTestTable WHERE int64_col >= 1.0E19 ORDER BY time",
+        headerInt64,
+        emptyResult,
+        DATABASE_NAME);
+
+    // TC-4: int64 <= 1.0E19
+    // Logic: Always True for valid values. Must exclude NULLs (Row 6 and 7).
+    // Expected: All rows where int64_col is not null.
+    String[] allInt64Rows = {
+      "1970-01-01T00:00:00.001Z,20,",
+      "1970-01-01T00:00:00.002Z,29,",
+      "1970-01-01T00:00:00.003Z,30,",
+      "1970-01-01T00:00:00.004Z,31,",
+      "1970-01-01T00:00:00.005Z,35,", // Row 5 has int64
+      "1970-01-01T00:00:00.008Z,1000,",
+      "1970-01-01T00:00:00.009Z,-29,",
+      "1970-01-01T00:00:00.010Z,-30,"
+    };
+    tableResultSetEqualTest(
+        "SELECT time, int64_col FROM PredicateTestTable WHERE int64_col <= 1.0E19 ORDER BY time",
+        headerInt64,
+        allInt64Rows,
+        DATABASE_NAME);
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/visitor/predicate/ConvertPredicateToFilterVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/visitor/predicate/ConvertPredicateToFilterVisitor.java
@@ -47,12 +47,17 @@ import com.google.common.io.BaseEncoding;
 import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.common.regexp.LikePattern;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.external.commons.lang3.math.NumberUtils;
 import org.apache.tsfile.read.filter.basic.Filter;
 import org.apache.tsfile.read.filter.factory.FilterFactory;
 import org.apache.tsfile.read.filter.factory.ValueFilterApi;
+import org.apache.tsfile.read.filter.operator.FalseLiteralFilter;
+import org.apache.tsfile.read.filter.operator.ValueIsNotNullOperator;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.write.schema.IMeasurementSchema;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.ZoneId;
 import java.util.HashSet;
 import java.util.List;
@@ -61,6 +66,9 @@ import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.iotdb.db.queryengine.plan.expression.binary.CompareBinaryExpression.flipType;
+import static org.apache.tsfile.enums.TSDataType.DOUBLE;
+import static org.apache.tsfile.enums.TSDataType.INT32;
+import static org.apache.tsfile.enums.TSDataType.INT64;
 import static org.apache.tsfile.read.filter.operator.Not.CONTAIN_NOT_ERR_MSG;
 
 public class ConvertPredicateToFilterVisitor
@@ -265,7 +273,131 @@ public class ConvertPredicateToFilterVisitor
       Context context) {
     PartialPath path = ((TimeSeriesOperand) timeseriesOperand).getPath();
     int measurementIndex = context.getMeasurementIndex(path.getMeasurement());
-    TSDataType dataType = context.getType(path);
+    TSDataType columnDataType = context.getType(path);
+
+    ConstantOperand constantLiteral = (ConstantOperand) constantOperand;
+    TSDataType constantDataType = constantLiteral.getDataType();
+    String constantString = constantLiteral.getValueString();
+    if (constantDataType == DOUBLE && NumberUtils.isCreatable(constantString)) {
+      BigDecimal constantDecimal = new BigDecimal(constantString);
+
+      if (columnDataType == INT64) {
+        if (constantDecimal.compareTo(new BigDecimal(Long.MAX_VALUE)) > 0) {
+          return constructFilterForGreaterThanMax(expressionType, measurementIndex);
+        }
+        if (constantDecimal.compareTo(new BigDecimal(Long.MIN_VALUE)) < 0) {
+          return constructFilterForLessThanMin(expressionType, measurementIndex);
+        }
+        return constructFilterFromDouble(
+            expressionType, constantOperand, measurementIndex, columnDataType);
+
+      } else if (columnDataType == INT32) {
+        if (constantDecimal.compareTo(new BigDecimal(Integer.MAX_VALUE)) > 0) {
+          return constructFilterForGreaterThanMax(expressionType, measurementIndex);
+        }
+        if (constantDecimal.compareTo(new BigDecimal(Integer.MIN_VALUE)) < 0) {
+          return constructFilterForLessThanMin(expressionType, measurementIndex);
+        }
+        return constructFilterFromDouble(
+            expressionType, constantOperand, measurementIndex, columnDataType);
+      }
+    }
+
+    if (constantDataType == INT64 && columnDataType == INT32) {
+      return constructValueFilter(expressionType, constantOperand, INT64, measurementIndex);
+    }
+
+    return constructValueFilter(expressionType, constantOperand, columnDataType, measurementIndex);
+  }
+
+  private Filter constructFilterFromDouble(
+      ExpressionType expressionType,
+      Expression constantOperand,
+      int measurementIndex,
+      TSDataType dataType) {
+
+    ConstantOperand constantLiteral = (ConstantOperand) constantOperand;
+    BigDecimal constantDecimal = new BigDecimal(constantLiteral.getValueString());
+    switch (expressionType) {
+      case GREATER_EQUAL:
+      case LESS_THAN:
+        long ceilValue = constantDecimal.setScale(0, RoundingMode.CEILING).longValue();
+        return constructValueFilter(
+            expressionType,
+            new ConstantOperand(constantLiteral.getDataType(), String.valueOf(ceilValue)),
+            dataType,
+            measurementIndex);
+
+      case LESS_EQUAL:
+      case GREATER_THAN:
+        long floorVal = constantDecimal.setScale(0, RoundingMode.FLOOR).longValue();
+        return constructValueFilter(
+            expressionType,
+            new ConstantOperand(constantLiteral.getDataType(), String.valueOf(floorVal)),
+            dataType,
+            measurementIndex);
+
+      case EQUAL_TO:
+      case NON_EQUAL:
+        boolean isRoundNumber = constantDecimal.remainder(BigDecimal.ONE).signum() == 0;
+        if (isRoundNumber) {
+          String roundNumString = String.valueOf(constantDecimal.longValue());
+          ConstantOperand newOperand =
+              new ConstantOperand(constantLiteral.getDataType(), roundNumString);
+          return constructValueFilter(expressionType, newOperand, dataType, measurementIndex);
+        }
+        return (expressionType == ExpressionType.EQUAL_TO)
+            ? new FalseLiteralFilter()
+            : new ValueIsNotNullOperator(measurementIndex);
+
+      default:
+        throw new UnsupportedOperationException(
+            String.format("Unsupported expression type %s", expressionType));
+    }
+  }
+
+  public Filter constructFilterForGreaterThanMax(
+      ExpressionType expressionType, int measurementIndex) {
+    switch (expressionType) {
+      case GREATER_EQUAL:
+      case GREATER_THAN:
+      case EQUAL_TO:
+        return new FalseLiteralFilter();
+
+      case LESS_EQUAL:
+      case LESS_THAN:
+      case NON_EQUAL:
+        return new ValueIsNotNullOperator(measurementIndex);
+
+      default:
+        throw new UnsupportedOperationException(
+            String.format("Unsupported expression type %s", expressionType));
+    }
+  }
+
+  public Filter constructFilterForLessThanMin(ExpressionType expressionType, int measurementIndex) {
+    switch (expressionType) {
+      case LESS_EQUAL:
+      case LESS_THAN:
+      case EQUAL_TO:
+        return new FalseLiteralFilter();
+
+      case GREATER_EQUAL:
+      case GREATER_THAN:
+      case NON_EQUAL:
+        return new ValueIsNotNullOperator(measurementIndex);
+
+      default:
+        throw new UnsupportedOperationException(
+            String.format("Unsupported expression type %s", expressionType));
+    }
+  }
+
+  private <T extends Comparable<T>> Filter constructValueFilter(
+      ExpressionType expressionType,
+      Expression constantOperand,
+      TSDataType dataType,
+      int measurementIndex) {
     T value = getValue(((ConstantOperand) constantOperand).getValueString(), dataType);
     switch (expressionType) {
       case EQUAL_TO:

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/expression/predicate/TreePredicateConversionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/expression/predicate/TreePredicateConversionTest.java
@@ -1,0 +1,572 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.expression.predicate;
+
+import org.apache.iotdb.commons.exception.IllegalPathException;
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.db.queryengine.plan.analyze.PredicateUtils;
+import org.apache.iotdb.db.queryengine.plan.analyze.TypeProvider;
+import org.apache.iotdb.db.queryengine.plan.expression.Expression;
+import org.apache.iotdb.db.queryengine.plan.expression.binary.EqualToExpression;
+import org.apache.iotdb.db.queryengine.plan.expression.binary.GreaterEqualExpression;
+import org.apache.iotdb.db.queryengine.plan.expression.binary.GreaterThanExpression;
+import org.apache.iotdb.db.queryengine.plan.expression.binary.LessEqualExpression;
+import org.apache.iotdb.db.queryengine.plan.expression.binary.LessThanExpression;
+import org.apache.iotdb.db.queryengine.plan.expression.binary.NonEqualExpression;
+import org.apache.iotdb.db.queryengine.plan.expression.leaf.ConstantOperand;
+import org.apache.iotdb.db.queryengine.plan.expression.leaf.TimeSeriesOperand;
+
+import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.read.filter.basic.Filter;
+import org.apache.tsfile.read.filter.operator.FalseLiteralFilter;
+import org.apache.tsfile.read.filter.operator.LongFilterOperators;
+import org.apache.tsfile.read.filter.operator.ValueIsNotNullOperator;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+
+public class TreePredicateConversionTest {
+
+  Expression int64Column = new TimeSeriesOperand(new PartialPath("root.sg.d1.Int64Column"));
+  Expression int32Column = new TimeSeriesOperand(new PartialPath("root.sg.d1.Int32Column"));
+
+  public TreePredicateConversionTest() throws IllegalPathException {}
+
+  private TypeProvider getMockTypeProvider(TSDataType dataType) {
+    TypeProvider mockTypeProvider = Mockito.mock(TypeProvider.class);
+    Mockito.when(mockTypeProvider.getTreeModelType(Mockito.anyString())).thenReturn(dataType);
+    return mockTypeProvider;
+  }
+
+  @Test
+  public void testDoubleLiteralAndInt64Column() {
+    Expression doubleConstant = new ConstantOperand(TSDataType.DOUBLE, "123.3");
+
+    // 1. GreaterEqual (>=): int64 >= 123.3 -> int64 >= 124 (ceil)
+    // Result: ValueGtEq(124)
+    Expression greaterEqualExpression = new GreaterEqualExpression(int64Column, doubleConstant);
+    Filter actualFilter1 =
+        PredicateUtils.convertPredicateToFilter(
+            greaterEqualExpression,
+            Collections.singletonList("Int64Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT64),
+            null);
+    Assert.assertEquals(new LongFilterOperators.ValueGtEq(0, 124), actualFilter1);
+
+    // 2. LessEqual (<=): int64 <= 123.3 -> int64 <= 123 (floor)
+    // Result: ValueLtEq(123)
+    LessEqualExpression lessEqualExpression = new LessEqualExpression(int64Column, doubleConstant);
+    Filter actualFilter2 =
+        PredicateUtils.convertPredicateToFilter(
+            lessEqualExpression,
+            Collections.singletonList("Int64Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT64),
+            null);
+    Assert.assertEquals(new LongFilterOperators.ValueLtEq(0, 123), actualFilter2);
+
+    // 3. GreaterThan (>): int64 > 123.3 -> int64 > 123 (floor)
+    // Result: ValueGt(123)
+    GreaterThanExpression greaterThanExpression =
+        new GreaterThanExpression(int64Column, doubleConstant);
+    Filter actualFilter3 =
+        PredicateUtils.convertPredicateToFilter(
+            greaterThanExpression,
+            Collections.singletonList("Int64Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT64),
+            null);
+    Assert.assertEquals(new LongFilterOperators.ValueGt(0, 123), actualFilter3);
+
+    // 4. LessThan (<): int64 < 123.3 -> int64 < 124 (ceil)
+    // Result: ValueLt(124)
+    LessThanExpression lessThanExpression = new LessThanExpression(int64Column, doubleConstant);
+    Filter actualFilter4 =
+        PredicateUtils.convertPredicateToFilter(
+            lessThanExpression,
+            Collections.singletonList("Int64Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT64),
+            null);
+    Assert.assertEquals(new LongFilterOperators.ValueLt(0, 124), actualFilter4);
+
+    // 5. EqualTo (=): int64 = 123.3 -> Impossible for int64
+    // Result: FalseLiteralFilter (Always False)
+    EqualToExpression equalToExpression = new EqualToExpression(int64Column, doubleConstant);
+    Filter actualFilter5 =
+        PredicateUtils.convertPredicateToFilter(
+            equalToExpression,
+            Collections.singletonList("Int64Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT64),
+            null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter5);
+
+    // 6. NonEqual (!=): int64 != 123.3
+    // Result: ValueIsNotNullOperator (Always True, as long as value exists)
+    NonEqualExpression nonEqualExpression = new NonEqualExpression(int64Column, doubleConstant);
+    Filter actualFilter6 =
+        PredicateUtils.convertPredicateToFilter(
+            nonEqualExpression,
+            Collections.singletonList("Int64Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT64),
+            null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter6);
+  }
+
+  @Test
+  public void testNegativeDoubleLiteralAndInt64Column() {
+    Expression doubleConstant = new ConstantOperand(TSDataType.DOUBLE, "-123.3");
+
+    // 1. GreaterEqual (>=): int64 >= -123.3 -> int64 >= -123 (ceil)
+    // Result: ValueGtEq(-123)
+    Expression greaterEqualExpression = new GreaterEqualExpression(int64Column, doubleConstant);
+    Filter actualFilter1 =
+        PredicateUtils.convertPredicateToFilter(
+            greaterEqualExpression,
+            Collections.singletonList("Int64Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT64),
+            null);
+    Assert.assertEquals(new LongFilterOperators.ValueGtEq(0, -123), actualFilter1);
+
+    // 2. LessEqual (<=): int64 <= -123.3 -> int64 <= -124 (floor)
+    // Result: ValueLtEq(-124)
+    LessEqualExpression lessEqualExpression = new LessEqualExpression(int64Column, doubleConstant);
+    Filter actualFilter2 =
+        PredicateUtils.convertPredicateToFilter(
+            lessEqualExpression,
+            Collections.singletonList("Int64Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT64),
+            null);
+    Assert.assertEquals(new LongFilterOperators.ValueLtEq(0, -124), actualFilter2);
+
+    // 3. GreaterThan (>): int64 > -123.3 -> int64 > -124 (floor)
+    // Result: ValueGt(-124)
+    GreaterThanExpression greaterThanExpression =
+        new GreaterThanExpression(int64Column, doubleConstant);
+    Filter actualFilter3 =
+        PredicateUtils.convertPredicateToFilter(
+            greaterThanExpression,
+            Collections.singletonList("Int64Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT64),
+            null);
+    Assert.assertEquals(new LongFilterOperators.ValueGt(0, -124), actualFilter3);
+
+    // 4. LessThan (<): int64 < -123.3 -> int64 < -123 (ceil)
+    // Result: ValueLt(-123)
+    LessThanExpression lessThanExpression = new LessThanExpression(int64Column, doubleConstant);
+    Filter actualFilter4 =
+        PredicateUtils.convertPredicateToFilter(
+            lessThanExpression,
+            Collections.singletonList("Int64Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT64),
+            null);
+    Assert.assertEquals(new LongFilterOperators.ValueLt(0, -123), actualFilter4);
+
+    // 5. EqualTo (=): int64 = -123.3 -> Impossible for int64
+    // Result:FalseLiteralFilter(Always False)
+    EqualToExpression equalToExpression = new EqualToExpression(int64Column, doubleConstant);
+    Filter actualFilter5 =
+        PredicateUtils.convertPredicateToFilter(
+            equalToExpression,
+            Collections.singletonList("Int64Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT64),
+            null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter5);
+
+    // 6. NonEqual (!=): int64 != -123.3
+    // Result: ValueIsNotNullOperator (Always True, as long as value exists)
+    NonEqualExpression nonEqualExpression = new NonEqualExpression(int64Column, doubleConstant);
+    Filter actualFilter6 =
+        PredicateUtils.convertPredicateToFilter(
+            nonEqualExpression,
+            Collections.singletonList("Int64Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT64),
+            null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter6);
+  }
+
+  @Test
+  public void testDoubleLiteralOverLongMaxAndInt64Column() {
+    // Long.MAX_VALUE is approximately 9.22E18.
+    // We use "1.0E19" which is definitely greater than Long.MAX_VALUE.
+    Expression outPositiveRangeDoubleConstant = new ConstantOperand(TSDataType.DOUBLE, "1.0E19");
+
+    // 1. GreaterEqual (>=): int64 >= 1.0E19
+    // Result: FalseLiteralFilter (Always False)
+    Expression greaterEqualExpression =
+        new GreaterEqualExpression(int64Column, outPositiveRangeDoubleConstant);
+    Filter actualFilter1 =
+        PredicateUtils.convertPredicateToFilter(
+            greaterEqualExpression,
+            Collections.singletonList("Int64Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT64),
+            null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter1);
+
+    // 2. LessEqual (<=): int64 <= 1.0E19
+    // Result: ValueIsNotNullOperator (Always True, as long as value exists)
+    LessEqualExpression lessEqualExpression =
+        new LessEqualExpression(int64Column, outPositiveRangeDoubleConstant);
+    Filter actualFilter2 =
+        PredicateUtils.convertPredicateToFilter(
+            lessEqualExpression,
+            Collections.singletonList("Int64Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT64),
+            null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter2);
+
+    // 3. GreaterThan (>): int64 > 1.0E19
+    // Result: FalseLiteralFilter
+    GreaterThanExpression greaterThanExpression =
+        new GreaterThanExpression(int64Column, outPositiveRangeDoubleConstant);
+    Filter actualFilter3 =
+        PredicateUtils.convertPredicateToFilter(
+            greaterThanExpression,
+            Collections.singletonList("Int64Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT64),
+            null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter3);
+
+    // 4. LessThan (<): int64 < 1.0E19
+    // Result: ValueIsNotNullOperator
+    LessThanExpression lessThanExpression =
+        new LessThanExpression(int64Column, outPositiveRangeDoubleConstant);
+    Filter actualFilter4 =
+        PredicateUtils.convertPredicateToFilter(
+            lessThanExpression,
+            Collections.singletonList("Int64Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT64),
+            null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter4);
+
+    // 5. EqualTo (=): int64 = 1.0E19
+    // Result: FalseLiteralFilter
+    EqualToExpression equalToExpression =
+        new EqualToExpression(int64Column, outPositiveRangeDoubleConstant);
+    Filter actualFilter5 =
+        PredicateUtils.convertPredicateToFilter(
+            equalToExpression,
+            Collections.singletonList("Int64Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT64),
+            null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter5);
+
+    // 6. NonEqual (!=): int64 != 1.0E19
+    // Result: ValueIsNotNullOperator
+    NonEqualExpression nonEqualExpression =
+        new NonEqualExpression(int64Column, outPositiveRangeDoubleConstant);
+    Filter actualFilter6 =
+        PredicateUtils.convertPredicateToFilter(
+            nonEqualExpression,
+            Collections.singletonList("Int64Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT64),
+            null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter6);
+  }
+
+  @Test
+  public void testDoubleLiteralUnderLongMinAndInt64Column() {
+    // Long.MIN_VALUE is approximately -9.22E18.
+    // We use "-1.0E19" which is definitely smaller than Long.MIN_VALUE.
+    Expression outNegativeRangeDoubleConstant = new ConstantOperand(TSDataType.DOUBLE, "-1.0E19");
+
+    // 1. GreaterEqual (>=): int64 >= -1.0E19
+    // Result: ValueIsNotNullOperator (Always True, as long as value exists)
+    Expression greaterEqualExpression =
+        new GreaterEqualExpression(int64Column, outNegativeRangeDoubleConstant);
+    Filter actualFilter1 =
+        PredicateUtils.convertPredicateToFilter(
+            greaterEqualExpression,
+            Collections.singletonList("Int64Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT64),
+            null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter1);
+
+    // 2. LessEqual (<=): int64 <= -1.0E19
+    // Result: FalseLiteralFilter (Always False)
+    LessEqualExpression lessEqualExpression =
+        new LessEqualExpression(int64Column, outNegativeRangeDoubleConstant);
+    Filter actualFilter2 =
+        PredicateUtils.convertPredicateToFilter(
+            lessEqualExpression,
+            Collections.singletonList("Int64Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT64),
+            null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter2);
+
+    // 3. GreaterThan (>): int64 > -1.0E19
+    // Result: ValueIsNotNullOperator
+    GreaterThanExpression greaterThanExpression =
+        new GreaterThanExpression(int64Column, outNegativeRangeDoubleConstant);
+    Filter actualFilter3 =
+        PredicateUtils.convertPredicateToFilter(
+            greaterThanExpression,
+            Collections.singletonList("Int64Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT64),
+            null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter3);
+
+    // 4. LessThan (<): int64 < -1.0E19
+    // Result: FalseLiteralFilter
+    LessThanExpression lessThanExpression =
+        new LessThanExpression(int64Column, outNegativeRangeDoubleConstant);
+    Filter actualFilter4 =
+        PredicateUtils.convertPredicateToFilter(
+            lessThanExpression,
+            Collections.singletonList("Int64Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT64),
+            null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter4);
+
+    // 5. EqualTo (=): int64 = -1.0E19
+    // Result: FalseLiteralFilter
+    EqualToExpression equalToExpression =
+        new EqualToExpression(int64Column, outNegativeRangeDoubleConstant);
+    Filter actualFilter5 =
+        PredicateUtils.convertPredicateToFilter(
+            equalToExpression,
+            Collections.singletonList("Int64Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT64),
+            null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter5);
+
+    // 6. NonEqual (!=): int64 != -1.0E19
+    // Result: ValueIsNotNullOperator
+    NonEqualExpression nonEqualExpression =
+        new NonEqualExpression(int64Column, outNegativeRangeDoubleConstant);
+    Filter actualFilter6 =
+        PredicateUtils.convertPredicateToFilter(
+            nonEqualExpression,
+            Collections.singletonList("Int64Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT64),
+            null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter6);
+  }
+
+  @Test
+  public void testDoubleLiteralOverIntegerMaxAndInt32Column() {
+    // Integer.MAX_VALUE is approximately 2.14E9.
+    // We use "3.0E9" which is definitely greater than Integer.MAX_VALUE.
+    Expression outPositiveRangeDoubleConstant = new ConstantOperand(TSDataType.DOUBLE, "3.0E9");
+
+    // 1. GreaterEqual (>=): int32 >= 3.0E9
+    // Result: FalseLiteralFilter (Always False)
+    Expression greaterEqualExpression =
+        new GreaterEqualExpression(int32Column, outPositiveRangeDoubleConstant);
+    Filter actualFilter1 =
+        PredicateUtils.convertPredicateToFilter(
+            greaterEqualExpression,
+            Collections.singletonList("Int32Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT32),
+            null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter1);
+
+    // 2. LessEqual (<=): int32 <= 3.0E9
+    // Result: ValueIsNotNullOperator (Always True, as long as value exists)
+    LessEqualExpression lessEqualExpression =
+        new LessEqualExpression(int32Column, outPositiveRangeDoubleConstant);
+    Filter actualFilter2 =
+        PredicateUtils.convertPredicateToFilter(
+            lessEqualExpression,
+            Collections.singletonList("Int32Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT32),
+            null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter2);
+
+    // 3. GreaterThan (>): int32 > 3.0E9
+    // Result: FalseLiteralFilter
+    GreaterThanExpression greaterThanExpression =
+        new GreaterThanExpression(int32Column, outPositiveRangeDoubleConstant);
+    Filter actualFilter3 =
+        PredicateUtils.convertPredicateToFilter(
+            greaterThanExpression,
+            Collections.singletonList("Int32Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT32),
+            null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter3);
+
+    // 4. LessThan (<): int32 < 3.0E9
+    // Result: ValueIsNotNullOperator
+    LessThanExpression lessThanExpression =
+        new LessThanExpression(int32Column, outPositiveRangeDoubleConstant);
+    Filter actualFilter4 =
+        PredicateUtils.convertPredicateToFilter(
+            lessThanExpression,
+            Collections.singletonList("Int32Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT32),
+            null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter4);
+
+    // 5. EqualTo (=): int32 = 3.0E9
+    // Result: FalseLiteralFilter
+    EqualToExpression equalToExpression =
+        new EqualToExpression(int32Column, outPositiveRangeDoubleConstant);
+    Filter actualFilter5 =
+        PredicateUtils.convertPredicateToFilter(
+            equalToExpression,
+            Collections.singletonList("Int32Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT32),
+            null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter5);
+
+    // 6. NonEqual (!=): int32 != 3.0E9
+    // Result: ValueIsNotNullOperator
+    NonEqualExpression nonEqualExpression =
+        new NonEqualExpression(int32Column, outPositiveRangeDoubleConstant);
+    Filter actualFilter6 =
+        PredicateUtils.convertPredicateToFilter(
+            nonEqualExpression,
+            Collections.singletonList("Int32Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT32),
+            null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter6);
+  }
+
+  @Test
+  public void testDoubleLiteralUnderIntegerMinAndInt32Column() {
+    // Integer.MIN_VALUE is approximately -2.14E9.
+    // We use "-3.0E9" which is definitely smaller than Integer.MIN_VALUE.
+    Expression outNegativeRangeDoubleConstant = new ConstantOperand(TSDataType.DOUBLE, "-3.0E9");
+
+    // 1. GreaterEqual (>=): int32 >= -3.0E9
+    // Result: ValueIsNotNullOperator
+    Expression greaterEqualExpression =
+        new GreaterEqualExpression(int32Column, outNegativeRangeDoubleConstant);
+    Filter actualFilter1 =
+        PredicateUtils.convertPredicateToFilter(
+            greaterEqualExpression,
+            Collections.singletonList("Int32Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT32),
+            null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter1);
+
+    // 2. LessEqual (<=): int32 <= -3.0E9
+    // Result: FalseLiteralFilter (Always False)
+    LessEqualExpression lessEqualExpression =
+        new LessEqualExpression(int32Column, outNegativeRangeDoubleConstant);
+    Filter actualFilter2 =
+        PredicateUtils.convertPredicateToFilter(
+            lessEqualExpression,
+            Collections.singletonList("Int32Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT32),
+            null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter2);
+
+    // 3. GreaterThan (>): int32 > -3.0E9
+    // Result: ValueIsNotNullOperator
+    GreaterThanExpression greaterThanExpression =
+        new GreaterThanExpression(int32Column, outNegativeRangeDoubleConstant);
+    Filter actualFilter3 =
+        PredicateUtils.convertPredicateToFilter(
+            greaterThanExpression,
+            Collections.singletonList("Int32Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT32),
+            null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter3);
+
+    // 4. LessThan (<): int32 < -3.0E9
+    // Result: FalseLiteralFilter
+    LessThanExpression lessThanExpression =
+        new LessThanExpression(int32Column, outNegativeRangeDoubleConstant);
+    Filter actualFilter4 =
+        PredicateUtils.convertPredicateToFilter(
+            lessThanExpression,
+            Collections.singletonList("Int32Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT32),
+            null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter4);
+
+    // 5. EqualTo (=): int32 = -3.0E9
+    // Result: FalseLiteralFilter
+    EqualToExpression equalToExpression =
+        new EqualToExpression(int32Column, outNegativeRangeDoubleConstant);
+    Filter actualFilter5 =
+        PredicateUtils.convertPredicateToFilter(
+            equalToExpression,
+            Collections.singletonList("Int32Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT32),
+            null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter5);
+
+    // 6. NonEqual (!=): int32 != -3.0E9
+    // Result: ValueIsNotNullOperator
+    NonEqualExpression nonEqualExpression =
+        new NonEqualExpression(int32Column, outNegativeRangeDoubleConstant);
+    Filter actualFilter6 =
+        PredicateUtils.convertPredicateToFilter(
+            nonEqualExpression,
+            Collections.singletonList("Int32Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT32),
+            null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter6);
+  }
+
+  @Test
+  public void testInt64LiteralAndInt32Column() {
+    // Test INT64 constant ("123") with INT32 column.
+    // Since this logic relies on standard type promotion (INT32 -> INT64) and shares the same
+    // construction path for all operators, verifying one operator (>=) is sufficient.
+    Expression int64Constant = new ConstantOperand(TSDataType.INT64, "123");
+    Expression greaterEqualExpression = new GreaterEqualExpression(int32Column, int64Constant);
+    Filter actualFilter1 =
+        PredicateUtils.convertPredicateToFilter(
+            greaterEqualExpression,
+            Collections.singletonList("Int32Column"),
+            false,
+            getMockTypeProvider(TSDataType.INT32),
+            null);
+    Assert.assertEquals(new LongFilterOperators.ValueGtEq(0, 123), actualFilter1);
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/predicate/TablePredicateConversionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/predicate/TablePredicateConversionTest.java
@@ -1,0 +1,506 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.plan.relational.predicate;
+
+import org.apache.iotdb.db.queryengine.plan.analyze.PredicateUtils;
+import org.apache.iotdb.db.queryengine.plan.relational.metadata.ColumnSchema;
+import org.apache.iotdb.db.queryengine.plan.relational.planner.Symbol;
+import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.ComparisonExpression;
+import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.DoubleLiteral;
+import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Expression;
+import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.LongLiteral;
+import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.SymbolReference;
+
+import org.apache.tsfile.read.common.type.IntType;
+import org.apache.tsfile.read.common.type.LongType;
+import org.apache.tsfile.read.filter.basic.Filter;
+import org.apache.tsfile.read.filter.operator.FalseLiteralFilter;
+import org.apache.tsfile.read.filter.operator.LongFilterOperators;
+import org.apache.tsfile.read.filter.operator.ValueIsNotNullOperator;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.apache.iotdb.commons.schema.table.column.TsTableColumnCategory.FIELD;
+
+public class TablePredicateConversionTest {
+
+  SymbolReference int64Column = new SymbolReference("int64Column");
+  Map<String, Integer> int64MeasurementColumnsIndexMap = Collections.singletonMap("int64Column", 0);
+  Map<Symbol, ColumnSchema> int64SchemaMap =
+      Collections.singletonMap(
+          new Symbol("int64Column"), new ColumnSchema("int64Column", LongType.INT64, false, FIELD));
+
+  SymbolReference int32Column = new SymbolReference("int32Column");
+  Map<String, Integer> int32MeasurementColumnsIndexMap = Collections.singletonMap("int32Column", 0);
+  Map<Symbol, ColumnSchema> int32SchemaMap =
+      Collections.singletonMap(
+          new Symbol("int32Column"), new ColumnSchema("int32Column", IntType.INT32, false, FIELD));
+
+  @Test
+  public void testDoubleLiteralAndInt64Column() {
+
+    // 1. GreaterEqual (>=): int64 >= 123.3 -> int64 >= 124 (ceil)
+    // Result: ValueGtEq(124)
+    DoubleLiteral doubleLiteral = new DoubleLiteral("123.3");
+    Expression predicate1 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.GREATER_THAN_OR_EQUAL, int64Column, doubleLiteral);
+
+    Filter actualFilter1 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate1, int64MeasurementColumnsIndexMap, int64SchemaMap, null, null, null);
+    Assert.assertEquals(new LongFilterOperators.ValueGtEq(0, 124), actualFilter1);
+
+    // 2. LessThanOrEqual (<=): int64 <= 123.3 -> int64 <= 123 (floor)
+    // Result: ValueLtEq(123)
+    Expression predicate2 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.LESS_THAN_OR_EQUAL, int64Column, doubleLiteral);
+    Filter actualFilter2 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate2, int64MeasurementColumnsIndexMap, int64SchemaMap, null, null, null);
+    Assert.assertEquals(new LongFilterOperators.ValueLtEq(0, 123), actualFilter2);
+
+    // 3. GreaterThan (>): int64 > 123.3 -> int64 > 123 (floor)
+    // Result: ValueGt(123)
+    Expression predicate3 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.GREATER_THAN, int64Column, doubleLiteral);
+    Filter actualFilter3 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate3, int64MeasurementColumnsIndexMap, int64SchemaMap, null, null, null);
+    Assert.assertEquals(new LongFilterOperators.ValueGt(0, 123), actualFilter3);
+
+    // 4. LessThan (<): int64 < 123.3 -> int64 < 124 (ceil)
+    // Result: ValueLt(124)
+    Expression predicate4 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.LESS_THAN, int64Column, doubleLiteral);
+    Filter actualFilter4 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate4, int64MeasurementColumnsIndexMap, int64SchemaMap, null, null, null);
+    Assert.assertEquals(new LongFilterOperators.ValueLt(0, 124), actualFilter4);
+
+    // 5. Equal (=): int64 = 123.3 -> Impossible for int64
+    // Result: FalseLiteralFilter (Always False)
+    Expression predicate5 =
+        new ComparisonExpression(ComparisonExpression.Operator.EQUAL, int64Column, doubleLiteral);
+    Filter actualFilter5 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate5, int64MeasurementColumnsIndexMap, int64SchemaMap, null, null, null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter5);
+
+    // 6. NotEqual (!=): int64 != 123.3
+    // Result: ValueIsNotNullOperator (Always True, as long as value exists)
+    Expression predicate6 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.NOT_EQUAL, int64Column, doubleLiteral);
+    Filter actualFilter6 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate6, int64MeasurementColumnsIndexMap, int64SchemaMap, null, null, null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter6);
+  }
+
+  @Test
+  public void testNegativeDoubleLiteralAndInt64Column() {
+    DoubleLiteral doubleLiteral = new DoubleLiteral("-123.3");
+
+    // 1. GreaterEqual (>=): int64 >= -123.3 -> int64 >= -123 (ceil)
+    // Result: ValueGtEq(-123)
+    Expression predicate1 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.GREATER_THAN_OR_EQUAL, int64Column, doubleLiteral);
+    Filter actualFilter1 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate1, int64MeasurementColumnsIndexMap, int64SchemaMap, null, null, null);
+    Assert.assertEquals(new LongFilterOperators.ValueGtEq(0, -123), actualFilter1);
+
+    // 2. LessThanOrEqual (<=): int64 <= -123.3 -> int64 <= -124 (floor)
+    // Result: ValueLtEq(-124)
+    Expression predicate2 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.LESS_THAN_OR_EQUAL, int64Column, doubleLiteral);
+    Filter actualFilter2 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate2, int64MeasurementColumnsIndexMap, int64SchemaMap, null, null, null);
+    Assert.assertEquals(new LongFilterOperators.ValueLtEq(0, -124), actualFilter2);
+
+    // 3. GreaterThan (>): int64 > -123.3 -> int64 > -124 (floor)
+    // Note: > -124 (integer) is logically equivalent to >= -123
+    // Result: ValueGt(-124)
+    Expression predicate3 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.GREATER_THAN, int64Column, doubleLiteral);
+    Filter actualFilter3 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate3, int64MeasurementColumnsIndexMap, int64SchemaMap, null, null, null);
+    Assert.assertEquals(new LongFilterOperators.ValueGt(0, -124), actualFilter3);
+
+    // 4. LessThan (<): int64 < -123.3 -> int64 < -123 (ceil)
+    // Note: < -123 (integer) is logically equivalent to <= -124
+    // Result: ValueLt(-123)
+    Expression predicate4 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.LESS_THAN, int64Column, doubleLiteral);
+    Filter actualFilter4 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate4, int64MeasurementColumnsIndexMap, int64SchemaMap, null, null, null);
+    Assert.assertEquals(new LongFilterOperators.ValueLt(0, -123), actualFilter4);
+
+    // 5. Equal (=): int64 = -123.3 -> Impossible for int64
+    // Result: FalseLiteralFilter (Always False)
+    Expression predicate5 =
+        new ComparisonExpression(ComparisonExpression.Operator.EQUAL, int64Column, doubleLiteral);
+    Filter actualFilter5 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate5, int64MeasurementColumnsIndexMap, int64SchemaMap, null, null, null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter5);
+
+    // 6. NotEqual (!=): int64 != -123.3
+    // Result: ValueIsNotNullOperator (Always True, as long as value exists)
+    Expression predicate6 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.NOT_EQUAL, int64Column, doubleLiteral);
+    Filter actualFilter6 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate6, int64MeasurementColumnsIndexMap, int64SchemaMap, null, null, null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter6);
+  }
+
+  @Test
+  public void testDoubleLiteralOverLongMaxAndInt64Column() {
+    // Long.MAX_VALUE is approximately 9.22E18.
+    // We use "1.0E19" which is definitely greater than Long.MAX_VALUE.
+    DoubleLiteral outPositiveRangeDoubleConstant = new DoubleLiteral("1.0E19");
+    Map<String, Integer> measurementColumnsIndexMap = Collections.singletonMap("int64Column", 0);
+
+    // 1. GreaterEqual (>=): int64 >= 1.0E19
+    // Result: FalseLiteralFilter (Always False)
+    Expression predicate1 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.GREATER_THAN_OR_EQUAL,
+            int64Column,
+            outPositiveRangeDoubleConstant);
+    Filter actualFilter1 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate1, measurementColumnsIndexMap, int64SchemaMap, null, null, null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter1);
+
+    // 2. LessThanOrEqual (<=): int64 <= 1.0E19
+    // Result: ValueIsNotNullOperator (Always True, as long as value exists)
+    Expression predicate2 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.LESS_THAN_OR_EQUAL,
+            int64Column,
+            outPositiveRangeDoubleConstant);
+    Filter actualFilter2 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate2, measurementColumnsIndexMap, int64SchemaMap, null, null, null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter2);
+
+    // 3. GreaterThan (>): int64 > 1.0E19
+    // Result: FalseLiteralFilter
+    Expression predicate3 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.GREATER_THAN,
+            int64Column,
+            outPositiveRangeDoubleConstant);
+    Filter actualFilter3 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate3, measurementColumnsIndexMap, int64SchemaMap, null, null, null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter3);
+
+    // 4. LessThan (<): int64 < 1.0E19
+    // Result: ValueIsNotNullOperator
+    Expression predicate4 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.LESS_THAN, int64Column, outPositiveRangeDoubleConstant);
+    Filter actualFilter4 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate4, measurementColumnsIndexMap, int64SchemaMap, null, null, null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter4);
+
+    // 5. Equal (=): int64 = 1.0E19
+    // Result: FalseLiteralFilter
+    Expression predicate5 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.EQUAL, int64Column, outPositiveRangeDoubleConstant);
+    Filter actualFilter5 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate5, measurementColumnsIndexMap, int64SchemaMap, null, null, null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter5);
+
+    // 6. NotEqual (!=): int64 != 1.0E19
+    // Result: ValueIsNotNullOperator
+    Expression predicate6 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.NOT_EQUAL, int64Column, outPositiveRangeDoubleConstant);
+    Filter actualFilter6 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate6, measurementColumnsIndexMap, int64SchemaMap, null, null, null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter6);
+  }
+
+  @Test
+  public void testDoubleLiteralUnderLongMinAndInt64Column() {
+    // Long.MIN_VALUE is approximately -9.22E18.
+    // We use "-1.0E19" which is definitely smaller than Long.MIN_VALUE.
+    DoubleLiteral outNegativeRangeDoubleConstant = new DoubleLiteral("-1.0E19");
+    Map<String, Integer> measurementColumnsIndexMap = Collections.singletonMap("int64Column", 0);
+
+    // 1. GreaterEqual (>=): int64 >= -1.0E19
+    // Result: ValueIsNotNullOperator (Always True, as long as value exists)
+    Expression predicate1 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.GREATER_THAN_OR_EQUAL,
+            int64Column,
+            outNegativeRangeDoubleConstant);
+    Filter actualFilter1 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate1, measurementColumnsIndexMap, int64SchemaMap, null, null, null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter1);
+
+    // 2. LessThanOrEqual (<=): int64 <= -1.0E19
+    // Result: FalseLiteralFilter (Always False)
+    Expression predicate2 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.LESS_THAN_OR_EQUAL,
+            int64Column,
+            outNegativeRangeDoubleConstant);
+    Filter actualFilter2 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate2, measurementColumnsIndexMap, int64SchemaMap, null, null, null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter2);
+
+    // 3. GreaterThan (>): int64 > -1.0E19
+    // Result: ValueIsNotNullOperator
+    Expression predicate3 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.GREATER_THAN,
+            int64Column,
+            outNegativeRangeDoubleConstant);
+    Filter actualFilter3 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate3, measurementColumnsIndexMap, int64SchemaMap, null, null, null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter3);
+
+    // 4. LessThan (<): int64 < -1.0E19
+    // Result: FalseLiteralFilter
+    Expression predicate4 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.LESS_THAN, int64Column, outNegativeRangeDoubleConstant);
+    Filter actualFilter4 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate4, measurementColumnsIndexMap, int64SchemaMap, null, null, null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter4);
+
+    // 5. Equal (=): int64 = -1.0E19
+    // Result: FalseLiteralFilter
+    Expression predicate5 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.EQUAL, int64Column, outNegativeRangeDoubleConstant);
+    Filter actualFilter5 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate5, measurementColumnsIndexMap, int64SchemaMap, null, null, null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter5);
+
+    // 6. NotEqual (!=): int64 != -1.0E19
+    // Result: ValueIsNotNullOperator
+    Expression predicate6 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.NOT_EQUAL, int64Column, outNegativeRangeDoubleConstant);
+    Filter actualFilter6 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate6, measurementColumnsIndexMap, int64SchemaMap, null, null, null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter6);
+  }
+
+  @Test
+  public void testDoubleLiteralOverIntegerMaxAndInt32Column() {
+    // Integer.MAX_VALUE is approximately 2.14E9.
+    // We use "3.0E9" which is definitely greater than Integer.MAX_VALUE.
+    DoubleLiteral outPositiveRangeDoubleConstant = new DoubleLiteral("3.0E9");
+    Map<String, Integer> measurementColumnsIndexMap = Collections.singletonMap("int32Column", 0);
+
+    // 1. GreaterEqual (>=): int32 >= 3.0E9
+    // Result: FalseLiteralFilter (Always False)
+    Expression predicate1 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.GREATER_THAN_OR_EQUAL,
+            int32Column,
+            outPositiveRangeDoubleConstant);
+    Filter actualFilter1 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate1, measurementColumnsIndexMap, int32SchemaMap, null, null, null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter1);
+
+    // 2. LessThanOrEqual (<=): int32 <= 3.0E9
+    // Result: ValueIsNotNullOperator (Always True, as long as value exists)
+    Expression predicate2 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.LESS_THAN_OR_EQUAL,
+            int32Column,
+            outPositiveRangeDoubleConstant);
+    Filter actualFilter2 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate2, measurementColumnsIndexMap, int32SchemaMap, null, null, null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter2);
+
+    // 3. GreaterThan (>): int32 > 3.0E9
+    // Result: FalseLiteralFilter
+    Expression predicate3 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.GREATER_THAN,
+            int32Column,
+            outPositiveRangeDoubleConstant);
+    Filter actualFilter3 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate3, measurementColumnsIndexMap, int32SchemaMap, null, null, null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter3);
+
+    // 4. LessThan (<): int32 < 3.0E9
+    // Result: ValueIsNotNullOperator
+    Expression predicate4 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.LESS_THAN, int32Column, outPositiveRangeDoubleConstant);
+    Filter actualFilter4 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate4, measurementColumnsIndexMap, int32SchemaMap, null, null, null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter4);
+
+    // 5. Equal (=): int32 = 3.0E9
+    // Result: FalseLiteralFilter
+    Expression predicate5 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.EQUAL, int32Column, outPositiveRangeDoubleConstant);
+    Filter actualFilter5 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate5, measurementColumnsIndexMap, int32SchemaMap, null, null, null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter5);
+
+    // 6. NotEqual (!=): int32 != 3.0E9
+    // Result: ValueIsNotNullOperator
+    Expression predicate6 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.NOT_EQUAL, int32Column, outPositiveRangeDoubleConstant);
+    Filter actualFilter6 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate6, measurementColumnsIndexMap, int32SchemaMap, null, null, null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter6);
+  }
+
+  @Test
+  public void testDoubleLiteralUnderIntegerMinAndInt32Column() {
+    // Integer.MIN_VALUE is approximately -2.14E9.
+    // We use "-3.0E9" which is definitely smaller than Integer.MIN_VALUE.
+    DoubleLiteral outNegativeRangeDoubleConstant = new DoubleLiteral("-3.0E9");
+
+    // 1. GreaterEqual (>=): int32 >= -3.0E9
+    // Result: ValueIsNotNullOperator (Always True, as long as value exists)
+    Expression predicate1 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.GREATER_THAN_OR_EQUAL,
+            int32Column,
+            outNegativeRangeDoubleConstant);
+    Filter actualFilter1 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate1, int32MeasurementColumnsIndexMap, int32SchemaMap, null, null, null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter1);
+
+    // 2. LessThanOrEqual (<=): int32 <= -3.0E9
+    // Result: FalseLiteralFilter (Always False)
+    Expression predicate2 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.LESS_THAN_OR_EQUAL,
+            int32Column,
+            outNegativeRangeDoubleConstant);
+    Filter actualFilter2 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate2, int32MeasurementColumnsIndexMap, int32SchemaMap, null, null, null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter2);
+
+    // 3. GreaterThan (>): int32 > -3.0E9
+    // Result: ValueIsNotNullOperator
+    Expression predicate3 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.GREATER_THAN,
+            int32Column,
+            outNegativeRangeDoubleConstant);
+    Filter actualFilter3 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate3, int32MeasurementColumnsIndexMap, int32SchemaMap, null, null, null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter3);
+
+    // 4. LessThan (<): int32 < -3.0E9
+    // Result: FalseLiteralFilter
+    Expression predicate4 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.LESS_THAN, int32Column, outNegativeRangeDoubleConstant);
+    Filter actualFilter4 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate4, int32MeasurementColumnsIndexMap, int32SchemaMap, null, null, null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter4);
+
+    // 5. Equal (=): int32 = -3.0E9
+    // Result: FalseLiteralFilter
+    Expression predicate5 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.EQUAL, int32Column, outNegativeRangeDoubleConstant);
+    Filter actualFilter5 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate5, int32MeasurementColumnsIndexMap, int32SchemaMap, null, null, null);
+    Assert.assertEquals(new FalseLiteralFilter(), actualFilter5);
+
+    // 6. NotEqual (!=): int32 != -3.0E9
+    // Result: ValueIsNotNullOperator
+    Expression predicate6 =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.NOT_EQUAL, int32Column, outNegativeRangeDoubleConstant);
+    Filter actualFilter6 =
+        PredicateUtils.convertPredicateToFilter(
+            predicate6, int32MeasurementColumnsIndexMap, int32SchemaMap, null, null, null);
+    Assert.assertEquals(new ValueIsNotNullOperator(0), actualFilter6);
+  }
+
+  @Test
+  public void testInt64LiteralAndInt32Column() {
+    // Test INT64 constant ("123") with INT32 column.
+    // Since this logic relies on standard type promotion (INT32 -> INT64) and shares the same
+    // construction path for all operators, verifying one operator (>=) is sufficient.
+    LongLiteral int64Constant = new LongLiteral("123");
+
+    // int32Column >= 123 (Long)
+    // result: LongFilterOperators.ValueGtEq(123)
+    Expression predicate =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.GREATER_THAN_OR_EQUAL,
+            new SymbolReference("int32Column"),
+            int64Constant);
+
+    Filter actualFilter =
+        PredicateUtils.convertPredicateToFilter(
+            predicate, int32MeasurementColumnsIndexMap, int32SchemaMap, null, null, null);
+
+    Assert.assertEquals(new LongFilterOperators.ValueGtEq(0, 123), actualFilter);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
         <thrift.version>0.14.1</thrift.version>
         <xz.version>1.9</xz.version>
         <zstd-jni.version>1.5.6-3</zstd-jni.version>
-        <tsfile.version>2.2.0-251210-SNAPSHOT</tsfile.version>
+        <tsfile.version>2.2.0-251218-SNAPSHOT</tsfile.version>
     </properties>
     <!--
     if we claim dependencies in dependencyManagement, then we do not claim


### PR DESCRIPTION
1. Supported DoubleLiteral and LongLiteral comparisons for INT32 and INT64 columns. Implemented precise rounding logic (ceil/floor) for doubles and handled overflow scenarios 
2. introduce tsfile version: 2.2.0-251216-SNAPSHOT, update interfaces provided by tsfile