### PR TITLE
Fix pipe runtime meta push blocking user operations

### DIFF
--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/RpcUtils.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/RpcUtils.java
@@ -151,8 +151,7 @@ public class RpcUtils {
   }
 
   public static void verifySuccess(List<TSStatus> statuses) throws BatchExecutionException {
-    StringBuilder errMsgs =
-        new StringBuilder().append(TSStatusCode.MULTIPLE_ERROR.getStatusCode()).append(": ");
+    StringBuilder errMsgs = new StringBuilder();
     for (TSStatus status : statuses) {
       if (status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()
           && status.getCode() != TSStatusCode.REDIRECTION_RECOMMEND.getStatusCode()) {
@@ -160,7 +159,8 @@ public class RpcUtils {
       }
     }
     if (errMsgs.length() > 0) {
-      throw new BatchExecutionException(statuses, errMsgs.toString());
+      throw new BatchExecutionException(
+          statuses, TSStatusCode.MULTIPLE_ERROR.getStatusCode() + ": " + errMsgs);
     }
   }
 
@@ -181,9 +181,9 @@ public class RpcUtils {
       for (TSStatus subStatus : statusList) {
         if (subStatus.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()
             && subStatus.getCode() != TSStatusCode.REDIRECTION_RECOMMEND.getStatusCode()) {
-          if (!msgSet.contains(status)) {
-            errMsg.append(status).append("; ");
-            msgSet.add(status);
+          if (!msgSet.contains(subStatus)) {
+            errMsg.append(subStatus).append("; ");
+            msgSet.add(subStatus);
           }
         }
       }

--- a/iotdb-client/service-rpc/src/test/java/org/apache/iotdb/rpc/RpcUtilsTest.java
+++ b/iotdb-client/service-rpc/src/test/java/org/apache/iotdb/rpc/RpcUtilsTest.java
@@ -19,11 +19,15 @@
 
 package org.apache.iotdb.rpc;
 
+import org.apache.iotdb.common.rpc.thrift.TSStatus;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Collections;
 
 public class RpcUtilsTest {
 
@@ -73,5 +77,26 @@ public class RpcUtilsTest {
     Assert.assertTrue(RpcUtils.isSetSqlDialect("set  sql_dialect =table"));
     Assert.assertFalse(RpcUtils.isSetSqlDialect("setsql_dialect =table"));
     Assert.assertFalse(RpcUtils.isSetSqlDialect("set           sql_dia"));
+  }
+
+  @Test
+  public void testVerifySuccessListAllowsSuccessfulStatuses() throws BatchExecutionException {
+    RpcUtils.verifySuccess(
+        Arrays.asList(
+            RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS),
+            RpcUtils.getStatus(TSStatusCode.REDIRECTION_RECOMMEND)));
+  }
+
+  @Test
+  public void testVerifySuccessListThrowsOnFailure() {
+    TSStatus failedStatus = RpcUtils.getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR, "failed");
+
+    try {
+      RpcUtils.verifySuccess(Collections.singletonList(failedStatus));
+      Assert.fail("Expected BatchExecutionException");
+    } catch (BatchExecutionException e) {
+      Assert.assertEquals(Collections.singletonList(failedStatus), e.getStatusList());
+      Assert.assertTrue(e.getMessage().contains("failed"));
+    }
   }
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/AsyncAINodeHeartbeatClientPool.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/AsyncAINodeHeartbeatClientPool.java
@@ -54,8 +54,8 @@ public class AsyncAINodeHeartbeatClientPool {
       client = clientManager.borrowClient(endPoint);
       client.getAIHeartbeat(req, handler);
       dispatched = true;
-    } catch (Exception ignore) {
-      // Just ignore
+    } catch (Exception e) {
+      handleError(handler, e);
     } finally {
       // After the async call is dispatched, the client's onComplete/onError callback is
       // responsible for returning the client. If the RPC was not dispatched (exception
@@ -64,6 +64,14 @@ public class AsyncAINodeHeartbeatClientPool {
         ((ClientManager<TEndPoint, AsyncAINodeInternalServiceClient>) clientManager)
             .returnClient(endPoint, client);
       }
+    }
+  }
+
+  private void handleError(final AINodeHeartbeatHandler handler, final Exception e) {
+    try {
+      handler.onError(e);
+    } catch (final Exception ignore) {
+      // Ignore handler failures in heartbeat best-effort path.
     }
   }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/AsyncConfigNodeHeartbeatClientPool.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/AsyncConfigNodeHeartbeatClientPool.java
@@ -55,8 +55,8 @@ public class AsyncConfigNodeHeartbeatClientPool {
       client = clientManager.borrowClient(endPoint);
       client.getConfigNodeHeartBeat(heartbeatReq, handler);
       dispatched = true;
-    } catch (Exception ignore) {
-      // Just ignore
+    } catch (Exception e) {
+      handleError(handler, e);
     } finally {
       // After the async call is dispatched, the client's onComplete/onError callback is
       // responsible for returning the client. If the RPC was not dispatched (exception
@@ -65,6 +65,14 @@ public class AsyncConfigNodeHeartbeatClientPool {
         ((ClientManager<TEndPoint, AsyncConfigNodeInternalServiceClient>) clientManager)
             .returnClient(endPoint, client);
       }
+    }
+  }
+
+  private void handleError(final ConfigNodeHeartbeatHandler handler, final Exception e) {
+    try {
+      handler.onError(e);
+    } catch (final Exception ignore) {
+      // Ignore handler failures in heartbeat best-effort path.
     }
   }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/AsyncDataNodeHeartbeatClientPool.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/AsyncDataNodeHeartbeatClientPool.java
@@ -56,8 +56,8 @@ public class AsyncDataNodeHeartbeatClientPool {
       client = clientManager.borrowClient(endPoint);
       client.getDataNodeHeartBeat(req, handler);
       dispatched = true;
-    } catch (Exception ignore) {
-      // Just ignore
+    } catch (Exception e) {
+      handleError(handler, e);
     } finally {
       returnClientIfNotDispatched(endPoint, client, dispatched);
     }
@@ -72,7 +72,7 @@ public class AsyncDataNodeHeartbeatClientPool {
       client.writeAuditLog(req, handler);
       dispatched = true;
     } catch (Exception e) {
-      // Just ignore
+      handleError(handler, e);
     } finally {
       returnClientIfNotDispatched(endPoint, client, dispatched);
     }
@@ -86,6 +86,22 @@ public class AsyncDataNodeHeartbeatClientPool {
     if (!dispatched && client != null && clientManager instanceof ClientManager) {
       ((ClientManager<TEndPoint, AsyncDataNodeInternalServiceClient>) clientManager)
           .returnClient(endPoint, client);
+    }
+  }
+
+  private void handleError(final DataNodeHeartbeatHandler handler, final Exception e) {
+    try {
+      handler.onError(e);
+    } catch (final Exception ignore) {
+      // Ignore handler failures in heartbeat best-effort path.
+    }
+  }
+
+  private void handleError(final DataNodeWriteAuditLogHandler handler, final Exception e) {
+    try {
+      handler.onError(e);
+    } catch (final Exception ignore) {
+      // Ignore handler failures in audit-log best-effort path.
     }
   }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/handlers/rpc/CheckTimeSeriesExistenceRPCHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/handlers/rpc/CheckTimeSeriesExistenceRPCHandler.java
@@ -83,11 +83,11 @@ public class CheckTimeSeriesExistenceRPCHandler
             + e.getMessage();
     LOGGER.error(errorMsg);
 
-    countDownLatch.countDown();
     TCheckTimeSeriesExistenceResp resp = new TCheckTimeSeriesExistenceResp();
     resp.setStatus(
         new TSStatus(
             RpcUtils.getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode(), errorMsg)));
     responseMap.put(requestId, resp);
+    countDownLatch.countDown();
   }
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/handlers/rpc/CountPathsUsingTemplateRPCHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/handlers/rpc/CountPathsUsingTemplateRPCHandler.java
@@ -83,11 +83,11 @@ public class CountPathsUsingTemplateRPCHandler
             + e.getMessage();
     LOGGER.error(errorMsg);
 
-    countDownLatch.countDown();
     TCountPathsUsingTemplateResp resp = new TCountPathsUsingTemplateResp();
     resp.setStatus(
         new TSStatus(
             RpcUtils.getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode(), errorMsg)));
     responseMap.put(requestId, resp);
+    countDownLatch.countDown();
   }
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/handlers/rpc/FetchSchemaBlackListRPCHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/handlers/rpc/FetchSchemaBlackListRPCHandler.java
@@ -83,11 +83,11 @@ public class FetchSchemaBlackListRPCHandler
             + e.getMessage();
     LOGGER.error(errorMsg);
 
-    countDownLatch.countDown();
     TFetchSchemaBlackListResp resp = new TFetchSchemaBlackListResp();
     resp.setStatus(
         new TSStatus(
             RpcUtils.getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode(), errorMsg)));
     responseMap.put(requestId, resp);
+    countDownLatch.countDown();
   }
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/handlers/rpc/SchemaUpdateRPCHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/handlers/rpc/SchemaUpdateRPCHandler.java
@@ -77,10 +77,10 @@ public class SchemaUpdateRPCHandler extends DataNodeTSStatusRPCHandler {
             + e.getMessage();
     LOGGER.warn(errorMsg);
 
-    countDownLatch.countDown();
     responseMap.put(
         requestId,
         new TSStatus(
             RpcUtils.getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode(), errorMsg)));
+    countDownLatch.countDown();
   }
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/handlers/rpc/subscription/CheckSchemaRegionUsingTemplateRPCHandler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/client/async/handlers/rpc/subscription/CheckSchemaRegionUsingTemplateRPCHandler.java
@@ -85,11 +85,11 @@ public class CheckSchemaRegionUsingTemplateRPCHandler
             + e.getMessage();
     LOGGER.error(errorMsg);
 
-    countDownLatch.countDown();
     TCheckSchemaRegionUsingTemplateResp resp = new TCheckSchemaRegionUsingTemplateResp();
     resp.setStatus(
         new TSStatus(
             RpcUtils.getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode(), errorMsg)));
     responseMap.put(requestId, resp);
+    countDownLatch.countDown();
   }
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/service/TopologyService.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/service/TopologyService.java
@@ -44,6 +44,7 @@ import org.apache.iotdb.confignode.manager.load.cache.node.NodeStatistics;
 import org.apache.iotdb.confignode.manager.load.subscriber.IClusterStatusSubscriber;
 import org.apache.iotdb.confignode.manager.load.subscriber.NodeStatisticsChangeEvent;
 import org.apache.iotdb.mpp.rpc.thrift.TUpdateClusterTopologyReq;
+import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.apache.ratis.util.AwaitForSignal;
 import org.apache.tsfile.utils.Pair;
