### PR TITLE
Fix potential NPE while executing query

### DIFF
--- a/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/DataNodeQueryMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/DataNodeQueryMessages.java
@@ -1422,5 +1422,10 @@ public final class DataNodeQueryMessages {
 
   public static final String CANT_CONNECT_TO_NODE_PREFIX = "can't connect to node ";
   public static final String REMOVE_AINODE_FAILED = "Remove AINode failed: ";
+
+  public static final String QUERY_TIMEOUT_IN_FETCH_SCHEMA = "Query execution is time out while fetching schema";
+
+  public static final String QUERY_EXECUTION_MISSING = "Query execution %s is missing during fetching device schema";
+
   private DataNodeQueryMessages() {}
 }

--- a/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/StorageEngineMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/StorageEngineMessages.java
@@ -511,4 +511,8 @@ public final class StorageEngineMessages {
   public static final String STRING_NOT_LEGAL_REPAIR_LOG = "String '%s' is not a legal repair log";
 
   public static final String WRONG_LOAD_COMMAND_S = "Wrong load command %s.";
+
+  public static final String FAILED_TO_FIND_DATA_REGION = "Failed to create state machine for consensus group %s, because data region does not exist";
+
+  public static final String DATA_REGION_IS_NULL = "Data region is null";
 }

--- a/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/DataNodeQueryMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/DataNodeQueryMessages.java
@@ -1421,5 +1421,11 @@ public final class DataNodeQueryMessages {
 
   public static final String CANT_CONNECT_TO_NODE_PREFIX = "无法连接到节点 ";
   public static final String REMOVE_AINODE_FAILED = "移除 AINode 失败：";
+
+  public static final String QUERY_TIMEOUT_IN_FETCH_SCHEMA = "查询在拉取元数据时，执行超时";
+
+  public static final String QUERY_EXECUTION_MISSING = "查询执行实体 %s 在拉取元数据期间丢失";
+
+
   private DataNodeQueryMessages() {}
 }

