### PR TITLE
Change delay_analyzer_window_size log to INFO

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -1168,7 +1168,7 @@ public class IoTDBDescriptor {
                 "delay_analyzer_window_size",
                 ConfigurationFileUtils.getConfigurationDefaultValue("delay_analyzer_window_size")));
     if (delayAnalyzerWindowSize > 0) {
-      LOGGER.warn("[DelayAnalyzer] Set delay_analyzer_window_size to {}", delayAnalyzerWindowSize);
+      LOGGER.info("[DelayAnalyzer] Set delay_analyzer_window_size to {}", delayAnalyzerWindowSize);
       conf.setDelayAnalyzerWindowSize(delayAnalyzerWindowSize);
     }
 


### PR DESCRIPTION
## Summary
- change the startup log for delay_analyzer_window_size from WARN to INFO
- keep the message text and configuration behavior unchanged

## Testing
- git diff --check