### PR TITLE
Bump version to 2.0.7-SNAPSHOT

### DIFF
--- a/code-coverage/pom.xml
+++ b/code-coverage/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-parent</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-code-coverage</artifactId>
     <packaging>pom</packaging>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-parent</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-distribution</artifactId>
     <packaging>pom</packaging>
@@ -33,25 +33,25 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-server</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
             <type>zip</type>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-cli</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
             <type>zip</type>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-confignode</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
             <type>zip</type>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>library-udf</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <build>
@@ -174,7 +174,7 @@
                 <dependency>
                     <groupId>org.apache.iotdb</groupId>
                     <artifactId>iotdb-ainode</artifactId>
-                    <version>2.0.6-SNAPSHOT</version>
+                    <version>2.0.7-SNAPSHOT</version>
                 </dependency>
             </dependencies>
             <build>

--- a/example/client-cpp-example/pom.xml
+++ b/example/client-cpp-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-examples</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>client-cpp-example</artifactId>
     <name>IoTDB: Example: CPP Client</name>

--- a/example/jdbc/pom.xml
+++ b/example/jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-examples</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>jdbc-example</artifactId>
     <name>IoTDB: Example: JDBC</name>

--- a/example/mqtt-customize/pom.xml
+++ b/example/mqtt-customize/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-examples</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>customize-mqtt-example</artifactId>
     <name>IoTDB: Example: Customized MQTT</name>

--- a/example/mqtt/pom.xml
+++ b/example/mqtt/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-examples</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>mqtt-example</artifactId>
     <name>IoTDB: Example: MQTT</name>

--- a/example/pipe-count-point-processor/pom.xml
+++ b/example/pipe-count-point-processor/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-examples</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>pipe-count-point-processor-example</artifactId>
     <name>IoTDB: Example: Pipe: Count Point Processor</name>

--- a/example/pipe-opc-ua-sink/pom.xml
+++ b/example/pipe-opc-ua-sink/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-examples</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pipe-opc-ua-sink-example</artifactId>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-parent</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-examples</artifactId>
     <packaging>pom</packaging>

--- a/example/rest-java-example/pom.xml
+++ b/example/rest-java-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-examples</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>rest-java-example</artifactId>
     <name>IoTDB: Example: Java Rest</name>

--- a/example/schema/pom.xml
+++ b/example/schema/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>iotdb-examples</artifactId>
         <groupId>org.apache.iotdb</groupId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>schema-example</artifactId>
     <name>IoTDB: Example: Schema</name>

--- a/example/session/pom.xml
+++ b/example/session/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-examples</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>client-example</artifactId>
     <name>IoTDB: Example: Session Client</name>

--- a/example/trigger/pom.xml
+++ b/example/trigger/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-examples</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>trigger-example</artifactId>
     <name>IoTDB: Example: Trigger</name>

--- a/example/udf/pom.xml
+++ b/example/udf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-examples</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>udf-example</artifactId>
     <name>IoTDB: Example: UDF</name>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-parent</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>integration-test</artifactId>
     <name>IoTDB: Integration-Test</name>
@@ -87,47 +87,47 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-server</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-session</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-jdbc</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>trigger-api</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>isession</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-confignode</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>node-commons</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tsfile</groupId>
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>udf-api</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
@@ -147,7 +147,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-consensus</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -168,17 +168,17 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-confignode</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-cli</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
@@ -204,7 +204,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-server</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/iotdb-api/external-api/pom.xml
+++ b/iotdb-api/external-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-api</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>external-api</artifactId>
     <name>IoTDB: API: External API</name>

--- a/iotdb-api/pipe-api/pom.xml
+++ b/iotdb-api/pipe-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-api</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>pipe-api</artifactId>
     <name>IoTDB: API: Pipe API</name>

--- a/iotdb-api/pom.xml
+++ b/iotdb-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-parent</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-api</artifactId>
     <packaging>pom</packaging>

--- a/iotdb-api/trigger-api/pom.xml
+++ b/iotdb-api/trigger-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-api</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>trigger-api</artifactId>
     <name>IoTDB: API: Trigger API</name>

--- a/iotdb-api/udf-api/pom.xml
+++ b/iotdb-api/udf-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-api</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>udf-api</artifactId>
     <name>IoTDB: API: UDF API</name>

