### PR TITLE
Fix checkstyle line length violation in SubscriptionException

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/task/subtask/SubscriptionSinkSubtaskManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/task/subtask/SubscriptionSinkSubtaskManager.java
@@ -129,8 +129,7 @@ public class SubscriptionSinkSubtaskManager {
             String.format(
                 "Failed to construct subscription sink, because of %s or %s "
                     + "does not exist in pipe connector parameters",
-                PipeSinkConstant.SINK_TOPIC_KEY,
-                    PipeSinkConstant.SINK_CONSUMER_GROUP_KEY));
+                PipeSinkConstant.SINK_TOPIC_KEY, PipeSinkConstant.SINK_CONSUMER_GROUP_KEY));
       }
 
       // 3. Construct PipeConnectorSubtaskLifeCycle to manage PipeConnectorSubtask's life cycle


### PR DESCRIPTION
## Description

This PR fixes a Checkstyle LineLength violation by splitting a long
error message string into multiple lines.

The change is formatting-only and does not affect behavior or logic.

This change addresses a Sonar-reported Checkstyle issue:
https://sonarcloud.io/project/issues?sinceLeakPeriod=true&issueStatuses=OPEN%2CCONFIRMED&pullRequest=17126&id=apache_iotdb&open=AZwTGC1NrSTVAs2bWlqE

<hr>

This PR has:
- [x] been self-reviewed.
- [x] been built locally with `mvn -pl iotdb-core -am test -DskipTests`.

<hr>

##### Key changed classes in this PR
- Subscription-related class throwing `SubscriptionException`