### PR TITLE
Fix Windows CLI -pw argument parsing

### DIFF
--- a/scripts/sbin/windows/start-cli.bat
+++ b/scripts/sbin/windows/start-cli.bat
@@ -60,7 +60,11 @@ if /I "%~1"=="-u" (
     goto parse_args
 )
 if /I "%~1"=="-pw" (
+    call :is_known_option "%~2"
     if "%~2"=="" (
+        set "passwd_param=-pw"
+        shift
+    ) else if "!IS_KNOWN_OPTION!"=="true" (
         set "passwd_param=-pw"
         shift
     ) else (
@@ -92,6 +96,23 @@ if /I "%~1"=="-sql_dialect" (
 set "PARAMETERS=%PARAMETERS% %~1"
 shift
 goto parse_args
+
+:is_known_option
+set "IS_KNOWN_OPTION=false"
+if /I "%~1"=="-h" set "IS_KNOWN_OPTION=true"
+if /I "%~1"=="-p" set "IS_KNOWN_OPTION=true"
+if /I "%~1"=="-u" set "IS_KNOWN_OPTION=true"
+if /I "%~1"=="-pw" set "IS_KNOWN_OPTION=true"
+if /I "%~1"=="-e" set "IS_KNOWN_OPTION=true"
+if /I "%~1"=="-help" set "IS_KNOWN_OPTION=true"
+if /I "%~1"=="-sql_dialect" set "IS_KNOWN_OPTION=true"
+if /I "%~1"=="-disableISO8601" set "IS_KNOWN_OPTION=true"
+if /I "%~1"=="-c" set "IS_KNOWN_OPTION=true"
+if /I "%~1"=="-timeout" set "IS_KNOWN_OPTION=true"
+if /I "%~1"=="-usessl" set "IS_KNOWN_OPTION=true"
+if /I "%~1"=="-ts" set "IS_KNOWN_OPTION=true"
+if /I "%~1"=="-tpw" set "IS_KNOWN_OPTION=true"
+exit /b 0
 
 :after_parse
 REM Combine all parameters


### PR DESCRIPTION
## Summary
- Fix Windows start-cli.bat so -pw without an inline password does not consume the following CLI option
- Preserve existing behavior for -pw with an explicit password
- Cover the same behavior for start-cli-table.bat because it delegates to start-cli.bat

## Verification
- Used a temporary fake JAVA_HOME/bin/java.exe to capture launcher arguments for:
  - start-cli.bat -h 127.0.0.1 -pw -u root -p 6667
  - start-cli.bat -h 127.0.0.1 -u root -pw -e show databases
  - start-cli-table.bat -pw -h 127.0.0.1 -u root -p 6667
  - start-cli.bat -h 127.0.0.1 -pw root -u root -p 6667