### PR TITLE
Support objectLength in Record interface of udf-api

### DIFF
--- a/iotdb-api/udf-api/src/main/java/org/apache/iotdb/udf/api/relational/access/Record.java
+++ b/iotdb-api/udf-api/src/main/java/org/apache/iotdb/udf/api/relational/access/Record.java
@@ -125,6 +125,14 @@ public interface Record {
   Optional<File> getObjectFile(int columnIndex);
 
   /**
+   * Returns the OBJECT value's real file length at the specified column in this row.
+   *
+   * @param columnIndex index of the specified column
+   * @return length of the object
+   */
+  long objectLength(int columnIndex);
+
+  /**
    * Returns the Binary representation of an object stored at the specified column in this row.
    *
    * <p>Users need to ensure that the data type of the specified column is {@code

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/function/partition/Slice.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/function/partition/Slice.java
@@ -220,6 +220,15 @@ public class Slice {
     }
 
     @Override
+    public long objectLength(int columnIndex) {
+      if (getDataType(columnIndex) != Type.OBJECT) {
+        throw new UnsupportedOperationException("current column is not object column");
+      }
+      Binary binary = getBinarySafely(columnIndex);
+      return ObjectTypeUtils.getObjectLength(binary);
+    }
+
+    @Override
     public Binary readObject(int columnIndex, long offset, int length) {
       if (getDataType(columnIndex) != Type.OBJECT) {
         throw new UnsupportedOperationException("current column is not object column");

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/RecordIterator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/RecordIterator.java
@@ -165,6 +165,15 @@ public class RecordIterator implements Iterator<Record> {
     }
 
     @Override
+    public long objectLength(int columnIndex) {
+      if (getDataType(columnIndex) != Type.OBJECT) {
+        throw new UnsupportedOperationException("current column is not object column");
+      }
+      Binary binary = getBinarySafely(columnIndex);
+      return ObjectTypeUtils.getObjectLength(binary);
+    }
+
+    @Override
     public Binary readObject(int columnIndex, long offset, int length) {
       if (getDataType(columnIndex) != Type.OBJECT) {
         throw new UnsupportedOperationException("current column is not object column");

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/function/RecordObjectTypeTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/function/RecordObjectTypeTest.java
@@ -133,6 +133,8 @@ public class RecordObjectTypeTest {
     Optional<File> objectFile = record.getObjectFile(0);
     assertTrue(objectFile.isPresent());
 
+    assertEquals(100L, record.objectLength(0));
+
     assertEquals("(Object) 100 B", record.getString(0));
     Assert.assertFalse(recordIterator.hasNext());
   }


### PR DESCRIPTION
This pull request adds support for retrieving the actual file length of OBJECT-type columns in the `Record` interface and its implementations. It introduces a new `objectLength(int columnIndex)` method, ensures its implementation in relevant classes, and updates tests to verify the new functionality.

**API Enhancements:**

* Added a new method `objectLength(int columnIndex)` to the `Record` interface to return the length of an OBJECT-type column's underlying file.

**Implementation Updates:**

* Implemented the new `objectLength` method in `Slice`, including type checking and delegation to `ObjectTypeUtils.getObjectLength`.
* Implemented the new `objectLength` method in `RecordIterator`, with similar logic for type safety and binary extraction.

**Testing:**

* Updated `RecordObjectTypeTest` to assert that `objectLength` returns the expected value for OBJECT columns.