### PR TITLE
Bump AINode urllib3 to patched release

### DIFF
--- a/iotdb-core/ainode/pyproject.toml
+++ b/iotdb-core/ainode/pyproject.toml
@@ -115,7 +115,7 @@ black = ">=26.3.1"
 isort = "6.0.1"
 setuptools = ">=75.3.0"
 joblib = ">=1.4.2"
-urllib3 = "2.6.3"
+urllib3 = "2.7.0"
 jaxtyping = ">=0.2.24"
 rotary-embedding-torch = ">=0.8.0"
 


### PR DESCRIPTION
## Summary
- Update `iotdb-core/ainode/pyproject.toml` to bump `urllib3` from `2.6.3` to `2.7.0`.

## Why
Dependabot reports two open high-severity advisories for `urllib3 < 2.7.0` in the AINode Python dependencies. This change moves AINode to the patched version range.

## Validation
- `poetry check` in `iotdb-core/ainode` (metadata checks pass; only existing project-level deprecation warnings are reported by Poetry).