### PR TITLE
Fix operator tests for transient null TsBlocks

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/AlignedSeriesAggregationScanOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/AlignedSeriesAggregationScanOperatorTest.java
@@ -124,6 +124,9 @@ public class AlignedSeriesAggregationScanOperatorTest {
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       for (int i = 0; i < measurementSchemas.size(); i++) {
         assertEquals(500, resultTsBlock.getColumn(i).getLong(0));
       }
@@ -155,6 +158,9 @@ public class AlignedSeriesAggregationScanOperatorTest {
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       for (int i = 0; i < measurementSchemas.size(); i++) {
         assertEquals(500, resultTsBlock.getColumn(i).getLong(0));
       }
@@ -191,6 +197,9 @@ public class AlignedSeriesAggregationScanOperatorTest {
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       assertEquals(500, resultTsBlock.getColumn(0).getLong(0));
       assertEquals(6524750.0, resultTsBlock.getColumn(1).getDouble(0), 0.0001);
       count++;
@@ -229,6 +238,9 @@ public class AlignedSeriesAggregationScanOperatorTest {
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       assertTrue(resultTsBlock.getColumn(0).getBoolean(0));
       assertEquals(10499, resultTsBlock.getColumn(1).getInt(0));
       assertEquals(20199, resultTsBlock.getColumn(2).getLong(0));
@@ -271,6 +283,9 @@ public class AlignedSeriesAggregationScanOperatorTest {
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       assertTrue(resultTsBlock.getColumn(0).getBoolean(0));
       assertEquals(10499, resultTsBlock.getColumn(1).getInt(0));
       assertEquals(20199, resultTsBlock.getColumn(2).getLong(0));
@@ -306,6 +321,9 @@ public class AlignedSeriesAggregationScanOperatorTest {
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       for (int i = 0; i < measurementSchemas.size(); i++) {
         assertEquals(resultTsBlock.getColumn(i).getLong(0), 380);
       }
@@ -339,6 +357,9 @@ public class AlignedSeriesAggregationScanOperatorTest {
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       for (int i = 0; i < measurementSchemas.size(); i++) {
         assertEquals(resultTsBlock.getColumn(i).getLong(0), 380);
       }
@@ -372,6 +393,9 @@ public class AlignedSeriesAggregationScanOperatorTest {
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       for (int i = 0; i < measurementSchemas.size(); i++) {
         assertEquals(resultTsBlock.getColumn(i).getLong(0), 300);
       }
@@ -412,6 +436,9 @@ public class AlignedSeriesAggregationScanOperatorTest {
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       assertTrue(resultTsBlock.getColumn(0).getBoolean(0));
       assertEquals(399, resultTsBlock.getColumn(1).getInt(0));
       assertEquals(20199, resultTsBlock.getColumn(2).getLong(0));
@@ -450,6 +477,9 @@ public class AlignedSeriesAggregationScanOperatorTest {
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -491,6 +521,9 @@ public class AlignedSeriesAggregationScanOperatorTest {
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -536,6 +569,9 @@ public class AlignedSeriesAggregationScanOperatorTest {
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -582,6 +618,9 @@ public class AlignedSeriesAggregationScanOperatorTest {
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * (3 - count), resultTsBlock.getTimeColumn().getLong(pos));
@@ -618,6 +657,9 @@ public class AlignedSeriesAggregationScanOperatorTest {
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(50 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -651,6 +693,9 @@ public class AlignedSeriesAggregationScanOperatorTest {
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(timeColumn[count], resultTsBlock.getTimeColumn().getLong(pos));
@@ -695,6 +740,9 @@ public class AlignedSeriesAggregationScanOperatorTest {
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(timeColumn[count], resultTsBlock.getTimeColumn().getLong(pos));

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/AlignedSeriesAggregationScanOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/AlignedSeriesAggregationScanOperatorTest.java
@@ -69,7 +69,7 @@ import java.util.stream.Collectors;
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
 import static org.apache.iotdb.db.queryengine.execution.operator.AggregationOperatorTest.TEST_TIME_SLICE;
 import static org.apache.iotdb.db.queryengine.execution.operator.AggregationUtil.initTimeRangeIterator;
-import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonEmpty;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNullOrEmpty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -123,10 +123,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, true, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       for (int i = 0; i < measurementSchemas.size(); i++) {
         assertEquals(500, resultTsBlock.getColumn(i).getLong(0));
       }
@@ -157,10 +154,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, false, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       for (int i = 0; i < measurementSchemas.size(); i++) {
         assertEquals(500, resultTsBlock.getColumn(i).getLong(0));
       }
@@ -196,10 +190,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, true, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       assertEquals(500, resultTsBlock.getColumn(0).getLong(0));
       assertEquals(6524750.0, resultTsBlock.getColumn(1).getDouble(0), 0.0001);
       count++;
@@ -237,10 +228,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, true, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       assertTrue(resultTsBlock.getColumn(0).getBoolean(0));
       assertEquals(10499, resultTsBlock.getColumn(1).getInt(0));
       assertEquals(20199, resultTsBlock.getColumn(2).getLong(0));
@@ -282,10 +270,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, false, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       assertTrue(resultTsBlock.getColumn(0).getBoolean(0));
       assertEquals(10499, resultTsBlock.getColumn(1).getInt(0));
       assertEquals(20199, resultTsBlock.getColumn(2).getLong(0));
@@ -320,10 +305,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, timeFilter, true, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       for (int i = 0; i < measurementSchemas.size(); i++) {
         assertEquals(resultTsBlock.getColumn(i).getLong(0), 380);
       }
@@ -356,10 +338,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, timeFilter, true, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       for (int i = 0; i < measurementSchemas.size(); i++) {
         assertEquals(resultTsBlock.getColumn(i).getLong(0), 380);
       }
@@ -392,10 +371,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, timeFilter, true, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       for (int i = 0; i < measurementSchemas.size(); i++) {
         assertEquals(resultTsBlock.getColumn(i).getLong(0), 300);
       }
@@ -435,10 +411,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, timeFilter, true, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       assertTrue(resultTsBlock.getColumn(0).getBoolean(0));
       assertEquals(399, resultTsBlock.getColumn(1).getInt(0));
       assertEquals(20199, resultTsBlock.getColumn(2).getLong(0));
@@ -476,10 +449,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, true, groupByTimeParameter);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -520,10 +490,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
             aggregators, timeFilter, true, groupByTimeParameter);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -568,10 +535,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, true, groupByTimeParameter);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -617,10 +581,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, false, groupByTimeParameter);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * (3 - count), resultTsBlock.getTimeColumn().getLong(pos));
@@ -656,10 +617,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, true, groupByTimeParameter);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(50 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -692,10 +650,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, true, groupByTimeParameter);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(timeColumn[count], resultTsBlock.getTimeColumn().getLong(pos));
@@ -739,10 +694,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, true, groupByTimeParameter);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(timeColumn[count], resultTsBlock.getTimeColumn().getLong(pos));

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/AlignedSeriesAggregationScanOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/AlignedSeriesAggregationScanOperatorTest.java
@@ -69,6 +69,7 @@ import java.util.stream.Collectors;
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
 import static org.apache.iotdb.db.queryengine.execution.operator.AggregationOperatorTest.TEST_TIME_SLICE;
 import static org.apache.iotdb.db.queryengine.execution.operator.AggregationUtil.initTimeRangeIterator;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -122,7 +123,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, true, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       for (int i = 0; i < measurementSchemas.size(); i++) {
         assertEquals(500, resultTsBlock.getColumn(i).getLong(0));
       }
@@ -153,7 +154,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, false, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       for (int i = 0; i < measurementSchemas.size(); i++) {
         assertEquals(500, resultTsBlock.getColumn(i).getLong(0));
       }
@@ -189,7 +190,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, true, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       assertEquals(500, resultTsBlock.getColumn(0).getLong(0));
       assertEquals(6524750.0, resultTsBlock.getColumn(1).getDouble(0), 0.0001);
       count++;
@@ -227,7 +228,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, true, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       assertTrue(resultTsBlock.getColumn(0).getBoolean(0));
       assertEquals(10499, resultTsBlock.getColumn(1).getInt(0));
       assertEquals(20199, resultTsBlock.getColumn(2).getLong(0));
@@ -269,7 +270,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, false, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       assertTrue(resultTsBlock.getColumn(0).getBoolean(0));
       assertEquals(10499, resultTsBlock.getColumn(1).getInt(0));
       assertEquals(20199, resultTsBlock.getColumn(2).getLong(0));
@@ -304,7 +305,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, timeFilter, true, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       for (int i = 0; i < measurementSchemas.size(); i++) {
         assertEquals(resultTsBlock.getColumn(i).getLong(0), 380);
       }
@@ -337,7 +338,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, timeFilter, true, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       for (int i = 0; i < measurementSchemas.size(); i++) {
         assertEquals(resultTsBlock.getColumn(i).getLong(0), 380);
       }
@@ -370,7 +371,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, timeFilter, true, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       for (int i = 0; i < measurementSchemas.size(); i++) {
         assertEquals(resultTsBlock.getColumn(i).getLong(0), 300);
       }
@@ -410,7 +411,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, timeFilter, true, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       assertTrue(resultTsBlock.getColumn(0).getBoolean(0));
       assertEquals(399, resultTsBlock.getColumn(1).getInt(0));
       assertEquals(20199, resultTsBlock.getColumn(2).getLong(0));
@@ -448,7 +449,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, true, groupByTimeParameter);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -489,7 +490,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
             aggregators, timeFilter, true, groupByTimeParameter);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -534,7 +535,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, true, groupByTimeParameter);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -580,7 +581,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, false, groupByTimeParameter);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * (3 - count), resultTsBlock.getTimeColumn().getLong(pos));
@@ -616,7 +617,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, true, groupByTimeParameter);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(50 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -649,7 +650,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, true, groupByTimeParameter);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(timeColumn[count], resultTsBlock.getTimeColumn().getLong(pos));
@@ -693,7 +694,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, true, groupByTimeParameter);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(timeColumn[count], resultTsBlock.getTimeColumn().getLong(pos));

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/AlignedSeriesAggregationScanOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/AlignedSeriesAggregationScanOperatorTest.java
@@ -69,7 +69,7 @@ import java.util.stream.Collectors;
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
 import static org.apache.iotdb.db.queryengine.execution.operator.AggregationOperatorTest.TEST_TIME_SLICE;
 import static org.apache.iotdb.db.queryengine.execution.operator.AggregationUtil.initTimeRangeIterator;
-import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNull;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonEmpty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -123,7 +123,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, true, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       for (int i = 0; i < measurementSchemas.size(); i++) {
         assertEquals(500, resultTsBlock.getColumn(i).getLong(0));
       }
@@ -154,7 +154,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, false, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       for (int i = 0; i < measurementSchemas.size(); i++) {
         assertEquals(500, resultTsBlock.getColumn(i).getLong(0));
       }
@@ -190,7 +190,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, true, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       assertEquals(500, resultTsBlock.getColumn(0).getLong(0));
       assertEquals(6524750.0, resultTsBlock.getColumn(1).getDouble(0), 0.0001);
       count++;
@@ -228,7 +228,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, true, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       assertTrue(resultTsBlock.getColumn(0).getBoolean(0));
       assertEquals(10499, resultTsBlock.getColumn(1).getInt(0));
       assertEquals(20199, resultTsBlock.getColumn(2).getLong(0));
@@ -270,7 +270,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, false, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       assertTrue(resultTsBlock.getColumn(0).getBoolean(0));
       assertEquals(10499, resultTsBlock.getColumn(1).getInt(0));
       assertEquals(20199, resultTsBlock.getColumn(2).getLong(0));
@@ -305,7 +305,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, timeFilter, true, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       for (int i = 0; i < measurementSchemas.size(); i++) {
         assertEquals(resultTsBlock.getColumn(i).getLong(0), 380);
       }
@@ -338,7 +338,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, timeFilter, true, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       for (int i = 0; i < measurementSchemas.size(); i++) {
         assertEquals(resultTsBlock.getColumn(i).getLong(0), 380);
       }
@@ -371,7 +371,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, timeFilter, true, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       for (int i = 0; i < measurementSchemas.size(); i++) {
         assertEquals(resultTsBlock.getColumn(i).getLong(0), 300);
       }
@@ -411,7 +411,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, timeFilter, true, null);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       assertTrue(resultTsBlock.getColumn(0).getBoolean(0));
       assertEquals(399, resultTsBlock.getColumn(1).getInt(0));
       assertEquals(20199, resultTsBlock.getColumn(2).getLong(0));
@@ -449,7 +449,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, true, groupByTimeParameter);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -490,7 +490,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
             aggregators, timeFilter, true, groupByTimeParameter);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -535,7 +535,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, true, groupByTimeParameter);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -581,7 +581,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, false, groupByTimeParameter);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * (3 - count), resultTsBlock.getTimeColumn().getLong(pos));
