### PR TITLE
Fix wrong metric name in NetMetrics.unbindFrom for transmitted bytes

### DIFF
--- a/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/net/NetMetrics.java
+++ b/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/net/NetMetrics.java
@@ -114,7 +114,7 @@ public class NetMetrics implements IMetricSet {
           iface);
       metricService.remove(
           MetricType.AUTO_GAUGE,
-          TRANSMIT,
+          SystemMetric.TRANSMITTED_BYTES.toString(),
           SystemTag.TYPE.toString(),
           TRANSMIT,
           SystemTag.IFACE_NAME.toString(),


### PR DESCRIPTION
## Description

unbindFrom used TRANSMIT ("transmit") as the metric name instead of SystemMetric.TRANSMITTED_BYTES, causing the gauge to not be removed.