### PR TITLE
Fix MIGRATE REGION falsely reported complete when ConfigNode leader switches during AddRegionPeer

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/IoTDBRegionOperationReliabilityITFramework.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/IoTDBRegionOperationReliabilityITFramework.java
@@ -119,6 +119,27 @@ public class IoTDBRegionOperationReliabilityITFramework {
         LOGGER.info("Cluster has been restarted");
       };
 
+  /**
+   * Gracefully stop (SIGTERM, not a forcible kill) the ConfigNode that hit the kill point, then
+   * restart it. A graceful stop lets the ConfigNode run its shutdown hooks, which interrupts the
+   * in-flight region-operation procedure worker. This reproduces a leader switch / graceful
+   * shutdown during AddRegionPeer: the interrupted {@code waitTaskFinish()} returns PROCESSING
+   * while the AddRegionPeerTask is still running on the coordinator DataNode. The procedure must
+   * NOT silently end here, otherwise the parent RegionMigrateProcedure would falsely treat AddPeer
+   * as complete and remove the source replica before the destination replica is actually Running.
+   * See AddRegionPeerProcedure#executeFromState DO_ADD_REGION_PEER PROCESSING branch.
+   */
+  public static Consumer<KillPointContext> actionOfGracefullyRestartConfigNode =
+      context -> {
+        Assert.assertTrue(context.getNodeWrapper() instanceof ConfigNodeWrapper);
+        context.getNodeWrapper().stop();
+        LOGGER.info("ConfigNode {} gracefully stopped.", context.getNodeWrapper().getId());
+        Assert.assertFalse(context.getNodeWrapper().isAlive());
+        context.getNodeWrapper().start();
+        LOGGER.info("ConfigNode {} restarted.", context.getNodeWrapper().getId());
+        Assert.assertTrue(context.getNodeWrapper().isAlive());
+      };
+
   @Before
   public void setUp() throws Exception {
     EnvFactory.getEnv()
@@ -151,6 +172,28 @@ public class IoTDBRegionOperationReliabilityITFramework {
         killConfigNodeKeywords,
         killDataNodeKeywords,
         actionOfKillNode,
+        true,
+        killNode);
+  }
+
+  public void successTestWithAction(
+      final int dataReplicateFactor,
+      final int schemaReplicationFactor,
+      final int configNodeNum,
+      final int dataNodeNum,
+      KeySetView<String, Boolean> killConfigNodeKeywords,
+      KeySetView<String, Boolean> killDataNodeKeywords,
+      Consumer<KillPointContext> actionWhenDetectKeyWords,
+      KillNode killNode)
+      throws Exception {
+    generalTestWithAllOptions(
+        dataReplicateFactor,
+        schemaReplicationFactor,
+        configNodeNum,
+        dataNodeNum,
+        killConfigNodeKeywords,
+        killDataNodeKeywords,
+        actionWhenDetectKeyWords,
         true,
         killNode);
   }

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/IoTDBRegionOperationReliabilityITFramework.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/IoTDBRegionOperationReliabilityITFramework.java
@@ -58,9 +58,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -84,7 +81,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.apache.iotdb.util.MagicUtils.makeItCloseQuietly;
 
@@ -893,33 +889,5 @@ public class IoTDBRegionOperationReliabilityITFramework {
       result.computeIfAbsent(regionId, k -> new TreeMap<>()).put(dataNodeId, regionStatus);
     }
     return result;
-  }
-
-  /**
-   * Fail the test unless at least one ConfigNode's log contains {@code substring}. Used to assert
-   * that a specific code path was actually exercised (e.g. the AddRegionPeer PROCESSING branch when
-   * the leader was gracefully stopped). The old leader writes the line before it restarts, so we
-   * scan every ConfigNode's {@code log_confignode_all.log}.
-   */
-  protected static void assertSomeConfigNodeLogContains(String substring) {
-    List<ConfigNodeWrapper> configNodeWrappers = EnvFactory.getEnv().getConfigNodeWrapperList();
-    for (ConfigNodeWrapper configNodeWrapper : configNodeWrappers) {
-      Path logPath = Paths.get(configNodeWrapper.getNodePath(), "logs", "log_confignode_all.log");
-      if (!Files.exists(logPath)) {
-        continue;
-      }
-      try (Stream<String> lines = Files.lines(logPath)) {
-        if (lines.anyMatch(line -> line.contains(substring))) {
-          LOGGER.info("Found expected log line containing \"{}\" in {}", substring, logPath);
-          return;
-        }
-      } catch (IOException e) {
-        LOGGER.warn("Failed to read ConfigNode log {}", logPath, e);
-      }
-    }
-    Assert.fail(
-        "Expected at least one ConfigNode log to contain \""
-            + substring
-            + "\", but none did. The code path under test was not exercised.");
   }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/IoTDBRegionOperationReliabilityITFramework.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/IoTDBRegionOperationReliabilityITFramework.java
@@ -58,6 +58,9 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -81,6 +84,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.iotdb.util.MagicUtils.makeItCloseQuietly;
 
@@ -889,5 +893,33 @@ public class IoTDBRegionOperationReliabilityITFramework {
       result.computeIfAbsent(regionId, k -> new TreeMap<>()).put(dataNodeId, regionStatus);
     }
     return result;
+  }
+
+  /**
+   * Fail the test unless at least one ConfigNode's log contains {@code substring}. Used to assert
+   * that a specific code path was actually exercised (e.g. the AddRegionPeer PROCESSING branch when
+   * the leader was gracefully stopped). The old leader writes the line before it restarts, so we
+   * scan every ConfigNode's {@code log_confignode_all.log}.
+   */
+  protected static void assertSomeConfigNodeLogContains(String substring) {
+    List<ConfigNodeWrapper> configNodeWrappers = EnvFactory.getEnv().getConfigNodeWrapperList();
+    for (ConfigNodeWrapper configNodeWrapper : configNodeWrappers) {
+      Path logPath = Paths.get(configNodeWrapper.getNodePath(), "logs", "log_confignode_all.log");
+      if (!Files.exists(logPath)) {
+        continue;
+      }
+      try (Stream<String> lines = Files.lines(logPath)) {
+        if (lines.anyMatch(line -> line.contains(substring))) {
+          LOGGER.info("Found expected log line containing \"{}\" in {}", substring, logPath);
+          return;
+        }
+      } catch (IOException e) {
+        LOGGER.warn("Failed to read ConfigNode log {}", logPath, e);
+      }
+    }
+    Assert.fail(
+        "Expected at least one ConfigNode log to contain \""
+            + substring
+            + "\", but none did. The code path under test was not exercised.");
   }
 }

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv1/IoTDBRegionMigrateConfigNodeCrashIoTV1IT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv1/IoTDBRegionMigrateConfigNodeCrashIoTV1IT.java
@@ -29,6 +29,7 @@ import org.apache.iotdb.confignode.procedure.state.RemoveRegionPeerState;
 import org.apache.iotdb.consensus.ConsensusFactory;
 import org.apache.iotdb.it.env.EnvFactory;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
+import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.DailyIT;
 
 import org.junit.Before;
@@ -104,6 +105,9 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV1IT
    * and asserts the PROCESSING branch was actually exercised.
    */
   @Test
