### PR TITLE
Fix driver scheduler ready queue reservation leak

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/DriverScheduler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/DriverScheduler.java
@@ -336,16 +336,18 @@ public class DriverScheduler implements IDriverScheduler, IService {
             return;
           case READY:
             task.setStatus(DriverTaskStatus.ABORTED);
-            readyQueue.remove(task.getDriverTaskId());
+            if (readyQueue.remove(task.getDriverTaskId()) == null) {
+              readyQueue.decreaseReservedSize(task);
+            }
             break;
           case BLOCKED:
             task.setStatus(DriverTaskStatus.ABORTED);
             blockedTasks.remove(task);
-            readyQueue.decreaseReservedSize();
+            readyQueue.decreaseReservedSize(task);
             break;
           case RUNNING:
             task.setStatus(DriverTaskStatus.ABORTED);
-            readyQueue.decreaseReservedSize();
+            readyQueue.decreaseReservedSize(task);
             break;
           case FINISHED:
             break;
@@ -489,6 +491,7 @@ public class DriverScheduler implements IDriverScheduler, IService {
       task.lock();
       try {
         if (task.getStatus() != DriverTaskStatus.READY) {
+          readyQueue.decreaseReservedSize(task);
           return false;
         }
 
@@ -545,7 +548,7 @@ public class DriverScheduler implements IDriverScheduler, IService {
         }
         task.updateSchedulePriority(context);
         task.setStatus(DriverTaskStatus.FINISHED);
-        readyQueue.decreaseReservedSize();
+        readyQueue.decreaseReservedSize(task);
       } finally {
         task.unlock();
       }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/DriverScheduler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/DriverScheduler.java
@@ -416,6 +416,10 @@ public class DriverScheduler implements IDriverScheduler, IService {
     return readyQueue.size();
   }
 
+  public long getReadyQueueReservedTaskCount() {
+    return readyQueue.getReservedSize();
+  }
+
   public long getBlockQueueTaskCount() {
     return blockedTasks.size();
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/queue/IndexedBlockingReserveQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/queue/IndexedBlockingReserveQueue.java
@@ -82,6 +82,10 @@ public abstract class IndexedBlockingReserveQueue<E extends IDIndexedAccessible>
     return decreaseReservedSizeIfNecessary(element);
   }
 
+  public final synchronized int getReservedSize() {
+    return reservedSize;
+  }
+
   @Override
   public synchronized void clear() {
     super.clear();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/queue/IndexedBlockingReserveQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/queue/IndexedBlockingReserveQueue.java
@@ -47,6 +47,7 @@ public abstract class IndexedBlockingReserveQueue<E extends IDIndexedAccessible>
     E output = pollFirst();
     size--;
     reservedSize++;
+    markReserved(output);
     return output;
   }
 
@@ -66,7 +67,7 @@ public abstract class IndexedBlockingReserveQueue<E extends IDIndexedAccessible>
       throw new NullPointerException("pushed element is null");
     }
     pushToQueue(element);
-    reservedSize--;
+    decreaseReservedSizeIfNecessary(element);
     size++;
     this.notifyAll();
   }
@@ -74,7 +75,32 @@ public abstract class IndexedBlockingReserveQueue<E extends IDIndexedAccessible>
   /**
    * For task that is not in readyQueue when it's cleared, it won't be added into the queue again.
    */
