### PR TITLE
Speed up ITs by sharing the cluster across test methods

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/GrafanaApiServiceIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/GrafanaApiServiceIT.java
@@ -37,9 +37,9 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -47,6 +47,9 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -59,10 +62,10 @@ import static org.junit.Assert.fail;
 @Category({LocalStandaloneIT.class, ClusterIT.class, RemoteIT.class})
 public class GrafanaApiServiceIT {
 
-  private int port = 18080;
+  private static int port = 18080;
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     BaseEnv baseEnv = EnvFactory.getEnv();
     baseEnv.getConfig().getDataNodeConfig().setEnableRestService(true);
     baseEnv.initClusterEnvironment();
@@ -70,9 +73,26 @@ public class GrafanaApiServiceIT {
     port = portConflictDataNodeWrapper.getRestServicePort();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  private static void executeQuietly(Statement statement, String sql) {
+    try {
+      statement.execute(sql);
+    } catch (SQLException ignored) {
+      // ignore
+    }
+  }
+
+  private static void cleanupSg25() {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      executeQuietly(statement, "DELETE DATABASE root.sg25");
+    } catch (SQLException ignored) {
+      // ignore
+    }
   }
 
   private String getAuthorization(String username, String password) {
@@ -399,53 +419,69 @@ public class GrafanaApiServiceIT {
   @Test
   public void expressionWithConditionControlTest() {
     CloseableHttpClient httpClient = HttpClientBuilder.create().build();
-    rightInsertTablet(httpClient);
-    expressionWithConditionControl(httpClient);
     try {
-      httpClient.close();
-    } catch (IOException e) {
-      e.printStackTrace();
-      fail(e.getMessage());
+      rightInsertTablet(httpClient);
+      expressionWithConditionControl(httpClient);
+    } finally {
+      try {
+        httpClient.close();
+      } catch (IOException e) {
+        e.printStackTrace();
+        fail(e.getMessage());
+      }
+      cleanupSg25();
     }
   }
 
   @Test
   public void expressionTest() {
     CloseableHttpClient httpClient = HttpClientBuilder.create().build();
-    rightInsertTablet(httpClient);
-    expression(httpClient);
-    // expressionGroupByLevel(httpClient);
     try {
-      httpClient.close();
-    } catch (IOException e) {
-      e.printStackTrace();
-      fail(e.getMessage());
+      rightInsertTablet(httpClient);
+      expression(httpClient);
+      // expressionGroupByLevel(httpClient);
+    } finally {
+      try {
+        httpClient.close();
+      } catch (IOException e) {
+        e.printStackTrace();
+        fail(e.getMessage());
+      }
+      cleanupSg25();
     }
   }
 
   @Test
   public void expressionWithControlTest() {
     CloseableHttpClient httpClient = HttpClientBuilder.create().build();
-    rightInsertTablet(httpClient);
-    expressionWithControl(httpClient);
     try {
-      httpClient.close();
-    } catch (IOException e) {
-      e.printStackTrace();
-      fail(e.getMessage());
+      rightInsertTablet(httpClient);
+      expressionWithControl(httpClient);
+    } finally {
+      try {
+        httpClient.close();
+      } catch (IOException e) {
+        e.printStackTrace();
+        fail(e.getMessage());
+      }
+      cleanupSg25();
     }
   }
 
   @Test
   public void variableTest() {
     CloseableHttpClient httpClient = HttpClientBuilder.create().build();
-    rightInsertTablet(httpClient);
-    variable(httpClient);
     try {
-      httpClient.close();
-    } catch (IOException e) {
-      e.printStackTrace();
-      fail(e.getMessage());
+      rightInsertTablet(httpClient);
+      variable(httpClient);
+    } finally {
+      try {
+        httpClient.close();
+      } catch (IOException e) {
+        e.printStackTrace();
+        fail(e.getMessage());
+      }
+      cleanupSg25();
     }
   }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBDatetimeFormatIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBDatetimeFormatIT.java
@@ -24,9 +24,9 @@ import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 import org.apache.iotdb.itbase.category.RemoteIT;
 
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -42,15 +42,23 @@ import static org.junit.Assert.fail;
 @Category({LocalStandaloneIT.class, ClusterIT.class, RemoteIT.class})
 public class IoTDBDatetimeFormatIT {
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     EnvFactory.getEnv().getConfig().getCommonConfig().setTimestampPrecisionCheckEnabled(false);
     EnvFactory.getEnv().initClusterEnvironment();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  private static void executeQuietly(Statement statement, String sql) {
+    try {
+      statement.execute(sql);
+    } catch (SQLException ignored) {
+      // ignore: cleanup may fail if target does not exist
+    }
   }
 
   @Test
@@ -87,25 +95,28 @@ public class IoTDBDatetimeFormatIT {
     };
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
+      try {
+        connection.setClientInfo("time_zone", "+08:00");
 
-      connection.setClientInfo("time_zone", "+08:00");
+        for (int i = 0; i < datetimeStrings.length; i++) {
+          String insertSql =
+              String.format(
+                  "INSERT INTO root.sg1.d1(time, s1) values (%s, %d)", datetimeStrings[i], i);
+          statement.execute(insertSql);
+        }
 
-      for (int i = 0; i < datetimeStrings.length; i++) {
-        String insertSql =
-            String.format(
-                "INSERT INTO root.sg1.d1(time, s1) values (%s, %d)", datetimeStrings[i], i);
-        statement.execute(insertSql);
+        ResultSet resultSet = statement.executeQuery("SELECT s1 FROM root.sg1.d1");
+        Assert.assertNotNull(resultSet);
+
+        int cnt = 0;
+        while (resultSet.next()) {
+          Assert.assertEquals(timestamps[cnt], resultSet.getLong(1));
+          cnt++;
+        }
+        Assert.assertEquals(timestamps.length, cnt);
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
-
-      ResultSet resultSet = statement.executeQuery("SELECT s1 FROM root.sg1.d1");
-      Assert.assertNotNull(resultSet);
-
-      int cnt = 0;
-      while (resultSet.next()) {
-        Assert.assertEquals(timestamps[cnt], resultSet.getLong(1));
-        cnt++;
-      }
-      Assert.assertEquals(timestamps.length, cnt);
     } catch (SQLException e) {
       e.printStackTrace();
       fail();
@@ -116,26 +127,33 @@ public class IoTDBDatetimeFormatIT {
   public void testBigDateTime() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.setFetchSize(5);
-      statement.execute("CREATE DATABASE root.sg");
+      try {
+        statement.setFetchSize(5);
+        statement.execute("CREATE DATABASE root.sg");
 
-      statement.execute("CREATE TIMESERIES root.sg.d1.s2 WITH DATATYPE=DOUBLE, ENCODING=PLAIN;");
+        statement.execute("CREATE TIMESERIES root.sg.d1.s2 WITH DATATYPE=DOUBLE, ENCODING=PLAIN;");
 
-      statement.execute("insert into root.sg.d1(time,s2) values (1618283005586000, 8.76);");
-      statement.execute("select * from root.sg.d1;");
-      statement.execute("select * from root.sg.d1 where time=53251-05-07T17:06:26.000+08:00");
+        statement.execute("insert into root.sg.d1(time,s2) values (1618283005586000, 8.76);");
+        statement.execute("select * from root.sg.d1;");
+        statement.execute("select * from root.sg.d1 where time=53251-05-07T17:06:26.000+08:00");
+      } catch (SQLException e) {
+        e.printStackTrace();
+        fail();
+      }
+      try (Connection connection2 = EnvFactory.getEnv().getConnection();
+          Statement statement2 = connection2.createStatement()) {
+        statement2.execute("insert into root.sg.d1(time,s2) values (16182830055860000000, 8.76);");
+        fail();
+      } catch (SQLException e) {
+        Assert.assertTrue(
+            e.getMessage()
+                .contains("please check whether the timestamp 16182830055860000000 is correct."));
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg");
+      }
     } catch (SQLException e) {
       e.printStackTrace();
       fail();
-    }
-    try (Connection connection = EnvFactory.getEnv().getConnection();
-        Statement statement = connection.createStatement()) {
-      statement.execute("insert into root.sg.d1(time,s2) values (16182830055860000000, 8.76);");
-      fail();
-    } catch (SQLException e) {
-      Assert.assertTrue(
-          e.getMessage()
-              .contains("please check whether the timestamp 16182830055860000000 is correct."));
     }
   }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBDuplicateTimeIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBDuplicateTimeIT.java
@@ -24,8 +24,8 @@ import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -41,13 +41,13 @@ import static org.junit.Assert.assertEquals;
 @Category({LocalStandaloneIT.class, ClusterIT.class})
 public class IoTDBDuplicateTimeIT {
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     EnvFactory.getEnv().initClusterEnvironment();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
   }
 

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBExecuteBatchIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBExecuteBatchIT.java
@@ -25,8 +25,8 @@ import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 import org.apache.iotdb.itbase.category.RemoteIT;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -42,39 +42,51 @@ import static org.junit.Assert.fail;
 @RunWith(IoTDBTestRunner.class)
 @Category({LocalStandaloneIT.class, ClusterIT.class, RemoteIT.class})
 public class IoTDBExecuteBatchIT {
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     EnvFactory.getEnv().initClusterEnvironment();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  private static void executeQuietly(Statement statement, String sql) {
+    try {
+      statement.execute(sql);
+    } catch (SQLException ignored) {
+      // ignore: cleanup may fail if target does not exist
+    }
   }
 
   @Test
   public void testJDBCExecuteBatch() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.setFetchSize(5);
-      statement.addBatch(
-          "insert into root.ln.wf01.wt01(timestamp,temperature) values(1509465600000,1.2)");
-      statement.addBatch(
-          "insert into root.ln.wf01.wt01(timestamp,temperature) values(1509465600001,2.3)");
-      statement.addBatch("delete timeseries root.ln.wf01.wt01.**");
-      statement.addBatch(
-          "insert into root.ln.wf01.wt01(timestamp,temperature) values(1509465600002,3.4)");
-      statement.executeBatch();
-      ResultSet resultSet = statement.executeQuery("select * from root.ln.wf01.wt01");
-      int count = 0;
+      try {
+        statement.setFetchSize(5);
+        statement.addBatch(
+            "insert into root.ln.wf01.wt01(timestamp,temperature) values(1509465600000,1.2)");
+        statement.addBatch(
+            "insert into root.ln.wf01.wt01(timestamp,temperature) values(1509465600001,2.3)");
+        statement.addBatch("delete timeseries root.ln.wf01.wt01.**");
+        statement.addBatch(
+            "insert into root.ln.wf01.wt01(timestamp,temperature) values(1509465600002,3.4)");
+        statement.executeBatch();
+        ResultSet resultSet = statement.executeQuery("select * from root.ln.wf01.wt01");
+        int count = 0;
 
-      String[] timestamps = {"1509465600002"};
-      String[] values = {"3.4"};
+        String[] timestamps = {"1509465600002"};
+        String[] values = {"3.4"};
 
-      while (resultSet.next()) {
-        assertEquals(timestamps[count], resultSet.getString(ColumnHeaderConstant.TIME));
-        assertEquals(values[count], resultSet.getString("root.ln.wf01.wt01.temperature"));
-        count++;
+        while (resultSet.next()) {
+          assertEquals(timestamps[count], resultSet.getString(ColumnHeaderConstant.TIME));
+          assertEquals(values[count], resultSet.getString("root.ln.wf01.wt01.temperature"));
+          count++;
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.ln");
       }
     } catch (SQLException e) {
       fail(e.getMessage());
@@ -85,110 +97,115 @@ public class IoTDBExecuteBatchIT {
   public void testJDBCExecuteBatchForCreateMultiTimeSeriesPlan() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.setFetchSize(100);
-      statement.addBatch(
-          "insert into root.ln.wf01.wt01(timestamp,temperature) values(1509465600000,1.2)");
-      statement.addBatch(
-          "insert into root.ln.wf01.wt01(timestamp,temperature) values(1509465600001,2.3)");
-      statement.addBatch("delete timeseries root.ln.wf01.wt01.**");
-      statement.addBatch(
-          "create timeseries root.turbine.d1.s1(s1) with datatype=boolean, encoding=plain , compression=snappy "
-              + "tags('tag1'='v1', 'tag2'='v2') attributes('attr1'='v3', 'attr2'='v4')");
-      statement.addBatch(
-          "create timeseries root.turbine.d1.s2(s2) with datatype=float, encoding=rle, compression=uncompressed "
-              + "tags('tag1'='v5', 'tag2'='v6') attributes('attr1'='v7', 'attr2'='v8') ");
-      statement.addBatch(
-          "insert into root.ln.wf01.wt01(timestamp,temperature) values(1509465600002,3.4)");
-      statement.addBatch(
-          "create timeseries root.turbine.d1.s3 with datatype=boolean, encoding=rle");
-      statement.executeBatch();
-      statement.clearBatch();
-      ResultSet resultSet = statement.executeQuery("select * from root.ln.wf01.wt01");
-      String[] timestamps = {"1509465600002"};
-      String[] values = {"3.4"};
-      int count = 0;
-      while (resultSet.next()) {
-        assertEquals(timestamps[count], resultSet.getString(ColumnHeaderConstant.TIME));
-        assertEquals(values[count], resultSet.getString("root.ln.wf01.wt01.temperature"));
-        count++;
-      }
-      ResultSet timeSeriesResultSetForS1 =
-          statement.executeQuery("SHOW TIMESERIES root.turbine.d1.s1");
-      count = 0;
-      String[] key_s1 = {
-        ColumnHeaderConstant.TIMESERIES,
-        ColumnHeaderConstant.ALIAS,
-        ColumnHeaderConstant.DATABASE,
-        ColumnHeaderConstant.DATATYPE,
-        ColumnHeaderConstant.ENCODING,
-        ColumnHeaderConstant.COMPRESSION,
-        ColumnHeaderConstant.TAGS,
-        ColumnHeaderConstant.ATTRIBUTES
-      };
-      String[] value_s1 = {
-        "root.turbine.d1.s1",
-        "s1",
-        "root.turbine",
-        "BOOLEAN",
-        "PLAIN",
-        "SNAPPY",
-        "{\"tag1\":\"v1\",\"tag2\":\"v2\"}",
-        "{\"attr2\":\"v3\",\"attr1\":\"v4\"}"
-      };
+      try {
+        statement.setFetchSize(100);
+        statement.addBatch(
+            "insert into root.ln.wf01.wt01(timestamp,temperature) values(1509465600000,1.2)");
+        statement.addBatch(
+            "insert into root.ln.wf01.wt01(timestamp,temperature) values(1509465600001,2.3)");
+        statement.addBatch("delete timeseries root.ln.wf01.wt01.**");
+        statement.addBatch(
+            "create timeseries root.turbine.d1.s1(s1) with datatype=boolean, encoding=plain , compression=snappy "
+                + "tags('tag1'='v1', 'tag2'='v2') attributes('attr1'='v3', 'attr2'='v4')");
+        statement.addBatch(
+            "create timeseries root.turbine.d1.s2(s2) with datatype=float, encoding=rle, compression=uncompressed "
+                + "tags('tag1'='v5', 'tag2'='v6') attributes('attr1'='v7', 'attr2'='v8') ");
+        statement.addBatch(
+            "insert into root.ln.wf01.wt01(timestamp,temperature) values(1509465600002,3.4)");
+        statement.addBatch(
+            "create timeseries root.turbine.d1.s3 with datatype=boolean, encoding=rle");
+        statement.executeBatch();
+        statement.clearBatch();
+        ResultSet resultSet = statement.executeQuery("select * from root.ln.wf01.wt01");
+        String[] timestamps = {"1509465600002"};
+        String[] values = {"3.4"};
+        int count = 0;
+        while (resultSet.next()) {
+          assertEquals(timestamps[count], resultSet.getString(ColumnHeaderConstant.TIME));
+          assertEquals(values[count], resultSet.getString("root.ln.wf01.wt01.temperature"));
+          count++;
+        }
+        ResultSet timeSeriesResultSetForS1 =
+            statement.executeQuery("SHOW TIMESERIES root.turbine.d1.s1");
+        count = 0;
+        String[] key_s1 = {
+          ColumnHeaderConstant.TIMESERIES,
+          ColumnHeaderConstant.ALIAS,
+          ColumnHeaderConstant.DATABASE,
+          ColumnHeaderConstant.DATATYPE,
+          ColumnHeaderConstant.ENCODING,
+          ColumnHeaderConstant.COMPRESSION,
+          ColumnHeaderConstant.TAGS,
+          ColumnHeaderConstant.ATTRIBUTES
+        };
+        String[] value_s1 = {
+          "root.turbine.d1.s1",
+          "s1",
+          "root.turbine",
+          "BOOLEAN",
+          "PLAIN",
+          "SNAPPY",
+          "{\"tag1\":\"v1\",\"tag2\":\"v2\"}",
+          "{\"attr2\":\"v3\",\"attr1\":\"v4\"}"
+        };
 
-      while (timeSeriesResultSetForS1.next()) {
-        assertEquals(value_s1[count], timeSeriesResultSetForS1.getString(key_s1[count]));
-        count++;
-      }
+        while (timeSeriesResultSetForS1.next()) {
+          assertEquals(value_s1[count], timeSeriesResultSetForS1.getString(key_s1[count]));
+          count++;
+        }
 
-      ResultSet timeSeriesResultSetForS2 =
-          statement.executeQuery("SHOW TIMESERIES root.turbine.d1.s2");
-      count = 0;
-      String[] key_s2 = {
-        ColumnHeaderConstant.TIMESERIES,
-        ColumnHeaderConstant.ALIAS,
-        ColumnHeaderConstant.DATABASE,
-        ColumnHeaderConstant.DATATYPE,
-        ColumnHeaderConstant.ENCODING,
-        ColumnHeaderConstant.COMPRESSION,
-        ColumnHeaderConstant.TAGS,
-        ColumnHeaderConstant.ATTRIBUTES
-      };
-      String[] value_s2 = {
-        "root.turbine.d1.s2",
-        "s2",
-        "root.turbine",
-        "FLOAT",
-        "RLE",
-        "UNCOMPRESSED",
-        "{\"tag1\":\"v5\",\"tag2\":\"v6\"}",
-        "{\"attr2\":\"v7\",\"attr1\":\"v8\"}"
-      };
-      while (timeSeriesResultSetForS2.next()) {
-        assertEquals(value_s2[count], timeSeriesResultSetForS2.getString(key_s2[count]));
-        count++;
-      }
+        ResultSet timeSeriesResultSetForS2 =
+            statement.executeQuery("SHOW TIMESERIES root.turbine.d1.s2");
+        count = 0;
+        String[] key_s2 = {
+          ColumnHeaderConstant.TIMESERIES,
+          ColumnHeaderConstant.ALIAS,
+          ColumnHeaderConstant.DATABASE,
+          ColumnHeaderConstant.DATATYPE,
+          ColumnHeaderConstant.ENCODING,
+          ColumnHeaderConstant.COMPRESSION,
+          ColumnHeaderConstant.TAGS,
+          ColumnHeaderConstant.ATTRIBUTES
+        };
+        String[] value_s2 = {
+          "root.turbine.d1.s2",
+          "s2",
+          "root.turbine",
+          "FLOAT",
+          "RLE",
+          "UNCOMPRESSED",
+          "{\"tag1\":\"v5\",\"tag2\":\"v6\"}",
+          "{\"attr2\":\"v7\",\"attr1\":\"v8\"}"
+        };
+        while (timeSeriesResultSetForS2.next()) {
+          assertEquals(value_s2[count], timeSeriesResultSetForS2.getString(key_s2[count]));
+          count++;
+        }
 
-      count = 0;
-      String[] key_s3 = {
-        ColumnHeaderConstant.TIMESERIES,
-        ColumnHeaderConstant.ALIAS,
-        ColumnHeaderConstant.DATABASE,
-        ColumnHeaderConstant.DATATYPE,
-        ColumnHeaderConstant.ENCODING,
-        ColumnHeaderConstant.COMPRESSION,
-        ColumnHeaderConstant.TAGS,
-        ColumnHeaderConstant.ATTRIBUTES
-      };
-      String[] value_s3 = {
-        "root.turbine.d1.s3", "null", "root.turbine", "BOOLEAN", "RLE", "SNAPPY", "null", "null"
-      };
-      ResultSet timeSeriesResultSetForS3 =
-          statement.executeQuery("SHOW TIMESERIES root.turbine.d1.s3");
+        count = 0;
+        String[] key_s3 = {
+          ColumnHeaderConstant.TIMESERIES,
+          ColumnHeaderConstant.ALIAS,
+          ColumnHeaderConstant.DATABASE,
+          ColumnHeaderConstant.DATATYPE,
+          ColumnHeaderConstant.ENCODING,
+          ColumnHeaderConstant.COMPRESSION,
+          ColumnHeaderConstant.TAGS,
+          ColumnHeaderConstant.ATTRIBUTES
+        };
+        String[] value_s3 = {
+          "root.turbine.d1.s3", "null", "root.turbine", "BOOLEAN", "RLE", "SNAPPY", "null", "null"
+        };
+        ResultSet timeSeriesResultSetForS3 =
+            statement.executeQuery("SHOW TIMESERIES root.turbine.d1.s3");
 
-      while (timeSeriesResultSetForS3.next()) {
-        assertEquals(value_s3[count], timeSeriesResultSetForS3.getString(key_s3[count]));
-        count++;
+        while (timeSeriesResultSetForS3.next()) {
+          assertEquals(value_s3[count], timeSeriesResultSetForS3.getString(key_s3[count]));
+          count++;
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.ln");
+        executeQuietly(statement, "DELETE DATABASE root.turbine");
       }
     } catch (SQLException e) {
       fail(e.getMessage());

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBInsertWithoutTimeIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBInsertWithoutTimeIT.java
@@ -24,8 +24,8 @@ import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -51,18 +51,26 @@ public class IoTDBInsertWithoutTimeIT {
           "CREATE TIMESERIES root.sg1.d1.s2 FLOAT",
           "CREATE TIMESERIES root.sg1.d1.s3 TEXT");
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     EnvFactory.getEnv().initClusterEnvironment();
     createTimeseries();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
   }
 
-  private void createTimeseries() {
+  private static void executeQuietly(Statement statement, String sql) {
+    try {
+      statement.execute(sql);
+    } catch (SQLException ignored) {
+      // ignore: cleanup may fail if target does not exist
+    }
+  }
+
+  private static void createTimeseries() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
       for (String sql : sqls) {
@@ -78,24 +86,30 @@ public class IoTDBInsertWithoutTimeIT {
   public void testInsertWithoutTime() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("insert into root.sg1.d1(s1, s2, s3) values (1, 1, '1')");
-      Thread.sleep(1);
-      statement.execute("insert into root.sg1.d1(s2, s1, s3) values (2, 2, '2')");
-      Thread.sleep(1);
-      statement.execute("insert into root.sg1.d1(s3, s2, s1) values ('3', 3, 3)");
-      Thread.sleep(1);
-      statement.execute("insert into root.sg1.d1(s1) values (1)");
-      statement.execute("insert into root.sg1.d1(s2) values (2)");
-      statement.execute("insert into root.sg1.d1(s3) values ('3')");
+      try {
+        statement.execute("insert into root.sg1.d1(s1, s2, s3) values (1, 1, '1')");
+        Thread.sleep(1);
+        statement.execute("insert into root.sg1.d1(s2, s1, s3) values (2, 2, '2')");
+        Thread.sleep(1);
+        statement.execute("insert into root.sg1.d1(s3, s2, s1) values ('3', 3, 3)");
+        Thread.sleep(1);
+        statement.execute("insert into root.sg1.d1(s1) values (1)");
+        statement.execute("insert into root.sg1.d1(s2) values (2)");
+        statement.execute("insert into root.sg1.d1(s3) values ('3')");
+
+        String expectedHeader =
+            "count(root.sg1.d1.s1),count(root.sg1.d1.s2),count(root.sg1.d1.s3),";
+        String[] retArray = new String[] {"4,4,4,"};
+        resultSetEqualTest(
+            "select count(s1), count(s2), count(s3) from root.sg1.d1", expectedHeader, retArray);
+      } finally {
+        // remove the data inserted by this test, but keep the timeseries created in @BeforeClass
+        executeQuietly(statement, "DELETE FROM root.sg1.d1.s1, root.sg1.d1.s2, root.sg1.d1.s3");
+      }
     } catch (SQLException | InterruptedException e) {
       e.printStackTrace();
       fail(e.getMessage());
     }
-
-    String expectedHeader = "count(root.sg1.d1.s1),count(root.sg1.d1.s2),count(root.sg1.d1.s3),";
-    String[] retArray = new String[] {"4,4,4,"};
-    resultSetEqualTest(
-        "select count(s1), count(s2), count(s3) from root.sg1.d1", expectedHeader, retArray);
   }
 
   @Test

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBLoadTsFileWithModIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBLoadTsFileWithModIT.java
@@ -39,9 +39,9 @@ import org.apache.tsfile.exception.write.WriteProcessException;
 import org.apache.tsfile.write.TsFileWriter;
 import org.apache.tsfile.write.record.Tablet;
 import org.apache.tsfile.write.schema.MeasurementSchema;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -54,28 +54,75 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Collections;
-import java.util.Objects;
 
 @RunWith(IoTDBTestRunner.class)
 @Category({LocalStandaloneIT.class, ClusterIT.class})
 public class IoTDBLoadTsFileWithModIT {
-  private File tmpDir;
+  private static File tmpDir;
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     tmpDir = new File(Files.createTempDirectory("load").toUri());
     EnvFactory.getEnv().initClusterEnvironment();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     try {
-      for (final File file : Objects.requireNonNull(tmpDir.listFiles())) {
-        Files.delete(file.toPath());
+      if (tmpDir != null && tmpDir.exists()) {
+        File[] files = tmpDir.listFiles();
+        if (files != null) {
+          for (File file : files) {
+            try {
+              Files.delete(file.toPath());
+            } catch (IOException ignored) {
+              // ignore
+            }
+          }
+        }
+        try {
+          Files.delete(tmpDir.toPath());
+        } catch (IOException ignored) {
+          // ignore
+        }
       }
-      Files.delete(tmpDir.toPath());
     } finally {
       EnvFactory.getEnv().cleanClusterEnvironment();
+    }
+  }
+
+  private static void clearTmpDir() {
+    if (tmpDir == null || !tmpDir.exists()) {
+      return;
+    }
+    File[] files = tmpDir.listFiles();
+    if (files == null) {
+      return;
+    }
+    for (File file : files) {
+      try {
+        Files.delete(file.toPath());
+      } catch (IOException ignored) {
+        // ignore
+      }
+    }
+  }
+
+  private static void executeQuietly(Statement statement, String sql) {
+    try {
+      statement.execute(sql);
+    } catch (SQLException ignored) {
+      // ignore
+    }
+  }
+
+  private static void cleanupTestDb() {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      executeQuietly(statement, "DELETE DATABASE root.test.**");
+      executeQuietly(statement, "DELETE DATABASE root.test");
+    } catch (SQLException ignored) {
+      // ignore
     }
   }
 
@@ -131,17 +178,22 @@ public class IoTDBLoadTsFileWithModIT {
           DataRegionException,
           WriteProcessException,
           IllegalPathException {
-    generateFileWithNewModFile();
-    try (final Connection connection = EnvFactory.getEnv().getConnection();
-        final Statement statement = connection.createStatement()) {
+    try {
+      generateFileWithNewModFile();
+      try (final Connection connection = EnvFactory.getEnv().getConnection();
+          final Statement statement = connection.createStatement()) {
 
-      statement.execute(String.format("load \'%s\'", tmpDir.getAbsolutePath()));
+        statement.execute(String.format("load \'%s\'", tmpDir.getAbsolutePath()));
 
-      try (final ResultSet resultSet =
-          statement.executeQuery("select count(s1) as c from root.test.d1.de")) {
-        Assert.assertTrue(resultSet.next());
-        Assert.assertEquals(3, resultSet.getLong("c"));
+        try (final ResultSet resultSet =
+            statement.executeQuery("select count(s1) as c from root.test.d1.de")) {
+          Assert.assertTrue(resultSet.next());
+          Assert.assertEquals(3, resultSet.getLong("c"));
+        }
       }
+    } finally {
+      clearTmpDir();
+      cleanupTestDb();
     }
   }
 
@@ -152,44 +204,49 @@ public class IoTDBLoadTsFileWithModIT {
           DataRegionException,
           WriteProcessException,
           IllegalPathException {
-    generateFileWithNewModFile();
-    final String databaseName = "root.test.d1";
+    try {
+      generateFileWithNewModFile();
+      final String databaseName = "root.test.d1";
 
-    try (final Connection connection = EnvFactory.getEnv().getConnection();
-        final Statement statement = connection.createStatement()) {
+      try (final Connection connection = EnvFactory.getEnv().getConnection();
+          final Statement statement = connection.createStatement()) {
 
-      statement.execute(
-          String.format(
-              "load \'%s\' with ("
-                  + "'database-name'='%s',"
-                  + "'database-level'='2',"
-                  + "'verify'='true',"
-                  + "'on-success'='none',"
-                  + "'async'='true')",
-              tmpDir.getAbsolutePath(), databaseName));
+        statement.execute(
+            String.format(
+                "load \'%s\' with ("
+                    + "'database-name'='%s',"
+                    + "'database-level'='2',"
+                    + "'verify'='true',"
+                    + "'on-success'='none',"
+                    + "'async'='true')",
+                tmpDir.getAbsolutePath(), databaseName));
 
-      boolean databaseFound = false;
-      out:
-      for (int i = 0; i < 10; i++) {
-        try (final ResultSet resultSet = statement.executeQuery("show databases")) {
-          while (resultSet.next()) {
-            final String currentDatabase = resultSet.getString(1);
-            if (databaseName.equalsIgnoreCase(currentDatabase)) {
-              databaseFound = true;
-              break out;
+        boolean databaseFound = false;
+        out:
+        for (int i = 0; i < 10; i++) {
+          try (final ResultSet resultSet = statement.executeQuery("show databases")) {
+            while (resultSet.next()) {
+              final String currentDatabase = resultSet.getString(1);
+              if (databaseName.equalsIgnoreCase(currentDatabase)) {
+                databaseFound = true;
+                break out;
+              }
+            }
+
+            try {
+              Thread.sleep(1000);
+            } catch (InterruptedException e) {
+              break;
             }
           }
-
-          try {
-            Thread.sleep(1000);
-          } catch (InterruptedException e) {
-            break;
-          }
         }
+        Assert.assertTrue(
+            "The `database-level` parameter is not working; the generated database does not contain 'root.test.d1'.",
+            databaseFound);
       }
-      Assert.assertTrue(
-          "The `database-level` parameter is not working; the generated database does not contain 'root.test.d1'.",
-          databaseFound);
+    } finally {
+      clearTmpDir();
+      cleanupTestDb();
     }
   }
 
@@ -200,21 +257,26 @@ public class IoTDBLoadTsFileWithModIT {
           DataRegionException,
           WriteProcessException,
           IllegalPathException {
-    generateFileWithOldModFile();
-    try (final Connection connection = EnvFactory.getEnv().getConnection();
-        final Statement statement = connection.createStatement()) {
+    try {
+      generateFileWithOldModFile();
+      try (final Connection connection = EnvFactory.getEnv().getConnection();
+          final Statement statement = connection.createStatement()) {
 
-      statement.execute(String.format("load \'%s\'", tmpDir.getAbsolutePath()));
+        statement.execute(String.format("load \'%s\'", tmpDir.getAbsolutePath()));
 
-      try (final ResultSet resultSet =
-          statement.executeQuery("select count(s1) as c from root.test.d1.de")) {
-        Assert.assertTrue(resultSet.next());
-        Assert.assertEquals(3, resultSet.getLong("c"));
-        Assert.assertTrue(
-            new File(tmpDir, "1-1-0-0.tsfile" + ModificationFileV1.FILE_SUFFIX).exists());
-        Assert.assertFalse(
-            new File(tmpDir, "1-1-0-0.tsfile" + ModificationFile.FILE_SUFFIX).exists());
+        try (final ResultSet resultSet =
+            statement.executeQuery("select count(s1) as c from root.test.d1.de")) {
+          Assert.assertTrue(resultSet.next());
+          Assert.assertEquals(3, resultSet.getLong("c"));
+          Assert.assertTrue(
+              new File(tmpDir, "1-1-0-0.tsfile" + ModificationFileV1.FILE_SUFFIX).exists());
+          Assert.assertFalse(
+              new File(tmpDir, "1-1-0-0.tsfile" + ModificationFile.FILE_SUFFIX).exists());
+        }
       }
+    } finally {
+      clearTmpDir();
+      cleanupTestDb();
     }
   }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBMultiDeviceIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBMultiDeviceIT.java
@@ -24,8 +24,8 @@ import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 import org.apache.iotdb.itbase.constant.TestConstant;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -45,8 +45,8 @@ import static org.junit.Assert.fail;
 @Category({LocalStandaloneIT.class, ClusterIT.class})
 public class IoTDBMultiDeviceIT {
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     // use small page
     EnvFactory.getEnv()
         .getConfig()
@@ -64,8 +64,8 @@ public class IoTDBMultiDeviceIT {
     insertData();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
   }
 

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBPartialInsertionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBPartialInsertionIT.java
@@ -32,9 +32,9 @@ import org.apache.tsfile.read.common.RowRecord;
 import org.apache.tsfile.write.record.Tablet;
 import org.apache.tsfile.write.schema.IMeasurementSchema;
 import org.apache.tsfile.write.schema.MeasurementSchema;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -59,144 +59,172 @@ import static org.junit.Assert.fail;
 public class IoTDBPartialInsertionIT {
   private final Logger logger = LoggerFactory.getLogger(IoTDBPartialInsertionIT.class);
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     EnvFactory.getEnv().getConfig().getCommonConfig().setAutoCreateSchemaEnabled(false);
     EnvFactory.getEnv().initClusterEnvironment();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  private static void executeQuietly(Statement statement, String sql) {
+    try {
+      statement.execute(sql);
+    } catch (SQLException ignored) {
+      // ignore: cleanup may fail if target does not exist
+    }
+  }
+
+  private static void dropDatabaseQuietly(String database) {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      executeQuietly(statement, "DELETE DATABASE " + database);
+    } catch (SQLException ignored) {
+      // ignore: cleanup may fail if env is unhealthy
+    }
   }
 
   @Test
   public void testPartialInsertionAllFailed() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-
-      statement.execute("CREATE DATABASE root.sg1");
-
       try {
-        statement.execute("INSERT INTO root.sg1(timestamp, s0) VALUES (1, 1)");
-        fail();
-      } catch (SQLException e) {
-        assertTrue(e.getMessage().contains("Path [root.sg1.s0] does not exist"));
+        statement.execute("CREATE DATABASE root.sg1");
+
+        try {
+          statement.execute("INSERT INTO root.sg1(timestamp, s0) VALUES (1, 1)");
+          fail();
+        } catch (SQLException e) {
+          assertTrue(e.getMessage().contains("Path [root.sg1.s0] does not exist"));
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
     }
   }
 
   @Test
   public void testPartialInsertionRestart() throws SQLException {
-    try (Connection connection = EnvFactory.getEnv().getConnection();
-        Statement statement = connection.createStatement()) {
-
-      statement.execute("CREATE DATABASE root.sg");
-      statement.execute("CREATE TIMESERIES root.sg.d1.s1 datatype=text");
-      statement.execute("CREATE TIMESERIES root.sg.d1.s2 datatype=double");
-
-      try {
-        statement.execute("INSERT INTO root.sg.d1(time,s1,s2) VALUES(100,'test','test')");
-      } catch (SQLException e) {
-        // ignore
-      }
-    }
-
-    // TODO: replace restartDaemon() with new methods in Env.
-    /*
-    long time = 0;
     try {
-      EnvironmentUtils.restartDaemon();
-      StorageEngine.getInstance().recover();
-      // wait for recover
-      while (!StorageEngine.getInstance().isReadyForReadAndWrite()) {
-        Thread.sleep(500);
-        time += 500;
-        if (time > 10000) {
-          logger.warn("wait too long in restart, wait for: " + time / 1000 + "s");
+      try (Connection connection = EnvFactory.getEnv().getConnection();
+          Statement statement = connection.createStatement()) {
+
+        statement.execute("CREATE DATABASE root.sg");
+        statement.execute("CREATE TIMESERIES root.sg.d1.s1 datatype=text");
+        statement.execute("CREATE TIMESERIES root.sg.d1.s2 datatype=double");
+
+        try {
+          statement.execute("INSERT INTO root.sg.d1(time,s1,s2) VALUES(100,'test','test')");
+        } catch (SQLException e) {
+          // ignore
         }
       }
-    } catch (Exception e) {
-      fail(e.getMessage());
-    }
-     */
 
-    try (Connection connection = EnvFactory.getEnv().getConnection();
-        Statement statement = connection.createStatement()) {
-
-      try (ResultSet resultSet = statement.executeQuery("SELECT s1 FROM root.sg.d1")) {
-        assertNotNull(resultSet);
-        int cnt = 0;
-        while (resultSet.next()) {
-          cnt++;
-          assertEquals("test", resultSet.getString("root.sg.d1.s1"));
+      // TODO: replace restartDaemon() with new methods in Env.
+      /*
+      long time = 0;
+      try {
+        EnvironmentUtils.restartDaemon();
+        StorageEngine.getInstance().recover();
+        // wait for recover
+        while (!StorageEngine.getInstance().isReadyForReadAndWrite()) {
+          Thread.sleep(500);
+          time += 500;
+          if (time > 10000) {
+            logger.warn("wait too long in restart, wait for: " + time / 1000 + "s");
+          }
         }
-        assertEquals(1, cnt);
+      } catch (Exception e) {
+        fail(e.getMessage());
       }
-      try (ResultSet resultSet = statement.executeQuery("SELECT s2 FROM root.sg.d1")) {
-        assertNotNull(resultSet);
-        assertFalse(resultSet.next());
+       */
+
+      try (Connection connection = EnvFactory.getEnv().getConnection();
+          Statement statement = connection.createStatement()) {
+
+        try (ResultSet resultSet = statement.executeQuery("SELECT s1 FROM root.sg.d1")) {
+          assertNotNull(resultSet);
+          int cnt = 0;
+          while (resultSet.next()) {
+            cnt++;
+            assertEquals("test", resultSet.getString("root.sg.d1.s1"));
+          }
+          assertEquals(1, cnt);
+        }
+        try (ResultSet resultSet = statement.executeQuery("SELECT s2 FROM root.sg.d1")) {
+          assertNotNull(resultSet);
+          assertFalse(resultSet.next());
+        }
       }
+    } finally {
+      dropDatabaseQuietly("root.sg");
     }
   }
 
   @Test
   public void testPartialInsertTablet() {
-    try (ISession session = EnvFactory.getEnv().getSessionConnection()) {
-      session.createTimeseries(
-          "root.sg1.d1.s1", TSDataType.INT64, TSEncoding.PLAIN, CompressionType.SNAPPY);
-      session.createTimeseries(
-          "root.sg1.d1.s2", TSDataType.INT64, TSEncoding.PLAIN, CompressionType.SNAPPY);
-      List<IMeasurementSchema> schemaList = new ArrayList<>();
-      schemaList.add(new MeasurementSchema("s1", TSDataType.INT64));
-      schemaList.add(new MeasurementSchema("s2", TSDataType.INT64));
-      schemaList.add(new MeasurementSchema("s3", TSDataType.INT64));
-      Tablet tablet = new Tablet("root.sg1.d1", schemaList, 300);
-      long timestamp = 0;
-      for (long row = 0; row < 100; row++) {
-        int rowIndex = tablet.getRowSize();
-        tablet.addTimestamp(rowIndex, timestamp);
-        for (int s = 0; s < 3; s++) {
-          long value = timestamp;
-          tablet.addValue(schemaList.get(s).getMeasurementName(), rowIndex, value);
+    try {
+      try (ISession session = EnvFactory.getEnv().getSessionConnection()) {
+        session.createTimeseries(
+            "root.sg1.d1.s1", TSDataType.INT64, TSEncoding.PLAIN, CompressionType.SNAPPY);
+        session.createTimeseries(
+            "root.sg1.d1.s2", TSDataType.INT64, TSEncoding.PLAIN, CompressionType.SNAPPY);
+        List<IMeasurementSchema> schemaList = new ArrayList<>();
+        schemaList.add(new MeasurementSchema("s1", TSDataType.INT64));
+        schemaList.add(new MeasurementSchema("s2", TSDataType.INT64));
+        schemaList.add(new MeasurementSchema("s3", TSDataType.INT64));
+        Tablet tablet = new Tablet("root.sg1.d1", schemaList, 300);
+        long timestamp = 0;
+        for (long row = 0; row < 100; row++) {
+          int rowIndex = tablet.getRowSize();
+          tablet.addTimestamp(rowIndex, timestamp);
+          for (int s = 0; s < 3; s++) {
+            long value = timestamp;
+            tablet.addValue(schemaList.get(s).getMeasurementName(), rowIndex, value);
+          }
+          timestamp++;
         }
-        timestamp++;
-      }
-      timestamp = System.currentTimeMillis();
-      for (long row = 0; row < 100; row++) {
-        int rowIndex = tablet.getRowSize();
-        tablet.addTimestamp(rowIndex, timestamp);
-        for (int s = 0; s < 3; s++) {
-          long value = timestamp;
-          tablet.addValue(schemaList.get(s).getMeasurementName(), rowIndex, value);
+        timestamp = System.currentTimeMillis();
+        for (long row = 0; row < 100; row++) {
+          int rowIndex = tablet.getRowSize();
+          tablet.addTimestamp(rowIndex, timestamp);
+          for (int s = 0; s < 3; s++) {
+            long value = timestamp;
+            tablet.addValue(schemaList.get(s).getMeasurementName(), rowIndex, value);
+          }
+          timestamp++;
         }
-        timestamp++;
-      }
-      try {
-        session.insertTablet(tablet);
+        try {
+          session.insertTablet(tablet);
+        } catch (Exception e) {
+          if (!e.getMessage().contains("507")) {
+            fail(e.getMessage());
+          }
+        }
+        try (SessionDataSet dataSet = session.executeQueryStatement("SELECT * FROM root.sg1.d1")) {
+          assertEquals(dataSet.getColumnNames().size(), 3);
+          assertEquals(dataSet.getColumnNames().get(0), "Time");
+          assertEquals(dataSet.getColumnNames().get(1), "root.sg1.d1.s1");
+          assertEquals(dataSet.getColumnNames().get(2), "root.sg1.d1.s2");
+          int cnt = 0;
+          while (dataSet.hasNext()) {
+            RowRecord rowRecord = dataSet.next();
+            long time = rowRecord.getTimestamp();
+            assertEquals(time, rowRecord.getFields().get(0).getLongV());
+            assertEquals(time, rowRecord.getFields().get(1).getLongV());
+            cnt++;
+          }
+          Assert.assertEquals(200, cnt);
+        }
       } catch (Exception e) {
-        if (!e.getMessage().contains("507")) {
-          fail(e.getMessage());
-        }
+        e.printStackTrace();
+        fail(e.getMessage());
       }
-      try (SessionDataSet dataSet = session.executeQueryStatement("SELECT * FROM root.sg1.d1")) {
-        assertEquals(dataSet.getColumnNames().size(), 3);
-        assertEquals(dataSet.getColumnNames().get(0), "Time");
-        assertEquals(dataSet.getColumnNames().get(1), "root.sg1.d1.s1");
-        assertEquals(dataSet.getColumnNames().get(2), "root.sg1.d1.s2");
-        int cnt = 0;
-        while (dataSet.hasNext()) {
-          RowRecord rowRecord = dataSet.next();
-          long time = rowRecord.getTimestamp();
-          assertEquals(time, rowRecord.getFields().get(0).getLongV());
-          assertEquals(time, rowRecord.getFields().get(1).getLongV());
-          cnt++;
-        }
-        Assert.assertEquals(200, cnt);
-      }
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail(e.getMessage());
+    } finally {
+      dropDatabaseQuietly("root.sg1");
     }
   }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBRestServiceIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBRestServiceIT.java
@@ -41,9 +41,9 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -73,10 +73,10 @@ import static org.junit.Assert.fail;
 @Category({LocalStandaloneIT.class, ClusterIT.class, RemoteIT.class})
 public class IoTDBRestServiceIT {
 
-  private int port = 18080;
+  private static int port = 18080;
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     BaseEnv baseEnv = EnvFactory.getEnv();
     baseEnv.getConfig().getDataNodeConfig().setEnableRestService(true);
     baseEnv.getConfig().getCommonConfig().setEnforceStrongPassword(false);
@@ -85,9 +85,35 @@ public class IoTDBRestServiceIT {
     port = portConflictDataNodeWrapper.getRestServicePort();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  private static void executeQuietly(Statement statement, String sql) {
+    try {
+      statement.execute(sql);
+    } catch (SQLException ignored) {
+      // ignore
+    }
+  }
+
+  private static void cleanupAllData() {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      executeQuietly(statement, "DELETE DATABASE root.**");
+    } catch (SQLException ignored) {
+      // ignore
+    }
+  }
+
+  private static void dropUserQuietly(String username) {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      executeQuietly(statement, "DROP USER " + username);
+    } catch (SQLException ignored) {
+      // ignore
+    }
   }
 
   public static String getAuthorization(String username, String password) {
@@ -258,62 +284,66 @@ public class IoTDBRestServiceIT {
   public void errorInsertRecords() throws SQLException {
     CloseableHttpResponse response = null;
     CloseableHttpClient httpClient = HttpClientBuilder.create().build();
-    for (int i = 0; i < EnvFactory.getEnv().getDataNodeWrapperList().size(); i++) {
-      DataNodeWrapper wrapper = EnvFactory.getEnv().getDataNodeWrapperList().get(i);
-      try {
-        HttpPost httpPost =
-            getHttpPost(
-                "http://"
-                    + wrapper.getIp()
-                    + ":"
-                    + wrapper.getRestServicePort()
-                    + "/rest/v2/insertRecords");
-        String json =
-            "{\"timestamps\":["
-                + i
-                + "],\"measurements_list\":[[\"s33\",\"s44\"]],\"data_types_list\":[[\"INT32\",\"INT64\"]],\"values_list\":[[1,false]],\"is_aligned\":false,\"devices\":[\"root.s1\"]}";
-        httpPost.setEntity(new StringEntity(json, Charset.defaultCharset()));
-        for (int j = 0; j < 30; j++) {
-          try {
-            response = httpClient.execute(httpPost);
-            break;
-          } catch (Exception e) {
-            if (i == 29) {
-              throw e;
-            }
-            try {
-              TimeUnit.SECONDS.sleep(1);
-            } catch (InterruptedException ex) {
-              throw new RuntimeException(ex);
-            }
-          }
-        }
-        HttpEntity responseEntity = response.getEntity();
-        String message = EntityUtils.toString(responseEntity, "utf-8");
-        JsonObject result = JsonParser.parseString(message).getAsJsonObject();
-        assertEquals(507, Integer.parseInt(result.get("code").toString()));
-      } catch (IOException e) {
-        e.printStackTrace();
-        fail(e.getMessage());
-      } finally {
+    try {
+      for (int i = 0; i < EnvFactory.getEnv().getDataNodeWrapperList().size(); i++) {
+        DataNodeWrapper wrapper = EnvFactory.getEnv().getDataNodeWrapperList().get(i);
         try {
-          if (response != null) {
-            response.close();
+          HttpPost httpPost =
+              getHttpPost(
+                  "http://"
+                      + wrapper.getIp()
+                      + ":"
+                      + wrapper.getRestServicePort()
+                      + "/rest/v2/insertRecords");
+          String json =
+              "{\"timestamps\":["
+                  + i
+                  + "],\"measurements_list\":[[\"s33\",\"s44\"]],\"data_types_list\":[[\"INT32\",\"INT64\"]],\"values_list\":[[1,false]],\"is_aligned\":false,\"devices\":[\"root.s1\"]}";
+          httpPost.setEntity(new StringEntity(json, Charset.defaultCharset()));
+          for (int j = 0; j < 30; j++) {
+            try {
+              response = httpClient.execute(httpPost);
+              break;
+            } catch (Exception e) {
+              if (i == 29) {
+                throw e;
+              }
+              try {
+                TimeUnit.SECONDS.sleep(1);
+              } catch (InterruptedException ex) {
+                throw new RuntimeException(ex);
+              }
+            }
           }
+          HttpEntity responseEntity = response.getEntity();
+          String message = EntityUtils.toString(responseEntity, "utf-8");
+          JsonObject result = JsonParser.parseString(message).getAsJsonObject();
+          assertEquals(507, Integer.parseInt(result.get("code").toString()));
         } catch (IOException e) {
           e.printStackTrace();
           fail(e.getMessage());
+        } finally {
+          try {
+            if (response != null) {
+              response.close();
+            }
+          } catch (IOException e) {
+            e.printStackTrace();
+            fail(e.getMessage());
+          }
         }
       }
-    }
-    try (Connection connection = EnvFactory.getEnv().getConnection();
-        Statement statement = connection.createStatement()) {
+      try (Connection connection = EnvFactory.getEnv().getConnection();
+          Statement statement = connection.createStatement()) {
 
-      ResultSet resultSet = statement.executeQuery("select count(s33) from root.s1");
-      resultSet.next();
-      assertEquals(
-          EnvFactory.getEnv().getDataNodeWrapperList().size(),
-          resultSet.getInt("count(root.s1.s33)"));
+        ResultSet resultSet = statement.executeQuery("select count(s33) from root.s1");
+        resultSet.next();
+        assertEquals(
+            EnvFactory.getEnv().getDataNodeWrapperList().size(),
+            resultSet.getInt("count(root.s1.s33)"));
+      }
+    } finally {
+      cleanupAllData();
     }
   }
 
@@ -460,353 +490,363 @@ public class IoTDBRestServiceIT {
   @Test
   public void insertAndQuery() {
     CloseableHttpClient httpClient = HttpClientBuilder.create().build();
-    rightInsertTablet(httpClient);
-    query(httpClient);
-    queryGroupByLevel(httpClient);
-    queryRowLimit(httpClient);
-    queryShowChildPaths(httpClient);
-    queryShowNodes(httpClient);
-    showAllTTL(httpClient);
-    showDatabase(httpClient);
-    showFunctions(httpClient);
-    showTimeseries(httpClient);
-
-    showLastTimeseries(httpClient);
-    countTimeseries(httpClient);
-    countNodes(httpClient);
-    showDevices(httpClient);
-
-    showDevicesWithStroage(httpClient);
-    listUser(httpClient);
-    selectCount(httpClient);
-    selectLast(httpClient);
-    queryWithValidTimeZoneHeader(httpClient);
-    nonQueryWithValidTimeZoneHeader(httpClient);
-    queryWithInvalidTimeZoneHeader(httpClient);
-    nonQueryWithValidTimeZoneHeaderTableV1(httpClient);
-    queryWithValidTimeZoneHeaderTableV1(httpClient);
-    queryWithInvalidTimeZoneHeaderTableV1(httpClient);
-
-    queryV2(httpClient);
-    selectFastLast(httpClient);
-    queryGroupByLevelV2(httpClient);
-    queryRowLimitV2(httpClient);
-    queryShowChildPathsV2(httpClient);
-    queryShowNodesV2(httpClient);
-    showAllTTLV2(httpClient);
-    showDatabaseV2(httpClient);
-    showFunctionsV2(httpClient);
-    showTimeseriesV2(httpClient);
-
-    showLastTimeseriesV2(httpClient);
-    countTimeseriesV2(httpClient);
-    countNodesV2(httpClient);
-    showDevicesV2(httpClient);
-
-    showDevicesWithStroageV2(httpClient);
-    listUserV2(httpClient);
-    selectCountV2(httpClient);
-    selectLastV2(httpClient);
-    queryWithValidTimeZoneHeaderV2(httpClient);
-    nonQueryWithValidTimeZoneHeaderV2(httpClient);
-    queryWithInvalidTimeZoneHeaderV2(httpClient);
-    perData(httpClient);
-    List<String> insertTablet_right_json_list = new ArrayList<>();
-    List<String> insertTablet_error_json_list = new ArrayList<>();
-
-    List<String> insertRecords_right_json_list = new ArrayList<>();
-    List<String> insertRecords_error_json_list = new ArrayList<>();
-
-    List<String> nonQuery_right_json_list = new ArrayList<>();
-    List<String> nonQuery_error_json_list = new ArrayList<>();
-
-    List<String> insertTablet_right_json_list_v2 = new ArrayList<>();
-    List<String> insertTablet_error_json_list_v2 = new ArrayList<>();
-
-    List<String> insertRecords_right_json_list_v2 = new ArrayList<>();
-    List<String> insertRecords_error_json_list_v2 = new ArrayList<>();
-
-    List<String> nonQuery_right_json_list_v2 = new ArrayList<>();
-    List<String> nonQuery_error_json_list_v2 = new ArrayList<>();
-    for (int i = 0; i <= 1; i++) {
-      boolean isAligned = false;
-      if (i == 0) {
-        isAligned = true;
-      }
-      insertTablet_right_json_list.add(
-          "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"s3\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"dataTypes\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[11,2],[1635000012345555,1635000012345556],[1.41,null],[null,false],[null,3.5555]],\"isAligned\":\""
-              + isAligned
-              + "\",\"deviceId\":\"root.sg21"
-              + i
-              + "\"}");
-      insertTablet_right_json_list.add(
-          "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"`s3`\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"dataTypes\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[11,2],[1635000012345555,1635000012345556],[1.41,null],[null,false],[null,3.5555]],\"isAligned\":\""
-              + isAligned
-              + "\",\"deviceId\":\"root.sg22"
-              + i
-              + "\"}");
-      insertTablet_right_json_list.add(
-          "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"s3\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"dataTypes\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[11,2],[1635000012345555,1635000012345556],[1.41,null],[null,false],[null,3.5555]],\"isAligned\":\""
-              + isAligned
-              + "\",\"deviceId\":\"root.`sg23"
-              + i
-              + "`\"}");
-      insertTablet_right_json_list.add(
-          "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"`s3`\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"dataTypes\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[11,2],[1635000012345555,1635000012345556],[1.41,null],[null,false],[null,3.5555]],\"isAligned\":\""
-              + isAligned
-              + "\",\"deviceId\":\"root.`sg24"
-              + i
-              + "`\"}");
-      insertTablet_error_json_list.add(
-          "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"s3\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"dataTypes\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[111111112312312442352545452323123,2],[16,15],[1.41,null],[null,false],[null,3.55555555555555555555555555555555555555555555312234235345123127318927461482308478123645555555555555555555555555555555555555555555531223423534512312731892746148230847812364]],\"isAligned\":"
-              + isAligned
-              + ",\"deviceId\":\"root.sg25"
-              + i
-              + "\"}");
-      insertTablet_error_json_list.add(
-          "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"`s3`\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"dataTypes\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[111111112312312442352545452323123,2],[16,15],[1.41,null],[null,false],[null,3.55555555555555555555555555555555555555555555312234235345123127318927461482308478123645555555555555555555555555555555555555555555531223423534512312731892746148230847812364]],\"isAligned\":"
-              + isAligned
-              + ",\"deviceId\":\"root.sg36"
-              + i
-              + "\"}");
-      insertTablet_error_json_list.add(
-          "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"a123123\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"dataTypes\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[111111112312312442352545452323123,2],[16,15],[1.41,null],[null,false],[null,3.55555555555555555555555555555555555555555555312234235345123127318927461482308478123645555555555555555555555555555555555555555555531223423534512312731892746148230847812364]],\"isAligned\":"
-              + isAligned
-              + ",\"deviceId\":\"root.`sg46"
-              + i
-              + "`\"}");
-      insertTablet_error_json_list.add(
-          "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"`1231231`\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"dataTypes\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[111111112312312442352545452323123,2],[16,15],[1.41,null],[null,false],[null,3.55555555555555555555555555555555555555555555312234235345123127318927461482308478123645555555555555555555555555555555555555555555531223423534512312731892746148230847812364]],\"isAligned\":"
-              + isAligned
-              + ",\"deviceId\":\"root.`3333a"
-              + i
-              + "`\"}");
-      insertRecords_right_json_list.add(
-          "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurementsList\":[[\"s33\",\"s44\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"dataTypesList\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"valuesList\":[[1,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"deviceIds\":[\"root.s11\",\"root.s11\",\"root.s1\",\"root.s3\"],\"isAligned\":"
-              + isAligned
-              + "}");
-      insertRecords_right_json_list.add(
-          "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurementsList\":[[\"`s33`\",\"s44\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"dataTypesList\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"valuesList\":[[1,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"deviceIds\":[\"root.s11\",\"root.s11\",\"root.s1\",\"root.s3\"],\"isAligned\":"
-              + isAligned
-              + "}");
-      insertRecords_right_json_list.add(
-          "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurementsList\":[[\"s33\",\"s44\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"dataTypesList\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"valuesList\":[[1,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"deviceIds\":[\"root.s11\",\"root.s11\",\"root.s1\",\"root.`s3`\"],\"isAligned\":"
-              + isAligned
-              + "}");
-      insertRecords_right_json_list.add(
-          "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurementsList\":[[\"`s33`\",\"s44\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"dataTypesList\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"valuesList\":[[1,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"deviceIds\":[\"root.`s11`\",\"root.s11\",\"root.s1\",\"root.`s3`\"],\"isAligned\":"
-              + isAligned
-              + "}");
-
-      insertRecords_error_json_list.add(
-          "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurementsList\":[[\"root\",\"442\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"dataTypesList\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"valuesList\":[[true,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"deviceIds\":[\"root.s11\",\"root.s11\",\"root.s1\",\"root.time\"],\"isAligned\":"
-              + isAligned
-              + "}");
-      insertRecords_error_json_list.add(
-          "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurementsList\":[[\"time\",\"a123123\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"dataTypesList\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"valuesList\":[[true,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"deviceIds\":[\"root.s11\",\"root.s11\",\"root.s1\",\"root.time\"],\"isAligned\":"
-              + isAligned
-              + "}");
-      insertRecords_error_json_list.add(
-          "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurementsList\":[[\"time\",\"a12321\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"dataTypesList\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"valuesList\":[[true,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"deviceIds\":[\"root.111\",\"root.`s11`\",\"root.s1\",\"root.s3\"],\"isAligned\":"
-              + isAligned
-              + "}");
-      insertRecords_error_json_list.add(
-          "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurementsList\":[[\"`root`\",\"1111\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"dataTypesList\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"valuesList\":[[true,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"deviceIds\":[\"root.s11\",\"root.s11\",\"root.time\",\"root.`s3`\"],\"isAligned\":"
-              + isAligned
-              + "}");
-
-      nonQuery_right_json_list.add("{\"sql\":\"insert into root.aa(time,`bb`) values(111,1)\"}");
-      nonQuery_right_json_list.add("{\"sql\":\"insert into root.`aa`(time,bb) values(111,1)\"}");
-      nonQuery_right_json_list.add("{\"sql\":\"insert into root.`aa`(time,`bb`) values(111,1)\"}");
-      nonQuery_right_json_list.add("{\"sql\":\"insert into root.aa(time,bb) values(111,1)\"}");
-
-      nonQuery_error_json_list.add("{\"sql\":\"insert into root.time(time,1`bb`) values(111,1)\"}");
-      nonQuery_error_json_list.add(
-          "{\"sql\":\"insert into root.time.`aa`(time,bb) values(111,1)\"}");
-      nonQuery_error_json_list.add(
-          "{\"sql\":\"insert into root.time.`aa`(time,`bb`) values(111,1)\"}");
-      nonQuery_error_json_list.add("{\"sql\":\"insert into root.aa(time,root) values(111,1)\"}");
-
-      insertTablet_right_json_list_v2.add(
-          "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"s3\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"data_types\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[11,2],[1635000012345555,1635000012345556],[1.41,null],[null,false],[null,3.5555]],\"is_aligned\":\""
-              + isAligned
-              + "\",\"device\":\"root.sg21"
-              + i
-              + "\"}");
-      insertTablet_right_json_list_v2.add(
-          "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"`s3`\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"data_types\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[11,2],[1635000012345555,1635000012345556],[1.41,null],[null,false],[null,3.5555]],\"is_aligned\":"
-              + isAligned
-              + ",\"device\":\"root.sg22"
-              + i
-              + "\"}");
-      insertTablet_right_json_list_v2.add(
-          "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"s3\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"data_types\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[11,2],[1635000012345555,1635000012345556],[1.41,null],[null,false],[null,3.5555]],\"is_aligned\":"
-              + isAligned
-              + ",\"device\":\"root.`sg23"
-              + i
-              + "`\"}");
-      insertTablet_right_json_list_v2.add(
-          "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"`s3`\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"data_types\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[11,2],[1635000012345555,1635000012345556],[1.41,null],[null,false],[null,3.5555]],\"is_aligned\":"
-              + isAligned
-              + ",\"device\":\"root.`sg24"
-              + i
-              + "`\"}");
-      insertTablet_error_json_list_v2.add(
-          "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"s3\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"data_types\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[111111112312312442352545452323123,2],[16,15],[1.41,null],[null,false],[null,3.55555555555555555555555555555555555555555555312234235345123127318927461482308478123645555555555555555555555555555555555555555555531223423534512312731892746148230847812364]],\"is_aligned\":"
-              + isAligned
-              + ",\"device\":\"root.sg25"
-              + i
-              + "\"}");
-      insertTablet_error_json_list_v2.add(
-          "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"`s3`\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"data_types\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[111111112312312442352545452323123,2],[16,15],[1.41,null],[null,false],[null,3.55555555555555555555555555555555555555555555312234235345123127318927461482308478123645555555555555555555555555555555555555555555531223423534512312731892746148230847812364]],\"is_aligned\":"
-              + isAligned
-              + ",\"device\":\"root.sg26"
-              + i
-              + "\"}");
-      insertTablet_error_json_list_v2.add(
-          "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"cc123123\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"data_types\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[111111112312312442352545452323123,2],[16,15],[1.41,null],[null,false],[null,3.55555555555555555555555555555555555555555555312234235345123127318927461482308478123645555555555555555555555555555555555555555555531223423534512312731892746148230847812364]],\"is_aligned\":"
-              + isAligned
-              + ",\"device\":\"root.`sg26"
-              + i
-              + "`\"}");
-      insertTablet_error_json_list_v2.add(
-          "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"`1231231cc`\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"data_types\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[111111112312312442352545452323123,2],[16,15],[1.41,null],[null,false],[null,3.55555555555555555555555555555555555555555555312234235345123127318927461482308478123645555555555555555555555555555555555555555555531223423534512312731892746148230847812364]],\"is_aligned\":"
-              + isAligned
-              + ",\"device\":\"root.`3333a"
-              + i
-              + "`\"}");
-      insertRecords_right_json_list_v2.add(
-          "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurements_list\":[[\"s33\",\"s44\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"data_types_list\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"values_list\":[[1,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"devices\":[\"root.s11\",\"root.s11\",\"root.s1\",\"root.s3\"],\"is_aligned\":"
-              + isAligned
-              + "}");
-      insertRecords_right_json_list_v2.add(
-          "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurements_list\":[[\"`s33`\",\"s44\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"data_types_list\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"values_list\":[[1,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"devices\":[\"root.s11\",\"root.s11\",\"root.s1\",\"root.s3\"],\"is_aligned\":"
-              + isAligned
-              + "}");
-      insertRecords_right_json_list_v2.add(
-          "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurements_list\":[[\"s33\",\"s44\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"data_types_list\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"values_list\":[[1,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"devices\":[\"root.s11\",\"root.s11\",\"root.s1\",\"root.`s3`\"],\"is_aligned\":"
-              + isAligned
-              + "}");
-      insertRecords_right_json_list_v2.add(
-          "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurements_list\":[[\"`s33`\",\"s44\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"data_types_list\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"values_list\":[[1,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"devices\":[\"root.`s11`\",\"root.s11\",\"root.s1\",\"root.`s3`\"],\"is_aligned\":"
-              + isAligned
-              + "}");
-
-      insertRecords_error_json_list_v2.add(
-          "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurements_list\":[[\"root\",\"442\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"data_types_list\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"values_list\":[[true,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"devices\":[\"root.s11\",\"root.s11\",\"root.s1\",\"root.time\"],\"is_aligned\":"
-              + isAligned
-              + "}");
-      insertRecords_error_json_list_v2.add(
-          "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurements_list\":[[\"time\",\"123123\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"data_types_list\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"values_list\":[[true,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"devices\":[\"root.s11\",\"root.s11\",\"root.s1\",\"root.time\"],\"is_aligned\":"
-              + isAligned
-              + "}");
-      insertRecords_error_json_list_v2.add(
-          "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurements_list\":[[\"time\",\"12321\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"data_types_list\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"values_list\":[[true,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"devices\":[\"root.111\",\"root.`s11`\",\"root.s1\",\"root.s3\"],\"is_aligned\":"
-              + isAligned
-              + "}");
-      insertRecords_error_json_list_v2.add(
-          "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurements_list\":[[\"`root`\",\"1111\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"data_types_list\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"values_list\":[[true,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"devices\":[\"root.s11\",\"root.s11\",\"root.time\",\"root.`s3`\"],\"is_aligned\":"
-              + isAligned
-              + "}");
-
-      nonQuery_right_json_list_v2.add("{\"sql\":\"insert into root.aa(time,`bb`) values(111,1)\"}");
-      nonQuery_right_json_list_v2.add("{\"sql\":\"insert into root.`aa`(time,bb) values(111,1)\"}");
-      nonQuery_right_json_list_v2.add(
-          "{\"sql\":\"insert into root.`aa`(time,`bb`) values(111,1)\"}");
-      nonQuery_right_json_list_v2.add("{\"sql\":\"insert into root.aa(time,bb) values(111,1)\"}");
-
-      nonQuery_error_json_list_v2.add(
-          "{\"sql\":\"insert into root.time(time,1`bb`) values(111,1)\"}");
-      nonQuery_error_json_list_v2.add(
-          "{\"sql\":\"insert into root.time.`aa`(time,bb) values(111,1)\"}");
-      nonQuery_error_json_list_v2.add(
-          "{\"sql\":\"insert into root.time.`aa`(time,`bb`) values(111,1)\"}");
-      nonQuery_error_json_list_v2.add("{\"sql\":\"insert into root.aa(time,root) values(111,1)\"}");
-    }
-    HttpPost httpPost = getHttpPost("http://127.0.0.1:" + port + "/rest/v1/insertTablet");
-    HttpPost httpPost1 = getHttpPost_1("http://127.0.0.1:" + port + "/rest/v1/insertTablet");
-
-    List<HttpPost> httpPosts = new ArrayList<>();
-    httpPosts.add(httpPost);
-    httpPosts.add(httpPost1);
-    for (HttpPost hp : httpPosts) {
-      for (String json : insertTablet_right_json_list) {
-        rightInsertTablet(httpClient, json, hp);
-      }
-      for (String json : insertTablet_error_json_list) {
-        errorInsertTablet(json, hp);
-      }
-    }
-
-    HttpPost httpPost3 = getHttpPost("http://127.0.0.1:" + port + "/rest/v1/nonQuery");
-    HttpPost httpPost4 = getHttpPost_1("http://127.0.0.1:" + port + "/rest/v1/nonQuery");
-    List<HttpPost> httpPosts1 = new ArrayList<>();
-    httpPosts1.add(httpPost3);
-    httpPosts1.add(httpPost4);
-
-    for (HttpPost hp : httpPosts1) {
-      for (String json : nonQuery_right_json_list) {
-        nonQuery(httpClient, json, hp);
-      }
-      for (String json : nonQuery_error_json_list) {
-        errorNonQuery(httpClient, json, hp);
-      }
-    }
-
-    HttpPost httpPost5 = getHttpPost("http://127.0.0.1:" + port + "/rest/v1/insertRecords");
-    HttpPost httpPost6 = getHttpPost_1("http://127.0.0.1:" + port + "/rest/v1/insertRecords");
-    List<HttpPost> httpPosts2 = new ArrayList<>();
-    httpPosts2.add(httpPost5);
-    httpPosts2.add(httpPost6);
-
-    HttpPost httpPostV2 = getHttpPost("http://127.0.0.1:" + port + "/rest/v2/insertTablet");
-    HttpPost httpPost1V2 = getHttpPost_1("http://127.0.0.1:" + port + "/rest/v2/insertTablet");
-
-    List<HttpPost> httpPostsV2 = new ArrayList<>();
-    httpPostsV2.add(httpPostV2);
-    httpPostsV2.add(httpPost1V2);
-    for (HttpPost hp : httpPostsV2) {
-      for (String json : insertTablet_right_json_list_v2) {
-        rightInsertTablet(httpClient, json, hp);
-      }
-      for (String json : insertTablet_error_json_list_v2) {
-        errorInsertTablet(json, hp);
-      }
-    }
-
-    HttpPost httpPost3V2 = getHttpPost("http://127.0.0.1:" + port + "/rest/v2/nonQuery");
-    HttpPost httpPost4V2 = getHttpPost_1("http://127.0.0.1:" + port + "/rest/v2/nonQuery");
-    List<HttpPost> httpPosts1V2 = new ArrayList<>();
-    httpPosts1V2.add(httpPost3V2);
-    httpPosts1V2.add(httpPost4V2);
-    for (HttpPost hp : httpPosts1V2) {
-      for (String json : nonQuery_right_json_list_v2) {
-        nonQuery(httpClient, json, hp);
-      }
-      for (String json : nonQuery_error_json_list_v2) {
-        errorNonQuery(httpClient, json, hp);
-      }
-    }
-
-    HttpPost httpPost5V2 = getHttpPost("http://127.0.0.1:" + port + "/rest/v2/insertRecords");
-    HttpPost httpPost6V2 = getHttpPost_1("http://127.0.0.1:" + port + "/rest/v2/insertRecords");
-    List<HttpPost> httpPosts2V2 = new ArrayList<>();
-    httpPosts2V2.add(httpPost5V2);
-    httpPosts2V2.add(httpPost6V2);
-    for (HttpPost hp : httpPosts2V2) {
-      for (String json : insertRecords_right_json_list_v2) {
-        rightInsertRecords(httpClient, json, hp);
-      }
-      for (String json : insertRecords_error_json_list_v2) {
-        errorInsertRecords(httpClient, json, hp);
-      }
-    }
-    insertDate();
     try {
-      httpClient.close();
-    } catch (IOException e) {
-      e.printStackTrace();
-      fail(e.getMessage());
+      rightInsertTablet(httpClient);
+      query(httpClient);
+      queryGroupByLevel(httpClient);
+      queryRowLimit(httpClient);
+      queryShowChildPaths(httpClient);
+      queryShowNodes(httpClient);
+      showAllTTL(httpClient);
+      showDatabase(httpClient);
+      showFunctions(httpClient);
+      showTimeseries(httpClient);
+
+      showLastTimeseries(httpClient);
+      countTimeseries(httpClient);
+      countNodes(httpClient);
+      showDevices(httpClient);
+
+      showDevicesWithStroage(httpClient);
+      listUser(httpClient);
+      selectCount(httpClient);
+      selectLast(httpClient);
+      queryWithValidTimeZoneHeader(httpClient);
+      nonQueryWithValidTimeZoneHeader(httpClient);
+      queryWithInvalidTimeZoneHeader(httpClient);
+      nonQueryWithValidTimeZoneHeaderTableV1(httpClient);
+      queryWithValidTimeZoneHeaderTableV1(httpClient);
+      queryWithInvalidTimeZoneHeaderTableV1(httpClient);
+
+      queryV2(httpClient);
+      selectFastLast(httpClient);
+      queryGroupByLevelV2(httpClient);
+      queryRowLimitV2(httpClient);
+      queryShowChildPathsV2(httpClient);
+      queryShowNodesV2(httpClient);
+      showAllTTLV2(httpClient);
+      showDatabaseV2(httpClient);
+      showFunctionsV2(httpClient);
+      showTimeseriesV2(httpClient);
+
+      showLastTimeseriesV2(httpClient);
+      countTimeseriesV2(httpClient);
+      countNodesV2(httpClient);
+      showDevicesV2(httpClient);
+
+      showDevicesWithStroageV2(httpClient);
+      listUserV2(httpClient);
+      selectCountV2(httpClient);
+      selectLastV2(httpClient);
+      queryWithValidTimeZoneHeaderV2(httpClient);
+      nonQueryWithValidTimeZoneHeaderV2(httpClient);
+      queryWithInvalidTimeZoneHeaderV2(httpClient);
+      perData(httpClient);
+      List<String> insertTablet_right_json_list = new ArrayList<>();
+      List<String> insertTablet_error_json_list = new ArrayList<>();
+
+      List<String> insertRecords_right_json_list = new ArrayList<>();
+      List<String> insertRecords_error_json_list = new ArrayList<>();
+
+      List<String> nonQuery_right_json_list = new ArrayList<>();
+      List<String> nonQuery_error_json_list = new ArrayList<>();
+
+      List<String> insertTablet_right_json_list_v2 = new ArrayList<>();
+      List<String> insertTablet_error_json_list_v2 = new ArrayList<>();
+
+      List<String> insertRecords_right_json_list_v2 = new ArrayList<>();
+      List<String> insertRecords_error_json_list_v2 = new ArrayList<>();
+
+      List<String> nonQuery_right_json_list_v2 = new ArrayList<>();
+      List<String> nonQuery_error_json_list_v2 = new ArrayList<>();
+      for (int i = 0; i <= 1; i++) {
+        boolean isAligned = false;
+        if (i == 0) {
+          isAligned = true;
+        }
+        insertTablet_right_json_list.add(
+            "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"s3\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"dataTypes\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[11,2],[1635000012345555,1635000012345556],[1.41,null],[null,false],[null,3.5555]],\"isAligned\":\""
+                + isAligned
+                + "\",\"deviceId\":\"root.sg21"
+                + i
+                + "\"}");
+        insertTablet_right_json_list.add(
+            "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"`s3`\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"dataTypes\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[11,2],[1635000012345555,1635000012345556],[1.41,null],[null,false],[null,3.5555]],\"isAligned\":\""
+                + isAligned
+                + "\",\"deviceId\":\"root.sg22"
+                + i
+                + "\"}");
+        insertTablet_right_json_list.add(
+            "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"s3\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"dataTypes\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[11,2],[1635000012345555,1635000012345556],[1.41,null],[null,false],[null,3.5555]],\"isAligned\":\""
+                + isAligned
+                + "\",\"deviceId\":\"root.`sg23"
+                + i
+                + "`\"}");
+        insertTablet_right_json_list.add(
+            "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"`s3`\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"dataTypes\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[11,2],[1635000012345555,1635000012345556],[1.41,null],[null,false],[null,3.5555]],\"isAligned\":\""
+                + isAligned
+                + "\",\"deviceId\":\"root.`sg24"
+                + i
+                + "`\"}");
+        insertTablet_error_json_list.add(
+            "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"s3\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"dataTypes\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[111111112312312442352545452323123,2],[16,15],[1.41,null],[null,false],[null,3.55555555555555555555555555555555555555555555312234235345123127318927461482308478123645555555555555555555555555555555555555555555531223423534512312731892746148230847812364]],\"isAligned\":"
+                + isAligned
+                + ",\"deviceId\":\"root.sg25"
+                + i
+                + "\"}");
+        insertTablet_error_json_list.add(
+            "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"`s3`\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"dataTypes\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[111111112312312442352545452323123,2],[16,15],[1.41,null],[null,false],[null,3.55555555555555555555555555555555555555555555312234235345123127318927461482308478123645555555555555555555555555555555555555555555531223423534512312731892746148230847812364]],\"isAligned\":"
+                + isAligned
+                + ",\"deviceId\":\"root.sg36"
+                + i
+                + "\"}");
+        insertTablet_error_json_list.add(
+            "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"a123123\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"dataTypes\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[111111112312312442352545452323123,2],[16,15],[1.41,null],[null,false],[null,3.55555555555555555555555555555555555555555555312234235345123127318927461482308478123645555555555555555555555555555555555555555555531223423534512312731892746148230847812364]],\"isAligned\":"
+                + isAligned
+                + ",\"deviceId\":\"root.`sg46"
+                + i
+                + "`\"}");
+        insertTablet_error_json_list.add(
+            "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"`1231231`\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"dataTypes\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[111111112312312442352545452323123,2],[16,15],[1.41,null],[null,false],[null,3.55555555555555555555555555555555555555555555312234235345123127318927461482308478123645555555555555555555555555555555555555555555531223423534512312731892746148230847812364]],\"isAligned\":"
+                + isAligned
+                + ",\"deviceId\":\"root.`3333a"
+                + i
+                + "`\"}");
+        insertRecords_right_json_list.add(
+            "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurementsList\":[[\"s33\",\"s44\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"dataTypesList\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"valuesList\":[[1,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"deviceIds\":[\"root.s11\",\"root.s11\",\"root.s1\",\"root.s3\"],\"isAligned\":"
+                + isAligned
+                + "}");
+        insertRecords_right_json_list.add(
+            "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurementsList\":[[\"`s33`\",\"s44\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"dataTypesList\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"valuesList\":[[1,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"deviceIds\":[\"root.s11\",\"root.s11\",\"root.s1\",\"root.s3\"],\"isAligned\":"
+                + isAligned
+                + "}");
+        insertRecords_right_json_list.add(
+            "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurementsList\":[[\"s33\",\"s44\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"dataTypesList\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"valuesList\":[[1,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"deviceIds\":[\"root.s11\",\"root.s11\",\"root.s1\",\"root.`s3`\"],\"isAligned\":"
+                + isAligned
+                + "}");
+        insertRecords_right_json_list.add(
+            "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurementsList\":[[\"`s33`\",\"s44\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"dataTypesList\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"valuesList\":[[1,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"deviceIds\":[\"root.`s11`\",\"root.s11\",\"root.s1\",\"root.`s3`\"],\"isAligned\":"
+                + isAligned
+                + "}");
+
+        insertRecords_error_json_list.add(
+            "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurementsList\":[[\"root\",\"442\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"dataTypesList\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"valuesList\":[[true,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"deviceIds\":[\"root.s11\",\"root.s11\",\"root.s1\",\"root.time\"],\"isAligned\":"
+                + isAligned
+                + "}");
+        insertRecords_error_json_list.add(
+            "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurementsList\":[[\"time\",\"a123123\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"dataTypesList\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"valuesList\":[[true,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"deviceIds\":[\"root.s11\",\"root.s11\",\"root.s1\",\"root.time\"],\"isAligned\":"
+                + isAligned
+                + "}");
+        insertRecords_error_json_list.add(
+            "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurementsList\":[[\"time\",\"a12321\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"dataTypesList\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"valuesList\":[[true,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"deviceIds\":[\"root.111\",\"root.`s11`\",\"root.s1\",\"root.s3\"],\"isAligned\":"
+                + isAligned
+                + "}");
+        insertRecords_error_json_list.add(
+            "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurementsList\":[[\"`root`\",\"1111\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"dataTypesList\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"valuesList\":[[true,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"deviceIds\":[\"root.s11\",\"root.s11\",\"root.time\",\"root.`s3`\"],\"isAligned\":"
+                + isAligned
+                + "}");
+
+        nonQuery_right_json_list.add("{\"sql\":\"insert into root.aa(time,`bb`) values(111,1)\"}");
+        nonQuery_right_json_list.add("{\"sql\":\"insert into root.`aa`(time,bb) values(111,1)\"}");
+        nonQuery_right_json_list.add(
+            "{\"sql\":\"insert into root.`aa`(time,`bb`) values(111,1)\"}");
+        nonQuery_right_json_list.add("{\"sql\":\"insert into root.aa(time,bb) values(111,1)\"}");
+
+        nonQuery_error_json_list.add(
+            "{\"sql\":\"insert into root.time(time,1`bb`) values(111,1)\"}");
+        nonQuery_error_json_list.add(
+            "{\"sql\":\"insert into root.time.`aa`(time,bb) values(111,1)\"}");
+        nonQuery_error_json_list.add(
+            "{\"sql\":\"insert into root.time.`aa`(time,`bb`) values(111,1)\"}");
+        nonQuery_error_json_list.add("{\"sql\":\"insert into root.aa(time,root) values(111,1)\"}");
+
+        insertTablet_right_json_list_v2.add(
+            "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"s3\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"data_types\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[11,2],[1635000012345555,1635000012345556],[1.41,null],[null,false],[null,3.5555]],\"is_aligned\":\""
+                + isAligned
+                + "\",\"device\":\"root.sg21"
+                + i
+                + "\"}");
+        insertTablet_right_json_list_v2.add(
+            "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"`s3`\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"data_types\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[11,2],[1635000012345555,1635000012345556],[1.41,null],[null,false],[null,3.5555]],\"is_aligned\":"
+                + isAligned
+                + ",\"device\":\"root.sg22"
+                + i
+                + "\"}");
+        insertTablet_right_json_list_v2.add(
+            "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"s3\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"data_types\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[11,2],[1635000012345555,1635000012345556],[1.41,null],[null,false],[null,3.5555]],\"is_aligned\":"
+                + isAligned
+                + ",\"device\":\"root.`sg23"
+                + i
+                + "`\"}");
+        insertTablet_right_json_list_v2.add(
+            "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"`s3`\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"data_types\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[11,2],[1635000012345555,1635000012345556],[1.41,null],[null,false],[null,3.5555]],\"is_aligned\":"
+                + isAligned
+                + ",\"device\":\"root.`sg24"
+                + i
+                + "`\"}");
+        insertTablet_error_json_list_v2.add(
+            "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"s3\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"data_types\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[111111112312312442352545452323123,2],[16,15],[1.41,null],[null,false],[null,3.55555555555555555555555555555555555555555555312234235345123127318927461482308478123645555555555555555555555555555555555555555555531223423534512312731892746148230847812364]],\"is_aligned\":"
+                + isAligned
+                + ",\"device\":\"root.sg25"
+                + i
+                + "\"}");
+        insertTablet_error_json_list_v2.add(
+            "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"`s3`\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"data_types\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[111111112312312442352545452323123,2],[16,15],[1.41,null],[null,false],[null,3.55555555555555555555555555555555555555555555312234235345123127318927461482308478123645555555555555555555555555555555555555555555531223423534512312731892746148230847812364]],\"is_aligned\":"
+                + isAligned
+                + ",\"device\":\"root.sg26"
+                + i
+                + "\"}");
+        insertTablet_error_json_list_v2.add(
+            "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"cc123123\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"data_types\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[111111112312312442352545452323123,2],[16,15],[1.41,null],[null,false],[null,3.55555555555555555555555555555555555555555555312234235345123127318927461482308478123645555555555555555555555555555555555555555555531223423534512312731892746148230847812364]],\"is_aligned\":"
+                + isAligned
+                + ",\"device\":\"root.`sg26"
+                + i
+                + "`\"}");
+        insertTablet_error_json_list_v2.add(
+            "{\"timestamps\":[1635232143960,1635232153960],\"measurements\":[\"`1231231cc`\",\"s4\",\"s5\",\"s6\",\"s7\",\"s8\"],\"data_types\":[\"TEXT\",\"INT32\",\"INT64\",\"FLOAT\",\"BOOLEAN\",\"DOUBLE\"],\"values\":[[\"2aa\",\"\"],[111111112312312442352545452323123,2],[16,15],[1.41,null],[null,false],[null,3.55555555555555555555555555555555555555555555312234235345123127318927461482308478123645555555555555555555555555555555555555555555531223423534512312731892746148230847812364]],\"is_aligned\":"
+                + isAligned
+                + ",\"device\":\"root.`3333a"
+                + i
+                + "`\"}");
+        insertRecords_right_json_list_v2.add(
+            "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurements_list\":[[\"s33\",\"s44\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"data_types_list\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"values_list\":[[1,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"devices\":[\"root.s11\",\"root.s11\",\"root.s1\",\"root.s3\"],\"is_aligned\":"
+                + isAligned
+                + "}");
+        insertRecords_right_json_list_v2.add(
+            "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurements_list\":[[\"`s33`\",\"s44\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"data_types_list\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"values_list\":[[1,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"devices\":[\"root.s11\",\"root.s11\",\"root.s1\",\"root.s3\"],\"is_aligned\":"
+                + isAligned
+                + "}");
+        insertRecords_right_json_list_v2.add(
+            "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurements_list\":[[\"s33\",\"s44\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"data_types_list\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"values_list\":[[1,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"devices\":[\"root.s11\",\"root.s11\",\"root.s1\",\"root.`s3`\"],\"is_aligned\":"
+                + isAligned
+                + "}");
+        insertRecords_right_json_list_v2.add(
+            "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurements_list\":[[\"`s33`\",\"s44\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"data_types_list\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"values_list\":[[1,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"devices\":[\"root.`s11`\",\"root.s11\",\"root.s1\",\"root.`s3`\"],\"is_aligned\":"
+                + isAligned
+                + "}");
+
+        insertRecords_error_json_list_v2.add(
+            "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurements_list\":[[\"root\",\"442\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"data_types_list\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"values_list\":[[true,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"devices\":[\"root.s11\",\"root.s11\",\"root.s1\",\"root.time\"],\"is_aligned\":"
+                + isAligned
+                + "}");
+        insertRecords_error_json_list_v2.add(
+            "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurements_list\":[[\"time\",\"123123\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"data_types_list\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"values_list\":[[true,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"devices\":[\"root.s11\",\"root.s11\",\"root.s1\",\"root.time\"],\"is_aligned\":"
+                + isAligned
+                + "}");
+        insertRecords_error_json_list_v2.add(
+            "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurements_list\":[[\"time\",\"12321\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"data_types_list\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"values_list\":[[true,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"devices\":[\"root.111\",\"root.`s11`\",\"root.s1\",\"root.s3\"],\"is_aligned\":"
+                + isAligned
+                + "}");
+        insertRecords_error_json_list_v2.add(
+            "{\"timestamps\":[1635232113960,1635232151960,1123,10],\"measurements_list\":[[\"`root`\",\"1111\"],[\"s55\",\"s66\"],[\"s77\",\"s88\"],[\"s771\",\"s881\"]],\"data_types_list\":[[\"INT32\",\"INT64\"],[\"float\",\"double\"],[\"float\",\"double\"],[\"boolean\",\"text\"]],\"values_list\":[[true,11],[2.1,2],[4,6],[false,\"cccccc\"]],\"devices\":[\"root.s11\",\"root.s11\",\"root.time\",\"root.`s3`\"],\"is_aligned\":"
+                + isAligned
+                + "}");
+
+        nonQuery_right_json_list_v2.add(
+            "{\"sql\":\"insert into root.aa(time,`bb`) values(111,1)\"}");
+        nonQuery_right_json_list_v2.add(
+            "{\"sql\":\"insert into root.`aa`(time,bb) values(111,1)\"}");
+        nonQuery_right_json_list_v2.add(
+            "{\"sql\":\"insert into root.`aa`(time,`bb`) values(111,1)\"}");
+        nonQuery_right_json_list_v2.add("{\"sql\":\"insert into root.aa(time,bb) values(111,1)\"}");
+
+        nonQuery_error_json_list_v2.add(
+            "{\"sql\":\"insert into root.time(time,1`bb`) values(111,1)\"}");
+        nonQuery_error_json_list_v2.add(
+            "{\"sql\":\"insert into root.time.`aa`(time,bb) values(111,1)\"}");
+        nonQuery_error_json_list_v2.add(
+            "{\"sql\":\"insert into root.time.`aa`(time,`bb`) values(111,1)\"}");
+        nonQuery_error_json_list_v2.add(
+            "{\"sql\":\"insert into root.aa(time,root) values(111,1)\"}");
+      }
+      HttpPost httpPost = getHttpPost("http://127.0.0.1:" + port + "/rest/v1/insertTablet");
+      HttpPost httpPost1 = getHttpPost_1("http://127.0.0.1:" + port + "/rest/v1/insertTablet");
+
+      List<HttpPost> httpPosts = new ArrayList<>();
+      httpPosts.add(httpPost);
+      httpPosts.add(httpPost1);
+      for (HttpPost hp : httpPosts) {
+        for (String json : insertTablet_right_json_list) {
+          rightInsertTablet(httpClient, json, hp);
+        }
+        for (String json : insertTablet_error_json_list) {
+          errorInsertTablet(json, hp);
+        }
+      }
+
+      HttpPost httpPost3 = getHttpPost("http://127.0.0.1:" + port + "/rest/v1/nonQuery");
+      HttpPost httpPost4 = getHttpPost_1("http://127.0.0.1:" + port + "/rest/v1/nonQuery");
+      List<HttpPost> httpPosts1 = new ArrayList<>();
+      httpPosts1.add(httpPost3);
+      httpPosts1.add(httpPost4);
+
+      for (HttpPost hp : httpPosts1) {
+        for (String json : nonQuery_right_json_list) {
+          nonQuery(httpClient, json, hp);
+        }
+        for (String json : nonQuery_error_json_list) {
+          errorNonQuery(httpClient, json, hp);
+        }
+      }
+
+      HttpPost httpPost5 = getHttpPost("http://127.0.0.1:" + port + "/rest/v1/insertRecords");
+      HttpPost httpPost6 = getHttpPost_1("http://127.0.0.1:" + port + "/rest/v1/insertRecords");
+      List<HttpPost> httpPosts2 = new ArrayList<>();
+      httpPosts2.add(httpPost5);
+      httpPosts2.add(httpPost6);
+
+      HttpPost httpPostV2 = getHttpPost("http://127.0.0.1:" + port + "/rest/v2/insertTablet");
+      HttpPost httpPost1V2 = getHttpPost_1("http://127.0.0.1:" + port + "/rest/v2/insertTablet");
+
+      List<HttpPost> httpPostsV2 = new ArrayList<>();
+      httpPostsV2.add(httpPostV2);
+      httpPostsV2.add(httpPost1V2);
+      for (HttpPost hp : httpPostsV2) {
+        for (String json : insertTablet_right_json_list_v2) {
+          rightInsertTablet(httpClient, json, hp);
+        }
+        for (String json : insertTablet_error_json_list_v2) {
+          errorInsertTablet(json, hp);
+        }
+      }
+
+      HttpPost httpPost3V2 = getHttpPost("http://127.0.0.1:" + port + "/rest/v2/nonQuery");
+      HttpPost httpPost4V2 = getHttpPost_1("http://127.0.0.1:" + port + "/rest/v2/nonQuery");
+      List<HttpPost> httpPosts1V2 = new ArrayList<>();
+      httpPosts1V2.add(httpPost3V2);
+      httpPosts1V2.add(httpPost4V2);
+      for (HttpPost hp : httpPosts1V2) {
+        for (String json : nonQuery_right_json_list_v2) {
+          nonQuery(httpClient, json, hp);
+        }
+        for (String json : nonQuery_error_json_list_v2) {
+          errorNonQuery(httpClient, json, hp);
+        }
+      }
+
+      HttpPost httpPost5V2 = getHttpPost("http://127.0.0.1:" + port + "/rest/v2/insertRecords");
+      HttpPost httpPost6V2 = getHttpPost_1("http://127.0.0.1:" + port + "/rest/v2/insertRecords");
+      List<HttpPost> httpPosts2V2 = new ArrayList<>();
+      httpPosts2V2.add(httpPost5V2);
+      httpPosts2V2.add(httpPost6V2);
+      for (HttpPost hp : httpPosts2V2) {
+        for (String json : insertRecords_right_json_list_v2) {
+          rightInsertRecords(httpClient, json, hp);
+        }
+        for (String json : insertRecords_error_json_list_v2) {
+          errorInsertRecords(httpClient, json, hp);
+        }
+      }
+      insertDate();
+      try {
+        httpClient.close();
+      } catch (IOException e) {
+        e.printStackTrace();
+        fail(e.getMessage());
+      }
+    } finally {
+      dropUserQuietly("root1");
+      cleanupAllData();
     }
   }
 
@@ -964,6 +1004,7 @@ public class IoTDBRestServiceIT {
         e.printStackTrace();
         fail(e.getMessage());
       }
+      dropUserQuietly("abcd");
     }
   }
 

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBSimpleQueryIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBSimpleQueryIT.java
@@ -26,9 +26,9 @@ import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.apache.tsfile.enums.TSDataType;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -57,30 +57,41 @@ import static org.junit.Assert.fail;
 @Category({LocalStandaloneIT.class, ClusterIT.class})
 public class IoTDBSimpleQueryIT {
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     EnvFactory.getEnv().initClusterEnvironment();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  private static void executeQuietly(Statement statement, String sql) {
+    try {
+      statement.execute(sql);
+    } catch (SQLException ignored) {
+      // ignore cleanup errors
+    }
   }
 
   @Test
   public void testCreateTimeseries1() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.setFetchSize(5);
-      statement.execute("CREATE DATABASE root.sg1");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s1 WITH DATATYPE=INT32,ENCODING=PLAIN");
+      try {
+        statement.setFetchSize(5);
+        statement.execute("CREATE DATABASE root.sg1");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s1 WITH DATATYPE=INT32,ENCODING=PLAIN");
 
-      try (ResultSet resultSet = statement.executeQuery("show timeseries root.sg1.d0.s1")) {
-        if (resultSet.next()) {
-          assertEquals("PLAIN", resultSet.getString(ColumnHeaderConstant.ENCODING).toUpperCase());
+        try (ResultSet resultSet = statement.executeQuery("show timeseries root.sg1.d0.s1")) {
+          if (resultSet.next()) {
+            assertEquals("PLAIN", resultSet.getString(ColumnHeaderConstant.ENCODING).toUpperCase());
+          }
         }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
-
     } catch (SQLException e) {
       e.printStackTrace();
     }
@@ -90,27 +101,30 @@ public class IoTDBSimpleQueryIT {
   public void testFailedToCreateTimeseriesSDTProperties() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.setFetchSize(5);
-      statement.execute("CREATE DATABASE root.sg1");
       try {
-        statement.execute(
-            "CREATE TIMESERIES root.sg1.d0.s1 WITH DATATYPE=INT32,ENCODING=PLAIN,'LOSS'='SDT','COMPDEV'='-2'");
-        fail();
-      } catch (Exception e) {
-        assertEquals(
-            TSStatusCode.ILLEGAL_PARAMETER.getStatusCode()
-                + ": SDT compression deviation cannot be negative. Failed to create timeseries for path root.sg1.d0.s1",
-            e.getMessage());
-      }
-
-      int count = 0;
-      try (ResultSet resultSet = statement.executeQuery("show timeseries root.sg1.**")) {
-        while (resultSet.next()) {
-          count++;
+        statement.setFetchSize(5);
+        statement.execute("CREATE DATABASE root.sg1");
+        try {
+          statement.execute(
+              "CREATE TIMESERIES root.sg1.d0.s1 WITH DATATYPE=INT32,ENCODING=PLAIN,'LOSS'='SDT','COMPDEV'='-2'");
+          fail();
+        } catch (Exception e) {
+          assertEquals(
+              TSStatusCode.ILLEGAL_PARAMETER.getStatusCode()
+                  + ": SDT compression deviation cannot be negative. Failed to create timeseries for path root.sg1.d0.s1",
+              e.getMessage());
         }
-      }
-      assertEquals(0, count);
 
+        int count = 0;
+        try (ResultSet resultSet = statement.executeQuery("show timeseries root.sg1.**")) {
+          while (resultSet.next()) {
+            count++;
+          }
+        }
+        assertEquals(0, count);
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
+      }
     } catch (Exception e) {
       e.printStackTrace();
     }
@@ -120,34 +134,37 @@ public class IoTDBSimpleQueryIT {
   public void testLastQueryNonCached() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute(
-          "create timeseries root.turbine.d1.s1 with datatype=FLOAT, encoding=GORILLA, compression=SNAPPY");
-      statement.execute(
-          "create timeseries root.turbine.d1.s2 with datatype=FLOAT, encoding=GORILLA, compression=SNAPPY");
-      statement.execute(
-          "create timeseries root.turbine.d2.s1 with datatype=FLOAT, encoding=GORILLA, compression=SNAPPY");
-      statement.execute("insert into root.turbine.d1(timestamp,s1,s2) values(1,1,2)");
+      try {
+        statement.execute(
+            "create timeseries root.turbine.d1.s1 with datatype=FLOAT, encoding=GORILLA, compression=SNAPPY");
+        statement.execute(
+            "create timeseries root.turbine.d1.s2 with datatype=FLOAT, encoding=GORILLA, compression=SNAPPY");
+        statement.execute(
+            "create timeseries root.turbine.d2.s1 with datatype=FLOAT, encoding=GORILLA, compression=SNAPPY");
+        statement.execute("insert into root.turbine.d1(timestamp,s1,s2) values(1,1,2)");
 
-      List<String> expected = Arrays.asList("root.turbine.d1.s1", "root.turbine.d1.s2");
-      List<String> actual = new ArrayList<>();
+        List<String> expected = Arrays.asList("root.turbine.d1.s1", "root.turbine.d1.s2");
+        List<String> actual = new ArrayList<>();
 
-      try (ResultSet resultSet = statement.executeQuery("select last ** from root.turbine")) {
-        while (resultSet.next()) {
-          actual.add(resultSet.getString(ColumnHeaderConstant.TIMESERIES));
+        try (ResultSet resultSet = statement.executeQuery("select last ** from root.turbine")) {
+          while (resultSet.next()) {
+            actual.add(resultSet.getString(ColumnHeaderConstant.TIMESERIES));
+          }
         }
-      }
 
-      assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
-      actual.clear();
-      try (ResultSet resultSet = statement.executeQuery("select last * from root.turbine")) {
-        while (resultSet.next()) {
-          actual.add(resultSet.getString(ColumnHeaderConstant.TIMESERIES));
+        actual.clear();
+        try (ResultSet resultSet = statement.executeQuery("select last * from root.turbine")) {
+          while (resultSet.next()) {
+            actual.add(resultSet.getString(ColumnHeaderConstant.TIMESERIES));
+          }
         }
+
+        assertEquals(Collections.emptyList(), actual);
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.turbine");
       }
-
-      assertEquals(Collections.emptyList(), actual);
-
     } catch (Exception e) {
       e.printStackTrace();
     }
@@ -158,37 +175,40 @@ public class IoTDBSimpleQueryIT {
 
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.setFetchSize(5);
-      statement.execute("CREATE DATABASE root.sg1");
-      // test set sdt property
-      statement.execute(
-          "CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=DOUBLE,ENCODING=PLAIN,LOSS=SDT,COMPDEV=0.01");
+      try {
+        statement.setFetchSize(5);
+        statement.execute("CREATE DATABASE root.sg1");
+        // test set sdt property
+        statement.execute(
+            "CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=DOUBLE,ENCODING=PLAIN,LOSS=SDT,COMPDEV=0.01");
 
-      int degree = 0;
-      for (int time = 0; time < 100; time++) {
-        // generate data in sine wave pattern
-        double value = 10 * Math.sin(degree++ * 3.141592653589793D / 180.0D);
-        String sql = "insert into root.sg1.d0(timestamp,s0) values(" + time + "," + value + ")";
-        statement.execute(sql);
+        int degree = 0;
+        for (int time = 0; time < 100; time++) {
+          // generate data in sine wave pattern
+          double value = 10 * Math.sin(degree++ * 3.141592653589793D / 180.0D);
+          String sql = "insert into root.sg1.d0(timestamp,s0) values(" + time + "," + value + ")";
+          statement.execute(sql);
+        }
+
+        // before SDT encoding
+        ResultSet resultSet = statement.executeQuery("select s0 from root.sg1.d0");
+        int count = 0;
+        while (resultSet.next()) {
+          count++;
+        }
+        assertEquals(count, 100);
+
+        // after flush and SDT encoding
+        statement.execute("flush");
+        resultSet = statement.executeQuery("select s0 from root.sg1.d0");
+        count = 0;
+        while (resultSet.next()) {
+          count++;
+        }
+        assertEquals(15, count);
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
-
-      // before SDT encoding
-      ResultSet resultSet = statement.executeQuery("select s0 from root.sg1.d0");
-      int count = 0;
-      while (resultSet.next()) {
-        count++;
-      }
-      assertEquals(count, 100);
-
-      // after flush and SDT encoding
-      statement.execute("flush");
-      resultSet = statement.executeQuery("select s0 from root.sg1.d0");
-      count = 0;
-      while (resultSet.next()) {
-        count++;
-      }
-      assertEquals(15, count);
-
     } catch (SQLException e) {
       e.printStackTrace();
     }
@@ -199,38 +219,42 @@ public class IoTDBSimpleQueryIT {
 
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.setFetchSize(5);
-      statement.execute("CREATE DATABASE root.sg1");
-      // test set sdt property
-      statement.execute(
-          "CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=INT32,ENCODING=PLAIN,LOSS=SDT,COMPDEV=2");
+      try {
+        statement.setFetchSize(5);
+        statement.execute("CREATE DATABASE root.sg1");
+        // test set sdt property
+        statement.execute(
+            "CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=INT32,ENCODING=PLAIN,LOSS=SDT,COMPDEV=2");
 
-      for (int time = 1; time < 8; time++) {
-        String sql = "insert into root.sg1.d0(timestamp,s0) values(" + time + ",1)";
+        for (int time = 1; time < 8; time++) {
+          String sql = "insert into root.sg1.d0(timestamp,s0) values(" + time + ",1)";
+          statement.execute(sql);
+        }
+        statement.execute("flush");
+
+        String sql = "insert into root.sg1.d0(timestamp,s0) values(15,10)";
         statement.execute(sql);
-      }
-      statement.execute("flush");
+        sql = "insert into root.sg1.d0(timestamp,s0) values(16,20)";
+        statement.execute(sql);
+        sql = "insert into root.sg1.d0(timestamp,s0) values(17,1)";
+        statement.execute(sql);
+        sql = "insert into root.sg1.d0(timestamp,s0) values(18,30)";
+        statement.execute(sql);
+        statement.execute("flush");
 
-      String sql = "insert into root.sg1.d0(timestamp,s0) values(15,10)";
-      statement.execute(sql);
-      sql = "insert into root.sg1.d0(timestamp,s0) values(16,20)";
-      statement.execute(sql);
-      sql = "insert into root.sg1.d0(timestamp,s0) values(17,1)";
-      statement.execute(sql);
-      sql = "insert into root.sg1.d0(timestamp,s0) values(18,30)";
-      statement.execute(sql);
-      statement.execute("flush");
+        ResultSet resultSet = statement.executeQuery("select * from root.sg1.**");
+        int count = 0;
 
-      ResultSet resultSet = statement.executeQuery("select * from root.sg1.**");
-      int count = 0;
+        String[] timestamps = {"1", "7", "15", "16", "17", "18"};
+        String[] values = {"1", "1", "10", "20", "1", "30"};
 
-      String[] timestamps = {"1", "7", "15", "16", "17", "18"};
-      String[] values = {"1", "1", "10", "20", "1", "30"};
-
-      while (resultSet.next()) {
-        assertEquals(timestamps[count], resultSet.getString("Time"));
-        assertEquals(values[count], resultSet.getString("root.sg1.d0.s0"));
-        count++;
+        while (resultSet.next()) {
+          assertEquals(timestamps[count], resultSet.getString("Time"));
+          assertEquals(values[count], resultSet.getString("root.sg1.d0.s0"));
+          count++;
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
     } catch (SQLException e) {
       e.printStackTrace();
@@ -242,39 +266,43 @@ public class IoTDBSimpleQueryIT {
 
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.setFetchSize(5);
-      statement.execute("CREATE DATABASE root.sg1");
-      // test set sdt property
-      statement.execute(
-          "CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=INT32,ENCODING=PLAIN,LOSS=SDT,COMPDEV=2, COMPMINTIME=1");
+      try {
+        statement.setFetchSize(5);
+        statement.execute("CREATE DATABASE root.sg1");
+        // test set sdt property
+        statement.execute(
+            "CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=INT32,ENCODING=PLAIN,LOSS=SDT,COMPDEV=2, COMPMINTIME=1");
 
-      for (int time = 1; time < 8; time++) {
-        String sql = "insert into root.sg1.d0(timestamp,s0) values(" + time + ",1)";
+        for (int time = 1; time < 8; time++) {
+          String sql = "insert into root.sg1.d0(timestamp,s0) values(" + time + ",1)";
+          statement.execute(sql);
+        }
+        statement.execute("flush");
+
+        String sql = "insert into root.sg1.d0(timestamp,s0) values(15,10)";
         statement.execute(sql);
-      }
-      statement.execute("flush");
+        sql = "insert into root.sg1.d0(timestamp,s0) values(16,20)";
+        statement.execute(sql);
+        sql = "insert into root.sg1.d0(timestamp,s0) values(17,1)";
+        statement.execute(sql);
+        sql = "insert into root.sg1.d0(timestamp,s0) values(18,30)";
+        statement.execute(sql);
+        statement.execute("flush");
 
-      String sql = "insert into root.sg1.d0(timestamp,s0) values(15,10)";
-      statement.execute(sql);
-      sql = "insert into root.sg1.d0(timestamp,s0) values(16,20)";
-      statement.execute(sql);
-      sql = "insert into root.sg1.d0(timestamp,s0) values(17,1)";
-      statement.execute(sql);
-      sql = "insert into root.sg1.d0(timestamp,s0) values(18,30)";
-      statement.execute(sql);
-      statement.execute("flush");
+        ResultSet resultSet = statement.executeQuery("select * from root.sg1.**");
+        int count = 0;
 
-      ResultSet resultSet = statement.executeQuery("select * from root.sg1.**");
-      int count = 0;
+        // will not store time = 16 since time distance to last stored time 15 is within compMinTime
+        String[] timestamps = {"1", "7", "15", "17", "18"};
+        String[] values = {"1", "1", "10", "1", "30"};
 
-      // will not store time = 16 since time distance to last stored time 15 is within compMinTime
-      String[] timestamps = {"1", "7", "15", "17", "18"};
-      String[] values = {"1", "1", "10", "1", "30"};
-
-      while (resultSet.next()) {
-        assertEquals(timestamps[count], resultSet.getString("Time"));
-        assertEquals(values[count], resultSet.getString("root.sg1.d0.s0"));
-        count++;
+        while (resultSet.next()) {
+          assertEquals(timestamps[count], resultSet.getString("Time"));
+          assertEquals(values[count], resultSet.getString("root.sg1.d0.s0"));
+          count++;
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
     } catch (SQLException e) {
       e.printStackTrace();
@@ -286,28 +314,32 @@ public class IoTDBSimpleQueryIT {
 
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.setFetchSize(5);
-      statement.execute("CREATE DATABASE root.sg1");
-      // test set sdt property
-      statement.execute(
-          "CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=INT32,ENCODING=PLAIN,LOSS=SDT,COMPDEV=2, COMPMAXTIME=20");
+      try {
+        statement.setFetchSize(5);
+        statement.execute("CREATE DATABASE root.sg1");
+        // test set sdt property
+        statement.execute(
+            "CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=INT32,ENCODING=PLAIN,LOSS=SDT,COMPDEV=2, COMPMAXTIME=20");
 
-      for (int time = 1; time < 50; time++) {
-        String sql = "insert into root.sg1.d0(timestamp,s0) values(" + time + ",1)";
-        statement.execute(sql);
-      }
-      statement.execute("flush");
+        for (int time = 1; time < 50; time++) {
+          String sql = "insert into root.sg1.d0(timestamp,s0) values(" + time + ",1)";
+          statement.execute(sql);
+        }
+        statement.execute("flush");
 
-      ResultSet resultSet = statement.executeQuery("select * from root.sg1.**");
-      int count = 0;
+        ResultSet resultSet = statement.executeQuery("select * from root.sg1.**");
+        int count = 0;
 
-      String[] timestamps = {"1", "21", "41", "49"};
-      String[] values = {"1", "1", "1", "1"};
+        String[] timestamps = {"1", "21", "41", "49"};
+        String[] values = {"1", "1", "1", "1"};
 
-      while (resultSet.next()) {
-        assertEquals(timestamps[count], resultSet.getString("Time"));
-        assertEquals(values[count], resultSet.getString("root.sg1.d0.s0"));
-        count++;
+        while (resultSet.next()) {
+          assertEquals(timestamps[count], resultSet.getString("Time"));
+          assertEquals(values[count], resultSet.getString("root.sg1.d0.s0"));
+          count++;
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
     } catch (SQLException e) {
       e.printStackTrace();
@@ -319,41 +351,44 @@ public class IoTDBSimpleQueryIT {
 
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.setFetchSize(5);
-      statement.execute("CREATE DATABASE root.sg1");
-      // test set sdt property
-      statement.execute(
-          "CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=DOUBLE,ENCODING=PLAIN,LOSS=SDT,COMPDEV=0.01");
+      try {
+        statement.setFetchSize(5);
+        statement.execute("CREATE DATABASE root.sg1");
+        // test set sdt property
+        statement.execute(
+            "CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=DOUBLE,ENCODING=PLAIN,LOSS=SDT,COMPDEV=0.01");
 
-      int degree = 0;
-      for (int time = 0; time < 100; time++) {
-        // generate data in sine wave pattern
-        double value = 10 * Math.sin(degree++ * 3.141592653589793D / 180.0D);
-        String sql = "insert into root.sg1.d0(timestamp,s0) values(" + time + "," + value + ")";
+        int degree = 0;
+        for (int time = 0; time < 100; time++) {
+          // generate data in sine wave pattern
+          double value = 10 * Math.sin(degree++ * 3.141592653589793D / 180.0D);
+          String sql = "insert into root.sg1.d0(timestamp,s0) values(" + time + "," + value + ")";
+          statement.execute(sql);
+        }
+
+        // insert unseq
+        String sql = "insert into root.sg1.d0(timestamp,s0) values(2,19)";
         statement.execute(sql);
+
+        // before SDT encoding
+        ResultSet resultSet = statement.executeQuery("select s0 from root.sg1.d0");
+        int count = 0;
+        while (resultSet.next()) {
+          count++;
+        }
+        assertEquals(count, 100);
+
+        // after flush and SDT encoding
+        statement.execute("flush");
+        resultSet = statement.executeQuery("select s0 from root.sg1.d0");
+        count = 0;
+        while (resultSet.next()) {
+          count++;
+        }
+        assertEquals(18, count);
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
-
-      // insert unseq
-      String sql = "insert into root.sg1.d0(timestamp,s0) values(2,19)";
-      statement.execute(sql);
-
-      // before SDT encoding
-      ResultSet resultSet = statement.executeQuery("select s0 from root.sg1.d0");
-      int count = 0;
-      while (resultSet.next()) {
-        count++;
-      }
-      assertEquals(count, 100);
-
-      // after flush and SDT encoding
-      statement.execute("flush");
-      resultSet = statement.executeQuery("select s0 from root.sg1.d0");
-      count = 0;
-      while (resultSet.next()) {
-        count++;
-      }
-      assertEquals(18, count);
-
     } catch (SQLException e) {
       e.printStackTrace();
     }
@@ -364,36 +399,40 @@ public class IoTDBSimpleQueryIT {
 
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.setFetchSize(5);
-      statement.execute("CREATE DATABASE root.sg1");
-      // test set sdt property
-      statement.execute(
-          "CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=DOUBLE,ENCODING=PLAIN,LOSS=SDT,COMPDEV=0.01");
+      try {
+        statement.setFetchSize(5);
+        statement.execute("CREATE DATABASE root.sg1");
+        // test set sdt property
+        statement.execute(
+            "CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=DOUBLE,ENCODING=PLAIN,LOSS=SDT,COMPDEV=0.01");
 
-      int degree = 0;
-      for (int time = 0; time < 100; time++) {
-        // generate data in sine wave pattern
-        double value = 10 * Math.sin(degree++ * 3.141592653589793D / 180.0D);
-        String sql = "insert into root.sg1.d0(timestamp,s0) values(" + time + "," + value + ")";
-        statement.execute(sql);
-      }
+        int degree = 0;
+        for (int time = 0; time < 100; time++) {
+          // generate data in sine wave pattern
+          double value = 10 * Math.sin(degree++ * 3.141592653589793D / 180.0D);
+          String sql = "insert into root.sg1.d0(timestamp,s0) values(" + time + "," + value + ")";
+          statement.execute(sql);
+        }
 
-      // before SDT encoding
-      ResultSet resultSet = statement.executeQuery("select s0 from root.sg1.d0");
-      int count = 0;
-      while (resultSet.next()) {
-        count++;
-      }
-      assertEquals(100, count);
+        // before SDT encoding
+        ResultSet resultSet = statement.executeQuery("select s0 from root.sg1.d0");
+        int count = 0;
+        while (resultSet.next()) {
+          count++;
+        }
+        assertEquals(100, count);
 
-      // after flush and SDT encoding
-      statement.execute("flush");
-      resultSet = statement.executeQuery("select s0 from root.sg1.d0");
-      count = 0;
-      while (resultSet.next()) {
-        count++;
+        // after flush and SDT encoding
+        statement.execute("flush");
+        resultSet = statement.executeQuery("select s0 from root.sg1.d0");
+        count = 0;
+        while (resultSet.next()) {
+          count++;
+        }
+        assertEquals(15, count);
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
-      assertEquals(15, count);
     } catch (SQLException e) {
       e.printStackTrace();
     }
@@ -404,40 +443,44 @@ public class IoTDBSimpleQueryIT {
 
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.setFetchSize(5);
-      statement.execute("CREATE DATABASE root.sg1");
-      // test set sdt property
-      statement.execute(
-          "CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=DOUBLE,ENCODING=PLAIN,LOSS=SDT,COMPDEV=0.01");
+      try {
+        statement.setFetchSize(5);
+        statement.execute("CREATE DATABASE root.sg1");
+        // test set sdt property
+        statement.execute(
+            "CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=DOUBLE,ENCODING=PLAIN,LOSS=SDT,COMPDEV=0.01");
 
-      int degree = 0;
-      for (int time = 0; time < 100; time++) {
-        // generate data in sine wave pattern
-        double value = 10 * Math.sin(degree++ * 3.141592653589793D / 180.0D);
-        String sql = "insert into root.sg1.d0(timestamp,s0) values(" + time + "," + value + ")";
+        int degree = 0;
+        for (int time = 0; time < 100; time++) {
+          // generate data in sine wave pattern
+          double value = 10 * Math.sin(degree++ * 3.141592653589793D / 180.0D);
+          String sql = "insert into root.sg1.d0(timestamp,s0) values(" + time + "," + value + ")";
+          statement.execute(sql);
+        }
+
+        // insert unseq
+        String sql = "insert into root.sg1.d0(timestamp,s0) values(2,19)";
         statement.execute(sql);
-      }
 
-      // insert unseq
-      String sql = "insert into root.sg1.d0(timestamp,s0) values(2,19)";
-      statement.execute(sql);
+        // before SDT encoding
+        ResultSet resultSet = statement.executeQuery("select s0 from root.sg1.d0");
+        int count = 0;
+        while (resultSet.next()) {
+          count++;
+        }
+        assertEquals(100, count);
 
-      // before SDT encoding
-      ResultSet resultSet = statement.executeQuery("select s0 from root.sg1.d0");
-      int count = 0;
-      while (resultSet.next()) {
-        count++;
+        // after flush and SDT encoding
+        statement.execute("flush");
+        resultSet = statement.executeQuery("select s0 from root.sg1.d0");
+        count = 0;
+        while (resultSet.next()) {
+          count++;
+        }
+        assertEquals(18, count);
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
-      assertEquals(100, count);
-
-      // after flush and SDT encoding
-      statement.execute("flush");
-      resultSet = statement.executeQuery("select s0 from root.sg1.d0");
-      count = 0;
-      while (resultSet.next()) {
-        count++;
-      }
-      assertEquals(18, count);
     } catch (SQLException e) {
       e.printStackTrace();
     }
@@ -508,36 +551,40 @@ public class IoTDBSimpleQueryIT {
   public void testOrderByTimeDesc() throws Exception {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.setFetchSize(5);
-      statement.execute("CREATE DATABASE root.sg1");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s1 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (1, 1)");
-      statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (2, 2)");
-      statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (3, 3)");
-      statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (4, 4)");
-      statement.execute("INSERT INTO root.sg1.d0(timestamp, s1) VALUES (3, 3)");
-      statement.execute("INSERT INTO root.sg1.d0(timestamp, s1) VALUES (1, 1)");
-      statement.execute("flush");
+      try {
+        statement.setFetchSize(5);
+        statement.execute("CREATE DATABASE root.sg1");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s1 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (1, 1)");
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (2, 2)");
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (3, 3)");
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (4, 4)");
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s1) VALUES (3, 3)");
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s1) VALUES (1, 1)");
+        statement.execute("flush");
 
-      String[] ret =
-          new String[] {
-            "4,4,null", "3,3,3", "2,2,null", "1,1,1",
-          };
+        String[] ret =
+            new String[] {
+              "4,4,null", "3,3,3", "2,2,null", "1,1,1",
+            };
 
-      int cur = 0;
-      try (ResultSet resultSet =
-          statement.executeQuery("select * from root.sg1.** order by time desc")) {
-        while (resultSet.next()) {
-          String ans =
-              resultSet.getString(ColumnHeaderConstant.TIME)
-                  + ","
-                  + resultSet.getString("root.sg1.d0.s0")
-                  + ","
-                  + resultSet.getString("root.sg1.d0.s1");
-          assertEquals(ret[cur], ans);
-          cur++;
+        int cur = 0;
+        try (ResultSet resultSet =
+            statement.executeQuery("select * from root.sg1.** order by time desc")) {
+          while (resultSet.next()) {
+            String ans =
+                resultSet.getString(ColumnHeaderConstant.TIME)
+                    + ","
+                    + resultSet.getString("root.sg1.d0.s0")
+                    + ","
+                    + resultSet.getString("root.sg1.d0.s1");
+            assertEquals(ret[cur], ans);
+            cur++;
+          }
         }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
     }
   }
@@ -546,30 +593,33 @@ public class IoTDBSimpleQueryIT {
   public void testShowTimeseriesDataSet1() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.setFetchSize(5);
-      statement.execute("CREATE DATABASE root.sg1");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s1 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s2 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s3 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s4 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s5 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s6 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s7 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s8 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s9 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s10 WITH DATATYPE=INT32,ENCODING=PLAIN");
+      try {
+        statement.setFetchSize(5);
+        statement.execute("CREATE DATABASE root.sg1");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s1 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s2 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s3 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s4 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s5 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s6 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s7 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s8 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s9 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s10 WITH DATATYPE=INT32,ENCODING=PLAIN");
 
-      statement.execute("flush");
+        statement.execute("flush");
 
-      int count = 0;
-      try (ResultSet resultSet = statement.executeQuery("show timeseries root.sg1.**")) {
-        while (resultSet.next()) {
-          count++;
+        int count = 0;
+        try (ResultSet resultSet = statement.executeQuery("show timeseries root.sg1.**")) {
+          while (resultSet.next()) {
+            count++;
+          }
         }
+
+        Assert.assertEquals(10, count);
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
-
-      Assert.assertEquals(10, count);
-
     } catch (SQLException e) {
       e.printStackTrace();
     }
@@ -579,30 +629,33 @@ public class IoTDBSimpleQueryIT {
   public void testShowTimeseriesDataSet2() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.setFetchSize(10);
-      statement.execute("CREATE DATABASE root.sg1");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s1 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s2 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s3 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s4 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s5 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s6 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s7 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s8 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s9 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s10 WITH DATATYPE=INT32,ENCODING=PLAIN");
+      try {
+        statement.setFetchSize(10);
+        statement.execute("CREATE DATABASE root.sg1");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s1 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s2 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s3 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s4 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s5 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s6 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s7 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s8 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s9 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s10 WITH DATATYPE=INT32,ENCODING=PLAIN");
 
-      statement.execute("flush");
+        statement.execute("flush");
 
-      int count = 0;
-      try (ResultSet resultSet = statement.executeQuery("show timeseries root.sg1.**")) {
-        while (resultSet.next()) {
-          count++;
+        int count = 0;
+        try (ResultSet resultSet = statement.executeQuery("show timeseries root.sg1.**")) {
+          while (resultSet.next()) {
+            count++;
+          }
         }
+
+        Assert.assertEquals(10, count);
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
-
-      Assert.assertEquals(10, count);
-
     } catch (SQLException e) {
       e.printStackTrace();
     }
@@ -612,30 +665,33 @@ public class IoTDBSimpleQueryIT {
   public void testShowTimeseriesDataSet3() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.setFetchSize(15);
-      statement.execute("CREATE DATABASE root.sg1");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s1 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s2 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s3 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s4 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s5 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s6 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s7 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s8 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s9 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s10 WITH DATATYPE=INT32,ENCODING=PLAIN");
+      try {
+        statement.setFetchSize(15);
+        statement.execute("CREATE DATABASE root.sg1");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s1 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s2 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s3 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s4 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s5 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s6 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s7 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s8 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s9 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s10 WITH DATATYPE=INT32,ENCODING=PLAIN");
 
-      statement.execute("flush");
+        statement.execute("flush");
 
-      int count = 0;
-      try (ResultSet resultSet = statement.executeQuery("show timeseries root.sg1.**")) {
-        while (resultSet.next()) {
-          count++;
+        int count = 0;
+        try (ResultSet resultSet = statement.executeQuery("show timeseries root.sg1.**")) {
+          while (resultSet.next()) {
+            count++;
+          }
         }
+
+        Assert.assertEquals(10, count);
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
-
-      Assert.assertEquals(10, count);
-
     } catch (SQLException e) {
       e.printStackTrace();
     }
@@ -645,30 +701,33 @@ public class IoTDBSimpleQueryIT {
   public void testShowTimeseriesDataSet4() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.setFetchSize(5);
-      statement.execute("CREATE DATABASE root.sg1");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s1 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s2 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s3 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s4 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s5 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s6 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s7 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s8 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s9 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s10 WITH DATATYPE=INT32,ENCODING=PLAIN");
+      try {
+        statement.setFetchSize(5);
+        statement.execute("CREATE DATABASE root.sg1");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s1 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s2 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s3 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s4 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s5 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s6 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s7 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s8 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s9 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s10 WITH DATATYPE=INT32,ENCODING=PLAIN");
 
-      statement.execute("flush");
+        statement.execute("flush");
 
-      int count = 0;
-      try (ResultSet resultSet = statement.executeQuery("show timeseries limit 8")) {
-        while (resultSet.next()) {
-          count++;
+        int count = 0;
+        try (ResultSet resultSet = statement.executeQuery("show timeseries limit 8")) {
+          while (resultSet.next()) {
+            count++;
+          }
         }
+
+        Assert.assertEquals(8, count);
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
-
-      Assert.assertEquals(8, count);
-
     } catch (SQLException e) {
       e.printStackTrace();
     }
@@ -678,23 +737,26 @@ public class IoTDBSimpleQueryIT {
   public void testShowTimeseriesWithLimitOffset() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
+      try {
+        List<String> exps =
+            Arrays.asList("root.sg1.d0.s1", "root.sg1.d0.s2", "root.sg1.d0.s3", "root.sg1.d0.s4");
 
-      List<String> exps =
-          Arrays.asList("root.sg1.d0.s1", "root.sg1.d0.s2", "root.sg1.d0.s3", "root.sg1.d0.s4");
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s1) VALUES (5, 5)");
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s2) VALUES (5, 5)");
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s3) VALUES (5, 5)");
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s4) VALUES (5, 5)");
 
-      statement.execute("INSERT INTO root.sg1.d0(timestamp, s1) VALUES (5, 5)");
-      statement.execute("INSERT INTO root.sg1.d0(timestamp, s2) VALUES (5, 5)");
-      statement.execute("INSERT INTO root.sg1.d0(timestamp, s3) VALUES (5, 5)");
-      statement.execute("INSERT INTO root.sg1.d0(timestamp, s4) VALUES (5, 5)");
-
-      int count = 0;
-      try (ResultSet resultSet = statement.executeQuery("show timeseries limit 2 offset 1")) {
-        while (resultSet.next()) {
-          Assert.assertTrue(exps.contains(resultSet.getString(1)));
-          ++count;
+        int count = 0;
+        try (ResultSet resultSet = statement.executeQuery("show timeseries limit 2 offset 1")) {
+          while (resultSet.next()) {
+            Assert.assertTrue(exps.contains(resultSet.getString(1)));
+            ++count;
+          }
         }
+        Assert.assertEquals(2, count);
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
-      Assert.assertEquals(2, count);
     }
   }
 
@@ -702,127 +764,133 @@ public class IoTDBSimpleQueryIT {
   public void testShowTimeseriesWithOffsetOnly() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
+      try {
+        // Test Case 1: Single Region scenario (single database, single device)
+        // Create first database and write data to single device to ensure single Region
+        statement.execute("CREATE DATABASE root.db1");
+        statement.execute("INSERT INTO root.db1.d0(timestamp, s1) VALUES (1, 1)");
+        statement.execute("INSERT INTO root.db1.d0(timestamp, s2) VALUES (1, 2)");
+        statement.execute("INSERT INTO root.db1.d0(timestamp, s3) VALUES (1, 3)");
+        statement.execute("flush");
 
-      // Test Case 1: Single Region scenario (single database, single device)
-      // Create first database and write data to single device to ensure single Region
-      statement.execute("CREATE DATABASE root.db1");
-      statement.execute("INSERT INTO root.db1.d0(timestamp, s1) VALUES (1, 1)");
-      statement.execute("INSERT INTO root.db1.d0(timestamp, s2) VALUES (1, 2)");
-      statement.execute("INSERT INTO root.db1.d0(timestamp, s3) VALUES (1, 3)");
-      statement.execute("flush");
-
-      // Verify single Region scenario - offset only
-      List<String> sg1AllPaths = new ArrayList<>();
-      try (ResultSet resultSet = statement.executeQuery("show timeseries root.db1.**")) {
-        while (resultSet.next()) {
-          sg1AllPaths.add(resultSet.getString(1));
+        // Verify single Region scenario - offset only
+        List<String> sg1AllPaths = new ArrayList<>();
+        try (ResultSet resultSet = statement.executeQuery("show timeseries root.db1.**")) {
+          while (resultSet.next()) {
+            sg1AllPaths.add(resultSet.getString(1));
+          }
         }
-      }
-      Assert.assertEquals(3, sg1AllPaths.size());
+        Assert.assertEquals(3, sg1AllPaths.size());
 
-      int offset1 = 2;
-      List<String> sg1ResultPaths = new ArrayList<>();
-      try (ResultSet resultSet =
-          statement.executeQuery("show timeseries root.db1.** offset " + offset1)) {
-        while (resultSet.next()) {
-          sg1ResultPaths.add(resultSet.getString(1));
+        int offset1 = 2;
+        List<String> sg1ResultPaths = new ArrayList<>();
+        try (ResultSet resultSet =
+            statement.executeQuery("show timeseries root.db1.** offset " + offset1)) {
+          while (resultSet.next()) {
+            sg1ResultPaths.add(resultSet.getString(1));
+          }
         }
-      }
-      Assert.assertEquals(sg1AllPaths.size() - offset1, sg1ResultPaths.size());
-      for (int i = 0; i < sg1ResultPaths.size(); i++) {
-        Assert.assertEquals(sg1AllPaths.get(offset1 + i), sg1ResultPaths.get(i));
-      }
-
-      // Test Case 2: Single Region - different path patterns with offset
-      List<String> d0Paths = new ArrayList<>();
-      try (ResultSet resultSet = statement.executeQuery("show timeseries root.db1.d0.**")) {
-        while (resultSet.next()) {
-          d0Paths.add(resultSet.getString(1));
+        Assert.assertEquals(sg1AllPaths.size() - offset1, sg1ResultPaths.size());
+        for (int i = 0; i < sg1ResultPaths.size(); i++) {
+          Assert.assertEquals(sg1AllPaths.get(offset1 + i), sg1ResultPaths.get(i));
         }
-      }
 
-      int offset2 = 1;
-      List<String> d0ResultPaths = new ArrayList<>();
-      try (ResultSet resultSet =
-          statement.executeQuery("show timeseries root.db1.d0.** offset " + offset2)) {
-        while (resultSet.next()) {
-          d0ResultPaths.add(resultSet.getString(1));
+        // Test Case 2: Single Region - different path patterns with offset
+        List<String> d0Paths = new ArrayList<>();
+        try (ResultSet resultSet = statement.executeQuery("show timeseries root.db1.d0.**")) {
+          while (resultSet.next()) {
+            d0Paths.add(resultSet.getString(1));
+          }
         }
-      }
-      Assert.assertEquals(d0Paths.size() - offset2, d0ResultPaths.size());
-      for (int i = 0; i < d0ResultPaths.size(); i++) {
-        Assert.assertEquals(d0Paths.get(offset2 + i), d0ResultPaths.get(i));
-      }
 
-      // Test Case 3: Single Region - with time condition and offset
-      // Insert data with different timestamps
-      statement.execute("INSERT INTO root.db1.d0(timestamp, s4) VALUES (10, 10)");
-      statement.execute("INSERT INTO root.db1.d0(timestamp, s5) VALUES (20, 20)");
-      statement.execute("INSERT INTO root.db1.d0(timestamp, s6) VALUES (30, 30)");
-      statement.execute("flush");
-
-      // Get all timeseries with time condition
-      List<String> timeFilteredPaths = new ArrayList<>();
-      try (ResultSet resultSet =
-          statement.executeQuery("show timeseries root.db1.** where time > 5")) {
-        while (resultSet.next()) {
-          timeFilteredPaths.add(resultSet.getString(1));
+        int offset2 = 1;
+        List<String> d0ResultPaths = new ArrayList<>();
+        try (ResultSet resultSet =
+            statement.executeQuery("show timeseries root.db1.d0.** offset " + offset2)) {
+          while (resultSet.next()) {
+            d0ResultPaths.add(resultSet.getString(1));
+          }
         }
-      }
-
-      // Test offset with time condition in single Region
-      int offset3 = 1;
-      List<String> timeFilteredResultPaths = new ArrayList<>();
-      try (ResultSet resultSet =
-          statement.executeQuery("show timeseries root.db1.** where time > 5 offset " + offset3)) {
-        while (resultSet.next()) {
-          timeFilteredResultPaths.add(resultSet.getString(1));
+        Assert.assertEquals(d0Paths.size() - offset2, d0ResultPaths.size());
+        for (int i = 0; i < d0ResultPaths.size(); i++) {
+          Assert.assertEquals(d0Paths.get(offset2 + i), d0ResultPaths.get(i));
         }
-      }
-      Assert.assertEquals(timeFilteredPaths.size() - offset3, timeFilteredResultPaths.size());
-      for (int i = 0; i < timeFilteredResultPaths.size(); i++) {
-        Assert.assertEquals(timeFilteredPaths.get(offset3 + i), timeFilteredResultPaths.get(i));
-      }
 
-      // Test Case 4: Multiple Regions scenario (multiple databases)
-      // Create second database to test multi-Region scenario
-      statement.execute("CREATE DATABASE root.db2");
-      statement.execute("INSERT INTO root.db2.d0(timestamp, s1) VALUES (4, 7)");
-      statement.execute("INSERT INTO root.db2.d0(timestamp, s2) VALUES (4, 8)");
-      statement.execute("INSERT INTO root.db2.d1(timestamp, s1) VALUES (5, 9)");
-      statement.execute("flush");
+        // Test Case 3: Single Region - with time condition and offset
+        // Insert data with different timestamps
+        statement.execute("INSERT INTO root.db1.d0(timestamp, s4) VALUES (10, 10)");
+        statement.execute("INSERT INTO root.db1.d0(timestamp, s5) VALUES (20, 20)");
+        statement.execute("INSERT INTO root.db1.d0(timestamp, s6) VALUES (30, 30)");
+        statement.execute("flush");
 
-      // Test across multiple databases - offset only
-      List<String> allPaths = new ArrayList<>();
-      try (ResultSet resultSet = statement.executeQuery("show timeseries root.db*.**")) {
-        while (resultSet.next()) {
-          allPaths.add(resultSet.getString(1));
+        // Get all timeseries with time condition
+        List<String> timeFilteredPaths = new ArrayList<>();
+        try (ResultSet resultSet =
+            statement.executeQuery("show timeseries root.db1.** where time > 5")) {
+          while (resultSet.next()) {
+            timeFilteredPaths.add(resultSet.getString(1));
+          }
         }
-      }
-      Assert.assertEquals(9, allPaths.size());
 
-      int offset4 = 3;
-      List<String> resultPaths = new ArrayList<>();
-      try (ResultSet resultSet =
-          statement.executeQuery("show timeseries root.db*.** offset " + offset4)) {
-        while (resultSet.next()) {
-          resultPaths.add(resultSet.getString(1));
+        // Test offset with time condition in single Region
+        int offset3 = 1;
+        List<String> timeFilteredResultPaths = new ArrayList<>();
+        try (ResultSet resultSet =
+            statement.executeQuery(
+                "show timeseries root.db1.** where time > 5 offset " + offset3)) {
+          while (resultSet.next()) {
+            timeFilteredResultPaths.add(resultSet.getString(1));
+          }
         }
-      }
-      Assert.assertEquals(allPaths.size() - offset4, resultPaths.size());
-      for (int i = 0; i < resultPaths.size(); i++) {
-        Assert.assertEquals(allPaths.get(offset4 + i), resultPaths.get(i));
-      }
+        Assert.assertEquals(timeFilteredPaths.size() - offset3, timeFilteredResultPaths.size());
+        for (int i = 0; i < timeFilteredResultPaths.size(); i++) {
+          Assert.assertEquals(timeFilteredPaths.get(offset3 + i), timeFilteredResultPaths.get(i));
+        }
 
-      // Test Case 5: Edge case - offset equals or exceeds total count
-      int largeOffset = allPaths.size() + 10;
-      int count = 0;
-      try (ResultSet resultSet = statement.executeQuery("show timeseries offset " + largeOffset)) {
-        while (resultSet.next()) {
-          count++;
+        // Test Case 4: Multiple Regions scenario (multiple databases)
+        // Create second database to test multi-Region scenario
+        statement.execute("CREATE DATABASE root.db2");
+        statement.execute("INSERT INTO root.db2.d0(timestamp, s1) VALUES (4, 7)");
+        statement.execute("INSERT INTO root.db2.d0(timestamp, s2) VALUES (4, 8)");
+        statement.execute("INSERT INTO root.db2.d1(timestamp, s1) VALUES (5, 9)");
+        statement.execute("flush");
+
+        // Test across multiple databases - offset only
+        List<String> allPaths = new ArrayList<>();
+        try (ResultSet resultSet = statement.executeQuery("show timeseries root.db*.**")) {
+          while (resultSet.next()) {
+            allPaths.add(resultSet.getString(1));
+          }
         }
+        Assert.assertEquals(9, allPaths.size());
+
+        int offset4 = 3;
+        List<String> resultPaths = new ArrayList<>();
+        try (ResultSet resultSet =
+            statement.executeQuery("show timeseries root.db*.** offset " + offset4)) {
+          while (resultSet.next()) {
+            resultPaths.add(resultSet.getString(1));
+          }
+        }
+        Assert.assertEquals(allPaths.size() - offset4, resultPaths.size());
+        for (int i = 0; i < resultPaths.size(); i++) {
+          Assert.assertEquals(allPaths.get(offset4 + i), resultPaths.get(i));
+        }
+
+        // Test Case 5: Edge case - offset equals or exceeds total count
+        int largeOffset = allPaths.size() + 10;
+        int count = 0;
+        try (ResultSet resultSet =
+            statement.executeQuery("show timeseries offset " + largeOffset)) {
+          while (resultSet.next()) {
+            count++;
+          }
+        }
+        Assert.assertEquals("Should return 0 results when offset exceeds total count", 0, count);
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.db1");
+        executeQuietly(statement, "DELETE DATABASE root.db2");
       }
-      Assert.assertEquals("Should return 0 results when offset exceeds total count", 0, count);
     }
   }
 
@@ -830,115 +898,120 @@ public class IoTDBSimpleQueryIT {
   public void testShowDevicesWithOffsetOnly() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
+      try {
+        statement.execute("CREATE DATABASE root.db1");
+        statement.execute("INSERT INTO root.db1.d0(timestamp, s1) VALUES (1, 1)");
+        statement.execute("INSERT INTO root.db1.d0(timestamp, s2) VALUES (1, 2)");
+        statement.execute("INSERT INTO root.db1.d1(timestamp, s3) VALUES (1, 3)");
+        statement.execute("flush");
 
-      statement.execute("CREATE DATABASE root.db1");
-      statement.execute("INSERT INTO root.db1.d0(timestamp, s1) VALUES (1, 1)");
-      statement.execute("INSERT INTO root.db1.d0(timestamp, s2) VALUES (1, 2)");
-      statement.execute("INSERT INTO root.db1.d1(timestamp, s3) VALUES (1, 3)");
-      statement.execute("flush");
-
-      List<String> sg1AllDevices = new ArrayList<>();
-      try (ResultSet resultSet = statement.executeQuery("show devices root.db1.**")) {
-        while (resultSet.next()) {
-          sg1AllDevices.add(resultSet.getString(1));
+        List<String> sg1AllDevices = new ArrayList<>();
+        try (ResultSet resultSet = statement.executeQuery("show devices root.db1.**")) {
+          while (resultSet.next()) {
+            sg1AllDevices.add(resultSet.getString(1));
+          }
         }
-      }
-      Assert.assertEquals(2, sg1AllDevices.size());
+        Assert.assertEquals(2, sg1AllDevices.size());
 
-      int offset1 = 1;
-      List<String> sg1ResultDevices = new ArrayList<>();
-      try (ResultSet resultSet =
-          statement.executeQuery("show devices root.db1.** offset " + offset1)) {
-        while (resultSet.next()) {
-          sg1ResultDevices.add(resultSet.getString(1));
+        int offset1 = 1;
+        List<String> sg1ResultDevices = new ArrayList<>();
+        try (ResultSet resultSet =
+            statement.executeQuery("show devices root.db1.** offset " + offset1)) {
+          while (resultSet.next()) {
+            sg1ResultDevices.add(resultSet.getString(1));
+          }
         }
-      }
-      Assert.assertEquals(sg1AllDevices.size() - offset1, sg1ResultDevices.size());
-      for (int i = 0; i < sg1ResultDevices.size(); i++) {
-        Assert.assertEquals(sg1AllDevices.get(offset1 + i), sg1ResultDevices.get(i));
-      }
-
-      List<String> d0Devices = new ArrayList<>();
-      try (ResultSet resultSet = statement.executeQuery("show devices root.db1.d0.**")) {
-        while (resultSet.next()) {
-          d0Devices.add(resultSet.getString(1));
+        Assert.assertEquals(sg1AllDevices.size() - offset1, sg1ResultDevices.size());
+        for (int i = 0; i < sg1ResultDevices.size(); i++) {
+          Assert.assertEquals(sg1AllDevices.get(offset1 + i), sg1ResultDevices.get(i));
         }
-      }
 
-      int offset2 = 0;
-      List<String> d0ResultDevices = new ArrayList<>();
-      try (ResultSet resultSet =
-          statement.executeQuery("show devices root.db1.d0.** offset " + offset2)) {
-        while (resultSet.next()) {
-          d0ResultDevices.add(resultSet.getString(1));
+        List<String> d0Devices = new ArrayList<>();
+        try (ResultSet resultSet = statement.executeQuery("show devices root.db1.d0.**")) {
+          while (resultSet.next()) {
+            d0Devices.add(resultSet.getString(1));
+          }
         }
-      }
-      Assert.assertEquals(d0Devices.size() - offset2, d0ResultDevices.size());
-      for (int i = 0; i < d0ResultDevices.size(); i++) {
-        Assert.assertEquals(d0Devices.get(offset2 + i), d0ResultDevices.get(i));
-      }
 
-      statement.execute("INSERT INTO root.db1.d2(timestamp, s4) VALUES (10, 10)");
-      statement.execute("INSERT INTO root.db1.d3(timestamp, s5) VALUES (20, 20)");
-      statement.execute("INSERT INTO root.db1.d4(timestamp, s6) VALUES (30, 30)");
-      statement.execute("flush");
-
-      List<String> timeFilteredDevices = new ArrayList<>();
-      try (ResultSet resultSet =
-          statement.executeQuery("show devices root.db1.** where time > 5")) {
-        while (resultSet.next()) {
-          timeFilteredDevices.add(resultSet.getString(1));
+        int offset2 = 0;
+        List<String> d0ResultDevices = new ArrayList<>();
+        try (ResultSet resultSet =
+            statement.executeQuery("show devices root.db1.d0.** offset " + offset2)) {
+          while (resultSet.next()) {
+            d0ResultDevices.add(resultSet.getString(1));
+          }
         }
-      }
-
-      int offset3 = 1;
-      List<String> timeFilteredResultDevices = new ArrayList<>();
-      try (ResultSet resultSet =
-          statement.executeQuery("show devices root.db1.** where time > 5 offset " + offset3)) {
-        while (resultSet.next()) {
-          timeFilteredResultDevices.add(resultSet.getString(1));
+        Assert.assertEquals(d0Devices.size() - offset2, d0ResultDevices.size());
+        for (int i = 0; i < d0ResultDevices.size(); i++) {
+          Assert.assertEquals(d0Devices.get(offset2 + i), d0ResultDevices.get(i));
         }
-      }
-      Assert.assertEquals(timeFilteredDevices.size() - offset3, timeFilteredResultDevices.size());
-      for (int i = 0; i < timeFilteredResultDevices.size(); i++) {
-        Assert.assertEquals(timeFilteredDevices.get(offset3 + i), timeFilteredResultDevices.get(i));
-      }
 
-      statement.execute("CREATE DATABASE root.db2");
-      statement.execute("INSERT INTO root.db2.d0(timestamp, s1) VALUES (4, 7)");
-      statement.execute("INSERT INTO root.db2.d1(timestamp, s2) VALUES (4, 8)");
-      statement.execute("INSERT INTO root.db2.d2(timestamp, s1) VALUES (5, 9)");
-      statement.execute("flush");
+        statement.execute("INSERT INTO root.db1.d2(timestamp, s4) VALUES (10, 10)");
+        statement.execute("INSERT INTO root.db1.d3(timestamp, s5) VALUES (20, 20)");
+        statement.execute("INSERT INTO root.db1.d4(timestamp, s6) VALUES (30, 30)");
+        statement.execute("flush");
 
-      List<String> allDevices = new ArrayList<>();
-      try (ResultSet resultSet = statement.executeQuery("show devices root.db*.**")) {
-        while (resultSet.next()) {
-          allDevices.add(resultSet.getString(1));
+        List<String> timeFilteredDevices = new ArrayList<>();
+        try (ResultSet resultSet =
+            statement.executeQuery("show devices root.db1.** where time > 5")) {
+          while (resultSet.next()) {
+            timeFilteredDevices.add(resultSet.getString(1));
+          }
         }
-      }
-      Assert.assertEquals(8, allDevices.size());
 
-      int offset4 = 3;
-      List<String> resultDevices = new ArrayList<>();
-      try (ResultSet resultSet =
-          statement.executeQuery("show devices root.db*.** offset " + offset4)) {
-        while (resultSet.next()) {
-          resultDevices.add(resultSet.getString(1));
+        int offset3 = 1;
+        List<String> timeFilteredResultDevices = new ArrayList<>();
+        try (ResultSet resultSet =
+            statement.executeQuery("show devices root.db1.** where time > 5 offset " + offset3)) {
+          while (resultSet.next()) {
+            timeFilteredResultDevices.add(resultSet.getString(1));
+          }
         }
-      }
-      Assert.assertEquals(allDevices.size() - offset4, resultDevices.size());
-      for (int i = 0; i < resultDevices.size(); i++) {
-        Assert.assertEquals(allDevices.get(offset4 + i), resultDevices.get(i));
-      }
+        Assert.assertEquals(timeFilteredDevices.size() - offset3, timeFilteredResultDevices.size());
+        for (int i = 0; i < timeFilteredResultDevices.size(); i++) {
+          Assert.assertEquals(
+              timeFilteredDevices.get(offset3 + i), timeFilteredResultDevices.get(i));
+        }
 
-      int largeOffset = allDevices.size() + 10;
-      int count = 0;
-      try (ResultSet resultSet = statement.executeQuery("show devices offset " + largeOffset)) {
-        while (resultSet.next()) {
-          count++;
+        statement.execute("CREATE DATABASE root.db2");
+        statement.execute("INSERT INTO root.db2.d0(timestamp, s1) VALUES (4, 7)");
+        statement.execute("INSERT INTO root.db2.d1(timestamp, s2) VALUES (4, 8)");
+        statement.execute("INSERT INTO root.db2.d2(timestamp, s1) VALUES (5, 9)");
+        statement.execute("flush");
+
+        List<String> allDevices = new ArrayList<>();
+        try (ResultSet resultSet = statement.executeQuery("show devices root.db*.**")) {
+          while (resultSet.next()) {
+            allDevices.add(resultSet.getString(1));
+          }
         }
+        Assert.assertEquals(8, allDevices.size());
+
+        int offset4 = 3;
+        List<String> resultDevices = new ArrayList<>();
+        try (ResultSet resultSet =
+            statement.executeQuery("show devices root.db*.** offset " + offset4)) {
+          while (resultSet.next()) {
+            resultDevices.add(resultSet.getString(1));
+          }
+        }
+        Assert.assertEquals(allDevices.size() - offset4, resultDevices.size());
+        for (int i = 0; i < resultDevices.size(); i++) {
+          Assert.assertEquals(allDevices.get(offset4 + i), resultDevices.get(i));
+        }
+
+        int largeOffset = allDevices.size() + 10;
+        int count = 0;
+        try (ResultSet resultSet = statement.executeQuery("show devices offset " + largeOffset)) {
+          while (resultSet.next()) {
+            count++;
+          }
+        }
+        Assert.assertEquals("Should return 0 results when offset exceeds total count", 0, count);
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.db1");
+        executeQuietly(statement, "DELETE DATABASE root.db2");
       }
-      Assert.assertEquals("Should return 0 results when offset exceeds total count", 0, count);
     }
   }
 
@@ -946,23 +1019,26 @@ public class IoTDBSimpleQueryIT {
   public void testShowDevicesWithLimitOffset() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
+      try {
+        List<String> exps = Arrays.asList("root.sg1.d1,false", "root.sg1.d2,false");
 
-      List<String> exps = Arrays.asList("root.sg1.d1,false", "root.sg1.d2,false");
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s1) VALUES (5, 5)");
+        statement.execute("INSERT INTO root.sg1.d1(timestamp, s2) VALUES (5, 5)");
+        statement.execute("INSERT INTO root.sg1.d2(timestamp, s3) VALUES (5, 5)");
+        statement.execute("INSERT INTO root.sg1.d3(timestamp, s4) VALUES (5, 5)");
 
-      statement.execute("INSERT INTO root.sg1.d0(timestamp, s1) VALUES (5, 5)");
-      statement.execute("INSERT INTO root.sg1.d1(timestamp, s2) VALUES (5, 5)");
-      statement.execute("INSERT INTO root.sg1.d2(timestamp, s3) VALUES (5, 5)");
-      statement.execute("INSERT INTO root.sg1.d3(timestamp, s4) VALUES (5, 5)");
-
-      int count = 0;
-      try (ResultSet resultSet = statement.executeQuery("show devices limit 2 offset 1")) {
-        while (resultSet.next()) {
-          Assert.assertEquals(
-              exps.get(count), resultSet.getString(1) + "," + resultSet.getString(2));
-          ++count;
+        int count = 0;
+        try (ResultSet resultSet = statement.executeQuery("show devices limit 2 offset 1")) {
+          while (resultSet.next()) {
+            Assert.assertEquals(
+                exps.get(count), resultSet.getString(1) + "," + resultSet.getString(2));
+            ++count;
+          }
         }
+        Assert.assertEquals(2, count);
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
-      Assert.assertEquals(2, count);
     }
   }
 
@@ -970,23 +1046,26 @@ public class IoTDBSimpleQueryIT {
   public void testShowDevicesWithLimit() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
+      try {
+        List<String> exps = Arrays.asList("root.sg1.d0,false", "root.sg1.d1,false");
 
-      List<String> exps = Arrays.asList("root.sg1.d0,false", "root.sg1.d1,false");
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s1) VALUES (5, 5)");
+        statement.execute("INSERT INTO root.sg1.d1(timestamp, s2) VALUES (5, 5)");
+        statement.execute("INSERT INTO root.sg1.d2(timestamp, s3) VALUES (5, 5)");
+        statement.execute("INSERT INTO root.sg1.d3(timestamp, s4) VALUES (5, 5)");
 
-      statement.execute("INSERT INTO root.sg1.d0(timestamp, s1) VALUES (5, 5)");
-      statement.execute("INSERT INTO root.sg1.d1(timestamp, s2) VALUES (5, 5)");
-      statement.execute("INSERT INTO root.sg1.d2(timestamp, s3) VALUES (5, 5)");
-      statement.execute("INSERT INTO root.sg1.d3(timestamp, s4) VALUES (5, 5)");
-
-      int count = 0;
-      try (ResultSet resultSet = statement.executeQuery("show devices limit 2")) {
-        while (resultSet.next()) {
-          Assert.assertEquals(
-              exps.get(count), resultSet.getString(1) + "," + resultSet.getString(2));
-          ++count;
+        int count = 0;
+        try (ResultSet resultSet = statement.executeQuery("show devices limit 2")) {
+          while (resultSet.next()) {
+            Assert.assertEquals(
+                exps.get(count), resultSet.getString(1) + "," + resultSet.getString(2));
+            ++count;
+          }
         }
+        Assert.assertEquals(2, count);
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
-      Assert.assertEquals(2, count);
     }
   }
 
@@ -994,36 +1073,40 @@ public class IoTDBSimpleQueryIT {
   public void testFirstOverlappedPageFiltered() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("CREATE DATABASE root.sg1");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=INT32,ENCODING=PLAIN");
+      try {
+        statement.execute("CREATE DATABASE root.sg1");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=INT32,ENCODING=PLAIN");
 
-      // seq chunk : [1,10]
-      statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (1, 1)");
-      statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (10, 10)");
+        // seq chunk : [1,10]
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (1, 1)");
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (10, 10)");
 
-      statement.execute("flush");
+        statement.execute("flush");
 
-      // seq chunk : [13,20]
-      statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (13, 13)");
-      statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (20, 20)");
+        // seq chunk : [13,20]
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (13, 13)");
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (20, 20)");
 
-      statement.execute("flush");
+        statement.execute("flush");
 
-      // unseq chunk : [5,15]
-      statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (5, 5)");
-      statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (15, 15)");
+        // unseq chunk : [5,15]
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (5, 5)");
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (15, 15)");
 
-      statement.execute("flush");
+        statement.execute("flush");
 
-      long count = 0;
-      try (ResultSet resultSet =
-          statement.executeQuery("select s0 from root.sg1.d0 where s0 > 18")) {
-        while (resultSet.next()) {
-          count++;
+        long count = 0;
+        try (ResultSet resultSet =
+            statement.executeQuery("select s0 from root.sg1.d0 where s0 > 18")) {
+          while (resultSet.next()) {
+            count++;
+          }
         }
-      }
 
-      Assert.assertEquals(1, count);
+        Assert.assertEquals(1, count);
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
+      }
     }
   }
 
@@ -1031,22 +1114,26 @@ public class IoTDBSimpleQueryIT {
   public void testPartialInsertion() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("CREATE DATABASE root.sg1");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=INT32,ENCODING=PLAIN");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s1 WITH DATATYPE=INT32,ENCODING=PLAIN");
-
       try {
-        statement.execute("INSERT INTO root.sg1.d0(timestamp, s0, s1) VALUES (1, 1, 2.2)");
-        fail();
-      } catch (SQLException e) {
-        assertTrue(e.getMessage().contains("s1"));
-      }
+        statement.execute("CREATE DATABASE root.sg1");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=INT32,ENCODING=PLAIN");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s1 WITH DATATYPE=INT32,ENCODING=PLAIN");
 
-      try (ResultSet resultSet = statement.executeQuery("select s0, s1 from root.sg1.d0")) {
-        while (resultSet.next()) {
-          assertEquals(1, resultSet.getInt("root.sg1.d0.s0"));
-          assertEquals(null, resultSet.getString("root.sg1.d0.s1"));
+        try {
+          statement.execute("INSERT INTO root.sg1.d0(timestamp, s0, s1) VALUES (1, 1, 2.2)");
+          fail();
+        } catch (SQLException e) {
+          assertTrue(e.getMessage().contains("s1"));
         }
+
+        try (ResultSet resultSet = statement.executeQuery("select s0, s1 from root.sg1.d0")) {
+          while (resultSet.next()) {
+            assertEquals(1, resultSet.getInt("root.sg1.d0.s0"));
+            assertEquals(null, resultSet.getString("root.sg1.d0.s1"));
+          }
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
     }
   }
@@ -1055,41 +1142,45 @@ public class IoTDBSimpleQueryIT {
   public void testOverlappedPagesMerge() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("CREATE DATABASE root.sg1");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=INT32,ENCODING=PLAIN");
+      try {
+        statement.execute("CREATE DATABASE root.sg1");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=INT32,ENCODING=PLAIN");
 
-      // seq chunk : start-end [1000, 1000]
-      statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (1000, 0)");
+        // seq chunk : start-end [1000, 1000]
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (1000, 0)");
 
-      statement.execute("flush");
+        statement.execute("flush");
 
-      // unseq chunk : [1,10]
-      statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (1, 1)");
-      statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (10, 10)");
+        // unseq chunk : [1,10]
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (1, 1)");
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (10, 10)");
 
-      statement.execute("flush");
+        statement.execute("flush");
 
-      // usneq chunk : [5,15]
-      statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (5, 5)");
-      statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (15, 15)");
+        // usneq chunk : [5,15]
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (5, 5)");
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (15, 15)");
 
-      statement.execute("flush");
+        statement.execute("flush");
 
-      // unseq chunk : [15,15]
-      statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (15, 150)");
+        // unseq chunk : [15,15]
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (15, 150)");
 
-      statement.execute("flush");
+        statement.execute("flush");
 
-      long count = 0;
+        long count = 0;
 
-      try (ResultSet resultSet =
-          statement.executeQuery("select s0 from root.sg1.d0 where s0 < 100")) {
-        while (resultSet.next()) {
-          count++;
+        try (ResultSet resultSet =
+            statement.executeQuery("select s0 from root.sg1.d0 where s0 < 100")) {
+          while (resultSet.next()) {
+            count++;
+          }
         }
-      }
 
-      Assert.assertEquals(4, count);
+        Assert.assertEquals(4, count);
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
+      }
     }
   }
 
@@ -1097,37 +1188,41 @@ public class IoTDBSimpleQueryIT {
   public void testUnseqUnsealedDeleteQuery() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("CREATE DATABASE root.sg1");
-      statement.execute("CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=INT32,ENCODING=PLAIN");
+      try {
+        statement.execute("CREATE DATABASE root.sg1");
+        statement.execute("CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=INT32,ENCODING=PLAIN");
 
-      // seq data
-      statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (1000, 1)");
-      statement.execute("flush");
+        // seq data
+        statement.execute("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (1000, 1)");
+        statement.execute("flush");
 
-      for (int i = 1; i <= 10; i++) {
-        statement.execute(
-            String.format("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (%d, %d)", i, i));
-      }
-
-      statement.execute("flush");
-
-      // unseq data
-      for (int i = 11; i <= 20; i++) {
-        statement.execute(
-            String.format("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (%d, %d)", i, i));
-      }
-
-      statement.execute("delete from root.sg1.d0.s0 where time <= 15");
-
-      long count = 0;
-
-      try (ResultSet resultSet = statement.executeQuery("select * from root.sg1.**")) {
-        while (resultSet.next()) {
-          count++;
+        for (int i = 1; i <= 10; i++) {
+          statement.execute(
+              String.format("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (%d, %d)", i, i));
         }
-      }
 
-      System.out.println(count);
+        statement.execute("flush");
+
+        // unseq data
+        for (int i = 11; i <= 20; i++) {
+          statement.execute(
+              String.format("INSERT INTO root.sg1.d0(timestamp, s0) VALUES (%d, %d)", i, i));
+        }
+
+        statement.execute("delete from root.sg1.d0.s0 where time <= 15");
+
+        long count = 0;
+
+        try (ResultSet resultSet = statement.executeQuery("select * from root.sg1.**")) {
+          while (resultSet.next()) {
+            count++;
+          }
+        }
+
+        System.out.println(count);
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
+      }
     }
   }
 
@@ -1135,16 +1230,20 @@ public class IoTDBSimpleQueryIT {
   public void testTimeseriesMetadataCache() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("CREATE DATABASE root.sg1");
-      for (int i = 0; i < 10000; i++) {
-        statement.execute(
-            "CREATE TIMESERIES root.sg1.d0.s" + i + " WITH DATATYPE=INT32,ENCODING=PLAIN");
+      try {
+        statement.execute("CREATE DATABASE root.sg1");
+        for (int i = 0; i < 10000; i++) {
+          statement.execute(
+              "CREATE TIMESERIES root.sg1.d0.s" + i + " WITH DATATYPE=INT32,ENCODING=PLAIN");
+        }
+        for (int i = 1; i < 10000; i++) {
+          statement.execute("INSERT INTO root.sg1.d0(timestamp, s" + i + ") VALUES (1000, 1)");
+        }
+        statement.execute("flush");
+        statement.executeQuery("select s0 from root.sg1.d0");
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
-      for (int i = 1; i < 10000; i++) {
-        statement.execute("INSERT INTO root.sg1.d0(timestamp, s" + i + ") VALUES (1000, 1)");
-      }
-      statement.execute("flush");
-      statement.executeQuery("select s0 from root.sg1.d0");
     } catch (SQLException e) {
       fail();
     }
@@ -1154,39 +1253,43 @@ public class IoTDBSimpleQueryIT {
   public void testInvalidSchema() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("CREATE DATABASE root.sg1");
       try {
-        statement.execute(
-            "CREATE TIMESERIES root.sg1.d1.s1 with datatype=BOOLEAN, encoding=TS_2DIFF");
-        fail();
-      } catch (Exception e) {
-        Assert.assertEquals(
-            TSStatusCode.METADATA_ERROR.getStatusCode()
-                + ": encoding TS_2DIFF does not support BOOLEAN",
-            e.getMessage());
-      }
+        statement.execute("CREATE DATABASE root.sg1");
+        try {
+          statement.execute(
+              "CREATE TIMESERIES root.sg1.d1.s1 with datatype=BOOLEAN, encoding=TS_2DIFF");
+          fail();
+        } catch (Exception e) {
+          Assert.assertEquals(
+              TSStatusCode.METADATA_ERROR.getStatusCode()
+                  + ": encoding TS_2DIFF does not support BOOLEAN",
+              e.getMessage());
+        }
 
-      try {
-        statement.execute(
-            "CREATE TIMESERIES root.sg1.d1.s3 with datatype=DOUBLE, encoding=REGULAR");
-        fail();
-      } catch (Exception e) {
-        Assert.assertEquals(
-            TSStatusCode.METADATA_ERROR.getStatusCode()
-                + ": encoding REGULAR does not support DOUBLE",
-            e.getMessage());
-      }
+        try {
+          statement.execute(
+              "CREATE TIMESERIES root.sg1.d1.s3 with datatype=DOUBLE, encoding=REGULAR");
+          fail();
+        } catch (Exception e) {
+          Assert.assertEquals(
+              TSStatusCode.METADATA_ERROR.getStatusCode()
+                  + ": encoding REGULAR does not support DOUBLE",
+              e.getMessage());
+        }
 
-      try {
-        statement.execute("CREATE TIMESERIES root.sg1.d1.s4 with datatype=TEXT, encoding=TS_2DIFF");
-        fail();
-      } catch (Exception e) {
-        Assert.assertEquals(
-            TSStatusCode.METADATA_ERROR.getStatusCode()
-                + ": encoding TS_2DIFF does not support TEXT",
-            e.getMessage());
+        try {
+          statement.execute(
+              "CREATE TIMESERIES root.sg1.d1.s4 with datatype=TEXT, encoding=TS_2DIFF");
+          fail();
+        } catch (Exception e) {
+          Assert.assertEquals(
+              TSStatusCode.METADATA_ERROR.getStatusCode()
+                  + ": encoding TS_2DIFF does not support TEXT",
+              e.getMessage());
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
-
     } catch (SQLException e) {
       fail();
     }
@@ -1196,45 +1299,49 @@ public class IoTDBSimpleQueryIT {
   public void testUseSameStatement() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("CREATE DATABASE root.sg1");
-      statement.execute(
-          "CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=INT64, ENCODING=RLE, COMPRESSOR=SNAPPY");
-      statement.execute(
-          "CREATE TIMESERIES root.sg1.d0.s1 WITH DATATYPE=INT64, ENCODING=RLE, COMPRESSOR=SNAPPY");
-      statement.execute(
-          "CREATE TIMESERIES root.sg1.d1.s0 WITH DATATYPE=INT64, ENCODING=RLE, COMPRESSOR=SNAPPY");
-      statement.execute(
-          "CREATE TIMESERIES root.sg1.d1.s1 WITH DATATYPE=INT64, ENCODING=RLE, COMPRESSOR=SNAPPY");
+      try {
+        statement.execute("CREATE DATABASE root.sg1");
+        statement.execute(
+            "CREATE TIMESERIES root.sg1.d0.s0 WITH DATATYPE=INT64, ENCODING=RLE, COMPRESSOR=SNAPPY");
+        statement.execute(
+            "CREATE TIMESERIES root.sg1.d0.s1 WITH DATATYPE=INT64, ENCODING=RLE, COMPRESSOR=SNAPPY");
+        statement.execute(
+            "CREATE TIMESERIES root.sg1.d1.s0 WITH DATATYPE=INT64, ENCODING=RLE, COMPRESSOR=SNAPPY");
+        statement.execute(
+            "CREATE TIMESERIES root.sg1.d1.s1 WITH DATATYPE=INT64, ENCODING=RLE, COMPRESSOR=SNAPPY");
 
-      statement.execute("insert into root.sg1.d0(timestamp,s0,s1) values(1,1,1)");
-      statement.execute("insert into root.sg1.d1(timestamp,s0,s1) values(1000,1000,1000)");
-      statement.execute("insert into root.sg1.d0(timestamp,s0,s1) values(10,10,10)");
+        statement.execute("insert into root.sg1.d0(timestamp,s0,s1) values(1,1,1)");
+        statement.execute("insert into root.sg1.d1(timestamp,s0,s1) values(1000,1000,1000)");
+        statement.execute("insert into root.sg1.d0(timestamp,s0,s1) values(10,10,10)");
 
-      List<ResultSet> resultSetList = new ArrayList<>();
+        List<ResultSet> resultSetList = new ArrayList<>();
 
-      ResultSet r1 = statement.executeQuery("select * from root.sg1.d0 where time <= 1");
-      resultSetList.add(r1);
+        ResultSet r1 = statement.executeQuery("select * from root.sg1.d0 where time <= 1");
+        resultSetList.add(r1);
 
-      ResultSet r2 = statement.executeQuery("select * from root.sg1.d1 where s0 == 1000");
-      resultSetList.add(r2);
+        ResultSet r2 = statement.executeQuery("select * from root.sg1.d1 where s0 == 1000");
+        resultSetList.add(r2);
 
-      ResultSet r3 = statement.executeQuery("select * from root.sg1.d0 where s1 == 10");
-      resultSetList.add(r3);
+        ResultSet r3 = statement.executeQuery("select * from root.sg1.d0 where s1 == 10");
+        resultSetList.add(r3);
 
-      r1.next();
-      Assert.assertEquals(r1.getLong(1), 1L);
-      Assert.assertEquals(r1.getLong(2), 1L);
-      Assert.assertEquals(r1.getLong(3), 1L);
+        r1.next();
+        Assert.assertEquals(r1.getLong(1), 1L);
+        Assert.assertEquals(r1.getLong(2), 1L);
+        Assert.assertEquals(r1.getLong(3), 1L);
 
-      r2.next();
-      Assert.assertEquals(r2.getLong(1), 1000L);
-      Assert.assertEquals(r2.getLong(2), 1000L);
-      Assert.assertEquals(r2.getLong(3), 1000L);
+        r2.next();
+        Assert.assertEquals(r2.getLong(1), 1000L);
+        Assert.assertEquals(r2.getLong(2), 1000L);
+        Assert.assertEquals(r2.getLong(3), 1000L);
 
-      r3.next();
-      Assert.assertEquals(r3.getLong(1), 10L);
-      Assert.assertEquals(r3.getLong(2), 10L);
-      Assert.assertEquals(r3.getLong(3), 10L);
+        r3.next();
+        Assert.assertEquals(r3.getLong(1), 10L);
+        Assert.assertEquals(r3.getLong(2), 10L);
+        Assert.assertEquals(r3.getLong(3), 10L);
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
+      }
     }
   }
 
@@ -1242,42 +1349,45 @@ public class IoTDBSimpleQueryIT {
   public void testInvalidMaxPointNumber() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("CREATE DATABASE root.sg1");
-      statement.execute(
-          "CREATE TIMESERIES root.sg1.d1.s1 with datatype=FLOAT, encoding=TS_2DIFF, "
-              + "'max_point_number'='4'");
-      statement.execute(
-          "CREATE TIMESERIES root.sg1.d1.s2 with datatype=FLOAT, encoding=TS_2DIFF, "
-              + "'max_point_number'='2.5'");
-      statement.execute(
-          "CREATE TIMESERIES root.sg1.d1.s3 with datatype=FLOAT, encoding=RLE, "
-              + "'max_point_number'='q'");
-      statement.execute(
-          "CREATE TIMESERIES root.sg1.d1.s4 with datatype=FLOAT, encoding=RLE, "
-              + "'max_point_number'='-1'");
-      statement.execute(
-          "insert into root.sg1.d1(timestamp,s1,s2,s3,s4) values(1,1.1234,1.1234,1.1234,1.1234)");
+      try {
+        statement.execute("CREATE DATABASE root.sg1");
+        statement.execute(
+            "CREATE TIMESERIES root.sg1.d1.s1 with datatype=FLOAT, encoding=TS_2DIFF, "
+                + "'max_point_number'='4'");
+        statement.execute(
+            "CREATE TIMESERIES root.sg1.d1.s2 with datatype=FLOAT, encoding=TS_2DIFF, "
+                + "'max_point_number'='2.5'");
+        statement.execute(
+            "CREATE TIMESERIES root.sg1.d1.s3 with datatype=FLOAT, encoding=RLE, "
+                + "'max_point_number'='q'");
+        statement.execute(
+            "CREATE TIMESERIES root.sg1.d1.s4 with datatype=FLOAT, encoding=RLE, "
+                + "'max_point_number'='-1'");
+        statement.execute(
+            "insert into root.sg1.d1(timestamp,s1,s2,s3,s4) values(1,1.1234,1.1234,1.1234,1.1234)");
 
-      try (ResultSet r1 = statement.executeQuery("select s1 from root.sg1.d1")) {
-        r1.next();
-        Assert.assertEquals(1.1234f, r1.getFloat(2), 0);
+        try (ResultSet r1 = statement.executeQuery("select s1 from root.sg1.d1")) {
+          r1.next();
+          Assert.assertEquals(1.1234f, r1.getFloat(2), 0);
+        }
+
+        try (ResultSet r2 = statement.executeQuery("select s3 from root.sg1.d1")) {
+          r2.next();
+          Assert.assertEquals(1.12f, r2.getFloat(2), 0);
+        }
+
+        try (ResultSet r3 = statement.executeQuery("select s3 from root.sg1.d1")) {
+          r3.next();
+          Assert.assertEquals(1.12f, r3.getFloat(2), 0);
+        }
+
+        try (ResultSet r4 = statement.executeQuery("select s4 from root.sg1.d1")) {
+          r4.next();
+          Assert.assertEquals(1.12f, r4.getFloat(2), 0);
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
-
-      try (ResultSet r2 = statement.executeQuery("select s3 from root.sg1.d1")) {
-        r2.next();
-        Assert.assertEquals(1.12f, r2.getFloat(2), 0);
-      }
-
-      try (ResultSet r3 = statement.executeQuery("select s3 from root.sg1.d1")) {
-        r3.next();
-        Assert.assertEquals(1.12f, r3.getFloat(2), 0);
-      }
-
-      try (ResultSet r4 = statement.executeQuery("select s4 from root.sg1.d1")) {
-        r4.next();
-        Assert.assertEquals(1.12f, r4.getFloat(2), 0);
-      }
-
     } catch (SQLException e) {
       fail();
     }
@@ -1295,11 +1405,15 @@ public class IoTDBSimpleQueryIT {
 
     try (final Connection connection = EnvFactory.getEnv().getConnection();
         final Statement statement = connection.createStatement()) {
-      try (final ResultSet resultSet =
-          statement.executeQuery("SHOW DATABASES DETAILS root.group_with_hyphen")) {
-        while (resultSet.next()) {
-          Assert.assertEquals("root.group_with_hyphen", resultSet.getString(1));
+      try {
+        try (final ResultSet resultSet =
+            statement.executeQuery("SHOW DATABASES DETAILS root.group_with_hyphen")) {
+          while (resultSet.next()) {
+            Assert.assertEquals("root.group_with_hyphen", resultSet.getString(1));
+          }
         }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.group_with_hyphen");
       }
     } catch (final SQLException e) {
       fail();
@@ -1327,14 +1441,18 @@ public class IoTDBSimpleQueryIT {
   public void testEnableAlign() throws Exception {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("CREATE TIMESERIES root.sg1.d1.s1 WITH DATATYPE=INT32");
-      statement.execute("CREATE TIMESERIES root.sg1.d1.s2 WITH DATATYPE=BOOLEAN");
-      ResultSet resultSet = statement.executeQuery("select s1, s2 from root.sg1.d1");
-      ResultSetMetaData metaData = resultSet.getMetaData();
-      int[] types = {Types.TIMESTAMP, Types.INTEGER, Types.BOOLEAN};
-      int columnCount = metaData.getColumnCount();
-      for (int i = 0; i < columnCount; i++) {
-        Assert.assertEquals(types[i], metaData.getColumnType(i + 1));
+      try {
+        statement.execute("CREATE TIMESERIES root.sg1.d1.s1 WITH DATATYPE=INT32");
+        statement.execute("CREATE TIMESERIES root.sg1.d1.s2 WITH DATATYPE=BOOLEAN");
+        ResultSet resultSet = statement.executeQuery("select s1, s2 from root.sg1.d1");
+        ResultSetMetaData metaData = resultSet.getMetaData();
+        int[] types = {Types.TIMESTAMP, Types.INTEGER, Types.BOOLEAN};
+        int columnCount = metaData.getColumnCount();
+        for (int i = 0; i < columnCount; i++) {
+          Assert.assertEquals(types[i], metaData.getColumnType(i + 1));
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
     }
   }
@@ -1343,31 +1461,34 @@ public class IoTDBSimpleQueryIT {
   public void testFromFuzzyMatching() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("CREATE DATABASE root.sg1");
-      statement.execute(
-          "CREATE TIMESERIES root.sg1.d1.s1 with datatype=FLOAT, encoding=TS_2DIFF, "
-              + "'max_point_number'='4'");
-      statement.execute(
-          "CREATE TIMESERIES root.sg1.d1.s2 with datatype=FLOAT, encoding=TS_2DIFF, "
-              + "'max_point_number'='2.5'");
-      statement.execute(
-          "CREATE TIMESERIES root.sg1.d1.s3 with datatype=FLOAT, encoding=RLE, "
-              + "'max_point_number'='q'");
-      statement.execute(
-          "CREATE TIMESERIES root.sg1.d1.s4 with datatype=FLOAT, encoding=RLE, "
-              + "'max_point_number'='-1'");
-      statement.execute(
-          "insert into root.sg1.da1cb(timestamp,s1,s2,s3,s4) values(1,1.1234,1.1234,1.1234,1.1234)");
-      statement.execute(
-          "insert into root.sg1.da1ce(timestamp,s1,s2,s3,s4) values(1,1.1234,1.1234,1.1234,1.1234)");
+      try {
+        statement.execute("CREATE DATABASE root.sg1");
+        statement.execute(
+            "CREATE TIMESERIES root.sg1.d1.s1 with datatype=FLOAT, encoding=TS_2DIFF, "
+                + "'max_point_number'='4'");
+        statement.execute(
+            "CREATE TIMESERIES root.sg1.d1.s2 with datatype=FLOAT, encoding=TS_2DIFF, "
+                + "'max_point_number'='2.5'");
+        statement.execute(
+            "CREATE TIMESERIES root.sg1.d1.s3 with datatype=FLOAT, encoding=RLE, "
+                + "'max_point_number'='q'");
+        statement.execute(
+            "CREATE TIMESERIES root.sg1.d1.s4 with datatype=FLOAT, encoding=RLE, "
+                + "'max_point_number'='-1'");
+        statement.execute(
+            "insert into root.sg1.da1cb(timestamp,s1,s2,s3,s4) values(1,1.1234,1.1234,1.1234,1.1234)");
+        statement.execute(
+            "insert into root.sg1.da1ce(timestamp,s1,s2,s3,s4) values(1,1.1234,1.1234,1.1234,1.1234)");
 
-      try (ResultSet r1 = statement.executeQuery("select s1 from root.sg1.*a*")) {
-        while (r1.next()) {
-          Assert.assertEquals(1.1234f, r1.getDouble(2), 0.001);
+        try (ResultSet r1 = statement.executeQuery("select s1 from root.sg1.*a*")) {
+          while (r1.next()) {
+            Assert.assertEquals(1.1234f, r1.getDouble(2), 0.001);
+          }
+          Assert.assertEquals(3, r1.getMetaData().getColumnCount());
         }
-        Assert.assertEquals(3, r1.getMetaData().getColumnCount());
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
-
     } catch (SQLException e) {
       fail();
     }
@@ -1377,55 +1498,57 @@ public class IoTDBSimpleQueryIT {
   public void testNewDataType() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-
-      statement.execute("CREATE DATABASE root.sg1");
-      statement.execute(
-          "CREATE TIMESERIES root.sg1.d1.s4 WITH DATATYPE=DATE, ENCODING=PLAIN, COMPRESSOR=SNAPPY");
-      statement.execute(
-          "CREATE TIMESERIES root.sg1.d1.s5 WITH DATATYPE=TIMESTAMP, ENCODING=PLAIN, COMPRESSOR=SNAPPY");
-      statement.execute(
-          "CREATE TIMESERIES root.sg1.d1.s6 WITH DATATYPE=BLOB, ENCODING=PLAIN, COMPRESSOR=SNAPPY");
-      statement.execute(
-          "CREATE TIMESERIES root.sg1.d1.s7 WITH DATATYPE=STRING, ENCODING=PLAIN, COMPRESSOR=SNAPPY");
-      for (int i = 1; i <= 10; i++) {
+      try {
+        statement.execute("CREATE DATABASE root.sg1");
         statement.execute(
-            String.format(
-                "insert into root.sg1.d1(timestamp, s4, s5, s6, s7) values(%d, \"%s\", %d, %s, \"%s\")",
-                i, LocalDate.of(2024, 5, i % 31 + 1), i, "X'cafebabe'", i));
-      }
+            "CREATE TIMESERIES root.sg1.d1.s4 WITH DATATYPE=DATE, ENCODING=PLAIN, COMPRESSOR=SNAPPY");
+        statement.execute(
+            "CREATE TIMESERIES root.sg1.d1.s5 WITH DATATYPE=TIMESTAMP, ENCODING=PLAIN, COMPRESSOR=SNAPPY");
+        statement.execute(
+            "CREATE TIMESERIES root.sg1.d1.s6 WITH DATATYPE=BLOB, ENCODING=PLAIN, COMPRESSOR=SNAPPY");
+        statement.execute(
+            "CREATE TIMESERIES root.sg1.d1.s7 WITH DATATYPE=STRING, ENCODING=PLAIN, COMPRESSOR=SNAPPY");
+        for (int i = 1; i <= 10; i++) {
+          statement.execute(
+              String.format(
+                  "insert into root.sg1.d1(timestamp, s4, s5, s6, s7) values(%d, \"%s\", %d, %s, \"%s\")",
+                  i, LocalDate.of(2024, 5, i % 31 + 1), i, "X'cafebabe'", i));
+        }
 
-      try (ResultSet resultSet = statement.executeQuery("select * from root.sg1.**")) {
-        final ResultSetMetaData metaData = resultSet.getMetaData();
-        final int columnCount = metaData.getColumnCount();
-        assertEquals(5, columnCount);
-        HashMap<Integer, TSDataType> columnType = new HashMap<>();
-        for (int i = 1; i < columnCount; i++) {
-          if (metaData.getColumnLabel(i).endsWith("s4")) {
-            columnType.put(i, TSDataType.DATE);
-          } else if (metaData.getColumnLabel(i).endsWith("s5")) {
-            columnType.put(i, TSDataType.TIMESTAMP);
-          } else if (metaData.getColumnLabel(i).endsWith("s6")) {
-            columnType.put(i, TSDataType.BLOB);
-          } else if (metaData.getColumnLabel(i).endsWith("s7")) {
-            columnType.put(i, TSDataType.TEXT);
+        try (ResultSet resultSet = statement.executeQuery("select * from root.sg1.**")) {
+          final ResultSetMetaData metaData = resultSet.getMetaData();
+          final int columnCount = metaData.getColumnCount();
+          assertEquals(5, columnCount);
+          HashMap<Integer, TSDataType> columnType = new HashMap<>();
+          for (int i = 1; i < columnCount; i++) {
+            if (metaData.getColumnLabel(i).endsWith("s4")) {
+              columnType.put(i, TSDataType.DATE);
+            } else if (metaData.getColumnLabel(i).endsWith("s5")) {
+              columnType.put(i, TSDataType.TIMESTAMP);
+            } else if (metaData.getColumnLabel(i).endsWith("s6")) {
+              columnType.put(i, TSDataType.BLOB);
+            } else if (metaData.getColumnLabel(i).endsWith("s7")) {
+              columnType.put(i, TSDataType.TEXT);
+            }
+          }
+          byte[] byteArray = new byte[] {(byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE};
+          while (resultSet.next()) {
+            long time = resultSet.getLong(1);
+            Date date = resultSet.getDate(2);
+            long timestamp = resultSet.getLong(3);
+            byte[] blob = resultSet.getBytes(4);
+            String text = resultSet.getString(5);
+            assertEquals(2024 - 1900, date.getYear());
+            assertEquals(5 - 1, date.getMonth());
+            assertEquals(time % 31 + 1, date.getDate());
+            assertEquals(time, timestamp);
+            assertArrayEquals(byteArray, blob);
+            assertEquals(String.valueOf(time), text);
           }
         }
-        byte[] byteArray = new byte[] {(byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE};
-        while (resultSet.next()) {
-          long time = resultSet.getLong(1);
-          Date date = resultSet.getDate(2);
-          long timestamp = resultSet.getLong(3);
-          byte[] blob = resultSet.getBytes(4);
-          String text = resultSet.getString(5);
-          assertEquals(2024 - 1900, date.getYear());
-          assertEquals(5 - 1, date.getMonth());
-          assertEquals(time % 31 + 1, date.getDate());
-          assertEquals(time, timestamp);
-          assertArrayEquals(byteArray, blob);
-          assertEquals(String.valueOf(time), text);
-        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
-
     } catch (SQLException e) {
       fail();
     }
@@ -1435,34 +1558,37 @@ public class IoTDBSimpleQueryIT {
   public void testIllegalDateType() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-
-      statement.execute("CREATE DATABASE root.sg1");
-      statement.execute(
-          "CREATE TIMESERIES root.sg1.d1.s4 WITH DATATYPE=DATE, ENCODING=PLAIN, COMPRESSOR=SNAPPY");
-      statement.execute(
-          "CREATE TIMESERIES root.sg1.d1.s5 WITH DATATYPE=TIMESTAMP, ENCODING=PLAIN, COMPRESSOR=SNAPPY");
       try {
-        statement.execute("insert into root.sg1.d1(timestamp, s4) values(1, '2022-04-31')");
-        fail();
-      } catch (Exception e) {
-        assertEquals(
-            TSStatusCode.METADATA_ERROR.getStatusCode()
-                + ": Fail to insert measurements [s4] caused by [data type is not consistent, "
-                + "input '2022-04-31', registered DATE because Invalid date format. "
-                + "Please use YYYY-MM-DD format.]",
-            e.getMessage());
-      }
-      try {
+        statement.execute("CREATE DATABASE root.sg1");
         statement.execute(
-            "insert into root.sg1.d1(timestamp, s5) values(1999-04-31T00:00:00.000+08:00, 1999-04-31T00:00:00.000+08:00)");
-        fail();
-      } catch (Exception e) {
-        assertEquals(
-            TSStatusCode.SEMANTIC_ERROR.getStatusCode()
-                + ": Input time format 1999-04-31T00:00:00.000+08:00 error. "
-                + "Input like yyyy-MM-dd HH:mm:ss, yyyy-MM-ddTHH:mm:ss "
-                + "or refer to user document for more info.",
-            e.getMessage());
+            "CREATE TIMESERIES root.sg1.d1.s4 WITH DATATYPE=DATE, ENCODING=PLAIN, COMPRESSOR=SNAPPY");
+        statement.execute(
+            "CREATE TIMESERIES root.sg1.d1.s5 WITH DATATYPE=TIMESTAMP, ENCODING=PLAIN, COMPRESSOR=SNAPPY");
+        try {
+          statement.execute("insert into root.sg1.d1(timestamp, s4) values(1, '2022-04-31')");
+          fail();
+        } catch (Exception e) {
+          assertEquals(
+              TSStatusCode.METADATA_ERROR.getStatusCode()
+                  + ": Fail to insert measurements [s4] caused by [data type is not consistent, "
+                  + "input '2022-04-31', registered DATE because Invalid date format. "
+                  + "Please use YYYY-MM-DD format.]",
+              e.getMessage());
+        }
+        try {
+          statement.execute(
+              "insert into root.sg1.d1(timestamp, s5) values(1999-04-31T00:00:00.000+08:00, 1999-04-31T00:00:00.000+08:00)");
+          fail();
+        } catch (Exception e) {
+          assertEquals(
+              TSStatusCode.SEMANTIC_ERROR.getStatusCode()
+                  + ": Input time format 1999-04-31T00:00:00.000+08:00 error. "
+                  + "Input like yyyy-MM-dd HH:mm:ss, yyyy-MM-ddTHH:mm:ss "
+                  + "or refer to user document for more info.",
+              e.getMessage());
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
     } catch (SQLException e) {
       fail();
@@ -1473,14 +1599,18 @@ public class IoTDBSimpleQueryIT {
   public void testQueryWithGlobalTimeFilterOrderByTimeDesc() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("insert into root.sg1.d1(timestamp, s1, s2) aligned values(1, 1, 1)");
-      statement.execute("insert into root.sg1.d1(timestamp, s1, s2) aligned values(2, null, 2)");
-      statement.execute("insert into root.sg1.d1(timestamp, s1, s2) aligned values(3, null, 3)");
-      statement.execute("flush");
-      ResultSet resultSet =
-          statement.executeQuery(
-              "select s1 from root.sg1.d1 where time >= 3 and time <= 4 order by time desc");
-      Assert.assertFalse(resultSet.next());
+      try {
+        statement.execute("insert into root.sg1.d1(timestamp, s1, s2) aligned values(1, 1, 1)");
+        statement.execute("insert into root.sg1.d1(timestamp, s1, s2) aligned values(2, null, 2)");
+        statement.execute("insert into root.sg1.d1(timestamp, s1, s2) aligned values(3, null, 3)");
+        statement.execute("flush");
+        ResultSet resultSet =
+            statement.executeQuery(
+                "select s1 from root.sg1.d1 where time >= 3 and time <= 4 order by time desc");
+        Assert.assertFalse(resultSet.next());
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
+      }
     }
   }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBSimpleQueryStandaloneIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBSimpleQueryStandaloneIT.java
@@ -23,8 +23,8 @@ import org.apache.iotdb.it.env.EnvFactory;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -42,13 +42,13 @@ import static org.junit.Assert.fail;
 @Category({LocalStandaloneIT.class})
 public class IoTDBSimpleQueryStandaloneIT {
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     EnvFactory.getEnv().initClusterEnvironment();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
   }
 

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBSyntaxConventionIdentifierIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBSyntaxConventionIdentifierIT.java
@@ -25,9 +25,9 @@ import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -45,15 +45,23 @@ import static org.junit.Assert.fail;
 @RunWith(IoTDBTestRunner.class)
 @Category({LocalStandaloneIT.class, ClusterIT.class})
 public class IoTDBSyntaxConventionIdentifierIT {
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     EnvFactory.getEnv().getConfig().getCommonConfig().setEnforceStrongPassword(false);
     EnvFactory.getEnv().initClusterEnvironment();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  private static void executeQuietly(Statement statement, String sql) {
+    try {
+      statement.execute(sql);
+    } catch (SQLException ignored) {
+      // ignore cleanup errors
+    }
   }
 
   @Test
@@ -108,34 +116,38 @@ public class IoTDBSyntaxConventionIdentifierIT {
 
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      for (String createNodeName : createNodeNames) {
-        String createSql = String.format("CREATE TIMESERIES root.sg1.d1.%s INT32", createNodeName);
-        String insertSql =
-            String.format("INSERT INTO root.sg1.d1(time, %s) VALUES(1, 1)", createNodeName);
-        statement.execute(createSql);
-        statement.execute(insertSql);
-      }
-
-      try (ResultSet resultSet = statement.executeQuery("SHOW TIMESERIES root.sg1.**")) {
-        Set<String> expectedResult = new HashSet<>(Arrays.asList(resultTimeseries));
-
-        while (resultSet.next()) {
-          Assert.assertTrue(
-              expectedResult.contains(resultSet.getString(ColumnHeaderConstant.TIMESERIES)));
-          expectedResult.remove(resultSet.getString(ColumnHeaderConstant.TIMESERIES));
+      try {
+        for (String createNodeName : createNodeNames) {
+          String createSql =
+              String.format("CREATE TIMESERIES root.sg1.d1.%s INT32", createNodeName);
+          String insertSql =
+              String.format("INSERT INTO root.sg1.d1(time, %s) VALUES(1, 1)", createNodeName);
+          statement.execute(createSql);
+          statement.execute(insertSql);
         }
-        Assert.assertEquals(0, expectedResult.size());
-      }
 
-      for (int i = 0; i < selectNodeNames.length; i++) {
-        String selectSql =
-            String.format("SELECT %s FROM root.sg1.d1 WHERE time = 1", selectNodeNames[i]);
-        try (ResultSet resultSet = statement.executeQuery(selectSql)) {
-          Assert.assertTrue(resultSet.next());
-          Assert.assertEquals(1, resultSet.getInt("root.sg1.d1." + suffixInResultColumns[i]));
+        try (ResultSet resultSet = statement.executeQuery("SHOW TIMESERIES root.sg1.**")) {
+          Set<String> expectedResult = new HashSet<>(Arrays.asList(resultTimeseries));
+
+          while (resultSet.next()) {
+            Assert.assertTrue(
+                expectedResult.contains(resultSet.getString(ColumnHeaderConstant.TIMESERIES)));
+            expectedResult.remove(resultSet.getString(ColumnHeaderConstant.TIMESERIES));
+          }
+          Assert.assertEquals(0, expectedResult.size());
         }
-      }
 
+        for (int i = 0; i < selectNodeNames.length; i++) {
+          String selectSql =
+              String.format("SELECT %s FROM root.sg1.d1 WHERE time = 1", selectNodeNames[i]);
+          try (ResultSet resultSet = statement.executeQuery(selectSql)) {
+            Assert.assertTrue(resultSet.next());
+            Assert.assertEquals(1, resultSet.getInt("root.sg1.d1." + suffixInResultColumns[i]));
+          }
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
+      }
     } catch (SQLException e) {
       e.printStackTrace();
       fail();
@@ -266,34 +278,38 @@ public class IoTDBSyntaxConventionIdentifierIT {
 
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      for (String createNodeName : createNodeNames) {
-        String createSql = String.format("CREATE TIMESERIES root.sg1.d1.%s INT32", createNodeName);
-        String insertSql =
-            String.format("INSERT INTO root.sg1.d1(time, %s) VALUES(1, 1)", createNodeName);
-        statement.execute(createSql);
-        statement.execute(insertSql);
-      }
-
-      try (ResultSet resultSet = statement.executeQuery("SHOW TIMESERIES root.sg1.**")) {
-        Set<String> expectedResult = new HashSet<>(Arrays.asList(resultTimeseries));
-
-        while (resultSet.next()) {
-          Assert.assertTrue(
-              expectedResult.contains(resultSet.getString(ColumnHeaderConstant.TIMESERIES)));
-          expectedResult.remove(resultSet.getString(ColumnHeaderConstant.TIMESERIES));
+      try {
+        for (String createNodeName : createNodeNames) {
+          String createSql =
+              String.format("CREATE TIMESERIES root.sg1.d1.%s INT32", createNodeName);
+          String insertSql =
+              String.format("INSERT INTO root.sg1.d1(time, %s) VALUES(1, 1)", createNodeName);
+          statement.execute(createSql);
+          statement.execute(insertSql);
         }
-        Assert.assertEquals(0, expectedResult.size());
-      }
 
-      for (int i = 0; i < selectNodeNames.length; i++) {
-        String selectSql =
-            String.format("SELECT %s FROM root.sg1.d1 WHERE time = 1", selectNodeNames[i]);
-        try (ResultSet resultSet = statement.executeQuery(selectSql)) {
-          Assert.assertTrue(resultSet.next());
-          Assert.assertEquals(1, resultSet.getInt("root.sg1.d1." + suffixInResultColumns[i]));
+        try (ResultSet resultSet = statement.executeQuery("SHOW TIMESERIES root.sg1.**")) {
+          Set<String> expectedResult = new HashSet<>(Arrays.asList(resultTimeseries));
+
+          while (resultSet.next()) {
+            Assert.assertTrue(
+                expectedResult.contains(resultSet.getString(ColumnHeaderConstant.TIMESERIES)));
+            expectedResult.remove(resultSet.getString(ColumnHeaderConstant.TIMESERIES));
+          }
+          Assert.assertEquals(0, expectedResult.size());
         }
-      }
 
+        for (int i = 0; i < selectNodeNames.length; i++) {
+          String selectSql =
+              String.format("SELECT %s FROM root.sg1.d1 WHERE time = 1", selectNodeNames[i]);
+          try (ResultSet resultSet = statement.executeQuery(selectSql)) {
+            Assert.assertTrue(resultSet.next());
+            Assert.assertEquals(1, resultSet.getInt("root.sg1.d1." + suffixInResultColumns[i]));
+          }
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
+      }
     } catch (SQLException e) {
       e.printStackTrace();
       fail();
@@ -304,83 +320,85 @@ public class IoTDBSyntaxConventionIdentifierIT {
   public void testNodeNameIllegal() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-
-      // nodeName with special characters should be quoted with '`'
       try {
-        statement.execute("create timeseries root.sg1.d1.`a INT32");
-        fail();
-      } catch (Exception ignored) {
-      }
+        // nodeName with special characters should be quoted with '`'
+        try {
+          statement.execute("create timeseries root.sg1.d1.`a INT32");
+          fail();
+        } catch (Exception ignored) {
+        }
 
-      try {
-        statement.execute("create timeseries root.sg1.d1.[a INT32");
-        fail();
-      } catch (Exception ignored) {
-      }
+        try {
+          statement.execute("create timeseries root.sg1.d1.[a INT32");
+          fail();
+        } catch (Exception ignored) {
+        }
 
-      try {
-        statement.execute("create timeseries root.sg1.d1.a! INT32");
-        fail();
-      } catch (Exception ignored) {
-      }
+        try {
+          statement.execute("create timeseries root.sg1.d1.a! INT32");
+          fail();
+        } catch (Exception ignored) {
+        }
 
-      try {
-        statement.execute("create timeseries root.sg1.d1.a\" INT32");
-        fail();
-      } catch (Exception ignored) {
-      }
+        try {
+          statement.execute("create timeseries root.sg1.d1.a\" INT32");
+          fail();
+        } catch (Exception ignored) {
+        }
 
-      try {
-        statement.execute("create timeseries root.sg1.d1.a' INT32");
-        fail();
-      } catch (Exception ignored) {
-      }
+        try {
+          statement.execute("create timeseries root.sg1.d1.a' INT32");
+          fail();
+        } catch (Exception ignored) {
+        }
 
-      // nodeName consists of numbers should be quoted with '`'
-      try {
-        statement.execute("create timeseries root.sg1.d1.111 INT32");
-        fail();
-      } catch (Exception ignored) {
-      }
+        // nodeName consists of numbers should be quoted with '`'
+        try {
+          statement.execute("create timeseries root.sg1.d1.111 INT32");
+          fail();
+        } catch (Exception ignored) {
+        }
 
-      try {
-        statement.execute("create timeseries root.sg1.d1.012 INT32");
-        fail();
-      } catch (Exception ignored) {
-      }
+        try {
+          statement.execute("create timeseries root.sg1.d1.012 INT32");
+          fail();
+        } catch (Exception ignored) {
+        }
 
-      // shouled use double '`' in a quoted nodeName
-      try {
-        statement.execute("create timeseries root.sg1.d1.`a`` INT32");
-        fail();
-      } catch (Exception ignored) {
-      }
+        // shouled use double '`' in a quoted nodeName
+        try {
+          statement.execute("create timeseries root.sg1.d1.`a`` INT32");
+          fail();
+        } catch (Exception ignored) {
+        }
 
-      try {
-        statement.execute("create timeseries root.sg1.d1.``a` INT32");
-        fail();
-      } catch (Exception ignored) {
-      }
+        try {
+          statement.execute("create timeseries root.sg1.d1.``a` INT32");
+          fail();
+        } catch (Exception ignored) {
+        }
 
-      // reserved words can not be identifier
-      try {
-        statement.execute("create timeseries root.sg1.d1.root INT32");
-        fail();
-      } catch (Exception ignored) {
-      }
+        // reserved words can not be identifier
+        try {
+          statement.execute("create timeseries root.sg1.d1.root INT32");
+          fail();
+        } catch (Exception ignored) {
+        }
 
-      try {
-        statement.execute("create timeseries root.sg1.d1.time INT32");
-        fail();
-      } catch (Exception ignored) {
-      }
+        try {
+          statement.execute("create timeseries root.sg1.d1.time INT32");
+          fail();
+        } catch (Exception ignored) {
+        }
 
-      try {
-        statement.execute("create timeseries root.sg1.d1.timestamp INT32");
-        fail();
-      } catch (Exception ignored) {
+        try {
+          statement.execute("create timeseries root.sg1.d1.timestamp INT32");
+          fail();
+        } catch (Exception ignored) {
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
-
     } catch (SQLException e) {
       e.printStackTrace();
       fail();
@@ -391,13 +409,15 @@ public class IoTDBSyntaxConventionIdentifierIT {
   public void testCreateIllegalDatabase() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-
       try {
-        statement.execute("create database root.sg1.d1.");
-        fail();
-      } catch (Exception ignored) {
+        try {
+          statement.execute("create database root.sg1.d1.");
+          fail();
+        } catch (Exception ignored) {
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
-
     } catch (SQLException e) {
       e.printStackTrace();
       fail();
@@ -408,124 +428,128 @@ public class IoTDBSyntaxConventionIdentifierIT {
   public void testExpression() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("CREATE TIMESERIES root.sg1.d1.`1` INT32");
-      statement.execute("CREATE TIMESERIES root.sg1.d1.`a.b` INT32");
-      statement.execute("CREATE TIMESERIES root.sg1.d1.`a.``b` INT32");
-      statement.execute("CREATE TIMESERIES root.sg1.d1.text TEXT");
-      int pointCnt = 3;
-      for (int i = 0; i < pointCnt; i++) {
-        statement.execute(
-            String.format(
-                "insert into root.sg1.d1(time,%s,%s,%s) values(%d,%d,%d,%d)",
-                "`1`", "`a.b`", "`a.``b`", i, i, i, i));
-      }
-
-      int cnt = 0;
-      try (ResultSet resultSet = statement.executeQuery("SELECT `1` + 1 FROM root.sg1.d1")) {
-        while (resultSet.next()) {
-          cnt++;
+      try {
+        statement.execute("CREATE TIMESERIES root.sg1.d1.`1` INT32");
+        statement.execute("CREATE TIMESERIES root.sg1.d1.`a.b` INT32");
+        statement.execute("CREATE TIMESERIES root.sg1.d1.`a.``b` INT32");
+        statement.execute("CREATE TIMESERIES root.sg1.d1.text TEXT");
+        int pointCnt = 3;
+        for (int i = 0; i < pointCnt; i++) {
+          statement.execute(
+              String.format(
+                  "insert into root.sg1.d1(time,%s,%s,%s) values(%d,%d,%d,%d)",
+                  "`1`", "`a.b`", "`a.``b`", i, i, i, i));
         }
-        Assert.assertEquals(pointCnt, cnt);
-      }
 
-      cnt = 0;
-      try (ResultSet resultSet =
-          statement.executeQuery("SELECT (`1`*`1`)+1-`a.b` FROM root.sg1.d1 where `1` > 1")) {
-        while (resultSet.next()) {
-          cnt++;
+        int cnt = 0;
+        try (ResultSet resultSet = statement.executeQuery("SELECT `1` + 1 FROM root.sg1.d1")) {
+          while (resultSet.next()) {
+            cnt++;
+          }
+          Assert.assertEquals(pointCnt, cnt);
         }
-        Assert.assertEquals(1, cnt);
-      }
 
-      cnt = 0;
-      try (ResultSet resultSet =
-          statement.executeQuery("SELECT (`1`*`1`)+1-`a.b` FROM root.sg1.d1")) {
-        while (resultSet.next()) {
-          cnt++;
+        cnt = 0;
+        try (ResultSet resultSet =
+            statement.executeQuery("SELECT (`1`*`1`)+1-`a.b` FROM root.sg1.d1 where `1` > 1")) {
+          while (resultSet.next()) {
+            cnt++;
+          }
+          Assert.assertEquals(1, cnt);
         }
-        Assert.assertEquals(pointCnt, cnt);
-      }
 
-      cnt = 0;
-      try (ResultSet resultSet =
-          statement.executeQuery("SELECT (`1`*`1`)+1-`a.b` FROM root.sg1.d1 where `1`>0")) {
-        while (resultSet.next()) {
-          cnt++;
+        cnt = 0;
+        try (ResultSet resultSet =
+            statement.executeQuery("SELECT (`1`*`1`)+1-`a.b` FROM root.sg1.d1")) {
+          while (resultSet.next()) {
+            cnt++;
+          }
+          Assert.assertEquals(pointCnt, cnt);
         }
-        Assert.assertEquals(2, cnt);
-      }
 
-      cnt = 0;
-      try (ResultSet resultSet = statement.executeQuery("SELECT avg(`1`)+1 FROM root.sg1.d1")) {
-        while (resultSet.next()) {
-          cnt++;
+        cnt = 0;
+        try (ResultSet resultSet =
+            statement.executeQuery("SELECT (`1`*`1`)+1-`a.b` FROM root.sg1.d1 where `1`>0")) {
+          while (resultSet.next()) {
+            cnt++;
+          }
+          Assert.assertEquals(2, cnt);
         }
-        Assert.assertEquals(1, cnt);
-      }
 
-      cnt = 0;
-      try (ResultSet resultSet =
-          statement.executeQuery("SELECT count(`1`)+1 FROM root.sg1.d1 where `1`>1")) {
-        while (resultSet.next()) {
-          Assert.assertEquals(2.0, resultSet.getDouble(1), 1e-7);
-          cnt++;
+        cnt = 0;
+        try (ResultSet resultSet = statement.executeQuery("SELECT avg(`1`)+1 FROM root.sg1.d1")) {
+          while (resultSet.next()) {
+            cnt++;
+          }
+          Assert.assertEquals(1, cnt);
         }
-        Assert.assertEquals(1, cnt);
-      }
 
-      cnt = 0;
-      try (ResultSet resultSet = statement.executeQuery("SELECT sin(`1`) + 1 FROM root.sg1.d1")) {
-        while (resultSet.next()) {
-          cnt++;
+        cnt = 0;
+        try (ResultSet resultSet =
+            statement.executeQuery("SELECT count(`1`)+1 FROM root.sg1.d1 where `1`>1")) {
+          while (resultSet.next()) {
+            Assert.assertEquals(2.0, resultSet.getDouble(1), 1e-7);
+            cnt++;
+          }
+          Assert.assertEquals(1, cnt);
         }
-        Assert.assertEquals(pointCnt, cnt);
-      }
 
-      cnt = 0;
-      try (ResultSet resultSet =
-          statement.executeQuery("SELECT sin(`1`) + 1 FROM root.sg1.d1 where `1`>1")) {
-        while (resultSet.next()) {
-          cnt++;
+        cnt = 0;
+        try (ResultSet resultSet = statement.executeQuery("SELECT sin(`1`) + 1 FROM root.sg1.d1")) {
+          while (resultSet.next()) {
+            cnt++;
+          }
+          Assert.assertEquals(pointCnt, cnt);
         }
-        Assert.assertEquals(1, cnt);
-      }
 
-      cnt = 0;
-      try (ResultSet resultSet =
-          statement.executeQuery("SELECT text FROM root.sg1.d1 where text = '\'")) {
-        while (resultSet.next()) {
-          cnt++;
+        cnt = 0;
+        try (ResultSet resultSet =
+            statement.executeQuery("SELECT sin(`1`) + 1 FROM root.sg1.d1 where `1`>1")) {
+          while (resultSet.next()) {
+            cnt++;
+          }
+          Assert.assertEquals(1, cnt);
         }
-        Assert.assertEquals(0, cnt);
-      }
 
-      cnt = 0;
-      try (ResultSet resultSet =
-          statement.executeQuery(
-              "SELECT text FROM root.sg1.d1 where text = '\' or text = 'asdf'")) {
-        while (resultSet.next()) {
-          cnt++;
+        cnt = 0;
+        try (ResultSet resultSet =
+            statement.executeQuery("SELECT text FROM root.sg1.d1 where text = '\'")) {
+          while (resultSet.next()) {
+            cnt++;
+          }
+          Assert.assertEquals(0, cnt);
         }
-        Assert.assertEquals(0, cnt);
-      }
 
-      cnt = 0;
-      try (ResultSet resultSet =
-          statement.executeQuery("SELECT text FROM root.sg1.d1 where text = '\\'")) {
-        while (resultSet.next()) {
-          cnt++;
+        cnt = 0;
+        try (ResultSet resultSet =
+            statement.executeQuery(
+                "SELECT text FROM root.sg1.d1 where text = '\' or text = 'asdf'")) {
+          while (resultSet.next()) {
+            cnt++;
+          }
+          Assert.assertEquals(0, cnt);
         }
-        Assert.assertEquals(0, cnt);
-      }
 
-      cnt = 0;
-      try (ResultSet resultSet =
-          statement.executeQuery(
-              "SELECT text FROM root.sg1.d1 where text = '\\' and text = 'asdf'")) {
-        while (resultSet.next()) {
-          cnt++;
+        cnt = 0;
+        try (ResultSet resultSet =
+            statement.executeQuery("SELECT text FROM root.sg1.d1 where text = '\\'")) {
+          while (resultSet.next()) {
+            cnt++;
+          }
+          Assert.assertEquals(0, cnt);
         }
-        Assert.assertEquals(0, cnt);
+
+        cnt = 0;
+        try (ResultSet resultSet =
+            statement.executeQuery(
+                "SELECT text FROM root.sg1.d1 where text = '\\' and text = 'asdf'")) {
+          while (resultSet.next()) {
+            cnt++;
+          }
+          Assert.assertEquals(0, cnt);
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
       }
     } catch (SQLException e) {
       e.printStackTrace();
@@ -535,24 +559,29 @@ public class IoTDBSyntaxConventionIdentifierIT {
 
   @Test
   public void testUDFName() {
+    String[] udfNames = {"udf", "`udf.test`", "`012`", "`udf```"};
+    String[] resultNames = {"udf", "udf.test", "012", "udf`"};
+
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      String[] udfNames = {"udf", "`udf.test`", "`012`", "`udf```"};
-
-      String[] resultNames = {"udf", "udf.test", "012", "udf`"};
-
-      String createSql = "create function %s as 'org.apache.iotdb.db.query.udf.example.Adder'";
-      for (String udfName : udfNames) {
-        statement.execute(String.format(createSql, udfName));
-      }
-      try (ResultSet resultSet = statement.executeQuery("show functions")) {
-        Set<String> expectedResult = new HashSet<>(Arrays.asList(resultNames));
-        while (resultSet.next()) {
-          if (resultSet.getString(2).equals("external UDTF")) {
-            String udf = resultSet.getString(1).toLowerCase();
-            Assert.assertTrue(expectedResult.contains(udf));
-            expectedResult.remove(udf);
+      try {
+        String createSql = "create function %s as 'org.apache.iotdb.db.query.udf.example.Adder'";
+        for (String udfName : udfNames) {
+          statement.execute(String.format(createSql, udfName));
+        }
+        try (ResultSet resultSet = statement.executeQuery("show functions")) {
+          Set<String> expectedResult = new HashSet<>(Arrays.asList(resultNames));
+          while (resultSet.next()) {
+            if (resultSet.getString(2).equals("external UDTF")) {
+              String udf = resultSet.getString(1).toLowerCase();
+              Assert.assertTrue(expectedResult.contains(udf));
+              expectedResult.remove(udf);
+            }
           }
+        }
+      } finally {
+        for (String udfName : udfNames) {
+          executeQuietly(statement, String.format("drop function %s", udfName));
         }
       }
     } catch (SQLException e) {
@@ -603,23 +632,29 @@ public class IoTDBSyntaxConventionIdentifierIT {
 
   @Test
   public void testUserName() {
+    String[] userNames = new String[] {"userid", "userid0", "user_id", "user0id", "`a22233`"};
+
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      String[] userNames = new String[] {"userid", "userid0", "user_id", "user0id", "`a22233`"};
+      try {
+        String[] resultNames =
+            new String[] {"root", "userid", "userid0", "user_id", "user0id", "a22233"};
 
-      String[] resultNames =
-          new String[] {"root", "userid", "userid0", "user_id", "user0id", "a22233"};
-
-      String createUsersSql = "create user %s 'pwd123123456' ";
-      for (String userName : userNames) {
-        statement.execute(String.format(createUsersSql, userName));
-      }
-      Set<String> expectedResult = new HashSet<>(Arrays.asList(resultNames));
-      try (ResultSet resultSet = statement.executeQuery("list user")) {
-        while (resultSet.next()) {
-          String user = resultSet.getString(ColumnHeaderConstant.USER).toLowerCase();
-          Assert.assertTrue(expectedResult.contains(user));
-          expectedResult.remove(user);
+        String createUsersSql = "create user %s 'pwd123123456' ";
+        for (String userName : userNames) {
+          statement.execute(String.format(createUsersSql, userName));
+        }
+        Set<String> expectedResult = new HashSet<>(Arrays.asList(resultNames));
+        try (ResultSet resultSet = statement.executeQuery("list user")) {
+          while (resultSet.next()) {
+            String user = resultSet.getString(ColumnHeaderConstant.USER).toLowerCase();
+            Assert.assertTrue(expectedResult.contains(user));
+            expectedResult.remove(user);
+          }
+        }
+      } finally {
+        for (String userName : userNames) {
+          executeQuietly(statement, String.format("drop user %s", userName));
         }
       }
     } catch (SQLException e) {
@@ -668,21 +703,27 @@ public class IoTDBSyntaxConventionIdentifierIT {
 
   @Test
   public void testRoleName() {
+    String[] roleNames = new String[] {"roleid", "roleid0", "role_id", "role0id", "`a22233`"};
+
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      String[] roleNames = new String[] {"roleid", "roleid0", "role_id", "role0id", "`a22233`"};
-
-      String[] resultNames = new String[] {"roleid", "roleid0", "role_id", "role0id", "a22233"};
-      String createRolesSql = "create role %s";
-      for (String roleName : roleNames) {
-        statement.execute(String.format(createRolesSql, roleName));
-      }
-      Set<String> expectedResult = new HashSet<>(Arrays.asList(resultNames));
-      try (ResultSet resultSet = statement.executeQuery("list role")) {
-        while (resultSet.next()) {
-          String role = resultSet.getString(ColumnHeaderConstant.ROLE).toLowerCase();
-          Assert.assertTrue(expectedResult.contains(role));
-          expectedResult.remove(role);
+      try {
+        String[] resultNames = new String[] {"roleid", "roleid0", "role_id", "role0id", "a22233"};
+        String createRolesSql = "create role %s";
+        for (String roleName : roleNames) {
+          statement.execute(String.format(createRolesSql, roleName));
+        }
+        Set<String> expectedResult = new HashSet<>(Arrays.asList(resultNames));
+        try (ResultSet resultSet = statement.executeQuery("list role")) {
+          while (resultSet.next()) {
+            String role = resultSet.getString(ColumnHeaderConstant.ROLE).toLowerCase();
+            Assert.assertTrue(expectedResult.contains(role));
+            expectedResult.remove(role);
+          }
+        }
+      } finally {
+        for (String roleName : roleNames) {
+          executeQuietly(statement, String.format("drop role %s", roleName));
         }
       }
     } catch (SQLException e) {
@@ -937,21 +978,27 @@ public class IoTDBSyntaxConventionIdentifierIT {
 
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      for (String templateName : templateNames) {
-        String createTemplateSql =
-            String.format(
-                "create device template %s (temperature FLOAT encoding=RLE, status BOOLEAN encoding=PLAIN compression=SNAPPY)",
-                templateName);
-        statement.execute(createTemplateSql);
-      }
-
-      try (ResultSet resultSet = statement.executeQuery("SHOW DEVICE TEMPLATES")) {
-        Set<String> expectedResult = new HashSet<>(Arrays.asList(resultNames));
-        while (resultSet.next()) {
-          Assert.assertTrue(expectedResult.contains(resultSet.getString("TemplateName")));
-          expectedResult.remove(resultSet.getString("TemplateName"));
+      try {
+        for (String templateName : templateNames) {
+          String createTemplateSql =
+              String.format(
+                  "create device template %s (temperature FLOAT encoding=RLE, status BOOLEAN encoding=PLAIN compression=SNAPPY)",
+                  templateName);
+          statement.execute(createTemplateSql);
         }
-        Assert.assertEquals(0, expectedResult.size());
+
+        try (ResultSet resultSet = statement.executeQuery("SHOW DEVICE TEMPLATES")) {
+          Set<String> expectedResult = new HashSet<>(Arrays.asList(resultNames));
+          while (resultSet.next()) {
+            Assert.assertTrue(expectedResult.contains(resultSet.getString("TemplateName")));
+            expectedResult.remove(resultSet.getString("TemplateName"));
+          }
+          Assert.assertEquals(0, expectedResult.size());
+        }
+      } finally {
+        for (String templateName : templateNames) {
+          executeQuietly(statement, String.format("drop device template %s", templateName));
+        }
       }
     } catch (SQLException e) {
       e.printStackTrace();
@@ -1013,35 +1060,39 @@ public class IoTDBSyntaxConventionIdentifierIT {
   public void testNodeNameWithWildcard() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("CREATE TIMESERIES root.sg.device_123.s1 INT32");
+      try {
+        statement.execute("CREATE TIMESERIES root.sg.device_123.s1 INT32");
 
-      try (ResultSet resultSet = statement.executeQuery("SHOW DEVICES root.sg.device_123")) {
-        Assert.assertTrue(resultSet.next());
-        Assert.assertFalse(resultSet.next());
-      }
-      try (ResultSet resultSet = statement.executeQuery("SHOW DEVICES root.sg.device_*")) {
-        Assert.assertTrue(resultSet.next());
-        Assert.assertFalse(resultSet.next());
-      }
-      try (ResultSet resultSet = statement.executeQuery("SHOW DEVICES root.sg.*_123")) {
-        Assert.assertTrue(resultSet.next());
-        Assert.assertFalse(resultSet.next());
-      }
-      try (ResultSet resultSet = statement.executeQuery("SHOW DEVICES root.sg.*123")) {
-        Assert.assertTrue(resultSet.next());
-        Assert.assertFalse(resultSet.next());
-      }
-      try (ResultSet resultSet = statement.executeQuery("SHOW DEVICES root.sg.*_12*")) {
-        Assert.assertTrue(resultSet.next());
-        Assert.assertFalse(resultSet.next());
-      }
-      try (ResultSet resultSet = statement.executeQuery("SHOW DEVICES root.sg.*12*")) {
-        Assert.assertTrue(resultSet.next());
-        Assert.assertFalse(resultSet.next());
-      }
-      try (ResultSet resultSet = statement.executeQuery("SHOW DEVICES root.sg.*e*")) {
-        Assert.assertTrue(resultSet.next());
-        Assert.assertFalse(resultSet.next());
+        try (ResultSet resultSet = statement.executeQuery("SHOW DEVICES root.sg.device_123")) {
+          Assert.assertTrue(resultSet.next());
+          Assert.assertFalse(resultSet.next());
+        }
+        try (ResultSet resultSet = statement.executeQuery("SHOW DEVICES root.sg.device_*")) {
+          Assert.assertTrue(resultSet.next());
+          Assert.assertFalse(resultSet.next());
+        }
+        try (ResultSet resultSet = statement.executeQuery("SHOW DEVICES root.sg.*_123")) {
+          Assert.assertTrue(resultSet.next());
+          Assert.assertFalse(resultSet.next());
+        }
+        try (ResultSet resultSet = statement.executeQuery("SHOW DEVICES root.sg.*123")) {
+          Assert.assertTrue(resultSet.next());
+          Assert.assertFalse(resultSet.next());
+        }
+        try (ResultSet resultSet = statement.executeQuery("SHOW DEVICES root.sg.*_12*")) {
+          Assert.assertTrue(resultSet.next());
+          Assert.assertFalse(resultSet.next());
+        }
+        try (ResultSet resultSet = statement.executeQuery("SHOW DEVICES root.sg.*12*")) {
+          Assert.assertTrue(resultSet.next());
+          Assert.assertFalse(resultSet.next());
+        }
+        try (ResultSet resultSet = statement.executeQuery("SHOW DEVICES root.sg.*e*")) {
+          Assert.assertTrue(resultSet.next());
+          Assert.assertFalse(resultSet.next());
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg");
       }
     } catch (SQLException e) {
       e.printStackTrace();

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBSyntaxConventionStringLiteralIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBSyntaxConventionStringLiteralIT.java
@@ -29,9 +29,9 @@ import org.apache.iotdb.itbase.constant.BuiltinTimeSeriesGeneratingFunctionEnum;
 import org.apache.iotdb.itbase.constant.TestConstant;
 import org.apache.iotdb.rpc.TSStatusCode;
 
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -49,15 +49,23 @@ import static org.junit.Assert.fail;
 @Category({LocalStandaloneIT.class, ClusterIT.class})
 public class IoTDBSyntaxConventionStringLiteralIT {
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     EnvFactory.getEnv().getConfig().getCommonConfig().setEnforceStrongPassword(false);
     EnvFactory.getEnv().initClusterEnvironment();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  private static void executeQuietly(Statement statement, String sql) {
+    try {
+      statement.execute(sql);
+    } catch (SQLException ignored) {
+      // ignore cleanup errors
+    }
   }
 
   /** Legal cases of using StringLiteral with single quote in insert and select clause. */
@@ -89,29 +97,32 @@ public class IoTDBSyntaxConventionStringLiteralIT {
 
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("CREATE TIMESERIES root.sg1.d1.s1 TEXT");
-      for (int i = 0; i < insertData.length; i++) {
-        String insertSql =
-            String.format("INSERT INTO root.sg1.d1(time, s1) values (%d, %s)", i, insertData[i]);
-        statement.execute(insertSql);
-      }
-
-      try (ResultSet resultSet = statement.executeQuery("SELECT s1 FROM root.sg1.d1")) {
-        int cnt = 0;
-        while (resultSet.next()) {
-          Assert.assertEquals(resultData[cnt], resultSet.getString("root.sg1.d1.s1"));
-          cnt++;
+      try {
+        statement.execute("CREATE TIMESERIES root.sg1.d1.s1 TEXT");
+        for (int i = 0; i < insertData.length; i++) {
+          String insertSql =
+              String.format("INSERT INTO root.sg1.d1(time, s1) values (%d, %s)", i, insertData[i]);
+          statement.execute(insertSql);
         }
-        Assert.assertEquals(insertData.length, cnt);
-      }
 
-      for (String insertDatum : insertData) {
-        String querySql = String.format("SELECT s1 FROM root.sg1.d1 WHERE s1 = %s", insertDatum);
-        try (ResultSet resultSet = statement.executeQuery(querySql)) {
-          Assert.assertTrue(resultSet.next());
+        try (ResultSet resultSet = statement.executeQuery("SELECT s1 FROM root.sg1.d1")) {
+          int cnt = 0;
+          while (resultSet.next()) {
+            Assert.assertEquals(resultData[cnt], resultSet.getString("root.sg1.d1.s1"));
+            cnt++;
+          }
+          Assert.assertEquals(insertData.length, cnt);
         }
-      }
 
+        for (String insertDatum : insertData) {
+          String querySql = String.format("SELECT s1 FROM root.sg1.d1 WHERE s1 = %s", insertDatum);
+          try (ResultSet resultSet = statement.executeQuery(querySql)) {
+            Assert.assertTrue(resultSet.next());
+          }
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
+      }
     } catch (SQLException e) {
       e.printStackTrace();
       fail();
@@ -147,29 +158,32 @@ public class IoTDBSyntaxConventionStringLiteralIT {
 
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("CREATE TIMESERIES root.sg1.d1.s1 TEXT");
-      for (int i = 0; i < insertData.length; i++) {
-        String insertSql =
-            String.format("INSERT INTO root.sg1.d1(time, s1) values (%d, %s)", i, insertData[i]);
-        statement.execute(insertSql);
-      }
-
-      try (ResultSet resultSet = statement.executeQuery("SELECT s1 FROM root.sg1.d1")) {
-        int cnt = 0;
-        while (resultSet.next()) {
-          Assert.assertEquals(resultData[cnt], resultSet.getString("root.sg1.d1.s1"));
-          cnt++;
+      try {
+        statement.execute("CREATE TIMESERIES root.sg1.d1.s1 TEXT");
+        for (int i = 0; i < insertData.length; i++) {
+          String insertSql =
+              String.format("INSERT INTO root.sg1.d1(time, s1) values (%d, %s)", i, insertData[i]);
+          statement.execute(insertSql);
         }
-        Assert.assertEquals(insertData.length, cnt);
-      }
 
-      for (String insertDatum : insertData) {
-        String querySql = String.format("SELECT s1 FROM root.sg1.d1 WHERE s1 = %s", insertDatum);
-        try (ResultSet resultSet = statement.executeQuery(querySql)) {
-          Assert.assertTrue(resultSet.next());
+        try (ResultSet resultSet = statement.executeQuery("SELECT s1 FROM root.sg1.d1")) {
+          int cnt = 0;
+          while (resultSet.next()) {
+            Assert.assertEquals(resultData[cnt], resultSet.getString("root.sg1.d1.s1"));
+            cnt++;
+          }
+          Assert.assertEquals(insertData.length, cnt);
         }
-      }
 
+        for (String insertDatum : insertData) {
+          String querySql = String.format("SELECT s1 FROM root.sg1.d1 WHERE s1 = %s", insertDatum);
+          try (ResultSet resultSet = statement.executeQuery(querySql)) {
+            Assert.assertTrue(resultSet.next());
+          }
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
+      }
     } catch (SQLException e) {
       e.printStackTrace();
       fail();
@@ -178,62 +192,71 @@ public class IoTDBSyntaxConventionStringLiteralIT {
 
   @Test
   public void testStringLiteralIllegalCase() {
-    String errorMsg =
-        TSStatusCode.SQL_PARSE_ERROR.getStatusCode()
-            + ": Error occurred while parsing SQL to physical plan: "
-            + "line 1:45 mismatched input 'string' expecting {FALSE, NAN, NOW, NULL, TRUE, '-', '+', '/', '.', STRING_LITERAL, BINARY_LITERAL, DATETIME_LITERAL, INTEGER_LITERAL, EXPONENT_NUM_PART}";
-    try (Connection connection = EnvFactory.getEnv().getConnection();
-        Statement statement = connection.createStatement()) {
-      statement.execute("CREATE TIMESERIES root.sg1.d1.s1 TEXT");
-    } catch (SQLException e) {
-      fail(e.getMessage());
-    }
-    // without ' or "
-    try (Connection connection = EnvFactory.getEnv().getConnection();
-        Statement statement = connection.createStatement()) {
-      statement.execute("INSERT INTO root.sg1.d1(time, s1) values (1, string)");
-      fail();
-    } catch (SQLException e) {
-      Assert.assertEquals(errorMsg, e.getMessage());
-    }
+    try {
+      String errorMsg =
+          TSStatusCode.SQL_PARSE_ERROR.getStatusCode()
+              + ": Error occurred while parsing SQL to physical plan: "
+              + "line 1:45 mismatched input 'string' expecting {FALSE, NAN, NOW, NULL, TRUE, '-', '+', '/', '.', STRING_LITERAL, BINARY_LITERAL, DATETIME_LITERAL, INTEGER_LITERAL, EXPONENT_NUM_PART}";
+      try (Connection connection = EnvFactory.getEnv().getConnection();
+          Statement statement = connection.createStatement()) {
+        statement.execute("CREATE TIMESERIES root.sg1.d1.s1 TEXT");
+      } catch (SQLException e) {
+        fail(e.getMessage());
+      }
+      // without ' or "
+      try (Connection connection = EnvFactory.getEnv().getConnection();
+          Statement statement = connection.createStatement()) {
+        statement.execute("INSERT INTO root.sg1.d1(time, s1) values (1, string)");
+        fail();
+      } catch (SQLException e) {
+        Assert.assertEquals(errorMsg, e.getMessage());
+      }
 
-    String errorMsg1 =
-        TSStatusCode.SQL_PARSE_ERROR.getStatusCode()
-            + ": Error occurred while parsing SQL to physical plan: "
-            + "line 1:45 mismatched input '`string`' expecting {FALSE, NAN, NOW, NULL, TRUE, '-', '+', '/', '.', STRING_LITERAL, BINARY_LITERAL, DATETIME_LITERAL, INTEGER_LITERAL, EXPONENT_NUM_PART}";
-    try (Connection connection = EnvFactory.getEnv().getConnection();
-        Statement statement = connection.createStatement()) {
-      // wrap STRING_LITERAL with ``
-      statement.execute("INSERT INTO root.sg1.d1(time, s1) values (1, `string`)");
-      fail();
-    } catch (SQLException e) {
-      Assert.assertEquals(errorMsg1, e.getMessage());
-    }
+      String errorMsg1 =
+          TSStatusCode.SQL_PARSE_ERROR.getStatusCode()
+              + ": Error occurred while parsing SQL to physical plan: "
+              + "line 1:45 mismatched input '`string`' expecting {FALSE, NAN, NOW, NULL, TRUE, '-', '+', '/', '.', STRING_LITERAL, BINARY_LITERAL, DATETIME_LITERAL, INTEGER_LITERAL, EXPONENT_NUM_PART}";
+      try (Connection connection = EnvFactory.getEnv().getConnection();
+          Statement statement = connection.createStatement()) {
+        // wrap STRING_LITERAL with ``
+        statement.execute("INSERT INTO root.sg1.d1(time, s1) values (1, `string`)");
+        fail();
+      } catch (SQLException e) {
+        Assert.assertEquals(errorMsg1, e.getMessage());
+      }
 
-    String errorMsg2 =
-        TSStatusCode.SQL_PARSE_ERROR.getStatusCode()
-            + ": Error occurred while parsing SQL to physical plan: "
-            + "line 1:47 extraneous input 'string' expecting {',', ')'}";
-    try (Connection connection = EnvFactory.getEnv().getConnection();
-        Statement statement = connection.createStatement()) {
-      // single ' in ''
-      statement.execute("INSERT INTO root.sg1.d1(time, s1) values (1, ''string')");
-      fail();
-    } catch (SQLException e) {
-      Assert.assertEquals(errorMsg2, e.getMessage());
-    }
+      String errorMsg2 =
+          TSStatusCode.SQL_PARSE_ERROR.getStatusCode()
+              + ": Error occurred while parsing SQL to physical plan: "
+              + "line 1:47 extraneous input 'string' expecting {',', ')'}";
+      try (Connection connection = EnvFactory.getEnv().getConnection();
+          Statement statement = connection.createStatement()) {
+        // single ' in ''
+        statement.execute("INSERT INTO root.sg1.d1(time, s1) values (1, ''string')");
+        fail();
+      } catch (SQLException e) {
+        Assert.assertEquals(errorMsg2, e.getMessage());
+      }
 
-    String errorMsg3 =
-        TSStatusCode.SQL_PARSE_ERROR.getStatusCode()
-            + ": Error occurred while parsing SQL to physical plan: "
-            + "line 1:47 extraneous input 'string' expecting {',', ')'}";
-    try (Connection connection = EnvFactory.getEnv().getConnection();
-        Statement statement = connection.createStatement()) {
-      // single " in ""
-      statement.execute("INSERT INTO root.sg1.d1(time, s1) values (1, \"\"string\")");
-      fail();
-    } catch (SQLException e) {
-      Assert.assertEquals(errorMsg3, e.getMessage());
+      String errorMsg3 =
+          TSStatusCode.SQL_PARSE_ERROR.getStatusCode()
+              + ": Error occurred while parsing SQL to physical plan: "
+              + "line 1:47 extraneous input 'string' expecting {',', ')'}";
+      try (Connection connection = EnvFactory.getEnv().getConnection();
+          Statement statement = connection.createStatement()) {
+        // single " in ""
+        statement.execute("INSERT INTO root.sg1.d1(time, s1) values (1, \"\"string\")");
+        fail();
+      } catch (SQLException e) {
+        Assert.assertEquals(errorMsg3, e.getMessage());
+      }
+    } finally {
+      try (Connection connection = EnvFactory.getEnv().getConnection();
+          Statement statement = connection.createStatement()) {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
+      } catch (SQLException ignored) {
+        // ignore cleanup errors
+      }
     }
   }
 
@@ -281,121 +304,149 @@ public class IoTDBSyntaxConventionStringLiteralIT {
 
   @Test
   public void testUserPassword() {
-    String errorMsg =
-        TSStatusCode.SQL_PARSE_ERROR.getStatusCode()
-            + ": Error occurred while parsing SQL to physical plan: "
-            + "line 1:18 mismatched input 'test123456789' expecting STRING_LITERAL";
-    try (Connection connection = EnvFactory.getEnv().getConnection();
-        Statement statement = connection.createStatement()) {
-      statement.execute("CREATE USER test1 'test123456789'");
-      // password should be STRING_LITERAL
-      statement.execute("CREATE USER test1 test123456789");
-      fail();
-    } catch (SQLException e) {
-      Assert.assertEquals(errorMsg, e.getMessage());
-    }
+    try {
+      String errorMsg =
+          TSStatusCode.SQL_PARSE_ERROR.getStatusCode()
+              + ": Error occurred while parsing SQL to physical plan: "
+              + "line 1:18 mismatched input 'test123456789' expecting STRING_LITERAL";
+      try (Connection connection = EnvFactory.getEnv().getConnection();
+          Statement statement = connection.createStatement()) {
+        statement.execute("CREATE USER test1 'test123456789'");
+        // password should be STRING_LITERAL
+        statement.execute("CREATE USER test1 test123456789");
+        fail();
+      } catch (SQLException e) {
+        Assert.assertEquals(errorMsg, e.getMessage());
+      }
 
-    String errorMsg1 =
-        TSStatusCode.SQL_PARSE_ERROR.getStatusCode()
-            + ": Error occurred while parsing SQL to physical plan: "
-            + "line 1:17 mismatched input '`test123456789`' expecting STRING_LITERAL";
-    try (Connection connection = EnvFactory.getEnv().getConnection();
-        Statement statement = connection.createStatement()) {
-      statement.execute("CREATE USER test \"test123456789\"");
-      // password should be STRING_LITERAL
-      statement.execute("CREATE USER test `test123456789`");
-      fail();
-    } catch (SQLException e) {
-      Assert.assertEquals(errorMsg1, e.getMessage());
+      String errorMsg1 =
+          TSStatusCode.SQL_PARSE_ERROR.getStatusCode()
+              + ": Error occurred while parsing SQL to physical plan: "
+              + "line 1:17 mismatched input '`test123456789`' expecting STRING_LITERAL";
+      try (Connection connection = EnvFactory.getEnv().getConnection();
+          Statement statement = connection.createStatement()) {
+        statement.execute("CREATE USER test \"test123456789\"");
+        // password should be STRING_LITERAL
+        statement.execute("CREATE USER test `test123456789`");
+        fail();
+      } catch (SQLException e) {
+        Assert.assertEquals(errorMsg1, e.getMessage());
+      }
+    } finally {
+      try (Connection connection = EnvFactory.getEnv().getConnection();
+          Statement statement = connection.createStatement()) {
+        executeQuietly(statement, "DROP USER test1");
+        executeQuietly(statement, "DROP USER test");
+      } catch (SQLException ignored) {
+        // ignore cleanup errors
+      }
     }
   }
 
   @Test
   public void testUDFClassName() {
-    String errorMsg =
-        TSStatusCode.SQL_PARSE_ERROR.getStatusCode()
-            + ": Error occurred while parsing SQL to physical plan: "
-            + "line 1:23 mismatched input 'org' expecting STRING_LITERAL";
-    try (Connection connection = EnvFactory.getEnv().getConnection();
-        Statement statement = connection.createStatement()) {
-      // udf class name should be STRING_LITERAL
-      statement.execute("create function udf as 'org.apache.iotdb.db.query.udf.example.Adder'");
+    try {
+      String errorMsg =
+          TSStatusCode.SQL_PARSE_ERROR.getStatusCode()
+              + ": Error occurred while parsing SQL to physical plan: "
+              + "line 1:23 mismatched input 'org' expecting STRING_LITERAL";
+      try (Connection connection = EnvFactory.getEnv().getConnection();
+          Statement statement = connection.createStatement()) {
+        // udf class name should be STRING_LITERAL
+        statement.execute("create function udf as 'org.apache.iotdb.db.query.udf.example.Adder'");
 
-      // executed correctly
-      try (ResultSet resultSet = statement.executeQuery("show functions")) {
-        assertEquals(4, resultSet.getMetaData().getColumnCount());
-        int count = 0;
-        while (resultSet.next()) {
-          StringBuilder stringBuilder = new StringBuilder();
-          for (int i = 1; i <= resultSet.getMetaData().getColumnCount(); ++i) {
-            stringBuilder.append(resultSet.getString(i)).append(",");
+        // executed correctly
+        try (ResultSet resultSet = statement.executeQuery("show functions")) {
+          assertEquals(4, resultSet.getMetaData().getColumnCount());
+          int count = 0;
+          while (resultSet.next()) {
+            StringBuilder stringBuilder = new StringBuilder();
+            for (int i = 1; i <= resultSet.getMetaData().getColumnCount(); ++i) {
+              stringBuilder.append(resultSet.getString(i)).append(",");
+            }
+            String result = stringBuilder.toString();
+            if (result.contains(TestConstant.FUNCTION_TYPE_NATIVE)) {
+              continue;
+            }
+            ++count;
           }
-          String result = stringBuilder.toString();
-          if (result.contains(TestConstant.FUNCTION_TYPE_NATIVE)) {
-            continue;
-          }
-          ++count;
+          Assert.assertEquals(
+              1
+                  + BuiltinTimeSeriesGeneratingFunctionEnum.values().length
+                  + BuiltinScalarFunctionEnum.values().length,
+              count);
         }
-        Assert.assertEquals(
-            1
-                + BuiltinTimeSeriesGeneratingFunctionEnum.values().length
-                + BuiltinScalarFunctionEnum.values().length,
-            count);
+        statement.execute("drop function udf");
+
+        // without '' or ""
+        statement.execute("create function udf as org.apache.iotdb.db.query.udf.example.Adder");
+        fail();
+      } catch (SQLException e) {
+        Assert.assertEquals(errorMsg, e.getMessage());
       }
-      statement.execute("drop function udf");
 
-      // without '' or ""
-      statement.execute("create function udf as org.apache.iotdb.db.query.udf.example.Adder");
-      fail();
-    } catch (SQLException e) {
-      Assert.assertEquals(errorMsg, e.getMessage());
-    }
-
-    // Illegal name with back quote
-    String errorMsg1 =
-        TSStatusCode.SQL_PARSE_ERROR.getStatusCode()
-            + ": Error occurred while parsing SQL to physical plan: "
-            + "line 1:23 mismatched input '`org.apache.iotdb.db.query.udf.example.Adder`' "
-            + "expecting STRING_LITERAL";
-    try (Connection connection = EnvFactory.getEnv().getConnection();
-        Statement statement = connection.createStatement()) {
-      // udf class name should be STRING_LITERAL
-      statement.execute("create function udf as `org.apache.iotdb.db.query.udf.example.Adder`");
-      fail();
-    } catch (SQLException e) {
-      Assert.assertEquals(errorMsg1, e.getMessage());
+      // Illegal name with back quote
+      String errorMsg1 =
+          TSStatusCode.SQL_PARSE_ERROR.getStatusCode()
+              + ": Error occurred while parsing SQL to physical plan: "
+              + "line 1:23 mismatched input '`org.apache.iotdb.db.query.udf.example.Adder`' "
+              + "expecting STRING_LITERAL";
+      try (Connection connection = EnvFactory.getEnv().getConnection();
+          Statement statement = connection.createStatement()) {
+        // udf class name should be STRING_LITERAL
+        statement.execute("create function udf as `org.apache.iotdb.db.query.udf.example.Adder`");
+        fail();
+      } catch (SQLException e) {
+        Assert.assertEquals(errorMsg1, e.getMessage());
+      }
+    } finally {
+      try (Connection connection = EnvFactory.getEnv().getConnection();
+          Statement statement = connection.createStatement()) {
+        executeQuietly(statement, "drop function udf");
+      } catch (SQLException ignored) {
+        // ignore cleanup errors
+      }
     }
   }
 
   @Test
   public void testUDFAttribute() {
-    try (Connection connection = EnvFactory.getEnv().getConnection();
-        Statement statement = connection.createStatement()) {
-      statement.execute("CREATE TIMESERIES root.vehicle.d1.s1 FLOAT");
-      statement.execute("INSERT INTO root.vehicle.d1(time,s1) values (1,2.0),(2,3.0)");
+    try {
+      try (Connection connection = EnvFactory.getEnv().getConnection();
+          Statement statement = connection.createStatement()) {
+        statement.execute("CREATE TIMESERIES root.vehicle.d1.s1 FLOAT");
+        statement.execute("INSERT INTO root.vehicle.d1(time,s1) values (1,2.0),(2,3.0)");
 
-      try (ResultSet resultSet =
-          statement.executeQuery("select bottom_k(s1,'k' = '1') from root.vehicle.d1")) {
-        assertTrue(resultSet.next());
-        Assert.assertEquals("2.0", resultSet.getString(2));
+        try (ResultSet resultSet =
+            statement.executeQuery("select bottom_k(s1,'k' = '1') from root.vehicle.d1")) {
+          assertTrue(resultSet.next());
+          Assert.assertEquals("2.0", resultSet.getString(2));
+        }
+      } catch (SQLException e) {
+        e.printStackTrace();
+        fail();
       }
-    } catch (SQLException e) {
-      e.printStackTrace();
-      fail();
-    }
 
-    // Illegal attribute
-    String errorMsg =
-        TSStatusCode.SQL_PARSE_ERROR.getStatusCode()
-            + ": Error occurred while parsing SQL to physical plan: "
-            + "line 1:22 token recognition error at: '` = 1) from root.vehicle.d1'";
-    try (Connection connection = EnvFactory.getEnv().getConnection();
-        Statement statement = connection.createStatement()) {
-      // UDF attribute should be STRING_LITERAL
-      statement.executeQuery("select bottom_k(s1,``k` = 1) from root.vehicle.d1");
-      fail();
-    } catch (SQLException e) {
-      Assert.assertEquals(errorMsg, e.getMessage());
+      // Illegal attribute
+      String errorMsg =
+          TSStatusCode.SQL_PARSE_ERROR.getStatusCode()
+              + ": Error occurred while parsing SQL to physical plan: "
+              + "line 1:22 token recognition error at: '` = 1) from root.vehicle.d1'";
+      try (Connection connection = EnvFactory.getEnv().getConnection();
+          Statement statement = connection.createStatement()) {
+        // UDF attribute should be STRING_LITERAL
+        statement.executeQuery("select bottom_k(s1,``k` = 1) from root.vehicle.d1");
+        fail();
+      } catch (SQLException e) {
+        Assert.assertEquals(errorMsg, e.getMessage());
+      }
+    } finally {
+      try (Connection connection = EnvFactory.getEnv().getConnection();
+          Statement statement = connection.createStatement()) {
+        executeQuietly(statement, "DELETE DATABASE root.vehicle");
+      } catch (SQLException ignored) {
+        // ignore cleanup errors
+      }
     }
   }
 
@@ -403,32 +454,36 @@ public class IoTDBSyntaxConventionStringLiteralIT {
   public void testCreateTimeSeriesAttribute() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      // besides datatype,encoding,compression,compressor, attributes in create time series clause
-      // could be STRING_LITERAL
-      statement.execute(
-          "create timeseries root.vehicle.d1.s1 "
-              + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY");
-      statement.execute(
-          "create timeseries root.vehicle.d1.s2 "
-              + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY, max_point_number = 5");
-      statement.execute(
-          "create timeseries root.vehicle.d1.s3 "
-              + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY, 'max_point_number' = '5'");
-      statement.execute(
-          "create timeseries root.vehicle.d1.s4 "
-              + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY, max_point_number = '5'");
-      statement.execute(
-          "create timeseries root.vehicle.d1.s5 "
-              + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY, `max_point_number` = 5");
-      statement.execute(
-          "create timeseries root.vehicle.d1.s6 "
-              + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY, `max_point_number` = `5`");
-      try (ResultSet resultSet = statement.executeQuery("show timeseries root.vehicle.**")) {
-        int cnt = 0;
-        while (resultSet.next()) {
-          cnt++;
+      try {
+        // besides datatype,encoding,compression,compressor, attributes in create time series clause
+        // could be STRING_LITERAL
+        statement.execute(
+            "create timeseries root.vehicle.d1.s1 "
+                + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY");
+        statement.execute(
+            "create timeseries root.vehicle.d1.s2 "
+                + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY, max_point_number = 5");
+        statement.execute(
+            "create timeseries root.vehicle.d1.s3 "
+                + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY, 'max_point_number' = '5'");
+        statement.execute(
+            "create timeseries root.vehicle.d1.s4 "
+                + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY, max_point_number = '5'");
+        statement.execute(
+            "create timeseries root.vehicle.d1.s5 "
+                + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY, `max_point_number` = 5");
+        statement.execute(
+            "create timeseries root.vehicle.d1.s6 "
+                + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY, `max_point_number` = `5`");
+        try (ResultSet resultSet = statement.executeQuery("show timeseries root.vehicle.**")) {
+          int cnt = 0;
+          while (resultSet.next()) {
+            cnt++;
+          }
+          Assert.assertEquals(6, cnt);
         }
-        Assert.assertEquals(6, cnt);
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.vehicle");
       }
     } catch (SQLException e) {
       e.printStackTrace();
@@ -440,44 +495,48 @@ public class IoTDBSyntaxConventionStringLiteralIT {
   public void testCreateTimeSeriesTags() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute(
-          "create timeseries root.vehicle.d1.s1 "
-              + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY "
-              + "tags(tag1=v1)");
-      statement.execute(
-          "create timeseries root.vehicle.d1.s2 "
-              + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY "
-              + "tags(`tag1`=v1)");
-      statement.execute(
-          "create timeseries root.vehicle.d1.s3 "
-              + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY "
-              + "tags('tag1'=v1)");
-      statement.execute(
-          "create timeseries root.vehicle.d1.s4 "
-              + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY "
-              + "tags(\"tag1\"=v1)");
-      statement.execute(
-          "create timeseries root.vehicle.d1.s5 "
-              + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY "
-              + "tags(tag1=`v1`)");
-      statement.execute(
-          "create timeseries root.vehicle.d1.s6 "
-              + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY "
-              + "tags(tag1='v1')");
-      statement.execute(
-          "create timeseries root.vehicle.d1.s7 "
-              + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY "
-              + "tags(tag1=\"v1\")");
-      statement.execute(
-          "create timeseries root.vehicle.d1.s8 "
-              + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY "
-              + "tags(tag1=v1)");
-      try (ResultSet resultSet = statement.executeQuery("show timeseries root.vehicle.**")) {
-        int cnt = 0;
-        while (resultSet.next()) {
-          cnt++;
+      try {
+        statement.execute(
+            "create timeseries root.vehicle.d1.s1 "
+                + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY "
+                + "tags(tag1=v1)");
+        statement.execute(
+            "create timeseries root.vehicle.d1.s2 "
+                + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY "
+                + "tags(`tag1`=v1)");
+        statement.execute(
+            "create timeseries root.vehicle.d1.s3 "
+                + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY "
+                + "tags('tag1'=v1)");
+        statement.execute(
+            "create timeseries root.vehicle.d1.s4 "
+                + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY "
+                + "tags(\"tag1\"=v1)");
+        statement.execute(
+            "create timeseries root.vehicle.d1.s5 "
+                + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY "
+                + "tags(tag1=`v1`)");
+        statement.execute(
+            "create timeseries root.vehicle.d1.s6 "
+                + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY "
+                + "tags(tag1='v1')");
+        statement.execute(
+            "create timeseries root.vehicle.d1.s7 "
+                + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY "
+                + "tags(tag1=\"v1\")");
+        statement.execute(
+            "create timeseries root.vehicle.d1.s8 "
+                + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY "
+                + "tags(tag1=v1)");
+        try (ResultSet resultSet = statement.executeQuery("show timeseries root.vehicle.**")) {
+          int cnt = 0;
+          while (resultSet.next()) {
+            cnt++;
+          }
+          Assert.assertEquals(8, cnt);
         }
-        Assert.assertEquals(8, cnt);
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.vehicle");
       }
     } catch (SQLException e) {
       e.printStackTrace();
@@ -490,28 +549,32 @@ public class IoTDBSyntaxConventionStringLiteralIT {
 
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute(
-          "create timeseries root.vehicle.d1.s1 "
-              + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY "
-              + "attributes('attr1'='v1', 'attr2'='v2')");
-      statement.execute(
-          "create timeseries root.vehicle.d1.s2 "
-              + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY "
-              + "attributes(attr1=v1, attr2=v2)");
-      statement.execute(
-          "create timeseries root.vehicle.d1.s3 "
-              + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY "
-              + "attributes(`attr1`=`v1`, `attr2`=v2)");
-      statement.execute(
-          "create timeseries root.vehicle.d1.s4 "
-              + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY "
-              + "attributes('attr1'=v1, attr2=v2)");
-      try (ResultSet resultSet = statement.executeQuery("show timeseries root.vehicle.**")) {
-        int cnt = 0;
-        while (resultSet.next()) {
-          cnt++;
+      try {
+        statement.execute(
+            "create timeseries root.vehicle.d1.s1 "
+                + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY "
+                + "attributes('attr1'='v1', 'attr2'='v2')");
+        statement.execute(
+            "create timeseries root.vehicle.d1.s2 "
+                + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY "
+                + "attributes(attr1=v1, attr2=v2)");
+        statement.execute(
+            "create timeseries root.vehicle.d1.s3 "
+                + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY "
+                + "attributes(`attr1`=`v1`, `attr2`=v2)");
+        statement.execute(
+            "create timeseries root.vehicle.d1.s4 "
+                + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY "
+                + "attributes('attr1'=v1, attr2=v2)");
+        try (ResultSet resultSet = statement.executeQuery("show timeseries root.vehicle.**")) {
+          int cnt = 0;
+          while (resultSet.next()) {
+            cnt++;
+          }
+          Assert.assertEquals(4, cnt);
         }
-        Assert.assertEquals(4, cnt);
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.vehicle");
       }
     } catch (SQLException e) {
       e.printStackTrace();
@@ -531,24 +594,27 @@ public class IoTDBSyntaxConventionStringLiteralIT {
     };
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute(
-          "create timeseries root.sg.a "
-              + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY ");
-      statement.execute("insert into root.sg(time, a) values (1,1)");
-
-      String selectSql = "select a as %s from root.sg";
-      for (int i = 0; i < alias.length; i++) {
-        try (ResultSet resultSet = statement.executeQuery(String.format(selectSql, alias[i]))) {
-          Assert.assertEquals(res[i], resultSet.getMetaData().getColumnName(2));
-        }
-      }
-
       try {
-        statement.execute("select a as test.b from root.sg");
-        fail();
-      } catch (Exception ignored) {
-      }
+        statement.execute(
+            "create timeseries root.sg.a "
+                + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY ");
+        statement.execute("insert into root.sg(time, a) values (1,1)");
 
+        String selectSql = "select a as %s from root.sg";
+        for (int i = 0; i < alias.length; i++) {
+          try (ResultSet resultSet = statement.executeQuery(String.format(selectSql, alias[i]))) {
+            Assert.assertEquals(res[i], resultSet.getMetaData().getColumnName(2));
+          }
+        }
+
+        try {
+          statement.execute("select a as test.b from root.sg");
+          fail();
+        } catch (Exception ignored) {
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg");
+      }
     } catch (SQLException e) {
       e.printStackTrace();
       fail();
@@ -566,25 +632,28 @@ public class IoTDBSyntaxConventionStringLiteralIT {
     };
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute(
-          "create timeseries root.sg.a "
-              + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY ");
-
-      String alterSql = "ALTER timeseries root.sg.a UPSERT alias = %s";
-      for (int i = 0; i < alias.length; i++) {
-        statement.execute(String.format(alterSql, alias[i]));
-        try (ResultSet resultSet = statement.executeQuery("show timeseries")) {
-          resultSet.next();
-          Assert.assertEquals(res[i], resultSet.getString(ColumnHeaderConstant.ALIAS));
-        }
-      }
-
       try {
-        statement.execute("ALTER timeseries root.sg.a UPSERT alias = test.a");
-        fail();
-      } catch (Exception ignored) {
-      }
+        statement.execute(
+            "create timeseries root.sg.a "
+                + "with datatype=INT64, encoding=PLAIN, compression=SNAPPY ");
 
+        String alterSql = "ALTER timeseries root.sg.a UPSERT alias = %s";
+        for (int i = 0; i < alias.length; i++) {
+          statement.execute(String.format(alterSql, alias[i]));
+          try (ResultSet resultSet = statement.executeQuery("show timeseries")) {
+            resultSet.next();
+            Assert.assertEquals(res[i], resultSet.getString(ColumnHeaderConstant.ALIAS));
+          }
+        }
+
+        try {
+          statement.execute("ALTER timeseries root.sg.a UPSERT alias = test.a");
+          fail();
+        } catch (Exception ignored) {
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg");
+      }
     } catch (SQLException e) {
       e.printStackTrace();
       fail();

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBTimeZoneIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBTimeZoneIT.java
@@ -24,9 +24,9 @@ import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 import org.apache.iotdb.itbase.category.RemoteIT;
 
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -68,14 +68,14 @@ public class IoTDBTimeZoneIT {
         "1514789200000,6",
       };
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     EnvFactory.getEnv().initClusterEnvironment();
     createTimeseries();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
   }
 
@@ -141,7 +141,7 @@ public class IoTDBTimeZoneIT {
     }
   }
 
-  private void createTimeseries() {
+  private static void createTimeseries() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
 

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/aggregation/IoTDBAggregationDeleteIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/aggregation/IoTDBAggregationDeleteIT.java
@@ -23,8 +23,8 @@ import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -52,15 +52,15 @@ public class IoTDBAggregationDeleteIT {
         "delete from root.turbine.d1.s1 where time < 3"
       };
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     EnvFactory.getEnv().getConfig().getCommonConfig().setPartitionInterval(1000);
     EnvFactory.getEnv().initClusterEnvironment();
     prepareData();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
   }
 
@@ -80,7 +80,7 @@ public class IoTDBAggregationDeleteIT {
     }
   }
 
-  private void prepareData() throws SQLException {
+  private static void prepareData() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
 

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBAlignedMemQueryIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBAlignedMemQueryIT.java
@@ -21,8 +21,8 @@ package org.apache.iotdb.db.it.aligned;
 
 import org.apache.iotdb.it.env.EnvFactory;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.sql.Connection;
@@ -35,8 +35,8 @@ import static org.junit.Assert.assertEquals;
 
 public class IoTDBAlignedMemQueryIT {
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     Locale.setDefault(Locale.ENGLISH);
     EnvFactory.getEnv()
         .getConfig()
@@ -46,8 +46,8 @@ public class IoTDBAlignedMemQueryIT {
     EnvFactory.getEnv().initClusterEnvironment();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
   }
 

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBInsertAlignedValues2IT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBInsertAlignedValues2IT.java
@@ -23,8 +23,8 @@ import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -42,8 +42,8 @@ import static org.junit.Assert.assertTrue;
 @Category({LocalStandaloneIT.class, ClusterIT.class})
 public class IoTDBInsertAlignedValues2IT {
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     EnvFactory.getEnv()
         .getConfig()
         .getCommonConfig()
@@ -52,66 +52,79 @@ public class IoTDBInsertAlignedValues2IT {
     EnvFactory.getEnv().initClusterEnvironment();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  private static void executeQuietly(Statement statement, String sql) {
+    try {
+      statement.execute(sql);
+    } catch (SQLException ignored) {
+      // ignore: cleanup may fail if target does not exist
+    }
   }
 
   @Test
   public void testInsertAlignedWithEmptyPage() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute(
-          "CREATE ALIGNED TIMESERIES root.lz.dev.GPS(S1 INT32 encoding=PLAIN compressor=SNAPPY, S2 INT32 encoding=PLAIN compressor=SNAPPY, S3 INT32 encoding=PLAIN compressor=SNAPPY) ");
-      for (int i = 0; i < 100; i++) {
-        if (i == 99) {
-          statement.addBatch(
-              "insert into root.lz.dev.GPS(time,S1,S3) aligned values("
-                  + i
-                  + ","
-                  + i
-                  + ","
-                  + i
-                  + ")");
-        } else {
-          statement.addBatch(
-              "insert into root.lz.dev.GPS(time,S1,S2) aligned values("
-                  + i
-                  + ","
-                  + i
-                  + ","
-                  + i
-                  + ")");
+      try {
+        statement.execute(
+            "CREATE ALIGNED TIMESERIES root.lz.dev.GPS(S1 INT32 encoding=PLAIN compressor=SNAPPY, S2 INT32 encoding=PLAIN compressor=SNAPPY, S3 INT32 encoding=PLAIN compressor=SNAPPY) ");
+        for (int i = 0; i < 100; i++) {
+          if (i == 99) {
+            statement.addBatch(
+                "insert into root.lz.dev.GPS(time,S1,S3) aligned values("
+                    + i
+                    + ","
+                    + i
+                    + ","
+                    + i
+                    + ")");
+          } else {
+            statement.addBatch(
+                "insert into root.lz.dev.GPS(time,S1,S2) aligned values("
+                    + i
+                    + ","
+                    + i
+                    + ","
+                    + i
+                    + ")");
+          }
         }
-      }
-      statement.executeBatch();
+        statement.executeBatch();
 
-      statement.execute("flush");
-      int rowCount = 0;
-      try (ResultSet resultSet = statement.executeQuery("select S3 from root.lz.dev.GPS")) {
-        while (resultSet.next()) {
-          assertEquals(99, resultSet.getInt(2));
-          rowCount++;
+        statement.execute("flush");
+        int rowCount = 0;
+        try (ResultSet resultSet = statement.executeQuery("select S3 from root.lz.dev.GPS")) {
+          while (resultSet.next()) {
+            assertEquals(99, resultSet.getInt(2));
+            rowCount++;
+          }
+          assertEquals(1, rowCount);
         }
-        assertEquals(1, rowCount);
-      }
 
-      try (ResultSet resultSet = statement.executeQuery("select S2 from root.lz.dev.GPS")) {
-        rowCount = 0;
-        while (resultSet.next()) {
-          assertEquals(rowCount, resultSet.getInt(2));
-          rowCount++;
+        try (ResultSet resultSet = statement.executeQuery("select S2 from root.lz.dev.GPS")) {
+          rowCount = 0;
+          while (resultSet.next()) {
+            assertEquals(rowCount, resultSet.getInt(2));
+            rowCount++;
+          }
+          assertEquals(99, rowCount);
         }
-        assertEquals(99, rowCount);
-      }
 
-      try (ResultSet resultSet = statement.executeQuery("select S1 from root.lz.dev.GPS")) {
-        rowCount = 0;
-        while (resultSet.next()) {
-          assertEquals(rowCount, resultSet.getInt(2));
-          rowCount++;
+        try (ResultSet resultSet = statement.executeQuery("select S1 from root.lz.dev.GPS")) {
+          rowCount = 0;
+          while (resultSet.next()) {
+            assertEquals(rowCount, resultSet.getInt(2));
+            rowCount++;
+          }
+          assertEquals(100, rowCount);
         }
-        assertEquals(100, rowCount);
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.lz");
+        executeQuietly(statement, "DELETE DATABASE root.sg");
       }
     }
   }
@@ -120,11 +133,16 @@ public class IoTDBInsertAlignedValues2IT {
   public void testInsertAlignedWithEmptyPage2() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("insert into root.sg.d1(time, s1,s2) aligned values(1,'aa','bb')");
-      statement.execute("insert into root.sg.d1(time, s1,s2) aligned values(1,'aa','bb')");
-      statement.execute("insert into root.sg.d1(time, s1,s2) aligned values(1,'aa','bb')");
-      statement.execute("flush");
-      statement.execute("insert into root.sg.d1(time, s1,s2) aligned values(1,'aa','bb')");
+      try {
+        statement.execute("insert into root.sg.d1(time, s1,s2) aligned values(1,'aa','bb')");
+        statement.execute("insert into root.sg.d1(time, s1,s2) aligned values(1,'aa','bb')");
+        statement.execute("insert into root.sg.d1(time, s1,s2) aligned values(1,'aa','bb')");
+        statement.execute("flush");
+        statement.execute("insert into root.sg.d1(time, s1,s2) aligned values(1,'aa','bb')");
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.lz");
+        executeQuietly(statement, "DELETE DATABASE root.sg");
+      }
     }
   }
 
@@ -132,38 +150,43 @@ public class IoTDBInsertAlignedValues2IT {
   public void testInsertComplexAlignedValues() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.addBatch("create aligned timeseries root.sg.d1(s1 int32, s2 int32, s3 int32)");
-      statement.addBatch("insert into root.sg.d1(time,s1) values(3,1)");
-      statement.addBatch("insert into root.sg.d1(time,s1) values(1,1)");
-      statement.addBatch("insert into root.sg.d1(time,s1) values(2,1)");
-      statement.addBatch("insert into root.sg.d1(time,s2) values(2,2)");
-      statement.addBatch("insert into root.sg.d1(time,s2) values(1,2)");
-      statement.addBatch("insert into root.sg.d1(time,s2) values(3,2)");
-      statement.addBatch("insert into root.sg.d1(time,s3) values(1,3)");
-      statement.addBatch("insert into root.sg.d1(time,s3) values(3,3)");
-      statement.executeBatch();
+      try {
+        statement.addBatch("create aligned timeseries root.sg.d1(s1 int32, s2 int32, s3 int32)");
+        statement.addBatch("insert into root.sg.d1(time,s1) values(3,1)");
+        statement.addBatch("insert into root.sg.d1(time,s1) values(1,1)");
+        statement.addBatch("insert into root.sg.d1(time,s1) values(2,1)");
+        statement.addBatch("insert into root.sg.d1(time,s2) values(2,2)");
+        statement.addBatch("insert into root.sg.d1(time,s2) values(1,2)");
+        statement.addBatch("insert into root.sg.d1(time,s2) values(3,2)");
+        statement.addBatch("insert into root.sg.d1(time,s3) values(1,3)");
+        statement.addBatch("insert into root.sg.d1(time,s3) values(3,3)");
+        statement.executeBatch();
 
-      try (ResultSet resultSet =
-          statement.executeQuery("select count(s1), count(s2), count(s3) from root.sg.d1")) {
+        try (ResultSet resultSet =
+            statement.executeQuery("select count(s1), count(s2), count(s3) from root.sg.d1")) {
 
-        assertTrue(resultSet.next());
-        assertEquals(3, resultSet.getInt(1));
-        assertEquals(3, resultSet.getInt(2));
-        assertEquals(2, resultSet.getInt(3));
+          assertTrue(resultSet.next());
+          assertEquals(3, resultSet.getInt(1));
+          assertEquals(3, resultSet.getInt(2));
+          assertEquals(2, resultSet.getInt(3));
 
-        assertFalse(resultSet.next());
-      }
+          assertFalse(resultSet.next());
+        }
 
-      statement.execute("flush");
-      try (ResultSet resultSet =
-          statement.executeQuery("select count(s1), count(s2), count(s3) from root.sg.d1")) {
+        statement.execute("flush");
+        try (ResultSet resultSet =
+            statement.executeQuery("select count(s1), count(s2), count(s3) from root.sg.d1")) {
 
-        assertTrue(resultSet.next());
-        assertEquals(3, resultSet.getInt(1));
-        assertEquals(3, resultSet.getInt(2));
-        assertEquals(2, resultSet.getInt(3));
+          assertTrue(resultSet.next());
+          assertEquals(3, resultSet.getInt(1));
+          assertEquals(3, resultSet.getInt(2));
+          assertEquals(2, resultSet.getInt(3));
 
-        assertFalse(resultSet.next());
+          assertFalse(resultSet.next());
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.lz");
+        executeQuietly(statement, "DELETE DATABASE root.sg");
       }
     }
   }

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBInsertAlignedValues3IT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBInsertAlignedValues3IT.java
@@ -23,8 +23,8 @@ import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -40,8 +40,8 @@ import static org.junit.Assert.assertEquals;
 @Category({LocalStandaloneIT.class, ClusterIT.class})
 public class IoTDBInsertAlignedValues3IT {
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     EnvFactory.getEnv()
         .getConfig()
         .getCommonConfig()
@@ -50,8 +50,8 @@ public class IoTDBInsertAlignedValues3IT {
     EnvFactory.getEnv().initClusterEnvironment();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
   }
 

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBInsertAlignedValues4IT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBInsertAlignedValues4IT.java
@@ -23,8 +23,8 @@ import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -39,8 +39,8 @@ import static org.junit.Assert.fail;
 @Category({LocalStandaloneIT.class, ClusterIT.class})
 public class IoTDBInsertAlignedValues4IT {
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     EnvFactory.getEnv()
         .getConfig()
         .getCommonConfig()
@@ -49,8 +49,8 @@ public class IoTDBInsertAlignedValues4IT {
     EnvFactory.getEnv().initClusterEnvironment();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
   }
 

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBInsertAlignedValuesIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBInsertAlignedValuesIT.java
@@ -24,8 +24,8 @@ import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -45,58 +45,70 @@ import static org.junit.Assert.fail;
 @Category({LocalStandaloneIT.class, ClusterIT.class})
 public class IoTDBInsertAlignedValuesIT {
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     EnvFactory.getEnv().getConfig().getCommonConfig().setAutoCreateSchemaEnabled(true);
     EnvFactory.getEnv().initClusterEnvironment();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  private static void executeQuietly(Statement statement, String sql) {
+    try {
+      statement.execute(sql);
+    } catch (SQLException ignored) {
+      // ignore: cleanup may fail if target does not exist
+    }
   }
 
   @Test
   public void testInsertAlignedValues() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.addBatch(
-          "insert into root.t1.wf01.wt01(time, status, temperature) aligned values (4000, true, 17.1)");
-      statement.addBatch(
-          "insert into root.t1.wf01.wt01(time, status, temperature) aligned values (5000, true, 20.1)");
-      statement.addBatch(
-          "insert into root.t1.wf01.wt01(time, status, temperature) aligned values (6000, true, 22)");
-      statement.executeBatch();
+      try {
+        statement.addBatch(
+            "insert into root.t1.wf01.wt01(time, status, temperature) aligned values (4000, true, 17.1)");
+        statement.addBatch(
+            "insert into root.t1.wf01.wt01(time, status, temperature) aligned values (5000, true, 20.1)");
+        statement.addBatch(
+            "insert into root.t1.wf01.wt01(time, status, temperature) aligned values (6000, true, 22)");
+        statement.executeBatch();
 
-      try (ResultSet resultSet = statement.executeQuery("select status from root.t1.wf01.wt01")) {
-        assertTrue(resultSet.next());
-        assertTrue(resultSet.getBoolean(2));
-        assertTrue(resultSet.next());
-        assertTrue(resultSet.getBoolean(2));
-        assertTrue(resultSet.next());
-        assertTrue(resultSet.getBoolean(2));
-        assertFalse(resultSet.next());
-      }
+        try (ResultSet resultSet = statement.executeQuery("select status from root.t1.wf01.wt01")) {
+          assertTrue(resultSet.next());
+          assertTrue(resultSet.getBoolean(2));
+          assertTrue(resultSet.next());
+          assertTrue(resultSet.getBoolean(2));
+          assertTrue(resultSet.next());
+          assertTrue(resultSet.getBoolean(2));
+          assertFalse(resultSet.next());
+        }
 
-      try (ResultSet resultSet =
-          statement.executeQuery("select status, temperature from root.t1.wf01.wt01")) {
+        try (ResultSet resultSet =
+            statement.executeQuery("select status, temperature from root.t1.wf01.wt01")) {
 
-        assertTrue(resultSet.next());
-        assertEquals(4000, resultSet.getLong(1));
-        assertTrue(resultSet.getBoolean(2));
-        assertEquals(17.1, resultSet.getDouble(3), 0.1);
+          assertTrue(resultSet.next());
+          assertEquals(4000, resultSet.getLong(1));
+          assertTrue(resultSet.getBoolean(2));
+          assertEquals(17.1, resultSet.getDouble(3), 0.1);
 
-        assertTrue(resultSet.next());
-        assertEquals(5000, resultSet.getLong(1));
-        assertTrue(resultSet.getBoolean(2));
-        assertEquals(20.1, resultSet.getDouble(3), 0.1);
+          assertTrue(resultSet.next());
+          assertEquals(5000, resultSet.getLong(1));
+          assertTrue(resultSet.getBoolean(2));
+          assertEquals(20.1, resultSet.getDouble(3), 0.1);
 
-        assertTrue(resultSet.next());
-        assertEquals(6000, resultSet.getLong(1));
-        assertTrue(resultSet.getBoolean(2));
-        assertEquals(22, resultSet.getDouble(3), 0.1);
+          assertTrue(resultSet.next());
+          assertEquals(6000, resultSet.getLong(1));
+          assertTrue(resultSet.getBoolean(2));
+          assertEquals(22, resultSet.getDouble(3), 0.1);
 
-        assertFalse(resultSet.next());
+          assertFalse(resultSet.next());
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.t1");
       }
     }
   }
@@ -105,40 +117,45 @@ public class IoTDBInsertAlignedValuesIT {
   public void testInsertAlignedNullableValues() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.addBatch(
-          "insert into root.t1.wf01.wt01(time, status, temperature) aligned values (4000, true, 17.1)");
-      statement.addBatch("insert into root.t1.wf01.wt01(time, status) aligned values (5000, true)");
-      statement.addBatch(
-          "insert into root.t1.wf01.wt01(time, temperature) aligned values (6000, 22)");
-      statement.executeBatch();
+      try {
+        statement.addBatch(
+            "insert into root.t1.wf01.wt01(time, status, temperature) aligned values (4000, true, 17.1)");
+        statement.addBatch(
+            "insert into root.t1.wf01.wt01(time, status) aligned values (5000, true)");
+        statement.addBatch(
+            "insert into root.t1.wf01.wt01(time, temperature) aligned values (6000, 22)");
+        statement.executeBatch();
 
-      try (ResultSet resultSet = statement.executeQuery("select status from root.t1.wf01.wt01")) {
-        assertTrue(resultSet.next());
-        assertTrue(resultSet.getBoolean(2));
-        assertTrue(resultSet.next());
-        assertTrue(resultSet.getBoolean(2));
-        assertFalse(resultSet.next());
-      }
+        try (ResultSet resultSet = statement.executeQuery("select status from root.t1.wf01.wt01")) {
+          assertTrue(resultSet.next());
+          assertTrue(resultSet.getBoolean(2));
+          assertTrue(resultSet.next());
+          assertTrue(resultSet.getBoolean(2));
+          assertFalse(resultSet.next());
+        }
 
-      try (ResultSet resultSet =
-          statement.executeQuery("select status, temperature from root.t1.wf01.wt01")) {
+        try (ResultSet resultSet =
+            statement.executeQuery("select status, temperature from root.t1.wf01.wt01")) {
 
-        assertTrue(resultSet.next());
-        assertEquals(4000, resultSet.getLong(1));
-        assertTrue(resultSet.getBoolean(2));
-        assertEquals(17.1, resultSet.getDouble(3), 0.1);
+          assertTrue(resultSet.next());
+          assertEquals(4000, resultSet.getLong(1));
+          assertTrue(resultSet.getBoolean(2));
+          assertEquals(17.1, resultSet.getDouble(3), 0.1);
 
-        assertTrue(resultSet.next());
-        assertEquals(5000, resultSet.getLong(1));
-        assertTrue(resultSet.getBoolean(2));
-        assertNull(resultSet.getObject(3));
+          assertTrue(resultSet.next());
+          assertEquals(5000, resultSet.getLong(1));
+          assertTrue(resultSet.getBoolean(2));
+          assertNull(resultSet.getObject(3));
 
-        assertTrue(resultSet.next());
-        assertEquals(6000, resultSet.getLong(1));
-        assertNull(resultSet.getObject(2));
-        assertEquals(22.0d, resultSet.getObject(3));
+          assertTrue(resultSet.next());
+          assertEquals(6000, resultSet.getLong(1));
+          assertNull(resultSet.getObject(2));
+          assertEquals(22.0d, resultSet.getObject(3));
 
-        assertFalse(resultSet.next());
+          assertFalse(resultSet.next());
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.t1");
       }
     }
   }
@@ -147,72 +164,77 @@ public class IoTDBInsertAlignedValuesIT {
   public void testUpdatingAlignedValues() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.addBatch(
-          "insert into root.t1.wf01.wt01(time, status, temperature) aligned values (4000, true, 17.1)");
-      statement.addBatch("insert into root.t1.wf01.wt01(time, status) aligned values (5000, true)");
-      statement.addBatch(
-          "insert into root.t1.wf01.wt01(time, temperature) aligned values (5000, 20.1)");
-      statement.addBatch(
-          "insert into root.t1.wf01.wt01(time, temperature) aligned values (6000, 22)");
-      statement.executeBatch();
+      try {
+        statement.addBatch(
+            "insert into root.t1.wf01.wt01(time, status, temperature) aligned values (4000, true, 17.1)");
+        statement.addBatch(
+            "insert into root.t1.wf01.wt01(time, status) aligned values (5000, true)");
+        statement.addBatch(
+            "insert into root.t1.wf01.wt01(time, temperature) aligned values (5000, 20.1)");
+        statement.addBatch(
+            "insert into root.t1.wf01.wt01(time, temperature) aligned values (6000, 22)");
+        statement.executeBatch();
 
-      try (ResultSet resultSet = statement.executeQuery("select status from root.t1.wf01.wt01")) {
-        assertTrue(resultSet.next());
-        assertTrue(resultSet.getBoolean(2));
-        assertTrue(resultSet.next());
-        assertTrue(resultSet.getBoolean(2));
-        assertFalse(resultSet.next());
-      }
+        try (ResultSet resultSet = statement.executeQuery("select status from root.t1.wf01.wt01")) {
+          assertTrue(resultSet.next());
+          assertTrue(resultSet.getBoolean(2));
+          assertTrue(resultSet.next());
+          assertTrue(resultSet.getBoolean(2));
+          assertFalse(resultSet.next());
+        }
 
-      try (ResultSet resultSet =
-          statement.executeQuery("select status, temperature from root.t1.wf01.wt01")) {
+        try (ResultSet resultSet =
+            statement.executeQuery("select status, temperature from root.t1.wf01.wt01")) {
 
-        assertTrue(resultSet.next());
-        assertEquals(4000, resultSet.getLong(1));
-        assertTrue(resultSet.getBoolean(2));
-        assertEquals(17.1, resultSet.getDouble(3), 0.1);
+          assertTrue(resultSet.next());
+          assertEquals(4000, resultSet.getLong(1));
+          assertTrue(resultSet.getBoolean(2));
+          assertEquals(17.1, resultSet.getDouble(3), 0.1);
 
-        assertTrue(resultSet.next());
-        assertEquals(5000, resultSet.getLong(1));
-        assertTrue(resultSet.getBoolean(2));
-        assertEquals(20.1, resultSet.getDouble(3), 0.1);
+          assertTrue(resultSet.next());
+          assertEquals(5000, resultSet.getLong(1));
+          assertTrue(resultSet.getBoolean(2));
+          assertEquals(20.1, resultSet.getDouble(3), 0.1);
 
-        assertTrue(resultSet.next());
-        assertEquals(6000, resultSet.getLong(1));
-        assertNull(resultSet.getObject(2));
-        assertEquals(22.0d, resultSet.getObject(3));
+          assertTrue(resultSet.next());
+          assertEquals(6000, resultSet.getLong(1));
+          assertNull(resultSet.getObject(2));
+          assertEquals(22.0d, resultSet.getObject(3));
 
-        assertFalse(resultSet.next());
-      }
+          assertFalse(resultSet.next());
+        }
 
-      statement.execute("flush");
-      try (ResultSet resultSet = statement.executeQuery("select status from root.t1.wf01.wt01")) {
-        assertTrue(resultSet.next());
-        assertTrue(resultSet.getBoolean(2));
-        assertTrue(resultSet.next());
-        assertTrue(resultSet.getBoolean(2));
-        assertFalse(resultSet.next());
-      }
+        statement.execute("flush");
+        try (ResultSet resultSet = statement.executeQuery("select status from root.t1.wf01.wt01")) {
+          assertTrue(resultSet.next());
+          assertTrue(resultSet.getBoolean(2));
+          assertTrue(resultSet.next());
+          assertTrue(resultSet.getBoolean(2));
+          assertFalse(resultSet.next());
+        }
 
-      try (ResultSet resultSet =
-          statement.executeQuery("select status, temperature from root.t1.wf01.wt01")) {
+        try (ResultSet resultSet =
+            statement.executeQuery("select status, temperature from root.t1.wf01.wt01")) {
 
-        assertTrue(resultSet.next());
-        assertEquals(4000, resultSet.getLong(1));
-        assertTrue(resultSet.getBoolean(2));
-        assertEquals(17.1, resultSet.getDouble(3), 0.1);
+          assertTrue(resultSet.next());
+          assertEquals(4000, resultSet.getLong(1));
+          assertTrue(resultSet.getBoolean(2));
+          assertEquals(17.1, resultSet.getDouble(3), 0.1);
 
-        assertTrue(resultSet.next());
-        assertEquals(5000, resultSet.getLong(1));
-        assertTrue(resultSet.getBoolean(2));
-        assertEquals(20.1, resultSet.getDouble(3), 0.1);
+          assertTrue(resultSet.next());
+          assertEquals(5000, resultSet.getLong(1));
+          assertTrue(resultSet.getBoolean(2));
+          assertEquals(20.1, resultSet.getDouble(3), 0.1);
 
-        assertTrue(resultSet.next());
-        assertEquals(6000, resultSet.getLong(1));
-        assertNull(resultSet.getObject(2));
-        assertEquals(22.0d, resultSet.getObject(3));
+          assertTrue(resultSet.next());
+          assertEquals(6000, resultSet.getLong(1));
+          assertNull(resultSet.getObject(2));
+          assertEquals(22.0d, resultSet.getObject(3));
 
-        assertFalse(resultSet.next());
+          assertFalse(resultSet.next());
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.t1");
       }
     }
   }
@@ -221,29 +243,33 @@ public class IoTDBInsertAlignedValuesIT {
   public void testInsertAlignedValuesWithSameTimestamp() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.addBatch("insert into root.sg.d1(time,s2) aligned values(1,2)");
-      statement.addBatch("insert into root.sg.d1(time,s1) aligned values(1,2)");
-      statement.executeBatch();
+      try {
+        statement.addBatch("insert into root.sg.d1(time,s2) aligned values(1,2)");
+        statement.addBatch("insert into root.sg.d1(time,s1) aligned values(1,2)");
+        statement.executeBatch();
 
-      try (ResultSet resultSet = statement.executeQuery("select s1, s2 from root.sg.d1")) {
+        try (ResultSet resultSet = statement.executeQuery("select s1, s2 from root.sg.d1")) {
 
-        assertTrue(resultSet.next());
-        assertEquals(1, resultSet.getLong(1));
-        assertEquals(2.0d, resultSet.getObject(2));
-        assertEquals(2.0d, resultSet.getObject(3));
+          assertTrue(resultSet.next());
+          assertEquals(1, resultSet.getLong(1));
+          assertEquals(2.0d, resultSet.getObject(2));
+          assertEquals(2.0d, resultSet.getObject(3));
 
-        assertFalse(resultSet.next());
-      }
+          assertFalse(resultSet.next());
+        }
 
-      statement.execute("flush");
-      try (ResultSet resultSet = statement.executeQuery("select s1, s2 from root.sg.d1")) {
+        statement.execute("flush");
+        try (ResultSet resultSet = statement.executeQuery("select s1, s2 from root.sg.d1")) {
 
-        assertTrue(resultSet.next());
-        assertEquals(1, resultSet.getLong(1));
-        assertEquals(2.0d, resultSet.getObject(2));
-        assertEquals(2.0d, resultSet.getObject(3));
+          assertTrue(resultSet.next());
+          assertEquals(1, resultSet.getLong(1));
+          assertEquals(2.0d, resultSet.getObject(2));
+          assertEquals(2.0d, resultSet.getObject(3));
 
-        assertFalse(resultSet.next());
+          assertFalse(resultSet.next());
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg");
       }
     }
   }
@@ -252,14 +278,18 @@ public class IoTDBInsertAlignedValuesIT {
   public void testInsertWithWrongMeasurementNum1() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute(
-          "insert into root.t1.wf01.wt01(time, status, temperature) aligned values(11000, 100)");
-      fail();
-    } catch (SQLException e) {
-      assertTrue(
-          e.getMessage()
-              .contains(
-                  "the measurementList's size 2 is not consistent with the valueList's size 1"));
+      try {
+        statement.execute(
+            "insert into root.t1.wf01.wt01(time, status, temperature) aligned values(11000, 100)");
+        fail();
+      } catch (SQLException e) {
+        assertTrue(
+            e.getMessage()
+                .contains(
+                    "the measurementList's size 2 is not consistent with the valueList's size 1"));
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.t1");
+      }
     }
   }
 
@@ -267,15 +297,21 @@ public class IoTDBInsertAlignedValuesIT {
   public void testInsertWithWrongMeasurementNum2() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute(
-          "insert into root.t1.wf01.wt01(time, status, temperature) aligned values(11000, 100, 300, 400)");
-      fail();
+      try {
+        statement.execute(
+            "insert into root.t1.wf01.wt01(time, status, temperature) aligned values(11000, 100, 300, 400)");
+        fail();
+      } catch (SQLException e) {
+        assertTrue(
+            e.getMessage(),
+            e.getMessage()
+                .contains(
+                    "the measurementList's size 2 is not consistent with the valueList's size 3"));
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.t1");
+      }
     } catch (SQLException e) {
-      assertTrue(
-          e.getMessage(),
-          e.getMessage()
-              .contains(
-                  "the measurementList's size 2 is not consistent with the valueList's size 3"));
+      fail(e.getMessage());
     }
   }
 
@@ -283,11 +319,15 @@ public class IoTDBInsertAlignedValuesIT {
   public void testInsertWithWrongType() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute(
-          "CREATE ALIGNED TIMESERIES root.lz.dev.GPS(latitude INT32 encoding=PLAIN compressor=SNAPPY, longitude INT32 encoding=PLAIN compressor=SNAPPY) ");
-      statement.execute(
-          "insert into root.lz.dev.GPS(time,latitude,longitude) aligned values(1,1.3,6.7)");
-      fail();
+      try {
+        statement.execute(
+            "CREATE ALIGNED TIMESERIES root.lz.dev.GPS(latitude INT32 encoding=PLAIN compressor=SNAPPY, longitude INT32 encoding=PLAIN compressor=SNAPPY) ");
+        statement.execute(
+            "insert into root.lz.dev.GPS(time,latitude,longitude) aligned values(1,1.3,6.7)");
+        fail();
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.lz");
+      }
     }
   }
 
@@ -295,10 +335,15 @@ public class IoTDBInsertAlignedValuesIT {
   public void testInsertAlignedTimeseriesWithoutAligned() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute(
-          "CREATE ALIGNED TIMESERIES root.lz.dev.GPS2(latitude INT32 encoding=PLAIN compressor=SNAPPY, longitude INT32 encoding=PLAIN compressor=SNAPPY) ");
-      statement.execute("insert into root.lz.dev.GPS2(time,latitude,longitude) values(1,123,456)");
-      // it's supported.
+      try {
+        statement.execute(
+            "CREATE ALIGNED TIMESERIES root.lz.dev.GPS2(latitude INT32 encoding=PLAIN compressor=SNAPPY, longitude INT32 encoding=PLAIN compressor=SNAPPY) ");
+        statement.execute(
+            "insert into root.lz.dev.GPS2(time,latitude,longitude) values(1,123,456)");
+        // it's supported.
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.lz");
+      }
     }
   }
 
@@ -306,35 +351,41 @@ public class IoTDBInsertAlignedValuesIT {
   public void testInsertTimeseriesWithUnMatchedAlignedType() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("create ALIGNED timeseries root.db.d_aligned(s01 INT64 encoding=RLE)");
-      statement.execute("insert into root.db.d_aligned(time, s01) aligned values (4000, 123)");
-      statement.execute("insert into root.db.d_aligned(time, s01) values (5000, 456)");
-      statement.execute("create timeseries root.db.d_not_aligned.s01 INT64 encoding=RLE");
-      statement.execute("insert into root.db.d_not_aligned(time, s01) values (4000, 987)");
-      statement.execute("insert into root.db.d_not_aligned(time, s01) aligned values (5000, 654)");
+      try {
+        statement.execute("create ALIGNED timeseries root.db.d_aligned(s01 INT64 encoding=RLE)");
+        statement.execute("insert into root.db.d_aligned(time, s01) aligned values (4000, 123)");
+        statement.execute("insert into root.db.d_aligned(time, s01) values (5000, 456)");
+        statement.execute("create timeseries root.db.d_not_aligned.s01 INT64 encoding=RLE");
+        statement.execute("insert into root.db.d_not_aligned(time, s01) values (4000, 987)");
+        statement.execute(
+            "insert into root.db.d_not_aligned(time, s01) aligned values (5000, 654)");
 
-      try (ResultSet resultSet = statement.executeQuery("select s01 from root.db.d_aligned")) {
-        assertTrue(resultSet.next());
-        assertEquals(4000, resultSet.getLong(1));
-        assertEquals(123, resultSet.getLong(2));
+        try (ResultSet resultSet = statement.executeQuery("select s01 from root.db.d_aligned")) {
+          assertTrue(resultSet.next());
+          assertEquals(4000, resultSet.getLong(1));
+          assertEquals(123, resultSet.getLong(2));
 
-        assertTrue(resultSet.next());
-        assertEquals(5000, resultSet.getLong(1));
-        assertEquals(456, resultSet.getLong(2));
+          assertTrue(resultSet.next());
+          assertEquals(5000, resultSet.getLong(1));
+          assertEquals(456, resultSet.getLong(2));
 
-        assertFalse(resultSet.next());
-      }
+          assertFalse(resultSet.next());
+        }
 
-      try (ResultSet resultSet = statement.executeQuery("select s01 from root.db.d_not_aligned")) {
-        assertTrue(resultSet.next());
-        assertEquals(4000, resultSet.getLong(1));
-        assertEquals(987, resultSet.getLong(2));
+        try (ResultSet resultSet =
+            statement.executeQuery("select s01 from root.db.d_not_aligned")) {
+          assertTrue(resultSet.next());
+          assertEquals(4000, resultSet.getLong(1));
+          assertEquals(987, resultSet.getLong(2));
 
-        assertTrue(resultSet.next());
-        assertEquals(5000, resultSet.getLong(1));
-        assertEquals(654, resultSet.getLong(2));
+          assertTrue(resultSet.next());
+          assertEquals(5000, resultSet.getLong(1));
+          assertEquals(654, resultSet.getLong(2));
 
-        assertFalse(resultSet.next());
+          assertFalse(resultSet.next());
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.db");
       }
     }
   }
@@ -343,11 +394,15 @@ public class IoTDBInsertAlignedValuesIT {
   public void testInsertNonAlignedTimeseriesWithAligned() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("CREATE TIMESERIES root.lz.dev.GPS3.latitude with datatype=INT32");
-      statement.execute("CREATE TIMESERIES root.lz.dev.GPS3.longitude with datatype=INT32");
-      statement.execute(
-          "insert into root.lz.dev.GPS3(time,latitude,longitude) aligned values(1,123,456)");
-      // it's supported.
+      try {
+        statement.execute("CREATE TIMESERIES root.lz.dev.GPS3.latitude with datatype=INT32");
+        statement.execute("CREATE TIMESERIES root.lz.dev.GPS3.longitude with datatype=INT32");
+        statement.execute(
+            "insert into root.lz.dev.GPS3(time,latitude,longitude) aligned values(1,123,456)");
+        // it's supported.
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.lz");
+      }
     }
   }
 
@@ -355,12 +410,16 @@ public class IoTDBInsertAlignedValuesIT {
   public void testInsertAlignedValuesWithThreeLevelPath() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("insert into root.sg_device(time, status) aligned values (4000, true)");
+      try {
+        statement.execute("insert into root.sg_device(time, status) aligned values (4000, true)");
 
-      try (ResultSet resultSet = statement.executeQuery("select ** from root.sg_device")) {
-        assertTrue(resultSet.next());
-        assertTrue(resultSet.getBoolean(2));
-        assertFalse(resultSet.next());
+        try (ResultSet resultSet = statement.executeQuery("select ** from root.sg_device")) {
+          assertTrue(resultSet.next());
+          assertTrue(resultSet.getBoolean(2));
+          assertFalse(resultSet.next());
+        }
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg_device");
       }
     }
   }
@@ -369,13 +428,19 @@ public class IoTDBInsertAlignedValuesIT {
   public void testInsertWithDuplicatedMeasurements() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute(
-          "insert into root.t1.wf01.wt01(time, s3, status, status) aligned values(100, true, 20.1, 20.2)");
-      fail();
+      try {
+        statement.execute(
+            "insert into root.t1.wf01.wt01(time, s3, status, status) aligned values(100, true, 20.1, 20.2)");
+        fail();
+      } catch (SQLException e) {
+        assertTrue(
+            e.getMessage(),
+            e.getMessage().contains("Insertion contains duplicated measurement: status"));
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.t1");
+      }
     } catch (SQLException e) {
-      assertTrue(
-          e.getMessage(),
-          e.getMessage().contains("Insertion contains duplicated measurement: status"));
+      fail(e.getMessage());
     }
   }
 
@@ -383,11 +448,17 @@ public class IoTDBInsertAlignedValuesIT {
   public void testInsertMultiRows() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute(
-          "insert into root.sg1.d1(time, s1, s2) aligned values(10, 2, 2), (11, 3, '3'), (12,12.11,false);");
-      fail();
+      try {
+        statement.execute(
+            "insert into root.sg1.d1(time, s1, s2) aligned values(10, 2, 2), (11, 3, '3'), (12,12.11,false);");
+        fail();
+      } catch (SQLException e) {
+        assertTrue(e.getMessage(), e.getMessage().contains("data type is not consistent"));
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
+      }
     } catch (SQLException e) {
-      assertTrue(e.getMessage(), e.getMessage().contains("data type is not consistent"));
+      fail(e.getMessage());
     }
   }
 
@@ -395,10 +466,16 @@ public class IoTDBInsertAlignedValuesIT {
   public void testInsertLargeNumber() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute(
-          "insert into root.sg1.d1(time, s98, s99) aligned values(10, 2, 271840880000000000000000)");
+      try {
+        statement.execute(
+            "insert into root.sg1.d1(time, s98, s99) aligned values(10, 2, 271840880000000000000000)");
+      } catch (SQLException e) {
+        fail();
+      } finally {
+        executeQuietly(statement, "DELETE DATABASE root.sg1");
+      }
     } catch (SQLException e) {
-      fail();
+      fail(e.getMessage());
     }
   }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBClusterAuthorityIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBClusterAuthorityIT.java
@@ -38,8 +38,8 @@ import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.apache.thrift.TException;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -59,15 +59,15 @@ import static org.junit.Assert.fail;
 @Category({ClusterIT.class})
 public class IoTDBClusterAuthorityIT {
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     // Init 1C1D environment
     EnvFactory.getEnv().getConfig().getCommonConfig().setEnforceStrongPassword(false);
     EnvFactory.getEnv().initClusterEnvironment(1, 1);
   }
 
-  @After
-  public void tearDown() {
+  @AfterClass
+  public static void tearDown() {
     EnvFactory.getEnv().cleanClusterEnvironment();
   }
 

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBClusterAuthorityRelationalIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBClusterAuthorityRelationalIT.java
@@ -42,8 +42,8 @@ import org.apache.iotdb.itbase.category.TableClusterIT;
 import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.apache.thrift.TException;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -58,15 +58,15 @@ import static org.junit.Assert.assertTrue;
 @RunWith(IoTDBTestRunner.class)
 @Category({ClusterIT.class, TableClusterIT.class})
 public class IoTDBClusterAuthorityRelationalIT {
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     // Init 1C1D environment
     EnvFactory.getEnv().getConfig().getCommonConfig().setEnforceStrongPassword(false);
     EnvFactory.getEnv().initClusterEnvironment(1, 1);
   }
 
-  @After
-  public void tearDown() {
+  @AfterClass
+  public static void tearDown() {
     EnvFactory.getEnv().cleanClusterEnvironment();
   }
 

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBGrantOptionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBGrantOptionIT.java
@@ -24,9 +24,9 @@ import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -40,14 +40,14 @@ import java.sql.Statement;
 @RunWith(IoTDBTestRunner.class)
 @Category({LocalStandaloneIT.class, ClusterIT.class})
 public class IoTDBGrantOptionIT {
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     EnvFactory.getEnv().getConfig().getCommonConfig().setEnableGrantOption(false);
     EnvFactory.getEnv().initClusterEnvironment();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
   }
 

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBRelationalAuthIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBRelationalAuthIT.java
@@ -28,9 +28,9 @@ import org.apache.iotdb.itbase.category.TableLocalStandaloneIT;
 import org.apache.iotdb.itbase.env.BaseEnv;
 import org.apache.iotdb.jdbc.IoTDBSQLException;
 
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -49,573 +49,672 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @RunWith(IoTDBTestRunner.class)
 @Category({TableLocalStandaloneIT.class, TableClusterIT.class})
 public class IoTDBRelationalAuthIT {
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     EnvFactory.getEnv().getConfig().getCommonConfig().setEnforceStrongPassword(false);
     EnvFactory.getEnv().initClusterEnvironment();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  private static void executeQuietly(Statement statement, String sql) {
+    try {
+      statement.execute(sql);
+    } catch (SQLException ignored) {
+      // ignore
+    }
+  }
+
+  private static void cleanupAfterTest() {
+    try (Connection connection = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
+        Statement statement = connection.createStatement()) {
+      // drop all non-root users
+      try (ResultSet rs = statement.executeQuery("LIST USER")) {
+        java.util.List<String> users = new java.util.ArrayList<>();
+        while (rs.next()) {
+          String name = rs.getString(2);
+          if (!"root".equals(name)) {
+            users.add(name);
+          }
+        }
+        for (String user : users) {
+          executeQuietly(statement, "DROP USER \"" + user + "\"");
+        }
+      } catch (SQLException ignored) {
+        // ignore
+      }
+      // drop all roles
+      try (ResultSet rs = statement.executeQuery("LIST ROLE")) {
+        java.util.List<String> roles = new java.util.ArrayList<>();
+        while (rs.next()) {
+          roles.add(rs.getString(1));
+        }
+        for (String role : roles) {
+          executeQuietly(statement, "DROP ROLE \"" + role + "\"");
+        }
+      } catch (SQLException ignored) {
+        // ignore
+      }
+      // drop all non-system databases
+      try (ResultSet rs = statement.executeQuery("SHOW DATABASES")) {
+        java.util.List<String> dbs = new java.util.ArrayList<>();
+        while (rs.next()) {
+          String name = rs.getString(1);
+          if (name != null && !name.startsWith("information_schema") && !name.startsWith("__")) {
+            dbs.add(name);
+          }
+        }
+        for (String db : dbs) {
+          executeQuietly(statement, "DROP DATABASE IF EXISTS \"" + db + "\"");
+        }
+      } catch (SQLException ignored) {
+        // ignore
+      }
+    } catch (SQLException ignored) {
+      // ignore
+    }
   }
 
   @Test
   public void listUserPrivileges() throws SQLException {
-    try (Connection adminCon = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
-        Statement adminStmt = adminCon.createStatement()) {
+    try {
+      try (Connection adminCon = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
+          Statement adminStmt = adminCon.createStatement()) {
 
-      adminStmt.execute("create user testuser 'password123456'");
-      try (Connection userCon =
-              EnvFactory.getEnv()
-                  .getConnection("testuser", "password123456", BaseEnv.TABLE_SQL_DIALECT);
-          Statement userStmt = userCon.createStatement()) {
-        ResultSet resultSet = userStmt.executeQuery("LIST USER");
-        Assert.assertTrue(resultSet.next());
-        Assert.assertEquals("10000", resultSet.getString(1));
-        Assert.assertEquals("testuser", resultSet.getString(2));
-        Assert.assertFalse(resultSet.next());
+        adminStmt.execute("create user testuser 'password123456'");
+        try (Connection userCon =
+                EnvFactory.getEnv()
+                    .getConnection("testuser", "password123456", BaseEnv.TABLE_SQL_DIALECT);
+            Statement userStmt = userCon.createStatement()) {
+          ResultSet resultSet = userStmt.executeQuery("LIST USER");
+          Assert.assertTrue(resultSet.next());
+          Assert.assertEquals("10000", resultSet.getString(1));
+          Assert.assertEquals("testuser", resultSet.getString(2));
+          Assert.assertFalse(resultSet.next());
+        }
+        adminStmt.execute("create database testdb");
+        adminStmt.execute("GRANT SECURITY to user testuser");
+        Assert.assertThrows(
+            SQLException.class,
+            () -> {
+              adminStmt.execute("GRANT MANAGE_USER to user testuser");
+            });
+        Assert.assertThrows(
+            SQLException.class,
+            () -> {
+              adminStmt.execute("GRANT MANAGE_DATABASE to user testuser");
+            });
+        Assert.assertThrows(
+            SQLException.class,
+            () -> {
+              adminStmt.execute("GRANT read_data on database db1 to user testuser");
+            });
+        // No Maintain privilege in table model.
+        Assert.assertThrows(
+            SQLException.class,
+            () -> {
+              adminStmt.execute("GRANT MAINTAIN to user testuser");
+            });
+
+        Assert.assertThrows(
+            SQLException.class,
+            () -> {
+              adminStmt.execute("GRANT MANAGE_ROLE to user testuser");
+            });
+        adminStmt.execute("GRANT SELECT ON ANY TO USER testuser");
+        adminStmt.execute("GRANT INSERT ON ANY TO USER testuser");
+        adminStmt.execute("GRANT DELETE ON ANY TO USER testuser");
+        Assert.assertThrows(
+            SQLException.class,
+            () -> {
+              adminStmt.execute("GRANT SELECT ON TABLE TB to user testuser");
+            });
+        adminStmt.execute("GRANT SELECT ON DATABASE TESTDB TO USER testuser");
+        adminStmt.execute("GRANT SELECT ON DATABASE TESTDB TO USER testuser WITH GRANT OPTION");
+
+        adminStmt.execute("use testdb");
+        adminStmt.execute("GRANT SELECT ON TABLE TB to user testuser");
+        adminStmt.execute("GRANT INSERT ON TABLE TB to user testuser with grant option");
+        adminStmt.execute("GRANT DROP ON testdb.tb to user testuser with grant option");
+
+        ResultSet rs = adminStmt.executeQuery("LIST PRIVILEGES OF USER testuser");
+        Set<String> ans =
+            new HashSet<>(
+                Arrays.asList(
+                    ",,SECURITY,false,",
+                    ",*.*,SELECT,false,",
+                    ",*.*,INSERT,false,",
+                    ",*.*,DELETE,false,",
+                    ",testdb.*,SELECT,true,",
+                    ",testdb.tb,SELECT,false,",
+                    ",testdb.tb,INSERT,true,",
+                    ",testdb.tb,DROP,true,"));
+        TestUtils.assertResultSetEqual(rs, "Role,Scope,Privileges,GrantOption,", ans);
+        adminStmt.execute("create role testrole");
+        adminStmt.execute("GRANT ROLE testrole to testuser");
+        rs = adminStmt.executeQuery("LIST USER OF ROLE testrole");
+        TestUtils.assertResultSetEqual(
+            rs, "UserId,User,", Collections.singleton("10000,testuser,"));
+        rs = adminStmt.executeQuery("LIST ROLE OF USER testuser");
+        TestUtils.assertResultSetEqual(rs, "Role,", Collections.singleton("testrole,"));
       }
-      adminStmt.execute("create database testdb");
-      adminStmt.execute("GRANT SECURITY to user testuser");
-      Assert.assertThrows(
-          SQLException.class,
-          () -> {
-            adminStmt.execute("GRANT MANAGE_USER to user testuser");
-          });
-      Assert.assertThrows(
-          SQLException.class,
-          () -> {
-            adminStmt.execute("GRANT MANAGE_DATABASE to user testuser");
-          });
-      Assert.assertThrows(
-          SQLException.class,
-          () -> {
-            adminStmt.execute("GRANT read_data on database db1 to user testuser");
-          });
-      // No Maintain privilege in table model.
-      Assert.assertThrows(
-          SQLException.class,
-          () -> {
-            adminStmt.execute("GRANT MAINTAIN to user testuser");
-          });
-
-      Assert.assertThrows(
-          SQLException.class,
-          () -> {
-            adminStmt.execute("GRANT MANAGE_ROLE to user testuser");
-          });
-      adminStmt.execute("GRANT SELECT ON ANY TO USER testuser");
-      adminStmt.execute("GRANT INSERT ON ANY TO USER testuser");
-      adminStmt.execute("GRANT DELETE ON ANY TO USER testuser");
-      Assert.assertThrows(
-          SQLException.class,
-          () -> {
-            adminStmt.execute("GRANT SELECT ON TABLE TB to user testuser");
-          });
-      adminStmt.execute("GRANT SELECT ON DATABASE TESTDB TO USER testuser");
-      adminStmt.execute("GRANT SELECT ON DATABASE TESTDB TO USER testuser WITH GRANT OPTION");
-
-      adminStmt.execute("use testdb");
-      adminStmt.execute("GRANT SELECT ON TABLE TB to user testuser");
-      adminStmt.execute("GRANT INSERT ON TABLE TB to user testuser with grant option");
-      adminStmt.execute("GRANT DROP ON testdb.tb to user testuser with grant option");
-
-      ResultSet rs = adminStmt.executeQuery("LIST PRIVILEGES OF USER testuser");
-      Set<String> ans =
-          new HashSet<>(
-              Arrays.asList(
-                  ",,SECURITY,false,",
-                  ",*.*,SELECT,false,",
-                  ",*.*,INSERT,false,",
-                  ",*.*,DELETE,false,",
-                  ",testdb.*,SELECT,true,",
-                  ",testdb.tb,SELECT,false,",
-                  ",testdb.tb,INSERT,true,",
-                  ",testdb.tb,DROP,true,"));
-      TestUtils.assertResultSetEqual(rs, "Role,Scope,Privileges,GrantOption,", ans);
-      adminStmt.execute("create role testrole");
-      adminStmt.execute("GRANT ROLE testrole to testuser");
-      rs = adminStmt.executeQuery("LIST USER OF ROLE testrole");
-      TestUtils.assertResultSetEqual(rs, "UserId,User,", Collections.singleton("10000,testuser,"));
-      rs = adminStmt.executeQuery("LIST ROLE OF USER testuser");
-      TestUtils.assertResultSetEqual(rs, "Role,", Collections.singleton("testrole,"));
+    } finally {
+      cleanupAfterTest();
     }
   }
 
   @Test
   public void checkAuthorStatementPrivilegeCheck() throws SQLException {
-    try (Connection adminCon = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
-        Statement adminStmt = adminCon.createStatement()) {
-      adminStmt.execute("create user testuser 'password123456'");
-      adminStmt.execute("create user testuser2 'password123456'");
-      adminStmt.execute("create role testrole");
-      adminStmt.execute("create database testdb");
+    try {
+      try (Connection adminCon = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
+          Statement adminStmt = adminCon.createStatement()) {
+        adminStmt.execute("create user testuser 'password123456'");
+        adminStmt.execute("create user testuser2 'password123456'");
+        adminStmt.execute("create role testrole");
+        adminStmt.execute("create database testdb");
 
-      // cannot create admin user
-      Assert.assertThrows(
-          SQLException.class,
-          () -> {
-            adminStmt.execute("CREATE USER root 'password'");
-          });
-      // cannot create admin role
-      Assert.assertThrows(
-          SQLException.class,
-          () -> {
-            adminStmt.execute("CREATE role root");
-          });
+        // cannot create admin user
+        Assert.assertThrows(
+            SQLException.class,
+            () -> {
+              adminStmt.execute("CREATE USER root 'password'");
+            });
+        // cannot create admin role
+        Assert.assertThrows(
+            SQLException.class,
+            () -> {
+              adminStmt.execute("CREATE role root");
+            });
 
-      // cannot grant role to admin user
-      Assert.assertThrows(
-          SQLException.class,
-          () -> {
-            adminStmt.execute("GRANT ROLE testrole to root");
-          });
+        // cannot grant role to admin user
+        Assert.assertThrows(
+            SQLException.class,
+            () -> {
+              adminStmt.execute("GRANT ROLE testrole to root");
+            });
 
-      // cannot grant privilege to admin user
-      Assert.assertThrows(
-          SQLException.class,
-          () -> {
-            adminStmt.execute("GRANT MANAGE_USER to root");
-          });
+        // cannot grant privilege to admin user
+        Assert.assertThrows(
+            SQLException.class,
+            () -> {
+              adminStmt.execute("GRANT MANAGE_USER to root");
+            });
 
-      // admin can do all things below.
-      adminStmt.execute("GRANT SECURITY to user testuser with grant option");
+        // admin can do all things below.
+        adminStmt.execute("GRANT SECURITY to user testuser with grant option");
 
-      adminStmt.execute("use testdb");
-      adminStmt.execute("GRANT SELECT ON TABLE TB to user testuser");
-      adminStmt.execute("GRANT INSERT ON TABLE TB to user testuser");
-      adminStmt.execute("GRANT INSERT ON DATABASE testdb to user testuser");
-      adminStmt.execute("GRANT ALTER ON ANY to user testuser");
+        adminStmt.execute("use testdb");
+        adminStmt.execute("GRANT SELECT ON TABLE TB to user testuser");
+        adminStmt.execute("GRANT INSERT ON TABLE TB to user testuser");
+        adminStmt.execute("GRANT INSERT ON DATABASE testdb to user testuser");
+        adminStmt.execute("GRANT ALTER ON ANY to user testuser");
 
-      adminStmt.execute("GRANT DROP ON TABLE TB to user testuser2 with grant option");
-      adminStmt.execute("GRANT CREATE ON TABLE TB to user testuser2 with grant option");
-      adminStmt.execute("GRANT DROP ON DATABASE testdb to user testuser2 with grant option");
-      adminStmt.execute("GRANT SELECT ON ANY to user testuser2 with grant option");
+        adminStmt.execute("GRANT DROP ON TABLE TB to user testuser2 with grant option");
+        adminStmt.execute("GRANT CREATE ON TABLE TB to user testuser2 with grant option");
+        adminStmt.execute("GRANT DROP ON DATABASE testdb to user testuser2 with grant option");
+        adminStmt.execute("GRANT SELECT ON ANY to user testuser2 with grant option");
 
-      adminStmt.execute("GRANT ROLE testrole to testuser");
-    }
+        adminStmt.execute("GRANT ROLE testrole to testuser");
+      }
 
-    try (Connection userCon1 =
-            EnvFactory.getEnv()
-                .getConnection("testuser", "password123456", BaseEnv.TABLE_SQL_DIALECT);
-        Statement userStmt = userCon1.createStatement()) {
+      try (Connection userCon1 =
+              EnvFactory.getEnv()
+                  .getConnection("testuser", "password123456", BaseEnv.TABLE_SQL_DIALECT);
+          Statement userStmt = userCon1.createStatement()) {
 
-      // can create role
-      userStmt.execute("CREATE ROLE testrole2");
-      // can grant role to user
-      userStmt.execute("GRANT ROLE testrole2 to testuser");
+        // can create role
+        userStmt.execute("CREATE ROLE testrole2");
+        // can grant role to user
+        userStmt.execute("GRANT ROLE testrole2 to testuser");
 
-      // can list itself privileges and the all roles privileges
-      ResultSet rs = userStmt.executeQuery("List privileges of user testuser");
-      Set<String> ans =
-          new HashSet<>(
-              Arrays.asList(
-                  ",,SECURITY,true,",
-                  ",*.*,ALTER,false,",
-                  ",testdb.*,INSERT,false,",
-                  ",testdb.tb,SELECT,false,",
-                  ",testdb.tb,INSERT,false,"));
-      TestUtils.assertResultSetEqual(rs, "Role,Scope,Privileges,GrantOption,", ans);
-      rs = userStmt.executeQuery("List privileges of role testrole");
-      TestUtils.assertResultSetEqual(
-          rs, "Role,Scope,Privileges,GrantOption,", Collections.emptySet());
-      rs = userStmt.executeQuery("List privileges of role testrole2");
-      TestUtils.assertResultSetEqual(
-          rs, "Role,Scope,Privileges,GrantOption,", Collections.emptySet());
-      userStmt.execute("CREATE USER testuser3 'password123456'");
+        // can list itself privileges and the all roles privileges
+        ResultSet rs = userStmt.executeQuery("List privileges of user testuser");
+        Set<String> ans =
+            new HashSet<>(
+                Arrays.asList(
+                    ",,SECURITY,true,",
+                    ",*.*,ALTER,false,",
+                    ",testdb.*,INSERT,false,",
+                    ",testdb.tb,SELECT,false,",
+                    ",testdb.tb,INSERT,false,"));
+        TestUtils.assertResultSetEqual(rs, "Role,Scope,Privileges,GrantOption,", ans);
+        rs = userStmt.executeQuery("List privileges of role testrole");
+        TestUtils.assertResultSetEqual(
+            rs, "Role,Scope,Privileges,GrantOption,", Collections.emptySet());
+        rs = userStmt.executeQuery("List privileges of role testrole2");
+        TestUtils.assertResultSetEqual(
+            rs, "Role,Scope,Privileges,GrantOption,", Collections.emptySet());
+        userStmt.execute("CREATE USER testuser3 'password123456'");
 
-      userStmt.execute("GRANT drop on database testdb to user testuser3");
-      userStmt.execute("GRANT SELECT ON database testdb to user testuser3");
-      rs = userStmt.executeQuery("List privileges of user testuser3");
-      ans = new HashSet<>(Arrays.asList(",testdb.*,SELECT,false,", ",testdb.*,DROP,false,"));
-      TestUtils.assertResultSetEqual(rs, "Role,Scope,Privileges,GrantOption,", ans);
-      userStmt.execute("REVOKE SELECT ON DATABASE testdb from user testuser3");
+        userStmt.execute("GRANT drop on database testdb to user testuser3");
+        userStmt.execute("GRANT SELECT ON database testdb to user testuser3");
+        rs = userStmt.executeQuery("List privileges of user testuser3");
+        ans = new HashSet<>(Arrays.asList(",testdb.*,SELECT,false,", ",testdb.*,DROP,false,"));
+        TestUtils.assertResultSetEqual(rs, "Role,Scope,Privileges,GrantOption,", ans);
+        userStmt.execute("REVOKE SELECT ON DATABASE testdb from user testuser3");
 
-      rs = userStmt.executeQuery("List privileges of user testuser3");
-      TestUtils.assertResultSetEqual(
-          rs, "Role,Scope,Privileges,GrantOption,", Collections.singleton(",testdb.*,DROP,false,"));
+        rs = userStmt.executeQuery("List privileges of user testuser3");
+        TestUtils.assertResultSetEqual(
+            rs,
+            "Role,Scope,Privileges,GrantOption,",
+            Collections.singleton(",testdb.*,DROP,false,"));
+      }
+    } finally {
+      cleanupAfterTest();
     }
   }
 
   @Test
   public void checkGrantRevokeAllPrivileges() throws SQLException {
-    // In this IT:
-    // grant
-    // 1. grant all on table tb1 with grant option
-    // 2. grant all on database testdb
-    // 3. grant all on any
-    // revoke
-    // 1. revoke grant option for all on table tb1
-    // 2. revoke all on table tb1
-    // 3. revoke all on database testdb
-    // 4. revoke all on any
-    // grant and revoke
-    // 1. grant all on user/role
-    // 2. revoke all on any
-    // 3. revoke all on user/role
+    try {
+      // In this IT:
+      // grant
+      // 1. grant all on table tb1 with grant option
+      // 2. grant all on database testdb
+      // 3. grant all on any
+      // revoke
+      // 1. revoke grant option for all on table tb1
+      // 2. revoke all on table tb1
+      // 3. revoke all on database testdb
+      // 4. revoke all on any
+      // grant and revoke
+      // 1. grant all on user/role
+      // 2. revoke all on any
+      // 3. revoke all on user/role
 
-    for (boolean isUser : new boolean[] {true, false}) {
+      for (boolean isUser : new boolean[] {true, false}) {
+        try (Connection adminCon = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
+            Statement adminStmt = adminCon.createStatement()) {
+          adminStmt.execute("create database testdb");
+          adminStmt.execute(isUser ? "create user test 'password123456'" : "create role test");
+          adminStmt.execute("use testdb");
+
+          // 1. grant all on table tb1 with grant option
+          adminStmt.execute(
+              "grant all on table tb1 to "
+                  + (isUser ? "user test" : "role test")
+                  + " with grant option");
+          Set<String> listPrivilegeResult = new HashSet<>();
+          for (PrivilegeType privilegeType : PrivilegeType.values()) {
+            if (privilegeType.isRelationalPrivilege() && !privilegeType.isDeprecated()) {
+              listPrivilegeResult.add(
+                  (isUser ? "," : "test,") + "testdb.tb1," + privilegeType + ",true,");
+            }
+          }
+          ResultSet resultSet =
+              adminStmt.executeQuery("List privileges of " + (isUser ? "user test" : "role test"));
+          TestUtils.assertResultSetEqual(
+              resultSet, "Role,Scope,Privileges,GrantOption,", listPrivilegeResult);
+
+          // 2. grant all on database testdb
+          adminStmt.execute(
+              "grant all on database testdb to " + (isUser ? "user test" : "role test"));
+          for (PrivilegeType privilegeType : PrivilegeType.values()) {
+            if (privilegeType.isRelationalPrivilege()) {
+              listPrivilegeResult.add(
+                  (isUser ? "," : "test,") + "testdb.*," + privilegeType + ",false,");
+            }
+          }
+          resultSet =
+              adminStmt.executeQuery("List privileges of " + (isUser ? "user test" : "role test"));
+          TestUtils.assertResultSetEqual(
+              resultSet, "Role,Scope,Privileges,GrantOption,", listPrivilegeResult);
+
+          // 3. grant all on any
+          adminStmt.execute("grant all on any to " + (isUser ? "user test" : "role test"));
+          for (PrivilegeType privilegeType : PrivilegeType.values()) {
+            if (privilegeType.isRelationalPrivilege()) {
+              listPrivilegeResult.add(
+                  (isUser ? "," : "test,") + "*.*," + privilegeType + ",false,");
+            }
+          }
+          resultSet =
+              adminStmt.executeQuery("List privileges of " + (isUser ? "user test" : "role test"));
+          TestUtils.assertResultSetEqual(
+              resultSet, "Role,Scope,Privileges,GrantOption,", listPrivilegeResult);
+
+          // 1. revoke grant option for all on table tb1
+          adminStmt.execute(
+              "revoke grant option for all on table tb1 from "
+                  + (isUser ? "user test" : "role test"));
+          for (PrivilegeType privilegeType : PrivilegeType.values()) {
+            if (privilegeType.isRelationalPrivilege()) {
+              listPrivilegeResult.remove(
+                  (isUser ? "," : "test,") + "testdb.tb1," + privilegeType + ",true,");
+              listPrivilegeResult.add(
+                  (isUser ? "," : "test,") + "testdb.tb1," + privilegeType + ",false,");
+            }
+          }
+          resultSet =
+              adminStmt.executeQuery("List privileges of " + (isUser ? "user test" : "role test"));
+          TestUtils.assertResultSetEqual(
+              resultSet, "Role,Scope,Privileges,GrantOption,", listPrivilegeResult);
+
+          // 2. revoke all on table tb1
+          adminStmt.execute("revoke all on table tb1 from " + (isUser ? "user test" : "role test"));
+          for (PrivilegeType privilegeType : PrivilegeType.values()) {
+            if (privilegeType.isRelationalPrivilege()) {
+              listPrivilegeResult.remove(
+                  (isUser ? "," : "test,") + "testdb.tb1," + privilegeType + ",false,");
+            }
+          }
+          resultSet =
+              adminStmt.executeQuery("List privileges of " + (isUser ? "user test" : "role test"));
+          TestUtils.assertResultSetEqual(
+              resultSet, "Role,Scope,Privileges,GrantOption,", listPrivilegeResult);
+
+          // 3. revoke all on database testdb
+          adminStmt.execute(
+              "revoke all on database testdb from " + (isUser ? "user test" : "role test"));
+          for (PrivilegeType privilegeType : PrivilegeType.values()) {
+            if (privilegeType.isRelationalPrivilege()) {
+              listPrivilegeResult.remove(
+                  (isUser ? "," : "test,") + "testdb.*," + privilegeType + ",false,");
+            }
+          }
+          resultSet =
+              adminStmt.executeQuery("List privileges of " + (isUser ? "user test" : "role test"));
+          TestUtils.assertResultSetEqual(
+              resultSet, "Role,Scope,Privileges,GrantOption,", listPrivilegeResult);
+
+          // 4. revoke all on any
+          adminStmt.execute("revoke all on any from " + (isUser ? "user test" : "role test"));
+          for (PrivilegeType privilegeType : PrivilegeType.values()) {
+            if (privilegeType.isRelationalPrivilege()) {
+              listPrivilegeResult.remove(
+                  (isUser ? "," : "test,") + "*.*," + privilegeType + ",false,");
+            }
+          }
+          Assert.assertTrue(listPrivilegeResult.isEmpty());
+          resultSet =
+              adminStmt.executeQuery("List privileges of " + (isUser ? "user test" : "role test"));
+          TestUtils.assertResultSetEqual(
+              resultSet, "Role,Scope,Privileges,GrantOption,", listPrivilegeResult);
+
+          // 1. grant all on user/role
+          adminStmt.execute("grant all to " + (isUser ? "user test" : "role test"));
+          for (PrivilegeType privilegeType : PrivilegeType.values()) {
+            if (privilegeType.isDeprecated() || privilegeType.isHided()) {
+              continue;
+            }
+            if (privilegeType.isRelationalPrivilege()) {
+              listPrivilegeResult.add(
+                  (isUser ? "," : "test,") + "*.*," + privilegeType + ",false,");
+            } else if (privilegeType.forRelationalSys()) {
+              listPrivilegeResult.add((isUser ? "," : "test,") + "," + privilegeType + ",false,");
+            }
+          }
+          resultSet =
+              adminStmt.executeQuery("List privileges of " + (isUser ? "user test" : "role test"));
+          TestUtils.assertResultSetEqual(
+              resultSet, "Role,Scope,Privileges,GrantOption,", listPrivilegeResult);
+
+          // 2. revoke all on any
+          adminStmt.execute("revoke all on any from " + (isUser ? "user test" : "role test"));
+          for (PrivilegeType privilegeType : PrivilegeType.values()) {
+            if (privilegeType.isRelationalPrivilege()) {
+              listPrivilegeResult.remove(
+                  (isUser ? "," : "test,") + "*.*," + privilegeType + ",false,");
+            }
+          }
+          resultSet =
+              adminStmt.executeQuery("List privileges of " + (isUser ? "user test" : "role test"));
+          TestUtils.assertResultSetEqual(
+              resultSet, "Role,Scope,Privileges,GrantOption,", listPrivilegeResult);
+
+          // 3. revoke all on user/role
+          adminStmt.execute("revoke all from " + (isUser ? "user test" : "role test"));
+          listPrivilegeResult.clear();
+          resultSet =
+              adminStmt.executeQuery("List privileges of " + (isUser ? "user test" : "role test"));
+          TestUtils.assertResultSetEqual(
+              resultSet, "Role,Scope,Privileges,GrantOption,", listPrivilegeResult);
+          adminStmt.execute("drop database testdb");
+          adminStmt.execute(isUser ? "drop user test" : "drop role test");
+        }
+      }
+
       try (Connection adminCon = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
           Statement adminStmt = adminCon.createStatement()) {
-        adminStmt.execute("create database testdb");
-        adminStmt.execute(isUser ? "create user test 'password123456'" : "create role test");
-        adminStmt.execute("use testdb");
-
-        // 1. grant all on table tb1 with grant option
-        adminStmt.execute(
-            "grant all on table tb1 to "
-                + (isUser ? "user test" : "role test")
-                + " with grant option");
-        Set<String> listPrivilegeResult = new HashSet<>();
-        for (PrivilegeType privilegeType : PrivilegeType.values()) {
-          if (privilegeType.isRelationalPrivilege() && !privilegeType.isDeprecated()) {
-            listPrivilegeResult.add(
-                (isUser ? "," : "test,") + "testdb.tb1," + privilegeType + ",true,");
-          }
-        }
-        ResultSet resultSet =
-            adminStmt.executeQuery("List privileges of " + (isUser ? "user test" : "role test"));
-        TestUtils.assertResultSetEqual(
-            resultSet, "Role,Scope,Privileges,GrantOption,", listPrivilegeResult);
-
-        // 2. grant all on database testdb
-        adminStmt.execute(
-            "grant all on database testdb to " + (isUser ? "user test" : "role test"));
-        for (PrivilegeType privilegeType : PrivilegeType.values()) {
-          if (privilegeType.isRelationalPrivilege()) {
-            listPrivilegeResult.add(
-                (isUser ? "," : "test,") + "testdb.*," + privilegeType + ",false,");
-          }
-        }
-        resultSet =
-            adminStmt.executeQuery("List privileges of " + (isUser ? "user test" : "role test"));
-        TestUtils.assertResultSetEqual(
-            resultSet, "Role,Scope,Privileges,GrantOption,", listPrivilegeResult);
-
-        // 3. grant all on any
-        adminStmt.execute("grant all on any to " + (isUser ? "user test" : "role test"));
-        for (PrivilegeType privilegeType : PrivilegeType.values()) {
-          if (privilegeType.isRelationalPrivilege()) {
-            listPrivilegeResult.add((isUser ? "," : "test,") + "*.*," + privilegeType + ",false,");
-          }
-        }
-        resultSet =
-            adminStmt.executeQuery("List privileges of " + (isUser ? "user test" : "role test"));
-        TestUtils.assertResultSetEqual(
-            resultSet, "Role,Scope,Privileges,GrantOption,", listPrivilegeResult);
-
-        // 1. revoke grant option for all on table tb1
-        adminStmt.execute(
-            "revoke grant option for all on table tb1 from "
-                + (isUser ? "user test" : "role test"));
-        for (PrivilegeType privilegeType : PrivilegeType.values()) {
-          if (privilegeType.isRelationalPrivilege()) {
-            listPrivilegeResult.remove(
-                (isUser ? "," : "test,") + "testdb.tb1," + privilegeType + ",true,");
-            listPrivilegeResult.add(
-                (isUser ? "," : "test,") + "testdb.tb1," + privilegeType + ",false,");
-          }
-        }
-        resultSet =
-            adminStmt.executeQuery("List privileges of " + (isUser ? "user test" : "role test"));
-        TestUtils.assertResultSetEqual(
-            resultSet, "Role,Scope,Privileges,GrantOption,", listPrivilegeResult);
-
-        // 2. revoke all on table tb1
-        adminStmt.execute("revoke all on table tb1 from " + (isUser ? "user test" : "role test"));
-        for (PrivilegeType privilegeType : PrivilegeType.values()) {
-          if (privilegeType.isRelationalPrivilege()) {
-            listPrivilegeResult.remove(
-                (isUser ? "," : "test,") + "testdb.tb1," + privilegeType + ",false,");
-          }
-        }
-        resultSet =
-            adminStmt.executeQuery("List privileges of " + (isUser ? "user test" : "role test"));
-        TestUtils.assertResultSetEqual(
-            resultSet, "Role,Scope,Privileges,GrantOption,", listPrivilegeResult);
-
-        // 3. revoke all on database testdb
-        adminStmt.execute(
-            "revoke all on database testdb from " + (isUser ? "user test" : "role test"));
-        for (PrivilegeType privilegeType : PrivilegeType.values()) {
-          if (privilegeType.isRelationalPrivilege()) {
-            listPrivilegeResult.remove(
-                (isUser ? "," : "test,") + "testdb.*," + privilegeType + ",false,");
-          }
-        }
-        resultSet =
-            adminStmt.executeQuery("List privileges of " + (isUser ? "user test" : "role test"));
-        TestUtils.assertResultSetEqual(
-            resultSet, "Role,Scope,Privileges,GrantOption,", listPrivilegeResult);
-
-        // 4. revoke all on any
-        adminStmt.execute("revoke all on any from " + (isUser ? "user test" : "role test"));
-        for (PrivilegeType privilegeType : PrivilegeType.values()) {
-          if (privilegeType.isRelationalPrivilege()) {
-            listPrivilegeResult.remove(
-                (isUser ? "," : "test,") + "*.*," + privilegeType + ",false,");
-          }
-        }
-        Assert.assertTrue(listPrivilegeResult.isEmpty());
-        resultSet =
-            adminStmt.executeQuery("List privileges of " + (isUser ? "user test" : "role test"));
-        TestUtils.assertResultSetEqual(
-            resultSet, "Role,Scope,Privileges,GrantOption,", listPrivilegeResult);
-
-        // 1. grant all on user/role
-        adminStmt.execute("grant all to " + (isUser ? "user test" : "role test"));
-        for (PrivilegeType privilegeType : PrivilegeType.values()) {
-          if (privilegeType.isDeprecated() || privilegeType.isHided()) {
-            continue;
-          }
-          if (privilegeType.isRelationalPrivilege()) {
-            listPrivilegeResult.add((isUser ? "," : "test,") + "*.*," + privilegeType + ",false,");
-          } else if (privilegeType.forRelationalSys()) {
-            listPrivilegeResult.add((isUser ? "," : "test,") + "," + privilegeType + ",false,");
-          }
-        }
-        resultSet =
-            adminStmt.executeQuery("List privileges of " + (isUser ? "user test" : "role test"));
-        TestUtils.assertResultSetEqual(
-            resultSet, "Role,Scope,Privileges,GrantOption,", listPrivilegeResult);
-
-        // 2. revoke all on any
-        adminStmt.execute("revoke all on any from " + (isUser ? "user test" : "role test"));
-        for (PrivilegeType privilegeType : PrivilegeType.values()) {
-          if (privilegeType.isRelationalPrivilege()) {
-            listPrivilegeResult.remove(
-                (isUser ? "," : "test,") + "*.*," + privilegeType + ",false,");
-          }
-        }
-        resultSet =
-            adminStmt.executeQuery("List privileges of " + (isUser ? "user test" : "role test"));
-        TestUtils.assertResultSetEqual(
-            resultSet, "Role,Scope,Privileges,GrantOption,", listPrivilegeResult);
-
-        // 3. revoke all on user/role
-        adminStmt.execute("revoke all from " + (isUser ? "user test" : "role test"));
-        listPrivilegeResult.clear();
-        resultSet =
-            adminStmt.executeQuery("List privileges of " + (isUser ? "user test" : "role test"));
-        TestUtils.assertResultSetEqual(
-            resultSet, "Role,Scope,Privileges,GrantOption,", listPrivilegeResult);
-        adminStmt.execute("drop database testdb");
-        adminStmt.execute(isUser ? "drop user test" : "drop role test");
+        adminStmt.execute("create user test 'password123456'");
+        adminStmt.execute("create user test2 'password123456'");
+        adminStmt.execute("grant all to user test");
+        adminStmt.execute("grant all to user test2 with grant option");
+        adminStmt.execute("revoke SELECT ON ANY from user test");
+        adminStmt.execute("create role role1");
+        adminStmt.execute("grant all to role role1 with grant option");
       }
-    }
 
-    try (Connection adminCon = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
-        Statement adminStmt = adminCon.createStatement()) {
-      adminStmt.execute("create user test 'password123456'");
-      adminStmt.execute("create user test2 'password123456'");
-      adminStmt.execute("grant all to user test");
-      adminStmt.execute("grant all to user test2 with grant option");
-      adminStmt.execute("revoke SELECT ON ANY from user test");
-      adminStmt.execute("create role role1");
-      adminStmt.execute("grant all to role role1 with grant option");
-    }
-
-    Set<String> listUserPrivilegeResult = new HashSet<>();
-    for (PrivilegeType privilegeType : PrivilegeType.values()) {
-      if (privilegeType == PrivilegeType.SELECT
-          || privilegeType.isDeprecated()
-          || privilegeType.isHided()) {
-        continue;
-      }
-      if (privilegeType.isRelationalPrivilege()) {
-        listUserPrivilegeResult.add(",*.*," + privilegeType + ",false,");
-      }
-      if (privilegeType.forRelationalSys()) {
-        listUserPrivilegeResult.add(",," + privilegeType + ",false,");
-      }
-    }
-
-    Set<String> listRolePrivilegeResult = new HashSet<>();
-    for (PrivilegeType privilegeType : PrivilegeType.values()) {
-      if (privilegeType.isDeprecated() || privilegeType.isHided()) {
-        continue;
-      }
-      if (privilegeType.isRelationalPrivilege()) {
-        listRolePrivilegeResult.add("role1,*.*," + privilegeType + ",true,");
-      }
-      if (privilegeType.forRelationalSys()) {
-        listRolePrivilegeResult.add("role1,," + privilegeType + ",true,");
-      }
-    }
-
-    try (Connection userCon =
-            EnvFactory.getEnv().getConnection("test", "password123456", BaseEnv.TABLE_SQL_DIALECT);
-        Statement userConStatement = userCon.createStatement()) {
-      ResultSet resultSet = userConStatement.executeQuery("List privileges of user test");
-      TestUtils.assertResultSetEqual(
-          resultSet, "Role,Scope,Privileges,GrantOption,", listUserPrivilegeResult);
-
-      // Have manage_role privilege
-      resultSet = userConStatement.executeQuery("List privileges of role role1");
-      TestUtils.assertResultSetEqual(
-          resultSet, "Role,Scope,Privileges,GrantOption,", listRolePrivilegeResult);
-    }
-
-    try (Connection userCon =
-            EnvFactory.getEnv()
-                .getConnection("test2", "password123456", BaseEnv.TABLE_SQL_DIALECT);
-        Statement userConStatement = userCon.createStatement()) {
-      // user2 can grant all to user test
-      userConStatement.execute("GRANT ALL to user test");
-      // user2 can revoke all from user test
-      userConStatement.execute("REVOKE ALL from user test");
-
-      userConStatement.execute("GRANT ALL to user test");
-    }
-
-    try (Connection adminCon = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
-        Statement adminStmt = adminCon.createStatement()) {
-      adminStmt.execute("revoke SECURITY from user test2");
-    }
-
-    try (Connection userCon =
-            EnvFactory.getEnv()
-                .getConnection("test2", "password123456", BaseEnv.TABLE_SQL_DIALECT);
-        Statement userConStatement = userCon.createStatement()) {
-      // user2 can not grant all to user test
-      Assert.assertThrows(
-          SQLException.class,
-          () -> {
-            userConStatement.execute("GRANT ALL to user test2");
-          });
-
-      // user2 can not revoke all from user test because does not hava all privileges
-      Assert.assertThrows(
-          SQLException.class,
-          () -> {
-            userConStatement.execute("REVOKE ALL to user test2");
-          });
-    }
-
-    try (Connection adminCon = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
-        Statement adminStmt = adminCon.createStatement()) {
-      adminStmt.execute("REVOKE ALL FROM USER test");
-      ResultSet resultSet = adminStmt.executeQuery("List privileges of user test");
-      TestUtils.assertResultSetEqual(
-          resultSet, "Role,Scope,Privileges,GrantOption,", Collections.emptySet());
-      adminStmt.execute("GRANT ALL ON db1.test TO USER test");
-      adminStmt.execute("GRANT ALL ON DATABASE db2 TO USER test with grant option");
-      resultSet = adminStmt.executeQuery("List privileges of user test");
-      Set<String> resultSetALL = new HashSet<>();
+      Set<String> listUserPrivilegeResult = new HashSet<>();
       for (PrivilegeType privilegeType : PrivilegeType.values()) {
+        if (privilegeType == PrivilegeType.SELECT
+            || privilegeType.isDeprecated()
+            || privilegeType.isHided()) {
+          continue;
+        }
         if (privilegeType.isRelationalPrivilege()) {
-          resultSetALL.add(",db2.*," + privilegeType + ",true,");
-          resultSetALL.add(",db1.test," + privilegeType + ",false,");
+          listUserPrivilegeResult.add(",*.*," + privilegeType + ",false,");
+        }
+        if (privilegeType.forRelationalSys()) {
+          listUserPrivilegeResult.add(",," + privilegeType + ",false,");
         }
       }
-      TestUtils.assertResultSetEqual(resultSet, "Role,Scope,Privileges,GrantOption,", resultSetALL);
-      adminStmt.execute("REVOKE ALL FROM USER test");
-      resultSet = adminStmt.executeQuery("List privileges of user test");
-      TestUtils.assertResultSetEqual(
-          resultSet, "Role,Scope,Privileges,GrantOption,", Collections.emptySet());
+
+      Set<String> listRolePrivilegeResult = new HashSet<>();
+      for (PrivilegeType privilegeType : PrivilegeType.values()) {
+        if (privilegeType.isDeprecated() || privilegeType.isHided()) {
+          continue;
+        }
+        if (privilegeType.isRelationalPrivilege()) {
+          listRolePrivilegeResult.add("role1,*.*," + privilegeType + ",true,");
+        }
+        if (privilegeType.forRelationalSys()) {
+          listRolePrivilegeResult.add("role1,," + privilegeType + ",true,");
+        }
+      }
+
+      try (Connection userCon =
+              EnvFactory.getEnv()
+                  .getConnection("test", "password123456", BaseEnv.TABLE_SQL_DIALECT);
+          Statement userConStatement = userCon.createStatement()) {
+        ResultSet resultSet = userConStatement.executeQuery("List privileges of user test");
+        TestUtils.assertResultSetEqual(
+            resultSet, "Role,Scope,Privileges,GrantOption,", listUserPrivilegeResult);
+
+        // Have manage_role privilege
+        resultSet = userConStatement.executeQuery("List privileges of role role1");
+        TestUtils.assertResultSetEqual(
+            resultSet, "Role,Scope,Privileges,GrantOption,", listRolePrivilegeResult);
+      }
+
+      try (Connection userCon =
+              EnvFactory.getEnv()
+                  .getConnection("test2", "password123456", BaseEnv.TABLE_SQL_DIALECT);
+          Statement userConStatement = userCon.createStatement()) {
+        // user2 can grant all to user test
+        userConStatement.execute("GRANT ALL to user test");
+        // user2 can revoke all from user test
+        userConStatement.execute("REVOKE ALL from user test");
+
+        userConStatement.execute("GRANT ALL to user test");
+      }
+
+      try (Connection adminCon = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
+          Statement adminStmt = adminCon.createStatement()) {
+        adminStmt.execute("revoke SECURITY from user test2");
+      }
+
+      try (Connection userCon =
+              EnvFactory.getEnv()
+                  .getConnection("test2", "password123456", BaseEnv.TABLE_SQL_DIALECT);
+          Statement userConStatement = userCon.createStatement()) {
+        // user2 can not grant all to user test
+        Assert.assertThrows(
+            SQLException.class,
+            () -> {
+              userConStatement.execute("GRANT ALL to user test2");
+            });
+
+        // user2 can not revoke all from user test because does not hava all privileges
+        Assert.assertThrows(
+            SQLException.class,
+            () -> {
+              userConStatement.execute("REVOKE ALL to user test2");
+            });
+      }
+
+      try (Connection adminCon = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
+          Statement adminStmt = adminCon.createStatement()) {
+        adminStmt.execute("REVOKE ALL FROM USER test");
+        ResultSet resultSet = adminStmt.executeQuery("List privileges of user test");
+        TestUtils.assertResultSetEqual(
+            resultSet, "Role,Scope,Privileges,GrantOption,", Collections.emptySet());
+        adminStmt.execute("GRANT ALL ON db1.test TO USER test");
+        adminStmt.execute("GRANT ALL ON DATABASE db2 TO USER test with grant option");
+        resultSet = adminStmt.executeQuery("List privileges of user test");
+        Set<String> resultSetALL = new HashSet<>();
+        for (PrivilegeType privilegeType : PrivilegeType.values()) {
+          if (privilegeType.isRelationalPrivilege()) {
+            resultSetALL.add(",db2.*," + privilegeType + ",true,");
+            resultSetALL.add(",db1.test," + privilegeType + ",false,");
+          }
+        }
+        TestUtils.assertResultSetEqual(
+            resultSet, "Role,Scope,Privileges,GrantOption,", resultSetALL);
+        adminStmt.execute("REVOKE ALL FROM USER test");
+        resultSet = adminStmt.executeQuery("List privileges of user test");
+        TestUtils.assertResultSetEqual(
+            resultSet, "Role,Scope,Privileges,GrantOption,", Collections.emptySet());
+      }
+    } finally {
+      cleanupAfterTest();
     }
   }
 
   @Test
   public void testCreateUserAndRole() throws SQLException {
-    try (Connection adminCon = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
-        Statement adminStmt = adminCon.createStatement()) {
-      // normal case
-      adminStmt.execute("create user testuser 'password123456'");
-      // username abnormal
-      adminStmt.execute("create user \"!@#$%^*()_+-=1\" 'password123456'");
+    try {
+      try (Connection adminCon = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
+          Statement adminStmt = adminCon.createStatement()) {
+        // normal case
+        adminStmt.execute("create user testuser 'password123456'");
+        // username abnormal
+        adminStmt.execute("create user \"!@#$%^*()_+-=1\" 'password123456'");
 
-      // username and password abnormal
-      adminStmt.execute("create user \"!@#$%^*()_+-=2\" '!@#$%^*()_+-='");
+        // username and password abnormal
+        adminStmt.execute("create user \"!@#$%^*()_+-=2\" '!@#$%^*()_+-='");
 
-      // rolename abnormal
-      adminStmt.execute("create role \"!@#$%^*()_+-=3\" ");
+        // rolename abnormal
+        adminStmt.execute("create role \"!@#$%^*()_+-=3\" ");
 
-      ResultSet resultSet = adminStmt.executeQuery("List user");
-      Set<String> resultSetList = new HashSet<>();
-      resultSetList.add("0,root,");
-      resultSetList.add("10000,testuser,");
-      resultSetList.add("10001,!@#$%^*()_+-=1,");
-      resultSetList.add("10002,!@#$%^*()_+-=2,");
-      TestUtils.assertResultSetEqual(resultSet, "UserId,User,", resultSetList);
-      resultSet = adminStmt.executeQuery("List role");
-      TestUtils.assertResultSetEqual(resultSet, "Role,", Collections.singleton("!@#$%^*()_+-=3,"));
-      adminStmt.execute("GRANT role \"!@#$%^*()_+-=3\" to  \"!@#$%^*()_+-=1\"");
-      adminStmt.execute("ALTER user \"!@#$%^*()_+-=1\" set password '!@#$%^*()_+-=\'");
-    }
+        ResultSet resultSet = adminStmt.executeQuery("List user");
+        Set<String> resultSetList = new HashSet<>();
+        resultSetList.add("0,root,");
+        resultSetList.add("10000,testuser,");
+        resultSetList.add("10001,!@#$%^*()_+-=1,");
+        resultSetList.add("10002,!@#$%^*()_+-=2,");
+        TestUtils.assertResultSetEqual(resultSet, "UserId,User,", resultSetList);
+        resultSet = adminStmt.executeQuery("List role");
+        TestUtils.assertResultSetEqual(
+            resultSet, "Role,", Collections.singleton("!@#$%^*()_+-=3,"));
+        adminStmt.execute("GRANT role \"!@#$%^*()_+-=3\" to  \"!@#$%^*()_+-=1\"");
+        adminStmt.execute("ALTER user \"!@#$%^*()_+-=1\" set password '!@#$%^*()_+-=\'");
+      }
 
-    try (Connection userCon =
-            EnvFactory.getEnv()
-                .getConnection("!@#$%^*()_+-=1", "!@#$%^*()_+-=", BaseEnv.TABLE_SQL_DIALECT);
-        Statement userConStatement = userCon.createStatement()) {
-      // List his role.
-      ResultSet set = userConStatement.executeQuery("List role of user \"!@#$%^*()_+-=1\"");
-      TestUtils.assertResultSetEqual(set, "Role,", Collections.singleton("!@#$%^*()_+-=3,"));
-    } catch (IoTDBSQLException e) {
-      Assert.fail();
+      try (Connection userCon =
+              EnvFactory.getEnv()
+                  .getConnection("!@#$%^*()_+-=1", "!@#$%^*()_+-=", BaseEnv.TABLE_SQL_DIALECT);
+          Statement userConStatement = userCon.createStatement()) {
+        // List his role.
+        ResultSet set = userConStatement.executeQuery("List role of user \"!@#$%^*()_+-=1\"");
+        TestUtils.assertResultSetEqual(set, "Role,", Collections.singleton("!@#$%^*()_+-=3,"));
+      } catch (IoTDBSQLException e) {
+        Assert.fail();
+      }
+    } finally {
+      cleanupAfterTest();
     }
   }
 
   @Test
   public void testAlterNonExistingUser() throws SQLException {
-    try (Connection adminCon = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
-        Statement adminStmt = adminCon.createStatement()) {
-      try {
-        adminStmt.execute("ALTER USER nonExist SET PASSWORD 'asdfer1124566'");
-      } catch (SQLException e) {
-        assertEquals("804: User nonExist does not exist", e.getMessage());
+    try {
+      try (Connection adminCon = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
+          Statement adminStmt = adminCon.createStatement()) {
+        try {
+          adminStmt.execute("ALTER USER nonExist SET PASSWORD 'asdfer1124566'");
+        } catch (SQLException e) {
+          assertEquals("804: User nonExist does not exist", e.getMessage());
+        }
       }
+    } finally {
+      cleanupAfterTest();
     }
   }
 
   @Test
   public void testUserNameMustNotStartWithDoubleUnderscore() throws SQLException {
-    try (Connection adminCon = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
-        Statement adminStmt = adminCon.createStatement()) {
-      Assert.assertThrows(
-          SQLException.class, () -> adminStmt.execute("create user __badx 'password123456'"));
-      adminStmt.execute("create user gooduser 'password123456'");
-      Assert.assertThrows(
-          SQLException.class, () -> adminStmt.execute("ALTER USER gooduser RENAME TO __badx"));
-      adminStmt.execute("DROP USER gooduser");
+    try {
+      try (Connection adminCon = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
+          Statement adminStmt = adminCon.createStatement()) {
+        Assert.assertThrows(
+            SQLException.class, () -> adminStmt.execute("create user __badx 'password123456'"));
+        adminStmt.execute("create user gooduser 'password123456'");
+        Assert.assertThrows(
+            SQLException.class, () -> adminStmt.execute("ALTER USER gooduser RENAME TO __badx"));
+        adminStmt.execute("DROP USER gooduser");
+      }
+    } finally {
+      cleanupAfterTest();
     }
   }
 
   @Test
   public void testAudit() throws SQLException {
-    try (Connection adminCon = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
-        Statement adminStmt = adminCon.createStatement()) {
-      try {
-        adminStmt.execute("grant select on database __audit to user user2");
-      } catch (SQLException e) {
-        assertEquals(
-            "803: Access Denied: Cannot grant or revoke any privileges to __audit", e.getMessage());
+    try {
+      try (Connection adminCon = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
+          Statement adminStmt = adminCon.createStatement()) {
+        try {
+          adminStmt.execute("grant select on database __audit to user user2");
+        } catch (SQLException e) {
+          assertEquals(
+              "803: Access Denied: Cannot grant or revoke any privileges to __audit",
+              e.getMessage());
+        }
+        try {
+          adminStmt.execute("grant select on table __audit.t1 to user user2");
+        } catch (SQLException e) {
+          assertEquals(
+              "803: Access Denied: Cannot grant or revoke any privileges to __audit",
+              e.getMessage());
+        }
+        try {
+          adminStmt.execute("revoke select on table __audit.t1 from user user2");
+        } catch (SQLException e) {
+          assertEquals(
+              "803: Access Denied: Cannot grant or revoke any privileges to __audit",
+              e.getMessage());
+        }
+        try {
+          adminStmt.execute("grant select on table __audit.t1 to role role1");
+        } catch (SQLException e) {
+          assertEquals(
+              "803: Access Denied: Cannot grant or revoke any privileges to __audit",
+              e.getMessage());
+        }
+        try {
+          adminStmt.execute("revoke select on table __audit.t1 from role role1");
+        } catch (SQLException e) {
+          assertEquals(
+              "803: Access Denied: Cannot grant or revoke any privileges to __audit",
+              e.getMessage());
+        }
       }
-      try {
-        adminStmt.execute("grant select on table __audit.t1 to user user2");
-      } catch (SQLException e) {
-        assertEquals(
-            "803: Access Denied: Cannot grant or revoke any privileges to __audit", e.getMessage());
-      }
-      try {
-        adminStmt.execute("revoke select on table __audit.t1 from user user2");
-      } catch (SQLException e) {
-        assertEquals(
-            "803: Access Denied: Cannot grant or revoke any privileges to __audit", e.getMessage());
-      }
-      try {
-        adminStmt.execute("grant select on table __audit.t1 to role role1");
-      } catch (SQLException e) {
-        assertEquals(
-            "803: Access Denied: Cannot grant or revoke any privileges to __audit", e.getMessage());
-      }
-      try {
-        adminStmt.execute("revoke select on table __audit.t1 from role role1");
-      } catch (SQLException e) {
-        assertEquals(
-            "803: Access Denied: Cannot grant or revoke any privileges to __audit", e.getMessage());
-      }
+    } finally {
+      cleanupAfterTest();
     }
   }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBRelationalAuthIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBRelationalAuthIT.java
@@ -131,7 +131,6 @@ public class IoTDBRelationalAuthIT {
             Statement userStmt = userCon.createStatement()) {
           ResultSet resultSet = userStmt.executeQuery("LIST USER");
           Assert.assertTrue(resultSet.next());
-          Assert.assertEquals("10000", resultSet.getString(1));
           Assert.assertEquals("testuser", resultSet.getString(2));
           Assert.assertFalse(resultSet.next());
         }
@@ -196,8 +195,9 @@ public class IoTDBRelationalAuthIT {
         adminStmt.execute("create role testrole");
         adminStmt.execute("GRANT ROLE testrole to testuser");
         rs = adminStmt.executeQuery("LIST USER OF ROLE testrole");
-        TestUtils.assertResultSetEqual(
-            rs, "UserId,User,", Collections.singleton("10000,testuser,"));
+        Assert.assertTrue(rs.next());
+        Assert.assertEquals("testuser", rs.getString(2));
+        Assert.assertFalse(rs.next());
         rs = adminStmt.executeQuery("LIST ROLE OF USER testuser");
         TestUtils.assertResultSetEqual(rs, "Role,", Collections.singleton("testrole,"));
       }
@@ -611,12 +611,13 @@ public class IoTDBRelationalAuthIT {
         adminStmt.execute("create role \"!@#$%^*()_+-=3\" ");
 
         ResultSet resultSet = adminStmt.executeQuery("List user");
-        Set<String> resultSetList = new HashSet<>();
-        resultSetList.add("0,root,");
-        resultSetList.add("10000,testuser,");
-        resultSetList.add("10001,!@#$%^*()_+-=1,");
-        resultSetList.add("10002,!@#$%^*()_+-=2,");
-        TestUtils.assertResultSetEqual(resultSet, "UserId,User,", resultSetList);
+        Set<String> actualUsers = new HashSet<>();
+        while (resultSet.next()) {
+          actualUsers.add(resultSet.getString(2));
+        }
+        Set<String> expectedUsers =
+            new HashSet<>(Arrays.asList("root", "testuser", "!@#$%^*()_+-=1", "!@#$%^*()_+-=2"));
+        Assert.assertEquals(expectedUsers, actualUsers);
         resultSet = adminStmt.executeQuery("List role");
         TestUtils.assertResultSetEqual(
             resultSet, "Role,", Collections.singleton("!@#$%^*()_+-=3,"));

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBSeriesPermissionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBSeriesPermissionIT.java
@@ -26,9 +26,9 @@ import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -60,8 +60,8 @@ import static org.junit.Assert.fail;
 @Category({LocalStandaloneIT.class, ClusterIT.class})
 public class IoTDBSeriesPermissionIT {
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     EnvFactory.getEnv().getConfig().getCommonConfig().setEnforceStrongPassword(false);
     EnvFactory.getEnv().initClusterEnvironment();
     createUser("test", "test123123456");
@@ -69,16 +69,44 @@ public class IoTDBSeriesPermissionIT {
     createUser("test2", "test123123456");
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  private static void executeQuietly(Statement statement, String sql) {
+    try {
+      statement.execute(sql);
+    } catch (SQLException ignored) {
+      // ignore
+    }
+  }
+
+  private static void cleanupAfterTest() {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      executeQuietly(statement, "DELETE DATABASE root.test");
+      executeQuietly(statement, "DELETE DATABASE root.test1");
+      executeQuietly(statement, "DELETE DATABASE root.test3");
+      executeQuietly(statement, "DELETE DATABASE root.sg");
+      // revoke any privileges the tests may have granted
+      for (String user : new String[] {"test", "test1", "test2"}) {
+        executeQuietly(statement, "REVOKE ALL ON root.** FROM USER " + user);
+      }
+    } catch (SQLException ignored) {
+      // ignore
+    }
   }
 
   @Test
   public void testSchema() {
-    testWriteSchema();
+    try {
+      testWriteSchema();
 
-    testReadSchema();
+      testReadSchema();
+    } finally {
+      cleanupAfterTest();
+    }
   }
 
   private void testWriteSchema() {
@@ -261,9 +289,13 @@ public class IoTDBSeriesPermissionIT {
 
   @Test
   public void testData() {
-    testWriteData();
+    try {
+      testWriteData();
 
-    testReadData();
+      testReadData();
+    } finally {
+      cleanupAfterTest();
+    }
   }
 
   private void testWriteData() {
@@ -324,47 +356,51 @@ public class IoTDBSeriesPermissionIT {
 
   @Test
   public void ttlOperationsTest() {
-    try (Connection connection = EnvFactory.getEnv().getConnection("test2", "test123123456");
-        Statement statement = connection.createStatement()) {
-      ResultSet resultSet = statement.executeQuery("show all ttl");
-      Assert.assertFalse(resultSet.next());
-      assertNonQueryTestFail(
-          statement,
-          "set ttl to root.test.** 1",
-          "803: No permissions for this operation, please add privilege WRITE_SCHEMA on [root.test.**]");
-      assertNonQueryTestFail(
-          statement,
-          "unset ttl from root.test.**",
-          "803: No permissions for this operation, please add privilege WRITE_SCHEMA on [root.test.**]");
-    } catch (SQLException e) {
-      e.printStackTrace();
-      fail(e.getMessage());
-    }
-    try (Connection connection = EnvFactory.getEnv().getConnection();
-        Statement statement = connection.createStatement()) {
-      ResultSet resultSet = statement.executeQuery("show all ttl");
-      Assert.assertTrue(resultSet.next());
-      Assert.assertFalse(resultSet.next());
-      statement.execute("grant WRITE_SCHEMA on root.test.** to user test2");
+    try {
+      try (Connection connection = EnvFactory.getEnv().getConnection("test2", "test123123456");
+          Statement statement = connection.createStatement()) {
+        ResultSet resultSet = statement.executeQuery("show all ttl");
+        Assert.assertFalse(resultSet.next());
+        assertNonQueryTestFail(
+            statement,
+            "set ttl to root.test.** 1",
+            "803: No permissions for this operation, please add privilege WRITE_SCHEMA on [root.test.**]");
+        assertNonQueryTestFail(
+            statement,
+            "unset ttl from root.test.**",
+            "803: No permissions for this operation, please add privilege WRITE_SCHEMA on [root.test.**]");
+      } catch (SQLException e) {
+        e.printStackTrace();
+        fail(e.getMessage());
+      }
+      try (Connection connection = EnvFactory.getEnv().getConnection();
+          Statement statement = connection.createStatement()) {
+        ResultSet resultSet = statement.executeQuery("show all ttl");
+        Assert.assertTrue(resultSet.next());
+        Assert.assertFalse(resultSet.next());
+        statement.execute("grant WRITE_SCHEMA on root.test.** to user test2");
 
-      assertNonQueryTestFail(
-          statement,
-          "set ttl to root.__audit.** 1",
-          "803: The database 'root.__audit' is read-only.");
-    } catch (SQLException e) {
-      e.printStackTrace();
-      fail(e.getMessage());
-    }
-    try (Connection connection = EnvFactory.getEnv().getConnection("test2", "test123123456");
-        Statement statement = connection.createStatement()) {
-      statement.execute("set ttl to root.test.** 1");
-      ResultSet resultSet = statement.executeQuery("show all ttl");
-      Assert.assertTrue(resultSet.next());
-      Assert.assertFalse(resultSet.next());
-      statement.execute("unset ttl from root.test.**");
-    } catch (SQLException e) {
-      e.printStackTrace();
-      fail(e.getMessage());
+        assertNonQueryTestFail(
+            statement,
+            "set ttl to root.__audit.** 1",
+            "803: The database 'root.__audit' is read-only.");
+      } catch (SQLException e) {
+        e.printStackTrace();
+        fail(e.getMessage());
+      }
+      try (Connection connection = EnvFactory.getEnv().getConnection("test2", "test123123456");
+          Statement statement = connection.createStatement()) {
+        statement.execute("set ttl to root.test.** 1");
+        ResultSet resultSet = statement.executeQuery("show all ttl");
+        Assert.assertTrue(resultSet.next());
+        Assert.assertFalse(resultSet.next());
+        statement.execute("unset ttl from root.test.**");
+      } catch (SQLException e) {
+        e.printStackTrace();
+        fail(e.getMessage());
+      }
+    } finally {
+      cleanupAfterTest();
     }
   }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBTemplatePermissionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/auth/IoTDBTemplatePermissionIT.java
@@ -26,11 +26,15 @@ import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 
 import static org.apache.iotdb.commons.schema.column.ColumnHeaderConstant.showPathsUsingTemplateHeaders;
 import static org.apache.iotdb.db.it.utils.TestUtils.assertNonQueryTestFail;
@@ -48,113 +52,141 @@ import static org.apache.iotdb.db.it.utils.TestUtils.revokeUserSeriesPrivilege;
 @Category({LocalStandaloneIT.class, ClusterIT.class})
 public class IoTDBTemplatePermissionIT {
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     EnvFactory.getEnv().getConfig().getCommonConfig().setEnforceStrongPassword(false);
     EnvFactory.getEnv().initClusterEnvironment();
     createUser("test", "test123123456");
     executeNonQuery("create database root.test1");
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  private static void executeQuietly(Statement statement, String sql) {
+    try {
+      statement.execute(sql);
+    } catch (SQLException ignored) {
+      // ignore
+    }
+  }
+
+  private static void cleanupAfterTest() {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      executeQuietly(statement, "DELETE DATABASE root.sg1");
+      executeQuietly(statement, "DELETE DATABASE root.sg2");
+      executeQuietly(statement, "DROP DEVICE TEMPLATE t1");
+      executeQuietly(statement, "REVOKE ALL ON root.** FROM USER test");
+    } catch (SQLException ignored) {
+      // ignore
+    }
   }
 
   @Test
   public void adminOperationsTest() {
-    assertNonQueryTestFail(
-        "create device template t1 (temperature FLOAT encoding=RLE, status BOOLEAN encoding=PLAIN compression=SNAPPY)",
-        "803: No permissions for this operation, please add privilege SYSTEM",
-        "test",
-        "test123123456");
-    assertNonQueryTestFail(
-        "drop device template t1",
-        "803: No permissions for this operation, please add privilege SYSTEM",
-        "test",
-        "test123123456");
-    assertNonQueryTestFail(
-        "alter device template t1 add (speed FLOAT encoding=RLE, FLOAT TEXT encoding=PLAIN compression=SNAPPY)",
-        "803: No permissions for this operation, please add privilege SYSTEM",
-        "test",
-        "test123123456");
-    executeNonQuery("show device templates");
-    assertNonQueryTestFail(
-        "show nodes in device template t1",
-        "507: Template t1 does not exist",
-        "test",
-        "test123123456");
-    assertNonQueryTestFail(
-        "set device template t1 to root.sg1",
-        "803: No permissions for this operation, please add privilege SYSTEM",
-        "test",
-        "test123123456");
-    assertNonQueryTestFail(
-        "unset device template t1 from root.sg1",
-        "803: No permissions for this operation, please add privilege SYSTEM",
-        "test",
-        "test123123456");
-    assertNonQueryTestFail(
-        "show paths set device template t1",
-        "305: org.apache.iotdb.commons.exception.IoTDBException: Template t1 does not exist",
-        "test",
-        "test123123456");
+    try {
+      assertNonQueryTestFail(
+          "create device template t1 (temperature FLOAT encoding=RLE, status BOOLEAN encoding=PLAIN compression=SNAPPY)",
+          "803: No permissions for this operation, please add privilege SYSTEM",
+          "test",
+          "test123123456");
+      assertNonQueryTestFail(
+          "drop device template t1",
+          "803: No permissions for this operation, please add privilege SYSTEM",
+          "test",
+          "test123123456");
+      assertNonQueryTestFail(
+          "alter device template t1 add (speed FLOAT encoding=RLE, FLOAT TEXT encoding=PLAIN compression=SNAPPY)",
+          "803: No permissions for this operation, please add privilege SYSTEM",
+          "test",
+          "test123123456");
+      executeNonQuery("show device templates");
+      assertNonQueryTestFail(
+          "show nodes in device template t1",
+          "507: Template t1 does not exist",
+          "test",
+          "test123123456");
+      assertNonQueryTestFail(
+          "set device template t1 to root.sg1",
+          "803: No permissions for this operation, please add privilege SYSTEM",
+          "test",
+          "test123123456");
+      assertNonQueryTestFail(
+          "unset device template t1 from root.sg1",
+          "803: No permissions for this operation, please add privilege SYSTEM",
+          "test",
+          "test123123456");
+      assertNonQueryTestFail(
+          "show paths set device template t1",
+          "305: org.apache.iotdb.commons.exception.IoTDBException: Template t1 does not exist",
+          "test",
+          "test123123456");
+    } finally {
+      cleanupAfterTest();
+    }
   }
 
   @Test
   public void otherTest() {
-    executeNonQuery(
-        "create device template t1 (temperature FLOAT encoding=RLE, status BOOLEAN encoding=PLAIN compression=SNAPPY)");
-    executeNonQuery("create database root.sg1");
-    executeNonQuery("set device template t1 to root.sg1.d1");
+    try {
+      executeNonQuery(
+          "create device template t1 (temperature FLOAT encoding=RLE, status BOOLEAN encoding=PLAIN compression=SNAPPY)");
+      executeNonQuery("create database root.sg1");
+      executeNonQuery("set device template t1 to root.sg1.d1");
 
-    // active
-    assertNonQueryTestFail(
-        "create timeseries using device template on root.sg1.d1",
-        "803: No permissions for this operation, please add privilege WRITE_SCHEMA on [root.sg1.d1.temperature, root.sg1.d1.status]",
-        "test",
-        "test123123456");
-    grantUserSeriesPrivilege("test", PrivilegeType.WRITE_SCHEMA, "root.sg1.d1.**");
-    executeNonQuery(
-        "create timeseries using device template on root.sg1.d1", "test", "test123123456");
+      // active
+      assertNonQueryTestFail(
+          "create timeseries using device template on root.sg1.d1",
+          "803: No permissions for this operation, please add privilege WRITE_SCHEMA on [root.sg1.d1.temperature, root.sg1.d1.status]",
+          "test",
+          "test123123456");
+      grantUserSeriesPrivilege("test", PrivilegeType.WRITE_SCHEMA, "root.sg1.d1.**");
+      executeNonQuery(
+          "create timeseries using device template on root.sg1.d1", "test", "test123123456");
 
-    // insert
-    assertNonQueryTestFail(
-        "insert into root.sg1.d1(time, s1) values(1,1)",
-        "803: No permissions for this operation, please add privilege WRITE_DATA on [root.sg1.d1.s1]",
-        "test",
-        "test123123456");
-    grantUserSeriesPrivilege("test", PrivilegeType.WRITE_DATA, "root.sg1.**");
-    executeNonQuery(
-        "insert into root.sg1.d1(time, temperature) values(1,1)", "test", "test123123456");
-    assertNonQueryTestFail(
-        "insert into root.sg1.d1(time, s1) values(1,1)",
-        "803: No permissions for this operation, please add privilege SYSTEM",
-        "test",
-        "test123123456");
-    grantUserSeriesPrivilege("test", PrivilegeType.SYSTEM, "root.**");
-    executeNonQuery("insert into root.sg1.d1(time, s1) values(1,1)", "test", "test123123456");
+      // insert
+      assertNonQueryTestFail(
+          "insert into root.sg1.d1(time, s1) values(1,1)",
+          "803: No permissions for this operation, please add privilege WRITE_DATA on [root.sg1.d1.s1]",
+          "test",
+          "test123123456");
+      grantUserSeriesPrivilege("test", PrivilegeType.WRITE_DATA, "root.sg1.**");
+      executeNonQuery(
+          "insert into root.sg1.d1(time, temperature) values(1,1)", "test", "test123123456");
+      assertNonQueryTestFail(
+          "insert into root.sg1.d1(time, s1) values(1,1)",
+          "803: No permissions for this operation, please add privilege SYSTEM",
+          "test",
+          "test123123456");
+      grantUserSeriesPrivilege("test", PrivilegeType.SYSTEM, "root.**");
+      executeNonQuery("insert into root.sg1.d1(time, s1) values(1,1)", "test", "test123123456");
 
-    // show
-    executeNonQuery("create database root.sg2");
-    executeNonQuery("set device template t1 to root.sg2.d1");
-    resultSetEqualTest(
-        "show paths using device template t1",
-        showPathsUsingTemplateHeaders.stream()
-            .map(ColumnHeader::getColumnName)
-            .toArray(String[]::new),
-        new String[] {"root.sg1.d1,"},
-        "test",
-        "test123123456");
+      // show
+      executeNonQuery("create database root.sg2");
+      executeNonQuery("set device template t1 to root.sg2.d1");
+      resultSetEqualTest(
+          "show paths using device template t1",
+          showPathsUsingTemplateHeaders.stream()
+              .map(ColumnHeader::getColumnName)
+              .toArray(String[]::new),
+          new String[] {"root.sg1.d1,"},
+          "test",
+          "test123123456");
 
-    // deActive
-    revokeUserSeriesPrivilege("test", PrivilegeType.WRITE_SCHEMA, "root.sg1.d1.**");
-    assertNonQueryTestFail(
-        "deactivate device template t1 from root.sg1.d1",
-        "803: No permissions for this operation, please add privilege WRITE_SCHEMA on [root.sg1.d1.temperature, root.sg1.d1.s1, root.sg1.d1.status]",
-        "test",
-        "test123123456");
-    grantUserSeriesPrivilege("test", PrivilegeType.WRITE_SCHEMA, "root.sg1.d1.**");
-    executeNonQuery("deactivate device template t1 from root.sg1.d1", "test", "test123123456");
+      // deActive
+      revokeUserSeriesPrivilege("test", PrivilegeType.WRITE_SCHEMA, "root.sg1.d1.**");
+      assertNonQueryTestFail(
+          "deactivate device template t1 from root.sg1.d1",
+          "803: No permissions for this operation, please add privilege WRITE_SCHEMA on [root.sg1.d1.temperature, root.sg1.d1.s1, root.sg1.d1.status]",
+          "test",
+          "test123123456");
+      grantUserSeriesPrivilege("test", PrivilegeType.WRITE_SCHEMA, "root.sg1.d1.**");
+      executeNonQuery("deactivate device template t1 from root.sg1.d1", "test", "test123123456");
+    } finally {
+      cleanupAfterTest();
+    }
   }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/fill/IoTDBFillWithNewDataTypeIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/fill/IoTDBFillWithNewDataTypeIT.java
@@ -24,8 +24,8 @@ import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -57,14 +57,14 @@ public class IoTDBFillWithNewDataTypeIT {
         "insert into root.db.d1(time,s2) values(2,1.2)"
       };
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     Locale.setDefault(Locale.ENGLISH);
     EnvFactory.getEnv().initClusterEnvironment();
     prepareData();
   }
 
-  private void prepareData() {
+  private static void prepareData() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
 
@@ -78,8 +78,8 @@ public class IoTDBFillWithNewDataTypeIT {
     }
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
   }
 

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/fill/IoTDBFillWithThresholdInMSIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/fill/IoTDBFillWithThresholdInMSIT.java
@@ -24,8 +24,8 @@ import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -54,8 +54,8 @@ public class IoTDBFillWithThresholdInMSIT {
         "CREATE TIMESERIES root.fillTest.d0.s5 WITH DATATYPE=BOOLEAN, ENCODING=PLAIN",
       };
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     Locale.setDefault(Locale.ENGLISH);
 
     EnvFactory.getEnv().getConfig().getCommonConfig().setTimestampPrecision("ms");
@@ -63,8 +63,8 @@ public class IoTDBFillWithThresholdInMSIT {
     prepareData();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
   }
 
@@ -232,7 +232,7 @@ public class IoTDBFillWithThresholdInMSIT {
     }
   }
 
-  private void prepareData() {
+  private static void prepareData() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
 

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/fill/IoTDBFillWithThresholdInNSIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/fill/IoTDBFillWithThresholdInNSIT.java
@@ -24,8 +24,8 @@ import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -54,8 +54,8 @@ public class IoTDBFillWithThresholdInNSIT {
         "CREATE TIMESERIES root.fillTest.d0.s5 WITH DATATYPE=BOOLEAN, ENCODING=PLAIN",
       };
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     Locale.setDefault(Locale.ENGLISH);
 
     EnvFactory.getEnv().getConfig().getCommonConfig().setTimestampPrecision("ns");
@@ -63,8 +63,8 @@ public class IoTDBFillWithThresholdInNSIT {
     prepareData();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
   }
 
@@ -198,7 +198,7 @@ public class IoTDBFillWithThresholdInNSIT {
     }
   }
 
-  private void prepareData() {
+  private static void prepareData() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
 

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/fill/IoTDBFillWithThresholdInUSIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/fill/IoTDBFillWithThresholdInUSIT.java
@@ -24,8 +24,8 @@ import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -54,8 +54,8 @@ public class IoTDBFillWithThresholdInUSIT {
         "CREATE TIMESERIES root.fillTest.d0.s5 WITH DATATYPE=BOOLEAN, ENCODING=PLAIN",
       };
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     Locale.setDefault(Locale.ENGLISH);
 
     EnvFactory.getEnv().getConfig().getCommonConfig().setTimestampPrecision("us");
@@ -63,8 +63,8 @@ public class IoTDBFillWithThresholdInUSIT {
     prepareData();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
   }
 
@@ -198,7 +198,7 @@ public class IoTDBFillWithThresholdInUSIT {
     }
   }
 
-  private void prepareData() {
+  private static void prepareData() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
 

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/mqtt/IoTDBMQTTServiceJsonIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/mqtt/IoTDBMQTTServiceJsonIT.java
@@ -36,12 +36,17 @@ import org.fusesource.mqtt.client.BlockingConnection;
 import org.fusesource.mqtt.client.MQTT;
 import org.fusesource.mqtt.client.QoS;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -58,22 +63,32 @@ import static org.junit.Assert.fail;
 public class IoTDBMQTTServiceJsonIT {
 
   private BlockingConnection connection;
+  private static int mqttPort;
   private static final String IP = System.getProperty("RemoteIp", "127.0.0.1");
   private static final String USER = System.getProperty("RemoteUser", SessionConfig.DEFAULT_USER);
   private static final String PASSWORD =
       System.getProperty("RemotePassword", SessionConfig.DEFAULT_PASSWORD);
   public static final String FORMATTER = "json";
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void beforeClass() throws Exception {
     BaseEnv baseEnv = EnvFactory.getEnv();
     baseEnv.getConfig().getDataNodeConfig().setEnableMQTTService(true);
     baseEnv.getConfig().getDataNodeConfig().setMqttPayloadFormatter(FORMATTER);
     baseEnv.initClusterEnvironment();
     DataNodeWrapper portConflictDataNodeWrapper = EnvFactory.getEnv().getDataNodeWrapper(0);
-    int port = portConflictDataNodeWrapper.getMqttPort();
+    mqttPort = portConflictDataNodeWrapper.getMqttPort();
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  @Before
+  public void setUp() throws Exception {
     MQTT mqtt = new MQTT();
-    mqtt.setHost(IP, port);
+    mqtt.setHost(IP, mqttPort);
     mqtt.setUserName(USER);
     mqtt.setPassword(PASSWORD);
     mqtt.setConnectAttemptsMax(3);
@@ -94,7 +109,25 @@ public class IoTDBMQTTServiceJsonIT {
       e.printStackTrace();
       fail(e.getMessage());
     }
-    EnvFactory.getEnv().cleanClusterEnvironment();
+    cleanupSgData();
+  }
+
+  private static void executeQuietly(Statement statement, String sql) {
+    try {
+      statement.execute(sql);
+    } catch (SQLException ignored) {
+      // ignore
+    }
+  }
+
+  private static void cleanupSgData() {
+    try (Connection conn = EnvFactory.getEnv().getConnection();
+        Statement statement = conn.createStatement()) {
+      executeQuietly(statement, "DELETE DATABASE root.sg");
+      executeQuietly(statement, "DELETE DATABASE root.sg.**");
+    } catch (SQLException ignored) {
+      // ignore
+    }
   }
 
   /** Test single JSON message with multiple measurements */

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBSortedShowTimeseriesIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBSortedShowTimeseriesIT.java
@@ -24,8 +24,6 @@ import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 import org.apache.iotdb.util.AbstractSchemaIT;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runners.Parameterized;
@@ -106,22 +104,14 @@ public class IoTDBSortedShowTimeseriesIT extends AbstractSchemaIT {
       allocateMemoryForSchemaRegion(10000);
     }
     EnvFactory.getEnv().initClusterEnvironment();
+    createSchema();
   }
 
   @Parameterized.AfterParam
   public static void after() throws Exception {
+    clearSchema();
     EnvFactory.getEnv().cleanClusterEnvironment();
     tearDownEnvironment();
-  }
-
-  @Before
-  public void setUp() throws Exception {
-    createSchema();
-  }
-
-  @After
-  public void tearDown() throws Exception {
-    clearSchema();
   }
 
   @Test

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/specialwords/IoTDBSpecialWordsIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/specialwords/IoTDBSpecialWordsIT.java
@@ -23,8 +23,8 @@ import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -40,13 +40,13 @@ import static org.junit.Assert.assertEquals;
 @Category({LocalStandaloneIT.class, ClusterIT.class})
 public class IoTDBSpecialWordsIT {
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     EnvFactory.getEnv().initClusterEnvironment();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
   }
 

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/strangepath/IoTDBStrangePathIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/strangepath/IoTDBStrangePathIT.java
@@ -25,8 +25,8 @@ import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -42,13 +42,13 @@ import static org.junit.Assert.fail;
 @RunWith(IoTDBTestRunner.class)
 @Category({LocalStandaloneIT.class, ClusterIT.class})
 public class IoTDBStrangePathIT {
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     EnvFactory.getEnv().initClusterEnvironment();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
   }
 

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/trigger/IoTDBTriggerManagementIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/trigger/IoTDBTriggerManagementIT.java
@@ -25,8 +25,8 @@ import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.LocalStandaloneIT;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -82,15 +82,23 @@ public class IoTDBTriggerManagementIT {
 
   private static final String ACTIVE = "ACTIVE";
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     EnvFactory.getEnv().initClusterEnvironment();
     createTimeSeries();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  private static void dropTriggerQuietly(Statement statement, String name) {
+    try {
+      statement.execute(String.format("drop trigger %s", name));
+    } catch (SQLException ignored) {
+      // trigger may not exist; ignore
+    }
   }
 
   private static void createTimeSeries() {
@@ -118,169 +126,181 @@ public class IoTDBTriggerManagementIT {
   public void testCreateTriggersNormally() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      Map<String, String[]> result =
-          new HashMap<String, String[]>() {
-            {
-              put(
-                  STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "a",
-                  new String[] {
+      try {
+        Map<String, String[]> result =
+            new HashMap<String, String[]>() {
+              {
+                put(
                     STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "a",
-                    BEFORE_INSERT,
-                    STATELESS,
-                    ACTIVE,
-                    "root.test.stateless.a",
-                    TRIGGER_FILE_TIMES_COUNTER
-                  });
-              put(
-                  STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all",
-                  new String[] {
+                    new String[] {
+                      STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "a",
+                      BEFORE_INSERT,
+                      STATELESS,
+                      ACTIVE,
+                      "root.test.stateless.a",
+                      TRIGGER_FILE_TIMES_COUNTER
+                    });
+                put(
                     STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all",
-                    BEFORE_INSERT,
-                    STATELESS,
-                    ACTIVE,
-                    "root.test.stateless.*",
-                    TRIGGER_FILE_TIMES_COUNTER
-                  });
-              put(
-                  STATELESS_TRIGGER_AFTER_INSERTION_PREFIX + "a",
-                  new String[] {
+                    new String[] {
+                      STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all",
+                      BEFORE_INSERT,
+                      STATELESS,
+                      ACTIVE,
+                      "root.test.stateless.*",
+                      TRIGGER_FILE_TIMES_COUNTER
+                    });
+                put(
                     STATELESS_TRIGGER_AFTER_INSERTION_PREFIX + "a",
-                    AFTER_INSERT,
-                    STATELESS,
-                    ACTIVE,
-                    "root.test.stateless.a",
-                    TRIGGER_FILE_TIMES_COUNTER
-                  });
-              put(
-                  STATELESS_TRIGGER_AFTER_INSERTION_PREFIX + "all",
-                  new String[] {
+                    new String[] {
+                      STATELESS_TRIGGER_AFTER_INSERTION_PREFIX + "a",
+                      AFTER_INSERT,
+                      STATELESS,
+                      ACTIVE,
+                      "root.test.stateless.a",
+                      TRIGGER_FILE_TIMES_COUNTER
+                    });
+                put(
                     STATELESS_TRIGGER_AFTER_INSERTION_PREFIX + "all",
-                    AFTER_INSERT,
-                    STATELESS,
-                    ACTIVE,
-                    "root.test.stateless.*",
-                    TRIGGER_FILE_TIMES_COUNTER
-                  });
-              put(
-                  STATEFUL_TRIGGER_BEFORE_INSERTION_PREFIX + "a",
-                  new String[] {
+                    new String[] {
+                      STATELESS_TRIGGER_AFTER_INSERTION_PREFIX + "all",
+                      AFTER_INSERT,
+                      STATELESS,
+                      ACTIVE,
+                      "root.test.stateless.*",
+                      TRIGGER_FILE_TIMES_COUNTER
+                    });
+                put(
                     STATEFUL_TRIGGER_BEFORE_INSERTION_PREFIX + "a",
-                    BEFORE_INSERT,
-                    STATEFUL,
-                    ACTIVE,
-                    "root.test.stateful.a",
-                    TRIGGER_FILE_TIMES_COUNTER
-                  });
-              put(
-                  STATEFUL_TRIGGER_BEFORE_INSERTION_PREFIX + "all",
-                  new String[] {
+                    new String[] {
+                      STATEFUL_TRIGGER_BEFORE_INSERTION_PREFIX + "a",
+                      BEFORE_INSERT,
+                      STATEFUL,
+                      ACTIVE,
+                      "root.test.stateful.a",
+                      TRIGGER_FILE_TIMES_COUNTER
+                    });
+                put(
                     STATEFUL_TRIGGER_BEFORE_INSERTION_PREFIX + "all",
-                    BEFORE_INSERT,
-                    STATEFUL,
-                    ACTIVE,
-                    "root.test.stateful.*",
-                    TRIGGER_FILE_TIMES_COUNTER
-                  });
-              put(
-                  STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "a",
-                  new String[] {
+                    new String[] {
+                      STATEFUL_TRIGGER_BEFORE_INSERTION_PREFIX + "all",
+                      BEFORE_INSERT,
+                      STATEFUL,
+                      ACTIVE,
+                      "root.test.stateful.*",
+                      TRIGGER_FILE_TIMES_COUNTER
+                    });
+                put(
                     STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "a",
-                    AFTER_INSERT,
-                    STATEFUL,
-                    ACTIVE,
-                    "root.test.stateful.a",
-                    TRIGGER_FILE_TIMES_COUNTER
-                  });
-              put(
-                  STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "all",
-                  new String[] {
+                    new String[] {
+                      STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "a",
+                      AFTER_INSERT,
+                      STATEFUL,
+                      ACTIVE,
+                      "root.test.stateful.a",
+                      TRIGGER_FILE_TIMES_COUNTER
+                    });
+                put(
                     STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "all",
-                    AFTER_INSERT,
-                    STATEFUL,
-                    ACTIVE,
-                    "root.test.stateful.*",
-                    TRIGGER_FILE_TIMES_COUNTER
-                  });
-            }
-          };
+                    new String[] {
+                      STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "all",
+                      AFTER_INSERT,
+                      STATEFUL,
+                      ACTIVE,
+                      "root.test.stateful.*",
+                      TRIGGER_FILE_TIMES_COUNTER
+                    });
+              }
+            };
 
-      // create stateless triggers before insertion
-      statement.execute(
-          String.format(
-              "create stateless trigger %s before insert on root.test.stateless.a as '%s' using URI '%s' with (\"name\"=\"%s\")",
-              STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "a",
-              TRIGGER_FILE_TIMES_COUNTER,
-              TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
-              STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "a"));
-      statement.execute(
-          String.format(
-              "create stateless trigger %s before insert on root.test.stateless.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
-              STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all",
-              TRIGGER_FILE_TIMES_COUNTER,
-              TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
-              STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
+        // create stateless triggers before insertion
+        statement.execute(
+            String.format(
+                "create stateless trigger %s before insert on root.test.stateless.a as '%s' using URI '%s' with (\"name\"=\"%s\")",
+                STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "a",
+                TRIGGER_FILE_TIMES_COUNTER,
+                TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
+                STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "a"));
+        statement.execute(
+            String.format(
+                "create stateless trigger %s before insert on root.test.stateless.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
+                STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all",
+                TRIGGER_FILE_TIMES_COUNTER,
+                TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
+                STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
 
-      // create stateless triggers after insertion
-      statement.execute(
-          String.format(
-              "create stateless trigger %s after insert on root.test.stateless.a as '%s' using URI '%s' with (\"name\"=\"%s\")",
-              STATELESS_TRIGGER_AFTER_INSERTION_PREFIX + "a",
-              TRIGGER_FILE_TIMES_COUNTER,
-              TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
-              STATELESS_TRIGGER_AFTER_INSERTION_PREFIX + "a"));
-      statement.execute(
-          String.format(
-              "create stateless trigger %s after insert on root.test.stateless.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
-              STATELESS_TRIGGER_AFTER_INSERTION_PREFIX + "all",
-              TRIGGER_FILE_TIMES_COUNTER,
-              TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
-              STATELESS_TRIGGER_AFTER_INSERTION_PREFIX + "all"));
+        // create stateless triggers after insertion
+        statement.execute(
+            String.format(
+                "create stateless trigger %s after insert on root.test.stateless.a as '%s' using URI '%s' with (\"name\"=\"%s\")",
+                STATELESS_TRIGGER_AFTER_INSERTION_PREFIX + "a",
+                TRIGGER_FILE_TIMES_COUNTER,
+                TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
+                STATELESS_TRIGGER_AFTER_INSERTION_PREFIX + "a"));
+        statement.execute(
+            String.format(
+                "create stateless trigger %s after insert on root.test.stateless.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
+                STATELESS_TRIGGER_AFTER_INSERTION_PREFIX + "all",
+                TRIGGER_FILE_TIMES_COUNTER,
+                TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
+                STATELESS_TRIGGER_AFTER_INSERTION_PREFIX + "all"));
 
-      // create stateful triggers before insertion
-      statement.execute(
-          String.format(
-              "create stateful trigger %s before insert on root.test.stateful.a as '%s' using URI '%s' with (\"name\"=\"%s\")",
-              STATEFUL_TRIGGER_BEFORE_INSERTION_PREFIX + "a",
-              TRIGGER_FILE_TIMES_COUNTER,
-              TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
-              STATEFUL_TRIGGER_BEFORE_INSERTION_PREFIX + "a"));
-      statement.execute(
-          String.format(
-              "create stateful trigger %s before insert on root.test.stateful.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
-              STATEFUL_TRIGGER_BEFORE_INSERTION_PREFIX + "all",
-              TRIGGER_FILE_TIMES_COUNTER,
-              TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
-              STATEFUL_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
+        // create stateful triggers before insertion
+        statement.execute(
+            String.format(
+                "create stateful trigger %s before insert on root.test.stateful.a as '%s' using URI '%s' with (\"name\"=\"%s\")",
+                STATEFUL_TRIGGER_BEFORE_INSERTION_PREFIX + "a",
+                TRIGGER_FILE_TIMES_COUNTER,
+                TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
+                STATEFUL_TRIGGER_BEFORE_INSERTION_PREFIX + "a"));
+        statement.execute(
+            String.format(
+                "create stateful trigger %s before insert on root.test.stateful.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
+                STATEFUL_TRIGGER_BEFORE_INSERTION_PREFIX + "all",
+                TRIGGER_FILE_TIMES_COUNTER,
+                TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
+                STATEFUL_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
 
-      // create stateful triggers after insertion
-      statement.execute(
-          String.format(
-              "create stateful trigger %s after insert on root.test.stateful.a as '%s' using URI '%s' with (\"name\"=\"%s\")",
-              STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "a",
-              TRIGGER_FILE_TIMES_COUNTER,
-              TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
-              STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "a"));
-      statement.execute(
-          String.format(
-              "create stateful trigger %s after insert on root.test.stateful.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
-              STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "all",
-              TRIGGER_FILE_TIMES_COUNTER,
-              TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
-              STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "all"));
-      ResultSet resultSet = statement.executeQuery("show triggers");
-      int cnt = 0;
-      while (resultSet.next()) {
-        cnt++;
-        String triggerName = resultSet.getString(ColumnHeaderConstant.TRIGGER_NAME);
-        String[] triggerInformation = result.get(triggerName);
-        assertEquals(triggerInformation[0], triggerName);
-        assertEquals(triggerInformation[1], resultSet.getString(ColumnHeaderConstant.EVENT));
-        assertEquals(triggerInformation[2], resultSet.getString(ColumnHeaderConstant.TYPE));
-        assertEquals(triggerInformation[3], resultSet.getString(ColumnHeaderConstant.STATE));
-        assertEquals(triggerInformation[4], resultSet.getString(ColumnHeaderConstant.PATH_PATTERN));
-        assertEquals(triggerInformation[5], resultSet.getString(ColumnHeaderConstant.CLASS_NAME));
+        // create stateful triggers after insertion
+        statement.execute(
+            String.format(
+                "create stateful trigger %s after insert on root.test.stateful.a as '%s' using URI '%s' with (\"name\"=\"%s\")",
+                STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "a",
+                TRIGGER_FILE_TIMES_COUNTER,
+                TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
+                STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "a"));
+        statement.execute(
+            String.format(
+                "create stateful trigger %s after insert on root.test.stateful.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
+                STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "all",
+                TRIGGER_FILE_TIMES_COUNTER,
+                TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
+                STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "all"));
+        ResultSet resultSet = statement.executeQuery("show triggers");
+        int cnt = 0;
+        while (resultSet.next()) {
+          cnt++;
+          String triggerName = resultSet.getString(ColumnHeaderConstant.TRIGGER_NAME);
+          String[] triggerInformation = result.get(triggerName);
+          assertEquals(triggerInformation[0], triggerName);
+          assertEquals(triggerInformation[1], resultSet.getString(ColumnHeaderConstant.EVENT));
+          assertEquals(triggerInformation[2], resultSet.getString(ColumnHeaderConstant.TYPE));
+          assertEquals(triggerInformation[3], resultSet.getString(ColumnHeaderConstant.STATE));
+          assertEquals(
+              triggerInformation[4], resultSet.getString(ColumnHeaderConstant.PATH_PATTERN));
+          assertEquals(triggerInformation[5], resultSet.getString(ColumnHeaderConstant.CLASS_NAME));
+        }
+        assertEquals(cnt, result.size());
+      } finally {
+        dropTriggerQuietly(statement, STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "a");
+        dropTriggerQuietly(statement, STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all");
+        dropTriggerQuietly(statement, STATELESS_TRIGGER_AFTER_INSERTION_PREFIX + "a");
+        dropTriggerQuietly(statement, STATELESS_TRIGGER_AFTER_INSERTION_PREFIX + "all");
+        dropTriggerQuietly(statement, STATEFUL_TRIGGER_BEFORE_INSERTION_PREFIX + "a");
+        dropTriggerQuietly(statement, STATEFUL_TRIGGER_BEFORE_INSERTION_PREFIX + "all");
+        dropTriggerQuietly(statement, STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "a");
+        dropTriggerQuietly(statement, STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "all");
       }
-      assertEquals(cnt, result.size());
     } catch (Exception e) {
       fail(e.getMessage());
     }
@@ -290,44 +310,49 @@ public class IoTDBTriggerManagementIT {
   public void testCreateTriggersNormally2() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      Map<String, String[]> result =
-          new HashMap<String, String[]>() {
-            {
-              put(
-                  STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "a",
-                  new String[] {
+      try {
+        Map<String, String[]> result =
+            new HashMap<String, String[]>() {
+              {
+                put(
                     STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "a",
-                    BEFORE_INSERT,
-                    STATELESS,
-                    ACTIVE,
-                    "root.test.stateless.a",
-                    TRIGGER_FILE_TIMES_COUNTER
-                  });
-            }
-          };
+                    new String[] {
+                      STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "a",
+                      BEFORE_INSERT,
+                      STATELESS,
+                      ACTIVE,
+                      "root.test.stateless.a",
+                      TRIGGER_FILE_TIMES_COUNTER
+                    });
+              }
+            };
 
-      // create stateless triggers before insertion
-      statement.execute(
-          String.format(
-              "create stateless trigger %s before insert on root.test.stateless.a as '%s' with (\"name\"=\"%s\")",
-              STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "a",
-              TRIGGER_FILE_TIMES_COUNTER,
-              STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "a"));
+        // create stateless triggers before insertion
+        statement.execute(
+            String.format(
+                "create stateless trigger %s before insert on root.test.stateless.a as '%s' with (\"name\"=\"%s\")",
+                STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "a",
+                TRIGGER_FILE_TIMES_COUNTER,
+                STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "a"));
 
-      ResultSet resultSet = statement.executeQuery("show triggers");
-      int cnt = 0;
-      while (resultSet.next()) {
-        cnt++;
-        String triggerName = resultSet.getString(ColumnHeaderConstant.TRIGGER_NAME);
-        String[] triggerInformation = result.get(triggerName);
-        assertEquals(triggerInformation[0], triggerName);
-        assertEquals(triggerInformation[1], resultSet.getString(ColumnHeaderConstant.EVENT));
-        assertEquals(triggerInformation[2], resultSet.getString(ColumnHeaderConstant.TYPE));
-        assertEquals(triggerInformation[3], resultSet.getString(ColumnHeaderConstant.STATE));
-        assertEquals(triggerInformation[4], resultSet.getString(ColumnHeaderConstant.PATH_PATTERN));
-        assertEquals(triggerInformation[5], resultSet.getString(ColumnHeaderConstant.CLASS_NAME));
+        ResultSet resultSet = statement.executeQuery("show triggers");
+        int cnt = 0;
+        while (resultSet.next()) {
+          cnt++;
+          String triggerName = resultSet.getString(ColumnHeaderConstant.TRIGGER_NAME);
+          String[] triggerInformation = result.get(triggerName);
+          assertEquals(triggerInformation[0], triggerName);
+          assertEquals(triggerInformation[1], resultSet.getString(ColumnHeaderConstant.EVENT));
+          assertEquals(triggerInformation[2], resultSet.getString(ColumnHeaderConstant.TYPE));
+          assertEquals(triggerInformation[3], resultSet.getString(ColumnHeaderConstant.STATE));
+          assertEquals(
+              triggerInformation[4], resultSet.getString(ColumnHeaderConstant.PATH_PATTERN));
+          assertEquals(triggerInformation[5], resultSet.getString(ColumnHeaderConstant.CLASS_NAME));
+        }
+        assertEquals(cnt, result.size());
+      } finally {
+        dropTriggerQuietly(statement, STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "a");
       }
-      assertEquals(cnt, result.size());
     } catch (Exception e) {
       fail(e.getMessage());
     }
@@ -337,73 +362,77 @@ public class IoTDBTriggerManagementIT {
   public void testCreateAndDropMultipleTimes() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute(
-          String.format(
-              "create stateless trigger %s before insert on root.test.stateless.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
-              STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all",
-              TRIGGER_FILE_TIMES_COUNTER,
-              TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
-              STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
-      statement.execute(
-          String.format(
-              "create stateful trigger %s after insert on root.test.stateful.a as '%s' using URI '%s' with (\"name\"=\"%s\")",
-              STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "a",
-              TRIGGER_FILE_TIMES_COUNTER,
-              TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
-              STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "a"));
+      try {
+        statement.execute(
+            String.format(
+                "create stateless trigger %s before insert on root.test.stateless.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
+                STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all",
+                TRIGGER_FILE_TIMES_COUNTER,
+                TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
+                STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
+        statement.execute(
+            String.format(
+                "create stateful trigger %s after insert on root.test.stateful.a as '%s' using URI '%s' with (\"name\"=\"%s\")",
+                STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "a",
+                TRIGGER_FILE_TIMES_COUNTER,
+                TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
+                STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "a"));
 
-      // drop triggers
-      statement.execute(
-          String.format("drop trigger %s", STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
-      statement.execute(
-          String.format("drop trigger %s", STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "a"));
-      ResultSet resultSet = statement.executeQuery("show triggers");
-      assertFalse(resultSet.next());
+        // drop triggers
+        statement.execute(
+            String.format("drop trigger %s", STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
+        statement.execute(
+            String.format("drop trigger %s", STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "a"));
+        ResultSet resultSet = statement.executeQuery("show triggers");
+        assertFalse(resultSet.next());
 
-      statement.execute(
-          String.format(
-              "create stateless trigger %s before insert on root.test.stateless.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
-              STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all",
-              TRIGGER_FILE_TIMES_COUNTER,
-              TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
-              STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
-      statement.execute(
-          String.format(
-              "create stateful trigger %s after insert on root.test.stateful.a as '%s' using URI '%s' with (\"name\"=\"%s\")",
-              STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "a",
-              TRIGGER_FILE_TIMES_COUNTER,
-              TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
-              STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "a"));
+        statement.execute(
+            String.format(
+                "create stateless trigger %s before insert on root.test.stateless.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
+                STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all",
+                TRIGGER_FILE_TIMES_COUNTER,
+                TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
+                STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
+        statement.execute(
+            String.format(
+                "create stateful trigger %s after insert on root.test.stateful.a as '%s' using URI '%s' with (\"name\"=\"%s\")",
+                STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "a",
+                TRIGGER_FILE_TIMES_COUNTER,
+                TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
+                STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "a"));
 
-      // drop triggers
-      statement.execute(
-          String.format("drop trigger %s", STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
-      statement.execute(
-          String.format("drop trigger %s", STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "a"));
-      resultSet = statement.executeQuery("show triggers");
-      assertFalse(resultSet.next());
+        // drop triggers
+        statement.execute(
+            String.format("drop trigger %s", STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
+        statement.execute(
+            String.format("drop trigger %s", STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "a"));
+        resultSet = statement.executeQuery("show triggers");
+        assertFalse(resultSet.next());
 
-      statement.execute(
-          String.format(
-              "create stateless trigger %s before insert on root.test.stateless.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
-              STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all",
-              TRIGGER_FILE_TIMES_COUNTER,
-              TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
-              STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
-      statement.execute(
-          String.format(
-              "create stateful trigger %s after insert on root.test.stateful.a as '%s' using URI '%s' with (\"name\"=\"%s\")",
-              STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "a",
-              TRIGGER_FILE_TIMES_COUNTER,
-              TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
-              STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "a"));
-      resultSet = statement.executeQuery("show triggers");
-      int cnt = 0;
-      while (resultSet.next()) {
-        cnt++;
+        statement.execute(
+            String.format(
+                "create stateless trigger %s before insert on root.test.stateless.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
+                STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all",
+                TRIGGER_FILE_TIMES_COUNTER,
+                TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
+                STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
+        statement.execute(
+            String.format(
+                "create stateful trigger %s after insert on root.test.stateful.a as '%s' using URI '%s' with (\"name\"=\"%s\")",
+                STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "a",
+                TRIGGER_FILE_TIMES_COUNTER,
+                TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
+                STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "a"));
+        resultSet = statement.executeQuery("show triggers");
+        int cnt = 0;
+        while (resultSet.next()) {
+          cnt++;
+        }
+        assertEquals(cnt, 2);
+      } finally {
+        dropTriggerQuietly(statement, STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all");
+        dropTriggerQuietly(statement, STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "a");
       }
-      assertEquals(cnt, 2);
-
     } catch (Exception e) {
       fail(e.getMessage());
     }
@@ -413,14 +442,6 @@ public class IoTDBTriggerManagementIT {
   public void testCreateTriggerWithSameName() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute(
-          String.format(
-              "create stateless trigger %s before insert on root.test.stateless.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
-              STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all",
-              TRIGGER_FILE_TIMES_COUNTER,
-              TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
-              STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
-
       try {
         statement.execute(
             String.format(
@@ -429,9 +450,21 @@ public class IoTDBTriggerManagementIT {
                 TRIGGER_FILE_TIMES_COUNTER,
                 TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
                 STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
-      } catch (SQLException e) {
-        assertTrue(
-            e.getMessage().contains("same name") && e.getMessage().contains("has been created"));
+
+        try {
+          statement.execute(
+              String.format(
+                  "create stateless trigger %s before insert on root.test.stateless.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
+                  STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all",
+                  TRIGGER_FILE_TIMES_COUNTER,
+                  TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
+                  STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
+        } catch (SQLException e) {
+          assertTrue(
+              e.getMessage().contains("same name") && e.getMessage().contains("has been created"));
+        }
+      } finally {
+        dropTriggerQuietly(statement, STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all");
       }
     } catch (Exception e) {
       fail(e.getMessage());
@@ -442,30 +475,35 @@ public class IoTDBTriggerManagementIT {
   public void testTriggerNameCaseSensitivity() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute(
-          String.format(
-              "create stateless trigger %s before insert on root.test.stateless.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
-              "test",
-              TRIGGER_FILE_TIMES_COUNTER,
-              TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
-              STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
+      try {
+        statement.execute(
+            String.format(
+                "create stateless trigger %s before insert on root.test.stateless.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
+                "test",
+                TRIGGER_FILE_TIMES_COUNTER,
+                TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
+                STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
 
-      statement.execute(
-          String.format(
-              "create stateless trigger %s before insert on root.test.stateless.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
-              "Test",
-              TRIGGER_FILE_TIMES_COUNTER,
-              TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
-              STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
+        statement.execute(
+            String.format(
+                "create stateless trigger %s before insert on root.test.stateless.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
+                "Test",
+                TRIGGER_FILE_TIMES_COUNTER,
+                TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
+                STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
 
-      statement.execute(
-          String.format(
-              "create stateless trigger %s before insert on root.test.stateless.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
-              "TEST",
-              TRIGGER_FILE_TIMES_COUNTER,
-              TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
-              STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
-
+        statement.execute(
+            String.format(
+                "create stateless trigger %s before insert on root.test.stateless.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
+                "TEST",
+                TRIGGER_FILE_TIMES_COUNTER,
+                TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
+                STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
+      } finally {
+        dropTriggerQuietly(statement, "test");
+        dropTriggerQuietly(statement, "Test");
+        dropTriggerQuietly(statement, "TEST");
+      }
     } catch (Exception e) {
       fail(e.getMessage());
     }
@@ -512,48 +550,55 @@ public class IoTDBTriggerManagementIT {
   public void testDropTriggersAfterCreationNormally() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      // create first
-      statement.execute(
-          String.format(
-              "create stateless trigger %s before insert on root.test.stateless.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
-              STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all",
-              TRIGGER_FILE_TIMES_COUNTER,
-              TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
-              STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
-      statement.execute(
-          String.format(
-              "create stateless trigger %s after insert on root.test.stateless.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
-              STATELESS_TRIGGER_AFTER_INSERTION_PREFIX + "all",
-              TRIGGER_FILE_TIMES_COUNTER,
-              TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
-              STATELESS_TRIGGER_AFTER_INSERTION_PREFIX + "all"));
-      statement.execute(
-          String.format(
-              "create stateful trigger %s before insert on root.test.stateful.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
-              STATEFUL_TRIGGER_BEFORE_INSERTION_PREFIX + "all",
-              TRIGGER_FILE_TIMES_COUNTER,
-              TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
-              STATEFUL_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
-      statement.execute(
-          String.format(
-              "create stateful trigger %s after insert on root.test.stateful.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
-              STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "all",
-              TRIGGER_FILE_TIMES_COUNTER,
-              TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
-              STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "all"));
+      try {
+        // create first
+        statement.execute(
+            String.format(
+                "create stateless trigger %s before insert on root.test.stateless.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
+                STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all",
+                TRIGGER_FILE_TIMES_COUNTER,
+                TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
+                STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
+        statement.execute(
+            String.format(
+                "create stateless trigger %s after insert on root.test.stateless.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
+                STATELESS_TRIGGER_AFTER_INSERTION_PREFIX + "all",
+                TRIGGER_FILE_TIMES_COUNTER,
+                TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
+                STATELESS_TRIGGER_AFTER_INSERTION_PREFIX + "all"));
+        statement.execute(
+            String.format(
+                "create stateful trigger %s before insert on root.test.stateful.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
+                STATEFUL_TRIGGER_BEFORE_INSERTION_PREFIX + "all",
+                TRIGGER_FILE_TIMES_COUNTER,
+                TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
+                STATEFUL_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
+        statement.execute(
+            String.format(
+                "create stateful trigger %s after insert on root.test.stateful.* as '%s' using URI '%s' with (\"name\"=\"%s\")",
+                STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "all",
+                TRIGGER_FILE_TIMES_COUNTER,
+                TRIGGER_JAR_PREFIX + "TriggerFireTimesCounter.jar",
+                STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "all"));
 
-      // drop triggers
-      statement.execute(
-          String.format("drop trigger %s", STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
-      statement.execute(
-          String.format("drop trigger %s", STATELESS_TRIGGER_AFTER_INSERTION_PREFIX + "all"));
-      statement.execute(
-          String.format("drop trigger %s", STATEFUL_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
-      statement.execute(
-          String.format("drop trigger %s", STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "all"));
+        // drop triggers
+        statement.execute(
+            String.format("drop trigger %s", STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
+        statement.execute(
+            String.format("drop trigger %s", STATELESS_TRIGGER_AFTER_INSERTION_PREFIX + "all"));
+        statement.execute(
+            String.format("drop trigger %s", STATEFUL_TRIGGER_BEFORE_INSERTION_PREFIX + "all"));
+        statement.execute(
+            String.format("drop trigger %s", STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "all"));
 
-      ResultSet resultSet = statement.executeQuery("show triggers");
-      assertFalse(resultSet.next());
+        ResultSet resultSet = statement.executeQuery("show triggers");
+        assertFalse(resultSet.next());
+      } finally {
+        dropTriggerQuietly(statement, STATELESS_TRIGGER_BEFORE_INSERTION_PREFIX + "all");
+        dropTriggerQuietly(statement, STATELESS_TRIGGER_AFTER_INSERTION_PREFIX + "all");
+        dropTriggerQuietly(statement, STATEFUL_TRIGGER_BEFORE_INSERTION_PREFIX + "all");
+        dropTriggerQuietly(statement, STATEFUL_TRIGGER_AFTER_INSERTION_PREFIX + "all");
+      }
     } catch (Exception e) {
       fail(e.getMessage());
     }

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/udaf/IoTDBUDAFManagementIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/udaf/IoTDBUDAFManagementIT.java
@@ -27,9 +27,9 @@ import org.apache.iotdb.itbase.constant.BuiltinAggregationFunctionEnum;
 import org.apache.iotdb.itbase.constant.BuiltinScalarFunctionEnum;
 import org.apache.iotdb.itbase.constant.BuiltinTimeSeriesGeneratingFunctionEnum;
 
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -62,32 +62,43 @@ public class IoTDBUDAFManagementIT {
 
   private static final String UDF_JAR_PREFIX = new File(UDF_LIB_PREFIX).toURI().toString();
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     EnvFactory.getEnv().initClusterEnvironment();
   }
 
-  @After
-  public void tearDown() {
+  @AfterClass
+  public static void tearDown() {
     EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  private static void dropFunctionQuietly(Statement statement, String name) {
+    try {
+      statement.execute("DROP FUNCTION " + name);
+    } catch (SQLException ignored) {
+      // function may not exist; ignore
+    }
   }
 
   @Test
   public void createReflectShowDropUDAFTest() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute(
-          "CREATE FUNCTION udaf AS 'org.apache.iotdb.db.query.udf.example.UDAFCount'");
-      statement.executeQuery("SELECT udaf(*) FROM root.vehicle");
+      try {
+        statement.execute(
+            "CREATE FUNCTION udaf AS 'org.apache.iotdb.db.query.udf.example.UDAFCount'");
+        statement.executeQuery("SELECT udaf(*) FROM root.vehicle");
 
-      try (ResultSet resultSet = statement.executeQuery("SHOW FUNCTIONS")) {
-        assertEquals(4, resultSet.getMetaData().getColumnCount());
-        int count = 0;
-        while (resultSet.next()) {
-          ++count;
+        try (ResultSet resultSet = statement.executeQuery("SHOW FUNCTIONS")) {
+          assertEquals(4, resultSet.getMetaData().getColumnCount());
+          int count = 0;
+          while (resultSet.next()) {
+            ++count;
+          }
+          Assert.assertEquals(1 + FUNCTIONS_COUNT, count);
         }
-        Assert.assertEquals(1 + FUNCTIONS_COUNT, count);
-        statement.execute("DROP FUNCTION udaf");
+      } finally {
+        dropFunctionQuietly(statement, "udaf");
       }
     } catch (SQLException throwable) {
       fail(throwable.getMessage());
@@ -98,32 +109,35 @@ public class IoTDBUDAFManagementIT {
   public void createAndDropUDAFSeveralTimesTest() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute(
-          "CREATE FUNCTION udaf AS 'org.apache.iotdb.db.query.udf.example.UDAFCount'");
-      statement.executeQuery("SELECT udaf(*) FROM root.vehicle");
-
-      try (ResultSet resultSet = statement.executeQuery("SHOW FUNCTIONS")) {
-        int count = 0;
-        while (resultSet.next()) {
-          ++count;
-        }
-        Assert.assertEquals(1 + FUNCTIONS_COUNT, count);
-        assertEquals(4, resultSet.getMetaData().getColumnCount());
-        statement.execute("DROP FUNCTION udaf");
-
+      try {
         statement.execute(
             "CREATE FUNCTION udaf AS 'org.apache.iotdb.db.query.udf.example.UDAFCount'");
         statement.executeQuery("SELECT udaf(*) FROM root.vehicle");
-      }
 
-      try (ResultSet resultSet = statement.executeQuery("SHOW FUNCTIONS")) {
-        int count = 0;
-        while (resultSet.next()) {
-          ++count;
+        try (ResultSet resultSet = statement.executeQuery("SHOW FUNCTIONS")) {
+          int count = 0;
+          while (resultSet.next()) {
+            ++count;
+          }
+          Assert.assertEquals(1 + FUNCTIONS_COUNT, count);
+          assertEquals(4, resultSet.getMetaData().getColumnCount());
+          statement.execute("DROP FUNCTION udaf");
+
+          statement.execute(
+              "CREATE FUNCTION udaf AS 'org.apache.iotdb.db.query.udf.example.UDAFCount'");
+          statement.executeQuery("SELECT udaf(*) FROM root.vehicle");
         }
-        Assert.assertEquals(1 + FUNCTIONS_COUNT, count);
-        assertEquals(4, resultSet.getMetaData().getColumnCount());
-        statement.execute("DROP FUNCTION udaf");
+
+        try (ResultSet resultSet = statement.executeQuery("SHOW FUNCTIONS")) {
+          int count = 0;
+          while (resultSet.next()) {
+            ++count;
+          }
+          Assert.assertEquals(1 + FUNCTIONS_COUNT, count);
+          assertEquals(4, resultSet.getMetaData().getColumnCount());
+        }
+      } finally {
+        dropFunctionQuietly(statement, "udaf");
       }
     } catch (SQLException throwable) {
       fail(throwable.getMessage());
@@ -172,15 +186,19 @@ public class IoTDBUDAFManagementIT {
   public void createFunctionTwiceTest() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute(
-          "CREATE FUNCTION udaf AS 'org.apache.iotdb.db.query.udf.example.UDAFCount'");
-
       try {
         statement.execute(
             "CREATE FUNCTION udaf AS 'org.apache.iotdb.db.query.udf.example.UDAFCount'");
-        fail();
-      } catch (SQLException throwable) {
-        assertTrue(throwable.getMessage().contains("Failed to create"));
+
+        try {
+          statement.execute(
+              "CREATE FUNCTION udaf AS 'org.apache.iotdb.db.query.udf.example.UDAFCount'");
+          fail();
+        } catch (SQLException throwable) {
+          assertTrue(throwable.getMessage().contains("Failed to create"));
+        }
+      } finally {
+        dropFunctionQuietly(statement, "udaf");
       }
     }
   }
@@ -189,15 +207,19 @@ public class IoTDBUDAFManagementIT {
   public void createFunctionTwiceTest2() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute(
-          "CREATE FUNCTION udaf AS 'org.apache.iotdb.db.query.udf.example.UDAFCount'");
-
       try {
         statement.execute(
             "CREATE FUNCTION udaf AS 'org.apache.iotdb.db.query.udf.example.UDAFCount'");
-        fail();
-      } catch (SQLException throwable) {
-        assertTrue(throwable.getMessage().contains("the same name UDF has been created"));
+
+        try {
+          statement.execute(
+              "CREATE FUNCTION udaf AS 'org.apache.iotdb.db.query.udf.example.UDAFCount'");
+          fail();
+        } catch (SQLException throwable) {
+          assertTrue(throwable.getMessage().contains("the same name UDF has been created"));
+        }
+      } finally {
+        dropFunctionQuietly(statement, "udaf");
       }
     }
   }
@@ -206,27 +228,30 @@ public class IoTDBUDAFManagementIT {
   public void createFunctionWithURITest() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute(
-          String.format(
-              "CREATE FUNCTION udaf1 AS 'org.apache.iotdb.db.query.udf.example.UDAFCount' USING URI '%s'",
-              UDF_JAR_PREFIX + "udf-example.jar"));
+      try {
+        statement.execute(
+            String.format(
+                "CREATE FUNCTION udaf1 AS 'org.apache.iotdb.db.query.udf.example.UDAFCount' USING URI '%s'",
+                UDF_JAR_PREFIX + "udf-example.jar"));
 
-      statement.execute(
-          String.format(
-              "CREATE FUNCTION udaf2 AS 'org.apache.iotdb.db.query.udf.example.UDAFCount' USING URI '%s'",
-              UDF_JAR_PREFIX + "udf-example.jar"));
+        statement.execute(
+            String.format(
+                "CREATE FUNCTION udaf2 AS 'org.apache.iotdb.db.query.udf.example.UDAFCount' USING URI '%s'",
+                UDF_JAR_PREFIX + "udf-example.jar"));
 
-      try (ResultSet resultSet = statement.executeQuery("SHOW FUNCTIONS")) {
-        int count = 0;
-        while (resultSet.next()) {
-          ++count;
+        try (ResultSet resultSet = statement.executeQuery("SHOW FUNCTIONS")) {
+          int count = 0;
+          while (resultSet.next()) {
+            ++count;
+          }
+          Assert.assertEquals(2 + FUNCTIONS_COUNT, count);
+          assertEquals(4, resultSet.getMetaData().getColumnCount());
+        } catch (Exception e) {
+          fail();
         }
-        Assert.assertEquals(2 + FUNCTIONS_COUNT, count);
-        assertEquals(4, resultSet.getMetaData().getColumnCount());
-        statement.execute("DROP FUNCTION udaf1");
-        statement.execute("DROP FUNCTION udaf2");
-      } catch (Exception e) {
-        fail();
+      } finally {
+        dropFunctionQuietly(statement, "udaf1");
+        dropFunctionQuietly(statement, "udaf2");
       }
     }
   }
@@ -305,29 +330,32 @@ public class IoTDBUDAFManagementIT {
   public void testShowBuiltinFunction() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute(
-          "CREATE FUNCTION udaf AS 'org.apache.iotdb.db.query.udf.example.UDAFCount'");
+      try {
+        statement.execute(
+            "CREATE FUNCTION udaf AS 'org.apache.iotdb.db.query.udf.example.UDAFCount'");
 
-      try (ResultSet resultSet = statement.executeQuery("SHOW FUNCTIONS")) {
-        assertEquals(4, resultSet.getMetaData().getColumnCount());
-        int count = 0;
-        while (resultSet.next()) {
-          StringBuilder stringBuilder = new StringBuilder();
-          for (int i = 1; i <= resultSet.getMetaData().getColumnCount(); ++i) {
-            stringBuilder.append(resultSet.getString(i)).append(",");
+        try (ResultSet resultSet = statement.executeQuery("SHOW FUNCTIONS")) {
+          assertEquals(4, resultSet.getMetaData().getColumnCount());
+          int count = 0;
+          while (resultSet.next()) {
+            StringBuilder stringBuilder = new StringBuilder();
+            for (int i = 1; i <= resultSet.getMetaData().getColumnCount(); ++i) {
+              stringBuilder.append(resultSet.getString(i)).append(",");
+            }
+            String result = stringBuilder.toString();
+            if (result.contains(FUNCTION_TYPE_EXTERNAL_UDAF)) {
+              Assert.assertEquals(
+                  String.format(
+                      "UDAF,%s,org.apache.iotdb.db.query.udf.example.UDAFCount,AVAILABLE,",
+                      FUNCTION_TYPE_EXTERNAL_UDAF),
+                  result);
+            }
+            ++count;
           }
-          String result = stringBuilder.toString();
-          if (result.contains(FUNCTION_TYPE_EXTERNAL_UDAF)) {
-            Assert.assertEquals(
-                String.format(
-                    "UDAF,%s,org.apache.iotdb.db.query.udf.example.UDAFCount,AVAILABLE,",
-                    FUNCTION_TYPE_EXTERNAL_UDAF),
-                result);
-          }
-          ++count;
+          Assert.assertEquals(1 + FUNCTIONS_COUNT, count);
         }
-        Assert.assertEquals(1 + FUNCTIONS_COUNT, count);
-        statement.execute("DROP FUNCTION udaf");
+      } finally {
+        dropFunctionQuietly(statement, "udaf");
       }
     } catch (SQLException throwable) {
       fail(throwable.getMessage());

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/udf/IoTDBUDFManagementIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/udf/IoTDBUDFManagementIT.java
@@ -27,9 +27,9 @@ import org.apache.iotdb.itbase.constant.BuiltinAggregationFunctionEnum;
 import org.apache.iotdb.itbase.constant.BuiltinScalarFunctionEnum;
 import org.apache.iotdb.itbase.constant.BuiltinTimeSeriesGeneratingFunctionEnum;
 
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -70,39 +70,50 @@ public class IoTDBUDFManagementIT {
 
   private static final String UDF_JAR_PREFIX = new File(UDF_LIB_PREFIX).toURI().toString();
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void setUp() throws Exception {
     EnvFactory.getEnv().initClusterEnvironment();
   }
 
-  @After
-  public void tearDown() {
+  @AfterClass
+  public static void tearDown() {
     EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  private static void dropFunctionQuietly(Statement statement, String name) {
+    try {
+      statement.execute("DROP FUNCTION " + name);
+    } catch (SQLException ignored) {
+      // function may not exist; ignore
+    }
   }
 
   @Test
   public void testCreateReflectShowDrop() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("create function udf as 'org.apache.iotdb.db.query.udf.example.Adder'");
-      statement.executeQuery("select udf(*, *) from root.vehicle");
+      try {
+        statement.execute("create function udf as 'org.apache.iotdb.db.query.udf.example.Adder'");
+        statement.executeQuery("select udf(*, *) from root.vehicle");
 
-      try (ResultSet resultSet = statement.executeQuery("show functions")) {
-        assertEquals(4, resultSet.getMetaData().getColumnCount());
-        int count = 0;
-        while (resultSet.next()) {
-          StringBuilder stringBuilder = new StringBuilder();
-          for (int i = 1; i <= resultSet.getMetaData().getColumnCount(); ++i) {
-            stringBuilder.append(resultSet.getString(i)).append(",");
+        try (ResultSet resultSet = statement.executeQuery("show functions")) {
+          assertEquals(4, resultSet.getMetaData().getColumnCount());
+          int count = 0;
+          while (resultSet.next()) {
+            StringBuilder stringBuilder = new StringBuilder();
+            for (int i = 1; i <= resultSet.getMetaData().getColumnCount(); ++i) {
+              stringBuilder.append(resultSet.getString(i)).append(",");
+            }
+            String result = stringBuilder.toString();
+            if (result.contains(FUNCTION_TYPE_NATIVE)) {
+              continue;
+            }
+            ++count;
           }
-          String result = stringBuilder.toString();
-          if (result.contains(FUNCTION_TYPE_NATIVE)) {
-            continue;
-          }
-          ++count;
+          Assert.assertEquals(1 + BUILTIN_FUNCTIONS_COUNT + BUILTIN_SCALAR_FUNCTIONS_COUNT, count);
         }
-        Assert.assertEquals(1 + BUILTIN_FUNCTIONS_COUNT + BUILTIN_SCALAR_FUNCTIONS_COUNT, count);
-        statement.execute("drop function udf");
+      } finally {
+        dropFunctionQuietly(statement, "udf");
       }
     } catch (SQLException throwable) {
       fail(throwable.getMessage());
@@ -113,34 +124,37 @@ public class IoTDBUDFManagementIT {
   public void testCreateAndDropSeveralTimes() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("create function udf as 'org.apache.iotdb.db.query.udf.example.Adder'");
-      statement.executeQuery("select udf(*, *) from root.vehicle");
-
-      try (ResultSet resultSet = statement.executeQuery("show functions")) {
-        int count = 0;
-        while (resultSet.next()) {
-          ++count;
-        }
-        Assert.assertEquals(
-            1 + NATIVE_FUNCTIONS_COUNT + BUILTIN_FUNCTIONS_COUNT + BUILTIN_SCALAR_FUNCTIONS_COUNT,
-            count);
-        assertEquals(4, resultSet.getMetaData().getColumnCount());
-        statement.execute("drop function udf");
-
+      try {
         statement.execute("create function udf as 'org.apache.iotdb.db.query.udf.example.Adder'");
         statement.executeQuery("select udf(*, *) from root.vehicle");
-      }
 
-      try (ResultSet resultSet = statement.executeQuery("show functions")) {
-        int count = 0;
-        while (resultSet.next()) {
-          ++count;
+        try (ResultSet resultSet = statement.executeQuery("show functions")) {
+          int count = 0;
+          while (resultSet.next()) {
+            ++count;
+          }
+          Assert.assertEquals(
+              1 + NATIVE_FUNCTIONS_COUNT + BUILTIN_FUNCTIONS_COUNT + BUILTIN_SCALAR_FUNCTIONS_COUNT,
+              count);
+          assertEquals(4, resultSet.getMetaData().getColumnCount());
+          statement.execute("drop function udf");
+
+          statement.execute("create function udf as 'org.apache.iotdb.db.query.udf.example.Adder'");
+          statement.executeQuery("select udf(*, *) from root.vehicle");
         }
-        Assert.assertEquals(
-            1 + NATIVE_FUNCTIONS_COUNT + BUILTIN_FUNCTIONS_COUNT + BUILTIN_SCALAR_FUNCTIONS_COUNT,
-            count);
-        assertEquals(4, resultSet.getMetaData().getColumnCount());
-        statement.execute("drop function udf");
+
+        try (ResultSet resultSet = statement.executeQuery("show functions")) {
+          int count = 0;
+          while (resultSet.next()) {
+            ++count;
+          }
+          Assert.assertEquals(
+              1 + NATIVE_FUNCTIONS_COUNT + BUILTIN_FUNCTIONS_COUNT + BUILTIN_SCALAR_FUNCTIONS_COUNT,
+              count);
+          assertEquals(4, resultSet.getMetaData().getColumnCount());
+        }
+      } finally {
+        dropFunctionQuietly(statement, "udf");
       }
     } catch (SQLException throwable) {
       fail(throwable.getMessage());
@@ -202,13 +216,17 @@ public class IoTDBUDFManagementIT {
   public void testCreateFunction1() throws SQLException { // create function twice
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("create function udf as 'org.apache.iotdb.db.query.udf.example.Adder'");
-
       try {
         statement.execute("create function udf as 'org.apache.iotdb.db.query.udf.example.Adder'");
-        fail();
-      } catch (SQLException throwable) {
-        assertTrue(throwable.getMessage().contains("Failed to create"));
+
+        try {
+          statement.execute("create function udf as 'org.apache.iotdb.db.query.udf.example.Adder'");
+          fail();
+        } catch (SQLException throwable) {
+          assertTrue(throwable.getMessage().contains("Failed to create"));
+        }
+      } finally {
+        dropFunctionQuietly(statement, "udf");
       }
     }
   }
@@ -217,13 +235,17 @@ public class IoTDBUDFManagementIT {
   public void testCreateFunction3() throws SQLException { // create function twice
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("create function udf as 'org.apache.iotdb.db.query.udf.example.Adder'");
-
       try {
         statement.execute("create function udf as 'org.apache.iotdb.db.query.udf.example.Adder'");
-        fail();
-      } catch (SQLException throwable) {
-        assertTrue(throwable.getMessage().contains("the same name UDF has been created"));
+
+        try {
+          statement.execute("create function udf as 'org.apache.iotdb.db.query.udf.example.Adder'");
+          fail();
+        } catch (SQLException throwable) {
+          assertTrue(throwable.getMessage().contains("the same name UDF has been created"));
+        }
+      } finally {
+        dropFunctionQuietly(statement, "udf");
       }
     }
   }
@@ -232,29 +254,32 @@ public class IoTDBUDFManagementIT {
   public void testCreateFunctionWithURI() throws SQLException {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute(
-          String.format(
-              "create function udf as 'org.apache.iotdb.db.query.udf.example.Adder' using URI '%s'",
-              UDF_JAR_PREFIX + "udf-example.jar"));
+      try {
+        statement.execute(
+            String.format(
+                "create function udf as 'org.apache.iotdb.db.query.udf.example.Adder' using URI '%s'",
+                UDF_JAR_PREFIX + "udf-example.jar"));
 
-      statement.execute(
-          String.format(
-              "create function udf1 as 'org.apache.iotdb.db.query.udf.example.Adder' using URI '%s'",
-              UDF_JAR_PREFIX + "udf-example.jar"));
+        statement.execute(
+            String.format(
+                "create function udf1 as 'org.apache.iotdb.db.query.udf.example.Adder' using URI '%s'",
+                UDF_JAR_PREFIX + "udf-example.jar"));
 
-      try (ResultSet resultSet = statement.executeQuery("show functions")) {
-        int count = 0;
-        while (resultSet.next()) {
-          ++count;
+        try (ResultSet resultSet = statement.executeQuery("show functions")) {
+          int count = 0;
+          while (resultSet.next()) {
+            ++count;
+          }
+          Assert.assertEquals(
+              2 + NATIVE_FUNCTIONS_COUNT + BUILTIN_FUNCTIONS_COUNT + BUILTIN_SCALAR_FUNCTIONS_COUNT,
+              count);
+          assertEquals(4, resultSet.getMetaData().getColumnCount());
+        } catch (Exception e) {
+          fail();
         }
-        Assert.assertEquals(
-            2 + NATIVE_FUNCTIONS_COUNT + BUILTIN_FUNCTIONS_COUNT + BUILTIN_SCALAR_FUNCTIONS_COUNT,
-            count);
-        assertEquals(4, resultSet.getMetaData().getColumnCount());
-        statement.execute("drop function udf");
-        statement.execute("drop function udf1");
-      } catch (Exception e) {
-        fail();
+      } finally {
+        dropFunctionQuietly(statement, "udf");
+        dropFunctionQuietly(statement, "udf1");
       }
     }
   }
@@ -365,9 +390,12 @@ public class IoTDBUDFManagementIT {
   public void testReflectBuiltinFunction() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("create function adder as 'org.apache.iotdb.db.query.udf.example.Adder'");
-      statement.executeQuery("select adder(*, *) from root.vehicle");
-      statement.execute("drop function adder");
+      try {
+        statement.execute("create function adder as 'org.apache.iotdb.db.query.udf.example.Adder'");
+        statement.executeQuery("select adder(*, *) from root.vehicle");
+      } finally {
+        dropFunctionQuietly(statement, "adder");
+      }
     } catch (SQLException throwable) {
       fail(throwable.getMessage());
     }
@@ -377,34 +405,37 @@ public class IoTDBUDFManagementIT {
   public void testShowBuiltinFunction() {
     try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("create function udf as 'org.apache.iotdb.db.query.udf.example.Adder'");
+      try {
+        statement.execute("create function udf as 'org.apache.iotdb.db.query.udf.example.Adder'");
 
-      try (ResultSet resultSet = statement.executeQuery("show functions")) {
-        assertEquals(4, resultSet.getMetaData().getColumnCount());
-        int count = 0;
-        while (resultSet.next()) {
-          StringBuilder stringBuilder = new StringBuilder();
-          for (int i = 1; i <= resultSet.getMetaData().getColumnCount(); ++i) {
-            stringBuilder.append(resultSet.getString(i)).append(",");
-          }
-          String result = stringBuilder.toString();
-          if (result.contains(FUNCTION_TYPE_NATIVE)) {
-            continue;
-          }
+        try (ResultSet resultSet = statement.executeQuery("show functions")) {
+          assertEquals(4, resultSet.getMetaData().getColumnCount());
+          int count = 0;
+          while (resultSet.next()) {
+            StringBuilder stringBuilder = new StringBuilder();
+            for (int i = 1; i <= resultSet.getMetaData().getColumnCount(); ++i) {
+              stringBuilder.append(resultSet.getString(i)).append(",");
+            }
+            String result = stringBuilder.toString();
+            if (result.contains(FUNCTION_TYPE_NATIVE)) {
+              continue;
+            }
 
-          if (result.contains(FUNCTION_TYPE_EXTERNAL_UDTF)) {
-            Assert.assertEquals(
-                String.format(
-                    "UDF,%s,org.apache.iotdb.db.query.udf.example.Adder,AVAILABLE,",
-                    FUNCTION_TYPE_EXTERNAL_UDTF),
-                result);
-            ++count;
-          } else if (result.contains(FUNCTION_TYPE_BUILTIN_UDTF)) {
-            ++count;
+            if (result.contains(FUNCTION_TYPE_EXTERNAL_UDTF)) {
+              Assert.assertEquals(
+                  String.format(
+                      "UDF,%s,org.apache.iotdb.db.query.udf.example.Adder,AVAILABLE,",
+                      FUNCTION_TYPE_EXTERNAL_UDTF),
+                  result);
+              ++count;
+            } else if (result.contains(FUNCTION_TYPE_BUILTIN_UDTF)) {
+              ++count;
+            }
           }
+          Assert.assertEquals(1 + BUILTIN_FUNCTIONS_COUNT, count);
         }
-        Assert.assertEquals(1 + BUILTIN_FUNCTIONS_COUNT, count);
-        statement.execute("drop function udf");
+      } finally {
+        dropFunctionQuietly(statement, "udf");
       }
     } catch (SQLException throwable) {
       fail(throwable.getMessage());


### PR DESCRIPTION
## Motivation

Most ITs under `integration-test/src/test/java/org/apache/iotdb/db/it/` use `@Before`/`@After` to start and stop the cluster on every test method. For a class with N tests this means N full cluster start/stop cycles (~5s each), which dominates wall time on management/syntax/auth-style suites where the actual test body finishes in tens of milliseconds.

For example, `IoTDBSimpleQueryIT` has 36 tests; previously it spent roughly 36 × 5s ≈ 3 min just on cluster lifecycle. After this change the same suite finishes in ~14s.

## Changes

Converted 37 ITs to start the cluster once per class:

- `@Before` → `@BeforeClass public static void setUp()`
- `@After` → `@AfterClass public static void tearDown()`
- Each test wraps its body in `try { ... } finally { ... }` and cleans up the state it created (drop database / drop function / drop user / drop role / revoke privileges / drop trigger / drop template / etc.) via small static helpers like `dropFunctionQuietly`, `executeQuietly`, or `cleanupAfterTest` that swallow expected SQLExceptions.
- Where setup populated shared seed data (e.g. trigger timeseries, schema fixtures), the seed runs once in `@BeforeClass`.
- For `IoTDBMQTTServiceJsonIT` the cluster moves to `@BeforeClass`/`@AfterClass` while per-test MQTT connection setup stays in `@Before`/`@After` (each test still gets its own connection).

## Tests intentionally left on `@Before`/`@After`

These have semantics that are incompatible with sharing a cluster across tests:

- Tests that restart or kill nodes — `IoTDBRecoverIT`, `IoTDBRecoverUnclosedIT`, `IoTDBRestartIT`, `IoTDBRestartRatisIT`, `IoTDBVerifyConnectionIT`
- Tests that initialize the cluster with different topologies/configs per method — `IoTDBLoadLastCacheIT` (parameterized), `IoTDBLoadTsFileIT`, `metric/IoTDBMetricIT`, `iotconsensusv2/IoTDBIoTConsensusV23C3DBasicITBase`
- Tests that depend on a fresh global counter or accumulate global state — `quotas/IoTDBSpaceQuotaIT`, `audit/IoTDBAuditLogBasicIT`, `schema/IoTDBDeactivateTemplateIT`, `schema/IoTDBMetadataFetchIT`, `schema/IoTDBSchemaTemplateIT`, `IoTDBInsertWithQueryIT`, `aligned/IoTDBAlignedDataDeletionIT`
- Tests that mutate root credentials and could brick the cluster on failure — `auth/IoTDBUserRenameIT`
- Parameterized base class where `@BeforeClass` would run before `@Parameterized.BeforeParam` (cluster not yet up) — `schema/quota/IoTDBClusterQuotaIT`
- Two-test classes whose tests both `CREATE USER user1` and assert "no data → empty" on the same path — `schema/regionscan/IoTDBActiveSchemaQueryIT`

## Verification

Spotless and `mvn test-compile` pass on the integration-test module. Ran 4 batches of representative ITs locally:

| Batch | Tests | Failures | Skipped |
|---|---|---|---|
| 1 (UDF + SyntaxId + ExecuteBatch) | 31 | 0 | 0 |
| 2 (SimpleQuery + Aligned + Trigger + auth + StringLiteral + ...) | 85 | 0 | 2 (`@Ignore`) |
| 3 (single-test ITs + LoadTsFileWithMod + SortedShowTimeseries) | 28 | 0 | 0 |
| 4 (Grafana + REST + MQTT + auth) | 20 | 0 | 0 |
| **Total** | **164** | **0** | **2** |