### PR TITLE
Fix case-sensitive CONTAINS behavior in tag filtering

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/tag/TagManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/tag/TagManager.java
@@ -58,6 +58,8 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.Locale;
+
 
 import static java.util.stream.Collectors.toList;
 
@@ -242,9 +244,12 @@ public class TagManager {
           continue;
         }
         String tagValue = entry.getKey();
-        if (tagValue.contains(tagFilter.getValue())) {
+        if (tagValue
+        .toLowerCase(Locale.ROOT)
+        .contains(tagFilter.getValue().toLowerCase(Locale.ROOT))) {
           allMatchedNodes.addAll(entry.getValue());
         }
+
       }
     } else {
       for (Map.Entry<String, Set<IMeasurementMNode<?>>> entry : value2Node.entrySet()) {


### PR DESCRIPTION
### Description

This PR fixes inconsistent behavior of the `CONTAINS` operator when filtering
timeseries by TAGS.

Previously, `SHOW TIMESERIES WHERE TAGS(k) CONTAINS 'value'` performed
case-sensitive matching, which differed from the case-insensitive behavior
used for timeseries name filtering. This made tag-based metadata searches
less intuitive and required users to know the exact casing of tag values.

This change normalizes tag values during CONTAINS evaluation, making tag
filtering case-insensitive and consistent with other metadata filters.

### Changes
- Updated tag CONTAINS matching logic to be case-insensitive
- Aligned tag filtering semantics with timeseries CONTAINS behavior

### Motivation
- Improves usability of metadata discovery
- Ensures consistent query behavior across schema filters

### Related Issue
Fixes #16876
