### PR TITLE
Fix duplicate peer in createNewRegionPeer; harden reconstruct IT

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/IoTDBRegionOperationReliabilityITFramework.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/IoTDBRegionOperationReliabilityITFramework.java
@@ -736,4 +736,23 @@ public class IoTDBRegionOperationReliabilityITFramework {
     }
     return result;
   }
+
+  /** Returns regionId -> dataNodeId -> status as reported by {@code show regions}. */
+  protected static Map<Integer, Map<Integer, String>> getRegionStatusMap(Session session)
+      throws IoTDBConnectionException, StatementExecutionException {
+    SessionDataSet dataSet = session.executeQueryStatement("show regions");
+    final int regionIdIndex = dataSet.getColumnNames().indexOf("RegionId");
+    final int dataNodeIdIndex = dataSet.getColumnNames().indexOf("DataNodeId");
+    final int regionStatusIndex = dataSet.getColumnNames().indexOf("Status");
+    dataSet.setFetchSize(1024);
+    Map<Integer, Map<Integer, String>> result = new TreeMap<>();
+    while (dataSet.hasNext()) {
+      List<Field> fields = dataSet.next().getFields();
+      final int regionId = fields.get(regionIdIndex).getIntV();
+      final int dataNodeId = fields.get(dataNodeIdIndex).getIntV();
+      final String regionStatus = fields.get(regionStatusIndex).toString();
+      result.computeIfAbsent(regionId, k -> new TreeMap<>()).put(dataNodeId, regionStatus);
+    }
+    return result;
+  }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/IoTDBRegionReconstructForIoTV1IT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/IoTDBRegionReconstructForIoTV1IT.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.sql.Connection;
 import java.sql.Statement;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -108,7 +109,9 @@ public class IoTDBRegionReconstructForIoTV1IT extends IoTDBRegionOperationReliab
       Assert.assertTrue(dataRegionMap.containsKey(selectedRegion));
       Pair<Integer, Set<Integer>> leaderAndNodeIds = dataRegionMap.get(selectedRegion);
       Assert.assertEquals(2, leaderAndNodeIds.right.size());
-      // reconstruct from the leader to ensure no data is lost
+      // Stop the current leader; reconstruct will later target the surviving follower (whose
+      // tsfiles get deleted below). When the original leader is restarted, the follower's
+      // missing data is replicated back from it, so no committed data is lost.
       final int dataNodeToBeClosed = leaderAndNodeIds.left;
       final int dataNodeToBeReconstructed =
           leaderAndNodeIds.right.stream().filter(x -> x != dataNodeToBeClosed).findAny().get();
@@ -172,19 +175,25 @@ public class IoTDBRegionReconstructForIoTV1IT extends IoTDBRegionOperationReliab
       EnvFactory.getAbstractEnv().checkNodeInStatus(dataNodeToBeClosed, NodeStatus.Running);
       session.executeNonQueryStatement(
           String.format(RECONSTRUCT_FORMAT, selectedRegion, dataNodeToBeReconstructed));
