### PR TITLE
Fix incorrect early termination in descending scan of unpackOneFakeMemChunkMetaData

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBFlushQueryIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBFlushQueryIT.java
@@ -243,6 +243,29 @@ public class IoTDBFlushQueryIT {
     }
   }
 
+  @Test
+  public void testStreamingQueryMemTableDescWithTimeFilter()
+      throws IoTDBConnectionException, StatementExecutionException {
+    String device = "root.stream3.d1";
+    try (ISession session = EnvFactory.getEnv().getSessionConnection()) {
+      session.open();
+      generateTimeRangeWithTimestamp(session, device, 1, 2);
+      session.executeNonQueryStatement("flush");
+      generateTimeRangeWithTimestamp(session, device, 100000, 200000);
+      generateTimeRangeWithTimestamp(session, device, 400000, 500000);
+
+      SessionDataSet sessionDataSet =
+          session.executeQueryStatement(
+              "select s1 from root.stream3.d1 where time >= 350000 order by time desc limit 1");
+      SessionDataSet.DataIterator iterator = sessionDataSet.iterator();
+      long value = 0;
+      while (iterator.next()) {
+        value = iterator.getLong(1);
+      }
+      Assert.assertEquals(500000L, value);
+    }
+  }
+
   private static void generateTimeRangeWithTimestamp(
       ISession session, String device, long start, long end)
       throws IoTDBConnectionException, StatementExecutionException {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/SeriesScanUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/SeriesScanUtil.java
@@ -724,28 +724,50 @@ public class SeriesScanUtil implements Accountable {
     MemPointIterator memPointIterator =
         readOnlyMemChunk.createMemPointIterator(
             orderUtils.getScanOrder(), scanOptions.getGlobalTimeFilter());
-    for (Statistics<? extends Serializable> statistics : statisticsList) {
-      long orderTime = orderUtils.getOrderTime(statistics);
-      boolean canSkip =
-          (orderUtils.getAscending() && orderTime > satisfiedTimeRange.getMax())
-              || (!orderUtils.getAscending() && orderTime < satisfiedTimeRange.getMin());
-      if (canSkip) {
-        break;
+    if (orderUtils.getAscending()) {
+      for (Statistics<? extends Serializable> statistics : statisticsList) {
+        long orderTime = orderUtils.getOrderTime(statistics);
+        if (orderTime > satisfiedTimeRange.getMax()) {
+          break;
+        }
+        IVersionPageReader versionPageReader =
+            new LazyMemVersionPageReader(
+                context,
+                timestampInFileName,
+                chunkMetaData.getVersion(),
+                chunkMetaData.getOffsetOfChunkHeader(),
+                isAligned,
+                statistics,
+                memPointIterator,
+                chunkMetaData.isSeq());
+        if (chunkMetaData.isSeq()) {
+          seqPageReaders.add(versionPageReader);
+        } else {
+          unSeqPageReaders.add(versionPageReader);
+        }
       }
-      IVersionPageReader versionPageReader =
-          new LazyMemVersionPageReader(
-              context,
-              timestampInFileName,
-              chunkMetaData.getVersion(),
-              chunkMetaData.getOffsetOfChunkHeader(),
-              isAligned,
-              statistics,
-              memPointIterator,
-              chunkMetaData.isSeq());
-      if (chunkMetaData.isSeq()) {
-        seqPageReaders.add(versionPageReader);
-      } else {
-        unSeqPageReaders.add(versionPageReader);
+    } else {
+      for (int i = statisticsList.size() - 1; i >= 0; i--) {
+        Statistics<? extends Serializable> statistics = statisticsList.get(i);
+        long orderTime = orderUtils.getOrderTime(statistics);
+        if (orderTime < satisfiedTimeRange.getMin()) {
+          break;
+        }
+        IVersionPageReader versionPageReader =
+            new LazyMemVersionPageReader(
+                context,
+                timestampInFileName,
+                chunkMetaData.getVersion(),
+                chunkMetaData.getOffsetOfChunkHeader(),
+                isAligned,
+                statistics,
+                memPointIterator,
+                chunkMetaData.isSeq());
+        if (chunkMetaData.isSeq()) {
+          seqPageReaders.add(versionPageReader);
+        } else {
+          unSeqPageReaders.add(versionPageReader);
+        }
       }
     }
   }


### PR DESCRIPTION
## Description
### Problem
In the streaming query path of MemChunkLoader, unpackOneFakeMemChunkMetaData iterates through statisticsList to construct LazyMemVersionPageReader instances.

However, the original implementation always iterated statisticsList in ascending order while using the following early termination logic:
```
(orderUtils.getAscending() && orderTime > satisfiedTimeRange.getMax())
|| (!orderUtils.getAscending() && orderTime < satisfiedTimeRange.getMin())
```
When executing a descending scan, statisticsList is still ordered from small to large timestamps. This may cause the loop to break prematurely because the first element already satisfies orderTime < satisfiedTimeRange.getMin(), even though later elements could still fall within the query time range.

As a result, some valid pages may not be added to the page reader list, leading to missing data during descending scans.

### Solution

This PR fixes the issue by iterating statisticsList according to the scan order:
	•	Ascending scan: iterate statisticsList in its natural order.
	•	Descending scan: iterate statisticsList in reverse order.

With this change, the early termination condition (break) becomes correct for both scan directions because the iteration order now matches the scan order.

The behavior is now consistent with the logic used in unpackOneChunkMetaData, where pageReaderList is also traversed differently depending on the scan order.