### PR TITLE
Fix cannot find Formatter when put mqtt-dependency-jar in ext folder

### DIFF
--- a/external-service-impl/mqtt/src/main/java/org/apache/iotdb/mqtt/PayloadFormatManager.java
+++ b/external-service-impl/mqtt/src/main/java/org/apache/iotdb/mqtt/PayloadFormatManager.java
@@ -79,7 +79,8 @@ public class PayloadFormatManager {
   }
 
   private static void buildMqttPluginMap() throws IOException {
-    ServiceLoader<PayloadFormatter> payloadFormatters = ServiceLoader.load(PayloadFormatter.class);
+    ServiceLoader<PayloadFormatter> payloadFormatters =
+        ServiceLoader.load(PayloadFormatter.class, PayloadFormatManager.class.getClassLoader());
     for (PayloadFormatter formatter : payloadFormatters) {
       if (formatter == null) {
         logger.error("PayloadFormatManager(), formatter is null.");


### PR DESCRIPTION
appearance: ![img_v3_02u6_bfe533f9-2f92-4c67-863e-51cf62e0e7fg](https://github.com/user-attachments/assets/acaec5ec-b144-4e02-9570-9378cc1c8389)
fix: use path of current ClassLoader to fetch Formatter config file
