### PR TITLE
Ignore claude code related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ iotdb-core/tsfile/src/main/antlr4/org/apache/tsfile/parser/gen/
 
 # Relational Grammar ANTLR
 iotdb-core/relational-grammar/src/main/antlr4/org/apache/iotdb/db/relational/grammar/sql/.antlr/
+
+.claude/
+CLAUDE.md
+.worktreeinclude

--- a/iotdb-core/relational-grammar/pom.xml
+++ b/iotdb-core/relational-grammar/pom.xml
@@ -96,8 +96,12 @@
                 <configuration>
                     <consoleOutput>true</consoleOutput>
                     <excludes combine.children="append">
-                        <exclude>**/SqlLexer.java</exclude>
-                        <exclude>**/SqlLexer.interp</exclude>
+                        <exclude>**/RelationalSqlParser.java</exclude>
+                        <exclude>**/RelationalSqlLexer.java</exclude>
+                        <exclude>**/RelationalSqlLexer.interp</exclude>
+                        <exclude>**/RelationalSql.interp</exclude>
+                        <exclude>**/RelationalSqlBaseListener.java</exclude>
+                        <exclude>**/RelationalSqlListener.java</exclude>
                     </excludes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
This pull request updates the test exclusion list in the `pom.xml` configuration for the `iotdb-core/relational-grammar` module. The change ensures that the correct generated files for the relational SQL grammar are excluded from certain plugin operations, likely to prevent unnecessary processing or test runs on these files.

Test configuration updates:

* Updated the `<excludes>` section to exclude all relevant generated files for the relational SQL grammar, replacing previous exclusions for `SqlLexer` files with new exclusions for `RelationalSqlParser.java`, `RelationalSqlLexer.java`, `RelationalSqlLexer.interp`, `RelationalSql.interp`, `RelationalSqlBaseListener.java`, and `RelationalSqlListener.java`.