### PR TITLE
Session:  session-c interface

### DIFF
--- a/example/client-c-example/README.md
+++ b/example/client-c-example/README.md
@@ -1,0 +1,68 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+# How to get a complete C client demo project (SessionC)
+
+Pure **C** examples for the IoTDB Session **C API** (`SessionC.h`): **tree model** (`tree_example`) and **table model** (`table_example`). Default connection: `127.0.0.1:6667`, user `root` / password `root` (edit the macros at the top of each `.c` file).
+
+## Get a project
+
+Using Maven to build this example project (requires **Boost**, same as the C++ client; on Windows see [`iotdb-client/client-cpp/README.md`](../../iotdb-client/client-cpp/README.md)):
+
+* `cd` the root path of the whole project
+* run  
+  `mvn package -DskipTests -P with-cpp -pl example/client-c-example -am`  
+  (use `mvn clean package ...` when no other process holds files under `iotdb-client/client-cpp/target`; on Windows add Boost paths, e.g.  
+  `-D"boost.include.dir=C:\local\boost_1_87_0" -D"boost.library.dir=C:\local\boost_1_87_0\lib64-msvc-14.2"`)
+* `cd example/client-c-example/target`
+
+After a successful build you should have:
+
+* Unpacked C++ client headers and libraries under `client/` and Thrift under `thrift/` (same layout as [client-cpp-example](../client-cpp-example/README.md))
+* CMake-generated binaries, for example on Windows MSVC:  
+  `Release/tree_example.exe`, `Release/table_example.exe`  
+  (exact path depends on the CMake generator)
+
+## Run
+
+Start IoTDB first, then:
+
+```text
+# Windows (example)
+Release\tree_example.exe
+Release\table_example.exe
+```
+
+On failure, the programs print to `stderr` and you can inspect `ts_get_last_error()`.
+
+## Source layout
+
+```
+example/client-c-example/
++-- README.md
++-- pom.xml
++-- src/
+|   +-- CMakeLists.txt
+|   +-- tree_example.c
+|   +-- table_example.c
+```
+
+The Maven build copies `src/*.c` and `src/CMakeLists.txt` into `target/` next to the unpacked `client/` and `thrift/` trees, then runs CMake to compile the two executables.

--- a/example/client-c-example/pom.xml
+++ b/example/client-c-example/pom.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.iotdb</groupId>
+        <artifactId>iotdb-examples</artifactId>
+        <version>2.0.7-SNAPSHOT</version>
+    </parent>
+    <artifactId>client-c-example</artifactId>
+    <name>IoTDB: Example: C Client (SessionC)</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.iotdb</groupId>
+            <artifactId>client-cpp</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.coderplus.maven.plugins</groupId>
+                <artifactId>copy-rename-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-c-sources-and-cmake</id>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <fileSets>
+                                <fileSet>
+                                    <sourceFile>${project.basedir}/src/tree_example.c</sourceFile>
+                                    <destinationFile>${project.build.directory}/tree_example.c</destinationFile>
+                                </fileSet>
+                                <fileSet>
+                                    <sourceFile>${project.basedir}/src/table_example.c</sourceFile>
+                                    <destinationFile>${project.build.directory}/table_example.c</destinationFile>
+                                </fileSet>
+                                <fileSet>
+                                    <sourceFile>${project.basedir}/src/CMakeLists.txt</sourceFile>
+                                    <destinationFile>${project.build.directory}/CMakeLists.txt</destinationFile>
+                                </fileSet>
+                            </fileSets>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-client</id>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.apache.iotdb</groupId>
+                                    <artifactId>client-cpp</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>zip</type>
+                                    <classifier>cpp-${os.classifier}</classifier>
+                                    <overWrite>true</overWrite>
+                                </artifactItem>
+                            </artifactItems>
+                            <outputDirectory>${project.build.directory}/client</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpack-thrift</id>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.apache.iotdb.tools</groupId>
+                                    <artifactId>iotdb-tools-thrift</artifactId>
+                                    <version>${iotdb-tools-thrift.version}</version>
+                                    <classifier>${os.classifier}</classifier>
+                                    <type>zip</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/thrift</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.github.cmake-maven-plugin</groupId>
+                <artifactId>cmake-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>cmake-generate</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <phase>compile</phase>
+                        <configuration>
+                            <generator>${cmake.generator}</generator>
+                            <sourcePath>${project.build.directory}</sourcePath>
+                            <projectDirectory>${project.build.directory}</projectDirectory>
+                            <options>
+                                <option>-DBOOST_INCLUDEDIR=${boost.include.dir}</option>
+                            </options>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>cmake-compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <phase>compile</phase>
+                        <configuration>
+                            <config>${cmake.build.type}</config>
+                            <projectDirectory>${project.build.directory}</projectDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/example/client-c-example/src/table_example.c
+++ b/example/client-c-example/src/table_example.c
@@ -1,0 +1,151 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Table model: CREATE DATABASE/TABLE, insert rows via Tablet, SELECT, DROP DATABASE.
+ * Requires IoTDB table-SQL support. Edit HOST / PORT / credentials below.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "SessionC.h"
+
+#define HOST "127.0.0.1"
+#define PORT 6667
+#define USER "root"
+#define PASS "root"
+
+#define DB_NAME "cdemo_db"
+#define TABLE_NAME "cdemo_t0"
+
+static void fail(const char* ctx, CTableSession* s) {
+    fprintf(stderr, "[table_example] %s failed: %s\n", ctx, ts_get_last_error());
+    if (s) {
+        ts_table_session_close(s);
+        ts_table_session_destroy(s);
+    }
+    exit(1);
+}
+
+int main(void) {
+    CTableSession* session = ts_table_session_new(HOST, PORT, USER, PASS, "");
+    if (!session) {
+        fprintf(stderr, "[table_example] ts_table_session_new returned NULL: %s\n", ts_get_last_error());
+        return 1;
+    }
+    if (ts_table_session_open(session) != TS_OK) {
+        fail("ts_table_session_open", session);
+    }
+
+    char sql[512];
+    snprintf(sql, sizeof(sql), "DROP DATABASE IF EXISTS %s", DB_NAME);
+    (void)ts_table_session_execute_non_query(session, sql);
+
+    snprintf(sql, sizeof(sql), "CREATE DATABASE %s", DB_NAME);
+    if (ts_table_session_execute_non_query(session, sql) != TS_OK) {
+        fail("CREATE DATABASE", session);
+    }
+
+    snprintf(sql, sizeof(sql), "USE \"%s\"", DB_NAME);
+    if (ts_table_session_execute_non_query(session, sql) != TS_OK) {
+        fail("USE DATABASE", session);
+    }
+
+    const char* ddl =
+        "CREATE TABLE " TABLE_NAME " ("
+        "tag1 string tag,"
+        "attr1 string attribute,"
+        "m1 double field)";
+    if (ts_table_session_execute_non_query(session, ddl) != TS_OK) {
+        fail("CREATE TABLE", session);
+    }
+
+    const char* columnNames[] = {"tag1", "attr1", "m1"};
+    TSDataType_C dataTypes[] = {TS_TYPE_STRING, TS_TYPE_STRING, TS_TYPE_DOUBLE};
+    TSColumnCategory_C colCategories[] = {TS_COL_TAG, TS_COL_ATTRIBUTE, TS_COL_FIELD};
+
+    CTablet* tablet = ts_tablet_new_with_category(TABLE_NAME, 3, columnNames, dataTypes, colCategories, 100);
+    if (!tablet) {
+        fail("ts_tablet_new_with_category", session);
+    }
+
+    int i;
+    for (i = 0; i < 5; i++) {
+        if (ts_tablet_add_timestamp(tablet, i, (int64_t)i) != TS_OK) {
+            ts_tablet_destroy(tablet);
+            fail("ts_tablet_add_timestamp", session);
+        }
+        if (ts_tablet_add_value_string(tablet, 0, i, "device_A") != TS_OK) {
+            ts_tablet_destroy(tablet);
+            fail("ts_tablet_add_value_string tag", session);
+        }
+        if (ts_tablet_add_value_string(tablet, 1, i, "attr_val") != TS_OK) {
+            ts_tablet_destroy(tablet);
+            fail("ts_tablet_add_value_string attr", session);
+        }
+        if (ts_tablet_add_value_double(tablet, 2, i, (double)i * 1.5) != TS_OK) {
+            ts_tablet_destroy(tablet);
+            fail("ts_tablet_add_value_double", session);
+        }
+    }
+    if (ts_tablet_set_row_count(tablet, 5) != TS_OK) {
+        ts_tablet_destroy(tablet);
+        fail("ts_tablet_set_row_count", session);
+    }
+
+    if (ts_table_session_insert(session, tablet) != TS_OK) {
+        ts_tablet_destroy(tablet);
+        fail("ts_table_session_insert", session);
+    }
+    ts_tablet_destroy(tablet);
+
+    CSessionDataSet* dataSet = NULL;
+    if (ts_table_session_execute_query(session, "SELECT * FROM " TABLE_NAME, &dataSet) != TS_OK) {
+        fail("ts_table_session_execute_query", session);
+    }
+    if (!dataSet) {
+        fprintf(stderr, "[table_example] dataSet is NULL\n");
+        ts_table_session_close(session);
+        ts_table_session_destroy(session);
+        return 1;
+    }
+    ts_dataset_set_fetch_size(dataSet, 1024);
+
+    int count = 0;
+    while (ts_dataset_has_next(dataSet)) {
+        CRowRecord* record = ts_dataset_next(dataSet);
+        if (!record) {
+            break;
+        }
+        printf("[table_example] row %d: time=%lld\n", count, (long long)ts_row_record_get_timestamp(record));
+        ts_row_record_destroy(record);
+        count++;
+    }
+    ts_dataset_destroy(dataSet);
+    printf("[table_example] SELECT returned %d row(s).\n", count);
+
+    snprintf(sql, sizeof(sql), "DROP DATABASE IF EXISTS %s", DB_NAME);
+    (void)ts_table_session_execute_non_query(session, sql);
+
+    ts_table_session_close(session);
+    ts_table_session_destroy(session);
+    return 0;
+}

--- a/example/client-c-example/src/table_example.c
+++ b/example/client-c-example/src/table_example.c
@@ -46,6 +46,7 @@ static void fail(const char* ctx, CTableSession* s) {
 }
 
 int main(void) {
+    /* Last arg: default database name; empty string leaves it unset (we USE "cdemo_db" via SQL below). */
     CTableSession* session = ts_table_session_new(HOST, PORT, USER, PASS, "");
     if (!session) {
         fprintf(stderr, "[table_example] ts_table_session_new returned NULL: %s\n", ts_get_last_error());

--- a/example/client-c-example/src/tree_example.c
+++ b/example/client-c-example/src/tree_example.c
@@ -1,0 +1,114 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Tree model: create one timeseries, insert one row via string values, SELECT, cleanup.
+ * Edit HOST / PORT / credentials below to match your IoTDB.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "SessionC.h"
+
+#define HOST "127.0.0.1"
+#define PORT 6667
+#define USER "root"
+#define PASS "root"
+
+#define TS_PATH "root.cdemo.d0.s0"
+#define DEVICE "root.cdemo.d0"
+
+static void fail(const char* ctx, CSession* s) {
+    fprintf(stderr, "[tree_example] %s failed: %s\n", ctx, ts_get_last_error());
+    if (s) {
+        ts_session_close(s);
+        ts_session_destroy(s);
+    }
+    exit(1);
+}
+
+int main(void) {
+    const char* path = TS_PATH;
+    CSession* session = ts_session_new(HOST, PORT, USER, PASS);
+    if (!session) {
+        fprintf(stderr, "[tree_example] ts_session_new returned NULL: %s\n", ts_get_last_error());
+        return 1;
+    }
+    if (ts_session_open(session) != TS_OK) {
+        fail("ts_session_open", session);
+    }
+
+    bool exists = false;
+    if (ts_session_check_timeseries_exists(session, path, &exists) != TS_OK) {
+        fail("ts_session_check_timeseries_exists", session);
+    }
+    if (exists) {
+        if (ts_session_delete_timeseries(session, path) != TS_OK) {
+            fail("ts_session_delete_timeseries (cleanup old)", session);
+        }
+    }
+    if (ts_session_create_timeseries(session, path, TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY) !=
+        TS_OK) {
+        fail("ts_session_create_timeseries", session);
+    }
+
+    const char* measurements[] = {"s0"};
+    const char* values[] = {"100"};
+    if (ts_session_insert_record_str(session, DEVICE, 1LL, 1, measurements, values) != TS_OK) {
+        fail("ts_session_insert_record_str", session);
+    }
+
+    CSessionDataSet* dataSet = NULL;
+    if (ts_session_execute_query(session, "select s0 from root.cdemo.d0", &dataSet) != TS_OK) {
+        fail("ts_session_execute_query", session);
+    }
+    if (!dataSet) {
+        fprintf(stderr, "[tree_example] dataSet is NULL\n");
+        ts_session_close(session);
+        ts_session_destroy(session);
+        return 1;
+    }
+    ts_dataset_set_fetch_size(dataSet, 1024);
+
+    int rows = 0;
+    while (ts_dataset_has_next(dataSet)) {
+        CRowRecord* record = ts_dataset_next(dataSet);
+        if (!record) {
+            break;
+        }
+        int64_t v = ts_row_record_get_int64(record, 0);
+        printf("[tree_example] row %d: s0 = %lld\n", rows, (long long)v);
+        ts_row_record_destroy(record);
+        rows++;
+    }
+    ts_dataset_destroy(dataSet);
+
+    printf("[tree_example] done, read %d row(s).\n", rows);
+
+    if (ts_session_delete_timeseries(session, path) != TS_OK) {
+        fail("ts_session_delete_timeseries", session);
+    }
+
+    ts_session_close(session);
+    ts_session_destroy(session);
+    return 0;
+}

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -85,6 +85,7 @@
             <id>with-cpp</id>
             <modules>
                 <module>client-cpp-example</module>
+                <module>client-c-example</module>
             </modules>
         </profile>
     </profiles>

--- a/iotdb-client/client-cpp/pom.xml
+++ b/iotdb-client/client-cpp/pom.xml
@@ -315,8 +315,8 @@
                             <skip>${ctest.skip.tests}</skip>
                             <name>iotdb-server</name>
                             <waitForInterrupt>false</waitForInterrupt>
-                            <!-- Maximum time in seconds to wait after launching IoTDB -->
-                            <waitAfterLaunch>15</waitAfterLaunch>
+                            <!-- Maximum time in seconds to wait after launching IoTDB (JVM cold start on Windows can exceed 15s) -->
+                            <waitAfterLaunch>45</waitAfterLaunch>
                             <!-- Redirect IoTDB server log to /dev/null -->
                             <processLogFile>${project.build.directory}/build/test/test.log</processLogFile>
                             <arguments>

--- a/iotdb-client/client-cpp/pom.xml
+++ b/iotdb-client/client-cpp/pom.xml
@@ -273,6 +273,7 @@
                         </goals>
                         <phase>integration-test</phase>
                         <configuration>
+                            <config>${cmake.build.type}</config>
                             <projectDirectory>${project.build.directory}/build/test</projectDirectory>
                             <skipTests>${maven.test.skip}</skipTests>
                         </configuration>

--- a/iotdb-client/client-cpp/src/main/CMakeLists.txt
+++ b/iotdb-client/client-cpp/src/main/CMakeLists.txt
@@ -21,7 +21,10 @@ PROJECT(iotdb_session CXX)
 SET(CMAKE_CXX_STANDARD 11)
 SET(CMAKE_CXX_STANDARD_REQUIRED ON)
 SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -g -O2 ")
+IF(NOT MSVC)
+    # Keep GCC/Clang style flags off on MSVC to avoid invalid-option build errors.
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -g -O2")
+ENDIF()
 
 # Add Thrift include directory
 INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/../../thrift/include)

--- a/iotdb-client/client-cpp/src/main/Common.h
+++ b/iotdb-client/client-cpp/src/main/Common.h
@@ -193,6 +193,31 @@ public:
     }
 
     Field() = default;
