### PR TITLE
added iterator dst tests

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/aggregation/TimeRangeIteratorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/aggregation/TimeRangeIteratorTest.java
@@ -25,10 +25,13 @@ import org.apache.iotdb.db.queryengine.execution.aggregation.timerangeiterator.T
 import org.apache.tsfile.read.common.TimeRange;
 import org.apache.tsfile.utils.TimeDuration;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.TimeZone;
 
 public class TimeRangeIteratorTest {
@@ -220,10 +223,9 @@ public class TimeRangeIteratorTest {
 
   @Test
   public void testNaturalMonthTimeRange() {
-    // The following test results greatly depend on the timezone the test is run in.
     TimeZone oldDefault = TimeZone.getDefault();
     try {
-      TimeZone.setDefault(TimeZone.getTimeZone("Bejing"));
+      TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
 
       String[] res1 = {
         "[ 1604102400000 : 1606694399999 ]",
@@ -433,6 +435,90 @@ public class TimeRangeIteratorTest {
             true,
             ZoneId.systemDefault()),
         res);
+  }
+
+  @Test
+  @Ignore(
+      "org.apache.tsfile.utils.TimeDuration treats days as a physical duration, not calendar days")
+  public void testOffsetCases() {
+    ZoneId berlin = ZoneId.of("Europe/Berlin");
+    ZoneId apia = ZoneId.of("Pacific/Apia");
+
+    // 23h day (DST Spring transition)
+    assertDailyWindows(2023, 3, 26, 0, 0, 0, berlin);
+    // 25h day (DST Autumn/Fall transition)
+    assertDailyWindows(2023, 10, 29, 0, 0, 0, berlin);
+    // historical offset
+    assertDailyWindows(1893, 4, 1, 0, 0, 0, berlin);
+    // 2011-12-30 skipped
+    assertDailyWindows(2011, 12, 29, 0, 0, 0, apia);
+  }
+
+  private void assertDailyWindows(int y, int m, int d, int h, int min, int s, ZoneId zone) {
+    LocalDate date = LocalDate.of(y, m, d);
+    ZonedDateTime start = date.atStartOfDay(zone);
+    ZonedDateTime end = date.plusDays(2).atStartOfDay(zone);
+
+    long startMs = start.toInstant().toEpochMilli();
+    long endMs = end.toInstant().toEpochMilli() - 1;
+
+    String[] expected = new String[2];
+    ZonedDateTime day1End = date.plusDays(1).atStartOfDay(zone);
+    expected[0] = "[ " + startMs + " : " + (day1End.toInstant().toEpochMilli() - 1) + " ]";
+    expected[1] = "[ " + day1End.toInstant().toEpochMilli() + " : " + endMs + " ]";
+
+    checkRes(
+        TimeRangeIteratorFactory.getTimeRangeIterator(
+            startMs,
+            endMs + 1,
+            new TimeDuration(0, 86400000L),
+            new TimeDuration(0, 86400000L),
+            true,
+            true,
+            true,
+            zone),
+        expected);
+  }
+
+  @Test
+  public void testMonthOffsetCases() {
+    ZoneId berlin = ZoneId.of("Europe/Berlin");
+    ZoneId apia = ZoneId.of("Pacific/Apia");
+
+    // 23h day (DST Spring transition)
+    assertMonthlyWindows(2023, 3, 1, berlin);
+    // 25h day (DST Autumn/Fall transition)
+    assertMonthlyWindows(2023, 10, 1, berlin);
+    // historical offset
+    assertMonthlyWindows(1893, 3, 1, berlin);
+    // 2011-12-30 skipped
+    assertMonthlyWindows(2011, 12, 1, apia);
+  }
+
+  private void assertMonthlyWindows(int y, int m, int d, ZoneId zone) {
+    LocalDate date = LocalDate.of(y, m, d);
+    ZonedDateTime start = date.atStartOfDay(zone);
+    ZonedDateTime end = date.plusMonths(2).atStartOfDay(zone);
+
+    long startMs = start.toInstant().toEpochMilli();
+    long endMs = end.toInstant().toEpochMilli() - 1;
+
+    String[] expected = new String[2];
+    ZonedDateTime month1End = date.plusMonths(1).atStartOfDay(zone);
+    expected[0] = "[ " + startMs + " : " + (month1End.toInstant().toEpochMilli() - 1) + " ]";
+    expected[1] = "[ " + month1End.toInstant().toEpochMilli() + " : " + endMs + " ]";
+
+    checkRes(
+        TimeRangeIteratorFactory.getTimeRangeIterator(
+            startMs,
+            endMs + 1,
+            new TimeDuration(1, 0),
+            new TimeDuration(1, 0),
+            true,
+            true,
+            true,
+            zone),
+        expected);
   }
 
   private void checkRes(ITimeRangeIterator timeRangeIterator, String[] res) {


### PR DESCRIPTION
## Description

For #12537

This PR does not fully fix the TimeRangeIterator timezone bug, it adds reproducible tests that document the current behavior.

Changes in TimeRangeIteratorTest:
1. testNaturalMonthTimeRange – it's hardcoded to UTC.
2. Added testMonthOffsetCases() – tests monthly windows across DST transitions and historical offset changes:
3. Added testOffsetCases().
This test is marked @Ignore on purpose.
org.apache.tsfile.utils.TimeDuration treats a day as a fixed physical duration of 86400000ms, not a calendar day in the given ZoneId. Because of that, daily windows drift on 23h/25h DST days and on historical offset changes.

The DateTimeUtils.toZoneOffset(ZoneId zoneId) fix  has been moved to a separate issue.
<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ x] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [x ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>
