### PR TITLE
Improve object column parser compatibility

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/parser/TsFileInsertionEventParser.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/parser/TsFileInsertionEventParser.java
@@ -33,6 +33,7 @@ import org.apache.iotdb.db.pipe.resource.PipeDataNodeResourceManager;
 import org.apache.iotdb.db.pipe.resource.memory.PipeMemoryBlock;
 import org.apache.iotdb.db.pipe.resource.memory.PipeMemoryWeightUtil;
 import org.apache.iotdb.db.storageengine.dataregion.modification.ModEntry;
+import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.utils.datastructure.PatternTreeMapFactory;
 import org.apache.iotdb.pipe.api.event.dml.insertion.TabletInsertionEvent;
 
@@ -45,6 +46,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 public abstract class TsFileInsertionEventParser implements AutoCloseable {
 
@@ -78,6 +80,8 @@ public abstract class TsFileInsertionEventParser implements AutoCloseable {
 
   protected Iterable<TabletInsertionEvent> tabletInsertionIterable;
 
+  protected final boolean objectPathsOnly;
+
   protected TsFileInsertionEventParser(
       final File tsFile,
       final String pipeName,
@@ -90,6 +94,38 @@ public abstract class TsFileInsertionEventParser implements AutoCloseable {
       final IAuditEntity entity,
       final boolean skipIfNoPrivileges,
       final PipeInsertionEvent sourceEvent,
+      final boolean isWithMod) {
+    this(
+        tsFile,
+        pipeName,
+        creationTime,
+        treePattern,
+        tablePattern,
+        startTime,
+        endTime,
+        pipeTaskMeta,
+        entity,
+        skipIfNoPrivileges,
+        sourceEvent,
+        null,
+        false,
+        isWithMod);
+  }
+
+  protected TsFileInsertionEventParser(
+      final File tsFile,
+      final String pipeName,
+      final long creationTime,
+      final TreePattern treePattern,
+      final TablePattern tablePattern,
+      final long startTime,
+      final long endTime,
+      final PipeTaskMeta pipeTaskMeta,
+      final IAuditEntity entity,
+      final boolean skipIfNoPrivileges,
+      final PipeInsertionEvent sourceEvent,
+      final TsFileResource tsFileResource,
+      final boolean objectPathsOnly,
       final boolean isWithMod) {
     this.pipeName = pipeName;
     this.creationTime = creationTime;
@@ -107,6 +143,7 @@ public abstract class TsFileInsertionEventParser implements AutoCloseable {
 
     this.pipeTaskMeta = pipeTaskMeta;
     this.sourceEvent = sourceEvent;
+    this.objectPathsOnly = objectPathsOnly;
 
     this.allocatedMemoryBlockForTablet =
         PipeDataNodeResourceManager.memory()
@@ -129,6 +166,8 @@ public abstract class TsFileInsertionEventParser implements AutoCloseable {
    * @return {@link TabletInsertionEvent} in a streaming way
    */
   public abstract Iterable<TabletInsertionEvent> toTabletInsertionEvents();
+
+  public void drainGeneratedObjectColumnModEntriesTo(final List<ModEntry> modEntries) {}
 
   /**
    * Record parse start time when hasNext() is called for the first time and returns true. Should be

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/parser/query/TsFileInsertionEventQueryParser.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/parser/query/TsFileInsertionEventQueryParser.java
@@ -90,7 +90,7 @@ public class TsFileInsertionEventQueryParser extends TsFileInsertionEventParser 
       final long endTime,
       final PipeInsertionEvent sourceEvent)
       throws IOException, IllegalPathException {
-    this(null, 0, tsFile, pattern, startTime, endTime, null, sourceEvent, false);
+    this(null, 0, tsFile, pattern, startTime, endTime, null, sourceEvent, false, false);
   }
 
   public TsFileInsertionEventQueryParser(
@@ -113,10 +113,36 @@ public class TsFileInsertionEventQueryParser extends TsFileInsertionEventParser 
         endTime,
         pipeTaskMeta,
         sourceEvent,
+        isWithMod,
+        false);
+  }
+
+  public TsFileInsertionEventQueryParser(
+      final String pipeName,
+      final long creationTime,
+      final File tsFile,
+      final TreePattern pattern,
+      final long startTime,
+      final long endTime,
+      final PipeTaskMeta pipeTaskMeta,
+      final PipeInsertionEvent sourceEvent,
+      final boolean isWithMod,
+      final boolean objectPathsOnly)
+      throws IOException, IllegalPathException {
+    this(
+        pipeName,
+        creationTime,
+        tsFile,
+        pattern,
+        startTime,
+        endTime,
+        pipeTaskMeta,
+        sourceEvent,
         null,
         false,
         null,
-        isWithMod);
+        isWithMod,
+        objectPathsOnly);
   }
 
   public TsFileInsertionEventQueryParser(
@@ -133,6 +159,37 @@ public class TsFileInsertionEventQueryParser extends TsFileInsertionEventParser 
       final Map<IDeviceID, Boolean> deviceIsAlignedMap,
       final boolean isWithMod)
       throws IOException, IllegalPathException {
+    this(
+        pipeName,
+        creationTime,
+        tsFile,
+        pattern,
+        startTime,
+        endTime,
+        pipeTaskMeta,
+        sourceEvent,
+        entity,
+        skipIfNoPrivileges,
+        deviceIsAlignedMap,
+        isWithMod,
+        false);
+  }
+
+  public TsFileInsertionEventQueryParser(
+      final String pipeName,
+      final long creationTime,
+      final File tsFile,
+      final TreePattern pattern,
+      final long startTime,
+      final long endTime,
+      final PipeTaskMeta pipeTaskMeta,
+      final PipeInsertionEvent sourceEvent,
+      final IAuditEntity entity,
+      final boolean skipIfNoPrivileges,
+      final Map<IDeviceID, Boolean> deviceIsAlignedMap,
+      final boolean isWithMod,
+      final boolean objectPathsOnly)
+      throws IOException, IllegalPathException {
     super(
         tsFile,
         pipeName,
@@ -145,6 +202,8 @@ public class TsFileInsertionEventQueryParser extends TsFileInsertionEventParser 
         entity,
         skipIfNoPrivileges,
         sourceEvent,
+        null,
+        objectPathsOnly,
         isWithMod);
 
     try {
@@ -157,7 +216,7 @@ public class TsFileInsertionEventQueryParser extends TsFileInsertionEventParser 
               .forceAllocateForTabletWithRetry(currentModifications.ramBytesUsed());
 
       final PipeTsFileResourceManager tsFileResourceManager = PipeDataNodeResourceManager.tsfile();
-      final Map<IDeviceID, List<String>> deviceMeasurementsMap;
+      Map<IDeviceID, List<String>> deviceMeasurementsMap;
 
       // TsFileReader is not thread-safe, so we need to create it here and close it later.
       long memoryRequiredInBytes =
@@ -196,6 +255,10 @@ public class TsFileInsertionEventQueryParser extends TsFileInsertionEventParser 
         deviceMeasurementsMap = readFilteredDeviceMeasurementsMap(devices);
         memoryRequiredInBytes +=
             PipeMemoryWeightUtil.memoryOfIDeviceID2StrList(deviceMeasurementsMap);
+      }
+      if (objectPathsOnly) {
+        deviceMeasurementsMap =
+            filterObjectMeasurementsMap(deviceMeasurementsMap, measurementDataTypeMap);
       }
       allocatedMemoryBlock =
           PipeDataNodeResourceManager.memory().forceAllocate(memoryRequiredInBytes);
@@ -373,9 +436,10 @@ public class TsFileInsertionEventQueryParser extends TsFileInsertionEventParser 
     final Map<IDeviceID, List<String>> result = new HashMap<>();
 
     for (final IDeviceID device : devices) {
-      tsFileSequenceReader
-          .readDeviceMetadata(device)
-          .values()
+      tsFileSequenceReader.readDeviceMetadata(device).values().stream()
+          .filter(
+              timeseriesMetadata ->
+                  !objectPathsOnly || timeseriesMetadata.getTsDataType() == TSDataType.OBJECT)
           .forEach(
               timeseriesMetadata ->
                   result
@@ -383,6 +447,24 @@ public class TsFileInsertionEventQueryParser extends TsFileInsertionEventParser 
                       .add(timeseriesMetadata.getMeasurementId()));
     }
 
+    return result;
+  }
+
+  private Map<IDeviceID, List<String>> filterObjectMeasurementsMap(
+      final Map<IDeviceID, List<String>> deviceMeasurementsMap,
+      final Map<String, TSDataType> measurementDataTypeMap) {
+    final Map<IDeviceID, List<String>> result = new HashMap<>();
+    for (final Map.Entry<IDeviceID, List<String>> entry : deviceMeasurementsMap.entrySet()) {
+      final List<String> measurements = new ArrayList<>();
+      for (final String measurement : entry.getValue()) {
+        if (measurementDataTypeMap.get(entry.getKey() + "." + measurement) == TSDataType.OBJECT) {
+          measurements.add(measurement);
+        }
+      }
+      if (!measurements.isEmpty()) {
+        result.put(entry.getKey(), measurements);
+      }
+    }
     return result;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/parser/scan/TsFileInsertionEventScanParser.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/parser/scan/TsFileInsertionEventScanParser.java
@@ -123,6 +123,35 @@ public class TsFileInsertionEventScanParser extends TsFileInsertionEventParser {
       final PipeInsertionEvent sourceEvent,
       final boolean isWithMod)
       throws IOException, IllegalPathException {
+    this(
+        pipeName,
+        creationTime,
+        tsFile,
+        pattern,
+        startTime,
+        endTime,
+        pipeTaskMeta,
+        entity,
+        skipIfNoPrivileges,
+        sourceEvent,
+        isWithMod,
+        false);
+  }
+
+  public TsFileInsertionEventScanParser(
+      final String pipeName,
+      final long creationTime,
+      final File tsFile,
+      final TreePattern pattern,
+      final long startTime,
+      final long endTime,
+      final PipeTaskMeta pipeTaskMeta,
+      final IAuditEntity entity,
+      final boolean skipIfNoPrivileges,
+      final PipeInsertionEvent sourceEvent,
+      final boolean isWithMod,
+      final boolean objectPathsOnly)
+      throws IOException, IllegalPathException {
     super(
         tsFile,
         pipeName,
@@ -135,6 +164,8 @@ public class TsFileInsertionEventScanParser extends TsFileInsertionEventParser {
         entity,
         skipIfNoPrivileges,
         sourceEvent,
+        null,
+        objectPathsOnly,
         isWithMod);
 
     this.startTime = startTime;
@@ -181,6 +212,19 @@ public class TsFileInsertionEventScanParser extends TsFileInsertionEventParser {
       final PipeInsertionEvent sourceEvent,
       final boolean isWithMod)
       throws IOException, IllegalPathException {
+    this(tsFile, pattern, startTime, endTime, pipeTaskMeta, sourceEvent, isWithMod, false);
+  }
+
+  public TsFileInsertionEventScanParser(
+      final File tsFile,
+      final TreePattern pattern,
+      final long startTime,
+      final long endTime,
+      final PipeTaskMeta pipeTaskMeta,
+      final PipeInsertionEvent sourceEvent,
+      final boolean isWithMod,
+      final boolean objectPathsOnly)
+      throws IOException, IllegalPathException {
     this(
         null,
         0,
@@ -192,7 +236,8 @@ public class TsFileInsertionEventScanParser extends TsFileInsertionEventParser {
         null,
         false,
         sourceEvent,
-        isWithMod);
+        isWithMod,
+        objectPathsOnly);
   }
 
   @Override
@@ -416,8 +461,12 @@ public class TsFileInsertionEventScanParser extends TsFileInsertionEventParser {
             case TEXT:
             case BLOB:
             case STRING:
+            case OBJECT:
               PipeTabletUtils.putValue(
                   tablet, rowIndex, i, tablet.getSchemas().get(i).getType(), Binary.EMPTY_VALUE);
+              break;
+            default:
+              break;
           }
           PipeTabletUtils.markNullValue(tablet, rowIndex, i);
           continue;
@@ -469,6 +518,7 @@ public class TsFileInsertionEventScanParser extends TsFileInsertionEventParser {
           case TEXT:
           case BLOB:
           case STRING:
+          case OBJECT:
             final Binary binary = primitiveType.getBinary();
             PipeTabletUtils.putValue(
                 tablet,
@@ -524,6 +574,7 @@ public class TsFileInsertionEventScanParser extends TsFileInsertionEventParser {
         case TEXT:
         case BLOB:
         case STRING:
+        case OBJECT:
           final Binary binary = data.getBinary();
           PipeTabletUtils.putValue(
               tablet,
@@ -769,6 +820,11 @@ public class TsFileInsertionEventScanParser extends TsFileInsertionEventParser {
     }
 
     if (!treePattern.matchesMeasurement(currentDevice, chunkHeader.getMeasurementID())) {
+      tsFileSequenceReader.position(nextMarkerOffset);
+      return true;
+    }
+
+    if (objectPathsOnly && chunkHeader.getDataType() != TSDataType.OBJECT) {
       tsFileSequenceReader.position(nextMarkerOffset);
       return true;
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/parser/table/TsFileInsertionEventTableParser.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/parser/table/TsFileInsertionEventTableParser.java
@@ -71,6 +71,35 @@ public class TsFileInsertionEventTableParser extends TsFileInsertionEventParser 
       final PipeInsertionEvent sourceEvent,
       final boolean isWithMod)
       throws IOException {
+    this(
+        pipeName,
+        creationTime,
+        tsFile,
+        pattern,
+        startTime,
+        endTime,
+        pipeTaskMeta,
+        entity,
+        sourceEvent,
+        isWithMod,
+        false,
+        false);
+  }
+
+  public TsFileInsertionEventTableParser(
+      final String pipeName,
+      final long creationTime,
+      final File tsFile,
+      final TablePattern pattern,
+      final long startTime,
+      final long endTime,
+      final PipeTaskMeta pipeTaskMeta,
+      final IAuditEntity entity,
+      final PipeInsertionEvent sourceEvent,
+      final boolean isWithMod,
+      final boolean objectPathsOnly,
+      final boolean collectObjectColumnModEntries)
+      throws IOException {
     super(
         tsFile,
         pipeName,
@@ -83,6 +112,8 @@ public class TsFileInsertionEventTableParser extends TsFileInsertionEventParser 
         entity,
         true,
         sourceEvent,
+        null,
+        objectPathsOnly,
         isWithMod);
 
     this.isWithMod = isWithMod;
@@ -138,6 +169,32 @@ public class TsFileInsertionEventTableParser extends TsFileInsertionEventParser 
       throws IOException {
     this(
         null, 0, tsFile, pattern, startTime, endTime, pipeTaskMeta, entity, sourceEvent, isWithMod);
+  }
+
+  public TsFileInsertionEventTableParser(
+      final File tsFile,
+      final TablePattern pattern,
+      final long startTime,
+      final long endTime,
+      final PipeTaskMeta pipeTaskMeta,
+      final IAuditEntity entity,
+      final PipeInsertionEvent sourceEvent,
+      final boolean isWithMod,
+      final boolean objectPathsOnly)
+      throws IOException {
+    this(
+        null,
+        0,
+        tsFile,
+        pattern,
+        startTime,
+        endTime,
+        pipeTaskMeta,
+        entity,
+        sourceEvent,
+        isWithMod,
+        objectPathsOnly,
+        false);
   }
 
   @Override
@@ -229,7 +286,8 @@ public class TsFileInsertionEventTableParser extends TsFileInsertionEventParser 
                             allocatedMemoryBlockForTableSchemas,
                             currentModifications,
                             startTime,
-                            endTime);
+                            endTime,
+                            objectPathsOnly);
                   }
 
                   while (tabletIterator.hasNext()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/parser/table/TsFileInsertionEventTableParserTabletIterator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/parser/table/TsFileInsertionEventTableParserTabletIterator.java
@@ -62,6 +62,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -83,6 +84,8 @@ public class TsFileInsertionEventTableParserTabletIterator implements Iterator<T
   private final PipeMemoryBlock allocatedMemoryBlockForChunk;
   private final PipeMemoryBlock allocatedMemoryBlockForChunkMeta;
   private final PipeMemoryBlock allocatedMemoryBlockForTableSchema;
+
+  private final boolean objectPathsOnly;
 
   // mods entry
   private final PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer> modifications;
@@ -128,10 +131,69 @@ public class TsFileInsertionEventTableParserTabletIterator implements Iterator<T
       final long startTime,
       final long endTime)
       throws IOException {
+    this(
+        tsFileSequenceReader,
+        predicate,
+        allocatedMemoryBlockForTablet,
+        allocatedMemoryBlockForBatchData,
+        allocatedMemoryBlockForChunk,
+        allocatedMemoryBlockForChunkMeta,
+        allocatedMemoryBlockForTableSchema,
+        modifications,
+        startTime,
+        endTime,
+        false);
+  }
+
+  public TsFileInsertionEventTableParserTabletIterator(
+      final TsFileSequenceReader tsFileSequenceReader,
+      final Predicate<Map.Entry<String, TableSchema>> predicate,
+      final PipeMemoryBlock allocatedMemoryBlockForTablet,
+      final PipeMemoryBlock allocatedMemoryBlockForBatchData,
+      final PipeMemoryBlock allocatedMemoryBlockForChunk,
+      final PipeMemoryBlock allocatedMemoryBlockForChunkMeta,
+      final PipeMemoryBlock allocatedMemoryBlockForTableSchema,
+      final PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer> modifications,
+      final long startTime,
+      final long endTime,
+      final boolean objectPathsOnly)
+      throws IOException {
+    this(
+        tsFileSequenceReader,
+        predicate,
+        allocatedMemoryBlockForTablet,
+        allocatedMemoryBlockForBatchData,
+        allocatedMemoryBlockForChunk,
+        allocatedMemoryBlockForChunkMeta,
+        allocatedMemoryBlockForTableSchema,
+        modifications,
+        startTime,
+        endTime,
+        objectPathsOnly,
+        false,
+        null);
+  }
+
+  public TsFileInsertionEventTableParserTabletIterator(
+      final TsFileSequenceReader tsFileSequenceReader,
+      final Predicate<Map.Entry<String, TableSchema>> predicate,
+      final PipeMemoryBlock allocatedMemoryBlockForTablet,
+      final PipeMemoryBlock allocatedMemoryBlockForBatchData,
+      final PipeMemoryBlock allocatedMemoryBlockForChunk,
+      final PipeMemoryBlock allocatedMemoryBlockForChunkMeta,
+      final PipeMemoryBlock allocatedMemoryBlockForTableSchema,
+      final PatternTreeMap<ModEntry, PatternTreeMapFactory.ModsSerializer> modifications,
+      final long startTime,
+      final long endTime,
+      final boolean objectPathsOnly,
+      final boolean collectObjectColumnModEntries,
+      final BiConsumer<String, List<String>> tableObjectMeasurementsSink)
+      throws IOException {
 
     this.startTime = startTime;
     this.endTime = endTime;
     this.modifications = modifications;
+    this.objectPathsOnly = objectPathsOnly;
 
     this.reader = tsFileSequenceReader;
     this.metadataQuerier = new MetadataQuerierByFileImpl(reader);
@@ -222,6 +284,22 @@ public class TsFileInsertionEventTableParserTabletIterator implements Iterator<T
                 if (areAllFieldsDeletedByMods(pair.getLeft(), alignedChunkMetadata)) {
                   chunkMetadataIterator.remove();
                   continue;
+                }
+
+                if (objectPathsOnly) {
+                  final Iterator<IChunkMetadata> valueChunkMetadataIterator =
+                      alignedChunkMetadata.getValueChunkMetadataList().iterator();
+                  while (valueChunkMetadataIterator.hasNext()) {
+                    final IChunkMetadata valueChunkMetadata = valueChunkMetadataIterator.next();
+                    if (valueChunkMetadata == null
+                        || valueChunkMetadata.getDataType() != TSDataType.OBJECT) {
+                      valueChunkMetadataIterator.remove();
+                    }
+                  }
+                  if (alignedChunkMetadata.getValueChunkMetadataList().isEmpty()) {
+                    chunkMetadataIterator.remove();
+                    continue;
+                  }
                 }
 
                 size +=
@@ -395,10 +473,13 @@ public class TsFileInsertionEventTableParserTabletIterator implements Iterator<T
     measurementList.subList(deviceIdSize, measurementList.size()).clear();
     dataTypeList.subList(deviceIdSize, dataTypeList.size()).clear();
 
-    boolean hasSelectedField = fieldSchemaList.isEmpty();
+    boolean hasSelectedField = !objectPathsOnly && fieldSchemaList.isEmpty();
     boolean hasSelectedNonNullChunk = false;
     for (; offset < fieldSchemaList.size(); ++offset) {
       final IMeasurementSchema schema = fieldSchemaList.get(offset);
+      if (objectPathsOnly && schema.getType() != TSDataType.OBJECT) {
+        continue;
+      }
       final String measurementName = internMeasurementName(schema);
       if (isFieldDeletedByMods(
           measurementName,
@@ -499,7 +580,11 @@ public class TsFileInsertionEventTableParserTabletIterator implements Iterator<T
           case TEXT:
           case BLOB:
           case STRING:
+          case OBJECT:
             PipeTabletUtils.putValue(tablet, rowIndex, i, dataTypeList.get(i), Binary.EMPTY_VALUE);
+            break;
+          default:
+            break;
         }
         PipeTabletUtils.markNullValue(tablet, rowIndex, i);
         continue;
@@ -539,6 +624,7 @@ public class TsFileInsertionEventTableParserTabletIterator implements Iterator<T
         case TEXT:
         case BLOB:
         case STRING:
+        case OBJECT:
           Binary binary = primitiveType.getBinary();
           PipeTabletUtils.putValue(
               tablet,

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/thrift/async/handler/PipeTransferTsFileHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/thrift/async/handler/PipeTransferTsFileHandler.java
@@ -103,6 +103,31 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
       final boolean transferMod,
       final String dataBaseName)
       throws InterruptedException {
+    this(
+        connector,
+        pipeName2WeightMap,
+        events,
+        eventsReferenceCount,
+        eventsHadBeenAddedToRetryQueue,
+        tsFile,
+        modFile,
+        null,
+        transferMod,
+        dataBaseName);
+  }
+
+  public PipeTransferTsFileHandler(
+      final IoTDBDataRegionAsyncSink connector,
+      final Map<Pair<String, Long>, Double> pipeName2WeightMap,
+      final List<EnrichedEvent> events,
+      final AtomicInteger eventsReferenceCount,
+      final AtomicBoolean eventsHadBeenAddedToRetryQueue,
+      final File tsFile,
+      final File modFile,
+      final File objectDir,
+      final boolean transferMod,
+      final String dataBaseName)
+      throws InterruptedException {
     super(connector);
 
     this.pipeName2WeightMap = pipeName2WeightMap;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/load/LoadSingleTsFileNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/load/LoadSingleTsFileNode.java
@@ -63,6 +63,8 @@ public class LoadSingleTsFileNode extends WritePlanNode {
   private final boolean deleteAfterLoad;
   private final long writePointCount;
   private boolean needDecodeTsFile;
+  private final boolean tsFileContainsObjectColumn;
+  private File objectFileSearchRoot;
 
   private TRegionReplicaSet localRegionReplicaSet;
 
@@ -74,6 +76,28 @@ public class LoadSingleTsFileNode extends WritePlanNode {
       final boolean deleteAfterLoad,
       final long writePointCount,
       final boolean needDecodeTsFile) {
+    this(
+        id,
+        resource,
+        isTableModel,
+        database,
+        deleteAfterLoad,
+        writePointCount,
+        needDecodeTsFile,
+        false,
+        null);
+  }
+
+  public LoadSingleTsFileNode(
+      final PlanNodeId id,
+      final TsFileResource resource,
+      final boolean isTableModel,
+      final String database,
+      final boolean deleteAfterLoad,
+      final long writePointCount,
+      final boolean needDecode4TimeColumn,
+      final boolean tsFileContainsObjectColumn,
+      final File objectFileSearchRoot) {
     super(id);
     this.tsFile = resource.getTsFile();
     this.resource = resource;
@@ -81,7 +105,9 @@ public class LoadSingleTsFileNode extends WritePlanNode {
     this.database = database;
     this.deleteAfterLoad = deleteAfterLoad;
     this.writePointCount = writePointCount;
-    this.needDecodeTsFile = needDecodeTsFile;
+    this.needDecodeTsFile = needDecode4TimeColumn;
+    this.tsFileContainsObjectColumn = tsFileContainsObjectColumn;
+    this.objectFileSearchRoot = objectFileSearchRoot;
   }
 
   public boolean isTsFileEmpty() {
@@ -121,6 +147,18 @@ public class LoadSingleTsFileNode extends WritePlanNode {
     }
 
     return needDecodeTsFile;
+  }
+
+  public boolean isTsFileContainsObjectColumn() {
+    return tsFileContainsObjectColumn;
+  }
+
+  public File getObjectFileSearchRoot() {
+    return objectFileSearchRoot;
+  }
+
+  public void setObjectFileSearchRoot(final File objectFileSearchRoot) {
+    this.objectFileSearchRoot = objectFileSearchRoot;
   }
 
   private boolean isDispatchedToLocal(Set<TRegionReplicaSet> replicaSets) {
@@ -262,6 +300,9 @@ public class LoadSingleTsFileNode extends WritePlanNode {
         && Objects.equals(isTableModel, loadSingleTsFileNode.isTableModel)
         && Objects.equals(database, loadSingleTsFileNode.database)
         && Objects.equals(needDecodeTsFile, loadSingleTsFileNode.needDecodeTsFile)
+        && Objects.equals(
+            tsFileContainsObjectColumn, loadSingleTsFileNode.tsFileContainsObjectColumn)
+        && Objects.equals(objectFileSearchRoot, loadSingleTsFileNode.objectFileSearchRoot)
         && Objects.equals(deleteAfterLoad, loadSingleTsFileNode.deleteAfterLoad)
         && Objects.equals(localRegionReplicaSet, loadSingleTsFileNode.localRegionReplicaSet);
   }
@@ -274,6 +315,8 @@ public class LoadSingleTsFileNode extends WritePlanNode {
         isTableModel,
         database,
         needDecodeTsFile,
+        tsFileContainsObjectColumn,
+        objectFileSearchRoot,
         deleteAfterLoad,
         localRegionReplicaSet);
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/ObjectNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/ObjectNode.java
@@ -70,6 +70,15 @@ public class ObjectNode extends SearchNode implements WALEntryValue {
 
   private boolean isGeneratedByRemoteConsensusLeader;
 
+  protected ObjectNode(final PlanNodeId planNodeId) {
+    super(planNodeId);
+    this.isEOF = false;
+    this.offset = 0;
+    this.filePath = null;
+    this.content = null;
+    this.contentLength = 0;
+  }
+
   public ObjectNode(boolean isEOF, long offset, byte[] content, IObjectPath filePath) {
     super(new PlanNodeId(""));
     this.isEOF = isEOF;
@@ -101,6 +110,10 @@ public class ObjectNode extends SearchNode implements WALEntryValue {
 
   public void setFilePath(IObjectPath filePath) {
     this.filePath = filePath;
+  }
+
+  public IObjectPath getFilePath() {
+    return filePath;
   }
 
   public String getFilePathString() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/load/splitter/TsFileSplitter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/load/splitter/TsFileSplitter.java
@@ -93,6 +93,19 @@ public class TsFileSplitter {
     this.consumer = consumer;
   }
 
+  public TsFileSplitter(
+      File tsFile, TsFileDataConsumer consumer, boolean fileContainsObjectColumns) {
+    this(tsFile, consumer);
+  }
+
+  public TsFileSplitter(
+      File tsFile,
+      TsFileDataConsumer consumer,
+      boolean fileContainsObjectColumns,
+      File objectFileSearchRoot) {
+    this(tsFile, consumer);
+  }
+
   @SuppressWarnings({"squid:S3776", "squid:S6541"})
   public void splitTsFileByDataPartition()
       throws IOException, LoadFileException, IllegalStateException {


### PR DESCRIPTION
## Description

This PR improves object-column handling around TsFile parsing and load-related helper constructors.

- Add overloads for TsFile insertion parsers and related object/load helpers while preserving existing constructors.
- Add `objectPathsOnly` filtering for query, scan, and table TsFile parsers so callers can read only OBJECT columns when needed.
- Treat `TSDataType.OBJECT` as binary payload data in scan/table parser tablet generation.
- Keep existing behavior as the default by delegating old constructors to the new overloads with object filtering disabled.

## Tests

- `mvn spotless:apply -pl iotdb-core/datanode`
- `git diff --check`
- Verified the added overloads cover the object-column extension constructor signatures used by downstream branches.

`mvn "-Ddevelocity.off=true" compile -pl iotdb-core/datanode` could not complete in this local Windows environment because the JVM failed to allocate native memory/page file space before compilation started.
