### PR TITLE
[IOTDB-17108] Support inclusive end time syntax [start, end] in GROUP BY clause

### DIFF
--- a/iotdb-core/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IoTDBSqlParser.g4
+++ b/iotdb-core/antlr/src/main/antlr4/org/apache/iotdb/db/qp/sql/IoTDBSqlParser.g4
@@ -978,6 +978,7 @@ number
 timeRange
     : LS_BRACKET startTime=timeValue COMMA endTime=timeValue RR_BRACKET
     | LR_BRACKET startTime=timeValue COMMA endTime=timeValue RS_BRACKET
+    | LS_BRACKET startTime=timeValue COMMA endTime=timeValue RS_BRACKET
     ;
 
 // ---- Having Clause

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/timerangeiterator/PreAggrWindowWithNaturalMonthIterator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/timerangeiterator/PreAggrWindowWithNaturalMonthIterator.java
@@ -32,6 +32,7 @@ public class PreAggrWindowWithNaturalMonthIterator implements ITimeRangeIterator
 
   private final boolean isAscending;
   private final boolean leftCRightO;
+  private final boolean rightClosed;
   private final TimeSelector timeBoundaryHeap;
 
   private final AggrWindowIterator aggrWindowIterator;
@@ -49,12 +50,21 @@ public class PreAggrWindowWithNaturalMonthIterator implements ITimeRangeIterator
       TimeDuration slidingStep,
       boolean isAscending,
       boolean leftCRightO,
+      boolean rightClosed,
       ZoneId zoneId) {
     this.isAscending = isAscending;
+    this.rightClosed = rightClosed;
     this.timeBoundaryHeap = new TimeSelector(HEAP_MAX_SIZE, isAscending);
     this.aggrWindowIterator =
         new AggrWindowIterator(
-            startTime, endTime, interval, slidingStep, isAscending, leftCRightO, zoneId);
+            startTime,
+            endTime,
+            interval,
+            slidingStep,
+            isAscending,
+            leftCRightO,
+            rightClosed,
+            zoneId);
     this.leftCRightO = leftCRightO;
     initHeap();
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/timerangeiterator/TimeRangeIteratorFactory.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/timerangeiterator/TimeRangeIteratorFactory.java
@@ -42,6 +42,7 @@ public class TimeRangeIteratorFactory {
       TimeDuration slidingStep,
       boolean isAscending,
       boolean leftCRightO,
+      boolean rightClosed,
       boolean outputPartialTimeWindow,
       ZoneId zoneId) {
     if (outputPartialTimeWindow
@@ -54,14 +55,22 @@ public class TimeRangeIteratorFactory {
             interval.nonMonthDuration,
             slidingStep.nonMonthDuration,
             isAscending,
-            leftCRightO);
+            leftCRightO,
+            rightClosed);
       } else {
         return new PreAggrWindowWithNaturalMonthIterator(
-            startTime, endTime, interval, slidingStep, isAscending, leftCRightO, zoneId);
+            startTime,
+            endTime,
+            interval,
+            slidingStep,
+            isAscending,
+            leftCRightO,
+            rightClosed,
+            zoneId);
       }
     } else {
       return new AggrWindowIterator(
-          startTime, endTime, interval, slidingStep, isAscending, leftCRightO, zoneId);
+          startTime, endTime, interval, slidingStep, isAscending, leftCRightO, rightClosed, zoneId);
     }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/AggregationUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/AggregationUtil.java
@@ -86,6 +86,7 @@ public class AggregationUtil {
           groupByTimeParameter.getSlidingStep(),
           ascending,
           groupByTimeParameter.isLeftCRightO(),
+          groupByTimeParameter.isRightClosed(),
           outputPartialTimeWindow,
           zoneId);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/ExpressionFactory.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/ExpressionFactory.java
