### PR TITLE
[ISSUE-xxxx] Fix IPv6 address parsing across server and client components

### DIFF
--- a/iotdb-client/client-py/iotdb/Session.py
+++ b/iotdb-client/client-py/iotdb/Session.py
@@ -150,9 +150,22 @@ class Session(object):
         session.__hosts = []
         session.__ports = []
         for node_url in node_urls:
-            split = node_url.split(":")
-            session.__hosts.append(split[0])
-            session.__ports.append(int(split[1]))
+            # Handle IPv6 address format [ipv6]:port
+            if node_url.startswith("["):
+                bracket_end = node_url.find("]")
+                if bracket_end > 0:
+                    host = node_url[1:bracket_end]
+                    # Port comes after "]:"
+                    port_str = node_url[bracket_end + 2:]
+                    session.__hosts.append(host)
+                    session.__ports.append(int(port_str))
+                else:
+                    raise RuntimeError(f"Invalid IPv6 address format: {node_url}")
+            else:
+                # IPv4 format: host:port
+                split = node_url.split(":")
+                session.__hosts.append(split[0])
+                session.__ports.append(int(split[1]))
         session.__host = session.__hosts[0]
         session.__port = session.__ports[0]
         session.__default_endpoint = TEndPoint(session.__host, session.__port)

--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/Utils.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/Utils.java
@@ -42,8 +42,8 @@ public class Utils {
   static final String RPC_COMPRESS = "rpc_compress";
 
   /**
-   * Parse JDBC connection URL The only supported format of the URL is:
-   * jdbc:iotdb://localhost:6667/.
+   * Parse JDBC connection URL The only supported format of the URL is: jdbc:iotdb://localhost:6667/
+   * or jdbc:iotdb://[::1]:6667/ for IPv6.
    */
   static IoTDBConnectionParams parseUrl(String url, Properties info) throws IoTDBURLException {
     IoTDBConnectionParams params = new IoTDBConnectionParams(url);
@@ -57,10 +57,24 @@ public class Utils {
     String suffixURL = null;
     if (url.startsWith(Config.IOTDB_URL_PREFIX)) {
       String subURL = url.substring(Config.IOTDB_URL_PREFIX.length());
-      int i = subURL.lastIndexOf(COLON);
-      host = subURL.substring(0, i);
+      int i;
+      // Handle IPv6 address format [ipv6]:port
+      if (subURL.startsWith("[")) {
+        int bracketEnd = subURL.indexOf(']');
+        if (bracketEnd > 0) {
+          host = subURL.substring(1, bracketEnd);
+          // Find port after "]:"
+          i = bracketEnd + 2;
+        } else {
+          throw new IoTDBURLException("Invalid IPv6 address format in URL: " + url);
+        }
+      } else {
+        // IPv4 format: use lastIndexOf to find port separator
+        i = subURL.lastIndexOf(COLON);
+        host = subURL.substring(0, i);
+        i++;
+      }
       params.setHost(host);
-      i++;
       // parse port
       int port = 0;
       for (; i < subURL.length() && Character.isDigit(subURL.charAt(i)); i++) {

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/utils/Utils.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/utils/Utils.java
@@ -85,7 +85,12 @@ public class Utils {
   private Utils() {}
 
   public static String hostAddress(TEndPoint endpoint) {
-    return String.format("%s:%d", endpoint.getIp(), endpoint.getPort());
+    String ip = endpoint.getIp();
+    // IPv6 addresses need to be wrapped in brackets
+    if (ip.contains(":")) {
+      return String.format("[%s]:%d", ip, endpoint.getPort());
+    }
+    return String.format("%s:%d", ip, endpoint.getPort());
   }
 
   public static String fromTEndPointToString(TEndPoint endpoint) {
@@ -106,6 +111,14 @@ public class Utils {
   }
 
   public static TEndPoint fromRaftPeerAddressToTEndPoint(String address) {
+    // Handle IPv6 address format [ipv6]:port
+    if (address.startsWith("[")) {
+      int bracketEnd = address.indexOf(']');
+      String ip = address.substring(1, bracketEnd);
+      int port = Integer.parseInt(address.substring(bracketEnd + 2));
+      return new TEndPoint(ip, port);
+    }
+    // IPv4 format: ip:port
     String[] items = address.split(":");
     return new TEndPoint(items[0], Integer.parseInt(items[1]));
   }
@@ -115,7 +128,16 @@ public class Utils {
   }
 
   public static TEndPoint fromRaftPeerProtoToTEndPoint(RaftPeerProto proto) {
-    String[] items = proto.getAddress().split(":");
+    String address = proto.getAddress();
+    // Handle IPv6 address format [ipv6]:port
+    if (address.startsWith("[")) {
+      int bracketEnd = address.indexOf(']');
+      String ip = address.substring(1, bracketEnd);
+      int port = Integer.parseInt(address.substring(bracketEnd + 2));
+      return new TEndPoint(ip, port);
+    }
+    // IPv4 format: ip:port
+    String[] items = address.split(":");
     return new TEndPoint(items[0], Integer.parseInt(items[1]));
   }
 


### PR DESCRIPTION
## Problem

Multiple components in IoTDB cannot correctly handle IPv6 addresses when configured with IPv6 endpoints like `[::1]:10710`. Using `split(":")` to parse IPv6 addresses causes:

- `NumberFormatException` when parsing empty string as port
- ConfigNode/DataNode startup failure
- JDBC URL parsing failure
- Python client `init_from_node_urls` failure

For IPv6 address `[::1]:10710`, `split(":")` produces:
- `items[0]` = `[`
- `items[1]` = `""` (empty string) ← **Integer.parseInt throws exception**
- `items[2]` = `1]`
- `items[3]` = `10710`

## Solution

This PR fixes IPv6 address parsing in 3 components:

### 1. Ratis Consensus Utils (Server-side)
- **File**: `iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/utils/Utils.java`
- **Methods**:
  - `hostAddress()` - Wrap IPv6 addresses in brackets `[ip]:port` format
  - `fromRaftPeerAddressToTEndPoint()` - Parse IPv6 format `[ipv6]:port` correctly
  - `fromRaftPeerProtoToTEndPoint()` - Parse IPv6 format correctly

### 2. JDBC Client
- **File**: `iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/Utils.java`
- **Method**: `parseUrl()` - Handle JDBC URLs like `jdbc:iotdb://[::1]:6667/` by detecting `[ipv6]` format

### 3. Python Client
- **File**: `iotdb-client/client-py/iotdb/Session.py`
- **Method**: `init_from_node_urls()` - Parse IPv6 node URLs like `[::1]:6667` correctly

## Affected Components

| Component | IPv6 Support Before | IPv6 Support After |
|-----------|--------------------|--------------------|
| ConfigNode/DataNode | ❌ Startup fails | ✅ Works |
| JDBC URL | ❌ Parse fails | ✅ `jdbc:iotdb://[::1]:6667/` |
| Python Session | ❌ `init_from_node_urls` fails | ✅ `[::1]:6667` |
| Java Session | ✅ Already works | ✅ No change needed |
| C++ Client | ✅ Already works | ✅ No change needed |

## Test Plan

- Manual testing with IPv6 configuration:
  - `cn_internal_address=::1`
  - `dn_rpc_address=::1`
  - JDBC URL: `jdbc:iotdb://[::1]:6667/`
  - Python: `Session.init_from_node_urls(["[::1]:6667"])`
- Verify ConfigNode and DataNode can start successfully with IPv6 addresses
- Verify JDBC and Python clients can connect to IPv6 endpoints