### PR TITLE
Speed up Codecov CI ~38% with parallel surefire forks

### DIFF
--- a/.github/workflows/sonar-codecov.yml
+++ b/.github/workflows/sonar-codecov.yml
@@ -50,7 +50,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2-
       - name: Test
         run: |
-          mvn -B -P with-code-coverage clean package -pl distribution,iotdb-client/cli,iotdb-client/session,iotdb-client/jdbc -am -Dtest.port.closed=true -DforkCount=2
+          mvn -B -P with-code-coverage clean package -pl distribution,iotdb-client/cli,iotdb-client/session,iotdb-client/jdbc -am -Dtest.port.closed=true -DforkCount=4
           mvn -B -P with-code-coverage post-integration-test -pl code-coverage
       - name: Upload coverage reports to codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/sonar-codecov.yml
+++ b/.github/workflows/sonar-codecov.yml
@@ -50,7 +50,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2-
       - name: Test
         run: |
-          mvn -B -P with-code-coverage clean package -pl distribution,iotdb-client/cli,iotdb-client/session,iotdb-client/jdbc -am -Dtest.port.closed=true
+          mvn -B -P with-code-coverage clean package -pl distribution,iotdb-client/cli,iotdb-client/session,iotdb-client/jdbc -am -Dtest.port.closed=true -DforkCount=2
           mvn -B -P with-code-coverage post-integration-test -pl code-coverage
       - name: Upload coverage reports to codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
## Summary

The `codecov` job in the Sonar-Codecov workflow currently runs ~66 minutes, of which ~51 minutes is the DataNode unit tests. Two factors stack to make these tests fully serial:

- `iotdb-core/datanode/pom.xml` sets `<reuseForks>false</reuseForks>` (fresh JVM per test class).
- Surefire's default `forkCount=1` is never overridden, so only one JVM exists at a time.

On a 4-vCPU `ubuntu-latest` runner this means at most one test class runs at any moment, paying full JVM startup + JaCoCo instrumentation per class.

The parent `pom.xml` already sets `<workingDirectory>${project.build.directory}/fork_${surefire.forkNumber}</workingDirectory>`, so per-fork filesystem isolation is configured but unused. This PR passes `-DforkCount=4` to the codecov `mvn` invocation so four test JVMs run in parallel.

## Measured impact (this PR's draft runs)

| Phase | Baseline | forkCount=2 | forkCount=4 |
|---|---|---|---|
| DataNode UTs | 51 min | 34 min | 32 min |
| ConfigNode UTs | 6 min | 4 min | 3 min |
| Consensus UTs | 4 min | 2 min | 2 min |
| **Job total** | **66 min** | 45 min | **41 min** |

Net: **66 → 41 min (–38%)**. forkCount=4 saturates the 4-vCPU runner; the floor is now set by the long-tail tests (slowest single class is 127s).

Memory budget on the 16 GB runner: 4 × 1024m heap + maven + jacoco ≈ 5 GB, well within limits.

## Test plan

- [x] CI green on draft PR with forkCount=2
- [x] CI green on draft PR with forkCount=4
- [x] Codecov job wall time drops materially
- [x] Coverage report uploads to Codecov
- [x] No new test failures introduced by parallel forks