### PR TITLE
Fix last_by returning null row after deleting all table data (#16985)

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBDeletionTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBDeletionTableIT.java
@@ -1049,6 +1049,84 @@ public class IoTDBDeletionTableIT {
   }
 
   @Test
+  public void testLastByWithTimeShouldReturnNoRowsAfterDeletingAllData() throws SQLException {
+    try (Connection connection = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
+        Statement statement = connection.createStatement()) {
+      statement.execute("use test");
+      statement.execute("create table last_by_delete_0(deviceId string tag, s0 int32 field)");
+      statement.execute("insert into last_by_delete_0(time, deviceId, s0) values (1, 'd0', 1)");
+      statement.execute("flush");
+
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              "select last_by(s0, time) from last_by_delete_0 where deviceId = 'd0'")) {
+        assertTrue(resultSet.next());
+      }
+
+      statement.execute("delete from last_by_delete_0 where deviceId = 'd0'");
+
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              "select last_by(s0, time) from last_by_delete_0 where deviceId = 'd0'")) {
+        assertResultSetEmpty(resultSet);
+      }
+
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              "select last_by(s0, time) from last_by_delete_0 where deviceId = 'd0'")) {
+        assertResultSetEmpty(resultSet);
+      }
+    }
+  }
+
+  @Test
+  public void testThreeArgLastByShouldReturnNoRowsAfterDeletingAllData() throws SQLException {
+    try (Connection connection = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
+        Statement statement = connection.createStatement()) {
+      statement.execute("use test");
+      statement.execute("create table last_by_delete_1(deviceId string tag, s0 int32 field)");
+      statement.execute("insert into last_by_delete_1(time, deviceId, s0) values (1, 'd0', 1)");
+      statement.execute("flush");
+
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              "select last_by(time, s0, time) from last_by_delete_1 where deviceId = 'd0'")) {
+        assertTrue(resultSet.next());
+      }
+
+      statement.execute("delete from last_by_delete_1 where deviceId = 'd0'");
+
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              "select last_by(time, s0, time) from last_by_delete_1 where deviceId = 'd0'")) {
+        assertResultSetEmpty(resultSet);
+      }
+
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              "select last_by(time, s0, time) from last_by_delete_1 where deviceId = 'd0'")) {
+        assertResultSetEmpty(resultSet);
+      }
+    }
+  }
+
+  private void assertResultSetEmpty(ResultSet resultSet) throws SQLException {
+    if (!resultSet.next()) {
+      return;
+    }
+
+    StringBuilder rowBuilder = new StringBuilder();
+    int columnCount = resultSet.getMetaData().getColumnCount();
+    for (int i = 1; i <= columnCount; i++) {
+      if (i > 1) {
+        rowBuilder.append(", ");
+      }
+      rowBuilder.append(resultSet.getString(i));
+    }
+    fail("Expected no rows, but got: " + rowBuilder);
+  }
+
+  @Test
   public void testFullDeleteWithoutWhereClause() throws SQLException {
     prepareData(5, 1);
     try (Connection connection = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/FileLoaderUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/FileLoaderUtils.java
@@ -380,7 +380,7 @@ public class FileLoaderUtils {
     // deal with time column
     List<ModEntry> timeModifications =
         context.getPathModifications(
-            resource, alignedPath.getDeviceId(), timeColumnMetadata.getMeasurementId());
+            resource, alignedPath.getDeviceId(), AlignedFullPath.VECTOR_PLACEHOLDER);
     // all rows are deleted, just return null to skip device data in this file
     if (ModificationUtils.isAllDeletedByMods(
         timeModifications,

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/LastQueryAggTableScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/LastQueryAggTableScanOperator.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.queryengine.execution.operator.source.relational;
 
 import org.apache.iotdb.calc.execution.operator.source.relational.aggregation.LastAccumulator;
+import org.apache.iotdb.calc.execution.operator.source.relational.aggregation.LastByAccumulator;
 import org.apache.iotdb.calc.execution.operator.source.relational.aggregation.LastByDescAccumulator;
 import org.apache.iotdb.calc.execution.operator.source.relational.aggregation.LastDescAccumulator;
 import org.apache.iotdb.calc.execution.operator.source.relational.aggregation.TableAggregator;
@@ -322,12 +323,14 @@ public class LastQueryAggTableScanOperator extends AbstractAggTableScanOperator 
 
   private void buildResultUseLastValuesCache() {
     TimeValuePair[] currentHitResult = lastValuesCacheResults.get(currentHitCacheIndex);
-    // if it is EMPTY_PRIMITIVE_TYPE, means there is no data in device
+    // if it is PLACEHOLDER_NO_VALUE, means there is no data in device
     TsPrimitiveType timeLastValue = currentHitResult[currentHitResult.length - 1].getValue();
     // when there is no data, no need to append result if the query is GROUP BY or output of
     // aggregator is partial (final operator will produce NULL result)
     if (timeLastValue == PLACEHOLDER_NO_VALUE
-        && (groupingKeySize != 0 || tableAggregators.get(0).getStep().isOutputPartial())) {
+        && (groupingKeySize != 0
+            || tableAggregators.get(0).getStep().isOutputPartial()
+            || shouldSkipEmptyLastByResult(currentHitResult))) {
       outputDeviceIndex++;
       currentHitCacheIndex++;
       return;
@@ -715,7 +718,9 @@ public class LastQueryAggTableScanOperator extends AbstractAggTableScanOperator 
 
   @Override
   protected void updateResultTsBlock() {
-    appendAggregationResult();
+    if (!shouldSkipEmptyLastByResult()) {
+      appendAggregationResult();
+    }
 
     if (needUpdateCache && timeIterator.hasCachedTimeRange()) {
       if (lastRowCacheResults != null) {
@@ -733,6 +738,38 @@ public class LastQueryAggTableScanOperator extends AbstractAggTableScanOperator 
 
     // after appendAggregationResult invoked, aggregators must be cleared
     resetTableAggregators();
+  }
+
+  private boolean shouldSkipEmptyLastByResult() {
+    if (groupingKeySize != 0 || tableAggregators.isEmpty()) {
+      return false;
+    }
+    for (TableAggregator aggregator : tableAggregators) {
+      if (!(aggregator.getAccumulator() instanceof LastByAccumulator)) {
+        return false;
+      }
+      if (((LastByAccumulator) aggregator.getAccumulator()).hasInitResult()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean shouldSkipEmptyLastByResult(TimeValuePair[] currentHitResult) {
+    if (groupingKeySize != 0 || tableAggregators.isEmpty()) {
+      return false;
+    }
+    for (TableAggregator aggregator : tableAggregators) {
+      if (!(aggregator.getAccumulator() instanceof LastByAccumulator)) {
+        return false;
+      }
+    }
+    for (TimeValuePair timeValuePair : currentHitResult) {
+      if (timeValuePair.getValue() != PLACEHOLDER_NO_VALUE) {
+        return false;
+      }
+    }
+    return true;
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/ModificationUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/ModificationUtils.java
@@ -145,6 +145,7 @@ public class ModificationUtils {
         for (TimeRange range : valueChunkMetadata.getDeleteIntervalList()) {
           if (range.contains(valueChunkMetadata.getStartTime(), valueChunkMetadata.getEndTime())) {
             valueChunkMetadataList.set(i, null);
+            modified = true;
             currentRemoved = true;
             break;
           } else {


### PR DESCRIPTION
## Description

Fixes #16985

In table model, after deleting all data of a device, `last_by` queries still returned one row with null values instead of returning no rows:

```sql
-- After deleting all data:
select last_by(s0, time) from table where deviceId = 'd0'
-- Expected: 0 rows
-- Actual: 1 row with null
```

### Root Cause

Three related issues:

1. **`LastQueryAggTableScanOperator`** could still emit a result row for non-grouped `last_by` scans even when every `LastByAccumulator` had no initialized result, causing `evaluateFinal()` to produce a null row.

2. **`FileLoaderUtils`** read aligned time-column modifications using the concrete measurement ID instead of `AlignedFullPath.VECTOR_PLACEHOLDER`, inconsistent with aligned deletion semantics used in other paths.

3. **`ModificationUtils`** did not set `modified = true` when an aligned value chunk was fully deleted, allowing statistics-based shortcuts to use stale metadata.

### Changes

| File | Change |
|------|--------|
| `LastQueryAggTableScanOperator.java` | Skip emitting result row when all aggregators are `LastByAccumulator` and none has initialized result. Applied to both normal aggregation and cache-hit paths. |
| `FileLoaderUtils.java` | Use `AlignedFullPath.VECTOR_PLACEHOLDER` for time-column modification lookups |
| `ModificationUtils.java` | Set `modified = true` when value chunk is fully removed |
| `IoTDBDeletionTableIT.java` | Add regression tests for 2-arg and 3-arg `last_by` after delete |

### Semantic Note

This changes non-grouped `last_by` on empty results from returning one null row to returning zero rows, consistent with grouped-query behavior (which already returns zero rows for empty devices). Other aggregations like `count`/`max`/`last` are not affected by this change. Please confirm this is the intended semantics.

### Verification

Integration tests pass locally:
```
mvn -P with-integration-tests,TableSimpleIT -pl integration-test -am \
  -DskipUTs -Dspotless.skip=true -Dcheckstyle.skip=true -Drat.skip=true \
  -Dit.test=IoTDBDeletionTableIT#testLastByWithTimeShouldReturnNoRowsAfterDeletingAllData+testThreeArgLastByShouldReturnNoRowsAfterDeletingAllData \
  verify
```
Result: 2 tests run, 0 failures, 0 errors.