### PR TITLE
Fix Python client CI: handle Timestamps outside Python stdlib range

### DIFF
--- a/iotdb-client/client-py/iotdb/utils/rpc_utils.py
+++ b/iotdb-client/client-py/iotdb/utils/rpc_utils.py
@@ -79,10 +79,10 @@ def verify_success_with_redirection_for_multi_devices(status: TSStatus, devices:
 
 def convert_to_timestamp(time: int, precision: str, timezone: str):
     try:
-        return pd.Timestamp(time, unit=precision, tz=timezone)
+        ts = pd.Timestamp(time, unit=precision, tz=timezone)
     except OutOfBoundsDatetime:
         try:
-            return pd.Timestamp(time, unit=precision).tz_localize(timezone)
+            ts = pd.Timestamp(time, unit=precision).tz_localize(timezone)
         except NotImplementedError:
             return pd.Timestamp(time, unit=precision)
     except ValueError:
@@ -90,12 +90,23 @@ def convert_to_timestamp(time: int, precision: str, timezone: str):
             f"Timezone string '{timezone}' cannot be recognized by pandas. "
             f"Falling back to local timezone: '{get_localzone_name()}'."
         )
-        return pd.Timestamp(time, unit=precision, tz=get_localzone_name())
+        ts = pd.Timestamp(time, unit=precision, tz=get_localzone_name())
     except NotImplementedError:
         # Timestamp falls outside Python's stdlib datetime range (year < 1 or
         # > 9999). pandas >= 3.0 cannot attach a timezone to such Timestamps
         # because tz conversion relies on toordinal(). Return naive instead.
         return pd.Timestamp(time, unit=precision)
+    # Construction succeeded but utcoffset() may still fail downstream (e.g.
+    # in pd.DataFrame's tz alignment) when the Timestamp's year is outside
+    # 1..9999 and tz is not the canonical UTC. Probe early and fall back to
+    # naive so callers like result_set_to_pandas() don't blow up. NaT does
+    # not need this check (and does not support utcoffset()).
+    if ts is not pd.NaT:
+        try:
+            ts.utcoffset()
+        except NotImplementedError:
+            return pd.Timestamp(time, unit=precision)
+    return ts
 
 
 unit_map = {

--- a/iotdb-client/client-py/iotdb/utils/rpc_utils.py
+++ b/iotdb-client/client-py/iotdb/utils/rpc_utils.py
@@ -81,13 +81,21 @@ def convert_to_timestamp(time: int, precision: str, timezone: str):
     try:
         return pd.Timestamp(time, unit=precision, tz=timezone)
     except OutOfBoundsDatetime:
-        return pd.Timestamp(time, unit=precision).tz_localize(timezone)
+        try:
+            return pd.Timestamp(time, unit=precision).tz_localize(timezone)
+        except NotImplementedError:
+            return pd.Timestamp(time, unit=precision)
     except ValueError:
         logger.warning(
             f"Timezone string '{timezone}' cannot be recognized by pandas. "
             f"Falling back to local timezone: '{get_localzone_name()}'."
         )
         return pd.Timestamp(time, unit=precision, tz=get_localzone_name())
+    except NotImplementedError:
+        # Timestamp falls outside Python's stdlib datetime range (year < 1 or
+        # > 9999). pandas >= 3.0 cannot attach a timezone to such Timestamps
+        # because tz conversion relies on toordinal(). Return naive instead.
+        return pd.Timestamp(time, unit=precision)
 
 
 unit_map = {
@@ -108,3 +116,34 @@ def isoformat(ts: pd.Timestamp, unit: str):
             f"Falling back to use auto timespec'."
         )
         return ts.isoformat()
+    except NotImplementedError:
+        # Timestamp falls outside Python's stdlib datetime range. pandas >= 3.0
+        # routes isoformat through datetime.isoformat, which calls toordinal()
+        # and fails. Build the ISO 8601 string from individual components.
+        return _isoformat_from_components(ts, unit)
+
+
+def _isoformat_from_components(ts: pd.Timestamp, unit: str) -> str:
+    base = (
+        f"{ts.year:04d}-{ts.month:02d}-{ts.day:02d}"
+        f"T{ts.hour:02d}:{ts.minute:02d}:{ts.second:02d}"
+    )
+    if unit == "ms":
+        base += f".{ts.microsecond // 1000:03d}"
+    elif unit == "us":
+        base += f".{ts.microsecond:06d}"
+    elif unit == "ns":
+        base += f".{ts.microsecond:06d}{ts.nanosecond:03d}"
+    if ts.tzinfo is not None:
+        try:
+            offset = ts.utcoffset()
+        except NotImplementedError:
+            # utcoffset() needs toordinal() for zones like Etc/UTC. Omit offset.
+            offset = None
+        if offset is not None:
+            total_seconds = int(offset.total_seconds())
+            sign = "+" if total_seconds >= 0 else "-"
+            total_seconds = abs(total_seconds)
+            hh, mm = divmod(total_seconds // 60, 60)
+            base += f"{sign}{hh:02d}:{mm:02d}"
+    return base


### PR DESCRIPTION
## Summary

- Catch `NotImplementedError` in `convert_to_timestamp` (fall back to naive Timestamp) and `isoformat` (build ISO 8601 string from components).
- Unblocks the Python client CI which has been red on master since 2026-05-06.

## Root cause

`pandas==3.0.3` (released early May 2026) restricts `Timestamp.toordinal()` to year range 1..9999, and Python 3.14's `datetime.isoformat` calls it internally. Several integration tests insert `9223372036854775807` (Long.MAX_VALUE) into TIMESTAMP fields; reading back yields year 292,278,994, and `print(row_record)` then crashes with:

```
NotImplementedError: toordinal not yet supported on Timestamps which are
outside the range of Python's standard library.
```

`tz`-aware Timestamps in that range crash even harder — `utcoffset()` itself raises `NotImplementedError` for zones like `Etc/UTC`/`Asia/Shanghai`, so just catching the error in `isoformat` isn't enough.

The failure is not caused by #17696 — that PR only inherits the existing master failure.

## Fix

| Function | Change |
|---|---|
| `convert_to_timestamp` | Catch `NotImplementedError`, return a naive Timestamp. |
| `isoformat` | Catch `NotImplementedError`, format via new `_isoformat_from_components` helper. |
| `_isoformat_from_components` | Build `YYYY-MM-DDTHH:MM:SS.fff` from `.year/.month/.day/...`, append UTC offset when available; omit it when `utcoffset()` also fails. |

Verified locally on Python 3.13.2 and 3.14.4 (pandas 3.0.3) against every boundary value the failing tests use (Long.MIN/MAX, int32 boundaries, 0, ±1) × ms/us/ns × UTC/Etc/UTC/Asia/Shanghai/America/Los_Angeles → 0 failures.

## Test plan

- [ ] CI `python (3.x)` job passes against this PR.
- [ ] Existing test assertions still match (none depended on the previously crashing format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)