### PR TITLE
[Iotdb-2041] Added javadocs for Session and SessionPool and made methods consistent

### DIFF
--- a/example/mqtt/src/main/java/org/apache/iotdb/mqtt/MQTTClient.java
+++ b/example/mqtt/src/main/java/org/apache/iotdb/mqtt/MQTTClient.java
@@ -27,6 +27,7 @@ import java.util.Random;
 public class MQTTClient {
 
   private static final String DATABASE = "myMqttTest";
+  private static final String MY_TOPIC = "/myTopic";
 
   public static void main(String[] args) throws Exception {
     MQTT mqtt = new MQTT();
@@ -74,39 +75,39 @@ public class MQTTClient {
   private static void linePayloadFormatter(BlockingConnection connection) throws Exception {
     // myTable,tag1=t1,tag2=t2 fieldKey1="1,2,3" 1740109006001
     String payload = "myTable,tag1=t1,tag2=t2 fieldKey1=\"1,2,3\" 1740109006001";
-    connection.publish(DATABASE + "/myTopic", payload.getBytes(), QoS.AT_LEAST_ONCE, false);
+    connection.publish(DATABASE + MY_TOPIC, payload.getBytes(), QoS.AT_LEAST_ONCE, false);
     Thread.sleep(10);
 
     payload = "myTable,tag1=t1,tag2=t2 fieldKey1=\"1,2,3\" 1740109006002";
-    connection.publish(DATABASE + "/myTopic", payload.getBytes(), QoS.AT_LEAST_ONCE, false);
+    connection.publish(DATABASE + MY_TOPIC, payload.getBytes(), QoS.AT_LEAST_ONCE, false);
     Thread.sleep(10);
 
     payload = "myTable,tag1=t1,tag2=t2 fieldKey1=\"1,2,3\" 1740109006003";
-    connection.publish(DATABASE + "/myTopic", payload.getBytes(), QoS.AT_LEAST_ONCE, false);
+    connection.publish(DATABASE + MY_TOPIC, payload.getBytes(), QoS.AT_LEAST_ONCE, false);
     Thread.sleep(10);
     payload =
         "test1,tag1=t1,tag2=t2 attr3=a5,attr4=a4 field1=\"fieldValue1\",field2=1i,field3=1u 1";
-    connection.publish(DATABASE + "/myTopic", payload.getBytes(), QoS.AT_LEAST_ONCE, false);
+    connection.publish(DATABASE + MY_TOPIC, payload.getBytes(), QoS.AT_LEAST_ONCE, false);
     Thread.sleep(10);
 
     payload = "test1,tag1=t1,tag2=t2  field4=2,field5=2i32,field6=2f 2";
-    connection.publish(DATABASE, payload.getBytes(), QoS.AT_LEAST_ONCE, false);
+    connection.publish(DATABASE + MY_TOPIC, payload.getBytes(), QoS.AT_LEAST_ONCE, false);
     Thread.sleep(10);
 
     payload =
         "test1,tag1=t1,tag2=t2  field7=t,field8=T,field9=true 3 \n "
             + "test1,tag1=t1,tag2=t2  field7=f,field8=F,field9=FALSE 4";
-    connection.publish(DATABASE + "/myTopic", payload.getBytes(), QoS.AT_LEAST_ONCE, false);
+    connection.publish(DATABASE + MY_TOPIC, payload.getBytes(), QoS.AT_LEAST_ONCE, false);
     Thread.sleep(10);
 
     payload =
         "test1,tag1=t1,tag2=t2 attr1=a1,attr2=a2 field1=\"fieldValue1\",field2=1i,field3=1u 4 \n "
             + "test1,tag1=t1,tag2=t2 field4=2,field5=2i32,field6=2f 5";
-    connection.publish(DATABASE + "/myTopic", payload.getBytes(), QoS.AT_LEAST_ONCE, false);
+    connection.publish(DATABASE + MY_TOPIC, payload.getBytes(), QoS.AT_LEAST_ONCE, false);
     Thread.sleep(10);
 
     payload = "# It's a remark\n " + "test1,tag1=t1,tag2=t2 field4=2,field5=2i32,field6=2f 6";
-    connection.publish(DATABASE + "/myTopic", payload.getBytes(), QoS.AT_LEAST_ONCE, false);
+    connection.publish(DATABASE + MY_TOPIC, payload.getBytes(), QoS.AT_LEAST_ONCE, false);
     Thread.sleep(10);
   }
 }

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/Session.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/Session.java
@@ -108,6 +108,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+/** Represents a client session for connecting to and interacting with the IoTDB server. */
 @SuppressWarnings({"java:S107", "java:S1135"}) // need enough parameters, ignore todos
 public class Session implements ISession {
 
@@ -226,6 +227,12 @@ public class Session implements ISession {
       TSFileDescriptor.getInstance().getConfig().getCompressor();
   public Map<TSDataType, TSEncoding> columnEncodersMap = Collections.emptyMap();
 
+  /**
+   * Creates a Session to connect to a single node.
+   *
+   * @param host IP address or hostname of the node
+   * @param rpcPort RPC port of the node
+   */
   public Session(String host, int rpcPort) {
     this(
         host,
@@ -240,6 +247,14 @@ public class Session implements ISession {
         SessionConfig.DEFAULT_VERSION);
   }
 
+  /**
+   * Creates a Session to connect to a single node with username and password.
+   *
+   * @param host IP address or hostname of the node
+   * @param rpcPort RPC port of the node (as String)
+   * @param username Database user
+   * @param password Database password
+   */
   public Session(String host, String rpcPort, String username, String password) {
     this(
         host,
@@ -254,6 +269,14 @@ public class Session implements ISession {
         SessionConfig.DEFAULT_VERSION);
   }
 
+  /**
+   * Creates a Session to connect to a single node with username and password.
+   *
+   * @param host IP address or hostname of the node
+   * @param rpcPort RPC port of the node
+   * @param username Database user
+   * @param password Database password
+   */
   public Session(String host, int rpcPort, String username, String password) {
     this(
         host,
@@ -268,6 +291,15 @@ public class Session implements ISession {
         SessionConfig.DEFAULT_VERSION);
   }
 
+  /**
+   * Creates a Session to connect to a single node.
+   *
+   * @param host IP address or hostname of the node
+   * @param rpcPort RPC port of the node
+   * @param username Database user
+   * @param password Database password
+   * @param fetchSize Number of rows fetched per query by default
+   */
   public Session(String host, int rpcPort, String username, String password, int fetchSize) {
     this(
         host,
@@ -282,6 +314,16 @@ public class Session implements ISession {
         SessionConfig.DEFAULT_VERSION);
   }
 
+  /**
+   * Creates a Session to connect to a single node.
+   *
+   * @param host IP address or hostname of the node
+   * @param rpcPort RPC port of the node
+   * @param username Database user
+   * @param password Database password
+   * @param fetchSize Number of rows fetched per query by default
+   * @param queryTimeoutInMs Timeout for queries in milliseconds
+   */
   public Session(
       String host,
       int rpcPort,
@@ -303,6 +345,15 @@ public class Session implements ISession {
     this.queryTimeoutInMs = queryTimeoutInMs;
   }
 
+  /**
+   * Creates a Session to connect to a single node.
+   *
+   * @param host IP address or hostname of the node
+   * @param rpcPort RPC port of the node
+   * @param username Database user
+   * @param password Database password
+   * @param zoneId Timezone used by this session
+   */
   public Session(String host, int rpcPort, String username, String password, ZoneId zoneId) {
     this(
         host,
@@ -317,6 +368,15 @@ public class Session implements ISession {
         SessionConfig.DEFAULT_VERSION);
   }
 
+  /**
+   * Creates a Session to connect to a single node.
+   *
+   * @param host IP address or hostname of the node
+   * @param rpcPort RPC port of the node
+   * @param username Database user
+   * @param password Database password
+   * @param enableRedirection Automatically redirect write requests to the correct node
+   */
   public Session(
       String host, int rpcPort, String username, String password, boolean enableRedirection) {
     this(
@@ -332,6 +392,17 @@ public class Session implements ISession {
         SessionConfig.DEFAULT_VERSION);
   }
 
+  /**
+   * Creates a Session to connect to a single node.
+   *
+   * @param host IP address or hostname of the node
+   * @param rpcPort RPC port of the node
+   * @param username Database user
+   * @param password Database password
+   * @param fetchSize Number of rows fetched per query by default
+   * @param zoneId Timezone used by this session
+   * @param enableRedirection Automatically redirect write requests to the correct node
+   */
   public Session(
       String host,
       int rpcPort,
@@ -353,6 +424,20 @@ public class Session implements ISession {
         SessionConfig.DEFAULT_VERSION);
   }
 
+  /**
+   * Creates a Session to connect to a single node with all connection parameters configurable.
+   *
+   * @param host IP address or hostname of the node
+   * @param rpcPort RPC port of the node
+   * @param username Database user
+   * @param password Database password
+   * @param fetchSize Number of rows fetched per query by default
+   * @param zoneId Timezone used by this session
+   * @param thriftDefaultBufferSize Default buffer size for Thrift RPC
+   * @param thriftMaxFrameSize Max frame size for Thrift RPC
+   * @param enableRedirection Automatically redirect write requests to the correct node
+   * @param version Protocol version
+   */
   @SuppressWarnings("squid:S107")
   public Session(
       String host,
@@ -376,6 +461,13 @@ public class Session implements ISession {
     this.version = version;
   }
 
+  /**
+   * Creates a Session to connect to a cluster. If one node fails, it tries the next one.
+   *
+   * @param nodeUrls List of node endpoints (e.g., ["127.0.0.1:6667"])
+   * @param username Database user
+   * @param password Database password
+   */
   public Session(List<String> nodeUrls, String username, String password) {
     this(
         nodeUrls,
@@ -390,9 +482,12 @@ public class Session implements ISession {
   }
 
   /**
-   * Multiple nodeUrl,If one node down, connect to the next one
+   * Creates a Session to connect to a cluster. If one node fails, it tries the next one.
    *
-   * @param nodeUrls List<String> Multiple ip:rpcPort eg.127.0.0.1:9001
+   * @param nodeUrls List of node endpoints (e.g., ["127.0.0.1:6667"])
+   * @param username Database user
+   * @param password Database password
+   * @param fetchSize Number of rows fetched per query by default
    */
   public Session(List<String> nodeUrls, String username, String password, int fetchSize) {
     this(
@@ -407,6 +502,14 @@ public class Session implements ISession {
         SessionConfig.DEFAULT_VERSION);
   }
 
+  /**
+   * Creates a Session to connect to a cluster. If one node fails, it tries the next one.
+   *
+   * @param nodeUrls List of node endpoints (e.g., ["127.0.0.1:6667"])
+   * @param username Database user
+   * @param password Database password
+   * @param zoneId Timezone used by this session
+   */
   public Session(List<String> nodeUrls, String username, String password, ZoneId zoneId) {
     this(
         nodeUrls,
@@ -420,6 +523,19 @@ public class Session implements ISession {
         SessionConfig.DEFAULT_VERSION);
   }
 
+  /**
+   * Creates a Session to connect to a cluster. If one node fails, it tries the next one.
+   *
+   * @param nodeUrls List of node endpoints (e.g., ["127.0.0.1:6667"])
+   * @param username Database user
+   * @param password Database password
+   * @param fetchSize Number of rows fetched per query by default
+   * @param zoneId Timezone used by this session
+   * @param thriftDefaultBufferSize Default buffer size for Thrift RPC
+   * @param thriftMaxFrameSize Max frame size for Thrift RPC
+   * @param enableRedirection Automatically redirect write requests to the correct node
+   * @param version Protocol version
+   */
   public Session(
       List<String> nodeUrls,
       String username,
@@ -445,6 +561,11 @@ public class Session implements ISession {
     this.version = version;
   }
 
+  /**
+   * Creates a Session from a builder object.
+   *
+   * @param builder System builder with custom configurations
+   */
   public Session(AbstractSessionBuilder builder) {
     if (builder.nodeUrls != null) {
       if (builder.nodeUrls.isEmpty()) {
@@ -482,36 +603,74 @@ public class Session implements ISession {
     this.database = builder.database;
   }
 
+  /**
+   * Sets the default number of rows fetched per query.
+   *
+   * @param fetchSize Number of rows to fetch
+   */
   @Override
   public void setFetchSize(int fetchSize) {
     this.fetchSize = fetchSize;
   }
 
+  /**
+   * Gets the default number of rows fetched per query.
+   *
+   * @return Number of rows
+   */
   @Override
   public int getFetchSize() {
     return this.fetchSize;
   }
 
+  /**
+   * Gets the protocol version of this session.
+   *
+   * @return Protocol version
+   */
   @Override
   public Version getVersion() {
     return version;
   }
 
+  /**
+   * Sets the protocol version for this session.
+   *
+   * @param version Protocol version
+   */
   @Override
   public void setVersion(Version version) {
     this.version = version;
   }
 
+  /**
+   * Opens the session connection.
+   *
+   * @throws IoTDBConnectionException If connection fails
+   */
   @Override
   public synchronized void open() throws IoTDBConnectionException {
     open(false, SessionConfig.DEFAULT_CONNECTION_TIMEOUT_MS);
   }
 
+  /**
+   * Opens the session connection with RPC compression option.
+   *
+   * @param enableRPCCompaction True to enable RPC compression
+   * @throws IoTDBConnectionException If connection fails
+   */
   @Override
   public synchronized void open(boolean enableRPCCompaction) throws IoTDBConnectionException {
     open(enableRPCCompaction, SessionConfig.DEFAULT_CONNECTION_TIMEOUT_MS);
   }
 
+  /**
+   * Opens the session connection with RPC compression and specific timeout.
+   *
+   * @param enableRPCCompaction True to enable RPC compression
+   * @param connectionTimeoutInMs Timeout for connection in milliseconds
+   * @throws IoTDBConnectionException If connection fails
+   */
   @Override
   public synchronized void open(boolean enableRPCCompaction, int connectionTimeoutInMs)
       throws IoTDBConnectionException {
@@ -561,6 +720,7 @@ public class Session implements ISession {
     }
   }
 
+  /** Initializes a background thread pool to periodically update the list of data nodes. */
   private void initThreadPool() {
     this.executorService =
         Executors.newSingleThreadScheduledExecutor(
@@ -578,6 +738,12 @@ public class Session implements ISession {
             });
   }
 
+  /**
+   * Shuffles the provided list of node endpoints to help load balance initial connections.
+   *
+   * @param endPoints List of node URLs
+   * @return A shuffled list of node URLs
+   */
   private static List<String> shuffleNodeUrls(List<String> endPoints) {
     try {
       Collections.shuffle(endPoints);
@@ -588,6 +754,12 @@ public class Session implements ISession {
     return endPoints;
   }
 
+  /**
+   * Retrieves the target node endpoints, either parsing the configured cluster URLs or using the
+   * single default endpoint.
+   *
+   * @return List of parsed endpoints
+   */
   private List<TEndPoint> getNodeUrls() {
     if (defaultEndPoint != null) {
       return Collections.singletonList(defaultEndPoint);
@@ -596,6 +768,15 @@ public class Session implements ISession {
     }
   }
 
+  /**
+   * Opens the session connection with compression, timeout, and redirection configurations.
+   *
+   * @param enableThriftRpcCompaction True to enable Thrift RPC compression
+   * @param connectionTimeoutInMs Connection timeout in milliseconds
+   * @param deviceIdToEndpoint Mapping of device IDs to endpoints
+   * @param nodesSupplier Supplier of cluster nodes
+   * @throws IoTDBConnectionException If connection fails
+   */
   @Override
   public synchronized void open(
       boolean enableThriftRpcCompaction,
@@ -621,6 +802,17 @@ public class Session implements ISession {
     }
   }
 
+  /**
+   * Opens the session connection with compression, timeout, and table model redirection
+   * configurations.
+   *
+   * @param enableThriftRpcCompaction True to enable Thrift RPC compression
+   * @param connectionTimeoutInMs Connection timeout in milliseconds
+   * @param deviceIdToEndpoint Mapping of device IDs to endpoints
+   * @param tableModelDeviceIdToEndpoint Mapping of table model device IDs to endpoints
+   * @param nodesSupplier Supplier of cluster nodes
+   * @throws IoTDBConnectionException If connection fails
+   */
   @Override
   public synchronized void open(
       boolean enableThriftRpcCompaction,
@@ -647,6 +839,11 @@ public class Session implements ISession {
     }
   }
 
+  /**
+   * Closes the session connection and releases resources.
+   *
+   * @throws IoTDBConnectionException If an error occurs during close
+   */
   @Override
   public synchronized void close() throws IoTDBConnectionException {
     try {
@@ -674,6 +871,15 @@ public class Session implements ISession {
     }
   }
 
+  /**
+   * Constructs a new SessionConnection to a specific endpoint.
+   *
+   * @param session The parent session
+   * @param endpoint The target endpoint to connect to
+   * @param zoneId Timezone ID
+   * @return The created session connection
+   * @throws IoTDBConnectionException If connection fails
+   */
   public SessionConnection constructSessionConnection(
       Session session, TEndPoint endpoint, ZoneId zoneId) throws IoTDBConnectionException {
     if (endpoint == null) {
@@ -696,6 +902,13 @@ public class Session implements ISession {
     return getDefaultSessionConnection().getTimeZone();
   }
 
+  /**
+   * Sets the timezone of the session.
+   *
+   * @param zoneId Timezone ID
+   * @throws StatementExecutionException If execution fails
+   * @throws IoTDBConnectionException If connection fails
+   */
   @Override
   public synchronized void setTimeZone(String zoneId)
       throws StatementExecutionException, IoTDBConnectionException {
@@ -710,6 +923,13 @@ public class Session implements ISession {
     this.zoneId = ZoneId.of(zoneId);
   }
 
+  /**
+   * Sets the storage group.
+   *
+   * @param storageGroup Name of the storage group
+   * @throws IoTDBConnectionException If connection fails
+   * @throws StatementExecutionException If execution fails
+   */
   @Override
   public void setStorageGroup(String storageGroup)
       throws IoTDBConnectionException, StatementExecutionException {
@@ -728,6 +948,13 @@ public class Session implements ISession {
     getDefaultSessionConnection().deleteStorageGroups(storageGroups);
   }
 
+  /**
+   * Creates a database (storage group).
+   *
+   * @param database Name of the database
+   * @throws IoTDBConnectionException If connection fails
+   * @throws StatementExecutionException If execution fails
+   */
   @Override
   public void createDatabase(String database)
       throws IoTDBConnectionException, StatementExecutionException {
@@ -746,6 +973,16 @@ public class Session implements ISession {
     getDefaultSessionConnection().deleteStorageGroups(databases);
   }
 
+  /**
+   * Creates a single timeseries with basic properties.
+   *
+   * @param path The path of the timeseries
+   * @param dataType Data type of the timeseries
+   * @param encoding Encoding method
+   * @param compressor Compression method
+   * @throws IoTDBConnectionException If connection fails
+   * @throws StatementExecutionException If execution fails
+   */
   @Override
   public void createTimeseries(
       String path, TSDataType dataType, TSEncoding encoding, CompressionType compressor)
@@ -755,6 +992,20 @@ public class Session implements ISession {
     getDefaultSessionConnection().createTimeseries(request);
   }
 
+  /**
+   * Creates a single timeseries with advanced properties.
+   *
+   * @param path The path of the timeseries
+   * @param dataType Data type of the timeseries
+   * @param encoding Encoding method
+   * @param compressor Compression method
+   * @param props Properties of the timeseries
+   * @param tags Tags of the timeseries
+   * @param attributes Attributes of the timeseries
+   * @param measurementAlias Measurement alias
+   * @throws IoTDBConnectionException If connection fails
+   * @throws StatementExecutionException If execution fails
+   */
   @Override
   public void createTimeseries(
       String path,
@@ -966,21 +1217,33 @@ public class Session implements ISession {
     return getDefaultSessionConnection().checkTimeseriesExists(path, queryTimeoutInMs);
   }
 
+  /**
+   * Sets the timeout for queries. A negative value uses server default.
+   *
+   * @param timeoutInMs Timeout in milliseconds
+   */
   @Override
   public void setQueryTimeout(long timeoutInMs) {
     this.queryTimeoutInMs = timeoutInMs;
   }
 
+  /**
+   * Gets the timeout for queries.
+   *
+   * @return Timeout in milliseconds
+   */
   @Override
   public long getQueryTimeout() {
     return queryTimeoutInMs;
   }
 
   /**
-   * execute query sql
+   * Executes a query statement.
    *
-   * @param sql query statement
-   * @return result set
+   * @param sql The SQL query statement
+   * @return SessionDataSet containing the query result
+   * @throws StatementExecutionException If execution fails
+   * @throws IoTDBConnectionException If connection fails
    */
   @Override
   public SessionDataSet executeQueryStatement(String sql)
@@ -989,11 +1252,13 @@ public class Session implements ISession {
   }
 
   /**
-   * execute query sql with explicit timeout
+   * Executes a query statement with a specific timeout.
    *
-   * @param sql query statement
-   * @param timeoutInMs the timeout of this query, in milliseconds
-   * @return result set
+   * @param sql The SQL query statement
+   * @param timeoutInMs Query timeout in milliseconds
+   * @return SessionDataSet containing the query result
+   * @throws StatementExecutionException If execution fails
+   * @throws IoTDBConnectionException If connection fails
    */
   @Override
   public SessionDataSet executeQueryStatement(String sql, long timeoutInMs)
@@ -1002,7 +1267,7 @@ public class Session implements ISession {
   }
 
   /**
-   * execute the query, may redirect query to other node.
+   * Executes a query and handles possible redirection.
    *
    * @param sql the query statement
    * @param timeoutInMs time in ms
@@ -1050,9 +1315,11 @@ public class Session implements ISession {
   }
 
   /**
-   * execute non query statement
+   * Executes a non-query statement (like INSERT or CREATE).
    *
-   * @param sql non query statement
+   * @param sql The non-query statement
+   * @throws StatementExecutionException If execution fails
+   * @throws IoTDBConnectionException If connection fails
    */
   @Override
   public void executeNonQueryStatement(String sql)
@@ -1089,6 +1356,17 @@ public class Session implements ISession {
    * @return data set
    * @throws StatementExecutionException statement is not right
    * @throws IoTDBConnectionException the network is not good
+   */
+  /**
+   * Executes a raw data query for a list of paths within a time range.
+   *
+   * @param paths List of time series paths to query
+   * @param startTime Start time (inclusive)
+   * @param endTime End time (exclusive)
+   * @param timeOut Timeout in milliseconds
+   * @return SessionDataSet containing the query result
+   * @throws StatementExecutionException If execution fails
+   * @throws IoTDBConnectionException If connection fails
    */
   @Override
   public SessionDataSet executeRawDataQuery(
@@ -1309,11 +1587,16 @@ public class Session implements ISession {
   }
 
   /**
-   * insert data in one row, if you want to improve your performance, please use insertRecords
-   * method or insertTablet method
+   * Inserts data in one row/record for a single device. For better performance, batch methods like
+   * insertRecords or insertTablet are recommended.
    *
-   * @see Session#insertRecords(List, List, List, List, List)
-   * @see Session#insertTablet(Tablet)
+   * @param deviceId Device ID to insert into
+   * @param time Timestamp of the record
+   * @param measurements List of measurements
+   * @param types Data types for the measurements
+   * @param values Values array
+   * @see Session#insertRecords
+   * @see Session#insertTablet
    */
   @Override
   public void insertRecord(
@@ -1454,6 +1737,12 @@ public class Session implements ISession {
     }
   }
 
+  /**
+   * Handles write request redirection by updating the local route cache.
+   *
+   * @param deviceId The target device ID
+   * @param endpoint The redirected endpoint
+   */
   private void handleRedirection(String deviceId, TEndPoint endpoint) {
     if (enableRedirection) {
       // no need to redirection
@@ -1480,6 +1769,12 @@ public class Session implements ISession {
     }
   }
 
+  /**
+   * Handles write request redirection by updating the local route cache (table model).
+   *
+   * @param deviceId The target device ID
+   * @param endpoint The redirected endpoint
+   */
   private void handleRedirection(IDeviceID deviceId, TEndPoint endpoint) {
     if (enableRedirection) {
       // no need to redirection
@@ -1506,6 +1801,12 @@ public class Session implements ISession {
     }
   }
 
+  /**
+   * Handles query request redirection by establishing a connection to the correct endpoint.
+   *
+   * @param endPoint The redirected endpoint
+   * @throws IoTDBConnectionException If the new connection fails
+   */
   private void handleQueryRedirection(TEndPoint endPoint) throws IoTDBConnectionException {
     if (enableQueryRedirection) {
       AtomicReference<IoTDBConnectionException> exceptionReference = new AtomicReference<>();
@@ -1531,11 +1832,16 @@ public class Session implements ISession {
   }
 
   /**
-   * insert data in one row, if you want improve your performance, please use insertRecords method
-   * or insertTablet method
+   * Inserts data in one row/record for a single device. For better performance, batch methods like
+   * insertRecords or insertTablet are recommended.
    *
-   * @see Session#insertRecords(List, List, List, List, List)
-   * @see Session#insertTablet(Tablet)
+   * @param deviceId Device ID to insert into
+   * @param time Timestamp of the record
+   * @param measurements List of measurements
+   * @param types Data types for the measurements
+   * @param values Values list
+   * @see Session#insertRecords
+   * @see Session#insertTablet
    */
   @Override
   public void insertRecord(
@@ -1622,11 +1928,15 @@ public class Session implements ISession {
   }
 
   /**
-   * insert data in one row, if you want improve your performance, please use insertRecords method
-   * or insertTablet method
+   * Inserts data in one row/record for a single device (using String values). For better
+   * performance, batch methods like insertRecords or insertTablet are recommended.
    *
-   * @see Session#insertRecords(List, List, List, List, List)
-   * @see Session#insertTablet(Tablet)
+   * @param deviceId Device ID to insert into
+   * @param time Timestamp of the record
+   * @param measurements List of measurements
+   * @param values String values list
+   * @see Session#insertRecords
+   * @see Session#insertTablet
    */
   @Override
   public void insertRecord(
@@ -1697,13 +2007,15 @@ public class Session implements ISession {
   }
 
   /**
-   * Insert multiple rows, which can reduce the overhead of network. This method is just like jdbc
-   * executeBatch, we pack some insert request in batch and send them to server. If you want improve
-   * your performance, please see insertTablet method
+   * Inserts multiple rows of data, which reduces network overhead. Each row can have a different
+   * deviceId, time, and number of measurements. For better performance, consider using
+   * insertTablet.
    *
-   * <p>Each row is independent, which could have different deviceId, time, number of measurements
-   *
-   * @see Session#insertTablet(Tablet)
+   * @param deviceIds List of device IDs
+   * @param times List of timestamps
+   * @param measurementsList List of measurement lists for each row
+   * @param valuesList List of value lists (as Strings) for each row
+   * @see Session#insertTablet
    */
   @Override
   public void insertRecords(
@@ -1762,7 +2074,7 @@ public class Session implements ISession {
     }
   }
 
-  /** Filter the null value of list。 */
+  /** Filters out null values and their corresponding measurements for a single device. */
   private void filterNullValueAndMeasurementOfOneDevice(
       String deviceId,
       List<Long> times,
@@ -1787,7 +2099,7 @@ public class Session implements ISession {
     }
   }
 
-  /** Filter the null value of list。 */
+  /** Filters out null string values and their corresponding measurements for a single device. */
   private void filterNullValueAndMeasurementWithStringTypeOfOneDevice(
       List<Long> times,
       String deviceId,
@@ -1810,9 +2122,9 @@ public class Session implements ISession {
   }
 
   /**
-   * Filter the null object of list。
+   * Filters out null objects from the list.
    *
-   * @return true:all value is null;false:not all null value is null.
+   * @return True if all values are null; false otherwise.
    */
   private boolean filterNullValueAndMeasurement(
       String deviceId,
@@ -1837,7 +2149,7 @@ public class Session implements ISession {
     return false;
   }
 
-  /** Filter the null object of list。 */
+  /** Filters out null string objects from the list. */
   private void filterNullValueAndMeasurementWithStringType(
       List<String> prefixPaths,
       List<Long> times,
@@ -1884,6 +2196,12 @@ public class Session implements ISession {
     return false;
   }
 
+  /**
+   * Checks if the value list contains any null elements.
+   *
+   * @param valuesList List of values to check
+   * @return True if there is at least one null value; false otherwise
+   */
   private boolean hasNull(List valuesList) {
     boolean haveNull = false;
     for (int i1 = 0; i1 < valuesList.size(); i1++) {
@@ -1905,14 +2223,15 @@ public class Session implements ISession {
   }
 
   /**
-   * Insert aligned multiple rows, which can reduce the overhead of network. This method is just
-   * like jdbc executeBatch, we pack some insert request in batch and send them to server. If you
-   * want improve your performance, please see insertTablet method
+   * Inserts aligned multiple rows, which reduces network overhead. Each row can have a different
+   * deviceId, time, and number of measurements. For better performance, consider using
+   * insertTablet.
    *
-   * <p>Each row is independent, which could have different prefixPath, time, number of
-   * subMeasurements
-   *
-   * @see Session#insertTablet(Tablet)
+   * @param deviceIds List of device IDs
+   * @param times List of timestamps
+   * @param measurementsList List of measurement lists for each row
+   * @param valuesList List of value lists (as Strings) for each row
+   * @see Session#insertTablet
    */
   @Override
   public void insertAlignedRecords(
@@ -2080,13 +2399,16 @@ public class Session implements ISession {
   }
 
   /**
-   * Insert multiple rows, which can reduce the overhead of network. This method is just like jdbc
-   * executeBatch, we pack some insert request in batch and send them to server. If you want improve
-   * your performance, please see insertTablet method
+   * Inserts multiple rows of data, which reduces network overhead. Each row can have a different
+   * deviceId, time, and number of measurements. For better performance, consider using
+   * insertTablet.
    *
-   * <p>Each row is independent, which could have different deviceId, time, number of measurements
-   *
-   * @see Session#insertTablet(Tablet)
+   * @param deviceIds List of device IDs
+   * @param times List of timestamps
+   * @param measurementsList List of measurement lists for each row
+   * @param typesList List of data type lists for each row
+   * @param valuesList List of value lists for each row
+   * @see Session#insertTablet
    */
   @Override
   public void insertRecords(
@@ -2186,13 +2508,16 @@ public class Session implements ISession {
   }
 
   /**
-   * Insert multiple rows, which can reduce the overhead of network. This method is just like jdbc
-   * executeBatch, we pack some insert request in batch and send them to server. If you want improve
-   * your performance, please see insertTablet method
+   * Inserts multiple rows of data for a single device, which reduces network overhead. Each row can
+   * have a different time and number of measurements. For better performance, consider using
+   * insertTablet.
    *
-   * <p>Each row could have same deviceId but different time, number of measurements
-   *
-   * @see Session#insertTablet(Tablet)
+   * @param deviceId Device ID
+   * @param times List of timestamps
+   * @param measurementsList List of measurement lists for each row
+   * @param typesList List of data type lists for each row
+   * @param valuesList List of value lists for each row
+   * @see Session#insertTablet
    */
   @Override
   public void insertRecordsOfOneDevice(
@@ -2206,14 +2531,17 @@ public class Session implements ISession {
   }
 
   /**
-   * Insert multiple rows, which can reduce the overhead of network. This method is just like jdbc
-   * executeBatch, we pack some insert request in batch and send them to server. If you want improve
-   * your performance, please see insertTablet method
+   * Inserts multiple rows of data for a single device, which reduces network overhead. Each row can
+   * have a different time and number of measurements. For better performance, consider using
+   * insertTablet.
    *
-   * <p>Each row could have same deviceId but different time, number of measurements
-   *
-   * @param haveSorted deprecated, whether the times have been sorted
-   * @see Session#insertTablet(Tablet)
+   * @param deviceId Device ID
+   * @param times List of timestamps
+   * @param measurementsList List of measurement lists for each row
+   * @param typesList List of data type lists for each row
+   * @param valuesList List of value lists for each row
+   * @param haveSorted Whether the times list is already sorted
+   * @see Session#insertTablet
    */
   @Override
   public void insertRecordsOfOneDevice(
@@ -4138,6 +4466,8 @@ public class Session implements ISession {
 
   /**
    * Create timeseries represented by device template under given device paths.
+   *
+   * <p>/** Creates timeseries using a predefined schema template.
    *
    * @param devicePathList the target device paths used for timeseries creation
    */

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
@@ -1354,8 +1354,8 @@ public class SessionPool implements ISessionPool {
   }
 
   /**
-   * Inserts multiple records for a single device. This performs the same operation as
-   * {@link #insertRecordsOfOneDevice}.
+   * Inserts multiple records for a single device. This performs the same operation as {@link
+   * #insertRecordsOfOneDevice}.
    *
    * @param deviceId Device ID
    * @param times List of timestamps

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
@@ -84,7 +84,8 @@ import static org.apache.iotdb.rpc.RpcUtils.isUseDatabase;
  * when you call SessionDataSetWrapper.hasNext() or next()
  */
 
-// ignore Generic exceptions & Throwable should never be throw, ignore Either log or rethrow this
+// ignore Generic exceptions & Throwable should never be throw, ignore Either
+// log or rethrow this
 // exception.
 @SuppressWarnings({"squid:S112", "java:S1181", "java:S2139"})
 public class SessionPool implements ISessionPool {
@@ -116,13 +117,18 @@ public class SessionPool implements ISessionPool {
 
   private String trustStorePwd;
   private ZoneId zoneId;
-  // this field only take effect in write request, nothing to do with any other type requests,
+  // this field only take effect in write request, nothing to do with any other
+  // type requests,
   // like query, load and so on.
-  // if set to true, it means that we may redirect the write request to its corresponding leader
-  // if set to false, it means that we will only send write request to first available DataNode(it
-  // may be changed while current DataNode is not available, for example, we may retry to connect
+  // if set to true, it means that we may redirect the write request to its
+  // corresponding leader
+  // if set to false, it means that we will only send write request to first
+  // available DataNode(it
+  // may be changed while current DataNode is not available, for example, we may
+  // retry to connect
   // to another available DataNode)
-  // so even if enableRedirection is set to false, we may also send write request to another
+  // so even if enableRedirection is set to false, we may also send write request
+  // to another
   // datanode while encountering retriable errors in current DataNode
   private boolean enableRedirection;
   private boolean enableRecordsAutoConvertTablet;
@@ -154,7 +160,8 @@ public class SessionPool implements ISessionPool {
   // Redirect-able SessionPool
   private final List<String> nodeUrls;
 
-  // formatted nodeUrls for logging e.g. "host:port" or "[host:port, host:port, host:port]"
+  // formatted nodeUrls for logging e.g. "host:port" or "[host:port, host:port,
+  // host:port]"
   private final String formattedNodeUrls;
 
   // used to update datanodeList periodically
@@ -163,12 +170,15 @@ public class SessionPool implements ISessionPool {
 
   private INodeSupplier availableNodes;
 
-  // set to true, means that we will start a background thread to fetch all available (Status is
-  // not Removing) datanodes in cluster, and these available nodes will be used in retrying stage
+  // set to true, means that we will start a background thread to fetch all
+  // available (Status is
+  // not Removing) datanodes in cluster, and these available nodes will be used in
+  // retrying stage
   private boolean enableAutoFetch = true;
 
   // max retry count, if set to 0, means that we won't do any retry
-  // we can use any available DataNodes(fetched in background thread if enableAutoFetch is true,
+  // we can use any available DataNodes(fetched in background thread if
+  // enableAutoFetch is true,
   // or nodeUrls user specified) to retry, even if enableRedirection is false
   protected int maxRetryCount = SessionConfig.MAX_RETRY_COUNT;
 
@@ -209,6 +219,15 @@ public class SessionPool implements ISessionPool {
 
   private static final String CREATE_SCHEMA_TEMPLATE_FAIL = "createSchemaTemplate failed";
 
+  /**
+   * Constructs a SessionPool for a single node connection.
+   *
+   * @param host Target node host
+   * @param port Target node port
+   * @param user Username for authentication
+   * @param password Password for authentication
+   * @param maxSize Maximum pool size
+   */
   public SessionPool(String host, int port, String user, String password, int maxSize) {
     this(
         host,
@@ -227,6 +246,14 @@ public class SessionPool implements ISessionPool {
         SessionConfig.DEFAULT_MAX_FRAME_SIZE);
   }
 
+  /**
+   * Constructs a SessionPool for a cluster connection.
+   *
+   * @param nodeUrls List of node URLs (host:port) to connect
+   * @param user Username for authentication
+   * @param password Password for authentication
+   * @param maxSize Maximum pool size
+   */
   public SessionPool(List<String> nodeUrls, String user, String password, int maxSize) {
     this(
         nodeUrls,
@@ -244,6 +271,16 @@ public class SessionPool implements ISessionPool {
         SessionConfig.DEFAULT_MAX_FRAME_SIZE);
   }
 
+  /**
+   * Constructs a SessionPool for a single node connection with Thrift compression.
+   *
+   * @param host Target node host
+   * @param port Target node port
+   * @param user Username for authentication
+   * @param password Password for authentication
+   * @param maxSize Maximum pool size
+   * @param enableThriftCompression True to enable Thrift compression
+   */
   public SessionPool(
       String host,
       int port,
@@ -268,6 +305,15 @@ public class SessionPool implements ISessionPool {
         SessionConfig.DEFAULT_MAX_FRAME_SIZE);
   }
 
+  /**
+   * Constructs a SessionPool for a cluster connection with Thrift compression.
+   *
+   * @param nodeUrls List of node URLs (host:port) to connect
+   * @param user Username for authentication
+   * @param password Password for authentication
+   * @param maxSize Maximum pool size
+   * @param enableThriftCompression True to enable Thrift compression
+   */
   public SessionPool(
       List<String> nodeUrls,
       String user,
@@ -290,6 +336,18 @@ public class SessionPool implements ISessionPool {
         SessionConfig.DEFAULT_MAX_FRAME_SIZE);
   }
 
+  /**
+   * Constructs a SessionPool for a single node connection with Thrift compression and redirection
+   * options.
+   *
+   * @param host Target node host
+   * @param port Target node port
+   * @param user Username for authentication
+   * @param password Password for authentication
+   * @param maxSize Maximum pool size
+   * @param enableThriftCompression True to enable Thrift compression
+   * @param enableRedirection True to enable query redirection
+   */
   public SessionPool(
       String host,
       int port,
@@ -315,6 +373,17 @@ public class SessionPool implements ISessionPool {
         SessionConfig.DEFAULT_MAX_FRAME_SIZE);
   }
 
+  /**
+   * Constructs a SessionPool for a cluster connection with Thrift compression and redirection
+   * options.
+   *
+   * @param nodeUrls List of node URLs (host:port) to connect
+   * @param user Username for authentication
+   * @param password Password for authentication
+   * @param maxSize Maximum pool size
+   * @param enableThriftCompression True to enable Thrift compression
+   * @param enableRedirection True to enable query redirection
+   */
   public SessionPool(
       List<String> nodeUrls,
       String user,
@@ -338,6 +407,16 @@ public class SessionPool implements ISessionPool {
         SessionConfig.DEFAULT_MAX_FRAME_SIZE);
   }
 
+  /**
+   * Constructs a SessionPool for a single node connection with a specific timezone.
+   *
+   * @param host Target node host
+   * @param port Target node port
+   * @param user Username for authentication
+   * @param password Password for authentication
+   * @param maxSize Maximum pool size
+   * @param zoneId Timezone ID
+   */
   public SessionPool(
       String host, int port, String user, String password, int maxSize, ZoneId zoneId) {
     this(
@@ -357,6 +436,15 @@ public class SessionPool implements ISessionPool {
         SessionConfig.DEFAULT_MAX_FRAME_SIZE);
   }
 
+  /**
+   * Constructs a SessionPool for a cluster connection with a specific timezone.
+   *
+   * @param nodeUrls List of node URLs (host:port) to connect
+   * @param user Username for authentication
+   * @param password Password for authentication
+   * @param maxSize Maximum pool size
+   * @param zoneId Timezone ID
+   */
   public SessionPool(
       List<String> nodeUrls, String user, String password, int maxSize, ZoneId zoneId) {
     this(
@@ -375,6 +463,24 @@ public class SessionPool implements ISessionPool {
         SessionConfig.DEFAULT_MAX_FRAME_SIZE);
   }
 
+  /**
+   * Constructs a SessionPool for a single node with detailed configuration.
+   *
+   * @param host Target node host
+   * @param port Target node port
+   * @param user Username for authentication
+   * @param password Password for authentication
+   * @param maxSize Maximum number of connections in the pool
+   * @param fetchSize Default fetch size for queries
+   * @param waitToGetSessionTimeoutInMs Maximum time to wait for a session from the pool
+   * @param enableThriftCompression Whether to enable Thrift compression
+   * @param zoneId Timezone ID
+   * @param enableRedirection Whether to enable query redirection
+   * @param connectionTimeoutInMs Connection timeout in milliseconds
+   * @param version Protocol version
+   * @param thriftDefaultBufferSize Default buffer size for Thrift
+   * @param thriftMaxFrameSize Maximum frame size for Thrift
+   */
   @SuppressWarnings("squid:S107")
   public SessionPool(
       String host,
@@ -416,6 +522,27 @@ public class SessionPool implements ISessionPool {
     initAvailableNodes(Collections.singletonList(new TEndPoint(host, port)));
   }
 
+  /**
+   * Constructs a SessionPool with SSL enabled for a single node.
+   *
+   * @param host Target node host
+   * @param port Target node port
+   * @param user Username for authentication
+   * @param password Password for authentication
+   * @param maxSize Maximum number of connections in the pool
+   * @param fetchSize Default fetch size for queries
+   * @param waitToGetSessionTimeoutInMs Maximum time to wait for a session from the pool
+   * @param enableThriftCompression Whether to enable Thrift compression
+   * @param zoneId Timezone ID
+   * @param enableRedirection Whether to enable query redirection
+   * @param connectionTimeoutInMs Connection timeout in milliseconds
+   * @param version Protocol version
+   * @param thriftDefaultBufferSize Default buffer size for Thrift
+   * @param thriftMaxFrameSize Maximum frame size for Thrift
+   * @param useSSL Whether to use SSL for connection
+   * @param trustStore Trust store path
+   * @param trustStorePwd Trust store password
+   */
   public SessionPool(
       String host,
       int port,
@@ -462,6 +589,23 @@ public class SessionPool implements ISessionPool {
     initAvailableNodes(Collections.singletonList(new TEndPoint(host, port)));
   }
 
+  /**
+   * Constructs a SessionPool for cluster nodes with detailed configuration.
+   *
+   * @param nodeUrls List of node URLs (host:port)
+   * @param user Username for authentication
+   * @param password Password for authentication
+   * @param maxSize Maximum number of connections in the pool
+   * @param fetchSize Default fetch size for queries
+   * @param waitToGetSessionTimeoutInMs Maximum time to wait for a session from the pool
+   * @param enableThriftCompression Whether to enable Thrift compression
+   * @param zoneId Timezone ID
+   * @param enableRedirection Whether to enable query redirection
+   * @param connectionTimeoutInMs Connection timeout in milliseconds
+   * @param version Protocol version
+   * @param thriftDefaultBufferSize Default buffer size for Thrift
+   * @param thriftMaxFrameSize Maximum frame size for Thrift
+   */
   @SuppressWarnings("squid:S107") // ignore Methods should not have too many parameters
   public SessionPool(
       List<String> nodeUrls,
@@ -505,6 +649,11 @@ public class SessionPool implements ISessionPool {
     initAvailableNodes(SessionUtils.parseSeedNodeUrls(nodeUrls));
   }
 
+  /**
+   * Constructs a SessionPool using a builder.
+   *
+   * @param builder Session pool builder
+   */
   public SessionPool(AbstractSessionPoolBuilder builder) {
     this.maxSize = builder.maxSize;
     this.user = builder.username;
@@ -658,8 +807,16 @@ public class SessionPool implements ISessionPool {
             version.toString());
   }
 
-  // if this method throws an exception, either the server is broken, or the ip/port/user/password
+  // if this method throws an exception, either the server is broken, or the
+  // ip/port/user/password
   // is incorrect.
+  /**
+   * Retrieves a session from the pool. If no session is available and the pool is not full, a new
+   * session is created. If the pool is full, it waits until a session is returned.
+   *
+   * @return A session instance
+   * @throws IoTDBConnectionException If the pool is closed or connection fails
+   */
   @SuppressWarnings({"squid:S3776", "squid:S2446"}) // Suppress high Cognitive Complexity warning
   private ISession getSession() throws IoTDBConnectionException {
     ISession session = queue.poll();
@@ -679,7 +836,8 @@ public class SessionPool implements ISessionPool {
           // we can create more session
           size++;
           shouldCreate = true;
-          // but we do it after skip synchronized block because connection a session is time
+          // but we do it after skip synchronized block because connection a session is
+          // time
           // consuming.
           break;
         }
@@ -746,7 +904,8 @@ public class SessionPool implements ISessionPool {
         // Meanwhile, we have to set size--
         synchronized (this) {
           size--;
-          // we do not need to notifyAll as any waited thread can continue to work after waked up.
+          // we do not need to notifyAll as any waited thread can continue to work after
+          // waked up.
           this.notify();
         }
         throw e;
@@ -770,17 +929,23 @@ public class SessionPool implements ISessionPool {
     return occupied.size();
   }
 
+  /**
+   * Returns a session to the pool and notifies waiting threads.
+   *
+   * @param session The session to return
+   */
   @SuppressWarnings({"squid:S2446"})
   protected void putBack(ISession session) {
     queue.push(session);
     synchronized (this) {
-      // we do not need to notifyAll as any waited thread can continue to work after waked up.
+      // we do not need to notifyAll as any waited thread can continue to work after
+      // waked up.
       this.notify();
       // comment the following codes as putBack is too frequently called.
-      //      if (logger.isTraceEnabled()) {
-      //        logger.trace("put a session back and notify others..., queue.size = {}",
+      // if (logger.isTraceEnabled()) {
+      // logger.trace("put a session back and notify others..., queue.size = {}",
       // queue.size());
-      //      }
+      // }
     }
   }
 
@@ -788,7 +953,7 @@ public class SessionPool implements ISessionPool {
     occupied.put(session, session);
   }
 
-  /** close all connections in the pool */
+  /** Closes all connections in the pool and releases resources. */
   @Override
   public synchronized void close() {
     for (ISession session : queue) {
@@ -821,6 +986,11 @@ public class SessionPool implements ISessionPool {
     occupied.clear();
   }
 
+  /**
+   * Closes the result set and returns the associated session to the pool.
+   *
+   * @param wrapper The dataset wrapper to close
+   */
   @Override
   public void closeResultSet(SessionDataSetWrapper wrapper) {
     boolean putback = true;
@@ -860,7 +1030,8 @@ public class SessionPool implements ISessionPool {
     } catch (IoTDBConnectionException e) {
       synchronized (this) {
         size--;
-        // we do not need to notifyAll as any waited thread can continue to work after waked up.
+        // we do not need to notifyAll as any waited thread can continue to work after
+        // waked up.
         this.notify();
       }
     }
@@ -904,12 +1075,12 @@ public class SessionPool implements ISessionPool {
   public void insertTablet(Tablet tablet)
       throws IoTDBConnectionException, StatementExecutionException {
     /*
-     *  A Tablet example:
-     *        device1
-     *     time s1, s2, s3
-     *     1,   1,  1,  1
-     *     2,   2,  2,  2
-     *     3,   3,  3,  3
+     * A Tablet example:
+     * device1
+     * time s1, s2, s3
+     * 1, 1, 1, 1
+     * 2, 2, 2, 2
+     * 3, 3, 3, 3
      *
      * times in Tablet may be not in ascending orde
      */
@@ -929,12 +1100,12 @@ public class SessionPool implements ISessionPool {
   public void insertTablet(Tablet tablet, boolean sorted)
       throws IoTDBConnectionException, StatementExecutionException {
     /*
-     *  A Tablet example:
-     *        device1
-     *     time s1, s2, s3
-     *     1,   1,  1,  1
-     *     2,   2,  2,  2
-     *     3,   3,  3,  3
+     * A Tablet example:
+     * device1
+     * time s1, s2, s3
+     * 1, 1, 1, 1
+     * 2, 2, 2, 2
+     * 3, 3, 3, 3
      */
 
     ISession session = getSession();
@@ -999,9 +1170,11 @@ public class SessionPool implements ISessionPool {
   }
 
   /**
-   * use batch interface to insert data
+   * Inserts multiple tablets.
    *
-   * @param tablets multiple batch
+   * @param tablets Map of device IDs to tablets
+   * @throws IoTDBConnectionException If connection fails
+   * @throws StatementExecutionException If execution fails
    */
   @Override
   public void insertTablets(Map<String, Tablet> tablets)
@@ -1023,7 +1196,10 @@ public class SessionPool implements ISessionPool {
   /**
    * use batch interface to insert aligned data
    *
-   * @param tablets multiple batch
+   * @param tablets Map of device IDs to tablets
+   * @param sorted Whether the tablets are already sorted by time
+   * @throws IoTDBConnectionException If connection fails
+   * @throws StatementExecutionException If execution fails
    */
   @SuppressWarnings({"squid:S112"}) // ignore Generic exceptions should never be throw
   @Override
@@ -1178,12 +1354,18 @@ public class SessionPool implements ISessionPool {
   }
 
   /**
-   * Insert data that belong to the same device in batch format, which can reduce the overhead of
-   * network. This method is just like jdbc batch insert, we pack some insert request in batch and
-   * send them to server If you want improve your performance, please see insertTablet method
+   * Inserts multiple records for a single device. This performs the same operation as
+   * {@link #insertRecordsOfOneDevice}.
    *
-   * @see Session#insertTablet(Tablet)
-   * @deprecated
+   * @param deviceId Device ID
+   * @param times List of timestamps
+   * @param measurementsList List of measurement names for each timestamp
+   * @param typesList List of data types for each timestamp
+   * @param valuesList List of values for each timestamp
+   * @throws IoTDBConnectionException If connection fails
+   * @throws StatementExecutionException If execution fails
+   * @see Session#insertRecordsOfOneDevice(String, List, List, List, List)
+   * @deprecated Use {@link #insertRecordsOfOneDevice} instead.
    */
   @Deprecated
   @Override
@@ -1283,13 +1465,19 @@ public class SessionPool implements ISessionPool {
   }
 
   /**
-   * Insert data that belong to the same device in batch format, which can reduce the overhead of
-   * network. This method is just like jdbc batch insert, we pack some insert request in batch and
-   * send them to server If you want improve your performance, please see insertTablet method
+   * Inserts multiple records for a single device with a sort option. This performs the same
+   * operation as {@link #insertRecordsOfOneDevice}.
    *
-   * @param haveSorted whether the times list has been ordered.
-   * @see Session#insertTablet(Tablet)
-   * @deprecated
+   * @param deviceId Device ID
+   * @param times List of timestamps
+   * @param measurementsList List of measurement names for each timestamp
+   * @param typesList List of data types for each timestamp
+   * @param valuesList List of values for each timestamp
+   * @param haveSorted Whether the timestamps are already sorted
+   * @throws IoTDBConnectionException If connection fails
+   * @throws StatementExecutionException If execution fails
+   * @see Session#insertRecordsOfOneDevice(String, List, List, List, List, boolean)
+   * @deprecated Use {@link #insertRecordsOfOneDevice} instead.
    */
   @Override
   @Deprecated
@@ -1567,6 +1755,11 @@ public class SessionPool implements ISessionPool {
    * insert data in one row, if you want improve your performance, please use insertRecords method
    * or insertTablet method
    *
+   * @param deviceId Device ID
+   * @param time Timestamp
+   * @param measurements List of measurement names
+   * @param types List of data types
+   * @param values Values to insert
    * @see Session#insertRecords(List, List, List, List, List)
    * @see Session#insertTablet(Tablet)
    */
@@ -1600,6 +1793,11 @@ public class SessionPool implements ISessionPool {
    * insert data in one row, if you want improve your performance, please use insertRecords method
    * or insertTablet method
    *
+   * @param deviceId Device ID
+   * @param time Timestamp
+   * @param measurements List of measurement names
+   * @param types List of data types
+   * @param values List of values to insert
    * @see Session#insertRecords(List, List, List, List, List)
    * @see Session#insertTablet(Tablet)
    */
@@ -3092,13 +3290,16 @@ public class SessionPool implements ISessionPool {
   /**
    * execute non query statement
    *
-   * @param sql non query statement
+   * @param sql Non-query statement
+   * @throws IoTDBConnectionException If connection fails
+   * @throws StatementExecutionException If execution fails
    */
   @Override
   public void executeNonQueryStatement(String sql)
       throws StatementExecutionException, IoTDBConnectionException {
 
-    // 'use XXX' and 'set sql_dialect' is forbidden in SessionPool.executeNonQueryStatement
+    // 'use XXX' and 'set sql_dialect' is forbidden in
+    // SessionPool.executeNonQueryStatement
     if (isUseDatabase(sql) || isSetSqlDialect(sql)) {
       throw new IllegalArgumentException(
           String.format("SessionPool doesn't support executing %s directly", sql));
@@ -3122,6 +3323,17 @@ public class SessionPool implements ISessionPool {
     }
   }
 
+  /**
+   * Executes a raw data query for multiple paths over a time range.
+   *
+   * @param paths List of time series paths
+   * @param startTime Start time
+   * @param endTime End time
+   * @param timeOut Timeout in milliseconds
+   * @return Result set wrapper
+   * @throws IoTDBConnectionException If connection fails
+   * @throws StatementExecutionException If execution fails
+   */
   @SuppressWarnings("squid:S2095") // Suppress wrapper not closed warning
   @Override
   public SessionDataSetWrapper executeRawDataQuery(


### PR DESCRIPTION
### What is changed

This PR adds and improves Javadoc for `Session` and `SessionPool`.

* Added missing Javadoc for constructors, public methods, and selected helper methods
* Improved clarity of some existing Javadoc where needed
* Kept the documentation simple and consistent across both classes

### Consistency updates

* Ensured similar methods in `Session` and `SessionPool` have consistent descriptions
* Added references between related methods using `@see`
* Clarified the relation between:

  * `Session.insertRecordsOfOneDevice`
  * `SessionPool.insertOneDeviceRecords`

### Fixes Issue: 

* https://issues.apache.org/jira/browse/IOTDB-2041?filter=-4&jql=project%20%3D%20IOTDB%20AND%20text%20~%20%22javadoc%22%20order%20by%20created%20DESC

### Notes

* Did not modify any method logic or signatures
* Avoided changing existing Javadoc unless necessary
* Focused only on missing or unclear documentation

### Why this change is needed

Improves readability and usability of the client API by making method behavior easier to understand and documentation more consistent.


<hr>

This PR has:
- [x] been self-reviewed.
    - [x] concurrent read
    - [x] concurrent write
    - [x] concurrent read and write 
- [x] added Javadocs for most classes and all non-trivial methods. 

<hr>