+
+    /** True if this field is SQL NULL (optional for the active dataType is unset). Unknown types are treated as null. */
+    bool isNull() const {
+        switch (dataType) {
+            case TSDataType::BOOLEAN:
+                return !boolV.is_initialized();
+            case TSDataType::INT32:
+                return !intV.is_initialized();
+            case TSDataType::INT64:
+            case TSDataType::TIMESTAMP:
+                return !longV.is_initialized();
+            case TSDataType::FLOAT:
+                return !floatV.is_initialized();
+            case TSDataType::DOUBLE:
+                return !doubleV.is_initialized();
+            case TSDataType::TEXT:
+            case TSDataType::STRING:
+            case TSDataType::BLOB:
+                return !stringV.is_initialized();
+            case TSDataType::DATE:
+                return !dateV.is_initialized();
+            default:
+                return true;
+        }
+    }
 };
 
 enum class ColumnCategory {

--- a/iotdb-client/client-cpp/src/main/SessionC.cpp
+++ b/iotdb-client/client-cpp/src/main/SessionC.cpp
@@ -1,0 +1,1417 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "SessionC.h"
+#include "Session.h"
+#include "TableSession.h"
+#include "TableSessionBuilder.h"
+#include "SessionBuilder.h"
+#include "SessionDataSet.h"
+
+#include <cstring>
+#include <string>
+#include <vector>
+#include <map>
+#include <unordered_map>
+#include <memory>
+
+/* ============================================================
+ *  Internal wrapper structs — the opaque handles point to these
+ * ============================================================ */
+
+struct CSession_ {
+    std::shared_ptr<Session> cpp;
+};
+
+struct CTableSession_ {
+    std::shared_ptr<TableSession> cpp;
+    std::shared_ptr<Session> innerSession;  // kept alive for lifetime
+};
+
+struct CTablet_ {
+    Tablet cpp;
+};
+
+struct CSessionDataSet_ {
+    std::unique_ptr<SessionDataSet> cpp;
+};
+
+struct CRowRecord_ {
+    std::shared_ptr<RowRecord> cpp;
+};
+
+/* ============================================================
+ *  Thread-local error message buffer
+ * ============================================================ */
+
+static thread_local std::string g_lastError;
+
+static void clearError() {
+    g_lastError.clear();
+}
+
+static TsStatus setError(TsStatus code, const std::string& msg) {
+    g_lastError = msg;
+    return code;
+}
+
+static TsStatus setError(TsStatus code, const std::exception& e) {
+    g_lastError = e.what();
+    return code;
+}
+
+static TsStatus handleException(const std::exception& e) {
+    const std::string msg = e.what();
+    // Try to classify exception type
+    if (dynamic_cast<const IoTDBConnectionException*>(&e)) {
+        return setError(TS_ERR_CONNECTION, e);
+    }
+    if (dynamic_cast<const ExecutionException*>(&e) ||
+        dynamic_cast<const StatementExecutionException*>(&e) ||
+        dynamic_cast<const BatchExecutionException*>(&e)) {
+        return setError(TS_ERR_EXECUTION, e);
+    }
+    return setError(TS_ERR_UNKNOWN, e);
+}
+
+extern "C" {
+
+const char* ts_get_last_error(void) {
+    return g_lastError.c_str();
+}
+
+/* ============================================================
+ *  Helpers — convert C arrays to C++ vectors
+ * ============================================================ */
+
+static std::vector<std::string> toStringVec(const char* const* arr, int count) {
+    std::vector<std::string> v;
+    v.reserve(count);
+    for (int i = 0; i < count; i++) {
+        v.emplace_back(arr[i]);
+    }
+    return v;
+}
+
+static std::vector<TSDataType::TSDataType> toTypeVec(const TSDataType_C* arr, int count) {
+    std::vector<TSDataType::TSDataType> v;
+    v.reserve(count);
+    for (int i = 0; i < count; i++) {
+        v.push_back(static_cast<TSDataType::TSDataType>(arr[i]));
+    }
+    return v;
+}
+
+static std::vector<TSEncoding::TSEncoding> toEncodingVec(const TSEncoding_C* arr, int count) {
+    std::vector<TSEncoding::TSEncoding> v;
+    v.reserve(count);
+    for (int i = 0; i < count; i++) {
+        v.push_back(static_cast<TSEncoding::TSEncoding>(arr[i]));
+    }
+    return v;
+}
+
+static std::vector<CompressionType::CompressionType> toCompressionVec(const TSCompressionType_C* arr, int count) {
+    std::vector<CompressionType::CompressionType> v;
+    v.reserve(count);
+    for (int i = 0; i < count; i++) {
+        v.push_back(static_cast<CompressionType::CompressionType>(arr[i]));
+    }
+    return v;
+}
+
+static std::map<std::string, std::string> toStringMap(int count, const char* const* keys, const char* const* values) {
+    std::map<std::string, std::string> m;
+    for (int i = 0; i < count; i++) {
+        m[keys[i]] = values[i];
+    }
+    return m;
+}
+
+/**
+ * Convert C typed values (void* const* values, TSDataType_C* types, int count)
+ * to C++ vector<char*> that Session expects.
+ * The caller must free the returned char* pointers using freeCharPtrVec().
+ */
+static std::vector<char*> toCharPtrVec(const TSDataType_C* types, const void* const* values, int count) {
+    std::vector<char*> result(count);
+    for (int i = 0; i < count; i++) {
+        switch (types[i]) {
+            case TS_TYPE_BOOLEAN: {
+                bool* p = new bool(*static_cast<const bool*>(values[i]));
+                result[i] = reinterpret_cast<char*>(p);
+                break;
+            }
+            case TS_TYPE_INT32: {
+                int32_t* p = new int32_t(*static_cast<const int32_t*>(values[i]));
+                result[i] = reinterpret_cast<char*>(p);
+                break;
+            }
+            case TS_TYPE_INT64:
+            case TS_TYPE_TIMESTAMP: {
+                int64_t* p = new int64_t(*static_cast<const int64_t*>(values[i]));
+                result[i] = reinterpret_cast<char*>(p);
+                break;
+            }
+            case TS_TYPE_FLOAT: {
+                float* p = new float(*static_cast<const float*>(values[i]));
+                result[i] = reinterpret_cast<char*>(p);
+                break;
+            }
+            case TS_TYPE_DOUBLE: {
+                double* p = new double(*static_cast<const double*>(values[i]));
+                result[i] = reinterpret_cast<char*>(p);
+                break;
+            }
+            case TS_TYPE_TEXT:
+            case TS_TYPE_STRING:
+            case TS_TYPE_BLOB:
+            default: {
+                const char* src = static_cast<const char*>(values[i]);
+                size_t len = strlen(src) + 1;
+                char* p = new char[len];
+                memcpy(p, src, len);
+                result[i] = p;
+                break;
+            }
+        }
+    }
+    return result;
+}
+
+static void freeCharPtrVec(std::vector<char*>& vec, const TSDataType_C* types, int count) {
+    for (int i = 0; i < count; i++) {
+        switch (types[i]) {
+            case TS_TYPE_BOOLEAN:   delete reinterpret_cast<bool*>(vec[i]); break;
+            case TS_TYPE_INT32:     delete reinterpret_cast<int32_t*>(vec[i]); break;
+            case TS_TYPE_INT64:
+            case TS_TYPE_TIMESTAMP: delete reinterpret_cast<int64_t*>(vec[i]); break;
+            case TS_TYPE_FLOAT:     delete reinterpret_cast<float*>(vec[i]); break;
+            case TS_TYPE_DOUBLE:    delete reinterpret_cast<double*>(vec[i]); break;
+            default:                delete[] vec[i]; break;
+        }
+    }
+}
+
+/* ============================================================
+ *  Session Lifecycle  —  Tree Model
+ * ============================================================ */
+
+CSession* ts_session_new(const char* host, int rpcPort,
+                          const char* username, const char* password) {
+    clearError();
+    try {
+        auto* cs = new CSession_();
+        cs->cpp = std::make_shared<Session>(
+            std::string(host), rpcPort,
+            std::string(username), std::string(password));
+        return cs;
+    } catch (const std::exception& e) {
+        handleException(e);
+        return nullptr;
+    }
+}
+
+CSession* ts_session_new_with_zone(const char* host, int rpcPort,
+                                    const char* username, const char* password,
+                                    const char* zoneId, int fetchSize) {
+    clearError();
+    try {
+        auto* cs = new CSession_();
+        cs->cpp = std::make_shared<Session>(
+            std::string(host), rpcPort,
+            std::string(username), std::string(password),
+            std::string(zoneId), fetchSize);
+        return cs;
+    } catch (const std::exception& e) {
+        handleException(e);
+        return nullptr;
+    }
+}
+
+CSession* ts_session_new_multi_node(const char* const* nodeUrls, int urlCount,
+                                     const char* username, const char* password) {
+    clearError();
+    try {
+        auto urls = toStringVec(nodeUrls, urlCount);
+        auto* cs = new CSession_();
+        cs->cpp = std::make_shared<Session>(urls, std::string(username), std::string(password));
+        return cs;
+    } catch (const std::exception& e) {
+        handleException(e);
+        return nullptr;
+    }
+}
+
+void ts_session_destroy(CSession* session) {
+    delete session;
+}
+
+TsStatus ts_session_open(CSession* session) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        session->cpp->open();
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_open_with_compression(CSession* session, bool enableRPCCompression) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        session->cpp->open(enableRPCCompression);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_close(CSession* session) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        session->cpp->close();
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+/* ============================================================
+ *  Session Lifecycle  —  Table Model
+ * ============================================================ */
+
+CTableSession* ts_table_session_new(const char* host, int rpcPort,
+                                     const char* username, const char* password,
+                                     const char* database) {
+    clearError();
+    try {
+        std::unique_ptr<TableSessionBuilder> builder(new TableSessionBuilder());
+        auto tableSession = builder->host(std::string(host))
+            ->rpcPort(rpcPort)
+            ->username(std::string(username))
+            ->password(std::string(password))
+            ->database(std::string(database ? database : ""))
+            ->build();
+        auto* cts = new CTableSession_();
+        cts->cpp = tableSession;
+        return cts;
+    } catch (const std::exception& e) {
+        handleException(e);
+        return nullptr;
+    }
+}
+
+CTableSession* ts_table_session_new_multi_node(const char* const* nodeUrls, int urlCount,
+                                                const char* username, const char* password,
+                                                const char* database) {
+    clearError();
+    try {
+        auto urls = toStringVec(nodeUrls, urlCount);
+        std::unique_ptr<TableSessionBuilder> builder(new TableSessionBuilder());
+        auto tableSession = builder->nodeUrls(urls)
+            ->username(std::string(username))
+            ->password(std::string(password))
+            ->database(std::string(database ? database : ""))
+            ->build();
+        auto* cts = new CTableSession_();
+        cts->cpp = tableSession;
+        return cts;
+    } catch (const std::exception& e) {
+        handleException(e);
+        return nullptr;
+    }
+}
+
+void ts_table_session_destroy(CTableSession* session) {
+    delete session;
+}
+
+TsStatus ts_table_session_open(CTableSession* session) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        session->cpp->open();
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_table_session_close(CTableSession* session) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        session->cpp->close();
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+/* ============================================================
+ *  Timezone
+ * ============================================================ */
+
+TsStatus ts_session_set_timezone(CSession* session, const char* zoneId) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        session->cpp->setTimeZone(std::string(zoneId));
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_get_timezone(CSession* session, char* buf, int bufLen) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    if (!buf || bufLen <= 0) return setError(TS_ERR_INVALID_PARAM, "invalid buffer");
+    try {
+        std::string tz = session->cpp->getTimeZone();
+        if ((int)tz.size() >= bufLen) {
+            return setError(TS_ERR_INVALID_PARAM, "buffer too small");
+        }
+        strncpy(buf, tz.c_str(), bufLen);
+        buf[bufLen - 1] = '\0';
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+/* ============================================================
+ *  Database Management  (Tree Model)
+ * ============================================================ */
+
+TsStatus ts_session_create_database(CSession* session, const char* database) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        session->cpp->createDatabase(std::string(database));
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_delete_database(CSession* session, const char* database) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        session->cpp->deleteDatabase(std::string(database));
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_delete_databases(CSession* session, const char* const* databases, int count) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        auto dbs = toStringVec(databases, count);
+        session->cpp->deleteDatabases(dbs);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+/* ============================================================
+ *  Timeseries Management  (Tree Model)
+ * ============================================================ */
+
+TsStatus ts_session_create_timeseries(CSession* session, const char* path,
+                                       TSDataType_C dataType, TSEncoding_C encoding,
+                                       TSCompressionType_C compressor) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        session->cpp->createTimeseries(
+            std::string(path),
+            static_cast<TSDataType::TSDataType>(dataType),
+            static_cast<TSEncoding::TSEncoding>(encoding),
+            static_cast<CompressionType::CompressionType>(compressor));
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_create_timeseries_ex(CSession* session, const char* path,
+                                          TSDataType_C dataType, TSEncoding_C encoding,
+                                          TSCompressionType_C compressor,
+                                          int propsCount,
+                                          const char* const* propKeys,
+                                          const char* const* propValues,
+                                          int tagsCount,
+                                          const char* const* tagKeys,
+                                          const char* const* tagValues,
+                                          int attrsCount,
+                                          const char* const* attrKeys,
+                                          const char* const* attrValues,
+                                          const char* measurementAlias) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        std::map<std::string, std::string> props = propsCount > 0 ? toStringMap(propsCount, propKeys, propValues) : std::map<std::string, std::string>();
+        std::map<std::string, std::string> tags = tagsCount > 0 ? toStringMap(tagsCount, tagKeys, tagValues) : std::map<std::string, std::string>();
+        std::map<std::string, std::string> attrs = attrsCount > 0 ? toStringMap(attrsCount, attrKeys, attrValues) : std::map<std::string, std::string>();
+        session->cpp->createTimeseries(
+            std::string(path),
+            static_cast<TSDataType::TSDataType>(dataType),
+            static_cast<TSEncoding::TSEncoding>(encoding),
+            static_cast<CompressionType::CompressionType>(compressor),
+            &props, &tags, &attrs,
+            std::string(measurementAlias ? measurementAlias : ""));
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_create_multi_timeseries(CSession* session, int count,
+                                             const char* const* paths,
+                                             const TSDataType_C* dataTypes,
+                                             const TSEncoding_C* encodings,
+                                             const TSCompressionType_C* compressors) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        auto pathsVec = toStringVec(paths, count);
+        auto typesVec = toTypeVec(dataTypes, count);
+        auto encVec = toEncodingVec(encodings, count);
+        auto compVec = toCompressionVec(compressors, count);
+        session->cpp->createMultiTimeseries(
+            pathsVec, typesVec, encVec, compVec,
+            nullptr, nullptr, nullptr, nullptr);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_create_aligned_timeseries(CSession* session, const char* deviceId,
+                                               int count,
+                                               const char* const* measurements,
+                                               const TSDataType_C* dataTypes,
+                                               const TSEncoding_C* encodings,
+                                               const TSCompressionType_C* compressors) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        auto measurementsVec = toStringVec(measurements, count);
+        auto typesVec = toTypeVec(dataTypes, count);
+        auto encVec = toEncodingVec(encodings, count);
+        auto compVec = toCompressionVec(compressors, count);
+        session->cpp->createAlignedTimeseries(
+            std::string(deviceId), measurementsVec, typesVec, encVec, compVec);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_check_timeseries_exists(CSession* session, const char* path, bool* exists) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    if (!exists) return setError(TS_ERR_INVALID_PARAM, "exists pointer is null");
+    try {
+        *exists = session->cpp->checkTimeseriesExists(std::string(path));
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_delete_timeseries(CSession* session, const char* path) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        session->cpp->deleteTimeseries(std::string(path));
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_delete_timeseries_batch(CSession* session, const char* const* paths, int count) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        auto pathsVec = toStringVec(paths, count);
+        session->cpp->deleteTimeseries(pathsVec);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+/* ============================================================
+ *  Tablet Operations
+ * ============================================================ */
+
+CTablet* ts_tablet_new(const char* deviceId, int columnCount,
+                        const char* const* columnNames,
+                        const TSDataType_C* dataTypes,
+                        int maxRowNumber) {
+    try {
+        std::vector<std::pair<std::string, TSDataType::TSDataType>> schemas;
+        schemas.reserve(columnCount);
+        for (int i = 0; i < columnCount; i++) {
+            schemas.emplace_back(std::string(columnNames[i]),
+                                 static_cast<TSDataType::TSDataType>(dataTypes[i]));
+        }
+        auto* ct = new CTablet_();
+        ct->cpp = Tablet(std::string(deviceId), schemas, maxRowNumber);
+        return ct;
+    } catch (const std::exception& e) {
+        handleException(e);
+        return nullptr;
+    }
+}
+
+CTablet* ts_tablet_new_with_category(const char* deviceId, int columnCount,
+                                      const char* const* columnNames,
+                                      const TSDataType_C* dataTypes,
+                                      const TSColumnCategory_C* columnCategories,
+                                      int maxRowNumber) {
+    try {
+        std::vector<std::pair<std::string, TSDataType::TSDataType>> schemas;
+        std::vector<ColumnCategory> colTypes;
+        schemas.reserve(columnCount);
+        colTypes.reserve(columnCount);
+        for (int i = 0; i < columnCount; i++) {
+            schemas.emplace_back(std::string(columnNames[i]),
+                                 static_cast<TSDataType::TSDataType>(dataTypes[i]));
+            colTypes.push_back(static_cast<ColumnCategory>(columnCategories[i]));
+        }
+        auto* ct = new CTablet_();
+        ct->cpp = Tablet(std::string(deviceId), schemas, colTypes, maxRowNumber);
+        return ct;
+    } catch (const std::exception& e) {
+        handleException(e);
+        return nullptr;
+    }
+}
+
+void ts_tablet_destroy(CTablet* tablet) {
+    delete tablet;
+}
+
+void ts_tablet_reset(CTablet* tablet) {
+    if (tablet) {
+        tablet->cpp.reset();
+    }
+}
+
+int ts_tablet_get_row_count(CTablet* tablet) {
+    if (!tablet) return 0;
+    return static_cast<int>(tablet->cpp.rowSize);
+}
+
+TsStatus ts_tablet_set_row_count(CTablet* tablet, int rowCount) {
+    clearError();
+    if (!tablet) return setError(TS_ERR_NULL_PTR, "tablet is null");
+    tablet->cpp.rowSize = rowCount;
+    return TS_OK;
+}
+
+TsStatus ts_tablet_add_timestamp(CTablet* tablet, int rowIndex, int64_t timestamp) {
+    clearError();
+    if (!tablet) return setError(TS_ERR_NULL_PTR, "tablet is null");
+    try {
+        tablet->cpp.addTimestamp(static_cast<size_t>(rowIndex), timestamp);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_tablet_add_value_bool(CTablet* tablet, int colIndex, int rowIndex, bool value) {
+    clearError();
+    if (!tablet) return setError(TS_ERR_NULL_PTR, "tablet is null");
+    try {
+        tablet->cpp.addValue(static_cast<size_t>(colIndex), static_cast<size_t>(rowIndex), value);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_tablet_add_value_int32(CTablet* tablet, int colIndex, int rowIndex, int32_t value) {
+    clearError();
+    if (!tablet) return setError(TS_ERR_NULL_PTR, "tablet is null");
+    try {
+        tablet->cpp.addValue(static_cast<size_t>(colIndex), static_cast<size_t>(rowIndex), value);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_tablet_add_value_int64(CTablet* tablet, int colIndex, int rowIndex, int64_t value) {
+    clearError();
+    if (!tablet) return setError(TS_ERR_NULL_PTR, "tablet is null");
+    try {
+        tablet->cpp.addValue(static_cast<size_t>(colIndex), static_cast<size_t>(rowIndex), value);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_tablet_add_value_float(CTablet* tablet, int colIndex, int rowIndex, float value) {
+    clearError();
+    if (!tablet) return setError(TS_ERR_NULL_PTR, "tablet is null");
+    try {
+        tablet->cpp.addValue(static_cast<size_t>(colIndex), static_cast<size_t>(rowIndex), value);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_tablet_add_value_double(CTablet* tablet, int colIndex, int rowIndex, double value) {
+    clearError();
+    if (!tablet) return setError(TS_ERR_NULL_PTR, "tablet is null");
+    try {
+        tablet->cpp.addValue(static_cast<size_t>(colIndex), static_cast<size_t>(rowIndex), value);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_tablet_add_value_string(CTablet* tablet, int colIndex, int rowIndex, const char* value) {
+    clearError();
+    if (!tablet) return setError(TS_ERR_NULL_PTR, "tablet is null");
+    try {
+        std::string str(value);
+        tablet->cpp.addValue(static_cast<size_t>(colIndex), static_cast<size_t>(rowIndex), str);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+/* ============================================================
+ *  Data Insertion  —  Tree Model  (Record, string values)
+ * ============================================================ */
+
+TsStatus ts_session_insert_record_str(CSession* session, const char* deviceId,
+                                       int64_t time, int count,
+                                       const char* const* measurements,
+                                       const char* const* values) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        auto measurementsVec = toStringVec(measurements, count);
+        auto valuesVec = toStringVec(values, count);
+        session->cpp->insertRecord(std::string(deviceId), time, measurementsVec, valuesVec);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_insert_record(CSession* session, const char* deviceId,
+                                   int64_t time, int count,
+                                   const char* const* measurements,
+                                   const TSDataType_C* types,
+                                   const void* const* values) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        auto measurementsVec = toStringVec(measurements, count);
+        auto typesVec = toTypeVec(types, count);
+        auto charVec = toCharPtrVec(types, values, count);
+        session->cpp->insertRecord(std::string(deviceId), time, measurementsVec, typesVec, charVec);
+        freeCharPtrVec(charVec, types, count);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_insert_aligned_record_str(CSession* session, const char* deviceId,
+                                               int64_t time, int count,
+                                               const char* const* measurements,
+                                               const char* const* values) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        auto measurementsVec = toStringVec(measurements, count);
+        auto valuesVec = toStringVec(values, count);
+        session->cpp->insertAlignedRecord(std::string(deviceId), time, measurementsVec, valuesVec);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_insert_aligned_record(CSession* session, const char* deviceId,
+                                           int64_t time, int count,
+                                           const char* const* measurements,
+                                           const TSDataType_C* types,
+                                           const void* const* values) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        auto measurementsVec = toStringVec(measurements, count);
+        auto typesVec = toTypeVec(types, count);
+        auto charVec = toCharPtrVec(types, values, count);
+        session->cpp->insertAlignedRecord(std::string(deviceId), time, measurementsVec, typesVec, charVec);
+        freeCharPtrVec(charVec, types, count);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+/* ============================================================
+ *  Data Insertion  —  Batch, multiple devices (string values)
+ * ============================================================ */
+
+TsStatus ts_session_insert_records_str(CSession* session, int deviceCount,
+                                        const char* const* deviceIds,
+                                        const int64_t* times,
+                                        const int* measurementCounts,
+                                        const char* const* const* measurementsList,
+                                        const char* const* const* valuesList) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        auto devVec = toStringVec(deviceIds, deviceCount);
+        std::vector<int64_t> timesVec(times, times + deviceCount);
+        std::vector<std::vector<std::string>> mList, vList;
+        mList.reserve(deviceCount);
+        vList.reserve(deviceCount);
+        for (int i = 0; i < deviceCount; i++) {
+            mList.push_back(toStringVec(measurementsList[i], measurementCounts[i]));
+            vList.push_back(toStringVec(valuesList[i], measurementCounts[i]));
+        }
+        session->cpp->insertRecords(devVec, timesVec, mList, vList);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_insert_aligned_records_str(CSession* session, int deviceCount,
+                                                const char* const* deviceIds,
+                                                const int64_t* times,
+                                                const int* measurementCounts,
+                                                const char* const* const* measurementsList,
+                                                const char* const* const* valuesList) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        auto devVec = toStringVec(deviceIds, deviceCount);
+        std::vector<int64_t> timesVec(times, times + deviceCount);
+        std::vector<std::vector<std::string>> mList, vList;
+        mList.reserve(deviceCount);
+        vList.reserve(deviceCount);
+        for (int i = 0; i < deviceCount; i++) {
+            mList.push_back(toStringVec(measurementsList[i], measurementCounts[i]));
+            vList.push_back(toStringVec(valuesList[i], measurementCounts[i]));
+        }
+        session->cpp->insertAlignedRecords(devVec, timesVec, mList, vList);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+/* ============================================================
+ *  Data Insertion  —  Batch, multiple devices (typed values)
+ * ============================================================ */
+
+TsStatus ts_session_insert_records(CSession* session, int deviceCount,
+                                    const char* const* deviceIds,
+                                    const int64_t* times,
+                                    const int* measurementCounts,
+                                    const char* const* const* measurementsList,
+                                    const TSDataType_C* const* typesList,
+                                    const void* const* const* valuesList) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        auto devVec = toStringVec(deviceIds, deviceCount);
+        std::vector<int64_t> timesVec(times, times + deviceCount);
+        std::vector<std::vector<std::string>> mList;
+        std::vector<std::vector<TSDataType::TSDataType>> tList;
+        std::vector<std::vector<char*>> vList;
+        mList.reserve(deviceCount);
+        tList.reserve(deviceCount);
+        vList.reserve(deviceCount);
+        for (int i = 0; i < deviceCount; i++) {
+            mList.push_back(toStringVec(measurementsList[i], measurementCounts[i]));
+            tList.push_back(toTypeVec(typesList[i], measurementCounts[i]));
+            vList.push_back(toCharPtrVec(typesList[i], valuesList[i], measurementCounts[i]));
+        }
+        session->cpp->insertRecords(devVec, timesVec, mList, tList, vList);
+        for (int i = 0; i < deviceCount; i++) {
+            freeCharPtrVec(vList[i], typesList[i], measurementCounts[i]);
+        }
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_insert_aligned_records(CSession* session, int deviceCount,
+                                            const char* const* deviceIds,
+                                            const int64_t* times,
+                                            const int* measurementCounts,
+                                            const char* const* const* measurementsList,
+                                            const TSDataType_C* const* typesList,
+                                            const void* const* const* valuesList) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        auto devVec = toStringVec(deviceIds, deviceCount);
+        std::vector<int64_t> timesVec(times, times + deviceCount);
+        std::vector<std::vector<std::string>> mList;
+        std::vector<std::vector<TSDataType::TSDataType>> tList;
+        std::vector<std::vector<char*>> vList;
+        mList.reserve(deviceCount);
+        tList.reserve(deviceCount);
+        vList.reserve(deviceCount);
+        for (int i = 0; i < deviceCount; i++) {
+            mList.push_back(toStringVec(measurementsList[i], measurementCounts[i]));
+            tList.push_back(toTypeVec(typesList[i], measurementCounts[i]));
+            vList.push_back(toCharPtrVec(typesList[i], valuesList[i], measurementCounts[i]));
+        }
+        session->cpp->insertAlignedRecords(devVec, timesVec, mList, tList, vList);
+        for (int i = 0; i < deviceCount; i++) {
+            freeCharPtrVec(vList[i], typesList[i], measurementCounts[i]);
+        }
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+/* ============================================================
+ *  Data Insertion  —  Batch, single device (typed values)
+ * ============================================================ */
+
+TsStatus ts_session_insert_records_of_one_device(CSession* session, const char* deviceId,
+                                                  int rowCount, const int64_t* times,
+                                                  const int* measurementCounts,
+                                                  const char* const* const* measurementsList,
+                                                  const TSDataType_C* const* typesList,
+                                                  const void* const* const* valuesList,
+                                                  bool sorted) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        std::vector<int64_t> timesVec(times, times + rowCount);
+        std::vector<std::vector<std::string>> mList;
+        std::vector<std::vector<TSDataType::TSDataType>> tList;
+        std::vector<std::vector<char*>> vList;
+        mList.reserve(rowCount);
+        tList.reserve(rowCount);
+        vList.reserve(rowCount);
+        for (int i = 0; i < rowCount; i++) {
+            mList.push_back(toStringVec(measurementsList[i], measurementCounts[i]));
+            tList.push_back(toTypeVec(typesList[i], measurementCounts[i]));
+            vList.push_back(toCharPtrVec(typesList[i], valuesList[i], measurementCounts[i]));
+        }
+        session->cpp->insertRecordsOfOneDevice(std::string(deviceId), timesVec, mList, tList, vList, sorted);
+        for (int i = 0; i < rowCount; i++) {
+            freeCharPtrVec(vList[i], typesList[i], measurementCounts[i]);
+        }
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_insert_aligned_records_of_one_device(CSession* session, const char* deviceId,
+                                                          int rowCount, const int64_t* times,
+                                                          const int* measurementCounts,
+                                                          const char* const* const* measurementsList,
+                                                          const TSDataType_C* const* typesList,
+                                                          const void* const* const* valuesList,
+                                                          bool sorted) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        std::vector<int64_t> timesVec(times, times + rowCount);
+        std::vector<std::vector<std::string>> mList;
+        std::vector<std::vector<TSDataType::TSDataType>> tList;
+        std::vector<std::vector<char*>> vList;
+        mList.reserve(rowCount);
+        tList.reserve(rowCount);
+        vList.reserve(rowCount);
+        for (int i = 0; i < rowCount; i++) {
+            mList.push_back(toStringVec(measurementsList[i], measurementCounts[i]));
+            tList.push_back(toTypeVec(typesList[i], measurementCounts[i]));
+            vList.push_back(toCharPtrVec(typesList[i], valuesList[i], measurementCounts[i]));
+        }
+        session->cpp->insertAlignedRecordsOfOneDevice(std::string(deviceId), timesVec, mList, tList, vList, sorted);
+        for (int i = 0; i < rowCount; i++) {
+            freeCharPtrVec(vList[i], typesList[i], measurementCounts[i]);
+        }
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+/* ============================================================
+ *  Data Insertion  —  Tree Model  (Tablet)
+ * ============================================================ */
+
+TsStatus ts_session_insert_tablet(CSession* session, CTablet* tablet, bool sorted) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    if (!tablet) return setError(TS_ERR_NULL_PTR, "tablet is null");
+    try {
+        session->cpp->insertTablet(tablet->cpp, sorted);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_insert_aligned_tablet(CSession* session, CTablet* tablet, bool sorted) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    if (!tablet) return setError(TS_ERR_NULL_PTR, "tablet is null");
+    try {
+        session->cpp->insertAlignedTablet(tablet->cpp, sorted);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_insert_tablets(CSession* session, int tabletCount,
+                                    const char* const* deviceIds,
+                                    CTablet** tablets, bool sorted) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        std::unordered_map<std::string, Tablet*> tabletMap;
+        for (int i = 0; i < tabletCount; i++) {
+            tabletMap[std::string(deviceIds[i])] = &(tablets[i]->cpp);
+        }
+        session->cpp->insertTablets(tabletMap, sorted);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_insert_aligned_tablets(CSession* session, int tabletCount,
+                                            const char* const* deviceIds,
+                                            CTablet** tablets, bool sorted) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        std::unordered_map<std::string, Tablet*> tabletMap;
+        for (int i = 0; i < tabletCount; i++) {
+            tabletMap[std::string(deviceIds[i])] = &(tablets[i]->cpp);
+        }
+        session->cpp->insertAlignedTablets(tabletMap, sorted);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+/* ============================================================
+ *  Data Insertion  —  Table Model  (Tablet)
+ * ============================================================ */
+
+TsStatus ts_table_session_insert(CTableSession* session, CTablet* tablet) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    if (!tablet) return setError(TS_ERR_NULL_PTR, "tablet is null");
+    try {
+        session->cpp->insert(tablet->cpp);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+/* ============================================================
+ *  Query  —  Tree Model
+ * ============================================================ */
+
+TsStatus ts_session_execute_query(CSession* session, const char* sql,
+                                   CSessionDataSet** dataSet) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    if (!dataSet) return setError(TS_ERR_INVALID_PARAM, "dataSet pointer is null");
+    try {
+        auto ds = session->cpp->executeQueryStatement(std::string(sql));
+        auto* cds = new CSessionDataSet_();
+        cds->cpp = std::move(ds);
+        *dataSet = cds;
+        return TS_OK;
+    } catch (const std::exception& e) {
+        *dataSet = nullptr;
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_execute_query_with_timeout(CSession* session, const char* sql,
+                                                int64_t timeoutInMs,
+                                                CSessionDataSet** dataSet) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    if (!dataSet) return setError(TS_ERR_INVALID_PARAM, "dataSet pointer is null");
+    try {
+        auto ds = session->cpp->executeQueryStatement(std::string(sql), timeoutInMs);
+        auto* cds = new CSessionDataSet_();
+        cds->cpp = std::move(ds);
+        *dataSet = cds;
+        return TS_OK;
+    } catch (const std::exception& e) {
+        *dataSet = nullptr;
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_execute_non_query(CSession* session, const char* sql) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        session->cpp->executeNonQueryStatement(std::string(sql));
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_execute_raw_data_query(CSession* session,
+                                            int pathCount, const char* const* paths,
+                                            int64_t startTime, int64_t endTime,
+                                            CSessionDataSet** dataSet) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    if (!dataSet) return setError(TS_ERR_INVALID_PARAM, "dataSet pointer is null");
+    try {
+        auto pathsVec = toStringVec(paths, pathCount);
+        auto ds = session->cpp->executeRawDataQuery(pathsVec, startTime, endTime);
+        auto* cds = new CSessionDataSet_();
+        cds->cpp = std::move(ds);
+        *dataSet = cds;
+        return TS_OK;
+    } catch (const std::exception& e) {
+        *dataSet = nullptr;
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_execute_last_data_query(CSession* session,
+                                             int pathCount, const char* const* paths,
+                                             CSessionDataSet** dataSet) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    if (!dataSet) return setError(TS_ERR_INVALID_PARAM, "dataSet pointer is null");
+    try {
+        auto pathsVec = toStringVec(paths, pathCount);
+        auto ds = session->cpp->executeLastDataQuery(pathsVec);
+        auto* cds = new CSessionDataSet_();
+        cds->cpp = std::move(ds);
+        *dataSet = cds;
+        return TS_OK;
+    } catch (const std::exception& e) {
+        *dataSet = nullptr;
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_execute_last_data_query_with_time(CSession* session,
+                                                       int pathCount, const char* const* paths,
+                                                       int64_t lastTime,
+                                                       CSessionDataSet** dataSet) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    if (!dataSet) return setError(TS_ERR_INVALID_PARAM, "dataSet pointer is null");
+    try {
+        auto pathsVec = toStringVec(paths, pathCount);
+        auto ds = session->cpp->executeLastDataQuery(pathsVec, lastTime);
+        auto* cds = new CSessionDataSet_();
+        cds->cpp = std::move(ds);
+        *dataSet = cds;
+        return TS_OK;
+    } catch (const std::exception& e) {
+        *dataSet = nullptr;
+        return handleException(e);
+    }
+}
+
+/* ============================================================
+ *  Query  —  Table Model
+ * ============================================================ */
+
+TsStatus ts_table_session_execute_query(CTableSession* session, const char* sql,
+                                         CSessionDataSet** dataSet) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    if (!dataSet) return setError(TS_ERR_INVALID_PARAM, "dataSet pointer is null");
+    try {
+        auto ds = session->cpp->executeQueryStatement(std::string(sql));
+        auto* cds = new CSessionDataSet_();
+        cds->cpp = std::move(ds);
+        *dataSet = cds;
+        return TS_OK;
+    } catch (const std::exception& e) {
+        *dataSet = nullptr;
+        return handleException(e);
+    }
+}
+
+TsStatus ts_table_session_execute_query_with_timeout(CTableSession* session, const char* sql,
+                                                      int64_t timeoutInMs,
+                                                      CSessionDataSet** dataSet) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    if (!dataSet) return setError(TS_ERR_INVALID_PARAM, "dataSet pointer is null");
+    try {
+        auto ds = session->cpp->executeQueryStatement(std::string(sql), timeoutInMs);
+        auto* cds = new CSessionDataSet_();
+        cds->cpp = std::move(ds);
+        *dataSet = cds;
+        return TS_OK;
+    } catch (const std::exception& e) {
+        *dataSet = nullptr;
+        return handleException(e);
+    }
+}
+
+TsStatus ts_table_session_execute_non_query(CTableSession* session, const char* sql) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        session->cpp->executeNonQueryStatement(std::string(sql));
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+/* ============================================================
+ *  SessionDataSet & RowRecord  —  Result Iteration
+ * ============================================================ */
+
+void ts_dataset_destroy(CSessionDataSet* dataSet) {
+    if (dataSet) {
+        if (dataSet->cpp) {
+            dataSet->cpp->closeOperationHandle();
+        }
+        delete dataSet;
+    }
+}
+
+bool ts_dataset_has_next(CSessionDataSet* dataSet) {
+    if (!dataSet || !dataSet->cpp) return false;
+    try {
+        return dataSet->cpp->hasNext();
+    } catch (...) {
+        return false;
+    }
+}
+
+CRowRecord* ts_dataset_next(CSessionDataSet* dataSet) {
+    if (!dataSet || !dataSet->cpp) return nullptr;
+    try {
+        auto row = dataSet->cpp->next();
+        if (!row) return nullptr;
+        auto* crr = new CRowRecord_();
+        crr->cpp = row;
+        return crr;
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+int ts_dataset_get_column_count(CSessionDataSet* dataSet) {
+    if (!dataSet || !dataSet->cpp) return 0;
+    return static_cast<int>(dataSet->cpp->getColumnNames().size());
+}
+
+static thread_local std::string g_colNameBuf;
+
+const char* ts_dataset_get_column_name(CSessionDataSet* dataSet, int index) {
+    if (!dataSet || !dataSet->cpp) return "";
+    const auto& names = dataSet->cpp->getColumnNames();
+    if (index < 0 || index >= (int)names.size()) return "";
+    g_colNameBuf = names[index];
+    return g_colNameBuf.c_str();
+}
+
+static thread_local std::string g_colTypeBuf;
+
+const char* ts_dataset_get_column_type(CSessionDataSet* dataSet, int index) {
+    if (!dataSet || !dataSet->cpp) return "";
+    const auto& types = dataSet->cpp->getColumnTypeList();
+    if (index < 0 || index >= (int)types.size()) return "";
+    g_colTypeBuf = types[index];
+    return g_colTypeBuf.c_str();
+}
+
+void ts_dataset_set_fetch_size(CSessionDataSet* dataSet, int fetchSize) {
+    if (dataSet && dataSet->cpp) {
+        dataSet->cpp->setFetchSize(fetchSize);
+    }
+}
+
+void ts_row_record_destroy(CRowRecord* record) {
+    delete record;
+}
+
+int64_t ts_row_record_get_timestamp(CRowRecord* record) {
+    if (!record || !record->cpp) return -1;
+    return record->cpp->timestamp;
+}
+
+int ts_row_record_get_field_count(CRowRecord* record) {
+    if (!record || !record->cpp) return 0;
+    return static_cast<int>(record->cpp->fields.size());
+}
+
+bool ts_row_record_is_null(CRowRecord* record, int index) {
+    if (!record || !record->cpp) return true;
+    if (index < 0 || index >= (int)record->cpp->fields.size()) return true;
+    const Field& f = record->cpp->fields[index];
+    switch (f.dataType) {
+        case TSDataType::BOOLEAN:   return !f.boolV.is_initialized();
+        case TSDataType::INT32:     return !f.intV.is_initialized();
+        case TSDataType::INT64:
+        case TSDataType::TIMESTAMP: return !f.longV.is_initialized();
+        case TSDataType::FLOAT:     return !f.floatV.is_initialized();
+        case TSDataType::DOUBLE:    return !f.doubleV.is_initialized();
+        case TSDataType::TEXT:
+        case TSDataType::STRING:
+        case TSDataType::BLOB:      return !f.stringV.is_initialized();
+        case TSDataType::DATE:      return !f.dateV.is_initialized();
+        default:                    return true;
+    }
+}
+
+bool ts_row_record_get_bool(CRowRecord* record, int index) {
+    if (!record || !record->cpp) return false;
+    if (index < 0 || index >= (int)record->cpp->fields.size()) return false;
+    const Field& f = record->cpp->fields[index];
+    return f.boolV.is_initialized() ? f.boolV.value() : false;
+}
+
+int32_t ts_row_record_get_int32(CRowRecord* record, int index) {
+    if (!record || !record->cpp) return 0;
+    if (index < 0 || index >= (int)record->cpp->fields.size()) return 0;
+    const Field& f = record->cpp->fields[index];
+    return f.intV.is_initialized() ? f.intV.value() : 0;
+}
+
+int64_t ts_row_record_get_int64(CRowRecord* record, int index) {
+    if (!record || !record->cpp) return 0;
+    if (index < 0 || index >= (int)record->cpp->fields.size()) return 0;
+    const Field& f = record->cpp->fields[index];
+    return f.longV.is_initialized() ? f.longV.value() : 0;
+}
+
+float ts_row_record_get_float(CRowRecord* record, int index) {
+    if (!record || !record->cpp) return 0.0f;
+    if (index < 0 || index >= (int)record->cpp->fields.size()) return 0.0f;
+    const Field& f = record->cpp->fields[index];
+    return f.floatV.is_initialized() ? f.floatV.value() : 0.0f;
+}
+
+double ts_row_record_get_double(CRowRecord* record, int index) {
+    if (!record || !record->cpp) return 0.0;
+    if (index < 0 || index >= (int)record->cpp->fields.size()) return 0.0;
+    const Field& f = record->cpp->fields[index];
+    return f.doubleV.is_initialized() ? f.doubleV.value() : 0.0;
+}
+
+static thread_local std::string g_stringBuf;
+
+const char* ts_row_record_get_string(CRowRecord* record, int index) {
+    if (!record || !record->cpp) return "";
+    if (index < 0 || index >= (int)record->cpp->fields.size()) return "";
+    const Field& f = record->cpp->fields[index];
+    if (f.stringV.is_initialized()) {
+        g_stringBuf = f.stringV.value();
+        return g_stringBuf.c_str();
+    }
+    return "";
+}
+
+TSDataType_C ts_row_record_get_data_type(CRowRecord* record, int index) {
+    if (!record || !record->cpp) return TS_TYPE_TEXT;
+    if (index < 0 || index >= (int)record->cpp->fields.size()) return TS_TYPE_TEXT;
+    return static_cast<TSDataType_C>(record->cpp->fields[index].dataType);
+}
+
+/* ============================================================
+ *  Data Deletion  (Tree Model)
+ * ============================================================ */
+
+TsStatus ts_session_delete_data(CSession* session, const char* path, int64_t endTime) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        session->cpp->deleteData(std::string(path), endTime);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_delete_data_batch(CSession* session, int pathCount,
+                                       const char* const* paths, int64_t endTime) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        auto pathsVec = toStringVec(paths, pathCount);
+        session->cpp->deleteData(pathsVec, endTime);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+TsStatus ts_session_delete_data_range(CSession* session, int pathCount,
+                                       const char* const* paths,
+                                       int64_t startTime, int64_t endTime) {
+    clearError();
+    if (!session) return setError(TS_ERR_NULL_PTR, "session is null");
+    try {
+        auto pathsVec = toStringVec(paths, pathCount);
+        session->cpp->deleteData(pathsVec, startTime, endTime);
+        return TS_OK;
+    } catch (const std::exception& e) {
+        return handleException(e);
+    }
+}
+
+}  /* extern "C" */

--- a/iotdb-client/client-cpp/src/main/SessionC.cpp
+++ b/iotdb-client/client-cpp/src/main/SessionC.cpp
@@ -221,10 +221,11 @@ CSession* ts_session_new(const char* host, int rpcPort,
                           const char* username, const char* password) {
     clearError();
     try {
-        auto* cs = new CSession_();
-        cs->cpp = std::make_shared<Session>(
+        auto cpp = std::make_shared<Session>(
             std::string(host), rpcPort,
             std::string(username), std::string(password));
+        auto* cs = new CSession_();
+        cs->cpp = std::move(cpp);
         return cs;
     } catch (const std::exception& e) {
         handleException(e);
@@ -237,11 +238,12 @@ CSession* ts_session_new_with_zone(const char* host, int rpcPort,
                                     const char* zoneId, int fetchSize) {
     clearError();
     try {
-        auto* cs = new CSession_();
-        cs->cpp = std::make_shared<Session>(
+        auto cpp = std::make_shared<Session>(
             std::string(host), rpcPort,
             std::string(username), std::string(password),
             std::string(zoneId), fetchSize);
+        auto* cs = new CSession_();
+        cs->cpp = std::move(cpp);
         return cs;
     } catch (const std::exception& e) {
         handleException(e);
@@ -254,8 +256,9 @@ CSession* ts_session_new_multi_node(const char* const* nodeUrls, int urlCount,
     clearError();
     try {
         auto urls = toStringVec(nodeUrls, urlCount);
+        auto cpp = std::make_shared<Session>(urls, std::string(username), std::string(password));
         auto* cs = new CSession_();
-        cs->cpp = std::make_shared<Session>(urls, std::string(username), std::string(password));
+        cs->cpp = std::move(cpp);
         return cs;
     } catch (const std::exception& e) {
         handleException(e);
@@ -316,8 +319,10 @@ CTableSession* ts_table_session_new(const char* host, int rpcPort,
             ->password(std::string(password))
             ->database(std::string(database ? database : ""))
             ->build();
+        CTableSession_ tmp{};
+        tmp.cpp = std::move(tableSession);
         auto* cts = new CTableSession_();
-        cts->cpp = tableSession;
+        cts->cpp = std::move(tmp.cpp);
         return cts;
     } catch (const std::exception& e) {
         handleException(e);
@@ -337,8 +342,10 @@ CTableSession* ts_table_session_new_multi_node(const char* const* nodeUrls, int 
             ->password(std::string(password))
             ->database(std::string(database ? database : ""))
             ->build();
+        CTableSession_ tmp{};
+        tmp.cpp = std::move(tableSession);
         auto* cts = new CTableSession_();
-        cts->cpp = tableSession;
+        cts->cpp = std::move(tmp.cpp);
         return cts;
     } catch (const std::exception& e) {
         handleException(e);
@@ -587,8 +594,9 @@ CTablet* ts_tablet_new(const char* deviceId, int columnCount,
             schemas.emplace_back(std::string(columnNames[i]),
                                  static_cast<TSDataType::TSDataType>(dataTypes[i]));
         }
+        Tablet tablet(std::string(deviceId), schemas, maxRowNumber);
         auto* ct = new CTablet_();
-        ct->cpp = Tablet(std::string(deviceId), schemas, maxRowNumber);
+        ct->cpp = std::move(tablet);
         return ct;
     } catch (const std::exception& e) {
         handleException(e);
@@ -611,8 +619,9 @@ CTablet* ts_tablet_new_with_category(const char* deviceId, int columnCount,
                                  static_cast<TSDataType::TSDataType>(dataTypes[i]));
             colTypes.push_back(static_cast<ColumnCategory>(columnCategories[i]));
         }
+        Tablet tablet(std::string(deviceId), schemas, colTypes, maxRowNumber);
         auto* ct = new CTablet_();
-        ct->cpp = Tablet(std::string(deviceId), schemas, colTypes, maxRowNumber);
+        ct->cpp = std::move(tablet);
         return ct;
     } catch (const std::exception& e) {
         handleException(e);
@@ -1075,8 +1084,10 @@ TsStatus ts_session_execute_query(CSession* session, const char* sql,
     if (!dataSet) return setError(TS_ERR_INVALID_PARAM, "dataSet pointer is null");
     try {
         auto ds = session->cpp->executeQueryStatement(std::string(sql));
+        CSessionDataSet_ tmp{};
+        tmp.cpp = std::move(ds);
         auto* cds = new CSessionDataSet_();
-        cds->cpp = std::move(ds);
+        cds->cpp = std::move(tmp.cpp);
         *dataSet = cds;
         return TS_OK;
     } catch (const std::exception& e) {
@@ -1093,8 +1104,10 @@ TsStatus ts_session_execute_query_with_timeout(CSession* session, const char* sq
     if (!dataSet) return setError(TS_ERR_INVALID_PARAM, "dataSet pointer is null");
     try {
         auto ds = session->cpp->executeQueryStatement(std::string(sql), timeoutInMs);
+        CSessionDataSet_ tmp{};
+        tmp.cpp = std::move(ds);
         auto* cds = new CSessionDataSet_();
-        cds->cpp = std::move(ds);
+        cds->cpp = std::move(tmp.cpp);
         *dataSet = cds;
         return TS_OK;
     } catch (const std::exception& e) {
@@ -1124,8 +1137,10 @@ TsStatus ts_session_execute_raw_data_query(CSession* session,
     try {
         auto pathsVec = toStringVec(paths, pathCount);
         auto ds = session->cpp->executeRawDataQuery(pathsVec, startTime, endTime);
+        CSessionDataSet_ tmp{};
+        tmp.cpp = std::move(ds);
         auto* cds = new CSessionDataSet_();
-        cds->cpp = std::move(ds);
+        cds->cpp = std::move(tmp.cpp);
         *dataSet = cds;
         return TS_OK;
     } catch (const std::exception& e) {
@@ -1143,8 +1158,10 @@ TsStatus ts_session_execute_last_data_query(CSession* session,
     try {
         auto pathsVec = toStringVec(paths, pathCount);
         auto ds = session->cpp->executeLastDataQuery(pathsVec);
+        CSessionDataSet_ tmp{};
+        tmp.cpp = std::move(ds);
         auto* cds = new CSessionDataSet_();
-        cds->cpp = std::move(ds);
+        cds->cpp = std::move(tmp.cpp);
         *dataSet = cds;
         return TS_OK;
     } catch (const std::exception& e) {
@@ -1163,8 +1180,10 @@ TsStatus ts_session_execute_last_data_query_with_time(CSession* session,
     try {
         auto pathsVec = toStringVec(paths, pathCount);
         auto ds = session->cpp->executeLastDataQuery(pathsVec, lastTime);
+        CSessionDataSet_ tmp{};
+        tmp.cpp = std::move(ds);
         auto* cds = new CSessionDataSet_();
-        cds->cpp = std::move(ds);
+        cds->cpp = std::move(tmp.cpp);
         *dataSet = cds;
         return TS_OK;
     } catch (const std::exception& e) {
@@ -1184,8 +1203,10 @@ TsStatus ts_table_session_execute_query(CTableSession* session, const char* sql,
     if (!dataSet) return setError(TS_ERR_INVALID_PARAM, "dataSet pointer is null");
     try {
         auto ds = session->cpp->executeQueryStatement(std::string(sql));
+        CSessionDataSet_ tmp{};
+        tmp.cpp = std::move(ds);
         auto* cds = new CSessionDataSet_();
-        cds->cpp = std::move(ds);
+        cds->cpp = std::move(tmp.cpp);
         *dataSet = cds;
         return TS_OK;
     } catch (const std::exception& e) {
@@ -1202,8 +1223,10 @@ TsStatus ts_table_session_execute_query_with_timeout(CTableSession* session, con
     if (!dataSet) return setError(TS_ERR_INVALID_PARAM, "dataSet pointer is null");
     try {
         auto ds = session->cpp->executeQueryStatement(std::string(sql), timeoutInMs);
+        CSessionDataSet_ tmp{};
+        tmp.cpp = std::move(ds);
         auto* cds = new CSessionDataSet_();
-        cds->cpp = std::move(ds);
+        cds->cpp = std::move(tmp.cpp);
         *dataSet = cds;
         return TS_OK;
     } catch (const std::exception& e) {
@@ -1250,8 +1273,10 @@ CRowRecord* ts_dataset_next(CSessionDataSet* dataSet) {
     try {
         auto row = dataSet->cpp->next();
         if (!row) return nullptr;
+        CRowRecord_ tmp{};
+        tmp.cpp = std::move(row);
         auto* crr = new CRowRecord_();
-        crr->cpp = row;
+        crr->cpp = std::move(tmp.cpp);
         return crr;
     } catch (...) {
         return nullptr;

--- a/iotdb-client/client-cpp/src/main/SessionC.cpp
+++ b/iotdb-client/client-cpp/src/main/SessionC.cpp
@@ -1260,16 +1260,36 @@ void ts_dataset_destroy(CSessionDataSet* dataSet) {
 }
 
 bool ts_dataset_has_next(CSessionDataSet* dataSet) {
-    if (!dataSet || !dataSet->cpp) return false;
+    clearError();
+    if (!dataSet) {
+        (void)setError(TS_ERR_NULL_PTR, "dataSet is null");
+        return false;
+    }
+    if (!dataSet->cpp) {
+        (void)setError(TS_ERR_NULL_PTR, "dataSet is not initialized");
+        return false;
+    }
     try {
         return dataSet->cpp->hasNext();
+    } catch (const std::exception& e) {
+        (void)handleException(e);
+        return false;
     } catch (...) {
+        (void)setError(TS_ERR_UNKNOWN, "non-standard exception");
         return false;
     }
 }
 
 CRowRecord* ts_dataset_next(CSessionDataSet* dataSet) {
-    if (!dataSet || !dataSet->cpp) return nullptr;
+    clearError();
+    if (!dataSet) {
+        (void)setError(TS_ERR_NULL_PTR, "dataSet is null");
+        return nullptr;
+    }
+    if (!dataSet->cpp) {
+        (void)setError(TS_ERR_NULL_PTR, "dataSet is not initialized");
+        return nullptr;
+    }
     try {
         auto row = dataSet->cpp->next();
         if (!row) return nullptr;
@@ -1278,7 +1298,11 @@ CRowRecord* ts_dataset_next(CSessionDataSet* dataSet) {
         auto* crr = new CRowRecord_();
         crr->cpp = std::move(tmp.cpp);
         return crr;
+    } catch (const std::exception& e) {
+        (void)handleException(e);
+        return nullptr;
     } catch (...) {
+        (void)setError(TS_ERR_UNKNOWN, "non-standard exception");
         return nullptr;
     }
 }
@@ -1331,20 +1355,7 @@ int ts_row_record_get_field_count(CRowRecord* record) {
 bool ts_row_record_is_null(CRowRecord* record, int index) {
     if (!record || !record->cpp) return true;
     if (index < 0 || index >= (int)record->cpp->fields.size()) return true;
-    const Field& f = record->cpp->fields[index];
-    switch (f.dataType) {
-        case TSDataType::BOOLEAN:   return !f.boolV.is_initialized();
-        case TSDataType::INT32:     return !f.intV.is_initialized();
-        case TSDataType::INT64:
-        case TSDataType::TIMESTAMP: return !f.longV.is_initialized();
-        case TSDataType::FLOAT:     return !f.floatV.is_initialized();
-        case TSDataType::DOUBLE:    return !f.doubleV.is_initialized();
-        case TSDataType::TEXT:
-        case TSDataType::STRING:
-        case TSDataType::BLOB:      return !f.stringV.is_initialized();
-        case TSDataType::DATE:      return !f.dateV.is_initialized();
-        default:                    return true;
-    }
+    return record->cpp->fields[index].isNull();
 }
 
 bool ts_row_record_get_bool(CRowRecord* record, int index) {
@@ -1396,8 +1407,8 @@ const char* ts_row_record_get_string(CRowRecord* record, int index) {
 }
 
 TSDataType_C ts_row_record_get_data_type(CRowRecord* record, int index) {
-    if (!record || !record->cpp) return TS_TYPE_TEXT;
-    if (index < 0 || index >= (int)record->cpp->fields.size()) return TS_TYPE_TEXT;
+    if (!record || !record->cpp) return TS_TYPE_INVALID;
+    if (index < 0 || index >= (int)record->cpp->fields.size()) return TS_TYPE_INVALID;
     return static_cast<TSDataType_C>(record->cpp->fields[index].dataType);
 }
 

--- a/iotdb-client/client-cpp/src/main/SessionC.cpp
+++ b/iotdb-client/client-cpp/src/main/SessionC.cpp
@@ -41,7 +41,6 @@ struct CSession_ {
 
 struct CTableSession_ {
     std::shared_ptr<TableSession> cpp;
-    std::shared_ptr<Session> innerSession;  // kept alive for lifetime
 };
 
 struct CTablet_ {

--- a/iotdb-client/client-cpp/src/main/SessionC.cpp
+++ b/iotdb-client/client-cpp/src/main/SessionC.cpp
@@ -77,8 +77,8 @@ static TsStatus setError(TsStatus code, const std::exception& e) {
 }
 
 static TsStatus handleException(const std::exception& e) {
-    const std::string msg = e.what();
-    // Try to classify exception type
+#if defined(_CPPRTTI) || defined(__GXX_RTTI)
+    // Try to classify exception type (requires RTTI enabled).
     if (dynamic_cast<const IoTDBConnectionException*>(&e)) {
         return setError(TS_ERR_CONNECTION, e);
     }
@@ -87,6 +87,7 @@ static TsStatus handleException(const std::exception& e) {
         dynamic_cast<const BatchExecutionException*>(&e)) {
         return setError(TS_ERR_EXECUTION, e);
     }
+#endif
     return setError(TS_ERR_UNKNOWN, e);
 }
 
@@ -95,6 +96,8 @@ extern "C" {
 const char* ts_get_last_error(void) {
     return g_lastError.c_str();
 }
+
+}  /* extern "C" */
 
 /* ============================================================
  *  Helpers — convert C arrays to C++ vectors
@@ -212,6 +215,8 @@ static void freeCharPtrVec(std::vector<char*>& vec, const TSDataType_C* types, i
 /* ============================================================
  *  Session Lifecycle  —  Tree Model
  * ============================================================ */
+
+extern "C" {
 
 CSession* ts_session_new(const char* host, int rpcPort,
                           const char* username, const char* password) {

--- a/iotdb-client/client-cpp/src/main/SessionC.h
+++ b/iotdb-client/client-cpp/src/main/SessionC.h
@@ -71,7 +71,9 @@ typedef enum {
     TS_TYPE_TIMESTAMP = 8,
     TS_TYPE_DATE      = 9,
     TS_TYPE_BLOB      = 10,
-    TS_TYPE_STRING    = 11
+    TS_TYPE_STRING    = 11,
+    /** Not a server type; used for invalid arguments / error paths in the C API. */
+    TS_TYPE_INVALID   = 255
 } TSDataType_C;
 
 typedef enum {
@@ -386,8 +388,10 @@ TsStatus ts_table_session_execute_non_query(CTableSession* session, const char* 
 
 void ts_dataset_destroy(CSessionDataSet* dataSet);
 
+/** On failure (null handle, exception), see ts_get_last_error(). */
 bool ts_dataset_has_next(CSessionDataSet* dataSet);
 
+/** On failure (null handle, exception), see ts_get_last_error(); nullptr may also mean end of rows. */
 CRowRecord* ts_dataset_next(CSessionDataSet* dataSet);
 
 int ts_dataset_get_column_count(CSessionDataSet* dataSet);
@@ -418,6 +422,7 @@ double ts_row_record_get_double(CRowRecord* record, int index);
 
 const char* ts_row_record_get_string(CRowRecord* record, int index);
 
+/** Returns TS_TYPE_INVALID if record is null or index is out of range. */
 TSDataType_C ts_row_record_get_data_type(CRowRecord* record, int index);
 
 /* ============================================================

--- a/iotdb-client/client-cpp/src/main/SessionC.h
+++ b/iotdb-client/client-cpp/src/main/SessionC.h
@@ -1,0 +1,440 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef IOTDB_SESSION_C_H
+#define IOTDB_SESSION_C_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ============================================================
+ *  Error Handling
+ * ============================================================ */
+
+typedef int64_t TsStatus;
+
+#define TS_OK                   0
+#define TS_ERR_CONNECTION      -1
+#define TS_ERR_EXECUTION       -2
+#define TS_ERR_INVALID_PARAM   -3
+#define TS_ERR_NULL_PTR        -4
+#define TS_ERR_UNKNOWN         -99
+
+/**
+ * Returns the error message from the last failed C API call on the current thread.
+ * The returned pointer is valid until the next C API call on the same thread.
+ */
+const char* ts_get_last_error(void);
+
+/* ============================================================
+ *  Opaque Handle Types
+ * ============================================================ */
+
+typedef struct CSession_        CSession;
+typedef struct CTableSession_   CTableSession;
+typedef struct CTablet_         CTablet;
+typedef struct CSessionDataSet_ CSessionDataSet;
+typedef struct CRowRecord_      CRowRecord;
+
+/* ============================================================
+ *  Enums  (values match C++ TSDataType / TSEncoding / CompressionType)
+ * ============================================================ */
+
+typedef enum {
+    TS_TYPE_BOOLEAN   = 0,
+    TS_TYPE_INT32     = 1,
+    TS_TYPE_INT64     = 2,
+    TS_TYPE_FLOAT     = 3,
+    TS_TYPE_DOUBLE    = 4,
+    TS_TYPE_TEXT      = 5,
+    TS_TYPE_TIMESTAMP = 8,
+    TS_TYPE_DATE      = 9,
+    TS_TYPE_BLOB      = 10,
+    TS_TYPE_STRING    = 11
+} TSDataType_C;
+
+typedef enum {
+    TS_ENCODING_PLAIN      = 0,
+    TS_ENCODING_DICTIONARY = 1,
+    TS_ENCODING_RLE        = 2,
+    TS_ENCODING_DIFF       = 3,
+    TS_ENCODING_TS_2DIFF   = 4,
+    TS_ENCODING_BITMAP     = 5,
+    TS_ENCODING_GORILLA_V1 = 6,
+    TS_ENCODING_REGULAR    = 7,
+    TS_ENCODING_GORILLA    = 8,
+    TS_ENCODING_ZIGZAG     = 9,
+    TS_ENCODING_FREQ       = 10
+} TSEncoding_C;
+
+typedef enum {
+    TS_COMPRESSION_UNCOMPRESSED = 0,
+    TS_COMPRESSION_SNAPPY       = 1,
+    TS_COMPRESSION_GZIP         = 2,
+    TS_COMPRESSION_LZO          = 3,
+    TS_COMPRESSION_SDT          = 4,
+    TS_COMPRESSION_PAA          = 5,
+    TS_COMPRESSION_PLA          = 6,
+    TS_COMPRESSION_LZ4          = 7,
+    TS_COMPRESSION_ZSTD         = 8,
+    TS_COMPRESSION_LZMA2        = 9
+} TSCompressionType_C;
+
+typedef enum {
+    TS_COL_TAG       = 0,
+    TS_COL_FIELD     = 1,
+    TS_COL_ATTRIBUTE = 2
+} TSColumnCategory_C;
+
+/* ============================================================
+ *  Session Lifecycle  —  Tree Model
+ * ============================================================ */
+
+CSession* ts_session_new(const char* host, int rpcPort,
+                          const char* username, const char* password);
+
+CSession* ts_session_new_with_zone(const char* host, int rpcPort,
+                                    const char* username, const char* password,
+                                    const char* zoneId, int fetchSize);
+
+CSession* ts_session_new_multi_node(const char* const* nodeUrls, int urlCount,
+                                     const char* username, const char* password);
+
+void ts_session_destroy(CSession* session);
+
+TsStatus ts_session_open(CSession* session);
+
+TsStatus ts_session_open_with_compression(CSession* session, bool enableRPCCompression);
+
+TsStatus ts_session_close(CSession* session);
+
+/* ============================================================
+ *  Session Lifecycle  —  Table Model
+ * ============================================================ */
+
+CTableSession* ts_table_session_new(const char* host, int rpcPort,
+                                     const char* username, const char* password,
+                                     const char* database);
+
+CTableSession* ts_table_session_new_multi_node(const char* const* nodeUrls, int urlCount,
+                                                const char* username, const char* password,
+                                                const char* database);
+
+void ts_table_session_destroy(CTableSession* session);
+
+TsStatus ts_table_session_open(CTableSession* session);
+
+TsStatus ts_table_session_close(CTableSession* session);
+
+/* ============================================================
+ *  Timezone
+ * ============================================================ */
+
+TsStatus ts_session_set_timezone(CSession* session, const char* zoneId);
+
+TsStatus ts_session_get_timezone(CSession* session, char* buf, int bufLen);
+
+/* ============================================================
+ *  Database Management  (Tree Model)
+ * ============================================================ */
+
+TsStatus ts_session_create_database(CSession* session, const char* database);
+
+TsStatus ts_session_delete_database(CSession* session, const char* database);
+
+TsStatus ts_session_delete_databases(CSession* session, const char* const* databases, int count);
+
+/* ============================================================
+ *  Timeseries Management  (Tree Model)
+ * ============================================================ */
+
+TsStatus ts_session_create_timeseries(CSession* session, const char* path,
+                                       TSDataType_C dataType, TSEncoding_C encoding,
+                                       TSCompressionType_C compressor);
+
+TsStatus ts_session_create_timeseries_ex(CSession* session, const char* path,
+                                          TSDataType_C dataType, TSEncoding_C encoding,
+                                          TSCompressionType_C compressor,
+                                          int propsCount,
+                                          const char* const* propKeys,
+                                          const char* const* propValues,
+                                          int tagsCount,
+                                          const char* const* tagKeys,
+                                          const char* const* tagValues,
+                                          int attrsCount,
+                                          const char* const* attrKeys,
+                                          const char* const* attrValues,
+                                          const char* measurementAlias);
+
+TsStatus ts_session_create_multi_timeseries(CSession* session, int count,
+                                             const char* const* paths,
+                                             const TSDataType_C* dataTypes,
+                                             const TSEncoding_C* encodings,
+                                             const TSCompressionType_C* compressors);
+
+TsStatus ts_session_create_aligned_timeseries(CSession* session, const char* deviceId,
+                                               int count,
+                                               const char* const* measurements,
+                                               const TSDataType_C* dataTypes,
+                                               const TSEncoding_C* encodings,
+                                               const TSCompressionType_C* compressors);
+
+TsStatus ts_session_check_timeseries_exists(CSession* session, const char* path, bool* exists);
+
+TsStatus ts_session_delete_timeseries(CSession* session, const char* path);
+
+TsStatus ts_session_delete_timeseries_batch(CSession* session, const char* const* paths, int count);
+
+/* ============================================================
+ *  Tablet Operations
+ * ============================================================ */
+
+CTablet* ts_tablet_new(const char* deviceId, int columnCount,
+                        const char* const* columnNames,
+                        const TSDataType_C* dataTypes,
+                        int maxRowNumber);
+
+CTablet* ts_tablet_new_with_category(const char* deviceId, int columnCount,
+                                      const char* const* columnNames,
+                                      const TSDataType_C* dataTypes,
+                                      const TSColumnCategory_C* columnCategories,
+                                      int maxRowNumber);
+
+void ts_tablet_destroy(CTablet* tablet);
+
+void ts_tablet_reset(CTablet* tablet);
+
+int ts_tablet_get_row_count(CTablet* tablet);
+
+TsStatus ts_tablet_set_row_count(CTablet* tablet, int rowCount);
+
+TsStatus ts_tablet_add_timestamp(CTablet* tablet, int rowIndex, int64_t timestamp);
+
+TsStatus ts_tablet_add_value_bool(CTablet* tablet, int colIndex, int rowIndex, bool value);
+
+TsStatus ts_tablet_add_value_int32(CTablet* tablet, int colIndex, int rowIndex, int32_t value);
+
+TsStatus ts_tablet_add_value_int64(CTablet* tablet, int colIndex, int rowIndex, int64_t value);
+
+TsStatus ts_tablet_add_value_float(CTablet* tablet, int colIndex, int rowIndex, float value);
+
+TsStatus ts_tablet_add_value_double(CTablet* tablet, int colIndex, int rowIndex, double value);
+
+TsStatus ts_tablet_add_value_string(CTablet* tablet, int colIndex, int rowIndex, const char* value);
+
+/* ============================================================
+ *  Data Insertion  —  Tree Model  (Record)
+ * ============================================================ */
+
+TsStatus ts_session_insert_record_str(CSession* session, const char* deviceId,
+                                       int64_t time, int count,
+                                       const char* const* measurements,
+                                       const char* const* values);
+
+TsStatus ts_session_insert_record(CSession* session, const char* deviceId,
+                                   int64_t time, int count,
+                                   const char* const* measurements,
+                                   const TSDataType_C* types,
+                                   const void* const* values);
+
+TsStatus ts_session_insert_aligned_record_str(CSession* session, const char* deviceId,
+                                               int64_t time, int count,
+                                               const char* const* measurements,
+                                               const char* const* values);
+
+TsStatus ts_session_insert_aligned_record(CSession* session, const char* deviceId,
+                                           int64_t time, int count,
+                                           const char* const* measurements,
+                                           const TSDataType_C* types,
+                                           const void* const* values);
+
+/* Batch insert — multiple devices (string values) */
+TsStatus ts_session_insert_records_str(CSession* session, int deviceCount,
+                                        const char* const* deviceIds,
+                                        const int64_t* times,
+                                        const int* measurementCounts,
+                                        const char* const* const* measurementsList,
+                                        const char* const* const* valuesList);
+
+TsStatus ts_session_insert_aligned_records_str(CSession* session, int deviceCount,
+                                                const char* const* deviceIds,
+                                                const int64_t* times,
+                                                const int* measurementCounts,
+                                                const char* const* const* measurementsList,
+                                                const char* const* const* valuesList);
+
+/* Batch insert — multiple devices (typed values) */
+TsStatus ts_session_insert_records(CSession* session, int deviceCount,
+                                    const char* const* deviceIds,
+                                    const int64_t* times,
+                                    const int* measurementCounts,
+                                    const char* const* const* measurementsList,
+                                    const TSDataType_C* const* typesList,
+                                    const void* const* const* valuesList);
+
+TsStatus ts_session_insert_aligned_records(CSession* session, int deviceCount,
+                                            const char* const* deviceIds,
+                                            const int64_t* times,
+                                            const int* measurementCounts,
+                                            const char* const* const* measurementsList,
+                                            const TSDataType_C* const* typesList,
+                                            const void* const* const* valuesList);
+
+/* Batch insert — single device (typed values) */
+TsStatus ts_session_insert_records_of_one_device(CSession* session, const char* deviceId,
+                                                  int rowCount, const int64_t* times,
+                                                  const int* measurementCounts,
+                                                  const char* const* const* measurementsList,
+                                                  const TSDataType_C* const* typesList,
+                                                  const void* const* const* valuesList,
+                                                  bool sorted);
+
+TsStatus ts_session_insert_aligned_records_of_one_device(CSession* session, const char* deviceId,
+                                                          int rowCount, const int64_t* times,
+                                                          const int* measurementCounts,
+                                                          const char* const* const* measurementsList,
+                                                          const TSDataType_C* const* typesList,
+                                                          const void* const* const* valuesList,
+                                                          bool sorted);
+
+/* ============================================================
+ *  Data Insertion  —  Tree Model  (Tablet)
+ * ============================================================ */
+
+TsStatus ts_session_insert_tablet(CSession* session, CTablet* tablet, bool sorted);
+
+TsStatus ts_session_insert_aligned_tablet(CSession* session, CTablet* tablet, bool sorted);
+
+TsStatus ts_session_insert_tablets(CSession* session, int tabletCount,
+                                    const char* const* deviceIds,
+                                    CTablet** tablets, bool sorted);
+
+TsStatus ts_session_insert_aligned_tablets(CSession* session, int tabletCount,
+                                            const char* const* deviceIds,
+                                            CTablet** tablets, bool sorted);
+
+/* ============================================================
+ *  Data Insertion  —  Table Model  (Tablet)
+ * ============================================================ */
+
+TsStatus ts_table_session_insert(CTableSession* session, CTablet* tablet);
+
+/* ============================================================
+ *  Query  —  Tree Model
+ * ============================================================ */
+
+TsStatus ts_session_execute_query(CSession* session, const char* sql,
+                                   CSessionDataSet** dataSet);
+
+TsStatus ts_session_execute_query_with_timeout(CSession* session, const char* sql,
+                                                int64_t timeoutInMs,
+                                                CSessionDataSet** dataSet);
+
+TsStatus ts_session_execute_non_query(CSession* session, const char* sql);
+
+TsStatus ts_session_execute_raw_data_query(CSession* session,
+                                            int pathCount, const char* const* paths,
+                                            int64_t startTime, int64_t endTime,
+                                            CSessionDataSet** dataSet);
+
+TsStatus ts_session_execute_last_data_query(CSession* session,
+                                             int pathCount, const char* const* paths,
+                                             CSessionDataSet** dataSet);
+
+TsStatus ts_session_execute_last_data_query_with_time(CSession* session,
+                                                       int pathCount, const char* const* paths,
+                                                       int64_t lastTime,
+                                                       CSessionDataSet** dataSet);
+
+/* ============================================================
+ *  Query  —  Table Model
+ * ============================================================ */
+
+TsStatus ts_table_session_execute_query(CTableSession* session, const char* sql,
+                                         CSessionDataSet** dataSet);
+
+TsStatus ts_table_session_execute_query_with_timeout(CTableSession* session, const char* sql,
+                                                      int64_t timeoutInMs,
+                                                      CSessionDataSet** dataSet);
+
+TsStatus ts_table_session_execute_non_query(CTableSession* session, const char* sql);
+
+/* ============================================================
+ *  SessionDataSet & RowRecord  —  Result Iteration
+ * ============================================================ */
+
+void ts_dataset_destroy(CSessionDataSet* dataSet);
+
+bool ts_dataset_has_next(CSessionDataSet* dataSet);
+
+CRowRecord* ts_dataset_next(CSessionDataSet* dataSet);
+
+int ts_dataset_get_column_count(CSessionDataSet* dataSet);
+
+const char* ts_dataset_get_column_name(CSessionDataSet* dataSet, int index);
+
+const char* ts_dataset_get_column_type(CSessionDataSet* dataSet, int index);
+
+void ts_dataset_set_fetch_size(CSessionDataSet* dataSet, int fetchSize);
+
+void ts_row_record_destroy(CRowRecord* record);
+
+int64_t ts_row_record_get_timestamp(CRowRecord* record);
+
+int ts_row_record_get_field_count(CRowRecord* record);
+
+bool ts_row_record_is_null(CRowRecord* record, int index);
+
+bool ts_row_record_get_bool(CRowRecord* record, int index);
+
+int32_t ts_row_record_get_int32(CRowRecord* record, int index);
+
+int64_t ts_row_record_get_int64(CRowRecord* record, int index);
+
+float ts_row_record_get_float(CRowRecord* record, int index);
+
+double ts_row_record_get_double(CRowRecord* record, int index);
+
+const char* ts_row_record_get_string(CRowRecord* record, int index);
+
+TSDataType_C ts_row_record_get_data_type(CRowRecord* record, int index);
+
+/* ============================================================
+ *  Data Deletion  (Tree Model)
+ * ============================================================ */
+
+TsStatus ts_session_delete_data(CSession* session, const char* path, int64_t endTime);
+
+TsStatus ts_session_delete_data_batch(CSession* session, int pathCount,
+                                       const char* const* paths, int64_t endTime);
+
+TsStatus ts_session_delete_data_range(CSession* session, int pathCount,
+                                       const char* const* paths,
+                                       int64_t startTime, int64_t endTime);
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif
+
+#endif /* IOTDB_SESSION_C_H */

--- a/iotdb-client/client-cpp/src/main/SessionDataSet.cpp
+++ b/iotdb-client/client-cpp/src/main/SessionDataSet.cpp
@@ -51,59 +51,65 @@ std::string RowRecord::toString() {
         if (i != 0) {
             ret.append("\t");
         }
-        TSDataType::TSDataType dataType = fields[i].dataType;
-        switch (dataType) {
+        const Field& f = fields[i];
+        switch (f.dataType) {
         case TSDataType::BOOLEAN:
-            if (!fields[i].boolV.is_initialized()) {
+            if (f.isNull()) {
                 ret.append("null");
             } else {
-                ret.append(fields[i].boolV.value() ? "true" : "false");
+                ret.append(f.boolV.value() ? "true" : "false");
             }
             break;
         case TSDataType::INT32:
-            if (!fields[i].intV.is_initialized()) {
+            if (f.isNull()) {
                 ret.append("null");
             } else {
-                ret.append(std::to_string(fields[i].intV.value()));
+                ret.append(std::to_string(f.intV.value()));
             }
             break;
         case TSDataType::DATE:
-            if (!fields[i].dateV.is_initialized()) {
+            if (f.isNull()) {
                 ret.append("null");
             } else {
-                ret.append(boost::gregorian::to_iso_extended_string(fields[i].dateV.value()));
+                ret.append(boost::gregorian::to_iso_extended_string(f.dateV.value()));
             }
             break;
         case TSDataType::TIMESTAMP:
         case TSDataType::INT64:
-            if (!fields[i].longV.is_initialized()) {
+            if (f.isNull()) {
                 ret.append("null");
             } else {
-                ret.append(std::to_string(fields[i].longV.value()));
+                ret.append(std::to_string(f.longV.value()));
             }
             break;
         case TSDataType::FLOAT:
-            if (!fields[i].floatV.is_initialized()) {
+            if (f.isNull()) {
                 ret.append("null");
             } else {
-                ret.append(std::to_string(fields[i].floatV.value()));
+                ret.append(std::to_string(f.floatV.value()));
             }
             break;
         case TSDataType::DOUBLE:
-            if (!fields[i].doubleV.is_initialized()) {
+            if (f.isNull()) {
                 ret.append("null");
             } else {
-                ret.append(std::to_string(fields[i].doubleV.value()));
+                ret.append(std::to_string(f.doubleV.value()));
             }
             break;
         case TSDataType::BLOB:
         case TSDataType::STRING:
-        case TSDataType::OBJECT:
         case TSDataType::TEXT:
-            if (!fields[i].stringV.is_initialized()) {
+            if (f.isNull()) {
                 ret.append("null");
             } else {
-                ret.append(fields[i].stringV.value());
+                ret.append(f.stringV.value());
+            }
+            break;
+        case TSDataType::OBJECT:
+            if (!f.stringV.is_initialized()) {
+                ret.append("null");
+            } else {
+                ret.append(f.stringV.value());
             }
             break;
         default:

--- a/iotdb-client/client-cpp/src/test/CMakeLists.txt
+++ b/iotdb-client/client-cpp/src/test/CMakeLists.txt
@@ -22,7 +22,10 @@ SET(CMAKE_CXX_STANDARD 11)
 SET(CMAKE_CXX_STANDARD_REQUIRED ON)
 SET(TARGET_NAME session_tests)
 SET(TARGET_NAME_RELATIONAL session_relational_tests)
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -g -O2")
+IF(NOT MSVC)
+    # Keep GCC/Clang style flags off on MSVC to avoid invalid-option build errors.
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -g -O2")
+ENDIF()
 ENABLE_TESTING()
 
 # =========================

--- a/iotdb-client/client-cpp/src/test/CMakeLists.txt
+++ b/iotdb-client/client-cpp/src/test/CMakeLists.txt
@@ -141,6 +141,9 @@ ELSE()
     ADD_TEST(NAME sessionCRelationalIT COMMAND ${TARGET_NAME_C_RELATIONAL})
 ENDIF()
 
+# One process at a time: parallel ctest overloads a single local IoTDB on 127.0.0.1:6667.
+SET_TESTS_PROPERTIES(sessionIT sessionRelationalIT sessionCIT sessionCRelationalIT PROPERTIES RUN_SERIAL TRUE)
+
 if(UNIX AND NOT APPLE)
   target_link_options(session_tests PRIVATE -Wl,--no-as-needed)
   target_link_options(session_relational_tests PRIVATE -Wl,--no-as-needed)

--- a/iotdb-client/client-cpp/src/test/CMakeLists.txt
+++ b/iotdb-client/client-cpp/src/test/CMakeLists.txt
@@ -71,74 +71,76 @@ IF(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang" AND NOT MSVC)
     add_link_options(-fsanitize=address)
 ENDIF()
 
+SET(TARGET_NAME_C session_c_tests)
+SET(TARGET_NAME_C_RELATIONAL session_c_relational_tests)
+
 ADD_EXECUTABLE(${TARGET_NAME} main.cpp cpp/sessionIT.cpp)
 ADD_EXECUTABLE(${TARGET_NAME_RELATIONAL} main_Relational.cpp cpp/sessionRelationalIT.cpp)
+ADD_EXECUTABLE(${TARGET_NAME_C} main_c.cpp cpp/sessionCIT.cpp)
+ADD_EXECUTABLE(${TARGET_NAME_C_RELATIONAL} main_c_Relational.cpp cpp/sessionCRelationalIT.cpp)
 
 # Link with shared library iotdb_session and pthread
+SET(ALL_TEST_TARGETS ${TARGET_NAME} ${TARGET_NAME_RELATIONAL} ${TARGET_NAME_C} ${TARGET_NAME_C_RELATIONAL})
+
 IF(MSVC)
     IF(WITH_SSL)
-        TARGET_LINK_LIBRARIES(${TARGET_NAME}
-            iotdb_session
-            ${THRIFT_STATIC_LIB}
-            OpenSSL::SSL
-            OpenSSL::Crypto
-        )
-        TARGET_LINK_LIBRARIES(${TARGET_NAME_RELATIONAL}
-            iotdb_session
-            ${THRIFT_STATIC_LIB}
-            OpenSSL::SSL
-            OpenSSL::Crypto
-        )
+        FOREACH(T ${ALL_TEST_TARGETS})
+            TARGET_LINK_LIBRARIES(${T}
+                iotdb_session
+                ${THRIFT_STATIC_LIB}
+                OpenSSL::SSL
+                OpenSSL::Crypto
+            )
+        ENDFOREACH()
     ELSE()
-        TARGET_LINK_LIBRARIES(${TARGET_NAME}
-            iotdb_session
-            ${THRIFT_STATIC_LIB}
-        )
-        TARGET_LINK_LIBRARIES(${TARGET_NAME_RELATIONAL}
-            iotdb_session
-            ${THRIFT_STATIC_LIB}
-        )
+        FOREACH(T ${ALL_TEST_TARGETS})
+            TARGET_LINK_LIBRARIES(${T}
+                iotdb_session
+                ${THRIFT_STATIC_LIB}
+            )
+        ENDFOREACH()
     ENDIF()
 ELSE()
     IF(WITH_SSL)
-        TARGET_LINK_LIBRARIES(${TARGET_NAME}
-            iotdb_session
-            pthread
-            OpenSSL::SSL
-            OpenSSL::Crypto
-        )
-        TARGET_LINK_LIBRARIES(${TARGET_NAME_RELATIONAL}
-            iotdb_session
-            pthread
-            OpenSSL::SSL
-            OpenSSL::Crypto
-        )
+        FOREACH(T ${ALL_TEST_TARGETS})
+            TARGET_LINK_LIBRARIES(${T}
+                iotdb_session
+                pthread
+                OpenSSL::SSL
+                OpenSSL::Crypto
+            )
+        ENDFOREACH()
     ELSE()
-        TARGET_LINK_LIBRARIES(${TARGET_NAME}
-            iotdb_session
-            pthread
-        )
-        TARGET_LINK_LIBRARIES(${TARGET_NAME_RELATIONAL}
-            iotdb_session
-            pthread
-        )
+        FOREACH(T ${ALL_TEST_TARGETS})
+            TARGET_LINK_LIBRARIES(${T}
+                iotdb_session
+                pthread
+            )
+        ENDFOREACH()
     ENDIF()
 ENDIF()
 
 # Add Catch2 include directory
-TARGET_INCLUDE_DIRECTORIES(${TARGET_NAME} PUBLIC ./catch2/)
-TARGET_INCLUDE_DIRECTORIES(${TARGET_NAME_RELATIONAL} PUBLIC ./catch2/)
+FOREACH(T ${ALL_TEST_TARGETS})
+    TARGET_INCLUDE_DIRECTORIES(${T} PUBLIC ./catch2/)
+ENDFOREACH()
 
-# Add 'sessionIT' to the project to be run by ctest
+# Add tests to ctest
 IF(MSVC)
     ADD_TEST(NAME sessionIT CONFIGURATIONS Release COMMAND ${TARGET_NAME})
     ADD_TEST(NAME sessionRelationalIT CONFIGURATIONS Release COMMAND ${TARGET_NAME_RELATIONAL})
+    ADD_TEST(NAME sessionCIT CONFIGURATIONS Release COMMAND ${TARGET_NAME_C})
+    ADD_TEST(NAME sessionCRelationalIT CONFIGURATIONS Release COMMAND ${TARGET_NAME_C_RELATIONAL})
 ELSE()
     ADD_TEST(NAME sessionIT COMMAND ${TARGET_NAME})
     ADD_TEST(NAME sessionRelationalIT COMMAND ${TARGET_NAME_RELATIONAL})
+    ADD_TEST(NAME sessionCIT COMMAND ${TARGET_NAME_C})
+    ADD_TEST(NAME sessionCRelationalIT COMMAND ${TARGET_NAME_C_RELATIONAL})
 ENDIF()
 
 if(UNIX AND NOT APPLE)
   target_link_options(session_tests PRIVATE -Wl,--no-as-needed)
   target_link_options(session_relational_tests PRIVATE -Wl,--no-as-needed)
+  target_link_options(session_c_tests PRIVATE -Wl,--no-as-needed)
+  target_link_options(session_c_relational_tests PRIVATE -Wl,--no-as-needed)
 endif()

--- a/iotdb-client/client-cpp/src/test/cpp/sessionCIT.cpp
+++ b/iotdb-client/client-cpp/src/test/cpp/sessionCIT.cpp
@@ -748,7 +748,7 @@ TEST_CASE("C API - RowRecord and delete data APIs", "[c_rowDeleteCov]") {
             TS_OK);
     REQUIRE(ts_session_create_timeseries(g_session, pd, TS_TYPE_DOUBLE, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY) ==
             TS_OK);
-    REQUIRE(ts_session_create_timeseries(g_session, pt, TS_TYPE_TEXT, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY) ==
+    REQUIRE(ts_session_create_timeseries(g_session, pt, TS_TYPE_TEXT, TS_ENCODING_PLAIN, TS_COMPRESSION_SNAPPY) ==
             TS_OK);
 
     const char* dev = "root.cov_types.d1";

--- a/iotdb-client/client-cpp/src/test/cpp/sessionCIT.cpp
+++ b/iotdb-client/client-cpp/src/test/cpp/sessionCIT.cpp
@@ -19,6 +19,7 @@
 
 #include "catch.hpp"
 #include "SessionC.h"
+#include <cmath>
 #include <cstring>
 #include <iostream>
 #include <string>
@@ -425,5 +426,369 @@ TEST_CASE("C API - Dataset column info", "[c_datasetColumns]") {
     const char* col0 = ts_dataset_get_column_name(dataSet, 0);
     REQUIRE(std::string(col0) == "Time");
 
+    int n = ts_dataset_get_column_count(dataSet);
+    for (int i = 0; i < n; i++) {
+        const char* ct = ts_dataset_get_column_type(dataSet, i);
+        REQUIRE(ct != nullptr);
+        REQUIRE(strlen(ct) > 0);
+    }
+
     ts_dataset_destroy(dataSet);
+}
+
+/* ============================================================
+ *  SessionC.h API coverage (tree model) — additional smoke tests
+ * ============================================================ */
+
+TEST_CASE("C API - Session lifecycle variants", "[c_sessionLifecycleCov]") {
+    CaseReporter cr("c_sessionLifecycleCov");
+
+    CSession* s1 = ts_session_new_with_zone("127.0.0.1", 6667, "root", "root", "Asia/Shanghai", 1024);
+    REQUIRE(s1 != nullptr);
+    REQUIRE(ts_session_open(s1) == TS_OK);
+    ts_session_close(s1);
+    ts_session_destroy(s1);
+
+    CSession* s2 = ts_session_new("127.0.0.1", 6667, "root", "root");
+    REQUIRE(s2 != nullptr);
+    REQUIRE(ts_session_open_with_compression(s2, true) == TS_OK);
+    ts_session_close(s2);
+    ts_session_destroy(s2);
+}
+
+static void covIgnoreStatus(TsStatus s) {
+    (void)s;
+}
+
+TEST_CASE("C API - Database and extended timeseries APIs", "[c_dbTimeseriesCov]") {
+    CaseReporter cr("c_dbTimeseriesCov");
+
+    const char* sg1 = "root.cov_sg_a";
+    const char* sg2 = "root.cov_sg_b";
+    covIgnoreStatus(ts_session_delete_database(g_session, sg1));
+    covIgnoreStatus(ts_session_delete_database(g_session, sg2));
+    REQUIRE(ts_session_create_database(g_session, sg1) == TS_OK);
+    REQUIRE(ts_session_create_database(g_session, sg2) == TS_OK);
+    const char* dbs[] = {sg1, sg2};
+    REQUIRE(ts_session_delete_databases(g_session, dbs, 2) == TS_OK);
+
+    const char* sg3 = "root.cov_sg_c";
+    covIgnoreStatus(ts_session_delete_database(g_session, sg3));
+    REQUIRE(ts_session_create_database(g_session, sg3) == TS_OK);
+    REQUIRE(ts_session_delete_database(g_session, sg3) == TS_OK);
+
+    const char* sgEx = "root.cov_sg_ex";
+    covIgnoreStatus(ts_session_delete_database(g_session, sgEx));
+    REQUIRE(ts_session_create_database(g_session, sgEx) == TS_OK);
+
+    const char* pathEx = "root.cov_sg_ex.d1.s_ex";
+    bool ex = false;
+    ts_session_check_timeseries_exists(g_session, pathEx, &ex);
+    if (ex) {
+        ts_session_delete_timeseries(g_session, pathEx);
+    }
+    REQUIRE(ts_session_create_timeseries_ex(
+                g_session, pathEx, TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY, 0, nullptr, nullptr, 0,
+                nullptr, nullptr, 0, nullptr, nullptr, nullptr) == TS_OK);
+
+    const char* pathsM[] = {"root.cov_sg_ex.d1.s_m1", "root.cov_sg_ex.d1.s_m2"};
+    TSDataType_C tsM[] = {TS_TYPE_INT64, TS_TYPE_DOUBLE};
+    TSEncoding_C encM[] = {TS_ENCODING_RLE, TS_ENCODING_RLE};
+    TSCompressionType_C compM[] = {TS_COMPRESSION_SNAPPY, TS_COMPRESSION_SNAPPY};
+    for (int i = 0; i < 2; i++) {
+        ts_session_check_timeseries_exists(g_session, pathsM[i], &ex);
+        if (ex) {
+            ts_session_delete_timeseries(g_session, pathsM[i]);
+        }
+    }
+    REQUIRE(ts_session_create_multi_timeseries(g_session, 2, pathsM, tsM, encM, compM) == TS_OK);
+    REQUIRE(ts_session_delete_timeseries_batch(g_session, pathsM, 2) == TS_OK);
+    REQUIRE(ts_session_delete_timeseries(g_session, pathEx) == TS_OK);
+    REQUIRE(ts_session_delete_database(g_session, sgEx) == TS_OK);
+}
+
+TEST_CASE("C API - Tablet row count and reset", "[c_tabletResetCov]") {
+    CaseReporter cr("c_tabletResetCov");
+    const char* colNames[] = {"s1"};
+    TSDataType_C dts[] = {TS_TYPE_INT64};
+    CTablet* tablet = ts_tablet_new("root.ctest.d1", 1, colNames, dts, 10);
+    REQUIRE(tablet != nullptr);
+    REQUIRE(ts_tablet_get_row_count(tablet) == 0);
+    REQUIRE(ts_tablet_set_row_count(tablet, 1) == TS_OK);
+    REQUIRE(ts_tablet_get_row_count(tablet) == 1);
+    ts_tablet_reset(tablet);
+    REQUIRE(ts_tablet_get_row_count(tablet) == 0);
+    ts_tablet_destroy(tablet);
+}
+
+TEST_CASE("C API - Aligned timeseries and aligned writes", "[c_alignedCov]") {
+    CaseReporter cr("c_alignedCov");
+
+    const char* sg = "root.cov_al";
+    covIgnoreStatus(ts_session_delete_database(g_session, sg));
+    REQUIRE(ts_session_create_database(g_session, sg) == TS_OK);
+
+    const char* alDev = "root.cov_al.dev";
+    const char* meas[] = {"m1", "m2"};
+    TSDataType_C adt[] = {TS_TYPE_INT64, TS_TYPE_INT64};
+    TSEncoding_C aenc[] = {TS_ENCODING_RLE, TS_ENCODING_RLE};
+    TSCompressionType_C acomp[] = {TS_COMPRESSION_SNAPPY, TS_COMPRESSION_SNAPPY};
+    REQUIRE(ts_session_create_aligned_timeseries(g_session, alDev, 2, meas, adt, aenc, acomp) == TS_OK);
+
+    const char* mstr[] = {"m1", "m2"};
+    const char* vstr[] = {"1", "2"};
+    REQUIRE(ts_session_insert_aligned_record_str(g_session, alDev, 100LL, 2, mstr, vstr) == TS_OK);
+
+    int64_t v1 = 3;
+    int64_t v2 = 4;
+    const void* vals[] = {&v1, &v2};
+    REQUIRE(ts_session_insert_aligned_record(g_session, alDev, 101LL, 2, mstr, adt, vals) == TS_OK);
+
+    const char* devs1[] = {alDev};
+    int64_t times1[] = {102LL};
+    int mc1[] = {2};
+    const char* const* mlist1[] = {mstr};
+    const char* const* vlist1[] = {vstr};
+    REQUIRE(ts_session_insert_aligned_records_str(g_session, 1, devs1, times1, mc1, mlist1, vlist1) == TS_OK);
+
+    const TSDataType_C* trows[] = {adt};
+    const void* const* vrows[] = {vals};
+    REQUIRE(ts_session_insert_aligned_records(g_session, 1, devs1, times1, mc1, mlist1, trows, vrows) == TS_OK);
+
+    int64_t tRows[] = {104LL, 105LL};
+    int mcRows[] = {2, 2};
+    const char* const* mRows[] = {mstr, mstr};
+    const TSDataType_C* tRowsList[] = {adt, adt};
+    int64_t v1a = 5, v1b = 6;
+    int64_t v2a = 7, v2b = 8;
+    const void* row0[] = {&v1a, &v2a};
+    const void* row1[] = {&v1b, &v2b};
+    const void* const* vRowsList[] = {row0, row1};
+    REQUIRE(ts_session_insert_aligned_records_of_one_device(g_session, alDev, 2, tRows, mcRows, mRows, tRowsList,
+                                                            vRowsList, true) == TS_OK);
+
+    const char* alDev2 = "root.cov_al.dev2";
+    REQUIRE(ts_session_create_aligned_timeseries(g_session, alDev2, 2, meas, adt, aenc, acomp) == TS_OK);
+    CTablet* tab = ts_tablet_new(alDev, 2, meas, adt, 10);
+    CTablet* tab2 = ts_tablet_new(alDev2, 2, meas, adt, 5);
+    REQUIRE(tab != nullptr);
+    REQUIRE(tab2 != nullptr);
+    ts_tablet_add_timestamp(tab, 0, 106LL);
+    ts_tablet_add_value_int64(tab, 0, 0, 9);
+    ts_tablet_add_value_int64(tab, 1, 0, 10);
+    ts_tablet_set_row_count(tab, 1);
+    ts_tablet_add_timestamp(tab2, 0, 107LL);
+    ts_tablet_add_value_int64(tab2, 0, 0, 11);
+    ts_tablet_add_value_int64(tab2, 1, 0, 12);
+    ts_tablet_set_row_count(tab2, 1);
+    const char* devIds[] = {alDev, alDev2};
+    CTablet* tabs[] = {tab, tab2};
+    REQUIRE(ts_session_insert_aligned_tablets(g_session, 2, devIds, tabs, false) == TS_OK);
+
+    ts_tablet_reset(tab);
+    ts_tablet_add_timestamp(tab, 0, 200LL);
+    ts_tablet_add_value_int64(tab, 0, 0, 13);
+    ts_tablet_add_value_int64(tab, 1, 0, 14);
+    ts_tablet_set_row_count(tab, 1);
+    REQUIRE(ts_session_insert_aligned_tablet(g_session, tab, false) == TS_OK);
+
+    ts_tablet_destroy(tab2);
+    ts_tablet_destroy(tab);
+
+    REQUIRE(ts_session_delete_database(g_session, sg) == TS_OK);
+}
+
+TEST_CASE("C API - Typed batch inserts and insert_tablets", "[c_batchTabletCov]") {
+    CaseReporter cr("c_batchTabletCov");
+
+    const char* sg = "root.cov_batch";
+    covIgnoreStatus(ts_session_delete_database(g_session, sg));
+    REQUIRE(ts_session_create_database(g_session, sg) == TS_OK);
+
+    const char* p1 = "root.cov_batch.da.s1";
+    const char* p2 = "root.cov_batch.db.s1";
+    bool ex = false;
+    ts_session_check_timeseries_exists(g_session, p1, &ex);
+    if (ex) {
+        ts_session_delete_timeseries(g_session, p1);
+    }
+    ts_session_check_timeseries_exists(g_session, p2, &ex);
+    if (ex) {
+        ts_session_delete_timeseries(g_session, p2);
+    }
+    REQUIRE(ts_session_create_timeseries(g_session, p1, TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY) ==
+            TS_OK);
+    REQUIRE(ts_session_create_timeseries(g_session, p2, TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY) ==
+            TS_OK);
+
+    const char* devIds[] = {"root.cov_batch.da", "root.cov_batch.db"};
+    int64_t tt[] = {1LL, 2LL};
+    int mmc[] = {1, 1};
+    const char* mda[] = {"s1"};
+    const char* mdb[] = {"s1"};
+    const char* const* mlist[] = {mda, mdb};
+    int64_t va = 11;
+    int64_t vb = 22;
+    const void* vva[] = {&va};
+    const void* vvb[] = {&vb};
+    const void* const* vlist[] = {vva, vvb};
+    TSDataType_C ta[] = {TS_TYPE_INT64};
+    TSDataType_C tb[] = {TS_TYPE_INT64};
+    const TSDataType_C* tlist[] = {ta, tb};
+    REQUIRE(ts_session_insert_records(g_session, 2, devIds, tt, mmc, mlist, tlist, vlist) == TS_OK);
+
+    const char* dc = "root.cov_batch.dc";
+    const char* p3 = "root.cov_batch.dc.s1";
+    ts_session_check_timeseries_exists(g_session, p3, &ex);
+    if (ex) {
+        ts_session_delete_timeseries(g_session, p3);
+    }
+    REQUIRE(ts_session_create_timeseries(g_session, p3, TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY) ==
+            TS_OK);
+    int64_t tdc[] = {3LL, 4LL};
+    int mcdc[] = {1, 1};
+    const char* const* mdcList[] = {mda, mda};
+    const TSDataType_C* tdcList[] = {ta, ta};
+    int64_t vc = 30, vd = 40;
+    const void* rv0[] = {&vc};
+    const void* rv1[] = {&vd};
+    const void* const* vdcList[] = {rv0, rv1};
+    REQUIRE(ts_session_insert_records_of_one_device(g_session, dc, 2, tdc, mcdc, mdcList, tdcList, vdcList, true) ==
+            TS_OK);
+
+    const char* col1[] = {"s1"};
+    TSDataType_C dt1[] = {TS_TYPE_INT64};
+    CTablet* tb1 = ts_tablet_new("root.cov_batch.ta", 1, col1, dt1, 5);
+    CTablet* tb2 = ts_tablet_new("root.cov_batch.tb", 1, col1, dt1, 5);
+    REQUIRE(tb1 != nullptr);
+    REQUIRE(tb2 != nullptr);
+    const char* pta = "root.cov_batch.ta.s1";
+    const char* ptb = "root.cov_batch.tb.s1";
+    ts_session_check_timeseries_exists(g_session, pta, &ex);
+    if (ex) {
+        ts_session_delete_timeseries(g_session, pta);
+    }
+    ts_session_check_timeseries_exists(g_session, ptb, &ex);
+    if (ex) {
+        ts_session_delete_timeseries(g_session, ptb);
+    }
+    REQUIRE(ts_session_create_timeseries(g_session, pta, TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY) ==
+            TS_OK);
+    REQUIRE(ts_session_create_timeseries(g_session, ptb, TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY) ==
+            TS_OK);
+    ts_tablet_add_timestamp(tb1, 0, 1LL);
+    ts_tablet_add_value_int64(tb1, 0, 0, 100);
+    ts_tablet_set_row_count(tb1, 1);
+    ts_tablet_add_timestamp(tb2, 0, 2LL);
+    ts_tablet_add_value_int64(tb2, 0, 0, 200);
+    ts_tablet_set_row_count(tb2, 1);
+    const char* tabDevs[] = {"root.cov_batch.ta", "root.cov_batch.tb"};
+    CTablet* tbs[] = {tb1, tb2};
+    REQUIRE(ts_session_insert_tablets(g_session, 2, tabDevs, tbs, false) == TS_OK);
+    ts_tablet_destroy(tb2);
+    ts_tablet_destroy(tb1);
+
+    REQUIRE(ts_session_delete_database(g_session, sg) == TS_OK);
+}
+
+TEST_CASE("C API - Query timeout and last data queries", "[c_queryLastCov]") {
+    CaseReporter cr("c_queryLastCov");
+    prepareTimeseries();
+
+    const char* deviceId = "root.ctest.d1";
+    const char* measurements[] = {"s1", "s2", "s3"};
+    for (int64_t time = 300; time < 310; time++) {
+        const char* values[] = {"7", "8", "9"};
+        REQUIRE(ts_session_insert_record_str(g_session, deviceId, time, 3, measurements, values) == TS_OK);
+    }
+
+    const char* paths[] = {"root.ctest.d1.s1", "root.ctest.d1.s2"};
+    CSessionDataSet* ds = nullptr;
+    REQUIRE(ts_session_execute_query_with_timeout(g_session, "select s1 from root.ctest.d1 where time>=300", 60000,
+                                                  &ds) == TS_OK);
+    REQUIRE(ds != nullptr);
+    ts_dataset_destroy(ds);
+
+    ds = nullptr;
+    REQUIRE(ts_session_execute_last_data_query(g_session, 2, paths, &ds) == TS_OK);
+    REQUIRE(ds != nullptr);
+    ts_dataset_destroy(ds);
+
+    ds = nullptr;
+    REQUIRE(ts_session_execute_last_data_query_with_time(g_session, 2, paths, 305LL, &ds) == TS_OK);
+    REQUIRE(ds != nullptr);
+    ts_dataset_destroy(ds);
+}
+
+TEST_CASE("C API - RowRecord and delete data APIs", "[c_rowDeleteCov]") {
+    CaseReporter cr("c_rowDeleteCov");
+
+    const char* sg = "root.cov_types";
+    covIgnoreStatus(ts_session_delete_database(g_session, sg));
+    REQUIRE(ts_session_create_database(g_session, sg) == TS_OK);
+
+    const char* pb = "root.cov_types.d1.sb";
+    const char* pi = "root.cov_types.d1.si";
+    const char* pf = "root.cov_types.d1.sf";
+    const char* pd = "root.cov_types.d1.sd";
+    const char* pt = "root.cov_types.d1.st";
+    bool ex = false;
+    const char* tpaths[] = {pb, pi, pf, pd, pt};
+    for (const char* tp : tpaths) {
+        ts_session_check_timeseries_exists(g_session, tp, &ex);
+        if (ex) {
+            ts_session_delete_timeseries(g_session, tp);
+        }
+    }
+    REQUIRE(ts_session_create_timeseries(g_session, pb, TS_TYPE_BOOLEAN, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY) ==
+            TS_OK);
+    REQUIRE(ts_session_create_timeseries(g_session, pi, TS_TYPE_INT32, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY) ==
+            TS_OK);
+    REQUIRE(ts_session_create_timeseries(g_session, pf, TS_TYPE_FLOAT, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY) ==
+            TS_OK);
+    REQUIRE(ts_session_create_timeseries(g_session, pd, TS_TYPE_DOUBLE, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY) ==
+            TS_OK);
+    REQUIRE(ts_session_create_timeseries(g_session, pt, TS_TYPE_TEXT, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY) ==
+            TS_OK);
+
+    const char* dev = "root.cov_types.d1";
+    const char* names[] = {"sb", "si", "sf", "sd", "st"};
+    TSDataType_C types[] = {TS_TYPE_BOOLEAN, TS_TYPE_INT32, TS_TYPE_FLOAT, TS_TYPE_DOUBLE, TS_TYPE_TEXT};
+    bool bv = true;
+    int32_t iv = 42;
+    float fv = 2.5f;
+    double dv = 3.25;
+    const char* tv = "hi";
+    const void* vals[] = {&bv, &iv, &fv, &dv, tv};
+    REQUIRE(ts_session_insert_record(g_session, dev, 500LL, 5, names, types, vals) == TS_OK);
+
+    CSessionDataSet* dataSet = nullptr;
+    REQUIRE(ts_session_execute_query(
+                g_session, "select sb,si,sf,sd,st from root.cov_types.d1 where time=500", &dataSet) == TS_OK);
+    REQUIRE(dataSet != nullptr);
+    REQUIRE(ts_dataset_has_next(dataSet));
+    CRowRecord* record = ts_dataset_next(dataSet);
+    REQUIRE(record != nullptr);
+    REQUIRE(ts_row_record_get_timestamp(record) == 500LL);
+    REQUIRE(ts_row_record_get_field_count(record) == 5);
+    REQUIRE_FALSE(ts_row_record_is_null(record, 0));
+    REQUIRE(ts_row_record_get_bool(record, 0) == true);
+    REQUIRE(ts_row_record_get_int32(record, 1) == 42);
+    REQUIRE(std::fabs(ts_row_record_get_float(record, 2) - 2.5f) < 1e-4f);
+    REQUIRE(std::fabs(ts_row_record_get_double(record, 3) - 3.25) < 1e-9);
+    REQUIRE(std::string(ts_row_record_get_string(record, 4)) == "hi");
+    REQUIRE(ts_row_record_get_data_type(record, 0) == TS_TYPE_BOOLEAN);
+    ts_row_record_destroy(record);
+    ts_dataset_destroy(dataSet);
+
+    REQUIRE(ts_session_delete_data(g_session, pb, 500LL) == TS_OK);
+    const char* delPaths[] = {pi, pf};
+    REQUIRE(ts_session_delete_data_range(g_session, 2, delPaths, 400LL, 600LL) == TS_OK);
+
+    REQUIRE(ts_session_delete_timeseries(g_session, pb) == TS_OK);
+    REQUIRE(ts_session_delete_timeseries(g_session, pi) == TS_OK);
+    REQUIRE(ts_session_delete_timeseries(g_session, pf) == TS_OK);
+    REQUIRE(ts_session_delete_timeseries(g_session, pd) == TS_OK);
+    REQUIRE(ts_session_delete_timeseries(g_session, pt) == TS_OK);
+    REQUIRE(ts_session_delete_database(g_session, sg) == TS_OK);
 }

--- a/iotdb-client/client-cpp/src/test/cpp/sessionCIT.cpp
+++ b/iotdb-client/client-cpp/src/test/cpp/sessionCIT.cpp
@@ -46,15 +46,44 @@ private:
 static const char* testTimeseries[] = {"root.ctest.d1.s1", "root.ctest.d1.s2", "root.ctest.d1.s3"};
 static const int testTimeseriesCount = 3;
 
+static void dropTimeseriesIfExists(CSession* session, const char* path) {
+    bool exists = false;
+    REQUIRE(ts_session_check_timeseries_exists(session, path, &exists) == TS_OK);
+    if (exists) {
+        REQUIRE(ts_session_delete_timeseries(session, path) == TS_OK);
+    }
+}
+
+static void ensureTimeseries(CSession* session, const char* path, TSDataType_C type, TSEncoding_C encoding,
+                             TSCompressionType_C compression) {
+    dropTimeseriesIfExists(session, path);
+    REQUIRE(ts_session_create_timeseries(session, path, type, encoding, compression) == TS_OK);
+}
+
+static int queryRowCount(CSession* session, const char* sql, int fetchSize = 1024) {
+    CSessionDataSet* dataSet = nullptr;
+    REQUIRE(ts_session_execute_query(session, sql, &dataSet) == TS_OK);
+    REQUIRE(dataSet != nullptr);
+    ts_dataset_set_fetch_size(dataSet, fetchSize);
+    int count = 0;
+    while (ts_dataset_has_next(dataSet)) {
+        CRowRecord* record = ts_dataset_next(dataSet);
+        REQUIRE(record != nullptr);
+        ++count;
+        ts_row_record_destroy(record);
+    }
+    ts_dataset_destroy(dataSet);
+    return count;
+}
+
+static void dropDatabaseIfExists(CSession* session, const char* database) {
+    TsStatus status = ts_session_delete_database(session, database);
+    (void)status;
+}
+
 static void prepareTimeseries() {
     for (int i = 0; i < testTimeseriesCount; i++) {
-        bool exists = false;
-        ts_session_check_timeseries_exists(g_session, testTimeseries[i], &exists);
-        if (exists) {
-            ts_session_delete_timeseries(g_session, testTimeseries[i]);
-        }
-        ts_session_create_timeseries(g_session, testTimeseries[i],
-                                     TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY);
+        ensureTimeseries(g_session, testTimeseries[i], TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY);
     }
 }
 
@@ -65,34 +94,21 @@ static void prepareTimeseries() {
 TEST_CASE("C API - Create timeseries", "[c_createTimeseries]") {
     CaseReporter cr("c_createTimeseries");
     const char* path = "root.ctest.d1.s1";
+    ensureTimeseries(g_session, path, TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY);
     bool exists = false;
-    ts_session_check_timeseries_exists(g_session, path, &exists);
-    if (!exists) {
-        TsStatus status = ts_session_create_timeseries(g_session, path,
-                                                        TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY);
-        REQUIRE(status == TS_OK);
-    }
-    ts_session_check_timeseries_exists(g_session, path, &exists);
-    REQUIRE(exists == true);
-    ts_session_delete_timeseries(g_session, path);
+    REQUIRE(ts_session_check_timeseries_exists(g_session, path, &exists) == TS_OK);
+    REQUIRE(exists);
+    REQUIRE(ts_session_delete_timeseries(g_session, path) == TS_OK);
 }
 
 TEST_CASE("C API - Delete timeseries", "[c_deleteTimeseries]") {
     CaseReporter cr("c_deleteTimeseries");
     const char* path = "root.ctest.d1.s1";
-
-    bool exists = false;
-    ts_session_check_timeseries_exists(g_session, path, &exists);
-    if (!exists) {
-        ts_session_create_timeseries(g_session, path, TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY);
-    }
-    ts_session_check_timeseries_exists(g_session, path, &exists);
-    REQUIRE(exists == true);
-
-    TsStatus status = ts_session_delete_timeseries(g_session, path);
-    REQUIRE(status == TS_OK);
-    ts_session_check_timeseries_exists(g_session, path, &exists);
-    REQUIRE(exists == false);
+    ensureTimeseries(g_session, path, TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY);
+    REQUIRE(ts_session_delete_timeseries(g_session, path) == TS_OK);
+    bool exists = true;
+    REQUIRE(ts_session_check_timeseries_exists(g_session, path, &exists) == TS_OK);
+    REQUIRE_FALSE(exists);
 }
 
 TEST_CASE("C API - Login failure", "[c_Authentication]") {
@@ -126,7 +142,6 @@ TEST_CASE("C API - Insert record by string", "[c_insertRecordStr]") {
     TsStatus status = ts_session_execute_query(g_session, "select s1,s2,s3 from root.ctest.d1", &dataSet);
     REQUIRE(status == TS_OK);
     REQUIRE(dataSet != nullptr);
-
     ts_dataset_set_fetch_size(dataSet, 1024);
     int count = 0;
     while (ts_dataset_has_next(dataSet)) {
@@ -135,7 +150,7 @@ TEST_CASE("C API - Insert record by string", "[c_insertRecordStr]") {
         REQUIRE(ts_row_record_get_int64(record, 0) == 1);
         REQUIRE(ts_row_record_get_int64(record, 1) == 2);
         REQUIRE(ts_row_record_get_int64(record, 2) == 3);
-        count++;
+        ++count;
         ts_row_record_destroy(record);
     }
     REQUIRE(count == 100);
@@ -155,10 +170,7 @@ TEST_CASE("C API - Insert record with types", "[c_insertRecordTyped]") {
     TSCompressionType_C compressions[] = {TS_COMPRESSION_SNAPPY, TS_COMPRESSION_SNAPPY, TS_COMPRESSION_SNAPPY};
 
     for (int i = 0; i < 3; i++) {
-        bool exists = false;
-        ts_session_check_timeseries_exists(g_session, timeseries[i], &exists);
-        if (exists) ts_session_delete_timeseries(g_session, timeseries[i]);
-        ts_session_create_timeseries(g_session, timeseries[i], types[i], encodings[i], compressions[i]);
+        ensureTimeseries(g_session, timeseries[i], types[i], encodings[i], compressions[i]);
     }
 
     const char* deviceId = "root.ctest.d1";
@@ -173,17 +185,7 @@ TEST_CASE("C API - Insert record with types", "[c_insertRecordTyped]") {
         REQUIRE(status == TS_OK);
     }
 
-    CSessionDataSet* dataSet = nullptr;
-    ts_session_execute_query(g_session, "select s1,s2,s3 from root.ctest.d1", &dataSet);
-    ts_dataset_set_fetch_size(dataSet, 1024);
-    int count = 0;
-    while (ts_dataset_has_next(dataSet)) {
-        CRowRecord* record = ts_dataset_next(dataSet);
-        count++;
-        ts_row_record_destroy(record);
-    }
-    REQUIRE(count == 100);
-    ts_dataset_destroy(dataSet);
+    REQUIRE(queryRowCount(g_session, "select s1,s2,s3 from root.ctest.d1") == 100);
 }
 
 /* ============================================================
@@ -217,17 +219,7 @@ TEST_CASE("C API - Insert records batch", "[c_insertRecordsBatch]") {
                                                      measurementCounts, measurementsList, valuesList);
     REQUIRE(status == TS_OK);
 
-    CSessionDataSet* dataSet = nullptr;
-    ts_session_execute_query(g_session, "select s1,s2,s3 from root.ctest.d1", &dataSet);
-    ts_dataset_set_fetch_size(dataSet, 1024);
-    int count = 0;
-    while (ts_dataset_has_next(dataSet)) {
-        CRowRecord* record = ts_dataset_next(dataSet);
-        count++;
-        ts_row_record_destroy(record);
-    }
-    REQUIRE(count == BATCH);
-    ts_dataset_destroy(dataSet);
+    REQUIRE(queryRowCount(g_session, "select s1,s2,s3 from root.ctest.d1") == BATCH);
 }
 
 /* ============================================================
@@ -257,7 +249,8 @@ TEST_CASE("C API - Insert tablet", "[c_insertTablet]") {
     REQUIRE(status == TS_OK);
 
     CSessionDataSet* dataSet = nullptr;
-    ts_session_execute_query(g_session, "select s1,s2,s3 from root.ctest.d1", &dataSet);
+    REQUIRE(ts_session_execute_query(g_session, "select s1,s2,s3 from root.ctest.d1", &dataSet) == TS_OK);
+    REQUIRE(dataSet != nullptr);
     ts_dataset_set_fetch_size(dataSet, 1024);
     int count = 0;
     while (ts_dataset_has_next(dataSet)) {
@@ -265,7 +258,7 @@ TEST_CASE("C API - Insert tablet", "[c_insertTablet]") {
         REQUIRE(ts_row_record_get_int64(record, 0) == 0);
         REQUIRE(ts_row_record_get_int64(record, 1) == 1);
         REQUIRE(ts_row_record_get_int64(record, 2) == 2);
-        count++;
+        ++count;
         ts_row_record_destroy(record);
     }
     REQUIRE(count == 100);
@@ -344,17 +337,7 @@ TEST_CASE("C API - Delete data", "[c_deleteData]") {
     TsStatus status = ts_session_delete_data_batch(g_session, 3, paths, 49);
     REQUIRE(status == TS_OK);
 
-    CSessionDataSet* dataSet = nullptr;
-    ts_session_execute_query(g_session, "select s1,s2,s3 from root.ctest.d1", &dataSet);
-    ts_dataset_set_fetch_size(dataSet, 1024);
-    int count = 0;
-    while (ts_dataset_has_next(dataSet)) {
-        CRowRecord* record = ts_dataset_next(dataSet);
-        count++;
-        ts_row_record_destroy(record);
-    }
-    REQUIRE(count == 50);
-    ts_dataset_destroy(dataSet);
+    REQUIRE(queryRowCount(g_session, "select s1,s2,s3 from root.ctest.d1") == 50);
 }
 
 /* ============================================================
@@ -390,14 +373,11 @@ TEST_CASE("C API - Multi-node session", "[c_multiNode]") {
     REQUIRE(status == TS_OK);
 
     const char* path = "root.ctest.d1.s1";
+    ensureTimeseries(localSession, path, TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY);
     bool exists = false;
-    ts_session_check_timeseries_exists(localSession, path, &exists);
-    if (!exists) {
-        ts_session_create_timeseries(localSession, path, TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY);
-    }
-    ts_session_check_timeseries_exists(localSession, path, &exists);
-    REQUIRE(exists == true);
-    ts_session_delete_timeseries(localSession, path);
+    REQUIRE(ts_session_check_timeseries_exists(localSession, path, &exists) == TS_OK);
+    REQUIRE(exists);
+    REQUIRE(ts_session_delete_timeseries(localSession, path) == TS_OK);
 
     ts_session_close(localSession);
     ts_session_destroy(localSession);
@@ -440,8 +420,8 @@ TEST_CASE("C API - Dataset column info", "[c_datasetColumns]") {
  *  SessionC.h API coverage (tree model) — additional smoke tests
  * ============================================================ */
 
-TEST_CASE("C API - Session lifecycle variants", "[c_sessionLifecycleCov]") {
-    CaseReporter cr("c_sessionLifecycleCov");
+TEST_CASE("C API - Session lifecycle variants", "[c_sessionLifecycle]") {
+    CaseReporter cr("c_sessionLifecycle");
 
     CSession* s1 = ts_session_new_with_zone("127.0.0.1", 6667, "root", "root", "Asia/Shanghai", 1024);
     REQUIRE(s1 != nullptr);
@@ -456,37 +436,29 @@ TEST_CASE("C API - Session lifecycle variants", "[c_sessionLifecycleCov]") {
     ts_session_destroy(s2);
 }
 
-static void covIgnoreStatus(TsStatus s) {
-    (void)s;
-}
-
-TEST_CASE("C API - Database and extended timeseries APIs", "[c_dbTimeseriesCov]") {
-    CaseReporter cr("c_dbTimeseriesCov");
+TEST_CASE("C API - Database and extended timeseries APIs", "[c_dbTimeseries]") {
+    CaseReporter cr("c_dbTimeseries");
 
     const char* sg1 = "root.cov_sg_a";
     const char* sg2 = "root.cov_sg_b";
-    covIgnoreStatus(ts_session_delete_database(g_session, sg1));
-    covIgnoreStatus(ts_session_delete_database(g_session, sg2));
+    dropDatabaseIfExists(g_session, sg1);
+    dropDatabaseIfExists(g_session, sg2);
     REQUIRE(ts_session_create_database(g_session, sg1) == TS_OK);
     REQUIRE(ts_session_create_database(g_session, sg2) == TS_OK);
     const char* dbs[] = {sg1, sg2};
     REQUIRE(ts_session_delete_databases(g_session, dbs, 2) == TS_OK);
 
     const char* sg3 = "root.cov_sg_c";
-    covIgnoreStatus(ts_session_delete_database(g_session, sg3));
+    dropDatabaseIfExists(g_session, sg3);
     REQUIRE(ts_session_create_database(g_session, sg3) == TS_OK);
     REQUIRE(ts_session_delete_database(g_session, sg3) == TS_OK);
 
     const char* sgEx = "root.cov_sg_ex";
-    covIgnoreStatus(ts_session_delete_database(g_session, sgEx));
+    dropDatabaseIfExists(g_session, sgEx);
     REQUIRE(ts_session_create_database(g_session, sgEx) == TS_OK);
 
     const char* pathEx = "root.cov_sg_ex.d1.s_ex";
-    bool ex = false;
-    ts_session_check_timeseries_exists(g_session, pathEx, &ex);
-    if (ex) {
-        ts_session_delete_timeseries(g_session, pathEx);
-    }
+    dropTimeseriesIfExists(g_session, pathEx);
     REQUIRE(ts_session_create_timeseries_ex(
                 g_session, pathEx, TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY, 0, nullptr, nullptr, 0,
                 nullptr, nullptr, 0, nullptr, nullptr, nullptr) == TS_OK);
@@ -496,10 +468,7 @@ TEST_CASE("C API - Database and extended timeseries APIs", "[c_dbTimeseriesCov]"
     TSEncoding_C encM[] = {TS_ENCODING_RLE, TS_ENCODING_RLE};
     TSCompressionType_C compM[] = {TS_COMPRESSION_SNAPPY, TS_COMPRESSION_SNAPPY};
     for (int i = 0; i < 2; i++) {
-        ts_session_check_timeseries_exists(g_session, pathsM[i], &ex);
-        if (ex) {
-            ts_session_delete_timeseries(g_session, pathsM[i]);
-        }
+        dropTimeseriesIfExists(g_session, pathsM[i]);
     }
     REQUIRE(ts_session_create_multi_timeseries(g_session, 2, pathsM, tsM, encM, compM) == TS_OK);
     REQUIRE(ts_session_delete_timeseries_batch(g_session, pathsM, 2) == TS_OK);
@@ -507,8 +476,8 @@ TEST_CASE("C API - Database and extended timeseries APIs", "[c_dbTimeseriesCov]"
     REQUIRE(ts_session_delete_database(g_session, sgEx) == TS_OK);
 }
 
-TEST_CASE("C API - Tablet row count and reset", "[c_tabletResetCov]") {
-    CaseReporter cr("c_tabletResetCov");
+TEST_CASE("C API - Tablet row count and reset", "[c_tabletReset]") {
+    CaseReporter cr("c_tabletReset");
     const char* colNames[] = {"s1"};
     TSDataType_C dts[] = {TS_TYPE_INT64};
     CTablet* tablet = ts_tablet_new("root.ctest.d1", 1, colNames, dts, 10);
@@ -521,11 +490,11 @@ TEST_CASE("C API - Tablet row count and reset", "[c_tabletResetCov]") {
     ts_tablet_destroy(tablet);
 }
 
-TEST_CASE("C API - Aligned timeseries and aligned writes", "[c_alignedCov]") {
-    CaseReporter cr("c_alignedCov");
+TEST_CASE("C API - Aligned timeseries and aligned writes", "[c_aligned]") {
+    CaseReporter cr("c_aligned");
 
     const char* sg = "root.cov_al";
-    covIgnoreStatus(ts_session_delete_database(g_session, sg));
+    dropDatabaseIfExists(g_session, sg);
     REQUIRE(ts_session_create_database(g_session, sg) == TS_OK);
 
     const char* alDev = "root.cov_al.dev";
@@ -598,28 +567,17 @@ TEST_CASE("C API - Aligned timeseries and aligned writes", "[c_alignedCov]") {
     REQUIRE(ts_session_delete_database(g_session, sg) == TS_OK);
 }
 
-TEST_CASE("C API - Typed batch inserts and insert_tablets", "[c_batchTabletCov]") {
-    CaseReporter cr("c_batchTabletCov");
+TEST_CASE("C API - Typed batch inserts and insert_tablets", "[c_batchTablet]") {
+    CaseReporter cr("c_batchTablet");
 
     const char* sg = "root.cov_batch";
-    covIgnoreStatus(ts_session_delete_database(g_session, sg));
+    dropDatabaseIfExists(g_session, sg);
     REQUIRE(ts_session_create_database(g_session, sg) == TS_OK);
 
     const char* p1 = "root.cov_batch.da.s1";
     const char* p2 = "root.cov_batch.db.s1";
-    bool ex = false;
-    ts_session_check_timeseries_exists(g_session, p1, &ex);
-    if (ex) {
-        ts_session_delete_timeseries(g_session, p1);
-    }
-    ts_session_check_timeseries_exists(g_session, p2, &ex);
-    if (ex) {
-        ts_session_delete_timeseries(g_session, p2);
-    }
-    REQUIRE(ts_session_create_timeseries(g_session, p1, TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY) ==
-            TS_OK);
-    REQUIRE(ts_session_create_timeseries(g_session, p2, TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY) ==
-            TS_OK);
+    ensureTimeseries(g_session, p1, TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY);
+    ensureTimeseries(g_session, p2, TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY);
 
     const char* devIds[] = {"root.cov_batch.da", "root.cov_batch.db"};
     int64_t tt[] = {1LL, 2LL};
@@ -639,12 +597,7 @@ TEST_CASE("C API - Typed batch inserts and insert_tablets", "[c_batchTabletCov]"
 
     const char* dc = "root.cov_batch.dc";
     const char* p3 = "root.cov_batch.dc.s1";
-    ts_session_check_timeseries_exists(g_session, p3, &ex);
-    if (ex) {
-        ts_session_delete_timeseries(g_session, p3);
-    }
-    REQUIRE(ts_session_create_timeseries(g_session, p3, TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY) ==
-            TS_OK);
+    ensureTimeseries(g_session, p3, TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY);
     int64_t tdc[] = {3LL, 4LL};
     int mcdc[] = {1, 1};
     const char* const* mdcList[] = {mda, mda};
@@ -664,18 +617,8 @@ TEST_CASE("C API - Typed batch inserts and insert_tablets", "[c_batchTabletCov]"
     REQUIRE(tb2 != nullptr);
     const char* pta = "root.cov_batch.ta.s1";
     const char* ptb = "root.cov_batch.tb.s1";
-    ts_session_check_timeseries_exists(g_session, pta, &ex);
-    if (ex) {
-        ts_session_delete_timeseries(g_session, pta);
-    }
-    ts_session_check_timeseries_exists(g_session, ptb, &ex);
-    if (ex) {
-        ts_session_delete_timeseries(g_session, ptb);
-    }
-    REQUIRE(ts_session_create_timeseries(g_session, pta, TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY) ==
-            TS_OK);
-    REQUIRE(ts_session_create_timeseries(g_session, ptb, TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY) ==
-            TS_OK);
+    ensureTimeseries(g_session, pta, TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY);
+    ensureTimeseries(g_session, ptb, TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY);
     ts_tablet_add_timestamp(tb1, 0, 1LL);
     ts_tablet_add_value_int64(tb1, 0, 0, 100);
     ts_tablet_set_row_count(tb1, 1);
@@ -691,8 +634,8 @@ TEST_CASE("C API - Typed batch inserts and insert_tablets", "[c_batchTabletCov]"
     REQUIRE(ts_session_delete_database(g_session, sg) == TS_OK);
 }
 
-TEST_CASE("C API - Query timeout and last data queries", "[c_queryLastCov]") {
-    CaseReporter cr("c_queryLastCov");
+TEST_CASE("C API - Query timeout and last data queries", "[c_queryLast]") {
+    CaseReporter cr("c_queryLast");
     prepareTimeseries();
 
     const char* deviceId = "root.ctest.d1";
@@ -720,11 +663,11 @@ TEST_CASE("C API - Query timeout and last data queries", "[c_queryLastCov]") {
     ts_dataset_destroy(ds);
 }
 
-TEST_CASE("C API - RowRecord and delete data APIs", "[c_rowDeleteCov]") {
-    CaseReporter cr("c_rowDeleteCov");
+TEST_CASE("C API - RowRecord and delete data APIs", "[c_rowDelete]") {
+    CaseReporter cr("c_rowDelete");
 
     const char* sg = "root.cov_types";
-    covIgnoreStatus(ts_session_delete_database(g_session, sg));
+    dropDatabaseIfExists(g_session, sg);
     REQUIRE(ts_session_create_database(g_session, sg) == TS_OK);
 
     const char* pb = "root.cov_types.d1.sb";
@@ -732,13 +675,9 @@ TEST_CASE("C API - RowRecord and delete data APIs", "[c_rowDeleteCov]") {
     const char* pf = "root.cov_types.d1.sf";
     const char* pd = "root.cov_types.d1.sd";
     const char* pt = "root.cov_types.d1.st";
-    bool ex = false;
     const char* tpaths[] = {pb, pi, pf, pd, pt};
     for (const char* tp : tpaths) {
-        ts_session_check_timeseries_exists(g_session, tp, &ex);
-        if (ex) {
-            ts_session_delete_timeseries(g_session, tp);
-        }
+        dropTimeseriesIfExists(g_session, tp);
     }
     REQUIRE(ts_session_create_timeseries(g_session, pb, TS_TYPE_BOOLEAN, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY) ==
             TS_OK);

--- a/iotdb-client/client-cpp/src/test/cpp/sessionCIT.cpp
+++ b/iotdb-client/client-cpp/src/test/cpp/sessionCIT.cpp
@@ -1,0 +1,429 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "catch.hpp"
+#include "SessionC.h"
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+extern CSession* g_session;
+
+static int global_test_id = 0;
+
+class CaseReporter {
+public:
+    CaseReporter(const char* caseNameArg) : caseName(caseNameArg) {
+        test_id = global_test_id++;
+        std::cout << "C-API Test " << test_id << ": " << caseName << std::endl;
+    }
+    ~CaseReporter() {
+        std::cout << "C-API Test " << test_id << ": " << caseName << " Done" << std::endl << std::endl;
+    }
+private:
+    const char* caseName;
+    int test_id;
+};
+
+static const char* testTimeseries[] = {"root.ctest.d1.s1", "root.ctest.d1.s2", "root.ctest.d1.s3"};
+static const int testTimeseriesCount = 3;
+
+static void prepareTimeseries() {
+    for (int i = 0; i < testTimeseriesCount; i++) {
+        bool exists = false;
+        ts_session_check_timeseries_exists(g_session, testTimeseries[i], &exists);
+        if (exists) {
+            ts_session_delete_timeseries(g_session, testTimeseries[i]);
+        }
+        ts_session_create_timeseries(g_session, testTimeseries[i],
+                                     TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY);
+    }
+}
+
+/* ============================================================
+ *  Timeseries CRUD
+ * ============================================================ */
+
+TEST_CASE("C API - Create timeseries", "[c_createTimeseries]") {
+    CaseReporter cr("c_createTimeseries");
+    const char* path = "root.ctest.d1.s1";
+    bool exists = false;
+    ts_session_check_timeseries_exists(g_session, path, &exists);
+    if (!exists) {
+        TsStatus status = ts_session_create_timeseries(g_session, path,
+                                                        TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY);
+        REQUIRE(status == TS_OK);
+    }
+    ts_session_check_timeseries_exists(g_session, path, &exists);
+    REQUIRE(exists == true);
+    ts_session_delete_timeseries(g_session, path);
+}
+
+TEST_CASE("C API - Delete timeseries", "[c_deleteTimeseries]") {
+    CaseReporter cr("c_deleteTimeseries");
+    const char* path = "root.ctest.d1.s1";
+
+    bool exists = false;
+    ts_session_check_timeseries_exists(g_session, path, &exists);
+    if (!exists) {
+        ts_session_create_timeseries(g_session, path, TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY);
+    }
+    ts_session_check_timeseries_exists(g_session, path, &exists);
+    REQUIRE(exists == true);
+
+    TsStatus status = ts_session_delete_timeseries(g_session, path);
+    REQUIRE(status == TS_OK);
+    ts_session_check_timeseries_exists(g_session, path, &exists);
+    REQUIRE(exists == false);
+}
+
+TEST_CASE("C API - Login failure", "[c_Authentication]") {
+    CaseReporter cr("c_LoginTest");
+    CSession* badSession = ts_session_new("127.0.0.1", 6667, "root", "wrong-password");
+    REQUIRE(badSession != nullptr);
+    TsStatus status = ts_session_open(badSession);
+    REQUIRE(status != TS_OK);
+    const char* err = ts_get_last_error();
+    REQUIRE(std::string(err).find("801") != std::string::npos);
+    ts_session_destroy(badSession);
+}
+
+/* ============================================================
+ *  Insert Record (string values)
+ * ============================================================ */
+
+TEST_CASE("C API - Insert record by string", "[c_insertRecordStr]") {
+    CaseReporter cr("c_insertRecordStr");
+    prepareTimeseries();
+    const char* deviceId = "root.ctest.d1";
+    const char* measurements[] = {"s1", "s2", "s3"};
+
+    for (int64_t time = 0; time < 100; time++) {
+        const char* values[] = {"1", "2", "3"};
+        TsStatus status = ts_session_insert_record_str(g_session, deviceId, time, 3, measurements, values);
+        REQUIRE(status == TS_OK);
+    }
+
+    CSessionDataSet* dataSet = nullptr;
+    TsStatus status = ts_session_execute_query(g_session, "select s1,s2,s3 from root.ctest.d1", &dataSet);
+    REQUIRE(status == TS_OK);
+    REQUIRE(dataSet != nullptr);
+
+    ts_dataset_set_fetch_size(dataSet, 1024);
+    int count = 0;
+    while (ts_dataset_has_next(dataSet)) {
+        CRowRecord* record = ts_dataset_next(dataSet);
+        REQUIRE(record != nullptr);
+        REQUIRE(ts_row_record_get_int64(record, 0) == 1);
+        REQUIRE(ts_row_record_get_int64(record, 1) == 2);
+        REQUIRE(ts_row_record_get_int64(record, 2) == 3);
+        count++;
+        ts_row_record_destroy(record);
+    }
+    REQUIRE(count == 100);
+    ts_dataset_destroy(dataSet);
+}
+
+/* ============================================================
+ *  Insert Record (typed values)
+ * ============================================================ */
+
+TEST_CASE("C API - Insert record with types", "[c_insertRecordTyped]") {
+    CaseReporter cr("c_insertRecordTyped");
+
+    const char* timeseries[] = {"root.ctest.d1.s1", "root.ctest.d1.s2", "root.ctest.d1.s3"};
+    TSDataType_C types[] = {TS_TYPE_INT32, TS_TYPE_DOUBLE, TS_TYPE_INT64};
+    TSEncoding_C encodings[] = {TS_ENCODING_RLE, TS_ENCODING_RLE, TS_ENCODING_RLE};
+    TSCompressionType_C compressions[] = {TS_COMPRESSION_SNAPPY, TS_COMPRESSION_SNAPPY, TS_COMPRESSION_SNAPPY};
+
+    for (int i = 0; i < 3; i++) {
+        bool exists = false;
+        ts_session_check_timeseries_exists(g_session, timeseries[i], &exists);
+        if (exists) ts_session_delete_timeseries(g_session, timeseries[i]);
+        ts_session_create_timeseries(g_session, timeseries[i], types[i], encodings[i], compressions[i]);
+    }
+
+    const char* deviceId = "root.ctest.d1";
+    const char* measurements[] = {"s1", "s2", "s3"};
+
+    for (int64_t time = 0; time < 100; time++) {
+        int32_t v1 = 1;
+        double v2 = 2.2;
+        int64_t v3 = 3;
+        const void* values[] = {&v1, &v2, &v3};
+        TsStatus status = ts_session_insert_record(g_session, deviceId, time, 3, measurements, types, values);
+        REQUIRE(status == TS_OK);
+    }
+
+    CSessionDataSet* dataSet = nullptr;
+    ts_session_execute_query(g_session, "select s1,s2,s3 from root.ctest.d1", &dataSet);
+    ts_dataset_set_fetch_size(dataSet, 1024);
+    int count = 0;
+    while (ts_dataset_has_next(dataSet)) {
+        CRowRecord* record = ts_dataset_next(dataSet);
+        count++;
+        ts_row_record_destroy(record);
+    }
+    REQUIRE(count == 100);
+    ts_dataset_destroy(dataSet);
+}
+
+/* ============================================================
+ *  Insert Records (batch, string values)
+ * ============================================================ */
+
+TEST_CASE("C API - Insert records batch", "[c_insertRecordsBatch]") {
+    CaseReporter cr("c_insertRecordsBatch");
+    prepareTimeseries();
+
+    const int BATCH = 100;
+    const char* deviceId = "root.ctest.d1";
+    const char* measurements[] = {"s1", "s2", "s3"};
+
+    const char* deviceIds[BATCH];
+    int64_t times[BATCH];
+    int measurementCounts[BATCH];
+    const char* const* measurementsList[BATCH];
+    const char* values[] = {"1", "2", "3"};
+    const char* const* valuesList[BATCH];
+
+    for (int i = 0; i < BATCH; i++) {
+        deviceIds[i] = deviceId;
+        times[i] = i;
+        measurementCounts[i] = 3;
+        measurementsList[i] = measurements;
+        valuesList[i] = values;
+    }
+
+    TsStatus status = ts_session_insert_records_str(g_session, BATCH, deviceIds, times,
+                                                     measurementCounts, measurementsList, valuesList);
+    REQUIRE(status == TS_OK);
+
+    CSessionDataSet* dataSet = nullptr;
+    ts_session_execute_query(g_session, "select s1,s2,s3 from root.ctest.d1", &dataSet);
+    ts_dataset_set_fetch_size(dataSet, 1024);
+    int count = 0;
+    while (ts_dataset_has_next(dataSet)) {
+        CRowRecord* record = ts_dataset_next(dataSet);
+        count++;
+        ts_row_record_destroy(record);
+    }
+    REQUIRE(count == BATCH);
+    ts_dataset_destroy(dataSet);
+}
+
+/* ============================================================
+ *  Insert Tablet
+ * ============================================================ */
+
+TEST_CASE("C API - Insert tablet", "[c_insertTablet]") {
+    CaseReporter cr("c_insertTablet");
+    prepareTimeseries();
+
+    const char* columnNames[] = {"s1", "s2", "s3"};
+    TSDataType_C dataTypes[] = {TS_TYPE_INT64, TS_TYPE_INT64, TS_TYPE_INT64};
+
+    CTablet* tablet = ts_tablet_new("root.ctest.d1", 3, columnNames, dataTypes, 100);
+    REQUIRE(tablet != nullptr);
+
+    for (int64_t time = 0; time < 100; time++) {
+        ts_tablet_add_timestamp(tablet, (int)time, time);
+        for (int col = 0; col < 3; col++) {
+            int64_t val = col;
+            ts_tablet_add_value_int64(tablet, col, (int)time, val);
+        }
+    }
+    ts_tablet_set_row_count(tablet, 100);
+
+    TsStatus status = ts_session_insert_tablet(g_session, tablet, false);
+    REQUIRE(status == TS_OK);
+
+    CSessionDataSet* dataSet = nullptr;
+    ts_session_execute_query(g_session, "select s1,s2,s3 from root.ctest.d1", &dataSet);
+    ts_dataset_set_fetch_size(dataSet, 1024);
+    int count = 0;
+    while (ts_dataset_has_next(dataSet)) {
+        CRowRecord* record = ts_dataset_next(dataSet);
+        REQUIRE(ts_row_record_get_int64(record, 0) == 0);
+        REQUIRE(ts_row_record_get_int64(record, 1) == 1);
+        REQUIRE(ts_row_record_get_int64(record, 2) == 2);
+        count++;
+        ts_row_record_destroy(record);
+    }
+    REQUIRE(count == 100);
+    ts_dataset_destroy(dataSet);
+    ts_tablet_destroy(tablet);
+}
+
+/* ============================================================
+ *  Execute SQL directly
+ * ============================================================ */
+
+TEST_CASE("C API - Execute non-query SQL", "[c_executeNonQuery]") {
+    CaseReporter cr("c_executeNonQuery");
+    prepareTimeseries();
+
+    TsStatus status = ts_session_execute_non_query(g_session,
+        "insert into root.ctest.d1(timestamp,s1,s2,s3) values(200,10,20,30)");
+    REQUIRE(status == TS_OK);
+
+    CSessionDataSet* dataSet = nullptr;
+    ts_session_execute_query(g_session, "select s1 from root.ctest.d1 where time=200", &dataSet);
+    REQUIRE(ts_dataset_has_next(dataSet));
+    CRowRecord* record = ts_dataset_next(dataSet);
+    REQUIRE(ts_row_record_get_int64(record, 0) == 10);
+    ts_row_record_destroy(record);
+    ts_dataset_destroy(dataSet);
+}
+
+/* ============================================================
+ *  Raw data query
+ * ============================================================ */
+
+TEST_CASE("C API - Execute raw data query", "[c_executeRawDataQuery]") {
+    CaseReporter cr("c_executeRawDataQuery");
+    prepareTimeseries();
+
+    const char* deviceId = "root.ctest.d1";
+    const char* measurements[] = {"s1", "s2", "s3"};
+
+    for (int64_t time = 0; time < 50; time++) {
+        const char* values[] = {"1", "2", "3"};
+        ts_session_insert_record_str(g_session, deviceId, time, 3, measurements, values);
+    }
+
+    const char* paths[] = {"root.ctest.d1.s1", "root.ctest.d1.s2", "root.ctest.d1.s3"};
+    CSessionDataSet* dataSet = nullptr;
+    TsStatus status = ts_session_execute_raw_data_query(g_session, 3, paths, 0, 50, &dataSet);
+    REQUIRE(status == TS_OK);
+
+    int count = 0;
+    while (ts_dataset_has_next(dataSet)) {
+        CRowRecord* record = ts_dataset_next(dataSet);
+        count++;
+        ts_row_record_destroy(record);
+    }
+    REQUIRE(count == 50);
+    ts_dataset_destroy(dataSet);
+}
+
+/* ============================================================
+ *  Data deletion
+ * ============================================================ */
+
+TEST_CASE("C API - Delete data", "[c_deleteData]") {
+    CaseReporter cr("c_deleteData");
+    prepareTimeseries();
+
+    const char* deviceId = "root.ctest.d1";
+    const char* measurements[] = {"s1", "s2", "s3"};
+    for (int64_t time = 0; time < 100; time++) {
+        const char* values[] = {"1", "2", "3"};
+        ts_session_insert_record_str(g_session, deviceId, time, 3, measurements, values);
+    }
+
+    const char* paths[] = {"root.ctest.d1.s1", "root.ctest.d1.s2", "root.ctest.d1.s3"};
+    TsStatus status = ts_session_delete_data_batch(g_session, 3, paths, 49);
+    REQUIRE(status == TS_OK);
+
+    CSessionDataSet* dataSet = nullptr;
+    ts_session_execute_query(g_session, "select s1,s2,s3 from root.ctest.d1", &dataSet);
+    ts_dataset_set_fetch_size(dataSet, 1024);
+    int count = 0;
+    while (ts_dataset_has_next(dataSet)) {
+        CRowRecord* record = ts_dataset_next(dataSet);
+        count++;
+        ts_row_record_destroy(record);
+    }
+    REQUIRE(count == 50);
+    ts_dataset_destroy(dataSet);
+}
+
+/* ============================================================
+ *  Timezone
+ * ============================================================ */
+
+TEST_CASE("C API - Timezone", "[c_timezone]") {
+    CaseReporter cr("c_timezone");
+    char buf[64] = {0};
+    TsStatus status = ts_session_get_timezone(g_session, buf, sizeof(buf));
+    REQUIRE(status == TS_OK);
+    REQUIRE(strlen(buf) > 0);
+
+    status = ts_session_set_timezone(g_session, "Asia/Shanghai");
+    REQUIRE(status == TS_OK);
+
+    memset(buf, 0, sizeof(buf));
+    ts_session_get_timezone(g_session, buf, sizeof(buf));
+    REQUIRE(std::string(buf) == "Asia/Shanghai");
+}
+
+/* ============================================================
+ *  Multi-node constructor
+ * ============================================================ */
+
+TEST_CASE("C API - Multi-node session", "[c_multiNode]") {
+    CaseReporter cr("c_multiNode");
+    const char* urls[] = {"127.0.0.1:6667"};
+    CSession* localSession = ts_session_new_multi_node(urls, 1, "root", "root");
+    REQUIRE(localSession != nullptr);
+
+    TsStatus status = ts_session_open(localSession);
+    REQUIRE(status == TS_OK);
+
+    const char* path = "root.ctest.d1.s1";
+    bool exists = false;
+    ts_session_check_timeseries_exists(localSession, path, &exists);
+    if (!exists) {
+        ts_session_create_timeseries(localSession, path, TS_TYPE_INT64, TS_ENCODING_RLE, TS_COMPRESSION_SNAPPY);
+    }
+    ts_session_check_timeseries_exists(localSession, path, &exists);
+    REQUIRE(exists == true);
+    ts_session_delete_timeseries(localSession, path);
+
+    ts_session_close(localSession);
+    ts_session_destroy(localSession);
+}
+
+/* ============================================================
+ *  Dataset column info
+ * ============================================================ */
+
+TEST_CASE("C API - Dataset column info", "[c_datasetColumns]") {
+    CaseReporter cr("c_datasetColumns");
+    prepareTimeseries();
+
+    const char* deviceId = "root.ctest.d1";
+    const char* measurements[] = {"s1", "s2", "s3"};
+    const char* values[] = {"1", "2", "3"};
+    ts_session_insert_record_str(g_session, deviceId, 0, 3, measurements, values);
+
+    CSessionDataSet* dataSet = nullptr;
+    ts_session_execute_query(g_session, "select s1,s2,s3 from root.ctest.d1", &dataSet);
+    REQUIRE(dataSet != nullptr);
+
+    int colCount = ts_dataset_get_column_count(dataSet);
+    REQUIRE(colCount == 4);  // Time + s1 + s2 + s3
+
+    const char* col0 = ts_dataset_get_column_name(dataSet, 0);
+    REQUIRE(std::string(col0) == "Time");
+
+    ts_dataset_destroy(dataSet);
+}

--- a/iotdb-client/client-cpp/src/test/cpp/sessionCRelationalIT.cpp
+++ b/iotdb-client/client-cpp/src/test/cpp/sessionCRelationalIT.cpp
@@ -1,0 +1,291 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "catch.hpp"
+#include "SessionC.h"
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <cmath>
+
+extern CTableSession* g_table_session;
+
+static int global_test_tag = 0;
+
+class CaseReporter {
+public:
+    CaseReporter(const char* caseNameArg) : caseName(caseNameArg) {
+        test_tag = global_test_tag++;
+        std::cout << "C-API Table Test " << test_tag << ": " << caseName << std::endl;
+    }
+    ~CaseReporter() {
+        std::cout << "C-API Table Test " << test_tag << ": " << caseName << " Done" << std::endl << std::endl;
+    }
+private:
+    const char* caseName;
+    int test_tag;
+};
+
+/* ============================================================
+ *  DDL via SQL — create database & table
+ * ============================================================ */
+
+TEST_CASE("C API Table - Create table", "[c_table_createTable]") {
+    CaseReporter cr("c_table_createTable");
+
+    ts_table_session_execute_non_query(g_table_session, "DROP DATABASE IF EXISTS c_db1");
+    TsStatus status = ts_table_session_execute_non_query(g_table_session, "CREATE DATABASE c_db1");
+    REQUIRE(status == TS_OK);
+
+    ts_table_session_execute_non_query(g_table_session, "USE \"c_db1\"");
+    status = ts_table_session_execute_non_query(g_table_session,
+        "CREATE TABLE c_table0 ("
+        "tag1 string tag,"
+        "attr1 string attribute,"
+        "m1 double field)");
+    REQUIRE(status == TS_OK);
+
+    CSessionDataSet* dataSet = nullptr;
+    status = ts_table_session_execute_query(g_table_session, "SHOW TABLES", &dataSet);
+    REQUIRE(status == TS_OK);
+    REQUIRE(dataSet != nullptr);
+
+    ts_dataset_set_fetch_size(dataSet, 1024);
+    bool tableExist = false;
+    while (ts_dataset_has_next(dataSet)) {
+        CRowRecord* record = ts_dataset_next(dataSet);
+        const char* tableName = ts_row_record_get_string(record, 0);
+        if (std::string(tableName) == "c_table0") {
+            tableExist = true;
+        }
+        ts_row_record_destroy(record);
+        if (tableExist) break;
+    }
+    REQUIRE(tableExist == true);
+    ts_dataset_destroy(dataSet);
+}
+
+/* ============================================================
+ *  Insert Tablet (table model, with TAG/FIELD/ATTRIBUTE columns)
+ * ============================================================ */
+
+TEST_CASE("C API Table - Insert tablet", "[c_table_insertTablet]") {
+    CaseReporter cr("c_table_insertTablet");
+
+    ts_table_session_execute_non_query(g_table_session, "DROP DATABASE IF EXISTS c_db2");
+    ts_table_session_execute_non_query(g_table_session, "CREATE DATABASE c_db2");
+    ts_table_session_execute_non_query(g_table_session, "USE \"c_db2\"");
+    ts_table_session_execute_non_query(g_table_session,
+        "CREATE TABLE c_table1 ("
+        "tag1 string tag,"
+        "attr1 string attribute,"
+        "m1 double field)");
+
+    const char* columnNames[] = {"tag1", "attr1", "m1"};
+    TSDataType_C dataTypes[] = {TS_TYPE_STRING, TS_TYPE_STRING, TS_TYPE_DOUBLE};
+    TSColumnCategory_C colCategories[] = {TS_COL_TAG, TS_COL_ATTRIBUTE, TS_COL_FIELD};
+
+    CTablet* tablet = ts_tablet_new_with_category("c_table1", 3, columnNames, dataTypes,
+                                                    colCategories, 100);
+    REQUIRE(tablet != nullptr);
+
+    for (int i = 0; i < 50; i++) {
+        ts_tablet_add_timestamp(tablet, i, (int64_t)i);
+        ts_tablet_add_value_string(tablet, 0, i, "device_A");
+        ts_tablet_add_value_string(tablet, 1, i, "attr_val");
+        ts_tablet_add_value_double(tablet, 2, i, i * 1.5);
+    }
+    ts_tablet_set_row_count(tablet, 50);
+
+    TsStatus status = ts_table_session_insert(g_table_session, tablet);
+    REQUIRE(status == TS_OK);
+
+    CSessionDataSet* dataSet = nullptr;
+    status = ts_table_session_execute_query(g_table_session, "SELECT * FROM c_table1", &dataSet);
+    REQUIRE(status == TS_OK);
+
+    ts_dataset_set_fetch_size(dataSet, 1024);
+    int count = 0;
+    while (ts_dataset_has_next(dataSet)) {
+        CRowRecord* record = ts_dataset_next(dataSet);
+        count++;
+        ts_row_record_destroy(record);
+    }
+    REQUIRE(count == 50);
+    ts_dataset_destroy(dataSet);
+    ts_tablet_destroy(tablet);
+}
+
+/* ============================================================
+ *  Query with timeout
+ * ============================================================ */
+
+TEST_CASE("C API Table - Query with timeout", "[c_table_queryTimeout]") {
+    CaseReporter cr("c_table_queryTimeout");
+
+    ts_table_session_execute_non_query(g_table_session, "DROP DATABASE IF EXISTS c_db3");
+    ts_table_session_execute_non_query(g_table_session, "CREATE DATABASE c_db3");
+    ts_table_session_execute_non_query(g_table_session, "USE \"c_db3\"");
+    ts_table_session_execute_non_query(g_table_session,
+        "CREATE TABLE c_table2 (tag1 string tag, m1 int32 field)");
+
+    const char* columnNames[] = {"tag1", "m1"};
+    TSDataType_C dataTypes[] = {TS_TYPE_STRING, TS_TYPE_INT32};
+    TSColumnCategory_C colCategories[] = {TS_COL_TAG, TS_COL_FIELD};
+
+    CTablet* tablet = ts_tablet_new_with_category("c_table2", 2, columnNames, dataTypes,
+                                                    colCategories, 10);
+    for (int i = 0; i < 10; i++) {
+        ts_tablet_add_timestamp(tablet, i, (int64_t)i);
+        ts_tablet_add_value_string(tablet, 0, i, "dev1");
+        ts_tablet_add_value_int32(tablet, 1, i, i * 10);
+    }
+    ts_tablet_set_row_count(tablet, 10);
+    ts_table_session_insert(g_table_session, tablet);
+    ts_tablet_destroy(tablet);
+
+    CSessionDataSet* dataSet = nullptr;
+    TsStatus status = ts_table_session_execute_query_with_timeout(g_table_session,
+        "SELECT * FROM c_table2", 60000, &dataSet);
+    REQUIRE(status == TS_OK);
+
+    int count = 0;
+    while (ts_dataset_has_next(dataSet)) {
+        CRowRecord* record = ts_dataset_next(dataSet);
+        count++;
+        ts_row_record_destroy(record);
+    }
+    REQUIRE(count == 10);
+    ts_dataset_destroy(dataSet);
+}
+
+/* ============================================================
+ *  Multi-type tablet insert
+ * ============================================================ */
+
+TEST_CASE("C API Table - Multi-type tablet", "[c_table_multiType]") {
+    CaseReporter cr("c_table_multiType");
+
+    ts_table_session_execute_non_query(g_table_session, "DROP DATABASE IF EXISTS c_db4");
+    ts_table_session_execute_non_query(g_table_session, "CREATE DATABASE c_db4");
+    ts_table_session_execute_non_query(g_table_session, "USE \"c_db4\"");
+    ts_table_session_execute_non_query(g_table_session,
+        "CREATE TABLE c_table3 ("
+        "tag1 string tag,"
+        "m_bool boolean field,"
+        "m_int32 int32 field,"
+        "m_int64 int64 field,"
+        "m_float float field,"
+        "m_double double field,"
+        "m_text text field)");
+
+    const char* columnNames[] = {"tag1", "m_bool", "m_int32", "m_int64", "m_float", "m_double", "m_text"};
+    TSDataType_C dataTypes[] = {TS_TYPE_STRING, TS_TYPE_BOOLEAN, TS_TYPE_INT32, TS_TYPE_INT64,
+                                TS_TYPE_FLOAT, TS_TYPE_DOUBLE, TS_TYPE_TEXT};
+    TSColumnCategory_C colCategories[] = {TS_COL_TAG, TS_COL_FIELD, TS_COL_FIELD, TS_COL_FIELD,
+                                          TS_COL_FIELD, TS_COL_FIELD, TS_COL_FIELD};
+
+    CTablet* tablet = ts_tablet_new_with_category("c_table3", 7, columnNames, dataTypes,
+                                                    colCategories, 20);
+    for (int i = 0; i < 20; i++) {
+        ts_tablet_add_timestamp(tablet, i, (int64_t)(i + 1000));
+        ts_tablet_add_value_string(tablet, 0, i, "dev1");
+        ts_tablet_add_value_bool(tablet, 1, i, (i % 2 == 0));
+        ts_tablet_add_value_int32(tablet, 2, i, i * 10);
+        ts_tablet_add_value_int64(tablet, 3, i, (int64_t)i * 100);
+        ts_tablet_add_value_float(tablet, 4, i, i * 1.1f);
+        ts_tablet_add_value_double(tablet, 5, i, i * 2.2);
+        ts_tablet_add_value_string(tablet, 6, i, "hello");
+    }
+    ts_tablet_set_row_count(tablet, 20);
+
+    TsStatus status = ts_table_session_insert(g_table_session, tablet);
+    REQUIRE(status == TS_OK);
+
+    CSessionDataSet* dataSet = nullptr;
+    status = ts_table_session_execute_query(g_table_session, "SELECT * FROM c_table3", &dataSet);
+    REQUIRE(status == TS_OK);
+
+    int count = 0;
+    while (ts_dataset_has_next(dataSet)) {
+        CRowRecord* record = ts_dataset_next(dataSet);
+        count++;
+        ts_row_record_destroy(record);
+    }
+    REQUIRE(count == 20);
+    ts_dataset_destroy(dataSet);
+    ts_tablet_destroy(tablet);
+}
+
+/* ============================================================
+ *  Multi-node table session
+ * ============================================================ */
+
+TEST_CASE("C API Table - Multi-node table session", "[c_table_multiNode]") {
+    CaseReporter cr("c_table_multiNode");
+
+    const char* urls[] = {"127.0.0.1:6667"};
+    CTableSession* localSession = ts_table_session_new_multi_node(urls, 1, "root", "root", "");
+    REQUIRE(localSession != nullptr);
+
+    TsStatus status = ts_table_session_execute_non_query(localSession, "DROP DATABASE IF EXISTS c_db5");
+    REQUIRE(status == TS_OK);
+    ts_table_session_execute_non_query(localSession, "CREATE DATABASE c_db5");
+
+    ts_table_session_close(localSession);
+    ts_table_session_destroy(localSession);
+}
+
+/* ============================================================
+ *  Dataset column info (table model)
+ * ============================================================ */
+
+TEST_CASE("C API Table - Dataset column info", "[c_table_datasetColumns]") {
+    CaseReporter cr("c_table_datasetColumns");
+
+    ts_table_session_execute_non_query(g_table_session, "DROP DATABASE IF EXISTS c_db6");
+    ts_table_session_execute_non_query(g_table_session, "CREATE DATABASE c_db6");
+    ts_table_session_execute_non_query(g_table_session, "USE \"c_db6\"");
+    ts_table_session_execute_non_query(g_table_session,
+        "CREATE TABLE c_table6 (tag1 string tag, m1 int64 field)");
+
+    const char* columnNames[] = {"tag1", "m1"};
+    TSDataType_C dataTypes[] = {TS_TYPE_STRING, TS_TYPE_INT64};
+    TSColumnCategory_C colCategories[] = {TS_COL_TAG, TS_COL_FIELD};
+
+    CTablet* tablet = ts_tablet_new_with_category("c_table6", 2, columnNames, dataTypes,
+                                                    colCategories, 5);
+    for (int i = 0; i < 5; i++) {
+        ts_tablet_add_timestamp(tablet, i, (int64_t)i);
+        ts_tablet_add_value_string(tablet, 0, i, "dev1");
+        ts_tablet_add_value_int64(tablet, 1, i, (int64_t)(i * 100));
+    }
+    ts_tablet_set_row_count(tablet, 5);
+    ts_table_session_insert(g_table_session, tablet);
+    ts_tablet_destroy(tablet);
+
+    CSessionDataSet* dataSet = nullptr;
+    ts_table_session_execute_query(g_table_session, "SELECT * FROM c_table6", &dataSet);
+    REQUIRE(dataSet != nullptr);
+
+    int colCount = ts_dataset_get_column_count(dataSet);
+    REQUIRE(colCount >= 2);  // at least time + tag1 + m1
+
+    ts_dataset_destroy(dataSet);
+}

--- a/iotdb-client/client-cpp/src/test/cpp/sessionCRelationalIT.cpp
+++ b/iotdb-client/client-cpp/src/test/cpp/sessionCRelationalIT.cpp
@@ -287,5 +287,21 @@ TEST_CASE("C API Table - Dataset column info", "[c_table_datasetColumns]") {
     int colCount = ts_dataset_get_column_count(dataSet);
     REQUIRE(colCount >= 2);  // at least time + tag1 + m1
 
+    for (int i = 0; i < colCount; i++) {
+        const char* colType = ts_dataset_get_column_type(dataSet, i);
+        REQUIRE(colType != nullptr);
+        REQUIRE(strlen(colType) > 0);
+    }
+
+    if (ts_dataset_has_next(dataSet)) {
+        CRowRecord* record = ts_dataset_next(dataSet);
+        REQUIRE(record != nullptr);
+        REQUIRE(ts_row_record_get_field_count(record) >= 1);
+        (void)ts_row_record_get_timestamp(record);
+        (void)ts_row_record_get_data_type(record, 0);
+        (void)ts_row_record_is_null(record, 0);
+        ts_row_record_destroy(record);
+    }
+
     ts_dataset_destroy(dataSet);
 }

--- a/iotdb-client/client-cpp/src/test/cpp/sessionCRelationalIT.cpp
+++ b/iotdb-client/client-cpp/src/test/cpp/sessionCRelationalIT.cpp
@@ -46,7 +46,7 @@ private:
  *  DDL via SQL — create database & table
  * ============================================================ */
 
-TEST_CASE("C API Table - Create table", "[c_table_createTable]") {
+TEST_CASE("C API Table - Create table", "[c_table_createTable][c_table_ddl]") {
     CaseReporter cr("c_table_createTable");
 
     ts_table_session_execute_non_query(g_table_session, "DROP DATABASE IF EXISTS c_db1");
@@ -85,7 +85,7 @@ TEST_CASE("C API Table - Create table", "[c_table_createTable]") {
  *  Insert Tablet (table model, with TAG/FIELD/ATTRIBUTE columns)
  * ============================================================ */
 
-TEST_CASE("C API Table - Insert tablet", "[c_table_insertTablet]") {
+TEST_CASE("C API Table - Insert tablet", "[c_table_insertTablet][c_table_write]") {
     CaseReporter cr("c_table_insertTablet");
 
     ts_table_session_execute_non_query(g_table_session, "DROP DATABASE IF EXISTS c_db2");
@@ -136,7 +136,7 @@ TEST_CASE("C API Table - Insert tablet", "[c_table_insertTablet]") {
  *  Query with timeout
  * ============================================================ */
 
-TEST_CASE("C API Table - Query with timeout", "[c_table_queryTimeout]") {
+TEST_CASE("C API Table - Query with timeout", "[c_table_queryTimeout][c_table_query]") {
     CaseReporter cr("c_table_queryTimeout");
 
     ts_table_session_execute_non_query(g_table_session, "DROP DATABASE IF EXISTS c_db3");
@@ -179,7 +179,7 @@ TEST_CASE("C API Table - Query with timeout", "[c_table_queryTimeout]") {
  *  Multi-type tablet insert
  * ============================================================ */
 
-TEST_CASE("C API Table - Multi-type tablet", "[c_table_multiType]") {
+TEST_CASE("C API Table - Multi-type tablet", "[c_table_multiType][c_table_write]") {
     CaseReporter cr("c_table_multiType");
 
     ts_table_session_execute_non_query(g_table_session, "DROP DATABASE IF EXISTS c_db4");
@@ -237,7 +237,7 @@ TEST_CASE("C API Table - Multi-type tablet", "[c_table_multiType]") {
  *  Multi-node table session
  * ============================================================ */
 
-TEST_CASE("C API Table - Multi-node table session", "[c_table_multiNode]") {
+TEST_CASE("C API Table - Multi-node table session", "[c_table_multiNode][c_table_lifecycle]") {
     CaseReporter cr("c_table_multiNode");
 
     const char* urls[] = {"127.0.0.1:6667"};
@@ -256,7 +256,7 @@ TEST_CASE("C API Table - Multi-node table session", "[c_table_multiNode]") {
  *  Dataset column info (table model)
  * ============================================================ */
 
-TEST_CASE("C API Table - Dataset column info", "[c_table_datasetColumns]") {
+TEST_CASE("C API Table - Dataset column info", "[c_table_datasetColumns][c_table_query]") {
     CaseReporter cr("c_table_datasetColumns");
 
     ts_table_session_execute_non_query(g_table_session, "DROP DATABASE IF EXISTS c_db6");

--- a/iotdb-client/client-cpp/src/test/main.cpp
+++ b/iotdb-client/client-cpp/src/test/main.cpp
@@ -23,30 +23,35 @@
 #include "Session.h"
 #include "SessionBuilder.h"
 
-auto builder = std::unique_ptr<SessionBuilder>(new SessionBuilder());
-std::shared_ptr<Session> session =
-    std::shared_ptr<Session>(
-        builder
-        ->host("127.0.0.1")
-        ->rpcPort(6667)
-        ->username("root")
-        ->password("root")
-        ->useSSL(false)
-        ->build()
-    );
+std::shared_ptr<Session> session;
 
 struct SessionListener : Catch::TestEventListenerBase {
 
     using TestEventListenerBase::TestEventListenerBase;
 
     void testCaseStarting(Catch::TestCaseInfo const &testInfo) override {
-        // Perform some setup before a test case is run
-        session->open(false);
+        if (!session) {
+            SessionBuilder builder;
+            session = builder.host("127.0.0.1")
+                          ->rpcPort(6667)
+                          ->username("root")
+                          ->password("root")
+                          ->useSSL(false)
+                          ->build();
+        } else {
+            session->open(false);
+        }
     }
 
     void testCaseEnded(Catch::TestCaseStats const &testCaseStats) override {
-        // Tear-down after a test case is run
-        session->close();
+        if (session) {
+            session->close();
+        }
+    }
+
+    void testRunEnded(Catch::TestRunStats const &testRunStats) override {
+        // Release session before static/global teardown on Windows.
+        session.reset();
     }
 };
 

--- a/iotdb-client/client-cpp/src/test/main_Relational.cpp
+++ b/iotdb-client/client-cpp/src/test/main_Relational.cpp
@@ -1,5 +1,5 @@
 /**
-* Licensed to the Apache Software Foundation (ASF) under one
+ * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file
@@ -22,28 +22,33 @@
 #include <catch.hpp>
 #include "TableSessionBuilder.h"
 
-auto builder = std::unique_ptr<TableSessionBuilder>(new TableSessionBuilder());
-std::shared_ptr<TableSession> session =
-    std::shared_ptr<TableSession>(
-        builder
-        ->host("127.0.0.1")
-        ->rpcPort(6667)
-        ->username("root")
-        ->password("root")
-        ->build()
-    );
+std::shared_ptr<TableSession> session;
 
 struct SessionListener : Catch::TestEventListenerBase {
     using TestEventListenerBase::TestEventListenerBase;
 
     void testCaseStarting(Catch::TestCaseInfo const& testInfo) override {
-        // Perform some setup before a test case is run
-        session->open();
+        if (!session) {
+            TableSessionBuilder builder;
+            session = builder.host("127.0.0.1")
+                            ->rpcPort(6667)
+                            ->username("root")
+                            ->password("root")
+                            ->build();
+        } else {
+            session->open();
+        }
     }
 
     void testCaseEnded(Catch::TestCaseStats const& testCaseStats) override {
-        // Tear-down after a test case is run
-        session->close();
+        if (session) {
+            session->close();
+        }
+    }
+
+    void testRunEnded(Catch::TestRunStats const& testRunStats) override {
+        // Release session before static/global teardown on Windows.
+        session.reset();
     }
 };
 

--- a/iotdb-client/client-cpp/src/test/main_c.cpp
+++ b/iotdb-client/client-cpp/src/test/main_c.cpp
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#define CATCH_CONFIG_MAIN
+
+#include <catch.hpp>
+#include "SessionC.h"
+
+// Global session handle used by the C API tree-model tests
+CSession* g_session = nullptr;
+
+struct CSessionListener : Catch::TestEventListenerBase {
+    using TestEventListenerBase::TestEventListenerBase;
+
+    void testCaseStarting(Catch::TestCaseInfo const& testInfo) override {
+        g_session = ts_session_new("127.0.0.1", 6667, "root", "root");
+        ts_session_open(g_session);
+    }
+
+    void testCaseEnded(Catch::TestCaseStats const& testCaseStats) override {
+        if (g_session) {
+            ts_session_close(g_session);
+            ts_session_destroy(g_session);
+            g_session = nullptr;
+        }
+    }
+};
+
+CATCH_REGISTER_LISTENER(CSessionListener)

--- a/iotdb-client/client-cpp/src/test/main_c.cpp
+++ b/iotdb-client/client-cpp/src/test/main_c.cpp
@@ -30,7 +30,13 @@ struct CSessionListener : Catch::TestEventListenerBase {
 
     void testCaseStarting(Catch::TestCaseInfo const& testInfo) override {
         g_session = ts_session_new("127.0.0.1", 6667, "root", "root");
-        ts_session_open(g_session);
+        REQUIRE(g_session != nullptr);
+        TsStatus st = ts_session_open(g_session);
+        if (st != TS_OK) {
+            ts_session_destroy(g_session);
+            g_session = nullptr;
+            FAIL("ts_session_open failed; ensure distribution is built and IoTDB listens on 127.0.0.1:6667");
+        }
     }
 
     void testCaseEnded(Catch::TestCaseStats const& testCaseStats) override {

--- a/iotdb-client/client-cpp/src/test/main_c_Relational.cpp
+++ b/iotdb-client/client-cpp/src/test/main_c_Relational.cpp
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#define CATCH_CONFIG_MAIN
+
+#include <catch.hpp>
+#include "SessionC.h"
+
+// Global table session handle used by the C API table-model tests
+CTableSession* g_table_session = nullptr;
+
+struct CTableSessionListener : Catch::TestEventListenerBase {
+    using TestEventListenerBase::TestEventListenerBase;
+
+    void testCaseStarting(Catch::TestCaseInfo const& testInfo) override {
+        g_table_session = ts_table_session_new("127.0.0.1", 6667, "root", "root", "");
+    }
+
+    void testCaseEnded(Catch::TestCaseStats const& testCaseStats) override {
+        if (g_table_session) {
+            ts_table_session_close(g_table_session);
+            ts_table_session_destroy(g_table_session);
+            g_table_session = nullptr;
+        }
+    }
+};
+
+CATCH_REGISTER_LISTENER(CTableSessionListener)

--- a/iotdb-client/client-cpp/src/test/main_c_Relational.cpp
+++ b/iotdb-client/client-cpp/src/test/main_c_Relational.cpp
@@ -30,6 +30,9 @@ struct CTableSessionListener : Catch::TestEventListenerBase {
 
     void testCaseStarting(Catch::TestCaseInfo const& testInfo) override {
         g_table_session = ts_table_session_new("127.0.0.1", 6667, "root", "root", "");
+        if (g_table_session) {
+            ts_table_session_open(g_table_session);
+        }
     }
 
     void testCaseEnded(Catch::TestCaseStats const& testCaseStats) override {

--- a/iotdb-client/client-cpp/src/test/main_c_Relational.cpp
+++ b/iotdb-client/client-cpp/src/test/main_c_Relational.cpp
@@ -30,8 +30,12 @@ struct CTableSessionListener : Catch::TestEventListenerBase {
 
     void testCaseStarting(Catch::TestCaseInfo const& testInfo) override {
         g_table_session = ts_table_session_new("127.0.0.1", 6667, "root", "root", "");
-        if (g_table_session) {
-            ts_table_session_open(g_table_session);
+        REQUIRE(g_table_session != nullptr);
+        TsStatus st = ts_table_session_open(g_table_session);
+        if (st != TS_OK) {
+            ts_table_session_destroy(g_table_session);
+            g_table_session = nullptr;
+            FAIL("ts_table_session_open failed; ensure distribution is built and IoTDB listens on 127.0.0.1:6667");
         }
     }
 


### PR DESCRIPTION
## **Description**
### What
Adds a C API (SessionC.h / SessionC.cpp) around the existing C++ Session / TableSession, for C/FFI callers without exposing C++ types.

### Design

Opaque handles (CSession, CTableSession, CTablet, CSessionDataSet, CRowRecord); public symbols prefixed with ts_*.
TsStatus return codes + thread-local last error via ts_get_last_error().
Thin wrappers: convert C args → C++ types, map exceptions to status codes; reuse existing client logic (no duplicate Thrift layer).
### Scope
Tree + table model: connect, metadata, inserts (record/tablet), queries, result iteration, deletes—aligned with current Session behavior.

### This PR has:

self-reviewed
tests added or updated

### Key files
client-cpp/src/main/SessionC.h, SessionC.cpp
client-cpp/src/test/main_c*.cpp, sessionC*IT.cpp