### PR TITLE
Fix PBTree flush for negative child address

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/flush/Scheduler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/flush/Scheduler.java
@@ -77,7 +77,8 @@ public class Scheduler {
     this.releaseFlushStrategy = releaseFlushStrategy;
   }
 
-  private void executeFlush(CachedMTreeStore store, int regionId, AtomicInteger remainToFlush) {
+  private void executeFlush(
+      CachedMTreeStore store, int regionId, AtomicInteger remainToFlush, boolean propagateFailure) {
     IMemoryManager memoryManager = store.getMemoryManager();
     ISchemaFile file = store.getSchemaFile();
     LockManager lockManager = store.getLockManager();
@@ -98,6 +99,9 @@ public class Scheduler {
           regionId,
           e.getMessage(),
           e);
+      if (propagateFailure) {
+        throw new RuntimeException(e);
+      }
     } finally {
       long time = System.currentTimeMillis() - startTime;
       if (time > 10_000) {
@@ -158,7 +162,7 @@ public class Scheduler {
                             return;
                           }
                           try {
-                            executeFlush(store, regionId, null);
+                            executeFlush(store, regionId, null, true);
                             executeRelease(store, false);
                           } finally {
                             lockManager.globalReadUnlock();
@@ -235,7 +239,7 @@ public class Scheduler {
             }
             try {
 
-              executeFlush(store, regionId, remainToFlush);
+              executeFlush(store, regionId, remainToFlush, false);
             } finally {
               lockManager.globalReadUnlock();
             }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/flush/Scheduler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/flush/Scheduler.java
@@ -150,22 +150,26 @@ public class Scheduler {
                     CompletableFuture.runAsync(
                         () -> {
                           int regionId = entry.getKey();
-                          CachedMTreeStore store = entry.getValue();
-                          if (store == null) {
-                            // store has been closed
-                            return;
-                          }
-                          LockManager lockManager = store.getLockManager();
-                          lockManager.globalReadLock();
-                          if (!regionToStore.containsKey(regionId)) {
-                            // double check store have not been closed
-                            return;
-                          }
                           try {
-                            executeFlush(store, regionId, null, true);
-                            executeRelease(store, false);
+                            CachedMTreeStore store = entry.getValue();
+                            if (store == null) {
+                              // store has been closed
+                              return;
+                            }
+                            LockManager lockManager = store.getLockManager();
+                            lockManager.globalReadLock();
+                            try {
+                              if (!regionToStore.containsKey(regionId)) {
+                                // double check store have not been closed
+                                return;
+                              }
+                              executeFlush(store, regionId, null, true);
+                              executeRelease(store, false);
+                            } finally {
+                              lockManager.globalReadUnlock();
+                            }
                           } finally {
-                            lockManager.globalReadUnlock();
+                            flushingRegionSet.remove(regionId);
                           }
                         },
                         workerPool))
@@ -226,22 +230,25 @@ public class Scheduler {
       flushingRegionSet.add(regionId);
       workerPool.submit(
           () -> {
-            CachedMTreeStore store = regionToStore.get(regionId);
-            if (store == null) {
-              // store has been closed
-              return;
-            }
-            LockManager lockManager = store.getLockManager();
-            lockManager.globalReadLock();
-            if (!regionToStore.containsKey(regionId)) {
-              // double check store have not been closed
-              return;
-            }
             try {
-
-              executeFlush(store, regionId, remainToFlush, false);
+              CachedMTreeStore store = regionToStore.get(regionId);
+              if (store == null) {
+                // store has been closed
+                return;
+              }
+              LockManager lockManager = store.getLockManager();
+              lockManager.globalReadLock();
+              try {
+                if (!regionToStore.containsKey(regionId)) {
+                  // double check store have not been closed
+                  return;
+                }
+                executeFlush(store, regionId, remainToFlush, false);
+              } finally {
+                lockManager.globalReadUnlock();
+              }
             } finally {
-              lockManager.globalReadUnlock();
+              flushingRegionSet.remove(regionId);
             }
           });
       if (remainToFlush.get() <= 0) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/PageManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/PageManager.java
@@ -293,8 +293,6 @@ public abstract class PageManager implements IPageManager {
             .entrySet()) {
       child = entry.getValue();
       actualAddress = getTargetSegmentAddress(curSegAddr, entry.getKey(), cxt);
-      childBuffer = RecordUtils.node2Buffer(child);
-
       curPage = getPageInstance(SchemaFile.getPageIndex(actualAddress), cxt);
       if (curPage.getAsSegmentedPage().read(SchemaFile.getSegIndex(actualAddress), entry.getKey())
           == null) {
@@ -304,6 +302,19 @@ public abstract class PageManager implements IPageManager {
                 node.getName(),
                 entry.getKey()));
       }
+
+      if (!child.isMeasurement() && getNodeAddress(child) < 0) {
+        if (child.isDevice() && child.getAsDeviceMNode().isUseTemplate()) {
+          throw new MetadataException(
+              String.format(
+                  "Adding or updating children of device using template [%s] is NOT allowed.",
+                  child.getFullPath()));
+        }
+        short estSegSize = estimateSegmentSize(child);
+        long glbIndex = preAllocateSegment(estSegSize, cxt);
+        SchemaFile.setNodeAddress(child, glbIndex);
+      }
+      childBuffer = RecordUtils.node2Buffer(child);
 
       // prepare alias comparison
       if (child.isMeasurement() && child.getAsMeasurementMNode().getAlias() != null) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/PageManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/schemafile/pagemgr/PageManager.java
@@ -304,12 +304,6 @@ public abstract class PageManager implements IPageManager {
       }
 
       if (!child.isMeasurement() && getNodeAddress(child) < 0) {
-        if (child.isDevice() && child.getAsDeviceMNode().isUseTemplate()) {
-          throw new MetadataException(
-              String.format(
-                  "Adding or updating children of device using template [%s] is NOT allowed.",
-                  child.getFullPath()));
-        }
         short estSegSize = estimateSegmentSize(child);
         long glbIndex = preAllocateSegment(estSegSize, cxt);
         SchemaFile.setNodeAddress(child, glbIndex);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/SchemaFileTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/mtree/schemafile/SchemaFileTest.java
@@ -316,6 +316,39 @@ public class SchemaFileTest {
   }
 
   @Test
+  public void testFlushUpdatedChildWithNegativeSegmentAddress() throws Exception {
+    ISchemaFile sf = SchemaFile.initSchemaFile("root.sg", TEST_SCHEMA_REGION_ID);
+    ICachedMNode sgNode = nodeFactory.createDatabaseDeviceMNode(null, "sg").getAsMNode();
+    ICachedMNode device = nodeFactory.createDeviceMNode(sgNode, "d1").getAsMNode();
+    sgNode.addChild(device);
+
+    writeMNodeInTest(sf, sgNode);
+
+    // Typical flush order: the parent already has this child record on disk, while the updated
+    // child object in memory may still have no valid segment address.
+    ICachedMNodeContainer.getCachedMNodeContainer(device).setSegmentAddress(-1L);
+    addNodeToUpdateBuffer(sgNode, device);
+    writeMNodeInTest(sf, sgNode);
+
+    Assert.assertTrue(getSegAddrInContainer(device) >= 0);
+
+    device.addChild(getMeasurementNode(device, "s1", "alias_s1"));
+    writeMNodeInTest(sf, device);
+    Assert.assertEquals(
+        "alias_s1", sf.getChildNode(device, "s1").getAsMeasurementMNode().getAlias());
+
+    long deviceSegmentAddress = getSegAddrInContainer(device);
+    sf.close();
+
+    sf = SchemaFile.loadSchemaFile("root.sg", TEST_SCHEMA_REGION_ID);
+    ICachedMNode loadedDevice = sf.getChildNode(sgNode, "d1");
+    Assert.assertEquals(deviceSegmentAddress, getSegAddrInContainer(loadedDevice));
+    Assert.assertEquals(
+        "alias_s1", sf.getChildNode(loadedDevice, "s1").getAsMeasurementMNode().getAlias());
+    sf.close();
+  }
+
+  @Test
   public void testMassiveSegment() throws MetadataException, IOException {
     ICachedMNode dbNode = nodeFactory.createDatabaseDeviceMNode(null, "sgRoot");
     fillChildren(dbNode, 500, "MEN", this::supplyEntity);


### PR DESCRIPTION
Fix PBTree flush when an updated non-measurement child still has a negative segment address. The parent record now allocates a segment for that child before serialization, preventing later flush attempts from repeatedly failing with negative-address nodes. Also propagate failures from force flush so test helpers do not loop forever when a flush cannot make progress. Tests: .\mvnw.cmd -pl iotdb-core/datanode -DskipTests spotless:check passed. Attempted target UT with -am, but local build was blocked by generated thrift sources missing javax.annotation in iotdb-thrift.