### PR TITLE
Follow up pipe schema snapshot database creation fix

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/thrift/IoTDBDataNodeReceiver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/thrift/IoTDBDataNodeReceiver.java
@@ -629,8 +629,16 @@ public class IoTDBDataNodeReceiver extends IoTDBFileReceiver {
       throws IllegalPathException, IOException {
     final String databaseName = parameters.get(ColumnHeaderConstant.DATABASE);
     final PartialPath databasePath = PartialPath.getQualifiedDatabasePartialPath(databaseName);
+    final boolean isTreeModelDataAllowedToBeCaptured =
+        PipeTransferFileSealReqV2.isTreeModelDataAllowedToBeCaptured(parameters);
+    final TreePattern treePattern =
+        parseTreePattern(
+            parameters.get(ColumnHeaderConstant.PATH_PATTERN), isTreeModelDataAllowedToBeCaptured);
 
     if (!PathUtils.isTableModelDatabase(databaseName)) {
+      if (!shouldLoadTreeSchemaSnapshotDatabase(treePattern, databaseName)) {
+        return new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
+      }
       final TSStatus createDatabaseStatus = createSchemaSnapshotDatabaseIfNecessary(databasePath);
       if (createDatabaseStatus.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         return createDatabaseStatus;
@@ -650,13 +658,6 @@ public class IoTDBDataNodeReceiver extends IoTDBFileReceiver {
     final Set<StatementType> executionTypes =
         PipeSchemaRegionSnapshotEvent.getStatementTypeSet(
             parameters.get(ColumnHeaderConstant.TYPE));
-    final boolean isTreeModelDataAllowedToBeCaptured =
-        PipeTransferFileSealReqV2.isTreeModelDataAllowedToBeCaptured(parameters);
-    final TreePattern treePattern =
-        TreePattern.parsePatternFromString(
-            parameters.get(ColumnHeaderConstant.PATH_PATTERN),
-            isTreeModelDataAllowedToBeCaptured,
-            p -> new IoTDBTreePattern(isTreeModelDataAllowedToBeCaptured, p));
     final TablePattern tablePattern =
         new TablePattern(
             PipeTransferFileSealReqV2.isTableModelDataAllowedToBeCaptured(parameters),
@@ -705,6 +706,28 @@ public class IoTDBDataNodeReceiver extends IoTDBFileReceiver {
         .filter(Optional::isPresent)
         .forEach(statement -> results.add(executeStatementAndClassifyExceptions(statement.get())));
     return PipeReceiverStatusHandler.getPriorStatus(results);
+  }
+
+  static boolean shouldLoadTreeSchemaSnapshotDatabase(
+      final String pathPattern,
+      final boolean isTreeModelDataAllowedToBeCaptured,
+      final String databaseName) {
+    return shouldLoadTreeSchemaSnapshotDatabase(
+        parseTreePattern(pathPattern, isTreeModelDataAllowedToBeCaptured), databaseName);
+  }
+
+  private static TreePattern parseTreePattern(
+      final String pathPattern, final boolean isTreeModelDataAllowedToBeCaptured) {
+    return TreePattern.parsePatternFromString(
+        pathPattern,
+        isTreeModelDataAllowedToBeCaptured,
+        p -> new IoTDBTreePattern(isTreeModelDataAllowedToBeCaptured, p));
+  }
+
+  private static boolean shouldLoadTreeSchemaSnapshotDatabase(
+      final TreePattern treePattern, final String databaseName) {
+    return treePattern.isTreeModelDataAllowedToBeCaptured()
+        && treePattern.mayOverlapWithDb(databaseName);
   }
 
   private TSStatus createSchemaSnapshotDatabaseIfNecessary(final PartialPath databasePath) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/receiver/protocol/thrift/IoTDBDataNodeReceiverTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/receiver/protocol/thrift/IoTDBDataNodeReceiverTest.java
@@ -111,6 +111,16 @@ public class IoTDBDataNodeReceiverTest {
   }
 
   @Test
+  public void testTreeSchemaSnapshotDatabaseIsFilteredByPattern() {
+    Assert.assertTrue(
+        IoTDBDataNodeReceiver.shouldLoadTreeSchemaSnapshotDatabase("root.ln.**", true, "root.ln"));
+    Assert.assertFalse(
+        IoTDBDataNodeReceiver.shouldLoadTreeSchemaSnapshotDatabase("root.ln.**", true, "root.db"));
+    Assert.assertFalse(
+        IoTDBDataNodeReceiver.shouldLoadTreeSchemaSnapshotDatabase("root.ln.**", false, "root.ln"));
+  }
+
+  @Test
   public void testLoadTsFileSyncStatementVerifiesSchemaWhenConvertingType() throws Exception {
     final Path tsFile = Files.createTempFile("pipe-load-convert-verify-schema", ".tsfile");
     try {


### PR DESCRIPTION
Follow-up to #17910 / 98c823461be83181e454d15152d9c67e61c7b06d. That fix addressed pipe schema snapshot database creation, but master has since evolved around the TreePattern/TablePattern schema snapshot path, and the tree-model branch could still create the schema snapshot database before applying the tree path pattern filter.

This moves tree-snapshot database gating before database creation and adds a focused regression test so unrelated databases are not materialized during schema snapshot transfer.

Validation:
- git diff --check
- mvn -nsu -pl iotdb-core/datanode -Dtest=IoTDBDataNodeReceiverTest test (blocked in local master checkout by unrelated generated/parser/dependency compile errors before tests run)