### PR TITLE
Fix the HAS_MORE_STATE problem

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/AlterTimeSeriesDataTypeProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/AlterTimeSeriesDataTypeProcedure.java
@@ -124,7 +124,7 @@ public class AlterTimeSeriesDataTypeProcedure
               this::setFailure,
               true);
           collectPayload4Pipe(env);
-          break;
+          return Flow.NO_MORE_STATE;
         default:
           setFailure(
               new ProcedureException(


### PR DESCRIPTION
Fix the problem that "StateMachineProceduree not set next state, but return HAS_MORE_STATE".
![img_v3_02u5_e320e8a6-13ae-420a-8938-f44e5712f2ag](https://github.com/user-attachments/assets/48ed80a5-9c00-4fc3-85bf-d1883611e238)
