### PR TITLE
[Feat] Add table less query for table model

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBComplexQueryIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBComplexQueryIT.java
@@ -81,4 +81,32 @@ public class IoTDBComplexQueryIT {
         retArray,
         DATABASE_NAME);
   }
+
+  @Test
+  public void testTableLessQuery() {
+    String[] expectedHeader;
+    String[] retArray;
+
+    expectedHeader = new String[] {"_col0", "_col1", "_col2", "_col3"};
+    retArray = new String[] {"2,0,1,1,"};
+    tableResultSetEqualTest("SELECT 1+1, 1-1, 1*1, 1/1", expectedHeader, retArray, DATABASE_NAME);
+
+    expectedHeader = new String[] {"_col0", "_col1", "_col2"};
+    retArray = new String[] {"0.841471,0.540302,1.557408,"};
+    tableResultSetEqualTest(
+        "SELECT round(sin(1),6), round(cos(1),6), round(tan(1),6)",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+
+    expectedHeader = new String[] {"_col0"};
+    retArray = new String[] {"Hello world,"};
+    tableResultSetEqualTest(
+        "SELECT FORMAT('Hello %s','world')", expectedHeader, retArray, DATABASE_NAME);
+
+    // SELECT COUNT(*) without FROM returns 1 (implicit single-row semantics)
+    expectedHeader = new String[] {"_col0"};
+    retArray = new String[] {"1,"};
+    tableResultSetEqualTest("SELECT COUNT(*)", expectedHeader, retArray, DATABASE_NAME);
+  }
 }

--- a/iotdb-core/calc-commons/src/main/java/org/apache/iotdb/calc/plan/planner/TableOperatorGenerator.java
+++ b/iotdb-core/calc-commons/src/main/java/org/apache/iotdb/calc/plan/planner/TableOperatorGenerator.java
@@ -176,12 +176,14 @@ import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.common.conf.TSFileDescriptor;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.read.common.block.TsBlock;
 import org.apache.tsfile.read.common.block.column.BinaryColumn;
 import org.apache.tsfile.read.common.block.column.BooleanColumn;
 import org.apache.tsfile.read.common.block.column.DoubleColumn;
 import org.apache.tsfile.read.common.block.column.FloatColumn;
 import org.apache.tsfile.read.common.block.column.IntColumn;
 import org.apache.tsfile.read.common.block.column.LongColumn;
+import org.apache.tsfile.read.common.block.column.RunLengthEncodedColumn;
 import org.apache.tsfile.read.common.type.Type;
 import org.apache.tsfile.utils.Binary;
 
@@ -213,6 +215,7 @@ import static org.apache.iotdb.calc.execution.operator.source.relational.aggrega
 import static org.apache.iotdb.calc.execution.operator.source.relational.aggregation.AccumulatorFactory.createBuiltinAccumulator;
 import static org.apache.iotdb.calc.execution.operator.source.relational.aggregation.AccumulatorFactory.createGroupedAccumulator;
 import static org.apache.iotdb.calc.plan.planner.CommonOperatorUtils.IDENTITY_FILL;
+import static org.apache.iotdb.calc.plan.planner.CommonOperatorUtils.TIME_COLUMN_TEMPLATE;
 import static org.apache.iotdb.calc.plan.planner.CommonOperatorUtils.UNKNOWN_DATATYPE;
 import static org.apache.iotdb.calc.plan.planner.CommonOperatorUtils.getLinearFill;
 import static org.apache.iotdb.calc.plan.planner.CommonOperatorUtils.getPreviousFill;
@@ -2179,8 +2182,22 @@ public abstract class TableOperatorGenerator<
             context, node.getPlanNodeId(), MappingCollectOperator.class.getSimpleName());
 
     // Currently we only support empty values operator
