### PR TITLE
The grant option check for path privileges was not correctly logged in the audit log

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/security/TreeAccessCheckVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/security/TreeAccessCheckVisitor.java
@@ -2004,7 +2004,7 @@ public class TreeAccessCheckVisitor extends StatementVisitor<TSStatus, TreeAcces
                   false,
                   "Has no permission to execute "
                       + privilegeType
-                      + ", please ensure you have these privileges and the grant option is TRUE when granted)");
+                      + ", please ensure you have these privileges and the grant option is TRUE when granted");
           break;
         }
       } else if (privilegeType.isPathPrivilege()) {
@@ -2015,7 +2015,7 @@ public class TreeAccessCheckVisitor extends StatementVisitor<TSStatus, TreeAcces
                   false,
                   "Has no permission to execute "
                       + privilegeType
-                      + ", please ensure you have these privileges and the grant option is TRUE when granted)");
+                      + ", please ensure you have these privileges and the grant option is TRUE when granted");
           break;
         }
       } else {


### PR DESCRIPTION
## Description
The grant option check for path privileges was not correctly logged in the audit log