### PR TITLE
[To dev/1.3] Pipe: Fixed the bug that the parent class loader may wrongly load ext pipe plugins (#17580)

### DIFF
--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/plugin/service/PipePluginClassLoader.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/plugin/service/PipePluginClassLoader.java
@@ -35,6 +35,10 @@ import java.util.stream.Stream;
 @ThreadSafe
 public class PipePluginClassLoader extends URLClassLoader {
 
+  private static final String[] PARENT_FIRST_CLASS_PREFIXES = {
+    "java.", "javax.", "jdk.", "sun.", "org.slf4j.", "org.apache.iotdb.pipe.api."
+  };
+
   private final String libRoot;
 
   /**
@@ -50,7 +54,11 @@ public class PipePluginClassLoader extends URLClassLoader {
   private volatile boolean deprecated;
 
   public PipePluginClassLoader(String libRoot) throws IOException {
-    super(new URL[0]);
+    this(libRoot, ClassLoader.getSystemClassLoader());
+  }
+
+  PipePluginClassLoader(String libRoot, ClassLoader parent) throws IOException {
+    super(new URL[0], parent);
     this.libRoot = libRoot;
     activeInstanceCount = new AtomicLong(0);
     deprecated = false;
@@ -80,6 +88,38 @@ public class PipePluginClassLoader extends URLClassLoader {
   public synchronized void markAsDeprecated() throws IOException {
     deprecated = true;
     closeIfPossible();
+  }
+
+  @Override
+  protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+    synchronized (getClassLoadingLock(name)) {
+      Class<?> loadedClass = findLoadedClass(name);
+      if (loadedClass == null) {
+        loadedClass =
+            shouldLoadFromParentFirst(name) ? super.loadClass(name, false) : loadClassLocally(name);
+      }
+      if (resolve) {
+        resolveClass(loadedClass);
+      }
+      return loadedClass;
+    }
+  }
+
+  private Class<?> loadClassLocally(String name) throws ClassNotFoundException {
+    try {
+      return findClass(name);
+    } catch (ClassNotFoundException e) {
+      return super.loadClass(name, false);
+    }
+  }
+
+  private boolean shouldLoadFromParentFirst(String name) {
+    for (String prefix : PARENT_FIRST_CLASS_PREFIXES) {
+      if (name.startsWith(prefix)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private void closeIfPossible() throws IOException {

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/pipe/agent/plugin/service/PipePluginClassLoaderTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/pipe/agent/plugin/service/PipePluginClassLoaderTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.commons.pipe.agent.plugin.service;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.tools.JavaCompiler;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.stream.Stream;
+
+public class PipePluginClassLoaderTest {
+
+  @Test
+  public void testPluginClassesShouldOverrideParentClasses() throws Exception {
+    final Path tempDir = Files.createTempDirectory("pipe-plugin-classloader-test");
+    try {
+      final Path parentSources = Files.createDirectory(tempDir.resolve("parent-sources"));
+      final Path parentClasses = Files.createDirectory(tempDir.resolve("parent-classes"));
+      final Path childSources = Files.createDirectory(tempDir.resolve("child-sources"));
+      final Path childClasses = Files.createDirectory(tempDir.resolve("child-classes"));
+
+      final String sampleSource =
+          "package test.plugin;"
+              + "public class Sample {"
+              + "  public String ping() {"
+              + "    return test.dep.Helper.value();"
+              + "  }"
+              + "}";
+      final String parentHelperSource =
+          "package test.dep;"
+              + "public class Helper {"
+              + "  public static String value() {"
+              + "    return \"parent\";"
+              + "  }"
+              + "}";
+      final String childHelperSource =
+          "package test.dep;"
+              + "public class Helper {"
+              + "  public static String value() {"
+              + "    return \"child\";"
+              + "  }"
+              + "}";
+
+      compile(
+          parentSources,
+          parentClasses,
+          createSources(sampleSource, false),
+          createSources(parentHelperSource, true));
+      compile(
+          childSources,
+          childClasses,
+          createSources(sampleSource, false),
+          createSources(childHelperSource, true));
+
+      final Path parentJar = tempDir.resolve("parent.jar");
+      final Path childJar = tempDir.resolve("child.jar");
+      createJar(parentJar, parentClasses, Arrays.asList("test/plugin/Sample.class"));
+      createJar(
+          childJar,
+          childClasses,
+          Arrays.asList("test/plugin/Sample.class", "test/dep/Helper.class"));
+
+      try (final URLClassLoader parentClassLoader =
+              new URLClassLoader(new URL[] {parentJar.toUri().toURL()}, null);
+          final PipePluginClassLoader pluginClassLoader =
+              new PipePluginClassLoader(childJar.toString(), parentClassLoader)) {
+        final Class<?> sampleClass = Class.forName("test.plugin.Sample", true, pluginClassLoader);
+        Assert.assertSame(pluginClassLoader, sampleClass.getClassLoader());
+        final Object sample = sampleClass.getDeclaredConstructor().newInstance();
+        Assert.assertEquals("child", sampleClass.getMethod("ping").invoke(sample));
+      }
+    } finally {
+      deleteRecursively(tempDir);
+    }
+  }
+
+  private static Map<String, String> createSources(
+      final String source, final boolean helperSource) {
+    final Map<String, String> sources = new LinkedHashMap<>();
+    sources.put(helperSource ? "test.dep.Helper" : "test.plugin.Sample", source);
+    return sources;
+  }
+
+  private static void compile(
+      final Path sourcesDir, final Path classesDir, final Map<String, String>... sourceGroups)
+      throws IOException {
+    final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    Assert.assertNotNull("A JDK is required to run this test.", compiler);
+
+    final List<File> sourceFiles = new ArrayList<>();
+    for (final Map<String, String> sourceGroup : sourceGroups) {
+      for (final Map.Entry<String, String> entry : sourceGroup.entrySet()) {
+        final Path sourceFile = sourcesDir.resolve(entry.getKey().replace('.', '/') + ".java");
+        Files.createDirectories(sourceFile.getParent());
+        Files.write(sourceFile, entry.getValue().getBytes(StandardCharsets.UTF_8));
+        sourceFiles.add(sourceFile.toFile());
+      }
+    }
+
+    try (final StandardJavaFileManager fileManager =
+        compiler.getStandardFileManager(null, null, StandardCharsets.UTF_8)) {
+      final boolean success =
+          compiler
+              .getTask(
+                  null,
+                  fileManager,
+                  null,
+                  Arrays.asList("-d", classesDir.toString()),
+                  null,
+                  fileManager.getJavaFileObjectsFromFiles(sourceFiles))
+              .call();
+      Assert.assertTrue(success);
+    }
+  }
+
+  private static void createJar(
+      final Path jarPath, final Path classesDir, final List<String> classEntries)
+      throws IOException {
+    try (final JarOutputStream jarOutputStream =
+        new JarOutputStream(Files.newOutputStream(jarPath))) {
+      for (final String classEntry : classEntries) {
+        jarOutputStream.putNextEntry(new JarEntry(classEntry));
+        jarOutputStream.write(Files.readAllBytes(classesDir.resolve(classEntry)));
+        jarOutputStream.closeEntry();
+      }
+    }
+  }
+
+  private static void deleteRecursively(final Path path) throws IOException {
+    if (path == null || !Files.exists(path)) {
+      return;
+    }
+    try (final Stream<Path> stream = Files.walk(path)) {
+      for (final Path subPath :
+          (Iterable<Path>) stream.sorted(Comparator.reverseOrder())::iterator) {
+        Files.deleteIfExists(subPath);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description
As the title said.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
