### PR TITLE
Shard Windows datanode unit tests to speed up Unit-Test CI

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -42,6 +42,11 @@ jobs:
         java: [17]
         os: [ubuntu-latest, windows-latest]
         it_task: ["others", "datanode"]
+        # Windows datanode is the ~47min bottleneck; it's sharded in a
+        # separate job below (`unit-test-windows-datanode`).
+        exclude:
+          - os: windows-latest
+            it_task: "datanode"
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -69,3 +74,75 @@ jobs:
         run: |
           mvn clean install -DskipTests
           mvn -P get-jar-with-dependencies,with-integration-tests clean test -Dtest.port.closed=true -Diotdb.test.skip=true
+
+  # Windows datanode unit-test is the slowest cell in the matrix above (~47 min
+  # vs ~38 min on Ubuntu) because datanode has 597 UT classes and
+  # reuseForks=false spawns a new JVM per class — Windows process startup and
+  # NTFS IO are much slower than Linux. Split it into 3 parallel shards using
+  # the same hash-mod assignment trick as PR #17692 (Cluster IT - 1C1D), but
+  # with surefire.includesFile instead of failsafe.includesFile.
+  unit-test-windows-datanode:
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: corretto
+          java-version: 17
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cache Maven packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2-
+      - name: Adjust network dynamic TCP ports range
+        shell: pwsh
+        # 597 UT classes × reuseForks=false will burn through the default
+        # Windows ephemeral port pool. Same tweak applied in cluster-it-1c1d.yml.
+        run: |
+          netsh int ipv4 set dynamicport tcp start=32768 num=32768
+          netsh int ipv4 set dynamicport udp start=32768 num=32768
+          netsh int ipv6 set dynamicport tcp start=32768 num=32768
+          netsh int ipv6 set dynamicport udp start=32768 num=32768
+      - name: Build unit-test shard list
+        shell: bash
+        # Distribute datanode *Test.java classes across 3 shards using hash-mod
+        # assignment. The list is written to $RUNNER_TEMP (outside the repo) so
+        # apache-rat-plugin can never flag it as an unapproved-license file,
+        # and so it survives `mvn clean`. `find ... | awk` (no xargs) sidesteps
+        # the Windows ARG_MAX trap fixed in a343cf50e3.
+        run: |
+          set -euo pipefail
+          SHARD=${{ matrix.shard }}
+          TOTAL=3
+          SHARD_FILE="${RUNNER_TEMP}/unit-shard.txt"
+          find iotdb-core/datanode/src/test/java -type f -name '*Test.java' \
+            | awk -F'/' '{print $NF}' | sed 's/\.java$//' \
+            | sort \
+            | awk -v s=$SHARD -v t=$TOTAL 'NR%t==(s-1)' \
+            > "$SHARD_FILE"
+          echo "Shard $SHARD/$TOTAL contains $(wc -l < "$SHARD_FILE") test classes"
+          head -5 "$SHARD_FILE"
+      - name: Test Datanode Module with Maven (shard ${{ matrix.shard }})
+        shell: bash
+        # Only shard 1 runs the lone IT (EnvScriptIT); shards 2 and 3 skip
+        # failsafe entirely with -DskipITs.
+        run: |
+          SKIP_IT=""
+          if [ "${{ matrix.shard }}" != "1" ]; then SKIP_IT="-DskipITs"; fi
+          mvn clean integration-test \
+            -Dtest.port.closed=true \
+            -pl iotdb-core/datanode -am \
+            -DskipTests -Diotdb.test.only=true \
+            -Dsurefire.includesFile="${RUNNER_TEMP}/unit-shard.txt" \
+            -DfailIfNoTests=false \
+            -Dsurefire.failIfNoSpecifiedTests=false \
+            $SKIP_IT


### PR DESCRIPTION
## Summary

- Windows runner on the `Unit-Test` workflow's `datanode` cell takes ~47 min vs ~38 min on Ubuntu. With 597 UT classes and `reuseForks=false` (one JVM per class), Windows process startup + NTFS IO are the bottleneck.
- Excludes the `(windows-latest, datanode)` cell from the existing matrix and adds a new `unit-test-windows-datanode` job with 3 parallel shards via `-Dsurefire.includesFile=...`. Same hash-mod assignment pattern as #17692, but for surefire instead of failsafe.
- Expected wall clock: **~47 min → ~22 min** on Windows; whole pipeline drops accordingly.

## Design notes

- Shard list written to `$RUNNER_TEMP/unit-shard.txt` (outside the repo):
  - apache-rat can never flag it as an unapproved-license file even if a future workflow reaches `verify` phase.
  - Survives `mvn clean`.
  - Doesn't depend on workspace layout.
- `find | awk` (no xargs) sidesteps the Windows ARG_MAX trap fixed in a343cf50e3 (same root cause as the earlier 1C1D shard fix).
- The single datanode IT (`EnvScriptIT`) runs only in shard 1; shards 2 and 3 add `-DskipITs`.
- Sharded jobs adopt the `netsh dynamicport` tweak from `cluster-it-1c1d.yml` — 597 UTs × `reuseForks=false` will also burn through the Windows ephemeral port pool.
- 597 / 3 = 199 classes per shard, balanced.

## Notes for reviewers

- **Branch protection rules**: the matrix shape changes — the old required check `Unit-Test / unit-test (17, windows-latest, datanode)` goes away, replaced by `Unit-Test / unit-test-windows-datanode (1)`, `(2)`, `(3)`. If those are required checks in repo settings, an admin needs to update the rule (same situation as #17692).
- Pom files are untouched; this is a CI-only change.

## Test plan

- [ ] Confirm all 3 Windows shards complete and total wall-clock drops to ~22 min.
- [ ] Confirm Ubuntu jobs (`unit-test (17, ubuntu-latest, datanode)`, `(17, ubuntu-latest, others)`) and `unit-test (17, windows-latest, others)` still run as before.
- [ ] Spot-check that no UT class is silently skipped (sum of per-shard test counts should equal pre-change total).