### PR TITLE
Fix double living table schema race in IT

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/tablemodel/manual/enhanced/IoTDBPipeDoubleLivingIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/tablemodel/manual/enhanced/IoTDBPipeDoubleLivingIT.java
@@ -173,6 +173,12 @@ public class IoTDBPipeDoubleLivingIT extends AbstractPipeTableModelDualManualIT 
         TestUtils.executeNonQuery(
             senderEnv, String.format("insert into root.db.d1(time, s1) values (%s, 1)", i), conn);
       }
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+
+    try (Connection conn = receiverEnv.getConnection()) {
+      // insertion on receiver
       for (int i = 200; i < 300; ++i) {
         TestUtils.executeNonQuery(
             receiverEnv, String.format("insert into root.db.d1(time, s1) values (%s, 1)", i), conn);
@@ -182,6 +188,8 @@ public class IoTDBPipeDoubleLivingIT extends AbstractPipeTableModelDualManualIT 
     }
 
     TableModelUtils.insertData("test", "test", 100, 200, senderEnv);
+
+    TableModelUtils.assertData("test", "test", 0, 200, receiverEnv, handleFailure);
 
     TableModelUtils.insertData("test", "test", 200, 300, receiverEnv);
 


### PR DESCRIPTION
## Description

This PR fixes `IoTDBPipeDoubleLivingIT#testBasicDoubleLiving` by ensuring the receiver has synchronized the sender-side table data and schema before receiver-side table insertion starts. Without this wait, the receiver may try to auto-create a missing column from an insert statement that does not carry the column category, causing `Unknown column category for s5. Cannot auto create column.`.

It also fixes the receiver-side tree insertion block to use `receiverEnv.getConnection()` instead of reusing the sender connection.

### Verification

- `mvn spotless:apply -pl integration-test -P with-integration-tests`
- Attempted single IT verification with `IoTDBPipeDoubleLivingIT#testBasicDoubleLiving`; the run failed in `setUp` before reaching the test body because the local cluster did not start after 30 retries.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] modified existing integration tests.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- `integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/tablemodel/manual/enhanced/IoTDBPipeDoubleLivingIT.java`