### PR TITLE
Fix tree model load type mismatch conversion

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBAlterTimeSeriesTypeIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBAlterTimeSeriesTypeIT.java
@@ -879,8 +879,8 @@ public class IoTDBAlterTimeSeriesTypeIT {
           session.executeQueryStatement("select count(s1) from " + database + ".load_and_alter");
       RowRecord rec;
       rec = dataSet.next();
-      // Before alter, DOUBLE TsFiles loaded directly are invisible under the existing INT32 schema.
-      assertEquals(9, rec.getFields().get(0).getLongV());
+      // Before alter, DOUBLE TsFiles are converted to INT32 and visible under the existing schema.
+      assertEquals(15, rec.getFields().get(0).getLongV());
       assertFalse(dataSet.hasNext());
     }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/load/TreeSchemaAutoCreatorAndVerifier.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/load/TreeSchemaAutoCreatorAndVerifier.java
@@ -483,14 +483,15 @@ public class TreeSchemaAutoCreatorAndVerifier {
         }
 
         // check datatype
-        if (LOGGER.isDebugEnabled() && !tsFileSchema.getType().equals(iotdbSchema.getType())) {
-          LOGGER.debug(
-              "Measurement {}{}{} datatype not match, TsFile: {}, IoTDB: {}",
-              device,
-              TsFileConstant.PATH_SEPARATOR,
-              iotdbSchema.getMeasurementName(),
-              tsFileSchema.getType(),
-              iotdbSchema.getType());
+        if (!tsFileSchema.getType().equals(iotdbSchema.getType())) {
+          throw new LoadAnalyzeTypeMismatchException(
+              String.format(
+                  "Data type mismatch for measurement %s%s%s, type in TsFile: %s, type in IoTDB: %s",
+                  device,
+                  TsFileConstant.PATH_SEPARATOR,
+                  iotdbSchema.getMeasurementName(),
+                  tsFileSchema.getType(),
+                  iotdbSchema.getType()));
         }
 
         // check encoding

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/analyze/load/LoadTsFileAnalyzerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/analyze/load/LoadTsFileAnalyzerTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.queryengine.plan.analyze.load;
 
+import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.queryengine.plan.relational.metadata.ColumnSchema;
 import org.apache.iotdb.commons.schema.table.column.TsTableColumnCategory;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
@@ -26,7 +27,10 @@ import org.apache.iotdb.db.exception.load.LoadAnalyzeTypeMismatchException;
 import org.apache.iotdb.db.exception.load.LoadRuntimeOutOfMemoryException;
 import org.apache.iotdb.db.queryengine.common.MPPQueryContext;
 import org.apache.iotdb.db.queryengine.common.QueryId;
+import org.apache.iotdb.db.queryengine.common.schematree.ClusterSchemaTree;
+import org.apache.iotdb.db.queryengine.common.schematree.ISchemaTree;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.LoadTsFile;
+import org.apache.iotdb.db.queryengine.plan.statement.crud.LoadTsFileStatement;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 
 import org.apache.tsfile.enums.ColumnCategory;
@@ -149,6 +153,51 @@ public class LoadTsFileAnalyzerTest {
     }
   }
 
