### PR TITLE
[AINode] Fix inference output TsBlock type

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/ainode/it/AINodeSharedClusterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/ainode/it/AINodeSharedClusterIT.java
@@ -42,6 +42,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Types;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -271,8 +272,10 @@ public class AINodeSharedClusterIT {
       try (ResultSet resultSet = statement.executeQuery(callInferenceSQL)) {
         ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
         checkHeader(resultSetMetaData, "Time,output");
+        Assert.assertEquals(Types.DOUBLE, resultSetMetaData.getColumnType(2));
         int count = 0;
         while (resultSet.next()) {
+          resultSet.getDouble("output");
           count++;
         }
         Assert.assertEquals(DEFAULT_OUTPUT_LENGTH, count);
@@ -288,8 +291,10 @@ public class AINodeSharedClusterIT {
       try (ResultSet resultSet = statement.executeQuery(callInferenceSQL)) {
         ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
         checkHeader(resultSetMetaData, "output");
+        Assert.assertEquals(Types.DOUBLE, resultSetMetaData.getColumnType(1));
         int count = 0;
         while (resultSet.next()) {
+          resultSet.getDouble("output");
           count++;
         }
         Assert.assertTrue(count > 0);

--- a/iotdb-core/ainode/iotdb/ainode/core/manager/inference_manager.py
+++ b/iotdb-core/ainode/iotdb/ainode/core/manager/inference_manager.py
@@ -209,10 +209,11 @@ class InferenceManager:
                 logger.error("[Inference] Unsupported pipeline type.")
             outputs = inference_pipeline.postprocess(outputs, **inference_attrs)
 
-        # convert tensor into tsblock for the output in each batch
+        # DataNode currently exposes inference outputs as DOUBLE, so serialize the
+        # physical TsBlock column as double even when model tensors are float32.
         resp_list = []
-        for batch_idx, output in enumerate(outputs):
-            resp = convert_tensor_to_tsblock(output)
+        for output in outputs:
+            resp = convert_tensor_to_tsblock(output.to(dtype=torch.float64))
             resp_list.append(resp)
         return resp_list
 


### PR DESCRIPTION
## Description

### Fix inference output type

DataNode declares CALL INFERENCE output schema as DOUBLE, but AINode serialized model tensors using their original dtype. For float32 outputs such as chronos2, this produced a FLOAT TsBlock column and clients calling getDouble() failed.

This PR converts inference outputs to torch.float64 before TsBlock serialization so the physical TsBlock column matches the DOUBLE result schema.

### Tests

- Added coverage in AINodeSharedClusterIT to assert the output metadata type is DOUBLE and actually read values with ResultSet#getDouble("output").
- Verified AINode serde converts the manager output path to DOUBLE.
- Ran black .
- Ran isort --profile black .
- Ran mvn spotless:apply -pl integration-test -P with-integration-tests
- Ran mvn -pl integration-test -P with-integration-tests test-compile

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added integration tests.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- iotdb-core/ainode/iotdb/ainode/core/manager/inference_manager.py
- integration-test/src/test/java/org/apache/iotdb/ainode/it/AINodeSharedClusterIT.java