### PR TITLE
[IOTDB-17797] Support lateral column aliases in table SELECT list

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/Analysis.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/Analysis.java
@@ -1156,10 +1156,21 @@ public class Analysis implements IAnalysis {
     // referencing each field of the row.
     private final Expression expression;
     private final Optional<List<Expression>> unfoldedExpressions;
+    private final Map<NodeRef<Expression>, Expression> lateralColumnAliasReferences;
 
     public SelectExpression(Expression expression, Optional<List<Expression>> unfoldedExpressions) {
+      this(expression, unfoldedExpressions, ImmutableMap.of());
+    }
+
+    public SelectExpression(
+        Expression expression,
+        Optional<List<Expression>> unfoldedExpressions,
+        Map<NodeRef<Expression>, Expression> lateralColumnAliasReferences) {
       this.expression = requireNonNull(expression, "expression is null");
       this.unfoldedExpressions = requireNonNull(unfoldedExpressions);
+      this.lateralColumnAliasReferences =
+          ImmutableMap.copyOf(
+              requireNonNull(lateralColumnAliasReferences, "lateralColumnAliasReferences is null"));
     }
 
     public Expression getExpression() {
@@ -1168,6 +1179,10 @@ public class Analysis implements IAnalysis {
 
     public Optional<List<Expression>> getUnfoldedExpressions() {
       return unfoldedExpressions;
+    }
+
+    public Map<NodeRef<Expression>, Expression> getLateralColumnAliasReferences() {
+      return lateralColumnAliasReferences;
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/README.md
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/README.md
@@ -46,6 +46,9 @@ Lateral alias rewriting applies inside the later SELECT item's expression, inclu
 arguments and inline window specifications such as `OVER (PARTITION BY ... ORDER BY ...)`. Named
 `WINDOW` definitions are analyzed outside the SELECT list and do not see SELECT aliases.
 
+The target type in `CAST(value AS type)` is not part of expression name resolution, so type names
+are never treated as lateral column alias references.
+
 If a lateral alias reference expands to an expression containing a window function, the analyzer
 rejects it explicitly.
 
@@ -53,7 +56,7 @@ rejects it explicitly.
 
 `GROUP BY` can reuse SELECT aliases and uses the SELECT output expression after lateral alias
 rewriting. `ORDER BY` keeps the existing table-model behavior where output aliases take precedence
-over source columns.
+over source columns, including aliases whose expressions used lateral alias rewriting.
 
 `WHERE` and `HAVING` do not see SELECT aliases.
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/README.md
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/README.md
@@ -1,0 +1,64 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+# Table SELECT Alias Resolution
+
+The table-model analyzer resolves SELECT aliases with the following rules.
+
+## SELECT List
+
+Later `SingleColumn` items in a SELECT list can reference aliases explicitly defined by earlier
+`SingleColumn` items. Resolution is left-to-right: forward references and self references are not
+visible. `AllColumns` and `COLUMNS(...)` items do not register reusable aliases.
+
+Only unqualified identifiers are eligible for lateral column alias resolution. Qualified names and
+dereference expressions, such as `t.x`, `table1.x`, and `x.y`, continue through normal column
+resolution. Lateral alias rewriting does not enter subqueries.
+
+For an unqualified identifier in a later SELECT item, the resolution order is:
+
+1. Local source column.
+2. Previously visible SELECT aliases.
+3. Existing analyzer resolution.
+
+If multiple previous aliases have the same canonical name, the reference is ambiguous unless a
+local source column with that name takes precedence.
+
+Lateral alias rewriting applies inside the later SELECT item's expression, including function
+arguments and inline window specifications such as `OVER (PARTITION BY ... ORDER BY ...)`. Named
+`WINDOW` definitions are analyzed outside the SELECT list and do not see SELECT aliases.
+
+If a lateral alias reference expands to an expression containing a window function, the analyzer
+rejects it explicitly.
+
+## GROUP BY, ORDER BY, WHERE, And HAVING
+
+`GROUP BY` can reuse SELECT aliases and uses the SELECT output expression after lateral alias
+rewriting. `ORDER BY` keeps the existing table-model behavior where output aliases take precedence
+over source columns.
+
+`WHERE` and `HAVING` do not see SELECT aliases.
+
+## Output Field Names
+
+Lateral alias rewriting changes the semantic expression used for type analysis, source-column
+tracking, and planning. When a SELECT item has no explicit alias, the output field name is still
+derived from the original SELECT item text, not from the rewritten expression.

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/README.md
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/README.md
@@ -39,6 +39,11 @@ For an unqualified identifier in a later SELECT item, the resolution order is:
 2. Previously visible SELECT aliases.
 3. Existing analyzer resolution.
 
+SELECT alias matching uses a canonical alias key derived from `Identifier.getCanonicalValue()` and
+folded to uppercase. As a result, ordinary aliases and delimited aliases are matched
+case-insensitively for SELECT alias reuse: `x`, `X`, `"x"`, and `"X"` all refer to the same alias
+name. This alias rule does not change the source-column precedence above.
+
 If multiple previous aliases have the same canonical name, the reference is ambiguous unless a
 local source column with that name takes precedence.
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzer.java
@@ -36,28 +36,19 @@ import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.AllRows;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ArithmeticBinaryExpression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ArithmeticUnaryExpression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.BetweenPredicate;
-import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.BinaryLiteral;
-import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.BooleanLiteral;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Cast;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.CoalesceExpression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Columns;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ComparisonExpression;
-import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.CurrentDatabase;
-import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.CurrentTime;
-import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.CurrentUser;
-import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.DecimalLiteral;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.DereferenceExpression;
-import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.DoubleLiteral;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Except;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ExistsPredicate;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Expression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Extract;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.FieldReference;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Fill;
-import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.FloatLiteral;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.FrameBound;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.FunctionCall;
-import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.GenericLiteral;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.GroupBy;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.GroupingElement;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.GroupingSets;
@@ -82,7 +73,6 @@ import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.NaturalJoin;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Node;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.NotExpression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.NullIfExpression;
-import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.NullLiteral;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Offset;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.OrderBy;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Parameter;
@@ -257,6 +247,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -557,10 +548,6 @@ public class StatementAnalyzer {
         ExpressionTreeRewriter.rewriteWith(rewriter, expression), rewriter.getReferences());
   }
 
-  private static Expression copyExpression(Expression expression) {
-    return ExpressionTreeRewriter.rewriteWith(new DeepCopyExpressionRewriter(), expression);
-  }
-
   private static final class LateralColumnAliasRewrite {
     private final Expression expression;
     private final Map<NodeRef<Expression>, Expression> references;
@@ -583,8 +570,7 @@ public class StatementAnalyzer {
   private static final class LateralColumnAliasRewriter extends ExpressionRewriter<Void> {
     private final Scope scope;
     private final SelectAliasResolver visibleAliases;
-    private final ImmutableMap.Builder<NodeRef<Expression>, Expression> references =
-        ImmutableMap.builder();
+    private final Map<NodeRef<Expression>, Expression> references = new LinkedHashMap<>();
 
     private LateralColumnAliasRewriter(Scope scope, SelectAliasResolver visibleAliases) {
       this.scope = requireNonNull(scope, "scope is null");
@@ -592,7 +578,7 @@ public class StatementAnalyzer {
     }
 
     private Map<NodeRef<Expression>, Expression> getReferences() {
-      return references.buildOrThrow();
+      return ImmutableMap.copyOf(references);
     }
 
     @Override
@@ -613,9 +599,9 @@ public class StatementAnalyzer {
                 "Lateral column alias '%s' containing window function is not supported",
                 node.getValue()));
       }
-      Expression copiedExpression = copyExpression(selectAlias.get().getRewrittenExpression());
-      references.put(NodeRef.of(copiedExpression), selectAlias.get().getRewrittenExpression());
-      return copiedExpression;
+      Expression rewrittenExpression = selectAlias.get().getRewrittenExpression();
+      references.put(NodeRef.of(rewrittenExpression), rewrittenExpression);
+      return rewrittenExpression;
     }
 
     @Override
@@ -776,172 +762,6 @@ public class StatementAnalyzer {
       }
       return node;
     }
-  }
-
-  private static final class DeepCopyExpressionRewriter extends ExpressionRewriter<Void> {
-
-    @Override
-    public Expression rewriteIdentifier(
-        Identifier node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
-      return copyIdentifier(node);
-    }
-
-    @Override
-    public Expression rewriteFieldReference(
-        FieldReference node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
-      return new FieldReference(node.getFieldIndex());
-    }
-
-    @Override
-    public Expression rewriteAllRows(
-        AllRows node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
-      return node.getLocation().map(AllRows::new).orElseGet(AllRows::new);
-    }
-
-    @Override
-    public Expression rewriteFunctionCall(
-        FunctionCall node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
-      if (node.getWindow().isPresent()) {
-        throw new SemanticException(
-            String.format(
-                "Lateral column alias containing window function is not supported: %s", node));
-      }
-
-      List<Expression> arguments =
-          node.getArguments().stream()
-              .map(argument -> treeRewriter.rewrite(argument, context))
-              .collect(toImmutableList());
-      return node.getLocation()
-          .map(
-              location ->
-                  new FunctionCall(
-                      location,
-                      node.getName(),
-                      Optional.empty(),
-                      node.getNullTreatment(),
-                      node.isDistinct(),
-                      node.getProcessingMode(),
-                      arguments))
-          .orElseGet(
-              () ->
-                  new FunctionCall(
-                      node.getName(), node.isDistinct(), node.getProcessingMode(), arguments));
-    }
-
-    @Override
-    public Expression rewriteLiteral(
-        Literal node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
-      return copyLiteral(node);
-    }
-
-    @Override
-    public Expression rewriteParameter(
-        Parameter node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
-      return node.getLocation()
-          .map(location -> new Parameter(location, node.getId()))
-          .orElseGet(() -> new Parameter(node.getId()));
-    }
-
-    @Override
-    public Expression rewriteCurrentDatabase(
-        CurrentDatabase node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
-      return node.getLocation().map(CurrentDatabase::new).orElseGet(CurrentDatabase::new);
-    }
-
-    @Override
-    public Expression rewriteCurrentTime(
-        CurrentTime node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
-      return node.getLocation()
-          .map(
-              location ->
-                  node.getPrecision()
-                      .map(precision -> new CurrentTime(location, node.getFunction(), precision))
-                      .orElseGet(() -> new CurrentTime(location, node.getFunction())))
-          .orElseThrow(() -> new IllegalStateException("CurrentTime location is missing"));
-    }
-
-    @Override
-    public Expression rewriteCurrentUser(
-        CurrentUser node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
-      return node.getLocation().map(CurrentUser::new).orElseGet(CurrentUser::new);
-    }
-
-    @Override
-    public Expression rewriteSymbolReference(
-        SymbolReference node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
-      return new SymbolReference(node.getName());
-    }
-  }
-
-  private static Identifier copyIdentifier(Identifier node) {
-    return node.getLocation()
-        .map(location -> new Identifier(location, node.getValue(), node.isDelimited()))
-        .orElseGet(() -> new Identifier(node.getValue(), node.isDelimited()));
-  }
-
-  private static Literal copyLiteral(Literal node) {
-    if (node instanceof BinaryLiteral) {
-      BinaryLiteral literal = (BinaryLiteral) node;
-      return node.getLocation()
-          .map(location -> new BinaryLiteral(location, literal.toHexString()))
-          .orElseGet(() -> new BinaryLiteral(literal.getValue()));
-    }
-    if (node instanceof BooleanLiteral) {
-      BooleanLiteral literal = (BooleanLiteral) node;
-      String value = Boolean.toString(literal.getValue());
-      return node.getLocation()
-          .map(location -> new BooleanLiteral(location, value))
-          .orElseGet(() -> new BooleanLiteral(value));
-    }
-    if (node instanceof DecimalLiteral) {
-      DecimalLiteral literal = (DecimalLiteral) node;
-      return node.getLocation()
-          .map(location -> new DecimalLiteral(location, literal.getValue()))
-          .orElseGet(() -> new DecimalLiteral(literal.getValue()));
-    }
-    if (node instanceof DoubleLiteral) {
-      DoubleLiteral literal = (DoubleLiteral) node;
-      String value = Double.toString(literal.getValue());
-      return node.getLocation()
-          .map(location -> new DoubleLiteral(location, value))
-          .orElseGet(() -> new DoubleLiteral(literal.getValue()));
-    }
-    if (node instanceof FloatLiteral) {
-      FloatLiteral literal = (FloatLiteral) node;
-      String value = Float.toString(literal.getValue());
-      return node.getLocation()
-          .map(location -> new FloatLiteral(location, value))
-          .orElseGet(() -> new FloatLiteral(literal.getValue()));
-    }
-    if (node instanceof GenericLiteral) {
-      GenericLiteral literal = (GenericLiteral) node;
-      return node.getLocation()
-          .map(location -> new GenericLiteral(location, literal.getType(), literal.getValue()))
-          .orElseGet(() -> new GenericLiteral(literal.getType(), literal.getValue()));
-    }
-    if (node instanceof LongLiteral) {
-      LongLiteral literal = (LongLiteral) node;
-      return node.getLocation()
-          .map(location -> new LongLiteral(location, literal.getValue()))
-          .orElseGet(() -> new LongLiteral(literal.getValue()));
-    }
-    if (node instanceof NullLiteral) {
-      return node.getLocation().map(NullLiteral::new).orElseGet(NullLiteral::new);
-    }
-    if (node instanceof StringLiteral) {
-      StringLiteral literal = (StringLiteral) node;
-      return node.getLocation()
-          .map(location -> new StringLiteral(location, literal.getValue()))
-          .orElseGet(() -> new StringLiteral(literal.getValue()));
-    }
-    if (node instanceof TimeDurationLiteral) {
-      TimeDurationLiteral literal = (TimeDurationLiteral) node;
-      return node.getLocation()
-          .map(location -> new TimeDurationLiteral(location, literal.getValue()))
-          .orElseGet(() -> new TimeDurationLiteral(literal.getValue()));
-    }
-    throw new UnsupportedOperationException(
-        "Unsupported literal type for lateral column alias: " + node.getClass().getName());
   }
 
   /**

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzer.java
@@ -36,19 +36,28 @@ import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.AllRows;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ArithmeticBinaryExpression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ArithmeticUnaryExpression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.BetweenPredicate;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.BinaryLiteral;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.BooleanLiteral;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Cast;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.CoalesceExpression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Columns;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ComparisonExpression;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.CurrentDatabase;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.CurrentTime;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.CurrentUser;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.DecimalLiteral;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.DereferenceExpression;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.DoubleLiteral;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Except;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ExistsPredicate;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Expression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Extract;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.FieldReference;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Fill;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.FloatLiteral;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.FrameBound;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.FunctionCall;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.GenericLiteral;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.GroupBy;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.GroupingElement;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.GroupingSets;
@@ -73,6 +82,7 @@ import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.NaturalJoin;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Node;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.NotExpression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.NullIfExpression;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.NullLiteral;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Offset;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.OrderBy;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Parameter;
@@ -142,6 +152,8 @@ import org.apache.iotdb.db.queryengine.plan.relational.metadata.Metadata;
 import org.apache.iotdb.db.queryengine.plan.relational.planner.PlannerContext;
 import org.apache.iotdb.db.queryengine.plan.relational.planner.ScopeAware;
 import org.apache.iotdb.db.queryengine.plan.relational.planner.TranslationMap;
+import org.apache.iotdb.db.queryengine.plan.relational.planner.ir.ExpressionRewriter;
+import org.apache.iotdb.db.queryengine.plan.relational.planner.ir.ExpressionTreeRewriter;
 import org.apache.iotdb.db.queryengine.plan.relational.security.AccessControl;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.AbstractQueryDeviceWithCache;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.ast.AbstractTraverseDevice;
@@ -372,11 +384,18 @@ public class StatementAnalyzer {
   private static final class SelectAnalysis {
     private final List<Expression> outputExpressions;
     private final List<SelectAlias> aliases;
+    private final Map<NodeRef<SingleColumn>, Expression> singleColumnExpressions;
 
-    private SelectAnalysis(List<Expression> outputExpressions, List<SelectAlias> aliases) {
+    private SelectAnalysis(
+        List<Expression> outputExpressions,
+        List<SelectAlias> aliases,
+        Map<NodeRef<SingleColumn>, Expression> singleColumnExpressions) {
       this.outputExpressions =
           ImmutableList.copyOf(requireNonNull(outputExpressions, "outputExpressions is null"));
       this.aliases = ImmutableList.copyOf(requireNonNull(aliases, "aliases is null"));
+      this.singleColumnExpressions =
+          ImmutableMap.copyOf(
+              requireNonNull(singleColumnExpressions, "singleColumnExpressions is null"));
     }
 
     private List<Expression> getOutputExpressions() {
@@ -386,15 +405,24 @@ public class StatementAnalyzer {
     private List<SelectAlias> getAliases() {
       return aliases;
     }
+
+    private Optional<Expression> getSingleColumnExpression(SingleColumn column) {
+      return Optional.ofNullable(singleColumnExpressions.get(NodeRef.of(column)));
+    }
   }
 
   private static final class SelectAlias {
     private final String canonicalName;
     private final int position;
+    private final Expression rewrittenExpression;
+    private final boolean containsWindowFunction;
 
-    private SelectAlias(String canonicalName, int position) {
+    private SelectAlias(String canonicalName, int position, Expression rewrittenExpression) {
       this.canonicalName = requireNonNull(canonicalName, "canonicalName is null");
       this.position = position;
+      this.rewrittenExpression = requireNonNull(rewrittenExpression, "rewrittenExpression is null");
+      this.containsWindowFunction =
+          !extractWindowFunctions(ImmutableList.of(rewrittenExpression)).isEmpty();
     }
 
     private String getCanonicalName() {
@@ -403,6 +431,14 @@ public class StatementAnalyzer {
 
     private int getPosition() {
       return position;
+    }
+
+    private Expression getRewrittenExpression() {
+      return rewrittenExpression;
+    }
+
+    private boolean containsWindowFunction() {
+      return containsWindowFunction;
     }
   }
 
@@ -429,6 +465,272 @@ public class StatementAnalyzer {
                   .collect(Collectors.joining(", "))));
     }
     return matches.stream().findFirst();
+  }
+
+  private static Expression rewriteLateralColumnAliases(
+      Expression expression, Scope scope, List<SelectAlias> visibleAliases) {
+    if (visibleAliases.isEmpty()) {
+      return expression;
+    }
+    return ExpressionTreeRewriter.rewriteWith(
+        new LateralColumnAliasRewriter(scope, visibleAliases), expression);
+  }
+
+  private static Expression copyExpression(Expression expression) {
+    return ExpressionTreeRewriter.rewriteWith(new DeepCopyExpressionRewriter(), expression);
+  }
+
+  private static final class LateralColumnAliasRewriter extends ExpressionRewriter<Void> {
+    private final Scope scope;
+    private final List<SelectAlias> visibleAliases;
+
+    private LateralColumnAliasRewriter(Scope scope, List<SelectAlias> visibleAliases) {
+      this.scope = requireNonNull(scope, "scope is null");
+      this.visibleAliases = ImmutableList.copyOf(visibleAliases);
+    }
+
+    @Override
+    public Expression rewriteIdentifier(
+        Identifier node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
+      if (resolvesToInputColumn(scope, node)) {
+        return node;
+      }
+
+      Optional<SelectAlias> selectAlias = resolveSelectAlias(node, visibleAliases);
+      if (!selectAlias.isPresent()) {
+        return node;
+      }
+
+      if (selectAlias.get().containsWindowFunction()) {
+        throw new SemanticException(
+            String.format(
+                "Lateral column alias '%s' containing window function is not supported",
+                node.getValue()));
+      }
+      return copyExpression(selectAlias.get().getRewrittenExpression());
+    }
+
+    @Override
+    public Expression rewriteDereferenceExpression(
+        DereferenceExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
+      return node;
+    }
+
+    @Override
+    public Expression rewriteSubqueryExpression(
+        SubqueryExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
+      return node;
+    }
+
+    @Override
+    public Expression rewriteFunctionCall(
+        FunctionCall node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
+      List<Expression> arguments =
+          node.getArguments().stream()
+              .map(argument -> treeRewriter.rewrite(argument, context))
+              .collect(toImmutableList());
+      if (ExpressionTreeRewriter.sameElements(node.getArguments(), arguments)) {
+        return node;
+      }
+
+      if (node.getLocation().isPresent()) {
+        return new FunctionCall(
+            node.getLocation().get(),
+            node.getName(),
+            node.getWindow(),
+            node.getNullTreatment(),
+            node.isDistinct(),
+            node.getProcessingMode(),
+            arguments);
+      }
+
+      if (node.getWindow().isPresent() || node.getNullTreatment().isPresent()) {
+        throw new SemanticException(
+            String.format(
+                "Lateral column alias in window function arguments is not supported: %s", node));
+      }
+      return new FunctionCall(
+          node.getName(), node.isDistinct(), node.getProcessingMode(), arguments);
+    }
+
+    @Override
+    public Expression rewriteQuantifiedComparison(
+        QuantifiedComparisonExpression node,
+        Void context,
+        ExpressionTreeRewriter<Void> treeRewriter) {
+      Expression value = treeRewriter.rewrite(node.getValue(), context);
+      if (value != node.getValue()) {
+        return new QuantifiedComparisonExpression(
+            node.getOperator(), node.getQuantifier(), value, node.getSubquery());
+      }
+      return node;
+    }
+  }
+
+  private static final class DeepCopyExpressionRewriter extends ExpressionRewriter<Void> {
+
+    @Override
+    public Expression rewriteIdentifier(
+        Identifier node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
+      return copyIdentifier(node);
+    }
+
+    @Override
+    public Expression rewriteFieldReference(
+        FieldReference node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
+      return new FieldReference(node.getFieldIndex());
+    }
+
+    @Override
+    public Expression rewriteAllRows(
+        AllRows node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
+      return node.getLocation().map(AllRows::new).orElseGet(AllRows::new);
+    }
+
+    @Override
+    public Expression rewriteFunctionCall(
+        FunctionCall node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
+      if (node.getWindow().isPresent()) {
+        throw new SemanticException(
+            String.format(
+                "Lateral column alias containing window function is not supported: %s", node));
+      }
+
+      List<Expression> arguments =
+          node.getArguments().stream()
+              .map(argument -> treeRewriter.rewrite(argument, context))
+              .collect(toImmutableList());
+      return node.getLocation()
+          .map(
+              location ->
+                  new FunctionCall(
+                      location,
+                      node.getName(),
+                      Optional.empty(),
+                      node.getNullTreatment(),
+                      node.isDistinct(),
+                      node.getProcessingMode(),
+                      arguments))
+          .orElseGet(
+              () ->
+                  new FunctionCall(
+                      node.getName(), node.isDistinct(), node.getProcessingMode(), arguments));
+    }
+
+    @Override
+    public Expression rewriteLiteral(
+        Literal node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
+      return copyLiteral(node);
+    }
+
+    @Override
+    public Expression rewriteParameter(
+        Parameter node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
+      return node.getLocation()
+          .map(location -> new Parameter(location, node.getId()))
+          .orElseGet(() -> new Parameter(node.getId()));
+    }
+
+    @Override
+    public Expression rewriteCurrentDatabase(
+        CurrentDatabase node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
+      return node.getLocation().map(CurrentDatabase::new).orElseGet(CurrentDatabase::new);
+    }
+
+    @Override
+    public Expression rewriteCurrentTime(
+        CurrentTime node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
+      return node.getLocation()
+          .map(
+              location ->
+                  node.getPrecision()
+                      .map(precision -> new CurrentTime(location, node.getFunction(), precision))
+                      .orElseGet(() -> new CurrentTime(location, node.getFunction())))
+          .orElseThrow(() -> new IllegalStateException("CurrentTime location is missing"));
+    }
+
+    @Override
+    public Expression rewriteCurrentUser(
+        CurrentUser node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
+      return node.getLocation().map(CurrentUser::new).orElseGet(CurrentUser::new);
+    }
+
+    @Override
+    public Expression rewriteSymbolReference(
+        SymbolReference node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
+      return new SymbolReference(node.getName());
+    }
+  }
+
+  private static Identifier copyIdentifier(Identifier node) {
+    return node.getLocation()
+        .map(location -> new Identifier(location, node.getValue(), node.isDelimited()))
+        .orElseGet(() -> new Identifier(node.getValue(), node.isDelimited()));
+  }
+
+  private static Literal copyLiteral(Literal node) {
+    if (node instanceof BinaryLiteral) {
+      BinaryLiteral literal = (BinaryLiteral) node;
+      return node.getLocation()
+          .map(location -> new BinaryLiteral(location, literal.toHexString()))
+          .orElseGet(() -> new BinaryLiteral(literal.getValue()));
+    }
+    if (node instanceof BooleanLiteral) {
+      BooleanLiteral literal = (BooleanLiteral) node;
+      String value = Boolean.toString(literal.getValue());
+      return node.getLocation()
+          .map(location -> new BooleanLiteral(location, value))
+          .orElseGet(() -> new BooleanLiteral(value));
+    }
+    if (node instanceof DecimalLiteral) {
+      DecimalLiteral literal = (DecimalLiteral) node;
+      return node.getLocation()
+          .map(location -> new DecimalLiteral(location, literal.getValue()))
+          .orElseGet(() -> new DecimalLiteral(literal.getValue()));
+    }
+    if (node instanceof DoubleLiteral) {
+      DoubleLiteral literal = (DoubleLiteral) node;
+      String value = Double.toString(literal.getValue());
+      return node.getLocation()
+          .map(location -> new DoubleLiteral(location, value))
+          .orElseGet(() -> new DoubleLiteral(literal.getValue()));
+    }
+    if (node instanceof FloatLiteral) {
+      FloatLiteral literal = (FloatLiteral) node;
+      String value = Float.toString(literal.getValue());
+      return node.getLocation()
+          .map(location -> new FloatLiteral(location, value))
+          .orElseGet(() -> new FloatLiteral(literal.getValue()));
+    }
+    if (node instanceof GenericLiteral) {
+      GenericLiteral literal = (GenericLiteral) node;
+      return node.getLocation()
+          .map(location -> new GenericLiteral(location, literal.getType(), literal.getValue()))
+          .orElseGet(() -> new GenericLiteral(literal.getType(), literal.getValue()));
+    }
+    if (node instanceof LongLiteral) {
+      LongLiteral literal = (LongLiteral) node;
+      return node.getLocation()
+          .map(location -> new LongLiteral(location, literal.getValue()))
+          .orElseGet(() -> new LongLiteral(literal.getValue()));
+    }
+    if (node instanceof NullLiteral) {
+      return node.getLocation().map(NullLiteral::new).orElseGet(NullLiteral::new);
+    }
+    if (node instanceof StringLiteral) {
+      StringLiteral literal = (StringLiteral) node;
+      return node.getLocation()
+          .map(location -> new StringLiteral(location, literal.getValue()))
+          .orElseGet(() -> new StringLiteral(literal.getValue()));
+    }
+    if (node instanceof TimeDurationLiteral) {
+      TimeDurationLiteral literal = (TimeDurationLiteral) node;
+      return node.getLocation()
+          .map(location -> new TimeDurationLiteral(location, literal.getValue()))
+          .orElseGet(() -> new TimeDurationLiteral(literal.getValue()));
+    }
+    throw new UnsupportedOperationException(
+        "Unsupported literal type for lateral column alias: " + node.getClass().getName());
   }
 
   /**
@@ -1266,7 +1568,7 @@ public class StatementAnalyzer {
           analyzeGroupBy(node, sourceScope, outputExpressions, selectAnalysis.getAliases());
       analyzeHaving(node, sourceScope);
 
-      Scope outputScope = computeAndAssignOutputScope(node, scope, sourceScope);
+      Scope outputScope = computeAndAssignOutputScope(node, scope, sourceScope, selectAnalysis);
 
       node.getFill()
           .ifPresent(
@@ -1644,6 +1946,9 @@ public class StatementAnalyzer {
       ImmutableList.Builder<Analysis.SelectExpression> selectExpressionBuilder =
           ImmutableList.builder();
       ImmutableList.Builder<SelectAlias> selectAliasBuilder = ImmutableList.builder();
+      ImmutableMap.Builder<NodeRef<SingleColumn>, Expression> singleColumnExpressionBuilder =
+          ImmutableMap.builder();
+      List<SelectAlias> visibleAliases = new ArrayList<>();
 
       int outputPosition = 1;
       for (SelectItem item : node.getSelect().getSelectItems()) {
@@ -1670,11 +1975,17 @@ public class StatementAnalyzer {
               outputPosition++;
             }
           } else {
+            Expression rewrittenExpression =
+                rewriteLateralColumnAliases(selectExpression, scope, visibleAliases);
             analyzeSelectSingleColumn(
-                selectExpression, node, scope, outputExpressionBuilder, selectExpressionBuilder);
+                rewrittenExpression, node, scope, outputExpressionBuilder, selectExpressionBuilder);
+            singleColumnExpressionBuilder.put(NodeRef.of(singleColumn), rewrittenExpression);
             if (singleColumn.getAlias().isPresent()) {
               Identifier alias = singleColumn.getAlias().get();
-              selectAliasBuilder.add(new SelectAlias(alias.getCanonicalValue(), outputPosition));
+              SelectAlias selectAlias =
+                  new SelectAlias(alias.getCanonicalValue(), outputPosition, rewrittenExpression);
+              selectAliasBuilder.add(selectAlias);
+              visibleAliases.add(selectAlias);
             }
             outputPosition++;
           }
@@ -1689,7 +2000,10 @@ public class StatementAnalyzer {
         analysis.setContainsSelectDistinct();
       }
 
-      return new SelectAnalysis(outputExpressionBuilder.build(), selectAliasBuilder.build());
+      return new SelectAnalysis(
+          outputExpressionBuilder.build(),
+          selectAliasBuilder.build(),
+          singleColumnExpressionBuilder.build());
     }
 
     /**
@@ -2926,7 +3240,7 @@ public class StatementAnalyzer {
       }
 
       return resolveSelectAlias(identifier, selectAliases)
-          .map(alias -> outputExpressions.get(alias.getPosition() - 1))
+          .map(SelectAlias::getRewrittenExpression)
           .orElse(expression);
     }
 
@@ -3023,7 +3337,10 @@ public class StatementAnalyzer {
     }
 
     private Scope computeAndAssignOutputScope(
-        QuerySpecification node, Optional<Scope> scope, Scope sourceScope) {
+        QuerySpecification node,
+        Optional<Scope> scope,
+        Scope sourceScope,
+        SelectAnalysis selectAnalysis) {
       ImmutableList.Builder<Field> outputFields = ImmutableList.builder();
 
       for (SelectItem item : node.getSelect().getSelectItems()) {
@@ -3054,7 +3371,8 @@ public class StatementAnalyzer {
           }
         } else if (item instanceof SingleColumn) {
           SingleColumn column = (SingleColumn) item;
-          Expression expression = column.getExpression();
+          Expression expression =
+              selectAnalysis.getSingleColumnExpression(column).orElse(column.getExpression());
 
           // process Columns
           List<Expression> expandedExpressions = column.getExpandedExpressions();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzer.java
@@ -383,16 +383,16 @@ public class StatementAnalyzer {
 
   private static final class SelectAnalysis {
     private final List<Expression> outputExpressions;
-    private final List<SelectAlias> aliases;
+    private final SelectAliasLookup aliases;
     private final Map<NodeRef<SingleColumn>, Expression> singleColumnExpressions;
 
     private SelectAnalysis(
         List<Expression> outputExpressions,
-        List<SelectAlias> aliases,
+        SelectAliasLookup aliases,
         Map<NodeRef<SingleColumn>, Expression> singleColumnExpressions) {
       this.outputExpressions =
           ImmutableList.copyOf(requireNonNull(outputExpressions, "outputExpressions is null"));
-      this.aliases = ImmutableList.copyOf(requireNonNull(aliases, "aliases is null"));
+      this.aliases = requireNonNull(aliases, "aliases is null");
       this.singleColumnExpressions =
           ImmutableMap.copyOf(
               requireNonNull(singleColumnExpressions, "singleColumnExpressions is null"));
@@ -402,7 +402,7 @@ public class StatementAnalyzer {
       return outputExpressions;
     }
 
-    private List<SelectAlias> getAliases() {
+    private SelectAliasLookup getAliases() {
       return aliases;
     }
 
@@ -442,6 +442,71 @@ public class StatementAnalyzer {
     }
   }
 
+  private static final class SelectAliasLookup {
+    private final Map<String, List<SelectAlias>> aliasesByCanonicalName;
+    private final int size;
+
+    private SelectAliasLookup(Map<String, List<SelectAlias>> aliasesByCanonicalName) {
+      requireNonNull(aliasesByCanonicalName, "aliasesByCanonicalName is null");
+
+      ImmutableMap.Builder<String, List<SelectAlias>> aliasesBuilder = ImmutableMap.builder();
+      int aliasCount = 0;
+      for (Map.Entry<String, List<SelectAlias>> entry : aliasesByCanonicalName.entrySet()) {
+        List<SelectAlias> aliases = ImmutableList.copyOf(entry.getValue());
+        aliasesBuilder.put(entry.getKey(), aliases);
+        aliasCount += aliases.size();
+      }
+      this.aliasesByCanonicalName = aliasesBuilder.build();
+      this.size = aliasCount;
+    }
+
+    private static Builder builder() {
+      return new Builder();
+    }
+
+    private boolean isEmpty() {
+      return size == 0;
+    }
+
+    private Optional<SelectAlias> resolve(Identifier identifier) {
+      List<SelectAlias> matches = aliasesByCanonicalName.get(identifier.getCanonicalValue());
+      if (matches == null || matches.isEmpty()) {
+        return Optional.empty();
+      }
+      if (matches.size() > 1) {
+        throw new SemanticException(
+            String.format(
+                "Column alias '%s' is ambiguous at positions %s",
+                identifier.getValue(),
+                matches.stream()
+                    .map(alias -> Integer.toString(alias.getPosition()))
+                    .collect(Collectors.joining(", "))));
+      }
+      return Optional.of(matches.get(0));
+    }
+
+    private static final class Builder {
+      private final Map<String, List<SelectAlias>> aliasesByCanonicalName = new HashMap<>();
+      private int size;
+
+      private void add(SelectAlias alias) {
+        requireNonNull(alias, "alias is null");
+        aliasesByCanonicalName
+            .computeIfAbsent(alias.getCanonicalName(), ignored -> new ArrayList<>())
+            .add(alias);
+        size++;
+      }
+
+      private SelectAliasLookup build() {
+        return new SelectAliasLookup(aliasesByCanonicalName);
+      }
+
+      private boolean isEmpty() {
+        return size == 0;
+      }
+    }
+  }
+
   private static boolean resolvesToInputColumn(Scope scope, Identifier identifier) {
     return scope
         .tryResolveField(identifier, QualifiedName.of(identifier.getValue()))
@@ -450,25 +515,12 @@ public class StatementAnalyzer {
   }
 
   private static Optional<SelectAlias> resolveSelectAlias(
-      Identifier identifier, List<SelectAlias> aliases) {
-    List<SelectAlias> matches =
-        aliases.stream()
-            .filter(alias -> alias.getCanonicalName().equals(identifier.getCanonicalValue()))
-            .collect(toImmutableList());
-    if (matches.size() > 1) {
-      throw new SemanticException(
-          String.format(
-              "Column alias '%s' is ambiguous at positions %s",
-              identifier.getValue(),
-              matches.stream()
-                  .map(alias -> Integer.toString(alias.getPosition()))
-                  .collect(Collectors.joining(", "))));
-    }
-    return matches.stream().findFirst();
+      Identifier identifier, SelectAliasLookup aliases) {
+    return aliases.resolve(identifier);
   }
 
   private static Expression rewriteLateralColumnAliases(
-      Expression expression, Scope scope, List<SelectAlias> visibleAliases) {
+      Expression expression, Scope scope, SelectAliasLookup visibleAliases) {
     if (visibleAliases.isEmpty()) {
       return expression;
     }
@@ -482,11 +534,11 @@ public class StatementAnalyzer {
 
   private static final class LateralColumnAliasRewriter extends ExpressionRewriter<Void> {
     private final Scope scope;
-    private final List<SelectAlias> visibleAliases;
+    private final SelectAliasLookup visibleAliases;
 
-    private LateralColumnAliasRewriter(Scope scope, List<SelectAlias> visibleAliases) {
+    private LateralColumnAliasRewriter(Scope scope, SelectAliasLookup visibleAliases) {
       this.scope = requireNonNull(scope, "scope is null");
-      this.visibleAliases = ImmutableList.copyOf(visibleAliases);
+      this.visibleAliases = requireNonNull(visibleAliases, "visibleAliases is null");
     }
 
     @Override
@@ -2063,10 +2115,10 @@ public class StatementAnalyzer {
       ImmutableList.Builder<Expression> outputExpressionBuilder = ImmutableList.builder();
       ImmutableList.Builder<Analysis.SelectExpression> selectExpressionBuilder =
           ImmutableList.builder();
-      ImmutableList.Builder<SelectAlias> selectAliasBuilder = ImmutableList.builder();
+      SelectAliasLookup.Builder selectAliasBuilder = SelectAliasLookup.builder();
       ImmutableMap.Builder<NodeRef<SingleColumn>, Expression> singleColumnExpressionBuilder =
           ImmutableMap.builder();
-      List<SelectAlias> visibleAliases = new ArrayList<>();
+      SelectAliasLookup.Builder visibleAliasBuilder = SelectAliasLookup.builder();
 
       int outputPosition = 1;
       for (SelectItem item : node.getSelect().getSelectItems()) {
@@ -2093,6 +2145,7 @@ public class StatementAnalyzer {
               outputPosition++;
             }
           } else {
+            SelectAliasLookup visibleAliases = visibleAliasBuilder.build();
             Expression rewrittenExpression =
                 rewriteLateralColumnAliases(selectExpression, scope, visibleAliases);
             resolveFunctionCallAndMeasureWindows(node, rewrittenExpression);
@@ -2104,7 +2157,7 @@ public class StatementAnalyzer {
               SelectAlias selectAlias =
                   new SelectAlias(alias.getCanonicalValue(), outputPosition, rewrittenExpression);
               selectAliasBuilder.add(selectAlias);
-              visibleAliases.add(selectAlias);
+              visibleAliasBuilder.add(selectAlias);
             }
             outputPosition++;
           }
@@ -3196,7 +3249,7 @@ public class StatementAnalyzer {
         QuerySpecification node,
         Scope scope,
         List<Expression> outputExpressions,
-        List<SelectAlias> selectAliases) {
+        SelectAliasLookup selectAliases) {
       if (node.getGroupBy().isPresent()) {
         ImmutableList.Builder<List<Set<FieldId>>> cubes = ImmutableList.builder();
         ImmutableList.Builder<List<Set<FieldId>>> rollups = ImmutableList.builder();
@@ -3348,7 +3401,7 @@ public class StatementAnalyzer {
         Expression expression,
         Scope scope,
         List<Expression> outputExpressions,
-        List<SelectAlias> selectAliases) {
+        SelectAliasLookup selectAliases) {
       if (!(expression instanceof Identifier)) {
         return expression;
       }
@@ -4703,7 +4756,7 @@ public class StatementAnalyzer {
     }
 
     private List<Expression> analyzeOrderBy(
-        Node node, List<SortItem> sortItems, Scope orderByScope, List<SelectAlias> selectAliases) {
+        Node node, List<SortItem> sortItems, Scope orderByScope, SelectAliasLookup selectAliases) {
       ImmutableList.Builder<Expression> orderByFieldsBuilder = ImmutableList.builder();
 
       for (SortItem item : sortItems) {
@@ -4755,7 +4808,7 @@ public class StatementAnalyzer {
     }
 
     private Optional<SelectAlias> resolveOrderBySelectAlias(
-        Expression expression, List<SelectAlias> selectAliases) {
+        Expression expression, SelectAliasLookup selectAliases) {
       if (!(expression instanceof Identifier)) {
         return Optional.empty();
       }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzer.java
@@ -529,7 +529,10 @@ public class StatementAnalyzer {
           node.getArguments().stream()
               .map(argument -> treeRewriter.rewrite(argument, context))
               .collect(toImmutableList());
-      if (ExpressionTreeRewriter.sameElements(node.getArguments(), arguments)) {
+
+      Optional<Window> window = rewriteWindow(node.getWindow(), context, treeRewriter);
+      if (ExpressionTreeRewriter.sameElements(node.getArguments(), arguments)
+          && ExpressionTreeRewriter.sameElements(node.getWindow(), window)) {
         return node;
       }
 
@@ -537,7 +540,7 @@ public class StatementAnalyzer {
         return new FunctionCall(
             node.getLocation().get(),
             node.getName(),
-            node.getWindow(),
+            window,
             node.getNullTreatment(),
             node.isDistinct(),
             node.getProcessingMode(),
@@ -551,6 +554,96 @@ public class StatementAnalyzer {
       }
       return new FunctionCall(
           node.getName(), node.isDistinct(), node.getProcessingMode(), arguments);
+    }
+
+    private Optional<Window> rewriteWindow(
+        Optional<Window> window, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
+      if (!window.isPresent()) {
+        return Optional.empty();
+      }
+      if (!(window.get() instanceof WindowSpecification)) {
+        return window;
+      }
+
+      WindowSpecification specification = (WindowSpecification) window.get();
+      List<Expression> partitionBy =
+          specification.getPartitionBy().stream()
+              .map(expression -> treeRewriter.rewrite(expression, context))
+              .collect(toImmutableList());
+      Optional<OrderBy> orderBy =
+          specification.getOrderBy().map(value -> rewriteOrderBy(value, context, treeRewriter));
+      Optional<WindowFrame> frame =
+          specification.getFrame().map(value -> rewriteWindowFrame(value, context, treeRewriter));
+
+      if (ExpressionTreeRewriter.sameElements(specification.getPartitionBy(), partitionBy)
+          && ExpressionTreeRewriter.sameElements(specification.getOrderBy(), orderBy)
+          && ExpressionTreeRewriter.sameElements(specification.getFrame(), frame)) {
+        return window;
+      }
+
+      return Optional.of(
+          new WindowSpecification(
+              specification
+                  .getLocation()
+                  .orElseThrow(
+                      () -> new IllegalStateException("WindowSpecification location is missing")),
+              specification.getExistingWindowName(),
+              partitionBy,
+              orderBy,
+              frame));
+    }
+
+    private OrderBy rewriteOrderBy(
+        OrderBy node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
+      List<SortItem> sortItems =
+          node.getSortItems().stream()
+              .map(sortItem -> rewriteSortItem(sortItem, context, treeRewriter))
+              .collect(toImmutableList());
+      if (ExpressionTreeRewriter.sameElements(node.getSortItems(), sortItems)) {
+        return node;
+      }
+      return node.getLocation()
+          .map(location -> new OrderBy(location, sortItems))
+          .orElseGet(() -> new OrderBy(sortItems));
+    }
+
+    private SortItem rewriteSortItem(
+        SortItem node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
+      Expression sortKey = treeRewriter.rewrite(node.getSortKey(), context);
+      if (sortKey == node.getSortKey()) {
+        return node;
+      }
+      return node.getLocation()
+          .map(
+              location ->
+                  new SortItem(location, sortKey, node.getOrdering(), node.getNullOrdering()))
+          .orElseGet(() -> new SortItem(sortKey, node.getOrdering(), node.getNullOrdering()));
+    }
+
+    private WindowFrame rewriteWindowFrame(
+        WindowFrame node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
+      FrameBound start = rewriteFrameBound(node.getStart(), context, treeRewriter);
+      Optional<FrameBound> end =
+          node.getEnd().map(value -> rewriteFrameBound(value, context, treeRewriter));
+      if (start == node.getStart() && ExpressionTreeRewriter.sameElements(node.getEnd(), end)) {
+        return node;
+      }
+      return new WindowFrame(
+          node.getLocation()
+              .orElseThrow(() -> new IllegalStateException("WindowFrame location is missing")),
+          node.getType(),
+          start,
+          end);
+    }
+
+    private FrameBound rewriteFrameBound(
+        FrameBound node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
+      Optional<Expression> value =
+          node.getValue().map(expression -> treeRewriter.rewrite(expression, context));
+      if (ExpressionTreeRewriter.sameElements(node.getValue(), value)) {
+        return node;
+      }
+      return new FrameBound(node.getLocation().orElse(null), node.getType(), value.orElse(null));
     }
 
     @Override
@@ -1755,6 +1848,21 @@ public class StatementAnalyzer {
       }
 
       for (FunctionCall windowFunction : extractWindowFunctions(expressions.build())) {
+        if (analysis.getWindow(windowFunction) != null) {
+          continue;
+        }
+        Analysis.ResolvedWindow resolvedWindow =
+            resolveWindowSpecification(querySpecification, windowFunction.getWindow().get());
+        analysis.setWindow(windowFunction, resolvedWindow);
+      }
+    }
+
+    private void resolveFunctionCallAndMeasureWindows(
+        QuerySpecification querySpecification, Expression expression) {
+      for (FunctionCall windowFunction : extractWindowFunctions(ImmutableList.of(expression))) {
+        if (analysis.getWindow(windowFunction) != null) {
+          continue;
+        }
         Analysis.ResolvedWindow resolvedWindow =
             resolveWindowSpecification(querySpecification, windowFunction.getWindow().get());
         analysis.setWindow(windowFunction, resolvedWindow);
@@ -1977,6 +2085,7 @@ public class StatementAnalyzer {
           } else {
             Expression rewrittenExpression =
                 rewriteLateralColumnAliases(selectExpression, scope, visibleAliases);
+            resolveFunctionCallAndMeasureWindows(node, rewrittenExpression);
             analyzeSelectSingleColumn(
                 rewrittenExpression, node, scope, outputExpressionBuilder, selectExpressionBuilder);
             singleColumnExpressionBuilder.put(NodeRef.of(singleColumn), rewrittenExpression);
@@ -3373,6 +3482,7 @@ public class StatementAnalyzer {
           SingleColumn column = (SingleColumn) item;
           Expression expression =
               selectAnalysis.getSingleColumnExpression(column).orElse(column.getExpression());
+          Expression outputNameExpression = column.getExpression();
 
           // process Columns
           List<Expression> expandedExpressions = column.getExpandedExpressions();
@@ -3444,11 +3554,18 @@ public class StatementAnalyzer {
           Optional<QualifiedObjectName> originTable = Optional.empty();
           Optional<String> originColumn = Optional.empty();
           QualifiedName name = null;
+          QualifiedName outputName = null;
 
           if (expression instanceof Identifier) {
             name = QualifiedName.of(((Identifier) expression).getValue());
           } else if (expression instanceof DereferenceExpression) {
             name = getQualifiedName((DereferenceExpression) expression);
+          }
+
+          if (outputNameExpression instanceof Identifier) {
+            outputName = QualifiedName.of(((Identifier) outputNameExpression).getValue());
+          } else if (outputNameExpression instanceof DereferenceExpression) {
+            outputName = getQualifiedName((DereferenceExpression) outputNameExpression);
           }
 
           if (name != null) {
@@ -3467,8 +3584,8 @@ public class StatementAnalyzer {
             }
           }
 
-          if (!field.isPresent() && (name != null)) {
-            field = Optional.of(getLast(name.getOriginalParts()));
+          if (!field.isPresent() && (outputName != null)) {
+            field = Optional.of(getLast(outputName.getOriginalParts()));
           }
 
           Field newField =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzer.java
@@ -524,21 +524,56 @@ public class StatementAnalyzer {
     if (visibleAliases.isEmpty()) {
       return expression;
     }
-    return ExpressionTreeRewriter.rewriteWith(
-        new LateralColumnAliasRewriter(scope, visibleAliases), expression);
+    return rewriteLateralColumnAliasesWithReferences(expression, scope, visibleAliases)
+        .getExpression();
+  }
+
+  private static LateralColumnAliasRewrite rewriteLateralColumnAliasesWithReferences(
+      Expression expression, Scope scope, SelectAliasLookup visibleAliases) {
+    if (visibleAliases.isEmpty()) {
+      return new LateralColumnAliasRewrite(expression, ImmutableMap.of());
+    }
+    LateralColumnAliasRewriter rewriter = new LateralColumnAliasRewriter(scope, visibleAliases);
+    return new LateralColumnAliasRewrite(
+        ExpressionTreeRewriter.rewriteWith(rewriter, expression), rewriter.getReferences());
   }
 
   private static Expression copyExpression(Expression expression) {
     return ExpressionTreeRewriter.rewriteWith(new DeepCopyExpressionRewriter(), expression);
   }
 
+  private static final class LateralColumnAliasRewrite {
+    private final Expression expression;
+    private final Map<NodeRef<Expression>, Expression> references;
+
+    private LateralColumnAliasRewrite(
+        Expression expression, Map<NodeRef<Expression>, Expression> references) {
+      this.expression = requireNonNull(expression, "expression is null");
+      this.references = ImmutableMap.copyOf(requireNonNull(references, "references is null"));
+    }
+
+    private Expression getExpression() {
+      return expression;
+    }
+
+    private Map<NodeRef<Expression>, Expression> getReferences() {
+      return references;
+    }
+  }
+
   private static final class LateralColumnAliasRewriter extends ExpressionRewriter<Void> {
     private final Scope scope;
     private final SelectAliasLookup visibleAliases;
+    private final ImmutableMap.Builder<NodeRef<Expression>, Expression> references =
+        ImmutableMap.builder();
 
     private LateralColumnAliasRewriter(Scope scope, SelectAliasLookup visibleAliases) {
       this.scope = requireNonNull(scope, "scope is null");
       this.visibleAliases = requireNonNull(visibleAliases, "visibleAliases is null");
+    }
+
+    private Map<NodeRef<Expression>, Expression> getReferences() {
+      return references.buildOrThrow();
     }
 
     @Override
@@ -559,7 +594,9 @@ public class StatementAnalyzer {
                 "Lateral column alias '%s' containing window function is not supported",
                 node.getValue()));
       }
-      return copyExpression(selectAlias.get().getRewrittenExpression());
+      Expression copiedExpression = copyExpression(selectAlias.get().getRewrittenExpression());
+      references.put(NodeRef.of(copiedExpression), selectAlias.get().getRewrittenExpression());
+      return copiedExpression;
     }
 
     @Override
@@ -1425,7 +1462,10 @@ public class StatementAnalyzer {
       if (node.getOrderBy().isPresent()) {
         orderByExpressions =
             analyzeOrderBy(
-                node, getSortItemsFromOrderBy(node.getOrderBy()), queryBodyScope, emptyList());
+                node,
+                getSortItemsFromOrderBy(node.getOrderBy()),
+                queryBodyScope,
+                SelectAliasLookup.builder().build());
 
         if ((queryBodyScope.getOuterQueryParent().isPresent() || !isTopLevel)
             && !node.getLimit().isPresent()
@@ -2146,11 +2186,17 @@ public class StatementAnalyzer {
             }
           } else {
             SelectAliasLookup visibleAliases = visibleAliasBuilder.build();
-            Expression rewrittenExpression =
-                rewriteLateralColumnAliases(selectExpression, scope, visibleAliases);
+            LateralColumnAliasRewrite lateralColumnAliasRewrite =
+                rewriteLateralColumnAliasesWithReferences(selectExpression, scope, visibleAliases);
+            Expression rewrittenExpression = lateralColumnAliasRewrite.getExpression();
             resolveFunctionCallAndMeasureWindows(node, rewrittenExpression);
             analyzeSelectSingleColumn(
-                rewrittenExpression, node, scope, outputExpressionBuilder, selectExpressionBuilder);
+                rewrittenExpression,
+                node,
+                scope,
+                outputExpressionBuilder,
+                selectExpressionBuilder,
+                lateralColumnAliasRewrite.getReferences());
             singleColumnExpressionBuilder.put(NodeRef.of(singleColumn), rewrittenExpression);
             if (singleColumn.getAlias().isPresent()) {
               Identifier alias = singleColumn.getAlias().get();
@@ -3231,10 +3277,28 @@ public class StatementAnalyzer {
         Scope scope,
         ImmutableList.Builder<Expression> outputExpressionBuilder,
         ImmutableList.Builder<Analysis.SelectExpression> selectExpressionBuilder) {
+      analyzeSelectSingleColumn(
+          expression,
+          node,
+          scope,
+          outputExpressionBuilder,
+          selectExpressionBuilder,
+          ImmutableMap.of());
+    }
+
+    private void analyzeSelectSingleColumn(
+        Expression expression,
+        QuerySpecification node,
+        Scope scope,
+        ImmutableList.Builder<Expression> outputExpressionBuilder,
+        ImmutableList.Builder<Analysis.SelectExpression> selectExpressionBuilder,
+        Map<NodeRef<Expression>, Expression> lateralColumnAliasReferences) {
       ExpressionAnalysis expressionAnalysis = analyzeExpression(expression, scope);
       analysis.recordSubqueries(node, expressionAnalysis);
       outputExpressionBuilder.add(expression);
-      selectExpressionBuilder.add(new Analysis.SelectExpression(expression, Optional.empty()));
+      selectExpressionBuilder.add(
+          new Analysis.SelectExpression(
+              expression, Optional.empty(), lateralColumnAliasReferences));
 
       Type type = expressionAnalysis.getType(expression);
       if (node.getSelect().isDistinct() && !type.isComparable()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzer.java
@@ -442,7 +442,13 @@ public class StatementAnalyzer {
     }
   }
 
-  private static final class SelectAliasLookup {
+  private interface SelectAliasResolver {
+    boolean isEmpty();
+
+    Optional<SelectAlias> resolve(Identifier identifier);
+  }
+
+  private static final class SelectAliasLookup implements SelectAliasResolver {
     private final Map<String, List<SelectAlias>> aliasesByCanonicalName;
     private final int size;
 
@@ -464,11 +470,18 @@ public class StatementAnalyzer {
       return new Builder();
     }
 
-    private boolean isEmpty() {
+    @Override
+    public boolean isEmpty() {
       return size == 0;
     }
 
-    private Optional<SelectAlias> resolve(Identifier identifier) {
+    @Override
+    public Optional<SelectAlias> resolve(Identifier identifier) {
+      return resolveFrom(aliasesByCanonicalName, identifier);
+    }
+
+    private static Optional<SelectAlias> resolveFrom(
+        Map<String, List<SelectAlias>> aliasesByCanonicalName, Identifier identifier) {
       List<SelectAlias> matches = aliasesByCanonicalName.get(identifier.getCanonicalValue());
       if (matches == null || matches.isEmpty()) {
         return Optional.empty();
@@ -485,7 +498,7 @@ public class StatementAnalyzer {
       return Optional.of(matches.get(0));
     }
 
-    private static final class Builder {
+    private static final class Builder implements SelectAliasResolver {
       private final Map<String, List<SelectAlias>> aliasesByCanonicalName = new HashMap<>();
       private int size;
 
@@ -501,8 +514,14 @@ public class StatementAnalyzer {
         return new SelectAliasLookup(aliasesByCanonicalName);
       }
 
-      private boolean isEmpty() {
+      @Override
+      public boolean isEmpty() {
         return size == 0;
+      }
+
+      @Override
+      public Optional<SelectAlias> resolve(Identifier identifier) {
+        return resolveFrom(aliasesByCanonicalName, identifier);
       }
     }
   }
@@ -515,12 +534,12 @@ public class StatementAnalyzer {
   }
 
   private static Optional<SelectAlias> resolveSelectAlias(
-      Identifier identifier, SelectAliasLookup aliases) {
+      Identifier identifier, SelectAliasResolver aliases) {
     return aliases.resolve(identifier);
   }
 
   private static Expression rewriteLateralColumnAliases(
-      Expression expression, Scope scope, SelectAliasLookup visibleAliases) {
+      Expression expression, Scope scope, SelectAliasResolver visibleAliases) {
     if (visibleAliases.isEmpty()) {
       return expression;
     }
@@ -529,7 +548,7 @@ public class StatementAnalyzer {
   }
 
   private static LateralColumnAliasRewrite rewriteLateralColumnAliasesWithReferences(
-      Expression expression, Scope scope, SelectAliasLookup visibleAliases) {
+      Expression expression, Scope scope, SelectAliasResolver visibleAliases) {
     if (visibleAliases.isEmpty()) {
       return new LateralColumnAliasRewrite(expression, ImmutableMap.of());
     }
@@ -563,11 +582,11 @@ public class StatementAnalyzer {
 
   private static final class LateralColumnAliasRewriter extends ExpressionRewriter<Void> {
     private final Scope scope;
-    private final SelectAliasLookup visibleAliases;
+    private final SelectAliasResolver visibleAliases;
     private final ImmutableMap.Builder<NodeRef<Expression>, Expression> references =
         ImmutableMap.builder();
 
-    private LateralColumnAliasRewriter(Scope scope, SelectAliasLookup visibleAliases) {
+    private LateralColumnAliasRewriter(Scope scope, SelectAliasResolver visibleAliases) {
       this.scope = requireNonNull(scope, "scope is null");
       this.visibleAliases = requireNonNull(visibleAliases, "visibleAliases is null");
     }
@@ -2158,7 +2177,6 @@ public class StatementAnalyzer {
       SelectAliasLookup.Builder selectAliasBuilder = SelectAliasLookup.builder();
       ImmutableMap.Builder<NodeRef<SingleColumn>, Expression> singleColumnExpressionBuilder =
           ImmutableMap.builder();
-      SelectAliasLookup.Builder visibleAliasBuilder = SelectAliasLookup.builder();
 
       int outputPosition = 1;
       for (SelectItem item : node.getSelect().getSelectItems()) {
@@ -2185,9 +2203,9 @@ public class StatementAnalyzer {
               outputPosition++;
             }
           } else {
-            SelectAliasLookup visibleAliases = visibleAliasBuilder.build();
             LateralColumnAliasRewrite lateralColumnAliasRewrite =
-                rewriteLateralColumnAliasesWithReferences(selectExpression, scope, visibleAliases);
+                rewriteLateralColumnAliasesWithReferences(
+                    selectExpression, scope, selectAliasBuilder);
             Expression rewrittenExpression = lateralColumnAliasRewrite.getExpression();
             resolveFunctionCallAndMeasureWindows(node, rewrittenExpression);
             analyzeSelectSingleColumn(
@@ -2203,7 +2221,6 @@ public class StatementAnalyzer {
               SelectAlias selectAlias =
                   new SelectAlias(alias.getCanonicalValue(), outputPosition, rewrittenExpression);
               selectAliasBuilder.add(selectAlias);
-              visibleAliasBuilder.add(selectAlias);
             }
             outputPosition++;
           }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzer.java
@@ -523,6 +523,16 @@ public class StatementAnalyzer {
     }
 
     @Override
+    public Expression rewriteCast(
+        Cast node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
+      Expression expression = treeRewriter.rewrite(node.getExpression(), context);
+      if (expression == node.getExpression()) {
+        return node;
+      }
+      return new Cast(expression, node.getType(), node.isSafe(), node.isTypeOnly());
+    }
+
+    @Override
     public Expression rewriteFunctionCall(
         FunctionCall node, Void context, ExpressionTreeRewriter<Void> treeRewriter) {
       List<Expression> arguments =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/StatementAnalyzer.java
@@ -473,7 +473,7 @@ public class StatementAnalyzer {
 
     private static Optional<SelectAlias> resolveFrom(
         Map<String, List<SelectAlias>> aliasesByCanonicalName, Identifier identifier) {
-      List<SelectAlias> matches = aliasesByCanonicalName.get(identifier.getCanonicalValue());
+      List<SelectAlias> matches = aliasesByCanonicalName.get(canonicalSelectAliasName(identifier));
       if (matches == null || matches.isEmpty()) {
         return Optional.empty();
       }
@@ -515,6 +515,10 @@ public class StatementAnalyzer {
         return resolveFrom(aliasesByCanonicalName, identifier);
       }
     }
+  }
+
+  private static String canonicalSelectAliasName(Identifier identifier) {
+    return identifier.getCanonicalValue().toUpperCase(ENGLISH);
   }
 
   private static boolean resolvesToInputColumn(Scope scope, Identifier identifier) {
@@ -2039,7 +2043,8 @@ public class StatementAnalyzer {
             if (singleColumn.getAlias().isPresent()) {
               Identifier alias = singleColumn.getAlias().get();
               SelectAlias selectAlias =
-                  new SelectAlias(alias.getCanonicalValue(), outputPosition, rewrittenExpression);
+                  new SelectAlias(
+                      canonicalSelectAliasName(alias), outputPosition, rewrittenExpression);
               selectAliasBuilder.add(selectAlias);
             }
             outputPosition++;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/PlanBuilder.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/PlanBuilder.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.queryengine.plan.relational.planner;
 
 import org.apache.iotdb.commons.queryengine.plan.planner.plan.node.PlanNode;
+import org.apache.iotdb.commons.queryengine.plan.relational.analyzer.NodeRef;
 import org.apache.iotdb.commons.queryengine.plan.relational.planner.Assignments;
 import org.apache.iotdb.commons.queryengine.plan.relational.planner.Symbol;
 import org.apache.iotdb.commons.queryengine.plan.relational.planner.node.ProjectNode;
@@ -79,6 +80,10 @@ public class PlanBuilder {
 
   public PlanBuilder withScope(Scope scope, List<Symbol> fields) {
     return new PlanBuilder(translations.withScope(scope, fields), root);
+  }
+
+  public PlanBuilder withAdditionalIdentityMappings(Map<NodeRef<Expression>, Symbol> mappings) {
+    return new PlanBuilder(translations.withAdditionalIdentityMappings(mappings), root);
   }
 
   public boolean canTranslate(Expression expression) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/QueryPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/QueryPlanner.java
@@ -43,6 +43,8 @@ import org.apache.iotdb.commons.queryengine.plan.relational.planner.node.SortNod
 import org.apache.iotdb.commons.queryengine.plan.relational.planner.node.ValueFillNode;
 import org.apache.iotdb.commons.queryengine.plan.relational.planner.node.ValuesNode;
 import org.apache.iotdb.commons.queryengine.plan.relational.planner.node.WindowNode;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ArithmeticBinaryExpression;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ArithmeticUnaryExpression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Cast;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ComparisonExpression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Expression;
@@ -50,7 +52,9 @@ import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.FieldReferen
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Fill;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.FrameBound;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.FunctionCall;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Identifier;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.IfExpression;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Literal;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.LongLiteral;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.MeasureDefinition;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Node;
@@ -61,6 +65,7 @@ import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Query;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.QueryBody;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.QuerySpecification;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.SortItem;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.SymbolReference;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.VariableDefinition;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.WindowFrame;
 import org.apache.iotdb.commons.queryengine.plan.relational.type.InternalTypeManager;
@@ -90,6 +95,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -122,10 +128,13 @@ import static org.apache.iotdb.db.queryengine.plan.relational.planner.PlanBuilde
 import static org.apache.iotdb.db.queryengine.plan.relational.planner.ScopeAware.scopeAwareKey;
 import static org.apache.iotdb.db.queryengine.plan.relational.planner.SymbolAllocator.GROUP_KEY_SUFFIX;
 import static org.apache.iotdb.db.queryengine.plan.relational.planner.ir.GapFillStartAndEndTimeExtractVisitor.CAN_NOT_INFER_TIME_RANGE;
+import static org.apache.iotdb.db.queryengine.plan.relational.sql.util.AstUtil.preOrder;
 import static org.apache.iotdb.db.queryengine.plan.relational.utils.NodeUtils.getSortItemsFromOrderBy;
 import static org.apache.tsfile.read.common.type.BooleanType.BOOLEAN;
 
 public class QueryPlanner {
+  private static final int LATERAL_COLUMN_ALIAS_PROJECTION_BATCH_SIZE = 32;
+
   private final Analysis analysis;
   private final SymbolAllocator symbolAllocator;
   private final MPPQueryContext queryContext;
@@ -770,25 +779,84 @@ public class QueryPlanner {
           outputExpressions(selectExpressions), symbolAllocator, queryContext);
     }
 
+    List<Expression> projectionBatch = new ArrayList<>();
+    Set<NodeRef<Expression>> currentBatchAliases = new HashSet<>();
+    Set<NodeRef<Expression>> inlineableCurrentBatchAliases = new HashSet<>();
+
     for (Analysis.SelectExpression selectExpression : selectExpressions) {
-      if (!selectExpression.getLateralColumnAliasReferences().isEmpty()) {
-        ImmutableMap.Builder<NodeRef<Expression>, Symbol> mappings = ImmutableMap.builder();
-        for (Map.Entry<NodeRef<Expression>, Expression> entry :
-            selectExpression.getLateralColumnAliasReferences().entrySet()) {
-          mappings.put(entry.getKey(), builder.translate(entry.getValue()));
-        }
-        builder = builder.withAdditionalIdentityMappings(mappings.buildOrThrow());
+      List<Expression> expressions =
+          selectExpression
+              .getUnfoldedExpressions()
+              .orElseGet(() -> ImmutableList.of(selectExpression.getExpression()));
+      Map<NodeRef<Expression>, Expression> references =
+          selectExpression.getLateralColumnAliasReferences();
+
+      if (!projectionBatch.isEmpty()
+          && (projectionBatch.size() + expressions.size()
+                  > LATERAL_COLUMN_ALIAS_PROJECTION_BATCH_SIZE
+              || referencesCurrentNonInlineableAlias(
+                  references, currentBatchAliases, inlineableCurrentBatchAliases))) {
+        builder = appendProjectionBatch(builder, projectionBatch);
+        projectionBatch.clear();
+        currentBatchAliases.clear();
+        inlineableCurrentBatchAliases.clear();
       }
 
-      builder =
-          builder.appendProjections(
-              selectExpression
-                  .getUnfoldedExpressions()
-                  .orElseGet(() -> ImmutableList.of(selectExpression.getExpression())),
-              symbolAllocator,
-              queryContext);
+      if (!references.isEmpty()) {
+        ImmutableMap.Builder<NodeRef<Expression>, Symbol> mappingsBuilder = ImmutableMap.builder();
+        for (Map.Entry<NodeRef<Expression>, Expression> entry : references.entrySet()) {
+          if (!currentBatchAliases.contains(entry.getKey())) {
+            mappingsBuilder.put(entry.getKey(), builder.translate(entry.getValue()));
+          }
+        }
+        ImmutableMap<NodeRef<Expression>, Symbol> mappings = mappingsBuilder.buildOrThrow();
+        if (!mappings.isEmpty()) {
+          builder = builder.withAdditionalIdentityMappings(mappings);
+        }
+      }
+
+      projectionBatch.addAll(expressions);
+      NodeRef<Expression> selectExpressionRef = NodeRef.of(selectExpression.getExpression());
+      currentBatchAliases.add(selectExpressionRef);
+      if (!selectExpression.getUnfoldedExpressions().isPresent()
+          && isInlineableLateralColumnAlias(selectExpression.getExpression())) {
+        inlineableCurrentBatchAliases.add(selectExpressionRef);
+      }
     }
-    return builder;
+    return appendProjectionBatch(builder, projectionBatch);
+  }
+
+  private PlanBuilder appendProjectionBatch(PlanBuilder builder, List<Expression> expressions) {
+    if (expressions.isEmpty()) {
+      return builder;
+    }
+    return builder.appendProjections(expressions, symbolAllocator, queryContext);
+  }
+
+  private static boolean referencesCurrentNonInlineableAlias(
+      Map<NodeRef<Expression>, Expression> references,
+      Set<NodeRef<Expression>> currentBatchAliases,
+      Set<NodeRef<Expression>> inlineableCurrentBatchAliases) {
+    for (NodeRef<Expression> reference : references.keySet()) {
+      if (currentBatchAliases.contains(reference)
+          && !inlineableCurrentBatchAliases.contains(reference)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isInlineableLateralColumnAlias(Expression expression) {
+    return preOrder(expression).allMatch(QueryPlanner::isInlineableLateralColumnAliasNode);
+  }
+
+  private static boolean isInlineableLateralColumnAliasNode(Node node) {
+    return node instanceof ArithmeticBinaryExpression
+        || node instanceof ArithmeticUnaryExpression
+        || node instanceof FieldReference
+        || node instanceof Identifier
+        || node instanceof Literal
+        || node instanceof SymbolReference;
   }
 
   private static boolean hasLateralColumnAliasReferences(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/QueryPlanner.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/QueryPlanner.java
@@ -194,16 +194,21 @@ public class QueryPlanner {
 
     List<Expression> orderBy = analysis.getOrderByExpressions(query);
     if (!orderBy.isEmpty()) {
-      builder =
-          builder.appendProjections(
-              Iterables.concat(orderBy, outputs), symbolAllocator, queryContext);
+      if (hasLateralColumnAliasReferences(selectExpressions)) {
+        builder = builder.appendProjections(orderBy, symbolAllocator, queryContext);
+        builder = appendSelectProjections(builder, selectExpressions);
+      } else {
+        builder =
+            builder.appendProjections(
+                Iterables.concat(orderBy, outputs), symbolAllocator, queryContext);
+      }
     }
     Optional<OrderingScheme> orderingScheme =
         orderingScheme(builder, query.getOrderBy(), analysis.getOrderByExpressions(query));
     builder = sort(builder, orderingScheme);
     builder = offset(builder, query.getOffset());
     builder = limit(builder, query.getLimit(), orderingScheme);
-    builder = builder.appendProjections(outputs, symbolAllocator, queryContext);
+    builder = appendSelectProjections(builder, selectExpressions);
 
     return new RelationPlan(
         builder.getRoot(),
@@ -263,7 +268,7 @@ public class QueryPlanner {
       // Add projections for the outputs of SELECT, but stack them on top of the ones from the FROM
       // clause so both are visible
       // when resolving the ORDER BY clause.
-      builder = builder.appendProjections(outputs, symbolAllocator, queryContext);
+      builder = appendSelectProjections(builder, selectExpressions);
       // The new scope is the composite of the fields from the FROM and SELECT clause (local nested
       // scopes). Fields from the bottom of
       // the scope stack need to be placed first to match the expected layout for nested scopes.
@@ -290,7 +295,7 @@ public class QueryPlanner {
       // Add projections for the outputs of SELECT, but stack them on top of the ones from the FROM
       // clause so both are visible
       // when resolving the ORDER BY clause.
-      builder = builder.appendProjections(outputs, symbolAllocator, queryContext);
+      builder = appendSelectProjections(builder, selectExpressions);
 
       // The new scope is the composite of the fields from the FROM and SELECT clause (local nested
       // scopes). Fields from the bottom of
@@ -310,9 +315,14 @@ public class QueryPlanner {
 
     List<Expression> orderBy = analysis.getOrderByExpressions(node);
     if (!orderBy.isEmpty() || node.getSelect().isDistinct()) {
-      builder =
-          builder.appendProjections(
-              Iterables.concat(orderBy, outputs), symbolAllocator, queryContext);
+      if (hasLateralColumnAliasReferences(selectExpressions)) {
+        builder = builder.appendProjections(orderBy, symbolAllocator, queryContext);
+        builder = appendSelectProjections(builder, selectExpressions);
+      } else {
+        builder =
+            builder.appendProjections(
+                Iterables.concat(orderBy, outputs), symbolAllocator, queryContext);
+      }
     }
 
     builder = distinct(builder, node, outputs);
@@ -322,7 +332,7 @@ public class QueryPlanner {
     builder = offset(builder, node.getOffset());
     builder = limit(builder, node.getLimit(), orderingScheme);
 
-    builder = builder.appendProjections(outputs, symbolAllocator, queryContext);
+    builder = appendSelectProjections(builder, selectExpressions);
     for (Expression expr : expressions) {
       predicateWithUncorrelatedScalarSubqueryReconstructor.clearShadowExpression(expr);
     }
@@ -751,6 +761,41 @@ public class QueryPlanner {
       }
     }
     return result.build();
+  }
+
+  private PlanBuilder appendSelectProjections(
+      PlanBuilder builder, List<Analysis.SelectExpression> selectExpressions) {
+    if (!hasLateralColumnAliasReferences(selectExpressions)) {
+      return builder.appendProjections(
+          outputExpressions(selectExpressions), symbolAllocator, queryContext);
+    }
+
+    for (Analysis.SelectExpression selectExpression : selectExpressions) {
+      if (!selectExpression.getLateralColumnAliasReferences().isEmpty()) {
+        ImmutableMap.Builder<NodeRef<Expression>, Symbol> mappings = ImmutableMap.builder();
+        for (Map.Entry<NodeRef<Expression>, Expression> entry :
+            selectExpression.getLateralColumnAliasReferences().entrySet()) {
+          mappings.put(entry.getKey(), builder.translate(entry.getValue()));
+        }
+        builder = builder.withAdditionalIdentityMappings(mappings.buildOrThrow());
+      }
+
+      builder =
+          builder.appendProjections(
+              selectExpression
+                  .getUnfoldedExpressions()
+                  .orElseGet(() -> ImmutableList.of(selectExpression.getExpression())),
+              symbolAllocator,
+              queryContext);
+    }
+    return builder;
+  }
+
+  private static boolean hasLateralColumnAliasReferences(
+      List<Analysis.SelectExpression> selectExpressions) {
+    return selectExpressions.stream()
+        .map(Analysis.SelectExpression::getLateralColumnAliasReferences)
+        .anyMatch(references -> !references.isEmpty());
   }
 
   public PlanNode plan(Delete node) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/ir/ExpressionRewriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/ir/ExpressionRewriter.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.queryengine.plan.relational.planner.ir;
 
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.AllRows;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ArithmeticBinaryExpression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ArithmeticUnaryExpression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.BetweenPredicate;
@@ -26,6 +27,7 @@ import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Cast;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.CoalesceExpression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ComparisonExpression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.CurrentDatabase;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.CurrentTime;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.CurrentUser;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.DereferenceExpression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ExistsPredicate;
@@ -64,6 +66,11 @@ public class ExpressionRewriter<C> {
 
   public Expression rewriteFieldReference(
       FieldReference node, C context, ExpressionTreeRewriter<C> treeRewriter) {
+    return rewriteExpression(node, context, treeRewriter);
+  }
+
+  public Expression rewriteAllRows(
+      AllRows node, C context, ExpressionTreeRewriter<C> treeRewriter) {
     return rewriteExpression(node, context, treeRewriter);
   }
 
@@ -225,6 +232,11 @@ public class ExpressionRewriter<C> {
 
   public Expression rewriteCurrentDatabase(
       final CurrentDatabase node, final C context, final ExpressionTreeRewriter<C> treeRewriter) {
+    return rewriteExpression(node, context, treeRewriter);
+  }
+
+  public Expression rewriteCurrentTime(
+      final CurrentTime node, final C context, final ExpressionTreeRewriter<C> treeRewriter) {
     return rewriteExpression(node, context, treeRewriter);
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/ir/ExpressionTreeRewriter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/planner/ir/ExpressionTreeRewriter.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.queryengine.plan.relational.planner.ir;
 
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.AllRows;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ArithmeticBinaryExpression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ArithmeticUnaryExpression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.BetweenPredicate;
@@ -26,6 +27,7 @@ import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Cast;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.CoalesceExpression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ComparisonExpression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.CurrentDatabase;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.CurrentTime;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.CurrentUser;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.DataType;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.DataTypeParameter;
@@ -677,6 +679,19 @@ public final class ExpressionTreeRewriter<C> {
     }
 
     @Override
+    public Expression visitCurrentTime(final CurrentTime node, final Context<C> context) {
+      if (!context.isDefaultRewrite()) {
+        final Expression result =
+            rewriter.rewriteCurrentTime(node, context.get(), ExpressionTreeRewriter.this);
+        if (result != null) {
+          return result;
+        }
+      }
+
+      return node;
+    }
+
+    @Override
     public Expression visitCurrentUser(final CurrentUser node, final Context<C> context) {
       if (!context.isDefaultRewrite()) {
         final Expression result =
@@ -733,6 +748,19 @@ public final class ExpressionTreeRewriter<C> {
       if (!context.isDefaultRewrite()) {
         Expression result =
             rewriter.rewriteFieldReference(node, context.get(), ExpressionTreeRewriter.this);
+        if (result != null) {
+          return result;
+        }
+      }
+
+      return node;
+    }
+
+    @Override
+    public Expression visitAllRows(AllRows node, Context<C> context) {
+      if (!context.isDefaultRewrite()) {
+        Expression result =
+            rewriter.rewriteAllRows(node, context.get(), ExpressionTreeRewriter.this);
         if (result != null) {
           return result;
         }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/SelectAliasReuseTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/SelectAliasReuseTest.java
@@ -29,6 +29,7 @@ import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Cast;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ExistsPredicate;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Expression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.FieldReference;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.FrameBound;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.FunctionCall;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.GenericDataType;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Identifier;
@@ -253,6 +254,20 @@ public class SelectAliasReuseTest {
   }
 
   @Test
+  public void lateralColumnAliasSupportsWideSelectListChain() {
+    int aliasCount = 64;
+    String sql = wideLateralColumnAliasSql(aliasCount);
+
+    AnalyzedQuery analyzedQuery = analyze(sql);
+    assertEquals(
+        aliasCount + 1, analyzedQuery.analysis.getSelectExpressions(analyzedQuery.query).size());
+    assertTrue(
+        getSelectExpression(analyzedQuery, aliasCount) instanceof ArithmeticBinaryExpression);
+
+    new PlanTester().createPlan(sql);
+  }
+
+  @Test
   public void lateralColumnAliasDoesNotSupportForwardOrSelfReference() {
     assertAnalyzeSemanticException(
         "SELECT y + 1 AS x, s1 AS y FROM table1", "Column 'y' cannot be resolved");
@@ -269,6 +284,20 @@ public class SelectAliasReuseTest {
     assertArithmeticIdentifiers(getSelectExpression(analyzedQuery, 1), "x", null);
 
     new PlanTester().createPlan(sql);
+  }
+
+  @Test
+  public void lateralColumnAliasHonorsDelimitedCaseSensitivity() {
+    String exactMatch = "SELECT s1 AS \"x\", \"x\" + 1 AS y FROM table1";
+    AnalyzedQuery analyzedQuery = analyze(exactMatch);
+    assertArithmeticIdentifiers(getSelectExpression(analyzedQuery, 1), "s1", null);
+    new PlanTester().createPlan(exactMatch);
+
+    assertAnalyzeSemanticException(
+        "SELECT s1 AS \"x\", x + 1 AS y FROM table1", "Column 'x' cannot be resolved");
+
+    assertAnalyzeSemanticException(
+        "SELECT s1 AS x, \"x\" + 1 AS y FROM table1", "Column 'x' cannot be resolved");
   }
 
   @Test
@@ -339,6 +368,16 @@ public class SelectAliasReuseTest {
   }
 
   @Test
+  public void selectDistinctSupportsLateralColumnAliasWithoutOrderBy() {
+    String sql = "SELECT DISTINCT s1 AS x, x + 1 AS y FROM table1";
+
+    AnalyzedQuery analyzedQuery = analyze(sql);
+    assertArithmeticIdentifiers(getSelectExpression(analyzedQuery, 1), "s1", null);
+
+    new PlanTester().createPlan(sql);
+  }
+
+  @Test
   public void columnsSelectItemDoesNotRegisterLateralColumnAlias() {
     assertAnalyzeSemanticException(
         "SELECT COLUMNS('s.*') AS x, x + 1 AS y FROM table1", "Column 'x' cannot be resolved");
@@ -373,6 +412,27 @@ public class SelectAliasReuseTest {
     FunctionCall avg = (FunctionCall) getSelectExpression(analyzedPartitionBy, 1);
     assertIdentifier(analyzedPartitionBy.analysis.getWindow(avg).getPartitionBy().get(0), "s1");
     new PlanTester().createPlan(partitionBySql);
+  }
+
+  @Test
+  public void namedWindowDefinitionDoesNotSeeLateralColumnAlias() {
+    assertAnalyzeSemanticException(
+        "SELECT s1 AS x, row_number() OVER w AS rn FROM table1 WINDOW w AS (ORDER BY x)",
+        "Column 'x' cannot be resolved");
+  }
+
+  @Test
+  public void lateralColumnAliasCanBeUsedInWindowFrameBounds() {
+    String sql =
+        "SELECT s1 AS x, sum(s2) OVER "
+            + "(ORDER BY time ROWS BETWEEN x PRECEDING AND CURRENT ROW) AS total FROM table1";
+
+    AnalyzedQuery analyzedQuery = analyze(sql);
+    FunctionCall sum = (FunctionCall) getSelectExpression(analyzedQuery, 1);
+    FrameBound start = analyzedQuery.analysis.getWindow(sum).getFrame().get().getStart();
+    assertIdentifier(start.getValue().get(), "s1");
+
+    new PlanTester().createPlan(sql);
   }
 
   @Test
@@ -551,6 +611,15 @@ public class SelectAliasReuseTest {
                 .getRelationType()
                 .getVisibleFields());
     return fields.get(index).getName().orElse(null);
+  }
+
+  private static String wideLateralColumnAliasSql(int aliasCount) {
+    StringBuilder sql = new StringBuilder("SELECT s1 AS c0");
+    for (int i = 1; i < aliasCount; i++) {
+      sql.append(", c").append(i - 1).append(" + 1 AS c").append(i);
+    }
+    sql.append(", c0 + c").append(aliasCount - 1).append(" AS final_value FROM table1");
+    return sql.toString();
   }
 
   private static void assertArithmeticIdentifiers(

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/SelectAliasReuseTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/SelectAliasReuseTest.java
@@ -216,6 +216,131 @@ public class SelectAliasReuseTest {
   }
 
   @Test
+  public void lateralColumnAliasInSelectList() {
+    String sql = "SELECT s1 AS x, x + 1 AS y FROM table1";
+
+    AnalyzedQuery analyzedQuery = analyze(sql);
+    assertIdentifier(getSelectExpression(analyzedQuery, 0), "s1");
+    assertArithmeticIdentifiers(getSelectExpression(analyzedQuery, 1), "s1", null);
+
+    new PlanTester().createPlan(sql);
+  }
+
+  @Test
+  public void lateralColumnAliasCanChainAndRepeat() {
+    String chained = "SELECT s1 AS x, x + 1 AS y, y * 2 AS z FROM table1";
+    AnalyzedQuery analyzedChained = analyze(chained);
+    assertArithmeticIdentifiers(getSelectExpression(analyzedChained, 1), "s1", null);
+    assertTrue(
+        ((ArithmeticBinaryExpression) getSelectExpression(analyzedChained, 2)).getLeft()
+            instanceof ArithmeticBinaryExpression);
+    new PlanTester().createPlan(chained);
+
+    String repeated = "SELECT s1 AS x, x + x AS y FROM table1";
+    AnalyzedQuery analyzedRepeated = analyze(repeated);
+    assertArithmeticIdentifiers(getSelectExpression(analyzedRepeated, 1), "s1", "s1");
+    new PlanTester().createPlan(repeated);
+  }
+
+  @Test
+  public void lateralColumnAliasDoesNotSupportForwardOrSelfReference() {
+    assertAnalyzeSemanticException(
+        "SELECT y + 1 AS x, s1 AS y FROM table1", "Column 'y' cannot be resolved");
+
+    assertAnalyzeSemanticException(
+        "SELECT x + 1 AS x FROM table1", "Column 'x' cannot be resolved");
+  }
+
+  @Test
+  public void inputColumnTakesPrecedenceOverLateralColumnAlias() {
+    String sql = "SELECT s1 AS x, x + 1 AS y FROM table_with_x";
+
+    AnalyzedQuery analyzedQuery = analyze(sql);
+    assertArithmeticIdentifiers(getSelectExpression(analyzedQuery, 1), "x", null);
+
+    new PlanTester().createPlan(sql);
+  }
+
+  @Test
+  public void duplicateLateralColumnAliasesAreAmbiguousUnlessInputColumnMatches() {
+    assertAnalyzeSemanticException(
+        "SELECT s1 AS x, s2 AS x, x + 1 AS y FROM table1", "Column alias 'x' is ambiguous");
+
+    String sql = "SELECT s1 AS x, s2 AS x, x + 1 AS y FROM table_with_x";
+    AnalyzedQuery analyzedQuery = analyze(sql);
+    assertArithmeticIdentifiers(getSelectExpression(analyzedQuery, 2), "x", null);
+    new PlanTester().createPlan(sql);
+  }
+
+  @Test
+  public void lateralColumnAliasWorksWithAggregates() {
+    String sql = "SELECT avg(s1) AS a, a + 1 AS b FROM table1";
+
+    AnalyzedQuery analyzedQuery = analyze(sql);
+    assertTrue(
+        ((ArithmeticBinaryExpression) getSelectExpression(analyzedQuery, 1)).getLeft()
+            instanceof FunctionCall);
+
+    new PlanTester().createPlan(sql);
+  }
+
+  @Test
+  public void lateralColumnAliasCopiesAllRowsAggregate() {
+    String sql = "SELECT count(*) AS c, c + 1 AS c2 FROM table1";
+
+    AnalyzedQuery analyzedQuery = analyze(sql);
+    assertTrue(
+        ((ArithmeticBinaryExpression) getSelectExpression(analyzedQuery, 1)).getLeft()
+            instanceof FunctionCall);
+
+    new PlanTester().createPlan(sql);
+  }
+
+  @Test
+  public void lateralColumnAliasRewritesBeforeAggregationValidation() {
+    assertAnalyzeSemanticException(
+        "SELECT s1 AS x, avg(s2) + x AS y FROM table1",
+        "must be an aggregate expression or appear in GROUP BY clause");
+  }
+
+  @Test
+  public void groupByAliasUsesLateralColumnAliasRewrittenExpression() {
+    String sql = "SELECT s1 AS x, x + 1 AS y, COUNT(*) FROM table1 GROUP BY y, x";
+
+    AnalyzedQuery analyzedQuery = analyze(sql);
+    List<Expression> groupByExpressions =
+        analyzedQuery.analysis.getGroupingSets(analyzedQuery.query).getOriginalExpressions();
+    assertTrue(groupByExpressions.get(0) instanceof ArithmeticBinaryExpression);
+    assertArithmeticIdentifiers(groupByExpressions.get(0), "s1", null);
+    assertIdentifier(groupByExpressions.get(1), "s1");
+
+    new PlanTester().createPlan(sql);
+  }
+
+  @Test
+  public void columnsSelectItemDoesNotRegisterLateralColumnAlias() {
+    assertAnalyzeSemanticException(
+        "SELECT COLUMNS('s.*') AS x, x + 1 AS y FROM table1", "Column 'x' cannot be resolved");
+  }
+
+  @Test
+  public void windowFunctionLateralColumnAliasIsExplicitlyRejected() {
+    assertAnalyzeSemanticException(
+        "SELECT row_number() OVER (ORDER BY s1) AS rn, rn + 1 AS rn2 FROM table1",
+        "Lateral column alias 'rn' containing window function is not supported");
+  }
+
+  @Test
+  public void lateralColumnAliasCanBeSelectedDirectly() {
+    String sql = "SELECT s1 AS x, x FROM table1";
+
+    AnalyzedQuery analyzedQuery = analyze(sql);
+    assertIdentifier(getSelectExpression(analyzedQuery, 1), "s1");
+
+    new PlanTester().createPlan(sql);
+  }
+
+  @Test
   public void duplicateAliasesAreAmbiguous() {
     assertAnalyzeSemanticException(
         "SELECT s1 AS x, s2 AS x FROM table1 ORDER BY x", "Column alias 'x' is ambiguous");
@@ -259,9 +384,6 @@ public class SelectAliasReuseTest {
     assertAnalyzeSemanticException(
         "SELECT AVG(s1) AS avg_s1 FROM table1 HAVING avg_s1 > 1",
         "Column 'avg_s1' cannot be resolved");
-
-    assertAnalyzeSemanticException(
-        "SELECT s1 + 1 AS x, x * 2 AS y FROM table1", "Column 'x' cannot be resolved");
   }
 
   @Test
@@ -316,6 +438,24 @@ public class SelectAliasReuseTest {
       Analysis.GroupingSetAnalysis analysis, String name) {
     assertEquals(1, analysis.getOriginalExpressions().size());
     assertIdentifier(analysis.getOriginalExpressions().get(0), name);
+  }
+
+  private static Expression getSelectExpression(AnalyzedQuery analyzedQuery, int index) {
+    return analyzedQuery
+        .analysis
+        .getSelectExpressions(analyzedQuery.query)
+        .get(index)
+        .getExpression();
+  }
+
+  private static void assertArithmeticIdentifiers(
+      Expression expression, String leftName, String rightName) {
+    assertTrue(expression instanceof ArithmeticBinaryExpression);
+    ArithmeticBinaryExpression arithmeticExpression = (ArithmeticBinaryExpression) expression;
+    assertIdentifier(arithmeticExpression.getLeft(), leftName);
+    if (rightName != null) {
+      assertIdentifier(arithmeticExpression.getRight(), rightName);
+    }
   }
 
   private static void assertIdentifier(Expression expression, String name) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/SelectAliasReuseTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/SelectAliasReuseTest.java
@@ -21,6 +21,9 @@ package org.apache.iotdb.db.queryengine.plan.relational.analyzer;
 
 import org.apache.iotdb.commons.queryengine.common.SessionInfo;
 import org.apache.iotdb.commons.queryengine.common.SqlDialect;
+import org.apache.iotdb.commons.queryengine.plan.planner.plan.node.PlanNode;
+import org.apache.iotdb.commons.queryengine.plan.relational.planner.Symbol;
+import org.apache.iotdb.commons.queryengine.plan.relational.planner.node.ProjectNode;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ArithmeticBinaryExpression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Cast;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ExistsPredicate;
@@ -34,6 +37,8 @@ import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Query;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.QuerySpecification;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Statement;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.SubqueryExpression;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.SymbolReference;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.LogicalQueryPlan;
 import org.apache.iotdb.db.queryengine.plan.relational.planner.PlanTester;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.parser.SqlParser;
 
@@ -42,12 +47,14 @@ import org.junit.Test;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.iotdb.db.queryengine.plan.relational.analyzer.AnalyzerTest.analyzeStatement;
 import static org.apache.iotdb.db.queryengine.plan.relational.analyzer.TestUtils.QUERY_CONTEXT;
 import static org.apache.iotdb.db.queryengine.plan.relational.analyzer.TestUtils.TEST_MATADATA;
 import static org.apache.iotdb.db.queryengine.plan.relational.analyzer.TestUtils.assertAnalyzeSemanticException;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -404,6 +411,30 @@ public class SelectAliasReuseTest {
   }
 
   @Test
+  public void lateralColumnAliasPlanReusesPreviousProjection() {
+    LogicalQueryPlan plan =
+        new PlanTester().createPlan("SELECT CAST(s2 AS double) AS x, x + 1.0 AS y FROM table1");
+    List<ProjectNode> projects = new ArrayList<>();
+    collectProjectNodes(plan.getRootNode(), projects);
+
+    Symbol castSymbol = null;
+    int castAssignments = 0;
+    for (ProjectNode project : projects) {
+      for (Map.Entry<Symbol, Expression> assignment : project.getAssignments().entrySet()) {
+        if (assignment.getValue() instanceof Cast) {
+          castSymbol = assignment.getKey();
+          castAssignments++;
+        }
+      }
+    }
+
+    assertNotNull(castSymbol);
+    assertEquals(1, castAssignments);
+    assertTrue(hasArithmeticOnSymbol(projects, castSymbol));
+    assertFalse(hasArithmeticOnCast(projects));
+  }
+
+  @Test
   public void duplicateAliasesAreAmbiguous() {
     assertAnalyzeSemanticException(
         "SELECT s1 AS x, s2 AS x FROM table1 ORDER BY x", "Column alias 'x' is ambiguous");
@@ -540,6 +571,50 @@ public class SelectAliasReuseTest {
   private static void assertFieldReference(Expression expression, int index) {
     assertTrue(expression instanceof FieldReference);
     assertEquals(index, ((FieldReference) expression).getFieldIndex());
+  }
+
+  private static void collectProjectNodes(PlanNode node, List<ProjectNode> projects) {
+    if (node instanceof ProjectNode) {
+      projects.add((ProjectNode) node);
+    }
+    for (PlanNode child : node.getChildren()) {
+      collectProjectNodes(child, projects);
+    }
+  }
+
+  private static boolean hasArithmeticOnSymbol(List<ProjectNode> projects, Symbol symbol) {
+    for (ProjectNode project : projects) {
+      for (Expression expression : project.getAssignments().getExpressions()) {
+        if (expression instanceof ArithmeticBinaryExpression) {
+          ArithmeticBinaryExpression arithmeticExpression = (ArithmeticBinaryExpression) expression;
+          if (isSymbolReference(arithmeticExpression.getLeft(), symbol)
+              || isSymbolReference(arithmeticExpression.getRight(), symbol)) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  private static boolean hasArithmeticOnCast(List<ProjectNode> projects) {
+    for (ProjectNode project : projects) {
+      for (Expression expression : project.getAssignments().getExpressions()) {
+        if (expression instanceof ArithmeticBinaryExpression) {
+          ArithmeticBinaryExpression arithmeticExpression = (ArithmeticBinaryExpression) expression;
+          if (arithmeticExpression.getLeft() instanceof Cast
+              || arithmeticExpression.getRight() instanceof Cast) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  private static boolean isSymbolReference(Expression expression, Symbol symbol) {
+    return expression instanceof SymbolReference
+        && ((SymbolReference) expression).getName().equals(symbol.getName());
   }
 
   private static QuerySpecification getExistsSubquery(QuerySpecification query) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/SelectAliasReuseTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/SelectAliasReuseTest.java
@@ -40,6 +40,7 @@ import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Statement;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.SubqueryExpression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.SymbolReference;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.LogicalQueryPlan;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanGraphJsonPrinter;
 import org.apache.iotdb.db.queryengine.plan.relational.planner.PlanTester;
 import org.apache.iotdb.db.queryengine.plan.relational.sql.parser.SqlParser;
 
@@ -495,6 +496,24 @@ public class SelectAliasReuseTest {
   }
 
   @Test
+  public void lateralColumnAliasDeepChainPlanExpressionsRemainShallow() {
+    LogicalQueryPlan plan = new PlanTester().createPlan(wideLateralColumnAliasSql(200));
+    List<ProjectNode> projects = new ArrayList<>();
+    collectProjectNodes(plan.getRootNode(), projects);
+
+    int maxArithmeticDepth = 0;
+    for (ProjectNode project : projects) {
+      for (Expression expression : project.getAssignments().getExpressions()) {
+        maxArithmeticDepth = Math.max(maxArithmeticDepth, arithmeticDepth(expression));
+      }
+    }
+
+    assertTrue("Max arithmetic depth: " + maxArithmeticDepth, maxArithmeticDepth <= 32);
+    String planJson = PlanGraphJsonPrinter.toPrettyJson(plan.getRootNode());
+    assertTrue("Plan JSON length: " + planJson.length(), planJson.length() < 2_000_000);
+  }
+
+  @Test
   public void duplicateAliasesAreAmbiguous() {
     assertAnalyzeSemanticException(
         "SELECT s1 AS x, s2 AS x FROM table1 ORDER BY x", "Column alias 'x' is ambiguous");
@@ -679,6 +698,17 @@ public class SelectAliasReuseTest {
       }
     }
     return false;
+  }
+
+  private static int arithmeticDepth(Expression expression) {
+    if (!(expression instanceof ArithmeticBinaryExpression)) {
+      return 0;
+    }
+    ArithmeticBinaryExpression arithmeticExpression = (ArithmeticBinaryExpression) expression;
+    return 1
+        + Math.max(
+            arithmeticDepth(arithmeticExpression.getLeft()),
+            arithmeticDepth(arithmeticExpression.getRight()));
   }
 
   private static boolean isSymbolReference(Expression expression, Symbol symbol) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/SelectAliasReuseTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/SelectAliasReuseTest.java
@@ -38,6 +38,7 @@ import org.apache.iotdb.db.queryengine.plan.relational.sql.parser.SqlParser;
 import org.junit.Test;
 
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.iotdb.db.queryengine.plan.relational.analyzer.AnalyzerTest.analyzeStatement;
@@ -331,11 +332,47 @@ public class SelectAliasReuseTest {
   }
 
   @Test
+  public void lateralColumnAliasCanBeUsedInWindowSpecification() {
+    String orderBySql = "SELECT s1 AS x, row_number() OVER (ORDER BY x) AS rn FROM table1";
+    AnalyzedQuery analyzedOrderBy = analyze(orderBySql);
+    FunctionCall rowNumber = (FunctionCall) getSelectExpression(analyzedOrderBy, 1);
+    assertIdentifier(
+        analyzedOrderBy
+            .analysis
+            .getWindow(rowNumber)
+            .getOrderBy()
+            .get()
+            .getSortItems()
+            .get(0)
+            .getSortKey(),
+        "s1");
+    new PlanTester().createPlan(orderBySql);
+
+    String partitionBySql = "SELECT s1 AS x, avg(s2) OVER (PARTITION BY x) AS a FROM table1";
+    AnalyzedQuery analyzedPartitionBy = analyze(partitionBySql);
+    FunctionCall avg = (FunctionCall) getSelectExpression(analyzedPartitionBy, 1);
+    assertIdentifier(analyzedPartitionBy.analysis.getWindow(avg).getPartitionBy().get(0), "s1");
+    new PlanTester().createPlan(partitionBySql);
+  }
+
+  @Test
   public void lateralColumnAliasCanBeSelectedDirectly() {
     String sql = "SELECT s1 AS x, x FROM table1";
 
     AnalyzedQuery analyzedQuery = analyze(sql);
     assertIdentifier(getSelectExpression(analyzedQuery, 1), "s1");
+    assertEquals("x", getOutputFieldName(analyzedQuery, 1));
+
+    new PlanTester().createPlan(sql);
+  }
+
+  @Test
+  public void lateralColumnAliasPreservesOriginalOutputNameWithoutExplicitAlias() {
+    String sql = "SELECT s1 + 1 AS x, x FROM table1";
+
+    AnalyzedQuery analyzedQuery = analyze(sql);
+    assertTrue(getSelectExpression(analyzedQuery, 1) instanceof ArithmeticBinaryExpression);
+    assertEquals("x", getOutputFieldName(analyzedQuery, 1));
 
     new PlanTester().createPlan(sql);
   }
@@ -446,6 +483,17 @@ public class SelectAliasReuseTest {
         .getSelectExpressions(analyzedQuery.query)
         .get(index)
         .getExpression();
+  }
+
+  private static String getOutputFieldName(AnalyzedQuery analyzedQuery, int index) {
+    List<Field> fields =
+        new ArrayList<>(
+            analyzedQuery
+                .analysis
+                .getScope(analyzedQuery.query)
+                .getRelationType()
+                .getVisibleFields());
+    return fields.get(index).getName().orElse(null);
   }
 
   private static void assertArithmeticIdentifiers(

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/SelectAliasReuseTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/SelectAliasReuseTest.java
@@ -22,10 +22,12 @@ package org.apache.iotdb.db.queryengine.plan.relational.analyzer;
 import org.apache.iotdb.commons.queryengine.common.SessionInfo;
 import org.apache.iotdb.commons.queryengine.common.SqlDialect;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ArithmeticBinaryExpression;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Cast;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.ExistsPredicate;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Expression;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.FieldReference;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.FunctionCall;
+import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.GenericDataType;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Identifier;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.OrderBy;
 import org.apache.iotdb.commons.queryengine.plan.relational.sql.ast.Query;
@@ -319,6 +321,17 @@ public class SelectAliasReuseTest {
   }
 
   @Test
+  public void orderByCanReuseLateralColumnAliasOutput() {
+    String sql = "SELECT s1 AS x, x + 1 AS y FROM table1 ORDER BY y";
+
+    AnalyzedQuery analyzedQuery = analyze(sql);
+    assertFieldReference(
+        analyzedQuery.analysis.getOrderByExpressions(analyzedQuery.query).get(0), 1);
+
+    new PlanTester().createPlan(sql);
+  }
+
+  @Test
   public void columnsSelectItemDoesNotRegisterLateralColumnAlias() {
     assertAnalyzeSemanticException(
         "SELECT COLUMNS('s.*') AS x, x + 1 AS y FROM table1", "Column 'x' cannot be resolved");
@@ -353,6 +366,19 @@ public class SelectAliasReuseTest {
     FunctionCall avg = (FunctionCall) getSelectExpression(analyzedPartitionBy, 1);
     assertIdentifier(analyzedPartitionBy.analysis.getWindow(avg).getPartitionBy().get(0), "s1");
     new PlanTester().createPlan(partitionBySql);
+  }
+
+  @Test
+  public void lateralColumnAliasDoesNotRewriteCastTypeNames() {
+    String sql = "SELECT s1 AS INT64, CAST(s2 AS INT64) AS y FROM table1";
+
+    AnalyzedQuery analyzedQuery = analyze(sql);
+    Expression expression = getSelectExpression(analyzedQuery, 1);
+    assertTrue(expression instanceof Cast);
+    assertTrue(((Cast) expression).getType() instanceof GenericDataType);
+    assertEquals("INT64", ((GenericDataType) ((Cast) expression).getType()).getName().getValue());
+
+    new PlanTester().createPlan(sql);
   }
 
   @Test

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/SelectAliasReuseTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/relational/analyzer/SelectAliasReuseTest.java
@@ -288,23 +288,42 @@ public class SelectAliasReuseTest {
   }
 
   @Test
-  public void lateralColumnAliasHonorsDelimitedCaseSensitivity() {
+  public void lateralColumnAliasMatchesDelimitedIdentifiersByCanonicalName() {
     String exactMatch = "SELECT s1 AS \"x\", \"x\" + 1 AS y FROM table1";
     AnalyzedQuery analyzedQuery = analyze(exactMatch);
     assertArithmeticIdentifiers(getSelectExpression(analyzedQuery, 1), "s1", null);
     new PlanTester().createPlan(exactMatch);
 
-    assertAnalyzeSemanticException(
-        "SELECT s1 AS \"x\", x + 1 AS y FROM table1", "Column 'x' cannot be resolved");
+    String uppercaseExactMatch = "SELECT s1 AS \"X\", \"X\" + 1 AS y FROM table1";
+    AnalyzedQuery analyzedUppercaseQuery = analyze(uppercaseExactMatch);
+    assertArithmeticIdentifiers(getSelectExpression(analyzedUppercaseQuery, 1), "s1", null);
+    new PlanTester().createPlan(uppercaseExactMatch);
 
-    assertAnalyzeSemanticException(
-        "SELECT s1 AS x, \"x\" + 1 AS y FROM table1", "Column 'x' cannot be resolved");
+    String caseDifferingDelimitedMatch = "SELECT s1 AS \"X\", \"x\" + 1 AS y FROM table1";
+    AnalyzedQuery analyzedCaseDifferingDelimitedQuery = analyze(caseDifferingDelimitedMatch);
+    assertArithmeticIdentifiers(
+        getSelectExpression(analyzedCaseDifferingDelimitedQuery, 1), "s1", null);
+    new PlanTester().createPlan(caseDifferingDelimitedMatch);
+
+    String unquotedReferenceToDelimitedAlias = "SELECT s1 AS \"x\", x + 1 AS y FROM table1";
+    AnalyzedQuery analyzedUnquotedReferenceQuery = analyze(unquotedReferenceToDelimitedAlias);
+    assertArithmeticIdentifiers(getSelectExpression(analyzedUnquotedReferenceQuery, 1), "s1", null);
+    new PlanTester().createPlan(unquotedReferenceToDelimitedAlias);
+
+    String delimitedReferenceToUnquotedAlias = "SELECT s1 AS x, \"x\" + 1 AS y FROM table1";
+    AnalyzedQuery analyzedDelimitedReferenceQuery = analyze(delimitedReferenceToUnquotedAlias);
+    assertArithmeticIdentifiers(
+        getSelectExpression(analyzedDelimitedReferenceQuery, 1), "s1", null);
+    new PlanTester().createPlan(delimitedReferenceToUnquotedAlias);
   }
 
   @Test
   public void duplicateLateralColumnAliasesAreAmbiguousUnlessInputColumnMatches() {
     assertAnalyzeSemanticException(
         "SELECT s1 AS x, s2 AS x, x + 1 AS y FROM table1", "Column alias 'x' is ambiguous");
+
+    assertAnalyzeSemanticException(
+        "SELECT s1 AS \"x\", s2 AS X, x + 1 AS y FROM table1", "Column alias 'x' is ambiguous");
 
     String sql = "SELECT s1 AS x, s2 AS x, x + 1 AS y FROM table_with_x";
     AnalyzedQuery analyzedQuery = analyze(sql);


### PR DESCRIPTION
## Description

### Support lateral column aliases in table SELECT lists

This PR implements Part 2 of #17797 for the table-model analyzer: later `SingleColumn` SELECT items can reference aliases explicitly defined by earlier `SingleColumn` items in the same SELECT list.

Examples now supported:

```sql
SELECT s1 AS x, x + 1 AS y FROM table1;
SELECT s1 AS x, x + 1 AS y FROM table1 ORDER BY y;
SELECT s1 AS x, row_number() OVER (ORDER BY x) AS rn FROM table1;
SELECT s1 AS x, avg(s2) OVER (PARTITION BY x) AS a FROM table1;
```

### Name-resolution behavior

The LCA rewrite is left-to-right and only applies to unqualified identifiers in later SELECT items. It does not rewrite qualified references such as `t.x`, dereference expressions such as `x.y`, or identifiers inside subqueries.

Resolution order is:

1. local source column
2. visible previous SELECT aliases
3. existing analyzer resolution

If multiple previous aliases with the same canonical name are visible and no local source column wins, the analyzer raises a clear ambiguity error. `AllColumns` and `COLUMNS(...)` do not register reusable LCA aliases.

`GROUP BY` alias reuse uses the LCA-rewritten SELECT expression, while `ORDER BY` keeps the existing output-alias precedence. `WHERE` and `HAVING` still do not see SELECT aliases.

For `CAST(value AS type)`, only `value` participates in LCA rewriting. Type names are not treated as alias references.

### Implementation notes

The original AST is kept unchanged. The analyzer records each `SingleColumn`'s semantic expression after LCA rewriting and uses it for type analysis, source-column tracking, output expression analysis, and GROUP BY alias reuse. Output field names without explicit aliases are still derived from the original SELECT item text rather than from the rewritten expression.

Inline window specifications in later SELECT items are rewritten and registered against the rewritten `FunctionCall` nodes before expression analysis. Referencing an alias whose expression contains a window function is rejected explicitly.

Fixes #17797

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for code coverage.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- `StatementAnalyzer`: SELECT-list LCA rewrite, rewritten SELECT expression tracking, output-scope name handling, and window metadata registration for rewritten expressions.
- `ExpressionRewriter` / `ExpressionTreeRewriter`: support for leaf expression rewrite hooks used by LCA expression copying.
- `SelectAliasReuseTest`: coverage for LCA chaining, collisions, ambiguity, aggregates, GROUP BY/ORDER BY reuse, window specs, CAST type-name collisions, WHERE/HAVING isolation, and output field names.
- `relational/analyzer/README.md`: documented table-model SELECT alias resolution rules.

##### Tests

```bash
./mvnw spotless:apply -pl iotdb-core/datanode
./mvnw test -pl iotdb-core/datanode -Dtest=SelectAliasReuseTest
```
