### PR TITLE
Correct the getObjectPathFromBinary method in ObjectTypeUtils

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/ObjectTypeUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/ObjectTypeUtils.java
@@ -37,7 +37,6 @@ import org.apache.iotdb.db.storageengine.rescon.disk.TierManager;
 import org.apache.iotdb.mpp.rpc.thrift.TReadObjectReq;
 import org.apache.iotdb.rpc.TSStatusCode;
 
-import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.encoding.decoder.Decoder;
 import org.apache.tsfile.encoding.decoder.DecoderWrapper;
 import org.apache.tsfile.utils.Binary;
@@ -262,14 +261,10 @@ public class ObjectTypeUtils {
   }
 
   public static Optional<File> getObjectPathFromBinary(Binary binary) {
-    byte[] bytes = binary.getValues();
-    String relativeObjectFilePath =
-        new String(bytes, 8, bytes.length - 8, TSFileConfig.STRING_CHARSET);
-    return TIER_MANAGER.getAbsoluteObjectFilePath(relativeObjectFilePath);
+    return getObjectPathFromBinary(binary, false);
   }
 
-  public static Optional<File> getNullableObjectPathFromBinary(
-      Binary binary, boolean needTempFile) {
+  public static Optional<File> getObjectPathFromBinary(Binary binary, boolean needTempFile) {
     byte[] bytes = binary.getValues();
     ByteBuffer buffer = ByteBuffer.wrap(bytes, 8, bytes.length - 8);
     String relativeObjectFilePath =
@@ -278,7 +273,7 @@ public class ObjectTypeUtils {
   }
 
   public static void deleteObjectPathFromBinary(Binary binary) {
-    Optional<File> file = ObjectTypeUtils.getNullableObjectPathFromBinary(binary, true);
+    Optional<File> file = ObjectTypeUtils.getObjectPathFromBinary(binary, true);
     if (!file.isPresent()) {
       return;
     }


### PR DESCRIPTION
This pull request refactors methods related to retrieving file paths from `Binary` objects in the `ObjectTypeUtils` class to simplify and clarify their usage. The main focus is to consolidate redundant methods and update their usage throughout the codebase.

**Refactoring of file path retrieval methods:**

* The `getObjectPathFromBinary(Binary binary)` method now delegates to a new overloaded method that accepts a `needTempFile` parameter, improving code clarity and reducing duplication.
* The previously used `getNullableObjectPathFromBinary` method has been removed in favor of the new `getObjectPathFromBinary(Binary binary, boolean needTempFile)` method, streamlining the API.
* All internal usages, such as in `deleteObjectPathFromBinary`, have been updated to use the new method signature.

**Minor cleanup:**

* Removed an unused import of `TSFileConfig` from the file.