### PR TITLE
Remove dead surefire executions in root pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1301,48 +1301,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Separates the unit tests from the integration tests. -->
-            <!-- TODO: Integration-Tests should be executed by the failsafe plugin -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>unit-tests</id>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <phase>test</phase>
-                        <configuration>
-                            <includes>
-                                <!-- Include unit tests within integration-test phase. -->
-                                <include>src/test/**/*Test.java</include>
-                            </includes>
-                            <excludes>
-                                <!-- Exclude integration tests within (unit) test phase. -->
-                                <exclude>src/test/**/*IT.java</exclude>
-                            </excludes>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>integration-tests</id>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <phase>integration-test</phase>
-                        <configuration>
-                            <includes>
-                                <!-- Include integration tests within integration-test phase. -->
-                                <include>src/test/**/*IT.java</include>
-                            </includes>
-                            <excludes>
-                                <!-- Exclude unit tests within (unit) test phase. -->
-                                <exclude>src/test/**/*Test.java</exclude>
-                            </excludes>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <!-- Also package the sources as jar -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary

Removes two surefire `<execution>` blocks from the root `pom.xml` that never actually run any tests, but silently cause triple test-execution if anyone passes a CLI flag like `-Dsurefire.includesFile=` or `-Dtest=`. The TODO comment above the plugin already acknowledged they should be removed.

## What the dead executions look like

```xml
<plugin>
  <artifactId>maven-surefire-plugin</artifactId>
  <executions>
    <execution>
      <id>unit-tests</id>
      <phase>test</phase>
      <configuration>
        <includes><include>src/test/**/*Test.java</include></includes>
        <excludes><exclude>src/test/**/*IT.java</exclude></excludes>
      </configuration>
    </execution>
    <execution>
      <id>integration-tests</id>
      ...
    </execution>
  </executions>
</plugin>
```

## Why they are dead

Surefire scans `${project.build.testOutputDirectory}` — i.e. `target/test-classes/` — and matches `<includes>` against paths relative to that directory. Those paths look like `org/apache/iotdb/.../FooTest.class`, never prefixed by `src/test/`. So the patterns above match **zero** test classes on every build.

**Evidence from the latest master Unit-Test run** (job `76358113571`, Windows datanode):

| Plugin execution | Duration | Tests run |
|---|---|---|
| `surefire:test (default-test)` | 49 min | 3629 |
| `surefire:test (unit-tests)` | ~1 sec | 0 |
| `failsafe:integration-test (run-integration-tests)` | ~4 sec | 1 (`EnvScriptIT`) |
| `surefire:test (integration-tests)` | ~200 ms | 0 |

## Why they're worth removing even though master speed doesn't change

If someone tries to optimize CI by sharding via `-Dsurefire.includesFile=...` or selecting tests with `-Dtest=...`, the CLI flag *replaces* the broken `<includes>` with a valid pattern. Suddenly all three surefire executions (`default-test`, `unit-tests`, `integration-tests`) run the selected tests — the test list executes 3×. This trap was discovered while attempting #17693 (closed).

## Regression check

- **Modules with `*IT.java`**: only `iotdb-core/datanode/` and `integration-test/`. Both already configure `maven-failsafe-plugin` explicitly, so IT coverage is unaffected.
- **Module-level overrides**: no other pom redeclares an execution with id `unit-tests` or `integration-tests`.
- **CI flag usage**: no workflow on `master` currently passes a surefire test-selector flag.
- **Profiles**: the `with-code-coverage` profile only overrides the surefire/failsafe `<argLine>`; it does not depend on these executions' presence.

## Test plan

- [ ] Confirm the full Unit-Test workflow still runs the same number of tests (`default-test` reports `Tests run: 3629` on master Windows datanode).
- [ ] Confirm IT workflows (`Cluster IT - 1C1D`, `Table Cluster IT - 1C1D`, etc.) are unaffected.
- [ ] Confirm coverage report (`with-code-coverage` profile) still produces output.