### PR TITLE
[IOTDB-FIX] Fix LimitNode Serialization and Prevent NullPointerException in Relational Engine

### DIFF
--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/queryengine/plan/relational/planner/node/LimitNode.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/queryengine/plan/relational/planner/node/LimitNode.java
@@ -40,7 +40,6 @@ import java.util.Optional;
 
 public class LimitNode extends SingleChildProcessNode {
   private final long count;
-  // TODO(beyyes) useless variable?
   private final Optional<OrderingScheme> tiesResolvingScheme;
 
   // private final boolean partial;
@@ -85,18 +84,27 @@ public class LimitNode extends SingleChildProcessNode {
   protected void serializeAttributes(ByteBuffer byteBuffer) {
     PlanNodeType.TABLE_LIMIT_NODE.serialize(byteBuffer);
     ReadWriteIOUtils.write(count, byteBuffer);
+    ReadWriteIOUtils.write(tiesResolvingScheme.isPresent(), byteBuffer);
+    tiesResolvingScheme.ifPresent(scheme -> scheme.serialize(byteBuffer));
   }
 
   @Override
   protected void serializeAttributes(DataOutputStream stream) throws IOException {
     PlanNodeType.TABLE_LIMIT_NODE.serialize(stream);
     ReadWriteIOUtils.write(count, stream);
+    ReadWriteIOUtils.write(tiesResolvingScheme.isPresent(), stream);
+    if (tiesResolvingScheme.isPresent()) {
+      tiesResolvingScheme.get().serialize(stream);
+    }
   }
 
   public static LimitNode deserialize(ByteBuffer byteBuffer) {
     long count = ReadWriteIOUtils.readLong(byteBuffer);
+    Optional<OrderingScheme> tiesResolvingScheme = ReadWriteIOUtils.readBool(byteBuffer)
+        ? Optional.of(OrderingScheme.deserialize(byteBuffer))
+        : Optional.empty();
     PlanNodeId planNodeId = PlanNodeId.deserialize(byteBuffer);
-    return new LimitNode(planNodeId, null, count, null);
+    return new LimitNode(planNodeId, null, count, tiesResolvingScheme);
   }
 
   @Override
@@ -115,16 +123,19 @@ public class LimitNode extends SingleChildProcessNode {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    if (!super.equals(o)) return false;
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    if (!super.equals(o))
+      return false;
     LimitNode limitNode = (LimitNode) o;
-    return Objects.equal(count, limitNode.count);
+    return count == limitNode.count && Objects.equal(tiesResolvingScheme, limitNode.tiesResolvingScheme);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(super.hashCode(), count);
+    return Objects.hashCode(super.hashCode(), count, tiesResolvingScheme);
   }
 
   @Override


### PR DESCRIPTION
This PR fixes an issue in `LimitNode` where `tiesResolvingScheme` was not fully integrated into the node lifecycle.

Previously, the field was ignored during serialization and deserialization, meaning its state could be lost when query plans were reconstructed. In addition, the deserialization logic passed `null` to an `Optional<OrderingScheme>` field, which could lead to potential `NullPointerException` issues. The field was also not included in `equals()` and `hashCode()`, resulting in incomplete object comparisons.

### Changes included

* Added serialization and deserialization support for `tiesResolvingScheme`.
* Replaced `null` assignments with proper `Optional.empty()` / `Optional.of(...)` handling to improve null safety.
* Updated `equals()` and `hashCode()` to include `tiesResolvingScheme`.
* Removed the outdated TODO comment since the field is now fully utilized.

### Impact

This change helps ensure that:

* Query plan state is preserved correctly during serialization and deserialization.
* Potential `NullPointerException` risks are eliminated.
* `LimitNode` comparisons accurately reflect the complete node state.
* Planner behavior remains consistent and reliable when `tiesResolvingScheme` is present.

### Verification

* Verified that serialization and deserialization follow the same field order.
* Compared the implementation pattern with similar relational planner nodes such as `SortNode`.
* Confirmed that `Optional<OrderingScheme>` is handled safely without using `null`.
