### PR TITLE
[AINode] Fix call inference bug

### DIFF
--- a/iotdb-core/ainode/iotdb/ainode/core/manager/inference_manager.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/manager/inference_manager.py
@@ -265,7 +265,11 @@ class InferenceManager:
             req,
             data_getter=lambda r: r.dataset,
             extract_attrs=lambda r: {
-                "output_length": int(r.inferenceAttributes.pop("outputLength", 96)),
+                "output_length": (
+                    96
+                    if r.inferenceAttributes is None
+                    else int(r.inferenceAttributes.pop("outputLength", 96))
+                ),
                 **(r.inferenceAttributes or {}),
             },
             resp_cls=TInferenceResp,


### PR DESCRIPTION
The outputLength should be optional rather than default.