### PR TITLE
Fix refactor/s3024 stringbuilder append

### DIFF
--- a/example/session/src/main/java/org/apache/iotdb/SessionPoolExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/SessionPoolExample.java
@@ -115,8 +115,7 @@ public class SessionPoolExample {
               while (dataIterator.next()) {
                 StringBuilder builder = new StringBuilder();
                 for (String columnName : wrapper.getColumnNames()) {
-                  builder.append(dataIterator.getString(columnName))
-                          .append(" ");
+                  builder.append(dataIterator.getString(columnName)).append(" ");
                 }
                 System.out.println(builder);
               }


### PR DESCRIPTION
## Summary

This PR resolves SonarCloud rule `java:S3024` by replaces string concatenation inside `StringBuilder.append()` with multiple append calls.This avoids creating an unnecessary temporary String object.

## Affected Code

Before
`builder.append(dataIterator.getString(columnName) + " ");`
After
`builder.append(dataIterator.getString(columnName)).append(" ");`

This PR has:
- [x] been self-reviewed.
         - [x] mvn clean package -pl distribution -am -DskipTests
         - [x] mvn spotless:check
         - [x] mvn spotless:apply

Resolves : https://sonarcloud.io/project/issues?open=AZfI-87Z6bx1nQBkaMUy&id=apache_iotdb