+  @Test
+  public void testTreeSchemaVerifierShouldThrowMismatchWhenVerifyingDataType() throws Exception {
+    final File tsFile = new File("load-tree-type-mismatch.tsfile");
+    if (tsFile.exists()) {
+      Assert.assertTrue(tsFile.delete());
+    }
+    Assert.assertTrue(tsFile.createNewFile());
+
+    try (final LoadTsFileAnalyzer analyzer =
+        new LoadTsFileAnalyzer(
+            LoadTsFileStatement.createUnchecked(tsFile.getAbsolutePath()),
+            false,
+            new MPPQueryContext(new QueryId("load_tree_test")))) {
+      final TreeSchemaAutoCreatorAndVerifier verifier =
+          new TreeSchemaAutoCreatorAndVerifier(analyzer);
+      try {
+        final IDeviceID device = IDeviceID.Factory.DEFAULT_FACTORY.create("root.sg.d1");
+        final LoadTsFileTreeSchemaCache schemaCache = getTreeSchemaCache(verifier);
+        schemaCache.addTimeSeries(device, new MeasurementSchema("s1", TSDataType.BOOLEAN));
+        schemaCache.addIsAlignedCache(device, true, true);
+
+        final ClusterSchemaTree schemaTree = new ClusterSchemaTree();
+        schemaTree.appendSingleMeasurement(
+            new PartialPath("root.sg.d1.s1"),
+            new MeasurementSchema("s1", TSDataType.INT32),
+            null,
+            null,
+            null,
+            true);
+
+        final InvocationTargetException exception =
+            Assert.assertThrows(
+                InvocationTargetException.class,
+                () -> getVerifyTreeSchemaMethod().invoke(verifier, schemaTree));
+        Assert.assertTrue(exception.getCause() instanceof LoadAnalyzeTypeMismatchException);
+      } finally {
+        verifier.close();
+      }
+    } finally {
+      if (tsFile.exists()) {
+        Assert.assertTrue(tsFile.delete());
+      }
+    }
+  }
+
   private void writeTableTsFileWithMixedDevices(final File tsFile) throws Exception {
     if (tsFile.exists()) {
       Assert.assertTrue(tsFile.delete());
@@ -203,6 +252,14 @@ public class LoadTsFileAnalyzerTest {
     tableSchemaCacheField.set(analyzer, schemaCache);
   }
 
+  private LoadTsFileTreeSchemaCache getTreeSchemaCache(
+      final TreeSchemaAutoCreatorAndVerifier verifier) throws Exception {
+    final Field schemaCacheField =
+        TreeSchemaAutoCreatorAndVerifier.class.getDeclaredField("schemaCache");
+    schemaCacheField.setAccessible(true);
+    return (LoadTsFileTreeSchemaCache) schemaCacheField.get(verifier);
+  }
+
   private LoadTsFileTableSchemaCache createTableSchemaCache(final boolean shouldVerifyDataType)
       throws LoadRuntimeOutOfMemoryException {
     return new LoadTsFileTableSchemaCache(
@@ -215,6 +272,13 @@ public class LoadTsFileAnalyzerTest {
             "verifyTableDataTypeAndGenerateTagColumnMapper",
             org.apache.iotdb.commons.queryengine.plan.relational.metadata.TableSchema.class,
             org.apache.iotdb.commons.queryengine.plan.relational.metadata.TableSchema.class);
+    method.setAccessible(true);
+    return method;
+  }
+
+  private Method getVerifyTreeSchemaMethod() throws NoSuchMethodException {
+    final Method method =
+        TreeSchemaAutoCreatorAndVerifier.class.getDeclaredMethod("verifySchema", ISchemaTree.class);
     method.setAccessible(true);
     return method;
   }


### PR DESCRIPTION
## Description

Tree-model Load TsFile schema verification previously only logged data type mismatches at debug level. As a result, when convert-on-type-mismatch was enabled, the analysis stage could still accept the TsFile directly instead of triggering the existing tablet conversion path.

This patch makes tree schema verification throw LoadAnalyzeTypeMismatchException on measurement data type mismatch, matching the signal used by the load analyzer to convert TsFiles to tablets. It also adds a unit test covering the tree verifier mismatch path.

## Verification

- mvn -pl iotdb-core/datanode spotless:apply
- git diff --check
- mvn -nsu -pl iotdb-core/datanode -Dtest=LoadTsFileAnalyzerTest#testTreeSchemaVerifierShouldThrowMismatchWhenVerifyingDataType test could not complete locally because this checkout fails during datanode compilation/test compilation on unrelated existing source/target/API mismatches, before the new test is executed.