### PR TITLE
Fix NPE because of thread of DriverScheduler was not closed immediately when stop DN

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/DriverScheduler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/DriverScheduler.java
@@ -164,6 +164,7 @@ public class DriverScheduler implements IDriverScheduler, IService {
         t -> {
           try {
             t.close();
+            t.interrupt();
           } catch (IOException e) {
             // Only a field is set, there's no chance to throw an IOException
           }


### PR DESCRIPTION
Cause:

1. DriverScheduler.stop() returns before driver threads are fully gone.
2. During that gap, MPP teardown can deregister FI memory accounting first.
3. A still-running driver cleanup path then calls MemoryPool.free(...) using the same IDs.
4. free() hits a removed map entry (null) and throws IllegalArgumentException wrapping NPE.