### PR TITLE
[IOTDB-17433] Fix timezone offset bug in DateTimeUtils

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/transform/converter/ValueConverter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/transform/converter/ValueConverter.java
@@ -834,8 +834,7 @@ public class ValueConverter {
   private static int parseDateTimeToDate(final String value) {
     try {
       return DateUtils.parseDateExpressionToInt(
-          Instant.ofEpochMilli(
-                  DateTimeUtils.convertDatetimeStrToLong(value, ZoneOffset.UTC, 0, "ms"))
+          Instant.ofEpochMilli(DateTimeUtils.convertDatetimeStrToLong(value, ZoneOffset.UTC, "ms"))
               .atZone(ZoneOffset.UTC)
               .toLocalDate());
     } catch (final Exception e) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/DateTimeUtilsTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/DateTimeUtilsTest.java
@@ -452,4 +452,18 @@ public class DateTimeUtilsTest {
               DateTimeUtils.toZoneOffset("2024-12-31 10", zoneId);
             });
   }
+
+  @Test
+  public void testToZoneOffsetHistoricalLMT() {
+    ZoneId zoneId = ZoneId.of("Europe/Warsaw");
+    ZoneOffset offset = DateTimeUtils.toZoneOffset("0001-01-01 00:00:00", zoneId);
+    Assert.assertEquals(ZoneOffset.ofHoursMinutes(1, 24), offset);
+
+    ZoneId shanghaiId = ZoneId.of("Asia/Shanghai");
+    ZoneOffset shanghaiOffset = DateTimeUtils.toZoneOffset("0001-01-01 00:00:00", shanghaiId);
+    Assert.assertEquals(ZoneOffset.ofHoursMinutes(8, 5), shanghaiOffset);
+
+    ZoneId utcId = ZoneId.of("UTC");
+    Assert.assertEquals(ZoneOffset.UTC, DateTimeUtils.toZoneOffset("0001-01-01 00:00:00", utcId));
+  }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/DateTimeUtilsTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/DateTimeUtilsTest.java
@@ -28,12 +28,14 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.time.DateTimeException;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 public class DateTimeUtilsTest {
@@ -48,7 +50,7 @@ public class DateTimeUtilsTest {
   /** Test convertDatetimeStrToLong() method with different time precision. */
   @Test
   public void convertDatetimeStrToLongTest1() {
-    zoneOffset = ZonedDateTime.now().getOffset();
+    zoneOffset = Instant.ofEpochMilli(timestamp).atZone(ZoneId.systemDefault()).getOffset();
     zoneId = ZoneId.systemDefault();
     if (zoneOffset.toString().equals("Z")) {
       delta = 8 * 3600000;
@@ -372,5 +374,82 @@ public class DateTimeUtilsTest {
 
     timeDuration = DataNodeDateTimeUtils.constructTimeDuration("10000000000ms");
     Assert.assertEquals(10000000000L, timeDuration.nonMonthDuration);
+  }
+
+  @Test
+  public void testToZoneOffsetForWinterTime() {
+    ZoneId zoneId = ZoneId.of("Europe/Warsaw");
+    ZoneOffset offset = DateTimeUtils.toZoneOffset("2024-01-15 12:00:00", zoneId);
+    Assert.assertEquals(ZoneOffset.ofHours(1), offset);
+  }
+
+  @Test
+  public void testToZoneOffsetForSummerTime() {
+    ZoneId zoneId = ZoneId.of("Europe/Warsaw");
+    ZoneOffset offset = DateTimeUtils.toZoneOffset("2024-06-15 12:00:00", zoneId);
+    Assert.assertEquals(ZoneOffset.ofHours(2), offset);
+  }
+
+  @Test
+  public void testToZoneOffsetJustBeforeSpringDST() {
+    ZoneId zoneId = ZoneId.of("Europe/Warsaw");
+    ZoneOffset offset = DateTimeUtils.toZoneOffset("2024-03-31 02:00:00", zoneId);
+    Assert.assertEquals(ZoneOffset.ofHours(1), offset);
+  }
+
+  @Test
+  public void testToZoneOffsetJustAfterSpringDST() {
+    ZoneId zoneId = ZoneId.of("Europe/Warsaw");
+    ZoneOffset offset = DateTimeUtils.toZoneOffset("2024-03-31 03:00:00", zoneId);
+    Assert.assertEquals(ZoneOffset.ofHours(2), offset);
+  }
+
+  @Test
+  public void testToZoneOffsetDuringSpringDSTGap() {
+    ZoneId zoneId = ZoneId.of("Europe/Warsaw");
+    ZoneOffset offset = DateTimeUtils.toZoneOffset("2024-03-31 02:30:00", zoneId);
+    Assert.assertEquals(ZoneOffset.ofHours(1), offset);
+  }
+
+  @Test
+  public void testToZoneOffsetDuringAutumnDSTTransition() {
+    ZoneId zoneId = ZoneId.of("Europe/Warsaw");
+    ZoneOffset offset = DateTimeUtils.toZoneOffset("2024-10-27 02:30:00", zoneId);
+    Assert.assertEquals(ZoneOffset.ofHours(2), offset);
+  }
+
+  @Test
+  public void testToZoneOffsetAfterAutumnDST() {
+    ZoneId zoneId = ZoneId.of("Europe/Warsaw");
+    ZoneOffset offset = DateTimeUtils.toZoneOffset("2024-10-27 03:00:00", zoneId);
+    Assert.assertEquals(ZoneOffset.ofHours(1), offset);
+  }
+
+  @Test
+  public void testToZoneOffsetWithExplicitOffsetInString() {
+    ZoneId zoneId = ZoneId.of("Europe/Warsaw");
+    ZoneOffset offset = DateTimeUtils.toZoneOffset("2024-06-15 12:00:00+02:00", zoneId);
+    Assert.assertEquals(ZoneOffset.ofHours(2), offset);
+    offset = DateTimeUtils.toZoneOffset("2024-06-15 12:00:00Z", zoneId);
+    Assert.assertEquals(ZoneOffset.UTC, offset);
+    offset = DateTimeUtils.toZoneOffset("2024-06-15 12:00:00-08:00", zoneId);
+    Assert.assertEquals(ZoneOffset.ofHours(-8), offset);
+  }
+
+  @Test
+  public void testToZoneOffsetWithUTCZoneId() {
+    ZoneId utc = ZoneId.of("UTC");
+    Assert.assertEquals(ZoneOffset.UTC, DateTimeUtils.toZoneOffset("2024-06-15 12:00:00", utc));
+  }
+
+  @Test
+  public void testToZoneOffsetWithBrokenDate() {
+    ZoneId zoneId = ZoneId.of("Europe/Warsaw");
+    DateTimeException exception =
+        assertThrows(
+            DateTimeException.class,
+            () -> {
+              DateTimeUtils.toZoneOffset("2024-12-31 10", zoneId);
+            });
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/DateTimeUtilsTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/DateTimeUtilsTest.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 
 import java.time.DateTimeException;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -378,15 +377,13 @@ public class DateTimeUtilsTest {
     Assert.assertEquals(10000000000L, timeDuration.nonMonthDuration);
   }
 
+  // Winter and summer tests are both required to catch regressions year-round.
   @Test
   public void convertWinterTimeShouldUseUtcPlus1() {
     ZoneId zoneId = ZoneId.of("Europe/Warsaw");
     long winter = DateTimeUtils.convertDatetimeStrToLong("2024-01-15 12:00:00", zoneId, "ms");
-    assertEquals(
-        ZonedDateTime.of(LocalDateTime.parse("2024-01-15T12:00:00"), zoneId)
-            .toInstant()
-            .toEpochMilli(),
-        winter);
+    long expected = ZonedDateTime.of(2024, 1, 15, 12, 0, 0, 0, zoneId).toInstant().toEpochMilli();
+    assertEquals(expected, winter);
   }
 
   @Test
@@ -397,6 +394,7 @@ public class DateTimeUtilsTest {
     assertEquals(expected, summer);
   }
 
+  // Before and after DST tests are both required to catch regressions year-round.
   @Test
   public void convertJustBeforeSpringDstShouldKeepWinterOffset() {
     ZoneId zoneId = ZoneId.of("Europe/Warsaw");
@@ -433,7 +431,6 @@ public class DateTimeUtilsTest {
   public void historicalDateBeforeStandardizedOffsetShouldUseLMT() {
     ZoneId shanghaiId = ZoneId.of("Asia/Shanghai");
     long oldTime = DateTimeUtils.convertDatetimeStrToLong("1900-01-01 00:00:00", shanghaiId, "ms");
-    ZoneOffset offset = shanghaiId.getRules().getOffset(Instant.ofEpochMilli(oldTime));
     long expected = ZonedDateTime.of(1900, 1, 1, 0, 0, 0, 0, shanghaiId).toInstant().toEpochMilli();
     assertEquals(expected, oldTime);
   }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/DateTimeUtilsTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/DateTimeUtilsTest.java
@@ -30,12 +30,13 @@ import org.junit.Test;
 
 import java.time.DateTimeException;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 public class DateTimeUtilsTest {
@@ -86,11 +87,11 @@ public class DateTimeUtilsTest {
   public void convertDatetimeStrToLongTest4() {
     zoneOffset = ZoneOffset.UTC;
     try {
-      DateTimeUtils.convertDatetimeStrToLong("1999-02-29T00:00:00.000", zoneOffset, 0, "ms");
+      DateTimeUtils.convertDatetimeStrToLong("1999-02-29T00:00:00.000", (ZoneId) zoneOffset, "ms");
       fail();
     } catch (Exception e) {
       assertEquals(
-          "Text '1999-02-29T00:00:00.000+00:00' could not be parsed: Invalid date 'February 29' as '1999' is not a leap year",
+          "Text '1999-02-29T00:00:00.000' could not be parsed: Invalid date 'February 29' as '1999' is not a leap year",
           e.getMessage());
     }
   }
@@ -260,7 +261,8 @@ public class DateTimeUtilsTest {
           "2019.01.02T15:13:27" + zoneOffset,
         };
     for (String str : timeFormatWithoutMs) {
-      Assert.assertEquals(res, DateTimeUtils.convertDatetimeStrToLong(str, zoneOffset, 0, "ms"));
+      Assert.assertEquals(
+          res, DateTimeUtils.convertDatetimeStrToLong(str, (ZoneId) zoneOffset, "ms"));
     }
 
     for (String str : timeFormatWithoutMs) {
@@ -285,7 +287,7 @@ public class DateTimeUtilsTest {
           "2019.01.02T15:13:27.689" + zoneOffset,
         };
     for (String str : timeFormatWithoutMs) {
-      assertEquals(res, DateTimeUtils.convertDatetimeStrToLong(str, zoneOffset, 0, "ms"));
+      assertEquals(res, DateTimeUtils.convertDatetimeStrToLong(str, (ZoneId) zoneOffset, "ms"));
     }
 
     for (String str : timeFormatWithoutMs) {
@@ -324,7 +326,7 @@ public class DateTimeUtilsTest {
           "2019.01.02T15:13:27.68" + zoneOffset,
         };
     for (String str : timeFormatWithoutMs) {
-      assertEquals(res, DateTimeUtils.convertDatetimeStrToLong(str, zoneOffset, 0, "ms"));
+      assertEquals(res, DateTimeUtils.convertDatetimeStrToLong(str, (ZoneId) zoneOffset, "ms"));
     }
 
     for (String str : timeFormatWithoutMs) {
@@ -338,7 +340,7 @@ public class DateTimeUtilsTest {
           "2019-01-02", "2019/01/02", "2019.01.02",
         };
     for (String str : timeFormatWithoutMs) {
-      assertEquals(res, DateTimeUtils.convertDatetimeStrToLong(str, zoneOffset, 0, "ms"));
+      assertEquals(res, DateTimeUtils.convertDatetimeStrToLong(str, (ZoneId) zoneOffset, "ms"));
     }
 
     for (String str : timeFormatWithoutMs) {
@@ -377,93 +379,171 @@ public class DateTimeUtilsTest {
   }
 
   @Test
-  public void testToZoneOffsetForWinterTime() {
+  public void convertWinterTimeShouldUseUtcPlus1() {
     ZoneId zoneId = ZoneId.of("Europe/Warsaw");
-    ZoneOffset offset = DateTimeUtils.toZoneOffset("2024-01-15 12:00:00", zoneId);
-    Assert.assertEquals(ZoneOffset.ofHours(1), offset);
+    long winter = DateTimeUtils.convertDatetimeStrToLong("2024-01-15 12:00:00", zoneId, "ms");
+    assertEquals(
+        ZonedDateTime.of(LocalDateTime.parse("2024-01-15T12:00:00"), zoneId)
+            .toInstant()
+            .toEpochMilli(),
+        winter);
   }
 
   @Test
-  public void testToZoneOffsetForSummerTime() {
+  public void convertSummerTimeShouldUseUtcPlus2() {
     ZoneId zoneId = ZoneId.of("Europe/Warsaw");
-    ZoneOffset offset = DateTimeUtils.toZoneOffset("2024-06-15 12:00:00", zoneId);
-    Assert.assertEquals(ZoneOffset.ofHours(2), offset);
+    long summer = DateTimeUtils.convertDatetimeStrToLong("2024-06-15 12:00:00", zoneId, "ms");
+    long expected = ZonedDateTime.of(2024, 6, 15, 12, 0, 0, 0, zoneId).toInstant().toEpochMilli();
+    assertEquals(expected, summer);
   }
 
   @Test
-  public void testToZoneOffsetJustBeforeSpringDST() {
+  public void convertJustBeforeSpringDstShouldKeepWinterOffset() {
     ZoneId zoneId = ZoneId.of("Europe/Warsaw");
-    ZoneOffset offset = DateTimeUtils.toZoneOffset("2024-03-31 02:00:00", zoneId);
-    Assert.assertEquals(ZoneOffset.ofHours(1), offset);
+    long before = DateTimeUtils.convertDatetimeStrToLong("2024-03-31 01:59:59", zoneId, "ms");
+    long expected = ZonedDateTime.of(2024, 3, 31, 1, 59, 59, 0, zoneId).toInstant().toEpochMilli();
+    assertEquals(expected, before);
   }
 
   @Test
-  public void testToZoneOffsetJustAfterSpringDST() {
+  public void convertJustAfterSpringDstShouldUseSummerOffset() {
     ZoneId zoneId = ZoneId.of("Europe/Warsaw");
-    ZoneOffset offset = DateTimeUtils.toZoneOffset("2024-03-31 03:00:00", zoneId);
-    Assert.assertEquals(ZoneOffset.ofHours(2), offset);
+    long after = DateTimeUtils.convertDatetimeStrToLong("2024-03-31 03:00:00", zoneId, "ms");
+    long expected = ZonedDateTime.of(2024, 3, 31, 3, 0, 0, 0, zoneId).toInstant().toEpochMilli();
+    assertEquals(expected, after);
   }
 
   @Test
-  public void testToZoneOffsetDuringSpringDSTGap() {
+  public void convertAutumnOverlapShouldResolveToEarlierOffset() {
     ZoneId zoneId = ZoneId.of("Europe/Warsaw");
-    ZoneOffset offset = DateTimeUtils.toZoneOffset("2024-03-31 02:30:00", zoneId);
-    Assert.assertEquals(ZoneOffset.ofHours(1), offset);
+    long overlap = DateTimeUtils.convertDatetimeStrToLong("2024-10-27 02:30:00", zoneId, "ms");
+    long expected = ZonedDateTime.of(2024, 10, 27, 2, 30, 0, 0, zoneId).toInstant().toEpochMilli();
+    assertEquals(expected, overlap);
   }
 
   @Test
-  public void testToZoneOffsetDuringAutumnDSTTransition() {
+  public void convertAfterAutumnTransitionShouldUseWinterOffset() {
     ZoneId zoneId = ZoneId.of("Europe/Warsaw");
-    ZoneOffset offset = DateTimeUtils.toZoneOffset("2024-10-27 02:30:00", zoneId);
-    Assert.assertEquals(ZoneOffset.ofHours(2), offset);
+    long after = DateTimeUtils.convertDatetimeStrToLong("2024-10-27 03:00:00", zoneId, "ms");
+    long expected = ZonedDateTime.of(2024, 10, 27, 3, 0, 0, 0, zoneId).toInstant().toEpochMilli();
+    assertEquals(expected, after);
   }
 
   @Test
-  public void testToZoneOffsetAfterAutumnDST() {
-    ZoneId zoneId = ZoneId.of("Europe/Warsaw");
-    ZoneOffset offset = DateTimeUtils.toZoneOffset("2024-10-27 03:00:00", zoneId);
-    Assert.assertEquals(ZoneOffset.ofHours(1), offset);
-  }
-
-  @Test
-  public void testToZoneOffsetWithExplicitOffsetInString() {
-    ZoneId zoneId = ZoneId.of("Europe/Warsaw");
-    ZoneOffset offset = DateTimeUtils.toZoneOffset("2024-06-15 12:00:00+02:00", zoneId);
-    Assert.assertEquals(ZoneOffset.ofHours(2), offset);
-    offset = DateTimeUtils.toZoneOffset("2024-06-15 12:00:00Z", zoneId);
-    Assert.assertEquals(ZoneOffset.UTC, offset);
-    offset = DateTimeUtils.toZoneOffset("2024-06-15 12:00:00-08:00", zoneId);
-    Assert.assertEquals(ZoneOffset.ofHours(-8), offset);
-  }
-
-  @Test
-  public void testToZoneOffsetWithUTCZoneId() {
-    ZoneId utc = ZoneId.of("UTC");
-    Assert.assertEquals(ZoneOffset.UTC, DateTimeUtils.toZoneOffset("2024-06-15 12:00:00", utc));
-  }
-
-  @Test
-  public void testToZoneOffsetWithBrokenDate() {
-    ZoneId zoneId = ZoneId.of("Europe/Warsaw");
-    DateTimeException exception =
-        assertThrows(
-            DateTimeException.class,
-            () -> {
-              DateTimeUtils.toZoneOffset("2024-12-31 10", zoneId);
-            });
-  }
-
-  @Test
-  public void testToZoneOffsetHistoricalLMT() {
-    ZoneId zoneId = ZoneId.of("Europe/Warsaw");
-    ZoneOffset offset = DateTimeUtils.toZoneOffset("0001-01-01 00:00:00", zoneId);
-    Assert.assertEquals(ZoneOffset.ofHoursMinutes(1, 24), offset);
-
+  public void historicalDateBeforeStandardizedOffsetShouldUseLMT() {
     ZoneId shanghaiId = ZoneId.of("Asia/Shanghai");
-    ZoneOffset shanghaiOffset = DateTimeUtils.toZoneOffset("0001-01-01 00:00:00", shanghaiId);
-    Assert.assertEquals(ZoneOffset.ofHoursMinutes(8, 5), shanghaiOffset);
+    long oldTime = DateTimeUtils.convertDatetimeStrToLong("1900-01-01 00:00:00", shanghaiId, "ms");
+    ZoneOffset offset = shanghaiId.getRules().getOffset(Instant.ofEpochMilli(oldTime));
+    long expected = ZonedDateTime.of(1900, 1, 1, 0, 0, 0, 0, shanghaiId).toInstant().toEpochMilli();
+    assertEquals(expected, oldTime);
+  }
 
-    ZoneId utcId = ZoneId.of("UTC");
-    Assert.assertEquals(ZoneOffset.UTC, DateTimeUtils.toZoneOffset("0001-01-01 00:00:00", utcId));
+  @Test
+  public void explicitOffsetInStringOverridesZoneId() {
+    ZoneId zoneId = ZoneId.of("Europe/Warsaw");
+    long withMs = DateTimeUtils.convertDatetimeStrToLong("2024-06-15 12:00:00Z", zoneId, "ms");
+    long withoutMs = DateTimeUtils.convertDatetimeStrToLong("2024-06-15 14:00:00", zoneId, "ms");
+    assertEquals(withoutMs, withMs);
+
+    long withUs =
+        DateTimeUtils.convertDatetimeStrToLong("2024-06-15 12:00:00.123456Z", zoneId, "us");
+    long withoutUs =
+        DateTimeUtils.convertDatetimeStrToLong("2024-06-15 14:00:00.123456", zoneId, "us");
+    assertEquals(withoutUs, withUs);
+
+    long withNs =
+        DateTimeUtils.convertDatetimeStrToLong("2024-06-15 12:00:00.123456789Z", zoneId, "ns");
+    long withoutNs =
+        DateTimeUtils.convertDatetimeStrToLong("2024-06-15 14:00:00.123456789", zoneId, "ns");
+    assertEquals(withoutNs, withNs);
+  }
+
+  @Test
+  public void springGapShouldShiftForwardInWarsaw() {
+    ZoneId zoneId = ZoneId.of("Europe/Warsaw");
+    long gap = DateTimeUtils.convertDatetimeStrToLong("2024-03-31 02:30:00", zoneId, "ms");
+    long expected = ZonedDateTime.of(2024, 3, 31, 2, 30, 0, 0, zoneId).toInstant().toEpochMilli();
+    assertEquals(expected, gap);
+    long expectedMoved =
+        ZonedDateTime.of(2024, 3, 31, 3, 30, 0, 0, zoneId).toInstant().toEpochMilli();
+    assertEquals(expectedMoved, gap);
+  }
+
+  @Test
+  public void shouldAcceptOneDigitMonthAndDayWithSpace() {
+    ZoneId zoneId = ZoneId.systemDefault();
+    long result = DateTimeUtils.convertDatetimeStrToLong("2024-6-5 12:00:00", zoneId, "ms");
+    long expected = ZonedDateTime.of(2024, 6, 5, 12, 0, 0, 0, zoneId).toInstant().toEpochMilli();
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void shouldAcceptOneDigitMonthAndDayWithSpaceAndOffset() {
+    ZoneId zoneId = ZoneId.systemDefault();
+    long result = DateTimeUtils.convertDatetimeStrToLong("2024-6-5 12:00:00+02:00", zoneId, "ms");
+    long expected =
+        ZonedDateTime.of(2024, 6, 5, 12, 0, 0, 0, ZoneOffset.ofHours(2)).toInstant().toEpochMilli();
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void shouldParseLowercaseZAsUtc() {
+    ZoneId sessionZone = ZoneId.of("Europe/Warsaw");
+    long result = DateTimeUtils.convertDatetimeStrToLong("2024-06-15 12:00:00z", sessionZone, "ms");
+    long expected =
+        ZonedDateTime.of(2024, 6, 15, 12, 0, 0, 0, ZoneOffset.UTC).toInstant().toEpochMilli();
+    assertEquals(expected, result);
+  }
+
+  @Test(expected = DateTimeException.class)
+  public void shouldRejectNegativeYearWithSpace() {
+    DateTimeUtils.convertDatetimeStrToLong(
+        "-0004-06-15 12:00:00", ZoneId.of("Europe/Warsaw"), "ms");
+  }
+
+  @Test(expected = DateTimeException.class)
+  public void shouldRejectNegativeYearWithSpaceAndOffset() {
+    DateTimeUtils.convertDatetimeStrToLong(
+        "-0004-06-15 12:00:00+01:00", ZoneId.of("Europe/Warsaw"), "ms");
+  }
+
+  @Test
+  public void shouldAcceptLowercaseTWithSpace() {
+    ZoneId zoneId = ZoneId.of("Europe/Warsaw");
+    long result = DateTimeUtils.convertDatetimeStrToLong("2024-06-15t12:00:00", zoneId, "ms");
+    long expected = ZonedDateTime.of(2024, 6, 15, 12, 0, 0, 0, zoneId).toInstant().toEpochMilli();
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void shouldAcceptFiveDigitYearWithSpace() {
+    ZoneId zoneId = ZoneId.of("Europe/Warsaw");
+    long result = DateTimeUtils.convertDatetimeStrToLong("12024-06-15 12:00:00", zoneId, "ms");
+    long expected = ZonedDateTime.of(12024, 6, 15, 12, 0, 0, 0, zoneId).toInstant().toEpochMilli();
+    assertEquals(expected, result);
+  }
+
+  @Test(expected = DateTimeException.class)
+  public void shouldRejectPositiveSignedYearWithSpace() {
+    DateTimeUtils.convertDatetimeStrToLong(
+        "+12024-06-15 12:00:00", ZoneId.of("Europe/Warsaw"), "ms");
+  }
+
+  @Test(expected = DateTimeException.class)
+  public void shouldRejectPositiveSignedYearWithSpaceAndOffset() {
+    DateTimeUtils.convertDatetimeStrToLong(
+        "+12024-06-15 12:00:00+02:00", ZoneId.of("Europe/Warsaw"), "ms");
+  }
+
+  @Test
+  public void explicitPositiveOffsetInStringShouldOverrideZoneId() {
+    ZoneId zoneId = ZoneId.of("Europe/Warsaw");
+    long withOffset =
+        DateTimeUtils.convertDatetimeStrToLong("2024-06-15 12:00:00+04:00", zoneId, "ms");
+    long expected =
+        ZonedDateTime.of(2024, 6, 15, 12, 0, 0, 0, ZoneOffset.ofHours(4))
+            .toInstant()
+            .toEpochMilli();
+    assertEquals(expected, withOffset);
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/DateTimeUtilsTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/DateTimeUtilsTest.java
@@ -543,4 +543,18 @@ public class DateTimeUtilsTest {
             .toEpochMilli();
     assertEquals(expected, withOffset);
   }
+
+  @Test
+  public void shouldConvertBareDateWithoutTime() {
+    ZoneId zoneId = ZoneId.of("Europe/Warsaw");
+
+    String[] bareDates = new String[] {"2014-04-04", "2014-4-4", "2014/4/4", "2014.4.4"};
+
+    long expected = ZonedDateTime.of(2014, 4, 4, 0, 0, 0, 0, zoneId).toInstant().toEpochMilli();
+
+    for (String dateStr : bareDates) {
+      long result = DateTimeUtils.convertDatetimeStrToLong(dateStr, zoneId, "ms");
+      Assert.assertEquals("Failed to parse bare date: " + dateStr, expected, result);
+    }
+  }
 }

--- a/iotdb-core/node-commons/src/main/i18n/en/org/apache/iotdb/commons/i18n/QueryMessages.java
+++ b/iotdb-core/node-commons/src/main/i18n/en/org/apache/iotdb/commons/i18n/QueryMessages.java
@@ -227,8 +227,6 @@ public final class QueryMessages {
       "ExtractTimestampUsPart is null";
   public static final String EXTRACT_TIMESTAMP_NS_PART_NULL =
       "ExtractTimestampNsPart is null";
-  public static final String DATETIME_CONVERT_FAILED =
-      "Failed to convert %s to millisecond, zone offset is %s, please input like 2011-12-03T10:15:30 or 2011-12-03T10:15:30+01:00";
   public static final String DATETIME_TIME_REGION_NOT_SUPPORTED =
       "%s with [time-region] at end is not supported now, please input like 2011-12-03T10:15:30 or 2011-12-03T10:15:30+01:00";
   public static final String UNSUPPORTED_TIME_PRECISION =

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/queryengine/utils/DateTimeUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/queryengine/utils/DateTimeUtils.java
@@ -655,6 +655,7 @@ public class DateTimeUtils {
     return ZonedDateTime.ofInstant(Instant.ofEpochMilli(timestamp), zoneId);
   }
 
+  /** Converts string to ZoneOffset. Truncates seconds for HH:mm database compatibility. */
   public static ZoneOffset toZoneOffset(String str, ZoneId zoneId) {
     if (str.endsWith("Z")) {
       return ZoneOffset.UTC;
@@ -668,7 +669,8 @@ public class DateTimeUtils {
     long millis = convertDatetimeStrToLong(str, ZoneOffset.UTC, 0, "ms");
     LocalDateTime localDateTime =
         LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneOffset.UTC);
-    return zoneId.getRules().getOffset(localDateTime);
+    ZoneOffset offset = zoneId.getRules().getOffset(localDateTime);
+    return ZoneOffset.ofTotalSeconds((offset.getTotalSeconds() / 60) * 60);
   }
 
   public static ZonedDateTime convertMillsecondToZonedDateTime(long millisecond) {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/queryengine/utils/DateTimeUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/queryengine/utils/DateTimeUtils.java
@@ -550,14 +550,14 @@ public class DateTimeUtils {
   public static long convertDatetimeStrToLong(String str, ZoneId zoneId) {
     return convertDatetimeStrToLong(
         str,
-        toZoneOffset(zoneId),
+        toZoneOffset(str, zoneId),
         0,
         CommonDescriptor.getInstance().getConfig().getTimestampPrecision());
   }
 
   public static long convertDatetimeStrToLong(
       String str, ZoneId zoneId, String timestampPrecision) {
-    return convertDatetimeStrToLong(str, toZoneOffset(zoneId), 0, timestampPrecision);
+    return convertDatetimeStrToLong(str, toZoneOffset(str, zoneId), 0, timestampPrecision);
   }
 
   public static long getInstantWithPrecision(String str, String timestampPrecision) {
@@ -655,8 +655,20 @@ public class DateTimeUtils {
     return ZonedDateTime.ofInstant(Instant.ofEpochMilli(timestamp), zoneId);
   }
 
-  public static ZoneOffset toZoneOffset(ZoneId zoneId) {
-    return zoneId.getRules().getOffset(Instant.now());
+  public static ZoneOffset toZoneOffset(String str, ZoneId zoneId) {
+    if (str.endsWith("Z")) {
+      return ZoneOffset.UTC;
+    }
+
+    int offsetIndex = Math.max(str.lastIndexOf('+'), str.lastIndexOf('-'));
+    if (offsetIndex != -1 && str.length() - offsetIndex == 6) {
+      return ZoneOffset.of(str.substring(offsetIndex));
+    }
+
+    long millis = convertDatetimeStrToLong(str, ZoneOffset.UTC, 0, "ms");
+    LocalDateTime localDateTime =
+        LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneOffset.UTC);
+    return zoneId.getRules().getOffset(localDateTime);
   }
 
   public static ZonedDateTime convertMillsecondToZonedDateTime(long millisecond) {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/queryengine/utils/DateTimeUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/queryengine/utils/DateTimeUtils.java
@@ -29,6 +29,7 @@ import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -37,6 +38,7 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.ResolverStyle;
 import java.time.format.SignStyle;
 import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -359,7 +361,7 @@ public class DateTimeUtils {
     ISO_OFFSET_DATE_TIME_WITH_SPACE =
         new DateTimeFormatterBuilder()
             .parseCaseInsensitive()
-            .append(DateTimeFormatter.ISO_LOCAL_DATE)
+            .append(ISO_LOCAL_DATE_WIDTH_1_2)
             .appendLiteral(' ')
             .append(ISO_LOCAL_TIME_WITH_MS)
             .appendOffsetId()
@@ -373,7 +375,7 @@ public class DateTimeUtils {
     ISO_OFFSET_DATE_TIME_WITH_SPACE_US =
         new DateTimeFormatterBuilder()
             .parseCaseInsensitive()
-            .append(DateTimeFormatter.ISO_LOCAL_DATE)
+            .append(ISO_LOCAL_DATE_WIDTH_1_2)
             .appendLiteral(' ')
             .append(ISO_LOCAL_TIME_WITH_US)
             .appendOffsetId()
@@ -387,7 +389,7 @@ public class DateTimeUtils {
     ISO_OFFSET_DATE_TIME_WITH_SPACE_NS =
         new DateTimeFormatterBuilder()
             .parseCaseInsensitive()
-            .append(DateTimeFormatter.ISO_LOCAL_DATE)
+            .append(ISO_LOCAL_DATE_WIDTH_1_2)
             .appendLiteral(' ')
             .append(ISO_LOCAL_TIME_WITH_NS)
             .appendOffsetId()
@@ -478,6 +480,63 @@ public class DateTimeUtils {
             .toFormatter();
   }
 
+  private static final DateTimeFormatter ISO_LOCAL_DATE_TIME_WITH_NS_T;
+  private static final DateTimeFormatter ISO_LOCAL_DATE_TIME_WITH_SLASH_NS_T;
+  private static final DateTimeFormatter ISO_LOCAL_DATE_TIME_WITH_DOT_NS_T;
+  private static final DateTimeFormatter ISO_LOCAL_DATE_TIME_WITH_NS_SPACE;
+  private static final DateTimeFormatter ISO_LOCAL_DATE_TIME_WITH_SLASH_NS_SPACE;
+  private static final DateTimeFormatter ISO_LOCAL_DATE_TIME_WITH_DOT_NS_SPACE;
+
+  static {
+    ISO_LOCAL_DATE_TIME_WITH_NS_T =
+        new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(ISO_LOCAL_DATE_WIDTH_1_2)
+            .appendLiteral('T')
+            .append(ISO_LOCAL_TIME_WITH_NS)
+            .toFormatter();
+
+    ISO_LOCAL_DATE_TIME_WITH_SLASH_NS_T =
+        new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(ISO_LOCAL_DATE_WITH_SLASH)
+            .appendLiteral('T')
+            .append(ISO_LOCAL_TIME_WITH_NS)
+            .toFormatter();
+
+    ISO_LOCAL_DATE_TIME_WITH_DOT_NS_T =
+        new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(ISO_LOCAL_DATE_WITH_DOT)
+            .appendLiteral('T')
+            .append(ISO_LOCAL_TIME_WITH_NS)
+            .toFormatter();
+
+    ISO_LOCAL_DATE_TIME_WITH_NS_SPACE =
+        new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(ISO_LOCAL_DATE_WIDTH_1_2)
+            .appendLiteral(' ')
+            .append(ISO_LOCAL_TIME_WITH_NS)
+            .toFormatter();
+
+    ISO_LOCAL_DATE_TIME_WITH_SLASH_NS_SPACE =
+        new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(ISO_LOCAL_DATE_WITH_SLASH)
+            .appendLiteral(' ')
+            .append(ISO_LOCAL_TIME_WITH_NS)
+            .toFormatter();
+
+    ISO_LOCAL_DATE_TIME_WITH_DOT_NS_SPACE =
+        new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(ISO_LOCAL_DATE_WITH_DOT)
+            .appendLiteral(' ')
+            .append(ISO_LOCAL_TIME_WITH_NS)
+            .toFormatter();
+  }
+
   public static final DateTimeFormatter formatter =
       new DateTimeFormatterBuilder()
           /**
@@ -536,6 +595,12 @@ public class DateTimeUtils {
 
           /** such as '2011.12.03 10:15:30+01:00' or '2011.12.03 10:15:30.123456789+01:00'. */
           .appendOptional(ISO_OFFSET_DATE_TIME_WITH_DOT_WITH_SPACE_NS)
+          .appendOptional(ISO_LOCAL_DATE_TIME_WITH_NS_T)
+          .appendOptional(ISO_LOCAL_DATE_TIME_WITH_SLASH_NS_T)
+          .appendOptional(ISO_LOCAL_DATE_TIME_WITH_DOT_NS_T)
+          .appendOptional(ISO_LOCAL_DATE_TIME_WITH_NS_SPACE)
+          .appendOptional(ISO_LOCAL_DATE_TIME_WITH_SLASH_NS_SPACE)
+          .appendOptional(ISO_LOCAL_DATE_TIME_WITH_DOT_NS_SPACE)
           .toFormatter()
           .withResolverStyle(ResolverStyle.STRICT);
 
@@ -547,22 +612,33 @@ public class DateTimeUtils {
     }
   }
 
+  /**
+   * @deprecated The {@code depth} parameter is ignored. Use {@link
+   *     #convertDatetimeStrToLong(String, ZoneId, String)} instead.
+   */
+  @Deprecated
+  public static long convertDatetimeStrToLong(
+      String str, ZoneOffset offset, int depth, String timestampPrecision) {
+    return convertDatetimeStrToLong(str, (ZoneId) offset, timestampPrecision);
+  }
+
   public static long convertDatetimeStrToLong(String str, ZoneId zoneId) {
     return convertDatetimeStrToLong(
-        str,
-        toZoneOffset(str, zoneId),
-        0,
-        CommonDescriptor.getInstance().getConfig().getTimestampPrecision());
+        str, zoneId, CommonDescriptor.getInstance().getConfig().getTimestampPrecision());
   }
 
-  public static long convertDatetimeStrToLong(
-      String str, ZoneId zoneId, String timestampPrecision) {
-    return convertDatetimeStrToLong(str, toZoneOffset(str, zoneId), 0, timestampPrecision);
+  public static long getInstantWithPrecision(String str, String timestampPrecision, ZoneId zoneId) {
+    TemporalAccessor parsed = formatter.parseBest(str, OffsetDateTime::from, LocalDateTime::from);
+    Instant instant;
+    if (parsed instanceof OffsetDateTime) {
+      instant = ((OffsetDateTime) parsed).toInstant();
+    } else {
+      instant = ((LocalDateTime) parsed).atZone(zoneId).toInstant();
+    }
+    return getInstantWithPrecision(instant, timestampPrecision);
   }
 
-  public static long getInstantWithPrecision(String str, String timestampPrecision) {
-    ZonedDateTime zonedDateTime = ZonedDateTime.parse(str, formatter);
-    Instant instant = zonedDateTime.toInstant();
+  public static long getInstantWithPrecision(Instant instant, String timestampPrecision) {
     if ("us".equals(timestampPrecision) || "microsecond".equals(timestampPrecision)) {
       if (instant.getEpochSecond() < 0 && instant.getNano() > 0) {
         // adjustment can reduce the loss of the division
@@ -582,24 +658,17 @@ public class DateTimeUtils {
 
   /** convert date time string to millisecond, microsecond or nanosecond. */
   public static long convertDatetimeStrToLong(
-      String str, ZoneOffset offset, int depth, String timestampPrecision) {
-    if (depth >= 2) {
-      throw new DateTimeException(
-          String.format(QueryMessages.DATETIME_CONVERT_FAILED, str, offset));
-    }
+      String str, ZoneId zoneId, String timestampPrecision) {
     if (str.contains("Z")) {
       return convertDatetimeStrToLong(
-          str.substring(0, str.indexOf('Z')) + "+00:00", offset, depth, timestampPrecision);
+          str.substring(0, str.indexOf('Z')) + "+00:00", zoneId, timestampPrecision);
     } else if (str.length() == 10) {
-      return convertDatetimeStrToLong(str + "T00:00:00", offset, depth, timestampPrecision);
-    } else if (str.length() - str.lastIndexOf('+') != 6
-        && str.length() - str.lastIndexOf('-') != 6) {
-      return convertDatetimeStrToLong(str + offset, offset, depth + 1, timestampPrecision);
+      return convertDatetimeStrToLong(str + "T00:00:00", zoneId, timestampPrecision);
     } else if (str.contains("[") || str.contains("]")) {
       throw new DateTimeException(
           String.format(QueryMessages.DATETIME_TIME_REGION_NOT_SUPPORTED, str));
     }
-    return getInstantWithPrecision(str, timestampPrecision);
+    return getInstantWithPrecision(str, timestampPrecision, zoneId);
   }
 
   public static TimeUnit timestampPrecisionStringToTimeUnit(String timestampPrecision) {
@@ -653,24 +722,6 @@ public class DateTimeUtils {
   public static ZonedDateTime convertToZonedDateTime(long timestamp, ZoneId zoneId) {
     timestamp = castTimestampToMs.apply(timestamp);
     return ZonedDateTime.ofInstant(Instant.ofEpochMilli(timestamp), zoneId);
-  }
-
-  /** Converts string to ZoneOffset. Truncates seconds for HH:mm database compatibility. */
-  public static ZoneOffset toZoneOffset(String str, ZoneId zoneId) {
-    if (str.endsWith("Z")) {
-      return ZoneOffset.UTC;
-    }
-
-    int offsetIndex = Math.max(str.lastIndexOf('+'), str.lastIndexOf('-'));
-    if (offsetIndex != -1 && str.length() - offsetIndex == 6) {
-      return ZoneOffset.of(str.substring(offsetIndex));
-    }
-
-    long millis = convertDatetimeStrToLong(str, ZoneOffset.UTC, 0, "ms");
-    LocalDateTime localDateTime =
-        LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneOffset.UTC);
-    ZoneOffset offset = zoneId.getRules().getOffset(localDateTime);
-    return ZoneOffset.ofTotalSeconds((offset.getTotalSeconds() / 60) * 60);
   }
 
   public static ZonedDateTime convertMillsecondToZonedDateTime(long millisecond) {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/queryengine/utils/DateTimeUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/queryengine/utils/DateTimeUtils.java
@@ -31,7 +31,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -610,16 +609,6 @@ public class DateTimeUtils {
     } catch (NumberFormatException e) {
       return DateTimeUtils.convertDatetimeStrToLong(timeStr, ZoneId.systemDefault());
     }
-  }
-
-  /**
-   * @deprecated The {@code depth} parameter is ignored. Use {@link
-   *     #convertDatetimeStrToLong(String, ZoneId, String)} instead.
-   */
-  @Deprecated
-  public static long convertDatetimeStrToLong(
-      String str, ZoneOffset offset, int depth, String timestampPrecision) {
-    return convertDatetimeStrToLong(str, (ZoneId) offset, timestampPrecision);
   }
 
   public static long convertDatetimeStrToLong(String str, ZoneId zoneId) {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/queryengine/utils/DateTimeUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/queryengine/utils/DateTimeUtils.java
@@ -651,7 +651,7 @@ public class DateTimeUtils {
     if (str.contains("Z")) {
       return convertDatetimeStrToLong(
           str.substring(0, str.indexOf('Z')) + "+00:00", zoneId, timestampPrecision);
-    } else if (str.length() == 10) {
+    } else if (!str.contains(":")) {
       return convertDatetimeStrToLong(str + "T00:00:00", zoneId, timestampPrecision);
     } else if (str.contains("[") || str.contains("]")) {
       throw new DateTimeException(


### PR DESCRIPTION
## Description

Refactored DateTimeUtils.toZoneOffset to calculate the timezone offset based on the provided string instead of the current system time (Instant.now()).
Added comprehensive unit tests in DateTimeUtilsTest to cover DST transitions.
Fixes #17433

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
