### PR TITLE
Fixed the issue where prepareStatement did not support the Blob type.When the ResultSet is empty, an SQL exception should be thrown

### DIFF
--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSet.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSet.java
@@ -231,8 +231,15 @@ public class IoTDBJDBCResultSet implements ResultSet {
   }
 
   @Override
-  public int findColumn(String columnName) {
-    return ioTDBRpcDataSet.findColumn(columnName);
+  public int findColumn(String columnName) throws SQLException {
+    if (isClosed()) {
+      throw new SQLException("ResultSet is closed");
+    }
+    try {
+      return ioTDBRpcDataSet.findColumn(columnName);
+    } catch (NullPointerException e) {
+      throw new SQLException("Column '" + columnName + "' not found");
+    }
   }
 
   @Override

--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBPreparedStatement.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBPreparedStatement.java
@@ -257,7 +257,15 @@ public class IoTDBPreparedStatement extends IoTDBStatement implements PreparedSt
 
   @Override
   public void setBlob(int parameterIndex, Blob x) throws SQLException {
-    throw new SQLException(Constant.PARAMETER_SUPPORTED);
+    if (x == null) {
+      setNull(parameterIndex, Types.BLOB);
+    } else {
+      try {
+        setBytes(parameterIndex, x.getBytes(1, (int) x.length()));
+      } catch (SQLException e) {
+        throw new SQLException("Failed to read Blob data: " + e.getMessage(), e);
+      }
+    }
   }
 
   @Override

--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBTablePreparedStatement.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBTablePreparedStatement.java
@@ -568,7 +568,16 @@ public class IoTDBTablePreparedStatement extends IoTDBStatement implements Prepa
 
   @Override
   public void setBlob(int parameterIndex, Blob x) throws SQLException {
-    throw new SQLException(Constant.PARAMETER_SUPPORTED);
+    checkParameterIndex(parameterIndex);
+    if (x == null) {
+      setNull(parameterIndex, Types.BLOB);
+    } else {
+      try {
+        setBytes(parameterIndex, x.getBytes(1, (int) x.length()));
+      } catch (SQLException e) {
+        throw new SQLException("Failed to read Blob data: " + e.getMessage(), e);
+      }
+    }
   }
 
   @Override


### PR DESCRIPTION
## Description
The PreparedStatement.setBlob() method in IoTDB JDBC directly throws an exception, making it impossible to set Blob-type values.
ResultSet.findColumn() handles tree models and table models inconsistently. According to the JDBC specification, when the ResultSet is empty, an SQL exception should be thrown.
