### PR TITLE
Fix flaky StampedWriterPreferredLock test

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/mtree/lock/StampedWriterPreferredLockTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/mtree/lock/StampedWriterPreferredLockTest.java
@@ -25,6 +25,7 @@ import org.awaitility.core.ConditionTimeoutException;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -143,22 +144,41 @@ public class StampedWriterPreferredLockTest {
   }
 
   @Test
-  public void testAcquireReadLockWhileWriting() {
+  public void testAcquireReadLockWhileWriting() throws InterruptedException {
     StampedWriterPreferredLock lock = new StampedWriterPreferredLock();
     lock.writeLock();
     AtomicInteger counter = new AtomicInteger();
-    new Thread(
+    CountDownLatch readerFinished = new CountDownLatch(1);
+    Thread readerThread =
+        new Thread(
             () -> {
               lock.threadReadLock();
-              counter.incrementAndGet();
-              lock.threadReadUnlock();
-            })
-        .start();
-    // block reader util writer release write lock
-    Assert.assertEquals(0, counter.get());
-    lock.writeUnlock();
-    Awaitility.await().atMost(2, TimeUnit.SECONDS).until(() -> counter.get() == 1);
-    Assert.assertEquals(1, counter.get());
+              try {
+                counter.incrementAndGet();
+              } finally {
+                lock.threadReadUnlock();
+                readerFinished.countDown();
+              }
+            });
+    readerThread.setDaemon(true);
+    readerThread.start();
+
+    boolean writeLocked = true;
+    try {
+      // block reader until writer release write lock
+      Awaitility.await()
+          .atMost(10, TimeUnit.SECONDS)
+          .until(() -> readerThread.getState() == Thread.State.WAITING);
+      Assert.assertEquals(0, counter.get());
+      lock.writeUnlock();
+      writeLocked = false;
+      Assert.assertTrue(readerFinished.await(10, TimeUnit.SECONDS));
+      Assert.assertEquals(1, counter.get());
+    } finally {
+      if (writeLocked) {
+        lock.writeUnlock();
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
### What
- Make `testAcquireReadLockWhileWriting` wait until the reader is actually blocked by the held write lock before releasing it.
- Wait for the reader thread to finish with a latch and release the write lock in failure paths.

### Testing
- `mvn -pl iotdb-core/datanode spotless:apply`
- `javac --release 8 ... StampedWriterPreferredLock.java StampedWriterPreferredLockTest.java && java ... org.junit.runner.JUnitCore org.apache.iotdb.db.metadata.mtree.lock.StampedWriterPreferredLockTest`

The full Maven datanode test command is currently blocked locally by unrelated datanode generated-source/test compilation errors.