### PR TITLE
Use MemoizedCheckedSupplier for COPY TO folder manager & keep compatibility with another branch

### DIFF
--- a/iotdb-core/calc-commons/src/main/java/org/apache/iotdb/calc/execution/relational/ColumnTransformerBuilder.java
+++ b/iotdb-core/calc-commons/src/main/java/org/apache/iotdb/calc/execution/relational/ColumnTransformerBuilder.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.calc.execution.relational;
 
+import org.apache.iotdb.calc.plan.planner.memory.MemoryReservationManager;
 import org.apache.iotdb.calc.plan.relational.metadata.ITypeMetadata;
 import org.apache.iotdb.calc.transformation.dag.column.ColumnTransformer;
 import org.apache.iotdb.calc.transformation.dag.column.FailFunctionColumnTransformer;
@@ -214,6 +215,8 @@ import org.apache.tsfile.read.common.type.TimestampType;
 import org.apache.tsfile.read.common.type.Type;
 import org.apache.tsfile.read.common.type.TypeEnum;
 import org.apache.tsfile.utils.Binary;
+
+import javax.annotation.Nullable;
 
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -1944,6 +1947,10 @@ public class ColumnTransformerBuilder
 
     private final ITypeMetadata metadata;
 
+    // used in other branch
+    @SuppressWarnings("unused")
+    private final Optional<MemoryReservationManager> memoryReservationManager;
+
     public Context(
         SessionInfo sessionInfo,
         List<LeafColumnTransformer> leafList,
@@ -1954,7 +1961,8 @@ public class ColumnTransformerBuilder
         List<TSDataType> inputDataTypes,
         int originSize,
         ITableTypeProvider typeProvider,
-        ITypeMetadata metadata) {
+        ITypeMetadata metadata,
+        @Nullable MemoryReservationManager memoryReservationManager) {
       this.sessionInfo = sessionInfo;
       this.leafList = leafList;
       this.inputLocations = inputLocations;
@@ -1965,6 +1973,7 @@ public class ColumnTransformerBuilder
       this.originSize = originSize;
       this.typeProvider = typeProvider;
       this.metadata = metadata;
+      this.memoryReservationManager = Optional.ofNullable(memoryReservationManager);
     }
 
     public Type getType(SymbolReference symbolReference) {

--- a/iotdb-core/calc-commons/src/main/java/org/apache/iotdb/calc/plan/planner/ITableOperatorGeneratorContext.java
+++ b/iotdb-core/calc-commons/src/main/java/org/apache/iotdb/calc/plan/planner/ITableOperatorGeneratorContext.java
@@ -19,12 +19,15 @@
 
 package org.apache.iotdb.calc.plan.planner;
 
+import org.apache.iotdb.calc.plan.planner.memory.MemoryReservationManager;
 import org.apache.iotdb.commons.queryengine.plan.analyze.ITableTypeProvider;
 
 import java.time.ZoneId;
 
 public interface ITableOperatorGeneratorContext {
   ITableTypeProvider getTableTypeProvider();
+
+  MemoryReservationManager getMemoryReservationManager();
 
   ZoneId getZoneId();
 }

--- a/iotdb-core/calc-commons/src/main/java/org/apache/iotdb/calc/plan/planner/TableOperatorGenerator.java
+++ b/iotdb-core/calc-commons/src/main/java/org/apache/iotdb/calc/plan/planner/TableOperatorGenerator.java
@@ -331,7 +331,8 @@ public abstract class TableOperatorGenerator<
                           ImmutableList.of(),
                           0,
                           context.getTableTypeProvider(),
-                          metadata);
+                          metadata,
+                          context.getMemoryReservationManager());
 
                   return visitor.process(p, filterColumnTransformerContext);
                 })
@@ -358,7 +359,8 @@ public abstract class TableOperatorGenerator<
             filterOutputDataTypes,
             inputLocations.size(),
             context.getTableTypeProvider(),
