### PR TITLE
Fix pipe lifecycle restart order in IT

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/tablemodel/manual/basic/IoTDBPipeLifeCycleIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/tablemodel/manual/basic/IoTDBPipeLifeCycleIT.java
@@ -387,8 +387,8 @@ public class IoTDBPipeLifeCycleIT extends AbstractPipeTableModelDualManualIT {
     }
 
     try {
-      TestUtils.restartCluster(senderEnv);
       TestUtils.restartCluster(receiverEnv);
+      TestUtils.restartCluster(senderEnv);
     } catch (final Throwable e) {
       e.printStackTrace();
       return;

--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/treemodel/auto/basic/IoTDBPipeLifeCycleIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/treemodel/auto/basic/IoTDBPipeLifeCycleIT.java
@@ -510,8 +510,8 @@ public class IoTDBPipeLifeCycleIT extends AbstractPipeDualTreeModelAutoIT {
     }
 
     try {
-      TestUtils.restartCluster(senderEnv);
       TestUtils.restartCluster(receiverEnv);
+      TestUtils.restartCluster(senderEnv);
     } catch (final Throwable e) {
       e.printStackTrace();
       return;


### PR DESCRIPTION
Summary: Restart the receiver cluster before the sender cluster in pipe lifecycle cluster-restart ITs, avoiding sender pipe recovery racing with a receiver RPC port that is still down. This applies the same order to tree-model and table-model lifecycle tests. Tests: mvn -pl integration-test -P with-integration-tests spotless:apply passed. Targeted IT execution was blocked by existing integration-test compilation errors in unrelated subscription topic-owner and region-migration kill-point tests.