### PR TITLE
C++ client: build with OpenSSL by default (1.x) and bundle the runtime libs

### DIFF
--- a/.github/scripts/package-client-cpp-manylinux228.sh
+++ b/.github/scripts/package-client-cpp-manylinux228.sh
@@ -71,6 +71,18 @@ fi
 cmake --version
 java -version
 
+# WITH_SSL is on by default; install the system OpenSSL dev package so
+# find_package(OpenSSL) resolves it (manylinux_2_28 is AlmaLinux 8 -> OpenSSL
+# 1.1.1) instead of falling back to a from-source build.
+if ! rpm -q openssl-devel >/dev/null 2>&1; then
+  if command -v dnf >/dev/null 2>&1; then
+    dnf install -y openssl-devel
+  else
+    yum install -y openssl-devel
+  fi
+fi
+openssl version || true
+
 cd "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is not set}"
 ./mvnw clean package -P with-cpp -pl iotdb-client/client-cpp -am -DskipTests \
   -Dspotless.skip=true \

--- a/.github/workflows/client-cpp-package.yml
+++ b/.github/workflows/client-cpp-package.yml
@@ -299,6 +299,9 @@ jobs:
           ln -sf "$(brew --prefix llvm@17)/bin/clang-format" "$(brew --prefix)/bin/clang-format"
           echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"
           echo "$(brew --prefix llvm@17)/bin" >> "$GITHUB_PATH"
+          # WITH_SSL is on by default; Homebrew OpenSSL is keg-only, so point
+          # find_package(OpenSSL) at it instead of a from-source fallback.
+          echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl)" >> "$GITHUB_ENV"
           clang-format --version
           bison --version
       - name: Cache Maven packages

--- a/.github/workflows/client-cpp-package.yml
+++ b/.github/workflows/client-cpp-package.yml
@@ -295,13 +295,13 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          brew install boost openssl llvm@17 bison
+          # No openssl here: Homebrew only ships OpenSSL 3.x (openssl@1.1 is gone)
+          # and Thrift 0.21 needs 1.x, so the build compiles OpenSSL 1.1.1w from
+          # source (see cmake/FetchOpenSSL.cmake).
+          brew install boost llvm@17 bison
           ln -sf "$(brew --prefix llvm@17)/bin/clang-format" "$(brew --prefix)/bin/clang-format"
           echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"
           echo "$(brew --prefix llvm@17)/bin" >> "$GITHUB_PATH"
-          # WITH_SSL is on by default; Homebrew OpenSSL is keg-only, so point
-          # find_package(OpenSSL) at it instead of a from-source fallback.
-          echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl)" >> "$GITHUB_ENV"
           clang-format --version
           bison --version
       - name: Cache Maven packages
@@ -418,7 +418,8 @@ jobs:
             throw "Boost not found under C:\local after installing ${{ matrix.boost_choco }}"
           }
           echo $boostDir.FullName >> $env:GITHUB_PATH
-          choco install openssl -y --no-progress
+          # Pin OpenSSL 1.1.1: Thrift 0.21 does not build against OpenSSL 3.x.
+          choco install openssl --version=1.1.1.2100 -y --no-progress
           $sslPath = (Get-ChildItem 'C:\Program Files\OpenSSL*' -Directory | Select-Object -First 1).FullName
           echo "$sslPath\bin" >> $env:GITHUB_PATH
           echo "OPENSSL_ROOT_DIR=$sslPath" >> $env:GITHUB_ENV

--- a/.github/workflows/multi-language-client.yml
+++ b/.github/workflows/multi-language-client.yml
@@ -125,13 +125,13 @@ jobs:
         if: runner.os == 'macOS'
         shell: bash
         run: |
-          brew install boost openssl llvm@17 bison
+          # No openssl here: Homebrew only ships OpenSSL 3.x (openssl@1.1 is gone)
+          # and Thrift 0.21 needs 1.x, so the build compiles OpenSSL 1.1.1w from
+          # source (see cmake/FetchOpenSSL.cmake).
+          brew install boost llvm@17 bison
           ln -sf "$(brew --prefix llvm@17)/bin/clang-format" "$(brew --prefix)/bin/clang-format"
           echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"
           echo "$(brew --prefix llvm@17)/bin" >> "$GITHUB_PATH"
-          # WITH_SSL is on by default; Homebrew OpenSSL is keg-only, so point
-          # find_package(OpenSSL) at it instead of a from-source fallback.
-          echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl)" >> "$GITHUB_ENV"
           clang-format --version
           bison --version
           sudo rm -rf /Applications/Xcode_14.3.1.app
@@ -147,7 +147,8 @@ jobs:
           $boost_path = (Get-ChildItem -Path 'C:\local\' -Filter 'boost_*').FullName
           echo $boost_path >> $env:GITHUB_PATH
           
-          choco install openssl -y
+          # Pin OpenSSL 1.1.1: Thrift 0.21 does not build against OpenSSL 3.x.
+          choco install openssl --version=1.1.1.2100 -y
           $sslPath = (Get-ChildItem 'C:\Program Files\OpenSSL*' -Directory | Select-Object -First 1).FullName
           echo "$sslPath\bin" >> $env:GITHUB_PATH
           echo "OPENSSL_ROOT_DIR=$sslPath" >> $env:GITHUB_ENV

--- a/.github/workflows/multi-language-client.yml
+++ b/.github/workflows/multi-language-client.yml
@@ -129,6 +129,9 @@ jobs:
           ln -sf "$(brew --prefix llvm@17)/bin/clang-format" "$(brew --prefix)/bin/clang-format"
           echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"
           echo "$(brew --prefix llvm@17)/bin" >> "$GITHUB_PATH"
+          # WITH_SSL is on by default; Homebrew OpenSSL is keg-only, so point
+          # find_package(OpenSSL) at it instead of a from-source fallback.
+          echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl)" >> "$GITHUB_ENV"
           clang-format --version
           bison --version
           sudo rm -rf /Applications/Xcode_14.3.1.app

