### PR TITLE
Fix missing Objects import in ConfigurationFileUtilsTest

### DIFF
--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/env/AbstractEnv.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/env/AbstractEnv.java
@@ -557,7 +557,7 @@ public abstract class AbstractEnv implements BaseEnv {
         .append(processStatusPassed)
         .append(", expectedNodeSize=")
         .append(
-            configNodeWrapperList.size() + dataNodeWrapperList.size() + aiNodeWrapperList.size())
+            configNodeWrapperList.size() + dataNodeWrapperList.size() + extraNodeWrappers.size())
         .append(", actualNodeSize=")
         .append(actualNodeSize);
     if (showClusterStatus != null) {
@@ -592,7 +592,7 @@ public abstract class AbstractEnv implements BaseEnv {
     final List<AbstractNodeWrapper> allNodeWrappers = new ArrayList<>();
     allNodeWrappers.addAll(configNodeWrapperList);
     allNodeWrappers.addAll(dataNodeWrapperList);
-    allNodeWrappers.addAll(aiNodeWrapperList);
+    allNodeWrappers.addAll(extraNodeWrappers);
     return allNodeWrappers.stream()
         .map(AbstractNodeWrapper::getLogDirPath)
         .distinct()

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/ConfigurationFileUtilsTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/ConfigurationFileUtilsTest.java
@@ -36,6 +36,7 @@ import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 


### PR DESCRIPTION
## Description

Add the missing java.util.Objects import used by ConfigurationFileUtilsTest, fixing the maven-compiler-plugin:testCompile failure where Objects.requireNonNull(...) could not be resolved.

## Verification

- mvn -pl iotdb-core/datanode spotless:apply
- mvn -pl iotdb-core/datanode test-compile -DskipTests *(blocked locally before test compilation by existing datanode main-source/generated-source compilation errors unrelated to this import, e.g. missing generated-source dependencies/classes such as IFill, Accumulator, and ComparatorChain)*