### PR TITLE
Refactor Duplicate literal

### DIFF
--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TElasticFramedTransport.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/TElasticFramedTransport.java
@@ -99,6 +99,7 @@ public class TElasticFramedTransport extends TTransport {
   protected AutoScalingBufferWriteTransport writeBuffer;
   protected final byte[] i32buf = new byte[4];
   private final boolean copyBinary;
+  private static final String FROM = " from ";
 
   @Override
   public boolean isOpen() {
@@ -164,7 +165,7 @@ public class TElasticFramedTransport extends TTransport {
                 "You may be sending non-SSL requests"
                     + "%s to the SSL-enabled Thrift-RPC port, please confirm that you are "
                     + "using the right configuration",
-                remoteAddress == null ? "" : " from " + remoteAddress));
+                remoteAddress == null ? "" : FROM + remoteAddress));
       }
       throw e;
     }
@@ -209,7 +210,7 @@ public class TElasticFramedTransport extends TTransport {
     if (underlying instanceof TSocket) {
       remoteAddress = ((TSocket) underlying).getSocket().getRemoteSocketAddress();
     }
-    String remoteInfo = (remoteAddress == null) ? "" : " from " + remoteAddress;
+    String remoteInfo = (remoteAddress == null) ? "" : FROM + remoteAddress;
     close();
 
     error.throwException(size, remoteInfo, thriftMaxFrameSize);
@@ -289,7 +290,7 @@ public class TElasticFramedTransport extends TTransport {
       if (underlying instanceof TSocket) {
         remoteAddress = ((TSocket) underlying).getSocket().getRemoteSocketAddress();
       }
-      String remoteInfo = (remoteAddress == null) ? "" : " from " + remoteAddress;
+      String remoteInfo = (remoteAddress == null) ? "" : FROM + remoteAddress;
       close();
       FrameError.STRING_LENGTH_EXCEEDED.throwException(numBytes, remoteInfo, thriftMaxFrameSize);
     }


### PR DESCRIPTION
## Summary

This PR resolves SonarCloud rule `java:S1192` , String literals should not be duplicated. For that i have done some changes like

- Define a Constant `FROM` instead of duplicate literal `" from "`.

Addressed : #17630

This PR has:

- [x] been self-reviewed.
- [x] been built locally with `mvn spotless:apply`.
- [x] been built locally with `mvn clean package -DskipTests`.
- [x] been built locally with `mvn -pl iotdb-core -am test -DskipTests`.

Resolves : https://sonarcloud.io/project/issues?sinceLeakPeriod=true&issueStatuses=OPEN%2CCONFIRMED&pullRequest=17612&id=apache_iotdb&open=AZ4ASk9tfV3Ahp1Ty0tp
`Define a constant instead of duplicating literal`