### PR TITLE
Fix IoTConsensusV2 receiver writer borrow race

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/iotconsensusv2/IoTConsensusV2Receiver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/iotconsensusv2/IoTConsensusV2Receiver.java
@@ -1019,9 +1019,12 @@ public class IoTConsensusV2Receiver {
           final Optional<IoTConsensusV2TsFileWriter> idleWriter =
               iotConsensusV2TsFileWriterPool.stream().filter(item -> !item.isUsed()).findFirst();
           if (idleWriter.isPresent()) {
-            idleWriter.get().setUsed(true);
-            idleWriter.get().setCommitIdOfCorrespondingHolderEvent(commitId);
-            return idleWriter.get().refreshLastUsedTs();
+            final IoTConsensusV2TsFileWriter writer = idleWriter.get();
+            // Publish commitId before marking the writer as used so lock-free lookup callers
+            // observing isUsed=true can always see the bound commitId as well.
+            writer.setCommitIdOfCorrespondingHolderEvent(commitId);
+            writer.setUsed(true);
+            return writer.refreshLastUsedTs();
           }
 
           condition.await(RETRY_WAIT_TIME, TimeUnit.MILLISECONDS);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/iotconsensusv2/IoTConsensusV2Receiver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/iotconsensusv2/IoTConsensusV2Receiver.java
@@ -1001,47 +1001,43 @@ public class IoTConsensusV2Receiver {
       return tsFileWriter.orElse(null);
     }
 
-    @SuppressWarnings("java:S3655")
     public IoTConsensusV2TsFileWriter borrowCorrespondingWriter(TCommitId commitId) {
-      Optional<IoTConsensusV2TsFileWriter> tsFileWriter =
-          iotConsensusV2TsFileWriterPool.stream()
-              .filter(
-                  item ->
-                      item.isUsed()
-                          && Objects.equals(commitId, item.getCommitIdOfCorrespondingHolderEvent()))
-              .findFirst();
-
-      // If the TsFileInsertionEvent is first using tsFileWriter, we will find the first available
-      // buffer for it.
-      if (!tsFileWriter.isPresent()) {
-        // We should synchronously find the idle writer to avoid concurrency issues.
-        lock.lock();
-        try {
-          // We need to check tsFileWriter.isPresent() here. Since there may be both retry-sent
-          // tsfile
-          // events and real-time-sent tsfile events, causing the receiver's tsFileWriter load to
-          // exceed IOTDB_CONFIG.getIoTConsensusV2PipelineSize().
-          while (!tsFileWriter.isPresent()) {
-            tsFileWriter =
-                iotConsensusV2TsFileWriterPool.stream().filter(item -> !item.isUsed()).findFirst();
-            condition.await(RETRY_WAIT_TIME, TimeUnit.MILLISECONDS);
+      lock.lock();
+      try {
+        while (true) {
+          final Optional<IoTConsensusV2TsFileWriter> correspondingWriter =
+              iotConsensusV2TsFileWriterPool.stream()
+                  .filter(
+                      item ->
+                          item.isUsed()
+                              && Objects.equals(
+                                  commitId, item.getCommitIdOfCorrespondingHolderEvent()))
+                  .findFirst();
+          if (correspondingWriter.isPresent()) {
+            return correspondingWriter.get().refreshLastUsedTs();
           }
-          tsFileWriter.get().setUsed(true);
-          tsFileWriter.get().setCommitIdOfCorrespondingHolderEvent(commitId);
-        } catch (final InterruptedException e) {
-          Thread.currentThread().interrupt();
-          final String errorStr =
-              String.format(
-                  "IoTConsensusV2%s: receiver thread get interrupted when waiting for borrowing tsFileWriter.",
-                  consensusPipeName);
-          LOGGER.warn(errorStr);
-          throw new RuntimeException(errorStr);
-        } finally {
-          lock.unlock();
-        }
-      }
 
-      return tsFileWriter.get().refreshLastUsedTs();
+          final Optional<IoTConsensusV2TsFileWriter> idleWriter =
+              iotConsensusV2TsFileWriterPool.stream().filter(item -> !item.isUsed()).findFirst();
+          if (idleWriter.isPresent()) {
+            idleWriter.get().setUsed(true);
+            idleWriter.get().setCommitIdOfCorrespondingHolderEvent(commitId);
+            return idleWriter.get().refreshLastUsedTs();
+          }
+
+          condition.await(RETRY_WAIT_TIME, TimeUnit.MILLISECONDS);
+        }
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        final String errorStr =
+            String.format(
+                "IoTConsensusV2%s: receiver thread get interrupted when waiting for borrowing tsFileWriter.",
+                consensusPipeName);
+        LOGGER.warn(errorStr);
+        throw new RuntimeException(errorStr);
+      } finally {
+        lock.unlock();
+      }
     }
 
     private void checkZombieTsFileWriter() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/iotconsensusv2/IoTConsensusV2Receiver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/iotconsensusv2/IoTConsensusV2Receiver.java
@@ -1002,21 +1002,20 @@ public class IoTConsensusV2Receiver {
     }
 
     public IoTConsensusV2TsFileWriter borrowCorrespondingWriter(TCommitId commitId) {
+      final Optional<IoTConsensusV2TsFileWriter> correspondingWriter =
+          iotConsensusV2TsFileWriterPool.stream()
+              .filter(
+                  item ->
+                      item.isUsed()
+                          && Objects.equals(commitId, item.getCommitIdOfCorrespondingHolderEvent()))
+              .findFirst();
+      if (correspondingWriter.isPresent()) {
+        return correspondingWriter.get().refreshLastUsedTs();
+      }
+
       lock.lock();
       try {
         while (true) {
-          final Optional<IoTConsensusV2TsFileWriter> correspondingWriter =
-              iotConsensusV2TsFileWriterPool.stream()
-                  .filter(
-                      item ->
-                          item.isUsed()
-                              && Objects.equals(
-                                  commitId, item.getCommitIdOfCorrespondingHolderEvent()))
-                  .findFirst();
-          if (correspondingWriter.isPresent()) {
-            return correspondingWriter.get().refreshLastUsedTs();
-          }
-
           final Optional<IoTConsensusV2TsFileWriter> idleWriter =
               iotConsensusV2TsFileWriterPool.stream().filter(item -> !item.isUsed()).findFirst();
           if (idleWriter.isPresent()) {


### PR DESCRIPTION
## Summary
- keep the existing fast path for requests that already have a bound writer
- claim an idle writer immediately after it is found instead of waiting before marking it used
- keep waiting only when no matching writer and no idle writer are available

## Problem
This change fixes a receiver-side race that we hit while investigating unexpected `syncLag` in IoTConsensusV2.

In a local 3C3D reproduction with continuous writes and `flush`, two different tsfile events could be assigned to the same receiver writer slot.
A representative case on pipe `__consensus.DataRegion[3]_4_3` looked like this:

- tsfile `1776274436558-1-0-0.tsfile` started writing into receiver slot `/0`
- before that slot was actually claimed, tsfile `1776274436900-2-0-0.tsfile` also borrowed the same slot `/0`
- when the second file arrived, `updateWritingFileIfNeeded(...)` saw a different file name on the same writer, so it closed and deleted the previous temporary file
- later, the earlier file's seal request failed with `writing file null is not available`, and the sender had to retry

This transient failure is enough to create unnecessary retries, and it can amplify the lag symptoms we were debugging.

## Root Cause
The issue is in `IoTConsensusV2Receiver.borrowCorrespondingWriter(...)`.

Previously, when the receiver did not find an existing writer for a `commitId`, it:

1. found an idle writer
2. called `condition.await(RETRY_WAIT_TIME, ...)`
3. only after waking up marked that writer as `used` and bound the `commitId`

The problem is that `await(...)` releases the pool lock.
So another concurrent tsfile request can enter the same critical section during that 500ms window, observe the same writer as still idle, and select it as well.
That is how two different tsfile events can incorrectly share one writer slot.

## Fix
The fix is intentionally small and local to writer-pool bookkeeping:

- keep the existing fast path when a request can directly find its already-bound writer
- when a new writer is needed, use the pool lock only to find an idle writer and claim it immediately
- only wait when there is neither a matching writer on the fast path nor an idle writer under the lock

This removes the original "find first, claim later" window that caused the race, while preserving the hot-path behavior for already-bound writers.

## Why This Is Safe
- Different tsfile events are still distinguished by `TCommitId`; this PR does not change replicate index assignment or request ordering.
- The lock only protects writer-slot ownership bookkeeping for newly borrowed writers. Actual file transfer and file IO remain outside this critical section.
- The scope is deliberately narrow: no historical/realtime extraction logic is changed here.

