### PR TITLE
Set MQTT address to empty string.

### DIFF
--- a/external-service-impl/mqtt/src/main/java/org/apache/iotdb/mqtt/MPPPublishHandler.java
+++ b/external-service-impl/mqtt/src/main/java/org/apache/iotdb/mqtt/MPPPublishHandler.java
@@ -292,7 +292,7 @@ public class MPPPublishHandler extends AbstractInterceptHandler {
           AuthorityChecker.checkAuthority(
               statement,
               new TreeAccessCheckContext(
-                  session.getUserId(), session.getUsername(), session.getClientAddress()));
+                  session.getUserId(), session.getUsername(), session.getClientID()));
       if (tsStatus.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         LOG.warn(tsStatus.message);
       } else {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/session/MqttClientSession.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/session/MqttClientSession.java
@@ -26,6 +26,10 @@ import java.util.Set;
 
 public class MqttClientSession extends IClientSession {
 
+  public String getClientID() {
+    return clientID;
+  }
+
   private final String clientID;
 
   public MqttClientSession(String clientID) {
@@ -34,7 +38,7 @@ public class MqttClientSession extends IClientSession {
 
   @Override
   public String getClientAddress() {
-    return clientID;
+    return "";
   }
 
   @Override


### PR DESCRIPTION
Set MQTT address to empty string; using clientId as IP previously caused issues.