@@ -617,7 +617,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, true, groupByTimeParameter);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(50 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -650,7 +650,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, true, groupByTimeParameter);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(timeColumn[count], resultTsBlock.getTimeColumn().getLong(pos));
@@ -694,7 +694,7 @@ public class AlignedSeriesAggregationScanOperatorTest {
         initAlignedSeriesAggregationScanOperator(aggregators, null, true, groupByTimeParameter);
     int count = 0;
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(timeColumn[count], resultTsBlock.getTimeColumn().getLong(pos));

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/DeviceViewIntoOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/DeviceViewIntoOperatorTest.java
@@ -72,7 +72,7 @@ import java.util.concurrent.ExecutorService;
 
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
-import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.lastNonNull;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.lastNonEmpty;
 import static org.apache.iotdb.rpc.RpcUtils.SUCCESS_STATUS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -259,7 +259,7 @@ public class DeviceViewIntoOperatorTest {
     prepareDeviceData("device0", 2);
     operator = createAndInitOperatorForSingleDevices(2);
 
-    TsBlock result = lastNonNull(operator);
+    TsBlock result = lastNonEmpty(operator);
     assertNotNull(result);
     assertEquals(2, result.getPositionCount());
 
@@ -274,7 +274,7 @@ public class DeviceViewIntoOperatorTest {
     prepareDeviceData("device0", 10);
     operator = createAndInitOperatorForSingleDevices(10);
 
-    TsBlock result = lastNonNull(operator);
+    TsBlock result = lastNonEmpty(operator);
     assertNotNull(result);
     assertEquals(10, result.getPositionCount());
 
@@ -290,7 +290,7 @@ public class DeviceViewIntoOperatorTest {
     prepareDeviceData("device1", 1);
     operator = createAndInitOperatorForMultipleDevices(2, 1);
 
-    TsBlock result = lastNonNull(operator);
+    TsBlock result = lastNonEmpty(operator);
     assertNotNull(result);
     assertEquals(2, result.getPositionCount());
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/DeviceViewIntoOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/DeviceViewIntoOperatorTest.java
@@ -72,7 +72,7 @@ import java.util.concurrent.ExecutorService;
 
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
-import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.lastNonEmpty;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.lastNonNullOrEmpty;
 import static org.apache.iotdb.rpc.RpcUtils.SUCCESS_STATUS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -259,7 +259,7 @@ public class DeviceViewIntoOperatorTest {
     prepareDeviceData("device0", 2);
     operator = createAndInitOperatorForSingleDevices(2);
 
-    TsBlock result = lastNonEmpty(operator);
+    TsBlock result = lastNonNullOrEmpty(operator);
     assertNotNull(result);
     assertEquals(2, result.getPositionCount());
 
@@ -274,7 +274,7 @@ public class DeviceViewIntoOperatorTest {
     prepareDeviceData("device0", 10);
     operator = createAndInitOperatorForSingleDevices(10);
 
-    TsBlock result = lastNonEmpty(operator);
+    TsBlock result = lastNonNullOrEmpty(operator);
     assertNotNull(result);
     assertEquals(10, result.getPositionCount());
 
@@ -290,7 +290,7 @@ public class DeviceViewIntoOperatorTest {
     prepareDeviceData("device1", 1);
     operator = createAndInitOperatorForMultipleDevices(2, 1);
 
-    TsBlock result = lastNonEmpty(operator);
+    TsBlock result = lastNonNullOrEmpty(operator);
     assertNotNull(result);
     assertEquals(2, result.getPositionCount());
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/DeviceViewIntoOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/DeviceViewIntoOperatorTest.java
@@ -72,6 +72,7 @@ import java.util.concurrent.ExecutorService;
 
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.lastNonNull;
 import static org.apache.iotdb.rpc.RpcUtils.SUCCESS_STATUS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -258,10 +259,7 @@ public class DeviceViewIntoOperatorTest {
     prepareDeviceData("device0", 2);
     operator = createAndInitOperatorForSingleDevices(2);
 
-    TsBlock result = null;
-    while (operator.isBlocked().isDone() && operator.hasNext()) {
-      result = operator.next();
-    }
+    TsBlock result = lastNonNull(operator);
     assertNotNull(result);
     assertEquals(2, result.getPositionCount());
 
@@ -276,10 +274,7 @@ public class DeviceViewIntoOperatorTest {
     prepareDeviceData("device0", 10);
     operator = createAndInitOperatorForSingleDevices(10);
 
-    TsBlock result = null;
-    while (operator.isBlocked().isDone() && operator.hasNext()) {
-      result = operator.next();
-    }
+    TsBlock result = lastNonNull(operator);
     assertNotNull(result);
     assertEquals(10, result.getPositionCount());
 
@@ -295,10 +290,7 @@ public class DeviceViewIntoOperatorTest {
     prepareDeviceData("device1", 1);
     operator = createAndInitOperatorForMultipleDevices(2, 1);
 
-    TsBlock result = null;
-    while (operator.isBlocked().isDone() && operator.hasNext()) {
-      result = operator.next();
-    }
+    TsBlock result = lastNonNull(operator);
     assertNotNull(result);
     assertEquals(2, result.getPositionCount());
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/FillOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/FillOperatorTest.java
@@ -43,7 +43,7 @@ import org.junit.Test;
 import java.util.concurrent.ExecutorService;
 
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
-import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNull;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonEmpty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -211,7 +211,7 @@ public class FillOperatorTest {
             }
           };
       while (fillOperator.hasNext()) {
-        TsBlock block = nextNonNull(fillOperator);
+        TsBlock block = nextNonEmpty(fillOperator);
         for (int i = 0; i < block.getPositionCount(); i++) {
           long expectedTime = i + 1 + count * 10000L;
           assertEquals(expectedTime, block.getTimeByIndex(i));
@@ -384,7 +384,7 @@ public class FillOperatorTest {
             }
           };
       while (fillOperator.hasNext()) {
-        TsBlock block = nextNonNull(fillOperator);
+        TsBlock block = nextNonEmpty(fillOperator);
         for (int i = 0; i < block.getPositionCount(); i++) {
           long expectedTime = i + 1 + count * 10000L;
           assertEquals(expectedTime, block.getTimeByIndex(i));
@@ -561,7 +561,7 @@ public class FillOperatorTest {
             }
           };
       while (fillOperator.hasNext()) {
-        TsBlock block = nextNonNull(fillOperator);
+        TsBlock block = nextNonEmpty(fillOperator);
         for (int i = 0; i < block.getPositionCount(); i++) {
           long expectedTime = i + 1 + count * 10000L;
           assertEquals(expectedTime, block.getTimeByIndex(i));

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/FillOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/FillOperatorTest.java
@@ -43,7 +43,7 @@ import org.junit.Test;
 import java.util.concurrent.ExecutorService;
 
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
-import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonEmpty;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNullOrEmpty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -211,10 +211,7 @@ public class FillOperatorTest {
             }
           };
       while (fillOperator.hasNext()) {
-        TsBlock block = nextNonEmpty(fillOperator);
-        if (block == null) {
-          continue;
-        }
+        TsBlock block = nextNonNullOrEmpty(fillOperator);
         for (int i = 0; i < block.getPositionCount(); i++) {
           long expectedTime = i + 1 + count * 10000L;
           assertEquals(expectedTime, block.getTimeByIndex(i));
@@ -387,10 +384,7 @@ public class FillOperatorTest {
             }
           };
       while (fillOperator.hasNext()) {
-        TsBlock block = nextNonEmpty(fillOperator);
-        if (block == null) {
-          continue;
-        }
+        TsBlock block = nextNonNullOrEmpty(fillOperator);
         for (int i = 0; i < block.getPositionCount(); i++) {
           long expectedTime = i + 1 + count * 10000L;
           assertEquals(expectedTime, block.getTimeByIndex(i));
@@ -567,10 +561,7 @@ public class FillOperatorTest {
             }
           };
       while (fillOperator.hasNext()) {
-        TsBlock block = nextNonEmpty(fillOperator);
-        if (block == null) {
-          continue;
-        }
+        TsBlock block = nextNonNullOrEmpty(fillOperator);
         for (int i = 0; i < block.getPositionCount(); i++) {
           long expectedTime = i + 1 + count * 10000L;
           assertEquals(expectedTime, block.getTimeByIndex(i));

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/FillOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/FillOperatorTest.java
@@ -212,6 +212,9 @@ public class FillOperatorTest {
           };
       while (fillOperator.hasNext()) {
         TsBlock block = nextNonEmpty(fillOperator);
+        if (block == null) {
+          continue;
+        }
         for (int i = 0; i < block.getPositionCount(); i++) {
           long expectedTime = i + 1 + count * 10000L;
           assertEquals(expectedTime, block.getTimeByIndex(i));
@@ -385,6 +388,9 @@ public class FillOperatorTest {
           };
       while (fillOperator.hasNext()) {
         TsBlock block = nextNonEmpty(fillOperator);
+        if (block == null) {
+          continue;
+        }
         for (int i = 0; i < block.getPositionCount(); i++) {
           long expectedTime = i + 1 + count * 10000L;
           assertEquals(expectedTime, block.getTimeByIndex(i));
@@ -562,6 +568,9 @@ public class FillOperatorTest {
           };
       while (fillOperator.hasNext()) {
         TsBlock block = nextNonEmpty(fillOperator);
+        if (block == null) {
+          continue;
+        }
         for (int i = 0; i < block.getPositionCount(); i++) {
           long expectedTime = i + 1 + count * 10000L;
           assertEquals(expectedTime, block.getTimeByIndex(i));

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/FillOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/FillOperatorTest.java
@@ -43,6 +43,7 @@ import org.junit.Test;
 import java.util.concurrent.ExecutorService;
 
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -210,7 +211,7 @@ public class FillOperatorTest {
             }
           };
       while (fillOperator.hasNext()) {
-        TsBlock block = fillOperator.next();
+        TsBlock block = nextNonNull(fillOperator);
         for (int i = 0; i < block.getPositionCount(); i++) {
           long expectedTime = i + 1 + count * 10000L;
           assertEquals(expectedTime, block.getTimeByIndex(i));
@@ -383,7 +384,7 @@ public class FillOperatorTest {
             }
           };
       while (fillOperator.hasNext()) {
-        TsBlock block = fillOperator.next();
+        TsBlock block = nextNonNull(fillOperator);
         for (int i = 0; i < block.getPositionCount(); i++) {
           long expectedTime = i + 1 + count * 10000L;
           assertEquals(expectedTime, block.getTimeByIndex(i));
@@ -560,7 +561,7 @@ public class FillOperatorTest {
             }
           };
       while (fillOperator.hasNext()) {
-        TsBlock block = fillOperator.next();
+        TsBlock block = nextNonNull(fillOperator);
         for (int i = 0; i < block.getPositionCount(); i++) {
           long expectedTime = i + 1 + count * 10000L;
           assertEquals(expectedTime, block.getTimeByIndex(i));

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/HorizontallyConcatOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/HorizontallyConcatOperatorTest.java
@@ -68,7 +68,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
 import static org.apache.iotdb.db.queryengine.execution.operator.AggregationUtil.initTimeRangeIterator;
-import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNull;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonEmpty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -204,7 +204,7 @@ public class HorizontallyConcatOperatorTest {
       int count = 0;
       while (horizontallyConcatOperator.isBlocked().isDone()
           && horizontallyConcatOperator.hasNext()) {
-        TsBlock tsBlock = nextNonNull(horizontallyConcatOperator);
+        TsBlock tsBlock = nextNonEmpty(horizontallyConcatOperator);
         assertEquals(6, tsBlock.getValueColumnCount());
         for (int i = 0; i < tsBlock.getPositionCount(); i++, count++) {
           assertEquals(count, tsBlock.getTimeByIndex(i));

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/HorizontallyConcatOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/HorizontallyConcatOperatorTest.java
@@ -68,6 +68,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
 import static org.apache.iotdb.db.queryengine.execution.operator.AggregationUtil.initTimeRangeIterator;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -203,7 +204,7 @@ public class HorizontallyConcatOperatorTest {
       int count = 0;
       while (horizontallyConcatOperator.isBlocked().isDone()
           && horizontallyConcatOperator.hasNext()) {
-        TsBlock tsBlock = horizontallyConcatOperator.next();
+        TsBlock tsBlock = nextNonNull(horizontallyConcatOperator);
         assertEquals(6, tsBlock.getValueColumnCount());
         for (int i = 0; i < tsBlock.getPositionCount(); i++, count++) {
           assertEquals(count, tsBlock.getTimeByIndex(i));

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/HorizontallyConcatOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/HorizontallyConcatOperatorTest.java
@@ -68,7 +68,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
 import static org.apache.iotdb.db.queryengine.execution.operator.AggregationUtil.initTimeRangeIterator;
-import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonEmpty;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNullOrEmpty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -204,10 +204,7 @@ public class HorizontallyConcatOperatorTest {
       int count = 0;
       while (horizontallyConcatOperator.isBlocked().isDone()
           && horizontallyConcatOperator.hasNext()) {
-        TsBlock tsBlock = nextNonEmpty(horizontallyConcatOperator);
-        if (tsBlock == null) {
-          continue;
-        }
+        TsBlock tsBlock = nextNonNullOrEmpty(horizontallyConcatOperator);
         assertEquals(6, tsBlock.getValueColumnCount());
         for (int i = 0; i < tsBlock.getPositionCount(); i++, count++) {
           assertEquals(count, tsBlock.getTimeByIndex(i));

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/HorizontallyConcatOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/HorizontallyConcatOperatorTest.java
@@ -205,6 +205,9 @@ public class HorizontallyConcatOperatorTest {
       while (horizontallyConcatOperator.isBlocked().isDone()
           && horizontallyConcatOperator.hasNext()) {
         TsBlock tsBlock = nextNonEmpty(horizontallyConcatOperator);
+        if (tsBlock == null) {
+          continue;
+        }
         assertEquals(6, tsBlock.getValueColumnCount());
         for (int i = 0; i < tsBlock.getPositionCount(); i++, count++) {
           assertEquals(count, tsBlock.getTimeByIndex(i));

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/MergeTreeSortOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/MergeTreeSortOperatorTest.java
@@ -1796,6 +1796,9 @@ public class MergeTreeSortOperatorTest {
     int index = 0;
     while (treeMergeSortOperator.isBlocked().isDone() && treeMergeSortOperator.hasNext()) {
       TsBlock result = nextNonEmpty(treeMergeSortOperator);
+      if (result == null) {
+        continue;
+      }
       for (int i = 0; i < result.getPositionCount(); i++) {
         long time = result.getTimeByIndex(i);
         assertEquals(time, ans[index++]);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/MergeTreeSortOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/MergeTreeSortOperatorTest.java
@@ -93,7 +93,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
-import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNull;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonEmpty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -1795,7 +1795,7 @@ public class MergeTreeSortOperatorTest {
 
     int index = 0;
     while (treeMergeSortOperator.isBlocked().isDone() && treeMergeSortOperator.hasNext()) {
-      TsBlock result = nextNonNull(treeMergeSortOperator);
+      TsBlock result = nextNonEmpty(treeMergeSortOperator);
       for (int i = 0; i < result.getPositionCount(); i++) {
         long time = result.getTimeByIndex(i);
         assertEquals(time, ans[index++]);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/MergeTreeSortOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/MergeTreeSortOperatorTest.java
@@ -93,7 +93,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
-import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonEmpty;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNullOrEmpty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -1795,10 +1795,7 @@ public class MergeTreeSortOperatorTest {
 
     int index = 0;
     while (treeMergeSortOperator.isBlocked().isDone() && treeMergeSortOperator.hasNext()) {
-      TsBlock result = nextNonEmpty(treeMergeSortOperator);
-      if (result == null) {
-        continue;
-      }
+      TsBlock result = nextNonNullOrEmpty(treeMergeSortOperator);
       for (int i = 0; i < result.getPositionCount(); i++) {
         long time = result.getTimeByIndex(i);
         assertEquals(time, ans[index++]);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/MergeTreeSortOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/MergeTreeSortOperatorTest.java
@@ -93,6 +93,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -1794,7 +1795,7 @@ public class MergeTreeSortOperatorTest {
 
     int index = 0;
     while (treeMergeSortOperator.isBlocked().isDone() && treeMergeSortOperator.hasNext()) {
-      TsBlock result = treeMergeSortOperator.next();
+      TsBlock result = nextNonNull(treeMergeSortOperator);
       for (int i = 0; i < result.getPositionCount(); i++) {
         long time = result.getTimeByIndex(i);
         assertEquals(time, ans[index++]);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OffsetOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OffsetOperatorTest.java
@@ -65,6 +65,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.isNullOrEmpty;
 import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -383,11 +384,11 @@ public class OffsetOperatorTest {
           new OffsetOperator(driverContext.getOperatorContexts().get(3), 500, timeJoinOperator);
 
       while (offsetOperator.isBlocked().isDone() && offsetOperator.hasNext()) {
-        TsBlock tsBlock = nextNonNull(offsetOperator);
-        assertEquals(2, tsBlock.getValueColumnCount());
-        assertTrue(tsBlock.getColumn(0) instanceof IntColumn);
-        assertTrue(tsBlock.getColumn(1) instanceof IntColumn);
-        assertEquals(0, tsBlock.getPositionCount());
+        TsBlock tsBlock = offsetOperator.next();
+        if (isNullOrEmpty(tsBlock)) {
+          continue;
+        }
+        fail("Expected no data from offset operator");
       }
     } catch (IllegalPathException e) {
       e.printStackTrace();
@@ -475,11 +476,11 @@ public class OffsetOperatorTest {
               driverContext.getOperatorContexts().get(3), 98_784_247_808L, timeJoinOperator);
 
       while (offsetOperator.isBlocked().isDone() && offsetOperator.hasNext()) {
-        TsBlock tsBlock = nextNonNull(offsetOperator);
-        assertEquals(2, tsBlock.getValueColumnCount());
-        assertTrue(tsBlock.getColumn(0) instanceof IntColumn);
-        assertTrue(tsBlock.getColumn(1) instanceof IntColumn);
-        assertEquals(0, tsBlock.getPositionCount());
+        TsBlock tsBlock = offsetOperator.next();
+        if (isNullOrEmpty(tsBlock)) {
+          continue;
+        }
+        fail("Expected no data from offset operator");
       }
     } catch (IllegalPathException e) {
       e.printStackTrace();

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OffsetOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OffsetOperatorTest.java
@@ -65,6 +65,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -168,10 +169,7 @@ public class OffsetOperatorTest {
           new LimitOperator(driverContext.getOperatorContexts().get(4), 250, offsetOperator);
       int count = 100;
       while (limitOperator.isBlocked().isDone() && limitOperator.hasNext()) {
-        TsBlock tsBlock = limitOperator.next();
-        if (tsBlock == null) {
-          continue;
-        }
+        TsBlock tsBlock = nextNonNull(limitOperator);
         assertEquals(2, tsBlock.getValueColumnCount());
         assertTrue(tsBlock.getColumn(0) instanceof IntColumn);
         assertTrue(tsBlock.getColumn(1) instanceof IntColumn);
@@ -279,10 +277,7 @@ public class OffsetOperatorTest {
 
       int count = 0;
       while (offsetOperator.isBlocked().isDone() && offsetOperator.hasNext()) {
-        TsBlock tsBlock = offsetOperator.next();
-        if (tsBlock == null) {
-          continue;
-        }
+        TsBlock tsBlock = nextNonNull(offsetOperator);
         assertEquals(2, tsBlock.getValueColumnCount());
         assertTrue(tsBlock.getColumn(0) instanceof IntColumn);
         assertTrue(tsBlock.getColumn(1) instanceof IntColumn);
@@ -388,10 +383,7 @@ public class OffsetOperatorTest {
           new OffsetOperator(driverContext.getOperatorContexts().get(3), 500, timeJoinOperator);
 
       while (offsetOperator.isBlocked().isDone() && offsetOperator.hasNext()) {
-        TsBlock tsBlock = offsetOperator.next();
-        if (tsBlock == null) {
-          continue;
-        }
+        TsBlock tsBlock = nextNonNull(offsetOperator);
         assertEquals(2, tsBlock.getValueColumnCount());
         assertTrue(tsBlock.getColumn(0) instanceof IntColumn);
         assertTrue(tsBlock.getColumn(1) instanceof IntColumn);
@@ -483,10 +475,7 @@ public class OffsetOperatorTest {
               driverContext.getOperatorContexts().get(3), 98_784_247_808L, timeJoinOperator);
 
       while (offsetOperator.isBlocked().isDone() && offsetOperator.hasNext()) {
-        TsBlock tsBlock = offsetOperator.next();
-        if (tsBlock == null) {
-          continue;
-        }
+        TsBlock tsBlock = nextNonNull(offsetOperator);
         assertEquals(2, tsBlock.getValueColumnCount());
         assertTrue(tsBlock.getColumn(0) instanceof IntColumn);
         assertTrue(tsBlock.getColumn(1) instanceof IntColumn);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OffsetOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OffsetOperatorTest.java
@@ -65,7 +65,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
-import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.isNullOrEmpty;
 import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -385,7 +384,13 @@ public class OffsetOperatorTest {
 
       while (offsetOperator.isBlocked().isDone() && offsetOperator.hasNext()) {
         TsBlock tsBlock = offsetOperator.next();
-        if (isNullOrEmpty(tsBlock)) {
+        if (tsBlock == null) {
+          continue;
+        }
+        assertEquals(2, tsBlock.getValueColumnCount());
+        assertTrue(tsBlock.getColumn(0) instanceof IntColumn);
+        assertTrue(tsBlock.getColumn(1) instanceof IntColumn);
+        if (tsBlock.getPositionCount() == 0) {
           continue;
         }
         fail("Expected no data from offset operator");
@@ -477,7 +482,13 @@ public class OffsetOperatorTest {
 
       while (offsetOperator.isBlocked().isDone() && offsetOperator.hasNext()) {
         TsBlock tsBlock = offsetOperator.next();
-        if (isNullOrEmpty(tsBlock)) {
+        if (tsBlock == null) {
+          continue;
+        }
+        assertEquals(2, tsBlock.getValueColumnCount());
+        assertTrue(tsBlock.getColumn(0) instanceof IntColumn);
+        assertTrue(tsBlock.getColumn(1) instanceof IntColumn);
+        if (tsBlock.getPositionCount() == 0) {
           continue;
         }
         fail("Expected no data from offset operator");

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OffsetOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OffsetOperatorTest.java
@@ -66,7 +66,6 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
 import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonEmpty;
-import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonEmptyOrNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -171,6 +170,9 @@ public class OffsetOperatorTest {
       int count = 100;
       while (limitOperator.isBlocked().isDone() && limitOperator.hasNext()) {
         TsBlock tsBlock = nextNonEmpty(limitOperator);
+        if (tsBlock == null) {
+          continue;
+        }
         assertEquals(2, tsBlock.getValueColumnCount());
         assertTrue(tsBlock.getColumn(0) instanceof IntColumn);
         assertTrue(tsBlock.getColumn(1) instanceof IntColumn);
@@ -279,6 +281,9 @@ public class OffsetOperatorTest {
       int count = 0;
       while (offsetOperator.isBlocked().isDone() && offsetOperator.hasNext()) {
         TsBlock tsBlock = nextNonEmpty(offsetOperator);
+        if (tsBlock == null) {
+          continue;
+        }
         assertEquals(2, tsBlock.getValueColumnCount());
         assertTrue(tsBlock.getColumn(0) instanceof IntColumn);
         assertTrue(tsBlock.getColumn(1) instanceof IntColumn);
@@ -384,7 +389,7 @@ public class OffsetOperatorTest {
           new OffsetOperator(driverContext.getOperatorContexts().get(3), 500, timeJoinOperator);
 
       while (offsetOperator.isBlocked().isDone() && offsetOperator.hasNext()) {
-        TsBlock tsBlock = nextNonEmptyOrNull(offsetOperator);
+        TsBlock tsBlock = nextNonEmpty(offsetOperator);
         if (tsBlock == null) {
           continue;
         }
@@ -476,7 +481,7 @@ public class OffsetOperatorTest {
               driverContext.getOperatorContexts().get(3), 98_784_247_808L, timeJoinOperator);
 
       while (offsetOperator.isBlocked().isDone() && offsetOperator.hasNext()) {
-        TsBlock tsBlock = nextNonEmptyOrNull(offsetOperator);
+        TsBlock tsBlock = nextNonEmpty(offsetOperator);
         if (tsBlock == null) {
           continue;
         }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OffsetOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OffsetOperatorTest.java
@@ -65,7 +65,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
-import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNull;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonEmpty;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonEmptyOrNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -169,7 +170,7 @@ public class OffsetOperatorTest {
           new LimitOperator(driverContext.getOperatorContexts().get(4), 250, offsetOperator);
       int count = 100;
       while (limitOperator.isBlocked().isDone() && limitOperator.hasNext()) {
-        TsBlock tsBlock = nextNonNull(limitOperator);
+        TsBlock tsBlock = nextNonEmpty(limitOperator);
         assertEquals(2, tsBlock.getValueColumnCount());
         assertTrue(tsBlock.getColumn(0) instanceof IntColumn);
         assertTrue(tsBlock.getColumn(1) instanceof IntColumn);
@@ -277,7 +278,7 @@ public class OffsetOperatorTest {
 
       int count = 0;
       while (offsetOperator.isBlocked().isDone() && offsetOperator.hasNext()) {
-        TsBlock tsBlock = nextNonNull(offsetOperator);
+        TsBlock tsBlock = nextNonEmpty(offsetOperator);
         assertEquals(2, tsBlock.getValueColumnCount());
         assertTrue(tsBlock.getColumn(0) instanceof IntColumn);
         assertTrue(tsBlock.getColumn(1) instanceof IntColumn);
@@ -383,14 +384,8 @@ public class OffsetOperatorTest {
           new OffsetOperator(driverContext.getOperatorContexts().get(3), 500, timeJoinOperator);
 
       while (offsetOperator.isBlocked().isDone() && offsetOperator.hasNext()) {
-        TsBlock tsBlock = offsetOperator.next();
+        TsBlock tsBlock = nextNonEmptyOrNull(offsetOperator);
         if (tsBlock == null) {
-          continue;
-        }
-        assertEquals(2, tsBlock.getValueColumnCount());
-        assertTrue(tsBlock.getColumn(0) instanceof IntColumn);
-        assertTrue(tsBlock.getColumn(1) instanceof IntColumn);
-        if (tsBlock.getPositionCount() == 0) {
           continue;
         }
         fail("Expected no data from offset operator");
@@ -481,14 +476,8 @@ public class OffsetOperatorTest {
               driverContext.getOperatorContexts().get(3), 98_784_247_808L, timeJoinOperator);
 
       while (offsetOperator.isBlocked().isDone() && offsetOperator.hasNext()) {
-        TsBlock tsBlock = offsetOperator.next();
+        TsBlock tsBlock = nextNonEmptyOrNull(offsetOperator);
         if (tsBlock == null) {
-          continue;
-        }
-        assertEquals(2, tsBlock.getValueColumnCount());
-        assertTrue(tsBlock.getColumn(0) instanceof IntColumn);
-        assertTrue(tsBlock.getColumn(1) instanceof IntColumn);
-        if (tsBlock.getPositionCount() == 0) {
           continue;
         }
         fail("Expected no data from offset operator");

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OffsetOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OffsetOperatorTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.queryengine.execution.operator;
 
+import org.apache.iotdb.calc.execution.operator.Operator;
 import org.apache.iotdb.calc.execution.operator.process.LimitOperator;
 import org.apache.iotdb.calc.execution.operator.process.OffsetOperator;
 import org.apache.iotdb.commons.concurrent.IoTDBThreadPoolFactory;
@@ -65,7 +66,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
-import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonEmpty;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNullOrEmpty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -169,10 +170,7 @@ public class OffsetOperatorTest {
           new LimitOperator(driverContext.getOperatorContexts().get(4), 250, offsetOperator);
       int count = 100;
       while (limitOperator.isBlocked().isDone() && limitOperator.hasNext()) {
-        TsBlock tsBlock = nextNonEmpty(limitOperator);
-        if (tsBlock == null) {
-          continue;
-        }
+        TsBlock tsBlock = nextNonNullOrEmpty(limitOperator);
         assertEquals(2, tsBlock.getValueColumnCount());
         assertTrue(tsBlock.getColumn(0) instanceof IntColumn);
         assertTrue(tsBlock.getColumn(1) instanceof IntColumn);
@@ -280,10 +278,7 @@ public class OffsetOperatorTest {
 
       int count = 0;
       while (offsetOperator.isBlocked().isDone() && offsetOperator.hasNext()) {
-        TsBlock tsBlock = nextNonEmpty(offsetOperator);
-        if (tsBlock == null) {
-          continue;
-        }
+        TsBlock tsBlock = nextNonNullOrEmpty(offsetOperator);
         assertEquals(2, tsBlock.getValueColumnCount());
         assertTrue(tsBlock.getColumn(0) instanceof IntColumn);
         assertTrue(tsBlock.getColumn(1) instanceof IntColumn);
@@ -389,11 +384,11 @@ public class OffsetOperatorTest {
           new OffsetOperator(driverContext.getOperatorContexts().get(3), 500, timeJoinOperator);
 
       while (offsetOperator.isBlocked().isDone() && offsetOperator.hasNext()) {
-        TsBlock tsBlock = nextNonEmpty(offsetOperator);
-        if (tsBlock == null) {
-          continue;
-        }
-        fail("Expected no data from offset operator");
+        TsBlock tsBlock = nextNonNull(offsetOperator);
+        assertEquals(2, tsBlock.getValueColumnCount());
+        assertTrue(tsBlock.getColumn(0) instanceof IntColumn);
+        assertTrue(tsBlock.getColumn(1) instanceof IntColumn);
+        assertEquals(0, tsBlock.getPositionCount());
       }
     } catch (IllegalPathException e) {
       e.printStackTrace();
@@ -481,11 +476,11 @@ public class OffsetOperatorTest {
               driverContext.getOperatorContexts().get(3), 98_784_247_808L, timeJoinOperator);
 
       while (offsetOperator.isBlocked().isDone() && offsetOperator.hasNext()) {
-        TsBlock tsBlock = nextNonEmpty(offsetOperator);
-        if (tsBlock == null) {
-          continue;
-        }
-        fail("Expected no data from offset operator");
+        TsBlock tsBlock = nextNonNull(offsetOperator);
+        assertEquals(2, tsBlock.getValueColumnCount());
+        assertTrue(tsBlock.getColumn(0) instanceof IntColumn);
+        assertTrue(tsBlock.getColumn(1) instanceof IntColumn);
+        assertEquals(0, tsBlock.getPositionCount());
       }
     } catch (IllegalPathException e) {
       e.printStackTrace();
@@ -493,5 +488,15 @@ public class OffsetOperatorTest {
     } finally {
       instanceNotificationExecutor.shutdown();
     }
+  }
+
+  private static TsBlock nextNonNull(Operator operator) throws Exception {
+    while (operator.hasNext()) {
+      TsBlock result = operator.next();
+      if (result != null) {
+        return result;
+      }
+    }
+    throw new AssertionError("Expected a non-null TsBlock from operator");
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OffsetOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OffsetOperatorTest.java
@@ -169,6 +169,9 @@ public class OffsetOperatorTest {
       int count = 100;
       while (limitOperator.isBlocked().isDone() && limitOperator.hasNext()) {
         TsBlock tsBlock = limitOperator.next();
+        if (tsBlock == null) {
+          continue;
+        }
         assertEquals(2, tsBlock.getValueColumnCount());
         assertTrue(tsBlock.getColumn(0) instanceof IntColumn);
         assertTrue(tsBlock.getColumn(1) instanceof IntColumn);
@@ -277,6 +280,9 @@ public class OffsetOperatorTest {
       int count = 0;
       while (offsetOperator.isBlocked().isDone() && offsetOperator.hasNext()) {
         TsBlock tsBlock = offsetOperator.next();
+        if (tsBlock == null) {
+          continue;
+        }
         assertEquals(2, tsBlock.getValueColumnCount());
         assertTrue(tsBlock.getColumn(0) instanceof IntColumn);
         assertTrue(tsBlock.getColumn(1) instanceof IntColumn);
@@ -383,6 +389,9 @@ public class OffsetOperatorTest {
 
       while (offsetOperator.isBlocked().isDone() && offsetOperator.hasNext()) {
         TsBlock tsBlock = offsetOperator.next();
+        if (tsBlock == null) {
+          continue;
+        }
         assertEquals(2, tsBlock.getValueColumnCount());
         assertTrue(tsBlock.getColumn(0) instanceof IntColumn);
         assertTrue(tsBlock.getColumn(1) instanceof IntColumn);
@@ -475,6 +484,9 @@ public class OffsetOperatorTest {
 
       while (offsetOperator.isBlocked().isDone() && offsetOperator.hasNext()) {
         TsBlock tsBlock = offsetOperator.next();
+        if (tsBlock == null) {
+          continue;
+        }
         assertEquals(2, tsBlock.getValueColumnCount());
         assertTrue(tsBlock.getColumn(0) instanceof IntColumn);
         assertTrue(tsBlock.getColumn(1) instanceof IntColumn);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OperatorTestUtils.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OperatorTestUtils.java
@@ -28,17 +28,17 @@ public final class OperatorTestUtils {
     // Utility class.
   }
 
-  public static TsBlock nextNonEmpty(Operator operator) throws Exception {
+  public static TsBlock nextNonNullOrEmpty(Operator operator) throws Exception {
     while (operator.hasNext()) {
       TsBlock result = operator.next();
       if (!isNullOrEmpty(result)) {
         return result;
       }
     }
-    return null;
+    throw new AssertionError("Expected a non-null and non-empty TsBlock from operator");
   }
 
-  public static TsBlock lastNonEmpty(Operator operator) throws Exception {
+  public static TsBlock lastNonNullOrEmpty(Operator operator) throws Exception {
     TsBlock result = null;
     while (operator.isBlocked().isDone() && operator.hasNext()) {
       TsBlock nextResult = operator.next();

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OperatorTestUtils.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OperatorTestUtils.java
@@ -28,17 +28,25 @@ public final class OperatorTestUtils {
     // Utility class.
   }
 
-  public static TsBlock nextNonNull(Operator operator) throws Exception {
+  public static TsBlock nextNonEmpty(Operator operator) throws Exception {
+    TsBlock result = nextNonEmptyOrNull(operator);
+    if (result != null) {
+      return result;
+    }
+    throw new AssertionError("Expected a non-empty TsBlock from operator");
+  }
+
+  public static TsBlock nextNonEmptyOrNull(Operator operator) throws Exception {
     while (operator.hasNext()) {
       TsBlock result = operator.next();
       if (!isNullOrEmpty(result)) {
         return result;
       }
     }
-    throw new AssertionError("Expected a non-empty TsBlock from operator");
+    return null;
   }
 
-  public static TsBlock lastNonNull(Operator operator) throws Exception {
+  public static TsBlock lastNonEmpty(Operator operator) throws Exception {
     TsBlock result = null;
     while (operator.isBlocked().isDone() && operator.hasNext()) {
       TsBlock nextResult = operator.next();
@@ -49,7 +57,7 @@ public final class OperatorTestUtils {
     return result;
   }
 
-  public static boolean isNullOrEmpty(TsBlock tsBlock) {
+  private static boolean isNullOrEmpty(TsBlock tsBlock) {
     return tsBlock == null || tsBlock.getPositionCount() == 0;
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OperatorTestUtils.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OperatorTestUtils.java
@@ -31,21 +31,25 @@ public final class OperatorTestUtils {
   public static TsBlock nextNonNull(Operator operator) throws Exception {
     while (operator.hasNext()) {
       TsBlock result = operator.next();
-      if (result != null) {
+      if (!isNullOrEmpty(result)) {
         return result;
       }
     }
-    throw new AssertionError("Expected a non-null TsBlock from operator");
+    throw new AssertionError("Expected a non-empty TsBlock from operator");
   }
 
   public static TsBlock lastNonNull(Operator operator) throws Exception {
     TsBlock result = null;
     while (operator.isBlocked().isDone() && operator.hasNext()) {
       TsBlock nextResult = operator.next();
-      if (nextResult != null) {
+      if (!isNullOrEmpty(nextResult)) {
         result = nextResult;
       }
     }
     return result;
+  }
+
+  public static boolean isNullOrEmpty(TsBlock tsBlock) {
+    return tsBlock == null || tsBlock.getPositionCount() == 0;
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OperatorTestUtils.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OperatorTestUtils.java
@@ -29,14 +29,6 @@ public final class OperatorTestUtils {
   }
 
   public static TsBlock nextNonEmpty(Operator operator) throws Exception {
-    TsBlock result = nextNonEmptyOrNull(operator);
-    if (result != null) {
-      return result;
-    }
-    throw new AssertionError("Expected a non-empty TsBlock from operator");
-  }
-
-  public static TsBlock nextNonEmptyOrNull(Operator operator) throws Exception {
     while (operator.hasNext()) {
       TsBlock result = operator.next();
       if (!isNullOrEmpty(result)) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OperatorTestUtils.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/OperatorTestUtils.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.queryengine.execution.operator;
+
+import org.apache.iotdb.calc.execution.operator.Operator;
+
+import org.apache.tsfile.read.common.block.TsBlock;
+
+public final class OperatorTestUtils {
+
+  private OperatorTestUtils() {
+    // Utility class.
+  }
+
+  public static TsBlock nextNonNull(Operator operator) throws Exception {
+    while (operator.hasNext()) {
+      TsBlock result = operator.next();
+      if (result != null) {
+        return result;
+      }
+    }
+    throw new AssertionError("Expected a non-null TsBlock from operator");
+  }
+
+  public static TsBlock lastNonNull(Operator operator) throws Exception {
+    TsBlock result = null;
+    while (operator.isBlocked().isDone() && operator.hasNext()) {
+      TsBlock nextResult = operator.next();
+      if (nextResult != null) {
+        result = nextResult;
+      }
+    }
+    return result;
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/SeriesAggregationScanOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/SeriesAggregationScanOperatorTest.java
@@ -68,6 +68,7 @@ import java.util.concurrent.ExecutorService;
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
 import static org.apache.iotdb.db.queryengine.execution.operator.AggregationOperatorTest.TEST_TIME_SLICE;
 import static org.apache.iotdb.db.queryengine.execution.operator.AggregationUtil.initTimeRangeIterator;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNull;
 import static org.junit.Assert.assertEquals;
 
 public class SeriesAggregationScanOperatorTest {
@@ -113,7 +114,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       assertEquals(500, resultTsBlock.getColumn(0).getLong(0));
       count++;
     }
@@ -137,7 +138,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       assertEquals(500, resultTsBlock.getColumn(0).getLong(0));
       count++;
     }
@@ -163,7 +164,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       assertEquals(500, resultTsBlock.getColumn(0).getLong(0));
       assertEquals(6524750.0, resultTsBlock.getColumn(1).getDouble(0), 0.0001);
       count++;
@@ -194,7 +195,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       assertEquals(20000, resultTsBlock.getColumn(0).getInt(0));
       assertEquals(10499, resultTsBlock.getColumn(1).getInt(0));
       assertEquals(0, resultTsBlock.getColumn(2).getLong(0));
@@ -230,7 +231,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       assertEquals(20000, resultTsBlock.getColumn(0).getInt(0));
       assertEquals(10499, resultTsBlock.getColumn(1).getInt(0));
       assertEquals(0, resultTsBlock.getColumn(2).getLong(0));
@@ -261,7 +262,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       assertEquals(resultTsBlock.getColumn(0).getLong(0), 380);
       count++;
     }
@@ -287,7 +288,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       assertEquals(resultTsBlock.getColumn(0).getLong(0), 380);
       count++;
     }
@@ -313,7 +314,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       assertEquals(resultTsBlock.getColumn(0).getLong(0), 300);
       count++;
     }
@@ -345,7 +346,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       assertEquals(20100, resultTsBlock.getColumn(0).getInt(0));
       assertEquals(399, resultTsBlock.getColumn(1).getInt(0));
       assertEquals(100, resultTsBlock.getColumn(2).getLong(0));
@@ -377,7 +378,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -410,7 +411,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -452,7 +453,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -497,7 +498,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * (3 - count), resultTsBlock.getTimeColumn().getLong(pos));
@@ -532,7 +533,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(50 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -565,7 +566,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(timeColumn[count], resultTsBlock.getTimeColumn().getLong(pos));
@@ -608,7 +609,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = seriesAggregationScanOperator.next();
+      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(timeColumn[count], resultTsBlock.getTimeColumn().getLong(pos));

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/SeriesAggregationScanOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/SeriesAggregationScanOperatorTest.java
@@ -68,7 +68,7 @@ import java.util.concurrent.ExecutorService;
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
 import static org.apache.iotdb.db.queryengine.execution.operator.AggregationOperatorTest.TEST_TIME_SLICE;
 import static org.apache.iotdb.db.queryengine.execution.operator.AggregationUtil.initTimeRangeIterator;
-import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNull;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonEmpty;
 import static org.junit.Assert.assertEquals;
 
 public class SeriesAggregationScanOperatorTest {
@@ -114,7 +114,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       assertEquals(500, resultTsBlock.getColumn(0).getLong(0));
       count++;
     }
@@ -138,7 +138,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       assertEquals(500, resultTsBlock.getColumn(0).getLong(0));
       count++;
     }
@@ -164,7 +164,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       assertEquals(500, resultTsBlock.getColumn(0).getLong(0));
       assertEquals(6524750.0, resultTsBlock.getColumn(1).getDouble(0), 0.0001);
       count++;
@@ -195,7 +195,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       assertEquals(20000, resultTsBlock.getColumn(0).getInt(0));
       assertEquals(10499, resultTsBlock.getColumn(1).getInt(0));
       assertEquals(0, resultTsBlock.getColumn(2).getLong(0));
@@ -231,7 +231,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       assertEquals(20000, resultTsBlock.getColumn(0).getInt(0));
       assertEquals(10499, resultTsBlock.getColumn(1).getInt(0));
       assertEquals(0, resultTsBlock.getColumn(2).getLong(0));
@@ -262,7 +262,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       assertEquals(resultTsBlock.getColumn(0).getLong(0), 380);
       count++;
     }
@@ -288,7 +288,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       assertEquals(resultTsBlock.getColumn(0).getLong(0), 380);
       count++;
     }
@@ -314,7 +314,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       assertEquals(resultTsBlock.getColumn(0).getLong(0), 300);
       count++;
     }
@@ -346,7 +346,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       assertEquals(20100, resultTsBlock.getColumn(0).getInt(0));
       assertEquals(399, resultTsBlock.getColumn(1).getInt(0));
       assertEquals(100, resultTsBlock.getColumn(2).getLong(0));
@@ -378,7 +378,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -411,7 +411,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -453,7 +453,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -498,7 +498,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * (3 - count), resultTsBlock.getTimeColumn().getLong(pos));
@@ -533,7 +533,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(50 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -566,7 +566,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(timeColumn[count], resultTsBlock.getTimeColumn().getLong(pos));
@@ -609,7 +609,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonNull(seriesAggregationScanOperator);
+      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(timeColumn[count], resultTsBlock.getTimeColumn().getLong(pos));

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/SeriesAggregationScanOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/SeriesAggregationScanOperatorTest.java
@@ -115,6 +115,9 @@ public class SeriesAggregationScanOperatorTest {
 
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       assertEquals(500, resultTsBlock.getColumn(0).getLong(0));
       count++;
     }
@@ -139,6 +142,9 @@ public class SeriesAggregationScanOperatorTest {
 
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       assertEquals(500, resultTsBlock.getColumn(0).getLong(0));
       count++;
     }
@@ -165,6 +171,9 @@ public class SeriesAggregationScanOperatorTest {
 
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       assertEquals(500, resultTsBlock.getColumn(0).getLong(0));
       assertEquals(6524750.0, resultTsBlock.getColumn(1).getDouble(0), 0.0001);
       count++;
@@ -196,6 +205,9 @@ public class SeriesAggregationScanOperatorTest {
 
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       assertEquals(20000, resultTsBlock.getColumn(0).getInt(0));
       assertEquals(10499, resultTsBlock.getColumn(1).getInt(0));
       assertEquals(0, resultTsBlock.getColumn(2).getLong(0));
@@ -232,6 +244,9 @@ public class SeriesAggregationScanOperatorTest {
 
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       assertEquals(20000, resultTsBlock.getColumn(0).getInt(0));
       assertEquals(10499, resultTsBlock.getColumn(1).getInt(0));
       assertEquals(0, resultTsBlock.getColumn(2).getLong(0));
@@ -263,6 +278,9 @@ public class SeriesAggregationScanOperatorTest {
 
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       assertEquals(resultTsBlock.getColumn(0).getLong(0), 380);
       count++;
     }
@@ -289,6 +307,9 @@ public class SeriesAggregationScanOperatorTest {
 
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       assertEquals(resultTsBlock.getColumn(0).getLong(0), 380);
       count++;
     }
@@ -315,6 +336,9 @@ public class SeriesAggregationScanOperatorTest {
 
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       assertEquals(resultTsBlock.getColumn(0).getLong(0), 300);
       count++;
     }
@@ -347,6 +371,9 @@ public class SeriesAggregationScanOperatorTest {
 
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       assertEquals(20100, resultTsBlock.getColumn(0).getInt(0));
       assertEquals(399, resultTsBlock.getColumn(1).getInt(0));
       assertEquals(100, resultTsBlock.getColumn(2).getLong(0));
@@ -379,6 +406,9 @@ public class SeriesAggregationScanOperatorTest {
 
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -412,6 +442,9 @@ public class SeriesAggregationScanOperatorTest {
 
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -454,6 +487,9 @@ public class SeriesAggregationScanOperatorTest {
 
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -499,6 +535,9 @@ public class SeriesAggregationScanOperatorTest {
 
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * (3 - count), resultTsBlock.getTimeColumn().getLong(pos));
@@ -534,6 +573,9 @@ public class SeriesAggregationScanOperatorTest {
 
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(50 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -567,6 +609,9 @@ public class SeriesAggregationScanOperatorTest {
 
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(timeColumn[count], resultTsBlock.getTimeColumn().getLong(pos));
@@ -610,6 +655,9 @@ public class SeriesAggregationScanOperatorTest {
 
     while (seriesAggregationScanOperator.hasNext()) {
       TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
+      if (resultTsBlock == null) {
+        continue;
+      }
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(timeColumn[count], resultTsBlock.getTimeColumn().getLong(pos));

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/SeriesAggregationScanOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/SeriesAggregationScanOperatorTest.java
@@ -68,7 +68,7 @@ import java.util.concurrent.ExecutorService;
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
 import static org.apache.iotdb.db.queryengine.execution.operator.AggregationOperatorTest.TEST_TIME_SLICE;
 import static org.apache.iotdb.db.queryengine.execution.operator.AggregationUtil.initTimeRangeIterator;
-import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonEmpty;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNullOrEmpty;
 import static org.junit.Assert.assertEquals;
 
 public class SeriesAggregationScanOperatorTest {
@@ -114,10 +114,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       assertEquals(500, resultTsBlock.getColumn(0).getLong(0));
       count++;
     }
@@ -141,10 +138,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       assertEquals(500, resultTsBlock.getColumn(0).getLong(0));
       count++;
     }
@@ -170,10 +164,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       assertEquals(500, resultTsBlock.getColumn(0).getLong(0));
       assertEquals(6524750.0, resultTsBlock.getColumn(1).getDouble(0), 0.0001);
       count++;
@@ -204,10 +195,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       assertEquals(20000, resultTsBlock.getColumn(0).getInt(0));
       assertEquals(10499, resultTsBlock.getColumn(1).getInt(0));
       assertEquals(0, resultTsBlock.getColumn(2).getLong(0));
@@ -243,10 +231,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       assertEquals(20000, resultTsBlock.getColumn(0).getInt(0));
       assertEquals(10499, resultTsBlock.getColumn(1).getInt(0));
       assertEquals(0, resultTsBlock.getColumn(2).getLong(0));
@@ -277,10 +262,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       assertEquals(resultTsBlock.getColumn(0).getLong(0), 380);
       count++;
     }
@@ -306,10 +288,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       assertEquals(resultTsBlock.getColumn(0).getLong(0), 380);
       count++;
     }
@@ -335,10 +314,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       assertEquals(resultTsBlock.getColumn(0).getLong(0), 300);
       count++;
     }
@@ -370,10 +346,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       assertEquals(20100, resultTsBlock.getColumn(0).getInt(0));
       assertEquals(399, resultTsBlock.getColumn(1).getInt(0));
       assertEquals(100, resultTsBlock.getColumn(2).getLong(0));
@@ -405,10 +378,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -441,10 +411,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -486,10 +453,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -534,10 +498,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(100 * (3 - count), resultTsBlock.getTimeColumn().getLong(pos));
@@ -572,10 +533,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(50 * count, resultTsBlock.getTimeColumn().getLong(pos));
@@ -608,10 +566,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(timeColumn[count], resultTsBlock.getTimeColumn().getLong(pos));
@@ -654,10 +609,7 @@ public class SeriesAggregationScanOperatorTest {
     int count = 0;
 
     while (seriesAggregationScanOperator.hasNext()) {
-      TsBlock resultTsBlock = nextNonEmpty(seriesAggregationScanOperator);
-      if (resultTsBlock == null) {
-        continue;
-      }
+      TsBlock resultTsBlock = nextNonNullOrEmpty(seriesAggregationScanOperator);
       int positionCount = resultTsBlock.getPositionCount();
       for (int pos = 0; pos < positionCount; pos++) {
         assertEquals(timeColumn[count], resultTsBlock.getTimeColumn().getLong(pos));

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/SeriesScanOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/SeriesScanOperatorTest.java
@@ -58,7 +58,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
-import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNull;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonEmpty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -120,7 +120,7 @@ public class SeriesScanOperatorTest {
 
       int count = 0;
       while (seriesScanOperator.hasNext()) {
-        TsBlock tsBlock = nextNonNull(seriesScanOperator);
+        TsBlock tsBlock = nextNonEmpty(seriesScanOperator);
         if (tsBlock.isEmpty()) {
           continue;
         }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/SeriesScanOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/SeriesScanOperatorTest.java
@@ -121,7 +121,7 @@ public class SeriesScanOperatorTest {
       int count = 0;
       while (seriesScanOperator.hasNext()) {
         TsBlock tsBlock = nextNonEmpty(seriesScanOperator);
-        if (tsBlock.isEmpty()) {
+        if (tsBlock == null) {
           continue;
         }
         assertEquals(1, tsBlock.getValueColumnCount());

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/SeriesScanOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/SeriesScanOperatorTest.java
@@ -58,7 +58,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
-import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonEmpty;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNullOrEmpty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -120,10 +120,7 @@ public class SeriesScanOperatorTest {
 
       int count = 0;
       while (seriesScanOperator.hasNext()) {
-        TsBlock tsBlock = nextNonEmpty(seriesScanOperator);
-        if (tsBlock == null) {
-          continue;
-        }
+        TsBlock tsBlock = nextNonNullOrEmpty(seriesScanOperator);
         assertEquals(1, tsBlock.getValueColumnCount());
         assertTrue(tsBlock.getColumn(0) instanceof IntColumn);
         for (int i = 0; i < tsBlock.getPositionCount(); i++, count++) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/SeriesScanOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/SeriesScanOperatorTest.java
@@ -58,6 +58,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -119,7 +120,10 @@ public class SeriesScanOperatorTest {
 
       int count = 0;
       while (seriesScanOperator.hasNext()) {
-        TsBlock tsBlock = seriesScanOperator.next();
+        TsBlock tsBlock = nextNonNull(seriesScanOperator);
+        if (tsBlock.isEmpty()) {
+          continue;
+        }
         assertEquals(1, tsBlock.getValueColumnCount());
         assertTrue(tsBlock.getColumn(0) instanceof IntColumn);
         for (int i = 0; i < tsBlock.getPositionCount(); i++, count++) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/TreeIntoOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/TreeIntoOperatorTest.java
@@ -69,7 +69,7 @@ import java.util.concurrent.ExecutorService;
 
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
-import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.lastNonNull;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.lastNonEmpty;
 import static org.apache.iotdb.rpc.RpcUtils.SUCCESS_STATUS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -199,7 +199,7 @@ public class TreeIntoOperatorTest {
     prepareSourceTargetPairs(2);
     operator = createAndInitOperator(2);
 
-    TsBlock result = lastNonNull(operator);
+    TsBlock result = lastNonEmpty(operator);
     assertNotNull(result);
     assertEquals(2, result.getPositionCount());
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/TreeIntoOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/TreeIntoOperatorTest.java
@@ -69,7 +69,7 @@ import java.util.concurrent.ExecutorService;
 
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
-import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.lastNonEmpty;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.lastNonNullOrEmpty;
 import static org.apache.iotdb.rpc.RpcUtils.SUCCESS_STATUS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -199,7 +199,7 @@ public class TreeIntoOperatorTest {
     prepareSourceTargetPairs(2);
     operator = createAndInitOperator(2);
 
-    TsBlock result = lastNonEmpty(operator);
+    TsBlock result = lastNonNullOrEmpty(operator);
     assertNotNull(result);
     assertEquals(2, result.getPositionCount());
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/TreeIntoOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/TreeIntoOperatorTest.java
@@ -69,6 +69,7 @@ import java.util.concurrent.ExecutorService;
 
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.lastNonNull;
 import static org.apache.iotdb.rpc.RpcUtils.SUCCESS_STATUS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -198,10 +199,7 @@ public class TreeIntoOperatorTest {
     prepareSourceTargetPairs(2);
     operator = createAndInitOperator(2);
 
-    TsBlock result = null;
-    while (operator.isBlocked().isDone() && operator.hasNext()) {
-      result = operator.next();
-    }
+    TsBlock result = lastNonNull(operator);
     assertNotNull(result);
     assertEquals(2, result.getPositionCount());
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/TreeLinearFillOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/TreeLinearFillOperatorTest.java
@@ -1310,6 +1310,9 @@ public class TreeLinearFillOperatorTest {
 
       while (fillOperator.hasNext()) {
         TsBlock block = nextNonEmpty(fillOperator);
+        if (block == null) {
+          continue;
+        }
         for (int i = 0; i < block.getPositionCount(); i++) {
           long expectedTime = i + count;
           assertEquals(expectedTime, block.getTimeByIndex(i));

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/TreeLinearFillOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/TreeLinearFillOperatorTest.java
@@ -42,7 +42,7 @@ import org.junit.Test;
 import java.util.concurrent.ExecutorService;
 
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
-import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonEmpty;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNullOrEmpty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -1309,10 +1309,7 @@ public class TreeLinearFillOperatorTest {
           };
 
       while (fillOperator.hasNext()) {
-        TsBlock block = nextNonEmpty(fillOperator);
-        if (block == null) {
-          continue;
-        }
+        TsBlock block = nextNonNullOrEmpty(fillOperator);
         for (int i = 0; i < block.getPositionCount(); i++) {
           long expectedTime = i + count;
           assertEquals(expectedTime, block.getTimeByIndex(i));

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/TreeLinearFillOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/TreeLinearFillOperatorTest.java
@@ -42,7 +42,7 @@ import org.junit.Test;
 import java.util.concurrent.ExecutorService;
 
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
-import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNull;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonEmpty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -1309,7 +1309,7 @@ public class TreeLinearFillOperatorTest {
           };
 
       while (fillOperator.hasNext()) {
-        TsBlock block = nextNonNull(fillOperator);
+        TsBlock block = nextNonEmpty(fillOperator);
         for (int i = 0; i < block.getPositionCount(); i++) {
           long expectedTime = i + count;
           assertEquals(expectedTime, block.getTimeByIndex(i));

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/TreeLinearFillOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/TreeLinearFillOperatorTest.java
@@ -42,8 +42,8 @@ import org.junit.Test;
 import java.util.concurrent.ExecutorService;
 
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNull;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class TreeLinearFillOperatorTest {
@@ -1309,8 +1309,7 @@ public class TreeLinearFillOperatorTest {
           };
 
       while (fillOperator.hasNext()) {
-        TsBlock block = fillOperator.next();
-        assertNotNull(block);
+        TsBlock block = nextNonNull(fillOperator);
         for (int i = 0; i < block.getPositionCount(); i++) {
           long expectedTime = i + count;
           assertEquals(expectedTime, block.getTimeByIndex(i));

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/UpdateLastCacheOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/UpdateLastCacheOperatorTest.java
@@ -63,7 +63,7 @@ import java.util.concurrent.ExecutorService;
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
 import static org.apache.iotdb.db.queryengine.execution.operator.AggregationOperatorTest.TEST_TIME_SLICE;
 import static org.apache.iotdb.db.queryengine.execution.operator.AggregationUtil.initTimeRangeIterator;
-import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonEmpty;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNullOrEmpty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -106,7 +106,7 @@ public class UpdateLastCacheOperatorTest {
 
       assertTrue(updateLastCacheOperator.isBlocked().isDone());
       assertTrue(updateLastCacheOperator.hasNext());
-      TsBlock result = nextNonEmpty(updateLastCacheOperator);
+      TsBlock result = nextNonNullOrEmpty(updateLastCacheOperator);
       assertNotNull(result);
       assertEquals(1, result.getPositionCount());
       assertEquals(3, result.getValueColumnCount());
@@ -137,7 +137,7 @@ public class UpdateLastCacheOperatorTest {
 
       assertTrue(updateLastCacheOperator.isBlocked().isDone());
       assertTrue(updateLastCacheOperator.hasNext());
-      TsBlock result = nextNonEmpty(updateLastCacheOperator);
+      TsBlock result = nextNonNullOrEmpty(updateLastCacheOperator);
       assertNotNull(result);
       assertEquals(1, result.getPositionCount());
       assertEquals(3, result.getValueColumnCount());
@@ -168,7 +168,7 @@ public class UpdateLastCacheOperatorTest {
 
       assertTrue(updateLastCacheOperator.isBlocked().isDone());
       assertTrue(updateLastCacheOperator.hasNext());
-      TsBlock result = nextNonEmpty(updateLastCacheOperator);
+      TsBlock result = nextNonNullOrEmpty(updateLastCacheOperator);
       assertNotNull(result);
       assertEquals(1, result.getPositionCount());
       assertEquals(3, result.getValueColumnCount());

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/UpdateLastCacheOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/UpdateLastCacheOperatorTest.java
@@ -63,6 +63,7 @@ import java.util.concurrent.ExecutorService;
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
 import static org.apache.iotdb.db.queryengine.execution.operator.AggregationOperatorTest.TEST_TIME_SLICE;
 import static org.apache.iotdb.db.queryengine.execution.operator.AggregationUtil.initTimeRangeIterator;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -104,7 +105,7 @@ public class UpdateLastCacheOperatorTest {
 
       assertTrue(updateLastCacheOperator.isBlocked().isDone());
       assertTrue(updateLastCacheOperator.hasNext());
-      TsBlock result = updateLastCacheOperator.next();
+      TsBlock result = nextNonNull(updateLastCacheOperator);
       assertEquals(1, result.getPositionCount());
       assertEquals(3, result.getValueColumnCount());
 
@@ -134,7 +135,7 @@ public class UpdateLastCacheOperatorTest {
 
       assertTrue(updateLastCacheOperator.isBlocked().isDone());
       assertTrue(updateLastCacheOperator.hasNext());
-      TsBlock result = updateLastCacheOperator.next();
+      TsBlock result = nextNonNull(updateLastCacheOperator);
       assertEquals(1, result.getPositionCount());
       assertEquals(3, result.getValueColumnCount());
 
@@ -164,7 +165,7 @@ public class UpdateLastCacheOperatorTest {
 
       assertTrue(updateLastCacheOperator.isBlocked().isDone());
       assertTrue(updateLastCacheOperator.hasNext());
-      TsBlock result = updateLastCacheOperator.next();
+      TsBlock result = nextNonNull(updateLastCacheOperator);
       assertEquals(1, result.getPositionCount());
       assertEquals(3, result.getValueColumnCount());
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/UpdateLastCacheOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/UpdateLastCacheOperatorTest.java
@@ -66,6 +66,7 @@ import static org.apache.iotdb.db.queryengine.execution.operator.AggregationUtil
 import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonEmpty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -106,6 +107,7 @@ public class UpdateLastCacheOperatorTest {
       assertTrue(updateLastCacheOperator.isBlocked().isDone());
       assertTrue(updateLastCacheOperator.hasNext());
       TsBlock result = nextNonEmpty(updateLastCacheOperator);
+      assertNotNull(result);
       assertEquals(1, result.getPositionCount());
       assertEquals(3, result.getValueColumnCount());
 
@@ -136,6 +138,7 @@ public class UpdateLastCacheOperatorTest {
       assertTrue(updateLastCacheOperator.isBlocked().isDone());
       assertTrue(updateLastCacheOperator.hasNext());
       TsBlock result = nextNonEmpty(updateLastCacheOperator);
+      assertNotNull(result);
       assertEquals(1, result.getPositionCount());
       assertEquals(3, result.getValueColumnCount());
 
@@ -166,6 +169,7 @@ public class UpdateLastCacheOperatorTest {
       assertTrue(updateLastCacheOperator.isBlocked().isDone());
       assertTrue(updateLastCacheOperator.hasNext());
       TsBlock result = nextNonEmpty(updateLastCacheOperator);
+      assertNotNull(result);
       assertEquals(1, result.getPositionCount());
       assertEquals(3, result.getValueColumnCount());
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/UpdateLastCacheOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/UpdateLastCacheOperatorTest.java
@@ -63,7 +63,7 @@ import java.util.concurrent.ExecutorService;
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
 import static org.apache.iotdb.db.queryengine.execution.operator.AggregationOperatorTest.TEST_TIME_SLICE;
 import static org.apache.iotdb.db.queryengine.execution.operator.AggregationUtil.initTimeRangeIterator;
-import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNull;
+import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonEmpty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -105,7 +105,7 @@ public class UpdateLastCacheOperatorTest {
 
       assertTrue(updateLastCacheOperator.isBlocked().isDone());
       assertTrue(updateLastCacheOperator.hasNext());
-      TsBlock result = nextNonNull(updateLastCacheOperator);
+      TsBlock result = nextNonEmpty(updateLastCacheOperator);
       assertEquals(1, result.getPositionCount());
       assertEquals(3, result.getValueColumnCount());
 
@@ -135,7 +135,7 @@ public class UpdateLastCacheOperatorTest {
 
       assertTrue(updateLastCacheOperator.isBlocked().isDone());
       assertTrue(updateLastCacheOperator.hasNext());
-      TsBlock result = nextNonNull(updateLastCacheOperator);
+      TsBlock result = nextNonEmpty(updateLastCacheOperator);
       assertEquals(1, result.getPositionCount());
       assertEquals(3, result.getValueColumnCount());
 
@@ -165,7 +165,7 @@ public class UpdateLastCacheOperatorTest {
 
       assertTrue(updateLastCacheOperator.isBlocked().isDone());
       assertTrue(updateLastCacheOperator.hasNext());
-      TsBlock result = nextNonNull(updateLastCacheOperator);
+      TsBlock result = nextNonEmpty(updateLastCacheOperator);
       assertEquals(1, result.getPositionCount());
       assertEquals(3, result.getValueColumnCount());
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/UpdateLastCacheOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/UpdateLastCacheOperatorTest.java
@@ -66,7 +66,6 @@ import static org.apache.iotdb.db.queryengine.execution.operator.AggregationUtil
 import static org.apache.iotdb.db.queryengine.execution.operator.OperatorTestUtils.nextNonNullOrEmpty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -107,7 +106,6 @@ public class UpdateLastCacheOperatorTest {
       assertTrue(updateLastCacheOperator.isBlocked().isDone());
       assertTrue(updateLastCacheOperator.hasNext());
       TsBlock result = nextNonNullOrEmpty(updateLastCacheOperator);
-      assertNotNull(result);
       assertEquals(1, result.getPositionCount());
       assertEquals(3, result.getValueColumnCount());
 
@@ -138,7 +136,6 @@ public class UpdateLastCacheOperatorTest {
       assertTrue(updateLastCacheOperator.isBlocked().isDone());
       assertTrue(updateLastCacheOperator.hasNext());
       TsBlock result = nextNonNullOrEmpty(updateLastCacheOperator);
-      assertNotNull(result);
       assertEquals(1, result.getPositionCount());
       assertEquals(3, result.getValueColumnCount());
 
@@ -169,7 +166,6 @@ public class UpdateLastCacheOperatorTest {
       assertTrue(updateLastCacheOperator.isBlocked().isDone());
       assertTrue(updateLastCacheOperator.hasNext());
       TsBlock result = nextNonNullOrEmpty(updateLastCacheOperator);
-      assertNotNull(result);
       assertEquals(1, result.getPositionCount());
       assertEquals(3, result.getValueColumnCount());
 


### PR DESCRIPTION
## Summary
- add `OperatorTestUtils.nextNonNull` / `lastNonNull` for test-only consumption of operators whose `next()` may return transient `null`
- update Offset, series scan/aggregation, fill, concat, into, merge-sort, and last-cache operator tests to use the helper instead of directly dereferencing `next()` results
- keep tests that intentionally assert `null` or already validate null positions unchanged

## Tests
- `git diff --check`
- `mvn -pl iotdb-core/datanode spotless:check -Ddevelocity.off=true -DskipTests`
- Not run to completion locally: targeted datanode JUnit commands fail before selected tests because this workspace cannot currently compile/testCompile datanode cleanly without a complete main reactor output