### PR TITLE
Fix account unlock propagation for pipe password checks

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/treemodel/manual/IoTDBPipePermissionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/treemodel/manual/IoTDBPipePermissionIT.java
@@ -595,6 +595,7 @@ public class IoTDBPipePermissionIT extends AbstractPipeDualTreeModelManualIT {
 
     try {
       statement.execute("alter pipe a2b modify source ('password'='fake')");
+      fail();
     } catch (final SQLException e) {
       Assert.assertEquals("801: Failed to check password for pipe a2b.", e.getMessage());
     }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlan.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlan.java
@@ -311,6 +311,7 @@ public abstract class ConfigPhysicalPlan implements IConsensusRequest {
         case UpdateUserV2:
         case CreateUserWithRawPassword:
         case RenameUser:
+        case AccountUnlock:
           plan = new AuthorTreePlan(configPhysicalPlanType);
           break;
         case RCreateUser:
@@ -343,6 +344,7 @@ public abstract class ConfigPhysicalPlan implements IConsensusRequest {
         case RRevokeUserSysPri:
         case RRevokeRoleSysPri:
         case RRenameUser:
+        case RAccountUnlock:
           plan = new AuthorRelationalPlan(configPhysicalPlanType);
           break;
         case ApplyConfigNode:

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlanType.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlanType.java
@@ -333,6 +333,7 @@ public enum ConfigPhysicalPlanType {
   RDropUserV2((short) 2103),
   RenameUser((short) 2104),
   RRenameUser((short) 2105),
+  AccountUnlock((short) 2106),
 
   EnableSeparationOfAdminPowers((short) 2200),
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlanVisitor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlanVisitor.java
@@ -104,6 +104,8 @@ public abstract class ConfigPhysicalPlanVisitor<R, C> {
         return visitGrantRoleToUser((AuthorTreePlan) plan, context);
       case RevokeRoleFromUser:
         return visitRevokeRoleFromUser((AuthorTreePlan) plan, context);
+      case AccountUnlock:
+        return visitAccountUnlock((AuthorTreePlan) plan, context);
       case RCreateUser:
         return visitRCreateUser((AuthorRelationalPlan) plan, context);
       case RCreateRole:
@@ -160,6 +162,8 @@ public abstract class ConfigPhysicalPlanVisitor<R, C> {
         return visitRRevokeUserSysPrivilege((AuthorRelationalPlan) plan, context);
       case RRevokeRoleSysPri:
         return visitRRevokeRoleSysPrivilege((AuthorRelationalPlan) plan, context);
+      case RAccountUnlock:
+        return visitRAccountUnlock((AuthorRelationalPlan) plan, context);
       case SetTTL:
         return visitTTL((SetTTLPlan) plan, context);
       case PipeCreateTableOrView:
@@ -310,6 +314,10 @@ public abstract class ConfigPhysicalPlanVisitor<R, C> {
     return visitPlan(revokeRoleFromUserPlan, context);
   }
 
+  public R visitAccountUnlock(final AuthorTreePlan accountUnlockPlan, final C context) {
+    return visitPlan(accountUnlockPlan, context);
+  }
+
   public R visitRCreateUser(final AuthorRelationalPlan rCreateUserPlan, final C context) {
     return visitPlan(rCreateUserPlan, context);
   }
@@ -424,6 +432,10 @@ public abstract class ConfigPhysicalPlanVisitor<R, C> {
   public R visitRRevokeRoleSysPrivilege(
       final AuthorRelationalPlan rRevokeRoleSysPrivilegePlan, final C context) {
     return visitPlan(rRevokeRoleSysPrivilegePlan, context);
+  }
+
+  public R visitRAccountUnlock(final AuthorRelationalPlan rAccountUnlockPlan, final C context) {
+    return visitPlan(rAccountUnlockPlan, context);
   }
 
   public R visitTTL(final SetTTLPlan setTTLPlan, final C context) {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/auth/AuthorInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/auth/AuthorInfo.java
@@ -74,7 +74,9 @@ public class AuthorInfo implements SnapshotProcessor {
       throw new IndexOutOfBoundsException(ConfigNodeMessages.INVALID_AUTHOR_TYPE_ORDINAL);
     }
     ConfigPhysicalPlanType configPhysicalPlanType;
-    if (authorType >= AuthorType.RENAME_USER.ordinal()) {
+    if (authorType == AuthorType.ACCOUNT_UNLOCK.ordinal()) {
+      return ConfigPhysicalPlanType.AccountUnlock;
+    } else if (authorType >= AuthorType.RENAME_USER.ordinal()) {
       AuthorType type = AuthorType.values()[authorType];
       switch (type) {
         case RENAME_USER:
@@ -105,6 +107,8 @@ public class AuthorInfo implements SnapshotProcessor {
     ConfigPhysicalPlanType configPhysicalPlanType;
     if (authorRType == AuthorRType.RENAME_USER.ordinal()) {
       configPhysicalPlanType = ConfigPhysicalPlanType.RRenameUser;
+    } else if (authorRType == AuthorRType.ACCOUNT_UNLOCK.ordinal()) {
+      configPhysicalPlanType = ConfigPhysicalPlanType.RAccountUnlock;
     } else {
       configPhysicalPlanType =
           ConfigPhysicalPlanType.values()[

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/auth/AuthorPlanExecutor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/auth/AuthorPlanExecutor.java
@@ -125,7 +125,7 @@ public class AuthorPlanExecutor implements IAuthorPlanExecutor {
           authorizer.renameUser(userName, newUsername);
           break;
         case AccountUnlock:
-          authorizer.getUser(userName);
+          checkUserExistsForAccountUnlock(userName);
           break;
         case CreateUser:
           authorizer.createUser(userName, password);
@@ -244,7 +244,7 @@ public class AuthorPlanExecutor implements IAuthorPlanExecutor {
           authorizer.renameUser(userName, newUsername);
           break;
         case RAccountUnlock:
-          authorizer.getUser(userName);
+          checkUserExistsForAccountUnlock(userName);
           break;
         case RDropRole:
           authorizer.deleteRole(roleName);
@@ -450,6 +450,14 @@ public class AuthorPlanExecutor implements IAuthorPlanExecutor {
       return RpcUtils.getStatus(e.getCode(), e.getMessage());
     }
     return RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS);
+  }
+
+  private void checkUserExistsForAccountUnlock(final String userName) throws AuthException {
+    // Account unlock has no persistent ConfigNode auth state change, but the write path needs this
+    // validation before broadcasting DataNode unlocks and propagating through pipe.
+    if (authorizer.getUser(userName) == null) {
+      throw new AuthException(TSStatusCode.USER_NOT_EXIST, NO_USER_MSG + userName);
+    }
   }
 
   @Override

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/auth/AuthorPlanExecutor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/auth/AuthorPlanExecutor.java
@@ -124,6 +124,9 @@ public class AuthorPlanExecutor implements IAuthorPlanExecutor {
         case RenameUser:
           authorizer.renameUser(userName, newUsername);
           break;
+        case AccountUnlock:
+          authorizer.getUser(userName);
+          break;
         case CreateUser:
           authorizer.createUser(userName, password);
           break;
@@ -241,6 +244,7 @@ public class AuthorPlanExecutor implements IAuthorPlanExecutor {
           authorizer.renameUser(userName, newUsername);
           break;
         case RAccountUnlock:
+          authorizer.getUser(userName);
           break;
         case RDropRole:
           authorizer.deleteRole(roleName);

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/executor/ConfigPlanExecutor.java
@@ -488,6 +488,7 @@ public class ConfigPlanExecutor {
       case RevokeRoleFromUserDep:
       case UpdateUserDep:
       case RenameUser:
+      case AccountUnlock:
       case RCreateRole:
       case RCreateUser:
       case RDropUser:

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/sync/AuthOperationProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/sync/AuthOperationProcedure.java
@@ -28,6 +28,7 @@ import org.apache.iotdb.commons.utils.ThriftCommonsSerDeUtils;
 import org.apache.iotdb.confignode.client.sync.CnToDnSyncRequestType;
 import org.apache.iotdb.confignode.client.sync.SyncDataNodeClientPool;
 import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlan;
+import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlanType;
 import org.apache.iotdb.confignode.consensus.request.write.auth.AuthorPlan;
 import org.apache.iotdb.confignode.consensus.request.write.pipe.payload.PipeEnrichedPlan;
 import org.apache.iotdb.confignode.i18n.ProcedureMessages;
@@ -100,6 +101,11 @@ public class AuthOperationProcedure extends AbstractNodeProcedure<AuthOperationP
           TSStatus status;
           req.setUsername(user);
           req.setRoleName(role);
+          if (plan.getAuthorType() == ConfigPhysicalPlanType.AccountUnlock
+              || plan.getAuthorType() == ConfigPhysicalPlanType.RAccountUnlock) {
+            // For account unlock, role carries the optional login address.
+            req.setNeedDisconnect(true);
+          }
           Iterator<Pair<TDataNodeConfiguration, Long>> it = dataNodesToInvalid.iterator();
           while (it.hasNext()) {
             Pair<TDataNodeConfiguration, Long> pair = it.next();

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/auth/AuthorPlanExecutorTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/auth/AuthorPlanExecutorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.confignode.persistence.auth;
+
+import org.apache.iotdb.common.rpc.thrift.TSStatus;
+import org.apache.iotdb.commons.auth.authorizer.IAuthorizer;
+import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlanType;
+import org.apache.iotdb.confignode.consensus.request.write.auth.AuthorRelationalPlan;
+import org.apache.iotdb.confignode.consensus.request.write.auth.AuthorTreePlan;
+import org.apache.iotdb.rpc.TSStatusCode;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AuthorPlanExecutorTest {
+
+  @Test
+  public void testAccountUnlockRequiresExistingUser() throws Exception {
+    final IAuthorizer authorizer = mock(IAuthorizer.class);
+    when(authorizer.getUser("missing")).thenReturn(null);
+
+    final AuthorPlanExecutor executor = new AuthorPlanExecutor(authorizer);
+    final TSStatus status =
+        executor.executeAuthorNonQuery(
+            new AuthorTreePlan(
+                ConfigPhysicalPlanType.AccountUnlock,
+                "missing",
+                "",
+                "",
+                "",
+                Collections.emptySet(),
+                false,
+                Collections.emptyList()));
+
+    Assert.assertEquals(TSStatusCode.USER_NOT_EXIST.getStatusCode(), status.getCode());
+  }
+
+  @Test
+  public void testRAccountUnlockRequiresExistingUser() throws Exception {
+    final IAuthorizer authorizer = mock(IAuthorizer.class);
+    when(authorizer.getUser("missing")).thenReturn(null);
+
+    final AuthorPlanExecutor executor = new AuthorPlanExecutor(authorizer);
+    final TSStatus status =
+        executor.executeRelationalAuthorNonQuery(
+            new AuthorRelationalPlan(
+                ConfigPhysicalPlanType.RAccountUnlock,
+                "missing",
+                "",
+                "",
+                "",
+                Collections.emptySet(),
+                false,
+                ""));
+
+    Assert.assertEquals(TSStatusCode.USER_NOT_EXIST.getStatusCode(), status.getCode());
+  }
+}

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/sync/AuthOperationProcedureTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/sync/AuthOperationProcedureTest.java
@@ -99,6 +99,34 @@ public class AuthOperationProcedureTest {
     }
 
     try {
+      final AuthOperationProcedure proc =
+          new AuthOperationProcedure(
+              new AuthorTreePlan(
+                  ConfigPhysicalPlanType.AccountUnlock,
+                  "user1",
+                  "",
+                  "",
+                  "",
+                  Collections.emptySet(),
+                  false,
+                  Collections.emptyList()),
+              datanodes,
+              false);
+      proc.serialize(outputStream);
+      final ByteBuffer buffer =
+          ByteBuffer.wrap(byteArrayOutputStream.getBuf(), 0, byteArrayOutputStream.size());
+
+      final AuthOperationProcedure proc2 =
+          (AuthOperationProcedure) ProcedureFactory.getInstance().create(buffer);
+      Assert.assertEquals(proc, proc2);
+      buffer.clear();
+      byteArrayOutputStream.reset();
+    } catch (final Exception e) {
+      e.printStackTrace();
+      fail();
+    }
+
+    try {
       final int begin = ConfigPhysicalPlanType.RCreateUser.ordinal();
       final int end = ConfigPhysicalPlanType.RRevokeRoleSysPri.ordinal();
       for (int i = begin; i <= end; i++) {
@@ -125,6 +153,34 @@ public class AuthOperationProcedureTest {
         buffer.clear();
         byteArrayOutputStream.reset();
       }
+    } catch (final Exception e) {
+      e.printStackTrace();
+      fail();
+    }
+
+    try {
+      final AuthOperationProcedure proc =
+          new AuthOperationProcedure(
+              new AuthorRelationalPlan(
+                  ConfigPhysicalPlanType.RAccountUnlock,
+                  "user1",
+                  "127.0.0.1",
+                  "",
+                  "",
+                  Collections.emptySet(),
+                  false,
+                  ""),
+              datanodes,
+              false);
+      proc.serialize(outputStream);
+      final ByteBuffer buffer =
+          ByteBuffer.wrap(byteArrayOutputStream.getBuf(), 0, byteArrayOutputStream.size());
+
+      final AuthOperationProcedure proc2 =
+          (AuthOperationProcedure) ProcedureFactory.getInstance().create(buffer);
+      Assert.assertEquals(proc, proc2);
+      buffer.clear();
+      byteArrayOutputStream.reset();
     } catch (final Exception e) {
       e.printStackTrace();
       fail();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/auth/ClusterAuthorityFetcher.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/auth/ClusterAuthorityFetcher.java
@@ -424,44 +424,31 @@ public class ClusterAuthorityFetcher implements IAuthorityFetcher {
 
   @Override
   public SettableFuture<ConfigTaskResult> operatePermission(AuthorStatement authorStatement) {
-    return handleAccountUnlock(
-        authorStatement,
-        authorStatement.getUserName(),
-        false,
-        () -> onOperatePermissionSuccess(authorStatement));
+    return handleAccountUnlock(authorStatement, false);
   }
 
   @Override
   public SettableFuture<ConfigTaskResult> operatePermission(
       RelationalAuthorStatement authorStatement) {
-    return handleAccountUnlock(
-        authorStatement,
-        authorStatement.getUserName(),
-        true,
-        () -> onOperatePermissionSuccess(authorStatement));
+    return handleAccountUnlock(authorStatement, true);
   }
 
   private SettableFuture<ConfigTaskResult> handleAccountUnlock(
-      Object authorStatement, String username, boolean isRelational, Runnable successCallback) {
+      Object authorStatement, boolean isRelational) {
 
     if (isUnlockStatement(authorStatement, isRelational)) {
-      final SettableFuture<ConfigTaskResult> future = SettableFuture.create();
-      final User user;
-      try {
-        user = getUser(username, false);
-      } catch (final IoTDBRuntimeException e) {
-        future.setException(e);
-        return future;
-      }
       String loginAddr =
           isRelational
               ? ((RelationalAuthorStatement) authorStatement).getLoginAddr()
               : ((AuthorStatement) authorStatement).getLoginAddr();
 
-      LoginLockManager.getInstance().unlock(user.getUserId(), loginAddr);
-      successCallback.run();
-      future.set(new ConfigTaskResult(TSStatusCode.SUCCESS_STATUS));
-      return future;
+      // Reuse roleName to carry the optional login address for the internal unlock broadcast.
+      if (isRelational) {
+        ((RelationalAuthorStatement) authorStatement).setRoleName(loginAddr);
+      } else {
+        ((AuthorStatement) authorStatement).setRoleName(loginAddr);
+      }
+      return operatePermissionInternal(authorStatement, isRelational);
     }
     return operatePermissionInternal(authorStatement, isRelational);
   }
@@ -748,7 +735,7 @@ public class ClusterAuthorityFetcher implements IAuthorityFetcher {
 
   private TAuthorizerReq statementToAuthorizerReq(AuthorStatement authorStatement)
       throws AuthException {
-    if (authorStatement.getAuthorType() == null) {
+    if (authorStatement.getNodeNameList() == null) {
       authorStatement.setNodeNameList(new ArrayList<>());
     }
     return new TAuthorizerReq(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/DataNodeInternalRPCServiceImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/DataNodeInternalRPCServiceImpl.java
@@ -109,6 +109,7 @@ import org.apache.iotdb.consensus.exception.ConsensusGroupAlreadyExistException;
 import org.apache.iotdb.consensus.exception.ConsensusGroupNotExistException;
 import org.apache.iotdb.db.audit.DNAuditLogger;
 import org.apache.iotdb.db.auth.AuthorityChecker;
+import org.apache.iotdb.db.auth.LoginLockManager;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.consensus.DataRegionConsensusImpl;
 import org.apache.iotdb.db.consensus.SchemaRegionConsensusImpl;
@@ -2451,7 +2452,20 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
 
   @Override
   public TSStatus invalidatePermissionCache(TInvalidatePermissionCacheReq req) {
+    if (req.isSetNeedDisconnect() && req.isNeedDisconnect()) {
+      return unlockAccountAndInvalidateCache(req);
+    }
     if (AuthorityChecker.invalidateCache(req.getUsername(), req.getRoleName())) {
+      return RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS);
+    }
+    return RpcUtils.getStatus(TSStatusCode.CLEAR_PERMISSION_CACHE_ERROR);
+  }
+
+  private TSStatus unlockAccountAndInvalidateCache(TInvalidatePermissionCacheReq req) {
+    // For account-unlock broadcasts, roleName carries the optional login address.
+    AuthorityChecker.getUserId(req.getUsername())
+        .ifPresent(userId -> LoginLockManager.getInstance().unlock(userId, req.getRoleName()));
+    if (AuthorityChecker.invalidateCache(req.getUsername(), null)) {
       return RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS);
     }
     return RpcUtils.getStatus(TSStatusCode.CLEAR_PERMISSION_CACHE_ERROR);


### PR DESCRIPTION
## What failed

`IoTDBPipePermissionIT.testIllegalPassword` failed with an `AssertionError` at:

```text
TestUtils.assertDataEventuallyOnEnv(...)
IoTDBPipePermissionIT.java:606
```

The test expected the receiver to eventually observe `count(root.vehicle.plane.pressure) = 2`, but the count stayed at `1`.

The cluster logs showed repeated pipe metadata push failures on one sender DataNode:

```text
Failed to PIPE_PUSH_ALL_META / PIPE_PUSH_SINGLE_META on DataNodeId: 2
Failed to handle pipe meta changes for a2b, because Failed to check password for pipe a2b.
```

## Why it failed

In this test, the pipe password is intentionally changed to an invalid/stale value after restart. The pipe keeps retrying with the stale password and can trigger the login lock for user `thulab` on the DataNode that handles the pipe metadata push.

The test then runs:

```sql
alter user thulab account unlock
```

Before this patch, `ACCOUNT_UNLOCK` was handled only inside the DataNode that executed the SQL. It directly called the local `LoginLockManager` and never went through the ConfigNode auth procedure. That means only one DataNode was unlocked, while another DataNode could still keep `thulab` locked in its local in-memory login-lock state.

As a result, ConfigNode kept trying to push updated pipe metadata to the still-locked DataNode. That DataNode rejected the pipe password check, metadata synchronization was delayed, and the new insert was not replicated to the receiver before the assertion timed out.

## Why this needs a cluster-wide fix

Login lock state is local DataNode memory, not persistent auth metadata stored only on ConfigNode. A user-level `ACCOUNT_UNLOCK` statement is therefore incomplete if it only clears the lock on the SQL coordinator DataNode. For pipe password checks, any DataNode can be the one validating the pipe credentials during metadata push/recovery, so the unlock needs to reach every DataNode.

## What this patch changes

This patch routes `ACCOUNT_UNLOCK` through the normal ConfigNode auth operation procedure and reuses the existing DataNode permission-cache invalidation broadcast to clear the login lock on every DataNode.

Concretely:

- Adds tree-model `ConfigPhysicalPlanType.AccountUnlock` and maps tree `AuthorType.ACCOUNT_UNLOCK` to it.
- Keeps relational `RAccountUnlock` handling and adds the missing special mapping for `AuthorRType.ACCOUNT_UNLOCK`.
- Treats account unlock as a no-op persistent auth plan on ConfigNode, while still validating that the user exists.
- Marks the DataNode invalidation request for account unlock, so each DataNode clears its local `LoginLockManager` entry and invalidates the user permission cache.
- Adds factory/visitor/executor support so the new plan type can be serialized, deserialized, and dispatched correctly.
- Adds auth procedure serialization coverage for both `AccountUnlock` and `RAccountUnlock`.
- Adds the missing `fail()` assertion in `IoTDBPipePermissionIT.testIllegalPassword` after the intentionally invalid pipe password alteration.

This avoids thrift IDL changes and keeps the unlock operation scoped to the existing auth-cache invalidation path.

## Tests

```text
mvn -Ddevelocity.off=true test -pl iotdb-core/confignode -Dtest=AuthOperationProcedureTest -DforkCount=0
mvn -Ddevelocity.off=true compile -pl iotdb-core/datanode -DskipTests
mvn -Ddevelocity.off=true test-compile -pl integration-test -P with-integration-tests -DskipTests
```

I did not run the full `IoTDBPipePermissionIT#testIllegalPassword` ClusterIT locally because this machine repeatedly hit Windows pagefile/native-memory exhaustion when starting forked JVMs. The focused compile and serialization checks above passed.