### PR TITLE
Pipe: support unified pattern inclusion keys

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTaskAgent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTaskAgent.java
@@ -109,6 +109,7 @@ import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.E
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_HISTORY_END_TIME_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_HISTORY_START_TIME_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_PATH_EXCLUSION_KEY;
+import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_PATH_INCLUSION_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_PATH_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_PATTERN_EXCLUSION_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_PATTERN_INCLUSION_KEY;
@@ -121,6 +122,7 @@ import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.S
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_HISTORY_END_TIME_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_HISTORY_START_TIME_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_PATH_EXCLUSION_KEY;
+import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_PATH_INCLUSION_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_PATH_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_PATTERN_EXCLUSION_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_PATTERN_INCLUSION_KEY;
@@ -913,6 +915,8 @@ public class PipeDataNodeTaskAgent extends PipeTaskAgent {
             || sourceParameters.hasAnyAttributes(
                 EXTRACTOR_PATH_KEY,
                 SOURCE_PATH_KEY,
+                EXTRACTOR_PATH_INCLUSION_KEY,
+                SOURCE_PATH_INCLUSION_KEY,
                 EXTRACTOR_PATTERN_INCLUSION_KEY,
                 SOURCE_PATTERN_INCLUSION_KEY,
                 EXTRACTOR_PATH_EXCLUSION_KEY,

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/source/dataregion/IoTDBDataRegionSource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/source/dataregion/IoTDBDataRegionSource.java
@@ -85,6 +85,7 @@ import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.E
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_MODE_STRICT_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_MODS_ENABLE_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_MODS_KEY;
+import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_PATH_INCLUSION_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_PATH_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_PATTERN_FORMAT_IOTDB_VALUE;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_PATTERN_FORMAT_KEY;
@@ -119,6 +120,7 @@ import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.S
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_MODE_STRICT_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_MODS_ENABLE_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_MODS_KEY;
+import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_PATH_INCLUSION_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_PATH_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_PATTERN_FORMAT_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_PATTERN_INCLUSION_KEY;
@@ -197,6 +199,8 @@ public class IoTDBDataRegionSource extends IoTDBSource {
                 SOURCE_PATH_KEY,
                 EXTRACTOR_PATTERN_KEY,
                 SOURCE_PATTERN_KEY,
+                EXTRACTOR_PATH_INCLUSION_KEY,
+                SOURCE_PATH_INCLUSION_KEY,
                 EXTRACTOR_PATTERN_INCLUSION_KEY,
                 SOURCE_PATTERN_INCLUSION_KEY)) {
       throw new PipeException(DataNodePipeMessages.THE_PIPE_CANNOT_EXTRACT_TREE_MODEL_DATA);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/pattern/TreePatternPruningTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/pattern/TreePatternPruningTest.java
@@ -122,7 +122,7 @@ public class TreePatternPruningTest {
   }
 
   @Test
-  public void testLegacyPatternMultipleRulesRejected() {
+  public void testLegacyPatternMultipleRulesPreserved() {
     final PipeParameters params =
         new PipeParameters(
             new HashMap<String, String>() {
@@ -131,12 +131,9 @@ public class TreePatternPruningTest {
               }
             });
 
-    try {
-      TreePattern.parsePipePatternFromSourceParameters(params);
-      Assert.fail("Should throw PipeException for legacy multi-pattern parameters");
-    } catch (final PipeException ignored) {
-      // Expected exception
-    }
+    final TreePattern result = TreePattern.parsePipePatternFromSourceParameters(params);
+
+    Assert.assertEquals("root.sg.A,root.sg.B", result.getPattern());
   }
 
   @Test
@@ -157,7 +154,7 @@ public class TreePatternPruningTest {
   }
 
   @Test
-  public void testLegacyPathMultipleRulesRejected() {
+  public void testLegacyPathMultipleRulesPreserved() {
     final PipeParameters params =
         new PipeParameters(
             new HashMap<String, String>() {
@@ -166,12 +163,28 @@ public class TreePatternPruningTest {
               }
             });
 
-    try {
-      TreePattern.parsePipePatternFromSourceParameters(params);
-      Assert.fail("Should throw PipeException for legacy multi-path parameters");
-    } catch (final PipeException ignored) {
-      // Expected exception
-    }
+    final TreePattern result = TreePattern.parsePipePatternFromSourceParameters(params);
+
+    Assert.assertTrue(result instanceof UnionIoTDBTreePattern);
+    Assert.assertEquals("root.sg.d1,root.sg.d2", result.getPattern());
+  }
+
+  @Test
+  public void testLegacyPathMultipleExclusionsPreserved() {
+    final PipeParameters params =
+        new PipeParameters(
+            new HashMap<String, String>() {
+              {
+                put(PipeSourceConstant.SOURCE_PATH_KEY, "root.sg.**");
+                put(PipeSourceConstant.SOURCE_PATH_EXCLUSION_KEY, "root.sg.d1,root.sg.d2");
+              }
+            });
+
+    final TreePattern result = TreePattern.parsePipePatternFromSourceParameters(params);
+
+    Assert.assertTrue(result instanceof WithExclusionIoTDBTreePattern);
+    Assert.assertEquals(
+        "INCLUSION(root.sg.**), EXCLUSION(root.sg.d1,root.sg.d2)", result.getPattern());
   }
 
   @Test

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/constant/PipeSourceConstant.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/constant/PipeSourceConstant.java
@@ -58,6 +58,8 @@ public class PipeSourceConstant {
   public static final String SOURCE_PATTERN_INCLUSION_KEY = "source.pattern.inclusion";
   public static final String EXTRACTOR_PATH_KEY = "extractor.path";
   public static final String SOURCE_PATH_KEY = "source.path";
+  public static final String EXTRACTOR_PATH_INCLUSION_KEY = "extractor.path.inclusion";
+  public static final String SOURCE_PATH_INCLUSION_KEY = "source.path.inclusion";
   public static final String EXTRACTOR_PATTERN_FORMAT_KEY = "extractor.pattern.format";
   public static final String SOURCE_PATTERN_FORMAT_KEY = "source.pattern.format";
   public static final String EXTRACTOR_PATTERN_FORMAT_PREFIX_VALUE = "prefix";

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/datastructure/pattern/TreePattern.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/datastructure/pattern/TreePattern.java
@@ -44,6 +44,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_PATH_EXCLUSION_KEY;
+import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_PATH_INCLUSION_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_PATH_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_PATTERN_EXCLUSION_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_PATTERN_FORMAT_IOTDB_VALUE;
@@ -52,6 +53,7 @@ import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.E
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_PATTERN_INCLUSION_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_PATTERN_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_PATH_EXCLUSION_KEY;
+import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_PATH_INCLUSION_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_PATH_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_PATTERN_EXCLUSION_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_PATTERN_FORMAT_KEY;
@@ -164,49 +166,9 @@ public abstract class TreePattern {
     final boolean isTreeModelDataAllowedToBeCaptured =
         isTreeModelDataAllowToBeCaptured(sourceParameters);
 
-    final boolean hasPatternInclusionKey =
-        sourceParameters.hasAnyAttributes(
-            EXTRACTOR_PATTERN_INCLUSION_KEY, SOURCE_PATTERN_INCLUSION_KEY);
-    final boolean hasPatternExclusionKey =
-        sourceParameters.hasAnyAttributes(
-            EXTRACTOR_PATTERN_EXCLUSION_KEY, SOURCE_PATTERN_EXCLUSION_KEY);
-    final boolean hasLegacyPathKey =
-        sourceParameters.hasAnyAttributes(EXTRACTOR_PATH_KEY, SOURCE_PATH_KEY);
-    final boolean hasLegacyPatternKey =
-        sourceParameters.hasAnyAttributes(EXTRACTOR_PATTERN_KEY, SOURCE_PATTERN_KEY);
-    final boolean usePatternSyntax =
-        hasPatternInclusionKey
-            || (hasPatternExclusionKey && !hasLegacyPathKey && !hasLegacyPatternKey);
-
-    if (hasPatternInclusionKey && (hasLegacyPathKey || hasLegacyPatternKey)) {
-      final String msg =
-          String.format(
-              PipeMessages.PATTERN_INCLUSION_CANNOT_BE_USED_WITH_PATTERN_OR_PATH,
-              SOURCE_PATTERN_INCLUSION_KEY,
-              SOURCE_PATTERN_KEY,
-              SOURCE_PATH_KEY);
-      LOGGER.warn(msg);
-      throw new PipeException(msg);
-    }
-
     // 1. Parse INCLUSION patterns into a list
     List<TreePattern> inclusionPatterns =
-        usePatternSyntax
-            ? parseIoTDBPatternList(
-                sourceParameters.getStringByKeys(
-                    EXTRACTOR_PATTERN_INCLUSION_KEY, SOURCE_PATTERN_INCLUSION_KEY),
-                isTreeModelDataAllowedToBeCaptured,
-                true,
-                SOURCE_PATTERN_INCLUSION_KEY)
-            : parseLegacyPatternList(
-                sourceParameters,
-                isTreeModelDataAllowedToBeCaptured,
-                EXTRACTOR_PATH_KEY,
-                SOURCE_PATH_KEY,
-                EXTRACTOR_PATTERN_KEY,
-                SOURCE_PATTERN_KEY,
-                SOURCE_PATH_KEY,
-                SOURCE_PATTERN_KEY);
+        parseInclusionPatternList(sourceParameters, isTreeModelDataAllowedToBeCaptured);
 
     // If no inclusion patterns are specified, use default "root.**"
     if (inclusionPatterns.isEmpty()) {
@@ -217,35 +179,8 @@ public abstract class TreePattern {
     }
 
     // 2. Parse EXCLUSION patterns into a list
-    if (usePatternSyntax
-        && sourceParameters.hasAnyAttributes(
-            EXTRACTOR_PATH_EXCLUSION_KEY, SOURCE_PATH_EXCLUSION_KEY)) {
-      final String msg =
-          String.format(
-              PipeMessages.PATTERN_INCLUSION_CANNOT_BE_USED_WITH_PATH_EXCLUSION,
-              SOURCE_PATTERN_INCLUSION_KEY,
-              SOURCE_PATH_EXCLUSION_KEY);
-      LOGGER.warn(msg);
-      throw new PipeException(msg);
-    }
-
     List<TreePattern> exclusionPatterns =
-        usePatternSyntax
-            ? parseIoTDBPatternList(
-                sourceParameters.getStringByKeys(
-                    EXTRACTOR_PATTERN_EXCLUSION_KEY, SOURCE_PATTERN_EXCLUSION_KEY),
-                isTreeModelDataAllowedToBeCaptured,
-                true,
-                SOURCE_PATTERN_EXCLUSION_KEY)
-            : parseLegacyPatternList(
-                sourceParameters,
-                isTreeModelDataAllowedToBeCaptured,
-                EXTRACTOR_PATH_EXCLUSION_KEY,
-                SOURCE_PATH_EXCLUSION_KEY,
-                EXTRACTOR_PATTERN_EXCLUSION_KEY,
-                SOURCE_PATTERN_EXCLUSION_KEY,
-                SOURCE_PATH_EXCLUSION_KEY,
-                SOURCE_PATTERN_EXCLUSION_KEY);
+        parseExclusionPatternList(sourceParameters, isTreeModelDataAllowedToBeCaptured);
 
     // 3. Optimize the lists: remove redundant patterns (e.g., if "root.**" exists, "root.db" is
     // redundant)
@@ -264,6 +199,8 @@ public abstract class TreePattern {
               sourceParameters.getStringByKeys(
                   EXTRACTOR_PATTERN_INCLUSION_KEY,
                   SOURCE_PATTERN_INCLUSION_KEY,
+                  EXTRACTOR_PATH_INCLUSION_KEY,
+                  SOURCE_PATH_INCLUSION_KEY,
                   EXTRACTOR_PATH_KEY,
                   SOURCE_PATH_KEY,
                   EXTRACTOR_PATTERN_KEY,
@@ -382,49 +319,91 @@ public abstract class TreePattern {
         parseMultiplePatterns(trimmedPattern, basePatternSupplier));
   }
 
-  /**
-   * Helper method to parse legacy pattern parameters into a list of patterns without creating the
-   * Union object immediately.
-   */
-  private static List<TreePattern> parseLegacyPatternList(
-      final PipeParameters sourceParameters,
-      final boolean isTreeModelDataAllowedToBeCaptured,
-      final String extractorPathKey,
-      final String sourcePathKey,
-      final String extractorPatternKey,
-      final String sourcePatternKey,
-      final String pathKeyName,
-      final String patternKeyName) {
-
-    final String path = sourceParameters.getStringByKeys(extractorPathKey, sourcePathKey);
-    final String pattern = sourceParameters.getStringByKeys(extractorPatternKey, sourcePatternKey);
-
-    if (path != null && pattern != null) {
-      final String msg =
-          String.format(
-              PipeMessages.PATH_AND_PATTERN_CANNOT_BE_USED_TOGETHER, pathKeyName, patternKeyName);
-      LOGGER.warn(msg);
-      throw new PipeException(msg);
-    }
-
+  private static List<TreePattern> parseInclusionPatternList(
+      final PipeParameters sourceParameters, final boolean isTreeModelDataAllowedToBeCaptured) {
     final List<TreePattern> result = new ArrayList<>();
 
-    if (path != null) {
-      result.addAll(
-          parseIoTDBPatternList(path, isTreeModelDataAllowedToBeCaptured, false, pathKeyName));
-    }
+    addPatternsFromPatternParameterIfPresent(
+        result,
+        sourceParameters,
+        isTreeModelDataAllowedToBeCaptured,
+        EXTRACTOR_PATTERN_KEY,
+        SOURCE_PATTERN_KEY,
+        SOURCE_PATTERN_KEY);
+    addIoTDBPatternsIfPresent(
+        result,
+        sourceParameters,
+        isTreeModelDataAllowedToBeCaptured,
+        EXTRACTOR_PATTERN_INCLUSION_KEY,
+        SOURCE_PATTERN_INCLUSION_KEY,
+        SOURCE_PATTERN_INCLUSION_KEY);
+    addIoTDBPatternsIfPresent(
+        result,
+        sourceParameters,
+        isTreeModelDataAllowedToBeCaptured,
+        EXTRACTOR_PATH_KEY,
+        SOURCE_PATH_KEY,
+        SOURCE_PATH_KEY);
+    addIoTDBPatternsIfPresent(
+        result,
+        sourceParameters,
+        isTreeModelDataAllowedToBeCaptured,
+        EXTRACTOR_PATH_INCLUSION_KEY,
+        SOURCE_PATH_INCLUSION_KEY,
+        SOURCE_PATH_INCLUSION_KEY);
 
+    return result;
+  }
+
+  private static List<TreePattern> parseExclusionPatternList(
+      final PipeParameters sourceParameters, final boolean isTreeModelDataAllowedToBeCaptured) {
+    final List<TreePattern> result = new ArrayList<>();
+
+    addIoTDBPatternsIfPresent(
+        result,
+        sourceParameters,
+        isTreeModelDataAllowedToBeCaptured,
+        EXTRACTOR_PATTERN_EXCLUSION_KEY,
+        SOURCE_PATTERN_EXCLUSION_KEY,
+        SOURCE_PATTERN_EXCLUSION_KEY);
+    addIoTDBPatternsIfPresent(
+        result,
+        sourceParameters,
+        isTreeModelDataAllowedToBeCaptured,
+        EXTRACTOR_PATH_EXCLUSION_KEY,
+        SOURCE_PATH_EXCLUSION_KEY,
+        SOURCE_PATH_EXCLUSION_KEY);
+
+    return result;
+  }
+
+  private static void addIoTDBPatternsIfPresent(
+      final List<TreePattern> result,
+      final PipeParameters sourceParameters,
+      final boolean isTreeModelDataAllowedToBeCaptured,
+      final String extractorKey,
+      final String sourceKey,
+      final String parameterKey) {
+    final String pattern = sourceParameters.getStringByKeys(extractorKey, sourceKey);
+    if (pattern != null) {
+      result.addAll(
+          parseIoTDBPatternList(pattern, isTreeModelDataAllowedToBeCaptured, true, parameterKey));
+    }
+  }
+
+  private static void addPatternsFromPatternParameterIfPresent(
+      final List<TreePattern> result,
+      final PipeParameters sourceParameters,
+      final boolean isTreeModelDataAllowedToBeCaptured,
+      final String extractorKey,
+      final String sourceKey,
+      final String parameterKey) {
+    final String pattern = sourceParameters.getStringByKeys(extractorKey, sourceKey);
     if (pattern != null) {
       result.addAll(
           parsePatternsFromPatternParameter(
-              pattern,
-              sourceParameters,
-              isTreeModelDataAllowedToBeCaptured,
-              false,
-              patternKeyName));
+              pattern, sourceParameters, isTreeModelDataAllowedToBeCaptured, true, parameterKey));
     }
-
-    return result;
   }
 
   private static List<TreePattern> parseIoTDBPatternList(

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/pipe/datastructure/pattern/TreePatternParseTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/pipe/datastructure/pattern/TreePatternParseTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.commons.pipe.datastructure.pattern;
+
+import org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant;
+import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameters;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+public class TreePatternParseTest {
+
+  @Test
+  public void testPatternAndPatternInclusionPreserved() {
+    final PipeParameters params =
+        new PipeParameters(
+            new HashMap<String, String>() {
+              {
+                put(PipeSourceConstant.SOURCE_PATTERN_KEY, "root.sg.A");
+                put(PipeSourceConstant.SOURCE_PATTERN_INCLUSION_KEY, "root.sg.B");
+              }
+            });
+
+    final TreePattern result = TreePattern.parsePipePatternFromSourceParameters(params);
+
+    Assert.assertTrue(result instanceof UnionTreePattern);
+    Assert.assertEquals("root.sg.A,root.sg.B", result.getPattern());
+  }
+
+  @Test
+  public void testPathAndPathInclusionPreserved() {
+    final PipeParameters params =
+        new PipeParameters(
+            new HashMap<String, String>() {
+              {
+                put(PipeSourceConstant.SOURCE_PATH_KEY, "root.sg.d1");
+                put(PipeSourceConstant.SOURCE_PATH_INCLUSION_KEY, "root.sg.d2,root.sg.d3");
+              }
+            });
+
+    final TreePattern result = TreePattern.parsePipePatternFromSourceParameters(params);
+
+    Assert.assertTrue(result instanceof UnionIoTDBTreePattern);
+    Assert.assertEquals("root.sg.d1,root.sg.d2,root.sg.d3", result.getPattern());
+  }
+
+  @Test
+  public void testPathInclusionWithPathExclusionPreserved() {
+    final PipeParameters params =
+        new PipeParameters(
+            new HashMap<String, String>() {
+              {
+                put(PipeSourceConstant.SOURCE_PATH_INCLUSION_KEY, "root.sg.**");
+                put(PipeSourceConstant.SOURCE_PATH_EXCLUSION_KEY, "root.sg.d1,root.sg.d2");
+              }
+            });
+
+    final TreePattern result = TreePattern.parsePipePatternFromSourceParameters(params);
+
+    Assert.assertTrue(result instanceof WithExclusionIoTDBTreePattern);
+    Assert.assertEquals(
+        "INCLUSION(root.sg.**), EXCLUSION(root.sg.d1,root.sg.d2)", result.getPattern());
+  }
+}


### PR DESCRIPTION
## Summary
- allow legacy `source.pattern` / `source.path` and new `*.pattern.inclusion` / `*.path.inclusion` keys to contribute to the same tree-pattern inclusion set
- add `source.path.inclusion` / `extractor.path.inclusion` constants and include them in tree-capture validation and TSFile parser memory checks
- remove the legacy single-pattern restriction and add focused parsing tests

## Tests
- `mvn spotless:apply -pl iotdb-core/node-commons,iotdb-core/datanode`
- `mvn -pl iotdb-core/node-commons -Dtest=TreePatternParseTest test`

Note: `mvn -pl iotdb-core/node-commons,iotdb-core/datanode -Dtest=TreePatternPruningTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test` currently fails before running the datanode test because generated `ModeAccumulator` sources cannot compile (`org.apache.commons.collections4.comparators.ComparatorChain` missing and `IoTDBConfig#getModeMapSizeThreshold()` missing).