### PR TITLE
Fix set sql_dialect=table will clear current database bug

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/utils/TestUtils.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/utils/TestUtils.java
@@ -287,30 +287,37 @@ public class TestUtils {
         EnvFactory.getEnv().getConnection(userName, password, BaseEnv.TABLE_SQL_DIALECT)) {
       connection.setClientInfo("time_zone", timeZone);
       try (Statement statement = connection.createStatement()) {
-        statement.execute("use " + database);
+        if (database != null) {
+          statement.execute("use " + database);
+        }
         try (ResultSet resultSet = statement.executeQuery(sql)) {
-          ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
-          for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
-            assertEquals(expectedHeader[i - 1], resultSetMetaData.getColumnName(i));
-          }
-          assertEquals(expectedHeader.length, resultSetMetaData.getColumnCount());
-
-          int cnt = 0;
-          while (resultSet.next()) {
-            StringBuilder builder = new StringBuilder();
-            for (int i = 1; i <= expectedHeader.length; i++) {
-              builder.append(resultSet.getString(i)).append(",");
-            }
-            assertEquals(expectedRetArray[cnt], builder.toString());
-            cnt++;
-          }
-          assertEquals(expectedRetArray.length, cnt);
+          tableResultSetEqual(resultSet, expectedHeader, expectedRetArray);
         }
       }
     } catch (SQLException e) {
       e.printStackTrace();
       fail(e.getMessage());
     }
+  }
+
+  public static void tableResultSetEqual(
+      ResultSet resultSet, String[] expectedHeader, String[] expectedRetArray) throws SQLException {
+    ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+    for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
+      assertEquals(expectedHeader[i - 1], resultSetMetaData.getColumnName(i));
+    }
+    assertEquals(expectedHeader.length, resultSetMetaData.getColumnCount());
+
+    int cnt = 0;
+    while (resultSet.next()) {
+      StringBuilder builder = new StringBuilder();
+      for (int i = 1; i <= expectedHeader.length; i++) {
+        builder.append(resultSet.getString(i)).append(",");
+      }
+      assertEquals(expectedRetArray[cnt], builder.toString());
+      cnt++;
+    }
+    assertEquals(expectedRetArray.length, cnt);
   }
 
   public static void tableResultSetEqualByDataTypeTest(

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBFillTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBFillTableIT.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.it.env.EnvFactory;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.TableClusterIT;
 import org.apache.iotdb.itbase.category.TableLocalStandaloneIT;
+import org.apache.iotdb.itbase.env.BaseEnv;
 import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.junit.AfterClass;
@@ -31,9 +32,16 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
 import static org.apache.iotdb.db.it.utils.TestUtils.prepareTableData;
 import static org.apache.iotdb.db.it.utils.TestUtils.tableAssertTestFail;
+import static org.apache.iotdb.db.it.utils.TestUtils.tableResultSetEqual;
 import static org.apache.iotdb.db.it.utils.TestUtils.tableResultSetEqualTest;
+import static org.junit.Assert.fail;
 
 @RunWith(IoTDBTestRunner.class)
 @Category({TableLocalStandaloneIT.class, TableClusterIT.class})
@@ -631,6 +639,18 @@ public class IoTDBFillTableIT {
         expectedHeader,
         retArray,
         DATABASE_NAME);
+
+    try (Connection connection = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
+        Statement statement = connection.createStatement()) {
+      statement.execute("USE " + DATABASE_NAME);
+      statement.execute("SET SQL_DIALECT = TABLE");
+      try (ResultSet resultSet =
+          statement.executeQuery("select * from table1 FILL METHOD CONSTANT X'cafebabe99'")) {
+        tableResultSetEqual(resultSet, expectedHeader, retArray);
+      }
+    } catch (SQLException e) {
+      fail(e.getMessage());
+    }
   }
 
   @Test

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/session/IClientSession.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/session/IClientSession.java
@@ -175,6 +175,9 @@ public abstract class IClientSession {
   }
 
   public void setSqlDialectAndClean(SqlDialect sqlDialect) {
+    if (this.sqlDialect == sqlDialect) {
+      return;
+    }
     this.sqlDialect = sqlDialect;
     // clean database to avoid misuse of it between different SqlDialect
     this.databaseName = null;


### PR DESCRIPTION
This pull request introduces improvements to test utilities and refines SQL dialect handling to enhance reliability and maintainability. The main changes include extracting a reusable table result set comparison method, updating integration tests to use this utility, and optimizing dialect switching logic in the client session.

**Test utility improvements:**

* Extracted the core table result set comparison logic into a new reusable method `tableResultSetEqual`, simplifying `tableResultSetEqualTest` and improving code reuse in test assertions (`TestUtils.java`). [[1]](diffhunk://#diff-6efe0dd713ce5be5c7ea86f8694ea498481530afe2fa3aa2fcdcbbf3642013b3R290-R304) [[2]](diffhunk://#diff-6efe0dd713ce5be5c7ea86f8694ea498481530afe2fa3aa2fcdcbbf3642013b3L309-L314)
* Updated imports and usages in `IoTDBFillTableIT.java` to utilize the new `tableResultSetEqual` method, streamlining test code and reducing duplication. [[1]](diffhunk://#diff-1cad616625eaf99043e7ab0c7aacd265bc92f7da729a3f0e422345d70e791b44R26) [[2]](diffhunk://#diff-1cad616625eaf99043e7ab0c7aacd265bc92f7da729a3f0e422345d70e791b44R35-R44)
* Refactored the `normalFillTest` method in `IoTDBFillTableIT.java` to use the new utility for direct result set validation, improving clarity and error handling.

**SQL dialect handling:**

* Optimized the `setSqlDialectAndClean` method in `IClientSession.java` to avoid unnecessary operations when the dialect is unchanged, preventing redundant resets and potential side effects.