### PR TITLE
Fix flaky region-migration/cluster ITs and enable IoTV2 daily migration tests

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/IoTDBRegionOperationReliabilityITFramework.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/IoTDBRegionOperationReliabilityITFramework.java
@@ -355,6 +355,17 @@ public class IoTDBRegionOperationReliabilityITFramework {
         Assert.fail();
       }
 
+      // The kill point is detected by a background thread tailing the node log, so the migration
+      // result (observed by awaitUntilSuccess above) can become visible before that thread has read
+      // and processed the kill-point line of the last migration phase (e.g.
+      // RemoveRegionLocationCache). Give that thread a short grace period to catch up before
+      // asserting, otherwise checkKillPointsAllTriggered may fail spuriously with "Some kill points
+      // was not triggered". This is best-effort: the authoritative assertion remains
+      // checkKillPointsAllTriggered, which still fails the test if a kill point genuinely never
+      // triggers (e.g. the badKillPoint test).
+      graceWaitForKillPointsTriggered(configNodeKeywords);
+      graceWaitForKillPointsTriggered(dataNodeKeywords);
+
       // make sure all kill points have been triggered
       checkKillPointsAllTriggered(configNodeKeywords);
       checkKillPointsAllTriggered(dataNodeKeywords);
@@ -518,6 +529,26 @@ public class IoTDBRegionOperationReliabilityITFramework {
       return;
     }
     Awaitility.await().atMost(2, TimeUnit.MINUTES).until(killPoints::isEmpty);
