### PR TITLE
Support sink config key for pipe request slicing

### DIFF
--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppCommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppCommonConfig.java
@@ -538,7 +538,7 @@ public class MppCommonConfig extends MppBaseConfig implements CommonConfig {
   public CommonConfig setPipeConnectorRequestSliceThresholdBytes(
       int pipeConnectorRequestSliceThresholdBytes) {
     setProperty(
-        "pipe_connector_request_slice_threshold_bytes",
+        "pipe_sink_request_slice_threshold_bytes",
         String.valueOf(pipeConnectorRequestSliceThresholdBytes));
 
     return this;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/processor/twostage/plugin/TwoStageCountProcessor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/processor/twostage/plugin/TwoStageCountProcessor.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.commons.consensus.DataRegionId;
 import org.apache.iotdb.commons.consensus.index.ProgressIndex;
 import org.apache.iotdb.commons.consensus.index.impl.MinimumProgressIndex;
 import org.apache.iotdb.commons.consensus.index.impl.StateProgressIndex;
+import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeTaskMeta;
 import org.apache.iotdb.commons.pipe.config.plugin.env.PipeTaskProcessorRuntimeEnvironment;
@@ -146,7 +147,7 @@ public class TwoStageCountProcessor implements PipeProcessor {
       isTableModel = PathUtils.isTableModelDatabase(dataBaseName);
     }
 
-    outputSeries = new PartialPath(parameters.getString(_PROCESSOR_OUTPUT_SERIES_KEY));
+    outputSeries = parseOutputSeries(parameters);
 
     if (Objects.nonNull(pipeTaskMeta) && Objects.nonNull(pipeTaskMeta.getProgressIndex())) {
       if (pipeTaskMeta.getProgressIndex() instanceof MinimumProgressIndex) {
@@ -176,6 +177,12 @@ public class TwoStageCountProcessor implements PipeProcessor {
         .register(
             pipeName, creationTime, (combineId) -> new CountOperator(combineId, globalCountQueue));
     twoStageAggregateSender = new TwoStageAggregateSender(pipeName, creationTime);
+  }
+
+  static PartialPath parseOutputSeries(final PipeParameters parameters)
+      throws IllegalPathException {
+    return new PartialPath(
+        parameters.getStringByKeys(PROCESSOR_OUTPUT_SERIES_KEY, _PROCESSOR_OUTPUT_SERIES_KEY));
   }
 
   @Override

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/processor/twostage/plugin/TwoStageCountProcessorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/processor/twostage/plugin/TwoStageCountProcessorTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.pipe.processor.twostage.plugin;
+
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameters;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+
+public class TwoStageCountProcessorTest {
+
+  @Test
+  public void testOutputSeriesSupportsNewAndLegacyKeys() throws Exception {
+    Assert.assertEquals(
+        "root.db.d.s1", parseOutputSeries("processor.output.series", "root.db.d.s1").getFullPath());
+    Assert.assertEquals(
+        "root.db.d.s2", parseOutputSeries("processor.output-series", "root.db.d.s2").getFullPath());
+  }
+
+  private PartialPath parseOutputSeries(final String key, final String value) throws Exception {
+    return TwoStageCountProcessor.parseOutputSeries(
+        new PipeParameters(Collections.singletonMap(key, value)));
+  }
+}

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/PipeDescriptor.java
@@ -437,9 +437,11 @@ public class PipeDescriptor {
 
     config.setPipeSinkRequestSliceThresholdBytes(
         Integer.parseInt(
-            properties.getProperty(
-                "pipe_connector_request_slice_threshold_bytes",
-                String.valueOf(config.getPipeSinkRequestSliceThresholdBytes()))));
+            Optional.ofNullable(properties.getProperty("pipe_sink_request_slice_threshold_bytes"))
+                .orElse(
+                    properties.getProperty(
+                        "pipe_connector_request_slice_threshold_bytes",
+                        String.valueOf(config.getPipeSinkRequestSliceThresholdBytes())))));
 
     config.setPipeReceiverLoginPeriodicVerificationIntervalMs(
         Long.parseLong(

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/pipe/config/PipeDescriptorTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/pipe/config/PipeDescriptorTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.commons.pipe.config;
+
+import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
+import org.apache.iotdb.commons.conf.TrimProperties;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PipeDescriptorTest {
+
+  private final CommonConfig config = CommonDescriptor.getInstance().getConfig();
+
+  private int originalRequestSliceThresholdBytes;
+
+  @Before
+  public void setUp() {
+    originalRequestSliceThresholdBytes = config.getPipeSinkRequestSliceThresholdBytes();
+  }
+
+  @After
+  public void tearDown() {
+    config.setPipeSinkRequestSliceThresholdBytes(originalRequestSliceThresholdBytes);
+  }
+
+  @Test
+  public void testPipeRequestSliceThresholdSupportsSinkAndConnectorKeys() {
+    final TrimProperties connectorProperties = new TrimProperties();
+    connectorProperties.setProperty("pipe_connector_request_slice_threshold_bytes", "123");
+    PipeDescriptor.loadPipeInternalConfig(config, connectorProperties);
+    Assert.assertEquals(123, config.getPipeSinkRequestSliceThresholdBytes());
+
+    final TrimProperties sinkProperties = new TrimProperties();
+    sinkProperties.setProperty("pipe_sink_request_slice_threshold_bytes", "456");
+    PipeDescriptor.loadPipeInternalConfig(config, sinkProperties);
+    Assert.assertEquals(456, config.getPipeSinkRequestSliceThresholdBytes());
+
+    final TrimProperties bothProperties = new TrimProperties();
+    bothProperties.setProperty("pipe_connector_request_slice_threshold_bytes", "123");
+    bothProperties.setProperty("pipe_sink_request_slice_threshold_bytes", "456");
+    PipeDescriptor.loadPipeInternalConfig(config, bothProperties);
+    Assert.assertEquals(456, config.getPipeSinkRequestSliceThresholdBytes());
+  }
+}


### PR DESCRIPTION
### Summary
- Support pipe_sink_request_slice_threshold_bytes with pipe_connector_request_slice_threshold_bytes as fallback
- Update IT config helper to emit the sink key
- Add unit coverage for sink/connector precedence
- Support both processor.output.series and legacy processor.output-series when customizing TwoStageCountProcessor

### Tests
- mvn -pl iotdb-core/node-commons,integration-test spotless:apply -P with-integration-tests
- mvn -pl iotdb-core/node-commons -Dtest=PipeDescriptorTest test
- mvn -pl iotdb-core/datanode spotless:apply
- git diff --check HEAD~2..HEAD
- mvn -pl iotdb-core/datanode -Dtest=TwoStageCountProcessorTest test (blocked by existing datanode compile errors in QueryModificationLoader and memory reservation manager classes)