### PR TITLE
Add Claude Code project config and refine .gitignore

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; echo \"$f\" | grep -q '\\.java$' && mvn spotless:apply -f \"$(git rev-parse --show-toplevel)/pom.xml\" -DspotlessFiles=\"$(echo \"$f\" | sed 's/[.[\\\\/^$|?*+(){}]/\\\\&/g')\" -q || true; }",
+            "timeout": 30,
+            "statusMessage": "Running spotless format..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,8 @@ iotdb-core/tsfile/src/main/antlr4/org/apache/tsfile/parser/gen/
 # Relational Grammar ANTLR
 iotdb-core/relational-grammar/src/main/antlr4/org/apache/iotdb/db/relational/grammar/sql/.antlr/
 
-.claude/
-CLAUDE.md
-.worktreeinclude
+# Claude Code
+.claude/settings.local.json
+.claude/todos/
+.claude/worktrees/
+.claude/scheduled_tasks.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,24 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
 # CLAUDE.md
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ To run integration tests from IntelliJ: enable the `with-integration-tests` prof
 
 ## Code Style
 
+- **Apache License header**: Every new file committed to the repository MUST include the Apache License 2.0 header. Use the comment syntax appropriate for the file type (e.g., `<!-- -->` for `.md`, `/* */` for `.java`, `#` for `.properties`/`.py`). JSON files are exempt (no comment syntax). Refer to existing files in the repo for the exact format.
 - **Spotless** with Google Java Format (GOOGLE style). Import order: `org.apache.iotdb`, blank, `javax`, `java`, static.
 - **Checkstyle** is also configured (see `checkstyle.xml` at project root).
 - Java source/target level is 1.8 (compiled with `maven.compiler.release=8` on JDK 9+).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,158 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Apache IoTDB is a time series database for IoT data. It uses a distributed architecture with ConfigNodes (metadata/coordination) and DataNodes (storage/query). Data is stored in TsFile columnar format (separate repo: https://github.com/apache/tsfile). Current version is 2.0.7-SNAPSHOT.
+
+## Build Commands
+
+```bash
+# Full build (skip tests)
+mvn clean package -pl distribution -am -DskipTests
+
+# Build a specific module (e.g., datanode)
+mvn clean package -pl iotdb-core/datanode -am -DskipTests
+
+# Run unit tests for a specific module
+mvn clean test -pl iotdb-core/datanode
+
+# Run a single test class
+mvn clean test -pl iotdb-core/datanode -Dtest=ClassName
+
+# Run a single test method
+mvn clean test -pl iotdb-core/datanode -Dtest=ClassName#methodName
+
+# Format code (requires JDK 17+; auto-skipped on JDK <17)
+mvn spotless:apply
+
+# Format code in integration-test module
+mvn spotless:apply -P with-integration-tests
+
+# Check formatting without applying
+mvn spotless:check
+```
+
+## Integration Tests
+
+Integration tests live in `integration-test/` (not included in default build). They require the `with-integration-tests` profile:
+
+```bash
+# Build template-node first (needed once, or after code changes)
+mvn clean package -DskipTests -pl integration-test -am -P with-integration-tests
+
+# Run tree-model ITs (simple: 1 ConfigNode + 1 DataNode)
+mvn clean verify -DskipUTs -pl integration-test -am -P with-integration-tests
+
+# Run tree-model ITs (cluster: 1 ConfigNode + 3 DataNodes)
+mvn clean verify -DskipUTs -pl integration-test -am -PClusterIT -P with-integration-tests
+
+# Run table-model ITs (simple)
+mvn clean verify -DskipUTs -pl integration-test -am -PTableSimpleIT -P with-integration-tests
+
+# Run table-model ITs (cluster)
+mvn clean verify -DskipUTs -pl integration-test -am -PTableClusterIT -P with-integration-tests
+
+# Run a single IT class (tree-model simple, 1C1D)
+mvn clean verify -DskipUTs -Dit.test=ClassName -DfailIfNoTests=false -Dfailsafe.failIfNoSpecifiedTests=false -pl integration-test -am -P with-integration-tests
+
+# Run a single IT class (tree-model cluster, 1C3D)
+mvn clean verify -DskipUTs -Dit.test=ClassName -DfailIfNoTests=false -Dfailsafe.failIfNoSpecifiedTests=false -pl integration-test -am -PClusterIT -P with-integration-tests
+
+# Run a single IT class (table-model simple, 1C1D)
+mvn clean verify -DskipUTs -Dit.test=ClassName -DfailIfNoTests=false -Dfailsafe.failIfNoSpecifiedTests=false -pl integration-test -am -PTableSimpleIT -P with-integration-tests
+
+# Run a single IT class (table-model cluster, 1C3D)
+mvn clean verify -DskipUTs -Dit.test=ClassName -DfailIfNoTests=false -Dfailsafe.failIfNoSpecifiedTests=false -pl integration-test -am -PTableClusterIT -P with-integration-tests
+
+# Run a single test method within an IT class (use ClassName#methodName)
+mvn clean verify -DskipUTs -Dit.test=ClassName#methodName -DfailIfNoTests=false -Dfailsafe.failIfNoSpecifiedTests=false -pl integration-test -am -PTableSimpleIT -P with-integration-tests
+```
+
+When verifying a new feature, only run the specific IT classes/methods that were added or modified in the current branch — do not run all ITs.
+
+To run integration tests from IntelliJ: enable the `with-integration-tests` profile in Maven sidebar, then run test cases directly.
+
+## Code Style
+
+- **Spotless** with Google Java Format (GOOGLE style). Import order: `org.apache.iotdb`, blank, `javax`, `java`, static.
+- **Checkstyle** is also configured (see `checkstyle.xml` at project root).
+- Java source/target level is 1.8 (compiled with `maven.compiler.release=8` on JDK 9+).
+
+## Architecture
+
+### Node Types
+
+- **ConfigNode** (`iotdb-core/confignode`): Manages cluster metadata, schema regions, data regions, partition tables. Coordinates via Ratis consensus.
+- **DataNode** (`iotdb-core/datanode`): Handles data storage, query execution, and client connections. The main server component.
+- **AINode** (`iotdb-core/ainode`): Python-based node for AI/ML inference tasks.
+
+### Dual Data Model
+
+IoTDB supports two data models operating on the same storage:
+- **Tree model**: Traditional IoT hierarchy (e.g., `root.ln.wf01.wt01.temperature`). SQL uses path-based addressing.
+- **Table model** (relational): SQL table semantics. Grammar lives in `iotdb-core/relational-grammar/`. Query plan code under `queryengine/plan/relational/`.
+
+### Key DataNode Subsystems (`iotdb-core/datanode`)
+
+- **queryengine**: SQL parsing, planning, optimization, and execution.
+    - `plan/parser/` - ANTLR-based SQL parser
+    - `plan/statement/` - AST statement nodes
+    - `plan/planner/` - Logical and physical planning (tree model: `TreeModelPlanner`, table model: under `plan/relational/`)
+    - `plan/optimization/` - Query optimization rules
+    - `execution/operator/` - Physical operators (volcano-style iterator model)
+    - `execution/exchange/` - Inter-node data exchange
+    - `execution/fragment/` - Distributed query fragment management
+- **storageengine**: Write path, memtable, flush, WAL, compaction, TsFile management.
+    - `dataregion/` - DataRegion lifecycle, memtable, flush, compaction
+    - `dataregion/wal/` - Write-ahead log
+    - `buffer/` - Memory buffer management
+- **schemaengine**: Schema (timeseries metadata) management.
+- **pipe**: Data sync/replication framework (source -> processor -> sink pipeline).
+- **consensus**: DataNode-side consensus integration.
+- **subscription**: Client subscription service for streaming data changes.
+
+### Consensus (`iotdb-core/consensus`)
+
+Pluggable consensus protocols: Simple (single-node), Ratis (Raft-based), IoT Consensus (optimized for IoT writes). Factory pattern via `ConsensusFactory`.
+
+### Protocol Layer (`iotdb-protocol/`)
+
+Thrift IDL definitions for RPC between nodes. Generated sources are produced automatically during build. Sub-modules: `thrift-commons`, `thrift-confignode`, `thrift-datanode`, `thrift-consensus`, `thrift-ainode`.
+
+### Client Libraries (`iotdb-client/`)
+
+- `session/` - Java Session API (primary client interface)
+- `jdbc/` - JDBC driver
+- `cli/` - Command-line client
+- `client-cpp/`, `client-go/`, `client-py/` - Multi-language clients
+- `service-rpc/` - Shared Thrift service definitions
+
+### API Layer (`iotdb-api/`)
+
+Extension point interfaces: `udf-api` (user-defined functions), `trigger-api` (event triggers), `pipe-api` (data sync plugins), `external-api`, `external-service-api`.
+
+## IDE Setup
+
+After `mvn package`, right-click the root project in IntelliJ and choose "Maven -> Reload Project" to add generated source roots (Thrift and ANTLR).
+
+Generated source directories that need to be on the source path:
+- `**/target/generated-sources/thrift`
+- `**/target/generated-sources/antlr4`
+
+## Common Pitfalls
+
+### Build
+
+- **Missing Thrift compiler**: The local machine may not have the `thrift` binary installed. Running `mvn clean package -pl <module> -am -DskipTests` will fail at the `iotdb-thrift` module. **Workaround**: To verify your changes compile, use `mvn compile -pl <module>` (without `-am` or `clean`) to leverage existing target caches.
+- **Pre-existing compilation errors in unrelated modules**: The datanode module may have pre-existing compile errors in other subsystems (e.g., pipe, copyto) that cause `mvn clean test -pl iotdb-core/datanode -Dtest=XxxTest` to fail during compilation. **Workaround**: First run `mvn compile -pl iotdb-core/datanode` to confirm your changed files compile successfully. If the errors are in files you did not modify, they are pre-existing and do not affect your changes.
+
+### Code Style
+
+- **Always run `mvn spotless:apply` after editing Java files**: Spotless runs `spotless:check` automatically during the `compile` phase. Format violations cause an immediate BUILD FAILURE. Make it a habit to run `mvn spotless:apply -pl <module>` right after editing, not at the end. For files under `integration-test/`, add `-P with-integration-tests`.
+- **Gson version compatibility**: `JsonObject.isEmpty()` / `JsonArray.isEmpty()` may not be available in the Gson version used by this project. Use `size() > 0` instead and add a comment explaining why.
+
+## Git Commit
+
+- Do NOT add `Co-Authored-By` trailer to commit messages.


### PR DESCRIPTION
## Summary

Add Claude Code project-level configuration (`CLAUDE.md`, `.claude/settings.json`) and refine `.gitignore` to properly handle Claude Code generated files.

## Changes

### 1. `.gitignore` — Refine Claude Code ignore rules

**Before** (too coarse):
```
.claude/
CLAUDE.md
.worktreeinclude
```
This ignored the entire `.claude/` directory and `CLAUDE.md`, preventing any Claude Code config from being shared with the team.

**After** (fine-grained):
```
# Claude Code
.claude/settings.local.json
.claude/todos/
.claude/worktrees/
.claude/scheduled_tasks.json
```

**Why ignore these specific files:**
- `.claude/settings.local.json` — Machine-specific local settings (absolute paths, personal preferences). Committing this causes merge conflicts across different developer environments.
- `.claude/todos/` — Session-level task tracking, ephemeral and per-session.
- `.claude/worktrees/` — Temporary git worktree directories created during isolated development sessions.
- `.claude/scheduled_tasks.json` — Session-level scheduled/recurring tasks, not meaningful across sessions.

**Why commit `CLAUDE.md` and `.claude/settings.json`:**
- `CLAUDE.md` is the project instruction file — it tells Claude Code how to build, test, and format code in this project. Sharing it ensures all team members get consistent AI assistance.
- `.claude/settings.json` contains shared project hooks (e.g., auto-formatting). It should be committed so the whole team benefits from the same automated workflows.

### 2. `CLAUDE.md` — Project instructions for Claude Code

Comprehensive project guide covering:
- **Project overview**: IoTDB architecture, version info
- **Build commands**: Full build, per-module build, unit tests, single test class/method
- **Integration tests**: All profiles (tree-model, table-model, simple, cluster) with examples
- **Code style**: Spotless + Google Java Format, Checkstyle, import order
- **Architecture**: Node types (ConfigNode, DataNode, AINode), dual data model (tree/table), key subsystems (queryengine, storageengine, schemaengine, pipe, consensus), protocol layer, client libraries, API layer
- **IDE setup**: Generated source directories (Thrift, ANTLR)
- **Common pitfalls**: Missing Thrift compiler workaround, pre-existing compilation errors, Spotless formatting discipline, Gson compatibility
- **Git commit**: No `Co-Authored-By` trailer in commit messages

### 3. `.claude/settings.json` — Shared project hooks

Configures a `PostToolUse` hook that automatically runs `mvn spotless:apply` on Java files after Claude Code writes or edits them. This ensures all AI-generated code changes comply with the project's Spotless formatting rules without manual intervention.

```json
{
  "hooks": {
    "PostToolUse": [{
      "matcher": "Write|Edit",
      "hooks": [{
        "type": "command",
        "command": "...(spotless:apply on .java files only)...",
        "timeout": 30,
        "statusMessage": "Running spotless format..."
      }]
    }]
  }
}
```

## Test plan

- [ ] Verify `.gitignore` correctly ignores local files (`settings.local.json`, `todos/`, `worktrees/`, `scheduled_tasks.json`)
- [ ] Verify `CLAUDE.md` and `.claude/settings.json` are tracked by git
- [ ] Verify the PostToolUse hook triggers `mvn spotless:apply` when editing `.java` files
- [ ] Verify the hook skips non-Java files