### PR TITLE
Fix table delete with renamed time column

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBDeletionTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBDeletionTableIT.java
@@ -415,6 +415,27 @@ public class IoTDBDeletionTableIT {
   }
 
   @Test
+  public void testDeleteWithRenamedTimeColumn() throws SQLException {
+    try (Connection connection = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
+        Statement statement = connection.createStatement()) {
+      statement.execute("CREATE DATABASE time_column_rename");
+      statement.execute("use time_column_rename");
+      statement.execute("CREATE TABLE vehicle(ts time, deviceId STRING TAG, s0 INT32 FIELD)");
+      statement.execute("INSERT INTO vehicle(ts, deviceId, s0) VALUES(1, 'd0', 1)");
+      statement.execute("INSERT INTO vehicle(ts, deviceId, s0) VALUES(2, 'd0', 2)");
+
+      statement.execute("DELETE FROM vehicle WHERE ts <= 1");
+
+      try (ResultSet resultSet = statement.executeQuery("SELECT ts, s0 FROM vehicle")) {
+        assertTrue(resultSet.next());
+        assertEquals(2, resultSet.getLong("ts"));
+        assertEquals(2, resultSet.getInt("s0"));
+        assertFalse(resultSet.next());
+      }
+    }
+  }
+
+  @Test
   public void testRangeDelete() throws SQLException {
     prepareData(4, 1);
     try (Connection connection = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);

--- a/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/DataNodeQueryMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/DataNodeQueryMessages.java
@@ -259,6 +259,8 @@ public final class DataNodeQueryMessages {
       "Left hand expression is not an identifier: ";
   public static final String THE_LEFT_HAND_VALUE_MUST_BE_AN_IDENTIFIER =
       "The left hand value must be an identifier: ";
+  public static final String THE_TABLE_S_DOES_NOT_CONTAIN_A_TIME_COLUMN =
+      "The table '%s' does not contain a time column";
   public static final String THE_OPERATOR_OF_TAG_PREDICATE_MUST_BE_FOR =
       "The operator of tag predicate must be '=' for ";
   public static final String ONLY_TIME_FILTERS_ARE_SUPPORTED_IN_LAST_QUERY =

--- a/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/DataNodeQueryMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/DataNodeQueryMessages.java
@@ -258,6 +258,8 @@ public final class DataNodeQueryMessages {
       "左侧表达式不是标识符：";
   public static final String THE_LEFT_HAND_VALUE_MUST_BE_AN_IDENTIFIER =
       "左侧值必须是标识符：";
+  public static final String THE_TABLE_S_DOES_NOT_CONTAIN_A_TIME_COLUMN =
+      "表 '%s' 不包含时间列";
   public static final String THE_OPERATOR_OF_TAG_PREDICATE_MUST_BE_FOR =
       "标签谓词的运算符必须为 '='，目标：";
   public static final String ONLY_TIME_FILTERS_ARE_SUPPORTED_IN_LAST_QUERY =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeUtils.java
@@ -37,6 +37,7 @@ import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.LongLiteral;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.NullLiteral;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.StringLiteral;
 import org.apache.iotdb.commons.schema.table.TsTable;
+import org.apache.iotdb.commons.schema.table.column.TsTableColumnSchema;
 import org.apache.iotdb.commons.service.metric.PerformanceOverviewMetrics;
 import org.apache.iotdb.confignode.rpc.thrift.TRegionRouteMapResp;
 import org.apache.iotdb.db.i18n.DataNodeQueryMessages;
@@ -520,7 +521,7 @@ public class AnalyzeUtils {
     }
     Identifier identifier = (Identifier) left;
     // time predicate
-    if (identifier.getValue().equalsIgnoreCase("time")) {
+    if (identifier.getValue().equalsIgnoreCase(getTimeColumnName(table))) {
       long rightHandValue;
       if (right instanceof LongLiteral) {
         rightHandValue = ((LongLiteral) right).getParsedValue();
@@ -565,6 +566,15 @@ public class AnalyzeUtils {
 
     IDPredicate newPredicate = getTagPredicate(comparisonExpression, right, tagColumnOrdinal);
     return combinePredicates(oldPredicate, newPredicate);
+  }
+
+  private static String getTimeColumnName(final TsTable table) {
+    final TsTableColumnSchema timeColumnSchema = table.getTimeColumnSchema();
+    if (Objects.isNull(timeColumnSchema)) {
+      throw new SemanticException(
+          "The table '" + table.getTableName() + "' does not contain a time column");
+    }
+    return timeColumnSchema.getColumnName();
   }
 
   private static IDPredicate getTagPredicate(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeUtils.java
@@ -572,7 +572,9 @@ public class AnalyzeUtils {
     final TsTableColumnSchema timeColumnSchema = table.getTimeColumnSchema();
     if (Objects.isNull(timeColumnSchema)) {
       throw new SemanticException(
-          "The table '" + table.getTableName() + "' does not contain a time column");
+          String.format(
+              DataNodeQueryMessages.THE_TABLE_S_DOES_NOT_CONTAIN_A_TIME_COLUMN,
+              table.getTableName()));
     }
     return timeColumnSchema.getColumnName();
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/PredicateUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/PredicateUtils.java
@@ -57,14 +57,25 @@ public class PredicateUtils {
    */
   public static Pair<Expression, Boolean> extractGlobalTimePredicate(
       Expression predicate, boolean canRewrite, boolean isFirstOr) {
+    return extractGlobalTimePredicate(predicate, canRewrite, isFirstOr, TIME);
+  }
+
+  public static Pair<Expression, Boolean> extractGlobalTimePredicate(
+      Expression predicate, boolean canRewrite, boolean isFirstOr, String timeColumnName) {
     if (predicate instanceof LogicalExpression
         && ((LogicalExpression) predicate).getOperator().equals(AND)) {
       Pair<Expression, Boolean> leftResultPair =
           extractGlobalTimePredicate(
-              ((LogicalExpression) predicate).getTerms().get(0), canRewrite, isFirstOr);
+              ((LogicalExpression) predicate).getTerms().get(0),
+              canRewrite,
+              isFirstOr,
+              timeColumnName);
       Pair<Expression, Boolean> rightResultPair =
           extractGlobalTimePredicate(
-              ((LogicalExpression) predicate).getTerms().get(1), canRewrite, isFirstOr);
+              ((LogicalExpression) predicate).getTerms().get(1),
+              canRewrite,
+              isFirstOr,
+              timeColumnName);
 
       // rewrite predicate to avoid duplicate calculation on time filter
       // If Left-child or Right-child does not contain value filter
@@ -104,10 +115,10 @@ public class PredicateUtils {
         && ((LogicalExpression) predicate).getOperator().equals(OR)) {
       Pair<Expression, Boolean> leftResultPair =
           extractGlobalTimePredicate(
-              ((LogicalExpression) predicate).getTerms().get(0), false, false);
+              ((LogicalExpression) predicate).getTerms().get(0), false, false, timeColumnName);
       Pair<Expression, Boolean> rightResultPair =
           extractGlobalTimePredicate(
-              ((LogicalExpression) predicate).getTerms().get(1), false, false);
+              ((LogicalExpression) predicate).getTerms().get(1), false, false, timeColumnName);
 
       if (leftResultPair.left != null && rightResultPair.left != null) {
         if (Boolean.TRUE.equals(isFirstOr && !leftResultPair.right && !rightResultPair.right)) {
@@ -132,8 +143,8 @@ public class PredicateUtils {
     else if (predicate instanceof ComparisonExpression) {
       Expression leftExpression = ((ComparisonExpression) predicate).getLeft();
       Expression rightExpression = ((ComparisonExpression) predicate).getRight();
-      if (checkIsTimeFilter(leftExpression, rightExpression)
-          || checkIsTimeFilter(rightExpression, leftExpression)) {
+      if (checkIsTimeFilter(leftExpression, rightExpression, timeColumnName)
+          || checkIsTimeFilter(rightExpression, leftExpression, timeColumnName)) {
         return new Pair<>(predicate, false);
       }
       return new Pair<>(null, true);
@@ -190,9 +201,10 @@ public class PredicateUtils {
     }
   }
 
-  private static boolean checkIsTimeFilter(Expression timeExpression, Expression valueExpression) {
+  private static boolean checkIsTimeFilter(
+      Expression timeExpression, Expression valueExpression, String timeColumnName) {
     return timeExpression instanceof Identifier
-        && ((Identifier) timeExpression).getValue().equalsIgnoreCase(TIME)
+        && ((Identifier) timeExpression).getValue().equalsIgnoreCase(timeColumnName)
         && valueExpression instanceof LongLiteral;
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeUtilsTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeUtilsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.plan.analyze;
+
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ComparisonExpression;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Expression;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Identifier;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.LongLiteral;
+import org.apache.iotdb.commons.schema.table.TsTable;
+import org.apache.iotdb.commons.schema.table.column.TimeColumnSchema;
+import org.apache.iotdb.db.storageengine.dataregion.modification.TableDeletionEntry;
+
+import org.apache.tsfile.enums.TSDataType;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class AnalyzeUtilsTest {
+
+  @Test
+  public void testParseDeletePredicateWithRenamedTimeColumn() {
+    TsTable table = new TsTable("table1");
+    table.addColumnSchema(new TimeColumnSchema("ts", TSDataType.TIMESTAMP));
+    Expression expression =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.LESS_THAN_OR_EQUAL,
+            new Identifier("ts"),
+            new LongLiteral("100"));
+
+    List<TableDeletionEntry> entries = AnalyzeUtils.parseExpressions2ModEntries(expression, table);
+
+    assertEquals(1, entries.size());
+    assertEquals(Long.MIN_VALUE, entries.get(0).getStartTime());
+    assertEquals(100, entries.get(0).getEndTime());
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/planner/PredicateUtilsTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/planner/PredicateUtilsTest.java
@@ -22,7 +22,10 @@ package org.apache.iotdb.db.queryengine.plan.relational.planner;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.queryengine.common.SessionInfo;
 import org.apache.iotdb.commons.queryengine.common.SqlDialect;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ComparisonExpression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Expression;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Identifier;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.LongLiteral;
 import org.apache.iotdb.db.queryengine.common.MPPQueryContext;
 import org.apache.iotdb.db.queryengine.common.QueryId;
 import org.apache.iotdb.db.queryengine.plan.relational.analyzer.Analysis;
@@ -36,6 +39,7 @@ import java.time.ZoneId;
 
 import static org.apache.iotdb.db.queryengine.plan.relational.analyzer.AnalyzerTest.analyzeSQL;
 import static org.apache.iotdb.db.queryengine.plan.relational.planner.PredicateUtils.extractGlobalTimePredicate;
+import static org.junit.Assert.assertNotNull;
 
 public class PredicateUtilsTest {
   @Test
@@ -68,5 +72,14 @@ public class PredicateUtilsTest {
         extractGlobalTimePredicate(
             actualAnalysis.getWhereMap().values().iterator().next(), true, true);
     System.out.println(ret.getLeft());
+  }
+
+  @Test
+  public void extractGlobalTimePredicateWithCustomTimeColumnTest() {
+    Expression expression =
+        new ComparisonExpression(
+            ComparisonExpression.Operator.GREATER_THAN, new Identifier("ts"), new LongLiteral("1"));
+    Pair<Expression, Boolean> ret = extractGlobalTimePredicate(expression, true, true, "ts");
+    assertNotNull(ret.getLeft());
   }
 }


### PR DESCRIPTION
## Description

This PR fixes table-model DELETE predicate parsing when the TIME column has been renamed. The deletion analyzer now resolves the actual TIME column name from table schema instead of assuming the default time column name.

It also adds i18n messages for the newly added semantic error and covers the renamed-time-column path in unit tests.

## Tests

- mvn spotless:apply -pl iotdb-core/datanode
- mvn spotless:apply -pl integration-test -P with-integration-tests
- mvn test -pl iotdb-core/datanode -Dtest=AnalyzeUtilsTest,PredicateUtilsTest

Note: Running IoTDBDeletionTableIT#testDeleteWithRenamedTimeColumn was attempted, but the test class failed in its shared setup/teardown before the case body due to CREATE/DROP DATABASE IF EXISTS test being parsed by the tree-model parser in this local environment.