### PR TITLE
[Backport 1.3] Fix aggregate write-back output database metadata

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/row/PipeRowCollector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/row/PipeRowCollector.java
@@ -45,6 +45,30 @@ public class PipeRowCollector extends PipeRawTabletEventConverter implements Row
     super(pipeTaskMeta, sourceEvent);
   }
 
+  public PipeRowCollector(
+      PipeTaskMeta pipeTaskMeta,
+      EnrichedEvent sourceEvent,
+      String sourceEventDataBase,
+      Boolean isTableModel) {
+    super(pipeTaskMeta, sourceEvent, sourceEventDataBase, isTableModel);
+  }
+
+  public PipeRowCollector(
+      PipeTaskMeta pipeTaskMeta,
+      EnrichedEvent sourceEvent,
+      String sourceEventDataBase,
+      Boolean isTableModel,
+      String rawTableModelDataBaseName,
+      String rawTreeModelDataBaseName) {
+    super(
+        pipeTaskMeta,
+        sourceEvent,
+        sourceEventDataBase,
+        isTableModel,
+        rawTableModelDataBaseName,
+        rawTreeModelDataBaseName);
+  }
+
   @Override
   public void collectRow(Row row) {
     if (!(row instanceof PipeRow)) {
@@ -98,6 +122,10 @@ public class PipeRowCollector extends PipeRawTabletEventConverter implements Row
       PipeTabletUtils.compactBitMaps(tablet);
       tabletInsertionEventList.add(
           new PipeRawTabletInsertionEvent(
+              isTableModel,
+              sourceEventDataBaseName,
+              rawTableModelDataBaseName,
+              rawTreeModelDataBaseName,
               tablet,
               isAligned,
               sourceEvent == null ? null : sourceEvent.getPipeName(),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletEventConverter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletEventConverter.java
@@ -32,10 +32,60 @@ public abstract class PipeRawTabletEventConverter implements DataCollector {
   protected boolean isAligned = false;
   protected final PipeTaskMeta pipeTaskMeta; // Used to report progress
   protected final EnrichedEvent sourceEvent; // Used to report progress
+  protected String sourceEventDataBaseName;
+  protected Boolean isTableModel;
+  protected String rawTableModelDataBaseName;
+  protected String rawTreeModelDataBaseName;
 
   public PipeRawTabletEventConverter(PipeTaskMeta pipeTaskMeta, EnrichedEvent sourceEvent) {
     this.pipeTaskMeta = pipeTaskMeta;
     this.sourceEvent = sourceEvent;
+    if (sourceEvent instanceof PipeRawTabletInsertionEvent) {
+      final PipeRawTabletInsertionEvent pipeRawTabletInsertionEvent =
+          (PipeRawTabletInsertionEvent) sourceEvent;
+      sourceEventDataBaseName = pipeRawTabletInsertionEvent.getSourceDatabaseNameFromDataRegion();
+      isTableModel = pipeRawTabletInsertionEvent.getRawIsTableModelEvent();
+      rawTableModelDataBaseName = pipeRawTabletInsertionEvent.getRawTableModelDataBase();
+      rawTreeModelDataBaseName = pipeRawTabletInsertionEvent.getRawTreeModelDataBase();
+    } else {
+      sourceEventDataBaseName = null;
+      isTableModel = null;
+      rawTableModelDataBaseName = null;
+      rawTreeModelDataBaseName = null;
+    }
+  }
+
+  public PipeRawTabletEventConverter(
+      PipeTaskMeta pipeTaskMeta,
+      EnrichedEvent sourceEvent,
+      String sourceEventDataBase,
+      Boolean isTableModel) {
+    this(pipeTaskMeta, sourceEvent);
+    this.sourceEventDataBaseName = sourceEventDataBase;
+    this.isTableModel = isTableModel;
+  }
+
+  public PipeRawTabletEventConverter(
+      PipeTaskMeta pipeTaskMeta,
+      EnrichedEvent sourceEvent,
+      String sourceEventDataBase,
+      Boolean isTableModel,
+      String rawTableModelDataBaseName,
+      String rawTreeModelDataBaseName) {
+    this(pipeTaskMeta, sourceEvent, sourceEventDataBase, isTableModel);
+    this.rawTableModelDataBaseName = rawTableModelDataBaseName;
+    this.rawTreeModelDataBaseName = rawTreeModelDataBaseName;
+  }
+
+  public void resetDatabaseInfo(
+      final String sourceEventDataBaseName,
+      final Boolean isTableModel,
+      final String rawTableModelDataBaseName,
+      final String rawTreeModelDataBaseName) {
+    this.sourceEventDataBaseName = sourceEventDataBaseName;
+    this.isTableModel = isTableModel;
+    this.rawTableModelDataBaseName = rawTableModelDataBaseName;
+    this.rawTreeModelDataBaseName = rawTreeModelDataBaseName;
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeRawTabletInsertionEvent.java
@@ -54,6 +54,10 @@ public class PipeRawTabletInsertionEvent extends EnrichedEvent
   private Tablet tablet;
   private String deviceId; // Only used when the tablet is released.
   private final boolean isAligned;
+  private final Boolean isTableModelEvent;
+  private final String sourceDatabaseNameFromDataRegion;
+  private final String tableModelDatabaseName;
+  private final String treeModelDatabaseName;
 
   private final EnrichedEvent sourceEvent;
   private boolean needToReport;
@@ -65,6 +69,10 @@ public class PipeRawTabletInsertionEvent extends EnrichedEvent
   private volatile ProgressIndex overridingProgressIndex;
 
   private PipeRawTabletInsertionEvent(
+      final Boolean isTableModelEvent,
+      final String sourceDatabaseNameFromDataRegion,
+      final String tableModelDatabaseName,
+      final String treeModelDatabaseName,
       final Tablet tablet,
       final boolean isAligned,
       final EnrichedEvent sourceEvent,
@@ -78,6 +86,10 @@ public class PipeRawTabletInsertionEvent extends EnrichedEvent
     super(pipeName, creationTime, pipeTaskMeta, pattern, startTime, endTime);
     this.tablet = Objects.requireNonNull(tablet);
     this.isAligned = isAligned;
+    this.isTableModelEvent = isTableModelEvent;
+    this.sourceDatabaseNameFromDataRegion = sourceDatabaseNameFromDataRegion;
+    this.tableModelDatabaseName = tableModelDatabaseName;
+    this.treeModelDatabaseName = treeModelDatabaseName;
     this.sourceEvent = sourceEvent;
     this.needToReport = needToReport;
 
@@ -96,6 +108,10 @@ public class PipeRawTabletInsertionEvent extends EnrichedEvent
   }
 
   public PipeRawTabletInsertionEvent(
+      final Boolean isTableModelEvent,
+      final String sourceDatabaseNameFromDataRegion,
+      final String tableModelDatabaseName,
+      final String treeModelDatabaseName,
       final Tablet tablet,
       final boolean isAligned,
       final String pipeName,
@@ -104,6 +120,35 @@ public class PipeRawTabletInsertionEvent extends EnrichedEvent
       final EnrichedEvent sourceEvent,
       final boolean needToReport) {
     this(
+        isTableModelEvent,
+        sourceDatabaseNameFromDataRegion,
+        tableModelDatabaseName,
+        treeModelDatabaseName,
+        tablet,
+        isAligned,
+        sourceEvent,
+        needToReport,
+        pipeName,
+        creationTime,
+        pipeTaskMeta,
+        null,
+        Long.MIN_VALUE,
+        Long.MAX_VALUE);
+  }
+
+  public PipeRawTabletInsertionEvent(
+      final Tablet tablet,
+      final boolean isAligned,
+      final String pipeName,
+      final long creationTime,
+      final PipeTaskMeta pipeTaskMeta,
+      final EnrichedEvent sourceEvent,
+      final boolean needToReport) {
+    this(
+        null,
+        null,
+        null,
+        null,
         tablet,
         isAligned,
         sourceEvent,
@@ -118,19 +163,49 @@ public class PipeRawTabletInsertionEvent extends EnrichedEvent
 
   @TestOnly
   public PipeRawTabletInsertionEvent(final Tablet tablet, final boolean isAligned) {
-    this(tablet, isAligned, null, false, null, 0, null, null, Long.MIN_VALUE, Long.MAX_VALUE);
+    this(
+        null,
+        null,
+        null,
+        null,
+        tablet,
+        isAligned,
+        null,
+        false,
+        null,
+        0,
+        null,
+        null,
+        Long.MIN_VALUE,
+        Long.MAX_VALUE);
   }
 
   @TestOnly
   public PipeRawTabletInsertionEvent(
       final Tablet tablet, final boolean isAligned, final PipePattern pattern) {
-    this(tablet, isAligned, null, false, null, 0, null, pattern, Long.MIN_VALUE, Long.MAX_VALUE);
+    this(
+        null,
+        null,
+        null,
+        null,
+        tablet,
+        isAligned,
+        null,
+        false,
+        null,
+        0,
+        null,
+        pattern,
+        Long.MIN_VALUE,
+        Long.MAX_VALUE);
   }
 
   @TestOnly
   public PipeRawTabletInsertionEvent(
       final Tablet tablet, final long startTime, final long endTime) {
-    this(tablet, false, null, false, null, 0, null, null, startTime, endTime);
+    this(
+        null, null, null, null, tablet, false, null, false, null, 0, null, null, startTime,
+        endTime);
   }
 
   @Override
@@ -219,6 +294,10 @@ public class PipeRawTabletInsertionEvent extends EnrichedEvent
       final long startTime,
       final long endTime) {
     return new PipeRawTabletInsertionEvent(
+        isTableModelEvent,
+        sourceDatabaseNameFromDataRegion,
+        tableModelDatabaseName,
+        treeModelDatabaseName,
         tablet,
         isAligned,
         sourceEvent,
@@ -276,6 +355,36 @@ public class PipeRawTabletInsertionEvent extends EnrichedEvent
 
   public EnrichedEvent getSourceEvent() {
     return sourceEvent;
+  }
+
+  public boolean isTableModelEvent() {
+    return Boolean.TRUE.equals(isTableModelEvent);
+  }
+
+  public Boolean getRawIsTableModelEvent() {
+    return isTableModelEvent;
+  }
+
+  public String getSourceDatabaseNameFromDataRegion() {
+    return sourceDatabaseNameFromDataRegion;
+  }
+
+  public String getRawTableModelDataBase() {
+    return tableModelDatabaseName;
+  }
+
+  public String getRawTreeModelDataBase() {
+    return treeModelDatabaseName;
+  }
+
+  public String getTreeModelDatabaseName() {
+    return treeModelDatabaseName != null ? treeModelDatabaseName : sourceDatabaseNameFromDataRegion;
+  }
+
+  public String getTableModelDatabaseName() {
+    return tableModelDatabaseName != null
+        ? tableModelDatabaseName
+        : sourceDatabaseNameFromDataRegion;
   }
 
   @Override
@@ -344,7 +453,17 @@ public class PipeRawTabletInsertionEvent extends EnrichedEvent
 
   public PipeRawTabletInsertionEvent parseEventWithPatternOrTime() {
     return new PipeRawTabletInsertionEvent(
-        convertToTablet(), isAligned, pipeName, creationTime, pipeTaskMeta, this, needToReport);
+        isTableModelEvent,
+        sourceDatabaseNameFromDataRegion,
+        tableModelDatabaseName,
+        treeModelDatabaseName,
+        convertToTablet(),
+        isAligned,
+        pipeName,
+        creationTime,
+        pipeTaskMeta,
+        this,
+        needToReport);
   }
 
   public boolean hasNoNeedParsingAndIsEmpty() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeTabletCollector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tablet/PipeTabletCollector.java
@@ -31,10 +31,38 @@ public class PipeTabletCollector extends PipeRawTabletEventConverter implements 
     super(pipeTaskMeta, sourceEvent);
   }
 
+  public PipeTabletCollector(
+      PipeTaskMeta pipeTaskMeta,
+      EnrichedEvent sourceEvent,
+      String sourceEventDataBase,
+      Boolean isTableModel) {
+    super(pipeTaskMeta, sourceEvent, sourceEventDataBase, isTableModel);
+  }
+
+  public PipeTabletCollector(
+      PipeTaskMeta pipeTaskMeta,
+      EnrichedEvent sourceEvent,
+      String sourceEventDataBase,
+      Boolean isTableModel,
+      String rawTableModelDataBaseName,
+      String rawTreeModelDataBaseName) {
+    super(
+        pipeTaskMeta,
+        sourceEvent,
+        sourceEventDataBase,
+        isTableModel,
+        rawTableModelDataBaseName,
+        rawTreeModelDataBaseName);
+  }
+
   @Override
   public void collectTablet(final Tablet tablet) {
     tabletInsertionEventList.add(
         new PipeRawTabletInsertionEvent(
+            isTableModel,
+            sourceEventDataBaseName,
+            rawTableModelDataBaseName,
+            rawTreeModelDataBaseName,
             tablet,
             isAligned,
             sourceEvent == null ? null : sourceEvent.getPipeName(),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/processor/aggregate/AggregateProcessor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/processor/aggregate/AggregateProcessor.java
@@ -112,6 +112,7 @@ public class AggregateProcessor implements PipeProcessor {
   private PipeTaskMeta pipeTaskMeta;
   private long outputMaxDelayMilliseconds;
   private long outputMinReportIntervalMilliseconds;
+  private String outputDatabase;
   private String outputDatabaseWithPathSeparator;
 
   private final Map<String, AggregatedResultOperator> outputName2OperatorMap = new HashMap<>();
@@ -213,7 +214,7 @@ public class AggregateProcessor implements PipeProcessor {
                 PROCESSOR_OUTPUT_MIN_REPORT_INTERVAL_SECONDS_KEY,
                 PROCESSOR_OUTPUT_MIN_REPORT_INTERVAL_SECONDS_DEFAULT_VALUE)
             * 1000;
-    final String outputDatabase =
+    outputDatabase =
         parameters.getStringOrDefault(
             PROCESSOR_OUTPUT_DATABASE_KEY, PROCESSOR_OUTPUT_DATABASE_DEFAULT_VALUE);
     outputDatabaseWithPathSeparator =
@@ -413,6 +414,8 @@ public class AggregateProcessor implements PipeProcessor {
       final Row row, final RowCollector rowCollector, final AtomicReference<Exception> exception) {
     final Map<String, Pair<Long, ByteBuffer>> resultMap = new HashMap<>();
 
+    resetOutputDatabaseForGeneratedEvent(rowCollector);
+
     final long timestamp = row.getTime();
     for (int index = 0, size = row.size(); index < size; ++index) {
       // Do not calculate null values
@@ -564,6 +567,7 @@ public class AggregateProcessor implements PipeProcessor {
                     pipeName2timeSeries2TimeSeriesRuntimeStateMap.get(pipeName).get(timeSeries);
                 synchronized (stateReference) {
                   final PipeRowCollector rowCollector = new PipeRowCollector(pipeTaskMeta, null);
+                  resetOutputDatabaseForGeneratedEvent(rowCollector);
                   try {
                     collectWindowOutputs(
                         stateReference.get().forceOutput(), timeSeries, rowCollector);
@@ -594,6 +598,13 @@ public class AggregateProcessor implements PipeProcessor {
     }
 
     eventCollector.collect(event);
+  }
+
+  private void resetOutputDatabaseForGeneratedEvent(final RowCollector rowCollector) {
+    if (!outputDatabase.isEmpty() && rowCollector instanceof PipeRowCollector) {
+      ((PipeRowCollector) rowCollector)
+          .resetDatabaseInfo(outputDatabase, Boolean.FALSE, null, outputDatabase);
+    }
   }
 
   /**

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/PipeTabletInsertionEventTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/PipeTabletInsertionEventTest.java
@@ -22,6 +22,8 @@ package org.apache.iotdb.db.pipe.event;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.pipe.datastructure.pattern.PrefixPipePattern;
+import org.apache.iotdb.db.pipe.event.common.row.PipeResetTabletRow;
+import org.apache.iotdb.db.pipe.event.common.row.PipeRowCollector;
 import org.apache.iotdb.db.pipe.event.common.tablet.PipeRawTabletInsertionEvent;
 import org.apache.iotdb.db.pipe.event.common.tablet.PipeTabletUtils;
 import org.apache.iotdb.db.pipe.event.common.tablet.TabletInsertionDataContainer;
@@ -41,6 +43,7 @@ import org.junit.Test;
 
 import java.time.LocalDate;
 import java.util.Arrays;
+import java.util.List;
 
 public class PipeTabletInsertionEventTest {
 
@@ -318,6 +321,35 @@ public class PipeTabletInsertionEventTest {
     boolean isAligned4 = event4.isAligned();
     Assert.assertEquals(tablet2, tablet4);
     Assert.assertTrue(isAligned4);
+  }
+
+  @Test
+  public void collectRowWithOverriddenTreeDatabaseForTest() {
+    final PipeRowCollector rowCollector = new PipeRowCollector(null, null, "root.test.sg_0", false);
+    rowCollector.resetDatabaseInfo("root.userResultDB", false, null, "root.userResultDB");
+
+    final MeasurementSchema[] outputSchemas = {new MeasurementSchema("avg", TSDataType.INT32)};
+    rowCollector.collectRow(
+        new PipeResetTabletRow(
+            0,
+            "root.userResultDB.d_0.s_1",
+            false,
+            outputSchemas,
+            new long[] {1L},
+            new TSDataType[] {TSDataType.INT32},
+            new Object[] {new int[] {1}},
+            null,
+            new String[] {"avg"}));
+
+    final List<org.apache.iotdb.pipe.api.event.dml.insertion.TabletInsertionEvent> events =
+        rowCollector.convertToTabletInsertionEvents(false);
+    Assert.assertEquals(1, events.size());
+
+    final PipeRawTabletInsertionEvent event = (PipeRawTabletInsertionEvent) events.get(0);
+    Assert.assertEquals("root.userResultDB", event.getSourceDatabaseNameFromDataRegion());
+    Assert.assertFalse(event.isTableModelEvent());
+    Assert.assertEquals("root.userResultDB", event.getTreeModelDatabaseName());
+    Assert.assertEquals("root.userResultDB.d_0.s_1", event.convertToTablet().deviceId);
   }
 
   @Test

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/partition/DataPartition.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/partition/DataPartition.java
@@ -172,8 +172,20 @@ public class DataPartition extends Partition {
     List<TRegionReplicaSet> dataRegionReplicaSets = new ArrayList<>();
     Map<TSeriesPartitionSlot, Map<TTimePartitionSlot, List<TRegionReplicaSet>>>
         dataBasePartitionMap = dataPartitionMap.get(storageGroup);
+    if (dataBasePartitionMap == null) {
+      throw new RuntimeException(
+          "Database "
+              + storageGroup
+              + " not exists and failed to create automatically because enable_auto_create_schema is FALSE.");
+    }
     Map<TTimePartitionSlot, List<TRegionReplicaSet>> slotReplicaSetMap =
         dataBasePartitionMap.get(seriesPartitionSlot);
+    if (slotReplicaSetMap == null) {
+      throw new RuntimeException(
+          String.format(
+              "Data partition is empty. device: %s, seriesSlot: %s, database: %s",
+              deviceName, seriesPartitionSlot, storageGroup));
+    }
     for (TTimePartitionSlot timePartitionSlot : timePartitionSlotList) {
       List<TRegionReplicaSet> targetRegionList = slotReplicaSetMap.get(timePartitionSlot);
       if (targetRegionList == null || targetRegionList.isEmpty()) {
@@ -199,7 +211,9 @@ public class DataPartition extends Partition {
         databasePartitionMap = dataPartitionMap.get(storageGroup);
     if (databasePartitionMap == null) {
       throw new RuntimeException(
-          "Database not exists and failed to create automatically because enable_auto_create_schema is FALSE.");
+          "Database "
+              + storageGroup
+              + " not exists and failed to create automatically because enable_auto_create_schema is FALSE.");
     }
     List<TRegionReplicaSet> regions =
         databasePartitionMap.get(seriesPartitionSlot).get(timePartitionSlot);


### PR DESCRIPTION
Backport of #17938 to dev/1.3.

Original commit: 3f20717205688be0e3d98b7911bfc4284a1d95d3
Cherry-picked as: 03fac11923d

Verification:
- mvn -Ddevelocity.off=true -pl iotdb-core/datanode -DskipTests compile
- mvn -Ddevelocity.off=true -pl iotdb-core/node-commons -DskipTests compile