### PR TITLE
Fix query TVList snapshot race during working memtable reads

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/utils/ResourceByPathUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/utils/ResourceByPathUtils.java
@@ -171,11 +171,17 @@ public abstract class ResourceByPathUtils {
         list.getQueryContextSet().add(context);
         tvListQueryMap.put(list, list.rowCount());
       } else {
-        if (list.isSorted() || list.getQueryContextSet().isEmpty()) {
+        boolean isSorted;
+        int rowCount;
+        synchronized (list) {
+          isSorted = list.isSorted();
+          rowCount = list.rowCount();
+        }
+        if (isSorted || list.getQueryContextSet().isEmpty()) {
           LOGGER.debug(
               "Working MemTable - add current query context to mutable TVList's query list when it's sorted or no other query on it");
           list.getQueryContextSet().add(context);
-          tvListQueryMap.put(list, list.rowCount());
+          tvListQueryMap.put(list, rowCount);
         } else {
           /*
            * +----------------------+


### PR DESCRIPTION
## Summary
- Capture the sorted state and row count under the TVList monitor when preparing a working memtable TVList for query.
- Keep the query-visible row count consistent with the sorted snapshot so later query sorting does not mutate indices beyond an older iterator snapshot.

## Root Cause
The query context lock only protects query ownership metadata, not TVList row count, sorted state, writes, or sort operations. A query could share a currently sorted mutable working TVList while recording a row count from a different moment, allowing a later query sort to reorder indices used by an older iterator.

## Validation
Not run, per local workflow instruction.