### PR TITLE
Improve query modification loading memory control

### DIFF
--- a/iotdb-core/calc-commons/src/main/java/org/apache/iotdb/calc/plan/planner/memory/MemoryReservationManager.java
+++ b/iotdb-core/calc-commons/src/main/java/org/apache/iotdb/calc/plan/planner/memory/MemoryReservationManager.java
@@ -34,6 +34,14 @@ public interface MemoryReservationManager {
   void reserveMemoryImmediately();
 
   /**
+   * Reserve memory for the given size immediately without changing the accumulated pending
+   * reservation size maintained by this manager.
+   *
+   * @param size the size of memory to reserve immediately
+   */
+  void reserveMemoryImmediately(final long size);
+
+  /**
    * Release memory for the given size.
    *
    * @param size the size of memory to release

--- a/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/DataNodeQueryMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/DataNodeQueryMessages.java
@@ -136,6 +136,8 @@ public final class DataNodeQueryMessages {
 
   public static final String FREE_MORE_MEMORY_THAN_HAS_BEEN_RESERVED =
       "Free more memory than has been reserved.";
+  public static final String ESTIMATED_MODS_TREE_SIZE_DECREASED =
+      "Estimated mods tree size decreased from %d to %d for TsFile %s.";
 
   // --- Execution / Operator ---
 

--- a/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/DataNodeQueryMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/DataNodeQueryMessages.java
@@ -136,6 +136,8 @@ public final class DataNodeQueryMessages {
 
   public static final String FREE_MORE_MEMORY_THAN_HAS_BEEN_RESERVED =
       "释放的内存超过已预留的量。";
+  public static final String ESTIMATED_MODS_TREE_SIZE_DECREASED =
+      "估算的 mods tree 大小从 %d 减少到 %d，TsFile：%s。";
 
   // --- Execution / Operator ---
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceContext.java
@@ -410,7 +410,10 @@ public class FragmentInstanceContext extends QueryContext {
     try (QueryModificationLoader modificationLoader =
         getQueryModificationLoader(
             tsFileResource,
-            modification -> modification.affects(deviceID),
+            modification ->
+                deviceID.isTableModel()
+                    ? modification.affects(deviceID)
+                    : modification.affectsAll(deviceID),
             mods -> getPathModifications(mods, deviceID))) {
       return modificationLoader.getPathModifications();
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/FragmentInstanceContext.java
@@ -26,11 +26,11 @@ import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.audit.UserEntity;
 import org.apache.iotdb.commons.conf.CommonConfig;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
+import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.exception.IoTDBException;
 import org.apache.iotdb.commons.exception.IoTDBRuntimeException;
 import org.apache.iotdb.commons.path.AlignedFullPath;
 import org.apache.iotdb.commons.path.IFullPath;
-import org.apache.iotdb.commons.path.PatternTreeMap;
 import org.apache.iotdb.commons.queryengine.common.SessionInfo;
 import org.apache.iotdb.commons.queryengine.utils.TimestampPrecisionUtils;
 import org.apache.iotdb.commons.utils.TestOnly;
@@ -56,7 +56,6 @@ import org.apache.iotdb.db.storageengine.dataregion.read.QueryDataSourceForRegio
 import org.apache.iotdb.db.storageengine.dataregion.read.QueryDataSourceType;
 import org.apache.iotdb.db.storageengine.dataregion.read.control.FileReaderManager;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
-import org.apache.iotdb.db.utils.datastructure.PatternTreeMapFactory;
 import org.apache.iotdb.db.utils.datastructure.TVList;
 import org.apache.iotdb.mpp.rpc.thrift.TFetchFragmentInstanceStatisticsResp;
 
@@ -82,6 +81,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.apache.iotdb.commons.utils.ErrorHandlingCommonUtils.getRootCause;
@@ -99,6 +99,7 @@ public class FragmentInstanceContext extends QueryContext {
   private static final long END_TIME_INITIAL_VALUE = -1L;
   // wait over 5s for driver to close is abnormal
   private static final long LONG_WAIT_DURATION = 5_000_000_000L;
+  private static final int MODS_MEMORY_ESTIMATE_READ_INTERVAL = 10_000;
   private final FragmentInstanceId id;
 
   private final FragmentInstanceStateMachine stateMachine;
@@ -378,41 +379,57 @@ public class FragmentInstanceContext extends QueryContext {
   }
 
   @Override
-  protected PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer> getAllModifications(
-      TsFileResource resource) {
-    if (isSingleSourcePath() || memoryReservationManager == null) {
-      return loadAllModificationsFromDisk(resource);
+  public List<ModEntry> getPathModifications(
+      TsFileResource tsFileResource, IDeviceID deviceID, String measurement) {
+    if (!checkIfModificationExists(tsFileResource)) {
+      return Collections.emptyList();
     }
+    if (memoryReservationManager == null) {
+      return super.getPathModifications(tsFileResource, deviceID, measurement);
+    }
+    try (QueryModificationLoader modificationLoader =
+        getQueryModificationLoader(
+            tsFileResource,
+            modification -> modification.affects(deviceID) && modification.affects(measurement),
+            mods -> getPathModifications(mods, deviceID, measurement))) {
+      return modificationLoader.getPathModifications();
+    } catch (IllegalPathException e) {
+      throw new IllegalStateException(e);
+    }
+  }
 
-    AtomicReference<PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer>>
-        atomicReference = new AtomicReference<>();
-    PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer> cachedResult =
-        fileModCache.computeIfAbsent(
-            resource.getTsFileID(),
-            k -> {
-              PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer> allMods =
-                  loadAllModificationsFromDisk(resource);
-              atomicReference.set(allMods);
-              if (cachedModEntriesSize.get() >= CONFIG.getModsCacheSizeLimitPerFI()) {
-                return null;
-              }
-              long memCost =
-                  RamUsageEstimator.sizeOfObject(allMods)
-                      + RamUsageEstimator.SHALLOW_SIZE_OF_CONCURRENT_HASHMAP_ENTRY;
-              long alreadyUsedMemoryForCachedModEntries = cachedModEntriesSize.get();
-              while (alreadyUsedMemoryForCachedModEntries + memCost
-                  < CONFIG.getModsCacheSizeLimitPerFI()) {
-                if (cachedModEntriesSize.compareAndSet(
-                    alreadyUsedMemoryForCachedModEntries,
-                    alreadyUsedMemoryForCachedModEntries + memCost)) {
-                  memoryReservationManager.reserveMemoryCumulatively(memCost);
-                  return allMods;
-                }
-                alreadyUsedMemoryForCachedModEntries = cachedModEntriesSize.get();
-              }
-              return null;
-            });
-    return cachedResult == null ? atomicReference.get() : cachedResult;
+  @Override
+  public List<ModEntry> getPathModifications(TsFileResource tsFileResource, IDeviceID deviceID)
+      throws IllegalPathException {
+    if (!checkIfModificationExists(tsFileResource)) {
+      return Collections.emptyList();
+    }
+    if (memoryReservationManager == null) {
+      return super.getPathModifications(tsFileResource, deviceID);
+    }
+    try (QueryModificationLoader modificationLoader =
+        getQueryModificationLoader(
+            tsFileResource,
+            modification -> modification.affects(deviceID),
+            mods -> getPathModifications(mods, deviceID))) {
+      return modificationLoader.getPathModifications();
+    }
+  }
+
+  private QueryModificationLoader getQueryModificationLoader(
+      TsFileResource tsFileResource,
+      Predicate<ModEntry> fallbackModificationMatcher,
+      QueryModificationLoader.ModsTreeMatcher modsTreeMatcher) {
+    return new QueryModificationLoader(
+        this,
+        tsFileResource,
+        memoryReservationManager,
+        CONFIG.getModsCacheSizeLimitPerFI(),
+        MODS_MEMORY_ESTIMATE_READ_INTERVAL,
+        fileModCache,
+        cachedModEntriesSize,
+        fallbackModificationMatcher,
+        modsTreeMatcher);
   }
 
   // the state change listener is added here in a separate initialize() method

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryContext.java
@@ -127,18 +127,24 @@ public class QueryContext {
       TsFileResource resource) {
     PatternTreeMap<ModEntry, ModsSerializer> modifications =
         PatternTreeMapFactory.getModsPatternTreeMap();
-    TsFileResource.ModIterator modEntryIterator = resource.getModEntryIterator();
-    while (modEntryIterator.hasNext()) {
-      ModEntry modification = modEntryIterator.next();
-      if (tables != null && modification instanceof TableDeletionEntry) {
-        String tableName = ((TableDeletionEntry) modification).getTableName();
-        if (!tables.contains(tableName)) {
+    try (TsFileResource.ModIterator modEntryIterator = resource.getModEntryIterator()) {
+      while (modEntryIterator.hasNext()) {
+        ModEntry modification = modEntryIterator.next();
+        if (shouldSkipModification(modification)) {
           continue;
         }
+        modifications.append(modification.keyOfPatternTree(), modification);
       }
-      modifications.append(modification.keyOfPatternTree(), modification);
     }
     return modifications;
+  }
+
+  protected boolean shouldSkipModification(ModEntry modification) {
+    if (tables != null && modification instanceof TableDeletionEntry) {
+      String tableName = ((TableDeletionEntry) modification).getTableName();
+      return !tables.contains(tableName);
+    }
+    return false;
   }
 
   public List<ModEntry> getPathModifications(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryModificationLoader.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryModificationLoader.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.calc.exception.MemoryNotEnoughException;
 import org.apache.iotdb.calc.plan.planner.memory.MemoryReservationManager;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PatternTreeMap;
+import org.apache.iotdb.db.i18n.DataNodeQueryMessages;
 import org.apache.iotdb.db.storageengine.dataregion.modification.ModEntry;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileID;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
@@ -31,6 +32,7 @@ import org.apache.iotdb.db.utils.datastructure.PatternTreeMapFactory;
 
 import org.apache.tsfile.utils.RamUsageEstimator;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -118,43 +120,50 @@ class QueryModificationLoader implements AutoCloseable {
 
     long claimedCacheQuotaBytes = 0;
     int readModCount = 0;
+    boolean estimatedAfterLastAppend = false;
 
     while (currentIterator.hasNext()) {
       ModEntry modification = currentIterator.next();
       readModCount++;
       if (!queryContext.shouldSkipModification(modification)) {
         modifications.append(modification.keyOfPatternTree(), modification);
+        estimatedAfterLastAppend = false;
       }
 
       if (readModCount % modsMemoryEstimateReadInterval == 0) {
         long currentEstimatedSize = estimateModsTreeMemory(modifications);
-        if (currentEstimatedSize < claimedCacheQuotaBytes) {
-          throw new IllegalStateException(
-              String.format(
-                  "Estimated mods tree size decreased from %d to %d for TsFile %s.",
-                  claimedCacheQuotaBytes, currentEstimatedSize, resource));
-        }
+        checkEstimatedSizeNotDecreased(claimedCacheQuotaBytes, currentEstimatedSize);
         long delta = currentEstimatedSize - claimedCacheQuotaBytes;
         if (!tryClaimCacheQuota(delta)) {
           return new LoadedModsResult(modifications, claimedCacheQuotaBytes, false);
         }
         claimedCacheQuotaBytes = currentEstimatedSize;
+        estimatedAfterLastAppend = true;
       }
     }
 
-    long finalEstimatedSize = estimateModsTreeMemory(modifications);
-    if (finalEstimatedSize < claimedCacheQuotaBytes) {
+    if (!estimatedAfterLastAppend) {
+      long finalEstimatedSize = estimateModsTreeMemory(modifications);
+      checkEstimatedSizeNotDecreased(claimedCacheQuotaBytes, finalEstimatedSize);
+      long delta = finalEstimatedSize - claimedCacheQuotaBytes;
+      if (!tryClaimCacheQuota(delta)) {
+        return new LoadedModsResult(modifications, claimedCacheQuotaBytes, false);
+      }
+      claimedCacheQuotaBytes = finalEstimatedSize;
+    }
+    return new LoadedModsResult(modifications, claimedCacheQuotaBytes, true);
+  }
+
+  private void checkEstimatedSizeNotDecreased(
+      long previousEstimatedSize, long currentEstimatedSize) {
+    if (currentEstimatedSize < previousEstimatedSize) {
       throw new IllegalStateException(
           String.format(
-              "Estimated mods tree size decreased from %d to %d for TsFile %s.",
-              claimedCacheQuotaBytes, finalEstimatedSize, resource));
+              DataNodeQueryMessages.ESTIMATED_MODS_TREE_SIZE_DECREASED,
+              previousEstimatedSize,
+              currentEstimatedSize,
+              resource));
     }
-    long delta = finalEstimatedSize - claimedCacheQuotaBytes;
-    if (!tryClaimCacheQuota(delta)) {
-      return new LoadedModsResult(modifications, claimedCacheQuotaBytes, false);
-    }
-    claimedCacheQuotaBytes = finalEstimatedSize;
-    return new LoadedModsResult(modifications, claimedCacheQuotaBytes, true);
   }
 
   private boolean tryClaimCacheQuota(long delta) {
@@ -182,11 +191,12 @@ class QueryModificationLoader implements AutoCloseable {
       // has already been read, then continue scanning the same iterator by path.
       List<ModEntry> matchedMods;
       try {
-        matchedMods = modsTreeMatcher.match(partialTree.mods);
+        matchedMods = new ArrayList<>(modsTreeMatcher.match(partialTree.mods));
       } finally {
         partialTree.mods = null;
         releaseClaimedCacheQuota(partialTree);
       }
+      reserveMatchedModsMemory(matchedMods);
 
       while (currentIterator.hasNext()) {
         ModEntry modification = currentIterator.next();
@@ -194,12 +204,12 @@ class QueryModificationLoader implements AutoCloseable {
           continue;
         }
         if (modificationMatcher.test(modification)) {
+          reserveMatchedModMemory(modification);
           matchedMods.add(modification);
         }
       }
 
       matchedMods = ModificationUtils.sortAndMerge(matchedMods);
-      reserveMatchedModsMemory(matchedMods);
       return matchedMods;
     } finally {
       close();
@@ -213,7 +223,7 @@ class QueryModificationLoader implements AutoCloseable {
       // Return only the matched mods and release the cache quota claimed during loading.
       List<ModEntry> matchedMods;
       try {
-        matchedMods = modsTreeMatcher.match(loadedTree.mods);
+        matchedMods = new ArrayList<>(modsTreeMatcher.match(loadedTree.mods));
       } finally {
         loadedTree.mods = null;
         releaseClaimedCacheQuota(loadedTree);
@@ -226,26 +236,20 @@ class QueryModificationLoader implements AutoCloseable {
   }
 
   private void reserveMatchedModsMemory(List<ModEntry> matchedMods) {
-    long memCost =
-        RamUsageEstimator.shallowSizeOf(matchedMods)
-            + (long) matchedMods.size() * RamUsageEstimator.NUM_BYTES_OBJECT_REF
-            + matchedMods.stream().mapToLong(ModEntry::ramBytesUsed).sum();
-    if (memCost > 0) {
-      reserveMemoryImmediately(memCost);
+    reserveMemoryImmediately(RamUsageEstimator.shallowSizeOf(matchedMods));
+    for (ModEntry matchedMod : matchedMods) {
+      reserveMatchedModMemory(matchedMod);
     }
   }
 
+  private void reserveMatchedModMemory(ModEntry matchedMod) {
+    reserveMemoryImmediately(RamUsageEstimator.NUM_BYTES_OBJECT_REF + matchedMod.ramBytesUsed());
+  }
+
   private void reserveMemoryImmediately(long bytes) {
-    synchronized (memoryReservationManager) {
-      try {
-        memoryReservationManager.reserveMemoryCumulatively(bytes);
-        memoryReservationManager.reserveMemoryImmediately();
-      } catch (MemoryNotEnoughException e) {
-        // reserveMemoryCumulatively has already added bytes to the pending reservation. Clear it
-        // while holding the same lock so other loader threads cannot observe the stale pending
-        // size.
-        memoryReservationManager.releaseMemoryVirtually(bytes);
-        throw e;
+    if (bytes > 0) {
+      synchronized (memoryReservationManager) {
+        memoryReservationManager.reserveMemoryImmediately(bytes);
       }
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryModificationLoader.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryModificationLoader.java
@@ -76,36 +76,31 @@ class QueryModificationLoader implements AutoCloseable {
   }
 
   List<ModEntry> getPathModifications() throws IllegalPathException {
-    AtomicReference<LoadedModsResult> loadedResult = new AtomicReference<>();
+    AtomicReference<LoadModsResult> loadedResult = new AtomicReference<>();
     PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer> cachedMods =
         fileModCache.computeIfAbsent(
             resource.getTsFileID(), ignored -> loadAllModificationsForCache(loadedResult));
     if (cachedMods != null) {
-      // Either this loader cached the full tree successfully, or another loader had cached it.
       return modsTreeMatcher.match(cachedMods);
     }
 
-    LoadedModsResult result = loadedResult.get();
-    if (result.loadedAllModEntries) {
-      return fallbackByMatchLoadedPatternTree(result);
-    } else {
-      return fallbackByMatchedScan(result);
+    LoadModsResult result = loadedResult.get();
+    try {
+      if (result.loadedAllModEntries) {
+        return fallbackByMatchLoadedPatternTree(result);
+      } else {
+        return fallbackByMatchedScan(result);
+      }
+    } finally {
+      close();
     }
   }
 
   private PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer>
-      loadAllModificationsForCache(AtomicReference<LoadedModsResult> loadedResult) {
-    LoadedModsResult result = loadAllModificationsWithQuotaControl();
+      loadAllModificationsForCache(AtomicReference<LoadModsResult> loadedResult) {
+    LoadModsResult result = loadAllModificationsWithQuotaControl();
     loadedResult.set(result);
-    if (!result.loadedAllModEntries) {
-      return null;
-    }
-
-    try {
-      // The cache quota has already been claimed while loading. Reserve real query memory only
-      // once, just before the fully loaded tree becomes visible in fileModCache.
-      reserveMemoryImmediately(result.cacheQuotaBytes);
-    } catch (MemoryNotEnoughException e) {
+    if (!result.cacheable) {
       return null;
     }
 
@@ -113,57 +108,80 @@ class QueryModificationLoader implements AutoCloseable {
     return result.mods;
   }
 
-  private LoadedModsResult loadAllModificationsWithQuotaControl() {
+  private LoadModsResult loadAllModificationsWithQuotaControl() {
     PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer> modifications =
         PatternTreeMapFactory.getModsPatternTreeMap();
+    LoadModsResult result = new LoadModsResult(modifications);
+    if (resource.getTotalModSizeInByte() > getRemainingCacheQuota()) {
+      currentIterator = resource.getModEntryIterator();
+      result.loadedAllModEntries = false;
+      result.cacheable = false;
+      return result;
+    }
+
     currentIterator = resource.getModEntryIterator();
 
-    long claimedCacheQuotaBytes = 0;
-    int readModCount = 0;
+    int appendedModCount = 0;
     boolean estimatedAfterLastAppend = false;
 
     while (currentIterator.hasNext()) {
       ModEntry modification = currentIterator.next();
-      readModCount++;
-      if (!queryContext.shouldSkipModification(modification)) {
-        modifications.append(modification.keyOfPatternTree(), modification);
-        estimatedAfterLastAppend = false;
+      if (queryContext.shouldSkipModification(modification)) {
+        continue;
       }
 
-      if (readModCount % modsMemoryEstimateReadInterval == 0) {
-        long currentEstimatedSize = estimateModsTreeMemory(modifications);
-        checkEstimatedSizeNotDecreased(claimedCacheQuotaBytes, currentEstimatedSize);
-        long delta = currentEstimatedSize - claimedCacheQuotaBytes;
-        if (!tryClaimCacheQuota(delta)) {
-          return new LoadedModsResult(modifications, claimedCacheQuotaBytes, false);
+      modifications.append(modification.keyOfPatternTree(), modification);
+      appendedModCount++;
+      estimatedAfterLastAppend = false;
+
+      if (appendedModCount % modsMemoryEstimateReadInterval == 0) {
+        if (!tryEstimateAndReserveTreeMemory(result)) {
+          result.loadedAllModEntries = false;
+          result.cacheable = false;
+          return result;
         }
-        claimedCacheQuotaBytes = currentEstimatedSize;
         estimatedAfterLastAppend = true;
       }
     }
 
     if (!estimatedAfterLastAppend) {
-      long finalEstimatedSize = estimateModsTreeMemory(modifications);
-      checkEstimatedSizeNotDecreased(claimedCacheQuotaBytes, finalEstimatedSize);
-      long delta = finalEstimatedSize - claimedCacheQuotaBytes;
-      if (!tryClaimCacheQuota(delta)) {
-        return new LoadedModsResult(modifications, claimedCacheQuotaBytes, false);
-      }
-      claimedCacheQuotaBytes = finalEstimatedSize;
+      result.cacheable = tryEstimateAndReserveTreeMemory(result);
+    } else {
+      result.cacheable = true;
     }
-    return new LoadedModsResult(modifications, claimedCacheQuotaBytes, true);
+
+    result.loadedAllModEntries = true;
+    return result;
   }
 
-  private void checkEstimatedSizeNotDecreased(
-      long previousEstimatedSize, long currentEstimatedSize) {
-    if (currentEstimatedSize < previousEstimatedSize) {
+  private boolean tryEstimateAndReserveTreeMemory(LoadModsResult result) {
+    long currentEstimatedSize = estimateModsTreeMemory(result.mods);
+    long delta = currentEstimatedSize - result.reservedTreeMemoryBytes;
+    if (delta < 0) {
       throw new IllegalStateException(
           String.format(
               DataNodeQueryMessages.ESTIMATED_MODS_TREE_SIZE_DECREASED,
-              previousEstimatedSize,
+              result.reservedTreeMemoryBytes,
               currentEstimatedSize,
               resource));
     }
+    if (delta == 0) {
+      return true;
+    }
+
+    if (!tryClaimCacheQuota(delta)) {
+      return false;
+    }
+    result.cacheQuotaBytes += delta;
+
+    try {
+      memoryReservationManager.reserveMemoryImmediately(delta);
+    } catch (MemoryNotEnoughException e) {
+      return false;
+    }
+
+    result.reservedTreeMemoryBytes = currentEstimatedSize;
+    return true;
   }
 
   private boolean tryClaimCacheQuota(long delta) {
@@ -171,10 +189,8 @@ class QueryModificationLoader implements AutoCloseable {
       return true;
     }
 
-    // During loading, this only claims FI-level cache quota. Real memory is reserved once after the
-    // full tree is loaded and before computeIfAbsent publishes it to fileModCache.
     long alreadyUsedMemoryForCachedModEntries = cachedModEntriesSize.get();
-    while (alreadyUsedMemoryForCachedModEntries + delta < modsCacheSizeLimitPerFI) {
+    while (alreadyUsedMemoryForCachedModEntries + delta <= modsCacheSizeLimitPerFI) {
       if (cachedModEntriesSize.compareAndSet(
           alreadyUsedMemoryForCachedModEntries, alreadyUsedMemoryForCachedModEntries + delta)) {
         return true;
@@ -184,73 +200,78 @@ class QueryModificationLoader implements AutoCloseable {
     return false;
   }
 
-  private List<ModEntry> fallbackByMatchedScan(LoadedModsResult partialTree)
+  private long getRemainingCacheQuota() {
+    return modsCacheSizeLimitPerFI - cachedModEntriesSize.get();
+  }
+
+  private List<ModEntry> fallbackByMatchedScan(LoadModsResult partialTree)
+      throws IllegalPathException {
+    List<ModEntry> matchedMods = matchLoadedTreeAndRelease(partialTree);
+    long reservedMatchedModsMemoryBytes = reserveMatchedModsMemory(matchedMods);
+    int matchedModCount = matchedMods.size();
+
+    while (currentIterator.hasNext()) {
+      ModEntry modification = currentIterator.next();
+      if (queryContext.shouldSkipModification(modification)) {
+        continue;
+      }
+      if (modificationMatcher.test(modification)) {
+        matchedMods.add(modification);
+        matchedModCount++;
+        if (matchedModCount % modsMemoryEstimateReadInterval == 0) {
+          reservedMatchedModsMemoryBytes =
+              reserveMatchedModsMemoryIncrementally(matchedMods, reservedMatchedModsMemoryBytes);
+        }
+      }
+    }
+
+    List<ModEntry> sortedAndMergedMods = ModificationUtils.sortAndMerge(matchedMods);
+    adjustMatchedModsMemoryReservation(sortedAndMergedMods, reservedMatchedModsMemoryBytes);
+    return sortedAndMergedMods;
+  }
+
+  private List<ModEntry> fallbackByMatchLoadedPatternTree(LoadModsResult loadedTree)
+      throws IllegalPathException {
+    List<ModEntry> matchedMods = matchLoadedTreeAndRelease(loadedTree);
+    reserveMatchedModsMemory(matchedMods);
+    return matchedMods;
+  }
+
+  private List<ModEntry> matchLoadedTreeAndRelease(LoadModsResult loadedTree)
       throws IllegalPathException {
     try {
-      // The full tree exceeded the FI mods cache quota. Reuse the partial tree for the part that
-      // has already been read, then continue scanning the same iterator by path.
-      List<ModEntry> matchedMods;
-      try {
-        matchedMods = new ArrayList<>(modsTreeMatcher.match(partialTree.mods));
-      } finally {
-        partialTree.mods = null;
-        releaseClaimedCacheQuota(partialTree);
-      }
-      reserveMatchedModsMemory(matchedMods);
-
-      while (currentIterator.hasNext()) {
-        ModEntry modification = currentIterator.next();
-        if (queryContext.shouldSkipModification(modification)) {
-          continue;
-        }
-        if (modificationMatcher.test(modification)) {
-          reserveMatchedModMemory(modification);
-          matchedMods.add(modification);
-        }
-      }
-
-      matchedMods = ModificationUtils.sortAndMerge(matchedMods);
-      return matchedMods;
+      return new ArrayList<>(modsTreeMatcher.match(loadedTree.mods));
     } finally {
-      close();
+      loadedTree.mods = null;
+      cachedModEntriesSize.addAndGet(-loadedTree.cacheQuotaBytes);
+      loadedTree.cacheQuotaBytes = 0;
+      memoryReservationManager.releaseMemoryCumulatively(loadedTree.reservedTreeMemoryBytes);
+      loadedTree.reservedTreeMemoryBytes = 0;
     }
   }
 
-  private List<ModEntry> fallbackByMatchLoadedPatternTree(LoadedModsResult loadedTree)
-      throws IllegalPathException {
-    try {
-      // The tree was fully loaded but not cached, usually because final memory reservation failed.
-      // Return only the matched mods and release the cache quota claimed during loading.
-      List<ModEntry> matchedMods;
-      try {
-        matchedMods = new ArrayList<>(modsTreeMatcher.match(loadedTree.mods));
-      } finally {
-        loadedTree.mods = null;
-        releaseClaimedCacheQuota(loadedTree);
-      }
-      reserveMatchedModsMemory(matchedMods);
-      return matchedMods;
-    } finally {
-      close();
-    }
+  private long reserveMatchedModsMemory(List<ModEntry> matchedMods) {
+    long estimatedSize = RamUsageEstimator.sizeOfArrayList(matchedMods);
+    memoryReservationManager.reserveMemoryCumulatively(estimatedSize);
+    return estimatedSize;
   }
 
-  private void reserveMatchedModsMemory(List<ModEntry> matchedMods) {
-    reserveMemoryImmediately(RamUsageEstimator.shallowSizeOf(matchedMods));
-    for (ModEntry matchedMod : matchedMods) {
-      reserveMatchedModMemory(matchedMod);
-    }
+  private long reserveMatchedModsMemoryIncrementally(
+      List<ModEntry> matchedMods, long reservedMatchedModsMemoryBytes) {
+    long currentEstimatedSize = RamUsageEstimator.sizeOfArrayList(matchedMods);
+    long delta = currentEstimatedSize - reservedMatchedModsMemoryBytes;
+    memoryReservationManager.reserveMemoryCumulatively(delta);
+    return currentEstimatedSize;
   }
 
-  private void reserveMatchedModMemory(ModEntry matchedMod) {
-    reserveMemoryImmediately(RamUsageEstimator.NUM_BYTES_OBJECT_REF + matchedMod.ramBytesUsed());
-  }
-
-  private void reserveMemoryImmediately(long bytes) {
-    if (bytes > 0) {
-      synchronized (memoryReservationManager) {
-        memoryReservationManager.reserveMemoryImmediately(bytes);
-      }
+  private void adjustMatchedModsMemoryReservation(
+      List<ModEntry> matchedMods, long reservedMatchedModsMemoryBytes) {
+    long currentEstimatedSize = RamUsageEstimator.sizeOfArrayList(matchedMods);
+    long delta = currentEstimatedSize - reservedMatchedModsMemoryBytes;
+    if (delta >= 0) {
+      memoryReservationManager.reserveMemoryCumulatively(delta);
+    } else {
+      memoryReservationManager.releaseMemoryCumulatively(-delta);
     }
   }
 
@@ -271,26 +292,16 @@ class QueryModificationLoader implements AutoCloseable {
     }
   }
 
-  private void releaseClaimedCacheQuota(LoadedModsResult loadedResult) {
-    if (loadedResult.cacheQuotaBytes > 0) {
-      cachedModEntriesSize.addAndGet(-loadedResult.cacheQuotaBytes);
-      loadedResult.cacheQuotaBytes = 0;
-    }
-  }
-
-  private static class LoadedModsResult {
+  private static class LoadModsResult {
 
     private PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer> mods;
     private long cacheQuotaBytes;
-    private final boolean loadedAllModEntries;
+    private long reservedTreeMemoryBytes;
+    private boolean loadedAllModEntries;
+    private boolean cacheable;
 
-    private LoadedModsResult(
-        PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer> mods,
-        long cacheQuotaBytes,
-        boolean loadedAllModEntries) {
+    private LoadModsResult(PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer> mods) {
       this.mods = mods;
-      this.cacheQuotaBytes = cacheQuotaBytes;
-      this.loadedAllModEntries = loadedAllModEntries;
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryModificationLoader.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryModificationLoader.java
@@ -1,0 +1,299 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.execution.fragment;
+
+import org.apache.iotdb.calc.exception.MemoryNotEnoughException;
+import org.apache.iotdb.calc.plan.planner.memory.MemoryReservationManager;
+import org.apache.iotdb.commons.exception.IllegalPathException;
+import org.apache.iotdb.commons.path.PatternTreeMap;
+import org.apache.iotdb.db.storageengine.dataregion.modification.ModEntry;
+import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileID;
+import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
+import org.apache.iotdb.db.utils.ModificationUtils;
+import org.apache.iotdb.db.utils.datastructure.PatternTreeMapFactory;
+
+import org.apache.tsfile.utils.RamUsageEstimator;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+
+class QueryModificationLoader implements AutoCloseable {
+
+  private final QueryContext queryContext;
+  private final TsFileResource resource;
+  private final MemoryReservationManager memoryReservationManager;
+  private final long modsCacheSizeLimitPerFI;
+  private final int modsMemoryEstimateReadInterval;
+  private final Map<TsFileID, PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer>>
+      fileModCache;
+  private final AtomicLong cachedModEntriesSize;
+  private final Predicate<ModEntry> modificationMatcher;
+  private final ModsTreeMatcher modsTreeMatcher;
+
+  private TsFileResource.ModIterator currentIterator;
+
+  QueryModificationLoader(
+      QueryContext queryContext,
+      TsFileResource resource,
+      MemoryReservationManager memoryReservationManager,
+      long modsCacheSizeLimitPerFI,
+      int modsMemoryEstimateReadInterval,
+      Map<TsFileID, PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer>> fileModCache,
+      AtomicLong cachedModEntriesSize,
+      Predicate<ModEntry> modificationMatcher,
+      ModsTreeMatcher modsTreeMatcher) {
+    this.queryContext = queryContext;
+    this.resource = resource;
+    this.memoryReservationManager = memoryReservationManager;
+    this.modsCacheSizeLimitPerFI = modsCacheSizeLimitPerFI;
+    this.modsMemoryEstimateReadInterval = modsMemoryEstimateReadInterval;
+    this.fileModCache = fileModCache;
+    this.cachedModEntriesSize = cachedModEntriesSize;
+    this.modificationMatcher = modificationMatcher;
+    this.modsTreeMatcher = modsTreeMatcher;
+  }
+
+  List<ModEntry> getPathModifications() throws IllegalPathException {
+    AtomicReference<LoadedModsResult> loadedResult = new AtomicReference<>();
+    PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer> cachedMods =
+        fileModCache.computeIfAbsent(
+            resource.getTsFileID(), ignored -> loadAllModificationsForCache(loadedResult));
+    if (cachedMods != null) {
+      // Either this loader cached the full tree successfully, or another loader had cached it.
+      return modsTreeMatcher.match(cachedMods);
+    }
+
+    LoadedModsResult result = loadedResult.get();
+    if (result.loadedAllModEntries) {
+      return fallbackByMatchLoadedPatternTree(result);
+    } else {
+      return fallbackByMatchedScan(result);
+    }
+  }
+
+  private PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer>
+      loadAllModificationsForCache(AtomicReference<LoadedModsResult> loadedResult) {
+    LoadedModsResult result = loadAllModificationsWithQuotaControl();
+    loadedResult.set(result);
+    if (!result.loadedAllModEntries) {
+      return null;
+    }
+
+    try {
+      // The cache quota has already been claimed while loading. Reserve real query memory only
+      // once, just before the fully loaded tree becomes visible in fileModCache.
+      reserveMemoryImmediately(result.cacheQuotaBytes);
+    } catch (MemoryNotEnoughException e) {
+      return null;
+    }
+
+    closeCurrentIterator();
+    return result.mods;
+  }
+
+  private LoadedModsResult loadAllModificationsWithQuotaControl() {
+    PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer> modifications =
+        PatternTreeMapFactory.getModsPatternTreeMap();
+    currentIterator = resource.getModEntryIterator();
+
+    long claimedCacheQuotaBytes = 0;
+    int readModCount = 0;
+
+    while (currentIterator.hasNext()) {
+      ModEntry modification = currentIterator.next();
+      readModCount++;
+      if (!queryContext.shouldSkipModification(modification)) {
+        modifications.append(modification.keyOfPatternTree(), modification);
+      }
+
+      if (readModCount % modsMemoryEstimateReadInterval == 0) {
+        long currentEstimatedSize = estimateModsTreeMemory(modifications);
+        if (currentEstimatedSize < claimedCacheQuotaBytes) {
+          throw new IllegalStateException(
+              String.format(
+                  "Estimated mods tree size decreased from %d to %d for TsFile %s.",
+                  claimedCacheQuotaBytes, currentEstimatedSize, resource));
+        }
+        long delta = currentEstimatedSize - claimedCacheQuotaBytes;
+        if (!tryClaimCacheQuota(delta)) {
+          return new LoadedModsResult(modifications, claimedCacheQuotaBytes, false);
+        }
+        claimedCacheQuotaBytes = currentEstimatedSize;
+      }
+    }
+
+    long finalEstimatedSize = estimateModsTreeMemory(modifications);
+    if (finalEstimatedSize < claimedCacheQuotaBytes) {
+      throw new IllegalStateException(
+          String.format(
+              "Estimated mods tree size decreased from %d to %d for TsFile %s.",
+              claimedCacheQuotaBytes, finalEstimatedSize, resource));
+    }
+    long delta = finalEstimatedSize - claimedCacheQuotaBytes;
+    if (!tryClaimCacheQuota(delta)) {
+      return new LoadedModsResult(modifications, claimedCacheQuotaBytes, false);
+    }
+    claimedCacheQuotaBytes = finalEstimatedSize;
+    return new LoadedModsResult(modifications, claimedCacheQuotaBytes, true);
+  }
+
+  private boolean tryClaimCacheQuota(long delta) {
+    if (delta <= 0) {
+      return true;
+    }
+
+    // During loading, this only claims FI-level cache quota. Real memory is reserved once after the
+    // full tree is loaded and before computeIfAbsent publishes it to fileModCache.
+    long alreadyUsedMemoryForCachedModEntries = cachedModEntriesSize.get();
+    while (alreadyUsedMemoryForCachedModEntries + delta < modsCacheSizeLimitPerFI) {
+      if (cachedModEntriesSize.compareAndSet(
+          alreadyUsedMemoryForCachedModEntries, alreadyUsedMemoryForCachedModEntries + delta)) {
+        return true;
+      }
+      alreadyUsedMemoryForCachedModEntries = cachedModEntriesSize.get();
+    }
+    return false;
+  }
+
+  private List<ModEntry> fallbackByMatchedScan(LoadedModsResult partialTree)
+      throws IllegalPathException {
+    try {
+      // The full tree exceeded the FI mods cache quota. Reuse the partial tree for the part that
+      // has already been read, then continue scanning the same iterator by path.
+      List<ModEntry> matchedMods;
+      try {
+        matchedMods = modsTreeMatcher.match(partialTree.mods);
+      } finally {
+        partialTree.mods = null;
+        releaseClaimedCacheQuota(partialTree);
+      }
+
+      while (currentIterator.hasNext()) {
+        ModEntry modification = currentIterator.next();
+        if (queryContext.shouldSkipModification(modification)) {
+          continue;
+        }
+        if (modificationMatcher.test(modification)) {
+          matchedMods.add(modification);
+        }
+      }
+
+      matchedMods = ModificationUtils.sortAndMerge(matchedMods);
+      reserveMatchedModsMemory(matchedMods);
+      return matchedMods;
+    } finally {
+      close();
+    }
+  }
+
+  private List<ModEntry> fallbackByMatchLoadedPatternTree(LoadedModsResult loadedTree)
+      throws IllegalPathException {
+    try {
+      // The tree was fully loaded but not cached, usually because final memory reservation failed.
+      // Return only the matched mods and release the cache quota claimed during loading.
+      List<ModEntry> matchedMods;
+      try {
+        matchedMods = modsTreeMatcher.match(loadedTree.mods);
+      } finally {
+        loadedTree.mods = null;
+        releaseClaimedCacheQuota(loadedTree);
+      }
+      reserveMatchedModsMemory(matchedMods);
+      return matchedMods;
+    } finally {
+      close();
+    }
+  }
+
+  private void reserveMatchedModsMemory(List<ModEntry> matchedMods) {
+    long memCost =
+        RamUsageEstimator.shallowSizeOf(matchedMods)
+            + (long) matchedMods.size() * RamUsageEstimator.NUM_BYTES_OBJECT_REF
+            + matchedMods.stream().mapToLong(ModEntry::ramBytesUsed).sum();
+    if (memCost > 0) {
+      reserveMemoryImmediately(memCost);
+    }
+  }
+
+  private void reserveMemoryImmediately(long bytes) {
+    synchronized (memoryReservationManager) {
+      try {
+        memoryReservationManager.reserveMemoryCumulatively(bytes);
+        memoryReservationManager.reserveMemoryImmediately();
+      } catch (MemoryNotEnoughException e) {
+        // reserveMemoryCumulatively has already added bytes to the pending reservation. Clear it
+        // while holding the same lock so other loader threads cannot observe the stale pending
+        // size.
+        memoryReservationManager.releaseMemoryVirtually(bytes);
+        throw e;
+      }
+    }
+  }
+
+  private long estimateModsTreeMemory(
+      PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer> modifications) {
+    return RamUsageEstimator.sizeOfObject(modifications);
+  }
+
+  @Override
+  public void close() {
+    closeCurrentIterator();
+  }
+
+  private void closeCurrentIterator() {
+    if (currentIterator != null) {
+      currentIterator.close();
+      currentIterator = null;
+    }
+  }
+
+  private void releaseClaimedCacheQuota(LoadedModsResult loadedResult) {
+    if (loadedResult.cacheQuotaBytes > 0) {
+      cachedModEntriesSize.addAndGet(-loadedResult.cacheQuotaBytes);
+      loadedResult.cacheQuotaBytes = 0;
+    }
+  }
+
+  private static class LoadedModsResult {
+
+    private PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer> mods;
+    private long cacheQuotaBytes;
+    private final boolean loadedAllModEntries;
+
+    private LoadedModsResult(
+        PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer> mods,
+        long cacheQuotaBytes,
+        boolean loadedAllModEntries) {
+      this.mods = mods;
+      this.cacheQuotaBytes = cacheQuotaBytes;
+      this.loadedAllModEntries = loadedAllModEntries;
+    }
+  }
+
+  @FunctionalInterface
+  interface ModsTreeMatcher {
+
+    List<ModEntry> match(PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer> modsTree)
+        throws IllegalPathException;
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/memory/FakedMemoryReservationManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/memory/FakedMemoryReservationManager.java
@@ -32,6 +32,9 @@ public class FakedMemoryReservationManager implements MemoryReservationManager {
   public void reserveMemoryImmediately() {}
 
   @Override
+  public void reserveMemoryImmediately(final long size) {}
+
+  @Override
   public void releaseMemoryCumulatively(long size) {}
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/memory/NotThreadSafeMemoryReservationManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/memory/NotThreadSafeMemoryReservationManager.java
@@ -69,6 +69,15 @@ public class NotThreadSafeMemoryReservationManager implements MemoryReservationM
   }
 
   @Override
+  public void reserveMemoryImmediately(final long size) {
+    if (size != 0) {
+      LOCAL_EXECUTION_PLANNER.reserveFromFreeMemoryForOperators(
+          size, reservedBytesInTotal, queryId.getId(), contextHolder);
+      reservedBytesInTotal += size;
+    }
+  }
+
+  @Override
   public void releaseMemoryCumulatively(final long size) {
     bytesToBeReleased += size;
     if (bytesToBeReleased >= MEMORY_BATCH_THRESHOLD) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/memory/ThreadSafeMemoryReservationManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/memory/ThreadSafeMemoryReservationManager.java
@@ -42,6 +42,11 @@ public class ThreadSafeMemoryReservationManager extends NotThreadSafeMemoryReser
   }
 
   @Override
+  public synchronized void reserveMemoryImmediately(final long size) {
+    super.reserveMemoryImmediately(size);
+  }
+
+  @Override
   public synchronized void releaseMemoryCumulatively(long size) {
     super.releaseMemoryCumulatively(size);
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
@@ -1494,7 +1494,7 @@ public class TsFileResource implements PersistentResource, Cloneable {
     return entries;
   }
 
-  public class ModIterator implements Iterator<ModEntry> {
+  public class ModIterator implements Iterator<ModEntry>, AutoCloseable {
 
     private final Iterator<ModEntry> sharedModIterator;
     private final Iterator<ModEntry> exclusiveModIterator;
@@ -1536,6 +1536,22 @@ public class TsFileResource implements PersistentResource, Cloneable {
         return sharedModIterator.next();
       }
       throw new NoSuchElementException();
+    }
+
+    @Override
+    public void close() {
+      closeModIterator(exclusiveModIterator);
+      closeModIterator(sharedModIterator);
+    }
+
+    private void closeModIterator(Iterator<ModEntry> modIterator) {
+      if (modIterator instanceof AutoCloseable) {
+        try {
+          ((AutoCloseable) modIterator).close();
+        } catch (Exception e) {
+          LOGGER.info(StorageEngineMessages.CANNOT_CLOSE_MOD_FILE_INPUT_STREAM, getTsFile(), e);
+        }
+      }
     }
   }
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryModificationLoaderTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryModificationLoaderTest.java
@@ -46,7 +46,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class QueryModificationLoaderTest {
@@ -90,12 +89,13 @@ public class QueryModificationLoaderTest {
       assertTrue(fileModCache.containsKey(resource.getTsFileID()));
       assertTrue(cachedModEntriesSize.get() > 0);
       assertTrue(memoryReservationManager.getReservedBytes() >= cachedModEntriesSize.get());
+      assertTrue(memoryReservationManager.getImmediateReservationCount() > 0);
     }
   }
 
   @Test
-  public void testFallbackScansRemainingModsWhenQuotaExceeded() throws Exception {
-    TsFileResource resource = prepareResource("fallback");
+  public void testFallbackScansModsWhenFileSizeExceedsRemainingQuotaBeforeLoad() throws Exception {
+    TsFileResource resource = prepareResource("file-size-precheck-fallback");
     writeMods(
         resource,
         new TreeDeletionEntry(new MeasurementPath("root.sg.d1.s1"), 0, 10),
@@ -117,6 +117,40 @@ public class QueryModificationLoaderTest {
       assertEquals(0, cachedModEntriesSize.get());
       assertTrue(memoryReservationManager.getReservedBytes() > 0);
       assertEquals(0, memoryReservationManager.getRemainingImmediateFailures());
+      assertEquals(0, memoryReservationManager.getImmediateReservationCount());
+    }
+  }
+
+  @Test
+  public void testFallbackScansRemainingModsWhenEstimatedTreeExceedsQuota() throws Exception {
+    TsFileResource resource = prepareResource("estimated-tree-quota-fallback");
+    writeMods(
+        resource,
+        new TreeDeletionEntry(new MeasurementPath("root.sg.d1.s1"), 0, 10),
+        new TreeDeletionEntry(new MeasurementPath("root.sg.d2.s1"), 20, 30),
+        new TreeDeletionEntry(new MeasurementPath("root.sg.d1.s1"), 40, 50));
+
+    Map<TsFileID, PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer>> fileModCache =
+        new ConcurrentHashMap<>();
+    AtomicLong cachedModEntriesSize = new AtomicLong();
+    CountingMemoryReservationManager memoryReservationManager =
+        new CountingMemoryReservationManager();
+
+    try (QueryModificationLoader loader =
+        newLoader(
+            resource,
+            resource.getTotalModSizeInByte() + 1,
+            fileModCache,
+            cachedModEntriesSize,
+            memoryReservationManager,
+            1)) {
+      List<ModEntry> result = loader.getPathModifications();
+
+      assertEquals(2, result.size());
+      assertFalse(fileModCache.containsKey(resource.getTsFileID()));
+      assertEquals(0, cachedModEntriesSize.get());
+      assertTrue(memoryReservationManager.getReservedBytes() > 0);
+      assertTrue(memoryReservationManager.getCumulativeReleaseCount() > 0);
     }
   }
 
@@ -142,7 +176,7 @@ public class QueryModificationLoaderTest {
             fileModCache,
             cachedModEntriesSize,
             memoryReservationManager,
-            1)) {
+            100)) {
       List<ModEntry> result = loader.getPathModifications();
 
       assertEquals(2, result.size());
@@ -150,12 +184,13 @@ public class QueryModificationLoaderTest {
       assertEquals(0, cachedModEntriesSize.get());
       assertTrue(memoryReservationManager.getReservedBytes() > 0);
       assertEquals(0, memoryReservationManager.getRemainingImmediateFailures());
+      assertEquals(1, memoryReservationManager.getImmediateReservationCount());
     }
   }
 
   @Test
-  public void testFallbackThrowsWhenMatchedModsReservationFailed() throws Exception {
-    TsFileResource resource = prepareResource("fallback-reserve-failed");
+  public void testFallbackReservesMatchedModsCumulativelyWhenQuotaExceeded() throws Exception {
+    TsFileResource resource = prepareResource("fallback-cumulative-reserve");
     writeMods(
         resource,
         new TreeDeletionEntry(new MeasurementPath("root.sg.d1.s1"), 0, 10),
@@ -170,12 +205,41 @@ public class QueryModificationLoaderTest {
 
     try (QueryModificationLoader loader =
         newLoader(resource, 1, fileModCache, cachedModEntriesSize, memoryReservationManager, 1)) {
-      assertThrows(MemoryNotEnoughException.class, loader::getPathModifications);
+      List<ModEntry> result = loader.getPathModifications();
 
+      assertEquals(2, result.size());
       assertFalse(fileModCache.containsKey(resource.getTsFileID()));
       assertEquals(0, cachedModEntriesSize.get());
-      assertEquals(0, memoryReservationManager.getReservedBytes());
-      assertEquals(0, memoryReservationManager.getRemainingImmediateFailures());
+      assertTrue(memoryReservationManager.getReservedBytes() > 0);
+      assertEquals(1, memoryReservationManager.getRemainingImmediateFailures());
+      assertEquals(0, memoryReservationManager.getImmediateReservationCount());
+    }
+  }
+
+  @Test
+  public void testFallbackAdjustsReservedMemoryAfterSortAndMerge() throws Exception {
+    TsFileResource resource = prepareResource("fallback-sort-merge-adjust");
+    writeMods(
+        resource,
+        new TreeDeletionEntry(new MeasurementPath("root.sg.d1.s1"), 0, 10),
+        new TreeDeletionEntry(new MeasurementPath("root.sg.d1.s1"), 5, 15),
+        new TreeDeletionEntry(new MeasurementPath("root.sg.d2.s1"), 20, 30));
+
+    Map<TsFileID, PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer>> fileModCache =
+        new ConcurrentHashMap<>();
+    AtomicLong cachedModEntriesSize = new AtomicLong();
+    CountingMemoryReservationManager memoryReservationManager =
+        new CountingMemoryReservationManager();
+
+    try (QueryModificationLoader loader =
+        newLoader(resource, 1, fileModCache, cachedModEntriesSize, memoryReservationManager, 1)) {
+      List<ModEntry> result = loader.getPathModifications();
+
+      assertEquals(1, result.size());
+      assertFalse(fileModCache.containsKey(resource.getTsFileID()));
+      assertEquals(0, cachedModEntriesSize.get());
+      assertTrue(memoryReservationManager.getReservedBytes() > 0);
+      assertTrue(memoryReservationManager.getCumulativeReleaseCount() > 0);
     }
   }
 
@@ -220,6 +284,8 @@ public class QueryModificationLoaderTest {
 
     private long reservedBytes;
     private int remainingImmediateFailures;
+    private int immediateReservationCount;
+    private int cumulativeReleaseCount;
 
     private CountingMemoryReservationManager() {}
 
@@ -234,6 +300,7 @@ public class QueryModificationLoaderTest {
 
     @Override
     public void reserveMemoryImmediately() {
+      immediateReservationCount++;
       if (remainingImmediateFailures > 0) {
         remainingImmediateFailures--;
         throw new MemoryNotEnoughException("Mock memory reservation failure.");
@@ -242,6 +309,7 @@ public class QueryModificationLoaderTest {
 
     @Override
     public void reserveMemoryImmediately(long size) {
+      immediateReservationCount++;
       if (remainingImmediateFailures > 0) {
         remainingImmediateFailures--;
         throw new MemoryNotEnoughException("Mock memory reservation failure.");
@@ -251,6 +319,7 @@ public class QueryModificationLoaderTest {
 
     @Override
     public void releaseMemoryCumulatively(long size) {
+      cumulativeReleaseCount++;
       reservedBytes -= size;
     }
 
@@ -276,6 +345,14 @@ public class QueryModificationLoaderTest {
 
     private int getRemainingImmediateFailures() {
       return remainingImmediateFailures;
+    }
+
+    private int getImmediateReservationCount() {
+      return immediateReservationCount;
+    }
+
+    private int getCumulativeReleaseCount() {
+      return cumulativeReleaseCount;
     }
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryModificationLoaderTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/fragment/QueryModificationLoaderTest.java
@@ -1,0 +1,281 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.execution.fragment;
+
+import org.apache.iotdb.calc.exception.MemoryNotEnoughException;
+import org.apache.iotdb.calc.plan.planner.memory.MemoryReservationManager;
+import org.apache.iotdb.commons.path.MeasurementPath;
+import org.apache.iotdb.commons.path.PatternTreeMap;
+import org.apache.iotdb.db.storageengine.dataregion.modification.ModEntry;
+import org.apache.iotdb.db.storageengine.dataregion.modification.ModificationFile;
+import org.apache.iotdb.db.storageengine.dataregion.modification.TreeDeletionEntry;
+import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileID;
+import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
+import org.apache.iotdb.db.storageengine.dataregion.tsfile.generator.TsFileNameGenerator;
+import org.apache.iotdb.db.utils.constant.TestConstant;
+import org.apache.iotdb.db.utils.datastructure.PatternTreeMapFactory;
+
+import org.apache.tsfile.external.commons.io.FileUtils;
+import org.apache.tsfile.file.metadata.IDeviceID;
+import org.apache.tsfile.utils.Pair;
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class QueryModificationLoaderTest {
+
+  private static final IDeviceID DEVICE_ID = IDeviceID.Factory.DEFAULT_FACTORY.create("root.sg.d1");
+
+  private File testDir;
+
+  @After
+  public void tearDown() throws Exception {
+    if (testDir != null && testDir.exists()) {
+      FileUtils.deleteDirectory(testDir);
+    }
+  }
+
+  @Test
+  public void testCacheLoadedModsTreeWhenQuotaEnough() throws Exception {
+    TsFileResource resource = prepareResource("cache");
+    writeMods(
+        resource,
+        new TreeDeletionEntry(new MeasurementPath("root.sg.d1.s1"), 0, 10),
+        new TreeDeletionEntry(new MeasurementPath("root.sg.d2.s1"), 20, 30));
+
+    Map<TsFileID, PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer>> fileModCache =
+        new ConcurrentHashMap<>();
+    AtomicLong cachedModEntriesSize = new AtomicLong();
+    CountingMemoryReservationManager memoryReservationManager =
+        new CountingMemoryReservationManager();
+
+    try (QueryModificationLoader loader =
+        newLoader(
+            resource,
+            Long.MAX_VALUE,
+            fileModCache,
+            cachedModEntriesSize,
+            memoryReservationManager,
+            1)) {
+      List<ModEntry> result = loader.getPathModifications();
+
+      assertEquals(1, result.size());
+      assertTrue(fileModCache.containsKey(resource.getTsFileID()));
+      assertTrue(cachedModEntriesSize.get() > 0);
+      assertTrue(memoryReservationManager.getReservedBytes() >= cachedModEntriesSize.get());
+    }
+  }
+
+  @Test
+  public void testFallbackScansRemainingModsWhenQuotaExceeded() throws Exception {
+    TsFileResource resource = prepareResource("fallback");
+    writeMods(
+        resource,
+        new TreeDeletionEntry(new MeasurementPath("root.sg.d1.s1"), 0, 10),
+        new TreeDeletionEntry(new MeasurementPath("root.sg.d2.s1"), 20, 30),
+        new TreeDeletionEntry(new MeasurementPath("root.sg.d1.s1"), 40, 50));
+
+    Map<TsFileID, PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer>> fileModCache =
+        new ConcurrentHashMap<>();
+    AtomicLong cachedModEntriesSize = new AtomicLong();
+    CountingMemoryReservationManager memoryReservationManager =
+        new CountingMemoryReservationManager();
+
+    try (QueryModificationLoader loader =
+        newLoader(resource, 1, fileModCache, cachedModEntriesSize, memoryReservationManager, 1)) {
+      List<ModEntry> result = loader.getPathModifications();
+
+      assertEquals(2, result.size());
+      assertFalse(fileModCache.containsKey(resource.getTsFileID()));
+      assertEquals(0, cachedModEntriesSize.get());
+      assertTrue(memoryReservationManager.getReservedBytes() > 0);
+      assertEquals(0, memoryReservationManager.getRemainingImmediateFailures());
+    }
+  }
+
+  @Test
+  public void testFallbackMatchesLoadedTreeWhenFinalReservationFailed() throws Exception {
+    TsFileResource resource = prepareResource("final-reserve-failed");
+    writeMods(
+        resource,
+        new TreeDeletionEntry(new MeasurementPath("root.sg.d1.s1"), 0, 10),
+        new TreeDeletionEntry(new MeasurementPath("root.sg.d2.s1"), 20, 30),
+        new TreeDeletionEntry(new MeasurementPath("root.sg.d1.s1"), 40, 50));
+
+    Map<TsFileID, PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer>> fileModCache =
+        new ConcurrentHashMap<>();
+    AtomicLong cachedModEntriesSize = new AtomicLong();
+    CountingMemoryReservationManager memoryReservationManager =
+        new CountingMemoryReservationManager(1);
+
+    try (QueryModificationLoader loader =
+        newLoader(
+            resource,
+            Long.MAX_VALUE,
+            fileModCache,
+            cachedModEntriesSize,
+            memoryReservationManager,
+            1)) {
+      List<ModEntry> result = loader.getPathModifications();
+
+      assertEquals(2, result.size());
+      assertFalse(fileModCache.containsKey(resource.getTsFileID()));
+      assertEquals(0, cachedModEntriesSize.get());
+      assertTrue(memoryReservationManager.getReservedBytes() > 0);
+      assertEquals(0, memoryReservationManager.getRemainingImmediateFailures());
+    }
+  }
+
+  @Test
+  public void testFallbackThrowsWhenMatchedModsReservationFailed() throws Exception {
+    TsFileResource resource = prepareResource("fallback-reserve-failed");
+    writeMods(
+        resource,
+        new TreeDeletionEntry(new MeasurementPath("root.sg.d1.s1"), 0, 10),
+        new TreeDeletionEntry(new MeasurementPath("root.sg.d2.s1"), 20, 30),
+        new TreeDeletionEntry(new MeasurementPath("root.sg.d1.s1"), 40, 50));
+
+    Map<TsFileID, PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer>> fileModCache =
+        new ConcurrentHashMap<>();
+    AtomicLong cachedModEntriesSize = new AtomicLong();
+    CountingMemoryReservationManager memoryReservationManager =
+        new CountingMemoryReservationManager(1);
+
+    try (QueryModificationLoader loader =
+        newLoader(resource, 1, fileModCache, cachedModEntriesSize, memoryReservationManager, 1)) {
+      assertThrows(MemoryNotEnoughException.class, loader::getPathModifications);
+
+      assertFalse(fileModCache.containsKey(resource.getTsFileID()));
+      assertEquals(0, cachedModEntriesSize.get());
+      assertEquals(0, memoryReservationManager.getReservedBytes());
+      assertEquals(0, memoryReservationManager.getRemainingImmediateFailures());
+    }
+  }
+
+  private QueryModificationLoader newLoader(
+      TsFileResource resource,
+      long modsCacheSizeLimitPerFI,
+      Map<TsFileID, PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer>> fileModCache,
+      AtomicLong cachedModEntriesSize,
+      MemoryReservationManager memoryReservationManager,
+      int modsMemoryEstimateReadInterval) {
+    QueryContext queryContext = new QueryContext(false, false);
+    return new QueryModificationLoader(
+        queryContext,
+        resource,
+        memoryReservationManager,
+        modsCacheSizeLimitPerFI,
+        modsMemoryEstimateReadInterval,
+        fileModCache,
+        cachedModEntriesSize,
+        modification -> modification.affects(DEVICE_ID) && modification.affects("s1"),
+        modsTree -> queryContext.getPathModifications(modsTree, DEVICE_ID, "s1"));
+  }
+
+  private TsFileResource prepareResource(String name) {
+    testDir = new File(TestConstant.BASE_OUTPUT_PATH, "QueryModificationLoaderTest-" + name);
+    testDir.mkdirs();
+    File tsFile =
+        new File(TsFileNameGenerator.generateNewTsFilePath(testDir.getAbsolutePath(), 1, 1, 0, 0));
+    return new TsFileResource(tsFile);
+  }
+
+  private void writeMods(TsFileResource resource, TreeDeletionEntry... modifications)
+      throws Exception {
+    try (ModificationFile modificationFile = resource.getModFileForWrite()) {
+      for (TreeDeletionEntry modification : modifications) {
+        modificationFile.write(modification);
+      }
+    }
+  }
+
+  private static class CountingMemoryReservationManager implements MemoryReservationManager {
+
+    private long reservedBytes;
+    private int remainingImmediateFailures;
+
+    private CountingMemoryReservationManager() {}
+
+    private CountingMemoryReservationManager(int remainingImmediateFailures) {
+      this.remainingImmediateFailures = remainingImmediateFailures;
+    }
+
+    @Override
+    public void reserveMemoryCumulatively(long size) {
+      reservedBytes += size;
+    }
+
+    @Override
+    public void reserveMemoryImmediately() {
+      if (remainingImmediateFailures > 0) {
+        remainingImmediateFailures--;
+        throw new MemoryNotEnoughException("Mock memory reservation failure.");
+      }
+    }
+
+    @Override
+    public void reserveMemoryImmediately(long size) {
+      if (remainingImmediateFailures > 0) {
+        remainingImmediateFailures--;
+        throw new MemoryNotEnoughException("Mock memory reservation failure.");
+      }
+      reservedBytes += size;
+    }
+
+    @Override
+    public void releaseMemoryCumulatively(long size) {
+      reservedBytes -= size;
+    }
+
+    @Override
+    public void releaseAllReservedMemory() {
+      reservedBytes = 0;
+    }
+
+    @Override
+    public Pair<Long, Long> releaseMemoryVirtually(long size) {
+      reservedBytes -= size;
+      return new Pair<>(size, 0L);
+    }
+
+    @Override
+    public void reserveMemoryVirtually(long bytesToBeReserved, long bytesAlreadyReserved) {
+      reservedBytes += bytesToBeReserved + bytesAlreadyReserved;
+    }
+
+    private long getReservedBytes() {
+      return reservedBytes;
+    }
+
+    private int getRemainingImmediateFailures() {
+      return remainingImmediateFailures;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add quota pre-checking before loading modification files into the query mods cache.
- Reserve memory incrementally while building modification pattern trees.
- Fall back to path-matched scanning when cache quota or memory reservation is insufficient.
- Release partial tree quota and memory before returning fallback matched modifications.
- Extend unit coverage for cache loading, fallback scanning, final reservation failure, and sort/merge reservation adjustment.