### PR TITLE
Use independent test folder for LocalFileRoleAccessorTest

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/auth/role/LocalFileRoleAccessorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/auth/role/LocalFileRoleAccessorTest.java
@@ -49,7 +49,7 @@ public class LocalFileRoleAccessorTest {
   @Before
   public void setUp() {
     EnvironmentUtils.envSetUp();
-    testFolder = new File(TestConstant.BASE_OUTPUT_PATH.concat("test"));
+    testFolder = new File(TestConstant.BASE_OUTPUT_PATH.concat("test-LocalFileRoleAccessorTest"));
     testFolder.mkdirs();
     accessor = new LocalFileRoleAccessor(testFolder.getPath());
   }


### PR DESCRIPTION
We doubt the same folder name might result in file cannot be cleaned under concurrent tests.