### PR TITLE
[IOTDB-17268] Optimize: replace unbounded thread pool with bounded ThreadPoolExecutor in SessionPoolExample

### DIFF
--- a/example/session/src/main/java/org/apache/iotdb/SessionPoolExample.java
+++ b/example/session/src/main/java/org/apache/iotdb/SessionPoolExample.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -31,8 +31,10 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 @SuppressWarnings({"squid:S106", "squid:S1144"})
 public class SessionPoolExample {
@@ -72,7 +74,16 @@ public class SessionPoolExample {
     // Choose the SessionPool you going to use
     constructRedirectSessionPool();
 
-    service = Executors.newFixedThreadPool(10);
+    // Professional Bounded ThreadPool to avoid OOM
+    service =
+        new ThreadPoolExecutor(
+            10,
+            10,
+            0L,
+            TimeUnit.MILLISECONDS,
+            new ArrayBlockingQueue<>(1000),
+            new ThreadPoolExecutor.CallerRunsPolicy());
+
     insertRecord();
     Thread.sleep(1000);
     queryByIterator();


### PR DESCRIPTION
In the current SessionPoolExample.java, the ExecutorService was using Executors.newFixedThreadPool(10). While it limits the number of active threads, it uses an unbounded LinkedBlockingQueue by default. In a high-throughput scenario, this can lead to an excessive number of queued tasks, potentially causing an OutOfMemoryError (OOM).

This PR replaces the default fixed thread pool with a manually configured ThreadPoolExecutor that uses:

Core/Max Pool Size: 10 threads.

Bounded Queue: ArrayBlockingQueue with a capacity of 1000 tasks.

Rejection Policy: CallerRunsPolicy to throttle the submission of new tasks when the queue is full, ensuring system stability.

Changes
Modified SessionPoolExample.java to use ThreadPoolExecutor instead of Executors.newFixedThreadPool.

Added necessary imports for ArrayBlockingQueue, ThreadPoolExecutor, and TimeUnit.

Cleaned up the thread pool initialization to follow best practices for resource management.

Test Result
Built successfully using mvn clean install -DskipTests -pl example/session -am.

Verified that the example runs correctly and executes queries without resource exhaustion.