@@ -72,6 +73,7 @@ import java.util.stream.Collectors;
 public class TopologyService implements Runnable, IClusterStatusSubscriber {
   private static final Logger LOGGER = LoggerFactory.getLogger(TopologyService.class);
   private static final int SAMPLING_WINDOW_SIZE = 100;
+  private static final int TOPOLOGY_PROBING_RETRY_NUM = 1;
 
   private final ExecutorService topologyThread =
       IoTDBThreadPoolFactory.newSingleThreadExecutor(
@@ -222,7 +224,7 @@ public class TopologyService implements Runnable, IClusterStatusSubscriber {
                 nodeLocations,
                 proberLocationMap);
     CnToDnInternalServiceAsyncRequestManager.getInstance()
-        .sendAsyncRequestWithTimeoutInMs(dataNodeAsyncRequestContext, timeout);
+        .sendAsyncRequest(dataNodeAsyncRequestContext, TOPOLOGY_PROBING_RETRY_NUM, timeout, true);
     final List<TTestConnectionResult> results = new ArrayList<>();
     dataNodeAsyncRequestContext
         .getResponseMap()
@@ -360,15 +362,18 @@ public class TopologyService implements Runnable, IClusterStatusSubscriber {
     }
 
     CnToDnInternalServiceAsyncRequestManager.getInstance()
-        .sendAsyncRequestWithTimeoutInMs(context, CONF.getTopologyProbingBaseIntervalInMs());
+        .sendAsyncRequest(
+            context, TOPOLOGY_PROBING_RETRY_NUM, CONF.getTopologyProbingBaseIntervalInMs(), true);
 
     context
         .getResponseMap()
         .forEach(
             (nodeId, resp) -> {
-              Set<Integer> reachableSet =
-                  computedTopology.getOrDefault(nodeId, Collections.emptySet());
-              lastPushedTopology.put(nodeId, new HashSet<>(reachableSet));
+              if (resp.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+                Set<Integer> reachableSet =
+                    computedTopology.getOrDefault(nodeId, Collections.emptySet());
+                lastPushedTopology.put(nodeId, new HashSet<>(reachableSet));
+              }
             });
   }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/coordinator/runtime/heartbeat/PipeHeartbeatScheduler.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/coordinator/runtime/heartbeat/PipeHeartbeatScheduler.java
@@ -51,6 +51,7 @@ public class PipeHeartbeatScheduler {
       PipeConfig.getInstance().isSeperatedPipeHeartbeatEnabled();
   private static final long HEARTBEAT_INTERVAL_SECONDS =
       PipeConfig.getInstance().getPipeHeartbeatIntervalSecondsForCollectingPipeMeta();
+  private static final int PIPE_HEARTBEAT_RETRY_NUM = 1;
 
   private static final ScheduledExecutorService HEARTBEAT_EXECUTOR =
       IoTDBThreadPoolFactory.newSingleThreadScheduledExecutor(
@@ -100,12 +101,8 @@ public class PipeHeartbeatScheduler {
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.PIPE_HEARTBEAT, request, dataNodeLocationMap);
     CnToDnInternalServiceAsyncRequestManager.getInstance()
-        .sendAsyncRequestToNodeWithRetryAndTimeoutInMs(
-            clientHandler,
-            PipeConfig.getInstance().getPipeHeartbeatIntervalSecondsForCollectingPipeMeta()
-                * 1000L
-                * 2
-                / 3);
+        .sendAsyncRequest(
+            clientHandler, PIPE_HEARTBEAT_RETRY_NUM, getPipeHeartbeatRequestTimeoutInMs(), true);
     clientHandler
         .getResponseMap()
         .forEach(
@@ -132,6 +129,10 @@ public class PipeHeartbeatScheduler {
     } catch (final Exception e) {
       LOGGER.warn(ManagerMessages.FAILED_TO_COLLECT_PIPE_META_LIST_FROM_CONFIG_NODE_TASK, e);
     }
+  }
+
+  private static long getPipeHeartbeatRequestTimeoutInMs() {
+    return TimeUnit.SECONDS.toMillis(HEARTBEAT_INTERVAL_SECONDS) * 2 / 3;
   }
 
   public synchronized void stop() {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.commons.cluster.NodeStatus;
 import org.apache.iotdb.commons.cluster.NodeType;
 import org.apache.iotdb.commons.pipe.agent.plugin.meta.PipePluginMeta;
 import org.apache.iotdb.commons.pipe.config.PipeConfig;
+import org.apache.iotdb.commons.subscription.config.SubscriptionConfig;
 import org.apache.iotdb.commons.trigger.TriggerInformation;
 import org.apache.iotdb.confignode.client.CnToCnNodeRequestType;
 import org.apache.iotdb.confignode.client.async.CnToDnAsyncRequestType;
@@ -657,8 +658,9 @@ public class ConfigNodeProcedureEnv {
     final DataNodeAsyncRequestContext<TPushPipeMetaReq, TPushPipeMetaResp> clientHandler =
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.PIPE_PUSH_ALL_META, request, dataNodeLocationMap);
-    sendRequiredMetadataRequest(clientHandler);
-    fillMissingPipePushMetaResponses(clientHandler, getRequiredMetadataRequestTimeoutInMs());
+    final long timeoutInMs = getRequiredPipeMetadataRequestTimeoutInMs();
+    sendRequiredMetadataRequest(clientHandler, timeoutInMs);
+    fillMissingPipePushMetaResponses(clientHandler, timeoutInMs);
     return clientHandler.getResponseMap();
   }
 
@@ -671,7 +673,8 @@ public class ConfigNodeProcedureEnv {
     final DataNodeAsyncRequestContext<TPushPipeMetaReq, TPushPipeMetaResp> clientHandler =
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.PIPE_PUSH_ALL_META, request, dataNodeLocationMap);
-    sendBestEffortRuntimeMetaRequest(clientHandler);
+    final long timeoutInMs = sendBestEffortRuntimeMetaRequest(clientHandler);
+    fillMissingPipePushMetaResponses(clientHandler, timeoutInMs);
     return clientHandler.getResponseMap();
   }
 
@@ -683,8 +686,9 @@ public class ConfigNodeProcedureEnv {
     final DataNodeAsyncRequestContext<TPushSinglePipeMetaReq, TPushPipeMetaResp> clientHandler =
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.PIPE_PUSH_SINGLE_META, request, dataNodeLocationMap);
-    sendRequiredMetadataRequest(clientHandler);
-    fillMissingPipePushMetaResponses(clientHandler, getRequiredMetadataRequestTimeoutInMs());
+    final long timeoutInMs = getRequiredPipeMetadataRequestTimeoutInMs();
+    sendRequiredMetadataRequest(clientHandler, timeoutInMs);
+    fillMissingPipePushMetaResponses(clientHandler, timeoutInMs);
     return clientHandler.getResponseMap();
   }
 
@@ -697,8 +701,9 @@ public class ConfigNodeProcedureEnv {
     final DataNodeAsyncRequestContext<TPushSinglePipeMetaReq, TPushPipeMetaResp> clientHandler =
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.PIPE_PUSH_SINGLE_META, request, dataNodeLocationMap);
-    sendRequiredMetadataRequest(clientHandler);
-    fillMissingPipePushMetaResponses(clientHandler, getRequiredMetadataRequestTimeoutInMs());
+    final long timeoutInMs = getRequiredPipeMetadataRequestTimeoutInMs();
+    sendRequiredMetadataRequest(clientHandler, timeoutInMs);
+    fillMissingPipePushMetaResponses(clientHandler, timeoutInMs);
     return clientHandler.getResponseMap();
   }
 
@@ -712,8 +717,9 @@ public class ConfigNodeProcedureEnv {
     final DataNodeAsyncRequestContext<TPushMultiPipeMetaReq, TPushPipeMetaResp> clientHandler =
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.PIPE_PUSH_MULTI_META, request, dataNodeLocationMap);
-    sendRequiredMetadataRequest(clientHandler);
-    fillMissingPipePushMetaResponses(clientHandler, getRequiredMetadataRequestTimeoutInMs());
+    final long timeoutInMs = getRequiredPipeMetadataRequestTimeoutInMs();
+    sendRequiredMetadataRequest(clientHandler, timeoutInMs);
+    fillMissingPipePushMetaResponses(clientHandler, timeoutInMs);
     return clientHandler.getResponseMap();
   }
 
@@ -726,8 +732,9 @@ public class ConfigNodeProcedureEnv {
     final DataNodeAsyncRequestContext<TPushMultiPipeMetaReq, TPushPipeMetaResp> clientHandler =
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.PIPE_PUSH_MULTI_META, request, dataNodeLocationMap);
-    sendRequiredMetadataRequest(clientHandler);
-    fillMissingPipePushMetaResponses(clientHandler, getRequiredMetadataRequestTimeoutInMs());
+    final long timeoutInMs = getRequiredPipeMetadataRequestTimeoutInMs();
+    sendRequiredMetadataRequest(clientHandler, timeoutInMs);
+    fillMissingPipePushMetaResponses(clientHandler, timeoutInMs);
     return clientHandler.getResponseMap();
   }
 
@@ -740,8 +747,9 @@ public class ConfigNodeProcedureEnv {
     final DataNodeAsyncRequestContext<TPushTopicMetaReq, TPushTopicMetaResp> clientHandler =
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.TOPIC_PUSH_ALL_META, request, dataNodeLocationMap);
-    sendRequiredMetadataRequest(clientHandler);
-    fillMissingTopicPushMetaResponses(clientHandler, getRequiredMetadataRequestTimeoutInMs());
+    final long timeoutInMs = getRequiredSubscriptionMetadataRequestTimeoutInMs();
+    sendRequiredMetadataRequest(clientHandler, timeoutInMs);
+    fillMissingTopicPushMetaResponses(clientHandler, timeoutInMs);
     return clientHandler.getResponseMap();
   }
 
@@ -754,7 +762,8 @@ public class ConfigNodeProcedureEnv {
     final DataNodeAsyncRequestContext<TPushTopicMetaReq, TPushTopicMetaResp> clientHandler =
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.TOPIC_PUSH_ALL_META, request, dataNodeLocationMap);
-    sendBestEffortRuntimeMetaRequest(clientHandler);
+    final long timeoutInMs = sendBestEffortRuntimeMetaRequest(clientHandler);
+    fillMissingTopicPushMetaResponses(clientHandler, timeoutInMs);
     return clientHandler.getResponseMap();
   }
 
@@ -766,8 +775,9 @@ public class ConfigNodeProcedureEnv {
     final DataNodeAsyncRequestContext<TPushSingleTopicMetaReq, TPushTopicMetaResp> clientHandler =
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.TOPIC_PUSH_SINGLE_META, request, dataNodeLocationMap);
-    sendRequiredMetadataRequest(clientHandler);
-    fillMissingTopicPushMetaResponses(clientHandler, getRequiredMetadataRequestTimeoutInMs());
+    final long timeoutInMs = getRequiredSubscriptionMetadataRequestTimeoutInMs();
+    sendRequiredMetadataRequest(clientHandler, timeoutInMs);
+    fillMissingTopicPushMetaResponses(clientHandler, timeoutInMs);
     return clientHandler.getResponseList().stream()
         .map(TPushTopicMetaResp::getStatus)
         .collect(Collectors.toList());
@@ -782,8 +792,9 @@ public class ConfigNodeProcedureEnv {
     final DataNodeAsyncRequestContext<TPushSingleTopicMetaReq, TPushTopicMetaResp> clientHandler =
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.TOPIC_PUSH_SINGLE_META, request, dataNodeLocationMap);
-    sendRequiredMetadataRequest(clientHandler);
-    fillMissingTopicPushMetaResponses(clientHandler, getRequiredMetadataRequestTimeoutInMs());
+    final long timeoutInMs = getRequiredSubscriptionMetadataRequestTimeoutInMs();
+    sendRequiredMetadataRequest(clientHandler, timeoutInMs);
+    fillMissingTopicPushMetaResponses(clientHandler, timeoutInMs);
     return clientHandler.getResponseList().stream()
         .map(TPushTopicMetaResp::getStatus)
         .collect(Collectors.toList());
@@ -799,8 +810,9 @@ public class ConfigNodeProcedureEnv {
     final DataNodeAsyncRequestContext<TPushMultiTopicMetaReq, TPushTopicMetaResp> clientHandler =
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.TOPIC_PUSH_MULTI_META, request, dataNodeLocationMap);
-    sendRequiredMetadataRequest(clientHandler);
-    fillMissingTopicPushMetaResponses(clientHandler, getRequiredMetadataRequestTimeoutInMs());
+    final long timeoutInMs = getRequiredSubscriptionMetadataRequestTimeoutInMs();
+    sendRequiredMetadataRequest(clientHandler, timeoutInMs);
+    fillMissingTopicPushMetaResponses(clientHandler, timeoutInMs);
     return clientHandler.getResponseMap();
   }
 
@@ -813,8 +825,9 @@ public class ConfigNodeProcedureEnv {
     final DataNodeAsyncRequestContext<TPushMultiTopicMetaReq, TPushTopicMetaResp> clientHandler =
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.TOPIC_PUSH_MULTI_META, request, dataNodeLocationMap);
-    sendRequiredMetadataRequest(clientHandler);
-    fillMissingTopicPushMetaResponses(clientHandler, getRequiredMetadataRequestTimeoutInMs());
+    final long timeoutInMs = getRequiredSubscriptionMetadataRequestTimeoutInMs();
+    sendRequiredMetadataRequest(clientHandler, timeoutInMs);
+    fillMissingTopicPushMetaResponses(clientHandler, timeoutInMs);
     return clientHandler.getResponseMap();
   }
 
@@ -829,9 +842,9 @@ public class ConfigNodeProcedureEnv {
         clientHandler =
             new DataNodeAsyncRequestContext<>(
                 CnToDnAsyncRequestType.CONSUMER_GROUP_PUSH_ALL_META, request, dataNodeLocationMap);
-    sendRequiredMetadataRequest(clientHandler);
-    fillMissingConsumerGroupPushMetaResponses(
-        clientHandler, getRequiredMetadataRequestTimeoutInMs());
+    final long timeoutInMs = getRequiredSubscriptionMetadataRequestTimeoutInMs();
+    sendRequiredMetadataRequest(clientHandler, timeoutInMs);
+    fillMissingConsumerGroupPushMetaResponses(clientHandler, timeoutInMs);
     return clientHandler.getResponseMap();
   }
 
