### PR TITLE
Fix swallowed exceptions in query execution

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/driver/DataDriver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/driver/DataDriver.java
@@ -31,6 +31,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import java.util.List;
 
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static org.apache.iotdb.calc.metric.QueryExecutionMetricSet.QUERY_RESOURCE_INIT;
 import static org.apache.iotdb.db.storageengine.dataregion.VirtualDataRegion.UNFINISHED_QUERY_DATA_SOURCE;
 
@@ -68,7 +69,9 @@ public class DataDriver extends Driver {
             "Failed to do the initialization for driver {} ", driverContext.getDriverTaskID(), t);
         driverContext.failed(t);
         blockedFuture.setException(t);
-        return false;
+        throwIfUnchecked(t);
+        // should never happen
+        throw new AssertionError(t);
       }
     }
     return true;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/utils/ResourceByPathUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/utils/ResourceByPathUtils.java
@@ -216,6 +216,7 @@ public abstract class ResourceByPathUtils {
           listRamInfo.getArrayMemCost(),
           listRamInfo.getRowCount(),
           listRamInfo.getDataTypes());
+      throw ex;
     } finally {
       list.unlockQueryList();
     }


### PR DESCRIPTION
## Description

This PR fixes two exception propagation issues:

- Re-throw DataDriver initialization failures after marking the driver context failed, so scheduler abort handling can take over instead of treating the driver as normally finished.
- Re-throw ResourceByPathUtils calculation exceptions after logging detailed TVList RAM diagnostics.

