### PR TITLE
[To dev/1.3] Pipe: Removed the useless ban on async file transfer for non realtime-first pipes

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/thrift/async/IoTDBDataRegionAsyncSink.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/thrift/async/IoTDBDataRegionAsyncSink.java
@@ -433,7 +433,7 @@ public class IoTDBDataRegionAsyncSink extends IoTDBSink {
             },
             transferTsFileClientManager.getExecutor());
 
-    if (PipeConfig.getInstance().isTransferTsFileSync() || !isRealtimeFirst) {
+    if (PipeConfig.getInstance().isTransferTsFileSync()) {
       try {
         completableFuture.get();
       } catch (final Exception e) {


### PR DESCRIPTION
Backport 329fa102a49e5350ca213c6f69be2408170d34e6 to dev/1.3.

Tests:
- .\mvnw.cmd -pl iotdb-core/datanode spotless:apply
- git diff --check origin/dev/1.3..HEAD