### PR TITLE
[SessionPool] Fix graceful shutdown by notifying waiting threads in close()

### DIFF
--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
@@ -788,7 +788,7 @@ public class SessionPool implements ISessionPool {
     occupied.put(session, session);
   }
 
-/** close all connections in the pool and unblocks any waiting threads*/
+  /** Closes all connections in the pool and unblocks any waiting threads. */
   @Override
   public synchronized void close() {
     for (ISession session : queue) {

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
@@ -788,7 +788,7 @@ public class SessionPool implements ISessionPool {
     occupied.put(session, session);
   }
 
-  /** close all connections in the pool */
+/** close all connections in the pool and unblocks any waiting threads*/
   @Override
   public synchronized void close() {
     for (ISession session : queue) {
@@ -819,6 +819,8 @@ public class SessionPool implements ISessionPool {
     this.closed = true;
     queue.clear();
     occupied.clear();
+    // Notify all waiting threads in getSession() so they wake up immediately
+    this.notifyAll();
   }
 
   @Override

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/pool/TableSessionPool.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/pool/TableSessionPool.java
@@ -36,6 +36,7 @@ public class TableSessionPool implements ITableSessionPool {
     return sessionPool.getPooledTableSession();
   }
 
+  //Closes the underlying session pool and unblocks any waiting threads.
   @Override
   public void close() {
     this.sessionPool.close();

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/pool/TableSessionPool.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/pool/TableSessionPool.java
@@ -36,7 +36,7 @@ public class TableSessionPool implements ITableSessionPool {
     return sessionPool.getPooledTableSession();
   }
 
-  //Closes the underlying session pool and unblocks any waiting threads.
+  /** Closes the underlying session pool and unblocks any waiting threads. */
   @Override
   public void close() {
     this.sessionPool.close();

--- a/iotdb-client/session/src/test/java/org/apache/iotdb/session/pool/SessionPoolTest.java
+++ b/iotdb-client/session/src/test/java/org/apache/iotdb/session/pool/SessionPoolTest.java
@@ -76,6 +76,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -1622,5 +1623,72 @@ public class SessionPoolTest {
     }
 
     return Collections.singletonList(tsBlock);
+  }
+
+  // Regression test for graceful shutdown
+  @Test(timeout = 5000)
+  public void testCloseNotifiesWaitingThreads() throws Exception {
+    SessionPool pool =
+        new SessionPool.Builder()
+            .host("localhost")
+            .port(6667)
+            .user("root")
+            .password("root")
+            .maxSize(1)
+            .waitToGetSessionTimeoutInMs(10000)
+            // notifyAll()
+            .build();
+
+    try {
+      Session mockSession = Mockito.mock(Session.class);
+      ConcurrentLinkedDeque<ISession> queue =
+          (ConcurrentLinkedDeque<ISession>) Whitebox.getInternalState(pool, "queue");
+      queue.push(mockSession);
+      Whitebox.setInternalState(pool, "size", 1);
+
+      ISession occupiedSession = (ISession) Whitebox.invokeMethod(pool, "getSession");
+      assertEquals(mockSession, occupiedSession);
+      assertEquals(0, queue.size());
+
+      final Exception[] caughtException = {null};
+
+      Thread waiterThread =
+          new Thread(
+              () -> {
+                try {
+                  Whitebox.invokeMethod(pool, "getSession");
+                } catch (Exception e) {
+                  caughtException[0] = e;
+                }
+              });
+      waiterThread.start();
+
+      Thread.sleep(100);
+
+      long closeStartTime = System.currentTimeMillis();
+      pool.close();
+      long closeEndTime = System.currentTimeMillis();
+
+      waiterThread.join(1000);
+
+      assertNotNull("Waiter thread should have caught an exception", caughtException[0]);
+      assertTrue(
+          "Exception should be IoTDBConnectionException",
+          caughtException[0] instanceof IoTDBConnectionException);
+      assertTrue(
+          "Exception message should indicate pool is closed",
+          caughtException[0].getMessage().contains("closed"));
+
+      long closeDuration = closeEndTime - closeStartTime;
+      assertTrue(
+          "close() should complete quickly, but took " + closeDuration + "ms",
+          closeDuration < 1000);
+
+    } finally {
+      try {
+        pool.close();
+      } catch (Exception e) {
+      }
+    }
   }
 }

--- a/iotdb-client/session/src/test/java/org/apache/iotdb/session/pool/SessionPoolTest.java
+++ b/iotdb-client/session/src/test/java/org/apache/iotdb/session/pool/SessionPoolTest.java
@@ -74,6 +74,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -1636,7 +1638,6 @@ public class SessionPoolTest {
             .password("root")
             .maxSize(1)
             .waitToGetSessionTimeoutInMs(10000)
-            // notifyAll()
             .build();
 
     try {
@@ -1651,11 +1652,13 @@ public class SessionPoolTest {
       assertEquals(0, queue.size());
 
       final Exception[] caughtException = {null};
+      CountDownLatch latch = new CountDownLatch(1);
 
       Thread waiterThread =
           new Thread(
               () -> {
                 try {
+                  latch.countDown();
                   Whitebox.invokeMethod(pool, "getSession");
                 } catch (Exception e) {
                   caughtException[0] = e;
@@ -1663,13 +1666,14 @@ public class SessionPoolTest {
               });
       waiterThread.start();
 
-      Thread.sleep(100);
+      assertTrue("Waiter thread should have started", latch.await(10, TimeUnit.SECONDS));
+      // Give it a moment to enter the wait(1000) block in getSession()
+      Thread.sleep(200);
 
-      long closeStartTime = System.currentTimeMillis();
       pool.close();
-      long closeEndTime = System.currentTimeMillis();
 
-      waiterThread.join(1000);
+      waiterThread.join(500);
+      assertTrue("Waiter thread should be unblocked quickly", !waiterThread.isAlive());
 
       assertNotNull("Waiter thread should have caught an exception", caughtException[0]);
       assertTrue(
@@ -1679,15 +1683,11 @@ public class SessionPoolTest {
           "Exception message should indicate pool is closed",
           caughtException[0].getMessage().contains("closed"));
 
-      long closeDuration = closeEndTime - closeStartTime;
-      assertTrue(
-          "close() should complete quickly, but took " + closeDuration + "ms",
-          closeDuration < 1000);
-
     } finally {
       try {
         pool.close();
       } catch (Exception e) {
+        // ignore
       }
     }
   }


### PR DESCRIPTION
`SessionPool.close()` terminates all sessions and marks the pool as closed, but threads blocked in `getSession()` would not wake up immediately. They remained blocked in synchronized wait loops for up to the full timeout period only later discovering the pool was closed. This is inefficient during graceful shutdown scenarios, especially in streaming environments like Flink where fast cleanup is critical.

The fix adds `notifyAll()` at the end of the `close()` method to immediately wake all waiting threads, allowing them to check the closed flag and fail fast. Additionally, comprehensive JavaDoc was added to both SessionPool and TableSessionPool to document the unblocking behavior. A regression test verifies that waiting threads receive IoTDBConnectionException immediately upon pool closure.