### PR TITLE
Fix transport leak in ConfigNodeClient during leader redirect

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/client/ConfigNodeClient.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/client/ConfigNodeClient.java
@@ -265,10 +265,7 @@ public class ConfigNodeClient implements IConfigNodeRPCService.Iface, ThriftClie
   }
 
   public void connect(TEndPoint endpoint, int timeoutMs) throws TException {
-    // Close old transport to avoid leaking TCP connections on the server side.
-    // Without this, redirect scenarios (Follower -> Leader) overwrite the transport
-    // field and leave the old connection open, causing server-side RPC threads to
-    // block indefinitely on the abandoned socket.
+    // Close existing transport before reassigning to prevent connection leaks.
     if (transport != null) {
       transport.close();
     }
@@ -332,10 +329,6 @@ public class ConfigNodeClient implements IConfigNodeRPCService.Iface, ThriftClie
         Thread.currentThread().interrupt();
         logger.warn("Unexpected interruption when waiting to try to connect to ConfigNode");
       }
-    }
-
-    if (transport != null) {
-      transport.close();
     }
 
     for (int tryHostNum = 0; tryHostNum < configNodes.size(); tryHostNum++) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/client/ConfigNodeClient.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/client/ConfigNodeClient.java
@@ -265,6 +265,13 @@ public class ConfigNodeClient implements IConfigNodeRPCService.Iface, ThriftClie
   }
 
   public void connect(TEndPoint endpoint, int timeoutMs) throws TException {
+    // Close old transport to avoid leaking TCP connections on the server side.
+    // Without this, redirect scenarios (Follower -> Leader) overwrite the transport
+    // field and leave the old connection open, causing server-side RPC threads to
+    // block indefinitely on the abandoned socket.
+    if (transport != null) {
+      transport.close();
+    }
     transport =
         commonConfig.isEnableInternalSSL()
             ? DeepCopyRpcTransportFactory.INSTANCE.getTransport(


### PR DESCRIPTION
## Summary

- Fix a TCP connection leak in `ConfigNodeClient.connect()` on the DataNode side: when a DataNode is redirected from a Follower ConfigNode to the Leader, the old transport is not closed before being overwritten, causing server-side `TThreadPoolServer` worker threads to block indefinitely on abandoned sockets
- This was observed in a 5C20D cluster during ConfigNode failover testing — after two ConfigNodes were restarted, the former leader accumulated 55 leaked `ConfigNodeRPC-Processor` threads (vs. 1 for a normal follower), all stuck in `SocketDispatcher.read0` waiting on connections that would never receive data

## Root Cause

In `ConfigNodeClient.tryToConnect()`, when `configLeader` is set (redirect scenario), the code calls `connect(configLeader)` which directly overwrites `this.transport` with a new connection. The old transport to the previous ConfigNode is never closed. The server-side `TThreadPoolServer` keeps the corresponding worker thread alive, blocking on the now-orphaned socket.

The leak path:
1. DataNode borrows `ConfigNodeClient` from pool, already connected to ConfigNode A (Follower)
2. RPC returns `REDIRECTION_RECOMMEND` → `configLeader` is set to ConfigNode B (Leader)
3. Retry loop calls `connectAndSync()` → `tryToConnect()` → `connect(B)`
4. `connect()` overwrites `transport` with a new connection to B; old transport to A is leaked
5. ConfigNode A's `TThreadPoolServer` worker thread blocks forever on the abandoned socket

## Fix

Close the existing transport at the beginning of `connect()` before creating a new one. This covers all call paths (redirect branch and round-robin fallback loop in `tryToConnect()`).

## Test Plan

- [x] `mvn compile -pl iotdb-core/datanode` passes
- [ ] Verify in a multi-ConfigNode cluster: after leader failover and redirect, the old Follower's `ConfigNodeRPC-Processor` thread count stays at normal levels (1 for idle followers) instead of accumulating leaked threads