### PR TITLE
Fix line length violations across multiple example files

### DIFF
--- a/example/jdbc/src/main/java/org/apache/iotdb/TableModelJDBCExample.java
+++ b/example/jdbc/src/main/java/org/apache/iotdb/TableModelJDBCExample.java
@@ -51,10 +51,12 @@ public class TableModelJDBCExample {
 
       // or use full qualified table name
       statement.execute(
-          "create table test1.table1(region_id STRING TAG, plant_id STRING TAG, device_id STRING TAG, model STRING ATTRIBUTE, temperature FLOAT FIELD, humidity DOUBLE FIELD) with (TTL=3600000)");
+          "create table test1.table1(region_id STRING TAG, plant_id STRING TAG, device_id STRING TAG, "
+              + "model STRING ATTRIBUTE, temperature FLOAT FIELD, humidity DOUBLE FIELD) with (TTL=3600000)");
 
       statement.execute(
-          "create table table2(region_id STRING TAG, plant_id STRING TAG, color STRING ATTRIBUTE, temperature FLOAT FIELD, speed DOUBLE FIELD) with (TTL=6600000)");
+          "create table table2(region_id STRING TAG, plant_id STRING TAG, color STRING ATTRIBUTE, "
+              + "temperature FLOAT FIELD, speed DOUBLE FIELD) with (TTL=6600000)");
 
       // show tables from current database
       try (ResultSet resultSet = statement.executeQuery("SHOW TABLES")) {

--- a/example/rest-java-example/src/main/java/org/apache/iotdb/HttpExample.java
+++ b/example/rest-java-example/src/main/java/org/apache/iotdb/HttpExample.java
@@ -94,7 +94,10 @@ public class HttpExample {
     try {
       HttpPost httpPost = getHttpPost("http://127.0.0.1:18080/rest/v1/insertTablet");
       String json =
-          "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"s3\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"dataTypes\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[11,2],[1635000012345555,1635000012345556],[1.41,null],[null,false],[null,3.5555]],\"isAligned\":false,\"deviceId\":\"root.sg25\"}";
+          "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"s3\",\"s4\",\"s5\","
+              + "\"s6\",\"s7\",\"s8\"],\"dataTypes\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\","
+              + "\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[11,2],[1635000012345555,1635000012345556],"
+              + "[1.41,null],[null,false],[null,3.5555]],\"isAligned\":false,\"deviceId\":\"root.sg25\"}";
       httpPost.setEntity(new StringEntity(json, Charset.defaultCharset()));
       response = httpClient.execute(httpPost);
       HttpEntity responseEntity = response.getEntity();

--- a/example/rest-java-example/src/main/java/org/apache/iotdb/HttpsExample.java
+++ b/example/rest-java-example/src/main/java/org/apache/iotdb/HttpsExample.java
@@ -94,7 +94,10 @@ public class HttpsExample {
     try {
       HttpPost httpPost = getHttpPost("https://127.0.0.1:18080/rest/v1/insertTablet");
       String json =
-          "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"s3\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"dataTypes\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[11,2],[1635000012345555,1635000012345556],[1.41,null],[null,false],[null,3.5555]],\"isAligned\":false,\"deviceId\":\"root.sg25\"}";
+          "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"s3\",\"s4\",\"s5\","
+              + "\"s6\",\"s7\",\"s8\"],\"dataTypes\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\","
+              + "\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[11,2],[1635000012345555,1635000012345556],"
+              + "[1.41,null],[null,false],[null,3.5555]],\"isAligned\":false,\"deviceId\":\"root.sg25\"}";
       httpPost.setEntity(new StringEntity(json, Charset.defaultCharset()));
       response = httpClient.execute(httpPost);
       HttpEntity responseEntity = response.getEntity();


### PR DESCRIPTION
## Description

This PR fixes line length violations reported by the sonarcloud analysis tool.These changes ensure the code follows the project's formatting guidelines.

Changes:
- Updated multiple files in the example module.
- Adjusted lines to comply with the project's maximum line length rule.

## Files modified:
- `example/jdbc/src/main/java/org/apache/iotdb/TableModelJDBCExample.java`.
- `example/rest-java-example/src/main/java/org/apache/iotdb/HttpExample.java`.
- `example/rest-java-example/src/main/java/org/apache/iotdb/HttpsExample.java`.


This change addresses a Sonar-reported Line Length external_checkstyle:sizes.LineLengthCheck:

- https://sonarcloud.io/project/issues?open=AZUYD9W4mFkwrRLYG_iL&id=apache_iotdb
- https://sonarcloud.io/project/issues?open=AYMlMcinDl3pdh6pMbzZ&id=apache_iotdb
- https://sonarcloud.io/project/issues?open=AYMlMcWBDl3pdh6pMbzD&id=apache_iotdb

This PR has:

- [x] been self-reviewed.
- [x] been built locally with `mvn spotless:apply`.
- [x] been built locally with `mvn clean package -DskipTests`.
- [x] been built locally with `mvn -pl iotdb-core -am test -DskipTests`.