### PR TITLE
Fix locale message typo

### DIFF
--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/queryengine/plan/relational/function/tvf/PatternMatchTableFunction.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/queryengine/plan/relational/function/tvf/PatternMatchTableFunction.java
@@ -111,16 +111,17 @@ public class PatternMatchTableFunction implements TableFunction {
     Double widthValue = (Double) ((ScalarArgument) arguments.get(WIDTH_PARAM)).getValue();
     Double heightValue = (Double) ((ScalarArgument) arguments.get(HEIGHT_PARAM)).getValue();
     if (smoothValue < 0) {
-      throw new UDFException(QueryMessages.SMOOTH_MUST_BE_NON_NEGATIVE + smoothValue);
+      throw new UDFException(String.format(QueryMessages.SMOOTH_MUST_BE_NON_NEGATIVE, smoothValue));
     }
     if (thresholdValue < 0) {
-      throw new UDFException(QueryMessages.THRESHOLD_MUST_BE_NON_NEGATIVE + thresholdValue);
+      throw new UDFException(
+          String.format(QueryMessages.THRESHOLD_MUST_BE_NON_NEGATIVE, thresholdValue));
     }
     if (widthValue < 0) {
-      throw new UDFException(QueryMessages.WIDTH_MUST_BE_NON_NEGATIVE + widthValue);
+      throw new UDFException(String.format(QueryMessages.WIDTH_MUST_BE_NON_NEGATIVE, widthValue));
     }
     if (heightValue < 0) {
-      throw new UDFException(QueryMessages.HEIGHT_MUST_BE_NON_NEGATIVE + heightValue);
+      throw new UDFException(String.format(QueryMessages.HEIGHT_MUST_BE_NON_NEGATIVE, heightValue));
     }
 
     // outputColumnSchema description


### PR DESCRIPTION
This pull request improves the error messages thrown for invalid (negative) parameter values in the `PatternMatchTableFunction` by formatting them with the actual invalid value, making the messages clearer and more informative.

Error handling improvements:

* Updated all error messages for negative parameter values (`smooth`, `threshold`, `width`, `height`) to use `String.format` for including the actual invalid value in the exception message instead of simple string concatenation. (`iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/queryengine/plan/relational/function/tvf/PatternMatchTableFunction.java`)