### PR TITLE
Pipe: stop historical supply promptly on DROP PIPE

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTask.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.pipe.agent.task;
 import org.apache.iotdb.commons.pipe.agent.task.PipeTask;
 import org.apache.iotdb.commons.pipe.agent.task.stage.PipeTaskStage;
 import org.apache.iotdb.db.i18n.DataNodePipeMessages;
+import org.apache.iotdb.db.pipe.agent.task.stage.PipeTaskSourceStage;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,8 +69,12 @@ public class PipeDataNodeTask implements PipeTask {
   @Override
   public void drop() {
     final long startTime = System.currentTimeMillis();
-    // Drop downstream stages first so outbound transfer stops before source cleanup.
     sinkStage.drop();
+    // Interrupt the in-flight supply before dropping processor, so a long historical extraction
+    // does not keep processor stuck in supply().
+    if (sourceStage instanceof PipeTaskSourceStage) {
+      ((PipeTaskSourceStage) sourceStage).interruptActiveSupply();
+    }
     processorStage.drop();
     sourceStage.drop();
     LOGGER.info(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTask.java
@@ -68,9 +68,10 @@ public class PipeDataNodeTask implements PipeTask {
   @Override
   public void drop() {
     final long startTime = System.currentTimeMillis();
-    sourceStage.drop();
-    processorStage.drop();
+    // Drop downstream stages first so outbound transfer stops before source cleanup.
     sinkStage.drop();
+    processorStage.drop();
+    sourceStage.drop();
     LOGGER.info(
         DataNodePipeMessages.DROP_PIPE_DN_TASK_SUCCESSFULLY_WITHIN_MS,
         this,

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/connection/PipeEventCollector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/connection/PipeEventCollector.java
@@ -239,6 +239,11 @@ public class PipeEventCollector implements EventCollector {
         return;
       }
 
+      if (enrichedEvent.shouldSkipFurtherProcessing()) {
+        enrichedEvent.clearReferenceCount(PipeEventCollector.class.getName());
+        return;
+      }
+
       // Assign a commit id for this event in order to report progress in order.
       PipeEventCommitManager.getInstance()
           .enrichWithCommitterKeyAndCommitId(enrichedEvent, creationTime, regionId);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/stage/PipeTaskSourceStage.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/stage/PipeTaskSourceStage.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.commons.pipe.agent.task.stage.PipeTaskStage;
 import org.apache.iotdb.commons.pipe.config.plugin.configuraion.PipeTaskRuntimeConfiguration;
 import org.apache.iotdb.commons.pipe.config.plugin.env.PipeTaskSourceRuntimeEnvironment;
 import org.apache.iotdb.db.pipe.agent.PipeDataNodeAgent;
+import org.apache.iotdb.db.pipe.source.dataregion.IoTDBDataRegionSource;
 import org.apache.iotdb.db.storageengine.StorageEngine;
 import org.apache.iotdb.pipe.api.PipeExtractor;
 import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameterValidator;
@@ -107,5 +108,11 @@ public class PipeTaskSourceStage extends PipeTaskStage {
 
   public EventSupplier getEventSupplier() {
     return pipeExtractor::supply;
+  }
+
+  public void interruptActiveSupply() {
+    if (pipeExtractor instanceof IoTDBDataRegionSource) {
+      ((IoTDBDataRegionSource) pipeExtractor).interruptActiveSupply();
+    }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/processor/PipeProcessorSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/processor/PipeProcessorSubtask.java
@@ -138,6 +138,11 @@ public class PipeProcessorSubtask extends PipeReportableSubtask {
       return false;
     }
 
+    if (event instanceof EnrichedEvent && ((EnrichedEvent) event).shouldSkipFurtherProcessing()) {
+      clearReferenceCountAndReleaseLastEvent(event);
+      return false;
+    }
+
     outputEventCollector.resetFlags();
     try {
       if (event instanceof EnrichedEvent) {
@@ -293,6 +298,11 @@ public class PipeProcessorSubtask extends PipeReportableSubtask {
     // Always deregister the metrics to avoid the deletion of the data region
     PipeProcessorMetrics.getInstance().deregister(taskID);
     try {
+      synchronized (this) {
+        if (lastEvent instanceof EnrichedEvent) {
+          ((EnrichedEvent) lastEvent).markShouldSkipFurtherProcessing();
+        }
+      }
       isClosed.set(true);
       pipeProcessor.close();
       // It is important to note that even if the subtask and its corresponding processor are

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/sink/PipeSinkSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/sink/PipeSinkSubtask.java
@@ -103,6 +103,10 @@ public class PipeSinkSubtask extends PipeAbstractSinkSubtask {
       lastEvent = null;
       return true;
     }
+    if (event instanceof EnrichedEvent && ((EnrichedEvent) event).shouldSkipFurtherProcessing()) {
+      clearReferenceCountAndReleaseLastEvent(event);
+      return true;
+    }
 
     try {
       if (Objects.isNull(event)) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/source/dataregion/IoTDBDataRegionSource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/source/dataregion/IoTDBDataRegionSource.java
@@ -704,6 +704,12 @@ public class IoTDBDataRegionSource extends IoTDBSource {
     }
   }
 
+  public void interruptActiveSupply() {
+    if (Objects.nonNull(historicalSource)) {
+      historicalSource.interruptActiveSupply();
+    }
+  }
+
   //////////////////////////// APIs provided for metric framework ////////////////////////////
 
   public int getHistoricalTsFileInsertionEventCount() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/source/dataregion/historical/PipeHistoricalDataRegionSource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/source/dataregion/historical/PipeHistoricalDataRegionSource.java
@@ -26,4 +26,6 @@ public interface PipeHistoricalDataRegionSource extends PipeExtractor {
   boolean hasConsumedAll();
 
   int getPendingQueueSize();
+
+  default void interruptActiveSupply() {}
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/source/dataregion/historical/PipeHistoricalDataRegionTsFileAndDeletionSource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/source/dataregion/historical/PipeHistoricalDataRegionTsFileAndDeletionSource.java
@@ -84,6 +84,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -162,6 +163,9 @@ public class PipeHistoricalDataRegionTsFileAndDeletionSource
   private boolean isForwardingPipeRequests;
 
   private volatile boolean hasBeenStarted = false;
+
+  private volatile boolean isCloseRequested = false;
+  private final AtomicReference<Thread> activeSupplyThread = new AtomicReference<>();
 
   private Queue<PersistentResource> pendingQueue;
   private final Map<TsFileResource, Set<String>> filteredTsFileResources2TableNames =
@@ -478,8 +482,15 @@ public class PipeHistoricalDataRegionTsFileAndDeletionSource
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
   }
 
+  private boolean shouldAbortSupply() {
+    return isCloseRequested || Thread.currentThread().isInterrupted();
+  }
+
   @Override
   public synchronized void start() {
+    if (shouldAbortSupply()) {
+      return;
+    }
     if (!shouldExtractInsertion && !shouldExtractDeletion) {
       hasBeenStarted = true;
       return;
@@ -513,6 +524,9 @@ public class PipeHistoricalDataRegionTsFileAndDeletionSource
       if (shouldExtractDeletion) {
         Optional.ofNullable(DeletionResourceManager.getInstance(dataRegionId))
             .ifPresent(manager -> extractDeletions(manager, originalResourceList));
+      }
+      if (shouldAbortSupply()) {
+        return;
       }
 
       // Sort tsFileResource and deletionResource
@@ -645,6 +659,9 @@ public class PipeHistoricalDataRegionTsFileAndDeletionSource
           .keySet()
           .removeIf(
               resource -> {
+                if (shouldAbortSupply()) {
+                  return true;
+                }
                 // Pin the resource, in case the file is removed by compaction or anything.
                 // Will unpin it after the PipeTsFileInsertionEvent is created and pinned.
                 try {
@@ -821,35 +838,62 @@ public class PipeHistoricalDataRegionTsFileAndDeletionSource
 
   @Override
   public synchronized Event supply() {
-    if (!hasBeenStarted && StorageEngine.getInstance().isReadyForNonReadWriteFunctions()) {
-      start();
-    }
-
-    if (Objects.isNull(pendingQueue)) {
-      return null;
-    }
-
-    final PersistentResource resource = pendingQueue.peek();
-    if (resource == null) {
-      return supplyTerminateEvent();
-    }
-
-    if (resource instanceof TsFileResource) {
-      final TsFileResource tsFileResource = (TsFileResource) resource;
-      if (consumeSkippedHistoricalTsFileEventIfNecessary(tsFileResource)) {
-        clearReplicateIndexForResource(tsFileResource);
-        pendingQueue.poll();
-        return supplyProgressReportEvent(tsFileResource.getMaxProgressIndex());
+    activeSupplyThread.set(Thread.currentThread());
+    try {
+      if (shouldAbortSupply()) {
+        return null;
       }
 
-      final Event event = supplyTsFileEvent(tsFileResource);
+      if (!hasBeenStarted && StorageEngine.getInstance().isReadyForNonReadWriteFunctions()) {
+        start();
+        if (shouldAbortSupply()) {
+          return null;
+        }
+      }
+
+      if (Objects.isNull(pendingQueue)) {
+        return null;
+      }
+
+      final PersistentResource resource = pendingQueue.peek();
+      if (resource == null) {
+        return discardEventIfCloseRequested(supplyTerminateEvent());
+      }
+
+      if (resource instanceof TsFileResource) {
+        final TsFileResource tsFileResource = (TsFileResource) resource;
+        if (consumeSkippedHistoricalTsFileEventIfNecessary(tsFileResource)) {
+          clearReplicateIndexForResource(tsFileResource);
+          pendingQueue.poll();
+          return discardEventIfCloseRequested(
+              supplyProgressReportEvent(tsFileResource.getMaxProgressIndex()));
+        }
+
+        final Event event = supplyTsFileEvent(tsFileResource);
+        pendingQueue.poll();
+        return discardEventIfCloseRequested(event);
+      }
+
+      final Event event = supplyDeletionEvent((DeletionResource) resource);
       pendingQueue.poll();
+      return discardEventIfCloseRequested(event);
+    } finally {
+      activeSupplyThread.compareAndSet(Thread.currentThread(), null);
+      if (isCloseRequested && Thread.currentThread().isInterrupted()) {
+        Thread.interrupted();
+      }
+    }
+  }
+
+  private Event discardEventIfCloseRequested(final Event event) {
+    if (!shouldAbortSupply()) {
       return event;
     }
-
-    final Event event = supplyDeletionEvent((DeletionResource) resource);
-    pendingQueue.poll();
-    return event;
+    if (event instanceof EnrichedEvent) {
+      ((EnrichedEvent) event)
+          .clearReferenceCount(PipeHistoricalDataRegionTsFileAndDeletionSource.class.getName());
+    }
+    return null;
   }
 
   private Event supplyTerminateEvent() {
@@ -1083,11 +1127,12 @@ public class PipeHistoricalDataRegionTsFileAndDeletionSource
   }
 
   @Override
-  public synchronized boolean hasConsumedAll() {
+  public boolean hasConsumedAll() {
     // If the pendingQueue is null when the function is called, it implies that the extractor only
     // extracts deletion thus the historical event has nothing to consume.
-    return hasBeenStarted
-        && (Objects.isNull(pendingQueue) || pendingQueue.isEmpty() && isTerminateSignalSent);
+    return isCloseRequested
+        || hasBeenStarted
+            && (Objects.isNull(pendingQueue) || pendingQueue.isEmpty() && isTerminateSignalSent);
   }
 
   @Override
@@ -1096,30 +1141,40 @@ public class PipeHistoricalDataRegionTsFileAndDeletionSource
   }
 
   @Override
-  public synchronized void close() {
-    if (!isTerminateSignalSent) {
-      PipeTerminateEvent.clearHistoricalTransferSummary(pipeName, creationTime, dataRegionId);
+  public void close() {
+    isCloseRequested = true;
+    final Thread supplyThread = activeSupplyThread.get();
+    if (supplyThread != null) {
+      supplyThread.interrupt();
     }
-    if (Objects.nonNull(pendingQueue)) {
-      pendingQueue.forEach(
-          resource -> {
-            if (resource instanceof TsFileResource) {
-              try {
-                PipeDataNodeResourceManager.tsfile()
-                    .unpinTsFileResource(
-                        (TsFileResource) resource, shouldTransferModFile, pipeName);
-              } catch (final IOException e) {
-                LOGGER.warn(
-                    DataNodePipeMessages.PIPE_FAILED_TO_UNPIN_TSFILERESOURCE_AFTER_DROPPING,
-                    pipeName,
-                    dataRegionId,
-                    ((TsFileResource) resource).getTsFilePath());
-              }
-            }
-          });
-      pendingQueue.clear();
-      pendingQueue = null;
+
+    synchronized (this) {
+      if (!isTerminateSignalSent) {
+        PipeTerminateEvent.clearHistoricalTransferSummary(pipeName, creationTime, dataRegionId);
+      }
+
+      filteredTsFileResources2TableNames
+          .keySet()
+          .forEach(
+              resource -> {
+                try {
+                  PipeDataNodeResourceManager.tsfile()
+                      .unpinTsFileResource(resource, shouldTransferModFile, pipeName);
+                } catch (final IOException e) {
+                  LOGGER.warn(
+                      DataNodePipeMessages.PIPE_FAILED_TO_UNPIN_TSFILERESOURCE_AFTER_DROPPING,
+                      pipeName,
+                      dataRegionId,
+                      resource.getTsFilePath());
+                }
+              });
+      filteredTsFileResources2TableNames.clear();
+
+      if (Objects.nonNull(pendingQueue)) {
+        pendingQueue.clear();
+        pendingQueue = null;
+      }
+      pendingResource2ReplicateIndexForIoTV2.clear();
     }
-    pendingResource2ReplicateIndexForIoTV2.clear();
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/source/dataregion/historical/PipeHistoricalDataRegionTsFileAndDeletionSource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/source/dataregion/historical/PipeHistoricalDataRegionTsFileAndDeletionSource.java
@@ -164,7 +164,6 @@ public class PipeHistoricalDataRegionTsFileAndDeletionSource
 
   private volatile boolean hasBeenStarted = false;
 
-  private volatile boolean isCloseRequested = false;
   private final AtomicReference<Thread> activeSupplyThread = new AtomicReference<>();
 
   private Queue<PersistentResource> pendingQueue;
@@ -482,15 +481,8 @@ public class PipeHistoricalDataRegionTsFileAndDeletionSource
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
   }
 
-  private boolean shouldAbortSupply() {
-    return isCloseRequested || Thread.currentThread().isInterrupted();
-  }
-
   @Override
   public synchronized void start() {
-    if (shouldAbortSupply()) {
-      return;
-    }
     if (!shouldExtractInsertion && !shouldExtractDeletion) {
       hasBeenStarted = true;
       return;
@@ -525,7 +517,7 @@ public class PipeHistoricalDataRegionTsFileAndDeletionSource
         Optional.ofNullable(DeletionResourceManager.getInstance(dataRegionId))
             .ifPresent(manager -> extractDeletions(manager, originalResourceList));
       }
-      if (shouldAbortSupply()) {
+      if (Thread.currentThread().isInterrupted()) {
         return;
       }
 
@@ -659,7 +651,7 @@ public class PipeHistoricalDataRegionTsFileAndDeletionSource
           .keySet()
           .removeIf(
               resource -> {
-                if (shouldAbortSupply()) {
+                if (Thread.currentThread().isInterrupted()) {
                   return true;
                 }
                 // Pin the resource, in case the file is removed by compaction or anything.
@@ -840,15 +832,8 @@ public class PipeHistoricalDataRegionTsFileAndDeletionSource
   public synchronized Event supply() {
     activeSupplyThread.set(Thread.currentThread());
     try {
-      if (shouldAbortSupply()) {
-        return null;
-      }
-
       if (!hasBeenStarted && StorageEngine.getInstance().isReadyForNonReadWriteFunctions()) {
         start();
-        if (shouldAbortSupply()) {
-          return null;
-        }
       }
 
       if (Objects.isNull(pendingQueue)) {
@@ -857,7 +842,7 @@ public class PipeHistoricalDataRegionTsFileAndDeletionSource
 
       final PersistentResource resource = pendingQueue.peek();
       if (resource == null) {
-        return discardEventIfCloseRequested(supplyTerminateEvent());
+        return supplyTerminateEvent();
       }
 
       if (resource instanceof TsFileResource) {
@@ -865,35 +850,20 @@ public class PipeHistoricalDataRegionTsFileAndDeletionSource
         if (consumeSkippedHistoricalTsFileEventIfNecessary(tsFileResource)) {
           clearReplicateIndexForResource(tsFileResource);
           pendingQueue.poll();
-          return discardEventIfCloseRequested(
-              supplyProgressReportEvent(tsFileResource.getMaxProgressIndex()));
+          return supplyProgressReportEvent(tsFileResource.getMaxProgressIndex());
         }
 
         final Event event = supplyTsFileEvent(tsFileResource);
         pendingQueue.poll();
-        return discardEventIfCloseRequested(event);
+        return event;
       }
 
       final Event event = supplyDeletionEvent((DeletionResource) resource);
       pendingQueue.poll();
-      return discardEventIfCloseRequested(event);
+      return event;
     } finally {
       activeSupplyThread.compareAndSet(Thread.currentThread(), null);
-      if (isCloseRequested && Thread.currentThread().isInterrupted()) {
-        Thread.interrupted();
-      }
     }
-  }
-
-  private Event discardEventIfCloseRequested(final Event event) {
-    if (!shouldAbortSupply()) {
-      return event;
-    }
-    if (event instanceof EnrichedEvent) {
-      ((EnrichedEvent) event)
-          .clearReferenceCount(PipeHistoricalDataRegionTsFileAndDeletionSource.class.getName());
-    }
-    return null;
   }
 
   private Event supplyTerminateEvent() {
@@ -1127,12 +1097,11 @@ public class PipeHistoricalDataRegionTsFileAndDeletionSource
   }
 
   @Override
-  public boolean hasConsumedAll() {
+  public synchronized boolean hasConsumedAll() {
     // If the pendingQueue is null when the function is called, it implies that the extractor only
     // extracts deletion thus the historical event has nothing to consume.
-    return isCloseRequested
-        || hasBeenStarted
-            && (Objects.isNull(pendingQueue) || pendingQueue.isEmpty() && isTerminateSignalSent);
+    return hasBeenStarted
+        && (Objects.isNull(pendingQueue) || pendingQueue.isEmpty() && isTerminateSignalSent);
   }
 
   @Override
@@ -1141,40 +1110,38 @@ public class PipeHistoricalDataRegionTsFileAndDeletionSource
   }
 
   @Override
-  public void close() {
-    isCloseRequested = true;
+  public void interruptActiveSupply() {
     final Thread supplyThread = activeSupplyThread.get();
     if (supplyThread != null) {
       supplyThread.interrupt();
     }
+  }
 
-    synchronized (this) {
-      if (!isTerminateSignalSent) {
-        PipeTerminateEvent.clearHistoricalTransferSummary(pipeName, creationTime, dataRegionId);
-      }
-
-      filteredTsFileResources2TableNames
-          .keySet()
-          .forEach(
-              resource -> {
-                try {
-                  PipeDataNodeResourceManager.tsfile()
-                      .unpinTsFileResource(resource, shouldTransferModFile, pipeName);
-                } catch (final IOException e) {
-                  LOGGER.warn(
-                      DataNodePipeMessages.PIPE_FAILED_TO_UNPIN_TSFILERESOURCE_AFTER_DROPPING,
-                      pipeName,
-                      dataRegionId,
-                      resource.getTsFilePath());
-                }
-              });
-      filteredTsFileResources2TableNames.clear();
-
-      if (Objects.nonNull(pendingQueue)) {
-        pendingQueue.clear();
-        pendingQueue = null;
-      }
-      pendingResource2ReplicateIndexForIoTV2.clear();
+  @Override
+  public synchronized void close() {
+    if (!isTerminateSignalSent) {
+      PipeTerminateEvent.clearHistoricalTransferSummary(pipeName, creationTime, dataRegionId);
     }
+    if (Objects.nonNull(pendingQueue)) {
+      pendingQueue.forEach(
+          resource -> {
+            if (resource instanceof TsFileResource) {
+              try {
+                PipeDataNodeResourceManager.tsfile()
+                    .unpinTsFileResource(
+                        (TsFileResource) resource, shouldTransferModFile, pipeName);
+              } catch (final IOException e) {
+                LOGGER.warn(
+                    DataNodePipeMessages.PIPE_FAILED_TO_UNPIN_TSFILERESOURCE_AFTER_DROPPING,
+                    pipeName,
+                    dataRegionId,
+                    ((TsFileResource) resource).getTsFilePath());
+              }
+            }
+          });
+      pendingQueue.clear();
+      pendingQueue = null;
+    }
+    pendingResource2ReplicateIndexForIoTV2.clear();
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/event/EnrichedEvent.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/event/EnrichedEvent.java
@@ -53,6 +53,9 @@ public abstract class EnrichedEvent implements Event {
   // This variable is used to indicate whether the event's reference count has ever been decreased
   // to zero.
   protected final AtomicBoolean isReleased;
+  // Set when the processor subtask is closed while this event is still in-flight, indicating that
+  // no further processing or transfer should happen for this event.
+  protected final AtomicBoolean shouldSkipFurtherProcessing;
 
   protected final String pipeName;
   protected final long creationTime;
@@ -98,6 +101,7 @@ public abstract class EnrichedEvent implements Event {
       final long endTime) {
     referenceCount = new AtomicInteger(0);
     isReleased = new AtomicBoolean(false);
+    shouldSkipFurtherProcessing = new AtomicBoolean(false);
 
     this.pipeName = pipeName;
     this.creationTime = creationTime;
@@ -492,6 +496,14 @@ public abstract class EnrichedEvent implements Event {
 
   public boolean isReleased() {
     return isReleased.get();
+  }
+
+  public void markShouldSkipFurtherProcessing() {
+    shouldSkipFurtherProcessing.set(true);
+  }
+
+  public boolean shouldSkipFurtherProcessing() {
+    return shouldSkipFurtherProcessing.get();
   }
 
   /**


### PR DESCRIPTION
## Summary
- Drop pipe tasks in sink → processor → source order so outbound transfer stops before historical source cleanup begins.
- Track the processor thread currently inside `supply()` and interrupt it from `close()` via `compareAndSet`, avoiding stale-thread interrupts.
- Let `start()` abort promptly on close/interrupt and unpin only the TsFile resources that were pinned but not yet supplied.

## Why
On DROP PIPE, `close()` could block behind a long-running `supply()/start()` while processor and sink kept forwarding historical TsFile events even though the pipe had already disappeared from `SHOW PIPES`.

## Test plan
- [x] `mvn spotless:apply -pl iotdb-core/datanode`
- [ ] Reproduce pure historical pipe DROP and verify receiver stops receiving data immediately
- [ ] Capture thread dump and confirm drop worker no longer waits long behind historical extraction


Made with [Cursor](https://cursor.com)