### PR TITLE
[To dev/1.3] Fix pipe lifecycle restart order in IT (#17962)

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeLifeCycleIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/autocreate/IoTDBPipeLifeCycleIT.java
@@ -448,8 +448,8 @@ public class IoTDBPipeLifeCycleIT extends AbstractPipeDualAutoIT {
     }
 
     try {
-      TestUtils.restartCluster(senderEnv);
       TestUtils.restartCluster(receiverEnv);
+      TestUtils.restartCluster(senderEnv);
     } catch (final Throwable e) {
       e.printStackTrace();
       return;


### PR DESCRIPTION
Backport of db27f78a1b898c09f7bcf79b5e507a672a0003b4 to dev/1.3.\n\nValidation:\n- mvn -pl integration-test spotless:check -P with-integration-tests -DskipTests\n- attempted targeted integration-test run for IoTDBPipeLifeCycleIT, but local Maven/Develocity cache access and Windows memory limits blocked execution in this environment