--- a/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/StorageEngineMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/StorageEngineMessages.java
@@ -511,4 +511,8 @@ public final class StorageEngineMessages {
   public static final String STRING_NOT_LEGAL_REPAIR_LOG = "字符串 '%s' 不是合法的修复日志";
 
   public static final String WRONG_LOAD_COMMAND_S = "错误的 load 命令 %s。";
+
+  public static final String FAILED_TO_FIND_DATA_REGION = "共识组 %s 底层状态机创建失败, 因为 DataRegion 没找到。";
+
+  public static final String DATA_REGION_IS_NULL = "Data region 是空";
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/DataRegionConsensusImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/DataRegionConsensusImpl.java
@@ -43,6 +43,7 @@ import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.consensus.statemachine.dataregion.DataRegionStateMachine;
 import org.apache.iotdb.db.consensus.statemachine.dataregion.IoTConsensusDataRegionStateMachine;
+import org.apache.iotdb.db.i18n.StorageEngineMessages;
 import org.apache.iotdb.db.pipe.agent.PipeDataNodeAgent;
 import org.apache.iotdb.db.pipe.consensus.ReplicateProgressDataNodeManager;
 import org.apache.iotdb.db.pipe.consensus.deletion.DeletionResourceManager;
@@ -51,6 +52,8 @@ import org.apache.iotdb.db.storageengine.dataregion.DataRegion;
 
 import org.apache.ratis.util.SizeInBytes;
 import org.apache.ratis.util.TimeDuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.TimeUnit;
 
@@ -59,6 +62,8 @@ import java.util.concurrent.TimeUnit;
  * dataRegion's reading and writing
  */
 public class DataRegionConsensusImpl {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DataRegionConsensusImpl.class);
 
   private DataRegionConsensusImpl() {
     // do nothing
@@ -113,6 +118,11 @@ public class DataRegionConsensusImpl {
 
     private static DataRegionStateMachine createDataRegionStateMachine(ConsensusGroupId gid) {
       DataRegion dataRegion = StorageEngine.getInstance().getDataRegion((DataRegionId) gid);
+      if (dataRegion == null) {
+        String errorMsg = String.format(StorageEngineMessages.FAILED_TO_FIND_DATA_REGION, gid);
+        LOGGER.error(errorMsg);
+        throw new IllegalArgumentException(errorMsg);
+      }
       if (ConsensusFactory.IOT_CONSENSUS.equals(CONF.getDataRegionConsensusProtocolClass())) {
         return new IoTConsensusDataRegionStateMachine(dataRegion);
       } else {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataRegionStateMachine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataRegionStateMachine.java
@@ -31,6 +31,7 @@ import org.apache.iotdb.consensus.iot.log.GetConsensusReqReaderPlan;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.consensus.statemachine.BaseStateMachine;
 import org.apache.iotdb.db.i18n.DataNodeMiscMessages;
+import org.apache.iotdb.db.i18n.StorageEngineMessages;
 import org.apache.iotdb.db.pipe.agent.PipeDataNodeAgent;
 import org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceManager;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.FragmentInstance;
@@ -248,6 +249,10 @@ public class DataRegionStateMachine extends BaseStateMachine {
 
   @Override
   public DataSet read(IConsensusRequest request) {
+    if (region == null) {
+      logger.error(StorageEngineMessages.DATA_REGION_IS_NULL);
+      return null;
+    }
     if (request instanceof GetConsensusReqReaderPlan) {
       return region.getWALNode().orElseThrow(UnsupportedOperationException::new);
     } else {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/exception/query/QueryTimeoutRuntimeException.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/exception/query/QueryTimeoutRuntimeException.java
@@ -19,14 +19,19 @@
 
 package org.apache.iotdb.db.exception.query;
 
+import org.apache.iotdb.commons.exception.IoTDBRuntimeException;
+
+import static org.apache.iotdb.rpc.TSStatusCode.QUERY_TIMEOUT;
+
 /** This class is used to throw run time exception when query is time out. */
-public class QueryTimeoutRuntimeException extends RuntimeException {
+public class QueryTimeoutRuntimeException extends IoTDBRuntimeException {
   public static final String QUERY_TIMEOUT_EXCEPTION_MESSAGE =
       "Current query is time out, query start time is %d, ddl is %d, current time is %d, please check your statement or modify timeout parameter.";
 
   public QueryTimeoutRuntimeException(long startTime, long currentTime, long timeout) {
     super(
-        String.format(
-            QUERY_TIMEOUT_EXCEPTION_MESSAGE, startTime, startTime + timeout, currentTime));
+        String.format(QUERY_TIMEOUT_EXCEPTION_MESSAGE, startTime, startTime + timeout, currentTime),
+        QUERY_TIMEOUT.getStatusCode(),
+        true);
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/schema/ClusterSchemaFetchExecutor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/schema/ClusterSchemaFetchExecutor.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.queryengine.plan.analyze.schema;
 import org.apache.iotdb.calc.exception.MemoryNotEnoughException;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.exception.IoTDBException;
+import org.apache.iotdb.commons.exception.IoTDBRuntimeException;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.exception.QuerySchemaFetchFailedException;
 import org.apache.iotdb.commons.path.MeasurementPath;
@@ -30,6 +31,7 @@ import org.apache.iotdb.commons.path.PathPatternTree;
 import org.apache.iotdb.commons.schema.template.Template;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.i18n.DataNodeQueryMessages;
 import org.apache.iotdb.db.protocol.session.SessionManager;
 import org.apache.iotdb.db.queryengine.common.MPPQueryContext;
 import org.apache.iotdb.db.queryengine.common.schematree.ClusterSchemaTree;
@@ -294,8 +296,10 @@ class ClusterSchemaFetchExecutor {
             }
           }
         } else {
-          throw new RuntimeException(
-              String.format("Fetch Schema failed, because queryExecution is null for %s", queryId));
+          throw new IoTDBRuntimeException(
+              String.format(
+                  DataNodeQueryMessages.QUERY_EXECUTION_MISSING, executionResult.queryId.getId()),
+              TSStatusCode.INTERNAL_SERVER_ERROR.getStatusCode());
         }
 
         result.setDatabases(databaseSet);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/fetcher/TableDeviceSchemaFetcher.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/metadata/fetcher/TableDeviceSchemaFetcher.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.queryengine.plan.relational.metadata.fetcher;
 
 import org.apache.iotdb.commons.exception.IoTDBException;
 import org.apache.iotdb.commons.exception.IoTDBRuntimeException;
+import org.apache.iotdb.commons.exception.QueryTimeoutException;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Expression;
 import org.apache.iotdb.commons.schema.column.ColumnHeader;
 import org.apache.iotdb.commons.schema.filter.SchemaFilter;
@@ -30,10 +31,14 @@ import org.apache.iotdb.commons.schema.table.TreeViewSchema;
 import org.apache.iotdb.commons.schema.table.TsTable;
 import org.apache.iotdb.commons.schema.table.column.TsTableColumnCategory;
 import org.apache.iotdb.commons.schema.table.column.TsTableColumnSchema;
+import org.apache.iotdb.db.conf.IoTDBConfig;
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.i18n.DataNodeQueryMessages;
 import org.apache.iotdb.db.protocol.session.SessionManager;
 import org.apache.iotdb.db.queryengine.common.MPPQueryContext;
 import org.apache.iotdb.db.queryengine.plan.Coordinator;
 import org.apache.iotdb.db.queryengine.plan.execution.ExecutionResult;
+import org.apache.iotdb.db.queryengine.plan.execution.IQueryExecution;
 import org.apache.iotdb.db.queryengine.plan.planner.LocalExecutionPlanner;
 import org.apache.iotdb.db.queryengine.plan.relational.analyzer.predicate.schema.ConvertSchemaPredicateToFilterVisitor;
 import org.apache.iotdb.db.queryengine.plan.relational.metadata.AlignedDeviceEntry;
@@ -74,6 +79,8 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public class TableDeviceSchemaFetcher {
+
+  private static final IoTDBConfig CONFIG = IoTDBDescriptor.getInstance().getConfig();
 
   private final SqlParser relationSqlParser = new SqlParser();
 
@@ -143,43 +150,54 @@ public class TableDeviceSchemaFetcher {
             executionResult.status.getMessage(), executionResult.status.getCode());
       }
 
-      final List<ColumnHeader> columnHeaderList =
-          coordinator.getQueryExecution(queryId).getDatasetHeader().getColumnHeaders();
-      final int tagLength = DataNodeTableCache.getInstance().getTable(database, table).getTagNum();
-      final Map<IDeviceID, Map<String, Binary>> fetchedDeviceSchema = new HashMap<>();
+      IQueryExecution queryExecution = coordinator.getQueryExecution(queryId);
 
-      while (coordinator.getQueryExecution(queryId).hasNextResult()) {
-        final Optional<TsBlock> tsBlock;
-        try {
-          tsBlock = coordinator.getQueryExecution(queryId).getBatchResult();
-        } catch (final IoTDBException e) {
-          t = e;
-          throw AsyncSendPlanNodeHandler.needRetry(e)
-              ? new IoTDBRuntimeException(
-                  e.getCause(), TSStatusCode.SYNC_CONNECTION_ERROR.getStatusCode())
-              : new IoTDBRuntimeException(
-                  String.format("Fetch Table Device Schema failed because %s", e.getMessage()),
-                  e.getErrorCode(),
-                  e.isUserException());
-        }
-        if (!tsBlock.isPresent() || tsBlock.get().isEmpty()) {
-          break;
-        }
-        final Column[] columns = tsBlock.get().getValueColumns();
-        for (int i = 0; i < tsBlock.get().getPositionCount(); i++) {
-          final String[] nodes = new String[tagLength + 1];
-          final Map<String, Binary> attributeMap = new HashMap<>();
-          constructNodesArrayAndAttributeMap(
-              attributeMap, nodes, table, columnHeaderList, columns, tableInstance, i);
+      if (queryExecution != null) {
+        final List<ColumnHeader> columnHeaderList =
+            queryExecution.getDatasetHeader().getColumnHeaders();
+        final int tagLength =
+            DataNodeTableCache.getInstance().getTable(database, table).getTagNum();
+        final Map<IDeviceID, Map<String, Binary>> fetchedDeviceSchema = new HashMap<>();
 
-          fetchedDeviceSchema.put(IDeviceID.Factory.DEFAULT_FACTORY.create(nodes), attributeMap);
+        while (queryExecution.hasNextResult()) {
+          final Optional<TsBlock> tsBlock;
+          try {
+            tsBlock = queryExecution.getBatchResult();
+          } catch (final IoTDBException e) {
+            t = e;
+            throw AsyncSendPlanNodeHandler.needRetry(e)
+                ? new IoTDBRuntimeException(
+                    e.getCause(), TSStatusCode.SYNC_CONNECTION_ERROR.getStatusCode())
+                : new IoTDBRuntimeException(
+                    String.format("Fetch Table Device Schema failed because %s", e.getMessage()),
+                    e.getErrorCode(),
+                    e.isUserException());
+          }
+          if (!tsBlock.isPresent() || tsBlock.get().isEmpty()) {
+            break;
+          }
+          final Column[] columns = tsBlock.get().getValueColumns();
+          for (int i = 0; i < tsBlock.get().getPositionCount(); i++) {
+            final String[] nodes = new String[tagLength + 1];
+            final Map<String, Binary> attributeMap = new HashMap<>();
+            constructNodesArrayAndAttributeMap(
+                attributeMap, nodes, table, columnHeaderList, columns, tableInstance, i);
+
+            fetchedDeviceSchema.put(IDeviceID.Factory.DEFAULT_FACTORY.create(nodes), attributeMap);
+          }
         }
+
+        schema.setResult(fetchedDeviceSchema);
+        fetchedDeviceSchema.forEach((key, value) -> cache.putAttributes(database, key, value));
+
+        return fetchedDeviceSchema;
+      } else {
+        throw new IoTDBRuntimeException(
+            String.format(
+                DataNodeQueryMessages.QUERY_EXECUTION_MISSING, executionResult.queryId.getId()),
+            TSStatusCode.INTERNAL_SERVER_ERROR.getStatusCode());
       }
 
-      schema.setResult(fetchedDeviceSchema);
-      fetchedDeviceSchema.forEach((key, value) -> cache.putAttributes(database, key, value));
-
-      return fetchedDeviceSchema;
     } catch (final Throwable throwable) {
       t = throwable;
       throw throwable;
@@ -486,6 +504,11 @@ public class TableDeviceSchemaFetcher {
     }
 
     try {
+      long start = System.currentTimeMillis();
+      long timeoutDuration =
+          mppQueryContext == null
+              ? CONFIG.getQueryTimeoutThreshold()
+              : (mppQueryContext.getTimeOut() - (start - mppQueryContext.getStartTime()));
       final ExecutionResult executionResult =
           coordinator.executeForTableModel(
               statement,
@@ -501,45 +524,57 @@ public class TableDeviceSchemaFetcher {
                   mppQueryContext == null ? "unknown" : mppQueryContext.getQueryId(),
                   mppQueryContext == null ? "unknown" : mppQueryContext.getSql()),
               LocalExecutionPlanner.getInstance().metadata,
-              mppQueryContext.getTimeOut()
-                  - (System.currentTimeMillis() - mppQueryContext.getStartTime()),
+              timeoutDuration,
               false,
-              mppQueryContext.isDebug());
+              mppQueryContext != null && mppQueryContext.isDebug());
 
       if (executionResult.status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         throw new IoTDBRuntimeException(
             executionResult.status.getMessage(), executionResult.status.getCode());
       }
 
-      final List<ColumnHeader> columnHeaderList =
-          coordinator.getQueryExecution(queryId).getDatasetHeader().getColumnHeaders();
+      IQueryExecution queryExecution = coordinator.getQueryExecution(queryId);
 
-      while (coordinator.getQueryExecution(queryId).hasNextResult()) {
-        final Optional<TsBlock> tsBlock;
-        try {
-          tsBlock = coordinator.getQueryExecution(queryId).getBatchResult();
-        } catch (final IoTDBException e) {
-          t = e;
-          throw new IoTDBRuntimeException(
-              String.format("Fetch Table Device Schema failed because %s", e.getMessage()),
-              e.getErrorCode(),
-              e.isUserException());
+      if (queryExecution != null) {
+        final List<ColumnHeader> columnHeaderList =
+            queryExecution.getDatasetHeader().getColumnHeaders();
+
+        while (queryExecution.hasNextResult()) {
+          final Optional<TsBlock> tsBlock;
+          try {
+            tsBlock = queryExecution.getBatchResult();
+          } catch (final IoTDBException e) {
+            t = e;
+            throw new IoTDBRuntimeException(
+                String.format("Fetch Table Device Schema failed because %s", e.getMessage()),
+                e.getErrorCode(),
+                e.isUserException());
+          }
+          if (!tsBlock.isPresent() || tsBlock.get().isEmpty()) {
+            break;
+          }
+          if (!TreeViewSchema.isTreeViewTable(tableInstance)) {
+            constructTableResults(
+                tsBlock.get(),
+                columnHeaderList,
+                tableInstance,
+                statement,
+                mppQueryContext,
+                attributeColumns,
+                deviceEntryMap.get(database));
+          } else {
+            constructTreeResults(
+                tsBlock.get(), columnHeaderList, tableInstance, mppQueryContext, deviceEntryMap);
+          }
         }
-        if (!tsBlock.isPresent() || tsBlock.get().isEmpty()) {
-          break;
-        }
-        if (!TreeViewSchema.isTreeViewTable(tableInstance)) {
-          constructTableResults(
-              tsBlock.get(),
-              columnHeaderList,
-              tableInstance,
-              statement,
-              mppQueryContext,
-              attributeColumns,
-              deviceEntryMap.get(database));
+      } else {
+        if (System.currentTimeMillis() - start > timeoutDuration) {
+          throw new QueryTimeoutException(DataNodeQueryMessages.QUERY_TIMEOUT_IN_FETCH_SCHEMA);
         } else {
-          constructTreeResults(
-              tsBlock.get(), columnHeaderList, tableInstance, mppQueryContext, deviceEntryMap);
+          throw new IoTDBRuntimeException(
+              String.format(
+                  DataNodeQueryMessages.QUERY_EXECUTION_MISSING, executionResult.queryId.getId()),
+              TSStatusCode.INTERNAL_SERVER_ERROR.getStatusCode());
         }
       }
     } catch (final Throwable throwable) {


### PR DESCRIPTION
This pull request enhances error handling and internationalization for schema fetching and data region operations in the IoTDB DataNode module. The main improvements are the addition of more descriptive and localized error messages, better exception handling for missing query executions and timeouts, and clearer logging for data region issues.

**Error handling and messaging improvements:**

* Added new error messages for query timeouts and missing query executions during schema fetching, with support for both English and Chinese localizations in `DataNodeQueryMessages` (`en/org/apache/iotdb/db/i18n/DataNodeQueryMessages.java`, `zh/org/apache/iotdb/db/i18n/DataNodeQueryMessages.java`) [[1]](diffhunk://#diff-61b3507ac9a80934d7ecfffe5151a8b0dffacdd2c9cc2ad7f230995fd845a5b0R1425-R1429) [[2]](diffhunk://#diff-90a2ab34c2a35627d94fea1b116e736e1751d1d67f215886940235c3bf471382R1424-R1429).
* Improved error messages for missing or null data regions in `StorageEngineMessages`, also localized in both English and Chinese (`en/org/apache/iotdb/db/i18n/StorageEngineMessages.java`, `zh/org/apache/iotdb/db/i18n/StorageEngineMessages.java`) [[1]](diffhunk://#diff-cc31e94fc32f5c8f4be845445dfe22aff8866cd93747d7bc7bef80ee327a7709R514-R517) [[2]](diffhunk://#diff-0805be6595b7c16da2972bf75962449791a18ae61b59e3447a31b86dc3f4faedR514-R517).

**Exception handling and logging enhancements:**

* Updated `TableDeviceSchemaFetcher` and `ClusterSchemaFetchExecutor` to throw `IoTDBRuntimeException` with localized messages when query executions are missing, and to throw a specific `QueryTimeoutException` when a schema fetch times out (`TableDeviceSchemaFetcher.java`, `ClusterSchemaFetchExecutor.java`) [[1]](diffhunk://#diff-8666a9ce3ad0556e8bdcceaaa24895874f904e6211cdccd26225c6c2aa0d0ac8R153-R165) [[2]](diffhunk://#diff-8666a9ce3ad0556e8bdcceaaa24895874f904e6211cdccd26225c6c2aa0d0ac8R194-R200) [[3]](diffhunk://#diff-8666a9ce3ad0556e8bdcceaaa24895874f904e6211cdccd26225c6c2aa0d0ac8R507-R511) [[4]](diffhunk://#diff-8666a9ce3ad0556e8bdcceaaa24895874f904e6211cdccd26225c6c2aa0d0ac8L504-R545) [[5]](diffhunk://#diff-8666a9ce3ad0556e8bdcceaaa24895874f904e6211cdccd26225c6c2aa0d0ac8R570-R579) [[6]](diffhunk://#diff-0a3a6c9f42ab5060602d3fd721136a859d83a024d7f5de5d1dbb114e90bfe785L297-R302).
* Refactored `QueryTimeoutRuntimeException` to extend `IoTDBRuntimeException` and include a status code, improving consistency in exception handling (`QueryTimeoutRuntimeException.java`).

**Codebase robustness and maintainability:**

* Added null checks and error logging for data region retrieval in `DataRegionConsensusImpl` and `DataRegionStateMachine`, ensuring that missing or null regions are handled gracefully and with clear error messages (`DataRegionConsensusImpl.java`, `DataRegionStateMachine.java`) [[1]](diffhunk://#diff-3c23802b8067e5d5eabe910e2dedca920e8ea64e5244e2ad2205bcb993691588R121-R125) [[2]](diffhunk://#diff-8c557d27a49100d41e3cf7e7ce434c88cbbe5cafc7dcdb9c0f4f047d08992584R252-R255).
* Introduced new logger instances where needed and improved imports for better code clarity and maintainability (`DataRegionConsensusImpl.java`, `TableDeviceSchemaFetcher.java`) [[1]](diffhunk://#diff-3c23802b8067e5d5eabe910e2dedca920e8ea64e5244e2ad2205bcb993691588R46) [[2]](diffhunk://#diff-3c23802b8067e5d5eabe910e2dedca920e8ea64e5244e2ad2205bcb993691588R55-R56) [[3]](diffhunk://#diff-3c23802b8067e5d5eabe910e2dedca920e8ea64e5244e2ad2205bcb993691588R66-R67) [[4]](diffhunk://#diff-8666a9ce3ad0556e8bdcceaaa24895874f904e6211cdccd26225c6c2aa0d0ac8R24) [[5]](diffhunk://#diff-8666a9ce3ad0556e8bdcceaaa24895874f904e6211cdccd26225c6c2aa0d0ac8R34-R41) [[6]](diffhunk://#diff-8666a9ce3ad0556e8bdcceaaa24895874f904e6211cdccd26225c6c2aa0d0ac8R83-R84).

These changes make error reporting more informative for both users and developers, improve localization support, and ensure that exceptional cases in schema fetching and data region operations are handled in a robust and maintainable way.