### PR TITLE
Fix raw password user sync under strong policy

### DIFF
--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/AuthorInfoTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/AuthorInfoTest.java
@@ -649,7 +649,9 @@ public class AuthorInfoTest {
   }
 
   @Test
-  public void createUserWithRawPassword() {
+  public void createUserWithRawPassword() throws AuthException {
+    cleanUserAndRole();
+
     TSStatus status;
     AuthorPlan authorPlan;
     authorPlan =
@@ -666,6 +668,46 @@ public class AuthorInfoTest {
     assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), status.getCode());
     TPermissionInfoResp result = authorInfo.login("testuser", "password123456", false);
     assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), result.getStatus().getCode());
+
+    final boolean originalEnforceStrongPassword =
+        CommonDescriptor.getInstance().getConfig().isEnforceStrongPassword();
+    CommonDescriptor.getInstance().getConfig().setEnforceStrongPassword(true);
+    try {
+      authorPlan =
+          new AuthorTreePlan(
+              ConfigPhysicalPlanType.CreateUser,
+              "legacyuser",
+              "",
+              "legacyuser",
+              "",
+              new HashSet<>(),
+              false,
+              new ArrayList<>());
+      status = authorInfo.authorNonQuery(authorPlan);
+      assertEquals(TSStatusCode.ILLEGAL_PASSWORD.getStatusCode(), status.getCode());
+
+      assertEquals(
+          TSStatusCode.USER_NOT_EXIST.getStatusCode(),
+          authorInfo.login("legacyuser", "legacyuser", true).getStatus().getCode());
+      authorPlan =
+          new AuthorTreePlan(
+              ConfigPhysicalPlanType.CreateUserWithRawPassword,
+              "legacyuser",
+              "",
+              "legacyuser",
+              "",
+              new HashSet<>(),
+              false,
+              new ArrayList<>());
+      status = authorInfo.authorNonQuery(authorPlan);
+      assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), status.getCode());
+      result = authorInfo.login("legacyuser", "legacyuser", true);
+      assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), result.getStatus().getCode());
+    } finally {
+      CommonDescriptor.getInstance()
+          .getConfig()
+          .setEnforceStrongPassword(originalEnforceStrongPassword);
+    }
   }
 
   private void checkAuthorNonQueryReturn(AuthorPlan plan) {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/user/BasicUserManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/auth/user/BasicUserManager.java
@@ -205,7 +205,8 @@ public abstract class BasicUserManager extends BasicRoleManager {
   private void validCheckForNewUser(String username, String password, boolean enableEncrypt)
       throws AuthException {
     if (!CommonDescriptor.getInstance().getConfig().getDefaultAdminName().equals(username)) {
-      if (username.equals(password)
+      if (enableEncrypt
+          && username.equals(password)
           && CommonDescriptor.getInstance().getConfig().isEnforceStrongPassword()) {
         throw new AuthException(
             TSStatusCode.ILLEGAL_PASSWORD, AuthMessages.PASSWORD_SAME_AS_USERNAME);
@@ -220,7 +221,8 @@ public abstract class BasicUserManager extends BasicRoleManager {
   private void validCheckForBuiltinUser(
       String username, String password, boolean enableEncrypt, long userId) throws AuthException {
     if (!CommonDescriptor.getInstance().getConfig().getDefaultAdminName().equals(username)) {
-      if (username.equals(password)
+      if (enableEncrypt
+          && username.equals(password)
           && CommonDescriptor.getInstance().getConfig().isEnforceStrongPassword()) {
         throw new AuthException(
             TSStatusCode.ILLEGAL_PASSWORD, AuthMessages.PASSWORD_SAME_AS_USERNAME);


### PR DESCRIPTION
## Description
Pipe/config snapshot user sync may replay `CreateUserWithRawPassword`, where the password field is already the stored raw/encrypted password value from the source cluster. When the receiver has `enforce_strong_password=true`, comparing that raw stored value with the username can reject legacy users such as `legacyuser/legacyuser`, causing repeated `Failed to handleTransferConfigPlan` errors.

This change keeps normal `CreateUser` strong-password checks unchanged, but skips the username/password equality check for raw-password replay paths where `enableEncrypt=false`. Username validation is still preserved.

## Tests
- `mvn spotless:apply -pl iotdb-core/confignode,iotdb-core/node-commons`
- `git diff --check`
- Attempted `mvn -pl iotdb-core/confignode -am "-Dtest=AuthorInfoTest#createUserWithRawPassword" "-DfailIfNoTests=false" "-Dsurefire.failIfNoSpecifiedTests=false" test`, but the local JVM crashed during `node-commons` compilation with native memory allocation failure (`hs_err_pid9412.log` generated and removed).
