### PR TITLE
[Backport dev/1.3] Fix SingleDeviceViewOperatorTest row assertion

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/SingleDeviceViewOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/SingleDeviceViewOperatorTest.java
@@ -165,13 +165,11 @@ public class SingleDeviceViewOperatorTest {
               Arrays.asList(1, 2),
               Arrays.asList(TSDataType.TEXT, TSDataType.INT32, TSDataType.INT32, TSDataType.INT32));
       int count = 0;
-      int total = 0;
       while (singleDeviceViewOperator.isBlocked().isDone() && singleDeviceViewOperator.hasNext()) {
         TsBlock tsBlock = singleDeviceViewOperator.next();
         assertEquals(4, tsBlock.getValueColumnCount());
-        total += tsBlock.getPositionCount();
-        for (int i = 0; i < tsBlock.getPositionCount(); i++) {
-          long expectedTime = i + 20L * (count % 25);
+        for (int i = 0; i < tsBlock.getPositionCount(); i++, count++) {
+          long expectedTime = count;
           assertEquals(expectedTime, tsBlock.getTimeByIndex(i));
           assertEquals(
               SINGLE_DEVICE_MERGE_OPERATOR_TEST_SG + ".device0",
@@ -192,9 +190,8 @@ public class SingleDeviceViewOperatorTest {
             assertTrue(tsBlock.getColumn(3).isNull(i));
           }
         }
-        count++;
       }
-      assertEquals(500, total);
+      assertEquals(500, count);
     } catch (Exception e) {
       e.printStackTrace();
       fail();


### PR DESCRIPTION
Backport #17995 to dev/1.3.\n\nOriginal commit: 5f968335e12041bd65285662063e87c3540a0beb\nCherry-picked as: eb02d2554e5\n\nValidation:\n- git diff --check origin/dev/1.3..HEAD\n- mvn -pl iotdb-core/datanode -Dtest=SingleDeviceViewOperatorTest test (fails during datanode compilation before tests; errors are in DataNodeInternalRPCServiceImpl and pipe classes, not in the cherry-picked test file)