### PR TITLE
Subscription: Drain TsFile batches before termination

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/subscription/it/dual/tablemodel/IoTDBSubscriptionTopicIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/subscription/it/dual/tablemodel/IoTDBSubscriptionTopicIT.java
@@ -56,6 +56,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Consumer;
 
@@ -93,6 +94,8 @@ public class IoTDBSubscriptionTopicIT extends AbstractSubscriptionDualIT {
         .getConfig()
         .getCommonConfig()
         .setPipeMetaSyncerSyncIntervalMinutes(1)
+        .setSubscriptionPrefetchTsFileBatchMaxDelayInMs(600_000)
+        .setSubscriptionPrefetchTsFileBatchMaxSizeInBytes(64 * 1024 * 1024)
         .setPipeMemoryManagementEnabled(false)
         .setIsPipeEnableMemoryCheck(false);
   }
@@ -376,6 +379,89 @@ public class IoTDBSubscriptionTopicIT extends AbstractSubscriptionDualIT {
     } catch (final Exception e) {
       e.printStackTrace();
       fail(e.getMessage());
+    } finally {
+      isClosed.set(true);
+      thread.join();
+    }
+  }
+
+  @Test
+  public void testTsFileSnapshotDrainsPendingBatchBeforeTermination() throws Exception {
+    TableModelUtils.createDataBaseAndTable(senderEnv, "test1", "test1");
+    TableModelUtils.createDataBaseAndTable(receiverEnv, "test1", "test1");
+
+    // Insert historical data and create a closed TsFile before snapshot subscription starts.
+    TableModelUtils.insertData("test1", "test1", 0, 10, senderEnv);
+
+    final String topicName = "topic_drain_tsfile_batch_before_termination";
+    final String host = senderEnv.getIP();
+    final int port = Integer.parseInt(senderEnv.getPort());
+    try (final ISubscriptionTableSession session =
+        new SubscriptionTableSessionBuilder().host(host).port(port).build()) {
+      final Properties config = new Properties();
+      config.put(TopicConstant.FORMAT_KEY, TopicConstant.FORMAT_TS_FILE_HANDLER_VALUE);
+      config.put(TopicConstant.MODE_KEY, TopicConstant.MODE_SNAPSHOT_VALUE);
+      config.put(TopicConstant.DATABASE_KEY, "test1");
+      config.put(TopicConstant.TABLE_KEY, "test1");
+      // Force TsFile parsing so the snapshot data is buffered in SubscriptionPipeTsFileEventBatch.
+      config.put(TopicConstant.START_TIME_KEY, 1);
+      session.createTopic(topicName, config);
+    }
+    assertTopicCount(1);
+
+    final AtomicBoolean isClosed = new AtomicBoolean(false);
+    final AtomicReference<Throwable> consumerFailure = new AtomicReference<>();
+    final Thread thread =
+        new Thread(
+            () -> {
+              try (final ISubscriptionTablePullConsumer consumer =
+                      new SubscriptionTablePullConsumerBuilder()
+                          .host(host)
+                          .port(port)
+                          .consumerId("c_drain")
+                          .consumerGroupId("cg_drain")
+                          .autoCommit(false)
+                          .build();
+                  final ITableSession session = receiverEnv.getTableSessionConnection()) {
+                consumer.open();
+                consumer.subscribe(topicName);
+                while (!isClosed.get()) {
+                  final List<SubscriptionMessage> messages =
+                      consumer.poll(IoTDBSubscriptionITConstant.POLL_TIMEOUT_MS);
+                  insertData(messages, session);
+                  consumer.commitSync(messages);
+                }
+              } catch (final Throwable e) {
+                consumerFailure.set(e);
+              } finally {
+                LOGGER.info("draining consumer exiting...");
+              }
+            },
+            String.format("%s - draining consumer", testName.getDisplayName()));
+    thread.start();
+
+    try {
+      final Consumer<String> handleFailure =
+          o -> {
+            TestUtils.executeNonQueryWithRetry(senderEnv, "flush");
+            TestUtils.executeNonQueryWithRetry(receiverEnv, "flush");
+          };
+      AWAIT.untilAsserted(
+          () -> {
+            Assert.assertNull(consumerFailure.get());
+
+            try (final SyncConfigNodeIServiceClient client =
+                (SyncConfigNodeIServiceClient) senderEnv.getLeaderConfigNodeConnection()) {
+              final TShowSubscriptionResp showSubscriptionResp =
+                  client.showSubscription(new TShowSubscriptionReq());
+              Assert.assertEquals(
+                  RpcUtils.SUCCESS_STATUS.getCode(), showSubscriptionResp.status.getCode());
+              Assert.assertNotNull(showSubscriptionResp.subscriptionInfoList);
+              Assert.assertEquals(0, showSubscriptionResp.subscriptionInfoList.size());
+            }
+
+            TableModelUtils.assertData("test1", "test1", 1, 10, receiverEnv, handleFailure);
+          });
     } finally {
       isClosed.set(true);
       thread.join();

--- a/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/DataNodeMiscMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/DataNodeMiscMessages.java
@@ -777,6 +777,11 @@ public final class DataNodeMiscMessages {
       "Exception {} occurred when {} execute receiver subtask";
   public static final String EXCEPTION_CONSTRUCT_TABLET_ITERATOR =
       "Exception {} occurred when {} construct ToTabletIterator";
+  public static final String EXCEPTION_EMIT_EVENTS_BEFORE_COMMIT_TERMINATE_EVENT =
+      "Subscription: SubscriptionPrefetchingQueue {} failed to emit remaining events before "
+          + "committing PipeTerminateEvent {}";
+  public static final String COMMIT_TERMINATE_EVENT =
+      "Subscription: SubscriptionPrefetchingQueue {} commit PipeTerminateEvent {}";
 
   // ---------------------------------------------------------------------------
   // consensus – BaseStateMachine

--- a/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/DataNodeMiscMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/DataNodeMiscMessages.java
@@ -776,6 +776,10 @@ public final class DataNodeMiscMessages {
       "异常 {} 在 {} 执行接收子任务时发生";
   public static final String EXCEPTION_CONSTRUCT_TABLET_ITERATOR =
       "异常 {} 在 {} 构造 ToTabletIterator 时发生";
+  public static final String EXCEPTION_EMIT_EVENTS_BEFORE_COMMIT_TERMINATE_EVENT =
+      "订阅：SubscriptionPrefetchingQueue {} 在提交 PipeTerminateEvent {} 前封存剩余事件失败";
+  public static final String COMMIT_TERMINATE_EVENT =
+      "订阅：SubscriptionPrefetchingQueue {} 提交 PipeTerminateEvent {}";
 
   // ---------------------------------------------------------------------------
   // consensus – BaseStateMachine

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingQueue.java
@@ -117,6 +117,7 @@ public abstract class SubscriptionPrefetchingQueue {
   private volatile TsFileInsertionEvent currentTsFileInsertionEvent;
   private volatile RetryableEvent<TabletInsertionEvent> currentTabletInsertionEvent;
   private volatile SubscriptionTsFileToTabletIterator currentToTabletIterator;
+  private volatile PipeTerminateEvent currentTerminateEvent;
 
   public SubscriptionPrefetchingQueue(
       final String brokerId,
@@ -174,6 +175,10 @@ public abstract class SubscriptionPrefetchingQueue {
       ((EnrichedEvent) currentTabletInsertionEvent.innerEvent)
           .clearReferenceCount(this.getClass().getName());
       currentTabletInsertionEvent = null;
+    }
+    if (Objects.nonNull(currentTerminateEvent)) {
+      currentTerminateEvent.clearReferenceCount(this.getClass().getName());
+      currentTerminateEvent = null;
     }
   }
 
@@ -467,6 +472,10 @@ public abstract class SubscriptionPrefetchingQueue {
    * {@link SubscriptionPrefetchingQueue#inputPendingQueue} is empty.
    */
   private synchronized void tryPrefetch() {
+    if (Objects.nonNull(currentTerminateEvent) && !tryCommitCurrentTerminateEvent()) {
+      return;
+    }
+
     while (!inputPendingQueue.isEmpty() || Objects.nonNull(currentTabletInsertionEvent)) {
       if (Objects.nonNull(currentTabletInsertionEvent)) {
         final RetryableState state = onRetryableTabletInsertionEvent(currentTabletInsertionEvent);
@@ -497,16 +506,10 @@ public abstract class SubscriptionPrefetchingQueue {
       }
 
       if (event instanceof PipeTerminateEvent) {
-        final PipeTerminateEvent terminateEvent = (PipeTerminateEvent) event;
-        // add mark completed hook
-        terminateEvent.addOnCommittedHook(this::markCompleted);
-        // commit directly
-        ((PipeTerminateEvent) event)
-            .decreaseReferenceCount(SubscriptionPrefetchingQueue.class.getName(), true);
-        LOGGER.info(
-            "Subscription: SubscriptionPrefetchingQueue {} commit PipeTerminateEvent {}",
-            this,
-            terminateEvent);
+        currentTerminateEvent = (PipeTerminateEvent) event;
+        if (!tryCommitCurrentTerminateEvent()) {
+          return;
+        }
         continue;
       }
 
@@ -549,6 +552,11 @@ public abstract class SubscriptionPrefetchingQueue {
   }
 
   private synchronized void tryPrefetchV2() {
+    if (Objects.nonNull(currentTerminateEvent)) {
+      tryCommitCurrentTerminateEvent();
+      return;
+    }
+
     if (!prefetchingQueue.isEmpty()) {
       return;
     }
@@ -613,16 +621,8 @@ public abstract class SubscriptionPrefetchingQueue {
     }
 
     if (event instanceof PipeTerminateEvent) {
-      final PipeTerminateEvent terminateEvent = (PipeTerminateEvent) event;
-      // add mark completed hook
-      terminateEvent.addOnCommittedHook(this::markCompleted);
-      // commit directly
-      ((PipeTerminateEvent) event)
-          .decreaseReferenceCount(SubscriptionPrefetchingQueue.class.getName(), true);
-      LOGGER.info(
-          "Subscription: SubscriptionPrefetchingQueue {} commit PipeTerminateEvent {}",
-          this,
-          terminateEvent);
+      currentTerminateEvent = (PipeTerminateEvent) event;
+      tryCommitCurrentTerminateEvent();
       return;
     }
 
@@ -729,6 +729,34 @@ public abstract class SubscriptionPrefetchingQueue {
    */
   protected boolean onEvent() {
     return batches.onEvent(this::prefetchEvent);
+  }
+
+  private boolean tryCommitCurrentTerminateEvent() {
+    try {
+      batches.emitAll(this::prefetchEvent);
+    } catch (final Exception e) {
+      LOGGER.warn(
+          "Subscription: SubscriptionPrefetchingQueue {} failed to emit remaining events before committing PipeTerminateEvent {}.",
+          this,
+          currentTerminateEvent,
+          e);
+      return false;
+    }
+
+    if (!prefetchingQueue.isEmpty() || !inFlightEvents.isEmpty()) {
+      return false;
+    }
+
+    // Add mark completed hook only when all subscription events have been consumed.
+    currentTerminateEvent.addOnCommittedHook(this::markCompleted);
+    currentTerminateEvent.decreaseReferenceCount(
+        SubscriptionPrefetchingQueue.class.getName(), true);
+    LOGGER.info(
+        "Subscription: SubscriptionPrefetchingQueue {} commit PipeTerminateEvent {}",
+        this,
+        currentTerminateEvent);
+    currentTerminateEvent = null;
+    return true;
   }
 
   /////////////////////////////// commit ///////////////////////////////

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingQueue.java
@@ -241,44 +241,8 @@ public abstract class SubscriptionPrefetchingQueue {
       onEvent();
     }
 
-    final long size = prefetchingQueue.size();
-    long count = 0;
-
-    SubscriptionEvent event;
     try {
-      while (count++ < size // limit control
-          && Objects.nonNull(
-              event =
-                  prefetchingQueue.poll(
-                      SubscriptionConfig.getInstance().getSubscriptionPollMaxBlockingTimeMs(),
-                      TimeUnit.MILLISECONDS))) {
-        if (event.isCommitted()) {
-          LOGGER.warn(
-              "Subscription: SubscriptionPrefetchingQueue {} poll committed event {} from prefetching queue (broken invariant), remove it",
-              this,
-              event);
-          // no need to update inFlightEvents
-          continue;
-        }
-
-        if (!event.pollable()) {
-          LOGGER.warn(
-              "Subscription: SubscriptionPrefetchingQueue {} poll non-pollable event {} from prefetching queue (broken invariant), nack and remove it",
-              this,
-              event);
-          event.nack(); // now pollable
-          // no need to update inFlightEvents and prefetchingQueue
-          continue;
-        }
-
-        // This operation should be performed before updating inFlightEvents to prevent multiple
-        // consumers from consuming the same event.
-        event.recordLastPolledTimestamp(); // now non-pollable
-
-        inFlightEvents.put(new Pair<>(consumerId, event.getCommitContext()), event);
-        event.recordLastPolledConsumerId(consumerId);
-        return event;
-      }
+      return pollPrefetchedEvent(consumerId);
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
       LOGGER.warn(
@@ -312,40 +276,8 @@ public abstract class SubscriptionPrefetchingQueue {
           onEvent();
         }
 
-        final long size = prefetchingQueue.size();
-        long count = 0;
-
-        while (count++ < size // limit control
-            && Objects.nonNull(
-                event =
-                    prefetchingQueue.poll(
-                        SubscriptionConfig.getInstance().getSubscriptionPollMaxBlockingTimeMs(),
-                        TimeUnit.MILLISECONDS))) {
-          if (event.isCommitted()) {
-            LOGGER.warn(
-                "Subscription: SubscriptionPrefetchingQueue {} poll committed event {} from prefetching queue (broken invariant), remove it",
-                this,
-                event);
-            // no need to update inFlightEvents
-            continue;
-          }
-
-          if (!event.pollable()) {
-            LOGGER.warn(
-                "Subscription: SubscriptionPrefetchingQueue {} poll non-pollable event {} from prefetching queue (broken invariant), nack and remove it",
-                this,
-                event);
-            event.nack(); // now pollable
-            // no need to update inFlightEvents and prefetchingQueue
-            continue;
-          }
-
-          // This operation should be performed before updating inFlightEvents to prevent multiple
-          // consumers from consuming the same event.
-          event.recordLastPolledTimestamp(); // now non-pollable
-
-          inFlightEvents.put(new Pair<>(consumerId, event.getCommitContext()), event);
-          event.recordLastPolledConsumerId(consumerId);
+        event = pollPrefetchedEvent(consumerId);
+        if (Objects.nonNull(event)) {
           return event;
         }
       } catch (final InterruptedException e) {
@@ -361,6 +293,49 @@ public abstract class SubscriptionPrefetchingQueue {
     return null;
   }
 
+  private synchronized SubscriptionEvent pollPrefetchedEvent(final String consumerId)
+      throws InterruptedException {
+    final long size = prefetchingQueue.size();
+    long count = 0;
+
+    SubscriptionEvent event;
+    while (count++ < size // limit control
+        && Objects.nonNull(
+            event =
+                prefetchingQueue.poll(
+                    SubscriptionConfig.getInstance().getSubscriptionPollMaxBlockingTimeMs(),
+                    TimeUnit.MILLISECONDS))) {
+      if (event.isCommitted()) {
+        LOGGER.warn(
+            "Subscription: SubscriptionPrefetchingQueue {} poll committed event {} from prefetching queue (broken invariant), remove it",
+            this,
+            event);
+        // no need to update inFlightEvents
+        continue;
+      }
+
+      if (!event.pollable()) {
+        LOGGER.warn(
+            "Subscription: SubscriptionPrefetchingQueue {} poll non-pollable event {} from prefetching queue (broken invariant), nack and remove it",
+            this,
+            event);
+        event.nack(); // now pollable
+        // no need to update inFlightEvents and prefetchingQueue
+        continue;
+      }
+
+      // This operation should be performed before updating inFlightEvents to prevent multiple
+      // consumers from consuming the same event.
+      event.recordLastPolledTimestamp(); // now non-pollable
+
+      inFlightEvents.put(new Pair<>(consumerId, event.getCommitContext()), event);
+      event.recordLastPolledConsumerId(consumerId);
+      return event;
+    }
+
+    return null;
+  }
+
   /////////////////////////////// prefetch ///////////////////////////////
 
   public boolean executePrefetch() {
@@ -371,7 +346,12 @@ public abstract class SubscriptionPrefetchingQueue {
       }
       reportStateIfNeeded();
       // TODO: more refined behavior (prefetch/serialize/...) control
-      if (states.shouldPrefetch()) {
+      if (Objects.nonNull(currentTerminateEvent)) {
+        tryCommitCurrentTerminateEvent();
+        remapInFlightEventsSnapshot(
+            committedCleaner, pollableNacker, responsePrefetcher, responseSerializer);
+        return true;
+      } else if (states.shouldPrefetch()) {
         tryPrefetch();
         remapInFlightEventsSnapshot(
             committedCleaner, pollableNacker, responsePrefetcher, responseSerializer);
@@ -731,7 +711,7 @@ public abstract class SubscriptionPrefetchingQueue {
     return batches.onEvent(this::prefetchEvent);
   }
 
-  private boolean tryCommitCurrentTerminateEvent() {
+  private synchronized boolean tryCommitCurrentTerminateEvent() {
     try {
       batches.emitAll(this::prefetchEvent);
     } catch (final Exception e) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingQueue.java
@@ -117,7 +117,7 @@ public abstract class SubscriptionPrefetchingQueue {
   private volatile TsFileInsertionEvent currentTsFileInsertionEvent;
   private volatile RetryableEvent<TabletInsertionEvent> currentTabletInsertionEvent;
   private volatile SubscriptionTsFileToTabletIterator currentToTabletIterator;
-  private volatile PipeTerminateEvent currentTerminateEvent;
+  private PipeTerminateEvent currentTerminateEvent;
 
   public SubscriptionPrefetchingQueue(
       final String brokerId,
@@ -346,8 +346,7 @@ public abstract class SubscriptionPrefetchingQueue {
       }
       reportStateIfNeeded();
       // TODO: more refined behavior (prefetch/serialize/...) control
-      if (Objects.nonNull(currentTerminateEvent)) {
-        tryCommitCurrentTerminateEvent();
+      if (tryCommitCurrentTerminateEventIfPresent()) {
         remapInFlightEventsSnapshot(
             committedCleaner, pollableNacker, responsePrefetcher, responseSerializer);
         return true;
@@ -711,12 +710,21 @@ public abstract class SubscriptionPrefetchingQueue {
     return batches.onEvent(this::prefetchEvent);
   }
 
+  private synchronized boolean tryCommitCurrentTerminateEventIfPresent() {
+    if (Objects.isNull(currentTerminateEvent)) {
+      return false;
+    }
+    tryCommitCurrentTerminateEvent();
+    return true;
+  }
+
   private synchronized boolean tryCommitCurrentTerminateEvent() {
     try {
       batches.emitAll(this::prefetchEvent);
     } catch (final Exception e) {
       LOGGER.warn(
-          "Subscription: SubscriptionPrefetchingQueue {} failed to emit remaining events before committing PipeTerminateEvent {}.",
+          "Subscription: SubscriptionPrefetchingQueue {} failed to emit remaining events before "
+              + "committing PipeTerminateEvent {}.",
           this,
           currentTerminateEvent,
           e);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingQueue.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/broker/SubscriptionPrefetchingQueue.java
@@ -346,7 +346,8 @@ public abstract class SubscriptionPrefetchingQueue {
       }
       reportStateIfNeeded();
       // TODO: more refined behavior (prefetch/serialize/...) control
-      if (tryCommitCurrentTerminateEventIfPresent()) {
+      if (hasCurrentTerminateEvent()) {
+        tryCommitCurrentTerminateEventIfPresent();
         remapInFlightEventsSnapshot(
             committedCleaner, pollableNacker, responsePrefetcher, responseSerializer);
         return true;
@@ -710,12 +711,14 @@ public abstract class SubscriptionPrefetchingQueue {
     return batches.onEvent(this::prefetchEvent);
   }
 
-  private synchronized boolean tryCommitCurrentTerminateEventIfPresent() {
-    if (Objects.isNull(currentTerminateEvent)) {
-      return false;
+  private synchronized boolean hasCurrentTerminateEvent() {
+    return Objects.nonNull(currentTerminateEvent);
+  }
+
+  private synchronized void tryCommitCurrentTerminateEventIfPresent() {
+    if (Objects.nonNull(currentTerminateEvent)) {
+      tryCommitCurrentTerminateEvent();
     }
-    tryCommitCurrentTerminateEvent();
-    return true;
   }
 
   private synchronized boolean tryCommitCurrentTerminateEvent() {
@@ -723,8 +726,7 @@ public abstract class SubscriptionPrefetchingQueue {
       batches.emitAll(this::prefetchEvent);
     } catch (final Exception e) {
       LOGGER.warn(
-          "Subscription: SubscriptionPrefetchingQueue {} failed to emit remaining events before "
-              + "committing PipeTerminateEvent {}.",
+          DataNodeMiscMessages.EXCEPTION_EMIT_EVENTS_BEFORE_COMMIT_TERMINATE_EVENT,
           this,
           currentTerminateEvent,
           e);
@@ -739,10 +741,7 @@ public abstract class SubscriptionPrefetchingQueue {
     currentTerminateEvent.addOnCommittedHook(this::markCompleted);
     currentTerminateEvent.decreaseReferenceCount(
         SubscriptionPrefetchingQueue.class.getName(), true);
-    LOGGER.info(
-        "Subscription: SubscriptionPrefetchingQueue {} commit PipeTerminateEvent {}",
-        this,
-        currentTerminateEvent);
+    LOGGER.info(DataNodeMiscMessages.COMMIT_TERMINATE_EVENT, this, currentTerminateEvent);
     currentTerminateEvent = null;
     return true;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeEventBatch.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeEventBatch.java
@@ -76,20 +76,6 @@ public abstract class SubscriptionPipeEventBatch {
     return false;
   }
 
-  protected synchronized boolean emit(final Consumer<SubscriptionEvent> consumer) throws Exception {
-    if (enrichedEvents.isEmpty()) {
-      return false;
-    }
-    if (Objects.isNull(events)) {
-      events = generateSubscriptionEvents();
-    }
-    if (Objects.nonNull(events)) {
-      events.forEach(consumer);
-      return true;
-    }
-    return false;
-  }
-
   /**
    * @return {@code true} if there are subscription events consumed.
    */
@@ -106,6 +92,20 @@ public abstract class SubscriptionPipeEventBatch {
           "SubscriptionPipeEventBatch {} ignore EnrichedEvent {} when batching.", this, event);
     }
     return onEvent(consumer);
+  }
+
+  protected synchronized boolean emit(final Consumer<SubscriptionEvent> consumer) throws Exception {
+    if (enrichedEvents.isEmpty()) {
+      return false;
+    }
+    if (Objects.isNull(events)) {
+      events = generateSubscriptionEvents();
+    }
+    if (Objects.nonNull(events)) {
+      events.forEach(consumer);
+      return true;
+    }
+    return false;
   }
 
   /////////////////////////////// utility ///////////////////////////////

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeEventBatch.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeEventBatch.java
@@ -71,14 +71,21 @@ public abstract class SubscriptionPipeEventBatch {
   protected synchronized boolean onEvent(final Consumer<SubscriptionEvent> consumer)
       throws Exception {
     if (shouldEmit() && !enrichedEvents.isEmpty()) {
-      if (Objects.isNull(events)) {
-        events = generateSubscriptionEvents();
-      }
-      if (Objects.nonNull(events)) {
-        events.forEach(consumer);
-        return true;
-      }
+      return emit(consumer);
+    }
+    return false;
+  }
+
+  protected synchronized boolean emit(final Consumer<SubscriptionEvent> consumer) throws Exception {
+    if (enrichedEvents.isEmpty()) {
       return false;
+    }
+    if (Objects.isNull(events)) {
+      events = generateSubscriptionEvents();
+    }
+    if (Objects.nonNull(events)) {
+      events.forEach(consumer);
+      return true;
     }
     return false;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeEventBatches.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeEventBatches.java
@@ -90,6 +90,35 @@ public class SubscriptionPipeEventBatches {
     return hasNew.get();
   }
 
+  public boolean emitAll(final Consumer<SubscriptionEvent> consumer) throws Exception {
+    final AtomicBoolean hasNew = new AtomicBoolean(false);
+    Exception exception = null;
+    for (final int regionId : ImmutableList.copyOf(regionIdToBatch.keySet())) {
+      try {
+        segmentLock.lock(regionId);
+        final SubscriptionPipeEventBatch batch = regionIdToBatch.get(regionId);
+        if (Objects.isNull(batch)) {
+          continue;
+        }
+        if (batch.emit(consumer)) {
+          hasNew.set(true);
+          regionIdToBatch.remove(regionId);
+        }
+      } catch (final Exception e) {
+        LOGGER.warn(
+            DataNodeMiscMessages.EXCEPTION_SEALING_EVENTS, regionIdToBatch.get(regionId), e);
+        exception = e;
+      } finally {
+        segmentLock.unlock(regionId);
+      }
+    }
+
+    if (Objects.nonNull(exception)) {
+      throw exception;
+    }
+    return hasNew.get();
+  }
+
   /**
    * @return {@code true} if there are subscription events consumed.
    */

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeEventBatches.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/subscription/event/batch/SubscriptionPipeEventBatches.java
@@ -90,35 +90,6 @@ public class SubscriptionPipeEventBatches {
     return hasNew.get();
   }
 
-  public boolean emitAll(final Consumer<SubscriptionEvent> consumer) throws Exception {
-    final AtomicBoolean hasNew = new AtomicBoolean(false);
-    Exception exception = null;
-    for (final int regionId : ImmutableList.copyOf(regionIdToBatch.keySet())) {
-      try {
-        segmentLock.lock(regionId);
-        final SubscriptionPipeEventBatch batch = regionIdToBatch.get(regionId);
-        if (Objects.isNull(batch)) {
-          continue;
-        }
-        if (batch.emit(consumer)) {
-          hasNew.set(true);
-          regionIdToBatch.remove(regionId);
-        }
-      } catch (final Exception e) {
-        LOGGER.warn(
-            DataNodeMiscMessages.EXCEPTION_SEALING_EVENTS, regionIdToBatch.get(regionId), e);
-        exception = e;
-      } finally {
-        segmentLock.unlock(regionId);
-      }
-    }
-
-    if (Objects.nonNull(exception)) {
-      throw exception;
-    }
-    return hasNew.get();
-  }
-
   /**
    * @return {@code true} if there are subscription events consumed.
    */
@@ -168,6 +139,35 @@ public class SubscriptionPipeEventBatches {
       segmentLock.unlock(regionId);
     }
 
+    return hasNew.get();
+  }
+
+  public boolean emitAll(final Consumer<SubscriptionEvent> consumer) throws Exception {
+    final AtomicBoolean hasNew = new AtomicBoolean(false);
+    Exception exception = null;
+    for (final int regionId : ImmutableList.copyOf(regionIdToBatch.keySet())) {
+      try {
+        segmentLock.lock(regionId);
+        final SubscriptionPipeEventBatch batch = regionIdToBatch.get(regionId);
+        if (Objects.isNull(batch)) {
+          continue;
+        }
+        if (batch.emit(consumer)) {
+          hasNew.set(true);
+          regionIdToBatch.remove(regionId);
+        }
+      } catch (final Exception e) {
+        LOGGER.warn(
+            DataNodeMiscMessages.EXCEPTION_SEALING_EVENTS, regionIdToBatch.get(regionId), e);
+        exception = e;
+      } finally {
+        segmentLock.unlock(regionId);
+      }
+    }
+
+    if (Objects.nonNull(exception)) {
+      throw exception;
+    }
     return hasNew.get();
   }
 


### PR DESCRIPTION
### Motivation
When export-tsfile uses subscription/pipe to export TsFiles, a PipeTerminateEvent could mark the snapshot topic completed before the final internal TsFile batch was emitted and consumed. The client could then receive termination, clean up the topic, and miss the last batch of data.

### Modifications
- Hold PipeTerminateEvent in the subscription prefetching queue until pending batches are emitted.
- Add a forced batch emit path for termination draining.
- Commit the terminate event only after the prefetched queue and in-flight subscription events are empty.

### Tests
- `mvn spotless:apply -pl iotdb-core/datanode`
- `git diff --check`
- `mvn compile -pl iotdb-core/datanode` (fails in unrelated existing/generated dependency areas: missing `PipePeriodicalLogReducer`, relational grammar `identifier()`, `CalcMessages`, and `IndexedBlockingReserveQueue` API mismatches; modified files are not reported in the compilation errors)