-            metadata);
+            metadata,
+            context.getMemoryReservationManager());
 
     for (Expression expression : projectExpressions) {
       projectOutputTransformerList.add(

--- a/iotdb-core/datanode/pom.xml
+++ b/iotdb-core/datanode/pom.xml
@@ -407,6 +407,9 @@
                                 <resource>
                                     <directory>${maven.multiModuleProjectDirectory}/iotdb-core/calc-commons/src/main/codegen</directory>
                                     <filtering>false</filtering>
+                                    <excludes>
+                                        <exclude>templates/**</exclude>
+                                    </excludes>
                                 </resource>
                                 <resource>
                                     <directory>src/main/codegen</directory>

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/DataNodeTableOperatorGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/DataNodeTableOperatorGenerator.java
@@ -1240,7 +1240,8 @@ public class DataNodeTableOperatorGenerator
                                 ImmutableList.of(),
                                 0,
                                 context.getTypeProvider(),
-                                metadata)),
+                                metadata,
+                                context.getMemoryReservationManager())),
                     columnSchemaList,
                     database,
                     table)

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LocalExecutionPlanContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LocalExecutionPlanContext.java
@@ -20,6 +20,7 @@ package org.apache.iotdb.db.queryengine.plan.planner;
 
 import org.apache.iotdb.calc.execution.operator.Operator;
 import org.apache.iotdb.calc.plan.planner.ITableOperatorGeneratorContext;
+import org.apache.iotdb.calc.plan.planner.memory.MemoryReservationManager;
 import org.apache.iotdb.commons.queryengine.plan.analyze.ITableTypeProvider;
 import org.apache.iotdb.commons.queryengine.plan.planner.plan.node.PlanNode;
 import org.apache.iotdb.commons.queryengine.plan.planner.plan.node.PlanNodeId;
@@ -312,6 +313,11 @@ public class LocalExecutionPlanContext implements ITableOperatorGeneratorContext
   @Override
   public ITableTypeProvider getTableTypeProvider() {
     return typeProvider;
+  }
+
+  @Override
+  public MemoryReservationManager getMemoryReservationManager() {
+    return driverContext.getFragmentInstanceContext().getMemoryReservationContext();
   }
 
   public FragmentInstanceContext getInstanceContext() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/DeleteDevice.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/DeleteDevice.java
@@ -233,7 +233,8 @@ public class DeleteDevice extends AbstractTraverseDevice {
                     ImmutableList.of(),
                     0,
                     mockTypeProvider,
-                    metadata))
+                    metadata,
+                    null))
             : null;
 
     return new DeviceBlackListConstructor(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/impl/SchemaRegionMemoryImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/impl/SchemaRegionMemoryImpl.java
@@ -1574,7 +1574,8 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
                     ImmutableList.of(),
                     0,
                     mockTypeProvider,
-                    metadata))
+                    metadata,
+                    null))
             : null;
 
     final List<TSDataType> filterOutputDataTypes =
@@ -1601,7 +1602,8 @@ public class SchemaRegionMemoryImpl implements ISchemaRegion {
             filterOutputDataTypes,
             inputLocations.size(),
             mockTypeProvider,
-            metadata);
+            metadata,
+            null);
 
     final List<String> attributeNames =
         updateNode.getAssignments().stream()

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/DataNodeInternalRPCService.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/DataNodeInternalRPCService.java
@@ -45,7 +45,7 @@ public class DataNodeInternalRPCService extends ThriftService
   private static final CommonConfig commonConfig = CommonDescriptor.getInstance().getConfig();
 
   protected final AtomicReference<DataNodeInternalRPCServiceImpl> impl = new AtomicReference<>();
-  private DataNodeContext dataNodeContext;
+  protected DataNodeContext dataNodeContext;
 
   private DataNodeInternalRPCService() {}
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/DataNodeInternalRPCService.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/DataNodeInternalRPCService.java
@@ -44,7 +44,7 @@ public class DataNodeInternalRPCService extends ThriftService
   private static final IoTDBConfig config = IoTDBDescriptor.getInstance().getConfig();
   private static final CommonConfig commonConfig = CommonDescriptor.getInstance().getConfig();
 
-  private final AtomicReference<DataNodeInternalRPCServiceImpl> impl = new AtomicReference<>();
+  protected final AtomicReference<DataNodeInternalRPCServiceImpl> impl = new AtomicReference<>();
   private DataNodeContext dataNodeContext;
 
   private DataNodeInternalRPCService() {}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/TierManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/rescon/disk/TierManager.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.db.storageengine.rescon.disk.strategy.RandomOnDiskUsable
 import org.apache.iotdb.metrics.utils.FileStoreUtils;
 
 import com.google.common.io.BaseEncoding;
+import org.apache.ratis.util.MemoizedCheckedSupplier;
 import org.apache.tsfile.fileSystem.FSFactoryProducer;
 import org.apache.tsfile.fileSystem.FSType;
 import org.apache.tsfile.utils.FSUtils;
@@ -82,7 +83,10 @@ public class TierManager {
 
   private List<String> copyToTargetDirs;
 
-  private FolderManager copyToFolderManager;
+  //  private FolderManager copyToFolderManager;
+
+  private MemoizedCheckedSupplier<FolderManager, DiskSpaceInsufficientException>
+      copyToFolderManager;
 
   /** total space of each tier, Long.MAX_VALUE when one tier contains remote storage */
   private long[] tierDiskTotalSpace;
@@ -175,11 +179,9 @@ public class TierManager {
                             .getFile(v, IoTDBConstant.COPY_TO_TARGET_FOLDER_NAME)
                             .getPath())
                 .collect(Collectors.toList());
-        try {
-          copyToFolderManager = new FolderManager(copyToTargetDirs, directoryStrategyType);
-        } catch (DiskSpaceInsufficientException e) {
-          logger.error("All disks of tier {} are full.", tierLevel, e);
-        }
+        copyToFolderManager =
+            MemoizedCheckedSupplier.valueOf(
+                () -> new FolderManager(copyToTargetDirs, directoryStrategyType));
       }
 
       objectDirs =
@@ -248,14 +250,7 @@ public class TierManager {
   }
 
   public String getNextFolderForCopyToTargetFile() throws DiskSpaceInsufficientException {
-    if (copyToFolderManager == null) {
-      throw new DiskSpaceInsufficientException(
-          "copyToFolderManager is not initialized. This usually indicates that folder "
-              + "initialization in TierManager.initFolders() failed due to insufficient disk "
-              + "space. Please check disk space and related configuration before retrying the "
-              + "copy-to-target operation.");
-    }
-    return copyToFolderManager.getNextFolder();
+    return copyToFolderManager.get().getNextFolder();
   }
 
   public String getNextFolderForObjectFile() throws DiskSpaceInsufficientException {


### PR DESCRIPTION
## Description

This PR updates `TierManager` to lazily initialize the COPY TO target `FolderManager` with `MemoizedCheckedSupplier`, so COPY TO target directories are not created during startup or tier initialization when the COPY TO feature is not used.

It also keeps several query execution context and DataNode service visibility changes for compatibility with another branch, including passing an optional memory reservation manager through column transformer context construction.

## Key Changes

- Changed COPY TO target folder manager initialization in `TierManager` to use `MemoizedCheckedSupplier`.
- Avoided creating COPY TO target directories unless the COPY TO target folder is actually requested.
- Kept compatibility changes for another branch by adding optional `MemoryReservationManager` plumbing to column transformer contexts.
- Excluded `templates/**` from datanode codegen resources.
- Made `DataNodeInternalRPCService.impl` and `dataNodeContext` accessible to subclasses.

