### PR TITLE
[IOTDB-14788][Docker] Add REST API port to Docker Compose example

### DIFF
--- a/docker/src/main/DockerCompose/docker-compose-standalone.yml
+++ b/docker/src/main/DockerCompose/docker-compose-standalone.yml
@@ -24,7 +24,9 @@ services:
     container_name: iotdb-service
     ports:
       - "6667:6667"
+      - "18080:18080"
     environment:
+      - enable_rest_service=true
       - cn_internal_address=iotdb-service
       - cn_internal_port=10710
       - cn_consensus_port=10720

--- a/docker/src/main/DockerCompose/docker-compose-standalone.yml
+++ b/docker/src/main/DockerCompose/docker-compose-standalone.yml
@@ -24,9 +24,7 @@ services:
     container_name: iotdb-service
     ports:
       - "6667:6667"
-      - "18080:18080"
     environment:
-      - enable_rest_service=true
       - cn_internal_address=iotdb-service
       - cn_internal_port=10710
       - cn_consensus_port=10720


### PR DESCRIPTION
Fixes #14788

Description
Added port 18080 and enable_rest_service=true to the Docker Compose standalone configuration to allow REST API access by default.

Note
I searched for the Rest-Service.md documentation files but they do not appear to be present in the root of the current master branch.

CC: @CritasWang @HTHou