### PR TITLE
Fix IoTConsensus V2 metric unbinding

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/pipe/metric/IoTConsensusV2ServerMetrics.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/pipe/metric/IoTConsensusV2ServerMetrics.java
@@ -174,7 +174,7 @@ public class IoTConsensusV2ServerMetrics implements IMetricSet {
         Tag.NAME.toString(),
         Metric.IOT_CONSENSUS_V2.toString(),
         Tag.TYPE.toString(),
-        "writeStateMachine",
+        "userWriteStateMachine",
         Tag.REGION.toString(),
         impl.getConsensusGroupId());
     metricService.remove(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/consensus/metric/IoTConsensusV2SinkMetrics.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/consensus/metric/IoTConsensusV2SinkMetrics.java
@@ -239,7 +239,7 @@ public class IoTConsensusV2SinkMetrics implements IMetricSet {
         Tag.NAME.toString(),
         CONNECTOR,
         Tag.TYPE.toString(),
-        "connectorTsFileTransfer",
+        "connectorEnqueue",
         Tag.REGION.toString(),
         iotConsensusV2AsyncConnector.getConsensusGroupIdStr());
     metricService.remove(


### PR DESCRIPTION
## Summary
- Fix IoTConsensusV2ServerMetrics to remove the userWriteStateMachine timer with the same type used during binding.
- Fix IoTConsensusV2SinkMetrics timer unbinding so connectorEnqueue is removed and connectorTsFileTransfer is not removed twice.