### PR TITLE
[IOTDB-17635] Fix window function identity with OVER clause

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBWindowFunction3IT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBWindowFunction3IT.java
@@ -117,6 +117,25 @@ public class IoTDBWindowFunction3IT {
   }
 
   @Test
+  public void testSameWindowFunctionWithDifferentOrdering() {
+    String[] expectedHeader = new String[] {"time", "device", "value", "rank_time", "rank_value"};
+    String[] retArray =
+        new String[] {
+          "2021-01-01T09:05:00.000Z,d1,3.0,1,2,",
+          "2021-01-01T09:07:00.000Z,d1,5.0,2,4,",
+          "2021-01-01T09:09:00.000Z,d1,3.0,3,2,",
+          "2021-01-01T09:10:00.000Z,d1,1.0,4,1,",
+          "2021-01-01T09:08:00.000Z,d2,2.0,1,1,",
+          "2021-01-01T09:15:00.000Z,d2,4.0,2,2,",
+        };
+    tableResultSetEqualTest(
+        "SELECT *, rank() OVER (PARTITION BY device ORDER BY \"time\") AS rank_time, rank() OVER (PARTITION BY device ORDER BY value) AS rank_value FROM demo ORDER BY device, \"time\"",
+        expectedHeader,
+        retArray,
+        DATABASE_NAME);
+  }
+
+  @Test
   public void testPushDownFilterIntoWindow() {
     String[] expectedHeader = new String[] {"time", "device", "value", "rn"};
     String[] retArray =

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/queryengine/plan/relational/sql/ast/FunctionCall.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/queryengine/plan/relational/sql/ast/FunctionCall.java
@@ -177,6 +177,7 @@ public class FunctionCall extends Expression {
   public List<Node> getChildren() {
     ImmutableList.Builder<Node> nodes = ImmutableList.builder();
     nodes.addAll(arguments);
+    window.ifPresent(window -> nodes.add((Node) window));
     return nodes.build();
   }
 
@@ -190,6 +191,8 @@ public class FunctionCall extends Expression {
     }
     FunctionCall o = (FunctionCall) obj;
     return Objects.equals(name, o.name)
+        && Objects.equals(window, o.window)
+        && Objects.equals(nullTreatment, o.nullTreatment)
         && Objects.equals(distinct, o.distinct)
         && Objects.equals(processingMode, o.processingMode)
         && Objects.equals(arguments, o.arguments);
@@ -197,7 +200,7 @@ public class FunctionCall extends Expression {
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, distinct, processingMode, arguments);
+    return Objects.hash(name, window, nullTreatment, distinct, processingMode, arguments);
   }
 
   public enum NullTreatment {
@@ -214,6 +217,8 @@ public class FunctionCall extends Expression {
     FunctionCall otherFunction = (FunctionCall) other;
 
     return name.equals(otherFunction.name)
+        && window.isPresent() == otherFunction.window.isPresent()
+        && nullTreatment.equals(otherFunction.nullTreatment)
         && distinct == otherFunction.distinct
         && processingMode.equals(otherFunction.processingMode);
   }


### PR DESCRIPTION


```md
## Description

Fixes #17635.

### Bug fix

This PR fixes an incorrect result issue when the same window function appears multiple times with different `OVER` clauses.

For example, two `rank()` calls with different `ORDER BY` expressions could be treated as the same function expression during planning, causing one result symbol to be reused incorrectly.

### Root cause

`FunctionCall` did not include its `window` specification in AST children, equality, hashing, or shallow AST comparison.

As a result, scope-aware expression deduplication and symbol mapping could consider these two expressions equivalent:

```sql
rank() OVER (PARTITION BY device ORDER BY time)
rank() OVER (PARTITION BY device ORDER BY value)
```

### Fix

This PR updates `FunctionCall` identity to include window-related information:

- includes `window` in `FunctionCall#getChildren()`;
- includes `window` and `nullTreatment` in `equals()` and `hashCode()`;
- updates `shallowEquals()` to distinguish function calls with and without window specs and different null treatment;
- adds an integration test for duplicate `rank()` functions with different window ordering.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added integration tests.
- [x] been tested in a test IoTDB cluster.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- `org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.FunctionCall`
- `org.apache.iotdb.relational.it.db.it.IoTDBWindowFunction3IT`
```

```text
./mvnw spotless:apply -pl iotdb-core/node-commons,integration-test -P with-integration-tests
./mvnw verify -DskipUTs -Dit.test=IoTDBWindowFunction3IT#testSameWindowFunctionWithDifferentOrdering -DfailIfNoTests=false -Dfailsafe.failIfNoSpecifiedTests=false -pl integration-test -am -PTableSimpleIT -P with-integration-tests
git diff --check
```