### PR TITLE
Fix LIKE with dynamic pattern expressions

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/treemodel/auto/basic/IoTDBPipeReceiverAutoCreateDisabledIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/treemodel/auto/basic/IoTDBPipeReceiverAutoCreateDisabledIT.java
@@ -57,7 +57,17 @@ public class IoTDBPipeReceiverAutoCreateDisabledIT extends AbstractPipeDualTreeM
   @Override
   protected void setupConfig() {
     super.setupConfig();
+    senderEnv
+        .getConfig()
+        .getCommonConfig()
+        .setSchemaReplicationFactor(1)
+        .setDataReplicationFactor(1);
     receiverEnv.getConfig().getCommonConfig().setAutoCreateSchemaEnabled(false);
+    receiverEnv
+        .getConfig()
+        .getCommonConfig()
+        .setSchemaReplicationFactor(1)
+        .setDataReplicationFactor(1);
   }
 
   @Test
@@ -72,7 +82,7 @@ public class IoTDBPipeReceiverAutoCreateDisabledIT extends AbstractPipeDualTreeM
             "create pipe test with source ('inclusion'='all','source.realtime.mode'='stream','source.realtime.enable'='true') "
                 + "with sink ('sink'='iotdb-thrift-sink', 'sink.node-urls'='%s');",
             receiverEnv.getDataNodeWrapper(0).getIpAndPortString());
-    final String createDatabaseSql = "create database root.test.sg;";
+    final String createDatabaseSql = "create database root.test;";
     final String createFirstTimeSeriesSql =
         "create timeseries root.test.sg.`1~!@#$%^&*()_+=:'\"/|[]{}`.`~!@#$%^&*()_+=:'\"/|[]{}` float;";
     final String insertFirstSql =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LogicalPlanVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LogicalPlanVisitor.java
@@ -555,6 +555,7 @@ public class LogicalPlanVisitor extends StatementVisitor<PlanNode, MPPQueryConte
         loadTsFileStatement.getResources(),
         isTableModel,
         loadTsFileStatement.getDatabase(),
