### PR TITLE
Fix NPE in table model export when -q is not specified

### DIFF
--- a/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/data/ExportData.java
+++ b/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/data/ExportData.java
@@ -224,18 +224,22 @@ public class ExportData extends AbstractDataTool {
         exportData = new ExportDataTable();
         exportData.init();
       }
-      if (sqlDialectTree && queryCommand == null) {
-        LineReader lineReader =
-            JlineUtils.getLineReader(
-                new CliContext(System.in, System.out, System.err, ExitType.EXCEPTION),
-                username,
-                host,
-                port);
-        String sql = lineReader.readLine(Constants.EXPORT_CLI_PREFIX + "> please input query: ");
-        ioTPrinter.println(sql);
-        String[] values = sql.trim().split(";");
-        for (int i = 0; i < values.length; i++) {
-          exportData.exportBySql(values[i], i);
+      if (queryCommand == null) {
+        if (sqlDialectTree) {
+          LineReader lineReader =
+              JlineUtils.getLineReader(
+                  new CliContext(System.in, System.out, System.err, ExitType.EXCEPTION),
+                  username,
+                  host,
+                  port);
+          String sql = lineReader.readLine(Constants.EXPORT_CLI_PREFIX + "> please input query: ");
+          ioTPrinter.println(sql);
+          String[] values = sql.trim().split(";");
+          for (int i = 0; i < values.length; i++) {
+            exportData.exportBySql(values[i], i);
+          }
+        } else {
+          exportData.exportBySql(null, 0);
         }
       } else {
         String[] values = queryCommand.trim().split(";");


### PR DESCRIPTION
  When using export-data with table model (sql_dialect=table) and only
  specifying -db without -q, queryCommand is null. The original condition
  `sqlDialectTree && queryCommand == null` only handled the tree model
  case, causing the else branch to call `queryCommand.trim().split(";")`
  which throws NullPointerException.

  Restructure the branch logic to check `queryCommand == null` first:
  - Tree model + no query: interactive SQL input (unchanged)
  - Table model + no query: call exportBySql(null, 0) to auto-generate "select * from <table>" for all tables, which also correctly applies start_time/end_time filters
  - Query provided: split by semicolon for multi-statement support (unchanged)
