### PR TITLE
Fix the duplicate literals using the constant

### DIFF
--- a/example/jdbc/src/main/java/org/apache/iotdb/TableModelJDBCExample.java
+++ b/example/jdbc/src/main/java/org/apache/iotdb/TableModelJDBCExample.java
@@ -34,6 +34,7 @@ import java.sql.Statement;
 public class TableModelJDBCExample {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TableModelJDBCExample.class);
+  private static final String SHOW_TABLES = "SHOW TABLES";
 
   public static void main(String[] args) throws ClassNotFoundException, SQLException {
     Class.forName("org.apache.iotdb.jdbc.IoTDBDriver");
@@ -57,7 +58,7 @@ public class TableModelJDBCExample {
           "create table table2(region_id STRING TAG, plant_id STRING TAG, color STRING ATTRIBUTE, temperature FLOAT FIELD, speed DOUBLE FIELD) with (TTL=6600000)");
 
       // show tables from current database
-      try (ResultSet resultSet = statement.executeQuery("SHOW TABLES")) {
+      try (ResultSet resultSet = statement.executeQuery(SHOW_TABLES)) {
         ResultSetMetaData metaData = resultSet.getMetaData();
         System.out.println(metaData.getColumnCount());
         while (resultSet.next()) {
@@ -85,7 +86,7 @@ public class TableModelJDBCExample {
                 "jdbc:iotdb://127.0.0.1:6667/test1?sql_dialect=table", "root", "root");
         Statement statement = connection.createStatement()) {
       // show tables from current database test1
-      try (ResultSet resultSet = statement.executeQuery("SHOW TABLES")) {
+      try (ResultSet resultSet = statement.executeQuery(SHOW_TABLES)) {
         ResultSetMetaData metaData = resultSet.getMetaData();
         System.out.println(metaData.getColumnCount());
         while (resultSet.next()) {
@@ -96,7 +97,7 @@ public class TableModelJDBCExample {
       // change database to test2
       statement.execute("use test2");
 
-      try (ResultSet resultSet = statement.executeQuery("SHOW TABLES")) {
+      try (ResultSet resultSet = statement.executeQuery(SHOW_TABLES)) {
         ResultSetMetaData metaData = resultSet.getMetaData();
         System.out.println(metaData.getColumnCount());
         while (resultSet.next()) {

--- a/example/session/src/main/java/org/apache/iotdb/TableModelSessionExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/TableModelSessionExample.java
@@ -39,6 +39,7 @@ import static org.apache.iotdb.SessionExample.printDataSet;
 public class TableModelSessionExample {
 
   private static final String LOCAL_URL = "127.0.0.1:6667";
+  private static final String SHOW_TABLES = "SHOW TABLES";
 
   public static void main(String[] args) {
 
@@ -63,7 +64,7 @@ public class TableModelSessionExample {
           "create table table2(region_id STRING TAG, plant_id STRING TAG, color STRING ATTRIBUTE, temperature FLOAT FIELD, speed DOUBLE FIELD) with (TTL=6600000)");
 
       // show tables from current database
-      try (SessionDataSet dataSet = session.executeQueryStatement("SHOW TABLES")) {
+      try (SessionDataSet dataSet = session.executeQueryStatement(SHOW_TABLES)) {
         System.out.println(dataSet.getColumnNames());
         while (dataSet.hasNext()) {
           System.out.println(dataSet.next());
@@ -140,7 +141,7 @@ public class TableModelSessionExample {
             .build()) {
 
       // show tables from current database
-      try (SessionDataSet dataSet = session.executeQueryStatement("SHOW TABLES")) {
+      try (SessionDataSet dataSet = session.executeQueryStatement(SHOW_TABLES)) {
         printDataSet(dataSet);
       }
 
@@ -149,7 +150,7 @@ public class TableModelSessionExample {
 
       // show tables by specifying another database
       // using SHOW tables FROM
-      try (SessionDataSet dataSet = session.executeQueryStatement("SHOW TABLES")) {
+      try (SessionDataSet dataSet = session.executeQueryStatement(SHOW_TABLES)) {
         printDataSet(dataSet);
       }
 

--- a/example/session/src/main/java/org/apache/iotdb/TableModelSessionPoolExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/TableModelSessionPoolExample.java
@@ -40,6 +40,7 @@ import static org.apache.iotdb.SessionExample.printDataSet;
 public class TableModelSessionPoolExample {
 
   private static final String LOCAL_URL = "127.0.0.1:6667";
+  private static final String SHOW_TABLES = "SHOW TABLES";
 
   public static void main(String[] args) {
 
@@ -78,7 +79,7 @@ public class TableModelSessionPoolExample {
               + "speed DOUBLE FIELD) with (TTL=6600000)");
 
       // show tables from current database
-      try (SessionDataSet dataSet = session.executeQueryStatement("SHOW TABLES")) {
+      try (SessionDataSet dataSet = session.executeQueryStatement(SHOW_TABLES)) {
         printDataSet(dataSet);
       }
 
@@ -157,7 +158,7 @@ public class TableModelSessionPoolExample {
     try (ITableSession session = tableSessionPool.getSession()) {
 
       // show tables from current database
-      try (SessionDataSet dataSet = session.executeQueryStatement("SHOW TABLES")) {
+      try (SessionDataSet dataSet = session.executeQueryStatement(SHOW_TABLES)) {
         printDataSet(dataSet);
       }
 
@@ -166,7 +167,7 @@ public class TableModelSessionPoolExample {
 
       // show tables by specifying another database
       // using SHOW tables FROM
-      try (SessionDataSet dataSet = session.executeQueryStatement("SHOW TABLES")) {
+      try (SessionDataSet dataSet = session.executeQueryStatement(SHOW_TABLES)) {
         printDataSet(dataSet);
       }
 
@@ -179,7 +180,7 @@ public class TableModelSessionPoolExample {
     try (ITableSession session = tableSessionPool.getSession()) {
 
       // show tables from default database test1
-      try (SessionDataSet dataSet = session.executeQueryStatement("SHOW TABLES")) {
+      try (SessionDataSet dataSet = session.executeQueryStatement(SHOW_TABLES)) {
         printDataSet(dataSet);
       }
 


### PR DESCRIPTION
## Description

This PR fixes duplicate literals reported by the sonarcloud analysis tool.These changes ensure the code follows the project's formatting guidelines.

Changes:
- replace the duplicate literals with constant


## Files modified:
- `example/jdbc/src/main/java/org/apache/iotdb/TableModelJDBCExample.java`.
- `example/session/src/main/java/org/apache/iotdb/TableModelSessionExample.java`.
- `example/session/src/main/java/org/apache/iotdb/TableModelSessionPoolExample.java`.


This change addresses a Sonar-reported duplicate literals for the show tables:

- https://sonarcloud.io/project/issues?open=AZE17wkw7_EafdyqQKly&id=apache_iotdb
- https://sonarcloud.io/project/issues?open=AZE17wi77_EafdyqQKlE&id=apache_iotdb
- https://sonarcloud.io/project/issues?open=AZE17wkE7_EafdyqQKlf&id=apache_iotdb


This PR has:

- [x] been self-reviewed.
- [x] been built locally with `mvn spotless:apply`.
- [x] been built locally with `mvn clean package -DskipTests`.
- [x] been built locally with `mvn -pl iotdb-core -am test -DskipTests`.