-    assert node.getRowCount() == 0;
-    return new ValuesOperator(operatorContext, ImmutableList.of());
+    if (node.getRowCount() == 0) {
+      return new ValuesOperator(operatorContext, ImmutableList.of());
+    }
+
+    // No-FROM query (e.g. SELECT 1+1): produce rowCount rows with no value columns so that the
+    // upstream ProjectNode can evaluate expressions once per row.
+    if (node.getRowCount() == 1) {
+      TsBlock oneRowWithoutColumnsBlock =
+          new TsBlock(
+              node.getRowCount(),
+              new RunLengthEncodedColumn(TIME_COLUMN_TEMPLATE, node.getRowCount()),
+              new Column[0]);
+      return new ValuesOperator(operatorContext, ImmutableList.of(oneRowWithoutColumnsBlock));
+    } else {
+      throw new IllegalArgumentException("Row count must be 0 or 1");
+    }
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/QueryPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/QueryPlanner.java
@@ -40,6 +40,7 @@ import org.apache.iotdb.commons.queryengine.plan.relational.planner.node.Previou
 import org.apache.iotdb.commons.queryengine.plan.relational.planner.node.ProjectNode;
 import org.apache.iotdb.commons.queryengine.plan.relational.planner.node.SortNode;
 import org.apache.iotdb.commons.queryengine.plan.relational.planner.node.ValueFillNode;
+import org.apache.iotdb.commons.queryengine.plan.relational.planner.node.ValuesNode;
 import org.apache.iotdb.commons.queryengine.plan.relational.planner.node.WindowNode;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Cast;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ComparisonExpression;
@@ -61,6 +62,7 @@ import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.QuerySpecifi
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.SortItem;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.VariableDefinition;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.WindowFrame;
+import org.apache.iotdb.commons.queryengine.plan.relational.type.InternalTypeManager;
 import org.apache.iotdb.db.i18n.DataNodeQueryMessages;
 import org.apache.iotdb.db.queryengine.common.MPPQueryContext;
 import org.apache.iotdb.db.queryengine.common.QueryId;
@@ -68,6 +70,7 @@ import org.apache.iotdb.db.queryengine.plan.relational.analyzer.Analysis;
 import org.apache.iotdb.db.queryengine.plan.relational.analyzer.Analysis.GroupingSetAnalysis;
 import org.apache.iotdb.db.queryengine.plan.relational.analyzer.FieldId;
 import org.apache.iotdb.db.queryengine.plan.relational.analyzer.RelationType;
+import org.apache.iotdb.db.queryengine.plan.relational.metadata.TableMetadataImpl;
 import org.apache.iotdb.db.queryengine.plan.relational.planner.ir.GapFillStartAndEndTimeExtractVisitor;
 import org.apache.iotdb.db.queryengine.plan.relational.planner.ir.PredicateWithUncorrelatedScalarSubqueryReconstructor;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Delete;
@@ -792,7 +795,14 @@ public class QueryPlanner {
               .process(node.getFrom().orElse(null), null);
       return newPlanBuilder(relationPlan, analysis);
     } else {
-      throw new SemanticException(DataNodeQueryMessages.FROM_CLAUSE_MUST_NOT_BE_EMPTY);
+      return new PlanBuilder(
+          new TranslationMap(
+              outerContext,
+              analysis.getImplicitFromScope(node),
+              analysis,
+              ImmutableList.of(),
+              new PlannerContext(new TableMetadataImpl(), new InternalTypeManager())),
+          new ValuesNode(queryIdAllocator.genPlanNodeId(), 1));
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/optimizations/UnaliasSymbolReferences.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/optimizations/UnaliasSymbolReferences.java
@@ -53,6 +53,7 @@ import org.apache.iotdb.commons.queryengine.plan.relational.planner.node.TopKNod
 import org.apache.iotdb.commons.queryengine.plan.relational.planner.node.TopKRankingNode;
 import org.apache.iotdb.commons.queryengine.plan.relational.planner.node.UnionNode;
 import org.apache.iotdb.commons.queryengine.plan.relational.planner.node.ValueFillNode;
+import org.apache.iotdb.commons.queryengine.plan.relational.planner.node.ValuesNode;
 import org.apache.iotdb.commons.queryengine.plan.relational.planner.node.WindowNode;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Expression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.NullLiteral;
@@ -508,6 +509,19 @@ public class UnaliasSymbolReferences implements PlanOptimizer {
               newOrderingScheme,
               node.getPartitionKeyCount()),
           mapping);
