### PR TITLE
Support GROUP BY ALL in relational queries

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBGroupByAllTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBGroupByAllTableIT.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.relational.it.query.recent;
+
+import org.apache.iotdb.it.env.EnvFactory;
+import org.apache.iotdb.it.framework.IoTDBTestRunner;
+import org.apache.iotdb.itbase.category.TableClusterIT;
+import org.apache.iotdb.itbase.category.TableLocalStandaloneIT;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.apache.iotdb.db.it.utils.TestUtils.prepareTableData;
+import static org.apache.iotdb.db.it.utils.TestUtils.tableResultSetEqualTest;
+
+@RunWith(IoTDBTestRunner.class)
+@Category({TableLocalStandaloneIT.class, TableClusterIT.class})
+public class IoTDBGroupByAllTableIT {
+  private static final String DATABASE_NAME = "test";
+  private static final String[] createSqls =
+      new String[] {
+        "CREATE DATABASE " + DATABASE_NAME,
+        "USE " + DATABASE_NAME,
+        "CREATE TABLE t1(device_id STRING TAG, s1 INT32 FIELD, s2 INT64 FIELD, s3 DOUBLE FIELD)",
+        "INSERT INTO t1(time, device_id, s1, s2, s3) VALUES (1, 'a', 10, 100, 1.0)",
+        "INSERT INTO t1(time, device_id, s1, s2, s3) VALUES (2, 'a', 20, 200, 2.0)",
+        "INSERT INTO t1(time, device_id, s1, s2, s3) VALUES (3, 'a', 30, 300, 3.0)",
+        "INSERT INTO t1(time, device_id, s1, s2, s3) VALUES (4, 'b', 40, 400, 4.0)",
+        "INSERT INTO t1(time, device_id, s1, s2, s3) VALUES (5, 'b', 50, 500, 5.0)",
+        "INSERT INTO t1(time, device_id, s1, s2, s3) VALUES (6, 'c', 60, 600, 6.0)",
+        "FLUSH",
+      };
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    EnvFactory.getEnv().initClusterEnvironment();
+    prepareTableData(createSqls);
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  @Test
+  public void groupByAllSingleColumnTest() {
+    // GROUP BY ALL should infer device_id as the grouping key
+    String[] expectedHeader = new String[] {"device_id", "_col1"};
+    String[] retArray =
+        new String[] {
+          "a,3,", "b,2,", "c,1,",
+        };
+    tableResultSetEqualTest(
+        "SELECT device_id, count(s1) FROM t1 GROUP BY ALL ORDER BY device_id",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+  }
+
+  @Test
+  public void groupByAllMultipleColumnsTest() {
+    // GROUP BY ALL should infer device_id and s1 as grouping keys
+    String[] expectedHeader = new String[] {"device_id", "s1", "_col2"};
+    String[] retArray =
+        new String[] {
+          "a,10,100,", "a,20,200,", "a,30,300,", "b,40,400,", "b,50,500,", "c,60,600,",
+        };
+    tableResultSetEqualTest(
+        "SELECT device_id, s1, sum(s2) FROM t1 GROUP BY ALL ORDER BY device_id, s1",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+  }
+
+  @Test
+  public void groupByAllEquivalenceTest() {
+    // GROUP BY ALL and explicit GROUP BY should produce the same results
+    String[] expectedHeader = new String[] {"device_id", "_col1"};
+    String[] retArray =
+        new String[] {
+          "a,60,", "b,90,", "c,60,",
+        };
+    tableResultSetEqualTest(
+        "SELECT device_id, sum(s1) FROM t1 GROUP BY ALL ORDER BY device_id",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+    tableResultSetEqualTest(
+        "SELECT device_id, sum(s1) FROM t1 GROUP BY device_id ORDER BY device_id",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+  }
+
+  @Test
+  public void groupByAllGlobalAggregationTest() {
+    // All SELECT items are aggregates, GROUP BY ALL => global aggregation
+    String[] expectedHeader = new String[] {"_col0", "_col1"};
+    String[] retArray = new String[] {"6,2100,"};
+    tableResultSetEqualTest(
+        "SELECT count(s1), sum(s2) FROM t1 GROUP BY ALL",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+  }
+
+  @Test
+  public void groupByAllWithExpressionTest() {
+    // GROUP BY ALL with a computed expression (s1 + 1)
+    String[] expectedHeader = new String[] {"_col0", "_col1"};
+    String[] retArray =
+        new String[] {
+          "11,100,", "21,200,", "31,300,", "41,400,", "51,500,", "61,600,",
+        };
+    tableResultSetEqualTest(
+        "SELECT s1 + 1, sum(s2) FROM t1 GROUP BY ALL ORDER BY s1 + 1",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+  }
+
+  @Test
+  public void groupByAllMixedExpressionTest() {
+    // SELECT s1 + avg(s2) FROM t1 GROUP BY ALL
+    // should be equivalent to GROUP BY s1
+    String[] expectedHeader = new String[] {"_col0"};
+    String[] retArray =
+        new String[] {
+          "110.0,", "220.0,", "330.0,", "440.0,", "550.0,", "660.0,",
+        };
+    tableResultSetEqualTest(
+        "SELECT s1 + avg(s2) FROM t1 GROUP BY ALL ORDER BY s1 + avg(s2)",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+  }
+
+  @Test
+  public void groupByAllMixedExpressionEquivalenceTest() {
+    // GROUP BY ALL with s1 + avg(s2) should equal GROUP BY s1
+    String[] expectedHeader = new String[] {"_col0"};
+    String[] retArray =
+        new String[] {
+          "110.0,", "220.0,", "330.0,", "440.0,", "550.0,", "660.0,",
+        };
+    tableResultSetEqualTest(
+        "SELECT s1 + avg(s2) FROM t1 GROUP BY ALL ORDER BY s1 + avg(s2)",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+    tableResultSetEqualTest(
+        "SELECT s1 + avg(s2) FROM t1 GROUP BY s1 ORDER BY s1 + avg(s2)",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+  }
+
+  @Test
+  public void groupByAllMixedWithPureColumnTest() {
+    // SELECT device_id, s1 + avg(s2) FROM t1 GROUP BY ALL
+    // should be equivalent to GROUP BY device_id, s1
+    String[] expectedHeader = new String[] {"device_id", "_col1"};
+    String[] retArray =
+        new String[] {
+          "a,110.0,", "a,220.0,", "a,330.0,", "b,440.0,", "b,550.0,", "c,660.0,",
+        };
+    tableResultSetEqualTest(
+        "SELECT device_id, s1 + avg(s2) FROM t1 GROUP BY ALL ORDER BY device_id, s1 + avg(s2)",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+    tableResultSetEqualTest(
+        "SELECT device_id, s1 + avg(s2) FROM t1 GROUP BY device_id, s1 ORDER BY device_id, s1 + avg(s2)",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+  }
+
+  @Test
+  public void groupByAllMixedMultipleSubExpressionsTest() {
+    // SELECT s1 + s3 + avg(s2) FROM t1 GROUP BY ALL
+    // should be equivalent to GROUP BY s1, s3
+    String[] expectedHeader = new String[] {"_col0"};
+    String[] retArray =
+        new String[] {
+          "111.0,", "222.0,", "333.0,", "444.0,", "555.0,", "666.0,",
+        };
+    tableResultSetEqualTest(
+        "SELECT s1 + s3 + avg(s2) FROM t1 GROUP BY ALL ORDER BY s1 + s3 + avg(s2)",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+    tableResultSetEqualTest(
+        "SELECT s1 + s3 + avg(s2) FROM t1 GROUP BY s1, s3 ORDER BY s1 + s3 + avg(s2)",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+  }
+
+  @Test
+  public void groupByAllWithHavingTest() {
+    // GROUP BY ALL with HAVING clause
+    String[] expectedHeader = new String[] {"device_id", "_col1"};
+    String[] retArray =
+        new String[] {
+          "a,3,",
+        };
+    tableResultSetEqualTest(
+        "SELECT device_id, count(s1) FROM t1 GROUP BY ALL HAVING count(s1) >= 3 ORDER BY device_id",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+  }
+
+  @Test
+  public void groupByAllWithWhereTest() {
+    // GROUP BY ALL with WHERE clause
+    String[] expectedHeader = new String[] {"device_id", "_col1"};
+    String[] retArray =
+        new String[] {
+          "a,2,", "b,2,",
+        };
+    tableResultSetEqualTest(
+        "SELECT device_id, count(s1) FROM t1 WHERE s1 >= 20 GROUP BY ALL ORDER BY device_id",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+  }
+
+  @Test
+  public void groupByAllQuantifierBackwardCompatibilityTest() {
+    // GROUP BY ALL s1 (ALL as set-quantifier, not GROUP BY ALL feature)
+    String[] expectedHeader = new String[] {"s1", "_col1"};
+    String[] retArray =
+        new String[] {
+          "10,100,", "20,200,", "30,300,", "40,400,", "50,500,", "60,600,",
+        };
+    tableResultSetEqualTest(
+        "SELECT s1, sum(s2) FROM t1 GROUP BY ALL s1 ORDER BY s1",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+  }
+
+  @Test
+  public void groupByAllMultipleAggregatesTest() {
+    // Multiple aggregation functions with GROUP BY ALL
+    String[] expectedHeader = new String[] {"device_id", "_col1", "_col2", "_col3"};
+    String[] retArray =
+        new String[] {
+          "a,3,60,200.0,", "b,2,90,450.0,", "c,1,60,600.0,",
+        };
+    tableResultSetEqualTest(
+        "SELECT device_id, count(s1), sum(s1), avg(s2) FROM t1 GROUP BY ALL ORDER BY device_id",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/ExpressionTreeUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/ExpressionTreeUtils.java
@@ -105,6 +105,37 @@ public final class ExpressionTreeUtils {
     return name;
   }
 
+  /**
+   * Extracts column references (Identifiers and DereferenceExpressions) that appear outside of
+   * aggregate and window function call boundaries. For example, in {@code s1 + avg(s2)}, this
+   * returns {@code [s1]}, skipping {@code s2} inside the aggregate.
+   */
+  static List<Expression> extractNonAggregateColumnReferences(Expression expression) {
+    ImmutableList.Builder<Expression> result = ImmutableList.builder();
+    new DefaultExpressionTraversalVisitor<Void>() {
+      @Override
+      protected Void visitFunctionCall(FunctionCall node, Void context) {
+        if (isAggregation(node) || isWindowFunction(node)) {
+          return null;
+        }
+        return super.visitFunctionCall(node, context);
+      }
+
+      @Override
+      protected Void visitIdentifier(Identifier node, Void context) {
+        result.add(node);
+        return null;
+      }
+
+      @Override
+      protected Void visitDereferenceExpression(DereferenceExpression node, Void context) {
+        result.add(node);
+        return null;
+      }
+    }.process(expression, null);
+    return result.build();
+  }
+
   static boolean isAggregationFunction(String functionName) {
     return TableBuiltinAggregationFunction.getBuiltInAggregateFunctionName()
             .contains(functionName.toLowerCase())

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzer.java
@@ -2595,6 +2595,12 @@ public class StatementAnalyzer {
     private Analysis.GroupingSetAnalysis analyzeGroupBy(
         QuerySpecification node, Scope scope, List<Expression> outputExpressions) {
       if (node.getGroupBy().isPresent()) {
+
+        // Handle GROUP BY ALL: infer grouping columns from SELECT expressions
+        if (node.getGroupBy().get().isAll()) {
+          return analyzeGroupByAll(node, scope, outputExpressions);
+        }
+
         ImmutableList.Builder<List<Set<FieldId>>> cubes = ImmutableList.builder();
         ImmutableList.Builder<List<Set<FieldId>>> rollups = ImmutableList.builder();
         ImmutableList.Builder<List<Set<FieldId>>> sets = ImmutableList.builder();
@@ -2716,6 +2722,69 @@ public class StatementAnalyzer {
       }
 
       return result;
+    }
+
+    private Analysis.GroupingSetAnalysis analyzeGroupByAll(
+        QuerySpecification node, Scope scope, List<Expression> outputExpressions) {
+      ImmutableList.Builder<List<Set<FieldId>>> sets = ImmutableList.builder();
+      ImmutableList.Builder<Expression> complexExpressions = ImmutableList.builder();
+      ImmutableList.Builder<Expression> groupingExpressions = ImmutableList.builder();
+      FunctionCall gapFillColumn = null;
+      ImmutableList.Builder<Expression> gapFillGroupingExpressions = ImmutableList.builder();
+
+      for (Expression outputExpression : outputExpressions) {
+        List<FunctionCall> aggregates =
+            extractAggregateFunctions(ImmutableList.of(outputExpression));
+        List<FunctionCall> windowFunctions =
+            extractWindowFunctions(ImmutableList.of(outputExpression));
+        if (!aggregates.isEmpty() || !windowFunctions.isEmpty()) {
+          continue;
+        }
+
+        analyzeExpression(outputExpression, scope);
+        ResolvedField field =
+            analysis.getColumnReferenceFields().get(NodeRef.of(outputExpression));
+        if (field != null) {
+          sets.add(ImmutableList.of(ImmutableSet.of(field.getFieldId())));
+        } else {
+          complexExpressions.add(outputExpression);
+        }
+
+        if (isDateBinGapFill(outputExpression)) {
+          if (gapFillColumn != null) {
+            throw new SemanticException("multiple date_bin_gapfill calls not allowed");
+          }
+          gapFillColumn = (FunctionCall) outputExpression;
+        } else {
+          gapFillGroupingExpressions.add(outputExpression);
+        }
+
+        groupingExpressions.add(outputExpression);
+      }
+
+      List<Expression> expressions = groupingExpressions.build();
+      for (Expression expression : expressions) {
+        Type type = analysis.getType(expression);
+        if (!type.isComparable()) {
+          throw new SemanticException(
+              String.format(
+                  "%s is not comparable, and therefore cannot be used in GROUP BY", type));
+        }
+      }
+
+      Analysis.GroupingSetAnalysis groupingSets =
+          new Analysis.GroupingSetAnalysis(
+              expressions,
+              ImmutableList.of(),
+              ImmutableList.of(),
+              sets.build(),
+              complexExpressions.build());
+      analysis.setGroupingSets(node, groupingSets);
+      if (gapFillColumn != null) {
+        analysis.setGapFill(node, gapFillColumn);
+        analysis.setGapFillGroupingKeys(node, gapFillGroupingExpressions.build());
+      }
+      return groupingSets;
     }
 
     private boolean isDateBinGapFill(Expression column) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzer.java
@@ -2738,6 +2738,23 @@ public class StatementAnalyzer {
         List<FunctionCall> windowFunctions =
             extractWindowFunctions(ImmutableList.of(outputExpression));
         if (!aggregates.isEmpty() || !windowFunctions.isEmpty()) {
+          // Extract non-aggregate sub-expressions (column references outside aggregate
+          // boundaries).
+          // e.g. in `s1 + avg(s2)`, extract `s1` as a grouping key.
+          List<Expression> nonAggColumns =
+              ExpressionTreeUtils.extractNonAggregateColumnReferences(outputExpression);
+          for (Expression colRef : nonAggColumns) {
+            analyzeExpression(colRef, scope);
+            ResolvedField field =
+                analysis.getColumnReferenceFields().get(NodeRef.of(colRef));
+            if (field != null) {
+              sets.add(ImmutableList.of(ImmutableSet.of(field.getFieldId())));
+            } else {
+              complexExpressions.add(colRef);
+            }
+            gapFillGroupingExpressions.add(colRef);
+            groupingExpressions.add(colRef);
+          }
           continue;
         }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/GroupBy.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/GroupBy.java
@@ -33,11 +33,13 @@ public class GroupBy extends Node {
   private static final long INSTANCE_SIZE = RamUsageEstimator.shallowSizeOfInstance(GroupBy.class);
 
   private final boolean isDistinct;
+  private final boolean isAll;
   private final List<GroupingElement> groupingElements;
 
   public GroupBy(boolean isDistinct, List<GroupingElement> groupingElements) {
     super(null);
     this.isDistinct = isDistinct;
+    this.isAll = false;
     this.groupingElements = ImmutableList.copyOf(requireNonNull(groupingElements));
   }
 
@@ -45,11 +47,23 @@ public class GroupBy extends Node {
       NodeLocation location, boolean isDistinct, List<GroupingElement> groupingElements) {
     super(requireNonNull(location, "location is null"));
     this.isDistinct = isDistinct;
+    this.isAll = false;
     this.groupingElements = ImmutableList.copyOf(requireNonNull(groupingElements));
+  }
+
+  public GroupBy(NodeLocation location, boolean isAll) {
+    super(requireNonNull(location, "location is null"));
+    this.isDistinct = false;
+    this.isAll = isAll;
+    this.groupingElements = ImmutableList.of();
   }
 
   public boolean isDistinct() {
     return isDistinct;
+  }
+
+  public boolean isAll() {
+    return isAll;
   }
 
   public List<GroupingElement> getGroupingElements() {
@@ -76,18 +90,20 @@ public class GroupBy extends Node {
     }
     GroupBy groupBy = (GroupBy) o;
     return isDistinct == groupBy.isDistinct
+        && isAll == groupBy.isAll
         && Objects.equals(groupingElements, groupBy.groupingElements);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(isDistinct, groupingElements);
+    return Objects.hash(isDistinct, isAll, groupingElements);
   }
 
   @Override
   public String toString() {
     return toStringHelper(this)
         .add("isDistinct", isDistinct)
+        .add("isAll", isAll)
         .add("groupingElements", groupingElements)
         .toString();
   }
@@ -98,7 +114,7 @@ public class GroupBy extends Node {
       return false;
     }
 
-    return isDistinct == ((GroupBy) other).isDistinct;
+    return isDistinct == ((GroupBy) other).isDistinct && isAll == ((GroupBy) other).isAll;
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/parser/AstBuilder.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/parser/AstBuilder.java
@@ -2419,6 +2419,9 @@ public class AstBuilder extends RelationalSqlBaseVisitor<Node> {
 
   @Override
   public Node visitGroupBy(RelationalSqlParser.GroupByContext ctx) {
+    if (ctx.ALL() != null && ctx.groupingElement().isEmpty()) {
+      return new GroupBy(getLocation(ctx), true);
+    }
     return new GroupBy(
         getLocation(ctx),
         isDistinct(ctx.setQuantifier()),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/util/SqlFormatter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/util/SqlFormatter.java
@@ -248,13 +248,18 @@ public final class SqlFormatter {
 
       node.getGroupBy()
           .ifPresent(
-              groupBy ->
+              groupBy -> {
+                if (groupBy.isAll()) {
+                  append(indent, "GROUP BY ALL").append('\n');
+                } else {
                   append(
                           indent,
                           "GROUP BY "
                               + (groupBy.isDistinct() ? " DISTINCT " : "")
                               + formatGroupBy(groupBy.getGroupingElements()))
-                      .append('\n'));
+                      .append('\n');
+                }
+              });
 
       node.getHaving()
           .ifPresent(having -> append(indent, "HAVING " + formatExpression(having)).append('\n'));

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/GroupByAllTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/GroupByAllTest.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.plan.relational.analyzer;
+
+import org.apache.iotdb.db.queryengine.plan.planner.plan.LogicalQueryPlan;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNode;
+import org.apache.iotdb.db.queryengine.plan.relational.planner.PlanTester;
+import org.apache.iotdb.db.queryengine.plan.relational.planner.node.AggregationNode;
+import org.apache.iotdb.db.queryengine.plan.relational.planner.node.AggregationTableScanNode;
+import org.apache.iotdb.db.queryengine.plan.relational.planner.node.GapFillNode;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.apache.iotdb.db.queryengine.plan.relational.analyzer.TestUtils.assertAnalyzeSemanticException;
+import static org.apache.iotdb.db.queryengine.plan.relational.planner.assertions.PlanAssert.assertPlan;
+import static org.apache.iotdb.db.queryengine.plan.relational.planner.assertions.PlanMatchPattern.aggregation;
+import static org.apache.iotdb.db.queryengine.plan.relational.planner.assertions.PlanMatchPattern.aggregationFunction;
+import static org.apache.iotdb.db.queryengine.plan.relational.planner.assertions.PlanMatchPattern.output;
+import static org.apache.iotdb.db.queryengine.plan.relational.planner.assertions.PlanMatchPattern.singleGroupingSet;
+import static org.apache.iotdb.db.queryengine.plan.relational.planner.assertions.PlanMatchPattern.tableScan;
+import static org.apache.iotdb.db.queryengine.plan.relational.planner.node.AggregationNode.Step.SINGLE;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for the GROUP BY ALL syntax. Verifies that the analyzer correctly infers grouping columns
+ * from the SELECT clause and that integration with date_bin_gapfill is preserved.
+ */
+public class GroupByAllTest {
+
+  // ---- basic column inference ----
+
+  @Test
+  public void groupByAllSingleColumnTest() {
+    // GROUP BY ALL should infer s1 as the grouping key (the only non-aggregate expression)
+    PlanTester planTester = new PlanTester();
+    LogicalQueryPlan plan =
+        planTester.createPlan("SELECT s1, count(s2) FROM table1 GROUP BY ALL");
+    assertPlan(
+        plan,
+        output(
+            aggregation(
+                singleGroupingSet("s1"),
+                ImmutableMap.of(
+                    Optional.empty(),
+                    aggregationFunction("count", ImmutableList.of("s2"))),
+                ImmutableList.of(),
+                Optional.empty(),
+                SINGLE,
+                tableScan(
+                    "testdb.table1",
+                    ImmutableList.of("s1", "s2"),
+                    ImmutableSet.of("s1", "s2")))));
+  }
+
+  @Test
+  public void groupByAllMultipleColumnsTest() {
+    // GROUP BY ALL should infer tag1, tag2, tag3 as grouping keys.
+    // The optimizer pushes aggregation into the table scan, producing AggregationTableScanNode.
+    // Verify by walking the plan tree.
+    PlanTester planTester = new PlanTester();
+    LogicalQueryPlan plan =
+        planTester.createPlan(
+            "SELECT tag1, tag2, tag3, count(s2) FROM table1 GROUP BY ALL");
+
+    PlanNode root = plan.getRootNode();
+    AggregationTableScanNode aggScan = findNode(root, AggregationTableScanNode.class);
+    assertTrue(
+        "Expected AggregationTableScanNode with grouping keys [tag1, tag2, tag3]",
+        aggScan != null
+            && aggScan.getGroupingKeys().stream()
+                .map(s -> s.getName())
+                .collect(java.util.stream.Collectors.toSet())
+                .containsAll(ImmutableSet.of("tag1", "tag2", "tag3")));
+  }
+
+  @Test
+  public void groupByAllEquivalenceTest() {
+    // GROUP BY ALL and explicit GROUP BY should produce the same plan structure
+    PlanTester tester1 = new PlanTester();
+    PlanTester tester2 = new PlanTester();
+    LogicalQueryPlan allPlan =
+        tester1.createPlan("SELECT s1, count(s2) FROM table1 GROUP BY ALL");
+    LogicalQueryPlan explicitPlan =
+        tester2.createPlan("SELECT s1, count(s2) FROM table1 GROUP BY s1");
+
+    // Both plans should match the same pattern
+    assertPlan(
+        allPlan,
+        output(
+            aggregation(
+                singleGroupingSet("s1"),
+                ImmutableMap.of(
+                    Optional.empty(),
+                    aggregationFunction("count", ImmutableList.of("s2"))),
+                ImmutableList.of(),
+                Optional.empty(),
+                SINGLE,
+                tableScan(
+                    "testdb.table1",
+                    ImmutableList.of("s1", "s2"),
+                    ImmutableSet.of("s1", "s2")))));
+    assertPlan(
+        explicitPlan,
+        output(
+            aggregation(
+                singleGroupingSet("s1"),
+                ImmutableMap.of(
+                    Optional.empty(),
+                    aggregationFunction("count", ImmutableList.of("s2"))),
+                ImmutableList.of(),
+                Optional.empty(),
+                SINGLE,
+                tableScan(
+                    "testdb.table1",
+                    ImmutableList.of("s1", "s2"),
+                    ImmutableSet.of("s1", "s2")))));
+  }
+
+  // ---- complex expression in SELECT ----
+
+  @Test
+  public void groupByAllWithExpressionTest() {
+    // GROUP BY ALL with a non-aggregate expression (s1 + 1) should infer it as a grouping key
+    PlanTester planTester = new PlanTester();
+    LogicalQueryPlan plan =
+        planTester.createPlan("SELECT s1 + 1, count(s2) FROM table1 GROUP BY ALL");
+
+    // Verify there is an AggregationNode with a non-empty grouping set
+    PlanNode root = plan.getRootNode();
+    AggregationNode aggNode = findNode(root, AggregationNode.class);
+    assertTrue(
+        "Expected AggregationNode with non-empty grouping keys for expression grouping",
+        aggNode != null && !aggNode.getGroupingKeys().isEmpty());
+  }
+
+  // ---- global aggregation (all SELECT items are aggregates) ----
+
+  @Test
+  public void groupByAllGlobalAggregationTest() {
+    // When all SELECT expressions are aggregates, GROUP BY ALL is equivalent to no GROUP BY
+    PlanTester planTester = new PlanTester();
+    LogicalQueryPlan plan =
+        planTester.createPlan("SELECT count(s1), sum(s2) FROM table1 GROUP BY ALL");
+
+    // Verify global aggregation: grouping keys should be empty
+    PlanNode root = plan.getRootNode();
+    // May be AggregationNode or AggregationTableScanNode
+    AggregationNode aggNode = findNode(root, AggregationNode.class);
+    if (aggNode != null) {
+      assertTrue(
+          "Expected empty grouping keys for global aggregation",
+          aggNode.getGroupingKeys().isEmpty());
+    } else {
+      AggregationTableScanNode aggScan = findNode(root, AggregationTableScanNode.class);
+      assertTrue(
+          "Expected AggregationTableScanNode with empty grouping keys",
+          aggScan != null && aggScan.getGroupingKeys().isEmpty());
+    }
+  }
+
+  // ---- date_bin_gapfill integration ----
+
+  @Test
+  public void groupByAllWithGapFillTest() {
+    // GROUP BY ALL with date_bin_gapfill should produce a GapFillNode in the plan
+    PlanTester planTester = new PlanTester();
+    LogicalQueryPlan plan =
+        planTester.createPlan(
+            "SELECT date_bin_gapfill(1h, time), tag1, avg(s1) "
+                + "FROM table1 "
+                + "WHERE time >= 1 AND time <= 10 "
+                + "GROUP BY ALL");
+
+    // The plan should contain a GapFillNode
+    PlanNode root = plan.getRootNode();
+    GapFillNode gapFillNode = findNode(root, GapFillNode.class);
+    assertTrue("Expected GapFillNode in plan for date_bin_gapfill + GROUP BY ALL", gapFillNode != null);
+  }
+
+  @Test
+  public void groupByAllMultipleGapFillTest() {
+    // Two date_bin_gapfill calls should be rejected even with GROUP BY ALL
+    assertAnalyzeSemanticException(
+        "SELECT date_bin_gapfill(1h, time), date_bin_gapfill(2h, time), avg(s1) "
+            + "FROM table1 WHERE time >= 1 AND time <= 10 GROUP BY ALL",
+        "multiple date_bin_gapfill calls not allowed");
+  }
+
+  // ---- backward compatibility ----
+
+  @Test
+  public void groupByAllQuantifierBackwardCompatibilityTest() {
+    // GROUP BY ALL a, b (ALL as set-quantifier, not GROUP BY ALL feature)
+    // must still parse and plan correctly — the ALL keyword followed by explicit columns
+    // should be treated as the set-quantifier form, not the new GROUP BY ALL syntax.
+    PlanTester planTester = new PlanTester();
+    LogicalQueryPlan plan =
+        planTester.createPlan("SELECT count(s2) FROM table1 GROUP BY ALL s1");
+    PlanNode root = plan.getRootNode();
+    // The plan should have an aggregation with s1 as a grouping key
+    AggregationNode aggNode = findNode(root, AggregationNode.class);
+    AggregationTableScanNode aggScan = findNode(root, AggregationTableScanNode.class);
+    boolean hasS1Grouping;
+    if (aggNode != null) {
+      hasS1Grouping =
+          aggNode.getGroupingKeys().stream().anyMatch(s -> s.getName().equals("s1"));
+    } else {
+      hasS1Grouping =
+          aggScan != null
+              && aggScan.getGroupingKeys().stream().anyMatch(s -> s.getName().equals("s1"));
+    }
+    assertTrue(
+        "GROUP BY ALL s1 should parse as ALL-quantifier with explicit grouping key s1",
+        hasS1Grouping);
+  }
+
+  // ---- helper ----
+
+  @SuppressWarnings("unchecked")
+  private static <T extends PlanNode> T findNode(PlanNode root, Class<T> nodeClass) {
+    if (nodeClass.isInstance(root)) {
+      return (T) root;
+    }
+    for (PlanNode child : root.getChildren()) {
+      T result = findNode(child, nodeClass);
+      if (result != null) {
+        return result;
+      }
+    }
+    return null;
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/GroupByAllTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/GroupByAllTest.java
@@ -156,6 +156,64 @@ public class GroupByAllTest {
         aggNode != null && !aggNode.getGroupingKeys().isEmpty());
   }
 
+  // ---- mixed aggregate and non-aggregate sub-expressions ----
+
+  @Test
+  public void groupByAllMixedExpressionTest() {
+    // SELECT s1 + avg(s2) FROM table1 GROUP BY ALL
+    // should be equivalent to GROUP BY s1
+    PlanTester planTester = new PlanTester();
+    LogicalQueryPlan plan =
+        planTester.createPlan("SELECT s1 + avg(s2) FROM table1 GROUP BY ALL");
+
+    PlanNode root = plan.getRootNode();
+    AggregationNode aggNode = findNode(root, AggregationNode.class);
+    assertTrue(
+        "Expected AggregationNode with s1 as grouping key for s1 + avg(s2)",
+        aggNode != null
+            && aggNode.getGroupingKeys().stream()
+                .anyMatch(s -> s.getName().equals("s1")));
+  }
+
+  @Test
+  public void groupByAllMixedExpressionMultipleColumnsTest() {
+    // SELECT s1 + s3 + avg(s2) FROM table1 GROUP BY ALL
+    // should be equivalent to GROUP BY s1, s3
+    PlanTester planTester = new PlanTester();
+    LogicalQueryPlan plan =
+        planTester.createPlan("SELECT s1 + s3 + avg(s2) FROM table1 GROUP BY ALL");
+
+    PlanNode root = plan.getRootNode();
+    AggregationNode aggNode = findNode(root, AggregationNode.class);
+    assertTrue(
+        "Expected AggregationNode with s1 and s3 as grouping keys",
+        aggNode != null
+            && aggNode.getGroupingKeys().size() >= 2
+            && aggNode.getGroupingKeys().stream()
+                .map(s -> s.getName())
+                .collect(java.util.stream.Collectors.toSet())
+                .containsAll(ImmutableSet.of("s1", "s3")));
+  }
+
+  @Test
+  public void groupByAllMixedWithPureColumnTest() {
+    // SELECT s1, s3 + avg(s2) FROM table1 GROUP BY ALL
+    // should be equivalent to GROUP BY s1, s3
+    PlanTester planTester = new PlanTester();
+    LogicalQueryPlan plan =
+        planTester.createPlan("SELECT s1, s3 + avg(s2) FROM table1 GROUP BY ALL");
+
+    PlanNode root = plan.getRootNode();
+    AggregationNode aggNode = findNode(root, AggregationNode.class);
+    assertTrue(
+        "Expected AggregationNode with s1 and s3 as grouping keys",
+        aggNode != null
+            && aggNode.getGroupingKeys().stream()
+                .map(s -> s.getName())
+                .collect(java.util.stream.Collectors.toSet())
+                .containsAll(ImmutableSet.of("s1", "s3")));
+  }
+
   // ---- global aggregation (all SELECT items are aggregates) ----
 
   @Test

--- a/iotdb-core/relational-grammar/src/main/antlr4/org/apache/iotdb/db/relational/grammar/sql/RelationalSql.g4
+++ b/iotdb-core/relational-grammar/src/main/antlr4/org/apache/iotdb/db/relational/grammar/sql/RelationalSql.g4
@@ -1012,7 +1012,8 @@ querySpecification
     ;
 
 groupBy
-    : setQuantifier? groupingElement (',' groupingElement)*
+    : ALL
+    | setQuantifier? groupingElement (',' groupingElement)*
     ;
 
 groupingElement


### PR DESCRIPTION
Addresses #17337

## Description

This PR adds support for `GROUP BY ALL` in Table Model relational queries.

`GROUP BY ALL` infers grouping keys from non-aggregate and non-window expressions in the `SELECT` list, which improves query ergonomics and reduces duplicated grouping expressions in common aggregation queries.

This PR also keeps `date_bin_gapfill(...)` behavior consistent under `GROUP BY ALL`, including existing validation for multiple gapfill expressions.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for code coverage.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- `iotdb-core/relational-grammar/src/main/antlr4/org/apache/iotdb/db/relational/grammar/sql/RelationalSql.g4`
- `iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/parser/AstBuilder.java`
- `iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/GroupBy.java`
- `iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzer.java`
- `iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/util/SqlFormatter.java`
- `iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/GroupByAllTest.java`

Tested with:
- `./mvnw.cmd -pl iotdb-core/datanode -Dtest=GroupByAllTest test`
