### PR TITLE
Fix flaky WALNode outdated file deletion test

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNodeTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNodeTest.java
@@ -332,9 +332,7 @@ public class WALNodeTest {
 
   @Test
   public void testDeleteOutdatedFiles() throws Exception {
-    List<WALFlushListener> walFlushListeners = new ArrayList<>();
-    // write until log is rolled
-    long time = 0;
+    // write data to make the first WAL file non-empty
     IMemTable memTable = new PrimitiveMemTable(databasePath, dataRegionId);
     long memTableId = memTable.getMemTableId();
     String tsFilePath =
@@ -352,18 +350,16 @@ public class WALNodeTest {
         .setDataRegion(
             new DataRegionId(1), new DataRegionTest.DummyDataRegion(logDirectory, databasePath));
     walNode.onMemTableCreated(memTable, tsFilePath);
-    while (time < 20000) {
-      ++time;
+    for (long time = 1; time <= 100; ++time) {
       InsertTabletNode insertTabletNode =
           getInsertTabletNode(devicePath + memTableId, new long[] {time});
-      WALFlushListener walFlushListener =
-          walNode.log(
-              memTableId,
-              insertTabletNode,
-              Collections.singletonList(new int[] {0, insertTabletNode.getRowCount()}));
-      walFlushListeners.add(walFlushListener);
+      walNode.log(
+          memTableId,
+          insertTabletNode,
+          Collections.singletonList(new int[] {0, insertTabletNode.getRowCount()}));
     }
     walNode.onMemTableFlushed(memTable);
+    walNode.rollWALFile();
     walNode.onMemTableCreated(new PrimitiveMemTable(databasePath, dataRegionId), tsFilePath);
     Awaitility.await().until(() -> walNode.isAllWALEntriesConsumed());
     // check existence of _0-0-0.wal file and _1-0-1.wal file


### PR DESCRIPTION
This PR makes WALNodeTest#testDeleteOutdatedFiles deterministic by explicitly rolling the WAL after flushing the old memtable. The previous test relied on 20000 writes exceeding the WAL size threshold, which can fail when serialized entry size changes. Tests: mvn -pl iotdb-core/datanode spotless:apply; git diff --check; mvn -pl iotdb-core/datanode -am -Dtest=WALNodeTest#testDeleteOutdatedFiles -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test (blocked locally by datanode generated ModeAccumulator compile errors before test execution).