### PR TITLE
Fix duplicate catch blocks by combining into multi catch

### DIFF
--- a/example/session/src/main/java/org/apache/iotdb/TableModelSessionExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/TableModelSessionExample.java
@@ -124,9 +124,7 @@ public class TableModelSessionExample {
         printDataSet(dataSet);
       }
 
-    } catch (IoTDBConnectionException e) {
-      e.printStackTrace();
-    } catch (StatementExecutionException e) {
+    } catch (IoTDBConnectionException | StatementExecutionException e) {
       e.printStackTrace();
     }
 
@@ -153,9 +151,7 @@ public class TableModelSessionExample {
         printDataSet(dataSet);
       }
 
-    } catch (IoTDBConnectionException e) {
-      e.printStackTrace();
-    } catch (StatementExecutionException e) {
+    } catch (IoTDBConnectionException | StatementExecutionException e) {
       e.printStackTrace();
     }
   }


### PR DESCRIPTION
## Description

This PR fixes a duplicate catch blocks by combining into multi-catch.

The change is formatting-only and does not affect behavior or logic.

This change addresses a Sonar-reported Catches should be combined java:S2147
https://sonarcloud.io/project/issues?open=AZE17wkE7_EafdyqQKlg&id=apache_iotdb

This PR has:

- [x] been self-reviewed.
- [x] been built locally with `mvn spotless:apply`.
- [x] been built locally with `mvn clean package -DskipTests`.
- [x] been built locally with `mvn -pl iotdb-core -am test -DskipTests`