### PR TITLE
[Improvement] Use bounded thread pool in SessionPoolExample to avoid potential OOM (#17016)

### DIFF
--- a/example/session/src/main/java/org/apache/iotdb/SessionPoolExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/SessionPoolExample.java
@@ -18,7 +18,9 @@
  */
 
 package org.apache.iotdb;
-
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import org.apache.iotdb.isession.SessionDataSet.DataIterator;
 import org.apache.iotdb.isession.pool.SessionDataSetWrapper;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
@@ -72,7 +74,15 @@ public class SessionPoolExample {
     // Choose the SessionPool you going to use
     constructRedirectSessionPool();
 
-    service = Executors.newFixedThreadPool(10);
+//    before：
+//    service = Executors.newFixedThreadPool(10);
+
+//    after：
+    service = new ThreadPoolExecutor(
+            10, 10,
+            0L, TimeUnit.MILLISECONDS,
+            new ArrayBlockingQueue<>(1000)
+    );
     insertRecord();
     Thread.sleep(1000);
     queryByIterator();


### PR DESCRIPTION
## Description
This PR fixes issue #17016.

As discussed in the issue, the `SessionPoolExample` currently uses `Executors.newFixedThreadPool(10)`, which internally employs an unbounded `LinkedBlockingQueue`. This can lead to `OutOfMemoryError` in high-throughput scenarios if users copy this example code into production.

This PR replaces it with a `ThreadPoolExecutor` using a bounded `ArrayBlockingQueue` to provide backpressure and ensure system stability.

## Related Issue
Fixes #17016

## Type of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)

## Checklist:
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings