### PR TITLE
Fix flaky multilevel priority queue test

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/schedule/queue/MultilevelPriorityQueueTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/schedule/queue/MultilevelPriorityQueueTest.java
@@ -38,6 +38,9 @@ import org.mockito.Mockito;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.OptionalInt;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
 
 public class MultilevelPriorityQueueTest {
   @Test
@@ -58,12 +61,14 @@ public class MultilevelPriorityQueueTest {
                 }
               });
       t1.start();
-      Thread.sleep(100);
-      Assert.assertEquals(Thread.State.WAITING, t1.getState());
+      await()
+          .atMost(1, TimeUnit.MINUTES)
+          .untilAsserted(() -> Assert.assertEquals(Thread.State.WAITING, t1.getState()));
       DriverTask e2 = mockDriverTask(mockDriverTaskId(), false);
       queue.push(e2);
-      Thread.sleep(100);
-      Assert.assertEquals(Thread.State.TERMINATED, t1.getState());
+      await()
+          .atMost(1, TimeUnit.MINUTES)
+          .untilAsserted(() -> Assert.assertEquals(Thread.State.TERMINATED, t1.getState()));
       Assert.assertEquals(1, res.size());
       Assert.assertEquals(e2.getDriverTaskId().toString(), res.get(0).getDriverTaskId().toString());
     } catch (Exception e) {


### PR DESCRIPTION
## Description
This PR fixes a flaky assertion in MultilevelPriorityQueueTest#testPollBlocked by replacing fixed sleeps with Awaitility polling when checking the worker thread state.

This follows the existing pattern used by L2PriorityQueueTest#testPollBlocked and avoids sampling the thread state before the polling thread has actually entered WAITING.

## Verification
- mvn spotless:apply -pl iotdb-core/datanode
- git diff --check

The targeted test command could not reach surefire locally because datanode compilation fails first on unrelated generated/parser errors.