@@ -219,9 +219,19 @@ public class ExpressionFactory {
   public static GroupByTimeExpression groupByTime(GroupByTimeParameter parameter) {
     long startTime =
         parameter.isLeftCRightO() ? parameter.getStartTime() : parameter.getStartTime() + 1;
-    long endTime = parameter.isLeftCRightO() ? parameter.getEndTime() : parameter.getEndTime() + 1;
+    long endTime =
+        parameter.isRightClosed()
+            ? (parameter.getEndTime() == Long.MAX_VALUE
+                ? Long.MAX_VALUE
+                : parameter.getEndTime() + 1)
+            : (parameter.isLeftCRightO() ? parameter.getEndTime() : parameter.getEndTime() + 1);
     return new GroupByTimeExpression(
-        startTime, endTime, parameter.getInterval(), parameter.getSlidingStep());
+        startTime,
+        endTime,
+        parameter.getInterval(),
+        parameter.getSlidingStep(),
+        parameter.isLeftCRightO(),
+        parameter.isRightClosed());
   }
 
   public static GroupByTimeExpression groupByTime(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/other/GroupByTimeExpression.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/expression/other/GroupByTimeExpression.java
@@ -55,12 +55,30 @@ public class GroupByTimeExpression extends Expression {
   // sliding step
   private final TimeDuration slidingStep;
 
+  // if it is left close and right open interval
+  private final boolean leftCRightO;
+
+  // if the right boundary is closed (inclusive)
+  private final boolean rightClosed;
+
   public GroupByTimeExpression(
       long startTime, long endTime, TimeDuration interval, TimeDuration slidingStep) {
+    this(startTime, endTime, interval, slidingStep, true, false);
+  }
+
+  public GroupByTimeExpression(
+      long startTime,
+      long endTime,
+      TimeDuration interval,
+      TimeDuration slidingStep,
+      boolean leftCRightO,
+      boolean rightClosed) {
     this.startTime = startTime;
     this.endTime = endTime;
     this.interval = interval;
     this.slidingStep = slidingStep;
+    this.leftCRightO = leftCRightO;
+    this.rightClosed = rightClosed;
   }
 
   public GroupByTimeExpression(ByteBuffer byteBuffer) {
@@ -68,6 +86,8 @@ public class GroupByTimeExpression extends Expression {
     this.endTime = ReadWriteIOUtils.readLong(byteBuffer);
     this.interval = TimeDuration.deserialize(byteBuffer);
     this.slidingStep = TimeDuration.deserialize(byteBuffer);
+    this.leftCRightO = ReadWriteIOUtils.readBool(byteBuffer);
+    this.rightClosed = ReadWriteIOUtils.readBool(byteBuffer);
   }
 
   public long getStartTime() {
@@ -84,6 +104,14 @@ public class GroupByTimeExpression extends Expression {
 
   public TimeDuration getSlidingStep() {
     return slidingStep;
+  }
+
+  public boolean isLeftCRightO() {
+    return leftCRightO;
+  }
+
+  public boolean isRightClosed() {
+    return rightClosed;
   }
 
   @Override
@@ -147,6 +175,8 @@ public class GroupByTimeExpression extends Expression {
     ReadWriteIOUtils.write(endTime, byteBuffer);
     interval.serialize(byteBuffer);
     slidingStep.serialize(byteBuffer);
+    ReadWriteIOUtils.write(leftCRightO, byteBuffer);
+    ReadWriteIOUtils.write(rightClosed, byteBuffer);
   }
 
   @Override
@@ -155,6 +185,8 @@ public class GroupByTimeExpression extends Expression {
     ReadWriteIOUtils.write(endTime, stream);
     interval.serialize(stream);
     slidingStep.serialize(stream);
+    ReadWriteIOUtils.write(leftCRightO, stream);
+    ReadWriteIOUtils.write(rightClosed, stream);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/parser/ASTVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/parser/ASTVisitor.java
@@ -1874,6 +1874,7 @@ public class ASTVisitor extends IoTDBSqlParserBaseVisitor<Statement> {
     if (ctx.timeRange() != null) {
       parseTimeRangeForGroupByTime(ctx.timeRange(), groupByTimeComponent);
       groupByTimeComponent.setLeftCRightO(ctx.timeRange().LS_BRACKET() != null);
+      groupByTimeComponent.setRightClosed(ctx.timeRange().RS_BRACKET() != null);
     }
 
     // Parse time interval

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/parameter/GroupByTimeParameter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/parameter/GroupByTimeParameter.java
@@ -51,6 +51,9 @@ public class GroupByTimeParameter {
   // if it is left close and right open interval
   private boolean leftCRightO;
 
+  // if the right boundary is closed (inclusive)
+  private boolean rightClosed;
+
   public GroupByTimeParameter() {}
 
   public GroupByTimeParameter(
@@ -59,11 +62,22 @@ public class GroupByTimeParameter {
       TimeDuration interval,
       TimeDuration slidingStep,
       boolean leftCRightO) {
+    this(startTime, endTime, interval, slidingStep, leftCRightO, false);
+  }
+
+  public GroupByTimeParameter(
+      long startTime,
+      long endTime,
+      TimeDuration interval,
+      TimeDuration slidingStep,
+      boolean leftCRightO,
+      boolean rightClosed) {
     this.startTime = startTime;
     this.endTime = endTime;
     this.interval = interval;
     this.slidingStep = slidingStep;
     this.leftCRightO = leftCRightO;
+    this.rightClosed = rightClosed;
   }
 
   public GroupByTimeParameter(GroupByTimeComponent groupByTimeComponent) {
@@ -72,6 +86,7 @@ public class GroupByTimeParameter {
     this.interval = groupByTimeComponent.getInterval();
     this.slidingStep = groupByTimeComponent.getSlidingStep();
     this.leftCRightO = groupByTimeComponent.isLeftCRightO();
+    this.rightClosed = groupByTimeComponent.isRightClosed();
   }
 
   public long getStartTime() {
@@ -114,6 +129,14 @@ public class GroupByTimeParameter {
     this.leftCRightO = leftCRightO;
   }
 
+  public boolean isRightClosed() {
+    return rightClosed;
+  }
+
+  public void setRightClosed(boolean rightClosed) {
+    this.rightClosed = rightClosed;
+  }
+
   public boolean hasOverlap() {
     return interval.getTotalDuration(TimestampPrecisionUtils.currPrecision)
         > slidingStep.getTotalDuration(TimestampPrecisionUtils.currPrecision);
@@ -125,6 +148,7 @@ public class GroupByTimeParameter {
     interval.serialize(buffer);
     slidingStep.serialize(buffer);
     ReadWriteIOUtils.write(leftCRightO, buffer);
+    ReadWriteIOUtils.write(rightClosed, buffer);
   }
 
   public void serialize(DataOutputStream stream) throws IOException {
@@ -133,6 +157,7 @@ public class GroupByTimeParameter {
     interval.serialize(stream);
     slidingStep.serialize(stream);
     ReadWriteIOUtils.write(leftCRightO, stream);
+    ReadWriteIOUtils.write(rightClosed, stream);
   }
 
   public static GroupByTimeParameter deserialize(ByteBuffer buffer) {
@@ -142,6 +167,7 @@ public class GroupByTimeParameter {
     groupByTimeParameter.setInterval(TimeDuration.deserialize(buffer));
     groupByTimeParameter.setSlidingStep(TimeDuration.deserialize(buffer));
     groupByTimeParameter.setLeftCRightO(ReadWriteIOUtils.readBool(buffer));
+    groupByTimeParameter.setRightClosed(ReadWriteIOUtils.readBool(buffer));
     return groupByTimeParameter;
   }
 
@@ -155,11 +181,12 @@ public class GroupByTimeParameter {
         && this.endTime == other.endTime
         && this.interval.equals(other.interval)
         && this.slidingStep.equals(other.slidingStep)
-        && this.leftCRightO == other.leftCRightO;
+        && this.leftCRightO == other.leftCRightO
+        && this.rightClosed == other.rightClosed;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(startTime, endTime, interval, slidingStep, leftCRightO);
+    return Objects.hash(startTime, endTime, interval, slidingStep, leftCRightO, rightClosed);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/component/GroupByTimeComponent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/component/GroupByTimeComponent.java
@@ -43,6 +43,9 @@ public class GroupByTimeComponent extends StatementNode {
   // if it is left close and right open interval
   private boolean leftCRightO = true;
 
+  // if the right boundary is closed (inclusive)
+  private boolean rightClosed = false;
+
   public GroupByTimeComponent() {
     // do nothing
   }
@@ -53,6 +56,14 @@ public class GroupByTimeComponent extends StatementNode {
 
   public void setLeftCRightO(boolean leftCRightO) {
     this.leftCRightO = leftCRightO;
+  }
+
+  public boolean isRightClosed() {
+    return rightClosed;
+  }
+
+  public void setRightClosed(boolean rightClosed) {
+    this.rightClosed = rightClosed;
   }
 
   public TimeDuration getInterval() {
@@ -104,23 +115,11 @@ public class GroupByTimeComponent extends StatementNode {
     sqlBuilder.append("GROUP BY TIME").append(' ');
     sqlBuilder.append('(');
     if (startTime != 0 || endTime != 0) {
-      if (isLeftCRightO()) {
-        sqlBuilder
-            .append('[')
-            .append(startTime)
-            .append(',')
-            .append(' ')
-            .append(endTime)
-            .append(')');
-      } else {
-        sqlBuilder
-            .append('(')
-            .append(startTime)
-            .append(',')
-            .append(' ')
-            .append(endTime)
-            .append(']');
-      }
+      // Determine left bracket
+      sqlBuilder.append(isLeftCRightO() ? '[' : '(');
+      sqlBuilder.append(startTime).append(',').append(' ').append(endTime);
+      // Determine right bracket
+      sqlBuilder.append(isRightClosed() ? ']' : ')');
       sqlBuilder.append(',').append(' ');
     }
     sqlBuilder.append(originalInterval);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/aggregation/TimeRangeIteratorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/aggregation/TimeRangeIteratorTest.java
@@ -55,13 +55,29 @@ public class TimeRangeIteratorTest {
 
     ITimeRangeIterator timeRangeIterator =
         TimeRangeIteratorFactory.getTimeRangeIterator(
-            startTime, endTime, interval, slidingStep, true, true, false, ZoneId.systemDefault());
+            startTime,
+            endTime,
+            interval,
+            slidingStep,
+            true,
+            true,
+            false,
+            false,
+            ZoneId.systemDefault());
 
     checkRes(timeRangeIterator, res);
 
     ITimeRangeIterator descTimeRangeIterator =
         TimeRangeIteratorFactory.getTimeRangeIterator(
-            startTime, endTime, interval, slidingStep, false, true, false, ZoneId.systemDefault());
+            startTime,
+            endTime,
+            interval,
+            slidingStep,
+            false,
+            true,
+            false,
+            false,
+            ZoneId.systemDefault());
 
     checkRes(descTimeRangeIterator, res);
   }
@@ -170,51 +186,147 @@ public class TimeRangeIteratorTest {
     TimeDuration interval = new TimeDuration(0, 4);
     checkRes(
         TimeRangeIteratorFactory.getTimeRangeIterator(
-            0, 32, interval, new TimeDuration(0, 1), true, true, true, ZoneId.systemDefault()),
+            0,
+            32,
+            interval,
+            new TimeDuration(0, 1),
+            true,
+            true,
+            false,
+            true,
+            ZoneId.systemDefault()),
         res4_1);
     checkRes(
         TimeRangeIteratorFactory.getTimeRangeIterator(
-            0, 32, interval, new TimeDuration(0, 2), true, true, true, ZoneId.systemDefault()),
+            0,
+            32,
+            interval,
+            new TimeDuration(0, 2),
+            true,
+            true,
+            false,
+            true,
+            ZoneId.systemDefault()),
         res4_2);
     checkRes(
         TimeRangeIteratorFactory.getTimeRangeIterator(
-            0, 32, interval, new TimeDuration(0, 3), true, true, true, ZoneId.systemDefault()),
+            0,
+            32,
+            interval,
+            new TimeDuration(0, 3),
+            true,
+            true,
+            false,
+            true,
+            ZoneId.systemDefault()),
         res4_3);
     checkRes(
         TimeRangeIteratorFactory.getTimeRangeIterator(
-            0, 32, interval, new TimeDuration(0, 4), true, true, true, ZoneId.systemDefault()),
+            0,
+            32,
+            interval,
+            new TimeDuration(0, 4),
+            true,
+            true,
+            false,
+            true,
+            ZoneId.systemDefault()),
         res4_4);
     checkRes(
         TimeRangeIteratorFactory.getTimeRangeIterator(
-            0, 32, interval, new TimeDuration(0, 5), true, true, true, ZoneId.systemDefault()),
+            0,
+            32,
+            interval,
+            new TimeDuration(0, 5),
+            true,
+            true,
+            false,
+            true,
+            ZoneId.systemDefault()),
         res4_5);
     checkRes(
         TimeRangeIteratorFactory.getTimeRangeIterator(
-            0, 32, interval, new TimeDuration(0, 6), true, true, true, ZoneId.systemDefault()),
+            0,
+            32,
+            interval,
+            new TimeDuration(0, 6),
+            true,
+            true,
+            false,
+            true,
+            ZoneId.systemDefault()),
         res4_6);
     checkRes(
         TimeRangeIteratorFactory.getTimeRangeIterator(
-            0, 32, interval, new TimeDuration(0, 1), false, true, true, ZoneId.systemDefault()),
+            0,
+            32,
+            interval,
+            new TimeDuration(0, 1),
+            false,
+            true,
+            false,
+            true,
+            ZoneId.systemDefault()),
         res4_1);
     checkRes(
         TimeRangeIteratorFactory.getTimeRangeIterator(
-            0, 32, interval, new TimeDuration(0, 2), false, true, true, ZoneId.systemDefault()),
+            0,
+            32,
+            interval,
+            new TimeDuration(0, 2),
+            false,
+            true,
+            false,
+            true,
+            ZoneId.systemDefault()),
         res4_2);
     checkRes(
         TimeRangeIteratorFactory.getTimeRangeIterator(
-            0, 32, interval, new TimeDuration(0, 3), false, true, true, ZoneId.systemDefault()),
+            0,
+            32,
+            interval,
+            new TimeDuration(0, 3),
+            false,
+            true,
+            false,
+            true,
+            ZoneId.systemDefault()),
         res4_3);
     checkRes(
         TimeRangeIteratorFactory.getTimeRangeIterator(
-            0, 32, interval, new TimeDuration(0, 4), false, true, true, ZoneId.systemDefault()),
+            0,
+            32,
+            interval,
+            new TimeDuration(0, 4),
+            false,
+            true,
+            false,
+            true,
+            ZoneId.systemDefault()),
         res4_4);
     checkRes(
         TimeRangeIteratorFactory.getTimeRangeIterator(
-            0, 32, interval, new TimeDuration(0, 5), false, true, true, ZoneId.systemDefault()),
+            0,
+            32,
+            interval,
+            new TimeDuration(0, 5),
+            false,
+            true,
+            false,
+            true,
+            ZoneId.systemDefault()),
         res4_5);
     checkRes(
         TimeRangeIteratorFactory.getTimeRangeIterator(
-            0, 32, interval, new TimeDuration(0, 6), false, true, true, ZoneId.systemDefault()),
+            0,
+            32,
+            interval,
+            new TimeDuration(0, 6),
+            false,
+            true,
+            false,
+            true,
+            ZoneId.systemDefault()),
         res4_6);
   }
 
@@ -284,6 +396,7 @@ public class TimeRangeIteratorTest {
               true,
               true,
               false,
+              false,
               ZoneId.systemDefault()),
           res1);
       checkRes(
@@ -294,6 +407,7 @@ public class TimeRangeIteratorTest {
               new TimeDuration(1, 0),
               true,
               true,
+              false,
               true,
               ZoneId.systemDefault()),
           res1);
@@ -306,6 +420,7 @@ public class TimeRangeIteratorTest {
               true,
               true,
               false,
+              false,
               ZoneId.systemDefault()),
           res2);
       checkRes(
@@ -316,6 +431,7 @@ public class TimeRangeIteratorTest {
               new TimeDuration(1, 0),
               true,
               true,
+              false,
               true,
               ZoneId.systemDefault()),
           res2);
@@ -327,6 +443,7 @@ public class TimeRangeIteratorTest {
               new TimeDuration(0, 10 * MS_TO_DAY),
               true,
               true,
+              false,
               false,
               ZoneId.systemDefault()),
           res3);
@@ -338,6 +455,7 @@ public class TimeRangeIteratorTest {
               new TimeDuration(0, 10 * MS_TO_DAY),
               true,
               true,
+              false,
               true,
               ZoneId.systemDefault()),
           res4);
@@ -379,6 +497,7 @@ public class TimeRangeIteratorTest {
             new TimeDuration(1, MS_TO_DAY),
             true,
             true,
+            false,
             true,
             ZoneId.systemDefault()),
         res);
