### PR TITLE
Fix allocate of MemoryBlock

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/Coordinator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/Coordinator.java
@@ -1216,7 +1216,9 @@ public class Coordinator {
 
     @Override
     public long ramBytesUsed() {
+      // The result of this method is fixed
       return INSTANCE_SIZE
+          + sizeOfCharArray(queryId.length())
           + sizeOfCharArray(statement.length())
           + sizeOfCharArray(user.length())
           + sizeOfCharArray(clientHost.length());

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/memory/AtomicLongMemoryBlock.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/memory/AtomicLongMemoryBlock.java
@@ -23,7 +23,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class AtomicLongMemoryBlock extends IMemoryBlock {
@@ -58,30 +57,30 @@ public class AtomicLongMemoryBlock extends IMemoryBlock {
 
   @Override
   public boolean allocate(long sizeInByte) {
-    AtomicBoolean result = new AtomicBoolean(false);
-    usedMemoryInBytes.updateAndGet(
-        memCost -> {
-          if (memCost + sizeInByte > totalMemorySizeInBytes) {
-            return memCost;
-          }
-          result.set(true);
-          return memCost + sizeInByte;
-        });
-    return result.get();
+    long prev;
+    long next;
+    do {
+      prev = usedMemoryInBytes.get();
+      if (prev + sizeInByte > totalMemorySizeInBytes) {
+        return false;
+      }
+      next = prev + sizeInByte;
+    } while (!usedMemoryInBytes.compareAndSet(prev, next));
+    return true;
   }
 
   @Override
   public boolean allocateIfSufficient(final long sizeInByte, final double maxRatio) {
-    AtomicBoolean result = new AtomicBoolean(false);
-    usedMemoryInBytes.updateAndGet(
-        memCost -> {
-          if (memCost + sizeInByte > totalMemorySizeInBytes * maxRatio) {
-            return memCost;
-          }
-          result.set(true);
-          return memCost + sizeInByte;
-        });
-    return result.get();
+    long prev;
+    long next;
+    do {
+      prev = usedMemoryInBytes.get();
+      if (prev + sizeInByte > totalMemorySizeInBytes * maxRatio) {
+        return false;
+      }
+      next = prev + sizeInByte;
+    } while (!usedMemoryInBytes.compareAndSet(prev, next));
+    return true;
   }
 
   @Override

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/memory/AtomicLongMemoryBlock.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/memory/AtomicLongMemoryBlock.java
@@ -100,16 +100,20 @@ public class AtomicLongMemoryBlock extends IMemoryBlock {
 
   @Override
   public long release(long sizeInByte) {
-    return usedMemoryInBytes.updateAndGet(
-        memCost -> {
-          if (sizeInByte > memCost) {
-            LOGGER.warn(
-                "The memory cost to be released is larger than the memory cost of memory block {}",
-                this);
-            return 0;
-          }
-          return memCost - sizeInByte;
-        });
+    long prev;
+    long next;
+    do {
+      prev = usedMemoryInBytes.get();
+      if (sizeInByte > prev) {
+        LOGGER.warn(
+            "The memory cost to be released is larger than the memory cost of memory block {}",
+            this);
+        next = 0;
+      } else {
+        next = prev - sizeInByte;
+      }
+    } while (!usedMemoryInBytes.compareAndSet(prev, next));
+    return next;
   }
 
   @Override

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/memory/MemoryBlockTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/memory/MemoryBlockTest.java
@@ -21,6 +21,9 @@ package org.apache.iotdb.commons.memory;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
 public class MemoryBlockTest {
 
   @Test
@@ -63,5 +66,43 @@ public class MemoryBlockTest {
 
     memoryBlock1.close();
     memoryBlock2.close();
+  }
+
+  @Test
+  public void testAllocateNoPhantomSuccessUnderContention() throws InterruptedException {
+    final int rounds = 2000;
+    for (int i = 0; i < rounds; i++) {
+      AtomicLongMemoryBlock memoryBlock = new AtomicLongMemoryBlock("ContentionBlock", null, 1);
+      AtomicInteger successCount = new AtomicInteger(0);
+      CountDownLatch startLatch = new CountDownLatch(1);
+      CountDownLatch doneLatch = new CountDownLatch(2);
+
+      Runnable allocateTask =
+          () -> {
+            try {
+              startLatch.await();
+              if (memoryBlock.allocate(1)) {
+                successCount.incrementAndGet();
+              }
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+              throw new RuntimeException(e);
+            } finally {
+              doneLatch.countDown();
+            }
+          };
+
+      Thread t1 = new Thread(allocateTask, "memory-block-test-1");
+      Thread t2 = new Thread(allocateTask, "memory-block-test-2");
+      t1.start();
+      t2.start();
+      startLatch.countDown();
+      doneLatch.await();
+
+      Assert.assertEquals(1, successCount.get());
+      Assert.assertEquals(1, memoryBlock.getUsedMemoryInBytes());
+      Assert.assertEquals(0, memoryBlock.release(1));
+      Assert.assertEquals(0, memoryBlock.getUsedMemoryInBytes());
+    }
   }
 }


### PR DESCRIPTION
This PR fixes a memory concurrent allocate bug in AtomicLongMemoryBlock:
AtomicLongMemoryBlock.allocate() used AtomicLong.updateAndGet() with a lambda that had an external side effect (result.set(true)).

updateAndGet() is CAS-retry based: when CAS fails, the lambda can be executed multiple times. Under contention, this sequence could happen:

1. First lambda run sees enough memory, sets result=true, computes next.
2. CAS fails because another thread changed usedMemoryInBytes.
3. Lambda runs again with a new value and may decide allocation should fail (no increment).
4. Method still returns result=true from the earlier side effect.

So the caller may observe “allocation succeeded” while usedMemoryInBytes was not actually increased (phantom allocation success).
After enough such mismatches, release paths can try to release more than recorded memory, triggering warnings like “release is larger than memory cost.”