-  public synchronized void decreaseReservedSize() {
-    this.reservedSize--;
+  public synchronized boolean decreaseReservedSize(E element) {
+    if (element == null) {
+      throw new NullPointerException("pushed element is null");
+    }
+    return decreaseReservedSizeIfNecessary(element);
+  }
+
+  @Override
+  public synchronized void clear() {
+    super.clear();
+    this.reservedSize = 0;
+  }
+
+  protected void markReserved(E element) {
+    // Do nothing by default.
+  }
+
+  protected boolean releaseReserved(E element) {
+    return true;
+  }
+
+  private boolean decreaseReservedSizeIfNecessary(E element) {
+    if (!releaseReserved(element) || reservedSize <= 0) {
+      return false;
+    }
+    reservedSize--;
+    return true;
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/queue/multilevelqueue/MultilevelPriorityQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/queue/multilevelqueue/MultilevelPriorityQueue.java
@@ -192,6 +192,16 @@ public class MultilevelPriorityQueue extends IndexedBlockingReserveQueue<DriverT
   }
 
   @Override
+  protected void markReserved(DriverTask task) {
+    task.markReservedInReadyQueue();
+  }
+
+  @Override
+  protected boolean releaseReserved(DriverTask task) {
+    return task.releaseReservedInReadyQueue();
+  }
+
+  @Override
   protected void clearAllElements() {
     highestPriorityLevelQueue.clear();
     for (PriorityQueue<DriverTask> level : levelWaitingSplits) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/task/DriverTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/schedule/task/DriverTask.java
@@ -59,6 +59,7 @@ public class DriverTask implements IDIndexedAccessible {
   private final DriverTaskHandle driverTaskHandle;
   private long lastEnterReadyQueueTime;
   private long lastEnterBlockQueueTime;
+  private boolean reservedInReadyQueue;
 
   private long estimatedMemorySize;
 
@@ -208,6 +209,18 @@ public class DriverTask implements IDIndexedAccessible {
 
   public void setLastEnterBlockQueueTime(long lastEnterBlockQueueTime) {
     this.lastEnterBlockQueueTime = lastEnterBlockQueueTime;
+  }
+
+  public void markReservedInReadyQueue() {
+    reservedInReadyQueue = true;
+  }
+
+  public boolean releaseReservedInReadyQueue() {
+    if (!reservedInReadyQueue) {
+      return false;
+    }
+    reservedInReadyQueue = false;
+    return true;
   }
 
   /** a comparator of ddl, the less the ddl is, the low order it has. */

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/metric/DriverSchedulerMetricSet.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/metric/DriverSchedulerMetricSet.java
@@ -39,6 +39,7 @@ public class DriverSchedulerMetricSet implements IMetricSet {
   public static final String READY_QUEUED_TIME = "ready_queued_time";
   public static final String BLOCK_QUEUED_TIME = "block_queued_time";
   public static final String READY_QUEUE_TASK_COUNT = "ready_queue_task_count";
+  public static final String READY_QUEUE_RESERVED_TASK_COUNT = "ready_queue_reserved_task_count";
   public static final String BLOCK_QUEUE_TASK_COUNT = "block_queue_task_count";
   private static final String TIMEOUT_QUEUE_SIZE = "timeout_queue_task_count";
   private static final String QUERY_MAP_SIZE = "query_map_size";
@@ -67,6 +68,13 @@ public class DriverSchedulerMetricSet implements IMetricSet {
         DriverScheduler::getReadyQueueTaskCount,
         Tag.NAME.toString(),
         READY_QUEUE_TASK_COUNT);
+    metricService.createAutoGauge(
+        Metric.DRIVER_SCHEDULER.toString(),
+        MetricLevel.IMPORTANT,
+        DriverScheduler.getInstance(),
+        DriverScheduler::getReadyQueueReservedTaskCount,
+        Tag.NAME.toString(),
+        READY_QUEUE_RESERVED_TASK_COUNT);
     metricService.createAutoGauge(
         Metric.DRIVER_SCHEDULER.toString(),
         MetricLevel.IMPORTANT,
@@ -109,6 +117,11 @@ public class DriverSchedulerMetricSet implements IMetricSet {
         Metric.DRIVER_SCHEDULER.toString(),
         Tag.NAME.toString(),
         READY_QUEUE_TASK_COUNT);
+    metricService.remove(
+        MetricType.AUTO_GAUGE,
+        Metric.DRIVER_SCHEDULER.toString(),
+        Tag.NAME.toString(),
+        READY_QUEUE_RESERVED_TASK_COUNT);
     metricService.remove(
         MetricType.AUTO_GAUGE,
         Metric.DRIVER_SCHEDULER.toString(),

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/schedule/DefaultDriverSchedulerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/schedule/DefaultDriverSchedulerTest.java
@@ -42,7 +42,6 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.OptionalInt;
@@ -225,17 +224,17 @@ public class DefaultDriverSchedulerTest {
 
       DriverTask polledTask = manager.getReadyQueue().poll();
       Assert.assertSame(testTask, polledTask);
-      Assert.assertEquals(1, getReadyQueueReservedSize());
+      Assert.assertEquals(1, manager.getReadyQueueReservedTaskCount());
 
       manager.abortFragmentInstance(instanceId);
 
       Assert.assertEquals(DriverTaskStatus.ABORTED, testTask.getStatus());
       Assert.assertEquals(0, manager.getReadyQueue().size());
-      Assert.assertEquals(0, getReadyQueueReservedSize());
+      Assert.assertEquals(0, manager.getReadyQueueReservedTaskCount());
       Assert.assertFalse(defaultScheduler.readyToRunning(polledTask));
-      Assert.assertEquals(0, getReadyQueueReservedSize());
+      Assert.assertEquals(0, manager.getReadyQueueReservedTaskCount());
     } finally {
-      resetReadyQueueReservedSize();
+      clear();
     }
   }
 
@@ -535,33 +534,6 @@ public class DefaultDriverSchedulerTest {
     manager.getQueryMap().clear();
     manager.getBlockedTasks().clear();
     manager.getReadyQueue().clear();
-    resetReadyQueueReservedSize();
     manager.getTimeoutQueue().clear();
-  }
-
-  private int getReadyQueueReservedSize() throws IllegalAccessException {
-    return getReadyQueueReservedSizeField().getInt(manager.getReadyQueue());
-  }
-
-  private void resetReadyQueueReservedSize() {
-    try {
-      getReadyQueueReservedSizeField().setInt(manager.getReadyQueue(), 0);
-    } catch (IllegalAccessException e) {
-      throw new AssertionError(e);
-    }
-  }
-
-  private Field getReadyQueueReservedSizeField() {
-    Class<?> queueClass = manager.getReadyQueue().getClass();
-    while (queueClass != null) {
-      try {
-        Field reservedSizeField = queueClass.getDeclaredField("reservedSize");
-        reservedSizeField.setAccessible(true);
-        return reservedSizeField;
-      } catch (NoSuchFieldException e) {
-        queueClass = queueClass.getSuperclass();
-      }
-    }
-    throw new AssertionError("Cannot find reservedSize field in readyQueue hierarchy");
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/schedule/DefaultDriverSchedulerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/schedule/DefaultDriverSchedulerTest.java
@@ -42,6 +42,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.OptionalInt;
@@ -195,6 +196,47 @@ public class DefaultDriverSchedulerTest {
     Assert.assertTrue(manager.getQueryMap().get(queryId).get(instanceId).contains(testTask));
     Mockito.verify(mockDriver, Mockito.never()).failed(Mockito.any());
     clear();
+  }
+
+  @Test
+  public void testAbortReadyTaskAfterPollReleasesReadyQueueReservation() throws Exception {
+    IMPPDataExchangeManager mockMPPDataExchangeManager =
+        Mockito.mock(IMPPDataExchangeManager.class);
+    manager.setBlockManager(mockMPPDataExchangeManager);
+    ITaskScheduler defaultScheduler = manager.getScheduler();
+    IDriver mockDriver = Mockito.mock(IDriver.class);
+    DriverTaskHandle driverTaskHandle =
+        new DriverTaskHandle(
+            1,
+            (MultilevelPriorityQueue) manager.getReadyQueue(),
+            OptionalInt.of(Integer.MAX_VALUE));
+
+    QueryId queryId = new QueryId("test");
+    FragmentInstanceId instanceId =
+        new FragmentInstanceId(new PlanFragmentId(queryId, 0), "inst-0");
+    DriverTaskId driverTaskID = new DriverTaskId(instanceId, 0);
+    Mockito.when(mockDriver.getDriverTaskId()).thenReturn(driverTaskID);
+    DriverTask testTask =
+        new DriverTask(mockDriver, 100L, DriverTaskStatus.READY, driverTaskHandle, 0, false);
+
+    try {
+      manager.registerTaskToQueryMap(queryId, testTask);
+      manager.submitTaskToReadyQueue(testTask);
+
+      DriverTask polledTask = manager.getReadyQueue().poll();
+      Assert.assertSame(testTask, polledTask);
+      Assert.assertEquals(1, getReadyQueueReservedSize());
+
+      manager.abortFragmentInstance(instanceId);
+
+      Assert.assertEquals(DriverTaskStatus.ABORTED, testTask.getStatus());
+      Assert.assertEquals(0, manager.getReadyQueue().size());
+      Assert.assertEquals(0, getReadyQueueReservedSize());
+      Assert.assertFalse(defaultScheduler.readyToRunning(polledTask));
+      Assert.assertEquals(0, getReadyQueueReservedSize());
+    } finally {
+      resetReadyQueueReservedSize();
+    }
   }
 
   @Test
@@ -493,6 +535,33 @@ public class DefaultDriverSchedulerTest {
     manager.getQueryMap().clear();
     manager.getBlockedTasks().clear();
     manager.getReadyQueue().clear();
+    resetReadyQueueReservedSize();
     manager.getTimeoutQueue().clear();
+  }
+
+  private int getReadyQueueReservedSize() throws IllegalAccessException {
+    return getReadyQueueReservedSizeField().getInt(manager.getReadyQueue());
+  }
+
+  private void resetReadyQueueReservedSize() {
+    try {
+      getReadyQueueReservedSizeField().setInt(manager.getReadyQueue(), 0);
+    } catch (IllegalAccessException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private Field getReadyQueueReservedSizeField() {
+    Class<?> queueClass = manager.getReadyQueue().getClass();
+    while (queueClass != null) {
+      try {
+        Field reservedSizeField = queueClass.getDeclaredField("reservedSize");
+        reservedSizeField.setAccessible(true);
+        return reservedSizeField;
+      } catch (NoSuchFieldException e) {
+        queueClass = queueClass.getSuperclass();
+      }
+    }
+    throw new AssertionError("Cannot find reservedSize field in readyQueue hierarchy");
   }
 }


### PR DESCRIPTION
## Summary
- Track ready queue reservations on each DriverTask to avoid leaking reserved slots when a READY task is aborted after being polled.
- Release reservations only for tasks that actually own one, and expose ready_queue_reserved_task_count alongside ready_queue_task_count.
- Add a regression test for the abort-after-poll race.

## Tests
- ./mvnw test -pl iotdb-core/datanode -am -Dtest=DefaultDriverSchedulerTest#testAbortReadyTaskAfterPollReleasesReadyQueueReservation -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false