### PR TITLE
[IOTDB-17191] CLI: add space after error prefix in three messages

### DIFF
--- a/iotdb-client/cli/src/main/java/org/apache/iotdb/cli/Cli.java
+++ b/iotdb-client/cli/src/main/java/org/apache/iotdb/cli/Cli.java
@@ -95,7 +95,7 @@ public class Cli extends AbstractCli {
           .println(IOTDB_ERROR_PREFIX + ": Input params error because " + e.getMessage());
       ctx.exit(CODE_ERROR);
     } catch (Exception e) {
-      ctx.getPrinter().println(IOTDB_ERROR_PREFIX + ": Exit cli with error " + e.getMessage());
+      ctx.getPrinter().println(IOTDB_ERROR_PREFIX + ": Exit cli with error: " + e.getMessage());
       ctx.exit(CODE_ERROR);
     }
     LineReader lineReader = JlineUtils.getLineReader(ctx, username, host, port);


### PR DESCRIPTION
   ## What's changed
   Adds the missing separator after `IOTDB_ERROR_PREFIX` ("Error") in three CLI error messages so they display as "Error: ..." instead of "Error...".

   ## Changes
   - **ArgsErrorException** (init): `Error` + `: Input params error because ` + message
   - **Exception** (init): `Error` + `: Exit cli with error ` + message  
   - **SQLException** (executeSql): `Error` + `: Can't execute sql because ` + message

   Fixes #17191 