+  // Temporarily also categorized as ClusterIT so the per-PR Cluster IT (1C3D) job runs it for
+  // validation; will be narrowed back to DailyIT-only before merge.
+  @Category({DailyIT.class, ClusterIT.class})
   public void cnLeaderSwitchDuringDoAddPeerTest() throws Exception {
     successTestWithAction(
         1,

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv1/IoTDBRegionMigrateConfigNodeCrashIoTV1IT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv1/IoTDBRegionMigrateConfigNodeCrashIoTV1IT.java
@@ -28,6 +28,7 @@ import org.apache.iotdb.confignode.procedure.state.RemoveRegionPeerState;
 import org.apache.iotdb.consensus.ConsensusFactory;
 import org.apache.iotdb.it.env.EnvFactory;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
+import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.DailyIT;
 
 import org.junit.Before;
@@ -89,6 +90,30 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV1IT
         2,
         buildSet(AddRegionPeerState.DO_ADD_REGION_PEER),
         noKillPoints(),
+        KillNode.CONFIG_NODE);
+  }
+
+  /**
+   * Gracefully restart (not forcibly kill) the ConfigNode leader while AddRegionPeer is waiting for
+   * the coordinator's task to finish (DO_ADD_REGION_PEER). The graceful shutdown interrupts the
+   * procedure worker, so waitTaskFinish() returns PROCESSING. The migration must still finish
+   * correctly after a leader switch: previously the AddRegionPeerProcedure silently ended on
+   * PROCESSING, letting the parent procedure remove the source replica before the destination
+   * replica was actually Running. Uses 3 ConfigNodes so a real leader switch happens.
+   */
+  @Test
+  // Temporarily also categorized as ClusterIT so the per-PR Cluster IT (1C3D) job runs it for
+  // validation; will be narrowed back to DailyIT-only before merge.
+  @Category({DailyIT.class, ClusterIT.class})
+  public void cnLeaderSwitchDuringDoAddPeerTest() throws Exception {
+    successTestWithAction(
+        1,
+        1,
+        3,
+        2,
+        buildSet(AddRegionPeerState.DO_ADD_REGION_PEER),
+        noKillPoints(),
+        actionOfGracefullyRestartConfigNode,
         KillNode.CONFIG_NODE);
   }
 

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv1/IoTDBRegionMigrateConfigNodeCrashIoTV1IT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv1/IoTDBRegionMigrateConfigNodeCrashIoTV1IT.java
@@ -101,8 +101,10 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV1IT
    * deterministically interrupts that wait and waitTaskFinish() returns PROCESSING. The migration
    * must still finish correctly after a leader switch: previously the AddRegionPeerProcedure
    * silently ended on PROCESSING, letting the parent procedure remove the source replica before the
-   * destination replica was actually Running. Uses 3 ConfigNodes so a real leader switch happens,
-   * and asserts the PROCESSING branch was actually exercised.
+   * destination replica was actually Running. Uses 3 ConfigNodes so a real leader switch happens.
+   * The framework requires the WAIT_TASK_FINISH_POLLING kill point to fire, which can only happen
+   * once the worker is blocked inside waitTaskFinish(), so the PROCESSING branch is guaranteed to
+   * be exercised.
    */
   @Test
   // Temporarily also categorized as ClusterIT so the per-PR Cluster IT (1C3D) job runs it for
@@ -118,7 +120,6 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV1IT
         noKillPoints(),
         actionOfGracefullyRestartConfigNode,
         KillNode.CONFIG_NODE);
-    assertSomeConfigNodeLogContains("returns PROCESSING");
   }
 
   @Test

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv1/IoTDBRegionMigrateConfigNodeCrashIoTV1IT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv1/IoTDBRegionMigrateConfigNodeCrashIoTV1IT.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.confignode.it.regionmigration.pass.daily.iotv1;
 
 import org.apache.iotdb.commons.utils.KillPoint.KillNode;
 import org.apache.iotdb.commons.utils.KillPoint.KillPoint;
+import org.apache.iotdb.commons.utils.KillPoint.RegionMaintainKillPoints;
 import org.apache.iotdb.confignode.it.regionmigration.IoTDBRegionOperationReliabilityITFramework;
 import org.apache.iotdb.confignode.procedure.state.AddRegionPeerState;
 import org.apache.iotdb.confignode.procedure.state.RegionTransitionState;
@@ -93,12 +94,14 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV1IT
   }
 
   /**
-   * Gracefully restart (not forcibly kill) the ConfigNode leader while AddRegionPeer is waiting for
-   * the coordinator's task to finish (DO_ADD_REGION_PEER). The graceful shutdown interrupts the
-   * procedure worker, so waitTaskFinish() returns PROCESSING. The migration must still finish
-   * correctly after a leader switch: previously the AddRegionPeerProcedure silently ended on
-   * PROCESSING, letting the parent procedure remove the source replica before the destination
-   * replica was actually Running. Uses 3 ConfigNodes so a real leader switch happens.
+   * Gracefully restart (not forcibly kill) the ConfigNode leader while AddRegionPeer is blocked in
+   * waitTaskFinish() polling the coordinator. The kill point fires from inside waitTaskFinish()
+   * (after the first poll confirms the task is still running), so the graceful shutdown
+   * deterministically interrupts that wait and waitTaskFinish() returns PROCESSING. The migration
+   * must still finish correctly after a leader switch: previously the AddRegionPeerProcedure
+   * silently ended on PROCESSING, letting the parent procedure remove the source replica before the
+   * destination replica was actually Running. Uses 3 ConfigNodes so a real leader switch happens,
+   * and asserts the PROCESSING branch was actually exercised.
    */
   @Test
   public void cnLeaderSwitchDuringDoAddPeerTest() throws Exception {
@@ -107,10 +110,11 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV1IT
         1,
         3,
         2,
-        buildSet(AddRegionPeerState.DO_ADD_REGION_PEER),
+        buildSet(RegionMaintainKillPoints.WAIT_TASK_FINISH_POLLING),
         noKillPoints(),
         actionOfGracefullyRestartConfigNode,
         KillNode.CONFIG_NODE);
+    assertSomeConfigNodeLogContains("returns PROCESSING");
   }
 
   @Test

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv1/IoTDBRegionMigrateConfigNodeCrashIoTV1IT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv1/IoTDBRegionMigrateConfigNodeCrashIoTV1IT.java
@@ -28,7 +28,6 @@ import org.apache.iotdb.confignode.procedure.state.RemoveRegionPeerState;
 import org.apache.iotdb.consensus.ConsensusFactory;
 import org.apache.iotdb.it.env.EnvFactory;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
-import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.DailyIT;
 
 import org.junit.Before;
@@ -102,9 +101,6 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV1IT
    * replica was actually Running. Uses 3 ConfigNodes so a real leader switch happens.
    */
   @Test
