### PR TITLE
Fix Windows path segment validation

### DIFF
--- a/iotdb-core/node-commons/src/main/i18n/en/org/apache/iotdb/commons/i18n/UtilMessages.java
+++ b/iotdb-core/node-commons/src/main/i18n/en/org/apache/iotdb/commons/i18n/UtilMessages.java
@@ -87,6 +87,7 @@ public final class UtilMessages {
       "Renamed file {} to {} because it already exists in the target directory: {}";
   public static final String COPIED_FILE_ALREADY_EXISTS =
       "Copy file {} to {} because it already exists in the target directory: {}";
+  public static final String ILLEGAL_EMPTY_PATH = "The path cannot be empty. ";
   public static final String ILLEGAL_PATH_DOTS_OR_SEPARATORS =
       "The path cannot be '.', '..', './' or '.\\'. ";
 

--- a/iotdb-core/node-commons/src/main/i18n/zh/org/apache/iotdb/commons/i18n/UtilMessages.java
+++ b/iotdb-core/node-commons/src/main/i18n/zh/org/apache/iotdb/commons/i18n/UtilMessages.java
@@ -85,6 +85,7 @@ public final class UtilMessages {
       "已将文件 {} 重命名为 {}，因为目标目录 {} 中已存在同名文件";
   public static final String COPIED_FILE_ALREADY_EXISTS =
       "已将文件 {} 复制为 {}，因为目标目录 {} 中已存在同名文件";
+  public static final String ILLEGAL_EMPTY_PATH = "路径不能为空。 ";
   public static final String ILLEGAL_PATH_DOTS_OR_SEPARATORS =
       "路径不能为 '.'、'..'、'./' 或 '.\\\\'. ";
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/FileUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/FileUtils.java
@@ -568,6 +568,9 @@ public class FileUtils {
   }
 
   public static String getIllegalError4Directory(final String path) {
+    if (path == null || path.isEmpty()) {
+      return UtilMessages.ILLEGAL_EMPTY_PATH;
+    }
     if (path.equals(".") || path.equals("..") || path.contains("/") || path.contains("\\")) {
       return UtilMessages.ILLEGAL_PATH_DOTS_OR_SEPARATORS;
     }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/WindowsOSUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/WindowsOSUtils.java
@@ -29,7 +29,18 @@ import java.util.Set;
 public class WindowsOSUtils {
   private static final String ILLEGAL_WINDOWS_CHARS = "\\/:*?\"<>|";
   private static final Set<String> ILLEGAL_WINDOWS_NAMES =
-      new HashSet<>(Arrays.asList("CON", "PRN", "AUX", "NUL"));
+      new HashSet<>(
+          Arrays.asList(
+              "CON",
+              "PRN",
+              "AUX",
+              "NUL",
+              "COM\u00B9",
+              "COM\u00B2",
+              "COM\u00B3",
+              "LPT\u00B9",
+              "LPT\u00B2",
+              "LPT\u00B3"));
 
   static {
     for (int i = 1; i < 10; ++i) {
@@ -40,17 +51,15 @@ public class WindowsOSUtils {
 
   public static final String OS_SEGMENT_ERROR =
       String.format(
-          "In Windows System, the path shall not contains %s, equals one of %s with or without an extension, or ends with '.' or ' '.",
+          "In Windows System, the path shall not contain %s or ASCII control characters, equals one of %s with or without an extension, or ends with '.' or ' '.",
           ILLEGAL_WINDOWS_CHARS, ILLEGAL_WINDOWS_NAMES);
 
   public static boolean isLegalPathSegment4Windows(final String pathSegment) {
     if (!SystemUtils.IS_OS_WINDOWS) {
       return true;
     }
-    for (final char illegalChar : ILLEGAL_WINDOWS_CHARS.toCharArray()) {
-      if (pathSegment.indexOf(illegalChar) != -1) {
-        return false;
-      }
+    if (containsIllegalWindowsChar(pathSegment)) {
+      return false;
     }
     if (pathSegment.endsWith(".") || pathSegment.endsWith(" ")) {
       return false;
@@ -59,6 +68,16 @@ public class WindowsOSUtils {
       return false;
     }
     return true;
+  }
+
+  private static boolean containsIllegalWindowsChar(final String pathSegment) {
+    for (int i = 0; i < pathSegment.length(); ++i) {
+      final char ch = pathSegment.charAt(i);
+      if (ch < ' ' || ILLEGAL_WINDOWS_CHARS.indexOf(ch) != -1) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private static boolean isIllegalWindowsName(final String pathSegment) {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/WindowsOSUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/WindowsOSUtils.java
@@ -23,15 +23,16 @@ import org.apache.tsfile.external.commons.lang3.SystemUtils;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 public class WindowsOSUtils {
   private static final String ILLEGAL_WINDOWS_CHARS = "\\/:*?\"<>|";
   private static final Set<String> ILLEGAL_WINDOWS_NAMES =
-      new HashSet<>(Arrays.asList("CON", "PRN", "AUX", "NUL", "COM1-COM9, LPT1-LPT9"));
+      new HashSet<>(Arrays.asList("CON", "PRN", "AUX", "NUL"));
 
   static {
-    for (int i = 0; i < 10; ++i) {
+    for (int i = 1; i < 10; ++i) {
       ILLEGAL_WINDOWS_NAMES.add("COM" + i);
       ILLEGAL_WINDOWS_NAMES.add("LPT" + i);
     }
@@ -39,7 +40,7 @@ public class WindowsOSUtils {
 
   public static final String OS_SEGMENT_ERROR =
       String.format(
-          "In Windows System, the path shall not contains %s, equals one of %s, or ends with '.' or ' '.",
+          "In Windows System, the path shall not contains %s, equals one of %s with or without an extension, or ends with '.' or ' '.",
           ILLEGAL_WINDOWS_CHARS, ILLEGAL_WINDOWS_NAMES);
 
   public static boolean isLegalPathSegment4Windows(final String pathSegment) {
@@ -54,11 +55,16 @@ public class WindowsOSUtils {
     if (pathSegment.endsWith(".") || pathSegment.endsWith(" ")) {
       return false;
     }
-    for (final String illegalName : ILLEGAL_WINDOWS_NAMES) {
-      if (pathSegment.equalsIgnoreCase(illegalName)) {
-        return false;
-      }
+    if (isIllegalWindowsName(pathSegment)) {
+      return false;
     }
     return true;
+  }
+
+  private static boolean isIllegalWindowsName(final String pathSegment) {
+    final int extensionStartIndex = pathSegment.indexOf('.');
+    final String nameWithoutExtension =
+        extensionStartIndex < 0 ? pathSegment : pathSegment.substring(0, extensionStartIndex);
+    return ILLEGAL_WINDOWS_NAMES.contains(nameWithoutExtension.toUpperCase(Locale.ENGLISH));
   }
 }

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/utils/FileUtilsTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/utils/FileUtilsTest.java
@@ -25,6 +25,7 @@ import org.apache.tsfile.write.TsFileWriter;
 import org.apache.tsfile.write.record.Tablet;
 import org.apache.tsfile.write.schema.MeasurementSchema;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -58,6 +59,13 @@ public class FileUtilsTest {
     FileUtils.moveFileWithMD5Check(tstFile, targetDir);
     tstFile2.renameTo(tstFile);
     FileUtils.moveFileWithMD5Check(tstFile, targetDir);
+  }
+
+  @Test
+  public void testGetIllegalError4DirectoryRejectsEmptyPath() {
+    Assert.assertNotNull(FileUtils.getIllegalError4Directory(null));
+    Assert.assertNotNull(FileUtils.getIllegalError4Directory(""));
+    Assert.assertNull(FileUtils.getIllegalError4Directory("valid_dir"));
   }
 
   private void generateFile(File tsfile) throws WriteProcessException, IOException {

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/utils/WindowsOSUtilsTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/utils/WindowsOSUtilsTest.java
@@ -37,5 +37,12 @@ public class WindowsOSUtilsTest {
     Assert.assertFalse(isLegalPathSegment4Windows("C."));
     Assert.assertFalse(isLegalPathSegment4Windows("a:b<|"));
     Assert.assertFalse(isLegalPathSegment4Windows("COM1"));
+    Assert.assertFalse(isLegalPathSegment4Windows("com1"));
+    Assert.assertFalse(isLegalPathSegment4Windows("COM1.txt"));
+    Assert.assertFalse(isLegalPathSegment4Windows("NUL.log"));
+    Assert.assertFalse(isLegalPathSegment4Windows("LPT9.tmp"));
+
+    Assert.assertTrue(isLegalPathSegment4Windows("COM0"));
+    Assert.assertTrue(isLegalPathSegment4Windows("LPT0"));
   }
 }

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/utils/WindowsOSUtilsTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/utils/WindowsOSUtilsTest.java
@@ -41,8 +41,13 @@ public class WindowsOSUtilsTest {
     Assert.assertFalse(isLegalPathSegment4Windows("COM1.txt"));
     Assert.assertFalse(isLegalPathSegment4Windows("NUL.log"));
     Assert.assertFalse(isLegalPathSegment4Windows("LPT9.tmp"));
+    Assert.assertFalse(isLegalPathSegment4Windows("COM\u00B9"));
+    Assert.assertFalse(isLegalPathSegment4Windows("LPT\u00B2.log"));
+    Assert.assertFalse(isLegalPathSegment4Windows("name\tpart"));
+    Assert.assertFalse(isLegalPathSegment4Windows("name" + Character.toString((char) 0) + "part"));
 
     Assert.assertTrue(isLegalPathSegment4Windows("COM0"));
     Assert.assertTrue(isLegalPathSegment4Windows("LPT0"));
+    Assert.assertTrue(isLegalPathSegment4Windows("COM\u00B4"));
   }
 }


### PR DESCRIPTION
### Summary
- reject empty directory path segments in the shared directory-name validator
- reject Windows reserved device names with extensions, e.g. COM1.txt and NUL.log
- reject superscript digit device names, e.g. COM¹ and LPT².log
- reject ASCII control characters in Windows path segments
- keep COM0 and LPT0 accepted as non-reserved names

### Tests
- mvn -pl iotdb-core/node-commons spotless:apply
- mvn -pl iotdb-core/node-commons -Dtest=WindowsOSUtilsTest,FileUtilsTest test
- mvn -pl iotdb-core/node-commons -DskipTests compile -P with-zh-locale
- git diff --check