### PR TITLE
Fix region migration daily IT

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/IoTDBRegionOperationReliabilityITFramework.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/IoTDBRegionOperationReliabilityITFramework.java
@@ -580,7 +580,7 @@ public class IoTDBRegionOperationReliabilityITFramework {
     AtomicReference<SyncConfigNodeIServiceClient> clientRef = new AtomicReference<>(client);
     try {
       Awaitility.await()
-          .atMost(2, TimeUnit.MINUTES)
+          .atMost(4, TimeUnit.MINUTES)
           .pollDelay(2, TimeUnit.SECONDS)
           .until(
               () -> {


### PR DESCRIPTION
## Description

**Background**
When the original DataNode crashes during `DELETE_OLD_REGION_PEER`, the RemoveRegionPeerProcedure retries RPC calls to the dead node (up to 10 retries with backoff per attempt, 3 retry rounds with 5s intervals),
  which can take `~100-120s`. Combined with waitTaskFinish's 60s disconnection tolerance, the total recovery time easily exceeds the previous 2-minute timeout.


**Resolution**
Increase awaitUntilSuccess timeout from 2 to 4 minutes to fix daily IT failures