### PR TITLE
Fix pipe text-like DATE conversion

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/tablemodel/manual/enhanced/IoTDBPipeTypeConversionISessionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/tablemodel/manual/enhanced/IoTDBPipeTypeConversionISessionIT.java
@@ -346,6 +346,7 @@ public class IoTDBPipeTypeConversionISessionIT extends AbstractPipeTableModelDua
       "enable =  true",
       "true",
       "false",
+      "2024-06-28 08:00:00",
     };
     for (int i = 0; i < generateDataSize; i++) {
       tablet.addValue(

--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/treemodel/manual/IoTDBPipeTypeConversionISessionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/treemodel/manual/IoTDBPipeTypeConversionISessionIT.java
@@ -547,6 +547,7 @@ public class IoTDBPipeTypeConversionISessionIT extends AbstractPipeDualTreeModel
       "enable =  true",
       "true",
       "false",
+      "2024-06-28 08:00:00",
       "12345678910",
       "123231232132131233213123123123123123131312",
       "123231232132131233213123123123123123131312.212312321312312",

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/transform/converter/ValueConverter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/transform/converter/ValueConverter.java
@@ -808,16 +808,36 @@ public class ValueConverter {
   }
 
   private static int parseDate(final String value) {
-    if (value == null || value.isEmpty()) {
+    if (value == null) {
       return DEFAULT_DATE;
     }
-    try {
-      if (TypeInferenceUtils.isNumber(value)) {
-        int date = Integer.parseInt(value);
+    final String trimmedValue = StringUtils.trim(value);
+    if (trimmedValue.isEmpty()) {
+      return DEFAULT_DATE;
+    }
+    if (TypeInferenceUtils.isNumber(trimmedValue)) {
+      try {
+        int date = Integer.parseInt(trimmedValue);
         DateUtils.parseIntToLocalDate(date);
         return date;
+      } catch (final Exception e) {
+        return DEFAULT_DATE;
       }
-      return DateTimeUtils.parseDateExpressionToInt(StringUtils.trim(value));
+    }
+    try {
+      return DateTimeUtils.parseDateExpressionToInt(trimmedValue);
+    } catch (final Exception e) {
+      return parseDateTimeToDate(trimmedValue);
+    }
+  }
+
+  private static int parseDateTimeToDate(final String value) {
+    try {
+      return DateUtils.parseDateExpressionToInt(
+          Instant.ofEpochMilli(
+                  DateTimeUtils.convertDatetimeStrToLong(value, ZoneOffset.UTC, 0, "ms"))
+              .atZone(ZoneOffset.UTC)
+              .toLocalDate());
     } catch (final Exception e) {
       return DEFAULT_DATE;
     }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/receiver/transform/converter/ValueConverterTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/receiver/transform/converter/ValueConverterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.pipe.receiver.transform.converter;
+
+import org.apache.tsfile.common.conf.TSFileConfig;
+import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.utils.Binary;
+import org.apache.tsfile.utils.DateUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ValueConverterTest {
+
+  @Test
+  public void testTextLikeDateTimeToDate() {
+    final int expectedDate = DateUtils.parseDateExpressionToInt("2024-06-28");
+    final Binary dateTime = binary("2024-06-28 08:00:00");
+
+    Assert.assertEquals(expectedDate, ValueConverter.convertTextToDate(dateTime));
+    Assert.assertEquals(expectedDate, ValueConverter.convertStringToDate(dateTime));
+    Assert.assertEquals(expectedDate, ValueConverter.convertBlobToDate(dateTime));
+  }
+
+  @Test
+  public void testTextLikeDateToDateKeepsExistingFallbacks() {
+    final int expectedDate = DateUtils.parseDateExpressionToInt("2024-06-28");
+    final int defaultDate = DateUtils.parseDateExpressionToInt("1970-01-01");
+
+    Assert.assertEquals(expectedDate, ValueConverter.convertTextToDate(binary("20240628")));
+    Assert.assertEquals(expectedDate, ValueConverter.convertTextToDate(binary("2024-06-28")));
+    Assert.assertEquals(defaultDate, ValueConverter.convertTextToDate(binary("12345678910")));
+    Assert.assertEquals(defaultDate, ValueConverter.convertTextToDate(binary("invalid-date")));
+  }
+
+  @Test
+  public void testTextArrayDateTimeToDate() {
+    final int expectedDate = DateUtils.parseDateExpressionToInt("2024-06-28");
+    final int defaultDate = DateUtils.parseDateExpressionToInt("1970-01-01");
+
+    final int[] dates =
+        (int[])
+            ArrayConverter.convert(
+                TSDataType.TEXT,
+                TSDataType.DATE,
+                new Binary[] {binary("2024-06-28 08:00:00"), binary("invalid-date")});
+
+    Assert.assertArrayEquals(new int[] {expectedDate, defaultDate}, dates);
+  }
+
+  private static Binary binary(final String value) {
+    return new Binary(value, TSFileConfig.STRING_CHARSET);
+  }
+}


### PR DESCRIPTION
## Description
- Parse non-numeric TEXT/STRING/BLOB values with datetime syntax when converting to DATE in pipe receiver conversion.
- Keep numeric strings constrained to valid DATE integers and fall back to 1970-01-01 on invalid values.
- Add focused converter coverage and include the datetime sample in tree/table pipe type conversion IT data.

## Tests
- mvn -Ddevelocity.off=true -pl iotdb-core/datanode,integration-test -P with-integration-tests spotless:apply
- mvn -Ddevelocity.off=true -pl iotdb-core/datanode -am -Dtest=ValueConverterTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test