### PR TITLE
Allow packaging the C++ client in Debug mode (-Dcmake.build.type=Debug)

### DIFF
--- a/iotdb-client/client-cpp/pom.xml
+++ b/iotdb-client/client-cpp/pom.xml
@@ -219,6 +219,7 @@
                             <options>
                                 <option>-DBOOST_INCLUDEDIR=${boost.include.dir}</option>
                                 <option>-DWITH_SSL=${with.ssl}</option>
+                                <option>-DCMAKE_BUILD_TYPE=${cmake.build.type}</option>
                             </options>
                         </configuration>
                     </execution>

--- a/iotdb-client/client-cpp/src/main/CMakeLists.txt
+++ b/iotdb-client/client-cpp/src/main/CMakeLists.txt
@@ -22,8 +22,18 @@ SET(CMAKE_CXX_STANDARD 11)
 SET(CMAKE_CXX_STANDARD_REQUIRED ON)
 SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
 IF(NOT MSVC)
+    # Single-config generators (e.g. "Unix Makefiles") leave CMAKE_BUILD_TYPE empty
+    # unless told otherwise; default to Release to preserve the historical behavior.
+    IF(NOT CMAKE_BUILD_TYPE)
+        SET(CMAKE_BUILD_TYPE Release)
+    ENDIF()
     # Keep GCC/Clang style flags off on MSVC to avoid invalid-option build errors.
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -g -O2")
+    # -g is kept for all build types so Release still ships debug symbols (unchanged).
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -g")
+    # Release keeps the previous flags exactly (-O2, no -DNDEBUG); Debug is unoptimized
+    # (-O0) so the packaged library can be stepped through in a debugger.
+    SET(CMAKE_CXX_FLAGS_RELEASE "-O2")
+    SET(CMAKE_CXX_FLAGS_DEBUG "-O0")
 ENDIF()
 
 # Add Thrift include directory


### PR DESCRIPTION
## What

Make `-Dcmake.build.type=Debug` actually produce a debug build of the C++ client library (`libiotdb_session`).

## Why

On non-MSVC platforms, `iotdb-client/client-cpp/src/main/CMakeLists.txt` hardcoded:

```cmake
SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -g -O2")
```

and the `cmake-generate` step in `pom.xml` never passed `-DCMAKE_BUILD_TYPE`. Single-config generators (e.g. *Unix Makefiles*) ignore `cmake --build --config`, so on Linux/macOS the existing `cmake.build.type` property was effectively a no-op — the packaged library was always compiled at `-O2`. Even `-DCMAKE_BUILD_TYPE=Debug` stayed at `-O2`, because Debug only appends `-g` and never removes the hardcoded `-O2`.

## How

- **`pom.xml`**: pass `-DCMAKE_BUILD_TYPE=${cmake.build.type}` to the main-library `cmake-generate` execution.
- **`src/main/CMakeLists.txt`**: stop hardcoding the optimization level. Keep `-Wall -g` for all build types (Release still ships symbols, as before), set `CMAKE_CXX_FLAGS_RELEASE` to `-O2` and `CMAKE_CXX_FLAGS_DEBUG` to `-O0`, and default to `Release` when no type is given.

Release output is intentionally **unchanged** (`-g -O2`, no `-DNDEBUG`, asserts still active). MSVC is unaffected — it already selects the configuration via `cmake --build --config ${cmake.build.type}`.

## Usage

```bash
# Release (default, unchanged)
mvn clean package -P with-cpp -pl iotdb-client/client-cpp -am -DskipTests

# Debug package
mvn clean package -P with-cpp -pl iotdb-client/client-cpp -am -DskipTests -Dcmake.build.type=Debug
```

## Verification

Actual `CXX_FLAGS` produced by the configure step (macOS, Unix Makefiles) with these changes:

| build type | resulting flags | opt level |
|---|---|---|
| default / `Release` | `-Wall -g -O2 ...` | `-O2` (unchanged) |
| `Debug` | `-Wall -g -O0 ...` | `-O0` |

A full Debug build of `libiotdb_session` compiles and links; the resulting dylib is ~6.7 MB vs ~3.2 MB for Release, consistent with `-O0` + debug info.

🤖 Generated with [Claude Code](https://claude.com/claude-code)