--- a/iotdb-client/cli/pom.xml
+++ b/iotdb-client/cli/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-client</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-cli</artifactId>
     <name>IoTDB: Client: CLI</name>
@@ -37,37 +37,37 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-session</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-jdbc</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-antlr</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>node-commons</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-server</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>isession</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tsfile</groupId>
@@ -82,17 +82,17 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>pipe-api</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/iotdb-client/client-cpp/pom.xml
+++ b/iotdb-client/client-cpp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-client</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>client-cpp</artifactId>
     <packaging>pom</packaging>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/iotdb-client/client-py/pom.xml
+++ b/iotdb-client/client-py/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-client</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-python-api</artifactId>
     <name>IoTDB: Client: Python-API</name>
@@ -34,19 +34,19 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-confignode</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/iotdb-client/isession/pom.xml
+++ b/iotdb-client/isession/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-client</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>isession</artifactId>
     <name>IoTDB: Client: isession</name>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tsfile</groupId>
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.thrift</groupId>

--- a/iotdb-client/jdbc/pom.xml
+++ b/iotdb-client/jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-client</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-jdbc</artifactId>
     <name>IoTDB: Client: Jdbc</name>
@@ -38,12 +38,12 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tsfile</groupId>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.thrift</groupId>

--- a/iotdb-client/pom.xml
+++ b/iotdb-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-parent</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-client</artifactId>
     <packaging>pom</packaging>

--- a/iotdb-client/service-rpc/pom.xml
+++ b/iotdb-client/service-rpc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-client</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>service-rpc</artifactId>
     <name>IoTDB: Client: Service-RPC</name>
@@ -60,12 +60,12 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.thrift</groupId>

--- a/iotdb-client/session/pom.xml
+++ b/iotdb-client/session/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-client</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-session</artifactId>
     <name>IoTDB: Client: Session</name>
@@ -37,17 +37,17 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>isession</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tsfile</groupId>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/iotdb-core/ainode/pom.xml
+++ b/iotdb-core/ainode/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-core</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-ainode</artifactId>
     <name>IoTDB: Core: AINode</name>
@@ -33,31 +33,31 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-confignode</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-ainode</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-python-api</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/iotdb-core/antlr/pom.xml
+++ b/iotdb-core/antlr/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-core</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-antlr</artifactId>
     <name>IoTDB: Core: Antlr-Parser</name>

--- a/iotdb-core/confignode/pom.xml
+++ b/iotdb-core/confignode/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-core</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-confignode</artifactId>
     <name>IoTDB: Core: ConfigNode</name>
@@ -42,62 +42,62 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-consensus</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-server</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>pipe-api</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>trigger-api</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>metrics-interface</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-confignode</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-ainode</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>node-commons</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>udf-api</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tsfile</groupId>

--- a/iotdb-core/consensus/pom.xml
+++ b/iotdb-core/consensus/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-core</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-consensus</artifactId>
     <name>IoTDB: Core: Consensus</name>
@@ -39,32 +39,32 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>node-commons</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>metrics-interface</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-consensus</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>pipe-api</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.ratis</groupId>

--- a/iotdb-core/datanode/pom.xml
+++ b/iotdb-core/datanode/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-core</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-server</artifactId>
     <name>IoTDB: Core: Data-Node (Server)</name>
@@ -37,12 +37,12 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-consensus</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tsfile</groupId>
@@ -57,82 +57,82 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>external-api</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>openapi</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>node-commons</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>isession</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-antlr</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-relational-grammar</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-consensus</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>udf-api</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>trigger-api</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>metrics-interface</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-confignode</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-ainode</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>pipe-api</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-session</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.airlift</groupId>
@@ -301,7 +301,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/iotdb-core/metrics/core/pom.xml
+++ b/iotdb-core/metrics/core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-metrics</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>metrics-core</artifactId>
     <name>IoTDB: Core: Metrics: API Impl</name>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>metrics-interface</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>

--- a/iotdb-core/metrics/interface/pom.xml
+++ b/iotdb-core/metrics/interface/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-metrics</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>metrics-interface</artifactId>
     <name>IoTDB: Core: Metrics: Metrics API</name>
@@ -33,17 +33,17 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-session</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>isession</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tsfile</groupId>

--- a/iotdb-core/metrics/pom.xml
+++ b/iotdb-core/metrics/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-core</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-metrics</artifactId>
     <packaging>pom</packaging>

