### PR TITLE
[to dev/1.3] Fix nested ColumnTransformer close

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/CaseWhenThenColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/CaseWhenThenColumnTransformer.java
@@ -128,4 +128,14 @@ public class CaseWhenThenColumnTransformer extends ColumnTransformer {
   protected void checkType() {
     // do nothing
   }
+
+  @Override
+  public void close() {
+    super.close();
+    for (Pair<ColumnTransformer, ColumnTransformer> whenThenTransformer : whenThenTransformers) {
+      whenThenTransformer.left.close();
+      whenThenTransformer.right.close();
+    }
+    elseTransformer.close();
+  }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/binary/BinaryColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/binary/BinaryColumnTransformer.java
@@ -63,4 +63,11 @@ public abstract class BinaryColumnTransformer extends ColumnTransformer {
   public ColumnTransformer getRightTransformer() {
     return rightTransformer;
   }
+
+  @Override
+  public void close() {
+    super.close();
+    this.leftTransformer.close();
+    this.rightTransformer.close();
+  }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/multi/MappableUDFColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/multi/MappableUDFColumnTransformer.java
@@ -70,6 +70,10 @@ public class MappableUDFColumnTransformer extends ColumnTransformer {
 
   @Override
   public void close() {
+    super.close();
+    for (ColumnTransformer inputColumnTransformer : inputColumnTransformers) {
+      inputColumnTransformer.close();
+    }
     // finalize executor
     executor.beforeDestroy();
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/ternary/TernaryColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/ternary/TernaryColumnTransformer.java
@@ -54,4 +54,12 @@ public abstract class TernaryColumnTransformer extends ColumnTransformer {
   public ColumnTransformer getThirdColumnTransformer() {
     return thirdColumnTransformer;
   }
+
+  @Override
+  public void close() {
+    super.close();
+    firstColumnTransformer.close();
+    secondColumnTransformer.close();
+    thirdColumnTransformer.close();
+  }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/unary/UnaryColumnTransformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/transformation/dag/column/unary/UnaryColumnTransformer.java
@@ -53,4 +53,10 @@ public abstract class UnaryColumnTransformer extends ColumnTransformer {
   }
 
   protected abstract void doTransform(Column column, ColumnBuilder columnBuilder);
+
+  @Override
+  public void close() {
+    super.close();
+    childColumnTransformer.close();
+  }
 }


### PR DESCRIPTION
## Summary

- Propagate ColumnTransformer close calls through unary, binary, ternary, CASE WHEN, and mappable UDF transformer parents.
- Ensure nested UDF transformers are closed when wrapped by expression transformers.