@@ -846,7 +859,8 @@ public class ConfigNodeProcedureEnv {
         clientHandler =
             new DataNodeAsyncRequestContext<>(
                 CnToDnAsyncRequestType.CONSUMER_GROUP_PUSH_ALL_META, request, dataNodeLocationMap);
-    sendBestEffortRuntimeMetaRequest(clientHandler);
+    final long timeoutInMs = sendBestEffortRuntimeMetaRequest(clientHandler);
+    fillMissingConsumerGroupPushMetaResponses(clientHandler, timeoutInMs);
     return clientHandler.getResponseMap();
   }
 
@@ -862,9 +876,9 @@ public class ConfigNodeProcedureEnv {
                 CnToDnAsyncRequestType.CONSUMER_GROUP_PUSH_SINGLE_META,
                 request,
                 dataNodeLocationMap);
-    sendRequiredMetadataRequest(clientHandler);
-    fillMissingConsumerGroupPushMetaResponses(
-        clientHandler, getRequiredMetadataRequestTimeoutInMs());
+    final long timeoutInMs = getRequiredSubscriptionMetadataRequestTimeoutInMs();
+    sendRequiredMetadataRequest(clientHandler, timeoutInMs);
+    fillMissingConsumerGroupPushMetaResponses(clientHandler, timeoutInMs);
     return clientHandler.getResponseList().stream()
         .map(TPushConsumerGroupMetaResp::getStatus)
         .collect(Collectors.toList());
@@ -882,9 +896,9 @@ public class ConfigNodeProcedureEnv {
                 CnToDnAsyncRequestType.CONSUMER_GROUP_PUSH_SINGLE_META,
                 request,
                 dataNodeLocationMap);
-    sendRequiredMetadataRequest(clientHandler);
-    fillMissingConsumerGroupPushMetaResponses(
-        clientHandler, getRequiredMetadataRequestTimeoutInMs());
+    final long timeoutInMs = getRequiredSubscriptionMetadataRequestTimeoutInMs();
+    sendRequiredMetadataRequest(clientHandler, timeoutInMs);
+    fillMissingConsumerGroupPushMetaResponses(clientHandler, timeoutInMs);
     return clientHandler.getResponseList().stream()
         .map(TPushConsumerGroupMetaResp::getStatus)
         .collect(Collectors.toList());
@@ -899,8 +913,9 @@ public class ConfigNodeProcedureEnv {
         clientHandler =
             new DataNodeAsyncRequestContext<>(
                 CnToDnAsyncRequestType.PULL_COMMIT_PROGRESS, request, dataNodeLocationMap);
-    sendRequiredMetadataRequest(clientHandler);
-    fillMissingPullCommitProgressResponses(clientHandler, getRequiredMetadataRequestTimeoutInMs());
+    final long timeoutInMs = getRequiredSubscriptionMetadataRequestTimeoutInMs();
+    sendRequiredMetadataRequest(clientHandler, timeoutInMs);
+    fillMissingPullCommitProgressResponses(clientHandler, timeoutInMs);
     return clientHandler.getResponseMap();
   }
 
@@ -913,7 +928,8 @@ public class ConfigNodeProcedureEnv {
         clientHandler =
             new DataNodeAsyncRequestContext<>(
                 CnToDnAsyncRequestType.PULL_COMMIT_PROGRESS, request, dataNodeLocationMap);
-    sendBestEffortRuntimeMetaRequest(clientHandler);
+    final long timeoutInMs = sendBestEffortRuntimeMetaRequest(clientHandler);
+    fillMissingPullCommitProgressResponses(clientHandler, timeoutInMs);
     return clientHandler.getResponseMap();
   }
 
@@ -990,9 +1006,11 @@ public class ConfigNodeProcedureEnv {
         && getLoadManager().getNodeStatus(dataNodeId) != NodeStatus.Removing;
   }
 
