### PR TITLE
fix(tvf): validate non-negative width and height in pattern_match

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBWindowTVFIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBWindowTVFIT.java
@@ -881,5 +881,17 @@ public class IoTDBWindowTVFIT {
         "select * from pattern_match(data => t1 ORDER BY time, time_col => 'time', data_col => 'value', pattern => '1.0,2.0,1.0', smooth => 0.5, threshold => -1.1, width => 1000.0, height => 500.0, smooth_on_pattern => false)",
         "threshold must be a non-negative number",
         DATABASE_NAME);
+
+    // test negative width should be rejected
+    tableAssertTestFail(
+        "select * from pattern_match(data => t1 ORDER BY time, time_col => 'time', data_col => 'value', pattern => '1.0,2.0,1.0', smooth => 0.5, threshold => 10.0, width => -1.0, height => 500.0, smooth_on_pattern => false)",
+        "width must be a non-negative number",
+        DATABASE_NAME);
+
+    // test negative height should be rejected
+    tableAssertTestFail(
+        "select * from pattern_match(data => t1 ORDER BY time, time_col => 'time', data_col => 'value', pattern => '1.0,2.0,1.0', smooth => 0.5, threshold => 10.0, width => 1000.0, height => -10.0, smooth_on_pattern => false)",
+        "height must be a non-negative number",
+        DATABASE_NAME);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/function/tvf/PatternMatchTableFunction.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/function/tvf/PatternMatchTableFunction.java
@@ -107,11 +107,19 @@ public class PatternMatchTableFunction implements TableFunction {
 
     Double smoothValue = (Double) ((ScalarArgument) arguments.get(SMOOTH_PARAM)).getValue();
     Double thresholdValue = (Double) ((ScalarArgument) arguments.get(THRESHOLD_PARAM)).getValue();
+    Double widthValue = (Double) ((ScalarArgument) arguments.get(WIDTH_PARAM)).getValue();
+    Double heightValue = (Double) ((ScalarArgument) arguments.get(HEIGHT_PARAM)).getValue();
     if (smoothValue < 0) {
       throw new UDFException("smooth must be a non-negative number, but got: " + smoothValue);
     }
     if (thresholdValue < 0) {
       throw new UDFException("threshold must be a non-negative number, but got: " + thresholdValue);
+    }
+    if (widthValue < 0) {
+      throw new UDFException("width must be a non-negative number, but got: " + widthValue);
+    }
+    if (heightValue < 0) {
+      throw new UDFException("height must be a non-negative number, but got: " + heightValue);
     }
 
     // outputColumnSchema description


### PR DESCRIPTION
## Description

Add validation for negative `width` and `height` parameters in the `pattern_match` table-valued function. Previously, passing a negative value for either parameter was silently accepted and produced an empty result set with no indication of misuse, which is inconsistent with how `smooth` and `threshold` are already validated.

## Changes

- **`PatternMatchTableFunction.analyze()`**: Add non-negative checks for `WIDTH_PARAM` and `HEIGHT_PARAM`. A negative value now throws `UDFException` with a clear message, matching the existing behavior of `smooth` / `threshold`.
- **`IoTDBWindowTVFIT`**: Add two integration test cases asserting that `width => -1.0` and `height => -10.0` are rejected with the expected error messages.

## Before

```sql
IoTDB:test_db> select * from pattern_match(
  ..., width => -1.0, height => 500.0, ...);
Empty set.    -- silently returns nothing
```

## After

```sql
IoTDB:test_db> select * from pattern_match(
  ..., width => -1.0, ...);
Error: width must be a non-negative number, but got: -1.0
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test case

## Compatibility

No behavioral change for valid (non-negative) inputs. Only previously-undefined behavior with negative inputs is now rejected at analysis time.