### PR TITLE
Load balance service patch

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/service/EventService.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/service/EventService.java
@@ -115,9 +115,11 @@ public class EventService {
         currentEventServiceFuture = null;
         LOGGER.info("Event service is stopped successfully.");
       }
-      previousNodeStatisticsMap.clear();
-      previousRegionGroupStatisticsMap.clear();
-      previousConsensusGroupStatisticsMap.clear();
+      synchronized (this) {
+        previousNodeStatisticsMap.clear();
+        previousRegionGroupStatisticsMap.clear();
+        previousConsensusGroupStatisticsMap.clear();
+      }
     }
   }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/service/EventService.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/service/EventService.java
@@ -115,6 +115,9 @@ public class EventService {
         currentEventServiceFuture = null;
         LOGGER.info("Event service is stopped successfully.");
       }
+      previousNodeStatisticsMap.clear();
+      previousRegionGroupStatisticsMap.clear();
+      previousConsensusGroupStatisticsMap.clear();
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/ClusterPartitionFetcher.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/ClusterPartitionFetcher.java
@@ -523,7 +523,7 @@ public class ClusterPartitionFetcher implements IPartitionFetcher {
 
       Map<TSeriesPartitionSlot, TConsensusGroupId> orderedMap =
           new LinkedHashMap<>(entry1.getValue());
-      List<TConsensusGroupId> orderedGroupIds = new ArrayList<>(orderedMap.values());
+      List<TConsensusGroupId> orderedGroupIds = new ArrayList<>(new HashSet<>(orderedMap.values()));
       List<TRegionReplicaSet> regionReplicaSets =
           partitionCache.getRegionReplicaSet(orderedGroupIds);
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/ClusterPartitionFetcher.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/ClusterPartitionFetcher.java
@@ -523,13 +523,17 @@ public class ClusterPartitionFetcher implements IPartitionFetcher {
 
       Map<TSeriesPartitionSlot, TConsensusGroupId> orderedMap =
           new LinkedHashMap<>(entry1.getValue());
-      List<TConsensusGroupId> orderedGroupIds = new ArrayList<>(new HashSet<>(orderedMap.values()));
+      List<TConsensusGroupId> orderedGroupIds =
+          orderedMap.values().stream().distinct().collect(Collectors.toList());
       List<TRegionReplicaSet> regionReplicaSets =
           partitionCache.getRegionReplicaSet(orderedGroupIds);
+      Map<TConsensusGroupId, TRegionReplicaSet> groupIdToReplicaSet = new HashMap<>();
+      for (int index = 0; index < orderedGroupIds.size(); index++) {
+        groupIdToReplicaSet.put(orderedGroupIds.get(index), regionReplicaSets.get(index));
+      }
 
-      int index = 0;
       for (Map.Entry<TSeriesPartitionSlot, TConsensusGroupId> entry2 : orderedMap.entrySet()) {
-        result1.put(entry2.getKey(), regionReplicaSets.get(index++));
+        result1.put(entry2.getKey(), groupIdToReplicaSet.get(entry2.getValue()));
       }
     }
     return new SchemaPartition(


### PR DESCRIPTION
1. For ClusterPartitionFetcher, we should remove the duplicated consensus group ids before fetching schema partitions.
2. The previous statistics maps should be cleaned when the corresponding ConfigNode is no longer the leader; otherwise the ConfigNode would take obsolete statistics when next time it becomes the leader.