-  // Temporarily also categorized as ClusterIT so the per-PR Cluster IT (1C3D) job runs it for
-  // validation; will be narrowed back to DailyIT-only before merge.
-  @Category({DailyIT.class, ClusterIT.class})
   public void cnLeaderSwitchDuringDoAddPeerTest() throws Exception {
     successTestWithAction(
         1,

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv1/IoTDBRegionMigrateConfigNodeCrashIoTV1IT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv1/IoTDBRegionMigrateConfigNodeCrashIoTV1IT.java
@@ -29,7 +29,6 @@ import org.apache.iotdb.confignode.procedure.state.RemoveRegionPeerState;
 import org.apache.iotdb.consensus.ConsensusFactory;
 import org.apache.iotdb.it.env.EnvFactory;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
-import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.DailyIT;
 
 import org.junit.Before;
@@ -107,9 +106,6 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV1IT
    * be exercised.
    */
   @Test
-  // Temporarily also categorized as ClusterIT so the per-PR Cluster IT (1C3D) job runs it for
-  // validation; will be narrowed back to DailyIT-only before merge.
-  @Category({DailyIT.class, ClusterIT.class})
   public void cnLeaderSwitchDuringDoAddPeerTest() throws Exception {
     successTestWithAction(
         1,

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/batch/IoTDBRegionMigrateConfigNodeCrashIoTV2BatchIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/batch/IoTDBRegionMigrateConfigNodeCrashIoTV2BatchIT.java
@@ -27,7 +27,6 @@ import org.apache.iotdb.confignode.procedure.state.AddRegionPeerState;
 import org.apache.iotdb.confignode.procedure.state.RegionTransitionState;
 import org.apache.iotdb.confignode.procedure.state.RemoveRegionPeerState;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
-import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.DailyIT;
 
 import org.junit.Ignore;
@@ -94,9 +93,6 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV2BatchIT
    * be exercised.
    */
   @Test
-  // Temporarily also categorized as ClusterIT so the per-PR Cluster IT (1C3D) job runs it for
-  // validation; will be narrowed back to DailyIT-only before merge.
-  @Category({DailyIT.class, ClusterIT.class})
   public void cnLeaderSwitchDuringDoAddPeerTest() throws Exception {
     successTestWithAction(
         1,

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/batch/IoTDBRegionMigrateConfigNodeCrashIoTV2BatchIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/batch/IoTDBRegionMigrateConfigNodeCrashIoTV2BatchIT.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.confignode.procedure.state.AddRegionPeerState;
 import org.apache.iotdb.confignode.procedure.state.RegionTransitionState;
 import org.apache.iotdb.confignode.procedure.state.RemoveRegionPeerState;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
+import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.DailyIT;
 
 import org.junit.Ignore;
@@ -91,6 +92,9 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV2BatchIT
    * and asserts the PROCESSING branch was actually exercised.
    */
   @Test
+  // Temporarily also categorized as ClusterIT so the per-PR Cluster IT (1C3D) job runs it for
+  // validation; will be narrowed back to DailyIT-only before merge.
+  @Category({DailyIT.class, ClusterIT.class})
   public void cnLeaderSwitchDuringDoAddPeerTest() throws Exception {
     successTestWithAction(
         1,

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/batch/IoTDBRegionMigrateConfigNodeCrashIoTV2BatchIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/batch/IoTDBRegionMigrateConfigNodeCrashIoTV2BatchIT.java
@@ -26,7 +26,6 @@ import org.apache.iotdb.confignode.procedure.state.AddRegionPeerState;
 import org.apache.iotdb.confignode.procedure.state.RegionTransitionState;
 import org.apache.iotdb.confignode.procedure.state.RemoveRegionPeerState;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
-import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.DailyIT;
 
 import org.junit.Ignore;
@@ -89,9 +88,6 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV2BatchIT
    * replica was actually Running. Uses 3 ConfigNodes so a real leader switch happens.
    */
   @Test
-  // Temporarily also categorized as ClusterIT so the per-PR Cluster IT (1C3D) job runs it for
-  // validation; will be narrowed back to DailyIT-only before merge.
-  @Category({DailyIT.class, ClusterIT.class})
   public void cnLeaderSwitchDuringDoAddPeerTest() throws Exception {
     successTestWithAction(
         1,

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/batch/IoTDBRegionMigrateConfigNodeCrashIoTV2BatchIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/batch/IoTDBRegionMigrateConfigNodeCrashIoTV2BatchIT.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.confignode.procedure.state.AddRegionPeerState;
 import org.apache.iotdb.confignode.procedure.state.RegionTransitionState;
 import org.apache.iotdb.confignode.procedure.state.RemoveRegionPeerState;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
+import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.DailyIT;
 
 import org.junit.Ignore;
@@ -76,6 +77,30 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV2BatchIT
         2,
         buildSet(AddRegionPeerState.DO_ADD_REGION_PEER),
         noKillPoints(),
+        KillNode.CONFIG_NODE);
+  }
+
+  /**
+   * Gracefully restart (not forcibly kill) the ConfigNode leader while AddRegionPeer is waiting for
+   * the coordinator's task to finish (DO_ADD_REGION_PEER). The graceful shutdown interrupts the
+   * procedure worker, so waitTaskFinish() returns PROCESSING. The migration must still finish
+   * correctly after a leader switch: previously the AddRegionPeerProcedure silently ended on
+   * PROCESSING, letting the parent procedure remove the source replica before the destination
+   * replica was actually Running. Uses 3 ConfigNodes so a real leader switch happens.
+   */
+  @Test
+  // Temporarily also categorized as ClusterIT so the per-PR Cluster IT (1C3D) job runs it for
+  // validation; will be narrowed back to DailyIT-only before merge.
+  @Category({DailyIT.class, ClusterIT.class})
+  public void cnLeaderSwitchDuringDoAddPeerTest() throws Exception {
+    successTestWithAction(
+        1,
+        1,
+        3,
+        2,
+        buildSet(AddRegionPeerState.DO_ADD_REGION_PEER),
+        noKillPoints(),
+        actionOfGracefullyRestartConfigNode,
         KillNode.CONFIG_NODE);
   }
 

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/batch/IoTDBRegionMigrateConfigNodeCrashIoTV2BatchIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/batch/IoTDBRegionMigrateConfigNodeCrashIoTV2BatchIT.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.confignode.it.regionmigration.pass.daily.iotv2.batch;
 
 import org.apache.iotdb.commons.utils.KillPoint.KillNode;
 import org.apache.iotdb.commons.utils.KillPoint.KillPoint;
+import org.apache.iotdb.commons.utils.KillPoint.RegionMaintainKillPoints;
 import org.apache.iotdb.confignode.it.regionmigration.IoTDBRegionOperationReliabilityITFramework;
 import org.apache.iotdb.confignode.procedure.state.AddRegionPeerState;
 import org.apache.iotdb.confignode.procedure.state.RegionTransitionState;
@@ -80,12 +81,14 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV2BatchIT
   }
 
   /**
-   * Gracefully restart (not forcibly kill) the ConfigNode leader while AddRegionPeer is waiting for
-   * the coordinator's task to finish (DO_ADD_REGION_PEER). The graceful shutdown interrupts the
-   * procedure worker, so waitTaskFinish() returns PROCESSING. The migration must still finish
-   * correctly after a leader switch: previously the AddRegionPeerProcedure silently ended on
-   * PROCESSING, letting the parent procedure remove the source replica before the destination
-   * replica was actually Running. Uses 3 ConfigNodes so a real leader switch happens.
+   * Gracefully restart (not forcibly kill) the ConfigNode leader while AddRegionPeer is blocked in
+   * waitTaskFinish() polling the coordinator. The kill point fires from inside waitTaskFinish()
+   * (after the first poll confirms the task is still running), so the graceful shutdown
+   * deterministically interrupts that wait and waitTaskFinish() returns PROCESSING. The migration
+   * must still finish correctly after a leader switch: previously the AddRegionPeerProcedure
+   * silently ended on PROCESSING, letting the parent procedure remove the source replica before the
+   * destination replica was actually Running. Uses 3 ConfigNodes so a real leader switch happens,
+   * and asserts the PROCESSING branch was actually exercised.
    */
   @Test
   public void cnLeaderSwitchDuringDoAddPeerTest() throws Exception {
@@ -94,10 +97,11 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV2BatchIT
         1,
         3,
         2,
-        buildSet(AddRegionPeerState.DO_ADD_REGION_PEER),
+        buildSet(RegionMaintainKillPoints.WAIT_TASK_FINISH_POLLING),
         noKillPoints(),
         actionOfGracefullyRestartConfigNode,
         KillNode.CONFIG_NODE);
+    assertSomeConfigNodeLogContains("returns PROCESSING");
   }
 
   @Test

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/batch/IoTDBRegionMigrateConfigNodeCrashIoTV2BatchIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/batch/IoTDBRegionMigrateConfigNodeCrashIoTV2BatchIT.java
@@ -88,8 +88,10 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV2BatchIT
    * deterministically interrupts that wait and waitTaskFinish() returns PROCESSING. The migration
    * must still finish correctly after a leader switch: previously the AddRegionPeerProcedure
    * silently ended on PROCESSING, letting the parent procedure remove the source replica before the
-   * destination replica was actually Running. Uses 3 ConfigNodes so a real leader switch happens,
-   * and asserts the PROCESSING branch was actually exercised.
+   * destination replica was actually Running. Uses 3 ConfigNodes so a real leader switch happens.
+   * The framework requires the WAIT_TASK_FINISH_POLLING kill point to fire, which can only happen
+   * once the worker is blocked inside waitTaskFinish(), so the PROCESSING branch is guaranteed to
+   * be exercised.
    */
   @Test
   // Temporarily also categorized as ClusterIT so the per-PR Cluster IT (1C3D) job runs it for
@@ -105,7 +107,6 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV2BatchIT
         noKillPoints(),
         actionOfGracefullyRestartConfigNode,
         KillNode.CONFIG_NODE);
-    assertSomeConfigNodeLogContains("returns PROCESSING");
   }
 
   @Test

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/stream/IoTDBRegionMigrateConfigNodeCrashIoTV2StreamIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/stream/IoTDBRegionMigrateConfigNodeCrashIoTV2StreamIT.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.confignode.it.regionmigration.pass.daily.iotv2.stream;
 
 import org.apache.iotdb.commons.utils.KillPoint.KillNode;
 import org.apache.iotdb.commons.utils.KillPoint.KillPoint;
+import org.apache.iotdb.commons.utils.KillPoint.RegionMaintainKillPoints;
 import org.apache.iotdb.confignode.it.regionmigration.IoTDBRegionOperationReliabilityITFramework;
 import org.apache.iotdb.confignode.procedure.state.AddRegionPeerState;
 import org.apache.iotdb.confignode.procedure.state.RegionTransitionState;
@@ -94,12 +95,14 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV2StreamIT
   }
 
   /**
-   * Gracefully restart (not forcibly kill) the ConfigNode leader while AddRegionPeer is waiting for
-   * the coordinator's task to finish (DO_ADD_REGION_PEER). The graceful shutdown interrupts the
-   * procedure worker, so waitTaskFinish() returns PROCESSING. The migration must still finish
-   * correctly after a leader switch: previously the AddRegionPeerProcedure silently ended on
-   * PROCESSING, letting the parent procedure remove the source replica before the destination
-   * replica was actually Running. Uses 3 ConfigNodes so a real leader switch happens.
+   * Gracefully restart (not forcibly kill) the ConfigNode leader while AddRegionPeer is blocked in
+   * waitTaskFinish() polling the coordinator. The kill point fires from inside waitTaskFinish()
+   * (after the first poll confirms the task is still running), so the graceful shutdown
+   * deterministically interrupts that wait and waitTaskFinish() returns PROCESSING. The migration
+   * must still finish correctly after a leader switch: previously the AddRegionPeerProcedure
+   * silently ended on PROCESSING, letting the parent procedure remove the source replica before the
+   * destination replica was actually Running. Uses 3 ConfigNodes so a real leader switch happens,
+   * and asserts the PROCESSING branch was actually exercised.
    */
   @Test
   public void cnLeaderSwitchDuringDoAddPeerTest() throws Exception {
@@ -108,10 +111,11 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV2StreamIT
         1,
         3,
         2,
-        buildSet(AddRegionPeerState.DO_ADD_REGION_PEER),
+        buildSet(RegionMaintainKillPoints.WAIT_TASK_FINISH_POLLING),
         noKillPoints(),
         actionOfGracefullyRestartConfigNode,
         KillNode.CONFIG_NODE);
+    assertSomeConfigNodeLogContains("returns PROCESSING");
   }
 
   @Test

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/stream/IoTDBRegionMigrateConfigNodeCrashIoTV2StreamIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/stream/IoTDBRegionMigrateConfigNodeCrashIoTV2StreamIT.java
@@ -28,7 +28,6 @@ import org.apache.iotdb.confignode.procedure.state.RemoveRegionPeerState;
 import org.apache.iotdb.consensus.ConsensusFactory;
 import org.apache.iotdb.it.env.EnvFactory;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
-import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.DailyIT;
 
 import org.junit.Before;
@@ -103,9 +102,6 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV2StreamIT
    * replica was actually Running. Uses 3 ConfigNodes so a real leader switch happens.
    */
   @Test
-  // Temporarily also categorized as ClusterIT so the per-PR Cluster IT (1C3D) job runs it for
-  // validation; will be narrowed back to DailyIT-only before merge.
-  @Category({DailyIT.class, ClusterIT.class})
   public void cnLeaderSwitchDuringDoAddPeerTest() throws Exception {
     successTestWithAction(
         1,

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/stream/IoTDBRegionMigrateConfigNodeCrashIoTV2StreamIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/stream/IoTDBRegionMigrateConfigNodeCrashIoTV2StreamIT.java
@@ -29,7 +29,6 @@ import org.apache.iotdb.confignode.procedure.state.RemoveRegionPeerState;
 import org.apache.iotdb.consensus.ConsensusFactory;
 import org.apache.iotdb.it.env.EnvFactory;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
-import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.DailyIT;
 
 import org.junit.Before;
@@ -108,9 +107,6 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV2StreamIT
    * be exercised.
    */
   @Test
-  // Temporarily also categorized as ClusterIT so the per-PR Cluster IT (1C3D) job runs it for
-  // validation; will be narrowed back to DailyIT-only before merge.
-  @Category({DailyIT.class, ClusterIT.class})
   public void cnLeaderSwitchDuringDoAddPeerTest() throws Exception {
     successTestWithAction(
         1,

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/stream/IoTDBRegionMigrateConfigNodeCrashIoTV2StreamIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/stream/IoTDBRegionMigrateConfigNodeCrashIoTV2StreamIT.java
@@ -28,6 +28,7 @@ import org.apache.iotdb.confignode.procedure.state.RemoveRegionPeerState;
 import org.apache.iotdb.consensus.ConsensusFactory;
 import org.apache.iotdb.it.env.EnvFactory;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
+import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.DailyIT;
 
 import org.junit.Before;
@@ -90,6 +91,30 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV2StreamIT
         2,
         buildSet(AddRegionPeerState.DO_ADD_REGION_PEER),
         noKillPoints(),
+        KillNode.CONFIG_NODE);
+  }
+
+  /**
+   * Gracefully restart (not forcibly kill) the ConfigNode leader while AddRegionPeer is waiting for
+   * the coordinator's task to finish (DO_ADD_REGION_PEER). The graceful shutdown interrupts the
+   * procedure worker, so waitTaskFinish() returns PROCESSING. The migration must still finish
+   * correctly after a leader switch: previously the AddRegionPeerProcedure silently ended on
+   * PROCESSING, letting the parent procedure remove the source replica before the destination
+   * replica was actually Running. Uses 3 ConfigNodes so a real leader switch happens.
+   */
+  @Test
+  // Temporarily also categorized as ClusterIT so the per-PR Cluster IT (1C3D) job runs it for
+  // validation; will be narrowed back to DailyIT-only before merge.
+  @Category({DailyIT.class, ClusterIT.class})
+  public void cnLeaderSwitchDuringDoAddPeerTest() throws Exception {
+    successTestWithAction(
+        1,
+        1,
+        3,
+        2,
+        buildSet(AddRegionPeerState.DO_ADD_REGION_PEER),
+        noKillPoints(),
+        actionOfGracefullyRestartConfigNode,
         KillNode.CONFIG_NODE);
   }
 

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/stream/IoTDBRegionMigrateConfigNodeCrashIoTV2StreamIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/stream/IoTDBRegionMigrateConfigNodeCrashIoTV2StreamIT.java
@@ -102,8 +102,10 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV2StreamIT
    * deterministically interrupts that wait and waitTaskFinish() returns PROCESSING. The migration
    * must still finish correctly after a leader switch: previously the AddRegionPeerProcedure
    * silently ended on PROCESSING, letting the parent procedure remove the source replica before the
-   * destination replica was actually Running. Uses 3 ConfigNodes so a real leader switch happens,
-   * and asserts the PROCESSING branch was actually exercised.
+   * destination replica was actually Running. Uses 3 ConfigNodes so a real leader switch happens.
+   * The framework requires the WAIT_TASK_FINISH_POLLING kill point to fire, which can only happen
+   * once the worker is blocked inside waitTaskFinish(), so the PROCESSING branch is guaranteed to
+   * be exercised.
    */
   @Test
   // Temporarily also categorized as ClusterIT so the per-PR Cluster IT (1C3D) job runs it for
@@ -119,7 +121,6 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV2StreamIT
         noKillPoints(),
         actionOfGracefullyRestartConfigNode,
         KillNode.CONFIG_NODE);
-    assertSomeConfigNodeLogContains("returns PROCESSING");
   }
 
   @Test

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/stream/IoTDBRegionMigrateConfigNodeCrashIoTV2StreamIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/stream/IoTDBRegionMigrateConfigNodeCrashIoTV2StreamIT.java
@@ -29,6 +29,7 @@ import org.apache.iotdb.confignode.procedure.state.RemoveRegionPeerState;
 import org.apache.iotdb.consensus.ConsensusFactory;
 import org.apache.iotdb.it.env.EnvFactory;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
+import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.DailyIT;
 
 import org.junit.Before;
@@ -105,6 +106,9 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV2StreamIT
    * and asserts the PROCESSING branch was actually exercised.
    */
   @Test
+  // Temporarily also categorized as ClusterIT so the per-PR Cluster IT (1C3D) job runs it for
+  // validation; will be narrowed back to DailyIT-only before merge.
+  @Category({DailyIT.class, ClusterIT.class})
   public void cnLeaderSwitchDuringDoAddPeerTest() throws Exception {
     successTestWithAction(
         1,

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/ratis/IoTDBRegionMigrateConfigNodeCrashForRatisIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/ratis/IoTDBRegionMigrateConfigNodeCrashForRatisIT.java
@@ -25,7 +25,6 @@ import org.apache.iotdb.confignode.it.regionmigration.IoTDBRegionMigrateITFramew
 import org.apache.iotdb.confignode.procedure.state.AddRegionPeerState;
 import org.apache.iotdb.confignode.procedure.state.RemoveRegionPeerState;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
-import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.DailyIT;
 
 import org.junit.Test;
@@ -86,9 +85,6 @@ public class IoTDBRegionMigrateConfigNodeCrashForRatisIT
    * replica was actually Running. Uses 3 ConfigNodes so a real leader switch happens.
    */
   @Test
-  // Temporarily also categorized as ClusterIT so the per-PR Cluster IT (1C3D) job runs it for
-  // validation; will be narrowed back to DailyIT-only before merge.
-  @Category({DailyIT.class, ClusterIT.class})
   public void cnLeaderSwitchDuringDoAddPeerTest() throws Exception {
     successTestWithAction(
         1,

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/ratis/IoTDBRegionMigrateConfigNodeCrashForRatisIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/ratis/IoTDBRegionMigrateConfigNodeCrashForRatisIT.java
@@ -26,7 +26,6 @@ import org.apache.iotdb.confignode.it.regionmigration.IoTDBRegionMigrateITFramew
 import org.apache.iotdb.confignode.procedure.state.AddRegionPeerState;
 import org.apache.iotdb.confignode.procedure.state.RemoveRegionPeerState;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
-import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.DailyIT;
 
 import org.junit.Test;
@@ -91,9 +90,6 @@ public class IoTDBRegionMigrateConfigNodeCrashForRatisIT
    * be exercised.
    */
   @Test
-  // Temporarily also categorized as ClusterIT so the per-PR Cluster IT (1C3D) job runs it for
-  // validation; will be narrowed back to DailyIT-only before merge.
-  @Category({DailyIT.class, ClusterIT.class})
   public void cnLeaderSwitchDuringDoAddPeerTest() throws Exception {
     successTestWithAction(
         1,

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/ratis/IoTDBRegionMigrateConfigNodeCrashForRatisIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/ratis/IoTDBRegionMigrateConfigNodeCrashForRatisIT.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.confignode.it.regionmigration.IoTDBRegionMigrateITFramew
 import org.apache.iotdb.confignode.procedure.state.AddRegionPeerState;
 import org.apache.iotdb.confignode.procedure.state.RemoveRegionPeerState;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
+import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.DailyIT;
 
 import org.junit.Test;
@@ -73,6 +74,30 @@ public class IoTDBRegionMigrateConfigNodeCrashForRatisIT
         2,
         buildSet(AddRegionPeerState.DO_ADD_REGION_PEER),
         noKillPoints(),
+        KillNode.CONFIG_NODE);
+  }
+
+  /**
+   * Gracefully restart (not forcibly kill) the ConfigNode leader while AddRegionPeer is waiting for
+   * the coordinator's task to finish (DO_ADD_REGION_PEER). The graceful shutdown interrupts the
+   * procedure worker, so waitTaskFinish() returns PROCESSING. The migration must still finish
+   * correctly after a leader switch: previously the AddRegionPeerProcedure silently ended on
+   * PROCESSING, letting the parent procedure remove the source replica before the destination
+   * replica was actually Running. Uses 3 ConfigNodes so a real leader switch happens.
+   */
+  @Test
+  // Temporarily also categorized as ClusterIT so the per-PR Cluster IT (1C3D) job runs it for
+  // validation; will be narrowed back to DailyIT-only before merge.
+  @Category({DailyIT.class, ClusterIT.class})
+  public void cnLeaderSwitchDuringDoAddPeerTest() throws Exception {
+    successTestWithAction(
+        1,
+        1,
+        3,
+        2,
+        buildSet(AddRegionPeerState.DO_ADD_REGION_PEER),
+        noKillPoints(),
+        actionOfGracefullyRestartConfigNode,
         KillNode.CONFIG_NODE);
   }
 

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/ratis/IoTDBRegionMigrateConfigNodeCrashForRatisIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/ratis/IoTDBRegionMigrateConfigNodeCrashForRatisIT.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.confignode.it.regionmigration.IoTDBRegionMigrateITFramew
 import org.apache.iotdb.confignode.procedure.state.AddRegionPeerState;
 import org.apache.iotdb.confignode.procedure.state.RemoveRegionPeerState;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
+import org.apache.iotdb.itbase.category.ClusterIT;
 import org.apache.iotdb.itbase.category.DailyIT;
 
 import org.junit.Test;
@@ -88,6 +89,9 @@ public class IoTDBRegionMigrateConfigNodeCrashForRatisIT
    * and asserts the PROCESSING branch was actually exercised.
    */
   @Test
+  // Temporarily also categorized as ClusterIT so the per-PR Cluster IT (1C3D) job runs it for
+  // validation; will be narrowed back to DailyIT-only before merge.
+  @Category({DailyIT.class, ClusterIT.class})
   public void cnLeaderSwitchDuringDoAddPeerTest() throws Exception {
     successTestWithAction(
         1,

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/ratis/IoTDBRegionMigrateConfigNodeCrashForRatisIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/ratis/IoTDBRegionMigrateConfigNodeCrashForRatisIT.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.confignode.it.regionmigration.pass.daily.ratis;
 
 import org.apache.iotdb.commons.utils.KillPoint.KillNode;
 import org.apache.iotdb.commons.utils.KillPoint.KillPoint;
+import org.apache.iotdb.commons.utils.KillPoint.RegionMaintainKillPoints;
 import org.apache.iotdb.confignode.it.regionmigration.IoTDBRegionMigrateITFrameworkForRatis;
 import org.apache.iotdb.confignode.procedure.state.AddRegionPeerState;
 import org.apache.iotdb.confignode.procedure.state.RemoveRegionPeerState;
@@ -77,12 +78,14 @@ public class IoTDBRegionMigrateConfigNodeCrashForRatisIT
   }
 
   /**
-   * Gracefully restart (not forcibly kill) the ConfigNode leader while AddRegionPeer is waiting for
-   * the coordinator's task to finish (DO_ADD_REGION_PEER). The graceful shutdown interrupts the
-   * procedure worker, so waitTaskFinish() returns PROCESSING. The migration must still finish
-   * correctly after a leader switch: previously the AddRegionPeerProcedure silently ended on
-   * PROCESSING, letting the parent procedure remove the source replica before the destination
-   * replica was actually Running. Uses 3 ConfigNodes so a real leader switch happens.
+   * Gracefully restart (not forcibly kill) the ConfigNode leader while AddRegionPeer is blocked in
+   * waitTaskFinish() polling the coordinator. The kill point fires from inside waitTaskFinish()
+   * (after the first poll confirms the task is still running), so the graceful shutdown
+   * deterministically interrupts that wait and waitTaskFinish() returns PROCESSING. The migration
+   * must still finish correctly after a leader switch: previously the AddRegionPeerProcedure
+   * silently ended on PROCESSING, letting the parent procedure remove the source replica before the
+   * destination replica was actually Running. Uses 3 ConfigNodes so a real leader switch happens,
+   * and asserts the PROCESSING branch was actually exercised.
    */
   @Test
   public void cnLeaderSwitchDuringDoAddPeerTest() throws Exception {
@@ -91,10 +94,11 @@ public class IoTDBRegionMigrateConfigNodeCrashForRatisIT
         1,
         3,
         2,
-        buildSet(AddRegionPeerState.DO_ADD_REGION_PEER),
+        buildSet(RegionMaintainKillPoints.WAIT_TASK_FINISH_POLLING),
         noKillPoints(),
         actionOfGracefullyRestartConfigNode,
         KillNode.CONFIG_NODE);
+    assertSomeConfigNodeLogContains("returns PROCESSING");
   }
 
   @Test

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/ratis/IoTDBRegionMigrateConfigNodeCrashForRatisIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/ratis/IoTDBRegionMigrateConfigNodeCrashForRatisIT.java
@@ -85,8 +85,10 @@ public class IoTDBRegionMigrateConfigNodeCrashForRatisIT
    * deterministically interrupts that wait and waitTaskFinish() returns PROCESSING. The migration
    * must still finish correctly after a leader switch: previously the AddRegionPeerProcedure
    * silently ended on PROCESSING, letting the parent procedure remove the source replica before the
-   * destination replica was actually Running. Uses 3 ConfigNodes so a real leader switch happens,
-   * and asserts the PROCESSING branch was actually exercised.
+   * destination replica was actually Running. Uses 3 ConfigNodes so a real leader switch happens.
+   * The framework requires the WAIT_TASK_FINISH_POLLING kill point to fire, which can only happen
+   * once the worker is blocked inside waitTaskFinish(), so the PROCESSING branch is guaranteed to
+   * be exercised.
    */
   @Test
   // Temporarily also categorized as ClusterIT so the per-PR Cluster IT (1C3D) job runs it for
@@ -102,7 +104,6 @@ public class IoTDBRegionMigrateConfigNodeCrashForRatisIT
         noKillPoints(),
         actionOfGracefullyRestartConfigNode,
         KillNode.CONFIG_NODE);
-    assertSomeConfigNodeLogContains("returns PROCESSING");
   }
 
   @Test

--- a/iotdb-core/confignode/src/main/i18n/en/org/apache/iotdb/confignode/i18n/ProcedureMessages.java
+++ b/iotdb-core/confignode/src/main/i18n/en/org/apache/iotdb/confignode/i18n/ProcedureMessages.java
@@ -1001,7 +1001,7 @@ public final class ProcedureMessages {
   public static final String VALIDATE_TABLE_FOR_TABLE_WHEN_SETTING_PROPERTIES =
       "Validate table for table {}.{} when setting properties";
   public static final String WAITTASKFINISH_RETURNS_PROCESSING_WHICH_MEANS_THE_WAITING_HAS_BEEN_INTERRUPTED =
-      "waitTaskFinish() returns PROCESSING, which means the waiting has been interrupted, this procedure will end without rollback";
+      "waitTaskFinish() returns PROCESSING, which means the waiting has been interrupted (ConfigNode shutdown or leader change); the AddRegionPeer task is still running on the coordinator, this procedure will stay at DO_ADD_REGION_PEER and resume polling after recovery";
 
     public static final String FAILED_TO_CREATE_DATABASE_THE_TTL_SHOULD_BE_NON_NEGATIVE = "Failed to create database. The TTL should be non-negative.";
   public static final String FAILED_TO_CREATE_DATABASE_THE_DATAREGIONGROUPNUM_SHOULD_BE_POSITIVE = "Failed to create database. The dataRegionGroupNum should be positive.";

--- a/iotdb-core/confignode/src/main/i18n/zh/org/apache/iotdb/confignode/i18n/ProcedureMessages.java
+++ b/iotdb-core/confignode/src/main/i18n/zh/org/apache/iotdb/confignode/i18n/ProcedureMessages.java
@@ -999,7 +999,7 @@ public final class ProcedureMessages {
   public static final String VALIDATE_TABLE_FOR_TABLE_WHEN_SETTING_PROPERTIES =
       "Validate table for table {}.{} when setting properties";
   public static final String WAITTASKFINISH_RETURNS_PROCESSING_WHICH_MEANS_THE_WAITING_HAS_BEEN_INTERRUPTED =
-      "waitTaskFinish() returns PROCESSING, which means the waiting has been interrupted, this procedure will end without rollback";
+      "waitTaskFinish() 返回 PROCESSING，表示等待被中断（ConfigNode 关闭或主节点切换）；AddRegionPeer 任务仍在协调者上运行，该流程将停留在 DO_ADD_REGION_PEER 状态，恢复后继续轮询";
 
     public static final String FAILED_TO_CREATE_DATABASE_THE_TTL_SHOULD_BE_NON_NEGATIVE = "创建数据库失败。TTL 不能为负数。";
   public static final String FAILED_TO_CREATE_DATABASE_THE_DATAREGIONGROUPNUM_SHOULD_BE_POSITIVE = "创建数据库失败。dataRegionGroupNum 应为正数。";

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
@@ -454,7 +454,15 @@ public class ProcedureExecutor<Env> {
 
       updateStoreOnExecution(rootProcStack, proc, subprocs);
 
-      if (!store.isRunning()) {
+      // Stop the in-place re-execution loop once this executor is shutting down (e.g. ConfigNode
+      // leader switch / restart). Checking store.isRunning() alone is not enough: stopExecutor()
+      // calls executor.stop() and executor.join() before store.stop(), so the store is still
+      // running while join() waits for this very worker to finish. Without also checking the
+      // executor's own running flag, a procedure that keeps returning HAS_MORE_STATE for the same
+      // state (e.g. AddRegionPeerProcedure parking at DO_ADD_REGION_PEER after waitTaskFinish() is
+      // interrupted) would re-execute forever here and join() would hang. The persisted state lets
+      // the next leader resume from where it stopped.
+      if (!isRunning() || !store.isRunning()) {
         return;
       }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RegionMaintainHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/RegionMaintainHandler.java
@@ -89,6 +89,7 @@ import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.E
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_IOTDB_USER_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_REALTIME_MODE_KEY;
+import static org.apache.iotdb.commons.utils.KillPoint.KillPoint.setKillPoint;
 import static org.apache.iotdb.confignode.conf.ConfigNodeConstant.REGION_MIGRATE_PROCESS;
 import static org.apache.iotdb.consensus.ConsensusFactory.IOT_CONSENSUS;
 import static org.apache.iotdb.consensus.ConsensusFactory.IOT_CONSENSUS_V2;
@@ -360,10 +361,26 @@ public class RegionMaintainHandler {
 
   // TODO: will use 'procedure yield' to refactor later
   public TRegionMigrateResult waitTaskFinish(long taskId, TDataNodeLocation dataNodeLocation) {
+    return waitTaskFinish(taskId, dataNodeLocation, null);
+  }
+
+  /**
+   * Poll the coordinator DataNode until the region-maintain task identified by {@code taskId}
+   * reaches a terminal state.
+   *
+   * @param killPoint if non-null, fired once right after the first poll confirms the task is still
+   *     PROCESSING. At that point the worker thread is provably blocked inside this method, so
+   *     tests can use the kill point to deterministically interrupt the wait (e.g. by gracefully
+   *     stopping the ConfigNode leader) and exercise the interrupted-PROCESSING path. It is a no-op
+   *     outside integration tests.
+   */
+  public <T extends Enum<T>> TRegionMigrateResult waitTaskFinish(
+      long taskId, TDataNodeLocation dataNodeLocation, T killPoint) {
     final long MAX_DISCONNECTION_TOLERATE_MS = 600_000;
     final long INITIAL_DISCONNECTION_TOLERATE_MS = 60_000;
     long startTime = System.nanoTime();
     long lastReportTime = System.nanoTime();
+    boolean killPointTriggered = false;
     while (true) {
       try (SyncDataNodeInternalServiceClient dataNodeClient =
           dataNodeClientManager.borrowClient(dataNodeLocation.getInternalEndPoint())) {
@@ -371,6 +388,12 @@ public class RegionMaintainHandler {
         lastReportTime = System.nanoTime();
         if (report.getTaskStatus() != TRegionMaintainTaskStatus.PROCESSING) {
           return report;
+        }
+        // The task is confirmed still running and this thread is blocked here, so it is now safe to
+        // fire the kill point that tests use to interrupt waitTaskFinish() deterministically.
+        if (killPoint != null && !killPointTriggered) {
+          setKillPoint(killPoint);
+          killPointTriggered = true;
         }
       } catch (Exception ignore) {
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/region/AddRegionPeerProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/region/AddRegionPeerProcedure.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.commons.cluster.RegionStatus;
 import org.apache.iotdb.commons.exception.runtime.ThriftSerDeException;
 import org.apache.iotdb.commons.queryengine.utils.DateTimeUtils;
 import org.apache.iotdb.commons.utils.CommonDateTimeUtils;
+import org.apache.iotdb.commons.utils.KillPoint.RegionMaintainKillPoints;
 import org.apache.iotdb.commons.utils.ThriftCommonsSerDeUtils;
 import org.apache.iotdb.confignode.i18n.ProcedureMessages;
 import org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv;
@@ -104,8 +105,15 @@ public class AddRegionPeerProcedure extends RegionOperationProcedure<AddRegionPe
           break;
         case DO_ADD_REGION_PEER:
           handler.forceUpdateRegionCache(regionId, targetDataNode, RegionStatus.Adding);
-          // We don't want to re-submit AddRegionPeerTask when leader change or ConfigNode reboot
-          if (!this.isStateDeserialized()) {
+          // Only submit the AddRegionPeerTask on the very first entry of this state. We must NOT
+          // re-submit when:
+          //   - the state was restored from disk after a leader change / ConfigNode reboot
+          //     (isStateDeserialized()), or
+          //   - this state is being re-entered in place because a previous attempt parked here on
+          //     PROCESSING (getCycles() > 0, see the PROCESSING branch below).
+          // The coordinator DataNode also dedups by taskId, so a duplicate submit would be a no-op,
+          // but skipping it here avoids the useless RPC and keeps the re-poll cheap.
+          if (!this.isStateDeserialized() && getCycles() == 0) {
             TSStatus tsStatus =
                 handler.submitAddRegionPeerTask(
                     this.getProcId(), targetDataNode, regionId, coordinator);
@@ -115,7 +123,9 @@ public class AddRegionPeerProcedure extends RegionOperationProcedure<AddRegionPe
                   env, handler, "submit DO_ADD_REGION_PEER task fail");
             }
           }
-          TRegionMigrateResult result = handler.waitTaskFinish(this.getProcId(), coordinator);
+          TRegionMigrateResult result =
+              handler.waitTaskFinish(
+                  this.getProcId(), coordinator, RegionMaintainKillPoints.WAIT_TASK_FINISH_POLLING);
           switch (result.getTaskStatus()) {
             case TASK_NOT_EXIST:
             // coordinator crashed and lost its task table

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/region/AddRegionPeerProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/region/AddRegionPeerProcedure.java
@@ -124,10 +124,22 @@ public class AddRegionPeerProcedure extends RegionOperationProcedure<AddRegionPe
               return warnAndRollBackAndNoMoreState(
                   env, handler, String.format("%s result is %s", state, result.getTaskStatus()));
             case PROCESSING:
+              // waitTaskFinish() only returns PROCESSING when its polling loop was interrupted by
+              // an InterruptedException, i.e. this ConfigNode is shutting down / losing leadership
+              // (a user CANCEL or a coordinator disconnection both go through the FAIL branch
+              // above). The AddRegionPeerTask is still running on the coordinator DataNode, so we
+              // must NOT silently end here: doing so would let the parent RegionMigrateProcedure
+              // proceed to CHECK_ADD_REGION_PEER / REMOVE_REGION_PEER and remove the source replica
+              // before the destination replica has actually finished receiving the snapshot.
+              // Instead, stay in DO_ADD_REGION_PEER and persist it; after recovery the new leader
+              // re-enters this state and re-polls the still-running coordinator task (the
+              // isStateDeserialized() guard above prevents re-submitting the task) until it really
+              // reaches SUCCESS or FAIL.
               LOGGER.info(
                   ProcedureMessages
                       .WAITTASKFINISH_RETURNS_PROCESSING_WHICH_MEANS_THE_WAITING_HAS_BEEN_INTERRUPTED);
-              return Flow.NO_MORE_STATE;
+              setNextState(AddRegionPeerState.DO_ADD_REGION_PEER);
+              break outerSwitch;
             case SUCCESS:
               setNextState(UPDATE_REGION_LOCATION_CACHE);
               break outerSwitch;

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/KillPoint/RegionMaintainKillPoints.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/KillPoint/RegionMaintainKillPoints.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.commons.utils.KillPoint;
+
+/** Kill points for the ConfigNode-side region-maintain procedures (AddPeer / RemovePeer). */
+public enum RegionMaintainKillPoints {
+  /**
+   * Fired from {@code RegionMaintainHandler.waitTaskFinish()} once the coordinator DataNode has
+   * confirmed the task is still running (the first poll returned PROCESSING). Unlike the
+   * AddRegionPeerState.DO_ADD_REGION_PEER kill point, which fires right after the task is submitted
+   * and before waitTaskFinish() starts polling, this kill point guarantees the procedure worker is
+   * actually blocked inside waitTaskFinish(). Tests use it to deterministically interrupt
+   * waitTaskFinish() (e.g. by gracefully stopping the ConfigNode leader) so the PROCESSING branch
+   * is exercised instead of racing the task to completion.
+   */
+  WAIT_TASK_FINISH_POLLING,
+}


### PR DESCRIPTION
## Problem

When the ConfigNode leader is **gracefully** stopped — or otherwise loses leadership — while `AddRegionPeerProcedure` is in `DO_ADD_REGION_PEER` waiting for the coordinator DataNode's AddRegionPeer task to finish, `MIGRATE REGION` could be reported as **successful while the destination replica had not actually received the snapshot**, and the source replica was already removed. Queries against the region returned incorrect results during the gap.

### Reproduction (field case)

`MIGRATE REGION 1 FROM 3 TO 4`, then stop the current ConfigNode leader right after the source replica started transmitting the snapshot (an 8.85 GB region over IoTConsensus). Observed:

- ConfigNode printed `[MigrateRegion] success` and `show migrations` was already empty;
- `show regions` showed the destination replica as Running/Leader;
- but the destination DataNode only actually loaded the snapshot and became active **~17.5 minutes later**.

During that window the source replica was already deleted while the destination was still `Adding`, so query results were wrong.

### Root cause

`RegionMaintainHandler.waitTaskFinish()` returns `PROCESSING` **only** when its polling loop is interrupted by an `InterruptedException` (ConfigNode shutdown / leadership loss). A user `CANCEL` or a coordinator disconnection both go through the `FAIL` branch instead, so `PROCESSING` unambiguously means "interrupted by shutdown/leader switch".

The old `DO_ADD_REGION_PEER` code treated `PROCESSING` as a terminal no-op (`return Flow.NO_MORE_STATE`), silently ending `AddRegionPeerProcedure` with neither success nor rollback. The parent `RegionMigrateProcedure` had already persisted at `CHECK_ADD_REGION_PEER`, so the new leader resumed there directly. That check uses `isDataNodeContainsRegion()`, which only inspects the partition table's **location list** — and the location is written back at `CREATE_NEW_REGION_PEER`, long before the snapshot finishes transferring. So the check passed, the source replica was removed, and the migration was declared complete prematurely.

## Fix

In the `DO_ADD_REGION_PEER` `PROCESSING` branch, **stay at `DO_ADD_REGION_PEER` and persist it** (`HAS_MORE_STATE`) instead of ending. After recovery, the new leader re-enters `DO_ADD_REGION_PEER` and re-polls the coordinator task until it truly reaches `SUCCESS` or `FAIL`, so the parent only advances to `REMOVE_REGION_PEER` once the destination replica is genuinely added.

The re-poll is **idempotent**, so the AddRegionPeer task is never submitted twice:

- After a restart / leader switch, the `isStateDeserialized()` guard skips re-submitting the task and only re-polls;
- Even in a same-process immediate re-execute, the coordinator DataNode dedups by `taskId` (`taskResultMap.putIfAbsent`), so a duplicate submit is a no-op;
- If the coordinator crashed and lost its task table, the poll returns `TASK_NOT_EXIST`, which falls through to the existing `FAIL` / rollback path (safe degradation).

The `waitTaskFinish() returns PROCESSING ...` log message (en + zh) is updated to reflect the new behavior.

## Tests

Adds `cnLeaderSwitchDuringDoAddPeerTest` for each consensus protocol — IoTConsensus, IoTConsensusV2 (batch & stream), and Ratis.

The existing daily ConfigNode-crash ITs all use `stopForcibly()` (SIGKILL), which kills the process before it can run the `PROCESSING` branch, so this path was never covered. The new test introduces a graceful `stop()` (SIGTERM) action and stops the **leader** among 3 ConfigNodes, so the interrupted `PROCESSING` path is actually exercised across a real leader switch, and asserts the migration still completes correctly (destination Running, source removed).

These tests are tagged `@Category({DailyIT.class})` (they run in the daily IT pipeline). They were **already validated on CI**: during this PR they were temporarily also tagged `ClusterIT` so the per-PR `Cluster IT` pipeline would run them, and all four passed (each `Tests run: 1, Failures: 0, Errors: 0`, with the graceful-stop / leader-switch path confirmed firing in the logs). That temporary tag has since been reverted, so they are now `DailyIT`-only.
