### PR TITLE
Fix duplicate catch blocks by combining into multi-catch

### DIFF
--- a/example/session/src/main/java/org/apache/iotdb/TableModelSessionPoolExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/TableModelSessionPoolExample.java
@@ -136,9 +136,7 @@ public class TableModelSessionPoolExample {
         printDataSet(dataSet);
       }
 
-    } catch (IoTDBConnectionException e) {
-      e.printStackTrace();
-    } catch (StatementExecutionException e) {
+    } catch (IoTDBConnectionException | StatementExecutionException e) {
       e.printStackTrace();
     } finally {
       tableSessionPool.close();
@@ -170,9 +168,7 @@ public class TableModelSessionPoolExample {
         printDataSet(dataSet);
       }
 
-    } catch (IoTDBConnectionException e) {
-      e.printStackTrace();
-    } catch (StatementExecutionException e) {
+    } catch (IoTDBConnectionException | StatementExecutionException e) {
       e.printStackTrace();
     }
 
@@ -183,9 +179,7 @@ public class TableModelSessionPoolExample {
         printDataSet(dataSet);
       }
 
-    } catch (IoTDBConnectionException e) {
-      e.printStackTrace();
-    } catch (StatementExecutionException e) {
+    } catch (IoTDBConnectionException | StatementExecutionException e) {
       e.printStackTrace();
     } finally {
       tableSessionPool.close();


### PR DESCRIPTION
## Description

This PR fixes a duplicate catch blocks by combining into multi-catch.

The change is formatting-only and does not affect behavior or logic.

This change addresses a Sonar-reported Catches should be combined java:S2147
https://sonarcloud.io/project/issues?open=AZE17wi77_EafdyqQKlF&id=apache_iotdb


## Affected file
`example/session/src/main/java/org/apache/iotdb/TableModelSessionPoolExample.java`
line number : 139, 173, 186

This PR has:

- [x] been self-reviewed.
- [x] been built locally with `mvn spotless:apply`.
- [x] been built locally with `mvn clean package -DskipTests`.
- [x] been built locally with `mvn -pl iotdb-core -am test -DskipTests`.