### PR TITLE
Fix delete NPE after insert failed

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBDeletionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBDeletionIT.java
@@ -401,6 +401,31 @@ public class IoTDBDeletionIT {
   }
 
   @Test
+  public void testDeleteDataAfterInsertFailed() throws SQLException {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("create timeseries root.dd.wf01.wt01.status with datatype=BOOLEAN;");
+      statement.execute(
+          "INSERT INTO root.dd.wf01.wt01(Time,status) VALUES (2022-10-11 10:20:50,'rr');");
+    } catch (SQLException e) {
+      assertEquals(507, e.getErrorCode());
+    }
+
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("DELETE FROM root.dd.wf01.wt01.status");
+
+      try (ResultSet resultSet = statement.executeQuery("select ** from root.dd")) {
+        int cnt = 0;
+        while (resultSet.next()) {
+          cnt++;
+        }
+        Assert.assertEquals(0, cnt);
+      }
+    }
+  }
+
+  @Test
   public void testDelSeriesWithSpecialSymbol() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -1643,8 +1643,11 @@ public class DataRegion implements IDataRegionForQuery {
   private TsFileProcessor insertToTsFileProcessor(
       InsertRowNode insertRowNode, boolean sequence, long timePartitionId)
       throws WriteProcessException {
+    if (insertRowNode.allMeasurementFailed()) {
+      return null;
+    }
     TsFileProcessor tsFileProcessor = getOrCreateTsFileProcessor(timePartitionId, sequence);
-    if (tsFileProcessor == null || insertRowNode.allMeasurementFailed()) {
+    if (tsFileProcessor == null) {
       return null;
     }
     long[] infoForMetrics = new long[5];


### PR DESCRIPTION
This pull request introduces an additional test case to ensure correct deletion behavior after a failed insert, and improves the logic in the data region write path to avoid unnecessary file processor creation when all measurements in a row have failed.

**Testing improvements:**

* Added a new test `testDeleteDataAfterInsertFailed` in `IoTDBDeletionIT.java` to verify that data can be deleted successfully even after an insert operation fails due to invalid data, and to confirm that no residual data remains after the deletion.

**Write path robustness:**

* Updated `insertToTsFileProcessor` in `DataRegion.java` to immediately return `null` if all measurements in an `InsertRowNode` have failed, preventing unnecessary creation or retrieval of a `TsFileProcessor` in such cases.

![img_v3_02ue_648db5d8-1831-41d8-9b2b-31f103d8e37g](https://github.com/user-attachments/assets/702df07b-ecb1-480a-873c-677db6838d38)
