### PR TITLE
Fix flaky pipe auto split IT

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/treemodel/auto/basic/IoTDBPipeAutoSplitIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/treemodel/auto/basic/IoTDBPipeAutoSplitIT.java
@@ -99,12 +99,7 @@ public class IoTDBPipeAutoSplitIT extends AbstractPipeDualTreeModelAutoIT {
       final List<TShowPipeInfo> showPipeResult =
           client.showPipe(new TShowPipeReq().setUserName(SessionConfig.DEFAULT_USER)).pipeInfoList;
       showPipeResult.removeIf(i -> i.getId().startsWith("__consensus"));
-      Assert.assertEquals(2, showPipeResult.size());
-      Assert.assertTrue(
-          (Objects.equals(showPipeResult.get(0).id, "a2b_history")
-                  && Objects.equals(showPipeResult.get(1).id, "a2b_realtime"))
-              || (Objects.equals(showPipeResult.get(1).id, "a2b_history")
-                  && Objects.equals(showPipeResult.get(0).id, "a2b_realtime")));
+      assertAutoSplitResult(showPipeResult, "a2b");
     }
 
     // Do not split for pipes without insertion or non-full
@@ -149,10 +144,11 @@ public class IoTDBPipeAutoSplitIT extends AbstractPipeDualTreeModelAutoIT {
       final List<TShowPipeInfo> showPipeResult =
           client.showPipe(new TShowPipeReq().setUserName(SessionConfig.DEFAULT_USER)).pipeInfoList;
       showPipeResult.removeIf(i -> i.getId().startsWith("__consensus"));
-      Assert.assertTrue(
-          showPipeResult.stream()
-              .filter(i -> Objects.equals(i.id, "a2b_history"))
-              .anyMatch(i -> i.pipeConnector.contains("enable-send-tsfile-limit=false")));
+      assertAutoSplitResult(showPipeResult, "a2b");
+      showPipeResult.stream()
+          .filter(i -> Objects.equals(i.id, "a2b_history"))
+          .forEach(
+              i -> Assert.assertTrue(i.pipeConnector.contains("enable-send-tsfile-limit=false")));
     }
 
     TestUtils.assertDataEventuallyOnEnv(
@@ -160,5 +156,19 @@ public class IoTDBPipeAutoSplitIT extends AbstractPipeDualTreeModelAutoIT {
         "select * from root.test.device",
         "Time,root.test.device.field,",
         Collections.singleton("1,2.0,"));
+  }
+
+  private void assertAutoSplitResult(
+      final List<TShowPipeInfo> showPipeResult, final String pipeName) {
+    // The history pipe may have already been auto-dropped after snapshot transfer completes.
+    Assert.assertTrue(
+        showPipeResult.stream().anyMatch(i -> Objects.equals(i.id, pipeName + "_realtime")));
+    Assert.assertFalse(showPipeResult.stream().anyMatch(i -> Objects.equals(i.id, pipeName)));
+    Assert.assertTrue(
+        showPipeResult.stream()
+            .allMatch(
+                i ->
+                    Objects.equals(i.id, pipeName + "_history")
+                        || Objects.equals(i.id, pipeName + "_realtime")));
   }
 }


### PR DESCRIPTION
### Motivation

IoTDBPipeAutoSplitIT assumes that auto split always leaves both history and realtime pipes visible immediately after creation. In practice, the history snapshot pipe can finish and be auto-dropped very quickly when there is no historical data, so SHOW PIPE may only return the realtime pipe and the test fails with expected 2 but was 1.

### Modifications

- Relax the auto split assertion to require the realtime pipe and reject the original unsplit pipe.
- Allow the history pipe to be absent after automatic completion/drop.
- Keep validating the history pipe's sink option when that history pipe is still visible.

### Tests

- Passed: git diff --check -- integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/treemodel/auto/basic/IoTDBPipeAutoSplitIT.java
- Not run successfully locally: IoTDBPipeAutoSplitIT#testSingleEnv. Maven/JVM failed during compilation on this machine due Windows page file/native memory exhaustion.