### PR TITLE
Fix PBTree schema cache release after pre-delete

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/memory/ReleaseFlushMonitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/memory/ReleaseFlushMonitor.java
@@ -230,6 +230,7 @@ public class ReleaseFlushMonitor {
   public void forceFlushAndRelease() {
     boolean needFlush;
     while (true) {
+      waitUntilWorkerTasksDone();
       needFlush = false;
       for (CachedMTreeStore store : regionToStoreMap.values()) {
         if (store.getMemoryManager().getBufferNodeNum() > 0) {
@@ -239,11 +240,25 @@ public class ReleaseFlushMonitor {
       }
       if (needFlush) {
         scheduler.scheduleFlushAll().join();
+        waitUntilWorkerTasksDone();
         scheduler.scheduleRelease(true);
       } else {
         // No volatile nodes left, but clean unpinned cache may still remain after previous flushes.
         scheduler.scheduleRelease(true);
+        waitUntilWorkerTasksDone();
         break;
+      }
+    }
+  }
+
+  @TestOnly
+  private void waitUntilWorkerTasksDone() {
+    while (scheduler.getActiveWorkerNum() > 0 || !flushingRegionSet.isEmpty()) {
+      try {
+        Thread.sleep(10);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return;
       }
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/memory/ReleaseFlushMonitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/memory/ReleaseFlushMonitor.java
@@ -241,6 +241,8 @@ public class ReleaseFlushMonitor {
         scheduler.scheduleFlushAll().join();
         scheduler.scheduleRelease(true);
       } else {
+        // No volatile nodes left, but clean unpinned cache may still remain after previous flushes.
+        scheduler.scheduleRelease(true);
         break;
       }
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/traverser/Traverser.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/traverser/Traverser.java
@@ -184,6 +184,7 @@ public abstract class Traverser<R, N extends IMNode<N>> extends AbstractTreeVisi
           && skipPreDeletedSchema
           && child.isMeasurement()
           && child.getAsMeasurementMNode().isPreDeleted()) {
+        releaseNode(child);
         child = null;
       }
     }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaStatisticsTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaStatisticsTest.java
@@ -76,24 +76,12 @@ public class SchemaStatisticsTest extends AbstractSchemaRegionTest {
         || testParams.getTestModeName().equals("PBTree-NonMemory")) {
       final IMNodeFactory<ICachedMNode> nodeFactory =
           MNodeFactoryLoader.getInstance().getCachedMNodeIMNodeFactory();
-      // wait release and flush task
-      Thread.sleep(6000);
+      ReleaseFlushMonitor.getInstance().forceFlushAndRelease();
       // schemaRegion1
       final IMNode<ICachedMNode> sg1 = nodeFactory.createDatabaseMNode(null, "sg1");
       sg1.setFullPath("root.sg1");
       final long size1 = sg1.estimateSize();
-      if (size1 != schemaRegion1.getSchemaRegionStatistics().getRegionMemoryUsage()) {
-        // There are two possibilities here in PartialMemory mode:
-        // 1. only the "sg1" node remains
-        // 2. the "sg1" node and the "n" node remain
-        Assert.assertEquals("PBTree-PartialMemory", testParams.getTestModeName());
-        Assert.assertEquals(
-            size1 + nodeFactory.createDeviceMNode(sg1.getAsMNode(), "n").estimateSize(),
-            schemaRegion1.getSchemaRegionStatistics().getRegionMemoryUsage());
-        ReleaseFlushMonitor.getInstance().forceFlushAndRelease();
-        Assert.assertEquals(
-            size1, schemaRegion1.getSchemaRegionStatistics().getRegionMemoryUsage());
-      }
+      Assert.assertEquals(size1, schemaRegion1.getSchemaRegionStatistics().getRegionMemoryUsage());
     }
     Assert.assertEquals(0, schemaRegion1.getSchemaRegionStatistics().getSchemaRegionId());
     checkPBTreeStatistics(engineStatistics);
@@ -123,8 +111,7 @@ public class SchemaStatisticsTest extends AbstractSchemaRegionTest {
 
       final IMNodeFactory<?> nodeFactory =
           MNodeFactoryLoader.getInstance().getCachedMNodeIMNodeFactory();
-      // wait release and flush task
-      Thread.sleep(1000);
+      ReleaseFlushMonitor.getInstance().forceFlushAndRelease();
       // schemaRegion1
       final IMNode<?> sg1 = nodeFactory.createDatabaseMNode(null, "sg1");
       sg1.setFullPath("root.sg1");
@@ -232,36 +219,12 @@ public class SchemaStatisticsTest extends AbstractSchemaRegionTest {
         || testParams.getTestModeName().equals("PBTree-NonMemory")) {
       final IMNodeFactory<ICachedMNode> nodeFactory =
           MNodeFactoryLoader.getInstance().getCachedMNodeIMNodeFactory();
-      // wait release and flush task
-      Thread.sleep(1000);
+      ReleaseFlushMonitor.getInstance().forceFlushAndRelease();
       // schemaRegion1
       final IMNode<ICachedMNode> sg1 = nodeFactory.createDatabaseDeviceMNode(null, "sg1");
       sg1.setFullPath("root.sg1");
       final long size1 = sg1.estimateSize();
-      if (sg1.estimateSize() != schemaRegion1.getSchemaRegionStatistics().getRegionMemoryUsage()) {
-        // "d0" or "d1" node may remain in PartialMemory mode
-        Assert.assertEquals("PBTree-PartialMemory", testParams.getTestModeName());
-        final long d0ExistSize =
-            size1
-                + nodeFactory
-                    .createMeasurementMNode(
-                        sg1.getAsDeviceMNode(),
-                        "d0",
-                        new MeasurementSchema(
-                            "d0", TSDataType.INT64, TSEncoding.PLAIN, CompressionType.SNAPPY),
-                        null)
-                    .estimateSize();
-        final long d1ExistSize =
-            size1 + nodeFactory.createInternalMNode(sg1.getAsMNode(), "d1").estimateSize();
-        Assert.assertTrue(
-            d0ExistSize == schemaRegion1.getSchemaRegionStatistics().getRegionMemoryUsage()
-                || d1ExistSize == schemaRegion1.getSchemaRegionStatistics().getRegionMemoryUsage());
-        ReleaseFlushMonitor.getInstance().forceFlushAndRelease();
-        // wait release and flush task
-        Thread.sleep(1000);
-        Assert.assertEquals(
-            size1, schemaRegion1.getSchemaRegionStatistics().getRegionMemoryUsage());
-      }
+      Assert.assertEquals(size1, schemaRegion1.getSchemaRegionStatistics().getRegionMemoryUsage());
       // schemaRegion2
       final IMNode<?> sg2 = nodeFactory.createDatabaseMNode(null, "sg2");
       sg2.setFullPath("root.sg2");
@@ -443,7 +406,11 @@ public class SchemaStatisticsTest extends AbstractSchemaRegionTest {
       schemaRegion1.deleteTimeseriesInBlackList(patternTree);
       schemaRegion2.deleteTimeseriesInBlackList(patternTree);
 
-      Thread.sleep(1000);
+      if (testParams.getCachedMNodeSize() <= 3) {
+        ReleaseFlushMonitor.getInstance().forceFlushAndRelease();
+      } else {
+        Thread.sleep(1000);
+      }
       final CachedSchemaRegionStatistics cachedRegionStatistics1 =
           schemaRegion1.getSchemaRegionStatistics().getAsCachedSchemaRegionStatistics();
       final CachedSchemaRegionStatistics cachedRegionStatistics2 =
@@ -456,13 +423,7 @@ public class SchemaStatisticsTest extends AbstractSchemaRegionTest {
         Assert.assertEquals(4, cachedRegionStatistics2.getUnpinnedMNodeNum());
       } else {
         Assert.assertEquals(1, cachedRegionStatistics1.getPinnedMNodeNum());
-        if (0 != cachedRegionStatistics1.getUnpinnedMNodeNum()) {
-          // "d0" may remain in PartialMemory mode
-          Assert.assertEquals("PBTree-PartialMemory", testParams.getTestModeName());
-          ReleaseFlushMonitor.getInstance().forceFlushAndRelease();
-          Thread.sleep(1000);
-          Assert.assertEquals(0, cachedRegionStatistics1.getUnpinnedMNodeNum());
-        }
+        Assert.assertEquals(0, cachedRegionStatistics1.getUnpinnedMNodeNum());
         Assert.assertEquals(1, cachedRegionStatistics2.getPinnedMNodeNum());
         Assert.assertEquals(0, cachedRegionStatistics2.getUnpinnedMNodeNum());
       }


### PR DESCRIPTION
## Summary
- Make the PBTree test-only `forceFlushAndRelease` helper wait for outstanding flush/release workers before checking final memory statistics.
- Keep forcing release after all volatile buffers are flushed so low-cache PBTree statistics only retain the database root when expected.
- Release skipped pre-deleted measurements in `Traverser#getChild` so PBTree schema reads do not leak pinned cache entries.

## Why the Traverser change matters
This is not only a test fix. In PBTree mode, `fetchSchema` and `fetchSchemaWithoutWildcard` set `skipPreDeletedSchema=true` to hide measurements that are in the pre-delete blacklist. For exact child lookups, `store.getChild(...)` pins the cached node before `Traverser` decides to skip it. The old code changed the child to `null` without unpinning it, leaving that measurement and its ancestors pinned. That can prevent eviction/release under real schema reads after pre-delete operations and inflate PBTree memory usage until the region is cleared.

## Tests
- `mvn spotless:apply -pl iotdb-core/datanode`
- `git diff --check`
- `mvn -pl iotdb-core/datanode -am -Dtest=SchemaStatisticsTest#testMemoryStatistics2 -Dsurefire.failIfNoSpecifiedTests=false -Dspotless.skip=true -Dcheckstyle.skip=true test -DtrimStackTrace=false` fails before the target test runs during existing datanode compilation, with unrelated missing generated fill/aggregation symbols such as `IFill`, `IFillFilter`, `Accumulator`, and `IoTDBConfig#getModeMapSizeThreshold()`.