### PR TITLE
Support build project by jdk25

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 ![](https://github-size-badge.herokuapp.com/apache/iotdb.svg)
 ![](https://img.shields.io/github/downloads/apache/iotdb/total.svg)
 ![](https://img.shields.io/badge/platform-win%20%7C%20macos%20%7C%20linux-yellow.svg)
-![](https://img.shields.io/badge/java--language-1.8%20%7C%2011%20%7C%2017-blue.svg)
+![](https://img.shields.io/badge/java--language-1.8+-blue.svg)
 [![IoTDB Website](https://img.shields.io/website-up-down-green-red/https/shields.io.svg?label=iotdb-website)](https://iotdb.apache.org/)
 [![Maven Version](https://maven-badges.herokuapp.com/maven-central/org.apache.iotdb/iotdb-parent/badge.svg)](http://search.maven.org/#search|gav|1|g:"org.apache.iotdb")
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/apache/iotdb)
@@ -89,7 +89,7 @@ This short guide will walk you through the basic process of using IoTDB. For a m
 
 To use IoTDB, you need to have:
 
-1. Java >= 1.8 (1.8, 11 to 17 are verified. Please make sure the environment path has been set accordingly).
+1. Java >= 1.8 (1.8 to 25 are verified. Please make sure the environment path has been set accordingly).
 2. Maven >= 3.6 (If you want to compile and install IoTDB from source code).
 3. Set the max open files num as 65535 to avoid the "too many open files" error.
 4. (Optional) Set the somaxconn as 65535 to avoid "connection reset" error when the system is under high load.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -28,7 +28,7 @@
 ![](https://github-size-badge.herokuapp.com/apache/iotdb.svg)
 ![](https://img.shields.io/github/downloads/apache/iotdb/total.svg)
 ![](https://img.shields.io/badge/platform-win%20%7C%20macos%20%7C%20linux-yellow.svg)
-![](https://img.shields.io/badge/java--language-1.8%20%7C%2011%20%7C%2017-blue.svg)
+![](https://img.shields.io/badge/java--language-1.8+-blue.svg)
 [![Language grade: Java](https://img.shields.io/lgtm/grade/java/g/apache/iotdb.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/apache/iotdb/context:java)
 [![IoTDB Website](https://img.shields.io/website-up-down-green-red/https/shields.io.svg?label=iotdb-website)](https://iotdb.apache.org/)
 [![Maven Version](https://maven-badges.herokuapp.com/maven-central/org.apache.iotdb/iotdb-parent/badge.svg)](http://search.maven.org/#search|gav|1|g:"org.apache.iotdb")
@@ -86,7 +86,7 @@ IoTDB的主要特点如下:
 ## 环境准备
 
 要使用IoTDB，您需要:
-1. Java >= 1.8 (目前 1.8、11 到 17 已经被验证可用。请确保环变量境路径已正确设置)。
+1. Java >= 1.8 (目前 1.8 到 25 已经被验证可用。请确保环变量境路径已正确设置)。
 2. Maven >= 3.6 (如果希望从源代码编译和安装IoTDB)。
 3. 设置 max open files 为 65535，以避免"too many open files"错误。
 4. （可选） 将 somaxconn 设置为 65535 以避免系统在高负载时出现 "connection reset" 错误。 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/region/AddRegionPeerProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/region/AddRegionPeerProcedure.java
@@ -112,7 +112,7 @@ public class AddRegionPeerProcedure extends RegionOperationProcedure<AddRegionPe
           TRegionMigrateResult result = handler.waitTaskFinish(this.getProcId(), coordinator);
           switch (result.getTaskStatus()) {
             case TASK_NOT_EXIST:
-              // coordinator crashed and lost its task table
+            // coordinator crashed and lost its task table
             case FAIL:
               // maybe some DataNode crash
               return warnAndRollBackAndNoMoreState(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/opcda/OpcDaServerHandle.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/opcda/OpcDaServerHandle.java
@@ -315,8 +315,8 @@ public class OpcDaServerHandle implements Closeable {
         return Variant.VT_R8;
       case TEXT:
       case STRING:
-        // Note that "Variant" does not support "VT_BLOB" data, and not all the DA server
-        // support this, thus we use "VT_BSTR" to substitute
+      // Note that "Variant" does not support "VT_BLOB" data, and not all the DA server
+      // support this, thus we use "VT_BSTR" to substitute
       case BLOB:
       case OBJECT:
         return Variant.VT_BSTR;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/AccumulatorFactory.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/aggregation/AccumulatorFactory.java
@@ -439,10 +439,10 @@ public class AccumulatorFactory {
     switch (aggregationType) {
       case MAX_BY:
         checkState(inputDataTypes.size() == 2, "Wrong inputDataTypes size.");
-        // return new MaxByAccumulator(inputDataTypes.get(0), inputDataTypes.get(1));
+      // return new MaxByAccumulator(inputDataTypes.get(0), inputDataTypes.get(1));
       case MIN_BY:
         checkState(inputDataTypes.size() == 2, "Wrong inputDataTypes size.");
-        // return new MinByAccumulator(inputDataTypes.get(0), inputDataTypes.get(1));
+      // return new MinByAccumulator(inputDataTypes.get(0), inputDataTypes.get(1));
       default:
         throw new IllegalArgumentException("Invalid Aggregation function: " + aggregationType);
     }
@@ -459,46 +459,46 @@ public class AccumulatorFactory {
         return new CountAccumulator();
       case AVG:
         return new AvgAccumulator(tsDataType);
-        /*case SUM:
-          return new SumAccumulator(tsDataType);
-        case EXTREME:
-          return new ExtremeAccumulator(tsDataType);
-        case MAX_TIME:
-          return ascending ? new MaxTimeAccumulator() : new MaxTimeDescAccumulator();
-        case MIN_TIME:
-          return ascending ? new MinTimeAccumulator() : new MinTimeDescAccumulator();
-        case MAX_VALUE:
-          return new MaxValueAccumulator(tsDataType);
-        case MIN_VALUE:
-          return new MinValueAccumulator(tsDataType);
-        case LAST_VALUE:
-          return ascending
-              ? new LastValueAccumulator(tsDataType)
-              : new LastValueDescAccumulator(tsDataType);
-        case FIRST_VALUE:
-          return ascending
-              ? new FirstValueAccumulator(tsDataType)
-              : new FirstValueDescAccumulator(tsDataType);
-        case COUNT_IF:
-          return new CountIfAccumulator(
-              initKeepEvaluator(inputExpressions.get(1)),
-              Boolean.parseBoolean(inputAttributes.getOrDefault("ignoreNull", "true")));
-        case TIME_DURATION:
-          return new TimeDurationAccumulator();
-        case MODE:
-          return createModeAccumulator(tsDataType);
-        case COUNT_TIME:
-          return new CountTimeAccumulator();
-        case STDDEV:
-        case STDDEV_SAMP:
-          return new VarianceAccumulator(tsDataType, VarianceAccumulator.VarianceType.STDDEV_SAMP);
-        case STDDEV_POP:
-          return new VarianceAccumulator(tsDataType, VarianceAccumulator.VarianceType.STDDEV_POP);
-        case VARIANCE:
-        case VAR_SAMP:
-          return new VarianceAccumulator(tsDataType, VarianceAccumulator.VarianceType.VAR_SAMP);
-        case VAR_POP:
-          return new VarianceAccumulator(tsDataType, VarianceAccumulator.VarianceType.VAR_POP);*/
+      /*case SUM:
+        return new SumAccumulator(tsDataType);
+      case EXTREME:
+        return new ExtremeAccumulator(tsDataType);
+      case MAX_TIME:
+        return ascending ? new MaxTimeAccumulator() : new MaxTimeDescAccumulator();
+      case MIN_TIME:
+        return ascending ? new MinTimeAccumulator() : new MinTimeDescAccumulator();
+      case MAX_VALUE:
+        return new MaxValueAccumulator(tsDataType);
+      case MIN_VALUE:
+        return new MinValueAccumulator(tsDataType);
+      case LAST_VALUE:
+        return ascending
+            ? new LastValueAccumulator(tsDataType)
+            : new LastValueDescAccumulator(tsDataType);
+      case FIRST_VALUE:
+        return ascending
+            ? new FirstValueAccumulator(tsDataType)
+            : new FirstValueDescAccumulator(tsDataType);
+      case COUNT_IF:
+        return new CountIfAccumulator(
+            initKeepEvaluator(inputExpressions.get(1)),
+            Boolean.parseBoolean(inputAttributes.getOrDefault("ignoreNull", "true")));
+      case TIME_DURATION:
+        return new TimeDurationAccumulator();
+      case MODE:
+        return createModeAccumulator(tsDataType);
+      case COUNT_TIME:
+        return new CountTimeAccumulator();
+      case STDDEV:
+      case STDDEV_SAMP:
+        return new VarianceAccumulator(tsDataType, VarianceAccumulator.VarianceType.STDDEV_SAMP);
+      case STDDEV_POP:
+        return new VarianceAccumulator(tsDataType, VarianceAccumulator.VarianceType.STDDEV_POP);
+      case VARIANCE:
+      case VAR_SAMP:
+        return new VarianceAccumulator(tsDataType, VarianceAccumulator.VarianceType.VAR_SAMP);
+      case VAR_POP:
+        return new VarianceAccumulator(tsDataType, VarianceAccumulator.VarianceType.VAR_POP);*/
       default:
         throw new IllegalArgumentException("Invalid Aggregation function: " + aggregationType);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/DriverScheduler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/DriverScheduler.java
@@ -340,7 +340,7 @@ public class DriverScheduler implements IDriverScheduler, IService {
         task.lock();
         DriverTaskStatus status = task.getStatus();
         switch (status) {
-            // If it has been aborted, return directly
+          // If it has been aborted, return directly
           case ABORTED:
             return;
           case READY:

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/SubqueryPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/SubqueryPlanner.java
@@ -461,7 +461,7 @@ class SubqueryPlanner {
                 .getTranslations()
                 .withAdditionalMappings(mapAll(cluster, subPlan.getScope(), output)),
             subPlan.getRoot());
-        // Cannot be used with quantified comparison
+      // Cannot be used with quantified comparison
       case IS_DISTINCT_FROM:
       default:
         throw new IllegalArgumentException(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/util/ExpressionFormatter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/util/ExpressionFormatter.java
@@ -398,9 +398,9 @@ public final class ExpressionFormatter {
       String value = process(node.getValue(), context);
 
       switch (node.getSign()) {
-          // Unary is ambiguous with respect to negative numbers. "-1" parses as a number, but
-          // "-(1)" parses as "unaryMinus(number)"
-          // The parentheses are needed to ensure the parsing roundtrips properly.
+        // Unary is ambiguous with respect to negative numbers. "-1" parses as a number, but
+        // "-(1)" parses as "unaryMinus(number)"
+        // The parentheses are needed to ensure the parsing roundtrips properly.
         case MINUS:
           return "-(" + value + ")";
         case PLUS:

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/SchemaUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/SchemaUtils.java
@@ -122,7 +122,7 @@ public class SchemaUtils {
       case SqlConstant.VAR_POP:
       case SqlConstant.VAR_SAMP:
         return TSDataType.DOUBLE;
-        // Partial aggregation names
+      // Partial aggregation names
       case SqlConstant.STDDEV + "_partial":
       case SqlConstant.STDDEV_POP + "_partial":
       case SqlConstant.STDDEV_SAMP + "_partial":

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/TimestampPrecisionUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/TimestampPrecisionUtils.java
@@ -49,7 +49,7 @@ public class TimestampPrecisionUtils {
         convertToCurrPrecisionFunction = TimeUnit.NANOSECONDS::convert;
         currPrecision = TimeUnit.NANOSECONDS;
         break;
-        // this case will never reach
+      // this case will never reach
       default:
         throw new UnsupportedOperationException(
             "not supported time_precision: " + TIMESTAMP_PRECISION);
@@ -91,7 +91,7 @@ public class TimestampPrecisionUtils {
                   TIMESTAMP_PRECISION, time));
         }
         break;
-        // Long.MaxValue is 19 digits, therefore no problem when the precision is ns.
+      // Long.MaxValue is 19 digits, therefore no problem when the precision is ns.
       case "ns":
       default:
         break;

--- a/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/jvm/JvmGcMetrics.java
+++ b/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/jvm/JvmGcMetrics.java
@@ -74,22 +74,22 @@ public class JvmGcMetrics implements IMetricSet, AutoCloseable {
 
   private static boolean isPartiallyConcurrentGC(GarbageCollectorMXBean gc) {
     switch (gc.getName()) {
-        // First two are from the 'serial' collector which are not concurrent, obviously.
+      // First two are from the 'serial' collector which are not concurrent, obviously.
       case "Copy":
       case "MarkSweepCompact":
-        // The following 4 GCs do not contain concurrent execution phase.
+      // The following 4 GCs do not contain concurrent execution phase.
       case "PS MarkSweep":
       case "PS Scavenge":
       case "G1 Young Generation":
       case "ParNew":
         return false;
 
-        // The following 2 GCs' execution process consists of concurrent phase, which means they can
-        // run simultaneously with the user thread in some phases.
+      // The following 2 GCs' execution process consists of concurrent phase, which means they can
+      // run simultaneously with the user thread in some phases.
 
-        // Concurrent mark and concurrent sweep
+      // Concurrent mark and concurrent sweep
       case "ConcurrentMarkSweep":
-        // Concurrent mark
+      // Concurrent mark
       case "G1 Old Generation":
         return true;
       default:

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <findbugs.jsr305.version>3.0.2</findbugs.jsr305.version>
         <fusesource-mqtt-client.version>1.16</fusesource-mqtt-client.version>
         <!-- JDK1.8 only support google java format 1.7-->
-        <google.java.format.version>1.22.0</google.java.format.version>
+        <google.java.format.version>1.28.0</google.java.format.version>
         <gson.version>2.13.1</gson.version>
         <guava.version>32.1.2-jre</guava.version>
         <!-- This was the last version to support Java 8 -->
@@ -1569,9 +1569,9 @@
         </profile>
         <!-- Current version of spotless cannot support JDK11 below -->
         <profile>
-            <id>.java-11-below</id>
+            <id>.java-17-below</id>
             <activation>
-                <jdk>(,11]</jdk>
+                <jdk>(,17)</jdk>
             </activation>
             <properties>
                 <!-- This was the last version to support Java 8, Just for run -->


### PR DESCRIPTION
This pull request updates the documentation and build configuration to reflect expanded support for Java versions up to 25 and updates the Google Java Format tool version. The changes ensure that users and contributors are aware of the broader Java compatibility and that the build tooling is kept up to date.

**Documentation updates:**

* Updated Java compatibility badges and environment requirements in both `README.md` and `README_ZH.md` to indicate support for Java 1.8 and above, with explicit verification up to Java 25. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R31) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L92-R92) [[3]](diffhunk://#diff-e8764f49c916f94863b7aad80d30a29f7761a297d0b24be2c244cf90ce23d85aL31-R31) [[4]](diffhunk://#diff-e8764f49c916f94863b7aad80d30a29f7761a297d0b24be2c244cf90ce23d85aL89-R89)

**Build configuration updates:**

* Upgraded the `google.java.format.version` property in `pom.xml` from `1.22.0` to `1.28.0` for improved code formatting support.
* Modified the Maven profile in `pom.xml` to apply the `.java-17-below` profile for JDK versions below 17, instead of the previous `.java-11-below` for JDK versions up to 11.

<img width="2082" height="910" alt="image" src="https://github.com/user-attachments/assets/8cc8dc14-b043-4225-b478-54a953f69a47" />


