### PR TITLE
Refuse unreasonable string length in thrift frame

### DIFF
--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TElasticFramedTransport.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TElasticFramedTransport.java
@@ -235,7 +235,7 @@ public class TElasticFramedTransport extends TTransport {
 
     void throwException(long size, String remoteInfo, int maxSize) throws TTransportException {
       String message =
-          (this == FRAME_SIZE_EXCEEDED)
+          (this == FRAME_SIZE_EXCEEDED || this == STRING_LENGTH_EXCEEDED)
               ? String.format(messageFormat, size, maxSize, remoteInfo)
               : String.format(messageFormat, size, remoteInfo);
       throw new TTransportException(TTransportException.CORRUPTED_DATA, message);

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TElasticFramedTransport.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TElasticFramedTransport.java
@@ -224,7 +224,8 @@ public class TElasticFramedTransport extends TTransport {
             + "requests%s to the Non-SSL Thrift-RPC port, please confirm that you are using "
             + "the right configuration"),
     NEGATIVE_FRAME_SIZE("Read a negative frame size (%d)%s!"),
-    FRAME_SIZE_EXCEEDED("Frame size (%d) larger than protect max size (%d)%s!");
+    FRAME_SIZE_EXCEEDED("Frame size (%d) larger than protect max size (%d)%s!"),
+    STRING_LENGTH_EXCEEDED("String length (%d) larger than protect max size (%d)%s!");
 
     private final String messageFormat;
 
@@ -232,7 +233,7 @@ public class TElasticFramedTransport extends TTransport {
       this.messageFormat = messageFormat;
     }
 
-    void throwException(int size, String remoteInfo, int maxSize) throws TTransportException {
+    void throwException(long size, String remoteInfo, int maxSize) throws TTransportException {
       String message =
           (this == FRAME_SIZE_EXCEEDED)
               ? String.format(messageFormat, size, maxSize, remoteInfo)
@@ -283,8 +284,15 @@ public class TElasticFramedTransport extends TTransport {
 
   @Override
   public void checkReadBytesAvailable(long numBytes) throws TTransportException {
-    // do nothing now.
-    // here we can do some checkm, e.g., see whether the memory is enough.
+    if (numBytes >= thriftMaxFrameSize) {
+      SocketAddress remoteAddress = null;
+      if (underlying instanceof TSocket) {
+        remoteAddress = ((TSocket) underlying).getSocket().getRemoteSocketAddress();
+      }
+      String remoteInfo = (remoteAddress == null) ? "" : " from " + remoteAddress;
+      close();
+      FrameError.STRING_LENGTH_EXCEEDED.throwException(numBytes, remoteInfo, thriftMaxFrameSize);
+    }
   }
 
   @Override


### PR DESCRIPTION
This pull request introduces a new string length protection mechanism in the `TElasticFramedTransport` class to prevent excessively large string reads, and adds a new file to the `.worktreeinclude` list. The main focus is on improving safety and configuration by enforcing a maximum allowed string length during RPC operations.

**String Length Protection Enhancements:**

* Added a new `FrameError.STRING_LENGTH_EXCEEDED` error type to handle cases where the string length exceeds the configured maximum, and updated the `throwException` method to support this new error.
* Updated the `checkReadBytesAvailable` method to throw the new `STRING_LENGTH_EXCEEDED` error and close the connection if a string read request exceeds the maximum allowed size, enhancing security and robustness.