+    }
+
+    @Override
+    public PlanAndMappings visitValuesNode(ValuesNode node, UnaliasContext context) {
+      Map<Symbol, Symbol> mapping = new HashMap<>(context.getCorrelationMapping());
+      SymbolMapper mapper = symbolMapper(mapping);
+
+      List<Symbol> newOutputs = mapper.map(node.getOutputSymbols());
+      Optional<List<Expression>> newRows =
+          node.getRows().map(rows -> rows.stream().map(mapper::map).collect(toImmutableList()));
+
+      return new PlanAndMappings(
+          new ValuesNode(node.getPlanNodeId(), newOutputs, node.getRowCount(), newRows), mapping);
     }
 
     @Override

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/queryengine/plan/relational/planner/node/ValuesNode.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/queryengine/plan/relational/planner/node/ValuesNode.java
@@ -205,6 +205,11 @@ public class ValuesNode extends SourceNode {
         planNodeId, outputSymbols, rowCount, flag ? Optional.of(rows) : Optional.empty());
   }
 
+  @Override
+  public List<Symbol> getOutputSymbols() {
+    return outputSymbols;
+  }
+
   public int getRowCount() {
     return rowCount;
   }


### PR DESCRIPTION
This pull request adds support for SQL queries without a `FROM` clause (table-less queries) in the IoTDB query engine, along with corresponding tests and necessary planning and execution logic updates. The changes ensure that expressions such as `SELECT 1+1`, `SELECT sin(1)`, or `SELECT COUNT(*)` can be parsed, planned, and executed correctly, producing the expected single-row results even when no table is specified.

Key changes include:

**Support for Table-less (No-FROM) Queries:**
* Updated the query planner (`QueryPlanner.java`) to generate a `ValuesNode` with a single row when a `SELECT` statement does not have a `FROM` clause, enabling implicit single-row semantics for such queries.
* Modified the execution plan generator (`TableOperatorGenerator.java`) to correctly produce a `ValuesOperator` with the appropriate number of rows and columns for no-FROM queries, using a `RunLengthEncodedColumn` to simulate the required rows.

**Testing:**
* Added a new test case (`testTableLessQuery`) in `IoTDBComplexQueryIT.java` to verify correct behavior for queries without a `FROM` clause, including arithmetic, function, formatting, and aggregation expressions.

**Planner and Optimizer Enhancements:**
* Implemented `getOutputSymbols` in `ValuesNode` to support symbol mapping and output column handling in the planner.
* Updated the unaliasing optimizer (`UnaliasSymbolReferences.java`) to handle `ValuesNode`, ensuring correct symbol mapping and row transformation in the optimization pipeline.

**Dependency and Import Updates:**
* Added necessary imports for new classes and types used in the planner and operator generator, such as `ValuesNode`, `InternalTypeManager`, and `RunLengthEncodedColumn`. [[1]](diffhunk://#diff-fec6514dac9985830a9a11e980a4ab075a36ec9f7b05752283ae15a6d6049687R47) [[2]](diffhunk://#diff-fec6514dac9985830a9a11e980a4ab075a36ec9f7b05752283ae15a6d6049687R70) [[3]](diffhunk://#diff-2abcbede121b682a7a1ced195d8ba9e5d42b8774aa13831bf25aa10f4ceb6247R277-R284) [[4]](diffhunk://#diff-20eeca9bcc6e3d3ed5901b66248bf514aef41eb906a3a5fcb1fc7d2abdea61ffR68)