### PR TITLE
Add table type to table disk usage

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/IoTDBShowDiskUsageTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/IoTDBShowDiskUsageTableIT.java
@@ -80,6 +80,7 @@ public class IoTDBShowDiskUsageTableIT {
       Map<String, Long> tableSizes = new HashMap<>();
       while (iterator.next()) {
         String table = iterator.getString("table_name");
+        Assert.assertEquals("BASE TABLE", iterator.getString("table_type"));
         long timePartition = iterator.getLong("time_partition");
         long size = iterator.getLong("size_in_bytes");
         timePartitionSizes.compute(timePartition, (k, v) -> v == null ? size : v + size);

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/schema/IoTDBDatabaseIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/schema/IoTDBDatabaseIT.java
@@ -578,6 +578,7 @@ public class IoTDBDatabaseIT {
               Arrays.asList(
                   "database,STRING,FIELD,",
                   "table_name,STRING,FIELD,",
+                  "table_type,STRING,FIELD,",
                   "datanode_id,INT32,FIELD,",
                   "region_id,INT32,FIELD,",
                   "time_partition,INT64,FIELD,",

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/InformationSchemaContentSupplierFactory.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/relational/InformationSchemaContentSupplierFactory.java
@@ -1420,12 +1420,13 @@ public class InformationSchemaContentSupplierFactory {
         }
         totalValidTableCount++;
         if (pushDownFilter != null) {
-          Object[] row = new Object[5];
+          Object[] row = new Object[6];
           row[0] = new Binary(dataRegion.getDatabaseName(), TSFileConfig.STRING_CHARSET);
           row[1] = new Binary(tTableInfo.getTableName(), TSFileConfig.STRING_CHARSET);
-          row[2] = IoTDBDescriptor.getInstance().getConfig().getDataNodeId();
-          row[3] = dataRegion.getDataRegionId();
-          row[4] = timePartition;
+          row[2] = new Binary(getTableTypeName(tTableInfo), TSFileConfig.STRING_CHARSET);
+          row[3] = IoTDBDescriptor.getInstance().getConfig().getDataNodeId();
+          row[4] = dataRegion.getDataRegionId();
+          row[5] = timePartition;
           if (!pushDownFilter.satisfyRow(0, row)) {
             continue;
           }
@@ -1442,6 +1443,25 @@ public class InformationSchemaContentSupplierFactory {
       }
       currentDatabaseOnlyHasOneTable = totalValidTableCount == 1;
       return tablesToScan;
+    }
+
+    private String getTableTypeName(final TTableInfo tableInfo) {
+      if (tableInfo.isSetType()) {
+        return TableType.values()[tableInfo.getType()].getName();
+      }
+      return TableType.BASE_TABLE.getName();
+    }
+
+    private String getTableTypeName(final String databaseName, final String tableName) {
+      final List<TTableInfo> tableInfos = databaseTableInfoMap.get(databaseName);
+      if (tableInfos != null) {
+        for (TTableInfo tableInfo : tableInfos) {
+          if (tableName.equals(tableInfo.getTableName())) {
+            return getTableTypeName(tableInfo);
+          }
+        }
+      }
+      return TableType.BASE_TABLE.getName();
     }
 
     @Override
@@ -1531,10 +1551,14 @@ public class InformationSchemaContentSupplierFactory {
           columns[0].writeBinary(
               new Binary(currentDataRegion.getDatabaseName(), TSFileConfig.STRING_CHARSET));
           columns[1].writeBinary(new Binary(tableName, TSFileConfig.STRING_CHARSET));
-          columns[2].writeInt(IoTDBDescriptor.getInstance().getConfig().getDataNodeId());
-          columns[3].writeInt(currentDataRegion.getDataRegionId());
-          columns[4].writeLong(timePartition);
-          columns[5].writeLong(size);
+          columns[2].writeBinary(
+              new Binary(
+                  getTableTypeName(currentDataRegion.getDatabaseName(), tableName),
+                  TSFileConfig.STRING_CHARSET));
+          columns[3].writeInt(IoTDBDescriptor.getInstance().getConfig().getDataNodeId());
+          columns[4].writeInt(currentDataRegion.getDataRegionId());
+          columns[5].writeLong(timePartition);
+          columns[6].writeLong(size);
           builder.declarePosition();
         }
       }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/schema/table/InformationSchema.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/schema/table/InformationSchema.java
@@ -357,6 +357,8 @@ public class InformationSchema {
     tableDiskUsageTable.addColumnSchema(
         new FieldColumnSchema(ColumnHeaderConstant.TABLE_NAME_TABLE_MODEL, TSDataType.STRING));
     tableDiskUsageTable.addColumnSchema(
+        new FieldColumnSchema(ColumnHeaderConstant.TABLE_TYPE_TABLE_MODEL, TSDataType.STRING));
+    tableDiskUsageTable.addColumnSchema(
         new FieldColumnSchema(ColumnHeaderConstant.DATA_NODE_ID_TABLE_MODEL, TSDataType.INT32));
     tableDiskUsageTable.addColumnSchema(
         new FieldColumnSchema(ColumnHeaderConstant.REGION_ID_TABLE_MODEL, TSDataType.INT32));
@@ -430,6 +432,7 @@ public class InformationSchema {
         ImmutableSet.of(
             ColumnHeaderConstant.DATABASE.toLowerCase(),
             ColumnHeaderConstant.TABLE_NAME_TABLE_MODEL,
+            ColumnHeaderConstant.TABLE_TYPE_TABLE_MODEL,
             ColumnHeaderConstant.DATA_NODE_ID_TABLE_MODEL,
             ColumnHeaderConstant.REGION_ID_TABLE_MODEL,
             ColumnHeaderConstant.TIME_PARTITION_TABLE_MODEL));


### PR DESCRIPTION
## Summary

- Add a table_type column to information_schema.table_disk_usage.
- Populate table_type from TTableInfo using TableType names.
- Include table_type in predicate pushdown support and update related integration test expectations.

## Validation

- Not run, per user request.