### PR TITLE
Recover disk-space metrics when a cached FileStore's directory is removed during region migration

### DIFF
--- a/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/system/SystemMetrics.java
+++ b/iotdb-core/metrics/interface/src/main/java/org/apache/iotdb/metrics/metricsets/system/SystemMetrics.java
@@ -41,6 +41,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.management.ManagementFactory;
 import java.nio.file.FileStore;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -60,7 +62,8 @@ public class SystemMetrics implements IMetricSet {
 
   static final String SYSTEM = "system";
   private final com.sun.management.OperatingSystemMXBean osMxBean;
-  private Set<FileStore> fileStores = new HashSet<>();
+  private volatile Set<FileStore> fileStores = new HashSet<>();
+  private volatile List<String> diskDirs = Collections.emptyList();
   private static final String FAILED_TO_STATISTIC = "Failed to statistic the size of {}, because";
 
   public SystemMetrics() {
@@ -72,6 +75,7 @@ public class SystemMetrics implements IMetricSet {
         .getMetricConfig()
         .getMetricLevel()
         .equals(MetricLevel.OFF)) {
+      this.diskDirs = new ArrayList<>(diskDirs);
       this.fileStores = getFileStores(diskDirs);
     }
   }
@@ -334,39 +338,62 @@ public class SystemMetrics implements IMetricSet {
   }
 
   public long getSystemDiskTotalSpace() {
-    long sysTotalSpace = 0L;
-    for (FileStore fileStore : fileStores) {
-      try {
-        sysTotalSpace += fileStore.getTotalSpace();
-      } catch (IOException e) {
-        logger.error(FAILED_TO_STATISTIC, fileStore, e);
-      }
-    }
-    return sysTotalSpace;
+    return collectDiskSpace(FileStore::getTotalSpace);
   }
 
   public long getSystemDiskFreeSpace() {
-    long sysFreeSpace = 0L;
-    for (FileStore fileStore : fileStores) {
-      try {
-        sysFreeSpace += fileStore.getUnallocatedSpace();
-      } catch (IOException e) {
-        logger.error(FAILED_TO_STATISTIC, fileStore, e);
-      }
-    }
-    return sysFreeSpace;
+    return collectDiskSpace(FileStore::getUnallocatedSpace);
   }
 
   public long getSystemDiskAvailableSpace() {
-    long sysAvailableSpace = 0L;
-    for (FileStore fileStore : fileStores) {
-      try {
-        sysAvailableSpace += fileStore.getUsableSpace();
-      } catch (IOException e) {
-        logger.error(FAILED_TO_STATISTIC, fileStore, e);
+    return collectDiskSpace(FileStore::getUsableSpace);
+  }
+
+  /**
+   * Sum up a disk-space metric across all cached {@link FileStore}s.
+   *
+   * <p>A cached {@code FileStore} pins the exact path it was resolved from. That path can be
+   * removed while IoTDB is running (for example an empty data region directory deleted during
+   * region migration), after which every space query against the stale {@code FileStore} throws
+   * {@link java.nio.file.NoSuchFileException}. When that happens we re-resolve the {@code
+   * FileStore}s once: {@link org.apache.iotdb.metrics.utils.FileStoreUtils#getFileStore} walks up
+   * to an existing ancestor directory on the same device, so the metric recovers on the next
+   * sampling instead of flooding the log with errors on every heartbeat.
+   */
+  private long collectDiskSpace(DiskSpaceReader reader) {
+    boolean refreshed = false;
+    while (true) {
+      Set<FileStore> currentFileStores = fileStores;
+      long space = 0L;
+      boolean stale = false;
+      for (FileStore fileStore : currentFileStores) {
+        try {
+          space += reader.read(fileStore);
+        } catch (IOException e) {
+          stale = true;
+          if (refreshed) {
+            // Still failing after re-resolving: log once at warn level (instead of error on every
+            // sampling) and skip this file store to keep the metric best-effort.
+            logger.warn(FAILED_TO_STATISTIC, fileStore, e);
+          }
+        }
       }
+      if (!stale || refreshed) {
+        return space;
+      }
+      refreshFileStores();
+      refreshed = true;
     }
-    return sysAvailableSpace;
+  }
+
+  /** Re-resolve the cached {@link FileStore}s from the configured disk dirs. */
+  private synchronized void refreshFileStores() {
+    this.fileStores = getFileStores(diskDirs);
+  }
+
+  @FunctionalInterface
+  private interface DiskSpaceReader {
+    long read(FileStore fileStore) throws IOException;
   }
 
   public static SystemMetrics getInstance() {

--- a/iotdb-core/metrics/interface/src/test/java/org/apache/iotdb/metrics/metricsets/system/SystemMetricsTest.java
+++ b/iotdb-core/metrics/interface/src/test/java/org/apache/iotdb/metrics/metricsets/system/SystemMetricsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.metrics.metricsets.system;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Collections;
+
+import static org.junit.Assert.assertTrue;
+
+public class SystemMetricsTest {
+
+  private File tempDir;
+
+  @Before
+  public void setUp() {
+    tempDir = new File("target", "system-metrics-test-" + System.nanoTime());
+    File dataDir = new File(tempDir, "data");
+    assertTrue(dataDir.mkdirs());
+  }
+
+  @After
+  public void tearDown() {
+    if (tempDir != null) {
+      // Best-effort cleanup; the data subdir may already be gone after the test.
+      new File(tempDir, "data").delete();
+      tempDir.delete();
+    }
+  }
+
+  /**
+   * Regression test for the case where the directory backing a cached {@link
+   * java.nio.file.FileStore} is removed while IoTDB is running (e.g. an empty data region directory
+   * deleted during region migration). The disk-space metrics must recover by re-resolving the file
+   * stores instead of throwing / permanently returning the stale value.
+   */
+  @Test
+  public void testDiskSpaceRecoversWhenBackingDirIsRemoved() {
+    SystemMetrics systemMetrics = new SystemMetrics();
+    File dataDir = new File(tempDir, "data");
+    systemMetrics.setDiskDirs(Collections.singletonList(dataDir.getAbsolutePath()));
+
+    // Sanity check: the file store resolves to a real device with a positive size.
+    assertTrue(systemMetrics.getSystemDiskTotalSpace() > 0L);
+    assertTrue(systemMetrics.getSystemDiskFreeSpace() > 0L);
+    assertTrue(systemMetrics.getSystemDiskAvailableSpace() > 0L);
+
+    // The directory the FileStore was pinned to is removed; its parent still lives on the same
+    // device. The metrics should re-resolve the file store and keep reporting a positive size
+    // rather than flooding the log with NoSuchFileException.
+    assertTrue(dataDir.delete());
+
+    assertTrue(systemMetrics.getSystemDiskTotalSpace() > 0L);
+    assertTrue(systemMetrics.getSystemDiskFreeSpace() > 0L);
+    assertTrue(systemMetrics.getSystemDiskAvailableSpace() > 0L);
+  }
+}


### PR DESCRIPTION
## Description

This is a follow-up to #17880 ("Fix empty snapshot loading and region cleanup"), addressing the second problem reported in the same scenario: a cluster that contains an **empty `DataRegion`** (auto-created by the ConfigNode after a scale-out, carrying `0` `SeriesPartitionSlot`) being migrated during scale operations.

While #17880 fixed the empty-snapshot loading (`SnapshotLoader`) and the region-cleanup timeout (`TableDiskUsageIndex` / `DataRegion`), the affected DataNode kept flooding its log with `ERROR` entries like:

```
ERROR o.a.i.m.m.s.SystemMetrics:366 - Failed to statistic the size of /data (/dev/sdb1), because
java.nio.file.NoSuchFileException: /data/.../data/datanode/system
	at ...
	at org.apache.iotdb.metrics.metricsets.system.SystemMetrics.getSystemDiskAvailableSpace(SystemMetrics.java:364)
	at org.apache.iotdb.metrics.core.type.IoTDBAutoGauge.getValue(IoTDBAutoGauge.java:43)
	at ...DataNodeInternalRPCServiceImpl.sampleDiskLoad(...)
	at ...getDataNodeHeartBeat(...)
```

### Root cause

`SystemMetrics#setDiskDirs` resolves each configured disk directory into a `java.nio.file.FileStore` **once at startup** and caches the resulting objects. A `FileStore` pins the exact path it was resolved from; on Linux every `getTotalSpace()` / `getUnallocatedSpace()` / `getUsableSpace()` call re-runs `statvfs` on that pinned path.

When that directory is removed while IoTDB is running (e.g. an empty data region directory is deleted during region migration), the pinned path no longer exists and every space query throws `NoSuchFileException`. Because disk metrics are sampled on every DataNode heartbeat (and on every Prometheus scrape), the stale `FileStore` was logged at `ERROR` on every sampling, never recovered, and flooded the log.

### Fix

- `SystemMetrics` now also stores the configured disk dirs.
- When a space query against a cached `FileStore` fails, the `FileStore` set is re-resolved **once** via `FileStoreUtils#getFileStore`, which walks up to an existing ancestor directory on the same device. The metric then recovers on the next sampling instead of staying broken forever.
- A failure that persists even after re-resolving (practically impossible, since the lookup ultimately falls back to an existing directory) is logged at `WARN` instead of `ERROR`, so it can no longer flood the log.
- `fileStores` / `diskDirs` are made `volatile` and the re-resolution is done copy-on-write, since the getters are invoked concurrently from the heartbeat and Prometheus-reporter threads.

### Behavior

- No behavioral change on the happy path: when all directories exist, the reported total/free/available disk space is identical to before.
- When a backing directory disappears, the metric self-heals on the next sample (re-binding to a still-existing ancestor on the same device) rather than returning `0` and spamming `ERROR` logs.

PingCode: V2-974

<hr>

This PR has:
- [x] been self-reviewed.
    - [x] concurrent read
    - [x] concurrent write
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- `org.apache.iotdb.metrics.metricsets.system.SystemMetrics`
- `org.apache.iotdb.metrics.metricsets.system.SystemMetricsTest` (new)
