### PR TITLE
Pipe: isolate async sink client resources by endpoint

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/client/IoTDBDataNodeAsyncClientManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/client/IoTDBDataNodeAsyncClientManager.java
@@ -58,6 +58,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSinkConstant.CONNECTOR_LOAD_BALANCE_PRIORITY_STRATEGY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSinkConstant.CONNECTOR_LOAD_BALANCE_RANDOM_STRATEGY;
@@ -71,11 +72,11 @@ public class IoTDBDataNodeAsyncClientManager extends IoTDBClientManager
 
   private final Set<TEndPoint> endPointSet;
 
-  private static final Map<String, Integer> RECEIVER_ATTRIBUTES_REF_COUNT =
-      new ConcurrentHashMap<>();
+  private static final Map<String, Integer> CLIENT_RESOURCE_REF_COUNT = new ConcurrentHashMap<>();
   private final String receiverAttributes;
+  private final String clientResourceKey;
 
-  // receiverAttributes -> IClientManager<TEndPoint, AsyncPipeDataTransferServiceClient>
+  // clientResourceKey -> IClientManager<TEndPoint, AsyncPipeDataTransferServiceClient>
   private static final Map<String, IClientManager<TEndPoint, AsyncPipeDataTransferServiceClient>>
       ASYNC_PIPE_DATA_TRANSFER_CLIENT_MANAGER_HOLDER = new ConcurrentHashMap<>();
   private static final Map<String, ExecutorService> TS_FILE_ASYNC_EXECUTOR_HOLDER =
@@ -129,10 +130,11 @@ public class IoTDBDataNodeAsyncClientManager extends IoTDBClientManager
             shouldMarkAsPipeRequest,
             isTSFileUsed,
             skipIfNoPrivileges);