+      // Confirm reconstruct succeeded: the selected region must contain both the reconstructed
+      // peer and the (formerly closed) peer, with both rows reporting Running.
       try {
         Awaitility.await()
             .pollInterval(1, TimeUnit.SECONDS)
             .atMost(10, TimeUnit.MINUTES)
             .until(
-                () ->
-                    getRegionStatusWithoutRunning(session).isEmpty()
-                        && dataDirToBeReconstructed.getAbsoluteFile().exists());
+                () -> {
+                  Map<Integer, String> peerStatus =
+                      getRegionStatusMap(session)
+                          .getOrDefault(selectedRegion, Collections.emptyMap());
+                  return "Running".equals(peerStatus.get(dataNodeToBeReconstructed))
+                      && "Running".equals(peerStatus.get(dataNodeToBeClosed));
+                });
       } catch (Exception e) {
         LOGGER.error(
-            "Two factor: {} && {}",
-            getRegionStatusWithoutRunning(session),
-            dataDirToBeReconstructed.getAbsoluteFile().exists());
+            "Reconstruct did not finish in time. region {} status map: {}",
+            selectedRegion,
+            getRegionStatusMap(session).get(selectedRegion));
         fail();
       }
       EnvFactory.getEnv().dataNodeIdToWrapper(dataNodeToBeClosed).get().stopForcibly();

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RegionMaintainHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RegionMaintainHandler.java
@@ -175,9 +175,14 @@ public class RegionMaintainHandler {
     if (TConsensusGroupType.DataRegion.equals(regionId.getType())
         && (IOT_CONSENSUS.equals(CONF.getDataRegionConsensusProtocolClass())
             || IOT_CONSENSUS_V2.equals(CONF.getDataRegionConsensusProtocolClass()))) {
-      // parameter of createPeer for MultiLeader should be all peers
+      // parameter of createPeer for MultiLeader should be all peers; callers (e.g.
+      // AddRegionPeerProcedure) may have already inserted destDataNode into the partition
+      // table before reaching here, so append only when not already present to avoid
+      // sending a peer list with duplicates.
       currentPeerNodes = new ArrayList<>(regionReplicaNodes);
-      currentPeerNodes.add(destDataNode);
+      if (!currentPeerNodes.contains(destDataNode)) {
+        currentPeerNodes.add(destDataNode);
+      }
     } else {
       // parameter of createPeer for Ratis can be empty
       currentPeerNodes = Collections.emptyList();


### PR DESCRIPTION
## Description

### Fix duplicate peer entry in `createNewRegionPeer`

`AddRegionPeerProcedure.CREATE_NEW_REGION_PEER` runs two steps back-to-back:

```java
handler.addRegionLocation(regionId, targetDataNode);   // writes target into PartitionTable
TSStatus status = handler.createNewRegionPeer(regionId, targetDataNode);
```

`createNewRegionPeer` then reads the partition table back (which already contains `targetDataNode`) and unconditionally appends `destDataNode` again, so the `TCreatePeerReq` ships a duplicated peer — for example `[Peer{nodeId=2}, Peer{nodeId=3}, Peer{nodeId=3}]` when adding DN_3 to region 3.

The duplicate is silently swallowed downstream (`IoTConsensus.createLocalPeer` wraps the list in a `TreeSet`; `IoTConsensusV2PeerManager` uses a `Set` and also logs a misleading `DUPLICATE_PEERS_IGNORED` WARN), so it has not produced a visible failure, but it (a) pollutes V2 logs with a WARN on every add-peer, (b) makes per-region migration logs hard to read, and (c) is fragile should anyone later use `peers.size()` for an invariant check.

The fix is defensive: in the IoT-consensus branch, append `destDataNode` only when it is not already present in `regionReplicaNodes`. Behavior is identical to before for callers that do not pre-insert the target.

Affects every caller of `AddRegionPeerProcedure`: `reconstruct region`, `migrate region`, `extend region`, and procedure restore.

### Tighten `IoTDBRegionReconstructForIoTV1IT.normal1C3DTest` await

The post-`reconstruct` wait condition was:

```java
() -> getRegionStatusWithoutRunning(session).isEmpty()
      && dataDirToBeReconstructed.getAbsoluteFile().exists()
```

Both halves were weak:

- `dataDirToBeReconstructed.exists()` is effectively always true — `deleteTsFiles` only removes files whose name ends in `.tsfile`, never the containing directory.
- `getRegionStatusWithoutRunning(session).isEmpty()` is a negative check. When reconstruct rolled back, the reconstructed peer's row vanished from `show regions` briefly while the closed peer's status had not yet been refreshed from `Running` to `Unknown`, producing a ~3-second false-positive "everything is Running" window. The test then proceeded past the await, stopped the only live replica, and failed on the subsequent query loop with a misleading `Cannot execute query within 60s`.

Replaced with a positive assertion: the selected region must contain both peers and both rows must report `Running`. Done via a new `getRegionStatusMap(Session)` helper that returns `regionId -> dataNodeId -> status`. On timeout, the test now logs the actual region status map for the selected region, which is the data you want for diagnosing why reconstruct did not finish.

Also corrected the stale comment that claimed reconstruct happens "from the leader" — the code actually targets the surviving follower; the original leader is the replica that gets stopped and then restarted.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- `org.apache.iotdb.confignode.procedure.env.RegionMaintainHandler`
- `org.apache.iotdb.confignode.it.regionmigration.IoTDBRegionOperationReliabilityITFramework`
- `org.apache.iotdb.confignode.it.regionmigration.pass.commit.IoTDBRegionReconstructForIoTV1IT`