@@ -430,6 +549,7 @@ public class TimeRangeIteratorTest {
             new TimeDuration(1, MS_TO_DAY),
             true,
             true,
+            false,
             true,
             ZoneId.systemDefault()),
         res);


### PR DESCRIPTION
## Summary

This PR adds support for double-closed interval `[start, end]` in GROUP BY time clause, complementing the existing half-open interval `[start, end)`.

### New Syntax
```sql
-- Inclusive end time (NEW)
SELECT count(s1) FROM root.test GROUP BY ([0, 100], 10ms)  -- includes timestamp 100

-- Exclusive end time (existing)
SELECT count(s1) FROM root.test GROUP BY ([0, 100), 10ms)  -- excludes timestamp 100
```

## Changes

| File | Description |
|------|-------------|
| `IoTDBSqlParser.g4` | Add grammar rule for `]` right bracket |
| `GroupByTimeComponent.java` | Add `rightClosed` field |
| `GroupByTimeParameter.java` | Add serialization support for `rightClosed` |
| `ASTVisitor.java` | Parse right bracket type |
| `AggregationUtil.java` | Pass `rightClosed` to factory |
| `TimeRangeIteratorFactory.java` | Update signature (9 args) |
| `AggrWindowIterator.java` | Override `getFinalTimeRange()` for inclusive end |
| `PreAggrWindowIterator.java` | Override `getFinalTimeRange()` for inclusive end |
| `PreAggrWindowWithNaturalMonthIterator.java` | Constructor update |
| `GroupByTimeExpression.java` | Add fields and serialization |
| `ExpressionFactory.java` | Normalize `[start, end]` to `[start, end+1)` |
| `TimeRangeIteratorTest.java` | Fix test signatures for new factory |

## Test Plan

- [x] Unit tests pass (`TimeRangeIteratorTest` - 4 tests)
- [x] Code formatting verified (`mvn spotless:check`)
- [ ] Integration tests (to be added if needed)

## Compatibility

This is a **backward-compatible** change. The existing `[start, end)` syntax continues to work as before. The new `[start, end]` syntax is opt-in.

Fixes #17108