--- a/iotdb-client/client-cpp/CMakeLists.txt
+++ b/iotdb-client/client-cpp/CMakeLists.txt
@@ -78,7 +78,7 @@ if(NOT MSVC)
     file(WRITE "${_iotdb_cxx11_abi_stamp}" "${_iotdb_cxx11_abi_stamp_value}")
 endif()
 
-option(WITH_SSL "Build with OpenSSL support" OFF)
+option(WITH_SSL "Build with OpenSSL support" ON)
 option(BUILD_TESTING "Build IT test executables" OFF)
 option(IOTDB_OFFLINE "Disable all network access during configure" OFF)
 set(IOTDB_SESSION_VERSION "0.0.0"
@@ -120,6 +120,7 @@ include(FetchBoost)        # -> BOOST_INCLUDE_DIR (Thrift build only)
 include(FetchBuildTools)
 if(WITH_SSL)
     include(FetchOpenSSL)
+    include(InstallOpenSSLRuntime)
 endif()
 include(FetchThrift)
 include(GenerateThriftSources)
@@ -222,6 +223,12 @@ install(TARGETS iotdb_session
         RUNTIME DESTINATION lib
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)
+
+# Ship the OpenSSL shared libraries we link against next to iotdb_session so the
+# packaged SDK is self-contained on machines without a system OpenSSL.
+if(WITH_SSL)
+    iotdb_install_openssl_runtime()
+endif()
 
 foreach(_hdr IN LISTS IOTDB_PUBLIC_HEADERS)
     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/include/${_hdr}"

--- a/iotdb-client/client-cpp/README.md
+++ b/iotdb-client/client-cpp/README.md
@@ -492,11 +492,12 @@ Prerequisites:
 2. **flex / bison.** Install <https://sourceforge.net/projects/winflexbison/>
    and rename `win_flex.exe`→`flex.exe`, `win_bison.exe`→`bison.exe` on
    `PATH`.
-3. **OpenSSL** *(`WITH_SSL=ON` is the default)*: install OpenSSL — e.g.
-   `choco install openssl`, or run the Win64 OpenSSL installer from
-   <https://slproweb.com/products/Win32OpenSSL.html> — then pass
-   `-DOPENSSL_ROOT_DIR=...` to CMake if it is not auto-detected. Pass
-   `-DWITH_SSL=OFF` to build without SSL.
+3. **OpenSSL 1.1.1** *(`WITH_SSL=ON` is the default)*: install OpenSSL **1.x**
+   — e.g. `choco install openssl --version=1.1.1.2100`, or a Win64 OpenSSL
+   1.1.1 installer from <https://slproweb.com/products/Win32OpenSSL.html> —
+   then pass `-DOPENSSL_ROOT_DIR=...` to CMake if it is not auto-detected.
+   OpenSSL 3.x is not supported (Thrift 0.21 needs 1.x). Pass `-DWITH_SSL=OFF`
+   to build without SSL.
 
 On Windows the SDK ships as **`iotdb_session.dll`** plus an import library
 **`iotdb_session.lib`**, built with **`/MD`** (dynamic CRT, same as a
@@ -512,20 +513,23 @@ the GNU autotools tarballs assume a POSIX shell environment.
 `iotdb_session` builds **with OpenSSL by default** (`WITH_SSL=ON`). Disable
 it with `-Dwith.ssl=OFF` (Maven) or `-DWITH_SSL=OFF` (standalone CMake).
 
-CMake first calls `find_package(OpenSSL)` and **prefers any system / vendor
-OpenSSL** it finds, regardless of version (1.x or 3.x). When SSL is enabled the
-resolved OpenSSL shared libraries are **bundled into the package `lib/`
-directory** (next to `iotdb_session`) so the published SDK is self-contained.
+OpenSSL is **pinned to the 1.x series**. Apache Thrift 0.21's `TSSLSocket.cpp`
+uses APIs removed in OpenSSL 3.x (`SSLv3_method`, `TLSv1_method`,
+`ASN1_STRING_data`, non-const `X509_NAME*`), so a 3.x OpenSSL cannot be used.
 
-If no system OpenSSL is found, it falls back to:
+CMake calls `find_package(OpenSSL)` and **accepts a system OpenSSL only when it
+is 1.x**; a 3.x install is ignored. When a 1.x OpenSSL is used, its shared
+libraries are **bundled into the package `lib/` directory** (next to
+`iotdb_session`) so the published SDK is self-contained.
 
-- **Linux / macOS** – use a local `openssl-<ver>.tar.gz` (or download it
+If no usable 1.x OpenSSL is found, it falls back to:
+
+- **Linux / macOS** – use a local `openssl-1.1.1w.tar.gz` (or download it
   when not in offline mode), configure with `no-shared`, install into
-  `build/_deps/openssl/install`, and link statically. The fallback pins
-  **OpenSSL 1.1.1w (1.x)**, not 3.x.
+  `build/_deps/openssl/install`, and link statically.
 - **Windows** – fail with a friendly message that points at a prebuilt
-  OpenSSL (`choco install openssl` or the Win64 installer). Building OpenSSL
-  from source via MSVC is out of scope.
+  OpenSSL 1.1.1 (`choco install openssl --version=1.1.1.2100`). Building
+  OpenSSL from source via MSVC is out of scope.
 
 ## Tests
 

--- a/iotdb-client/client-cpp/README.md
+++ b/iotdb-client/client-cpp/README.md
@@ -378,7 +378,7 @@ etc. directly.
 
 | Option                | Default                          | Purpose                                                                                                  |
 |-----------------------|----------------------------------|----------------------------------------------------------------------------------------------------------|
-| `WITH_SSL`            | `OFF`                            | Link against OpenSSL. See *SSL* below.                                                                   |
+| `WITH_SSL`            | `ON`                             | Link against OpenSSL and bundle its runtime libraries. See *SSL* below.                                  |
 | `BUILD_TESTING`       | `OFF` (Maven sets `ON` for verify) | Build Catch2 IT executables (Catch2 v2.13.7 header downloaded at configure time).                        |
 | `CATCH2_INCLUDE_DIR`  | (unset)                          | Pre-downloaded Catch2 include dir (Maven sets this under `target/test/catch2`).                          |
 | `IOTDB_OFFLINE`       | `OFF`                            | Disallow any network access during configure.                                                            |
@@ -427,8 +427,8 @@ cmake --build build --config Release --target install
 
    | Platform   | Required files                                                                                                                                                       |
    |------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-   | `linux/`   | `thrift-0.21.0.tar.gz`, `boost_1_60_0.tar.gz`, `m4-1.4.19.tar.gz`, `flex-2.6.4.tar.gz`, `bison-3.8.tar.gz` (and `openssl-3.5.0.tar.gz` when `WITH_SSL=ON`)            |
-   | `mac/`     | `thrift-0.21.0.tar.gz`, `boost_1_84_0.tar.gz` (newer Boost for Xcode/Clang; Apple ships m4/flex/bison; `openssl-3.5.0.tar.gz` optional)                               |
+   | `linux/`   | `thrift-0.21.0.tar.gz`, `boost_1_60_0.tar.gz`, `m4-1.4.19.tar.gz`, `flex-2.6.4.tar.gz`, `bison-3.8.tar.gz` (and `openssl-1.1.1w.tar.gz` only when `WITH_SSL=ON` and no system OpenSSL is present) |
+   | `mac/`     | `thrift-0.21.0.tar.gz`, `boost_1_84_0.tar.gz` (newer Boost for Xcode/Clang; Apple ships m4/flex/bison; `openssl-1.1.1w.tar.gz` optional)                              |
    | `windows/` | `thrift-0.21.0.tar.gz`, `boost_1_60_0.tar.gz` (Boost headers only - no `b2` build required for `iotdb_session`)                                                      |
 
    Reference URLs (the configure step uses the same):
@@ -437,7 +437,7 @@ cmake --build build --config Release --target install
    - GNU m4 1.4.19:       <https://ftp.gnu.org/gnu/m4/m4-1.4.19.tar.gz>
    - GNU flex 2.6.4:      <https://github.com/westes/flex/releases/download/v2.6.4/flex-2.6.4.tar.gz>
    - GNU bison 3.8:       <https://ftp.gnu.org/gnu/bison/bison-3.8.tar.gz>
-   - OpenSSL 3.5.0:       <https://www.openssl.org/source/openssl-3.5.0.tar.gz>
+   - OpenSSL 1.1.1w:      <https://www.openssl.org/source/openssl-1.1.1w.tar.gz>
 
 2. Run the build with offline mode enabled:
 
@@ -492,9 +492,11 @@ Prerequisites:
 2. **flex / bison.** Install <https://sourceforge.net/projects/winflexbison/>
    and rename `win_flex.exe`→`flex.exe`, `win_bison.exe`→`bison.exe` on
    `PATH`.
-3. **OpenSSL** *(only when `WITH_SSL=ON`)*: run the Win64 OpenSSL
-   installer from <https://slproweb.com/products/Win32OpenSSL.html>, then
-   pass `-DOPENSSL_ROOT_DIR=...` to CMake.
+3. **OpenSSL** *(`WITH_SSL=ON` is the default)*: install OpenSSL — e.g.
+   `choco install openssl`, or run the Win64 OpenSSL installer from
+   <https://slproweb.com/products/Win32OpenSSL.html> — then pass
+   `-DOPENSSL_ROOT_DIR=...` to CMake if it is not auto-detected. Pass
+   `-DWITH_SSL=OFF` to build without SSL.
 
 On Windows the SDK ships as **`iotdb_session.dll`** plus an import library
 **`iotdb_session.lib`**, built with **`/MD`** (dynamic CRT, same as a
@@ -507,16 +509,23 @@ the GNU autotools tarballs assume a POSIX shell environment.
 
 ## SSL
 
-Both Thrift and `iotdb_session` build without OpenSSL by default. Enable
-SSL with `-Dwith.ssl=ON` (Maven) or `-DWITH_SSL=ON` (standalone CMake).
-CMake first calls `find_package(OpenSSL)`;
-if nothing is found, it falls back to:
+`iotdb_session` builds **with OpenSSL by default** (`WITH_SSL=ON`). Disable
+it with `-Dwith.ssl=OFF` (Maven) or `-DWITH_SSL=OFF` (standalone CMake).
+
+CMake first calls `find_package(OpenSSL)` and **prefers any system / vendor
+OpenSSL** it finds, regardless of version (1.x or 3.x). When SSL is enabled the
+resolved OpenSSL shared libraries are **bundled into the package `lib/`
+directory** (next to `iotdb_session`) so the published SDK is self-contained.
+
+If no system OpenSSL is found, it falls back to:
 
 - **Linux / macOS** – use a local `openssl-<ver>.tar.gz` (or download it
   when not in offline mode), configure with `no-shared`, install into
-  `build/_deps/openssl/install`, and link statically.
-- **Windows** – fail with a friendly message that points at the Win64
-  OpenSSL installer. Building OpenSSL from source via MSVC is out of scope.
+  `build/_deps/openssl/install`, and link statically. The fallback pins
+  **OpenSSL 1.1.1w (1.x)**, not 3.x.
+- **Windows** – fail with a friendly message that points at a prebuilt
+  OpenSSL (`choco install openssl` or the Win64 installer). Building OpenSSL
+  from source via MSVC is out of scope.
 
 ## Tests
 

--- a/iotdb-client/client-cpp/README_zh.md
+++ b/iotdb-client/client-cpp/README_zh.md
@@ -236,14 +236,17 @@ Maven 构建会把 SDK 安装到 `target/install/`，并生成
 
 | CMake 变量 | Maven 属性 |
 |------------|------------|
-| `WITH_SSL` | `with.ssl`，例如 `-Dwith.ssl=ON` |
+| `WITH_SSL` | `with.ssl`（默认 `ON`，关闭用 `-Dwith.ssl=OFF`） |
 | `IOTDB_OFFLINE` | `iotdb.offline` |
 | `BUILD_TESTING` | `build.tests` |
 | `IOTDB_DEPS_DIR` | `iotdb.deps.dir` |
 | `BOOST_INCLUDEDIR` | `boost.include.dir` |
 | `CMAKE_BUILD_TYPE` | `cmake.build.type`，例如 `-Dcmake.build.type=Debug` |
 
-直接使用 CMake 时传入 `-DWITH_SSL=ON`、`-DIOTDB_OFFLINE=ON` 等即可。
+SSL 默认开启（`WITH_SSL=ON`）：优先使用系统已安装的 OpenSSL（1.x 或 3.x 均可），
+找不到时回退到从源码构建 OpenSSL 1.1.1w（不再使用 3.x）；启用 SSL 时会把所用的
+OpenSSL 动态库一并复制到产物 `lib/` 目录。直接使用 CMake 时传入
+`-DWITH_SSL=OFF`、`-DIOTDB_OFFLINE=ON` 等即可。
 Debug 构建请在配置阶段传入 `-DCMAKE_BUILD_TYPE=Debug`。Windows 使用 Visual
 Studio 生成器时也需要传入该选项，以便内置 Thrift 静态库使用 Debug MSVC 运行时；
 随后用 `cmake --build build --config Debug --target install` 构建安装。

--- a/iotdb-client/client-cpp/README_zh.md
+++ b/iotdb-client/client-cpp/README_zh.md
@@ -243,9 +243,11 @@ Maven 构建会把 SDK 安装到 `target/install/`，并生成
 | `BOOST_INCLUDEDIR` | `boost.include.dir` |
 | `CMAKE_BUILD_TYPE` | `cmake.build.type`，例如 `-Dcmake.build.type=Debug` |
 
-SSL 默认开启（`WITH_SSL=ON`）：优先使用系统已安装的 OpenSSL（1.x 或 3.x 均可），
-找不到时回退到从源码构建 OpenSSL 1.1.1w（不再使用 3.x）；启用 SSL 时会把所用的
-OpenSSL 动态库一并复制到产物 `lib/` 目录。直接使用 CMake 时传入
+SSL 默认开启（`WITH_SSL=ON`），且**固定使用 OpenSSL 1.x**：Thrift 0.21 的
+`TSSLSocket.cpp` 用到了 OpenSSL 3.x 已移除的 API，因此不支持 3.x。CMake 仅在
+系统 OpenSSL 为 1.x 时才采用它（发现 3.x 会忽略），否则回退到从源码构建 OpenSSL
+1.1.1w；使用 1.x 动态库时会把它一并复制到产物 `lib/` 目录。Windows 请安装 1.1.1
+（如 `choco install openssl --version=1.1.1.2100`）。直接使用 CMake 时传入
 `-DWITH_SSL=OFF`、`-DIOTDB_OFFLINE=ON` 等即可。
 Debug 构建请在配置阶段传入 `-DCMAKE_BUILD_TYPE=Debug`。Windows 使用 Visual
 Studio 生成器时也需要传入该选项，以便内置 Thrift 静态库使用 Debug MSVC 运行时；

--- a/iotdb-client/client-cpp/cmake/FetchOpenSSL.cmake
+++ b/iotdb-client/client-cpp/cmake/FetchOpenSSL.cmake
@@ -19,21 +19,24 @@
 # FetchOpenSSL.cmake  (only included when WITH_SSL=ON)
 #
 # Resolution order:
-#   1. find_package(OpenSSL) - any system / vendor install is taken as-is.
-#   2. On Linux/macOS:
+#   1. find_package(OpenSSL) - any system / vendor install is taken as-is,
+#      whatever its version (1.x or 3.x). This is always preferred.
+#   2. On Linux/macOS, when no system OpenSSL is present:
 #         use tarball ${IOTDB_OS_DEPS_DIR}/openssl-${OPENSSL_VERSION}.tar.gz
 #         or download from openssl.org when not in offline mode, then
-#         ./Configure && make && make install_sw into ${CMAKE_BINARY_DIR}/_deps/openssl.
-#   3. On Windows: emit a FATAL_ERROR with instructions to run the bundled
-#      Win64OpenSSL installer (or any other prebuilt OpenSSL); building
-#      OpenSSL from source on MSVC is out of scope.
+#         ./config && make && make install_sw into ${CMAKE_BINARY_DIR}/_deps/openssl.
+#         The fallback pins OpenSSL 1.1.1 (1.x), not 3.x.
+#   3. On Windows: emit a FATAL_ERROR with instructions to install a prebuilt
+#      OpenSSL; building OpenSSL from source on MSVC is out of scope.
 #
 # Side effects:
 #   Defines imported targets OpenSSL::SSL / OpenSSL::Crypto via find_package
 #   so callers can just link against them.
 # =============================================================================
 
-set(OPENSSL_VERSION "3.5.0" CACHE STRING "OpenSSL version to fetch when missing")
+# Fallback build only: the system OpenSSL (any version) is preferred above. When
+# none is found we build 1.1.1 (1.x); 3.x is intentionally not used as a fallback.
+set(OPENSSL_VERSION "1.1.1w" CACHE STRING "OpenSSL version to fetch when no system OpenSSL is found")
 
 find_package(OpenSSL QUIET)
 if(OpenSSL_FOUND)
@@ -44,9 +47,10 @@ endif()
 if(WIN32)
     message(FATAL_ERROR
             "[OpenSSL] WITH_SSL=ON but no OpenSSL was found on Windows. "
-            "Please run third-party/windows/Win64OpenSSL-3_5_0.exe (or any "
-            "OpenSSL installer), then re-run the configure step with "
-            "-DOPENSSL_ROOT_DIR=<install_path>.")
+            "Please install a prebuilt OpenSSL (e.g. 'choco install openssl', "
+            "or any Win64 OpenSSL installer), then re-run the configure step "
+            "with -DOPENSSL_ROOT_DIR=<install_path>. Pass -DWITH_SSL=OFF to "
+            "build without SSL.")
 endif()
 
 # --- Linux / macOS fallback: build from source ---------------------------
@@ -88,12 +92,14 @@ if(NOT EXISTS "${_ossl_stamp}")
     endif()
 
     message(STATUS "[OpenSSL] configuring -> ${_ossl_inst}")
+    # ./config auto-detects the platform target (1.1.1's ./Configure needs an
+    # explicit one); no-shared links OpenSSL straight into libiotdb_session.
     execute_process(
-            COMMAND ./Configure --prefix=${_ossl_inst} --openssldir=${_ossl_inst}/ssl no-shared
+            COMMAND ./config --prefix=${_ossl_inst} --openssldir=${_ossl_inst}/ssl no-shared
             WORKING_DIRECTORY "${_ossl_src}"
             RESULT_VARIABLE _rc)
     if(NOT _rc EQUAL 0)
-        message(FATAL_ERROR "[OpenSSL] Configure failed (rc=${_rc})")
+        message(FATAL_ERROR "[OpenSSL] config failed (rc=${_rc})")
     endif()
 
     message(STATUS "[OpenSSL] building (-j${_jobs})")

--- a/iotdb-client/client-cpp/cmake/FetchOpenSSL.cmake
+++ b/iotdb-client/client-cpp/cmake/FetchOpenSSL.cmake
@@ -63,6 +63,37 @@ if(OpenSSL_FOUND AND OPENSSL_VERSION VERSION_GREATER_EQUAL "3.0")
 endif()
 if(OpenSSL_FOUND)
     message(STATUS "[OpenSSL] using system OpenSSL ${OPENSSL_VERSION} (1.x)")
+    if(WIN32)
+        # FindOpenSSL on the Shining Light / choco layout may pick an import lib
+        # under lib/VC/<arch>/<MD|MT>/ that binds to a different OpenSSL ABI than
+        # the bin/ DLLs. This happens on CI runners where a 1.1.1 install is laid
+        # on top of a pre-existing 3.x one: the top-level lib/ and include/ become
+        # 1.1.1 but the VC sub-dir import libs stay 3.x, so the link fails to
+        # resolve 1.1-only symbols (e.g. SSL_get_peer_certificate). Pin the import
+        # libs to the top-level lib/ ones, which match the 1.1 runtime DLLs we
+        # bundle. Derive the root from the include dir find_package actually used.
+        get_filename_component(_ossl_win_root "${OPENSSL_INCLUDE_DIR}" DIRECTORY)
+        set(_ossl_ssl_implib    "${_ossl_win_root}/lib/libssl.lib")
+        set(_ossl_crypto_implib "${_ossl_win_root}/lib/libcrypto.lib")
+        if(EXISTS "${_ossl_ssl_implib}" AND EXISTS "${_ossl_crypto_implib}")
+            message(STATUS
+                    "[OpenSSL] pinning Windows import libs to ${_ossl_ssl_implib} "
+                    "and ${_ossl_crypto_implib}")
+            # FindOpenSSL creates these as UNKNOWN imported targets, which link via
+            # IMPORTED_LOCATION_<CONFIG>; override both that and IMPORTED_IMPLIB for
+            # every config so the pin applies regardless of how the target is typed.
+            foreach(_cfg "" "_RELEASE" "_DEBUG" "_RELWITHDEBINFO" "_MINSIZEREL")
+                set_target_properties(OpenSSL::SSL PROPERTIES
+                        IMPORTED_LOCATION${_cfg} "${_ossl_ssl_implib}"
+                        IMPORTED_IMPLIB${_cfg} "${_ossl_ssl_implib}")
+                set_target_properties(OpenSSL::Crypto PROPERTIES
+                        IMPORTED_LOCATION${_cfg} "${_ossl_crypto_implib}"
+                        IMPORTED_IMPLIB${_cfg} "${_ossl_crypto_implib}")
+            endforeach()
+            set(OPENSSL_SSL_LIBRARY "${_ossl_ssl_implib}" CACHE FILEPATH "" FORCE)
+            set(OPENSSL_CRYPTO_LIBRARY "${_ossl_crypto_implib}" CACHE FILEPATH "" FORCE)
+        endif()
+    endif()
     return()
 endif()
 

--- a/iotdb-client/client-cpp/cmake/FetchOpenSSL.cmake
+++ b/iotdb-client/client-cpp/cmake/FetchOpenSSL.cmake
@@ -18,43 +18,66 @@
 # =============================================================================
 # FetchOpenSSL.cmake  (only included when WITH_SSL=ON)
 #
+# OpenSSL is pinned to the 1.x series. Apache Thrift 0.21's TSSLSocket.cpp uses
+# APIs that were removed in OpenSSL 3.x (SSLv3_method / TLSv1_method /
+# ASN1_STRING_data / non-const X509_NAME*), so a 3.x OpenSSL cannot be used.
+#
 # Resolution order:
-#   1. find_package(OpenSSL) - any system / vendor install is taken as-is,
-#      whatever its version (1.x or 3.x). This is always preferred.
-#   2. On Linux/macOS, when no system OpenSSL is present:
-#         use tarball ${IOTDB_OS_DEPS_DIR}/openssl-${OPENSSL_VERSION}.tar.gz
+#   1. find_package(OpenSSL) - accepted ONLY when it is 1.x. A 3.x system
+#      OpenSSL is deliberately ignored (we do not fall back to it).
+#   2. On Linux/macOS, when no usable 1.x OpenSSL is present:
+#         use tarball ${IOTDB_OS_DEPS_DIR}/openssl-${OPENSSL_FALLBACK_VERSION}.tar.gz
 #         or download from openssl.org when not in offline mode, then
 #         ./config && make && make install_sw into ${CMAKE_BINARY_DIR}/_deps/openssl.
-#         The fallback pins OpenSSL 1.1.1 (1.x), not 3.x.
-#   3. On Windows: emit a FATAL_ERROR with instructions to install a prebuilt
-#      OpenSSL; building OpenSSL from source on MSVC is out of scope.
+#   3. On Windows: emit a FATAL_ERROR asking for a prebuilt OpenSSL 1.1.1;
+#      building OpenSSL from source on MSVC is out of scope.
 #
 # Side effects:
 #   Defines imported targets OpenSSL::SSL / OpenSSL::Crypto via find_package
 #   so callers can just link against them.
 # =============================================================================
 
-# Fallback build only: the system OpenSSL (any version) is preferred above. When
-# none is found we build 1.1.1 (1.x); 3.x is intentionally not used as a fallback.
-set(OPENSSL_VERSION "1.1.1w" CACHE STRING "OpenSSL version to fetch when no system OpenSSL is found")
+# Version built from source when no usable 1.x OpenSSL is found. Named distinctly
+# from find_package's OPENSSL_VERSION output variable to avoid collisions.
+set(OPENSSL_FALLBACK_VERSION "1.1.1w"
+    CACHE STRING "OpenSSL 1.x version built from source when no usable system OpenSSL is found")
 
 find_package(OpenSSL QUIET)
+if(OpenSSL_FOUND AND OPENSSL_VERSION VERSION_GREATER_EQUAL "3.0")
+    # Reject 3.x: Thrift 0.21 does not compile against it. Clear the resolved
+    # state so the rest of the script treats it as "no usable OpenSSL".
+    message(STATUS
+            "[OpenSSL] ignoring system OpenSSL ${OPENSSL_VERSION}: Thrift "
+            "${THRIFT_VERSION} requires OpenSSL 1.x. Will use "
+            "${OPENSSL_FALLBACK_VERSION} instead.")
+    set(OpenSSL_FOUND FALSE)
+    unset(OPENSSL_INCLUDE_DIR CACHE)
+    unset(OPENSSL_SSL_LIBRARY CACHE)
+    unset(OPENSSL_CRYPTO_LIBRARY CACHE)
+    unset(OPENSSL_SSL_LIBRARIES CACHE)
+    unset(OPENSSL_CRYPTO_LIBRARIES CACHE)
+    unset(SSL_EAY_RELEASE CACHE)
+    unset(SSL_EAY_DEBUG CACHE)
+    unset(LIB_EAY_RELEASE CACHE)
+    unset(LIB_EAY_DEBUG CACHE)
+endif()
 if(OpenSSL_FOUND)
-    message(STATUS "[OpenSSL] using system OpenSSL ${OPENSSL_VERSION_MAJOR}.${OPENSSL_VERSION_MINOR}")
+    message(STATUS "[OpenSSL] using system OpenSSL ${OPENSSL_VERSION} (1.x)")
     return()
 endif()
 
 if(WIN32)
     message(FATAL_ERROR
-            "[OpenSSL] WITH_SSL=ON but no OpenSSL was found on Windows. "
-            "Please install a prebuilt OpenSSL (e.g. 'choco install openssl', "
-            "or any Win64 OpenSSL installer), then re-run the configure step "
-            "with -DOPENSSL_ROOT_DIR=<install_path>. Pass -DWITH_SSL=OFF to "
-            "build without SSL.")
+            "[OpenSSL] WITH_SSL=ON but no OpenSSL 1.x was found on Windows "
+            "(Thrift ${THRIFT_VERSION} does not build against OpenSSL 3.x). "
+            "Please install OpenSSL 1.1.1 (e.g. "
+            "'choco install openssl --version=1.1.1.2100'), then re-run the "
+            "configure step with -DOPENSSL_ROOT_DIR=<install_path>. Pass "
+            "-DWITH_SSL=OFF to build without SSL.")
 endif()
 
-# --- Linux / macOS fallback: build from source ---------------------------
-set(_ossl_tarname "openssl-${OPENSSL_VERSION}.tar.gz")
+# --- Linux / macOS fallback: build OpenSSL 1.x from source ---------------
+set(_ossl_tarname "openssl-${OPENSSL_FALLBACK_VERSION}.tar.gz")
 set(_ossl_tarball "${IOTDB_OS_DEPS_DIR}/${_ossl_tarname}")
 
 if(NOT EXISTS "${_ossl_tarball}")
@@ -75,9 +98,9 @@ if(NOT EXISTS "${_ossl_tarball}")
 endif()
 
 set(_ossl_root  "${CMAKE_BINARY_DIR}/_deps/openssl")
-set(_ossl_src   "${_ossl_root}/src/openssl-${OPENSSL_VERSION}")
+set(_ossl_src   "${_ossl_root}/src/openssl-${OPENSSL_FALLBACK_VERSION}")
 set(_ossl_inst  "${_ossl_root}/install")
-set(_ossl_stamp "${_ossl_root}/.built-${OPENSSL_VERSION}")
+set(_ossl_stamp "${_ossl_root}/.built-${OPENSSL_FALLBACK_VERSION}")
 
 if(NOT EXISTS "${_ossl_stamp}")
     file(REMOVE_RECURSE "${_ossl_root}/src")

--- a/iotdb-client/client-cpp/cmake/FetchThrift.cmake
+++ b/iotdb-client/client-cpp/cmake/FetchThrift.cmake
@@ -138,6 +138,15 @@ endif()
 
 if(WITH_SSL)
     list(APPEND _thrift_cmake_args "-DWITH_OPENSSL=ON")
+    # Build Thrift's TSSLSocket against the same OpenSSL that iotdb_session links
+    # and bundles, so the runtime libraries match. find_package does not set
+    # OPENSSL_ROOT_DIR itself, so derive it from the resolved include dir.
+    if(OPENSSL_ROOT_DIR)
+        list(APPEND _thrift_cmake_args "-DOPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR}")
+    elseif(OPENSSL_INCLUDE_DIR)
+        get_filename_component(_thrift_ossl_root "${OPENSSL_INCLUDE_DIR}" DIRECTORY)
+        list(APPEND _thrift_cmake_args "-DOPENSSL_ROOT_DIR=${_thrift_ossl_root}")
+    endif()
 else()
     list(APPEND _thrift_cmake_args "-DWITH_OPENSSL=OFF")
 endif()
@@ -152,7 +161,15 @@ if(IOTDB_USE_CXX11_ABI)
 else()
     set(_thrift_abi_stamp "-abidefault")
 endif()
-set(_thrift_stamp "${_thrift_build}/.built-${THRIFT_VERSION}-${_thrift_build_config}-mdll${_thrift_abi_stamp}")
+# Encode WITH_SSL in the stamp: toggling SSL changes WITH_OPENSSL, so a cached
+# build of the opposite flavour must not be reused (otherwise TSSLSocket is
+# missing/extra at link time).
+if(WITH_SSL)
+    set(_thrift_ssl_stamp "-ssl")
+else()
+    set(_thrift_ssl_stamp "-nossl")
+endif()
+set(_thrift_stamp "${_thrift_build}/.built-${THRIFT_VERSION}-${_thrift_build_config}-mdll${_thrift_abi_stamp}${_thrift_ssl_stamp}")
 if(NOT EXISTS "${_thrift_stamp}")
     file(MAKE_DIRECTORY "${_thrift_build}")
     message(STATUS "[Thrift] configuring ${_thrift_dirname}")

--- a/iotdb-client/client-cpp/cmake/InstallOpenSSLRuntime.cmake
+++ b/iotdb-client/client-cpp/cmake/InstallOpenSSLRuntime.cmake
@@ -1,0 +1,121 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# =============================================================================
+# InstallOpenSSLRuntime.cmake  (only used when WITH_SSL=ON)
+#
+# Bundles the OpenSSL shared libraries that iotdb_session links against into the
+# package lib/ directory, so the published SDK is self-contained and runs on
+# machines that do not have OpenSSL installed.
+#
+# Relies on a prior find_package(OpenSSL) having populated
+# OPENSSL_SSL_LIBRARY / OPENSSL_CRYPTO_LIBRARY / OPENSSL_ROOT_DIR /
+# OPENSSL_VERSION_MAJOR.
+#
+# When OpenSSL was linked statically (the from-source fallback uses no-shared),
+# there is nothing to bundle: those objects are already inside libiotdb_session.
+# =============================================================================
+
+# Windows: find_package resolves the import .lib; the runtime DLLs live in
+# <root>/bin. Collect them, filtering by major version so installs that ship
+# several ABIs side by side (e.g. libssl-1_1-x64.dll + libssl-3-x64.dll) only
+# bundle the one we actually linked.
+function(_iotdb_collect_openssl_windows_dlls _out_var)
+    set(_roots "")
+    if(OPENSSL_ROOT_DIR)
+        list(APPEND _roots "${OPENSSL_ROOT_DIR}")
+    endif()
+    foreach(_implib IN LISTS OPENSSL_SSL_LIBRARY OPENSSL_CRYPTO_LIBRARY OPENSSL_LIBRARIES)
+        if(_implib AND EXISTS "${_implib}")
+            # Walk up from the import lib (.../lib, .../lib/VC/x64/MD, ...) to find
+            # a directory that owns a bin/ holding the DLLs.
+            get_filename_component(_dir "${_implib}" DIRECTORY)
+            list(APPEND _roots "${_dir}")
+            foreach(_up RANGE 1 4)
+                get_filename_component(_dir "${_dir}" DIRECTORY)
+                list(APPEND _roots "${_dir}")
+            endforeach()
+        endif()
+    endforeach()
+    list(REMOVE_DUPLICATES _roots)
+
+    set(_dlls "")
+    set(_seen_names "")
+    foreach(_root IN LISTS _roots)
+        if(_root AND IS_DIRECTORY "${_root}")
+            file(GLOB _found
+                    "${_root}/bin/libssl-${OPENSSL_VERSION_MAJOR}*.dll"
+                    "${_root}/bin/libcrypto-${OPENSSL_VERSION_MAJOR}*.dll"
+                    "${_root}/libssl-${OPENSSL_VERSION_MAJOR}*.dll"
+                    "${_root}/libcrypto-${OPENSSL_VERSION_MAJOR}*.dll")
+            # The same DLL can appear under several candidate roots (e.g. bin/ and
+            # the install root); keep only the first occurrence of each filename.
+            foreach(_dll IN LISTS _found)
+                get_filename_component(_name "${_dll}" NAME)
+                if(NOT _name IN_LIST _seen_names)
+                    list(APPEND _seen_names "${_name}")
+                    list(APPEND _dlls "${_dll}")
+                endif()
+            endforeach()
+        endif()
+    endforeach()
+    set(${_out_var} "${_dlls}" PARENT_SCOPE)
+endfunction()
+
+function(iotdb_install_openssl_runtime)
+    if(WIN32)
+        _iotdb_collect_openssl_windows_dlls(_dlls)
+        if(NOT _dlls)
+            message(STATUS
+                    "[OpenSSL] no runtime DLLs found to bundle; ensure the OpenSSL "
+                    "bin/ directory is on PATH when running the SDK")
+            return()
+        endif()
+        foreach(_dll IN LISTS _dlls)
+            message(STATUS "[OpenSSL] bundling runtime library into lib/: ${_dll}")
+        endforeach()
+        install(FILES ${_dlls} DESTINATION lib)
+        return()
+    endif()
+
+    # Linux / macOS: OPENSSL_*_LIBRARY is the developer name (libssl.so /
+    # libssl.dylib), usually a symlink to the SONAME (libssl.so.3 / .1.1).
+    # FOLLOW_SYMLINK_CHAIN installs the whole chain with the symlinks preserved,
+    # so the loader finds the SONAME the binary records. Static archives (.a)
+    # are skipped: they are already linked into libiotdb_session.
+    set(_files_arg "")
+    set(_have_libs OFF)
+    foreach(_lib IN LISTS OPENSSL_SSL_LIBRARY OPENSSL_CRYPTO_LIBRARY)
+        if(_lib AND EXISTS "${_lib}" AND NOT _lib MATCHES "\\.a$")
+            string(APPEND _files_arg " \"${_lib}\"")
+            set(_have_libs ON)
+            message(STATUS "[OpenSSL] bundling runtime library into lib/: ${_lib}")
+        endif()
+    endforeach()
+
+    if(NOT _have_libs)
+        message(STATUS
+                "[OpenSSL] no shared runtime libraries to bundle "
+                "(OpenSSL linked statically); SDK is self-contained")
+        return()
+    endif()
+
+    install(CODE
+            "file(INSTALL DESTINATION \"\${CMAKE_INSTALL_PREFIX}/lib\"
+                  TYPE SHARED_LIBRARY FOLLOW_SYMLINK_CHAIN
+                  FILES ${_files_arg})")
+endfunction()

--- a/iotdb-client/client-cpp/pom.xml
+++ b/iotdb-client/client-cpp/pom.xml
@@ -49,7 +49,7 @@
         <cmake.install.prefix>${project.build.directory}/install</cmake.install.prefix>
         <iotdb.deps.dir>${project.basedir}/third-party</iotdb.deps.dir>
         <iotdb.offline>OFF</iotdb.offline>
-        <with.ssl>OFF</with.ssl>
+        <with.ssl>ON</with.ssl>
         <iotdb.cxx11.abi/>
         <!-- Switched to OFF by the .skipTests profile below. -->
         <build.tests>ON</build.tests>

--- a/iotdb-client/client-cpp/src/assembly/package-metadata/third_party/DEPENDENCIES.md
+++ b/iotdb-client/client-cpp/src/assembly/package-metadata/third_party/DEPENDENCIES.md
@@ -28,7 +28,7 @@ included for provenance.
 | --- | --- | --- |
 | Apache Thrift | 0.21.0 | Apache License 2.0 |
 | Boost | 1.60.0 on Linux/Windows, 1.84.0 on macOS by default | Boost Software License 1.0 |
-| OpenSSL | 3.5.0 when `WITH_SSL=ON` | Apache License 2.0 |
+| OpenSSL | system OpenSSL when present (`WITH_SSL=ON`, default); 1.1.1w from-source fallback | Apache License 2.0 |
 | GNU m4 | 1.4.19 on Linux build bootstrap | GPL-3.0-or-later |
 | GNU flex | 2.6.4 on Linux build bootstrap | BSD-style flex license |
 | GNU bison | 3.8 on Linux build bootstrap | GPL-3.0-or-later |

--- a/iotdb-client/client-cpp/src/assembly/package-metadata/third_party/DEPENDENCIES.md
+++ b/iotdb-client/client-cpp/src/assembly/package-metadata/third_party/DEPENDENCIES.md
@@ -28,7 +28,7 @@ included for provenance.
 | --- | --- | --- |
 | Apache Thrift | 0.21.0 | Apache License 2.0 |
 | Boost | 1.60.0 on Linux/Windows, 1.84.0 on macOS by default | Boost Software License 1.0 |
-| OpenSSL | system OpenSSL when present (`WITH_SSL=ON`, default); 1.1.1w from-source fallback | Apache License 2.0 |
+| OpenSSL | 1.x only (`WITH_SSL=ON`, default): system 1.x when present, else 1.1.1w from source. 3.x is not supported | Apache License 2.0 |
 | GNU m4 | 1.4.19 on Linux build bootstrap | GPL-3.0-or-later |
 | GNU flex | 2.6.4 on Linux build bootstrap | BSD-style flex license |
 | GNU bison | 3.8 on Linux build bootstrap | GPL-3.0-or-later |

--- a/iotdb-client/client-cpp/third-party/README.md
+++ b/iotdb-client/client-cpp/third-party/README.md
@@ -68,7 +68,7 @@ Alternatively copy files manually from the URLs listed in
 
 | Platform   | Typical files |
 |------------|---------------|
-| `linux/`   | `thrift-0.21.0.tar.gz`, `boost_1_60_0.tar.gz`, `m4-1.4.19.tar.gz`, `flex-2.6.4.tar.gz`, `bison-3.8.tar.gz` (+ `openssl-3.5.0.tar.gz` when `WITH_SSL=ON`) |
+| `linux/`   | `thrift-0.21.0.tar.gz`, `boost_1_60_0.tar.gz`, `m4-1.4.19.tar.gz`, `flex-2.6.4.tar.gz`, `bison-3.8.tar.gz` (+ `openssl-1.1.1w.tar.gz` only when `WITH_SSL=ON` and no system OpenSSL is present) |
 | `mac/`     | `thrift-0.21.0.tar.gz`, `boost_1_60_0.tar.gz` (Xcode CLT usually provides m4/flex/bison) |
 | `windows/` | `thrift-0.21.0.tar.gz`, `boost_1_60_0.tar.gz`, `win_flex_bison-2.5.25.zip` (or any `win_flex_bison*.zip`; skip if flex/bison already on `PATH`) |
 


### PR DESCRIPTION

### Description:

Default WITH_SSL/with.ssl to ON so the C++ client and CI build with SSL.
Bundle the linked OpenSSL shared libs into the package lib/ so the SDK is self-contained.
Pin OpenSSL to 1.x: Thrift 0.21 doesn't compile against 3.x. find_package accepts only 1.x (ignores 3.x); otherwise builds 1.1.1w from source. CI installs OpenSSL 1.1.1 accordingly.
On Windows, pin the OpenSSL import libs to the top-level lib/libssl.lib/libcrypto.lib to avoid a 3.x/1.1 mixed-install link failure (SSL_get_peer_certificate).