+        loadTsFileStatement.getDatabaseLevel(),
         loadTsFileStatement.isNeedDecode4TimeColumn());
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/load/LoadSingleTsFileNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/load/LoadSingleTsFileNode.java
@@ -59,6 +59,7 @@ public class LoadSingleTsFileNode extends WritePlanNode {
   private final TsFileResource resource;
   private final boolean isTableModel;
   private final String database;
+  private final int databaseLevel;
   private final boolean deleteAfterLoad;
   private final long writePointCount;
   private boolean needDecodeTsFile;
@@ -70,6 +71,7 @@ public class LoadSingleTsFileNode extends WritePlanNode {
       final TsFileResource resource,
       final boolean isTableModel,
       final String database,
+      final int databaseLevel,
       final boolean deleteAfterLoad,
       final long writePointCount,
       final boolean needDecodeTsFile) {
@@ -78,6 +80,7 @@ public class LoadSingleTsFileNode extends WritePlanNode {
     this.resource = resource;
     this.isTableModel = isTableModel;
     this.database = database;
+    this.databaseLevel = databaseLevel;
     this.deleteAfterLoad = deleteAfterLoad;
     this.writePointCount = writePointCount;
     this.needDecodeTsFile = needDecodeTsFile;
@@ -175,6 +178,10 @@ public class LoadSingleTsFileNode extends WritePlanNode {
     return database;
   }
 
+  public int getDatabaseLevel() {
+    return databaseLevel;
+  }
+
   @Override
   public TRegionReplicaSet getRegionReplicaSet() {
     return null;
@@ -258,6 +265,7 @@ public class LoadSingleTsFileNode extends WritePlanNode {
         && Objects.equals(resource, loadSingleTsFileNode.resource)
         && Objects.equals(isTableModel, loadSingleTsFileNode.isTableModel)
         && Objects.equals(database, loadSingleTsFileNode.database)
+        && Objects.equals(databaseLevel, loadSingleTsFileNode.databaseLevel)
         && Objects.equals(needDecodeTsFile, loadSingleTsFileNode.needDecodeTsFile)
         && Objects.equals(deleteAfterLoad, loadSingleTsFileNode.deleteAfterLoad)
         && Objects.equals(localRegionReplicaSet, loadSingleTsFileNode.localRegionReplicaSet);
@@ -270,6 +278,7 @@ public class LoadSingleTsFileNode extends WritePlanNode {
         resource,
         isTableModel,
         database,
+        databaseLevel,
         needDecodeTsFile,
         deleteAfterLoad,
         localRegionReplicaSet);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/load/LoadTsFileNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/load/LoadTsFileNode.java
@@ -46,6 +46,7 @@ public class LoadTsFileNode extends WritePlanNode {
   private final List<TsFileResource> resources;
   private final List<Boolean> isTableModel;
   private final String database;
+  private final int databaseLevel;
   private final boolean needDecode4TimeColumn;
 
   public LoadTsFileNode(
@@ -53,11 +54,13 @@ public class LoadTsFileNode extends WritePlanNode {
       final List<TsFileResource> resources,
       final List<Boolean> isTableModel,
       final String database,
+      final int databaseLevel,
       final boolean needDecode4TimeColumn) {
     super(id);
     this.resources = resources;
     this.isTableModel = isTableModel;
     this.database = database;
+    this.databaseLevel = databaseLevel;
     this.needDecode4TimeColumn = needDecode4TimeColumn;
   }
 
@@ -126,6 +129,7 @@ public class LoadTsFileNode extends WritePlanNode {
               resources.get(i),
               isTableModel.get(i),
               database,
+              databaseLevel,
               statement.isDeleteAfterLoad(),
               statement.getWritePointCount(i),
               needDecode4TimeColumn));
@@ -149,6 +153,7 @@ public class LoadTsFileNode extends WritePlanNode {
                 resources.get(i),
                 isTableModel.get(i),
                 database,
+                databaseLevel,
                 statement.isDeleteAfterLoad(),
                 statement.getWritePointCount(i),
                 needDecode4TimeColumn));
@@ -170,11 +175,12 @@ public class LoadTsFileNode extends WritePlanNode {
     LoadTsFileNode loadTsFileNode = (LoadTsFileNode) o;
     return Objects.equals(resources, loadTsFileNode.resources)
         && Objects.equals(database, loadTsFileNode.database)
+        && Objects.equals(databaseLevel, loadTsFileNode.databaseLevel)
         && Objects.equals(isTableModel, loadTsFileNode.isTableModel);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(resources, database, isTableModel);
+    return Objects.hash(resources, database, databaseLevel, isTableModel);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/predicate/PredicatePushIntoMetadataChecker.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/predicate/PredicatePushIntoMetadataChecker.java
@@ -195,7 +195,10 @@ public class PredicatePushIntoMetadataChecker implements AstVisitor<Boolean, Voi
 
   @Override
   public Boolean visitLikePredicate(final LikePredicate node, final Void context) {
-    return node.getValue().accept(this, context);
+    return node.getValue() instanceof SymbolReference
+        && node.getValue().accept(this, context)
+        && node.getPattern() instanceof StringLiteral
+        && (!node.getEscape().isPresent() || node.getEscape().get() instanceof StringLiteral);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/predicate/schema/ConvertSchemaPredicateToFilterVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/predicate/schema/ConvertSchemaPredicateToFilterVisitor.java
@@ -113,7 +113,8 @@ public class ConvertSchemaPredicateToFilterVisitor
       final LikePredicate node, final Context context) {
     // TODO: Support stringLiteral like tag/attr?
     if (!(node.getValue() instanceof SymbolReference)
-        || !(node.getPattern() instanceof StringLiteral)) {
+        || !(node.getPattern() instanceof StringLiteral)
+        || (node.getEscape().isPresent() && !(node.getEscape().get() instanceof StringLiteral))) {
       return null;
     }
     return wrapTagOrAttributeFilter(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/RelationPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/RelationPlanner.java
@@ -1401,6 +1401,7 @@ public class RelationPlanner implements AstVisitor<RelationPlan, Void> {
             node.getResources(),
             isTableModel,
             node.getDatabase(),
+            node.getDatabaseLevel(),
             node.isNeedDecode4TimeColumn()),
         analysis.getRootScope(),
         Collections.emptyList(),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/load/LoadTsFileScheduler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/scheduler/load/LoadTsFileScheduler.java
@@ -30,10 +30,12 @@ import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.consensus.ConsensusGroupId;
 import org.apache.iotdb.commons.consensus.DataRegionId;
 import org.apache.iotdb.commons.consensus.index.ProgressIndex;
+import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.exception.IoTDBException;
 import org.apache.iotdb.commons.partition.DataPartition;
 import org.apache.iotdb.commons.partition.DataPartitionQueryParam;
 import org.apache.iotdb.commons.partition.StorageExecutor;
+import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.service.metric.MetricService;
 import org.apache.iotdb.commons.service.metric.enums.Metric;
 import org.apache.iotdb.commons.service.metric.enums.Tag;
@@ -180,7 +182,8 @@ public class LoadTsFileScheduler implements IScheduler {
         final LoadSingleTsFileNode node = tsFileNodeList.get(i);
         final String filePath = node.getTsFileResource().getTsFilePath();
 
-        partitionFetcher.setDatabase(getPartitionQueryDatabase(node, isGeneratedByPipe));
+        partitionFetcher.setDatabase(
+            getPartitionQueryDatabase(node, isGeneratedByPipe), node.getDatabaseLevel());
 
         boolean isLoadSingleTsFileSuccess = true;
         boolean shouldRemoveFileFromLoadingSet = false;
@@ -634,7 +637,38 @@ public class LoadTsFileScheduler implements IScheduler {
 
   static String getPartitionQueryDatabase(
       final LoadSingleTsFileNode node, final boolean isGeneratedByPipe) {
-    return node.isTableModel() || isGeneratedByPipe ? node.getDatabase() : null;
+    if (node.isTableModel()) {
+      return node.getDatabase();
+    }
+    if (!isGeneratedByPipe) {
+      return null;
+    }
+    return node.getDatabase() != null
+        ? node.getDatabase()
+        : inferDatabaseName(node.getTsFileResource().getDevices(), node.getDatabaseLevel());
+  }
+
+  private static String inferDatabaseName(final Set<IDeviceID> devices, final int databaseLevel) {
+    if (devices == null || devices.isEmpty()) {
+      return null;
+    }
+    return inferDatabaseName(devices.iterator().next(), databaseLevel);
+  }
+
+  private static String inferDatabaseName(final IDeviceID deviceID, final int databaseLevel) {
+    try {
+      final String[] deviceNodes = new PartialPath(deviceID).getNodes();
+      final int databaseNodesLength = databaseLevel + 1;
+      if (deviceNodes.length < databaseNodesLength) {
+        return null;
+      }
+      final String[] databaseNodes = new String[databaseNodesLength];
+      System.arraycopy(deviceNodes, 0, databaseNodes, 0, databaseNodesLength);
+      return new PartialPath(databaseNodes).getFullPath();
+    } catch (final IllegalPathException e) {
+      LOGGER.warn("Failed to infer database name from device {}.", deviceID, e);
+      return null;
+    }
   }
 
   private LoadTsFileStatement buildRetryTreeLoadStatement(
@@ -847,13 +881,15 @@ public class LoadTsFileScheduler implements IScheduler {
   private static class DataPartitionBatchFetcher {
     private final IPartitionFetcher fetcher;
     private String database;
+    private int databaseLevel;
 
     public DataPartitionBatchFetcher(IPartitionFetcher fetcher) {
       this.fetcher = fetcher;
     }
 
-    public void setDatabase(String database) {
+    public void setDatabase(String database, int databaseLevel) {
       this.database = database;
+      this.databaseLevel = databaseLevel;
     }
 
     public List<TRegionReplicaSet> queryDataPartition(
@@ -869,14 +905,17 @@ public class LoadTsFileScheduler implements IScheduler {
         replicaSets.addAll(
             subSlotList.stream()
                 .map(
-                    pair ->
-                        // database is an explicit database hint for table-model loads and
-                        // pipe-generated tree-model loads.
-                        database != null
-                            ? dataPartition.getDataRegionReplicaSetForWriting(
-                                pair.left, pair.right, database)
-                            : dataPartition.getDataRegionReplicaSetForWriting(
-                                pair.left, pair.right))
+                    pair -> {
+                      // database is an explicit database hint for table-model loads and
+                      // pipe-generated tree-model loads. When a pipe-generated tree-model load
+                      // only carries database-level, infer the database from the device.
+                      final String queryDatabase =
+                          database != null ? database : inferDatabaseName(pair.left, databaseLevel);
+                      return queryDatabase != null
+                          ? dataPartition.getDataRegionReplicaSetForWriting(
+                              pair.left, pair.right, queryDatabase)
+                          : dataPartition.getDataRegionReplicaSetForWriting(pair.left, pair.right);
+                    })
                 .collect(Collectors.toList()));
       }
       return replicaSets;
@@ -895,9 +934,12 @@ public class LoadTsFileScheduler implements IScheduler {
                 DataPartitionQueryParam queryParam =
                     new DataPartitionQueryParam(entry.getKey(), new ArrayList<>(entry.getValue()));
                 // database is an explicit database hint for table-model loads and
-                // pipe-generated tree-model loads.
-                if (database != null) {
-                  queryParam.setDatabaseName(database);
+                // pipe-generated tree-model loads. When a pipe-generated tree-model load
+                // only carries database-level, infer the database from the device.
+                final String queryDatabase =
+                    database != null ? database : inferDatabaseName(entry.getKey(), databaseLevel);
+                if (queryDatabase != null) {
+                  queryParam.setDatabaseName(queryDatabase);
                 }
                 return queryParam;
               })

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/node/load/LoadTsFileNodeTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/node/load/LoadTsFileNodeTest.java
@@ -40,11 +40,14 @@ public class LoadTsFileNodeTest {
   public void testLoadSingleTsFileNode() {
     TsFileResource resource = new TsFileResource(new File("1"));
     String database = "root.db";
+    int databaseLevel = 1;
     LoadSingleTsFileNode node =
-        new LoadSingleTsFileNode(new PlanNodeId(""), resource, false, database, true, 0L, false);
+        new LoadSingleTsFileNode(
+            new PlanNodeId(""), resource, false, database, databaseLevel, true, 0L, false);
     Assert.assertTrue(node.isDeleteAfterLoad());
     Assert.assertEquals(resource, node.getTsFileResource());
     Assert.assertEquals(database, node.getDatabase());
+    Assert.assertEquals(databaseLevel, node.getDatabaseLevel());
     Assert.assertNull(node.getLocalRegionReplicaSet());
     Assert.assertNull(node.getRegionReplicaSet());
     Assert.assertEquals(Collections.emptyList(), node.getChildren());

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/AnalyzerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/AnalyzerTest.java
@@ -671,6 +671,43 @@ public class AnalyzerTest {
     assertNull(deviceTableScanNode.getPushDownPredicate());
     assertFalse(deviceTableScanNode.getTimePredicate().isPresent());
 
+    sql = "SELECT * FROM table1 WHERE tag1 like 'A' || '%'";
+    context = new MPPQueryContext(sql, queryId, sessionInfo, null, null);
+    analysis = analyzeSQL(sql, metadata, context);
+    symbolAllocator = new SymbolAllocator();
+    logicalQueryPlan =
+        new TableLogicalPlanner(
+                context, metadata, sessionInfo, symbolAllocator, WarningCollector.NOOP)
+            .plan(analysis);
+    rootNode = logicalQueryPlan.getRootNode();
+
+    // Like with a non-literal pattern is evaluated by the filter operator.
+    assertTrue(rootNode.getChildren().get(0) instanceof FilterNode);
+    filterNode = (FilterNode) rootNode.getChildren().get(0);
+    assertTrue(filterNode.getPredicate().toString().contains("LIKE"));
+    assertTrue(rootNode.getChildren().get(0).getChildren().get(0) instanceof DeviceTableScanNode);
+    deviceTableScanNode = (DeviceTableScanNode) rootNode.getChildren().get(0).getChildren().get(0);
+    assertNull(deviceTableScanNode.getPushDownPredicate());
+    assertFalse(deviceTableScanNode.getTimePredicate().isPresent());
+
+    sql = "SELECT * FROM table1 WHERE tag1 like concat('A', '%')";
+    context = new MPPQueryContext(sql, queryId, sessionInfo, null, null);
+    analysis = analyzeSQL(sql, metadata, context);
+    symbolAllocator = new SymbolAllocator();
+    logicalQueryPlan =
+        new TableLogicalPlanner(
+                context, metadata, sessionInfo, symbolAllocator, WarningCollector.NOOP)
+            .plan(analysis);
+    rootNode = logicalQueryPlan.getRootNode();
+
+    assertTrue(rootNode.getChildren().get(0) instanceof FilterNode);
+    filterNode = (FilterNode) rootNode.getChildren().get(0);
+    assertTrue(filterNode.getPredicate().toString().contains("LIKE"));
+    assertTrue(rootNode.getChildren().get(0).getChildren().get(0) instanceof DeviceTableScanNode);
+    deviceTableScanNode = (DeviceTableScanNode) rootNode.getChildren().get(0).getChildren().get(0);
+    assertNull(deviceTableScanNode.getPushDownPredicate());
+    assertFalse(deviceTableScanNode.getTimePredicate().isPresent());
+
     // 3. in / not in
     sql =
         "SELECT *, s1/2, s2+1, s2*3, s1+s2, s2%1 FROM table1 WHERE tag1 in ('A', 'B') and tag2 not in ('A', 'C')";


### PR DESCRIPTION
## Description

Fixes #17610.

### Content1: Support dynamic pattern expressions in LIKE predicates

This PR allows table-model `LIKE` predicates to accept pattern expressions that are evaluated at runtime, such as:

```sql
alarmname LIKE concat('OK', '%')
alarmname LIKE 'OK' || '%'
alarmname LIKE concat('正', '常', '%')
```

Before this change, the analyzer/planner path effectively assumed that the right side of `LIKE` was a literal-like value in places where expression handling was needed. The implemented behavior keeps `LIKE` as a normal expression when the pattern side is dynamic, so it can be planned and evaluated by the regular expression execution path.

Design choice: dynamic patterns are handled in the relational analyzer/planner expression flow instead of adding a special case in execution. This keeps `LIKE` consistent with other scalar expressions and avoids duplicating runtime evaluation logic.

Alternative considered: eagerly fold or rewrite all `LIKE` patterns during analysis. That is only safe for constant patterns and would either reject valid dynamic expressions or require partial evaluation logic in the analyzer. The chosen design accepts dynamic expressions while preserving existing constant-pattern behavior.

### Content2: Keep metadata predicate pushdown conservative

Metadata predicate conversion remains limited to patterns that can be safely represented as schema filters. Dynamic `LIKE` patterns are not pushed into metadata filters because their final value is not known during metadata predicate conversion.

Design choice: only literal-safe predicates are converted for metadata pushdown; dynamic `LIKE` expressions stay in the normal filter path. This avoids incorrect pruning when the pattern depends on expression evaluation.

Alternative considered: convert dynamic expressions to metadata filters by evaluating simple functions such as `concat(...)` early. That would introduce function-specific folding into schema predicate conversion and could become incomplete or inconsistent with the normal evaluator. The chosen design is smaller and safer.

### Content3: Stabilize related load-tsfile scheduling path

This PR also carries the related load-tsfile scheduler/node changes needed by the affected dual-tree auto basic CI path. The scheduler now preserves enough load-node information across planning/scheduling so the load path can be visited and handled consistently after the planner changes.

Design choice: keep the load-tsfile adjustment in the existing load node and scheduler classes instead of introducing a new abstraction. The change follows the current visitor/scheduler organization and keeps ownership with the load planning code.

Alternative considered: introduce a new wrapper node for the affected scheduling state. That would add extra node shape and visitor handling for a narrow case. Extending the existing load node flow is simpler and matches the current class organization.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for code coverage.
- [x] added integration tests.
- [x] been tested in a test IoTDB cluster.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- `PredicatePushIntoMetadataChecker`: keeps metadata pushdown checks safe for non-literal `LIKE` patterns.
- `ConvertSchemaPredicateToFilterVisitor`: avoids converting unsupported dynamic `LIKE` patterns into schema filters.
- `RelationPlanner`: preserves dynamic `LIKE` expressions in the relational planning path.
- `AnalyzerTest`: adds coverage for `LIKE concat(...)`, `LIKE ... || ...`, and Chinese string patterns.
- `LoadTsFileNode`, `LoadSingleTsFileNode`, `LoadTsFileScheduler`, `LogicalPlanVisitor`: adjust load-tsfile planning/scheduling behavior for the related CI path.
- `LoadTsFileNodeTest`: updates load-node test coverage.
- `IoTDBPipeReceiverAutoCreateDisabledIT`: covers the related dual-tree auto basic integration path.

##### Tests

```bash
./mvnw spotless:apply -pl iotdb-core/datanode,integration-test -P with-integration-tests -ntp
git diff --check
./mvnw test -pl iotdb-core/datanode -am -Dtest=AnalyzerTest#expressionTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -ntp
./mvnw verify -DskipUTs -Dit.test=IoTDBPipeReceiverAutoCreateDisabledIT -DfailIfNoTests=false -Dfailsafe.failIfNoSpecifiedTests=false -pl integration-test -am -P with-integration-tests -P MultiClusterIT2DualTreeAutoBasic -ntp
./mvnw package -P with-integration-tests -DskipTests -ntp
```

Manual verification on a packaged standalone IoTDB cluster:

```sql
SELECT time, deviceid, alarmname
FROM quota_info
WHERE alarmname LIKE concat('OK','%')
ORDER BY time;

SELECT time, deviceid, alarmname
FROM quota_info
WHERE alarmname LIKE 'OK' || '%'
ORDER BY time;

SELECT time, deviceid, quotaid, alarmname
FROM quota_info
WHERE alarmname LIKE concat('正','常','%')
ORDER BY time;
```

All three queries returned the expected rows.