--- a/iotdb-core/node-commons/pom.xml
+++ b/iotdb-core/node-commons/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-core</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>node-commons</artifactId>
     <name>IoTDB: Core: Node Commons</name>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tsfile</groupId>
@@ -48,42 +48,42 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>udf-api</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>trigger-api</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>pipe-api</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-confignode</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-ainode</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-consensus</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tsfile</groupId>
@@ -93,12 +93,12 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>metrics-interface</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>

--- a/iotdb-core/pom.xml
+++ b/iotdb-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-parent</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-core</artifactId>
     <packaging>pom</packaging>

--- a/iotdb-core/relational-grammar/pom.xml
+++ b/iotdb-core/relational-grammar/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-core</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-relational-grammar</artifactId>
     <name>IoTDB: Core: Relational-Antlr-Parser</name>

--- a/iotdb-protocol/openapi/pom.xml
+++ b/iotdb-protocol/openapi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-protocol</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>openapi</artifactId>
     <name>IoTDB: Protocol: OpenAPI</name>

--- a/iotdb-protocol/pom.xml
+++ b/iotdb-protocol/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-parent</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-protocol</artifactId>
     <packaging>pom</packaging>

--- a/iotdb-protocol/thrift-ainode/pom.xml
+++ b/iotdb-protocol/thrift-ainode/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-protocol</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-thrift-ainode</artifactId>
     <name>IoTDB: Protocol: Thrift AI Node</name>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <build>

--- a/iotdb-protocol/thrift-commons/pom.xml
+++ b/iotdb-protocol/thrift-commons/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-protocol</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-thrift-commons</artifactId>
     <name>IoTDB: Protocol: Thrift Commons</name>

--- a/iotdb-protocol/thrift-confignode/pom.xml
+++ b/iotdb-protocol/thrift-confignode/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-protocol</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-thrift-confignode</artifactId>
     <name>IoTDB: Protocol: Thrift Config Node</name>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <build>

--- a/iotdb-protocol/thrift-consensus/pom.xml
+++ b/iotdb-protocol/thrift-consensus/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-protocol</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-thrift-consensus</artifactId>
     <name>IoTDB: Protocol: Thrift Consensus</name>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/iotdb-protocol/thrift-datanode/pom.xml
+++ b/iotdb-protocol/thrift-datanode/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-protocol</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-thrift</artifactId>
     <name>IoTDB: Protocol: Thrift Data Node</name>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.thrift</groupId>

--- a/library-udf/pom.xml
+++ b/library-udf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-parent</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <artifactId>library-udf</artifactId>
     <name>IoTDB: UDF</name>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>udf-api</artifactId>
-            <version>2.0.6-SNAPSHOT</version>
+            <version>2.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     </parent>
     <groupId>org.apache.iotdb</groupId>
     <artifactId>iotdb-parent</artifactId>
-    <version>2.0.6-SNAPSHOT</version>
+    <version>2.0.7-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Apache IoTDB Project Parent POM</name>
     <description>This is the top level project that builds, packages the iotdb engine, client, and integration libs.</description>


### PR DESCRIPTION
This pull request updates the project version across multiple Maven `pom.xml` files from `2.0.6-SNAPSHOT` to `2.0.7-SNAPSHOT`. This ensures all modules and dependencies are aligned with the new development version, maintaining consistency throughout the project.

Version bump and dependency alignment:

