### PR TITLE
Remove unused AGGREGATE_TIME_LIST (was AGGREGRATE_TIME_LIST)

### DIFF
--- a/iotdb-client/cli/src/main/java/org/apache/iotdb/cli/AbstractCli.java
+++ b/iotdb-client/cli/src/main/java/org/apache/iotdb/cli/AbstractCli.java
@@ -88,7 +88,6 @@ public abstract class AbstractCli {
   static final int CODE_ERROR = 1;
 
   static final String ISO8601_ARGS = "disableISO8601";
-  static final List<String> AGGREGRATE_TIME_LIST = new ArrayList<>();
   static final String RPC_COMPRESS_ARGS = "c";
   private static final String RPC_COMPRESS_NAME = "rpcCompressed";
   static final String TIMEOUT_ARGS = "timeout";

--- a/iotdb-client/cli/src/main/java/org/apache/iotdb/cli/Cli.java
+++ b/iotdb-client/cli/src/main/java/org/apache/iotdb/cli/Cli.java
@@ -185,7 +185,6 @@ public class Cli extends AbstractCli {
       connection.setQueryTimeout(queryTimeout);
       properties = connection.getServerProperties();
       timestampPrecision = properties.getTimestampPrecision();
-      AGGREGRATE_TIME_LIST.addAll(properties.getSupportedTimeAggregationOperations());
       processCommand(ctx, execute, connection);
       ctx.exit(lastProcessStatus);
     } catch (SQLException e) {
@@ -200,7 +199,6 @@ public class Cli extends AbstractCli {
             DriverManager.getConnection(Config.IOTDB_URL_PREFIX + host + ":" + port + "/", info)) {
       connection.setQueryTimeout(queryTimeout);
       properties = connection.getServerProperties();
-      AGGREGRATE_TIME_LIST.addAll(properties.getSupportedTimeAggregationOperations());
       timestampPrecision = properties.getTimestampPrecision();
 
       echoStarting(ctx);


### PR DESCRIPTION
## Description

Remove the unused constant `AGGREGATE_TIME_LIST` (previously named `AGGREGRATE_TIME_LIST`) from the CLI, as requested by the maintainer. The list was only ever populated via `addAll(properties.getSupportedTimeAggregationOperations())` in `executeSql()` and `receiveCommands()` and was never read anywhere, so it is dead code.

### Changes
- **AbstractCli.java**: Remove the static field `AGGREGATE_TIME_LIST`.
- **Cli.java**: Remove both `AGGREGATE_TIME_LIST.addAll(...)` calls (in `executeSql()` and `receiveCommands()`).

No functional change; behavior is unchanged.

Closes #17155 