### PR TITLE
Improve Quick Start documentation for system resource limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,29 @@ To use IoTDB, you need to have:
     # FreeBSD or Darwin
     > sudo sysctl -w kern.ipc.somaxconn=65535
     ```
+
+> ⚠️ **Important: System Resource Limits**
+>
+> IoTDB requires sufficient system resource limits to start correctly.
+> If these limits are not configured, IoTDB may fail to start or emit warnings such as
+> `"too many open files"` or `"connection reset"` in the logs.
+>
+> **Linux / macOS**
+> ```bash
+> ulimit -n 65535
+> sudo sysctl -w net.core.somaxconn=65535
+> ```
+>
+> **Docker Users**
+> When running IoTDB in Docker, these limits must be applied on the **host machine**
+> or explicitly passed to the container:
+> ```bash
+> docker run --ulimit nofile=65535:65535 ...
+> ```
+>
+> **Windows Users**
+> These commands are not applicable on Windows.
+> Please follow the Windows installation steps below and ensure sufficient system resources.
 ### Linux
 
 (This guide is based on an installation of Ubuntu 22.04.)


### PR DESCRIPTION
Fixes #17028

This PR improves the visibility and clarity of system resource
requirements in the Quick Start guide, including notes for
Docker and Windows users.