* Updated the parent project version to `2.0.7-SNAPSHOT` in all relevant `pom.xml` files, including core modules like `iotdb-parent`, `iotdb-api`, `iotdb-examples`, and `iotdb-distribution`. [[1]](diffhunk://#diff-2bac683d4f72ea93cdf0cca5bc51a2732f966decf0d8cfcd502dbf35b8a9bfa2L27-R27) [[2]](diffhunk://#diff-3cb98b37eefd377c50bd743a0b2628c25a911d6a6ca1b4878621f1fb88758b13L27-R27) [[3]](diffhunk://#diff-c2d84bae59596b964dd1fcbc746a32d835547e5dada7b2df541ff8c666271e43L27-R27) [[4]](diffhunk://#diff-ac19e9d7369629bf473b9b6c514012d5fecc319f98a6b9b57855f3202e970610L27-R27)
* Updated all internal module dependencies to reference `2.0.7-SNAPSHOT` instead of `2.0.6-SNAPSHOT`, ensuring that all submodules and example projects build against the latest snapshot version. This includes modules such as `iotdb-server`, `iotdb-cli`, `iotdb-confignode`, `library-udf`, `iotdb-ainode`, and others in files like `distribution/pom.xml` and `integration-test/pom.xml`. [[1]](diffhunk://#diff-ac19e9d7369629bf473b9b6c514012d5fecc319f98a6b9b57855f3202e970610L36-R54) [[2]](diffhunk://#diff-ac19e9d7369629bf473b9b6c514012d5fecc319f98a6b9b57855f3202e970610L177-R177) [[3]](diffhunk://#diff-33f20ab05600d4770fb6debcaa4a32e507014ada70de812cfd58e2aadf42b852L90-R130) [[4]](diffhunk://#diff-33f20ab05600d4770fb6debcaa4a32e507014ada70de812cfd58e2aadf42b852L140-R140) [[5]](diffhunk://#diff-33f20ab05600d4770fb6debcaa4a32e507014ada70de812cfd58e2aadf42b852L150-R150) [[6]](diffhunk://#diff-33f20ab05600d4770fb6debcaa4a32e507014ada70de812cfd58e2aadf42b852L171-R181) [[7]](diffhunk://#diff-33f20ab05600d4770fb6debcaa4a32e507014ada70de812cfd58e2aadf42b852L207-R207)
* Updated example project parent references and dependencies to use the new version, including modules under `example/` such as `client-cpp-example`, `jdbc`, `mqtt`, `pipe-count-point-processor`, `pipe-opc-ua-sink`, `rest-java-example`, `schema`, `session`, `trigger`, and `udf`. [[1]](diffhunk://#diff-3c4ae5e822aafcf73a3078a09fb23f50f041610f38262a7d8aa06e8aa08d14c4L27-R27) [[2]](diffhunk://#diff-e94d4ed5d35cdc5f3ff28653aab8f62bdb4a9d3a6f97200560085ba2b069b38cL27-R27) [[3]](diffhunk://#diff-714d36e51cfa6c42f8dabd85bde3f6971c0438024760be3e753fb29f5131059dL27-R27) [[4]](diffhunk://#diff-e188f13d226041ad6c92944301f7b765045600f2a9c49fec381ba942660c0246L27-R27) [[5]](diffhunk://#diff-1c0fc3420dba8661bfd5de18586c85fee70be63c5d68bc83f57a4f460639e01eL27-R27) [[6]](diffhunk://#diff-6911d3ae06a53e4abd4caf85fd73a0738a9edc11c3b50560d509cc13ef8586c4L26-R26) [[7]](diffhunk://#diff-cf7c357324cbbba3cf36cec1513a71aa1aabd39e79094b6365c9a48f337d1e5fL27-R27) [[8]](diffhunk://#diff-4f2b7eb2178f2c53ec7b83425375cc70ce32e9a421e8108107850c8a523b1326L27-R27) [[9]](diffhunk://#diff-361c52360af5d0ab2b056e5e939a1d1be8c8fd6e86a004192bee90361b307850L27-R27) [[10]](diffhunk://#diff-cadbc76260ce30f24187882952934cb1434d9f766f4eb5eab1cd0a350448c1cfL27-R27) [[11]](diffhunk://#diff-866e4d83c0ade8bf3ddf7d385617698ef301fae976fbe0b4af0b2afa42a25260L27-R27)
* Updated API modules and their dependencies to reference `2.0.7-SNAPSHOT`, including `external-api`, `pipe-api`, `trigger-api`, and `udf-api`. [[1]](diffhunk://#diff-8e1ff88042f2d7668761b4000e80c14bf689e91715901fcfdb4bac0f866ae705L27-R27) [[2]](diffhunk://#diff-0dff18d45822b20d0bca6dae81f30e5c053fc11bf67e9f30d7e8d39f86e6887fL27-R27) [[3]](diffhunk://#diff-9dc9ac6e96f1cbf7a6f4f9be7440fff6709a37161873c5a2fead2a00e60c0908L27-R27) [[4]](diffhunk://#diff-2e5a23ce09d92444c9b9290f4163bd92f5d56946aa3d60dc4b703a915d3e0242L27-R27)

These changes are necessary for the next development cycle and to avoid version conflicts during builds and dependency resolution.