### PR TITLE
Fix REST table metric statement type labels

### DIFF
--- a/external-service-impl/rest/src/main/java/org/apache/iotdb/rest/protocol/table/v1/impl/RestApiServiceImpl.java
+++ b/external-service-impl/rest/src/main/java/org/apache/iotdb/rest/protocol/table/v1/impl/RestApiServiceImpl.java
@@ -34,6 +34,7 @@ import org.apache.iotdb.db.queryengine.plan.planner.LocalExecutionPlanner;
 import org.apache.iotdb.db.queryengine.plan.relational.metadata.Metadata;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.Insert;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.parser.SqlParser;
+import org.apache.iotdb.db.queryengine.plan.statement.StatementType;
 import org.apache.iotdb.db.queryengine.plan.statement.crud.InsertTabletStatement;
 import org.apache.iotdb.db.utils.CommonUtils;
 import org.apache.iotdb.db.utils.SetThreadName;
@@ -139,7 +140,7 @@ public class RestApiServiceImpl extends RestApiService {
           .ifPresent(
               s ->
                   CommonUtils.addStatementExecutionLatency(
-                      OperationType.EXECUTE_QUERY_STATEMENT, s.toString(), costTime));
+                      OperationType.EXECUTE_QUERY_STATEMENT, StatementType.QUERY.name(), costTime));
     }
   }
 
@@ -194,7 +195,6 @@ public class RestApiServiceImpl extends RestApiService {
     SqlParser relationSqlParser = new SqlParser();
     Long queryId = null;
     Statement statement = null;
-    long startTime = System.nanoTime();
     try {
       IClientSession clientSession = SESSION_MANAGER.getCurrSession();
       statement = createStatement(sql, clientSession, relationSqlParser);
@@ -233,12 +233,6 @@ public class RestApiServiceImpl extends RestApiService {
     } catch (Exception e) {
       return Response.ok().entity(ExceptionHandler.tryCatchException(e)).build();
     } finally {
-      long costTime = System.nanoTime() - startTime;
-      Optional.ofNullable(statement)
-          .ifPresent(
-              s ->
-                  CommonUtils.addStatementExecutionLatency(
-                      OperationType.EXECUTE_NON_QUERY_PLAN, s.toString(), costTime));
       if (queryId != null) {
         COORDINATOR.cleanupQueryExecution(queryId);
       }


### PR DESCRIPTION
## Description

This PR avoids recording full table-model AST strings in REST table v1 query metric labels.

The REST table v1 query endpoint previously passed Statement#toString() as the type label to performance_overview, which could expose long query text such as Query{queryBody=...} and produce unstable/high-cardinality labels.

The change records QUERY for the query endpoint instead. For REST table v1 non-query, this PR removes the separate EXECUTE_NON_QUERY_PLAN metric recording to keep it aligned with the RPC SQL statement path, which does not use a separate SQL non-query metric interface.

I also checked other CommonUtils.addStatementExecutionLatency call sites and did not find remaining toString() usage for metric type labels.

## Verification

./mvnw -pl external-service-impl/rest -am -DskipTests -DskipITs compile