-  private static void sendBestEffortRuntimeMetaRequest(
+  private static long sendBestEffortRuntimeMetaRequest(
       final DataNodeAsyncRequestContext<?, ?> clientHandler) {
-    sendRuntimeMetaRequest(clientHandler, true);
+    final long timeoutInMs = getRuntimeMetaPushTimeoutInMs();
+    sendRuntimeMetaRequest(clientHandler, true, timeoutInMs);
+    return timeoutInMs;
   }
 
   private static void sendRequiredRuntimeMetaRequest(
@@ -1001,8 +1019,8 @@ public class ConfigNodeProcedureEnv {
   }
 
   private static void sendRequiredMetadataRequest(
-      final DataNodeAsyncRequestContext<?, ?> clientHandler) {
-    sendRuntimeMetaRequest(clientHandler, false, getRequiredMetadataRequestTimeoutInMs());
+      final DataNodeAsyncRequestContext<?, ?> clientHandler, final long timeoutInMs) {
+    sendRuntimeMetaRequest(clientHandler, false, timeoutInMs);
   }
 
   private static void sendRuntimeMetaRequest(
@@ -1030,7 +1048,7 @@ public class ConfigNodeProcedureEnv {
                     .putIfAbsent(
                         dataNodeId,
                         new TPushPipeMetaResp(
-                            createRequiredMetadataTimeoutStatus(
+                            createMetadataTimeoutStatus(
                                 clientHandler.getRequestType(),
                                 dataNodeId,
                                 TSStatusCode.PIPE_PUSH_META_ERROR,
@@ -1049,7 +1067,7 @@ public class ConfigNodeProcedureEnv {
                     .putIfAbsent(
                         dataNodeId,
                         new TPushTopicMetaResp(
-                            createRequiredMetadataTimeoutStatus(
+                            createMetadataTimeoutStatus(
                                 clientHandler.getRequestType(),
                                 dataNodeId,
                                 TSStatusCode.TOPIC_PUSH_META_ERROR,
@@ -1068,7 +1086,7 @@ public class ConfigNodeProcedureEnv {
                     .putIfAbsent(
                         dataNodeId,
                         new TPushConsumerGroupMetaResp(
-                            createRequiredMetadataTimeoutStatus(
+                            createMetadataTimeoutStatus(
                                 clientHandler.getRequestType(),
                                 dataNodeId,
                                 TSStatusCode.CONSUMER_PUSH_META_ERROR,
@@ -1087,14 +1105,14 @@ public class ConfigNodeProcedureEnv {
                     .putIfAbsent(
                         dataNodeId,
                         new TPullCommitProgressResp(
-                            createRequiredMetadataTimeoutStatus(
+                            createMetadataTimeoutStatus(
                                 clientHandler.getRequestType(),
                                 dataNodeId,
                                 TSStatusCode.EXECUTE_STATEMENT_ERROR,
                                 timeoutInMs))));
   }
 
-  private static TSStatus createRequiredMetadataTimeoutStatus(
+  private static TSStatus createMetadataTimeoutStatus(
       final CnToDnAsyncRequestType requestType,
       final int dataNodeId,
       final TSStatusCode statusCode,
@@ -1102,7 +1120,7 @@ public class ConfigNodeProcedureEnv {
     return new TSStatus(statusCode.getStatusCode())
         .setMessage(
             String.format(
-                "Failed to %s on DataNode %s before required metadata request timeout %sms",
+                "Failed to %s on DataNode %s before metadata request timeout %sms",
                 requestType, dataNodeId, timeoutInMs));
   }
 
@@ -1113,9 +1131,16 @@ public class ConfigNodeProcedureEnv {
         / 3;
   }
 
-  private static long getRequiredMetadataRequestTimeoutInMs() {
+  private static long getRequiredPipeMetadataRequestTimeoutInMs() {
     return TimeUnit.MINUTES.toMillis(
             PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes())
+        * 2
+        / 3;
+  }
+
+  private static long getRequiredSubscriptionMetadataRequestTimeoutInMs() {
+    return TimeUnit.MINUTES.toMillis(
+            SubscriptionConfig.getInstance().getSubscriptionMetaSyncerSyncIntervalMinutes())
         * 2
         / 3;
   }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
@@ -988,10 +988,7 @@ public class ConfigNodeProcedureEnv {
               dataNodeId, new TPushSubscriptionRuntimeReq().setRuntimeStates(runtimeStates));
         });
 
-    CnToDnInternalServiceAsyncRequestManager.getInstance()
-        .sendAsyncRequestToNodeWithRetryAndTimeoutInMs(
-            readableDataNodeClientHandler,
-            PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes() * 60 * 1000 * 2 / 3);
+    sendRequiredRuntimeMetaRequest(readableDataNodeClientHandler);
     sendBestEffortRuntimeMetaRequest(unreadableDataNodeClientHandler);
 
     final Map<Integer, TSStatus> responseMap =
@@ -1008,9 +1005,22 @@ public class ConfigNodeProcedureEnv {
 
   private static void sendBestEffortRuntimeMetaRequest(
       final DataNodeAsyncRequestContext<?, ?> clientHandler) {
+    sendRuntimeMetaRequest(clientHandler, true);
+  }
+
+  private static void sendRequiredRuntimeMetaRequest(
+      final DataNodeAsyncRequestContext<?, ?> clientHandler) {
+    sendRuntimeMetaRequest(clientHandler, false);
+  }
+
+  private static void sendRuntimeMetaRequest(
+      final DataNodeAsyncRequestContext<?, ?> clientHandler, final boolean keepSilent) {
     CnToDnInternalServiceAsyncRequestManager.getInstance()
         .sendAsyncRequest(
-            clientHandler, RUNTIME_META_PUSH_RETRY_NUM, getRuntimeMetaPushTimeoutInMs(), true);
+            clientHandler,
+            RUNTIME_META_PUSH_RETRY_NUM,
+            getRuntimeMetaPushTimeoutInMs(),
+            keepSilent);
   }
 
   private static long getRuntimeMetaPushTimeoutInMs() {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
@@ -110,6 +110,8 @@ public class ConfigNodeProcedureEnv {
 
   private static final Logger LOG = LoggerFactory.getLogger(ConfigNodeProcedureEnv.class);
 
+  private static final int RUNTIME_META_PUSH_RETRY_NUM = 1;
+
   /** Add or remove node lock. */
   private final LockQueue nodeLock = new LockQueue();
 
@@ -662,6 +664,19 @@ public class ConfigNodeProcedureEnv {
     return clientHandler.getResponseMap();
   }
 
+  public Map<Integer, TPushPipeMetaResp> pushAllPipeMetaToDataNodesBestEffort(
+      List<ByteBuffer> pipeMetaBinaryList) {
+    final Map<Integer, TDataNodeLocation> dataNodeLocationMap =
+        configManager.getNodeManager().getRegisteredDataNodeLocations();
+    final TPushPipeMetaReq request = new TPushPipeMetaReq().setPipeMetas(pipeMetaBinaryList);
+
+    final DataNodeAsyncRequestContext<TPushPipeMetaReq, TPushPipeMetaResp> clientHandler =
+        new DataNodeAsyncRequestContext<>(
+            CnToDnAsyncRequestType.PIPE_PUSH_ALL_META, request, dataNodeLocationMap);
+    sendBestEffortRuntimeMetaRequest(clientHandler);
+    return clientHandler.getResponseMap();
+  }
+
   public Map<Integer, TPushPipeMetaResp> pushSinglePipeMetaToDataNodes(ByteBuffer pipeMetaBinary) {
     final Map<Integer, TDataNodeLocation> dataNodeLocationMap =
         configManager.getNodeManager().getRegisteredDataNodeLocations();
@@ -739,6 +754,19 @@ public class ConfigNodeProcedureEnv {
         .sendAsyncRequestToNodeWithRetryAndTimeoutInMs(
             clientHandler,
             PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes() * 60 * 1000 * 2 / 3);
+    return clientHandler.getResponseMap();
+  }
+
+  public Map<Integer, TPushTopicMetaResp> pushAllTopicMetaToDataNodesBestEffort(
+      List<ByteBuffer> topicMetaBinaryList) {
+    final Map<Integer, TDataNodeLocation> dataNodeLocationMap =
+        configManager.getNodeManager().getRegisteredDataNodeLocations();
+    final TPushTopicMetaReq request = new TPushTopicMetaReq().setTopicMetas(topicMetaBinaryList);
+
+    final DataNodeAsyncRequestContext<TPushTopicMetaReq, TPushTopicMetaResp> clientHandler =
+        new DataNodeAsyncRequestContext<>(
+            CnToDnAsyncRequestType.TOPIC_PUSH_ALL_META, request, dataNodeLocationMap);
+    sendBestEffortRuntimeMetaRequest(clientHandler);
     return clientHandler.getResponseMap();
   }
 
@@ -822,6 +850,21 @@ public class ConfigNodeProcedureEnv {
     return clientHandler.getResponseMap();
   }
 
+  public Map<Integer, TPushConsumerGroupMetaResp> pushAllConsumerGroupMetaToDataNodesBestEffort(
+      List<ByteBuffer> consumerGroupMetaBinaryList) {
+    final Map<Integer, TDataNodeLocation> dataNodeLocationMap =
+        configManager.getNodeManager().getRegisteredDataNodeLocations();
+    final TPushConsumerGroupMetaReq request =
+        new TPushConsumerGroupMetaReq().setConsumerGroupMetas(consumerGroupMetaBinaryList);
+
+    final DataNodeAsyncRequestContext<TPushConsumerGroupMetaReq, TPushConsumerGroupMetaResp>
+        clientHandler =
+            new DataNodeAsyncRequestContext<>(
+                CnToDnAsyncRequestType.CONSUMER_GROUP_PUSH_ALL_META, request, dataNodeLocationMap);
+    sendBestEffortRuntimeMetaRequest(clientHandler);
+    return clientHandler.getResponseMap();
+  }
+
   public List<TSStatus> pushSingleConsumerGroupOnDataNode(ByteBuffer consumerGroupMeta) {
     final Map<Integer, TDataNodeLocation> dataNodeLocationMap =
         configManager.getNodeManager().getRegisteredDataNodeLocations();
@@ -874,6 +917,19 @@ public class ConfigNodeProcedureEnv {
     return clientHandler.getResponseMap();
   }
 
+  public Map<Integer, TPullCommitProgressResp> pullCommitProgressFromDataNodesBestEffort() {
+    final Map<Integer, TDataNodeLocation> dataNodeLocationMap =
+        configManager.getNodeManager().getRegisteredDataNodeLocations();
+    final TPullCommitProgressReq request = new TPullCommitProgressReq();
+
+    final DataNodeAsyncRequestContext<TPullCommitProgressReq, TPullCommitProgressResp>
+        clientHandler =
+            new DataNodeAsyncRequestContext<>(
+                CnToDnAsyncRequestType.PULL_COMMIT_PROGRESS, request, dataNodeLocationMap);
+    sendBestEffortRuntimeMetaRequest(clientHandler);
+    return clientHandler.getResponseMap();
+  }
+
   public Map<Integer, TSStatus> pushSubscriptionRuntimeStatesToDataNodes(
       final Map<TConsensusGroupId, Pair<Integer, Integer>> regionGroupToOldAndNewLeaderPairMap,
       final long runtimeVersion) {
@@ -884,8 +940,12 @@ public class ConfigNodeProcedureEnv {
     final Set<Integer> readableDataNodeIds =
         getLoadManager().filterDataNodeThroughStatus(NodeStatus::isReadable).stream()
             .collect(Collectors.toSet());
-    final DataNodeAsyncRequestContext<TPushSubscriptionRuntimeReq, TSStatus> clientHandler =
-        new DataNodeAsyncRequestContext<>(CnToDnAsyncRequestType.SUBSCRIPTION_PUSH_RUNTIME);
+    final DataNodeAsyncRequestContext<TPushSubscriptionRuntimeReq, TSStatus>
+        readableDataNodeClientHandler =
+            new DataNodeAsyncRequestContext<>(CnToDnAsyncRequestType.SUBSCRIPTION_PUSH_RUNTIME);
+    final DataNodeAsyncRequestContext<TPushSubscriptionRuntimeReq, TSStatus>
+        unreadableDataNodeClientHandler =
+            new DataNodeAsyncRequestContext<>(CnToDnAsyncRequestType.SUBSCRIPTION_PUSH_RUNTIME);
 
     dataNodeLocationMap.forEach(
         (dataNodeId, dataNodeLocation) -> {
@@ -919,6 +979,10 @@ public class ConfigNodeProcedureEnv {
                         preferredWriterNodeId == dataNodeId,
                         new ArrayList<>(activeWriterNodeIds)));
               });
+          final DataNodeAsyncRequestContext<TPushSubscriptionRuntimeReq, TSStatus> clientHandler =
+              readableDataNodeIds.contains(dataNodeId)
+                  ? readableDataNodeClientHandler
+                  : unreadableDataNodeClientHandler;
           clientHandler.putNodeLocation(dataNodeId, dataNodeLocation);
           clientHandler.putRequest(
               dataNodeId, new TPushSubscriptionRuntimeReq().setRuntimeStates(runtimeStates));
@@ -926,15 +990,34 @@ public class ConfigNodeProcedureEnv {
 
     CnToDnInternalServiceAsyncRequestManager.getInstance()
         .sendAsyncRequestToNodeWithRetryAndTimeoutInMs(
-            clientHandler,
+            readableDataNodeClientHandler,
             PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes() * 60 * 1000 * 2 / 3);
-    return clientHandler.getResponseMap();
+    sendBestEffortRuntimeMetaRequest(unreadableDataNodeClientHandler);
+
+    final Map<Integer, TSStatus> responseMap =
+        new HashMap<>(readableDataNodeClientHandler.getResponseMap());
+    responseMap.putAll(unreadableDataNodeClientHandler.getResponseMap());
+    return responseMap;
   }
 
   private boolean isRuntimeActiveWriterNode(final int dataNodeId) {
     return dataNodeId >= 0
         && getLoadManager().getNodeStatus(dataNodeId) != NodeStatus.Unknown
         && getLoadManager().getNodeStatus(dataNodeId) != NodeStatus.Removing;
+  }
+
+  private static void sendBestEffortRuntimeMetaRequest(
+      final DataNodeAsyncRequestContext<?, ?> clientHandler) {
+    CnToDnInternalServiceAsyncRequestManager.getInstance()
+        .sendAsyncRequest(
+            clientHandler, RUNTIME_META_PUSH_RETRY_NUM, getRuntimeMetaPushTimeoutInMs(), true);
+  }
+
+  private static long getRuntimeMetaPushTimeoutInMs() {
+    return TimeUnit.SECONDS.toMillis(
+            PipeConfig.getInstance().getPipeHeartbeatIntervalSecondsForCollectingPipeMeta())
+        * 2
+        / 3;
   }
 
   public LockQueue getNodeLock() {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
@@ -991,8 +991,11 @@ public class ConfigNodeProcedureEnv {
               dataNodeId, new TPushSubscriptionRuntimeReq().setRuntimeStates(runtimeStates));
         });
 
-    sendRequiredRuntimeMetaRequest(readableDataNodeClientHandler);
-    sendBestEffortRuntimeMetaRequest(unreadableDataNodeClientHandler);
+    final long readableTimeoutInMs = sendRequiredRuntimeMetaRequest(readableDataNodeClientHandler);
+    fillMissingSubscriptionRuntimeResponses(readableDataNodeClientHandler, readableTimeoutInMs);
+    final long unreadableTimeoutInMs =
+        sendBestEffortRuntimeMetaRequest(unreadableDataNodeClientHandler);
+    fillMissingSubscriptionRuntimeResponses(unreadableDataNodeClientHandler, unreadableTimeoutInMs);
 
     final Map<Integer, TSStatus> responseMap =
         new HashMap<>(readableDataNodeClientHandler.getResponseMap());
@@ -1013,9 +1016,11 @@ public class ConfigNodeProcedureEnv {
     return timeoutInMs;
   }
 
-  private static void sendRequiredRuntimeMetaRequest(
+  private static long sendRequiredRuntimeMetaRequest(
       final DataNodeAsyncRequestContext<?, ?> clientHandler) {
-    sendRuntimeMetaRequest(clientHandler, false);
+    final long timeoutInMs = getRuntimeMetaPushTimeoutInMs();
+    sendRuntimeMetaRequest(clientHandler, false, timeoutInMs);
+    return timeoutInMs;
   }
 
   private static void sendRequiredMetadataRequest(
@@ -1110,6 +1115,23 @@ public class ConfigNodeProcedureEnv {
                                 dataNodeId,
                                 TSStatusCode.EXECUTE_STATEMENT_ERROR,
                                 timeoutInMs))));
+  }
+
+  private static void fillMissingSubscriptionRuntimeResponses(
+      final DataNodeAsyncRequestContext<?, TSStatus> clientHandler, final long timeoutInMs) {
+    clientHandler
+        .getRequestIndices()
+        .forEach(
+            dataNodeId ->
+                clientHandler
+                    .getResponseMap()
+                    .putIfAbsent(
+                        dataNodeId,
+                        createMetadataTimeoutStatus(
+                            clientHandler.getRequestType(),
+                            dataNodeId,
+                            TSStatusCode.EXECUTE_STATEMENT_ERROR,
+                            timeoutInMs)));
   }
 
   private static TSStatus createMetadataTimeoutStatus(

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
@@ -657,10 +657,8 @@ public class ConfigNodeProcedureEnv {
     final DataNodeAsyncRequestContext<TPushPipeMetaReq, TPushPipeMetaResp> clientHandler =
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.PIPE_PUSH_ALL_META, request, dataNodeLocationMap);
-    CnToDnInternalServiceAsyncRequestManager.getInstance()
-        .sendAsyncRequestToNodeWithRetryAndTimeoutInMs(
-            clientHandler,
-            PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes() * 60 * 1000 * 2 / 3);
+    sendRequiredMetadataRequest(clientHandler);
+    fillMissingPipePushMetaResponses(clientHandler, getRequiredMetadataRequestTimeoutInMs());
     return clientHandler.getResponseMap();
   }
 
@@ -685,10 +683,8 @@ public class ConfigNodeProcedureEnv {
     final DataNodeAsyncRequestContext<TPushSinglePipeMetaReq, TPushPipeMetaResp> clientHandler =
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.PIPE_PUSH_SINGLE_META, request, dataNodeLocationMap);
-    CnToDnInternalServiceAsyncRequestManager.getInstance()
-        .sendAsyncRequestToNodeWithRetryAndTimeoutInMs(
-            clientHandler,
-            PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes() * 60 * 1000 * 2 / 3);
+    sendRequiredMetadataRequest(clientHandler);
+    fillMissingPipePushMetaResponses(clientHandler, getRequiredMetadataRequestTimeoutInMs());
     return clientHandler.getResponseMap();
   }
 
@@ -701,10 +697,8 @@ public class ConfigNodeProcedureEnv {
     final DataNodeAsyncRequestContext<TPushSinglePipeMetaReq, TPushPipeMetaResp> clientHandler =
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.PIPE_PUSH_SINGLE_META, request, dataNodeLocationMap);
-    CnToDnInternalServiceAsyncRequestManager.getInstance()
-        .sendAsyncRequestToNodeWithRetryAndTimeoutInMs(
-            clientHandler,
-            PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes() * 60 * 1000 * 2 / 3);
+    sendRequiredMetadataRequest(clientHandler);
+    fillMissingPipePushMetaResponses(clientHandler, getRequiredMetadataRequestTimeoutInMs());
     return clientHandler.getResponseMap();
   }
 
@@ -718,10 +712,8 @@ public class ConfigNodeProcedureEnv {
     final DataNodeAsyncRequestContext<TPushMultiPipeMetaReq, TPushPipeMetaResp> clientHandler =
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.PIPE_PUSH_MULTI_META, request, dataNodeLocationMap);
-    CnToDnInternalServiceAsyncRequestManager.getInstance()
-        .sendAsyncRequestToNodeWithRetryAndTimeoutInMs(
-            clientHandler,
-            PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes() * 60 * 1000 * 2 / 3);
+    sendRequiredMetadataRequest(clientHandler);
+    fillMissingPipePushMetaResponses(clientHandler, getRequiredMetadataRequestTimeoutInMs());
     return clientHandler.getResponseMap();
   }
 
@@ -734,10 +726,8 @@ public class ConfigNodeProcedureEnv {
     final DataNodeAsyncRequestContext<TPushMultiPipeMetaReq, TPushPipeMetaResp> clientHandler =
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.PIPE_PUSH_MULTI_META, request, dataNodeLocationMap);
-    CnToDnInternalServiceAsyncRequestManager.getInstance()
-        .sendAsyncRequestToNodeWithRetryAndTimeoutInMs(
-            clientHandler,
-            PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes() * 60 * 1000 * 2 / 3);
+    sendRequiredMetadataRequest(clientHandler);
+    fillMissingPipePushMetaResponses(clientHandler, getRequiredMetadataRequestTimeoutInMs());
     return clientHandler.getResponseMap();
   }
 
@@ -750,10 +740,8 @@ public class ConfigNodeProcedureEnv {
     final DataNodeAsyncRequestContext<TPushTopicMetaReq, TPushTopicMetaResp> clientHandler =
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.TOPIC_PUSH_ALL_META, request, dataNodeLocationMap);
-    CnToDnInternalServiceAsyncRequestManager.getInstance()
-        .sendAsyncRequestToNodeWithRetryAndTimeoutInMs(
-            clientHandler,
-            PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes() * 60 * 1000 * 2 / 3);
+    sendRequiredMetadataRequest(clientHandler);
+    fillMissingTopicPushMetaResponses(clientHandler, getRequiredMetadataRequestTimeoutInMs());
     return clientHandler.getResponseMap();
   }
 
@@ -778,7 +766,8 @@ public class ConfigNodeProcedureEnv {
     final DataNodeAsyncRequestContext<TPushSingleTopicMetaReq, TPushTopicMetaResp> clientHandler =
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.TOPIC_PUSH_SINGLE_META, request, dataNodeLocationMap);
-    CnToDnInternalServiceAsyncRequestManager.getInstance().sendAsyncRequestWithRetry(clientHandler);
+    sendRequiredMetadataRequest(clientHandler);
+    fillMissingTopicPushMetaResponses(clientHandler, getRequiredMetadataRequestTimeoutInMs());
     return clientHandler.getResponseList().stream()
         .map(TPushTopicMetaResp::getStatus)
         .collect(Collectors.toList());
@@ -793,7 +782,8 @@ public class ConfigNodeProcedureEnv {
     final DataNodeAsyncRequestContext<TPushSingleTopicMetaReq, TPushTopicMetaResp> clientHandler =
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.TOPIC_PUSH_SINGLE_META, request, dataNodeLocationMap);
-    CnToDnInternalServiceAsyncRequestManager.getInstance().sendAsyncRequestWithRetry(clientHandler);
+    sendRequiredMetadataRequest(clientHandler);
+    fillMissingTopicPushMetaResponses(clientHandler, getRequiredMetadataRequestTimeoutInMs());
     return clientHandler.getResponseList().stream()
         .map(TPushTopicMetaResp::getStatus)
         .collect(Collectors.toList());
@@ -809,10 +799,8 @@ public class ConfigNodeProcedureEnv {
     final DataNodeAsyncRequestContext<TPushMultiTopicMetaReq, TPushTopicMetaResp> clientHandler =
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.TOPIC_PUSH_MULTI_META, request, dataNodeLocationMap);
-    CnToDnInternalServiceAsyncRequestManager.getInstance()
-        .sendAsyncRequestToNodeWithRetryAndTimeoutInMs(
-            clientHandler,
-            PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes() * 60 * 1000 * 2 / 3);
+    sendRequiredMetadataRequest(clientHandler);
+    fillMissingTopicPushMetaResponses(clientHandler, getRequiredMetadataRequestTimeoutInMs());
     return clientHandler.getResponseMap();
   }
 
@@ -825,10 +813,8 @@ public class ConfigNodeProcedureEnv {
     final DataNodeAsyncRequestContext<TPushMultiTopicMetaReq, TPushTopicMetaResp> clientHandler =
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.TOPIC_PUSH_MULTI_META, request, dataNodeLocationMap);
-    CnToDnInternalServiceAsyncRequestManager.getInstance()
-        .sendAsyncRequestToNodeWithRetryAndTimeoutInMs(
-            clientHandler,
-            PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes() * 60 * 1000 * 2 / 3);
+    sendRequiredMetadataRequest(clientHandler);
+    fillMissingTopicPushMetaResponses(clientHandler, getRequiredMetadataRequestTimeoutInMs());
     return clientHandler.getResponseMap();
   }
 
@@ -843,10 +829,9 @@ public class ConfigNodeProcedureEnv {
         clientHandler =
             new DataNodeAsyncRequestContext<>(
                 CnToDnAsyncRequestType.CONSUMER_GROUP_PUSH_ALL_META, request, dataNodeLocationMap);
-    CnToDnInternalServiceAsyncRequestManager.getInstance()
-        .sendAsyncRequestToNodeWithRetryAndTimeoutInMs(
-            clientHandler,
-            PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes() * 60 * 1000 * 2 / 3);
+    sendRequiredMetadataRequest(clientHandler);
+    fillMissingConsumerGroupPushMetaResponses(
+        clientHandler, getRequiredMetadataRequestTimeoutInMs());
     return clientHandler.getResponseMap();
   }
 
@@ -877,7 +862,9 @@ public class ConfigNodeProcedureEnv {
                 CnToDnAsyncRequestType.CONSUMER_GROUP_PUSH_SINGLE_META,
                 request,
                 dataNodeLocationMap);
-    CnToDnInternalServiceAsyncRequestManager.getInstance().sendAsyncRequestWithRetry(clientHandler);
+    sendRequiredMetadataRequest(clientHandler);
+    fillMissingConsumerGroupPushMetaResponses(
+        clientHandler, getRequiredMetadataRequestTimeoutInMs());
     return clientHandler.getResponseList().stream()
         .map(TPushConsumerGroupMetaResp::getStatus)
         .collect(Collectors.toList());
@@ -895,7 +882,9 @@ public class ConfigNodeProcedureEnv {
                 CnToDnAsyncRequestType.CONSUMER_GROUP_PUSH_SINGLE_META,
                 request,
                 dataNodeLocationMap);
-    CnToDnInternalServiceAsyncRequestManager.getInstance().sendAsyncRequestWithRetry(clientHandler);
+    sendRequiredMetadataRequest(clientHandler);
+    fillMissingConsumerGroupPushMetaResponses(
+        clientHandler, getRequiredMetadataRequestTimeoutInMs());
     return clientHandler.getResponseList().stream()
         .map(TPushConsumerGroupMetaResp::getStatus)
         .collect(Collectors.toList());
@@ -910,10 +899,8 @@ public class ConfigNodeProcedureEnv {
         clientHandler =
             new DataNodeAsyncRequestContext<>(
                 CnToDnAsyncRequestType.PULL_COMMIT_PROGRESS, request, dataNodeLocationMap);
-    CnToDnInternalServiceAsyncRequestManager.getInstance()
-        .sendAsyncRequestToNodeWithRetryAndTimeoutInMs(
-            clientHandler,
-            PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes() * 60 * 1000 * 2 / 3);
+    sendRequiredMetadataRequest(clientHandler);
+    fillMissingPullCommitProgressResponses(clientHandler, getRequiredMetadataRequestTimeoutInMs());
     return clientHandler.getResponseMap();
   }
 
@@ -1013,19 +1000,122 @@ public class ConfigNodeProcedureEnv {
     sendRuntimeMetaRequest(clientHandler, false);
   }
 
+  private static void sendRequiredMetadataRequest(
+      final DataNodeAsyncRequestContext<?, ?> clientHandler) {
+    sendRuntimeMetaRequest(clientHandler, false, getRequiredMetadataRequestTimeoutInMs());
+  }
+
   private static void sendRuntimeMetaRequest(
       final DataNodeAsyncRequestContext<?, ?> clientHandler, final boolean keepSilent) {
+    sendRuntimeMetaRequest(clientHandler, keepSilent, getRuntimeMetaPushTimeoutInMs());
+  }
+
+  private static void sendRuntimeMetaRequest(
+      final DataNodeAsyncRequestContext<?, ?> clientHandler,
+      final boolean keepSilent,
+      final long timeoutInMs) {
     CnToDnInternalServiceAsyncRequestManager.getInstance()
-        .sendAsyncRequest(
-            clientHandler,
-            RUNTIME_META_PUSH_RETRY_NUM,
-            getRuntimeMetaPushTimeoutInMs(),
-            keepSilent);
+        .sendAsyncRequest(clientHandler, RUNTIME_META_PUSH_RETRY_NUM, timeoutInMs, keepSilent);
+  }
+
+  private static void fillMissingPipePushMetaResponses(
+      final DataNodeAsyncRequestContext<?, TPushPipeMetaResp> clientHandler,
+      final long timeoutInMs) {
+    clientHandler
+        .getRequestIndices()
+        .forEach(
+            dataNodeId ->
+                clientHandler
+                    .getResponseMap()
+                    .putIfAbsent(
+                        dataNodeId,
+                        new TPushPipeMetaResp(
+                            createRequiredMetadataTimeoutStatus(
+                                clientHandler.getRequestType(),
+                                dataNodeId,
+                                TSStatusCode.PIPE_PUSH_META_ERROR,
+                                timeoutInMs))));
+  }
+
+  private static void fillMissingTopicPushMetaResponses(
+      final DataNodeAsyncRequestContext<?, TPushTopicMetaResp> clientHandler,
+      final long timeoutInMs) {
+    clientHandler
+        .getRequestIndices()
+        .forEach(
+            dataNodeId ->
+                clientHandler
+                    .getResponseMap()
+                    .putIfAbsent(
+                        dataNodeId,
+                        new TPushTopicMetaResp(
+                            createRequiredMetadataTimeoutStatus(
+                                clientHandler.getRequestType(),
+                                dataNodeId,
+                                TSStatusCode.TOPIC_PUSH_META_ERROR,
+                                timeoutInMs))));
+  }
+
+  private static void fillMissingConsumerGroupPushMetaResponses(
+      final DataNodeAsyncRequestContext<?, TPushConsumerGroupMetaResp> clientHandler,
+      final long timeoutInMs) {
+    clientHandler
+        .getRequestIndices()
+        .forEach(
+            dataNodeId ->
+                clientHandler
+                    .getResponseMap()
+                    .putIfAbsent(
+                        dataNodeId,
+                        new TPushConsumerGroupMetaResp(
+                            createRequiredMetadataTimeoutStatus(
+                                clientHandler.getRequestType(),
+                                dataNodeId,
+                                TSStatusCode.CONSUMER_PUSH_META_ERROR,
+                                timeoutInMs))));
+  }
+
+  private static void fillMissingPullCommitProgressResponses(
+      final DataNodeAsyncRequestContext<?, TPullCommitProgressResp> clientHandler,
+      final long timeoutInMs) {
+    clientHandler
+        .getRequestIndices()
+        .forEach(
+            dataNodeId ->
+                clientHandler
+                    .getResponseMap()
+                    .putIfAbsent(
+                        dataNodeId,
+                        new TPullCommitProgressResp(
+                            createRequiredMetadataTimeoutStatus(
+                                clientHandler.getRequestType(),
+                                dataNodeId,
+                                TSStatusCode.EXECUTE_STATEMENT_ERROR,
+                                timeoutInMs))));
+  }
+
+  private static TSStatus createRequiredMetadataTimeoutStatus(
+      final CnToDnAsyncRequestType requestType,
+      final int dataNodeId,
+      final TSStatusCode statusCode,
+      final long timeoutInMs) {
+    return new TSStatus(statusCode.getStatusCode())
+        .setMessage(
+            String.format(
+                "Failed to %s on DataNode %s before required metadata request timeout %sms",
+                requestType, dataNodeId, timeoutInMs));
   }
 
   private static long getRuntimeMetaPushTimeoutInMs() {
     return TimeUnit.SECONDS.toMillis(
             PipeConfig.getInstance().getPipeHeartbeatIntervalSecondsForCollectingPipeMeta())
+        * 2
+        / 3;
+  }
+
+  private static long getRequiredMetadataRequestTimeoutInMs() {
+    return TimeUnit.MINUTES.toMillis(
+            PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes())
         * 2
         / 3;
   }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/AbstractOperatePipeProcedureV2.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/AbstractOperatePipeProcedureV2.java
@@ -487,10 +487,11 @@ public abstract class AbstractOperatePipeProcedureV2
 
       if (resp.getStatus().getCode() == TSStatusCode.PIPE_PUSH_META_ERROR.getStatusCode()) {
         if (!resp.isSetExceptionMessages()) {
+          final String statusMessage = resp.getStatus().getMessage();
           exceptionMessageBuilder.append(
               String.format(
-                  "DataNodeId: %s, Message: Internal error while processing pushPipeMeta on dataNodes.",
-                  dataNodeId));
+                  "DataNodeId: %s, Message: Internal error while processing pushPipeMeta on dataNodes.%s",
+                  dataNodeId, statusMessage == null ? "" : " " + statusMessage));
           continue;
         }
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/AbstractOperatePipeProcedureV2.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/AbstractOperatePipeProcedureV2.java
@@ -538,13 +538,18 @@ public abstract class AbstractOperatePipeProcedureV2
     }
   }
 
+  protected Map<Integer, TPushPipeMetaResp> pushPipeMetaToDataNodesBestEffortAndGetResponse(
+      ConfigNodeProcedureEnv env) throws IOException {
+    final List<ByteBuffer> pipeMetaBinaryList = new ArrayList<>();
+    for (final PipeMeta pipeMeta : pipeTaskInfo.get().getPipeMetaList()) {
+      pipeMetaBinaryList.add(copyAndFilterOutNonWorkingDataRegionPipeTasks(pipeMeta).serialize());
+    }
+    return env.pushAllPipeMetaToDataNodesBestEffort(pipeMetaBinaryList);
+  }
+
   protected void pushPipeMetaToDataNodesBestEffort(ConfigNodeProcedureEnv env) {
     try {
-      final List<ByteBuffer> pipeMetaBinaryList = new ArrayList<>();
-      for (final PipeMeta pipeMeta : pipeTaskInfo.get().getPipeMetaList()) {
-        pipeMetaBinaryList.add(copyAndFilterOutNonWorkingDataRegionPipeTasks(pipeMeta).serialize());
-      }
-      env.pushAllPipeMetaToDataNodesBestEffort(pipeMetaBinaryList);
+      pushPipeMetaToDataNodesBestEffortAndGetResponse(env);
     } catch (Exception e) {
       LOGGER.info(ProcedureMessages.FAILED_TO_PUSH_PIPE_META_LIST_TO_DATA_NODES_WILL, e);
     }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/AbstractOperatePipeProcedureV2.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/AbstractOperatePipeProcedureV2.java
@@ -538,6 +538,18 @@ public abstract class AbstractOperatePipeProcedureV2
     }
   }
 
+  protected void pushPipeMetaToDataNodesBestEffort(ConfigNodeProcedureEnv env) {
+    try {
+      final List<ByteBuffer> pipeMetaBinaryList = new ArrayList<>();
+      for (final PipeMeta pipeMeta : pipeTaskInfo.get().getPipeMetaList()) {
+        pipeMetaBinaryList.add(copyAndFilterOutNonWorkingDataRegionPipeTasks(pipeMeta).serialize());
+      }
+      env.pushAllPipeMetaToDataNodesBestEffort(pipeMetaBinaryList);
+    } catch (Exception e) {
+      LOGGER.info(ProcedureMessages.FAILED_TO_PUSH_PIPE_META_LIST_TO_DATA_NODES_WILL, e);
+    }
+  }
+
   /**
    * Pushing one pipeMeta to all the dataNodes, forcing an update to the pipe's runtime state.
    *

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/runtime/PipeHandleLeaderChangeProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/runtime/PipeHandleLeaderChangeProcedure.java
@@ -113,7 +113,7 @@ public class PipeHandleLeaderChangeProcedure extends AbstractOperatePipeProcedur
   public void executeFromOperateOnDataNodes(ConfigNodeProcedureEnv env) {
     LOGGER.info(ProcedureMessages.PIPEHANDLELEADERCHANGEPROCEDURE_EXECUTEFROMHANDLEONDATANODES);
 
-    pushPipeMetaToDataNodesIgnoreException(env);
+    pushPipeMetaToDataNodesBestEffort(env);
   }
 
   @Override

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/runtime/PipeHandleMetaChangeProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/runtime/PipeHandleMetaChangeProcedure.java
@@ -131,7 +131,7 @@ public class PipeHandleMetaChangeProcedure extends AbstractOperatePipeProcedureV
       return;
     }
 
-    pushPipeMetaToDataNodesIgnoreException(env);
+    pushPipeMetaToDataNodesBestEffort(env);
   }
 
   @Override

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/runtime/PipeMetaSyncProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/runtime/PipeMetaSyncProcedure.java
@@ -51,6 +51,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -64,7 +65,8 @@ public class PipeMetaSyncProcedure extends AbstractOperatePipeProcedureV2 {
   private static final Logger LOGGER = LoggerFactory.getLogger(PipeMetaSyncProcedure.class);
 
   private static final long MIN_EXECUTION_INTERVAL_MS =
-      PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes() * 60 * 1000 / 2;
+      TimeUnit.MINUTES.toMillis(PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes())
+          / 2;
   // No need to serialize this field
   private static final AtomicLong LAST_EXECUTION_TIME = new AtomicLong(0);
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/runtime/PipeMetaSyncProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/runtime/PipeMetaSyncProcedure.java
@@ -201,7 +201,7 @@ public class PipeMetaSyncProcedure extends AbstractOperatePipeProcedureV2 {
       throws PipeException, IOException {
     LOGGER.debug(ProcedureMessages.PIPEMETASYNCPROCEDURE_EXECUTEFROMOPERATEONDATANODES);
 
-    Map<Integer, TPushPipeMetaResp> respMap = pushPipeMetaToDataNodes(env);
+    Map<Integer, TPushPipeMetaResp> respMap = pushPipeMetaToDataNodesBestEffortAndGetResponse(env);
     if (pipeTaskInfo.get().recordDataNodePushPipeMetaExceptions(respMap)) {
       throw new PipeException(
           String.format(

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/subscription/AbstractOperateSubscriptionProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/subscription/AbstractOperateSubscriptionProcedure.java
@@ -350,6 +350,16 @@ public abstract class AbstractOperateSubscriptionProcedure
     return env.pushAllTopicMetaToDataNodes(topicMetaBinaryList);
   }
 
+  protected Map<Integer, TPushTopicMetaResp> pushTopicMetaToDataNodesBestEffort(
+      ConfigNodeProcedureEnv env) throws IOException {
+    final List<ByteBuffer> topicMetaBinaryList = new ArrayList<>();
+    for (TopicMeta topicMeta : subscriptionInfo.get().getAllTopicMeta()) {
+      topicMetaBinaryList.add(topicMeta.serialize());
+    }
+
+    return env.pushAllTopicMetaToDataNodesBestEffort(topicMetaBinaryList);
+  }
+
   public static boolean pushTopicMetaHasException(Map<Integer, TPushTopicMetaResp> respMap) {
     for (TPushTopicMetaResp resp : respMap.values()) {
       if (resp.getStatus().getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
@@ -374,6 +384,16 @@ public abstract class AbstractOperateSubscriptionProcedure
     }
 
     return env.pushAllConsumerGroupMetaToDataNodes(consumerGroupMetaBinaryList);
+  }
+
+  protected Map<Integer, TPushConsumerGroupMetaResp> pushConsumerGroupMetaToDataNodesBestEffort(
+      ConfigNodeProcedureEnv env) throws IOException {
+    final List<ByteBuffer> consumerGroupMetaBinaryList = new ArrayList<>();
+    for (ConsumerGroupMeta consumerGroupMeta : subscriptionInfo.get().getAllConsumerGroupMeta()) {
+      consumerGroupMetaBinaryList.add(consumerGroupMeta.serialize());
+    }
+
+    return env.pushAllConsumerGroupMetaToDataNodesBestEffort(consumerGroupMetaBinaryList);
   }
 
   public static boolean pushConsumerGroupMetaHasException(

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/subscription/consumer/runtime/CommitProgressSyncProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/subscription/consumer/runtime/CommitProgressSyncProcedure.java
@@ -47,6 +47,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -59,7 +60,8 @@ public class CommitProgressSyncProcedure extends AbstractOperateSubscriptionProc
   private static final Logger LOGGER = LoggerFactory.getLogger(CommitProgressSyncProcedure.class);
 
   private static final long MIN_EXECUTION_INTERVAL_MS =
-      PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes() * 60 * 1000 / 2;
+      TimeUnit.MINUTES.toMillis(PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes())
+          / 2;
   private static final AtomicLong LAST_EXECUTION_TIME = new AtomicLong(0);
 
   public CommitProgressSyncProcedure() {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/subscription/consumer/runtime/CommitProgressSyncProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/subscription/consumer/runtime/CommitProgressSyncProcedure.java
@@ -106,7 +106,8 @@ public class CommitProgressSyncProcedure extends AbstractOperateSubscriptionProc
     LOGGER.info("CommitProgressSyncProcedure: executeFromOperateOnConfigNodes");
 
     // 1. Pull commit progress from all DataNodes
-    final Map<Integer, TPullCommitProgressResp> respMap = env.pullCommitProgressFromDataNodes();
+    final Map<Integer, TPullCommitProgressResp> respMap =
+        env.pullCommitProgressFromDataNodesBestEffort();
 
     // 2. Merge all DataNode responses with existing progress using Math::max
     final Map<String, RegionProgress> mergedRegionProgress =

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/subscription/consumer/runtime/CommitProgressSyncProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/subscription/consumer/runtime/CommitProgressSyncProcedure.java
@@ -20,7 +20,7 @@
 package org.apache.iotdb.confignode.procedure.impl.subscription.consumer.runtime;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
-import org.apache.iotdb.commons.pipe.config.PipeConfig;
+import org.apache.iotdb.commons.subscription.config.SubscriptionConfig;
 import org.apache.iotdb.confignode.consensus.request.write.subscription.consumer.runtime.CommitProgressHandleMetaChangePlan;
 import org.apache.iotdb.confignode.persistence.subscription.SubscriptionInfo;
 import org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv;
@@ -60,7 +60,8 @@ public class CommitProgressSyncProcedure extends AbstractOperateSubscriptionProc
   private static final Logger LOGGER = LoggerFactory.getLogger(CommitProgressSyncProcedure.class);
 
   private static final long MIN_EXECUTION_INTERVAL_MS =
-      TimeUnit.MINUTES.toMillis(PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes())
+      TimeUnit.MINUTES.toMillis(
+              SubscriptionConfig.getInstance().getSubscriptionMetaSyncerSyncIntervalMinutes())
           / 2;
   private static final AtomicLong LAST_EXECUTION_TIME = new AtomicLong(0);
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/subscription/consumer/runtime/ConsumerGroupMetaSyncProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/subscription/consumer/runtime/ConsumerGroupMetaSyncProcedure.java
@@ -44,6 +44,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -53,7 +54,8 @@ public class ConsumerGroupMetaSyncProcedure extends AbstractOperateSubscriptionP
       LoggerFactory.getLogger(ConsumerGroupMetaSyncProcedure.class);
 
   private static final long MIN_EXECUTION_INTERVAL_MS =
-      PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes() * 60 * 1000 / 2;
+      TimeUnit.MINUTES.toMillis(PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes())
+          / 2;
   // No need to serialize this field
   private static final AtomicLong LAST_EXECUTION_TIME = new AtomicLong(0);
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/subscription/consumer/runtime/ConsumerGroupMetaSyncProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/subscription/consumer/runtime/ConsumerGroupMetaSyncProcedure.java
@@ -20,7 +20,7 @@
 package org.apache.iotdb.confignode.procedure.impl.subscription.consumer.runtime;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
-import org.apache.iotdb.commons.pipe.config.PipeConfig;
+import org.apache.iotdb.commons.subscription.config.SubscriptionConfig;
 import org.apache.iotdb.commons.subscription.meta.consumer.ConsumerGroupMeta;
 import org.apache.iotdb.confignode.consensus.request.write.subscription.consumer.runtime.ConsumerGroupHandleMetaChangePlan;
 import org.apache.iotdb.confignode.i18n.ConfigNodeMessages;
@@ -54,7 +54,8 @@ public class ConsumerGroupMetaSyncProcedure extends AbstractOperateSubscriptionP
       LoggerFactory.getLogger(ConsumerGroupMetaSyncProcedure.class);
 
   private static final long MIN_EXECUTION_INTERVAL_MS =
-      TimeUnit.MINUTES.toMillis(PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes())
+      TimeUnit.MINUTES.toMillis(
+              SubscriptionConfig.getInstance().getSubscriptionMetaSyncerSyncIntervalMinutes())
           / 2;
   // No need to serialize this field
   private static final AtomicLong LAST_EXECUTION_TIME = new AtomicLong(0);

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/subscription/consumer/runtime/ConsumerGroupMetaSyncProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/subscription/consumer/runtime/ConsumerGroupMetaSyncProcedure.java
@@ -129,7 +129,8 @@ public class ConsumerGroupMetaSyncProcedure extends AbstractOperateSubscriptionP
       throws SubscriptionException, IOException {
     LOGGER.info(ProcedureMessages.CONSUMERGROUPMETASYNCPROCEDURE_EXECUTEFROMOPERATEONDATANODES);
 
-    Map<Integer, TPushConsumerGroupMetaResp> respMap = pushConsumerGroupMetaToDataNodes(env);
+    Map<Integer, TPushConsumerGroupMetaResp> respMap =
+        pushConsumerGroupMetaToDataNodesBestEffort(env);
     if (pushConsumerGroupMetaHasException(respMap)) {
       throw new SubscriptionException(
           String.format(

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/subscription/runtime/SubscriptionHandleLeaderChangeProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/subscription/runtime/SubscriptionHandleLeaderChangeProcedure.java
@@ -104,7 +104,8 @@ public class SubscriptionHandleLeaderChangeProcedure extends AbstractOperateSubs
       throws SubscriptionException {
     LOGGER.info("SubscriptionHandleLeaderChangeProcedure: executeFromOperateOnConfigNodes");
 
-    final Map<Integer, TPullCommitProgressResp> respMap = env.pullCommitProgressFromDataNodes();
+    final Map<Integer, TPullCommitProgressResp> respMap =
+        env.pullCommitProgressFromDataNodesBestEffort();
     final Map<String, RegionProgress> mergedRegionProgress =
         deserializeRegionProgressMap(
             subscriptionInfo.get().getCommitProgressKeeper().getAllRegionProgress());
@@ -158,7 +159,7 @@ public class SubscriptionHandleLeaderChangeProcedure extends AbstractOperateSubs
       throws SubscriptionException, IOException {
     LOGGER.info("SubscriptionHandleLeaderChangeProcedure: executeFromOperateOnDataNodes");
 
-    final Map<Integer, TPushTopicMetaResp> topicRespMap = pushTopicMetaToDataNodes(env);
+    final Map<Integer, TPushTopicMetaResp> topicRespMap = pushTopicMetaToDataNodesBestEffort(env);
     topicRespMap.forEach(
         (dataNodeId, resp) -> {
           if (resp.getStatus().getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
@@ -170,7 +171,7 @@ public class SubscriptionHandleLeaderChangeProcedure extends AbstractOperateSubs
         });
 
     final Map<Integer, TPushConsumerGroupMetaResp> consumerGroupRespMap =
-        pushConsumerGroupMetaToDataNodes(env);
+        pushConsumerGroupMetaToDataNodesBestEffort(env);
     consumerGroupRespMap.forEach(
         (dataNodeId, resp) -> {
           if (resp.getStatus().getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/subscription/topic/runtime/TopicMetaSyncProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/subscription/topic/runtime/TopicMetaSyncProcedure.java
@@ -44,6 +44,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -52,7 +53,8 @@ public class TopicMetaSyncProcedure extends AbstractOperateSubscriptionProcedure
   private static final Logger LOGGER = LoggerFactory.getLogger(TopicMetaSyncProcedure.class);
 
   private static final long MIN_EXECUTION_INTERVAL_MS =
-      PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes() * 60 * 1000 / 2;
+      TimeUnit.MINUTES.toMillis(PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes())
+          / 2;
   // No need to serialize this field
   private static final AtomicLong LAST_EXECUTION_TIME = new AtomicLong(0);
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/subscription/topic/runtime/TopicMetaSyncProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/subscription/topic/runtime/TopicMetaSyncProcedure.java
@@ -20,7 +20,7 @@
 package org.apache.iotdb.confignode.procedure.impl.subscription.topic.runtime;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
-import org.apache.iotdb.commons.pipe.config.PipeConfig;
+import org.apache.iotdb.commons.subscription.config.SubscriptionConfig;
 import org.apache.iotdb.commons.subscription.meta.topic.TopicMeta;
 import org.apache.iotdb.confignode.consensus.request.write.subscription.topic.runtime.TopicHandleMetaChangePlan;
 import org.apache.iotdb.confignode.i18n.ConfigNodeMessages;
@@ -53,7 +53,8 @@ public class TopicMetaSyncProcedure extends AbstractOperateSubscriptionProcedure
   private static final Logger LOGGER = LoggerFactory.getLogger(TopicMetaSyncProcedure.class);
 
   private static final long MIN_EXECUTION_INTERVAL_MS =
-      TimeUnit.MINUTES.toMillis(PipeConfig.getInstance().getPipeMetaSyncerSyncIntervalMinutes())
+      TimeUnit.MINUTES.toMillis(
+              SubscriptionConfig.getInstance().getSubscriptionMetaSyncerSyncIntervalMinutes())
           / 2;
   // No need to serialize this field
   private static final AtomicLong LAST_EXECUTION_TIME = new AtomicLong(0);

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/subscription/topic/runtime/TopicMetaSyncProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/subscription/topic/runtime/TopicMetaSyncProcedure.java
@@ -129,7 +129,7 @@ public class TopicMetaSyncProcedure extends AbstractOperateSubscriptionProcedure
       throws SubscriptionException, IOException {
     LOGGER.info(ProcedureMessages.TOPICMETASYNCPROCEDURE_EXECUTEFROMOPERATEONDATANODES);
 
-    Map<Integer, TPushTopicMetaResp> respMap = pushTopicMetaToDataNodes(env);
+    Map<Integer, TPushTopicMetaResp> respMap = pushTopicMetaToDataNodesBestEffort(env);
     if (pushTopicMetaHasException(respMap)) {
       throw new SubscriptionException(
           String.format(ProcedureMessages.FAILED_TO_PUSH_TOPIC_META_TO_DATANODES_DETAILS, respMap));

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/DataNodeInternalRPCServiceImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/DataNodeInternalRPCServiceImpl.java
@@ -434,6 +434,7 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
 
   private static final long TEST_CONNECTION_TIMEOUT_MS =
       CommonDescriptor.getInstance().getConfig().getDnConnectionTimeoutInMS();
+  private static final int TEST_CONNECTION_RETRY_NUM = 1;
 
   private static final ExecutorService TOPOLOGY_PROBING_EXECUTOR =
       IoTDBThreadPoolFactory.newFixedThreadPool(
@@ -2207,7 +2208,8 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
         DnToCnRequestType.TEST_CONNECTION,
         (AsyncRequestContext<Object, TSStatus, DnToCnRequestType, TConfigNodeLocation> handler) ->
             DnToCnInternalServiceAsyncRequestManager.getInstance()
-                .sendAsyncRequestWithTimeoutInMs(handler, TEST_CONNECTION_TIMEOUT_MS));
+                .sendAsyncRequest(
+                    handler, TEST_CONNECTION_RETRY_NUM, TEST_CONNECTION_TIMEOUT_MS, true));
   }
 
   private List<TTestConnectionResult> testAllDataNodeConnectionInHeartbeatChannel(
@@ -2233,7 +2235,8 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
         DnToDnRequestType.TEST_CONNECTION,
         (AsyncRequestContext<Object, TSStatus, DnToDnRequestType, TDataNodeLocation> handler) ->
             DnToDnInternalServiceAsyncRequestManager.getInstance()
-                .sendAsyncRequestWithTimeoutInMs(handler, TEST_CONNECTION_TIMEOUT_MS));
+                .sendAsyncRequest(
+                    handler, TEST_CONNECTION_RETRY_NUM, TEST_CONNECTION_TIMEOUT_MS, true));
   }
 
   private List<TTestConnectionResult> testAllDataNodeMPPServiceConnection(
@@ -2246,7 +2249,8 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
         DnToDnRequestType.TEST_CONNECTION,
         (AsyncRequestContext<Object, TSStatus, DnToDnRequestType, TDataNodeLocation> handler) ->
             DataNodeMPPServiceAsyncRequestManager.getInstance()
-                .sendAsyncRequestWithTimeoutInMs(handler, TEST_CONNECTION_TIMEOUT_MS));
+                .sendAsyncRequest(
+                    handler, TEST_CONNECTION_RETRY_NUM, TEST_CONNECTION_TIMEOUT_MS, true));
   }
 
   private List<TTestConnectionResult> testAllDataNodeExternalServiceConnection(
@@ -2259,7 +2263,8 @@ public class DataNodeInternalRPCServiceImpl implements IDataNodeRPCService.Iface
         DnToDnRequestType.TEST_CONNECTION,
         (AsyncRequestContext<Object, TSStatus, DnToDnRequestType, TDataNodeLocation> handler) ->
             DataNodeExternalServiceAsyncRequestManager.getInstance()
-                .sendAsyncRequestWithTimeoutInMs(handler, TEST_CONNECTION_TIMEOUT_MS));
+                .sendAsyncRequest(
+                    handler, TEST_CONNECTION_RETRY_NUM, TEST_CONNECTION_TIMEOUT_MS, true));
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/attribute/update/GeneralRegionAttributeSecurityService.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/attribute/update/GeneralRegionAttributeSecurityService.java
@@ -67,6 +67,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -77,6 +78,7 @@ public class GeneralRegionAttributeSecurityService extends AbstractPeriodicalSer
       LoggerFactory.getLogger(GeneralRegionAttributeSecurityService.class);
 
   private static final IoTDBConfig iotdbConfig = IoTDBDescriptor.getInstance().getConfig();
+  private static final int ATTRIBUTE_UPDATE_RETRY_NUM = 1;
   private final Map<Integer, Pair<Long, Integer>> dataNodeId2FailureDurationAndTimesMap =
       new HashMap<>();
   private final Set<ISchemaRegion> regionLeaders =
@@ -214,46 +216,42 @@ public class GeneralRegionAttributeSecurityService extends AbstractPeriodicalSer
                                   ByteBuffer.wrap(bytes)));
                     }));
 
-    DnToDnInternalServiceAsyncRequestManager.getInstance()
-        .sendAsyncRequestWithTimeoutInMs(
-            clientHandler,
+    final long timeoutInMs =
+        TimeUnit.SECONDS.toMillis(
             IoTDBDescriptor.getInstance()
                 .getConfig()
                 .getGeneralRegionAttributeSecurityServiceTimeoutSeconds());
+    DnToDnInternalServiceAsyncRequestManager.getInstance()
+        .sendAsyncRequest(clientHandler, ATTRIBUTE_UPDATE_RETRY_NUM, timeoutInMs);
 
     final AtomicBoolean needFetch = new AtomicBoolean(false);
+    final Set<Integer> failedDataNodes = new HashSet<>(clientHandler.getRequestIndices());
+    final long failureDurationToFetchInMs =
+        TimeUnit.SECONDS.toMillis(
+            iotdbConfig.getGeneralRegionAttributeSecurityServiceFailureDurationSecondsToFetch());
 
-    final Set<Integer> failedDataNodes =
-        clientHandler.getResponseMap().entrySet().stream()
-            .filter(
-                entry -> {
-                  final boolean failed =
-                      entry.getValue().getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode();
-                  if (failed) {
-                    dataNodeId2FailureDurationAndTimesMap.compute(
-                        entry.getKey(),
-                        (k, v) -> {
-                          if (Objects.isNull(v)) {
-                            return new Pair<>(System.currentTimeMillis(), 1);
-                          }
-                          v.setRight(v.getRight() + 1);
-                          if (System.currentTimeMillis() - v.getLeft()
-                                  >= iotdbConfig
-                                      .getGeneralRegionAttributeSecurityServiceFailureDurationSecondsToFetch()
-                              || v.getRight()
-                                  >= iotdbConfig
-                                      .getGeneralRegionAttributeSecurityServiceFailureTimesToFetch()) {
-                            needFetch.set(true);
-                          }
-                          return v;
-                        });
-                  } else {
-                    dataNodeId2FailureDurationAndTimesMap.remove(entry.getKey());
+    clientHandler.getResponseMap().entrySet().stream()
+        .filter(entry -> entry.getValue().getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode())
+        .map(Map.Entry::getKey)
+        .forEach(dataNodeId2FailureDurationAndTimesMap::remove);
+
+    failedDataNodes.forEach(
+        dataNodeId ->
+            dataNodeId2FailureDurationAndTimesMap.compute(
+                dataNodeId,
+                (k, v) -> {
+                  if (Objects.isNull(v)) {
+                    return new Pair<>(System.currentTimeMillis(), 1);
                   }
-                  return failed;
-                })
-            .map(Map.Entry::getKey)
-            .collect(Collectors.toSet());
+                  v.setRight(v.getRight() + 1);
+                  if (System.currentTimeMillis() - v.getLeft() >= failureDurationToFetchInMs
+                      || v.getRight()
+                          >= iotdbConfig
+                              .getGeneralRegionAttributeSecurityServiceFailureTimesToFetch()) {
+                    needFetch.set(true);
+                  }
+                  return v;
+                }));
 
     // Compute node shrinkage before failure removal in commit
     final Map<SchemaRegionId, Set<TDataNodeLocation>> result =
@@ -301,7 +299,8 @@ public class GeneralRegionAttributeSecurityService extends AbstractPeriodicalSer
     super(
         IoTDBThreadPoolFactory.newSingleThreadExecutor(
             ThreadName.GENERAL_REGION_ATTRIBUTE_SECURITY_SERVICE.getName()),
-        iotdbConfig.getGeneralRegionAttributeSecurityServiceIntervalSeconds() * 1000L);
+        TimeUnit.SECONDS.toMillis(
+            iotdbConfig.getGeneralRegionAttributeSecurityServiceIntervalSeconds()));
   }
 
   private static final class GeneralRegionAttributeSecurityServiceHolder {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/request/AsyncRequestManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/request/AsyncRequestManager.java
@@ -208,7 +208,17 @@ public abstract class AsyncRequestManager<RequestType, NodeLocation, Client> {
           e.getMessage(),
           retryCount);
       if (handler != null) {
-        handler.onError(e);
+        try {
+          handler.onError(e);
+        } catch (final Exception handlerException) {
+          LOGGER.warn(
+              "Failed to handle async request error for request type {} on node {}: {}",
+              requestContext.getRequestType(),
+              endPoint,
+              handlerException.getMessage(),
+              handlerException);
+          requestContext.getCountDownLatch().countDown();
+        }
       } else {
         requestContext.getCountDownLatch().countDown();
       }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/request/AsyncRequestManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/client/request/AsyncRequestManager.java
@@ -182,6 +182,7 @@ public abstract class AsyncRequestManager<RequestType, NodeLocation, Client> {
     final TEndPoint endPoint = nodeLocationToEndPoint(targetNode);
     Client client = null;
     boolean dispatched = false;
+    AsyncRequestRPCHandler<?, RequestType, NodeLocation> handler = null;
     try {
       if (!actionMap.containsKey(requestContext.getRequestType())) {
         throw new UnsupportedOperationException(
@@ -189,11 +190,10 @@ public abstract class AsyncRequestManager<RequestType, NodeLocation, Client> {
                 + requestContext.getRequestType()
                 + ", please set it in AsyncRequestManager::initActionMapBuilder()");
       }
+      handler = buildHandler(requestContext, requestId, targetNode);
       client = clientManager.borrowClient(endPoint);
       adjustClientTimeoutIfNecessary(requestContext.getRequestType(), client);
       Object req = requestContext.getRequest(requestId);
-      AsyncRequestRPCHandler<?, RequestType, NodeLocation> handler =
-          buildHandler(requestContext, requestId, targetNode);
       Objects.requireNonNull(actionMap.get(requestContext.getRequestType()))
           .accept(req, client, handler);
       // After accept() returns, the async callback (onComplete/onError) takes over the
@@ -207,6 +207,11 @@ public abstract class AsyncRequestManager<RequestType, NodeLocation, Client> {
           endPoint,
           e.getMessage(),
           retryCount);
+      if (handler != null) {
+        handler.onError(e);
+      } else {
+        requestContext.getCountDownLatch().countDown();
+      }
     } finally {
       if (!dispatched && client != null && clientManager instanceof ClientManager) {
         ((ClientManager<TEndPoint, Client>) clientManager).returnClient(endPoint, client);

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/client/request/AsyncRequestManagerTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/client/request/AsyncRequestManagerTest.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.commons.client.request;
+
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
+import org.apache.iotdb.commons.client.IClientManager;
+import org.apache.iotdb.commons.client.exception.ClientManagerException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class AsyncRequestManagerTest {
+
+  @Test
+  public void dispatchFailureShouldNotBlockRetryWithoutTimeout() throws Exception {
+    final TestAsyncRequestManager manager = new TestAsyncRequestManager();
+    final AsyncRequestContext<String, String, TestRequestType, TestNodeLocation> context =
+        new AsyncRequestContext<>(
+            TestRequestType.TEST,
+            "request",
+            Collections.singletonMap(1, new TestNodeLocation(new TEndPoint("localhost", 6667))));
+
+    final ExecutorService executorService = Executors.newSingleThreadExecutor();
+    try {
+      final Future<?> future =
+          executorService.submit(() -> manager.sendAsyncRequest(context, 2, null, true));
+      future.get(3, TimeUnit.SECONDS);
+    } finally {
+      executorService.shutdownNow();
+    }
+
+    Assert.assertEquals(2, manager.getBorrowAttempts());
+    Assert.assertEquals("borrow failed", context.getResponseMap().get(1));
+    Assert.assertEquals(Collections.singletonList(1), context.getRequestIndices());
+  }
+
+  private enum TestRequestType {
+    TEST
+  }
+
+  private static class TestNodeLocation {
+
+    private final TEndPoint endPoint;
+
+    private TestNodeLocation(final TEndPoint endPoint) {
+      this.endPoint = endPoint;
+    }
+  }
+
+  private static class TestAsyncRequestManager
+      extends AsyncRequestManager<TestRequestType, TestNodeLocation, Object> {
+
+    private final AtomicInteger borrowAttempts = new AtomicInteger();
+
+    private TestAsyncRequestManager() {
+      super(1);
+    }
+
+    private int getBorrowAttempts() {
+      return borrowAttempts.get();
+    }
+
+    @Override
+    protected void initClientManager(final int selectorNumOfAsyncClientManager) {
+      clientManager =
+          new IClientManager<TEndPoint, Object>() {
+
+            @Override
+            public Object borrowClient(final TEndPoint node) throws ClientManagerException {
+              borrowAttempts.incrementAndGet();
+              throw new ClientManagerException("borrow failed");
+            }
+
+            @Override
+            public void clear(final TEndPoint node) {
+              // Do nothing
+            }
+
+            @Override
+            public void clearAll() {
+              // Do nothing
+            }
+
+            @Override
+            public void close() {
+              // Do nothing
+            }
+          };
+    }
+
+    @Override
+    protected void initActionMapBuilder() {
+      actionMapBuilder.put(
+          TestRequestType.TEST,
+          (request, client, handler) ->
+              Assert.fail("The test client manager should fail before dispatch."));
+    }
+
+    @Override
+    protected TEndPoint nodeLocationToEndPoint(final TestNodeLocation location) {
+      return location.endPoint;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected AsyncRequestRPCHandler<?, TestRequestType, TestNodeLocation> buildHandler(
+        final AsyncRequestContext<?, ?, TestRequestType, TestNodeLocation> requestContext,
+        final int requestId,
+        final TestNodeLocation targetNode) {
+      return new TestAsyncRequestRPCHandler(
+          requestContext.getRequestType(),
+          requestId,
+          targetNode,
+          requestContext.getNodeLocationMap(),
+          (Map<Integer, String>) requestContext.getResponseMap(),
+          requestContext.getCountDownLatch());
+    }
+  }
+
+  private static class TestAsyncRequestRPCHandler
+      extends AsyncRequestRPCHandler<String, TestRequestType, TestNodeLocation> {
+
+    private TestAsyncRequestRPCHandler(
+        final TestRequestType requestType,
+        final int requestId,
+        final TestNodeLocation targetNode,
+        final Map<Integer, TestNodeLocation> nodeLocationMap,
+        final Map<Integer, String> responseMap,
+        final CountDownLatch countDownLatch) {
+      super(requestType, requestId, targetNode, nodeLocationMap, responseMap, countDownLatch);
+    }
+
+    @Override
+    protected String generateFormattedTargetLocation(final TestNodeLocation location) {
+      return location.endPoint.toString();
+    }
+
+    @Override
+    public void onComplete(final String response) {
+      responseMap.put(requestId, response);
+      nodeLocationMap.remove(requestId);
+      countDownLatch.countDown();
+    }
+
+    @Override
+    public void onError(final Exception exception) {
+      responseMap.put(requestId, exception.getMessage());
+      countDownLatch.countDown();
+    }
+  }
+}

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/client/request/AsyncRequestManagerTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/client/request/AsyncRequestManagerTest.java
@@ -60,6 +60,29 @@ public class AsyncRequestManagerTest {
     Assert.assertEquals(Collections.singletonList(1), context.getRequestIndices());
   }
 
+  @Test
+  public void handlerErrorFailureShouldNotEscapeDispatchFailure() throws Exception {
+    final TestAsyncRequestManager manager = new TestAsyncRequestManager(false, true, true);
+    final AsyncRequestContext<String, String, TestRequestType, TestNodeLocation> context =
+        new AsyncRequestContext<>(
+            TestRequestType.TEST,
+            "request",
+            Collections.singletonMap(1, new TestNodeLocation(new TEndPoint("localhost", 6667))));
+
+    final ExecutorService executorService = Executors.newSingleThreadExecutor();
+    try {
+      final Future<?> future =
+          executorService.submit(() -> manager.sendAsyncRequest(context, 1, null, true));
+      future.get(3, TimeUnit.SECONDS);
+    } finally {
+      executorService.shutdownNow();
+    }
+
+    Assert.assertEquals(1, manager.getBorrowAttempts());
+    Assert.assertTrue(context.getResponseMap().isEmpty());
+    Assert.assertEquals(Collections.singletonList(1), context.getRequestIndices());
+  }
+
   private enum TestRequestType {
     TEST
   }
@@ -77,9 +100,20 @@ public class AsyncRequestManagerTest {
       extends AsyncRequestManager<TestRequestType, TestNodeLocation, Object> {
 
     private final AtomicInteger borrowAttempts = new AtomicInteger();
+    private boolean failOnBorrow;
+    private boolean failOnDispatch;
+    private boolean failOnError;
 
     private TestAsyncRequestManager() {
+      this(true, false, false);
+    }
+
+    private TestAsyncRequestManager(
+        final boolean failOnBorrow, final boolean failOnDispatch, final boolean failOnError) {
       super(1);
+      this.failOnBorrow = failOnBorrow;
+      this.failOnDispatch = failOnDispatch;
+      this.failOnError = failOnError;
     }
 
     private int getBorrowAttempts() {
@@ -94,7 +128,10 @@ public class AsyncRequestManagerTest {
             @Override
             public Object borrowClient(final TEndPoint node) throws ClientManagerException {
               borrowAttempts.incrementAndGet();
-              throw new ClientManagerException("borrow failed");
+              if (failOnBorrow) {
+                throw new ClientManagerException("borrow failed");
+              }
+              return new Object();
             }
 
             @Override
@@ -118,8 +155,12 @@ public class AsyncRequestManagerTest {
     protected void initActionMapBuilder() {
       actionMapBuilder.put(
           TestRequestType.TEST,
-          (request, client, handler) ->
-              Assert.fail("The test client manager should fail before dispatch."));
+          (request, client, handler) -> {
+            if (failOnDispatch) {
+              throw new RuntimeException("dispatch failed");
+            }
+            Assert.fail("The test client manager should fail before dispatch.");
+          });
     }
 
     @Override
@@ -139,7 +180,8 @@ public class AsyncRequestManagerTest {
           targetNode,
           requestContext.getNodeLocationMap(),
           (Map<Integer, String>) requestContext.getResponseMap(),
-          requestContext.getCountDownLatch());
+          requestContext.getCountDownLatch(),
+          failOnError);
     }
   }
 
@@ -152,9 +194,13 @@ public class AsyncRequestManagerTest {
         final TestNodeLocation targetNode,
         final Map<Integer, TestNodeLocation> nodeLocationMap,
         final Map<Integer, String> responseMap,
-        final CountDownLatch countDownLatch) {
+        final CountDownLatch countDownLatch,
+        final boolean failOnError) {
       super(requestType, requestId, targetNode, nodeLocationMap, responseMap, countDownLatch);
+      this.failOnError = failOnError;
     }
+
+    private final boolean failOnError;
 
     @Override
     protected String generateFormattedTargetLocation(final TestNodeLocation location) {
@@ -170,6 +216,9 @@ public class AsyncRequestManagerTest {
 
     @Override
     public void onError(final Exception exception) {
+      if (failOnError) {
+        throw new RuntimeException("handler failed");
+      }
       responseMap.put(requestId, exception.getMessage());
       countDownLatch.countDown();
     }


### PR DESCRIPTION
Summary:
- Add a shared best-effort short-timeout runtime metadata request path for background procedures.
- Use it for pipe leader/meta change pushes and subscription leader-change commit progress/topic/consumer meta pushes so optional DataNode RPCs do not hold coordinator locks for the full sync interval.
- Split subscription runtime state push during leader change: readable DataNodes remain strict, while unreadable DataNodes are updated best-effort with a short timeout.
- Keep user-facing operations and periodic sync procedures on existing strict paths.

Fixes/targets:
- IoTDBPipeClusterIT.testPipeAfterDataRegionLeaderStop flaky timeout on the second createPipe after full cluster restart: the client saw SocketTimeoutException: Read timed out while createPipe(p2) was waiting behind background pipe runtime metadata work.
- In the 2026-06-11 failure logs, PipeHandleLeaderChangeProcedure was pushing PIPE_PUSH_ALL_META to restarting DataNodes, repeatedly hit Connection refused, held PipeTaskCoordinatorLock, and caused Pipe-Runtime-Heartbeat to skip rounds. This PR bounds those background runtime metadata pushes so they do not block user-facing pipe operations for the full sync interval.

Tests:
- git diff --check
- mvn -DskipTests spotless:apply -pl iotdb-core/confignode
- mvn '-Ddevelocity.off=true' -DskipTests compile -pl iotdb-core/confignode -am
- Attempted targeted IoTDBPipeClusterIT#testPipeAfterRegisterNewDataNode; local JVM native OOM during ConfigNode startup before pipe stage