+    clientResourceKey = generateClientResourceKey(receiverAttributes, endPoints);
     synchronized (IoTDBDataNodeAsyncClientManager.class) {
-      if (!ASYNC_PIPE_DATA_TRANSFER_CLIENT_MANAGER_HOLDER.containsKey(receiverAttributes)) {
+      if (!ASYNC_PIPE_DATA_TRANSFER_CLIENT_MANAGER_HOLDER.containsKey(clientResourceKey)) {
         ASYNC_PIPE_DATA_TRANSFER_CLIENT_MANAGER_HOLDER.putIfAbsent(
-            receiverAttributes,
+            clientResourceKey,
             new IClientManager.Factory<TEndPoint, AsyncPipeDataTransferServiceClient>()
                 .createClientManager(
                     isTSFileUsed
@@ -140,21 +142,21 @@ public class IoTDBDataNodeAsyncClientManager extends IoTDBClientManager
                             .AsyncPipeTsFileDataTransferServiceClientPoolFactory()
                         : new ClientPoolFactory.AsyncPipeDataTransferServiceClientPoolFactory()));
       }
-      endPoint2Client = ASYNC_PIPE_DATA_TRANSFER_CLIENT_MANAGER_HOLDER.get(receiverAttributes);
+      endPoint2Client = ASYNC_PIPE_DATA_TRANSFER_CLIENT_MANAGER_HOLDER.get(clientResourceKey);
 
       if (isTSFileUsed) {
-        if (!TS_FILE_ASYNC_EXECUTOR_HOLDER.containsKey(receiverAttributes)) {
+        if (!TS_FILE_ASYNC_EXECUTOR_HOLDER.containsKey(clientResourceKey)) {
           TS_FILE_ASYNC_EXECUTOR_HOLDER.putIfAbsent(
-              receiverAttributes,
+              clientResourceKey,
               IoTDBThreadPoolFactory.newFixedThreadPool(
                   PipeConfig.getInstance().getPipeRealTimeQueueMaxWaitingTsFileSize(),
                   ThreadName.PIPE_TSFILE_ASYNC_SEND_POOL.getName() + "-" + id.getAndIncrement()));
         }
-        executor = TS_FILE_ASYNC_EXECUTOR_HOLDER.get(receiverAttributes);
+        executor = TS_FILE_ASYNC_EXECUTOR_HOLDER.get(clientResourceKey);
       }
 
-      RECEIVER_ATTRIBUTES_REF_COUNT.compute(
-          receiverAttributes, (attributes, refCount) -> refCount == null ? 1 : refCount + 1);
+      CLIENT_RESOURCE_REF_COUNT.compute(
+          clientResourceKey, (attributes, refCount) -> refCount == null ? 1 : refCount + 1);
     }
 
     switch (loadBalanceStrategy) {
@@ -421,30 +423,30 @@ public class IoTDBDataNodeAsyncClientManager extends IoTDBClientManager
   public void close() {
     isClosed = true;
     synchronized (IoTDBDataNodeAsyncClientManager.class) {
-      RECEIVER_ATTRIBUTES_REF_COUNT.computeIfPresent(
-          receiverAttributes,
+      CLIENT_RESOURCE_REF_COUNT.computeIfPresent(
+          clientResourceKey,
           (attributes, refCount) -> {
             if (refCount <= 1) {
               final IClientManager<TEndPoint, AsyncPipeDataTransferServiceClient> clientManager =
-                  ASYNC_PIPE_DATA_TRANSFER_CLIENT_MANAGER_HOLDER.remove(receiverAttributes);
+                  ASYNC_PIPE_DATA_TRANSFER_CLIENT_MANAGER_HOLDER.remove(clientResourceKey);
               if (clientManager != null) {
                 try {
                   clientManager.close();
                   LOGGER.info(
                       DataNodePipeMessages
                           .CLOSED_ASYNCPIPEDATATRANSFERSERVICECLIENTMANAGER_FOR_RECEIVER_ATTRIBUTES,
-                      receiverAttributes);
+                      clientResourceKey);
                 } catch (final Exception e) {
                   LOGGER.warn(
                       DataNodePipeMessages
                           .FAILED_TO_CLOSE_ASYNCPIPEDATATRANSFERSERVICECLIENTMANAGER_FOR_RECEIVER_ATTRIBUTE,
-                      receiverAttributes,
+                      clientResourceKey,
                       e);
                 }
               }
 
               final ExecutorService executor =
-                  TS_FILE_ASYNC_EXECUTOR_HOLDER.remove(receiverAttributes);
+                  TS_FILE_ASYNC_EXECUTOR_HOLDER.remove(clientResourceKey);
               if (executor != null) {
                 try {
                   executor.shutdown();
@@ -551,5 +553,17 @@ public class IoTDBDataNodeAsyncClientManager extends IoTDBClientManager
 
   private void markHealthy(TEndPoint endPoint) {
     unhealthyEndPointMap.remove(endPoint);
+  }
+
+  private static String generateClientResourceKey(
+      final String receiverAttributes, final List<TEndPoint> endPoints) {
+    return String.format(
+        "%s-%s",
+        receiverAttributes,
+        endPoints.stream()
+            .map(endPoint -> String.format("%s:%s", endPoint.getIp(), endPoint.getPort()))
+            .distinct()
+            .sorted()
+            .collect(Collectors.joining(",", "[", "]")));
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/sink/IoTDBDataNodeAsyncClientManagerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/sink/IoTDBDataNodeAsyncClientManagerTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import java.lang.reflect.Field;
 import java.util.Collections;
+import java.util.concurrent.ExecutorService;
 
 public class IoTDBDataNodeAsyncClientManagerTest {
 
@@ -71,10 +72,59 @@ public class IoTDBDataNodeAsyncClientManagerTest {
     }
   }
 
+  @Test
+  public void testClientResourcesShouldDifferentiateEndPoints() throws Exception {
+    final IoTDBDataNodeAsyncClientManager firstManager =
+        new IoTDBDataNodeAsyncClientManager(
+            Collections.singletonList(new TEndPoint("127.0.0.1", 6667)),
+            false,
+            "round-robin",
+            new UserEntity(1L, "user", "cli-host"),
+            "password",
+            true,
+            "sync",
+            true,
+            true,
+            true,
+            true);
+    final IoTDBDataNodeAsyncClientManager secondManager =
+        new IoTDBDataNodeAsyncClientManager(
+            Collections.singletonList(new TEndPoint("127.0.0.2", 6667)),
+            false,
+            "round-robin",
+            new UserEntity(1L, "user", "cli-host"),
+            "password",
+            true,
+            "sync",
+            true,
+            true,
+            true,
+            true);
+
+    try {
+      Assert.assertEquals(
+          getReceiverAttributes(firstManager), getReceiverAttributes(secondManager));
+      Assert.assertNotEquals(
+          getClientResourceKey(firstManager), getClientResourceKey(secondManager));
+      Assert.assertNotSame(getEndPoint2Client(firstManager), getEndPoint2Client(secondManager));
+      Assert.assertNotSame(getExecutor(firstManager), getExecutor(secondManager));
+    } finally {
+      firstManager.close();
+      secondManager.close();
+    }
+  }
+
   private static String getReceiverAttributes(final IoTDBDataNodeAsyncClientManager manager)
       throws Exception {
     final Field field =
         IoTDBDataNodeAsyncClientManager.class.getDeclaredField("receiverAttributes");
+    field.setAccessible(true);
+    return (String) field.get(manager);
+  }
+
+  private static String getClientResourceKey(final IoTDBDataNodeAsyncClientManager manager)
+      throws Exception {
+    final Field field = IoTDBDataNodeAsyncClientManager.class.getDeclaredField("clientResourceKey");
     field.setAccessible(true);
     return (String) field.get(manager);
   }
@@ -84,5 +134,12 @@ public class IoTDBDataNodeAsyncClientManagerTest {
     final Field field = IoTDBDataNodeAsyncClientManager.class.getDeclaredField("endPoint2Client");
     field.setAccessible(true);
     return field.get(manager);
+  }
+
+  private static ExecutorService getExecutor(final IoTDBDataNodeAsyncClientManager manager)
+      throws Exception {
+    final Field field = IoTDBDataNodeAsyncClientManager.class.getDeclaredField("executor");
+    field.setAccessible(true);
+    return (ExecutorService) field.get(manager);
   }
 }


### PR DESCRIPTION
## Description

Async pipe sink client managers and TsFile async send executors were shared by receiver attributes only. Since receiver attributes do not include target endpoints, pipes with the same receiver configuration but different target addresses could share the same static client resources. When the shared TsFile executor is occupied by a dead receiver, tasks targeting other addresses can be blocked as well.

This patch adds a client resource key that combines receiver attributes with the sorted target endpoint set, and uses it for the shared client manager, TsFile async executor, and ref-count lifecycle.

## Tests

- `git diff --check`
- `mvn -Ddevelocity.off=true -pl iotdb-core/datanode -Dtest=IoTDBDataNodeAsyncClientManagerTest -DskipITs -Dskip.UT=false test`