### PR TITLE
ci: declare workflow-level `contents: read` on compile-check and todos-check

### DIFF
--- a/.github/workflows/compile-check.yml
+++ b/.github/workflows/compile-check.yml
@@ -32,6 +32,9 @@ env:
   MAVEN_ARGS: --batch-mode --no-transfer-progress
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
+permissions:
+  contents: read
+
 jobs:
   compile-check:
     strategy:

--- a/.github/workflows/todos-check.yml
+++ b/.github/workflows/todos-check.yml
@@ -14,6 +14,9 @@ on:
   # allow manually run the action:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   todo-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Both workflows are PR-time checks (compile sanity, todo comment validation). No GitHub API writes from the workflows. Workflow-level `contents: read` is the right cap.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.