### PR TITLE
Exclude unused thrift Jakarta annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,14 @@
                         <artifactId>jakarta.servlet-api</artifactId>
                     </exclusion>
                     <!--
+                      Thrift generated Java sources suppress @Generated annotations.
+                      IoTDB does not use libthrift APIs that require Jakarta annotations.
+                    -->
+                    <exclusion>
+                        <groupId>jakarta.annotation</groupId>
+                        <artifactId>jakarta.annotation-api</artifactId>
+                    </exclusion>
+                    <!--
                       commons-lang3 is only used by Thrift's partial deserialization runtime.
                       IoTDB does not use org.apache.thrift.partial APIs.
                     -->


### PR DESCRIPTION
## Summary

- Exclude `jakarta.annotation:jakarta.annotation-api` from the managed `org.apache.thrift:libthrift` dependency.
- Keep the project-level version management intact because REST/OpenAPI/Jersey still use Jakarta annotations through their own dependency path.

## Motivation

After upgrading Thrift, `libthrift` started exposing `jakarta.annotation-api` as a runtime transitive dependency. IoTDB's Thrift Java generator suppresses `@Generated` annotations, and current Thrift-generated sources use `org.apache.thrift.annotation.Nullable`, so the Thrift path does not need Jakarta annotation APIs.

## Validation

- `mvn -pl iotdb-protocol/thrift-commons dependency:tree -Dincludes=jakarta.annotation:jakarta.annotation-api,org.apache.thrift:libthrift -Dverbose`
- `mvn -pl external-service-impl/rest-openapi dependency:tree -Dincludes=jakarta.annotation:jakarta.annotation-api -Dverbose`