### PR TITLE
Pipe: drop sink before processor and source on task drop

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTask.java
@@ -68,9 +68,9 @@ public class PipeDataNodeTask implements PipeTask {
   @Override
   public void drop() {
     final long startTime = System.currentTimeMillis();
-    sourceStage.drop();
-    processorStage.drop();
     sinkStage.drop();
+    processorStage.drop();
+    sourceStage.drop();
     LOGGER.info(
         DataNodePipeMessages.DROP_PIPE_DN_TASK_SUCCESSFULLY_WITHIN_MS,
         this,


### PR DESCRIPTION
## Summary
- Change DataNode pipe task drop order to sink → processor → source
- Stop the connector first so downstream forwarding stops promptly when a pipe is dropped

## Test plan
- [ ] DROP PIPE while historical pipe is actively forwarding data
- [ ] Verify receiver stops receiving new data promptly after DROP PIPE
- [ ] Verify `SHOW PIPES` reflects dropped pipe state correctly

Made with [Cursor](https://cursor.com)