### PR TITLE
Fix PipeLogger handling of percent signs in messages

### DIFF
--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/resource/log/PipeLogger.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/resource/log/PipeLogger.java
@@ -30,7 +30,7 @@ public class PipeLogger {
 
   public static void log(
       final Consumer<String> loggerFunction, final String rawMessage, final Object... formatter) {
-    logger.log(loggerFunction, rawMessage, formatter);
+    logger.log(loggerFunction, "%s", format(rawMessage, formatter));
   }
 
   public static void log(
@@ -40,7 +40,7 @@ public class PipeLogger {
       final Object... formatter) {
     final ByteArrayOutputStream out = new ByteArrayOutputStream();
     throwable.printStackTrace(new PrintStream(out));
-    logger.log(loggerFunction, rawMessage + "\n" + out, formatter);
+    logger.log(loggerFunction, "%s", format(rawMessage, formatter) + "\n" + out);
   }
 
   public static void setLogger(final PipePeriodicalLogger logger) {
@@ -49,6 +49,12 @@ public class PipeLogger {
 
   private PipeLogger() {
     // static
+  }
+
+  private static String format(final String rawMessage, final Object... formatter) {
+    return formatter == null || formatter.length == 0
+        ? rawMessage
+        : String.format(rawMessage, formatter);
   }
 
   @FunctionalInterface

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/pipe/resource/PipeLoggerTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/pipe/resource/PipeLoggerTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.commons.pipe.resource;
+
+import org.apache.iotdb.commons.pipe.resource.log.PipeLogger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+public class PipeLoggerTest {
+
+  @Test
+  public void testLogMessageWithPercent() {
+    final AtomicReference<String> message = new AtomicReference<>();
+
+    setStringFormatLogger();
+    try {
+      PipeLogger.log(message::set, "data_{sink.password=%/broken}");
+    } finally {
+      setStringFormatLogger();
+    }
+
+    Assert.assertEquals("data_{sink.password=%/broken}", message.get());
+  }
+
+  @Test
+  public void testLogThrowableWithPercentInStackTrace() {
+    final AtomicReference<String> message = new AtomicReference<>();
+
+    setStringFormatLogger();
+    try {
+      PipeLogger.log(
+          message::set,
+          new RuntimeException("data_{sink.password=%/broken}"),
+          "Failed to transfer event %s",
+          "root.sg.d1");
+    } finally {
+      setStringFormatLogger();
+    }
+
+    Assert.assertTrue(message.get().contains("Failed to transfer event root.sg.d1"));
+    Assert.assertTrue(message.get().contains("data_{sink.password=%/broken}"));
+  }
+
+  private void setStringFormatLogger() {
+    PipeLogger.setLogger(
+        (loggerFunction, rawMessage, formatter) ->
+            loggerFunction.accept(String.format(rawMessage, formatter)));
+  }
+}


### PR DESCRIPTION
Summary: Format PipeLogger messages before handing them to the periodical logger, then pass the formatted text as a fixed %s payload so percent signs in dynamic messages or throwable stack traces are not interpreted by String.format. Added regression tests for plain messages and throwable stack traces containing percent signs. Tests: mvn -pl iotdb-core/node-commons spotless:apply passed; mvn -pl iotdb-core/node-commons -Dtest=PipeLoggerTest test currently fails during testCompile in existing CommitProgressKeeperTest because RegionProgress, WriterId, and WriterProgress are missing from org.apache.iotdb.rpc.subscription.payload.poll.