### PR TITLE
Due to the removal of the password history feature，remove the associated useless logic.

### DIFF
--- a/iotdb-client/client-py/tests/integration/test_treemodel_insert.py
+++ b/iotdb-client/client-py/tests/integration/test_treemodel_insert.py
@@ -5358,8 +5358,7 @@ def test_insert_auto_create():
         session = Session(db.get_container_host_ip(), db.get_exposed_port(6667))
         session.open()
 
-        # plus 2 for password history
-        expect = 360 + 2
+        expect = 360
         # Test non aligned tablet writing
         num = 0
         for i in range(1, 10):


### PR DESCRIPTION
Due to the removal of the password history feature，remove associated the useless logic.