### PR TITLE
Fix Process resource leak in system metrics collection

### DIFF
--- a/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/net/LinuxNetMetricManager.java
+++ b/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/net/LinuxNetMetricManager.java
@@ -218,8 +218,9 @@ public class LinuxNetMetricManager implements INetMetricManager {
 
     if (MetricLevel.higherOrEqual(MetricLevel.NORMAL, METRIC_CONFIG.getMetricLevel())) {
       // update socket num
+      Process process = null;
       try {
-        Process process = Runtime.getRuntime().exec(this.getConnectNumCmd);
+        process = Runtime.getRuntime().exec(this.getConnectNumCmd);
         StringBuilder result = new StringBuilder();
         try (BufferedReader input =
             new BufferedReader(new InputStreamReader(process.getInputStream()))) {
@@ -228,9 +229,19 @@ public class LinuxNetMetricManager implements INetMetricManager {
             result.append(line);
           }
         }
+        process.waitFor();
         this.connectionNum = Integer.parseInt(result.toString().trim());
       } catch (IOException e) {
         LOGGER.error("Failed to get socket num", e);
+      } catch (InterruptedException e) {
+        LOGGER.error("Interrupted while waiting for socket num command", e);
+        Thread.currentThread().interrupt();
+      } catch (NumberFormatException e) {
+        LOGGER.error("Failed to parse socket num from command output: '{}'", e.getMessage());
+      } finally {
+        if (process != null && process.isAlive()) {
+          process.destroyForcibly();
+        }
       }
     }
   }

--- a/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/system/SystemMetrics.java
+++ b/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/system/SystemMetrics.java
@@ -217,8 +217,9 @@ public class SystemMetrics implements IMetricSet {
     long time = System.currentTimeMillis();
     if (time - lastUpdateTime > MetricConstant.UPDATE_INTERVAL) {
       lastUpdateTime = time;
+      Process process = null;
       try {
-        Process process = runtime.exec(getSystemMemoryCommand);
+        process = runtime.exec(getSystemMemoryCommand);
         StringBuilder result = new StringBuilder();
         try (BufferedReader input =
             new BufferedReader(new InputStreamReader(process.getInputStream()))) {
@@ -227,6 +228,7 @@ public class SystemMetrics implements IMetricSet {
             result.append(line).append("\n");
           }
         }
+        process.waitFor();
         String[] lines = result.toString().trim().split("\n");
         // if failed to get result
         if (lines.length >= 2) {
@@ -240,6 +242,13 @@ public class SystemMetrics implements IMetricSet {
         }
       } catch (IOException e) {
         logger.debug("Failed to get memory, because ", e);
+      } catch (InterruptedException e) {
+        logger.debug("Interrupted while waiting for memory command", e);
+        Thread.currentThread().interrupt();
+      } finally {
+        if (process != null && process.isAlive()) {
+          process.destroyForcibly();
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Add `process.waitFor()` and `process.destroyForcibly()` in `finally` block to prevent zombie processes in periodic metrics collection
- Handle `InterruptedException` properly by restoring the interrupt flag
- Fixes both `SystemMetrics` (memory) and `LinuxNetMetricManager` (socket count)

Fixes #17211

## Test plan
- [x] Code compiles
- [ ] CI checks