### PR TITLE
Shard subscription-tree-regression-consumer to speed up Multi-Cluster IT

### DIFF
--- a/.github/workflows/pipe-it.yml
+++ b/.github/workflows/pipe-it.yml
@@ -548,6 +548,8 @@ jobs:
           name: cluster-log-subscription-table-arch-verification-java${{ matrix.java }}-${{ runner.os }}-${{ matrix.cluster1 }}-${{ matrix.cluster2 }}
           path: integration-test/target/cluster-logs
           retention-days: 30
+  # 72 IT classes split across 3 parallel shards to cut the longest-pole job
+  # from ~30-45 min to ~12-18 min. See cluster-it-1c1d.yml for the prior art.
   subscription-tree-regression-consumer:
     strategy:
       fail-fast: false
@@ -558,6 +560,7 @@ jobs:
         cluster1: [ScalableSingleNodeMode]
         cluster2: [ScalableSingleNodeMode]
         os: [ubuntu-latest]
+        shard: [0, 1, 2]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
@@ -577,6 +580,29 @@ jobs:
       - name: Sleep for a random duration between 0 and 10000 milliseconds
         run: |
           sleep  $(( $(( RANDOM % 10000 + 1 )) / 1000))
+      - name: Build IT shard list
+        shell: bash
+        # Distribute MultiClusterIT2SubscriptionTreeRegressionConsumer test classes
+        # across 3 shards using hash-mod assignment. The list is written under
+        # $RUNNER_TEMP (outside the repo) so Apache RAT's license check does not
+        # flag it - see cluster-it-1c1d.yml, which uses the same path for the
+        # same reason. Each runner has its own $RUNNER_TEMP, so this workflow
+        # and the 1C1D one writing to the same filename never collide.
+        # We emit paths relative to src/test/java/ (not bare class names like
+        # cluster-it-1c1d.yml does) because this suite has 6 pairs of duplicate
+        # simple names across pushconsumer/multi/ and pullconsumer/multi/ - bare
+        # names would cause those classes to run twice across shards.
+        run: |
+          set -euo pipefail
+          SHARD=${{ matrix.shard }}
+          TOTAL=3
+          grep -rlE --include='*IT.java' '\bMultiClusterIT2SubscriptionTreeRegressionConsumer\b' integration-test/src/test/java \
+            | sed 's|.*/src/test/java/||' \
+            | sort \
+            | awk -v s=$SHARD -v t=$TOTAL 'NR%t==s' \
+            > "$RUNNER_TEMP/it-shard.txt"
+          echo "Shard $SHARD/$TOTAL contains $(wc -l < "$RUNNER_TEMP/it-shard.txt") test classes"
+          head -5 "$RUNNER_TEMP/it-shard.txt"
       - name: IT Test
         shell: bash
         # we do not compile client-cpp for saving time, it is tested in client.yml
@@ -594,12 +620,15 @@ jobs:
               -DskipUTs \
               -DintegrationTest.forkCount=1 -DConfigNodeMaxHeapSize=256 -DDataNodeMaxHeapSize=1024 -DDataNodeMaxDirectMemorySize=768 \
               -DClusterConfigurations=${{ matrix.cluster1 }},${{ matrix.cluster2 }} \
+              -Dfailsafe.includesFile="$RUNNER_TEMP/it-shard.txt" \
+              -DfailIfNoTests=false \
+              -Dfailsafe.failIfNoSpecifiedTests=false \
               -pl integration-test \
               -am -PMultiClusterIT2SubscriptionTreeRegressionConsumer \
               -ntp >> ~/run-tests-$attempt.log && return 0
-              test_output=$(cat ~/run-tests-$attempt.log) 
+              test_output=$(cat ~/run-tests-$attempt.log)
 
-              echo "==================== BEGIN: ~/run-tests-$attempt.log ===================="          
+              echo "==================== BEGIN: ~/run-tests-$attempt.log ===================="
               echo "$test_output"
               echo "==================== END: ~/run-tests-$attempt.log ======================"
 
@@ -631,7 +660,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v6
         with:
-          name: cluster-log-subscription-tree-regression-consumer-java${{ matrix.java }}-${{ runner.os }}-${{ matrix.cluster1 }}-${{ matrix.cluster2 }}
+          name: cluster-log-subscription-tree-regression-consumer-shard${{ matrix.shard }}-java${{ matrix.java }}-${{ runner.os }}-${{ matrix.cluster1 }}-${{ matrix.cluster2 }}
           path: integration-test/target/cluster-logs
           retention-days: 30
   subscription-tree-regression-misc:


### PR DESCRIPTION
## Summary

- Splits the `subscription-tree-regression-consumer` job in `pipe-it.yml` into 3 parallel matrix shards. Expected: ~30–45 min → ~12–18 min per shard, removing it as the Multi-Cluster IT pipeline's long pole.
- Reuses the `\$RUNNER_TEMP/it-shard.txt` + `-Dfailsafe.includesFile` pattern from PR #17692 (the 1C1D Windows sharding work).
- Emits paths relative to `src/test/java/` (e.g. `org/apache/iotdb/.../IoTDBFooIT.java`) rather than bare class names — needed because this suite has 6 pairs of duplicate simple names across `pushconsumer/multi/` and `pullconsumer/multi/` that would otherwise run twice across shards.

## Why this job specifically

The Multi-Cluster IT pipeline currently runs 11 parallel jobs. All others finish in 10–20 min; `subscription-tree-regression-consumer` runs 72 IT classes serially in a single `forkCount=1` JVM, each restarting a 2-cluster environment. That single job dictates the whole pipeline's wall clock on every PR.

Other subscription/dual-cluster jobs in `pipe-it.yml` are not sharded:
- `subscription-tree-regression-misc` (13 classes) — borderline; defer to follow-up
- arch-verification jobs (1–4 classes each) — sharding overhead would exceed savings
- dual-tree/dual-table jobs (9–13 classes) — already under the new shard wall clock

## Local verification

```
$ grep -rlE --include='*IT.java' '\bMultiClusterIT2SubscriptionTreeRegressionConsumer\b' integration-test/src/test/java | wc -l
72
$ for s in 0 1 2; do
    grep -rlE --include='*IT.java' '\bMultiClusterIT2SubscriptionTreeRegressionConsumer\b' integration-test/src/test/java \
      | sed 's|.*/src/test/java/||' | sort | awk -v s=\$s -v t=3 'NR%t==s' | wc -l
  done
24
24
24
$ # And unique-paths == total (i.e. no collisions after disambiguation):
$ grep -rlE --include='*IT.java' '\bMultiClusterIT2SubscriptionTreeRegressionConsumer\b' integration-test/src/test/java | sed 's|.*/src/test/java/||' | sort -u | wc -l
72
```

## Test plan

- [ ] CI: 3 parallel `subscription-tree-regression-consumer (…, 0/1/2)` jobs appear under `Multi-Cluster IT` and all go green.
- [ ] Each shard finishes in ~12–18 min (down from ~30–45 min for the single un-sharded job).
- [ ] No \`Files with unapproved licenses\` warning referencing \`it-shard.txt\` in any shard's log.
- [ ] Union of executed test classes across the 3 shards == 72 (no class missing, no class run twice — verify via surefire-reports artifacts).

## Tracker

This is item #2 from `Remaining bottlenecks` in the CI optimization status doc. The other two (`AINode cold build` and broader Subscription/daily-it sharding) will be addressed separately.