### PR TITLE
Remove IoTConsensus auto leader balance toggle

### DIFF
--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppCommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppCommonConfig.java
@@ -352,15 +352,6 @@ public class MppCommonConfig extends MppBaseConfig implements CommonConfig {
   }
 
   @Override
-  public CommonConfig setEnableAutoLeaderBalanceForIoTConsensus(
-      boolean enableAutoLeaderBalanceForIoTConsensus) {
-    setProperty(
-        "enable_auto_leader_balance_for_iot_consensus",
-        String.valueOf(enableAutoLeaderBalanceForIoTConsensus));
-    return this;
-  }
-
-  @Override
   public CommonConfig setQueryThreadCount(int queryThreadCount) {
     if (queryThreadCount <= 0) {
       queryThreadCount = Runtime.getRuntime().availableProcessors();

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppSharedCommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/config/MppSharedCommonConfig.java
@@ -354,14 +354,6 @@ public class MppSharedCommonConfig implements CommonConfig {
   }
 
   @Override
-  public CommonConfig setEnableAutoLeaderBalanceForIoTConsensus(
-      boolean enableAutoLeaderBalanceForIoTConsensus) {
-    cnConfig.setEnableAutoLeaderBalanceForIoTConsensus(enableAutoLeaderBalanceForIoTConsensus);
-    dnConfig.setEnableAutoLeaderBalanceForIoTConsensus(enableAutoLeaderBalanceForIoTConsensus);
-    return this;
-  }
-
-  @Override
   public CommonConfig setQueryThreadCount(int queryThreadCount) {
     cnConfig.setQueryThreadCount(queryThreadCount);
     dnConfig.setQueryThreadCount(queryThreadCount);

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/remote/config/RemoteCommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/remote/config/RemoteCommonConfig.java
@@ -249,12 +249,6 @@ public class RemoteCommonConfig implements CommonConfig {
   }
 
   @Override
-  public CommonConfig setEnableAutoLeaderBalanceForIoTConsensus(
-      boolean enableAutoLeaderBalanceForIoTConsensus) {
-    return this;
-  }
-
-  @Override
   public CommonConfig setQueryThreadCount(int queryThreadCount) {
     return this;
   }

--- a/integration-test/src/main/java/org/apache/iotdb/itbase/env/CommonConfig.java
+++ b/integration-test/src/main/java/org/apache/iotdb/itbase/env/CommonConfig.java
@@ -113,9 +113,6 @@ public interface CommonConfig {
   CommonConfig setEnableAutoLeaderBalanceForRatisConsensus(
       boolean enableAutoLeaderBalanceForRatisConsensus);
 
-  CommonConfig setEnableAutoLeaderBalanceForIoTConsensus(
-      boolean enableAutoLeaderBalanceForIoTConsensus);
-
   CommonConfig setQueryThreadCount(int queryThreadCount);
 
   CommonConfig setWalBufferSize(int walBufferSize);

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/load/IoTDBMultiDBRegionGroupLeaderDistributionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/load/IoTDBMultiDBRegionGroupLeaderDistributionIT.java
@@ -71,7 +71,6 @@ public class IoTDBMultiDBRegionGroupLeaderDistributionIT {
     EnvFactory.getEnv()
         .getConfig()
         .getCommonConfig()
-        .setEnableAutoLeaderBalanceForIoTConsensus(true)
         .setDataReplicationFactor(TEST_REPLICATION_FACTOR)
         .setDataRegionConsensusProtocolClass(TEST_DATA_REGION_CONSENSUS_PROTOCOL_CLASS);
     EnvFactory.getEnv().initClusterEnvironment(1, TEST_DATA_NODE_NUM);

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/load/IoTDBPerDatabaseRegionGroupAllocationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/load/IoTDBPerDatabaseRegionGroupAllocationIT.java
@@ -79,9 +79,7 @@ public class IoTDBPerDatabaseRegionGroupAllocationIT {
         .setDataRegionConsensusProtocolClass(ConsensusFactory.IOT_CONSENSUS)
         .setDataReplicationFactor(TEST_REPLICATION_FACTOR)
         .setDataRegionGroupExtensionPolicy("CUSTOM")
-        .setDefaultDataRegionGroupNumPerDatabase(TEST_DATA_REGION_GROUP_NUM_PER_DATABASE)
-        // Avoid auto leader balancing rearranging anything during the test
-        .setEnableAutoLeaderBalanceForIoTConsensus(false);
+        .setDefaultDataRegionGroupNumPerDatabase(TEST_DATA_REGION_GROUP_NUM_PER_DATABASE);
     EnvFactory.getEnv().initClusterEnvironment(1, TEST_DATA_NODE_NUM);
   }
 
@@ -128,6 +126,10 @@ public class IoTDBPerDatabaseRegionGroupAllocationIT {
         TDataPartitionTableResp dataPartitionTableResp =
             client.getOrCreateDataPartitionTable(new TDataPartitionReq(partitionSlotsMap));
         Assert.assertEquals(
+            "Failed to create DataPartitions for "
+                + currentDatabase
+                + ": "
+                + dataPartitionTableResp.getStatus(),
             TSStatusCode.SUCCESS_STATUS.getStatusCode(),
             dataPartitionTableResp.getStatus().getCode());
       }

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/load/IoTDBRegionGroupLeaderDistributionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/load/IoTDBRegionGroupLeaderDistributionIT.java
@@ -73,7 +73,6 @@ public class IoTDBRegionGroupLeaderDistributionIT {
         .getConfig()
         .getCommonConfig()
         .setEnableAutoLeaderBalanceForRatisConsensus(true)
-        .setEnableAutoLeaderBalanceForIoTConsensus(true)
         .setSchemaRegionConsensusProtocolClass(TEST_SCHEMA_REGION_CONSENSUS_PROTOCOL_CLASS)
         .setDataRegionConsensusProtocolClass(TEST_DATA_REGION_CONSENSUS_PROTOCOL_CLASS)
         .setSchemaReplicationFactor(TEST_REPLICATION_FACTOR)

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeConfig.java
@@ -231,9 +231,6 @@ public class ConfigNodeConfig {
   /** Whether to enable auto leader balance for Ratis consensus protocol. */
   private boolean enableAutoLeaderBalanceForRatisConsensus = true;
 
-  /** Whether to enable auto leader balance for IoTConsensus protocol. */
-  private boolean enableAutoLeaderBalanceForIoTConsensus = true;
-
   /** The route priority policy of cluster read/write requests. */
   private String routePriorityPolicy = IPriorityBalancer.LEADER_POLICY;
 
@@ -750,15 +747,6 @@ public class ConfigNodeConfig {
   public void setEnableAutoLeaderBalanceForRatisConsensus(
       boolean enableAutoLeaderBalanceForRatisConsensus) {
     this.enableAutoLeaderBalanceForRatisConsensus = enableAutoLeaderBalanceForRatisConsensus;
-  }
-
-  public boolean isEnableAutoLeaderBalanceForIoTConsensus() {
-    return enableAutoLeaderBalanceForIoTConsensus;
-  }
-
-  public void setEnableAutoLeaderBalanceForIoTConsensus(
-      boolean enableAutoLeaderBalanceForIoTConsensus) {
-    this.enableAutoLeaderBalanceForIoTConsensus = enableAutoLeaderBalanceForIoTConsensus;
   }
 
   public String getRoutePriorityPolicy() {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/conf/ConfigNodeDescriptor.java
@@ -386,12 +386,6 @@ public class ConfigNodeDescriptor {
                 "enable_auto_leader_balance_for_ratis_consensus",
                 String.valueOf(conf.isEnableAutoLeaderBalanceForRatisConsensus()))));
 
-    conf.setEnableAutoLeaderBalanceForIoTConsensus(
-        Boolean.parseBoolean(
-            properties.getProperty(
-                "enable_auto_leader_balance_for_iot_consensus",
-                String.valueOf(conf.isEnableAutoLeaderBalanceForIoTConsensus()))));
-
     String routePriorityPolicy =
         properties.getProperty("route_priority_policy", conf.getRoutePriorityPolicy());
     if (IPriorityBalancer.GREEDY_POLICY.equals(routePriorityPolicy)

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/RouteBalancer.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/balancer/RouteBalancer.java
@@ -88,17 +88,14 @@ public class RouteBalancer implements IClusterStatusSubscriber {
   private static final boolean IS_ENABLE_AUTO_LEADER_BALANCE_FOR_DATA_REGION =
       (CONF.isEnableAutoLeaderBalanceForRatisConsensus()
               && ConsensusFactory.RATIS_CONSENSUS.equals(DATA_REGION_CONSENSUS_PROTOCOL_CLASS))
-          || (CONF.isEnableAutoLeaderBalanceForIoTConsensus()
-              && ConsensusFactory.IOT_CONSENSUS.equals(DATA_REGION_CONSENSUS_PROTOCOL_CLASS))
-          || (CONF.isEnableAutoLeaderBalanceForIoTConsensus()
-              && ConsensusFactory.IOT_CONSENSUS_V2.equals(DATA_REGION_CONSENSUS_PROTOCOL_CLASS))
+          || ConsensusFactory.IOT_CONSENSUS.equals(DATA_REGION_CONSENSUS_PROTOCOL_CLASS)
+          || ConsensusFactory.IOT_CONSENSUS_V2.equals(DATA_REGION_CONSENSUS_PROTOCOL_CLASS)
           // The simple consensus protocol will always automatically designate itself as the leader
           || ConsensusFactory.SIMPLE_CONSENSUS.equals(DATA_REGION_CONSENSUS_PROTOCOL_CLASS);
   private static final boolean IS_ENABLE_AUTO_LEADER_BALANCE_FOR_SCHEMA_REGION =
       (CONF.isEnableAutoLeaderBalanceForRatisConsensus()
               && ConsensusFactory.RATIS_CONSENSUS.equals(SCHEMA_REGION_CONSENSUS_PROTOCOL_CLASS))
-          || (CONF.isEnableAutoLeaderBalanceForIoTConsensus()
-              && ConsensusFactory.IOT_CONSENSUS.equals(SCHEMA_REGION_CONSENSUS_PROTOCOL_CLASS))
+          || ConsensusFactory.IOT_CONSENSUS.equals(SCHEMA_REGION_CONSENSUS_PROTOCOL_CLASS)
           // The simple consensus protocol will always automatically designate itself as the leader
           || ConsensusFactory.SIMPLE_CONSENSUS.equals(SCHEMA_REGION_CONSENSUS_PROTOCOL_CLASS);
   private static final long REGION_PRIORITY_WAITING_TIMEOUT =

--- a/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
+++ b/iotdb-core/node-commons/src/assembly/resources/conf/iotdb-system.properties.template
@@ -695,13 +695,6 @@ region_group_allocate_policy=GCR
 # Datatype: Boolean
 enable_auto_leader_balance_for_ratis_consensus=true
 
-# Whether to enable auto leader balance for IoTConsensus protocol.
-# The ConfigNode-leader will balance the leader of IoTConsensus-RegionGroups by leader_distribution_policy if set true.
-# Notice: Default is true because the IoTConsensus depends on this function to distribute leader.
-# effectiveMode: restart
-# Datatype: Boolean
-enable_auto_leader_balance_for_iot_consensus=true
-
 ####################
 ### Cluster management
 ####################


### PR DESCRIPTION
## Description
Remove the `enable_auto_leader_balance_for_iot_consensus` configuration option and its test-environment setter APIs.

IoTConsensus and IoTConsensusV2 RegionGroups now always participate in ConfigNode leader balancing. This matches the previous default behavior and avoids the invalid opt-out case where newly created IoTConsensus RegionGroups could remain with `leaderId=-1` until `CreateRegionGroupsProcedure` waited close to the procedure timeout. In the per-database allocation IT, that could surface as `CREATE_REGION_ERROR` under the GCR policy even though all replicas had been created successfully.

The Ratis auto leader balance toggle is left unchanged.

This patch also keeps the DataPartition creation assertion in `IoTDBPerDatabaseRegionGroupAllocationIT` more diagnostic by including the returned TSStatus in the failure message.

## Tests
- `mvn spotless:apply -pl iotdb-core/confignode,iotdb-core/node-commons,integration-test -P with-integration-tests`
- `mvn verify -Drat.skip=true -DskipUTs -Dit.test=IoTDBPerDatabaseRegionGroupAllocationIT,IoTDBRegionGroupLeaderDistributionIT,IoTDBMultiDBRegionGroupLeaderDistributionIT -DfailIfNoTests=false -Dfailsafe.failIfNoSpecifiedTests=false -pl integration-test -am -PClusterIT -P with-integration-tests`

Note: local full RAT validation is blocked by an unrelated `.claude/scheduled_tasks.lock` file in the working tree, so the focused IT verification used `-Drat.skip=true`.