### PR TITLE
Fix DirectoryChecker.deregisterAll to close/delete all lock resources

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/DirectoryChecker.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/DirectoryChecker.java
@@ -119,16 +119,32 @@ public class DirectoryChecker {
   }
 
   public void deregisterAll() {
-    try {
-      for (RandomAccessFile randomAccessFile : randomAccessFileList) {
+    IOException first = null;
+    for (RandomAccessFile randomAccessFile : randomAccessFileList) {
+      try {
         randomAccessFile.close();
         // it will release lock automatically after close
+      } catch (IOException e) {
+        if (first == null) {
+          first = e;
+        } else {
+          first.addSuppressed(e);
+        }
       }
-      for (File file : fileList) {
+    }
+    for (File file : fileList) {
+      try {
         FileUtils.delete(file);
+      } catch (IOException e) {
+        if (first == null) {
+          first = e;
+        } else {
+          first.addSuppressed(e);
+        }
       }
-    } catch (IOException e) {
-      logger.warn("Failed to deregister file lock because {}", e.getMessage(), e);
+    }
+    if (first != null) {
+      logger.warn("Failed to deregister one or more file locks: {}", e.getMessage(), e);
     }
   }
 


### PR DESCRIPTION
## Description

- Fix `DirectoryChecker#deregisterAll()` so cleanup doesn’t stop on the first `IOException`.

- Close all `RandomAccessFile` instances (releasing file locks) and then attempt deleting all lock files, even if earlier closes/deletes fail.

- Aggregate failures by keeping the first `IOException` and suppressing subsequent ones; log once at the end if any failures occurred.

<hr>

This PR has:

* [x] been self-reviewed.
* [ ] added documentation for new or modified features or behaviors.
* [ ] added Javadocs for most classes and all non-trivial methods.
* [ ] added or updated version, **license**, or notice information
* [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
* [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for code coverage.
* [ ] added integration tests.
* [ ] been tested in a test IoTDB cluster.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

* `org.apache.iotdb.db.storageengine.rescon.disk.DirectoryChecker`
