### PR TITLE
Fix SingleDeviceViewOperatorTest row assertion

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/SingleDeviceViewOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/SingleDeviceViewOperatorTest.java
@@ -171,16 +171,14 @@ public class SingleDeviceViewOperatorTest {
               Arrays.asList(1, 2),
               Arrays.asList(TSDataType.TEXT, TSDataType.INT32, TSDataType.INT32, TSDataType.INT32));
       int count = 0;
-      int total = 0;
       while (singleDeviceViewOperator.isBlocked().isDone() && singleDeviceViewOperator.hasNext()) {
         TsBlock tsBlock = singleDeviceViewOperator.next();
         if (tsBlock == null || tsBlock.isEmpty()) {
           continue;
         }
         assertEquals(4, tsBlock.getValueColumnCount());
-        total += tsBlock.getPositionCount();
-        for (int i = 0; i < tsBlock.getPositionCount(); i++) {
-          long expectedTime = i + 20L * (count % 25);
+        for (int i = 0; i < tsBlock.getPositionCount(); i++, count++) {
+          long expectedTime = count;
           assertEquals(expectedTime, tsBlock.getTimeByIndex(i));
           assertEquals(
               SINGLE_DEVICE_MERGE_OPERATOR_TEST_SG + ".device0",
@@ -201,9 +199,8 @@ public class SingleDeviceViewOperatorTest {
             assertTrue(tsBlock.getColumn(3).isNull(i));
           }
         }
-        count++;
       }
-      assertEquals(500, total);
+      assertEquals(500, count);
     } catch (Exception e) {
       e.printStackTrace();
       fail();


### PR DESCRIPTION
## Description
This PR fixes a fragile assertion in SingleDeviceViewOperatorTest. The test used to derive the expected timestamp from the TsBlock index and assumed each returned block contains 20 rows. The operator contract does not guarantee that block size, so when the child operator returns a larger block, the expected timestamp resets incorrectly and the test can fail with expected 20 but was 320.

The test now validates timestamps by a global row counter across all returned TsBlocks, while preserving the existing value and null-column checks.

This is unrelated to the show receivers changes: the current show-receivers branch does not modify SingleDeviceViewOperatorTest, SingleDeviceViewOperator, FullOuterTimeJoinOperator, or SeriesReaderTestUtil.

## Tests
- mvn -pl iotdb-core/datanode spotless:apply
- mvn -pl iotdb-core/datanode -Dtest=SingleDeviceViewOperatorTest#singleDeviceViewOperatorTest test (not completed locally: dependency resolution fails before tests run because snapshot artifacts such as org.apache.iotdb:node-commons:2.0.7-SNAPSHOT are unavailable from the configured Maven repositories)