### PR TITLE
Fix duplicate deletion emission in TsFileSplitter

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/load/splitter/DeletionData.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/load/splitter/DeletionData.java
@@ -57,6 +57,10 @@ public class DeletionData implements TsFileData {
     deletion.serialize(stream);
   }
 
+  public ModEntry getModEntry() {
+    return this.deletion;
+  }
+
   public static DeletionData deserialize(InputStream stream)
       throws IllegalPathException, IOException {
     return new DeletionData(ModEntry.createFrom(new DataInputStream(stream)));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/load/splitter/TsFileSplitter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/load/splitter/TsFileSplitter.java
@@ -153,7 +153,6 @@ public class TsFileSplitter {
     long chunkOffset = reader.position();
     timeChunkIndexOfCurrentValueColumn = pageIndex2TimesList.size();
     consumeAllAlignedChunkData(chunkOffset, pageIndex2ChunkData);
-    handleModification(deletions);
 
     ChunkHeader header = reader.readChunkHeader(marker);
     String measurementId = header.getMeasurementID();

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/BatchedCompactionWithTsFileSplitterTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/BatchedCompactionWithTsFileSplitterTest.java
@@ -268,26 +268,14 @@ public class BatchedCompactionWithTsFileSplitterTest extends AbstractCompactionT
               tsFileData -> {
                 if (tsFileData instanceof DeletionData) {
                   deletionMods.add(((DeletionData) tsFileData).getModEntry());
-                  try {
-                    ((DeletionData) tsFileData).writeToModificationFile(actualModificationFile);
-                  } catch (IOException e) {
-                    throw new RuntimeException(e);
-                  }
                 }
                 return true;
               });
       splitter.splitTsFileByDataPartition();
     }
 
-    List<ModEntry> actualMods;
-    try (ModificationFile actualModificationFile =
-        new ModificationFile(actualModsFile.getAbsolutePath(), false)) {
-      actualMods = actualModificationFile.getAllMods();
-    }
-    Assert.assertEquals(expectedMods, actualMods);
-    Files.deleteIfExists(actualModsFile.toPath());
-
     Assert.assertEquals(expectedMods, deletionMods);
