### PR TITLE
Fix DataNode startup in IDEA

### DIFF
--- a/iotdb-core/datanode/pom.xml
+++ b/iotdb-core/datanode/pom.xml
@@ -266,7 +266,6 @@
         <dependency>
             <groupId>at.yawk.lz4</groupId>
             <artifactId>lz4-java</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -476,6 +475,7 @@
                     <ignoredDependencies>
                         <!-- For some reason this plugin missed it being used for a constant import -->
                         <ignoredDependency>org.apache.iotdb:isession</ignoredDependency>
+                        <ignoredDependency>at.yawk.lz4:lz4-java</ignoredDependency>
                     </ignoredDependencies>
                 </configuration>
             </plugin>

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -187,7 +187,7 @@ public class DataNode extends ServerCommandLine implements DataNodeMBean {
   private volatile boolean schemaRegionConsensusStarted = false;
   private volatile boolean dataRegionConsensusStarted = false;
   private static Thread watcherThread;
-  private DataNodeContext context;
+  protected DataNodeContext context;
 
   public DataNode() {
     super("DataNode");


### PR DESCRIPTION
## Description

### Fix DataNode startup from IDEA

This PR keeps `at.yawk.lz4:lz4-java` available on the DataNode compile/runtime
classpath. The dependency was previously declared with `test` scope, but DataNode
can use LZ4 through TSFile compression paths at runtime, for example WAL
compression. Marking it as test-only can make IDEA launch configurations miss the
dependency.

The Maven dependency analyzer still reports `lz4-java` as test-only because
DataNode does not directly reference the implementation classes. This PR adds it
to the ignored dependency list to document that the warning is a false positive.

### Allow DataNode context access from subclasses

This PR changes `DataNode.context` from `private` to `protected`, allowing
subclasses or launch helpers to access the initialized context when starting
DataNode in development environments.

<hr>

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods.
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- `iotdb-core/datanode/pom.xml`
- `org.apache.iotdb.db.service.DataNode`
