### PR TITLE
Bound Ratis reconfiguration retries to avoid stuck region migration

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
@@ -318,6 +318,16 @@ public class ConfigNodeConfig {
   private long schemaRegionRatisInitialSleepTimeMs = 100;
   private long schemaRegionRatisMaxSleepTimeMs = 10000;
 
+  /**
+   * RatisConsensus protocol, max retry attempts for a configuration change (add/remove peer). Uses
+   * a fixed 2s retry interval; bounding the attempts stops a killed ADDING peer from blocking the
+   * reconfiguration -- and hence a region migration -- forever.
+   */
+  private int configNodeRatisReconfigurationMaxRetryAttempts = 600;
+
+  private int dataRegionRatisReconfigurationMaxRetryAttempts = 600;
+  private int schemaRegionRatisReconfigurationMaxRetryAttempts = 600;
+
   private long configNodeRatisPreserveLogsWhenPurge = 1000;
   private long schemaRegionRatisPreserveLogsWhenPurge = 1000;
   private long dataRegionRatisPreserveLogsWhenPurge = 1000;
@@ -1115,6 +1125,36 @@ public class ConfigNodeConfig {
 
   public void setSchemaRegionRatisMaxRetryAttempts(int schemaRegionRatisMaxRetryAttempts) {
     this.schemaRegionRatisMaxRetryAttempts = schemaRegionRatisMaxRetryAttempts;
+  }
+
+  public int getConfigNodeRatisReconfigurationMaxRetryAttempts() {
+    return configNodeRatisReconfigurationMaxRetryAttempts;
+  }
+
+  public void setConfigNodeRatisReconfigurationMaxRetryAttempts(
+      int configNodeRatisReconfigurationMaxRetryAttempts) {
+    this.configNodeRatisReconfigurationMaxRetryAttempts =
+        configNodeRatisReconfigurationMaxRetryAttempts;
+  }
+
+  public int getDataRegionRatisReconfigurationMaxRetryAttempts() {
+    return dataRegionRatisReconfigurationMaxRetryAttempts;
+  }
+
+  public void setDataRegionRatisReconfigurationMaxRetryAttempts(
+      int dataRegionRatisReconfigurationMaxRetryAttempts) {
+    this.dataRegionRatisReconfigurationMaxRetryAttempts =
+        dataRegionRatisReconfigurationMaxRetryAttempts;
+  }
+
+  public int getSchemaRegionRatisReconfigurationMaxRetryAttempts() {
+    return schemaRegionRatisReconfigurationMaxRetryAttempts;
+  }
+
+  public void setSchemaRegionRatisReconfigurationMaxRetryAttempts(
+      int schemaRegionRatisReconfigurationMaxRetryAttempts) {
+    this.schemaRegionRatisReconfigurationMaxRetryAttempts =
+        schemaRegionRatisReconfigurationMaxRetryAttempts;
   }
 
   public long getSchemaRegionRatisInitialSleepTimeMs() {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
@@ -629,6 +629,11 @@ public class ConfigNodeDescriptor {
             properties.getProperty(
                 "config_node_ratis_max_retry_attempts",
                 String.valueOf(conf.getConfigNodeRatisMaxRetryAttempts()))));
+    conf.setConfigNodeRatisReconfigurationMaxRetryAttempts(
+        Integer.parseInt(
+            properties.getProperty(
+                "config_node_ratis_reconfiguration_max_retry_attempts",
+                String.valueOf(conf.getConfigNodeRatisReconfigurationMaxRetryAttempts()))));
     conf.setConfigNodeRatisInitialSleepTimeMs(
         Long.parseLong(
             properties.getProperty(
@@ -645,6 +650,11 @@ public class ConfigNodeDescriptor {
             properties.getProperty(
                 "data_region_ratis_max_retry_attempts",
                 String.valueOf(conf.getDataRegionRatisMaxRetryAttempts()))));
+    conf.setDataRegionRatisReconfigurationMaxRetryAttempts(
+        Integer.parseInt(
+            properties.getProperty(
+                "data_region_ratis_reconfiguration_max_retry_attempts",
+                String.valueOf(conf.getDataRegionRatisReconfigurationMaxRetryAttempts()))));
     conf.setDataRegionRatisInitialSleepTimeMs(
         Long.parseLong(
             properties.getProperty(
@@ -661,6 +671,11 @@ public class ConfigNodeDescriptor {
             properties.getProperty(
                 "schema_region_ratis_max_retry_attempts",
                 String.valueOf(conf.getSchemaRegionRatisMaxRetryAttempts()))));
+    conf.setSchemaRegionRatisReconfigurationMaxRetryAttempts(
+        Integer.parseInt(
+            properties.getProperty(
+                "schema_region_ratis_reconfiguration_max_retry_attempts",
+                String.valueOf(conf.getSchemaRegionRatisReconfigurationMaxRetryAttempts()))));
     conf.setSchemaRegionRatisInitialSleepTimeMs(
         Long.parseLong(
             properties.getProperty(

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/consensus/ConsensusManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/consensus/ConsensusManager.java
@@ -233,6 +233,8 @@ public class ConsensusManager {
                                       .setClientRetryMaxSleepTimeMs(
                                           CONF.getConfigNodeRatisMaxSleepTimeMs())
                                       .setMaxClientNumForEachNode(CONF.getMaxClientNumForEachNode())
+                                      .setReconfigurationMaxRetryAttempts(
+                                          CONF.getConfigNodeRatisReconfigurationMaxRetryAttempts())
                                       .build())
                               .setImpl(
                                   RatisConfig.Impl.newBuilder()

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/node/NodeManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/node/NodeManager.java
@@ -233,6 +233,10 @@ public class NodeManager {
     ratisConfig.setSchemaMaxRetryAttempts(conf.getSchemaRegionRatisMaxRetryAttempts());
     ratisConfig.setSchemaInitialSleepTime(conf.getSchemaRegionRatisInitialSleepTimeMs());
     ratisConfig.setSchemaMaxSleepTime(conf.getSchemaRegionRatisMaxSleepTimeMs());
+    ratisConfig.setDataReconfigurationMaxRetryAttempts(
+        conf.getDataRegionRatisReconfigurationMaxRetryAttempts());
+    ratisConfig.setSchemaReconfigurationMaxRetryAttempts(
+        conf.getSchemaRegionRatisReconfigurationMaxRetryAttempts());
 
     ratisConfig.setSchemaPreserveWhenPurge(conf.getSchemaRegionRatisPreserveLogsWhenPurge());
     ratisConfig.setDataPreserveWhenPurge(conf.getDataRegionRatisPreserveLogsWhenPurge());

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/config/RatisConfig.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/config/RatisConfig.java
@@ -865,18 +865,21 @@ public class RatisConfig {
     private final long clientRetryInitialSleepTimeMs;
     private final long clientRetryMaxSleepTimeMs;
     private final int maxClientNumForEachNode;
+    private final int reconfigurationMaxRetryAttempts;
 
     public Client(
         long clientRequestTimeoutMillis,
         int clientMaxRetryAttempt,
         long clientRetryInitialSleepTimeMs,
         long clientRetryMaxSleepTimeMs,
-        int maxClientNumForEachNode) {
+        int maxClientNumForEachNode,
+        int reconfigurationMaxRetryAttempts) {
       this.clientRequestTimeoutMillis = clientRequestTimeoutMillis;
       this.clientMaxRetryAttempt = clientMaxRetryAttempt;
       this.clientRetryInitialSleepTimeMs = clientRetryInitialSleepTimeMs;
       this.clientRetryMaxSleepTimeMs = clientRetryMaxSleepTimeMs;
       this.maxClientNumForEachNode = maxClientNumForEachNode;
+      this.reconfigurationMaxRetryAttempts = reconfigurationMaxRetryAttempts;
     }
 
     public long getClientRequestTimeoutMillis() {
@@ -899,6 +902,10 @@ public class RatisConfig {
       return maxClientNumForEachNode;
     }
 
+    public int getReconfigurationMaxRetryAttempts() {
+      return reconfigurationMaxRetryAttempts;
+    }
+
     public static Client.Builder newBuilder() {
       return new Builder();
     }
@@ -910,6 +917,11 @@ public class RatisConfig {
       private long clientRetryInitialSleepTimeMs = 100;
       private long clientRetryMaxSleepTimeMs = 10000;
       private int maxClientNumForEachNode = DefaultProperty.MAX_CLIENT_NUM_FOR_EACH_NODE;
+      // A Ratis configuration change (add/remove peer) retries the "in progress / not ready"
+      // failures with a fixed 2s interval. Bounding the number of attempts (instead of retrying
+      // forever) prevents a killed ADDING peer that can never catch up from blocking the
+      // reconfiguration -- and hence the region migration -- indefinitely. 600 attempts ~= 20min.
+      private int reconfigurationMaxRetryAttempts = 600;
 
       public Client build() {
         return new Client(
@@ -917,7 +929,8 @@ public class RatisConfig {
             clientMaxRetryAttempt,
             clientRetryInitialSleepTimeMs,
             clientRetryMaxSleepTimeMs,
-            maxClientNumForEachNode);
+            maxClientNumForEachNode,
+            reconfigurationMaxRetryAttempts);
       }
 
       public Builder setClientRequestTimeoutMillis(long clientRequestTimeoutMillis) {
@@ -942,6 +955,11 @@ public class RatisConfig {
 
       public Builder setMaxClientNumForEachNode(int maxClientNumForEachNode) {
         this.maxClientNumForEachNode = maxClientNumForEachNode;
+        return this;
+      }
+
+      public Builder setReconfigurationMaxRetryAttempts(int reconfigurationMaxRetryAttempts) {
+        this.reconfigurationMaxRetryAttempts = reconfigurationMaxRetryAttempts;
         return this;
       }
     }

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisClient.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisClient.java
@@ -132,14 +132,14 @@ class RatisClient implements AutoCloseable {
     }
   }
 
-  static class EndlessRetryFactory extends BaseClientFactory<RaftGroup, RatisClient> {
+  static class ReconfigurationRetryFactory extends BaseClientFactory<RaftGroup, RatisClient> {
 
     private final RaftProperties raftProperties;
     private final RaftClientRpc clientRpc;
     private final RatisConfig.Client config;
     private final Parameters parameters;
 
-    public EndlessRetryFactory(
+    public ReconfigurationRetryFactory(
         ClientManager<RaftGroup, RatisClient> clientManager,
         RaftProperties raftProperties,
         RaftClientRpc clientRpc,
@@ -165,7 +165,7 @@ class RatisClient implements AutoCloseable {
               RaftClient.newBuilder()
                   .setProperties(raftProperties)
                   .setRaftGroup(group)
-                  .setRetryPolicy(new RatisEndlessRetryPolicy(config))
+                  .setRetryPolicy(new RatisReconfigurationRetryPolicy(config))
                   .setParameters(parameters)
                   .setClientRpc(clientRpc)
                   .build(),
@@ -226,16 +226,23 @@ class RatisClient implements AutoCloseable {
   }
 
   /** This policy is used to raft configuration change */
-  private static class RatisEndlessRetryPolicy implements RetryPolicy {
+  private static class RatisReconfigurationRetryPolicy implements RetryPolicy {
 
-    private static final Logger logger = LoggerFactory.getLogger(RatisEndlessRetryPolicy.class);
-    // for reconfiguration request, we use different retry policy
-    private final RetryPolicy endlessPolicy;
+    private static final Logger logger =
+        LoggerFactory.getLogger(RatisReconfigurationRetryPolicy.class);
+    // For a reconfiguration request we retry the "in progress / not ready" failures with a fixed
+    // 2s interval, but only up to a bounded number of attempts. An unbounded retry (the previous
+    // behavior) would block the setConfiguration call forever when a newly ADDING peer is killed
+    // and can never catch up, leaving the region migration permanently stuck. After the bound is
+    // exhausted the last failure is propagated, so the upper layer can fail and roll back.
+    private final RetryPolicy reconfigurationPolicy;
     private final RetryPolicy defaultPolicy;
 
-    RatisEndlessRetryPolicy(RatisConfig.Client config) {
-      endlessPolicy =
-          RetryPolicies.retryForeverWithSleep(TimeDuration.valueOf(2, TimeUnit.SECONDS));
+    RatisReconfigurationRetryPolicy(RatisConfig.Client config) {
+      reconfigurationPolicy =
+          RetryPolicies.retryUpToMaximumCountWithFixedSleep(
+              config.getReconfigurationMaxRetryAttempts(),
+              TimeDuration.valueOf(2, TimeUnit.SECONDS));
       defaultPolicy = new RatisRetryPolicy(config);
     }
 
@@ -248,7 +255,7 @@ class RatisClient implements AutoCloseable {
           || cause instanceof LeaderSteppingDownException
           || cause instanceof ServerNotReadyException
           || cause instanceof NotLeaderException) {
-        return endlessPolicy.handleAttemptFailure(event);
+        return reconfigurationPolicy.handleAttemptFailure(event);
       }
 
       return defaultPolicy.handleAttemptFailure(event);

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/ratis/RatisConsensus.java
@@ -1023,7 +1023,7 @@ class RatisConsensus implements IConsensus {
       GenericKeyedObjectPool<RaftGroup, RatisClient> clientPool =
           new GenericKeyedObjectPool<>(
               isReconfiguration
-                  ? new RatisClient.EndlessRetryFactory(
+                  ? new RatisClient.ReconfigurationRetryFactory(
                       manager, properties, clientRpc, config.getClient(), parameters)
                   : new RatisClient.Factory(
                       manager, properties, clientRpc, config.getClient(), parameters),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -1062,6 +1062,15 @@ public class IoTDBConfig {
 
   private int dataRatisConsensusMaxRetryAttempts = 10;
   private int schemaRatisConsensusMaxRetryAttempts = 10;
+
+  /**
+   * RatisConsensus protocol, max retry attempts for a configuration change (add/remove peer). Uses
+   * a fixed 2s retry interval; bounding the attempts stops a killed ADDING peer from blocking the
+   * reconfiguration -- and hence a region migration -- forever. Pushed from the ConfigNode.
+   */
+  private int dataRatisConsensusReconfigurationMaxRetryAttempts = 600;
+
+  private int schemaRatisConsensusReconfigurationMaxRetryAttempts = 600;
   private long dataRatisConsensusInitialSleepTimeMs = 100L;
   private long schemaRatisConsensusInitialSleepTimeMs = 100L;
   private long dataRatisConsensusMaxSleepTimeMs = 10000L;
@@ -3830,6 +3839,26 @@ public class IoTDBConfig {
 
   public void setSchemaRatisConsensusMaxRetryAttempts(int schemaRatisConsensusMaxRetryAttempts) {
     this.schemaRatisConsensusMaxRetryAttempts = schemaRatisConsensusMaxRetryAttempts;
+  }
+
+  public int getDataRatisConsensusReconfigurationMaxRetryAttempts() {
+    return dataRatisConsensusReconfigurationMaxRetryAttempts;
+  }
+
+  public void setDataRatisConsensusReconfigurationMaxRetryAttempts(
+      int dataRatisConsensusReconfigurationMaxRetryAttempts) {
+    this.dataRatisConsensusReconfigurationMaxRetryAttempts =
+        dataRatisConsensusReconfigurationMaxRetryAttempts;
+  }
+
+  public int getSchemaRatisConsensusReconfigurationMaxRetryAttempts() {
+    return schemaRatisConsensusReconfigurationMaxRetryAttempts;
+  }
+
+  public void setSchemaRatisConsensusReconfigurationMaxRetryAttempts(
+      int schemaRatisConsensusReconfigurationMaxRetryAttempts) {
+    this.schemaRatisConsensusReconfigurationMaxRetryAttempts =
+        schemaRatisConsensusReconfigurationMaxRetryAttempts;
   }
 
   public long getDataRatisConsensusInitialSleepTimeMs() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBDescriptor.java
@@ -2970,6 +2970,17 @@ public class IoTDBDescriptor {
     conf.setSchemaRatisConsensusInitialSleepTimeMs(ratisConfig.getSchemaInitialSleepTime());
     conf.setSchemaRatisConsensusMaxSleepTimeMs(ratisConfig.getSchemaMaxSleepTime());
 
+    // Optional fields: an old ConfigNode (rolling upgrade) will not set them, in which case the
+    // DataNode keeps its local default instead of overwriting it with 0.
+    if (ratisConfig.isSetDataReconfigurationMaxRetryAttempts()) {
+      conf.setDataRatisConsensusReconfigurationMaxRetryAttempts(
+          ratisConfig.getDataReconfigurationMaxRetryAttempts());
+    }
+    if (ratisConfig.isSetSchemaReconfigurationMaxRetryAttempts()) {
+      conf.setSchemaRatisConsensusReconfigurationMaxRetryAttempts(
+          ratisConfig.getSchemaReconfigurationMaxRetryAttempts());
+    }
+
     conf.setDataRatisConsensusPreserveWhenPurge(ratisConfig.getDataPreserveWhenPurge());
     conf.setSchemaRatisConsensusPreserveWhenPurge(ratisConfig.getSchemaPreserveWhenPurge());
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/DataRegionConsensusImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/DataRegionConsensusImpl.java
@@ -277,6 +277,8 @@ public class DataRegionConsensusImpl {
                               CONF.getDataRatisConsensusInitialSleepTimeMs())
                           .setClientRetryMaxSleepTimeMs(CONF.getDataRatisConsensusMaxSleepTimeMs())
                           .setMaxClientNumForEachNode(CONF.getMaxClientNumForEachNode())
+                          .setReconfigurationMaxRetryAttempts(
+                              CONF.getDataRatisConsensusReconfigurationMaxRetryAttempts())
                           .build())
                   .setImpl(
                       RatisConfig.Impl.newBuilder()

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/SchemaRegionConsensusImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/SchemaRegionConsensusImpl.java
@@ -155,6 +155,9 @@ public class SchemaRegionConsensusImpl {
                                       .setClientRetryMaxSleepTimeMs(
                                           CONF.getDataRatisConsensusMaxSleepTimeMs())
                                       .setMaxClientNumForEachNode(CONF.getMaxClientNumForEachNode())
+                                      .setReconfigurationMaxRetryAttempts(
+                                          CONF
+                                              .getSchemaRatisConsensusReconfigurationMaxRetryAttempts())
                                       .build())
                               .setImpl(
                                   RatisConfig.Impl.newBuilder()

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
@@ -2056,6 +2056,17 @@ data_region_ratis_max_retry_attempts=10
 data_region_ratis_initial_sleep_time_ms=100
 data_region_ratis_max_sleep_time_ms=10000
 
+# Max retry attempts for a Ratis configuration change (add/remove peer), e.g. during region
+# migration or cluster scale-in/out. Unlike the request retry policy above, reconfiguration retries
+# use a fixed 2s interval, so this roughly caps the wait at (attempts * 2s). Bounding it (instead of
+# retrying forever) prevents a killed ADDING peer that can never catch up from blocking the
+# reconfiguration -- and therefore the whole region migration -- indefinitely.
+# effectiveMode: restart
+# Datatype: int
+config_node_ratis_reconfiguration_max_retry_attempts=600
+schema_region_ratis_reconfiguration_max_retry_attempts=600
+data_region_ratis_reconfiguration_max_retry_attempts=600
+
 # first election timeout
 # effectiveMode: restart
 # Datatype: int

--- a/iotdb-protocol/thrift-confignode/src/main/thrift/confignode.thrift
+++ b/iotdb-protocol/thrift-confignode/src/main/thrift/confignode.thrift
@@ -104,6 +104,12 @@ struct TRatisConfig {
   34: required i64 dataRegionPeriodicSnapshotInterval
 
   35: required i32 ratisTransferLeaderTimeoutMs;
+
+  // Bound the retry attempts of a Ratis configuration change (add/remove peer) so a killed ADDING
+  // peer cannot block the reconfiguration forever. Optional for rolling-upgrade compatibility: an
+  // old ConfigNode will not set them and the DataNode falls back to its local default.
+  36: optional i32 schemaReconfigurationMaxRetryAttempts
+  37: optional i32 dataReconfigurationMaxRetryAttempts
 }
 
 struct TCQConfig {


### PR DESCRIPTION
## Problem

While benchmarking concurrent read/write and scaling in one healthy DataNode on a Ratis (3-replica) schema region, killing (`kill -9`) the DataNode that hosts an **ADDING** peer mid-migration leaves the schema-region `AddRegionPeer` task **stuck forever** (observed: `CHECK_ADD_REGION_PEER` / `WAITING` for 50+ minutes).

## Root cause

Ratis reconfiguration (add/remove peer) requires every new staging peer to *catch up* before the leader can commit the new configuration. If the ADDING peer is killed and can never catch up:

1. On the leader, the reconfiguration stays in the staging state and each `setConfiguration` attempt is rejected with `ReconfigurationInProgressException`.
2. The Ratis client used for reconfiguration uses an **unbounded** retry policy (`retryForeverWithSleep(2s)` in the former `RatisEndlessRetryPolicy`), so it retries forever.
3. The coordinator DataNode's `AddRegionPeerTask.run()` is a plain synchronous `Runnable` blocked inside `addRemotePeer → setConfiguration`, with no cancel checkpoint. It therefore never returns and the task status stays `PROCESSING` indefinitely.

Because the task never leaves `PROCESSING`, the existing **CANCEL ALL MIGRATIONS** mechanism (cooperative, only effective at a safe point) cannot recover this case either — there is no safe point to stop at.

## Fix

Bound the reconfiguration retries instead of retrying forever. The former `RatisEndlessRetryPolicy` now uses:

```java
RetryPolicies.retryUpToMaximumCountWithFixedSleep(
    config.getReconfigurationMaxRetryAttempts(),   // default 600
    TimeDuration.valueOf(2, TimeUnit.SECONDS));
```

After the bound is exhausted, the last failure propagates (`ConsensusException`) so the upper layer (`AddRegionPeerProcedure`) can **fail and roll back** the migration — and `CANCEL` becomes reachable again, since the DataNode task finally leaves `PROCESSING`.

The class/factory were renamed `EndlessRetryFactory` / `RatisEndlessRetryPolicy` → `ReconfigurationRetryFactory` / `RatisReconfigurationRetryPolicy`, since the policy is no longer endless.

## New configuration

Per-consensus-group, pushed from ConfigNode to DataNode via `TRatisConfig`:

| property | default |
| --- | --- |
| `config_node_ratis_reconfiguration_max_retry_attempts` | 600 |
| `schema_region_ratis_reconfiguration_max_retry_attempts` | 600 |
| `data_region_ratis_reconfiguration_max_retry_attempts` | 600 |

Reconfiguration retries use a fixed 2s interval, so the bound roughly caps the wait at `attempts × 2s` (600 ≈ 20 min). Tune lower for faster failover, higher for very large regions.

## Compatibility (rolling upgrade)

The two new `TRatisConfig` fields are `optional`. A ConfigNode running the old version will not set them, in which case the DataNode keeps its **local default** instead of overwriting it with `0` (guarded by `isSet...()` in `IoTDBDescriptor`).

## Verification

- `mvn compile` passes for `iotdb-core/consensus`, `iotdb-core/confignode`, `iotdb-core/datanode` (thrift regenerated).
- `spotless:check` is clean.

## Note for reviewers

- The default `600` (~20 min) favors not regressing legitimate slow `addPeer` (large snapshot transfer) over fast failover. Happy to adjust — schema-region snapshots are small, so a smaller `schema_region_*` default (e.g. 30–60) may be preferable.
- An integration test reproducing the killed-ADDING-peer scenario can be added as a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
