### PR TITLE
Add explicit read-only permissions to CI workflows

### DIFF
--- a/.github/workflows/client-cpp-package.yml
+++ b/.github/workflows/client-cpp-package.yml
@@ -20,6 +20,9 @@ env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
   MAVEN_ARGS: --batch-mode --no-transfer-progress
 
+permissions:
+  contents: read
+
 jobs:
   should-package:
     runs-on: ubuntu-latest

--- a/.github/workflows/cluster-it-1c1d.yml
+++ b/.github/workflows/cluster-it-1c1d.yml
@@ -29,6 +29,9 @@ env:
   MAVEN_ARGS: --batch-mode --no-transfer-progress
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
+permissions:
+  contents: read
+
 jobs:
   Simple:
     strategy:

--- a/.github/workflows/cluster-it-1c1d1a.yml
+++ b/.github/workflows/cluster-it-1c1d1a.yml
@@ -30,6 +30,9 @@ env:
   MAVEN_ARGS: --batch-mode --no-transfer-progress
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
+permissions:
+  contents: read
+
 jobs:
   AINode:
     strategy:

--- a/.github/workflows/cluster-it-1c3d.yml
+++ b/.github/workflows/cluster-it-1c3d.yml
@@ -30,6 +30,9 @@ env:
   MAVEN_ARGS: --batch-mode --no-transfer-progress
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
+permissions:
+  contents: read
+
 jobs:
   Simple:
     strategy:

--- a/.github/workflows/compile-check.yml
+++ b/.github/workflows/compile-check.yml
@@ -32,6 +32,9 @@ env:
   MAVEN_ARGS: --batch-mode --no-transfer-progress
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
+permissions:
+  contents: read
+
 jobs:
   compile-check:
     strategy:

--- a/.github/workflows/daily-it.yml
+++ b/.github/workflows/daily-it.yml
@@ -14,6 +14,9 @@ env:
   MAVEN_ARGS: --batch-mode --no-transfer-progress
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
+permissions:
+  contents: read
+
 jobs:
   Simple:
     strategy:

--- a/.github/workflows/daily-ut.yml
+++ b/.github/workflows/daily-ut.yml
@@ -14,6 +14,9 @@ env:
   MAVEN_ARGS: --batch-mode --no-transfer-progress
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
+permissions:
+  contents: read
+
 jobs:
   unit-test:
     strategy:

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -32,6 +32,9 @@ env:
   MAVEN_ARGS: --batch-mode --no-transfer-progress
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
+permissions:
+  contents: read
+
 jobs:
   dependency-check:
     strategy:

--- a/.github/workflows/greeting-ainode.yml
+++ b/.github/workflows/greeting-ainode.yml
@@ -24,6 +24,9 @@ env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
   MAVEN_ARGS: --batch-mode --no-transfer-progress
 
+permissions:
+  contents: read
+
 jobs:
   check-style:
     runs-on: ubuntu-latest

--- a/.github/workflows/multi-language-client.yml
+++ b/.github/workflows/multi-language-client.yml
@@ -39,6 +39,9 @@ env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
   MAVEN_ARGS: --batch-mode --no-transfer-progress
 
+permissions:
+  contents: read
+
 jobs:
   cpp:
     strategy:

--- a/.github/workflows/pipe-it.yml
+++ b/.github/workflows/pipe-it.yml
@@ -32,6 +32,9 @@ env:
   MAVEN_ARGS: --batch-mode --no-transfer-progress
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
+permissions:
+  contents: read
+
 jobs:
   single:
     strategy:

--- a/.github/workflows/sonar-codecov.yml
+++ b/.github/workflows/sonar-codecov.yml
@@ -35,6 +35,9 @@ env:
   PR_NUMBER: ${{ github.event.number }}
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
+permissions:
+  contents: read
+
 jobs:
   codecov:
     runs-on: ubuntu-latest

--- a/.github/workflows/table-cluster-it-1c1d.yml
+++ b/.github/workflows/table-cluster-it-1c1d.yml
@@ -30,6 +30,9 @@ env:
   MAVEN_ARGS: --batch-mode --no-transfer-progress
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
+permissions:
+  contents: read
+
 jobs:
   Simple:
     strategy:

--- a/.github/workflows/table-cluster-it-1c3d.yml
+++ b/.github/workflows/table-cluster-it-1c3d.yml
@@ -30,6 +30,9 @@ env:
   MAVEN_ARGS: --batch-mode --no-transfer-progress
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
+permissions:
+  contents: read
+
 jobs:
   Simple:
     strategy:

--- a/.github/workflows/todos-check.yml
+++ b/.github/workflows/todos-check.yml
@@ -14,6 +14,9 @@ on:
   # allow manually run the action:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   todo-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -33,6 +33,9 @@ env:
   MAVEN_ARGS: --batch-mode --no-transfer-progress
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
+permissions:
+  contents: read
+
 jobs:
   unit-test:
     strategy:


### PR DESCRIPTION
## Summary
- Add explicit workflow `permissions` blocks to 16 CI workflows that previously relied on default token scopes.
- Set least-privilege `contents: read` for these test/build/check workflows.

## Why
These workflows are CI validation jobs and only need repository read access for checkout and execution. Explicit permissions harden `GITHUB_TOKEN` usage and make required scope clear.