+  }
+
+  /**
+   * Best-effort wait for all kill points to be triggered. The kill point is detected by a
+   * background thread tailing the node log, so there can be a short lag between the migration
+   * result becoming visible and that thread processing the kill-point line. This gives it a brief
+   * grace period to catch up. Unlike {@link #awaitKillPointsTriggered}, it never throws: the
+   * authoritative check is {@link #checkKillPointsAllTriggered}, so a kill point that genuinely
+   * never triggers (e.g. the badKillPoint test) is still caught there as an AssertionError rather
+   * than masked here.
+   */
+  private static void graceWaitForKillPointsTriggered(KeySetView<String, Boolean> killPoints) {
+    if (killPoints.isEmpty()) {
+      return;
+    }
+    try {
+      Awaitility.await().atMost(1, TimeUnit.MINUTES).until(killPoints::isEmpty);
+    } catch (ConditionTimeoutException ignored) {
+      // Fall through to checkKillPointsAllTriggered, which makes the real assertion.
+    }
   }
 
   private static String buildRegionMigrateCommand(int who, int from, int to) {

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/datanodecrash/iotv2/batch/IoTDBRegionMigrateDataNodeCrashForIoTV2BatchIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/datanodecrash/iotv2/batch/IoTDBRegionMigrateDataNodeCrashForIoTV2BatchIT.java
@@ -25,10 +25,9 @@ import org.apache.iotdb.confignode.it.regionmigration.IoTDBRegionOperationReliab
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.DailyIT;
 
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-
-// TODO: @Yongzao Dan, reopen this CI after discussion with @HxpSerein
 
 @Category({DailyIT.class})
 @RunWith(IoTDBTestRunner.class)
@@ -41,7 +40,7 @@ public class IoTDBRegionMigrateDataNodeCrashForIoTV2BatchIT
   private final int configNodeNum = 1;
   private final int dataNodeNum = 3;
 
-  //  @Test
+  @Test
   public void coordinatorCrashDuringAddPeerTransition() throws Exception {
     failTest(
         2,
@@ -53,7 +52,7 @@ public class IoTDBRegionMigrateDataNodeCrashForIoTV2BatchIT
         KillNode.COORDINATOR_DATANODE);
   }
 
-  //  @Test
+  @Test
   public void coordinatorCrashDuringAddPeerDone() throws Exception {
     failTest(
         2,
@@ -69,9 +68,13 @@ public class IoTDBRegionMigrateDataNodeCrashForIoTV2BatchIT
 
   // region Original DataNode crash tests
 
-  //  @Test
+  @Test
   public void originalCrashDuringAddPeerDone() throws Exception {
-    failTest(
+    // Once the add-peer phase is done, the new peer already holds the data, so the migration is
+    // designed to tolerate the original (source) DataNode crashing afterwards: it completes
+    // successfully and merely leaves the region files on the dead node to be cleaned up later.
+    // Hence this is a successTest, not a failTest.
+    successTest(
         2,
         2,
         1,
@@ -85,7 +88,7 @@ public class IoTDBRegionMigrateDataNodeCrashForIoTV2BatchIT
 
   // region Destination DataNode crash tests
 
-  //  @Test
+  @Test
   public void destinationCrashDuringCreateLocalPeer() throws Exception {
     failTest(
         2,
@@ -97,7 +100,7 @@ public class IoTDBRegionMigrateDataNodeCrashForIoTV2BatchIT
         KillNode.DESTINATION_DATANODE);
   }
 
-  //  @Test
+  @Test
   public void destinationCrashDuringAddPeerDone() throws Exception {
     failTest(
         2,

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/datanodecrash/iotv2/stream/IoTDBRegionMigrateDataNodeCrashForIoTV2StreamIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/datanodecrash/iotv2/stream/IoTDBRegionMigrateDataNodeCrashForIoTV2StreamIT.java
@@ -28,10 +28,9 @@ import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.DailyIT;
 
 import org.junit.Before;
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-
-// TODO: @Yongzao Dan, reopen this CI after discussion with @HxpSerein
 
 @Category({DailyIT.class})
 @RunWith(IoTDBTestRunner.class)
@@ -54,7 +53,7 @@ public class IoTDBRegionMigrateDataNodeCrashForIoTV2StreamIT
         .setIoTConsensusV2Mode(ConsensusFactory.IOT_CONSENSUS_V2_STREAM_MODE);
   }
 
-  //  @Test
+  @Test
   public void coordinatorCrashDuringAddPeerTransition() throws Exception {
     failTest(
         2,
@@ -66,7 +65,7 @@ public class IoTDBRegionMigrateDataNodeCrashForIoTV2StreamIT
         KillNode.COORDINATOR_DATANODE);
   }
 
-  //  @Test
+  @Test
   public void coordinatorCrashDuringAddPeerDone() throws Exception {
     failTest(
         2,
@@ -82,9 +81,13 @@ public class IoTDBRegionMigrateDataNodeCrashForIoTV2StreamIT
 
   // region Original DataNode crash tests
 
-  //  @Test
+  @Test
   public void originalCrashDuringAddPeerDone() throws Exception {
-    failTest(
+    // Once the add-peer phase is done, the new peer already holds the data, so the migration is
+    // designed to tolerate the original (source) DataNode crashing afterwards: it completes
+    // successfully and merely leaves the region files on the dead node to be cleaned up later.
+    // Hence this is a successTest, not a failTest.
+    successTest(
         2,
         2,
         1,
@@ -98,7 +101,7 @@ public class IoTDBRegionMigrateDataNodeCrashForIoTV2StreamIT
 
   // region Destination DataNode crash tests
 
-  //  @Test
+  @Test
   public void destinationCrashDuringCreateLocalPeer() throws Exception {
     failTest(
         2,
@@ -110,7 +113,7 @@ public class IoTDBRegionMigrateDataNodeCrashForIoTV2StreamIT
         KillNode.DESTINATION_DATANODE);
   }
 
-  //  @Test
+  @Test
   public void destinationCrashDuringAddPeerDone() throws Exception {
     failTest(
         2,

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/batch/IoTDBRegionMigrateClusterCrashIoTV2BatchIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/batch/IoTDBRegionMigrateClusterCrashIoTV2BatchIT.java
@@ -39,8 +39,7 @@ public class IoTDBRegionMigrateClusterCrashIoTV2BatchIT
     killClusterTest(buildSet(AddRegionPeerState.CREATE_NEW_REGION_PEER), true);
   }
 
-  // TODO: @Yongzao Dan, reopen this CI after discussion with @HxpSerein
-  //  @Test
+  @Test
   public void clusterCrash2() throws Exception {
     killClusterTest(buildSet(AddRegionPeerState.DO_ADD_REGION_PEER), false);
   }
@@ -60,8 +59,7 @@ public class IoTDBRegionMigrateClusterCrashIoTV2BatchIT
     killClusterTest(buildSet(RemoveRegionPeerState.REMOVE_REGION_PEER), true);
   }
 
-  // TODO: @Yongzao Dan, reopen this CI after discussion with @HxpSerein
-  //  @Test
+  @Test
   public void clusterCrash7() throws Exception {
     killClusterTest(buildSet(RemoveRegionPeerState.DELETE_OLD_REGION_PEER), true);
   }

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/batch/IoTDBRegionMigrateConfigNodeCrashIoTV2BatchIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/batch/IoTDBRegionMigrateConfigNodeCrashIoTV2BatchIT.java
@@ -66,8 +66,7 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV2BatchIT
         KillNode.CONFIG_NODE);
   }
 
-  // TODO: @Yongzao Dan, reopen this CI after discussion with @HxpSerein
-  //  @Test
+  @Test
   public void testCnCrashDuringDoAddPeer() throws Exception {
     successTest(
         1,
@@ -127,8 +126,7 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV2BatchIT
         KillNode.CONFIG_NODE);
   }
 
-  // TODO: @Yongzao Dan, reopen this CI after discussion with @HxpSerein
-  //  @Test
+  @Test
   public void cnCrashDuringRemoveRegionLocationCacheTest() throws Exception {
     successTest(
         1,
@@ -140,8 +138,7 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV2BatchIT
         KillNode.CONFIG_NODE);
   }
 
-  // TODO: @Yongzao Dan, reopen this CI after discussion with @HxpSerein
-  //  @Test
+  @Test
   public void cnCrashTest() throws Exception {
     ConcurrentHashMap.KeySetView<String, Boolean> killConfigNodeKeywords = noKillPoints();
     killConfigNodeKeywords.addAll(

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/stream/IoTDBRegionMigrateClusterCrashIoTV2StreamIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/stream/IoTDBRegionMigrateClusterCrashIoTV2StreamIT.java
@@ -47,14 +47,12 @@ public class IoTDBRegionMigrateClusterCrashIoTV2StreamIT
         .setIoTConsensusV2Mode(ConsensusFactory.IOT_CONSENSUS_V2_STREAM_MODE);
   }
 
-  // TODO: @Yongzao Dan, reopen this CI after discussion with @HxpSerein
-  //  @Test
+  @Test
   public void clusterCrash1() throws Exception {
     killClusterTest(buildSet(AddRegionPeerState.CREATE_NEW_REGION_PEER), true);
   }
 
-  // TODO: @Yongzao Dan, reopen this CI after discussion with @HxpSerein
-  //  @Test
+  @Test
   public void clusterCrash2() throws Exception {
     killClusterTest(buildSet(AddRegionPeerState.DO_ADD_REGION_PEER), false);
   }
@@ -74,8 +72,7 @@ public class IoTDBRegionMigrateClusterCrashIoTV2StreamIT
     killClusterTest(buildSet(RemoveRegionPeerState.REMOVE_REGION_PEER), true);
   }
 
-  // TODO: @Yongzao Dan, reopen this CI after discussion with @HxpSerein
-  //  @Test
+  @Test
   public void clusterCrash7() throws Exception {
     killClusterTest(buildSet(RemoveRegionPeerState.DELETE_OLD_REGION_PEER), true);
   }

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/stream/IoTDBRegionMigrateConfigNodeCrashIoTV2StreamIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/daily/iotv2/stream/IoTDBRegionMigrateConfigNodeCrashIoTV2StreamIT.java
@@ -80,8 +80,7 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV2StreamIT
         KillNode.CONFIG_NODE);
   }
 
-  // TODO: @Yongzao Dan, reopen this CI after discussion with @HxpSerein
-  //  @Test
+  @Test
   public void testCnCrashDuringDoAddPeer() throws Exception {
     successTest(
         1,
@@ -141,8 +140,7 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV2StreamIT
         KillNode.CONFIG_NODE);
   }
 
-  // TODO: @Yongzao Dan, reopen this CI after discussion with @HxpSerein
-  //  @Test
+  @Test
   public void cnCrashDuringRemoveRegionLocationCacheTest() throws Exception {
     successTest(
         1,
@@ -154,8 +152,7 @@ public class IoTDBRegionMigrateConfigNodeCrashIoTV2StreamIT
         KillNode.CONFIG_NODE);
   }
 
-  // TODO: @Yongzao Dan, reopen this CI after discussion with @HxpSerein
-  //  @Test
+  @Test
   public void cnCrashTest() throws Exception {
     ConcurrentHashMap.KeySetView<String, Boolean> killConfigNodeKeywords = noKillPoints();
     killConfigNodeKeywords.addAll(

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBCustomizedClusterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBCustomizedClusterIT.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.it.env.cluster.env.SimpleEnv;
 import org.apache.iotdb.it.env.cluster.node.DataNodeWrapper;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.DailyIT;
+import org.apache.iotdb.itbase.exception.InconsistentDataException;
 import org.apache.iotdb.rpc.IoTDBConnectionException;
 import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.rpc.TSStatusCode;
@@ -73,14 +74,15 @@ public class IoTDBCustomizedClusterIT {
             // retry tolerates the brief convergence window (e.g. a replica that has not finished
             // recovering yet) without masking a genuine, persistent inconsistency.
             //
-            // ignoreExceptions() is required: a mismatch surfaces as InconsistentDataException
-            // (a RuntimeException) thrown from getString(), and untilAsserted() only retries on
-            // AssertionError by default, so without it the retry would not actually cover this
-            // failure.
+            // ignoreExceptionsMatching(InconsistentDataException) is required: a mismatch surfaces
+            // as InconsistentDataException (a RuntimeException) thrown from getString(), and
+            // untilAsserted() only retries on AssertionError by default, so without it the retry
+            // would not actually cover this failure. We match only InconsistentDataException so a
+            // genuine error (e.g. a real SQLException) still fails fast instead of being retried.
             Awaitility.await()
                 .atMost(60, TimeUnit.SECONDS)
                 .pollInterval(2, TimeUnit.SECONDS)
-                .ignoreExceptions()
+                .ignoreExceptionsMatching(e -> e instanceof InconsistentDataException)
                 .untilAsserted(
                     () -> {
                       try (ResultSet resultSet =

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBCustomizedClusterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBCustomizedClusterIT.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.rpc.StatementExecutionException;
 import org.apache.iotdb.rpc.TSStatusCode;
 import org.apache.iotdb.session.Session;
 
+import org.awaitility.Awaitility;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -64,22 +65,35 @@ public class IoTDBCustomizedClusterIT {
     testRepeatedlyRestartWholeCluster(
         (s, i, env) -> {
           if (i != 0) {
-            ResultSet resultSet = s.executeQuery("SELECT last s1 FROM root.**");
-            ResultSetMetaData metaData = resultSet.getMetaData();
-            assertEquals(4, metaData.getColumnCount());
-            int cnt = 0;
-            while (resultSet.next()) {
-              cnt++;
-              StringBuilder result = new StringBuilder();
-              for (int j = 0; j < metaData.getColumnCount(); j++) {
-                result
-                    .append(metaData.getColumnName(j + 1))
-                    .append(":")
-                    .append(resultSet.getString(j + 1))
-                    .append(",");
-              }
-              System.out.println(result);
-            }
+            // This query is fanned out to every DataNode and the results are compared across
+            // replicas. Right after a restart the last cache on each coordinator is reloaded
+            // lazily, so the cross-replica comparison may transiently observe an inconsistent
+            // result (e.g. different row order) until the cluster converges. ORDER BY TIMESERIES
+            // makes the row order deterministic across coordinators (the root cause of the observed
+            // flakiness), and the retry tolerates the brief convergence window without masking a
+            // genuine, persistent inconsistency.
+            Awaitility.await()
+                .atMost(60, TimeUnit.SECONDS)
+                .pollInterval(2, TimeUnit.SECONDS)
+                .untilAsserted(
+                    () -> {
+                      try (ResultSet resultSet =
+                          s.executeQuery("SELECT last s1 FROM root.** ORDER BY TIMESERIES ASC")) {
+                        ResultSetMetaData metaData = resultSet.getMetaData();
+                        assertEquals(4, metaData.getColumnCount());
+                        while (resultSet.next()) {
+                          StringBuilder result = new StringBuilder();
+                          for (int j = 0; j < metaData.getColumnCount(); j++) {
+                            result
+                                .append(metaData.getColumnName(j + 1))
+                                .append(":")
+                                .append(resultSet.getString(j + 1))
+                                .append(",");
+                          }
+                          System.out.println(result);
+                        }
+                      }
+                    });
           }
           s.execute("INSERT INTO root.db1.d1 (time, s1) VALUES (1, 1)");
           s.execute("INSERT INTO root.db2.d1 (time, s1) VALUES (1, 1)");

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBCustomizedClusterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBCustomizedClusterIT.java
@@ -68,13 +68,19 @@ public class IoTDBCustomizedClusterIT {
             // This query is fanned out to every DataNode and the results are compared across
             // replicas. Right after a restart the last cache on each coordinator is reloaded
             // lazily, so the cross-replica comparison may transiently observe an inconsistent
-            // result (e.g. different row order) until the cluster converges. ORDER BY TIMESERIES
-            // makes the row order deterministic across coordinators (the root cause of the observed
-            // flakiness), and the retry tolerates the brief convergence window without masking a
-            // genuine, persistent inconsistency.
+            // result until the cluster converges. ORDER BY TIMESERIES makes the row order
+            // deterministic across coordinators (the root cause of the observed flakiness), and the
+            // retry tolerates the brief convergence window (e.g. a replica that has not finished
+            // recovering yet) without masking a genuine, persistent inconsistency.
+            //
+            // ignoreExceptions() is required: a mismatch surfaces as InconsistentDataException
+            // (a RuntimeException) thrown from getString(), and untilAsserted() only retries on
+            // AssertionError by default, so without it the retry would not actually cover this
+            // failure.
             Awaitility.await()
                 .atMost(60, TimeUnit.SECONDS)
                 .pollInterval(2, TimeUnit.SECONDS)
+                .ignoreExceptions()
                 .untilAsserted(
                     () -> {
                       try (ResultSet resultSet =

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/iotconsensusv2/IoTDBIoTConsensusV23C3DBasicITBase.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/iotconsensusv2/IoTDBIoTConsensusV23C3DBasicITBase.java
@@ -342,11 +342,12 @@ public abstract class IoTDBIoTConsensusV23C3DBasicITBase
           // Restart the stopped node before moving to the next iteration
           LOGGER.info("Restarting {}", stoppedDesc);
           stoppedNode.start();
-          // Wait for the restarted node to rejoin
-          Awaitility.await()
-              .atMost(120, TimeUnit.SECONDS)
-              .pollInterval(2, TimeUnit.SECONDS)
-              .until(stoppedNode::isAlive);
+          // Wait for the restarted node to actually be able to serve queries again, not just for
+          // its process to be up. The next loop iteration will treat this node as a surviving node
+          // and connect to it, so if we only waited for isAlive() (process started) the node might
+          // still be in startup (RPC port not yet open / not registered), causing a spurious
+          // "Connection refused" failure.
+          waitUntilDataNodeQueryable(stoppedNode, stoppedDesc);
         }
       }
 
@@ -354,6 +355,43 @@ public abstract class IoTDBIoTConsensusV23C3DBasicITBase
           "DELETE TIMESERIES replica consistency test passed for mode: {}",
           getIoTConsensusV2Mode());
     }
+  }
+
+  /**
+   * Wait until the given DataNode can actually serve queries again after a restart. A node's
+   * process being alive ({@link DataNodeWrapper#isAlive()}) does not mean its client RPC service is
+   * open and it has rejoined the cluster, so we poll a real connection plus a trivial query until
+   * it succeeds.
+   */
+  private void waitUntilDataNodeQueryable(DataNodeWrapper node, String nodeDesc) {
+    Awaitility.await()
+        .atMost(120, TimeUnit.SECONDS)
+        .pollDelay(1, TimeUnit.SECONDS)
+        .pollInterval(2, TimeUnit.SECONDS)
+        .until(
+            () -> {
+              if (!node.isAlive()) {
+                return false;
+              }
+              try (Connection conn =
+                      EnvFactory.getEnv()
+                          .getConnection(
+                              node,
+                              SessionConfig.DEFAULT_USER,
+                              SessionConfig.DEFAULT_PASSWORD,
+                              BaseEnv.TREE_SQL_DIALECT);
+                  Statement stmt = conn.createStatement();
+                  ResultSet rs = stmt.executeQuery(SHOW_TIMESERIES_D1)) {
+                // Drain the result set to make sure the query fully executes.
+                while (rs.next()) {
+                  // no-op
+                }
+                return true;
+              } catch (Exception e) {
+                LOGGER.info("{} not queryable yet, retrying: {}", nodeDesc, e.getMessage());
+                return false;
+              }
+            });
   }
 
   /**


### PR DESCRIPTION
## What this PR does

Fixes three flaky integration tests that surfaced in the nightly **Daily IT**, and re-enables / corrects the IoTV2 region-migration daily tests. All region-migration daily tests stay in the `DailyIT` category — they were only **temporarily** run at PR granularity to pre-validate them (see "Pre-validation" below).

## Flaky-test fixes

All three are *"a result becomes visible before the state the test depends on is actually ready"* timing issues — test bugs, not product bugs:

1. **`IoTDBIoTConsensusV23C3DBasicITBase.testDeleteTimeSeriesReplicaConsistency`** (stream & batch)
   In Step 7 the restarted DataNode was only awaited via `isAlive()` (OS process up), not until it could serve queries. The next loop iteration connected to it and intermittently hit `Connection refused` (RPC port not yet open / not re-registered). Now we wait until the node is actually queryable.

2. **`IoTDBCustomizedClusterIT.testRepeatedlyRestartWholeClusterWithWrite`**
   The `SELECT last s1 FROM root.**` is fanned out to every DataNode and compared positionally across replicas. Right after a full-cluster restart the last cache is reloaded lazily, so the row order could differ across coordinators → `InconsistentDataException`. Added `ORDER BY TIMESERIES` to make the order deterministic (the root cause) and wrapped the comparison in a retry to tolerate the brief convergence window — without masking a genuine, persistent inconsistency.

3. **Region-migration kill-point framework** (`IoTDBRegionOperationReliabilityITFramework`)
   Kill points are detected by a background thread tailing the node log. In the success path `checkKillPointsAllTriggered` could run before that thread processed the kill-point line of the last phase (e.g. `RemoveRegionLocationCache`), failing spuriously with *"Some kill points was not triggered"*. Added a best-effort `graceWaitForKillPointsTriggered` (bounded wait, swallows the timeout) before the authoritative `checkKillPointsAllTriggered`. It deliberately does **not** throw, so the `badKillPoint` test (which expects an `AssertionError` when a kill point never triggers) still passes.

## IoTV2 region-migration daily tests

- **Re-enable** the ConfigNode / Cluster / DataNode crash tests that were commented out pending discussion. The `@Ignore`d `cnCrashDuringPreCheckTest` is left ignored.
- **`originalCrashDuringAddPeerDone`** (batch & stream): `failTest` → `successTest`. Once the add-peer phase is done the new peer already holds the data, so region migration is **designed** to tolerate the original (source) DataNode crashing afterwards — it completes successfully and only leaves the region files on the dead node for later cleanup (`DELETE_OLD_REGION_PEER` logs *"procedure will continue. You should manually delete region file"*). Only the coordinator / destination crash scenarios should fail, and those remain `failTest`.

## Pre-validation

To gain confidence before merging, the **entire region-migration daily suite** (IoTV2 batch/stream, IoTV1, Ratis) was **temporarily** moved from `DailyIT` to the per-PR `ClusterIT` category and run through the full PR pipeline. All region-migration tests passed; the only failures observed were pre-existing, unrelated flaky tests (`IoTDBUDTFAlignByTimeQueryIT.queryWithValueFilter5`, `IoTDBPipePermissionIT.testIllegalPassword`) that also pass on re-run. After validation, the category was restored to `DailyIT`, so this PR's net diff contains only the substantive fixes above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
