### PR TITLE
No need to init TierManager when using TsFileResourcePrinter

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/TsFileResourcePrinter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/tools/TsFileResourcePrinter.java
@@ -50,7 +50,7 @@ public class TsFileResourcePrinter {
       File[] files =
           FSFactoryProducer.getFSFactory()
               .listFilesBySuffix(folderFile.getAbsolutePath(), ".tsfile.resource");
-      Arrays.sort(files, Comparator.comparingLong(x -> Long.valueOf(x.getName().split("-")[0])));
+      Arrays.sort(files, Comparator.comparingLong(x -> Long.parseLong(x.getName().split("-")[0])));
 
       for (File file : files) {
         printResource(file.getAbsolutePath());
@@ -66,7 +66,8 @@ public class TsFileResourcePrinter {
   @SuppressWarnings("squid:S106")
   public static void printResource(String filename) throws IOException {
     filename = filename.substring(0, filename.length() - 9);
-    TsFileResource resource = new TsFileResource(SystemFileFactory.INSTANCE.getFile(filename));
+    TsFileResource resource = new TsFileResource();
+    resource.setFile(SystemFileFactory.INSTANCE.getFile(filename));
     System.out.printf("Analyzing %s ...%n", filename);
     System.out.println();
     resource.deserialize();


### PR DESCRIPTION
## Description

There is an error when using TsFileResourcePrinter. 
![img_v3_02to_46a114cc-a5b1-4ee9-ad64-478e2e76710g](https://github.com/user-attachments/assets/52293a74-2faa-4626-aded-316eda06adf0)