+    Files.deleteIfExists(actualModsFile.toPath());
   }
 
   private TsFileResource createAlignedMultiDeviceFile() throws IOException {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/BatchedCompactionWithTsFileSplitterTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/BatchedCompactionWithTsFileSplitterTest.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.storageengine.dataregion.compaction;
 import org.apache.iotdb.common.rpc.thrift.TTimePartitionSlot;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.exception.MetadataException;
+import org.apache.iotdb.commons.path.MeasurementPath;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.exception.load.LoadFileException;
@@ -30,10 +31,15 @@ import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.performer
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.task.CompactionTaskSummary;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.utils.CompactionUtils;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.utils.CompactionCheckerUtils;
+import org.apache.iotdb.db.storageengine.dataregion.compaction.utils.CompactionTestFileWriter;
+import org.apache.iotdb.db.storageengine.dataregion.modification.ModEntry;
+import org.apache.iotdb.db.storageengine.dataregion.modification.ModificationFile;
+import org.apache.iotdb.db.storageengine.dataregion.modification.TreeDeletionEntry;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.generator.TsFileNameGenerator;
 import org.apache.iotdb.db.storageengine.dataregion.utils.TsFileResourceUtils;
 import org.apache.iotdb.db.storageengine.load.splitter.AlignedChunkData;
+import org.apache.iotdb.db.storageengine.load.splitter.DeletionData;
 import org.apache.iotdb.db.storageengine.load.splitter.TsFileData;
 import org.apache.iotdb.db.storageengine.load.splitter.TsFileSplitter;
 
@@ -53,7 +59,9 @@ import org.junit.Test;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -230,6 +238,92 @@ public class BatchedCompactionWithTsFileSplitterTest extends AbstractCompactionT
 
     TsFileResource targetResource = performCompaction();
     consumeChunkDataAndValidate(targetResource);
+  }
+
+  @Test
+  public void testDeletionDataShouldOnlyBeGeneratedOnceAtEnd()
+      throws IOException, MetadataException, LoadFileException, IllegalPathException {
+    TsFileResource resource = createAlignedMultiDeviceFile();
+    try (ModificationFile modificationFile =
+        new ModificationFile(
+            ModificationFile.getExclusiveMods(resource.getTsFile()).getPath(), false)) {
+      modificationFile.write(
+          new TreeDeletionEntry(new MeasurementPath("root.testsg.d0.s0"), Long.MIN_VALUE, 100));
+      modificationFile.write(
+          new TreeDeletionEntry(new MeasurementPath("root.testsg.d0.s1"), 200, 300));
+      modificationFile.write(
+          new TreeDeletionEntry(new MeasurementPath("root.testsg.d1.s0"), Long.MIN_VALUE, 100));
+      modificationFile.write(
+          new TreeDeletionEntry(new MeasurementPath("root.testsg.d1.s1"), 200, 300));
+    }
+
+    List<ModEntry> expectedMods = ModificationFile.readAllModifications(resource.getTsFile(), true);
+    List<ModEntry> deletionMods = new ArrayList<>();
+    File actualModsFile = new File(resource.getTsFilePath() + ".mods");
+    try (ModificationFile actualModificationFile =
+        new ModificationFile(actualModsFile.getAbsolutePath(), false)) {
+      TsFileSplitter splitter =
+          new TsFileSplitter(
+              resource.getTsFile(),
+              tsFileData -> {
+                if (tsFileData instanceof DeletionData) {
+                  deletionMods.add(((DeletionData) tsFileData).getModEntry());
+                  try {
+                    ((DeletionData) tsFileData).writeToModificationFile(actualModificationFile);
+                  } catch (IOException e) {
+                    throw new RuntimeException(e);
+                  }
+                }
+                return true;
+              });
+      splitter.splitTsFileByDataPartition();
+    }
+
+    List<ModEntry> actualMods;
+    try (ModificationFile actualModificationFile =
+        new ModificationFile(actualModsFile.getAbsolutePath(), false)) {
+      actualMods = actualModificationFile.getAllMods();
+    }
+    Assert.assertEquals(expectedMods, actualMods);
+    Files.deleteIfExists(actualModsFile.toPath());
+
+    Assert.assertEquals(expectedMods, deletionMods);
+  }
+
+  private TsFileResource createAlignedMultiDeviceFile() throws IOException {
+    TsFileResource resource = createEmptyFileAndResource(true);
+    try (CompactionTestFileWriter writer = new CompactionTestFileWriter(resource)) {
+      writer.startChunkGroup("d0");
+      writer.generateSimpleAlignedSeriesToCurrentDeviceWithNullValue(
+          Arrays.asList("s0", "s1"),
+          new TimeRange[][] {
+            new TimeRange[] {new TimeRange(1, 100), new TimeRange(200, 300)},
+            new TimeRange[] {
+              new TimeRange(604799900, 604800020), new TimeRange(604810020, 604820020)
+            }
+          },
+          TSEncoding.PLAIN,
+          CompressionType.LZ4,
+          Arrays.asList(false, false));
+      writer.endChunkGroup();
+
+      writer.startChunkGroup("d1");
+      writer.generateSimpleAlignedSeriesToCurrentDeviceWithNullValue(
+          Arrays.asList("s0", "s1"),
+          new TimeRange[][] {
+            new TimeRange[] {new TimeRange(1, 100), new TimeRange(200, 300)},
+            new TimeRange[] {
+              new TimeRange(604799900, 604800020), new TimeRange(604810020, 604820020)
+            }
+          },
+          TSEncoding.PLAIN,
+          CompressionType.LZ4,
+          Arrays.asList(false, false));
+      writer.endChunkGroup();
+
+      writer.endFile();
+    }
+    return resource;
   }
 
   private TsFileResource performCompaction()


### PR DESCRIPTION
## Description
Avoid applying deletions while switching time chunk context, which could emit the same deletion entries multiple times for aligned multi-device files. Add a regression test that verifies emitted deletion mods match expected mods exactly.


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
