### PR TITLE
Fix sync objectNode error log

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/ObjectNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/ObjectNode.java
@@ -284,8 +284,8 @@ public class ObjectNode extends SearchNode implements WALEntryValue {
           }
         }
       }
-      if (!readSuccess) {
-        LOGGER.error("Error when read tmp object file {}.", filePath.toString(), ioException);
+      if (!readSuccess && LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Error when read object file {}.", filePath.toString(), ioException);
       }
       ReadWriteIOUtils.write(readSuccess && isEOF, stream);
       ReadWriteIOUtils.write(offset, stream);


### PR DESCRIPTION
## Description
When sync ObjectNode between datanodes, some unnecessary error logs may be printed. 

![img_v3_02t7_e83e2569-acc9-4649-949b-b1325255ccag](https://github.com/user-attachments/assets/04b3b7ea-453c-4323-96f8-c8babcd5696c)
