### PR TITLE
Update release information after 2.0.8 released

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache IoTDB
-Copyright 2018-2025 The Apache Software Foundation.
+Copyright 2018-2026 The Apache Software Foundation.
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -1,5 +1,5 @@
 Apache IoTDB
-Copyright 2018-2025 The Apache Software Foundation.
+Copyright 2018-2026 The Apache Software Foundation.
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,34 @@
 
 -->
 
+# Apache IoTDB 2.0.8
+
+## Features & Improvements
+- Data Query: Added list display for available DataNode nodes
+- Data Query: Added a system table for statistics on query latency in the table model
+- Data Query: Python SessionDataset supported converting TsBlock to DataFrame and returning DataFrame in batches
+- Storage Management: Supported custom column names for the TIME column
+- Storage Management: Supported viewing the complete definition statement of created tables/views via SQL
+- System Management: Added a system table for DataNode node connection status in the table model
+- Stream Processing: Pipe synchronization supported excluding specified devices / measurement points
+- Stream Processing: Supported specifying multiple exact paths in the path parameter of tree model data synchronization pipe statements
+- Stream Processing: Supported comma-separated mixed use of source.pattern and source.path parameters when filtering paths in Pipe
+- AI Management: Built-in Chronos-2 model supports prediction functions.
+- AI Management: Built-in Timer-XL and Sundial models supported concurrent inference
+- Others: Fixed security vulnerabilities CVE-2025-12183, CVE-2025-66566, and CVE-2025-11226
+- ...
+
+
+## Bugs
+- Fixed the issue where the result set returned by the query was empty after last cache hit.
+- Fixed the issue where reverse query with time filter conditions might miss partial data when a sequence in the memtable contained more than 200,000 points in TVList.
+- Fixed the issue that aligned time series query timed out because canSkip failed to filter out firstTimeseriesMetadata.
+- Fixed the issue where the result returned by LAST query with alias should be adjusted to the measurement alias.
+- Fixed the issue where time filter conditions incorrectly filtered valid data in latest point query under specific cases.
+- Fixed the issue that deletion would fail if performed immediately after a failed write operation.
+- Fixed the potential NPE issue when using the active load function to load TsFiles that use non-default time columns.
+- ...
+
 # Apache IoTDB 2.0.7
 
 ## Features & Improvements

--- a/iotdb-doap.rdf
+++ b/iotdb-doap.rdf
@@ -64,6 +64,14 @@
     <release>
       <Version>
         <name>Apache IoTDB</name>
+        <created>2026-04-14</created>
+        <revision>2.0.8</revision>
+      </Version>
+    </release>
+
+    <release>
+      <Version>
+        <name>Apache IoTDB</name>
         <created>2026-03-04</created>
         <revision>2.0.7</revision>
       </Version>


### PR DESCRIPTION
This pull request updates project documentation and metadata to reflect the new Apache IoTDB 2.0.8 release. It includes updates to copyright years, adds a new release entry, and documents new features, improvements, and bug fixes introduced in this version.

Release documentation and metadata updates:

* Updated the copyright year from 2025 to 2026 in both the `NOTICE` and `NOTICE-binary` files to reflect the new release year. [[1]](diffhunk://#diff-dfb14fbb9e7d095209ec4cfd621069437bf9c442ff9de9d4ce889781bd0fefcfL2-R2) [[2]](diffhunk://#diff-60c143e95fbc9a363ea1996064981304c2fc07e6758c66e26c0ccf305018ff2fL2-R2)
* Added a new release entry for version 2.0.8, dated 2026-04-14, in the `iotdb-doap.rdf` metadata file.
* Added detailed release notes for version 2.0.8 in `RELEASE_NOTES.md`, including a list of new features, improvements, and bug fixes.