### PR TITLE
Fix external service ClassLoader context handling and dependency scope

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -86,7 +86,6 @@
                                 <descriptor>src/assembly/confignode.xml</descriptor>
                                 <descriptor>src/assembly/cli.xml</descriptor>
                                 <descriptor>src/assembly/library-udf.xml</descriptor>
-                                <descriptor>src/assembly/external-service-impl.xml</descriptor>
                             </descriptors>
                             <finalName>apache-iotdb-${project.version}</finalName>
                         </configuration>

--- a/external-service-impl/rest/pom.xml
+++ b/external-service-impl/rest/pom.xml
@@ -153,7 +153,6 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>

--- a/iotdb-core/datanode/pom.xml
+++ b/iotdb-core/datanode/pom.xml
@@ -224,10 +224,6 @@
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.ws.rs</groupId>
-            <artifactId>jakarta.ws.rs-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
             <scope>test</scope>

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/view/visitor/TransformToExpressionVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/view/visitor/TransformToExpressionVisitor.java
@@ -76,8 +76,6 @@ import org.apache.iotdb.db.queryengine.plan.expression.leaf.TimestampOperand;
 
 import org.apache.tsfile.utils.Pair;
 
-import javax.ws.rs.NotSupportedException;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -90,15 +88,14 @@ public class TransformToExpressionVisitor extends ViewExpressionVisitor<Expressi
 
   @Override
   public Expression visitExpression(ViewExpression expression, Void context) {
-    throw new RuntimeException(
-        new NotSupportedException(
-            "visitExpression in TransformToExpressionVisitor is not supported."));
+    throw new UnsupportedOperationException(
+        "visitExpression in TransformToExpressionVisitor is not supported.");
   }
 
   // region leaf operand
   @Override
   public Expression visitLeafOperand(LeafViewOperand leafViewOperand, Void context) {
-    throw new RuntimeException(new NotSupportedException("Can not construct abstract class."));
+    throw new UnsupportedOperationException("Can not construct abstract class.");
   }
 
   @Override
@@ -131,7 +128,7 @@ public class TransformToExpressionVisitor extends ViewExpressionVisitor<Expressi
   // region Unary Expressions
   @Override
   public Expression visitUnaryExpression(UnaryViewExpression unaryViewExpression, Void context) {
-    throw new RuntimeException(new NotSupportedException("Can not construct abstract class."));
+    throw new UnsupportedOperationException("Can not construct abstract class.");
   }
 
   @Override
@@ -184,7 +181,7 @@ public class TransformToExpressionVisitor extends ViewExpressionVisitor<Expressi
   @Override
   // region Binary Expressions
   public Expression visitBinaryExpression(BinaryViewExpression binaryViewExpression, Void context) {
-    throw new RuntimeException(new NotSupportedException("Can not construct abstract class."));
+    throw new UnsupportedOperationException("Can not construct abstract class.");
   }
 
   private Pair<Expression, Expression> getExpressionsForBinaryExpression(
@@ -197,7 +194,7 @@ public class TransformToExpressionVisitor extends ViewExpressionVisitor<Expressi
   // region Binary : Arithmetic Binary Expression
   public Expression visitArithmeticBinaryExpression(
       ArithmeticBinaryViewExpression arithmeticBinaryExpression, Void context) {
-    throw new RuntimeException(new NotSupportedException("Can not construct abstract class."));
+    throw new UnsupportedOperationException("Can not construct abstract class.");
   }
 
   public Expression visitAdditionExpression(
@@ -236,7 +233,7 @@ public class TransformToExpressionVisitor extends ViewExpressionVisitor<Expressi
   // region Binary: Compare Binary Expression
   public Expression visitCompareBinaryExpression(
       CompareBinaryViewExpression compareBinaryExpression, Void context) {
-    throw new RuntimeException(new NotSupportedException("Can not construct abstract class."));
+    throw new UnsupportedOperationException("Can not construct abstract class.");
   }
 
   public Expression visitEqualToExpression(EqualToViewExpression equalToExpression, Void context) {
@@ -281,7 +278,7 @@ public class TransformToExpressionVisitor extends ViewExpressionVisitor<Expressi
   // region Binary : Logic Binary Expression
   public Expression visitLogicBinaryExpression(
       LogicBinaryViewExpression logicBinaryExpression, Void context) {
-    throw new RuntimeException(new NotSupportedException("Can not construct abstract class."));
+    throw new UnsupportedOperationException("Can not construct abstract class.");
   }
 
   public Expression visitLogicAndExpression(
@@ -302,7 +299,7 @@ public class TransformToExpressionVisitor extends ViewExpressionVisitor<Expressi
   // region Ternary Expressions
   public Expression visitTernaryExpression(
       TernaryViewExpression ternaryViewExpression, Void context) {
-    throw new RuntimeException(new NotSupportedException("Can not construct abstract class."));
+    throw new UnsupportedOperationException("Can not construct abstract class.");
   }
 
   public Expression visitBetweenExpression(

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/externalservice/ServiceInfo.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/externalservice/ServiceInfo.java
@@ -36,6 +36,7 @@ public class ServiceInfo {
   private State state;
 
   private transient IExternalService serviceInstance;
+  private transient ClassLoader serviceClassLoader;
 
   public ServiceInfo(String serviceName, String className, ServiceType serviceType) {
     this.serviceName = serviceName;
@@ -77,6 +78,14 @@ public class ServiceInfo {
 
   public void setServiceInstance(IExternalService serviceInstance) {
     this.serviceInstance = serviceInstance;
+  }
+
+  public ClassLoader getServiceClassLoader() {
+    return serviceClassLoader;
+  }
+
+  public void setServiceClassLoader(ClassLoader serviceClassLoader) {
+    this.serviceClassLoader = serviceClassLoader;
   }
 
   public void serialize(OutputStream stream) throws IOException {


### PR DESCRIPTION
Store and restore thread context ClassLoader when starting/stopping external services to ensure proper class loading
Remove `provided` scope from jakarta.ws.rs-api dependency in rest module
Remove unneed external-service-impl assembly descriptor from distribution
Add serviceClassLoader field to ServiceInfo for tracking service-specific ClassLoaders