### PR TITLE
Fix Java client time column access throwing ArrayIndexOutOfBoundsException (#17407)

### DIFF
--- a/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSetTest.java
+++ b/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSetTest.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.sql.Types;
@@ -258,6 +259,95 @@ public class IoTDBJDBCResultSetTest {
 
     // The client get TSQueryDataSet at the first request
     verify(fetchResultsResp, times(0)).getStatus();
+  }
+
+  /**
+   * The tree-model time pseudo-column is addressed by a negative TsBlock column index. getLong,
+   * getString and getObject handle it; the strictly-typed getters used to fall through to
+   * TsBlock.getColumn(-1) and escape as an unchecked ArrayIndexOutOfBoundsException instead of the
+   * SQLException a JDBC caller can handle. getDate delegates to getInt, so it is affected too.
+   */
+  @SuppressWarnings("resource")
+  @Test
+  public void testTimeColumnRejectedByStrictlyTypedGetters() throws Exception {
+    try (ResultSet resultSet = executeAndFetchTreeModelResultSet()) {
+      Assert.assertEquals(1, resultSet.findColumn("Time"));
+      Assert.assertTrue(resultSet.next());
+
+      // The getters that support the time column keep working.
+      Assert.assertEquals(2L, resultSet.getLong(1));
+      Assert.assertEquals("2", resultSet.getString(1));
+      Assert.assertEquals(new Timestamp(2), resultSet.getObject(1));
+      Assert.assertEquals(new Timestamp(2), resultSet.getTimestamp(1));
+
+      // The strictly-typed ones must report a SQLException, not an unchecked exception.
+      assertTimeColumnRejected(() -> resultSet.getBoolean(1));
+      assertTimeColumnRejected(() -> resultSet.getInt(1));
+      assertTimeColumnRejected(() -> resultSet.getFloat(1));
+      assertTimeColumnRejected(() -> resultSet.getDouble(1));
+      assertTimeColumnRejected(() -> resultSet.getDate(1));
+
+      // Reading by name goes through the same path.
+      assertTimeColumnRejected(() -> resultSet.getInt("Time"));
+    }
+  }
+
+  @FunctionalInterface
+  private interface ResultSetRead {
+    void run() throws SQLException;
+  }
+
+  private void assertTimeColumnRejected(ResultSetRead read) {
+    try {
+      read.run();
+      Assert.fail("reading the time column with a strictly-typed getter should have thrown");
+    } catch (SQLException e) {
+      // expected
+    } catch (RuntimeException e) {
+      Assert.fail(
+          "expected a SQLException but the time column leaked an unchecked "
+              + e.getClass().getName()
+              + ": "
+              + e.getMessage());
+    }
+  }
+
+  /** Same tree-model fixture as testQuery: column 1 is Time, columns 2..5 are measurements. */
+  private ResultSet executeAndFetchTreeModelResultSet() throws Exception {
+    List<String> columns = new ArrayList<>();
+    columns.add("root.vehicle.d0.s2");
+    columns.add("root.vehicle.d0.s1");
+    columns.add("root.vehicle.d0.s0");
+    columns.add("root.vehicle.d0.s2");
+
+    List<String> dataTypeList = new ArrayList<>();
+    dataTypeList.add("FLOAT");
+    dataTypeList.add("INT64");
+    dataTypeList.add("INT32");
+    dataTypeList.add("FLOAT");
+
+    when(execResp.isSetColumns()).thenReturn(true);
+    when(execResp.getColumns()).thenReturn(columns);
+    when(execResp.isSetDataTypeList()).thenReturn(true);
+    when(execResp.getDataTypeList()).thenReturn(dataTypeList);
+    when(execResp.isSetOperationType()).thenReturn(true);
+    when(execResp.getOperationType()).thenReturn("QUERY");
+    when(execResp.isSetQueryId()).thenReturn(true);
+    when(execResp.getQueryId()).thenReturn(queryId);
+    when(execResp.isSetTableModel()).thenReturn(false);
+    when(execResp.isIgnoreTimeStamp()).thenReturn(false);
+
+    List<Integer> columnIndex2TsBlockColumnIndexList = new ArrayList<>(columns.size());
+    columnIndex2TsBlockColumnIndexList.add(0);
+    columnIndex2TsBlockColumnIndexList.add(1);
+    columnIndex2TsBlockColumnIndexList.add(2);
+    columnIndex2TsBlockColumnIndexList.add(0);
+    when(execResp.getColumnIndex2TsBlockColumnIndexList())
+        .thenReturn(columnIndex2TsBlockColumnIndexList);
+
+    Assert.assertTrue(statement.execute("select * from root.vehicle.d0"));
+    fetchResultsResp.hasResultSet = true;
+    return statement.getResultSet();
   }
 
   private void constructObjectList(List<Object> standardObject) {

--- a/iotdb-client/service-rpc/src/main/i18n/en/org/apache/iotdb/rpc/i18n/RpcMessages.java
+++ b/iotdb-client/service-rpc/src/main/i18n/en/org/apache/iotdb/rpc/i18n/RpcMessages.java
@@ -68,6 +68,16 @@ public final class RpcMessages {
       "column index %d out of range %d";
   public static final String UNKNOWN_COLUMN_NAME = "Unknown column name: ";
   public static final String NO_RECORD_REMAINS = "No record remains";
+  public static final String CANNOT_READ_BOOLEAN_FROM_TIME_COLUMN =
+      "Cannot read boolean from time column";
+  public static final String CANNOT_READ_DOUBLE_FROM_TIME_COLUMN =
+      "Cannot read double from time column";
+  public static final String CANNOT_READ_FLOAT_FROM_TIME_COLUMN =
+      "Cannot read float from time column";
+  public static final String CANNOT_READ_INT32_FROM_TIME_COLUMN =
+      "Cannot read int32 from time column";
+  public static final String CANNOT_READ_BINARY_FROM_TIME_COLUMN =
+      "Cannot read binary from time column";
   public static final String CANNOT_CLOSE_DATASET =
       "Cannot close dataset, because of network connection: {} ";
 

--- a/iotdb-client/service-rpc/src/main/i18n/zh/org/apache/iotdb/rpc/i18n/RpcMessages.java
+++ b/iotdb-client/service-rpc/src/main/i18n/zh/org/apache/iotdb/rpc/i18n/RpcMessages.java
@@ -58,6 +58,11 @@ public final class RpcMessages {
   public static final String COLUMN_INDEX_OUT_OF_RANGE = "列索引 %d 超出范围 %d";
   public static final String UNKNOWN_COLUMN_NAME = "未知列名：";
   public static final String NO_RECORD_REMAINS = "没有剩余记录";
+  public static final String CANNOT_READ_BOOLEAN_FROM_TIME_COLUMN = "无法从时间列读取 boolean 值";
+  public static final String CANNOT_READ_DOUBLE_FROM_TIME_COLUMN = "无法从时间列读取 double 值";
+  public static final String CANNOT_READ_FLOAT_FROM_TIME_COLUMN = "无法从时间列读取 float 值";
+  public static final String CANNOT_READ_INT32_FROM_TIME_COLUMN = "无法从时间列读取 int32 值";
+  public static final String CANNOT_READ_BINARY_FROM_TIME_COLUMN = "无法从时间列读取 binary 值";
   public static final String CANNOT_CLOSE_DATASET = "无法关闭数据集，网络连接异常：{} ";
 
   // RpcUtils

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
@@ -328,9 +328,16 @@ public class IoTDBRpcDataSet {
     return getBooleanByTsBlockColumnIndex(getTsBlockColumnIndexForColumnName(columnName));
   }
 
+  // Note: tsBlockColumnIndex < 0 indicates the time pseudo-column in tree model.
+  // Only getLong, getString and getObject support reading the time column directly.
+  // The other strictly-typed getters throw StatementExecutionException to prevent
+  // ArrayIndexOutOfBoundsException from TsBlock.getColumn with a negative index.
   private boolean getBooleanByTsBlockColumnIndex(int tsBlockColumnIndex)
       throws StatementExecutionException {
     checkRecord();
+    if (tsBlockColumnIndex < 0) {
+      throw new StatementExecutionException("Cannot read boolean from time column");
+    }
     if (!isNull(tsBlockColumnIndex, tsBlockIndex)) {
       lastReadWasNull = false;
       return curTsBlock.getColumn(tsBlockColumnIndex).getBoolean(tsBlockIndex);
@@ -351,6 +358,9 @@ public class IoTDBRpcDataSet {
   private double getDoubleByTsBlockColumnIndex(int tsBlockColumnIndex)
       throws StatementExecutionException {
     checkRecord();
+    if (tsBlockColumnIndex < 0) {
+      throw new StatementExecutionException("Cannot read double from time column");
+    }
     if (!isNull(tsBlockColumnIndex, tsBlockIndex)) {
       lastReadWasNull = false;
       return curTsBlock.getColumn(tsBlockColumnIndex).getDouble(tsBlockIndex);
@@ -371,6 +381,9 @@ public class IoTDBRpcDataSet {
   private float getFloatByTsBlockColumnIndex(int tsBlockColumnIndex)
       throws StatementExecutionException {
     checkRecord();
+    if (tsBlockColumnIndex < 0) {
+      throw new StatementExecutionException("Cannot read float from time column");
+    }
     if (!isNull(tsBlockColumnIndex, tsBlockIndex)) {
       lastReadWasNull = false;
       return curTsBlock.getColumn(tsBlockColumnIndex).getFloat(tsBlockIndex);
@@ -391,6 +404,9 @@ public class IoTDBRpcDataSet {
   private int getIntByTsBlockColumnIndex(int tsBlockColumnIndex)
       throws StatementExecutionException {
     checkRecord();
+    if (tsBlockColumnIndex < 0) {
+      throw new StatementExecutionException("Cannot read int32 from time column");
+    }
     if (!isNull(tsBlockColumnIndex, tsBlockIndex)) {
       lastReadWasNull = false;
       TSDataType type = curTsBlock.getColumn(tsBlockColumnIndex).getDataType();
@@ -449,6 +465,9 @@ public class IoTDBRpcDataSet {
   private Binary getBinaryTsBlockColumnIndex(int tsBlockColumnIndex)
       throws StatementExecutionException {
     checkRecord();
+    if (tsBlockColumnIndex < 0) {
+      throw new StatementExecutionException("Cannot read binary from time column");
+    }
     if (!isNull(tsBlockColumnIndex, tsBlockIndex)) {
       lastReadWasNull = false;
       return curTsBlock.getColumn(tsBlockColumnIndex).getBinary(tsBlockIndex);

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
@@ -330,9 +330,16 @@ public class IoTDBRpcDataSet {
     return getBooleanByTsBlockColumnIndex(getTsBlockColumnIndexForColumnName(columnName));
   }
 
+  // A negative tsBlockColumnIndex denotes the tree-model time pseudo-column. Only getLong,
+  // getString and getObject can serve it; the strictly-typed getters reject it here so that
+  // callers see a StatementExecutionException instead of an ArrayIndexOutOfBoundsException
+  // escaping from TsBlock.getColumn(-1).
   private boolean getBooleanByTsBlockColumnIndex(int tsBlockColumnIndex)
       throws StatementExecutionException {
     checkRecord();
+    if (tsBlockColumnIndex < 0) {
+      throw new StatementExecutionException(RpcMessages.CANNOT_READ_BOOLEAN_FROM_TIME_COLUMN);
+    }
     if (!isNull(tsBlockColumnIndex, tsBlockIndex)) {
       lastReadWasNull = false;
       return curTsBlock.getColumn(tsBlockColumnIndex).getBoolean(tsBlockIndex);
@@ -353,6 +360,9 @@ public class IoTDBRpcDataSet {
   private double getDoubleByTsBlockColumnIndex(int tsBlockColumnIndex)
       throws StatementExecutionException {
     checkRecord();
+    if (tsBlockColumnIndex < 0) {
+      throw new StatementExecutionException(RpcMessages.CANNOT_READ_DOUBLE_FROM_TIME_COLUMN);
+    }
     if (!isNull(tsBlockColumnIndex, tsBlockIndex)) {
       lastReadWasNull = false;
       return curTsBlock.getColumn(tsBlockColumnIndex).getDouble(tsBlockIndex);
@@ -373,6 +383,9 @@ public class IoTDBRpcDataSet {
   private float getFloatByTsBlockColumnIndex(int tsBlockColumnIndex)
       throws StatementExecutionException {
     checkRecord();
+    if (tsBlockColumnIndex < 0) {
+      throw new StatementExecutionException(RpcMessages.CANNOT_READ_FLOAT_FROM_TIME_COLUMN);
+    }
     if (!isNull(tsBlockColumnIndex, tsBlockIndex)) {
       lastReadWasNull = false;
       return curTsBlock.getColumn(tsBlockColumnIndex).getFloat(tsBlockIndex);
@@ -393,6 +406,9 @@ public class IoTDBRpcDataSet {
   private int getIntByTsBlockColumnIndex(int tsBlockColumnIndex)
       throws StatementExecutionException {
     checkRecord();
+    if (tsBlockColumnIndex < 0) {
+      throw new StatementExecutionException(RpcMessages.CANNOT_READ_INT32_FROM_TIME_COLUMN);
+    }
     if (!isNull(tsBlockColumnIndex, tsBlockIndex)) {
       lastReadWasNull = false;
       TSDataType type = curTsBlock.getColumn(tsBlockColumnIndex).getDataType();
@@ -451,6 +467,9 @@ public class IoTDBRpcDataSet {
   private Binary getBinaryTsBlockColumnIndex(int tsBlockColumnIndex)
       throws StatementExecutionException {
     checkRecord();
+    if (tsBlockColumnIndex < 0) {
+      throw new StatementExecutionException(RpcMessages.CANNOT_READ_BINARY_FROM_TIME_COLUMN);
+    }
     if (!isNull(tsBlockColumnIndex, tsBlockIndex)) {
       lastReadWasNull = false;
       return curTsBlock.getColumn(tsBlockColumnIndex).getBinary(tsBlockIndex);


### PR DESCRIPTION
# Reject the tree-model time column in the strictly-typed getters (#17407)

In the tree model a result set's time pseudo-column is addressed by a *negative*
TsBlock column index. `getLong`, `getString` and `getObject` handle that;
`getBoolean`, `getInt`, `getFloat`, `getDouble` and `getBinary` do not — they
fall straight through to `TsBlock.getColumn(tsBlockColumnIndex)` with `-1`.

`isNull(index, rowNum)` is `index >= 0 && ...`, so it returns `false` for the
time column and execution enters the value branch rather than the null branch.

## Why this is a defect rather than a quirk

`java.sql.ResultSet.getInt` and its siblings declare `throws SQLException`. What
comes out here instead is an unchecked `ArrayIndexOutOfBoundsException`, and
`IoTDBJDBCResultSet` only catches `StatementExecutionException`:

```java
public int getInt(int columnIndex) throws SQLException {
  try {
    return ioTDBRpcDataSet.getInt(columnIndex);
  } catch (StatementExecutionException e) {
    throw new SQLException(e.getMessage());
  }
}
```

So the exception crosses the JDBC boundary uncaught. A caller writing the
documented `catch (SQLException)` cannot handle it. That is the argument for the
change: it is a JDBC contract violation, independent of any judgement about which
exception type is nicer.

The `Session` `DataIterator` getters share `IoTDBRpcDataSet` and pass it through
unwrapped as well.

## Why #17400 does not settle this for Java

The same defect in the C++ client was fixed in #17400 (approved by @jt2594838,
merged 2026-04-01). This PR is the Java counterpart, deliberately down to the
wording: the same five getters, the same guard placed after `checkRecord()` and
before `isNull(...)`, and the five messages character-for-character identical to
the ones that merged there.

```
client-cpp  throw IoTDBException("Cannot read int32 from time column");
this PR     CANNOT_READ_INT32_FROM_TIME_COLUMN = "Cannot read int32 from time column";
```

A user hitting this through two different clients should not have to learn two
different messages.

**But #17400 should not be read as having settled this for Java, and I do not
want to imply that it did.** In that review @CritasWang wrote:

> A fast-fail exception … is much safer, and it aligns perfectly with our Java
> client which typically throws `IndexOutOfBoundsException` or
> `ClassCastException` for mismatched types on the Time column.

That describes the behaviour this PR changes, and it describes it accurately —
`ArrayIndexOutOfBoundsException` is an `IndexOutOfBoundsException`. So #17400
cited the current Java behaviour as the model, and here I am arguing the Java
side should move. I think the JDBC contract is the reason it should, but that is
a new argument and not a conclusion anyone reached before, so it deserves an
explicit objection if you disagree.

`getBinary` is in the guarded set because it is in the merged #17400 set: that
review named four getters, and the patch that was approved and merged carries
five.

## Changes

| File | |
| --- | --- |
| `IoTDBRpcDataSet.java` | five `tsBlockColumnIndex < 0` guards throwing `StatementExecutionException` |
| `i18n/en/RpcMessages.java` | five message constants |
| `i18n/zh/RpcMessages.java` | the same five, translated |
| `IoTDBJDBCResultSetTest.java` | regression test |

The messages are constants rather than string literals because this class now
routes every message through `RpcMessages` (compile-time i18n, #17613 / #18110);
the previous revision of this PR predated that and had bare literals.

## A side effect worth naming

`getDate` delegates to `getIntByTsBlockColumnIndex`, so it now rejects the time
column too. Nobody has decided that — #17400 concerned the C++ client and did not
discuss `getDate`. It follows from guarding `getInt`, and reading a `LocalDate`
out of the time column was never meaningful, but it is a behaviour change beyond
the five getters and I would rather state it than have it noticed later.

## Verification

Test first, against unpatched master:

```
Tests run: 2, Failures: 1
java.lang.AssertionError: expected a SQLException but the time column leaked an
  unchecked java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 3
```

The assertion distinguishes "leaked an unchecked exception" from "threw
something", so it cannot pass by accident. With the guards applied it is green,
and the module suites are clean:

```
iotdb-client/jdbc + iotdb-client/service-rpc     114 tests, 0 failures
mvn -P with-zh-locale test-compile               BUILD SUCCESS
```

For the zh locale I checked the compiled artifact rather than the exit code:

```
javap -p -constants org.apache.iotdb.rpc.i18n.RpcMessages
  CANNOT_READ_INT32_FROM_TIME_COLUMN = "无法从时间列读取 int32 值"
```

Test scope: the test exercises the JDBC layer. The `Session` `DataIterator` path
shares `IoTDBRpcDataSet` and is fixed by the same guards, but I have not covered
it separately.

CI has never run on this branch's head: both
`commits/<head>/check-runs` and `actions/runs?head_sha=<head>` return zero. I
would appreciate the pending runs being approved.