### PR TITLE
Fix empty deleteTimeseries requests

### DIFF
--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -864,6 +864,9 @@ public class SessionConnection {
 
   protected void deleteTimeseries(List<String> paths)
       throws IoTDBConnectionException, StatementExecutionException {
+    if (paths.isEmpty()) {
+      return;
+    }
     callWithRetryAndVerify(() -> client.deleteTimeseries(sessionId, paths));
   }
 

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
@@ -2013,6 +2013,9 @@ public class SessionPool implements ISessionPool {
   @Override
   public void deleteTimeseries(List<String> paths)
       throws IoTDBConnectionException, StatementExecutionException {
+    if (paths.isEmpty()) {
+      return;
+    }
     ISession session = getSession();
     try {
       session.deleteTimeseries(paths);

--- a/iotdb-client/session/src/test/java/org/apache/iotdb/session/SessionConnectionTest.java
+++ b/iotdb-client/session/src/test/java/org/apache/iotdb/session/SessionConnectionTest.java
@@ -352,6 +352,14 @@ public class SessionConnectionTest {
   }
 
   @Test
+  public void testDeleteEmptyTimeseries()
+      throws IoTDBConnectionException, StatementExecutionException, TException {
+    sessionConnection.deleteTimeseries(Collections.emptyList());
+
+    Mockito.verify(client, Mockito.never()).deleteTimeseries(anyLong(), any());
+  }
+
+  @Test
   public void testDeleteData() throws IoTDBConnectionException, StatementExecutionException {
     sessionConnection.deleteData(new TSDeleteDataReq());
   }

--- a/iotdb-client/session/src/test/java/org/apache/iotdb/session/pool/SessionPoolTest.java
+++ b/iotdb-client/session/src/test/java/org/apache/iotdb/session/pool/SessionPoolTest.java
@@ -778,6 +778,17 @@ public class SessionPoolTest {
   }
 
   @Test
+  public void testDeleteEmptyTimeseriesList()
+      throws IoTDBConnectionException, StatementExecutionException {
+    sessionPool.deleteTimeseries(Collections.emptyList());
+
+    Mockito.verify(session, Mockito.never()).deleteTimeseries(Mockito.<List<String>>any());
+    assertEquals(
+        1,
+        ((ConcurrentLinkedDeque<ISession>) Whitebox.getInternalState(sessionPool, "queue")).size());
+  }
+
+  @Test
   public void testDeleteData() throws IoTDBConnectionException, StatementExecutionException {
     String path = "root.device1.temperature";
     long time = 2L;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/ClientRPCServiceImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/ClientRPCServiceImpl.java
@@ -2026,6 +2026,9 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
         return getNotLoggedInStatus();
       }
 
+      if (path.isEmpty()) {
+        return RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS);
+      }
       // Step 1: transfer from DeleteStorageGroupsReq to Statement
       DeleteTimeSeriesStatement statement =
           StatementGenerator.createDeleteTimeSeriesStatement(path);


### PR DESCRIPTION
## Summary
- Treat empty deleteTimeseries path lists as no-op in SessionConnection and SessionPool.
- Return SUCCESS for empty deleteTimeseries thrift requests after login validation.
- Add regression coverage for Session and SessionPool empty-list calls.

Fixes #11612

## Tests
- git diff --check
- mvn "-Ddevelocity.off=true" -pl iotdb-client/session "-Dtest=SessionConnectionTest#testDeleteEmptyTimeseries,SessionPoolTest#testDeleteEmptyTimeseriesList" test

## Notes
- Tried datanode compile with: mvn "-Ddevelocity.off=true" -pl iotdb-core/datanode -DskipTests compile
- That local compile fails on unrelated existing dependency/generated-source mismatches such as missing IOUtils.readFully, parser symbols, and freemarker aggregation dependencies.
