### PR TITLE
Fix typos: 'occured' in log message, 'seperated' in comments

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
@@ -666,7 +666,7 @@ public class ProcedureExecutor<Env> {
     } catch (IOException e) {
       LOG.error("Roll back failed for {}", procedure, e);
     } catch (InterruptedException e) {
-      LOG.warn("Interrupted exception occured for {}", procedure, e);
+      LOG.warn("Interrupted exception occurred for {}", procedure, e);
     } catch (Throwable t) {
       LOG.error("CODE-BUG: runtime exception for {}", procedure, t);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/SourceRewriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/distribution/SourceRewriter.java
@@ -1376,7 +1376,7 @@ public class SourceRewriter extends BaseSourceRewriter<DistributionPlanContext> 
     Map<String, Map<Integer, List<TRegionReplicaSet>>> cachedRegionReplicas = new HashMap<>();
     for (PlanNode child : node.getChildren()) {
       if (child instanceof SeriesSourceNode) {
-        // If the child is SeriesScanNode, we need to check whether this node should be seperated
+        // If the child is SeriesScanNode, we need to check whether this node should be separated
         // into several splits.
         SeriesSourceNode sourceNode = (SeriesSourceNode) child;
         List<TRegionReplicaSet> dataDistribution =
@@ -1389,7 +1389,7 @@ public class SourceRewriter extends BaseSourceRewriter<DistributionPlanContext> 
           // If there is some series which is distributed in multi DataRegions
           context.setOneSeriesInMultiRegion(true);
         }
-        // If the size of dataDistribution is N, this SeriesScanNode should be seperated into N
+        // If the size of dataDistribution is N, this SeriesScanNode should be separated into N
         // SeriesScanNode.
         for (TRegionReplicaSet dataRegion : dataDistribution) {
           SeriesSourceNode split =


### PR DESCRIPTION
Trivial typo fixes:

- `ProcedureExecutor.java`: log message `Interrupted exception occured` -> `occurred`
- `SourceRewriter.java`: two comments `should be seperated` -> `should be separated`

No behavior changes.