### PR TITLE
Fix error metric type when remove metrics in RPCServiceThriftHandlerMetrics

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/handler/RPCServiceThriftHandlerMetrics.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/handler/RPCServiceThriftHandlerMetrics.java
@@ -123,13 +123,13 @@ public class RPCServiceThriftHandlerMetrics implements IMetricSet {
         "ClientRPC");
 
     metricService.remove(
-        MetricType.TIMER,
+        MetricType.GAUGE,
         Metric.THRIFT_RPC_UNCOMPRESS_SIZE.toString(),
         Tag.NAME.toString(),
         "unCompressionSize");
 
     metricService.remove(
-        MetricType.TIMER,
+        MetricType.GAUGE,
         Metric.THRIFT_RPC_COMPRESS_SIZE.toString(),
         Tag.NAME.toString(),
         "compressionSize");


### PR DESCRIPTION
Fix error metric type when remove metrics in RPCServiceThriftHandlerMetrics