### PR TITLE
[To dev/1.3] Fix tree model load type mismatch conversion

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/load/LoadTsFileAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/load/LoadTsFileAnalyzer.java
@@ -897,14 +897,15 @@ public class LoadTsFileAnalyzer implements AutoCloseable {
           }
 
           // check datatype
-          if (LOGGER.isInfoEnabled() && !tsFileSchema.getType().equals(iotdbSchema.getType())) {
-            LOGGER.info(
-                "Measurement {}{}{} datatype not match, TsFile: {}, IoTDB: {}",
-                device,
-                TsFileConstant.PATH_SEPARATOR,
-                iotdbSchema.getMeasurementId(),
-                tsFileSchema.getType(),
-                iotdbSchema.getType());
+          if (!tsFileSchema.getType().equals(iotdbSchema.getType())) {
+            throw new LoadAnalyzeTypeMismatchException(
+                String.format(
+                    "Data type mismatch for measurement %s%s%s, type in TsFile: %s, type in IoTDB: %s",
+                    device,
+                    TsFileConstant.PATH_SEPARATOR,
+                    iotdbSchema.getMeasurementId(),
+                    tsFileSchema.getType(),
+                    iotdbSchema.getType()));
           }
 
           // check encoding


### PR DESCRIPTION
This PR cherry-picks #17949 to dev/1.3.

The original change touched refactored load-schema verifier classes on master. On dev/1.3, the equivalent logic lives in LoadTsFileAnalyzer.SchemaAutoCreatorAndVerifier, so this backport applies the same type-mismatch behavior there.

Verification:
- mvn -DskipTests spotless:apply -pl iotdb-core/datanode
- mvn -Ddevelocity.off=true compile -pl iotdb-core/datanode