### PR TITLE
CI: Add GitHub Actions workflow to package C++ client binaries

### DIFF
--- a/.github/workflows/client-cpp-package.yml
+++ b/.github/workflows/client-cpp-package.yml
@@ -165,11 +165,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: windows-vs2019
-            runs-on: windows-2019
-            boost_choco: boost-msvc-14.2
-            cmake_generator: Visual Studio 16 2019
-            iotdb_tools_thrift_version: 0.14.1.1-msvc142-SNAPSHOT
           - name: windows-vs2022
             runs-on: windows-2022
             boost_choco: boost-msvc-14.3

--- a/.github/workflows/client-cpp-package.yml
+++ b/.github/workflows/client-cpp-package.yml
@@ -1,0 +1,185 @@
+name: C++ Client package
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "rc/**"
+    tags:
+      - "*"
+    paths:
+      - "pom.xml"
+      - "iotdb-client/**"
+      - "iotdb-protocol/**"
+      - ".github/workflows/client-cpp-package.yml"
+
+concurrency:
+  group: client-cpp-package-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  MAVEN_ARGS: --batch-mode --no-transfer-progress
+
+jobs:
+  package-linux:
+    name: Package (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x86_64
+            runs-on: ubuntu-22.04
+          - name: linux-aarch64
+            runs-on: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+      - name: Install C++ dependencies (Linux)
+        shell: bash
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y libboost-all-dev openssl libssl-dev
+      - name: Cache Maven packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-${{ runner.arch }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-m2-
+      - name: Package client-cpp
+        shell: bash
+        run: |
+          set -euxo pipefail
+          ./mvnw clean package -P with-cpp -pl iotdb-client/client-cpp -am \
+            -DskipTests \
+            -Dspotless.check.skip=true -Dspotless.apply.skip=true
+      - name: Upload zip artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: client-cpp-${{ matrix.name }}
+          path: iotdb-client/client-cpp/target/client-cpp-*-cpp-*.zip
+          if-no-files-found: error
+
+  package-macos:
+    name: Package (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macos-x86_64
+            runs-on: macos-15-intel
+          - name: macos-arm64
+            runs-on: macos-latest
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+      - name: Install C++ dependencies (macOS)
+        shell: bash
+        run: |
+          set -euxo pipefail
+          brew install boost openssl
+      - name: Cache Maven packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-${{ runner.arch }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-m2-
+      - name: Package client-cpp
+        shell: bash
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "12.0"
+        run: |
+          set -euxo pipefail
+          ./mvnw clean package -P with-cpp -pl iotdb-client/client-cpp -am \
+            -DskipTests \
+            -Dspotless.check.skip=true -Dspotless.apply.skip=true
+      - name: Upload zip artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: client-cpp-${{ matrix.name }}
+          path: iotdb-client/client-cpp/target/client-cpp-*-cpp-*.zip
+          if-no-files-found: error
+
+  package-windows:
+    name: Package (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: windows-vs2019
+            runs-on: windows-2019
+            boost_choco: boost-msvc-14.2
+            cmake_generator: Visual Studio 16 2019
+            iotdb_tools_thrift_version: 0.14.1.1-msvc142-SNAPSHOT
+          - name: windows-vs2022
+            runs-on: windows-2022
+            boost_choco: boost-msvc-14.3
+            cmake_generator: ""
+            iotdb_tools_thrift_version: ""
+          - name: windows-vs2026
+            runs-on: windows-2025-vs2026
+            boost_choco: boost-msvc-14.3
+            cmake_generator: Visual Studio 18 2026
+            iotdb_tools_thrift_version: ""
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+      - name: Install C++ dependencies (Windows)
+        shell: pwsh
+        run: |
+          choco install winflexbison3 -y
+          choco install ${{ matrix.boost_choco }} -y
+          $boost_path = (Get-ChildItem -Path 'C:\local\' -Filter 'boost_*').FullName
+          echo $boost_path >> $env:GITHUB_PATH
+          choco install openssl -y
+          $sslPath = (Get-ChildItem 'C:\Program Files\OpenSSL*' -Directory | Select-Object -First 1).FullName
+          echo "$sslPath\bin" >> $env:GITHUB_PATH
+          echo "OPENSSL_ROOT_DIR=$sslPath" >> $env:GITHUB_ENV
+      - name: Cache Maven packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-
+      - name: Package client-cpp
+        shell: bash
+        env:
+          CMAKE_GENERATOR: ${{ matrix.cmake_generator }}
+          IOTDB_TOOLS_THRIFT_VERSION: ${{ matrix.iotdb_tools_thrift_version }}
+        run: |
+          set -euxo pipefail
+          MVN_ARGS=(./mvnw clean package -P with-cpp -pl iotdb-client/client-cpp -am \
+            -DskipTests \
+            -Dspotless.check.skip=true -Dspotless.apply.skip=true)
+          if [ -n "${CMAKE_GENERATOR:-}" ]; then
+            MVN_ARGS+=("-Dcmake.generator=${CMAKE_GENERATOR}")
+          fi
+          if [ -n "${IOTDB_TOOLS_THRIFT_VERSION:-}" ]; then
+            MVN_ARGS+=("-Diotdb-tools-thrift.version=${IOTDB_TOOLS_THRIFT_VERSION}")
+          fi
+          "${MVN_ARGS[@]}"
+      - name: Upload zip artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: client-cpp-${{ matrix.name }}
+          path: iotdb-client/client-cpp/target/client-cpp-*-cpp-*.zip
+          if-no-files-found: error

--- a/.github/workflows/client-cpp-package.yml
+++ b/.github/workflows/client-cpp-package.yml
@@ -1,17 +1,16 @@
+# Manual run; Release published; v* tag pushes; rc/** pushes only when C++-related paths change
+# (job should-package). release events use the workflow file from the default branch.
 name: C++ Client package
 
 on:
   workflow_dispatch:
+  release:
+    types: [published]
   push:
     branches:
       - "rc/**"
     tags:
-      - "*"
-    paths:
-      - "pom.xml"
-      - "iotdb-client/**"
-      - "iotdb-protocol/**"
-      - ".github/workflows/client-cpp-package.yml"
+      - "v*"
 
 concurrency:
   group: client-cpp-package-${{ github.workflow }}-${{ github.ref }}
@@ -22,8 +21,51 @@ env:
   MAVEN_ARGS: --batch-mode --no-transfer-progress
 
 jobs:
+  should-package:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.result.outputs.run }}
+    steps:
+      - uses: actions/checkout@v5
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/rc/')
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/rc/')
+        with:
+          filters: |
+            cpp:
+              - 'pom.xml'
+              - 'iotdb-client/**'
+              - 'iotdb-protocol/**'
+              - '.github/workflows/client-cpp-package.yml'
+      - id: result
+        shell: bash
+        run: |
+          set -euo pipefail
+          E="${{ github.event_name }}"
+          R="${{ github.ref }}"
+          if [[ "$E" == "workflow_dispatch" ]] || [[ "$E" == "release" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "$E" == "push" ]] && [[ "$R" == refs/tags/v* ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "$E" == "push" ]] && [[ "$R" =~ ^refs/heads/rc/ ]]; then
+            if [[ "${{ steps.filter.outputs.cpp }}" == "true" ]]; then
+              echo "run=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "run=false" >> "$GITHUB_OUTPUT"
+            fi
+            exit 0
+          fi
+          echo "run=false" >> "$GITHUB_OUTPUT"
+
   package-linux:
     name: Package (${{ matrix.name }})
+    needs: should-package
+    if: needs.should-package.outputs.run == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -69,6 +111,8 @@ jobs:
 
   package-macos:
     name: Package (${{ matrix.name }})
+    needs: should-package
+    if: needs.should-package.outputs.run == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -115,6 +159,8 @@ jobs:
 
   package-windows:
     name: Package (${{ matrix.name }})
+    needs: should-package
+    if: needs.should-package.outputs.run == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/client-cpp-package.yml
+++ b/.github/workflows/client-cpp-package.yml
@@ -73,7 +73,7 @@ jobs:
           - name: linux-x86_64
             runs-on: ubuntu-22.04
           - name: linux-aarch64
-            runs-on: ubuntu-24.04-arm
+            runs-on: ubuntu-22.04-arm
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

This PR adds a dedicated GitHub Actions workflow (`.github/workflows/client-cpp-package.yml`) that runs C++ client packaging only (no integration-test server startup), and uploads Maven-assembled archives:

`iotdb-client/client-cpp/target/client-cpp-*-cpp-*.zip`

The package step uses:

`./mvnw clean package -P with-cpp -pl iotdb-client/client-cpp -am -DskipTests -Dspotless.check.skip=true -Dspotless.apply.skip=true`

## Trigger strategy (save CI + avoid release misses)

- `workflow_dispatch`: manual run
- `release` with `published`: always run
- `push` on tags `v*`: always run
- `push` on `rc/**`: run only when C++-related paths changed (via `should-package` + `dorny/paths-filter`)

Filtered paths for `rc/**` pushes:
- `pom.xml`
- `iotdb-client/**`
- `iotdb-protocol/**`
- `.github/workflows/client-cpp-package.yml`

This avoids missing packaging on version tags while still reducing CI load on `rc/**` branches.

## Build matrix

- Linux
  - `ubuntu-22.04` (x86_64)
  - `ubuntu-22.04-arm` (aarch64)
- macOS
  - `macos-15-intel` (x86_64)
  - `macos-latest` (arm64)
  - `MACOSX_DEPLOYMENT_TARGET=12.0` in package step
- Windows
  - `windows-2022` (VS2022 toolchain path)
  - `windows-2025-vs2026` (explicit `-Dcmake.generator="Visual Studio 18 2026"`)

VS2019 was removed from CI matrix to avoid deprecated/scarce `windows-2019` hosted runners. Local VS2019 guidance remains in `iotdb-client/client-cpp/README.md` if needed.

## Notes

- `release` events use the workflow definition from the repository default branch (GitHub behavior).
- The existing `multi-language-client` workflow remains responsible for broader validation (`verify` / distribution-related flow); this workflow focuses on packaging artifacts.
