### PR TITLE
Optimize TsTable with Copy-on-Write pattern for thread-safe concurrent access

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/table/DataNodeTableCache.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/table/DataNodeTableCache.java
@@ -288,13 +288,17 @@ public class DataNodeTableCache implements ITableCache {
     try {
       if (databaseTableMap.containsKey(database)
           && databaseTableMap.get(database).containsKey(tableName)) {
-        databaseTableMap.get(database).get(tableName).removeColumnSchema(columnName);
+        final TsTable copyTable = new TsTable(databaseTableMap.get(database).get(tableName));
+        copyTable.removeColumnSchema(columnName);
+        databaseTableMap.get(database).put(tableName, copyTable);
       }
       if (preUpdateTableMap.containsKey(database)
           && preUpdateTableMap.get(database).containsKey(tableName)) {
         final Pair<TsTable, Long> tableVersionPair = preUpdateTableMap.get(database).get(tableName);
         if (Objects.nonNull(tableVersionPair.getLeft())) {
-          tableVersionPair.getLeft().removeColumnSchema(columnName);
+          final TsTable copyTable = new TsTable(tableVersionPair.getLeft());
+          copyTable.removeColumnSchema(columnName);
+          tableVersionPair.setLeft(copyTable);
         }
         tableVersionPair.setRight(tableVersionPair.getRight() + 1);
       }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/schema/table/TsTable.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/schema/table/TsTable.java
@@ -183,7 +183,6 @@ public class TsTable {
    * the map during copy (e.g., for rename operations) in a single pass.
    *
    * @param columnSchemaMapTransformer transforms columnSchemaMap entries during copy
-   * @param writeOperation the write operation to execute on the new map copies
    */
   private void executeWriteWithTransform(ColumnSchemaMapTransformer columnSchemaMapTransformer) {
     readWriteLock.writeLock().lock();

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/schema/table/TsTable.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/schema/table/TsTable.java
@@ -183,6 +183,7 @@ public class TsTable {
    * the map during copy (e.g., for rename operations) in a single pass.
    *
    * @param columnSchemaMapTransformer transforms columnSchemaMap entries during copy
+   * @param writeOperation the write operation to execute on the new map copies
    */
   private void executeWriteWithTransform(ColumnSchemaMapTransformer columnSchemaMapTransformer) {
     readWriteLock.writeLock().lock();

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/schema/table/TsTable.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/schema/table/TsTable.java
@@ -185,7 +185,8 @@ public class TsTable {
    * @param columnSchemaMapTransformer transforms columnSchemaMap entries during copy
    * @param writeOperation the write operation to execute on the new map copies
    */
-  private void executeWriteWithTransform(ColumnSchemaMapTransformer columnSchemaMapTransformer) {
+  private void executeWriteWithTransform(
+      ColumnSchemaMapTransformer columnSchemaMapTransformer, WriteOperation writeOperation) {
     readWriteLock.writeLock().lock();
     isNotWrite.set(false);
     try {
@@ -196,6 +197,9 @@ public class TsTable {
       }
       Map<String, Integer> newTagColumnIndexMap = new HashMap<>(tagColumnIndexMap);
       Map<String, Integer> newIdColumnIndexMap = new HashMap<>(idColumnIndexMap);
+
+      // Execute write operation on local copies
+      writeOperation.execute(newColumnSchemaMap, newTagColumnIndexMap, newIdColumnIndexMap);
 
       // After write completes, atomically update the class fields
       columnSchemaMap = newColumnSchemaMap;
@@ -309,6 +313,9 @@ public class TsTable {
           } else {
             targetMap.put(key, schema);
           }
+        },
+        (colMap, tagMap, idMap) -> {
+          // No additional operation needed, transformation already done during copy
         });
   }
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/schema/table/TsTable.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/schema/table/TsTable.java
@@ -185,8 +185,7 @@ public class TsTable {
    * @param columnSchemaMapTransformer transforms columnSchemaMap entries during copy
    * @param writeOperation the write operation to execute on the new map copies
    */
-  private void executeWriteWithTransform(
-      ColumnSchemaMapTransformer columnSchemaMapTransformer, WriteOperation writeOperation) {
+  private void executeWriteWithTransform(ColumnSchemaMapTransformer columnSchemaMapTransformer) {
     readWriteLock.writeLock().lock();
     isNotWrite.set(false);
     try {
@@ -197,9 +196,6 @@ public class TsTable {
       }
       Map<String, Integer> newTagColumnIndexMap = new HashMap<>(tagColumnIndexMap);
       Map<String, Integer> newIdColumnIndexMap = new HashMap<>(idColumnIndexMap);
-
-      // Execute write operation on local copies
-      writeOperation.execute(newColumnSchemaMap, newTagColumnIndexMap, newIdColumnIndexMap);
 
       // After write completes, atomically update the class fields
       columnSchemaMap = newColumnSchemaMap;
@@ -313,9 +309,6 @@ public class TsTable {
           } else {
             targetMap.put(key, schema);
           }
-        },
-        (colMap, tagMap, idMap) -> {
-          // No additional operation needed, transformation already done during copy
         });
   }
 


### PR DESCRIPTION
## Description
- Change columnSchemaMap, tagColumnIndexMap, and idColumnIndexMap from final to volatile
- Implement Copy-on-Write in executeWrite method:
  1. Create local copies of maps before modification
  2. Execute write operations on local copies
  3. Atomically update class fields after write completes
- Add WriteOperation functional interface to pass map copies to write operations
- This ensures readers see either complete old data or complete new data, avoiding ConcurrentModificationException


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
