### PR TITLE
Fix Integer overflow when converting 604800000000000ms to -3942554432415203328ns

### DIFF
--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/partition/SeriesPartitionTable.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/partition/SeriesPartitionTable.java
@@ -51,14 +51,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 public class SeriesPartitionTable {
-
-  // should only be used in CN scope, in DN scope should directly use
-  // TimePartitionUtils.getTimePartitionInterval()
-  private final long timePartitionInterval =
-      CommonDateTimeUtils.convertMilliTimeWithPrecision(
-          TimePartitionUtils.getTimePartitionInterval(),
-          CommonDescriptor.getInstance().getConfig().getTimestampPrecision());
-
   private final ConcurrentSkipListMap<TTimePartitionSlot, List<TConsensusGroupId>>
       seriesPartitionMap;
 
@@ -263,6 +255,10 @@ public class SeriesPartitionTable {
    */
   public List<TTimePartitionSlot> autoCleanPartitionTable(
       long TTL, TTimePartitionSlot currentTimeSlot) {
+    final long timePartitionInterval =
+        CommonDateTimeUtils.convertMilliTimeWithPrecision(
+            TimePartitionUtils.getTimePartitionInterval(),
+            CommonDescriptor.getInstance().getConfig().getTimestampPrecision());
     List<TTimePartitionSlot> removedTimePartitions = new ArrayList<>();
     Iterator<Map.Entry<TTimePartitionSlot, List<TConsensusGroupId>>> iterator =
         seriesPartitionMap.entrySet().iterator();

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/partition/SeriesPartitionTable.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/partition/SeriesPartitionTable.java
@@ -54,7 +54,7 @@ public class SeriesPartitionTable {
 
   // should only be used in CN scope, in DN scope should directly use
   // TimePartitionUtils.getTimePartitionInterval()
-  private static final long TIME_PARTITION_INTERVAL =
+  private final long timePartitionInterval =
       CommonDateTimeUtils.convertMilliTimeWithPrecision(
           TimePartitionUtils.getTimePartitionInterval(),
           CommonDescriptor.getInstance().getConfig().getTimestampPrecision());
@@ -269,7 +269,7 @@ public class SeriesPartitionTable {
     while (iterator.hasNext()) {
       Map.Entry<TTimePartitionSlot, List<TConsensusGroupId>> entry = iterator.next();
       TTimePartitionSlot timePartitionSlot = entry.getKey();
-      if (timePartitionSlot.getStartTime() + TIME_PARTITION_INTERVAL + TTL
+      if (timePartitionSlot.getStartTime() + timePartitionInterval + TTL
           <= currentTimeSlot.getStartTime()) {
         removedTimePartitions.add(timePartitionSlot);
         iterator.remove();


### PR DESCRIPTION
timePartitionInterval is inited use 604800000 * 1000000 by ns in the DataNode, and 604800000 * 1000000 again after loadGlobalConfig executed.