### PR TITLE
[to dev/1.3] Fix tree model WAL serialized sizes

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/DeleteDataNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/DeleteDataNode.java
@@ -36,6 +36,7 @@ import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanVisitor;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.WritePlanNode;
 import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.IWALByteBufferView;
 import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.WALEntryValue;
+import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALReadUtils;
 import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALWriteUtils;
 
 import org.apache.tsfile.read.filter.factory.TimeFilterApi;
@@ -153,10 +154,9 @@ public class DeleteDataNode extends SearchNode implements WALEntryValue {
     for (int i = 0; i < size; i++) {
       try {
         pathList.add(
-            DataNodeDevicePathCache.getInstance()
-                .getPartialPath(ReadWriteIOUtils.readString(stream)));
+            DataNodeDevicePathCache.getInstance().getPartialPath(WALReadUtils.readString(stream)));
       } catch (IllegalPathException e) {
-        throw new IllegalArgumentException("Cannot deserialize InsertRowNode", e);
+        throw new IllegalArgumentException("Cannot deserialize DeleteDataNode", e);
       }
     }
     long deleteStartTime = stream.readLong();
@@ -174,9 +174,9 @@ public class DeleteDataNode extends SearchNode implements WALEntryValue {
     List<PartialPath> pathList = new ArrayList<>(size);
     for (int i = 0; i < size; i++) {
       try {
-        pathList.add(new PartialPath(ReadWriteIOUtils.readString(buffer)));
+        pathList.add(new PartialPath(WALReadUtils.readString(buffer)));
       } catch (IllegalPathException e) {
-        throw new IllegalArgumentException("Cannot deserialize InsertRowNode", e);
+        throw new IllegalArgumentException("Cannot deserialize DeleteDataNode", e);
       }
     }
     long deleteStartTime = buffer.getLong();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/DeleteDataNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/DeleteDataNode.java
@@ -129,7 +129,7 @@ public class DeleteDataNode extends SearchNode implements WALEntryValue {
   public int serializedSize() {
     int size = FIXED_SERIALIZED_SIZE;
     for (PartialPath path : pathList) {
-      size += ReadWriteIOUtils.sizeToWrite(path.getFullPath());
+      size += WALWriteUtils.sizeToWrite(path.getFullPath());
     }
     return size;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertNode.java
@@ -31,6 +31,7 @@ import org.apache.iotdb.db.pipe.resource.memory.InsertNodeMemoryEstimator;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.db.storageengine.dataregion.memtable.DeviceIDFactory;
 import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.IWALByteBufferView;
+import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALReadUtils;
 import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALWriteUtils;
 
 import org.apache.tsfile.enums.TSDataType;
@@ -244,7 +245,7 @@ public abstract class InsertNode extends SearchNode implements ComparableConsens
    */
   protected void deserializeMeasurementSchemas(DataInputStream stream) throws IOException {
     for (int i = 0; i < measurements.length; i++) {
-      measurementSchemas[i] = MeasurementSchema.deserializeFrom(stream);
+      measurementSchemas[i] = WALReadUtils.readMeasurementSchema(stream);
       measurements[i] = measurementSchemas[i].getMeasurementId();
       dataTypes[i] = measurementSchemas[i].getType();
     }
@@ -252,7 +253,7 @@ public abstract class InsertNode extends SearchNode implements ComparableConsens
 
   protected void deserializeMeasurementSchemas(ByteBuffer buffer) {
     for (int i = 0; i < measurements.length; i++) {
-      measurementSchemas[i] = MeasurementSchema.deserializeFrom(buffer);
+      measurementSchemas[i] = WALReadUtils.readMeasurementSchema(buffer);
       measurements[i] = measurementSchemas[i].getMeasurementId();
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertNode.java
@@ -34,9 +34,11 @@ import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.IWALByteBufferVie
 import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALReadUtils;
 import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALWriteUtils;
 
+import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.exception.NotImplementedException;
 import org.apache.tsfile.file.metadata.IDeviceID;
+import org.apache.tsfile.utils.ReadWriteIOUtils;
 import org.apache.tsfile.write.schema.MeasurementSchema;
 
 import java.io.DataInputStream;
@@ -44,7 +46,9 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -212,6 +216,102 @@ public abstract class InsertNode extends SearchNode implements ComparableConsens
   @Override
   protected void serializeAttributes(DataOutputStream stream) throws IOException {
     throw new NotImplementedException("serializeAttributes of InsertNode is not implemented");
+  }
+
+  protected static int serializeString(String value, ByteBuffer buffer) {
+    if (value == null) {
+      return ReadWriteIOUtils.write(-1, buffer);
+    }
+    byte[] bytes = value.getBytes(TSFileConfig.STRING_CHARSET);
+    int len = ReadWriteIOUtils.write(bytes.length, buffer);
+    buffer.put(bytes);
+    return len + bytes.length;
+  }
+
+  protected static int serializeString(String value, DataOutputStream stream) throws IOException {
+    if (value == null) {
+      return ReadWriteIOUtils.write(-1, stream);
+    }
+    byte[] bytes = value.getBytes(TSFileConfig.STRING_CHARSET);
+    int len = ReadWriteIOUtils.write(bytes.length, stream);
+    stream.write(bytes);
+    return len + bytes.length;
+  }
+
+  protected static String deserializeString(ByteBuffer buffer) {
+    int strLength = ReadWriteIOUtils.readInt(buffer);
+    if (strLength < 0) {
+      return null;
+    } else if (strLength == 0) {
+      return "";
+    }
+    byte[] bytes = new byte[strLength];
+    buffer.get(bytes);
+    return new String(bytes, TSFileConfig.STRING_CHARSET);
+  }
+
+  protected static void serializeMeasurementSchema(
+      MeasurementSchema measurementSchema, ByteBuffer buffer) {
+    serializeString(measurementSchema.getMeasurementId(), buffer);
+    ReadWriteIOUtils.write(measurementSchema.getTypeInByte(), buffer);
+    ReadWriteIOUtils.write(measurementSchema.getEncodingType().serialize(), buffer);
+    ReadWriteIOUtils.write(measurementSchema.getCompressor().serialize(), buffer);
+    serializeProps(measurementSchema.getProps(), buffer);
+  }
+
+  protected static void serializeMeasurementSchema(
+      MeasurementSchema measurementSchema, DataOutputStream stream) throws IOException {
+    serializeString(measurementSchema.getMeasurementId(), stream);
+    ReadWriteIOUtils.write(measurementSchema.getTypeInByte(), stream);
+    ReadWriteIOUtils.write(measurementSchema.getEncodingType().serialize(), stream);
+    ReadWriteIOUtils.write(measurementSchema.getCompressor().serialize(), stream);
+    serializeProps(measurementSchema.getProps(), stream);
+  }
+
+  protected static MeasurementSchema deserializeMeasurementSchema(ByteBuffer buffer) {
+    String measurementId = deserializeString(buffer);
+    byte type = ReadWriteIOUtils.readByte(buffer);
+    byte encoding = ReadWriteIOUtils.readByte(buffer);
+    byte compressor = ReadWriteIOUtils.readByte(buffer);
+    Map<String, String> props = deserializeProps(buffer);
+    return new MeasurementSchema(measurementId, type, encoding, compressor, props);
+  }
+
+  private static void serializeProps(Map<String, String> props, ByteBuffer buffer) {
+    if (props == null) {
+      ReadWriteIOUtils.write(0, buffer);
+      return;
+    }
+    ReadWriteIOUtils.write(props.size(), buffer);
+    for (Map.Entry<String, String> entry : props.entrySet()) {
+      serializeString(entry.getKey(), buffer);
+      serializeString(entry.getValue(), buffer);
+    }
+  }
+
+  private static void serializeProps(Map<String, String> props, DataOutputStream stream)
+      throws IOException {
+    if (props == null) {
+      ReadWriteIOUtils.write(0, stream);
+      return;
+    }
+    ReadWriteIOUtils.write(props.size(), stream);
+    for (Map.Entry<String, String> entry : props.entrySet()) {
+      serializeString(entry.getKey(), stream);
+      serializeString(entry.getValue(), stream);
+    }
+  }
+
+  private static Map<String, String> deserializeProps(ByteBuffer buffer) {
+    int size = ReadWriteIOUtils.readInt(buffer);
+    if (size <= 0) {
+      return null;
+    }
+    Map<String, String> props = new HashMap<>();
+    for (int i = 0; i < size; i++) {
+      props.put(deserializeString(buffer), deserializeString(buffer));
+    }
+    return props;
   }
 
   // region Serialization methods for WAL

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertRowNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertRowNode.java
@@ -239,13 +239,13 @@ public class InsertRowNode extends InsertNode implements WALEntryValue {
 
   void subSerialize(ByteBuffer buffer) {
     ReadWriteIOUtils.write(time, buffer);
-    ReadWriteIOUtils.write(devicePath.getFullPath(), buffer);
+    serializeString(devicePath.getFullPath(), buffer);
     serializeMeasurementsAndValues(buffer);
   }
 
   void subSerialize(DataOutputStream stream) throws IOException {
     ReadWriteIOUtils.write(time, stream);
-    ReadWriteIOUtils.write(devicePath.getFullPath(), stream);
+    serializeString(devicePath.getFullPath(), stream);
     serializeMeasurementsAndValues(stream);
   }
 
@@ -282,9 +282,9 @@ public class InsertRowNode extends InsertNode implements WALEntryValue {
       }
       // serialize measurement schemas when exist
       if (measurementSchemas != null) {
-        measurementSchemas[i].serializeTo(buffer);
+        serializeMeasurementSchema(measurementSchemas[i], buffer);
       } else {
-        ReadWriteIOUtils.write(measurements[i], buffer);
+        serializeString(measurements[i], buffer);
       }
     }
   }
@@ -304,9 +304,9 @@ public class InsertRowNode extends InsertNode implements WALEntryValue {
       }
       // serialize measurement schemas when exist
       if (measurementSchemas != null) {
-        measurementSchemas[i].serializeTo(stream);
+        serializeMeasurementSchema(measurementSchemas[i], stream);
       } else {
-        ReadWriteIOUtils.write(measurements[i], stream);
+        serializeString(measurements[i], stream);
       }
     }
   }
@@ -332,7 +332,7 @@ public class InsertRowNode extends InsertNode implements WALEntryValue {
       // and is forwarded to other nodes
       if (isNeedInferType) {
         ReadWriteIOUtils.write(TYPE_RAW_STRING, buffer);
-        ReadWriteIOUtils.write(values[i].toString(), buffer);
+        serializeString(values[i].toString(), buffer);
       } else {
         ReadWriteIOUtils.write(dataTypes[i], buffer);
         switch (dataTypes[i]) {
@@ -387,7 +387,7 @@ public class InsertRowNode extends InsertNode implements WALEntryValue {
       // and is forwarded to other nodes
       if (isNeedInferType) {
         ReadWriteIOUtils.write(TYPE_RAW_STRING, stream);
-        ReadWriteIOUtils.write(values[i].toString(), stream);
+        serializeString(values[i].toString(), stream);
       } else {
         ReadWriteIOUtils.write(dataTypes[i], stream);
         switch (dataTypes[i]) {
@@ -433,7 +433,7 @@ public class InsertRowNode extends InsertNode implements WALEntryValue {
     try {
       devicePath =
           DataNodeDevicePathCache.getInstance()
-              .getPartialPath(ReadWriteIOUtils.readString(byteBuffer));
+              .getPartialPath(deserializeString(byteBuffer));
     } catch (IllegalPathException e) {
       throw new IllegalArgumentException(DESERIALIZE_ERROR, e);
     }
@@ -448,12 +448,12 @@ public class InsertRowNode extends InsertNode implements WALEntryValue {
     if (hasSchema) {
       measurementSchemas = new MeasurementSchema[measurementSize];
       for (int i = 0; i < measurementSize; i++) {
-        measurementSchemas[i] = MeasurementSchema.deserializeFrom(buffer);
+        measurementSchemas[i] = deserializeMeasurementSchema(buffer);
         measurements[i] = measurementSchemas[i].getMeasurementId();
       }
     } else {
       for (int i = 0; i < measurementSize; i++) {
-        measurements[i] = ReadWriteIOUtils.readString(buffer);
+        measurements[i] = deserializeString(buffer);
       }
     }
 
@@ -477,7 +477,7 @@ public class InsertRowNode extends InsertNode implements WALEntryValue {
       // and is forwarded to other nodes
       byte typeNum = (byte) ReadWriteIOUtils.read(buffer);
       if (typeNum == TYPE_RAW_STRING || typeNum == TYPE_NULL) {
-        values[i] = typeNum == TYPE_RAW_STRING ? ReadWriteIOUtils.readString(buffer) : null;
+        values[i] = typeNum == TYPE_RAW_STRING ? deserializeString(buffer) : null;
         continue;
       }
       dataTypes[i] = TSDataType.values()[typeNum];

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertRowNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertRowNode.java
@@ -524,7 +524,7 @@ public class InsertRowNode extends InsertNode implements WALEntryValue {
   protected int subSerializeSize() {
     int size = 0;
     size += Long.BYTES;
-    size += ReadWriteIOUtils.sizeToWrite(devicePath.getFullPath());
+    size += WALWriteUtils.sizeToWrite(devicePath.getFullPath());
     return size + serializeMeasurementsAndValuesSize();
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertRowNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertRowNode.java
@@ -432,8 +432,7 @@ public class InsertRowNode extends InsertNode implements WALEntryValue {
     time = byteBuffer.getLong();
     try {
       devicePath =
-          DataNodeDevicePathCache.getInstance()
-              .getPartialPath(deserializeString(byteBuffer));
+          DataNodeDevicePathCache.getInstance().getPartialPath(deserializeString(byteBuffer));
     } catch (IllegalPathException e) {
       throw new IllegalArgumentException(DESERIALIZE_ERROR, e);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertRowNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertRowNode.java
@@ -34,6 +34,7 @@ import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanVisitor;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.WritePlanNode;
 import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.IWALByteBufferView;
 import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.WALEntryValue;
+import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALReadUtils;
 import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALWriteUtils;
 import org.apache.iotdb.db.utils.TypeInferenceUtils;
 
@@ -671,8 +672,7 @@ public class InsertRowNode extends InsertNode implements WALEntryValue {
     insertNode.setTime(stream.readLong());
     try {
       insertNode.setDevicePath(
-          DataNodeDevicePathCache.getInstance()
-              .getPartialPath(ReadWriteIOUtils.readString(stream)));
+          DataNodeDevicePathCache.getInstance().getPartialPath(WALReadUtils.readString(stream)));
     } catch (IllegalPathException e) {
       throw new IllegalArgumentException(DESERIALIZE_ERROR, e);
     }
@@ -757,8 +757,7 @@ public class InsertRowNode extends InsertNode implements WALEntryValue {
     insertNode.setTime(buffer.getLong());
     try {
       insertNode.setDevicePath(
-          DataNodeDevicePathCache.getInstance()
-              .getPartialPath(ReadWriteIOUtils.readString(buffer)));
+          DataNodeDevicePathCache.getInstance().getPartialPath(WALReadUtils.readString(buffer)));
     } catch (IllegalPathException e) {
       throw new IllegalArgumentException(DESERIALIZE_ERROR, e);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertRowsOfOneDeviceNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertRowsOfOneDeviceNode.java
@@ -237,7 +237,7 @@ public class InsertRowsOfOneDeviceNode extends InsertNode {
     try {
       devicePath =
           DataNodeDevicePathCache.getInstance()
-              .getPartialPath((ReadWriteIOUtils.readString(byteBuffer)));
+              .getPartialPath((deserializeString(byteBuffer)));
     } catch (IllegalPathException e) {
       throw new IllegalArgumentException("Cannot deserialize InsertRowsOfOneDeviceNode", e);
     }
@@ -269,7 +269,7 @@ public class InsertRowsOfOneDeviceNode extends InsertNode {
   @Override
   protected void serializeAttributes(ByteBuffer byteBuffer) {
     PlanNodeType.INSERT_ROWS_OF_ONE_DEVICE.serialize(byteBuffer);
-    ReadWriteIOUtils.write(devicePath.getFullPath(), byteBuffer);
+    serializeString(devicePath.getFullPath(), byteBuffer);
 
     ReadWriteIOUtils.write(insertRowNodeList.size(), byteBuffer);
 
@@ -285,7 +285,7 @@ public class InsertRowsOfOneDeviceNode extends InsertNode {
   @Override
   protected void serializeAttributes(DataOutputStream stream) throws IOException {
     PlanNodeType.INSERT_ROWS_OF_ONE_DEVICE.serialize(stream);
-    ReadWriteIOUtils.write(devicePath.getFullPath(), stream);
+    serializeString(devicePath.getFullPath(), stream);
 
     ReadWriteIOUtils.write(insertRowNodeList.size(), stream);
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertRowsOfOneDeviceNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertRowsOfOneDeviceNode.java
@@ -236,8 +236,7 @@ public class InsertRowsOfOneDeviceNode extends InsertNode {
 
     try {
       devicePath =
-          DataNodeDevicePathCache.getInstance()
-              .getPartialPath((deserializeString(byteBuffer)));
+          DataNodeDevicePathCache.getInstance().getPartialPath((deserializeString(byteBuffer)));
     } catch (IllegalPathException e) {
       throw new IllegalArgumentException("Cannot deserialize InsertRowsOfOneDeviceNode", e);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertTabletNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertTabletNode.java
@@ -36,6 +36,7 @@ import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanVisitor;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.WritePlanNode;
 import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.IWALByteBufferView;
 import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.WALEntryValue;
+import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALReadUtils;
 import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALWriteUtils;
 import org.apache.iotdb.db.utils.BitMapUtils;
 import org.apache.iotdb.db.utils.QueryDataSetUtils;
@@ -943,7 +944,7 @@ public class InsertTabletNode extends InsertNode implements WALEntryValue {
     searchIndex = stream.readLong();
     try {
       devicePath =
-          DataNodeDevicePathCache.getInstance().getPartialPath(ReadWriteIOUtils.readString(stream));
+          DataNodeDevicePathCache.getInstance().getPartialPath(WALReadUtils.readString(stream));
     } catch (IllegalPathException e) {
       throw new IllegalArgumentException("Cannot deserialize InsertTabletNode", e);
     }
@@ -979,8 +980,7 @@ public class InsertTabletNode extends InsertNode implements WALEntryValue {
     searchIndex = buffer.getLong();
     try {
       devicePath =
-          DataNodeDevicePathCache.getInstance()
-              .getPartialPath((ReadWriteIOUtils.readString(buffer)));
+          DataNodeDevicePathCache.getInstance().getPartialPath((WALReadUtils.readString(buffer)));
     } catch (IllegalPathException e) {
       throw new IllegalArgumentException("Cannot deserialize InsertTabletNode", e);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertTabletNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertTabletNode.java
@@ -414,7 +414,7 @@ public class InsertTabletNode extends InsertNode implements WALEntryValue {
   }
 
   void subSerialize(ByteBuffer buffer) {
-    ReadWriteIOUtils.write(devicePath.getFullPath(), buffer);
+    serializeString(devicePath.getFullPath(), buffer);
     writeMeasurementsOrSchemas(buffer);
     writeDataTypes(buffer);
     writeTimes(buffer);
@@ -424,7 +424,7 @@ public class InsertTabletNode extends InsertNode implements WALEntryValue {
   }
 
   void subSerialize(DataOutputStream stream) throws IOException {
-    ReadWriteIOUtils.write(devicePath.getFullPath(), stream);
+    serializeString(devicePath.getFullPath(), stream);
     writeMeasurementsOrSchemas(stream);
     writeDataTypes(stream);
     writeTimes(stream);
@@ -445,9 +445,9 @@ public class InsertTabletNode extends InsertNode implements WALEntryValue {
       }
       // serialize measurement schemas when exist
       if (measurementSchemas != null) {
-        measurementSchemas[i].serializeTo(buffer);
+        serializeMeasurementSchema(measurementSchemas[i], buffer);
       } else {
-        ReadWriteIOUtils.write(measurements[i], buffer);
+        serializeString(measurements[i], buffer);
       }
     }
   }
@@ -464,9 +464,9 @@ public class InsertTabletNode extends InsertNode implements WALEntryValue {
       }
       // serialize measurement schemas when exist
       if (measurementSchemas != null) {
-        measurementSchemas[i].serializeTo(stream);
+        serializeMeasurementSchema(measurementSchemas[i], stream);
       } else {
-        ReadWriteIOUtils.write(measurements[i], stream);
+        serializeString(measurements[i], stream);
       }
     }
   }
@@ -684,7 +684,7 @@ public class InsertTabletNode extends InsertNode implements WALEntryValue {
     try {
       devicePath =
           DataNodeDevicePathCache.getInstance()
-              .getPartialPath((ReadWriteIOUtils.readString(buffer)));
+              .getPartialPath((deserializeString(buffer)));
     } catch (IllegalPathException e) {
       throw new IllegalArgumentException("Cannot deserialize InsertTabletNode", e);
     }
@@ -696,12 +696,12 @@ public class InsertTabletNode extends InsertNode implements WALEntryValue {
     if (hasSchema) {
       this.measurementSchemas = new MeasurementSchema[measurementSize];
       for (int i = 0; i < measurementSize; i++) {
-        measurementSchemas[i] = MeasurementSchema.deserializeFrom(buffer);
+        measurementSchemas[i] = deserializeMeasurementSchema(buffer);
         measurements[i] = measurementSchemas[i].getMeasurementId();
       }
     } else {
       for (int i = 0; i < measurementSize; i++) {
-        measurements[i] = ReadWriteIOUtils.readString(buffer);
+        measurements[i] = deserializeString(buffer);
       }
     }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertTabletNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertTabletNode.java
@@ -738,7 +738,7 @@ public class InsertTabletNode extends InsertNode implements WALEntryValue {
   int subSerializeSize(int start, int end) {
     int size = 0;
     size += Long.BYTES;
-    size += ReadWriteIOUtils.sizeToWrite(devicePath.getFullPath());
+    size += WALWriteUtils.sizeToWrite(devicePath.getFullPath());
     // measurements size
     size += Integer.BYTES;
     size += serializeMeasurementSchemasSize();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertTabletNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertTabletNode.java
@@ -683,8 +683,7 @@ public class InsertTabletNode extends InsertNode implements WALEntryValue {
   public void subDeserialize(ByteBuffer buffer) {
     try {
       devicePath =
-          DataNodeDevicePathCache.getInstance()
-              .getPartialPath((deserializeString(buffer)));
+          DataNodeDevicePathCache.getInstance().getPartialPath((deserializeString(buffer)));
     } catch (IllegalPathException e) {
       throw new IllegalArgumentException("Cannot deserialize InsertTabletNode", e);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AbstractMemTable.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AbstractMemTable.java
@@ -40,6 +40,7 @@ import org.apache.iotdb.db.storageengine.dataregion.read.filescan.IChunkHandle;
 import org.apache.iotdb.db.storageengine.dataregion.read.filescan.impl.MemAlignedChunkHandleImpl;
 import org.apache.iotdb.db.storageengine.dataregion.read.filescan.impl.MemChunkHandleImpl;
 import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.IWALByteBufferView;
+import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALReadUtils;
 import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALWriteUtils;
 import org.apache.iotdb.db.utils.MemUtils;
 import org.apache.iotdb.db.utils.ModificationUtils;
@@ -901,7 +902,7 @@ public abstract class AbstractMemTable implements IMemTable {
     }
     int size = FIXED_SERIALIZED_SIZE;
     for (Map.Entry<IDeviceID, IWritableMemChunkGroup> entry : memTableMap.entrySet()) {
-      size += ReadWriteIOUtils.sizeToWrite(((PlainDeviceID) entry.getKey()).toStringID());
+      size += WALWriteUtils.sizeToWrite(((PlainDeviceID) entry.getKey()).toStringID());
       size += Byte.BYTES;
       size += entry.getValue().serializedSize();
     }
@@ -948,7 +949,7 @@ public abstract class AbstractMemTable implements IMemTable {
     int memTableMapSize = stream.readInt();
     for (int i = 0; i < memTableMapSize; ++i) {
 
-      IDeviceID deviceID = deviceIDFactory.getDeviceID(ReadWriteIOUtils.readString(stream));
+      IDeviceID deviceID = deviceIDFactory.getDeviceID(WALReadUtils.readString(stream));
       boolean isAligned = ReadWriteIOUtils.readBool(stream);
       IWritableMemChunkGroup memChunkGroup;
       if (multiTvListMemChunk) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/WritableMemChunkGroup.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/memtable/WritableMemChunkGroup.java
@@ -22,10 +22,10 @@ package org.apache.iotdb.db.storageengine.dataregion.memtable;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.path.PathPatternUtil;
 import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.IWALByteBufferView;
+import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALReadUtils;
 import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALWriteUtils;
 
 import org.apache.tsfile.utils.BitMap;
-import org.apache.tsfile.utils.ReadWriteIOUtils;
 import org.apache.tsfile.write.schema.IMeasurementSchema;
 
 import java.io.DataInputStream;
@@ -180,7 +180,7 @@ public class WritableMemChunkGroup implements IWritableMemChunkGroup {
     int size = 0;
     size += Integer.BYTES;
     for (Map.Entry<String, IWritableMemChunk> entry : memChunkMap.entrySet()) {
-      size += ReadWriteIOUtils.sizeToWrite(entry.getKey());
+      size += WALWriteUtils.sizeToWrite(entry.getKey());
       size += entry.getValue().serializedSize();
     }
     return size;
@@ -200,7 +200,7 @@ public class WritableMemChunkGroup implements IWritableMemChunkGroup {
     WritableMemChunkGroup memChunkGroup = new WritableMemChunkGroup();
     int memChunkMapSize = stream.readInt();
     for (int i = 0; i < memChunkMapSize; ++i) {
-      String measurement = ReadWriteIOUtils.readString(stream);
+      String measurement = WALReadUtils.readString(stream);
       IWritableMemChunk memChunk = WritableMemChunk.deserialize(stream);
       memChunkGroup.memChunkMap.put(measurement, memChunk);
     }
@@ -212,7 +212,7 @@ public class WritableMemChunkGroup implements IWritableMemChunkGroup {
     WritableMemChunkGroup memChunkGroup = new WritableMemChunkGroup();
     int memChunkMapSize = stream.readInt();
     for (int i = 0; i < memChunkMapSize; ++i) {
-      String measurement = ReadWriteIOUtils.readString(stream);
+      String measurement = WALReadUtils.readString(stream);
       IWritableMemChunk memChunk = WritableMemChunk.deserializeSingleTVListMemChunks(stream);
       memChunkGroup.memChunkMap.put(measurement, memChunk);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/modification/Deletion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/modification/Deletion.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.utils.PathUtils;
 import org.apache.iotdb.db.queryengine.execution.MemoryEstimationHelper;
 
+import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.common.constant.TsFileConstant;
 import org.apache.tsfile.read.common.TimeRange;
 import org.apache.tsfile.utils.RamUsageEstimator;
@@ -137,7 +138,14 @@ public class Deletion extends Modification implements Cloneable {
   }
 
   public long getSerializedSize() {
-    return Long.BYTES * 2 + Integer.BYTES + (long) getPathString().length() * Character.BYTES;
+    return Long.BYTES * 2L + sizeToWriteString(getPathString());
+  }
+
+  private static int sizeToWriteString(String value) {
+    if (value == null) {
+      return Integer.BYTES;
+    }
+    return Integer.BYTES + value.getBytes(TSFileConfig.STRING_CHARSET).length;
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/modification/Deletion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/modification/Deletion.java
@@ -28,7 +28,6 @@ import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.common.constant.TsFileConstant;
 import org.apache.tsfile.read.common.TimeRange;
 import org.apache.tsfile.utils.RamUsageEstimator;
-import org.apache.tsfile.utils.ReadWriteIOUtils;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -114,7 +113,7 @@ public class Deletion extends Modification implements Cloneable {
     serializeSize += Long.BYTES;
     stream.writeLong(getEndTime());
     serializeSize += Long.BYTES;
-    serializeSize += ReadWriteIOUtils.write(getPathString(), stream);
+    serializeSize += writeString(getPathString(), stream);
     return serializeSize;
   }
 
@@ -122,8 +121,30 @@ public class Deletion extends Modification implements Cloneable {
       throws IOException, IllegalPathException {
     long startTime = stream.readLong();
     long endTime = stream.readLong();
-    return new Deletion(
-        getMeasurementPath(ReadWriteIOUtils.readString(stream)), 0, startTime, endTime);
+    return new Deletion(getMeasurementPath(readString(stream)), 0, startTime, endTime);
+  }
+
+  private static int writeString(String value, DataOutputStream stream) throws IOException {
+    if (value == null) {
+      stream.writeInt(-1);
+      return Integer.BYTES;
+    }
+    byte[] bytes = value.getBytes(TSFileConfig.STRING_CHARSET);
+    stream.writeInt(bytes.length);
+    stream.write(bytes);
+    return Integer.BYTES + bytes.length;
+  }
+
+  private static String readString(DataInputStream stream) throws IOException {
+    int strLength = stream.readInt();
+    if (strLength < 0) {
+      return null;
+    } else if (strLength == 0) {
+      return "";
+    }
+    byte[] bytes = new byte[strLength];
+    stream.readFully(bytes);
+    return new String(bytes, TSFileConfig.STRING_CHARSET);
   }
 
   private static PartialPath getMeasurementPath(String path) throws IllegalPathException {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/buffer/WALInfoEntry.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/buffer/WALInfoEntry.java
@@ -64,7 +64,14 @@ public class WALInfoEntry extends WALEntry {
 
   @Override
   public int serializedSize() {
-    return FIXED_SERIALIZED_SIZE + (value == null ? 0 : value.serializedSize());
+    if (value == null) {
+      return FIXED_SERIALIZED_SIZE;
+    }
+    if (value instanceof InsertTabletNode && tabletInfo != null) {
+      return FIXED_SERIALIZED_SIZE
+          + ((InsertTabletNode) value).serializedSize(tabletInfo.tabletStart, tabletInfo.tabletEnd);
+    }
+    return FIXED_SERIALIZED_SIZE + value.serializedSize();
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/utils/WALReadUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/utils/WALReadUtils.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.storageengine.dataregion.wal.utils;
+
+import org.apache.tsfile.common.conf.TSFileConfig;
+import org.apache.tsfile.write.schema.MeasurementSchema;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Read methods paired with {@link WALWriteUtils}. */
+public class WALReadUtils {
+
+  private WALReadUtils() {}
+
+  public static String readString(DataInputStream stream) throws IOException {
+    int strLength = stream.readInt();
+    if (strLength < 0) {
+      return null;
+    } else if (strLength == 0) {
+      return "";
+    }
+    byte[] bytes = new byte[strLength];
+    stream.readFully(bytes);
+    return new String(bytes, TSFileConfig.STRING_CHARSET);
+  }
+
+  public static String readString(ByteBuffer buffer) {
+    int strLength = buffer.getInt();
+    if (strLength < 0) {
+      return null;
+    } else if (strLength == 0) {
+      return "";
+    }
+    byte[] bytes = new byte[strLength];
+    buffer.get(bytes);
+    return new String(bytes, TSFileConfig.STRING_CHARSET);
+  }
+
+  public static MeasurementSchema readMeasurementSchema(DataInputStream stream) throws IOException {
+    String measurementId = readString(stream);
+    byte type = stream.readByte();
+    byte encoding = stream.readByte();
+    byte compressor = stream.readByte();
+    Map<String, String> props = readProps(stream);
+    return new MeasurementSchema(measurementId, type, encoding, compressor, props);
+  }
+
+  public static MeasurementSchema readMeasurementSchema(ByteBuffer buffer) {
+    String measurementId = readString(buffer);
+    byte type = buffer.get();
+    byte encoding = buffer.get();
+    byte compressor = buffer.get();
+    Map<String, String> props = readProps(buffer);
+    return new MeasurementSchema(measurementId, type, encoding, compressor, props);
+  }
+
+  private static Map<String, String> readProps(DataInputStream stream) throws IOException {
+    int size = stream.readInt();
+    if (size <= 0) {
+      return null;
+    }
+    Map<String, String> props = new HashMap<>();
+    for (int i = 0; i < size; i++) {
+      props.put(readString(stream), readString(stream));
+    }
+    return props;
+  }
+
+  private static Map<String, String> readProps(ByteBuffer buffer) {
+    int size = buffer.getInt();
+    if (size <= 0) {
+      return null;
+    }
+    Map<String, String> props = new HashMap<>();
+    for (int i = 0; i < size; i++) {
+      props.put(readString(buffer), readString(buffer));
+    }
+    return props;
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/utils/WALWriteUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/wal/utils/WALWriteUtils.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.storageengine.dataregion.wal.utils;
 
 import org.apache.iotdb.db.storageengine.dataregion.wal.buffer.IWALByteBufferView;
 
+import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.file.metadata.enums.CompressionType;
@@ -127,11 +128,18 @@ public class WALWriteUtils {
       return write(NO_BYTE_TO_READ, buffer);
     }
     int len = 0;
-    byte[] bytes = s.getBytes();
+    byte[] bytes = s.getBytes(TSFileConfig.STRING_CHARSET);
     len += write(bytes.length, buffer);
     buffer.put(bytes);
     len += bytes.length;
     return len;
+  }
+
+  public static int sizeToWrite(String s) {
+    if (s == null) {
+      return INT_LEN;
+    }
+    return INT_LEN + s.getBytes(TSFileConfig.STRING_CHARSET).length;
   }
 
   /**
@@ -196,15 +204,15 @@ public class WALWriteUtils {
 
   public static int sizeToWrite(MeasurementSchema measurementSchema) {
     int byteLen = 0;
-    byteLen += ReadWriteIOUtils.sizeToWrite(measurementSchema.getMeasurementId());
+    byteLen += sizeToWrite(measurementSchema.getMeasurementId());
     byteLen += 3 * Byte.BYTES;
 
     Map<String, String> props = measurementSchema.getProps();
     byteLen += Integer.BYTES;
     if (props != null) {
       for (Map.Entry<String, String> entry : props.entrySet()) {
-        byteLen += ReadWriteIOUtils.sizeToWrite(entry.getKey());
-        byteLen += ReadWriteIOUtils.sizeToWrite(entry.getValue());
+        byteLen += sizeToWrite(entry.getKey());
+        byteLen += sizeToWrite(entry.getValue());
       }
     }
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/node/write/DeleteDataNodeSerdeTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/node/write/DeleteDataNodeSerdeTest.java
@@ -25,10 +25,14 @@ import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeType;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.DeleteDataNode;
+import org.apache.iotdb.db.storageengine.dataregion.wal.utils.WALByteBufferForTest;
 
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -63,5 +67,29 @@ public class DeleteDataNodeSerdeTest {
     for (int i = 0; i < pathList.size(); i++) {
       Assert.assertEquals(pathList.get(i), deserializedPathList.get(i));
     }
+  }
+
+  @Test
+  public void testSerializeAndDeserializeForWAL() throws IllegalPathException, IOException {
+    long startTime = 1;
+    long endTime = 10;
+    List<PartialPath> pathList = new ArrayList<>();
+    pathList.add(new PartialPath("root.\u6570\u636e\u5e93.d1.\u6e29\u5ea6"));
+    pathList.add(new PartialPath("root.\u6570\u636e\u5e93.d2.*"));
+    DeleteDataNode deleteDataNode =
+        new DeleteDataNode(new PlanNodeId("DeleteDataNode"), pathList, startTime, endTime);
+
+    ByteBuffer byteBuffer = ByteBuffer.allocate(deleteDataNode.serializedSize());
+    deleteDataNode.serializeToWAL(new WALByteBufferForTest(byteBuffer));
+    Assert.assertEquals(deleteDataNode.serializedSize(), byteBuffer.position());
+
+    DataInputStream dataInputStream =
+        new DataInputStream(new ByteArrayInputStream(byteBuffer.array()));
+    Assert.assertEquals(PlanNodeType.DELETE_DATA.getNodeType(), dataInputStream.readShort());
+
+    DeleteDataNode deserializedNode = DeleteDataNode.deserializeFromWAL(dataInputStream);
+    Assert.assertEquals(startTime, deserializedNode.getDeleteStartTime());
+    Assert.assertEquals(endTime, deserializedNode.getDeleteEndTime());
+    Assert.assertEquals(pathList, deserializedNode.getPathList());
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/node/write/InsertRowNodeSerdeTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/node/write/InsertRowNodeSerdeTest.java
@@ -89,8 +89,8 @@ public class InsertRowNodeSerdeTest {
     tmpNode.setPlanNodeId(insertRowNode.getPlanNodeId());
     tmpNode.setMeasurementSchemas(
         new MeasurementSchema[] {
-          new MeasurementSchema("s1", TSDataType.DOUBLE),
-          new MeasurementSchema("s2", TSDataType.FLOAT),
+          new MeasurementSchema("\u6e29\u5ea6", TSDataType.DOUBLE),
+          new MeasurementSchema("\u6e7f\u5ea6", TSDataType.FLOAT),
           new MeasurementSchema("s3", TSDataType.INT64),
           new MeasurementSchema("s4", TSDataType.INT32),
           new MeasurementSchema("s5", TSDataType.BOOLEAN)
@@ -148,9 +148,9 @@ public class InsertRowNodeSerdeTest {
     InsertRowNode insertRowNode =
         new InsertRowNode(
             new PlanNodeId("plannode 2"),
-            new PartialPath("root.isp.d2"),
+            new PartialPath("root.\u6570\u636e\u5e93.d2"),
             false,
-            new String[] {"s1", "s2", "s3", "s4", "s5"},
+            new String[] {"\u6e29\u5ea6", "\u6e7f\u5ea6", "s3", "s4", "s5"},
             dataTypes,
             time,
             columns,
@@ -158,8 +158,8 @@ public class InsertRowNodeSerdeTest {
 
     insertRowNode.setMeasurementSchemas(
         new MeasurementSchema[] {
-          new MeasurementSchema("s1", TSDataType.DOUBLE),
-          new MeasurementSchema("s2", TSDataType.FLOAT),
+          new MeasurementSchema("\u6e29\u5ea6", TSDataType.DOUBLE),
+          new MeasurementSchema("\u6e7f\u5ea6", TSDataType.FLOAT),
           new MeasurementSchema("s3", TSDataType.INT64),
           new MeasurementSchema("s4", TSDataType.INT32),
           new MeasurementSchema("s5", TSDataType.BOOLEAN)

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/node/write/InsertTabletNodeSerdeTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/planner/node/write/InsertTabletNodeSerdeTest.java
@@ -84,8 +84,8 @@ public class InsertTabletNodeSerdeTest {
 
     tmpNode.setMeasurementSchemas(
         new MeasurementSchema[] {
-          new MeasurementSchema("s1", TSDataType.DOUBLE),
-          new MeasurementSchema("s2", TSDataType.FLOAT),
+          new MeasurementSchema("\u6e29\u5ea6", TSDataType.DOUBLE),
+          new MeasurementSchema("\u6e7f\u5ea6", TSDataType.FLOAT),
           new MeasurementSchema("s3", TSDataType.INT64),
           new MeasurementSchema("s4", TSDataType.INT32),
           new MeasurementSchema("s5", TSDataType.BOOLEAN)
@@ -191,9 +191,9 @@ public class InsertTabletNodeSerdeTest {
     InsertTabletNode insertTabletNode =
         new InsertTabletNode(
             new PlanNodeId("plannode 1"),
-            new PartialPath("root.isp.d1"),
+            new PartialPath("root.\u6570\u636e\u5e93.d1"),
             false,
-            new String[] {"s1", "s2", "s3", "s4", "s5"},
+            new String[] {"\u6e29\u5ea6", "\u6e7f\u5ea6", "s3", "s4", "s5"},
             dataTypes,
             times,
             null,
@@ -201,8 +201,8 @@ public class InsertTabletNodeSerdeTest {
             times.length);
     insertTabletNode.setMeasurementSchemas(
         new MeasurementSchema[] {
-          new MeasurementSchema("s1", TSDataType.DOUBLE),
-          new MeasurementSchema("s2", TSDataType.FLOAT),
+          new MeasurementSchema("\u6e29\u5ea6", TSDataType.DOUBLE),
+          new MeasurementSchema("\u6e7f\u5ea6", TSDataType.FLOAT),
           new MeasurementSchema("s3", TSDataType.INT64),
           new MeasurementSchema("s4", TSDataType.INT32),
           new MeasurementSchema("s5", TSDataType.BOOLEAN)

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/modification/DeletionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/modification/DeletionTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.storageengine.dataregion.modification;
+
+import org.apache.iotdb.commons.path.PartialPath;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+
+import static org.junit.Assert.assertEquals;
+
+public class DeletionTest {
+
+  @Test
+  public void testSerializedSize() throws Exception {
+    Deletion deletion =
+        new Deletion(new PartialPath("root.\u6570\u636e\u5e93.d1.\u6e29\u5ea6"), 0, 1, 5);
+
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    long serializedSize =
+        deletion.serializeWithoutFileOffset(new DataOutputStream(byteArrayOutputStream));
+    byte[] bytes = byteArrayOutputStream.toByteArray();
+
+    assertEquals(deletion.getSerializedSize(), serializedSize);
+    assertEquals(deletion.getSerializedSize(), bytes.length);
+    assertEquals(
+        deletion,
+        Deletion.deserializeWithoutFileOffset(
+            new DataInputStream(new ByteArrayInputStream(bytes))));
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALFileTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/io/WALFileTest.java
@@ -61,7 +61,7 @@ public class WALFileTest {
       new File(
           TestConstant.BASE_OUTPUT_PATH.concat(
               WALFileUtils.getLogFileName(0, 0, WALFileStatus.CONTAINS_SEARCH_INDEX)));
-  private final String devicePath = "root.test_sg.test_d";
+  private final String devicePath = "root.\u6570\u636e\u5e93.test_d";
 
   @Before
   public void setUp() throws Exception {
@@ -169,6 +169,16 @@ public class WALFileTest {
     WALMetaData walMetaData = WALMetaData.readFromWALFile(walFile, fileChannel2);
     fileChannel2.close();
     assertTrue(walMetaData.getMemTablesId().isEmpty());
+  }
+
+  @Test
+  public void testInsertTabletEntrySerializedSizeWithRange()
+      throws IOException, IllegalPathException {
+    WALEntry walEntry = new WALInfoEntry(1, getInsertTabletNode(devicePath), 1, 3);
+    ByteBuffer byteBuffer = ByteBuffer.allocate(walEntry.serializedSize());
+    WALByteBufferForTest buffer = new WALByteBufferForTest(byteBuffer);
+    walEntry.serialize(buffer);
+    assertEquals(walEntry.serializedSize(), byteBuffer.position());
   }
 
   public static InsertRowNode getInsertRowNode(String devicePath) throws IllegalPathException {


### PR DESCRIPTION
Cherry-picks the tree-model relevant parts of ab887eb98ea2d4f44a243d2df723a9bfa619df16 (#17867) to dev/1.3.

Included:
- Fix WAL string serialized-size calculations for tree delete/insert nodes and measurement schemas.
- Fix partial InsertTablet WAL entry size calculation on dev/1.3's tablet start/end path.
- Fix legacy tree Deletion serialized size and add coverage for non-ASCII paths.

Validation:
- mvn spotless:apply -pl iotdb-core/datanode
- git diff --check
- Attempted targeted datanode tests, but the module currently fails during main compilation before test execution with existing pipe/schema API mismatches unrelated to these changed files.