### PR TITLE
Fixed TTL problems

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/TTLManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/TTLManager.java
@@ -127,6 +127,10 @@ public class TTLManager {
     return ((ShowTTLResp) showTTL(new ShowTTLPlan())).getPathTTLMap();
   }
 
+  public long getTTL(final String[] pathPattern) {
+    return ttlInfo.getTTL(pathPattern);
+  }
+
   public int getTTLCount() {
     return ttlInfo.getTTLCount();
   }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/TTLInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/TTLInfo.java
@@ -175,6 +175,15 @@ public class TTLInfo implements SnapshotProcessor {
     }
   }
 
+  public long getTTL(final String[] pathPattern) {
+    lock.readLock().lock();
+    try {
+      return ttlCache.getLastNodeTTL(pathPattern);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
   /**
    * Get the maximum ttl of the corresponding database level.
    *

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/TTLInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/TTLInfo.java
@@ -71,13 +71,14 @@ public class TTLInfo implements SnapshotProcessor {
       // check ttl rule capacity
       final int tTlRuleCapacity = CommonDescriptor.getInstance().getConfig().getTTlRuleCapacity();
       final int newTTLRuleCount = calculateNewTTLRuleCount(plan);
-      if (newTTLRuleCount > 0 && ttlCache.getTtlCount() + newTTLRuleCount > tTlRuleCapacity) {
+      final int requestedTTLRuleCount = ttlCache.getTtlCount() + newTTLRuleCount;
+      if (newTTLRuleCount > 0 && requestedTTLRuleCount > tTlRuleCapacity) {
         TSStatus errorStatus = new TSStatus(TSStatusCode.OVERSIZE_TTL.getStatusCode());
         errorStatus.setMessage(
             String.format(
-                "The number of TTL rules has reached the limit (%d). Please delete "
-                    + "some existing rules first.",
-                tTlRuleCapacity));
+                "The number of TTL rules has reached the limit "
+                    + "(capacity: %d, requested total: %d). Please delete some existing rules first.",
+                tTlRuleCapacity, requestedTTLRuleCount));
         return errorStatus;
       }
       ttlCache.setTTL(plan.getPathPattern(), plan.getTTL());
@@ -94,17 +95,17 @@ public class TTLInfo implements SnapshotProcessor {
   }
 
   private int calculateNewTTLRuleCount(SetTTLPlan plan) {
-    int newTTLRuleCount = getNewTTLRuleCount(plan.getPathPattern());
+    int newTTLRuleCount = isNewTTLRule(plan.getPathPattern()) ? 1 : 0;
     if (plan.isDataBase()) {
       String[] pathNodes = Arrays.copyOf(plan.getPathPattern(), plan.getPathPattern().length + 1);
       pathNodes[pathNodes.length - 1] = IoTDBConstant.MULTI_LEVEL_PATH_WILDCARD;
-      newTTLRuleCount += getNewTTLRuleCount(pathNodes);
+      newTTLRuleCount += isNewTTLRule(pathNodes) ? 1 : 0;
     }
     return newTTLRuleCount;
   }
 
-  private int getNewTTLRuleCount(String[] pathNodes) {
-    return ttlCache.getLastNodeTTL(pathNodes) == TTLCache.NULL_TTL ? 1 : 0;
+  private boolean isNewTTLRule(String[] pathNodes) {
+    return ttlCache.getLastNodeTTL(pathNodes) == TTLCache.NULL_TTL;
   }
 
   /** Only used for upgrading from database level ttl to device level ttl. */

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/TTLInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/TTLInfo.java
@@ -70,7 +70,8 @@ public class TTLInfo implements SnapshotProcessor {
     try {
       // check ttl rule capacity
       final int tTlRuleCapacity = CommonDescriptor.getInstance().getConfig().getTTlRuleCapacity();
-      if (getTTLCount() >= tTlRuleCapacity) {
+      final int newTTLRuleCount = calculateNewTTLRuleCount(plan);
+      if (newTTLRuleCount > 0 && ttlCache.getTtlCount() + newTTLRuleCount > tTlRuleCapacity) {
         TSStatus errorStatus = new TSStatus(TSStatusCode.OVERSIZE_TTL.getStatusCode());
         errorStatus.setMessage(
             String.format(
@@ -90,6 +91,20 @@ public class TTLInfo implements SnapshotProcessor {
       lock.writeLock().unlock();
     }
     return RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS);
+  }
+
+  private int calculateNewTTLRuleCount(SetTTLPlan plan) {
+    int newTTLRuleCount = getNewTTLRuleCount(plan.getPathPattern());
+    if (plan.isDataBase()) {
+      String[] pathNodes = Arrays.copyOf(plan.getPathPattern(), plan.getPathPattern().length + 1);
+      pathNodes[pathNodes.length - 1] = IoTDBConstant.MULTI_LEVEL_PATH_WILDCARD;
+      newTTLRuleCount += getNewTTLRuleCount(pathNodes);
+    }
+    return newTTLRuleCount;
+  }
+
+  private int getNewTTLRuleCount(String[] pathNodes) {
+    return ttlCache.getLastNodeTTL(pathNodes) == TTLCache.NULL_TTL ? 1 : 0;
   }
 
   /** Only used for upgrading from database level ttl to device level ttl. */

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/SetTTLProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/SetTTLProcedure.java
@@ -56,6 +56,7 @@ import java.util.Objects;
 
 public class SetTTLProcedure extends StateMachineProcedure<ConfigNodeProcedureEnv, SetTTLState> {
   private static final Logger LOGGER = LoggerFactory.getLogger(SetTTLProcedure.class);
+  // Distinguishes no previous TTL from TTLCache.NULL_TTL, the explicit unset marker for rollback.
   private static final long TTL_NOT_EXIST = Long.MIN_VALUE;
 
   private SetTTLPlan plan;

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/SetTTLProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/SetTTLProcedure.java
@@ -302,8 +302,10 @@ public class SetTTLProcedure extends StateMachineProcedure<ConfigNodeProcedureEn
   public void deserialize(ByteBuffer byteBuffer) {
     super.deserialize(byteBuffer);
     try {
-      ReadWriteIOUtils.readInt(byteBuffer);
+      final int length = ReadWriteIOUtils.readInt(byteBuffer);
+      final int position = byteBuffer.position();
       this.plan = (SetTTLPlan) ConfigPhysicalPlan.Factory.create(byteBuffer);
+      byteBuffer.position(position + length);
       if (byteBuffer.remaining() >= 17) {
         this.previousTTLStateCaptured = byteBuffer.get() != 0;
         this.previousTTL = byteBuffer.getLong();

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/SetTTLProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/SetTTLProcedure.java
@@ -58,6 +58,7 @@ public class SetTTLProcedure extends StateMachineProcedure<ConfigNodeProcedureEn
   private static final Logger LOGGER = LoggerFactory.getLogger(SetTTLProcedure.class);
   // Distinguishes no previous TTL from TTLCache.NULL_TTL, the explicit unset marker for rollback.
   private static final long TTL_NOT_EXIST = Long.MIN_VALUE;
+  private static final int ROLLBACK_STATE_BYTES = Byte.BYTES + Long.BYTES * 2;
 
   private SetTTLPlan plan;
   private long previousTTL = TTL_NOT_EXIST;
@@ -202,8 +203,10 @@ public class SetTTLProcedure extends StateMachineProcedure<ConfigNodeProcedureEn
   private void restoreTTLOnConfigNode(
       final ConfigNodeProcedureEnv env, final String[] pathPattern, final long ttl)
       throws ProcedureException {
+    // TTL_NOT_EXIST means the original ttl was absent; NULL_TTL asks the executor to unset it.
     final SetTTLPlan rollbackPlan =
         new SetTTLPlan(pathPattern, ttl == TTL_NOT_EXIST ? TTLCache.NULL_TTL : ttl);
+    // Database rollback restores the database path and db.** separately, so avoid auto-expansion.
     rollbackPlan.setDataBase(false);
     final TSStatus status = writeConfigNodePlan(env, rollbackPlan);
     if (status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
@@ -247,6 +250,9 @@ public class SetTTLProcedure extends StateMachineProcedure<ConfigNodeProcedureEn
     }
   }
 
+  /**
+   * Best-effort rollback: restore both sides, throw the earliest failure, and suppress later ones.
+   */
   @Override
   protected void rollbackState(final ConfigNodeProcedureEnv env, final SetTTLState setTTLState)
       throws IOException, InterruptedException, ProcedureException {
@@ -266,6 +272,8 @@ public class SetTTLProcedure extends StateMachineProcedure<ConfigNodeProcedureEn
       LOGGER.error("Failed to rollback DataNode ttl cache.", e);
       if (rollbackFailure == null) {
         rollbackFailure = e;
+      } else {
+        rollbackFailure.addSuppressed(e);
       }
     }
     if (rollbackFailure != null) {
@@ -313,8 +321,9 @@ public class SetTTLProcedure extends StateMachineProcedure<ConfigNodeProcedureEn
       final int length = ReadWriteIOUtils.readInt(byteBuffer);
       final int position = byteBuffer.position();
       this.plan = (SetTTLPlan) ConfigPhysicalPlan.Factory.create(byteBuffer);
+      // The serialized plan buffer may include padding; skip to the actual payload end.
       byteBuffer.position(position + length);
-      if (byteBuffer.remaining() >= 17) {
+      if (byteBuffer.remaining() >= ROLLBACK_STATE_BYTES) {
         this.previousTTLStateCaptured = byteBuffer.get() != 0;
         this.previousTTL = byteBuffer.getLong();
         this.previousDatabaseWildcardTTL = byteBuffer.getLong();

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/SetTTLProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/SetTTLProcedure.java
@@ -112,7 +112,7 @@ public class SetTTLProcedure extends StateMachineProcedure<ConfigNodeProcedureEn
             dataNodeLocationMap,
             buildSetTTLReq(plan.getPathPattern(), plan.getTTL(), plan.isDataBase()));
     if (hasFailedDataNode(clientHandler)) {
-      LOGGER.error("Failed to update ttl cache of dataNode.");
+      LOGGER.error(ProcedureMessages.FAILED_TO_UPDATE_TTL_CACHE_OF_DATANODE);
       setFailure(
           new ProcedureException(
               new MetadataException(ProcedureMessages.UPDATE_DATANODE_TTL_CACHE_FAILED)));

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/SetTTLProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/SetTTLProcedure.java
@@ -22,8 +22,10 @@ package org.apache.iotdb.confignode.procedure.impl.schema;
 import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.common.rpc.thrift.TSetTTLReq;
+import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.IoTDBException;
 import org.apache.iotdb.commons.exception.MetadataException;
+import org.apache.iotdb.commons.schema.ttl.TTLCache;
 import org.apache.iotdb.confignode.client.async.CnToDnAsyncRequestType;
 import org.apache.iotdb.confignode.client.async.CnToDnInternalServiceAsyncRequestManager;
 import org.apache.iotdb.confignode.client.async.handlers.DataNodeAsyncRequestContext;
@@ -47,14 +49,19 @@ import org.slf4j.LoggerFactory;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
 public class SetTTLProcedure extends StateMachineProcedure<ConfigNodeProcedureEnv, SetTTLState> {
   private static final Logger LOGGER = LoggerFactory.getLogger(SetTTLProcedure.class);
+  private static final long TTL_NOT_EXIST = Long.MIN_VALUE;
 
   private SetTTLPlan plan;
+  private long previousTTL = TTL_NOT_EXIST;
+  private long previousDatabaseWildcardTTL = TTL_NOT_EXIST;
+  private boolean previousTTLStateCaptured = false;
 
   public SetTTLProcedure(final boolean isGeneratedByPipe) {
     super(isGeneratedByPipe);
@@ -86,18 +93,9 @@ public class SetTTLProcedure extends StateMachineProcedure<ConfigNodeProcedureEn
     }
   }
 
-  private void setConfigNodeTTL(ConfigNodeProcedureEnv env) {
-    TSStatus res;
-    try {
-      res =
-          env.getConfigManager()
-              .getConsensusManager()
-              .write(isGeneratedByPipe ? new PipeEnrichedPlan(this.plan) : this.plan);
-    } catch (ConsensusException e) {
-      LOGGER.warn(ConfigNodeMessages.FAILED_IN_THE_WRITE_API_EXECUTING_THE_CONSENSUS_LAYER_DUE, e);
-      res = new TSStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode());
-      res.setMessage(e.getMessage());
-    }
+  protected void setConfigNodeTTL(final ConfigNodeProcedureEnv env) {
+    capturePreviousTTLState(env);
+    final TSStatus res = writeConfigNodePlan(env, plan);
     if (res.code != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
       LOGGER.info(ProcedureMessages.FAILED_TO_EXECUTE_PLAN_BECAUSE, plan, res.message);
       setFailure(new ProcedureException(new IoTDBException(res)));
@@ -106,35 +104,171 @@ public class SetTTLProcedure extends StateMachineProcedure<ConfigNodeProcedureEn
     }
   }
 
-  private void updateDataNodeTTL(ConfigNodeProcedureEnv env) {
-    Map<Integer, TDataNodeLocation> dataNodeLocationMap =
+  protected void updateDataNodeTTL(final ConfigNodeProcedureEnv env) {
+    final Map<Integer, TDataNodeLocation> dataNodeLocationMap =
         env.getConfigManager().getNodeManager().getRegisteredDataNodeLocations();
-    DataNodeAsyncRequestContext<TSetTTLReq, TSStatus> clientHandler =
-        new DataNodeAsyncRequestContext<>(
-            CnToDnAsyncRequestType.SET_TTL,
-            new TSetTTLReq(
-                Collections.singletonList(String.join(".", plan.getPathPattern())),
-                plan.getTTL(),
-                plan.isDataBase()),
-            dataNodeLocationMap);
+    final DataNodeAsyncRequestContext<TSetTTLReq, TSStatus> clientHandler =
+        sendTTLRequest(
+            dataNodeLocationMap,
+            buildSetTTLReq(plan.getPathPattern(), plan.getTTL(), plan.isDataBase()));
+    if (hasFailedDataNode(clientHandler)) {
+      LOGGER.error("Failed to update ttl cache of dataNode.");
+      setFailure(
+          new ProcedureException(
+              new MetadataException(ProcedureMessages.UPDATE_DATANODE_TTL_CACHE_FAILED)));
+    }
+  }
+
+  private void capturePreviousTTLState(final ConfigNodeProcedureEnv env) {
+    if (previousTTLStateCaptured) {
+      return;
+    }
+    final Map<String, Long> ttlMap = env.getConfigManager().getTTLManager().getAllTTL();
+    previousTTL = getTTLOrDefault(ttlMap, plan.getPathPattern());
+    if (plan.isDataBase()) {
+      previousDatabaseWildcardTTL =
+          getTTLOrDefault(ttlMap, getDatabaseWildcardPathPattern(plan.getPathPattern()));
+    }
+    previousTTLStateCaptured = true;
+  }
+
+  protected TSStatus writeConfigNodePlan(
+      final ConfigNodeProcedureEnv env, final SetTTLPlan setTTLPlan) {
+    try {
+      return env.getConfigManager()
+          .getConsensusManager()
+          .write(isGeneratedByPipe ? new PipeEnrichedPlan(setTTLPlan) : setTTLPlan);
+    } catch (ConsensusException e) {
+      LOGGER.warn(ConfigNodeMessages.FAILED_IN_THE_WRITE_API_EXECUTING_THE_CONSENSUS_LAYER_DUE, e);
+      final TSStatus res = new TSStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode());
+      res.setMessage(e.getMessage());
+      return res;
+    }
+  }
+
+  protected DataNodeAsyncRequestContext<TSetTTLReq, TSStatus> sendTTLRequest(
+      final Map<Integer, TDataNodeLocation> dataNodeLocationMap, final TSetTTLReq req) {
+    final DataNodeAsyncRequestContext<TSetTTLReq, TSStatus> clientHandler =
+        new DataNodeAsyncRequestContext<>(CnToDnAsyncRequestType.SET_TTL, req, dataNodeLocationMap);
     CnToDnInternalServiceAsyncRequestManager.getInstance().sendAsyncRequestWithRetry(clientHandler);
-    Map<Integer, TSStatus> statusMap = clientHandler.getResponseMap();
-    for (TSStatus status : statusMap.values()) {
-      // all dataNodes must clear the related schemaengine cache
+    return clientHandler;
+  }
+
+  private TSetTTLReq buildSetTTLReq(
+      final String[] pathPattern, final long ttl, final boolean isDataBase) {
+    return new TSetTTLReq(
+        Collections.singletonList(String.join(".", pathPattern)), ttl, isDataBase);
+  }
+
+  private boolean hasFailedDataNode(
+      final DataNodeAsyncRequestContext<TSetTTLReq, TSStatus> clientHandler) {
+    if (!clientHandler.getRequestIndices().isEmpty()) {
+      return true;
+    }
+    for (TSStatus status : clientHandler.getResponseMap().values()) {
       if (status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
-        LOGGER.error(ProcedureMessages.FAILED_TO_UPDATE_TTL_CACHE_OF_DATANODE);
-        setFailure(
-            new ProcedureException(
-                new MetadataException(ProcedureMessages.UPDATE_DATANODE_TTL_CACHE_FAILED)));
-        return;
+        return true;
       }
+    }
+    return false;
+  }
+
+  private long getTTLOrDefault(final Map<String, Long> ttlMap, final String[] pathPattern) {
+    return ttlMap.getOrDefault(String.join(".", pathPattern), TTL_NOT_EXIST);
+  }
+
+  private String[] getDatabaseWildcardPathPattern(final String[] pathPattern) {
+    final String[] pathNodes = Arrays.copyOf(pathPattern, pathPattern.length + 1);
+    pathNodes[pathNodes.length - 1] = IoTDBConstant.MULTI_LEVEL_PATH_WILDCARD;
+    return pathNodes;
+  }
+
+  private void rollbackConfigNodeTTL(final ConfigNodeProcedureEnv env) throws ProcedureException {
+    restoreTTLOnConfigNode(env, plan.getPathPattern(), previousTTL);
+    if (plan.isDataBase()) {
+      restoreTTLOnConfigNode(
+          env, getDatabaseWildcardPathPattern(plan.getPathPattern()), previousDatabaseWildcardTTL);
+    }
+  }
+
+  private void restoreTTLOnConfigNode(
+      final ConfigNodeProcedureEnv env, final String[] pathPattern, final long ttl)
+      throws ProcedureException {
+    final SetTTLPlan rollbackPlan =
+        new SetTTLPlan(pathPattern, ttl == TTL_NOT_EXIST ? TTLCache.NULL_TTL : ttl);
+    rollbackPlan.setDataBase(false);
+    final TSStatus status = writeConfigNodePlan(env, rollbackPlan);
+    if (status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+      throw new ProcedureException(
+          new MetadataException(
+              "Rollback ConfigNode ttl failed for "
+                  + String.join(".", pathPattern)
+                  + ": "
+                  + status.getMessage()));
+    }
+  }
+
+  private void rollbackDataNodeTTL(final ConfigNodeProcedureEnv env) throws ProcedureException {
+    final Map<Integer, TDataNodeLocation> dataNodeLocationMap =
+        env.getConfigManager().getNodeManager().getRegisteredDataNodeLocations();
+    restoreTTLOnDataNodes(dataNodeLocationMap, plan.getPathPattern(), previousTTL);
+    if (plan.isDataBase()) {
+      restoreTTLOnDataNodes(
+          dataNodeLocationMap,
+          getDatabaseWildcardPathPattern(plan.getPathPattern()),
+          previousDatabaseWildcardTTL);
+    }
+  }
+
+  private void restoreTTLOnDataNodes(
+      final Map<Integer, TDataNodeLocation> dataNodeLocationMap,
+      final String[] pathPattern,
+      final long ttl)
+      throws ProcedureException {
+    if (dataNodeLocationMap.isEmpty()) {
+      return;
+    }
+    final DataNodeAsyncRequestContext<TSetTTLReq, TSStatus> clientHandler =
+        sendTTLRequest(
+            dataNodeLocationMap,
+            buildSetTTLReq(pathPattern, ttl == TTL_NOT_EXIST ? TTLCache.NULL_TTL : ttl, false));
+    if (hasFailedDataNode(clientHandler)) {
+      throw new ProcedureException(
+          new MetadataException(
+              "Rollback dataNode ttl cache failed for " + String.join(".", pathPattern)));
     }
   }
 
   @Override
-  protected void rollbackState(
-      ConfigNodeProcedureEnv configNodeProcedureEnv, SetTTLState setTTLState)
-      throws IOException, InterruptedException, ProcedureException {}
+  protected void rollbackState(final ConfigNodeProcedureEnv env, final SetTTLState setTTLState)
+      throws IOException, InterruptedException, ProcedureException {
+    if (setTTLState != SetTTLState.UPDATE_DATANODE_CACHE || !previousTTLStateCaptured) {
+      return;
+    }
+    ProcedureException rollbackFailure = null;
+    try {
+      rollbackConfigNodeTTL(env);
+    } catch (ProcedureException e) {
+      LOGGER.error("Failed to rollback ConfigNode ttl state.", e);
+      rollbackFailure = e;
+    }
+    try {
+      rollbackDataNodeTTL(env);
+    } catch (ProcedureException e) {
+      LOGGER.error("Failed to rollback DataNode ttl cache.", e);
+      if (rollbackFailure == null) {
+        rollbackFailure = e;
+      }
+    }
+    if (rollbackFailure != null) {
+      throw rollbackFailure;
+    }
+  }
+
+  @Override
+  protected boolean isRollbackSupported(final SetTTLState state) {
+    return state == SetTTLState.UPDATE_DATANODE_CACHE;
+  }
 
   @Override
   protected SetTTLState getState(int stateId) {
@@ -159,6 +293,9 @@ public class SetTTLProcedure extends StateMachineProcedure<ConfigNodeProcedureEn
             : ProcedureType.SET_TTL_PROCEDURE.getTypeCode());
     super.serialize(stream);
     ReadWriteIOUtils.write(plan.serializeToByteBuffer(), stream);
+    stream.writeBoolean(previousTTLStateCaptured);
+    stream.writeLong(previousTTL);
+    stream.writeLong(previousDatabaseWildcardTTL);
   }
 
   @Override
@@ -167,6 +304,11 @@ public class SetTTLProcedure extends StateMachineProcedure<ConfigNodeProcedureEn
     try {
       ReadWriteIOUtils.readInt(byteBuffer);
       this.plan = (SetTTLPlan) ConfigPhysicalPlan.Factory.create(byteBuffer);
+      if (byteBuffer.remaining() >= 17) {
+        this.previousTTLStateCaptured = byteBuffer.get() != 0;
+        this.previousTTL = byteBuffer.getLong();
+        this.previousDatabaseWildcardTTL = byteBuffer.getLong();
+      }
     } catch (IOException e) {
       LOGGER.error(ProcedureMessages.IO_ERROR_WHEN_DESERIALIZE_SETTTL_PLAN, e);
     }
@@ -180,12 +322,21 @@ public class SetTTLProcedure extends StateMachineProcedure<ConfigNodeProcedureEn
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    return this.plan.equals(((SetTTLProcedure) o).plan)
-        && this.isGeneratedByPipe == (((SetTTLProcedure) o).isGeneratedByPipe);
+    final SetTTLProcedure that = (SetTTLProcedure) o;
+    return this.isGeneratedByPipe == that.isGeneratedByPipe
+        && this.previousTTL == that.previousTTL
+        && this.previousDatabaseWildcardTTL == that.previousDatabaseWildcardTTL
+        && this.previousTTLStateCaptured == that.previousTTLStateCaptured
+        && this.plan.equals(that.plan);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(plan, isGeneratedByPipe);
+    return Objects.hash(
+        plan,
+        isGeneratedByPipe,
+        previousTTL,
+        previousDatabaseWildcardTTL,
+        previousTTLStateCaptured);
   }
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/SetTTLProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/schema/SetTTLProcedure.java
@@ -79,6 +79,10 @@ public class SetTTLProcedure extends StateMachineProcedure<ConfigNodeProcedureEn
     long startTime = System.currentTimeMillis();
     try {
       switch (state) {
+        case CAPTURE_PREVIOUS_TTL:
+          capturePreviousTTLState(env);
+          setNextState(SetTTLState.SET_CONFIGNODE_TTL);
+          return Flow.HAS_MORE_STATE;
         case SET_CONFIGNODE_TTL:
           setConfigNodeTTL(env);
           return Flow.HAS_MORE_STATE;
@@ -94,8 +98,12 @@ public class SetTTLProcedure extends StateMachineProcedure<ConfigNodeProcedureEn
     }
   }
 
-  protected void setConfigNodeTTL(final ConfigNodeProcedureEnv env) {
-    capturePreviousTTLState(env);
+  void setConfigNodeTTL(final ConfigNodeProcedureEnv env) {
+    if (!previousTTLStateCaptured) {
+      capturePreviousTTLState(env);
+      setNextState(SetTTLState.SET_CONFIGNODE_TTL);
+      return;
+    }
     final TSStatus res = writeConfigNodePlan(env, plan);
     if (res.code != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
       LOGGER.info(ProcedureMessages.FAILED_TO_EXECUTE_PLAN_BECAUSE, plan, res.message);
@@ -105,7 +113,7 @@ public class SetTTLProcedure extends StateMachineProcedure<ConfigNodeProcedureEn
     }
   }
 
-  protected void updateDataNodeTTL(final ConfigNodeProcedureEnv env) {
+  void updateDataNodeTTL(final ConfigNodeProcedureEnv env) {
     final Map<Integer, TDataNodeLocation> dataNodeLocationMap =
         env.getConfigManager().getNodeManager().getRegisteredDataNodeLocations();
     final DataNodeAsyncRequestContext<TSetTTLReq, TSStatus> clientHandler =
@@ -124,17 +132,15 @@ public class SetTTLProcedure extends StateMachineProcedure<ConfigNodeProcedureEn
     if (previousTTLStateCaptured) {
       return;
     }
-    final Map<String, Long> ttlMap = env.getConfigManager().getTTLManager().getAllTTL();
-    previousTTL = getTTLOrDefault(ttlMap, plan.getPathPattern());
+    previousTTL = getTTLOrDefault(env, plan.getPathPattern());
     if (plan.isDataBase()) {
       previousDatabaseWildcardTTL =
-          getTTLOrDefault(ttlMap, getDatabaseWildcardPathPattern(plan.getPathPattern()));
+          getTTLOrDefault(env, getDatabaseWildcardPathPattern(plan.getPathPattern()));
     }
     previousTTLStateCaptured = true;
   }
 
-  protected TSStatus writeConfigNodePlan(
-      final ConfigNodeProcedureEnv env, final SetTTLPlan setTTLPlan) {
+  TSStatus writeConfigNodePlan(final ConfigNodeProcedureEnv env, final SetTTLPlan setTTLPlan) {
     try {
       return env.getConfigManager()
           .getConsensusManager()
@@ -147,7 +153,7 @@ public class SetTTLProcedure extends StateMachineProcedure<ConfigNodeProcedureEn
     }
   }
 
-  protected DataNodeAsyncRequestContext<TSetTTLReq, TSStatus> sendTTLRequest(
+  DataNodeAsyncRequestContext<TSetTTLReq, TSStatus> sendTTLRequest(
       final Map<Integer, TDataNodeLocation> dataNodeLocationMap, final TSetTTLReq req) {
     final DataNodeAsyncRequestContext<TSetTTLReq, TSStatus> clientHandler =
         new DataNodeAsyncRequestContext<>(CnToDnAsyncRequestType.SET_TTL, req, dataNodeLocationMap);
@@ -174,8 +180,9 @@ public class SetTTLProcedure extends StateMachineProcedure<ConfigNodeProcedureEn
     return false;
   }
 
-  private long getTTLOrDefault(final Map<String, Long> ttlMap, final String[] pathPattern) {
-    return ttlMap.getOrDefault(String.join(".", pathPattern), TTL_NOT_EXIST);
+  private long getTTLOrDefault(final ConfigNodeProcedureEnv env, final String[] pathPattern) {
+    final long ttl = env.getConfigManager().getTTLManager().getTTL(pathPattern);
+    return ttl == TTLCache.NULL_TTL ? TTL_NOT_EXIST : ttl;
   }
 
   private String[] getDatabaseWildcardPathPattern(final String[] pathPattern) {
@@ -283,7 +290,7 @@ public class SetTTLProcedure extends StateMachineProcedure<ConfigNodeProcedureEn
 
   @Override
   protected SetTTLState getInitialState() {
-    return SetTTLState.SET_CONFIGNODE_TTL;
+    return SetTTLState.CAPTURE_PREVIOUS_TTL;
   }
 
   @Override

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/state/schema/SetTTLState.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/state/schema/SetTTLState.java
@@ -19,6 +19,8 @@
 package org.apache.iotdb.confignode.procedure.state.schema;
 
 public enum SetTTLState {
+  // Keep existing state ordinals stable for persisted procedures.
   SET_CONFIGNODE_TTL,
-  UPDATE_DATANODE_CACHE
+  UPDATE_DATANODE_CACHE,
+  CAPTURE_PREVIOUS_TTL
 }

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/TTLInfoTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/TTLInfoTest.java
@@ -22,6 +22,7 @@ import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.schema.ttl.TTLCache;
 import org.apache.iotdb.confignode.consensus.request.read.ttl.ShowTTLPlan;
 import org.apache.iotdb.confignode.consensus.request.write.database.SetTTLPlan;
 import org.apache.iotdb.confignode.consensus.response.ttl.ShowTTLResp;
@@ -209,6 +210,17 @@ public class TTLInfoTest {
     resultMap.remove(path.getFullPath());
     Assert.assertEquals(resultMap, ttlInfo.showTTL(new ShowTTLPlan()).getPathTTLMap());
     Assert.assertEquals(4, ttlInfo.getTTLCount());
+  }
+
+  @Test
+  public void testGetTTLReturnsExactPathTTL() throws IllegalPathException {
+    PartialPath path = new PartialPath("root.test.db1.**");
+    ttlInfo.setTTL(new SetTTLPlan(Arrays.asList(path.getNodes()), 121322323L));
+
+    Assert.assertEquals(121322323L, ttlInfo.getTTL(path.getNodes()));
+    Assert.assertEquals(
+        TTLCache.NULL_TTL, ttlInfo.getTTL(new PartialPath("root.test.db1").getNodes()));
+    Assert.assertEquals(Long.MAX_VALUE, ttlInfo.getTTL(new PartialPath("root.**").getNodes()));
   }
 
   @Test

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/TTLInfoTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/TTLInfoTest.java
@@ -244,7 +244,8 @@ public class TTLInfoTest {
     final TSStatus status = ttlInfo.setTTL(setTTLPlan);
     assertEquals(TSStatusCode.OVERSIZE_TTL.getStatusCode(), status.code);
     assertEquals(
-        "The number of TTL rules has reached the limit (1000). Please delete some existing rules first.",
+        "The number of TTL rules has reached the limit "
+            + "(capacity: 1000, requested total: 1001). Please delete some existing rules first.",
         status.message);
   }
 

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/TTLInfoTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/TTLInfoTest.java
@@ -50,6 +50,7 @@ public class TTLInfoTest {
   private final File snapshotDir = new File(BASE_OUTPUT_PATH, "ttlInfo-snapshot");
   private final long ttl = 123435565323L;
   private long[] originTTLArr;
+  private int originTTlRuleCapacity;
 
   @Before
   public void setup() throws IOException {
@@ -57,6 +58,7 @@ public class TTLInfoTest {
       snapshotDir.mkdirs();
     }
     originTTLArr = CommonDescriptor.getInstance().getConfig().getTierTTLInMs();
+    originTTlRuleCapacity = CommonDescriptor.getInstance().getConfig().getTTlRuleCapacity();
     long[] ttlArr = new long[2];
     ttlArr[0] = 10000000L;
     ttlArr[1] = ttl;
@@ -70,6 +72,7 @@ public class TTLInfoTest {
       FileUtils.deleteDirectory(snapshotDir);
     }
     CommonDescriptor.getInstance().getConfig().setTierTTLInMs(originTTLArr);
+    CommonDescriptor.getInstance().getConfig().setTTlRuleCapacity(originTTlRuleCapacity);
   }
 
   @Test
@@ -243,6 +246,56 @@ public class TTLInfoTest {
     assertEquals(
         "The number of TTL rules has reached the limit (1000). Please delete some existing rules first.",
         status.message);
+  }
+
+  @Test
+  public void testUpdateExistingTTLWhenCapacityIsReached() {
+    CommonDescriptor.getInstance().getConfig().setTTlRuleCapacity(2);
+
+    SetTTLPlan setTTLPlan =
+        new SetTTLPlan(PathNodesGenerator.splitPathToNodes("root.sg1.d1.**"), 1000);
+    assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), ttlInfo.setTTL(setTTLPlan).code);
+    assertEquals(2, ttlInfo.getTTLCount());
+
+    setTTLPlan = new SetTTLPlan(PathNodesGenerator.splitPathToNodes("root.sg1.d1.**"), 2000);
+    assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), ttlInfo.setTTL(setTTLPlan).code);
+    assertEquals(2, ttlInfo.getTTLCount());
+    assertEquals(
+        Long.valueOf(2000),
+        ttlInfo.showTTL(new ShowTTLPlan()).getPathTTLMap().get("root.sg1.d1.**"));
+  }
+
+  @Test
+  public void testUpdateExistingTTLWhenCurrentStateIsAlreadyOversize() {
+    SetTTLPlan setTTLPlan =
+        new SetTTLPlan(PathNodesGenerator.splitPathToNodes("root.sg1.d1.**"), 1000);
+    assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), ttlInfo.setTTL(setTTLPlan).code);
+    assertEquals(2, ttlInfo.getTTLCount());
+
+    CommonDescriptor.getInstance().getConfig().setTTlRuleCapacity(1);
+
+    setTTLPlan = new SetTTLPlan(PathNodesGenerator.splitPathToNodes("root.sg1.d1.**"), 2000);
+    assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), ttlInfo.setTTL(setTTLPlan).code);
+    assertEquals(2, ttlInfo.getTTLCount());
+    assertEquals(
+        Long.valueOf(2000),
+        ttlInfo.showTTL(new ShowTTLPlan()).getPathTTLMap().get("root.sg1.d1.**"));
+  }
+
+  @Test
+  public void testDatabaseTTLShouldReserveTwoSlots() {
+    CommonDescriptor.getInstance().getConfig().setTTlRuleCapacity(2);
+
+    SetTTLPlan setTTLPlan = new SetTTLPlan(PathNodesGenerator.splitPathToNodes("root.sg1"), 1000);
+    setTTLPlan.setDataBase(true);
+
+    final TSStatus status = ttlInfo.setTTL(setTTLPlan);
+    assertEquals(TSStatusCode.OVERSIZE_TTL.getStatusCode(), status.code);
+    assertEquals(1, ttlInfo.getTTLCount());
+    assertEquals(1, ttlInfo.showTTL(new ShowTTLPlan()).getPathTTLMap().size());
+    assertEquals(
+        Long.valueOf(Long.MAX_VALUE),
+        ttlInfo.showTTL(new ShowTTLPlan()).getPathTTLMap().get("root.**"));
   }
 
   @Test

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/schema/SetTTLProcedureTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/schema/SetTTLProcedureTest.java
@@ -42,6 +42,7 @@ import org.mockito.Mockito;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -105,7 +106,8 @@ public class SetTTLProcedureTest {
         ByteBuffer.wrap(byteArrayOutputStream.getBuf(), 0, byteArrayOutputStream.size());
     final SetTTLProcedure deserializedProcedure =
         (SetTTLProcedure) ProcedureFactory.getInstance().create(buffer);
-    Assert.assertTrue(procedure.equals(deserializedProcedure));
+    assertSerializedProcedure(
+        deserializedProcedure, "root.db", 2000L, true, true, 500L, 600L, false);
   }
 
   @Test
@@ -194,6 +196,53 @@ public class SetTTLProcedureTest {
     Assert.assertEquals(Collections.singletonList(path), req.getPathPattern());
     Assert.assertEquals(ttl, req.getTTL());
     Assert.assertEquals(isDataBase, req.isDataBase);
+  }
+
+  private void assertSerializedProcedure(
+      final SetTTLProcedure procedure,
+      final String path,
+      final long ttl,
+      final boolean isDataBase,
+      final boolean previousTTLStateCaptured,
+      final long previousTTL,
+      final long previousDatabaseWildcardTTL,
+      final boolean isGeneratedByPipe)
+      throws Exception {
+    final Field planField = findField(SetTTLProcedure.class, "plan");
+    planField.setAccessible(true);
+    assertPlan((SetTTLPlan) planField.get(procedure), path, ttl, isDataBase);
+
+    final Field previousTTLStateCapturedField =
+        findField(SetTTLProcedure.class, "previousTTLStateCaptured");
+    previousTTLStateCapturedField.setAccessible(true);
+    Assert.assertEquals(previousTTLStateCaptured, previousTTLStateCapturedField.get(procedure));
+
+    final Field previousTTLField = findField(SetTTLProcedure.class, "previousTTL");
+    previousTTLField.setAccessible(true);
+    Assert.assertEquals(previousTTL, previousTTLField.get(procedure));
+
+    final Field previousDatabaseWildcardTTLField =
+        findField(SetTTLProcedure.class, "previousDatabaseWildcardTTL");
+    previousDatabaseWildcardTTLField.setAccessible(true);
+    Assert.assertEquals(
+        previousDatabaseWildcardTTL, previousDatabaseWildcardTTLField.get(procedure));
+
+    final Field isGeneratedByPipeField = findField(SetTTLProcedure.class, "isGeneratedByPipe");
+    isGeneratedByPipeField.setAccessible(true);
+    Assert.assertEquals(isGeneratedByPipe, isGeneratedByPipeField.get(procedure));
+  }
+
+  private Field findField(final Class<?> clazz, final String fieldName)
+      throws NoSuchFieldException {
+    Class<?> current = clazz;
+    while (current != null) {
+      try {
+        return current.getDeclaredField(fieldName);
+      } catch (NoSuchFieldException e) {
+        current = current.getSuperclass();
+      }
+    }
+    throw new NoSuchFieldException(fieldName);
   }
 
   private static class TestingSetTTLProcedure extends SetTTLProcedure {

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/schema/SetTTLProcedureTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/schema/SetTTLProcedureTest.java
@@ -131,7 +131,14 @@ public class SetTTLProcedureTest {
         (SetTTLProcedure) ProcedureFactory.getInstance().create(buffer);
 
     assertSerializedProcedure(
-        deserializedProcedure, "root.db", 2000L, true, false, Long.MIN_VALUE, Long.MIN_VALUE, false);
+        deserializedProcedure,
+        "root.db",
+        2000L,
+        true,
+        false,
+        Long.MIN_VALUE,
+        Long.MIN_VALUE,
+        false);
   }
 
   @Test

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/schema/SetTTLProcedureTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/schema/SetTTLProcedureTest.java
@@ -19,19 +19,36 @@
 
 package org.apache.iotdb.confignode.procedure.impl.schema;
 
+import org.apache.iotdb.common.rpc.thrift.TDataNodeLocation;
+import org.apache.iotdb.common.rpc.thrift.TSStatus;
+import org.apache.iotdb.common.rpc.thrift.TSetTTLReq;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.confignode.client.async.CnToDnAsyncRequestType;
+import org.apache.iotdb.confignode.client.async.handlers.DataNodeAsyncRequestContext;
 import org.apache.iotdb.confignode.consensus.request.write.database.SetTTLPlan;
+import org.apache.iotdb.confignode.manager.ConfigManager;
+import org.apache.iotdb.confignode.manager.TTLManager;
+import org.apache.iotdb.confignode.manager.node.NodeManager;
+import org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv;
+import org.apache.iotdb.confignode.procedure.state.schema.SetTTLState;
 import org.apache.iotdb.confignode.procedure.store.ProcedureFactory;
+import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.apache.tsfile.utils.PublicBAOS;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class SetTTLProcedureTest {
 
@@ -64,5 +81,187 @@ public class SetTTLProcedureTest {
     Assert.assertTrue(proc.equals(proc2));
     buffer.clear();
     byteArrayOutputStream.reset();
+  }
+
+  @Test
+  public void serializeDeserializeTestWithCapturedRollbackState() throws Exception {
+    final PublicBAOS byteArrayOutputStream = new PublicBAOS();
+    final DataOutputStream outputStream = new DataOutputStream(byteArrayOutputStream);
+
+    final SetTTLPlan setTTLPlan =
+        new SetTTLPlan(Arrays.asList(new PartialPath("root.db").getNodes()), 2000L);
+    setTTLPlan.setDataBase(true);
+    final TestingSetTTLProcedure procedure = new TestingSetTTLProcedure(setTTLPlan);
+
+    final Map<String, Long> ttlMap = new HashMap<>();
+    ttlMap.put("root.**", Long.MAX_VALUE);
+    ttlMap.put("root.db", 500L);
+    ttlMap.put("root.db.**", 600L);
+
+    procedure.executeFromState(mockProcedureEnv(ttlMap), SetTTLState.SET_CONFIGNODE_TTL);
+
+    procedure.serialize(outputStream);
+    final ByteBuffer buffer =
+        ByteBuffer.wrap(byteArrayOutputStream.getBuf(), 0, byteArrayOutputStream.size());
+    final SetTTLProcedure deserializedProcedure =
+        (SetTTLProcedure) ProcedureFactory.getInstance().create(buffer);
+    Assert.assertTrue(procedure.equals(deserializedProcedure));
+  }
+
+  @Test
+  public void rollbackStateShouldUnsetNewTTLWhenPreviousStateDidNotExist() throws Exception {
+    final SetTTLPlan setTTLPlan =
+        new SetTTLPlan(Arrays.asList(new PartialPath("root.test.sg1.**").getNodes()), 1000L);
+    final TestingSetTTLProcedure procedure = new TestingSetTTLProcedure(setTTLPlan);
+    procedure.failFirstDataNodeUpdateForTest();
+
+    final ConfigNodeProcedureEnv env =
+        mockProcedureEnv(Collections.singletonMap("root.**", Long.MAX_VALUE));
+
+    procedure.executeFromState(env, SetTTLState.SET_CONFIGNODE_TTL);
+    procedure.executeFromState(env, SetTTLState.UPDATE_DATANODE_CACHE);
+    Assert.assertTrue(procedure.isFailed());
+
+    procedure.rollbackState(env, SetTTLState.UPDATE_DATANODE_CACHE);
+
+    Assert.assertEquals(2, procedure.getWrittenPlans().size());
+    assertPlan(procedure.getWrittenPlans().get(0), "root.test.sg1.**", 1000L, false);
+    assertPlan(procedure.getWrittenPlans().get(1), "root.test.sg1.**", -1L, false);
+
+    Assert.assertEquals(2, procedure.getRequests().size());
+    assertRequest(procedure.getRequests().get(0), "root.test.sg1.**", 1000L, false);
+    assertRequest(procedure.getRequests().get(1), "root.test.sg1.**", -1L, false);
+  }
+
+  @Test
+  public void rollbackStateShouldRestoreDatabaseWildcardTTLSeparately() throws Exception {
+    final SetTTLPlan setTTLPlan =
+        new SetTTLPlan(Arrays.asList(new PartialPath("root.db").getNodes()), 2000L);
+    setTTLPlan.setDataBase(true);
+    final TestingSetTTLProcedure procedure = new TestingSetTTLProcedure(setTTLPlan);
+    procedure.failFirstDataNodeUpdateForTest();
+
+    final Map<String, Long> ttlMap = new HashMap<>();
+    ttlMap.put("root.**", Long.MAX_VALUE);
+    ttlMap.put("root.db", 500L);
+    ttlMap.put("root.db.**", 600L);
+    final ConfigNodeProcedureEnv env = mockProcedureEnv(ttlMap);
+
+    procedure.executeFromState(env, SetTTLState.SET_CONFIGNODE_TTL);
+    procedure.executeFromState(env, SetTTLState.UPDATE_DATANODE_CACHE);
+    Assert.assertTrue(procedure.isFailed());
+
+    procedure.rollbackState(env, SetTTLState.UPDATE_DATANODE_CACHE);
+
+    Assert.assertEquals(3, procedure.getWrittenPlans().size());
+    assertPlan(procedure.getWrittenPlans().get(0), "root.db", 2000L, true);
+    assertPlan(procedure.getWrittenPlans().get(1), "root.db", 500L, false);
+    assertPlan(procedure.getWrittenPlans().get(2), "root.db.**", 600L, false);
+
+    Assert.assertEquals(3, procedure.getRequests().size());
+    assertRequest(procedure.getRequests().get(0), "root.db", 2000L, true);
+    assertRequest(procedure.getRequests().get(1), "root.db", 500L, false);
+    assertRequest(procedure.getRequests().get(2), "root.db.**", 600L, false);
+  }
+
+  private ConfigNodeProcedureEnv mockProcedureEnv(final Map<String, Long> ttlMap) {
+    final ConfigNodeProcedureEnv env = Mockito.mock(ConfigNodeProcedureEnv.class);
+    final ConfigManager configManager = Mockito.mock(ConfigManager.class);
+    final TTLManager ttlManager = Mockito.mock(TTLManager.class);
+    final NodeManager nodeManager = Mockito.mock(NodeManager.class);
+
+    final TDataNodeLocation dataNodeLocation = new TDataNodeLocation();
+    dataNodeLocation.setDataNodeId(1);
+
+    Mockito.when(env.getConfigManager()).thenReturn(configManager);
+    Mockito.when(configManager.getTTLManager()).thenReturn(ttlManager);
+    Mockito.when(ttlManager.getAllTTL()).thenReturn(ttlMap);
+    Mockito.when(configManager.getNodeManager()).thenReturn(nodeManager);
+    Mockito.when(nodeManager.getRegisteredDataNodeLocations())
+        .thenReturn(Collections.singletonMap(1, dataNodeLocation));
+    return env;
+  }
+
+  private void assertPlan(
+      final SetTTLPlan plan, final String path, final long ttl, final boolean isDataBase) {
+    Assert.assertEquals(path, String.join(".", plan.getPathPattern()));
+    Assert.assertEquals(ttl, plan.getTTL());
+    Assert.assertEquals(isDataBase, plan.isDataBase());
+  }
+
+  private void assertRequest(
+      final TSetTTLReq req, final String path, final long ttl, final boolean isDataBase) {
+    Assert.assertEquals(Collections.singletonList(path), req.getPathPattern());
+    Assert.assertEquals(ttl, req.getTTL());
+    Assert.assertEquals(isDataBase, req.isDataBase);
+  }
+
+  private static class TestingSetTTLProcedure extends SetTTLProcedure {
+
+    private final List<TSetTTLReq> requests = new ArrayList<>();
+    private final List<SetTTLPlan> writtenPlans = new ArrayList<>();
+    private boolean failFirstDataNodeUpdate = false;
+    private int requestCount = 0;
+
+    private TestingSetTTLProcedure(final SetTTLPlan plan) {
+      super(plan, false);
+    }
+
+    private void failFirstDataNodeUpdateForTest() {
+      failFirstDataNodeUpdate = true;
+    }
+
+    private List<TSetTTLReq> getRequests() {
+      return requests;
+    }
+
+    private List<SetTTLPlan> getWrittenPlans() {
+      return writtenPlans;
+    }
+
+    @Override
+    protected TSStatus writeConfigNodePlan(
+        final ConfigNodeProcedureEnv env, final SetTTLPlan setTTLPlan) {
+      writtenPlans.add(copyPlan(setTTLPlan));
+      return new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
+    }
+
+    @Override
+    protected DataNodeAsyncRequestContext<TSetTTLReq, TSStatus> sendTTLRequest(
+        final Map<Integer, TDataNodeLocation> dataNodeLocationMap, final TSetTTLReq req) {
+      requests.add(copyRequest(req));
+
+      final DataNodeAsyncRequestContext<TSetTTLReq, TSStatus> clientHandler =
+          new DataNodeAsyncRequestContext<>(
+              CnToDnAsyncRequestType.SET_TTL, copyRequest(req), dataNodeLocationMap);
+      final List<Integer> requestIds = new ArrayList<>(clientHandler.getNodeLocationMap().keySet());
+      final boolean shouldFail = failFirstDataNodeUpdate && requestCount++ == 0;
+
+      for (Integer requestId : requestIds) {
+        clientHandler
+            .getResponseMap()
+            .put(
+                requestId,
+                new TSStatus(
+                    shouldFail
+                        ? TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode()
+                        : TSStatusCode.SUCCESS_STATUS.getStatusCode()));
+        if (!shouldFail) {
+          clientHandler.getNodeLocationMap().remove(requestId);
+        }
+      }
+      return clientHandler;
+    }
+
+    private SetTTLPlan copyPlan(final SetTTLPlan plan) {
+      final SetTTLPlan copiedPlan =
+          new SetTTLPlan(Arrays.asList(plan.getPathPattern()), plan.getTTL());
+      copiedPlan.setDataBase(plan.isDataBase());
+      return copiedPlan;
+    }
+
+    private TSetTTLReq copyRequest(final TSetTTLReq req) {
+      return new TSetTTLReq(new ArrayList<>(req.getPathPattern()), req.getTTL(), req.isDataBase);
+    }
   }
 }

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/schema/SetTTLProcedureTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/schema/SetTTLProcedureTest.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.common.rpc.thrift.TSetTTLReq;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.schema.ttl.TTLCache;
 import org.apache.iotdb.confignode.client.async.CnToDnAsyncRequestType;
 import org.apache.iotdb.confignode.client.async.handlers.DataNodeAsyncRequestContext;
 import org.apache.iotdb.confignode.consensus.request.write.database.SetTTLPlan;
@@ -99,7 +100,7 @@ public class SetTTLProcedureTest {
     ttlMap.put("root.db", 500L);
     ttlMap.put("root.db.**", 600L);
 
-    procedure.executeFromState(mockProcedureEnv(ttlMap), SetTTLState.SET_CONFIGNODE_TTL);
+    procedure.executeFromState(mockProcedureEnv(ttlMap), SetTTLState.CAPTURE_PREVIOUS_TTL);
 
     procedure.serialize(outputStream);
     final ByteBuffer buffer =
@@ -108,6 +109,29 @@ public class SetTTLProcedureTest {
         (SetTTLProcedure) ProcedureFactory.getInstance().create(buffer);
     assertSerializedProcedure(
         deserializedProcedure, "root.db", 2000L, true, true, 500L, 600L, false);
+  }
+
+  @Test
+  public void setConfigNodeTTLShouldNotWriteBeforePreviousStateIsCaptured() throws Exception {
+    final SetTTLPlan setTTLPlan =
+        new SetTTLPlan(Arrays.asList(new PartialPath("root.db").getNodes()), 2000L);
+    setTTLPlan.setDataBase(true);
+    final TestingSetTTLProcedure procedure = new TestingSetTTLProcedure(setTTLPlan);
+
+    final Map<String, Long> ttlMap = new HashMap<>();
+    ttlMap.put("root.**", Long.MAX_VALUE);
+    ttlMap.put("root.db", 500L);
+    ttlMap.put("root.db.**", 600L);
+
+    procedure.executeFromState(mockProcedureEnv(ttlMap), SetTTLState.SET_CONFIGNODE_TTL);
+
+    Assert.assertTrue(procedure.getWrittenPlans().isEmpty());
+    assertSerializedProcedure(procedure, "root.db", 2000L, true, true, 500L, 600L, false);
+
+    procedure.executeFromState(mockProcedureEnv(ttlMap), SetTTLState.SET_CONFIGNODE_TTL);
+
+    Assert.assertEquals(1, procedure.getWrittenPlans().size());
+    assertPlan(procedure.getWrittenPlans().get(0), "root.db", 2000L, true);
   }
 
   @Test
@@ -120,6 +144,7 @@ public class SetTTLProcedureTest {
     final ConfigNodeProcedureEnv env =
         mockProcedureEnv(Collections.singletonMap("root.**", Long.MAX_VALUE));
 
+    procedure.executeFromState(env, SetTTLState.CAPTURE_PREVIOUS_TTL);
     procedure.executeFromState(env, SetTTLState.SET_CONFIGNODE_TTL);
     procedure.executeFromState(env, SetTTLState.UPDATE_DATANODE_CACHE);
     Assert.assertTrue(procedure.isFailed());
@@ -149,6 +174,7 @@ public class SetTTLProcedureTest {
     ttlMap.put("root.db.**", 600L);
     final ConfigNodeProcedureEnv env = mockProcedureEnv(ttlMap);
 
+    procedure.executeFromState(env, SetTTLState.CAPTURE_PREVIOUS_TTL);
     procedure.executeFromState(env, SetTTLState.SET_CONFIGNODE_TTL);
     procedure.executeFromState(env, SetTTLState.UPDATE_DATANODE_CACHE);
     Assert.assertTrue(procedure.isFailed());
@@ -177,7 +203,12 @@ public class SetTTLProcedureTest {
 
     Mockito.when(env.getConfigManager()).thenReturn(configManager);
     Mockito.when(configManager.getTTLManager()).thenReturn(ttlManager);
-    Mockito.when(ttlManager.getAllTTL()).thenReturn(ttlMap);
+    Mockito.when(ttlManager.getTTL(Mockito.any(String[].class)))
+        .thenAnswer(
+            invocation -> {
+              final String[] pathPattern = invocation.getArgument(0);
+              return ttlMap.getOrDefault(String.join(".", pathPattern), TTLCache.NULL_TTL);
+            });
     Mockito.when(configManager.getNodeManager()).thenReturn(nodeManager);
     Mockito.when(nodeManager.getRegisteredDataNodeLocations())
         .thenReturn(Collections.singletonMap(1, dataNodeLocation));
@@ -269,14 +300,13 @@ public class SetTTLProcedureTest {
     }
 
     @Override
-    protected TSStatus writeConfigNodePlan(
-        final ConfigNodeProcedureEnv env, final SetTTLPlan setTTLPlan) {
+    TSStatus writeConfigNodePlan(final ConfigNodeProcedureEnv env, final SetTTLPlan setTTLPlan) {
       writtenPlans.add(copyPlan(setTTLPlan));
       return new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
     }
 
     @Override
-    protected DataNodeAsyncRequestContext<TSetTTLReq, TSStatus> sendTTLRequest(
+    DataNodeAsyncRequestContext<TSetTTLReq, TSStatus> sendTTLRequest(
         final Map<Integer, TDataNodeLocation> dataNodeLocationMap, final TSetTTLReq req) {
       requests.add(copyRequest(req));
 

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/schema/SetTTLProcedureTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/schema/SetTTLProcedureTest.java
@@ -31,12 +31,16 @@ import org.apache.iotdb.confignode.consensus.request.write.database.SetTTLPlan;
 import org.apache.iotdb.confignode.manager.ConfigManager;
 import org.apache.iotdb.confignode.manager.TTLManager;
 import org.apache.iotdb.confignode.manager.node.NodeManager;
+import org.apache.iotdb.confignode.procedure.Procedure;
 import org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv;
+import org.apache.iotdb.confignode.procedure.state.ProcedureState;
 import org.apache.iotdb.confignode.procedure.state.schema.SetTTLState;
 import org.apache.iotdb.confignode.procedure.store.ProcedureFactory;
+import org.apache.iotdb.confignode.procedure.store.ProcedureType;
 import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.apache.tsfile.utils.PublicBAOS;
+import org.apache.tsfile.utils.ReadWriteIOUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -109,6 +113,25 @@ public class SetTTLProcedureTest {
         (SetTTLProcedure) ProcedureFactory.getInstance().create(buffer);
     assertSerializedProcedure(
         deserializedProcedure, "root.db", 2000L, true, true, 500L, 600L, false);
+  }
+
+  @Test
+  public void deserializeOldFormatWithoutRollbackStateTest() throws Exception {
+    final SetTTLPlan setTTLPlan =
+        new SetTTLPlan(Arrays.asList(new PartialPath("root.db").getNodes()), 2000L);
+    setTTLPlan.setDataBase(true);
+
+    final PublicBAOS byteArrayOutputStream = new PublicBAOS();
+    final DataOutputStream outputStream = new DataOutputStream(byteArrayOutputStream);
+    writeOldFormatProcedure(outputStream, setTTLPlan);
+
+    final ByteBuffer buffer =
+        ByteBuffer.wrap(byteArrayOutputStream.getBuf(), 0, byteArrayOutputStream.size());
+    final SetTTLProcedure deserializedProcedure =
+        (SetTTLProcedure) ProcedureFactory.getInstance().create(buffer);
+
+    assertSerializedProcedure(
+        deserializedProcedure, "root.db", 2000L, true, false, Long.MIN_VALUE, Long.MIN_VALUE, false);
   }
 
   @Test
@@ -227,6 +250,25 @@ public class SetTTLProcedureTest {
     Assert.assertEquals(Collections.singletonList(path), req.getPathPattern());
     Assert.assertEquals(ttl, req.getTTL());
     Assert.assertEquals(isDataBase, req.isDataBase);
+  }
+
+  private void writeOldFormatProcedure(final DataOutputStream stream, final SetTTLPlan plan)
+      throws IOException {
+    stream.writeShort(ProcedureType.SET_TTL_PROCEDURE.getTypeCode());
+    // Procedure fields.
+    stream.writeLong(Procedure.NO_PROC_ID);
+    stream.writeInt(ProcedureState.INITIALIZING.ordinal());
+    stream.writeLong(0L);
+    stream.writeLong(0L);
+    stream.writeLong(Procedure.NO_PROC_ID);
+    stream.writeLong(Procedure.NO_TIMEOUT);
+    stream.writeInt(-1); // no stack indexes
+    stream.write((byte) 0); // no exception
+    stream.writeInt(-1); // no result
+    stream.write((byte) 0); // no lock
+    // StateMachineProcedure fields.
+    stream.writeInt(0); // no states
+    ReadWriteIOUtils.write(plan.serializeToByteBuffer(), stream);
   }
 
   private void assertSerializedProcedure(


### PR DESCRIPTION
## Description

  This PR fixes two correctness issues in ConfigNode TTL handling.

  1. TTL rule capacity checking incorrectly treated updates to existing TTL rules as new rules.
  2. `SetTTLProcedure` did not rollback TTL state when ConfigNode metadata had been updated but DataNode TTL cache
  update failed.

  ## Details

  ### 1. Fix TTL rule capacity accounting

  `TTLInfo` now checks the number of newly introduced TTL rules instead of simply checking the current total rule count.

  This also fixes the database TTL case: setting TTL on a database effectively writes both the database path and its
  `**` wildcard path, so capacity validation now accounts for both entries.

  As a result:
  - updating an existing TTL rule no longer fails when the capacity limit is already reached
  - database-level TTL no longer bypasses the real capacity requirement

  ### 2. Add rollback for `SetTTLProcedure`

  `SetTTLProcedure` now captures the previous TTL state before writing the new value to ConfigNode.

  If the procedure fails while updating DataNode TTL cache, it will rollback:
  - the TTL metadata on ConfigNode
  - the TTL cache on DataNodes

  For database TTL, the rollback also restores the wildcard TTL entry (`db.**`) separately.

  The rollback state is serialized with the procedure so that recovery/replay can still restore the previous TTL state
  correctly.

  ## Tests

  Added/updated tests for:
  - updating existing TTL when capacity is reached
  - updating existing TTL when current state is already oversize
  - database TTL capacity accounting
  - rollback when previous TTL does not exist
  - rollback of database wildcard TTL
  - procedure serialization with captured rollback state

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
