### PR TITLE
Fix schema path display quoting

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/last/AlignedUpdateLastCacheOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/last/AlignedUpdateLastCacheOperator.java
@@ -32,6 +32,8 @@ import org.apache.tsfile.read.common.block.TsBlock;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.TsPrimitiveType;
 
+import static org.apache.iotdb.db.utils.SchemaPathUtils.getFullPathWithNecessaryBackQuotes;
+
 /** update last cache for aligned series. */
 public class AlignedUpdateLastCacheOperator extends AbstractUpdateLastCacheOperator {
 
@@ -104,7 +106,11 @@ public class AlignedUpdateLastCacheOperator extends AbstractUpdateLastCacheOpera
   protected void appendLastValueToTsBlockBuilder(
       long lastTime, TsPrimitiveType lastValue, MeasurementPath measurementPath, String type) {
     LastQueryUtil.appendLastValueRespectBlob(
-        tsBlockBuilder, lastTime, measurementPath.getFullPath(), lastValue, type);
+        tsBlockBuilder,
+        lastTime,
+        getFullPathWithNecessaryBackQuotes(measurementPath),
+        lastValue,
+        type);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/last/AlignedUpdateViewPathLastCacheOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/last/AlignedUpdateViewPathLastCacheOperator.java
@@ -31,6 +31,7 @@ import org.apache.tsfile.utils.TsPrimitiveType;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.iotdb.db.utils.SchemaPathUtils.getFullPathWithNecessaryBackQuotes;
 
 public class AlignedUpdateViewPathLastCacheOperator extends AlignedUpdateLastCacheOperator {
   // Now not only a view path will be set here, but also the measurement path with alias will be set
@@ -66,7 +67,7 @@ public class AlignedUpdateViewPathLastCacheOperator extends AlignedUpdateLastCac
     LastQueryUtil.appendLastValueRespectBlob(
         tsBlockBuilder,
         lastTime,
-        outputPath == null ? measurementPath.getFullPath() : outputPath,
+        outputPath == null ? getFullPathWithNecessaryBackQuotes(measurementPath) : outputPath,
         lastValue,
         type);
     outputPathIndex++;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/last/UpdateLastCacheOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/last/UpdateLastCacheOperator.java
@@ -31,6 +31,7 @@ import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.TsPrimitiveType;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.iotdb.db.utils.SchemaPathUtils.getFullPathWithNecessaryBackQuotes;
 
 public class UpdateLastCacheOperator extends AbstractUpdateLastCacheOperator {
 
@@ -116,7 +117,11 @@ public class UpdateLastCacheOperator extends AbstractUpdateLastCacheOperator {
 
   protected void appendLastValueToTsBlockBuilder(long lastTime, TsPrimitiveType lastValue) {
     LastQueryUtil.appendLastValueRespectBlob(
-        tsBlockBuilder, lastTime, fullPath.getFullPath(), lastValue, dataType);
+        tsBlockBuilder,
+        lastTime,
+        getFullPathWithNecessaryBackQuotes(fullPath),
+        lastValue,
+        dataType);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/CountGroupByLevelScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/CountGroupByLevelScanOperator.java
@@ -49,6 +49,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static org.apache.iotdb.db.utils.SchemaPathUtils.getFullPathWithNecessaryBackQuotes;
 
 public class CountGroupByLevelScanOperator<T extends ISchemaInfo> implements SourceOperator {
 
@@ -198,7 +199,9 @@ public class CountGroupByLevelScanOperator<T extends ISchemaInfo> implements Sou
       tsBlockBuilder.getTimeColumnBuilder().writeLong(0L);
       tsBlockBuilder
           .getColumnBuilder(0)
-          .writeBinary(new Binary(entry.getKey().getFullPath(), TSFileConfig.STRING_CHARSET));
+          .writeBinary(
+              new Binary(
+                  getFullPathWithNecessaryBackQuotes(entry.getKey()), TSFileConfig.STRING_CHARSET));
       tsBlockBuilder.getColumnBuilder(1).writeLong(entry.getValue());
       tsBlockBuilder.declarePosition();
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/NodeManageMemoryMergeOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/NodeManageMemoryMergeOperator.java
@@ -44,6 +44,7 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
+import static org.apache.iotdb.db.utils.SchemaPathUtils.getFullPathWithNecessaryBackQuotes;
 
 public class NodeManageMemoryMergeOperator implements ProcessOperator {
   private final OperatorContext operatorContext;
@@ -125,7 +126,10 @@ public class NodeManageMemoryMergeOperator implements ProcessOperator {
           tsBlockBuilder.getTimeColumnBuilder().writeLong(0L);
           tsBlockBuilder
               .getColumnBuilder(0)
-              .writeBinary(new Binary(node.getNodeName(), TSFileConfig.STRING_CHARSET));
+              .writeBinary(
+                  new Binary(
+                      getFullPathWithNecessaryBackQuotes(node.getNodeName()),
+                      TSFileConfig.STRING_CHARSET));
           tsBlockBuilder
               .getColumnBuilder(1)
               .writeBinary(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/NodePathsConvertOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/NodePathsConvertOperator.java
@@ -21,12 +21,9 @@ package org.apache.iotdb.db.queryengine.execution.operator.schema;
 
 import org.apache.iotdb.calc.execution.operator.Operator;
 import org.apache.iotdb.calc.execution.operator.process.ProcessOperator;
-import org.apache.iotdb.commons.exception.IllegalPathException;
-import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.queryengine.execution.MemoryEstimationHelper;
 import org.apache.iotdb.commons.schema.column.ColumnHeader;
 import org.apache.iotdb.commons.schema.column.ColumnHeaderConstant;
-import org.apache.iotdb.db.i18n.DataNodeQueryMessages;
 import org.apache.iotdb.db.queryengine.execution.operator.OperatorContext;
 
 import com.google.common.util.concurrent.ListenableFuture;
@@ -36,17 +33,14 @@ import org.apache.tsfile.read.common.block.TsBlock;
 import org.apache.tsfile.read.common.block.TsBlockBuilder;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.RamUsageEstimator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
+import static org.apache.iotdb.db.utils.SchemaPathUtils.getTailNodeWithNecessaryBackQuotes;
 
 public class NodePathsConvertOperator implements ProcessOperator {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(NodePathsConvertOperator.class);
 
   private static final long INSTANCE_SIZE =
       RamUsageEstimator.shallowSizeOfInstance(NodePathsConvertOperator.class);
@@ -85,17 +79,11 @@ public class NodePathsConvertOperator implements ProcessOperator {
 
     for (int i = 0; i < block.getPositionCount(); i++) {
       String path = block.getColumn(0).getBinary(i).toString();
-      PartialPath partialPath;
-      try {
-        partialPath = new PartialPath(path);
-      } catch (IllegalPathException e) {
-        LOGGER.warn(DataNodeQueryMessages.FAILED_TO_CONVERT_NODE_PATH_TO_PARTIALPATH, path);
-        continue;
-      }
       tsBlockBuilder.getTimeColumnBuilder().writeLong(0L);
       tsBlockBuilder
           .getColumnBuilder(0)
-          .writeBinary(new Binary(partialPath.getTailNode(), TSFileConfig.STRING_CHARSET));
+          .writeBinary(
+              new Binary(getTailNodeWithNecessaryBackQuotes(path), TSFileConfig.STRING_CHARSET));
       tsBlockBuilder.declarePosition();
     }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/source/DeviceSchemaSource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/source/DeviceSchemaSource.java
@@ -42,6 +42,7 @@ import org.apache.tsfile.utils.Binary;
 import java.util.List;
 
 import static org.apache.iotdb.commons.schema.SchemaConstant.ALL_MATCH_PATTERN;
+import static org.apache.iotdb.db.utils.SchemaPathUtils.getFullPathWithNecessaryBackQuotes;
 
 public class DeviceSchemaSource implements ISchemaSource<IDeviceSchemaInfo> {
 
@@ -97,9 +98,8 @@ public class DeviceSchemaSource implements ISchemaSource<IDeviceSchemaInfo> {
   public void transformToTsBlockColumns(
       IDeviceSchemaInfo device, TsBlockBuilder builder, String database) {
     builder.getTimeColumnBuilder().writeLong(0L);
-    builder
-        .getColumnBuilder(0)
-        .writeBinary(new Binary(device.getFullPath(), TSFileConfig.STRING_CHARSET));
+    String devicePath = getFullPathWithNecessaryBackQuotes(device.getPartialPath());
+    builder.getColumnBuilder(0).writeBinary(new Binary(devicePath, TSFileConfig.STRING_CHARSET));
     int templateId = device.getTemplateId();
     long ttl = DataNodeTTLCache.getInstance().getTTLInMSForTree(device.getPartialPath().getNodes());
     // TODO: make it more readable, like "30 days" or "10 hours"

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/source/LogicalViewSchemaSource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/source/LogicalViewSchemaSource.java
@@ -41,6 +41,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.apache.iotdb.db.utils.SchemaPathUtils.getFullPathWithNecessaryBackQuotes;
+
 public class LogicalViewSchemaSource implements ISchemaSource<ITimeSeriesSchemaInfo> {
 
   private final PartialPath pathPattern;
@@ -95,7 +97,7 @@ public class LogicalViewSchemaSource implements ISchemaSource<ITimeSeriesSchemaI
   public void transformToTsBlockColumns(
       ITimeSeriesSchemaInfo series, TsBlockBuilder builder, String database) {
     builder.getTimeColumnBuilder().writeLong(0);
-    builder.writeNullableText(0, series.getFullPath());
+    builder.writeNullableText(0, getFullPathWithNecessaryBackQuotes(series.getPartialPath()));
     builder.writeNullableText(1, database);
 
     builder.writeNullableText(2, series.getSchema().getType().toString());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/source/PathsUsingTemplateSource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/source/PathsUsingTemplateSource.java
@@ -38,6 +38,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
+import static org.apache.iotdb.db.utils.SchemaPathUtils.getFullPathWithNecessaryBackQuotes;
+
 public class PathsUsingTemplateSource implements ISchemaSource<IDeviceSchemaInfo> {
 
   private final List<PartialPath> pathPatternList;
@@ -68,7 +70,10 @@ public class PathsUsingTemplateSource implements ISchemaSource<IDeviceSchemaInfo
     builder.getTimeColumnBuilder().writeLong(0L);
     builder
         .getColumnBuilder(0)
-        .writeBinary(new Binary(device.getFullPath(), TSFileConfig.STRING_CHARSET));
+        .writeBinary(
+            new Binary(
+                getFullPathWithNecessaryBackQuotes(device.getPartialPath()),
+                TSFileConfig.STRING_CHARSET));
     builder.declarePosition();
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/source/TimeSeriesSchemaSource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/schema/source/TimeSeriesSchemaSource.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.apache.iotdb.commons.schema.SchemaConstant.ALL_MATCH_PATTERN;
+import static org.apache.iotdb.db.utils.SchemaPathUtils.getFullPathWithNecessaryBackQuotes;
 
 public class TimeSeriesSchemaSource implements ISchemaSource<ITimeSeriesSchemaInfo> {
 
@@ -113,7 +114,7 @@ public class TimeSeriesSchemaSource implements ISchemaSource<ITimeSeriesSchemaIn
   public void transformToTsBlockColumns(
       ITimeSeriesSchemaInfo series, TsBlockBuilder builder, String database) {
     builder.getTimeColumnBuilder().writeLong(0);
-    builder.writeNullableText(0, series.getFullPath());
+    builder.writeNullableText(0, getFullPathWithNecessaryBackQuotes(series.getPartialPath()));
     builder.writeNullableText(1, series.getAlias());
     builder.writeNullableText(2, database);
     builder.writeNullableText(3, series.getSchema().getType().toString());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/ActiveDeviceRegionScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/ActiveDeviceRegionScanOperator.java
@@ -47,6 +47,7 @@ import java.util.stream.Collectors;
 public class ActiveDeviceRegionScanOperator extends AbstractRegionScanDataSourceOperator {
   // The devices which need to be checked.
   private final Map<IDeviceID, DeviceContext> deviceContextMap;
+  private final Map<IDeviceID, String> deviceIDToDisplayPath;
 
   private static final long INSTANCE_SIZE =
       RamUsageEstimator.shallowSizeOfInstance(ActiveDeviceRegionScanOperator.class)
@@ -56,6 +57,7 @@ public class ActiveDeviceRegionScanOperator extends AbstractRegionScanDataSource
       OperatorContext operatorContext,
       PlanNodeId sourceId,
       Map<IDeviceID, DeviceContext> deviceContextMap,
+      Map<IDeviceID, String> deviceIDToDisplayPath,
       Filter timeFilter,
       Map<IDeviceID, Long> ttlCache,
       boolean outputCount) {
@@ -63,6 +65,7 @@ public class ActiveDeviceRegionScanOperator extends AbstractRegionScanDataSource
     this.sourceId = sourceId;
     this.operatorContext = operatorContext;
     this.deviceContextMap = deviceContextMap;
+    this.deviceIDToDisplayPath = deviceIDToDisplayPath;
     this.regionScanUtil = new RegionScanForActiveDeviceUtil(timeFilter, ttlCache);
   }
 
@@ -96,7 +99,10 @@ public class ActiveDeviceRegionScanOperator extends AbstractRegionScanDataSource
         String ttlStr = ttl == Long.MAX_VALUE ? IoTDBConstant.TTL_INFINITE : String.valueOf(ttl);
 
         timeColumnBuilder.writeLong(-1);
-        columnBuilders[0].writeBinary(new Binary(deviceID.toString(), TSFileConfig.STRING_CHARSET));
+        columnBuilders[0].writeBinary(
+            new Binary(
+                deviceIDToDisplayPath.getOrDefault(deviceID, deviceID.toString()),
+                TSFileConfig.STRING_CHARSET));
         columnBuilders[1].writeBinary(
             new Binary(
                 String.valueOf(deviceContextMap.get(deviceID).isAligned()),

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/ActiveTimeSeriesRegionScanOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/source/ActiveTimeSeriesRegionScanOperator.java
@@ -44,6 +44,7 @@ import java.util.stream.Collectors;
 public class ActiveTimeSeriesRegionScanOperator extends AbstractRegionScanDataSourceOperator {
   // Timeseries which need to be checked.
   private final Map<IDeviceID, Map<String, TimeseriesContext>> timeSeriesToSchemasInfo;
+  private final Map<IDeviceID, Map<String, String>> timeSeriesToDisplayPath;
   private final Set<String> countedLogicalViews;
   private static final Binary BASE_VIEW_TYPE =
       new Binary("BASE".getBytes(TSFileConfig.STRING_CHARSET));
@@ -60,6 +61,7 @@ public class ActiveTimeSeriesRegionScanOperator extends AbstractRegionScanDataSo
       OperatorContext operatorContext,
       PlanNodeId sourceId,
       Map<IDeviceID, Map<String, TimeseriesContext>> timeSeriesToSchemasInfo,
+      Map<IDeviceID, Map<String, String>> timeSeriesToDisplayPath,
       Filter timeFilter,
       Map<IDeviceID, Long> ttlCache,
       boolean isOutputCount) {
@@ -67,6 +69,7 @@ public class ActiveTimeSeriesRegionScanOperator extends AbstractRegionScanDataSo
     this.operatorContext = operatorContext;
     this.sourceId = sourceId;
     this.timeSeriesToSchemasInfo = timeSeriesToSchemasInfo;
+    this.timeSeriesToDisplayPath = timeSeriesToDisplayPath;
     this.countedLogicalViews = new HashSet<>();
     this.regionScanUtil = new RegionScanForActiveTimeSeriesUtil(timeFilter, ttlCache);
     this.dataBaseNameString =
@@ -122,22 +125,20 @@ public class ActiveTimeSeriesRegionScanOperator extends AbstractRegionScanDataSo
 
     for (Map.Entry<IDeviceID, List<String>> entry : activeTimeSeries.entrySet()) {
       IDeviceID deviceID = entry.getKey();
-      String deviceStr = deviceID.toString();
+      Map<String, String> displayPathMap = timeSeriesToDisplayPath.get(deviceID);
       List<String> timeSeriesList = entry.getValue();
       Map<String, TimeseriesContext> timeSeriesInfo = timeSeriesToSchemasInfo.get(deviceID);
       for (String timeSeries : timeSeriesList) {
         TimeseriesContext schemaInfo = timeSeriesInfo.get(timeSeries);
         if (schemaInfo.getActiveCountMultiplier() > 0) {
           appendTimeseries(
-              contactDeviceAndMeasurement(deviceStr, timeSeries), schemaInfo, BASE_VIEW_TYPE);
+              getDisplayPath(deviceID, displayPathMap, timeSeries), schemaInfo, BASE_VIEW_TYPE);
         }
         for (Map.Entry<String, TimeseriesContext> logicalViewEntry :
             schemaInfo.getActiveLogicalViewContextMap().entrySet()) {
           if (countedLogicalViews.add(logicalViewEntry.getKey())) {
             appendTimeseries(
-                logicalViewEntry.getKey().getBytes(TSFileConfig.STRING_CHARSET),
-                logicalViewEntry.getValue(),
-                LOGICAL_VIEW_TYPE);
+                logicalViewEntry.getKey(), logicalViewEntry.getValue(), LOGICAL_VIEW_TYPE);
           }
         }
       }
@@ -146,12 +147,12 @@ public class ActiveTimeSeriesRegionScanOperator extends AbstractRegionScanDataSo
   }
 
   private void appendTimeseries(
-      byte[] timeseriesPath, TimeseriesContext schemaInfo, Binary viewType) {
+      String timeseriesPath, TimeseriesContext schemaInfo, Binary viewType) {
     TimeColumnBuilder timeColumnBuilder = resultTsBlockBuilder.getTimeColumnBuilder();
     ColumnBuilder[] columnBuilders = resultTsBlockBuilder.getValueColumnBuilders();
 
     timeColumnBuilder.writeLong(-1);
-    columnBuilders[0].writeBinary(new Binary(timeseriesPath));
+    columnBuilders[0].writeBinary(new Binary(timeseriesPath, TSFileConfig.STRING_CHARSET));
 
     checkAndAppend(schemaInfo.getAlias(), columnBuilders[1]); // Measurement
     if (schemaInfo.getDatabase() == null || dataBaseNameString.equals(schemaInfo.getDatabase())) {
@@ -180,8 +181,12 @@ public class ActiveTimeSeriesRegionScanOperator extends AbstractRegionScanDataSo
     }
   }
 
-  private byte[] contactDeviceAndMeasurement(String deviceStr, String measurementId) {
-    return (deviceStr + "." + measurementId).getBytes(TSFileConfig.STRING_CHARSET);
+  private String getDisplayPath(
+      IDeviceID deviceID, Map<String, String> displayPathMap, String measurementId) {
+    if (displayPathMap == null) {
+      return deviceID + "." + measurementId;
+    }
+    return displayPathMap.getOrDefault(measurementId, deviceID + "." + measurementId);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/AnalyzeVisitor.java
@@ -210,6 +210,7 @@ import static org.apache.iotdb.db.queryengine.plan.optimization.LimitOffsetPushD
 import static org.apache.iotdb.db.queryengine.plan.parser.ASTVisitor.parseNodeString;
 import static org.apache.iotdb.db.queryengine.plan.relational.planner.optimizations.DataNodeLocationSupplierFactory.getReadableDataNodeLocations;
 import static org.apache.iotdb.db.schemaengine.schemaregion.view.visitor.GetSourcePathsVisitor.getSourcePaths;
+import static org.apache.iotdb.db.utils.SchemaPathUtils.getFullPathWithNecessaryBackQuotes;
 
 /** This visitor is used to analyze each type of Statement and returns the {@link Analysis}. */
 public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> {
@@ -3059,7 +3060,8 @@ public class AnalyzeVisitor extends StatementVisitor<Analysis, MPPQueryContext> 
       return;
     }
 
-    String viewPath = viewDevicePath.concatNode(viewSchemaInfo.getName()).getFullPath();
+    String viewPath =
+        getFullPathWithNecessaryBackQuotes(viewDevicePath.concatNode(viewSchemaInfo.getName()));
     String viewDataType = getLogicalViewDataType(logicalViewSchema, schemaTree);
     String viewDatabase = schemaTree.getBelongedDatabase(viewDevicePath);
     for (PartialPath sourcePath : getSourcePaths(logicalViewSchema.getExpression())) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/metadata/template/ShowPathSetTemplateTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/config/metadata/template/ShowPathSetTemplateTask.java
@@ -40,6 +40,8 @@ import org.apache.tsfile.utils.Binary;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.apache.iotdb.db.utils.SchemaPathUtils.getFullPathWithNecessaryBackQuotes;
+
 public class ShowPathSetTemplateTask implements IConfigTask {
 
   private final ShowPathSetTemplateStatement showPathSetTemplateStatement;
@@ -67,7 +69,8 @@ public class ShowPathSetTemplateTask implements IConfigTask {
         builder.getTimeColumnBuilder().writeLong(0L);
         builder
             .getColumnBuilder(0)
-            .writeBinary(new Binary(path.getFullPath(), TSFileConfig.STRING_CHARSET));
+            .writeBinary(
+                new Binary(getFullPathWithNecessaryBackQuotes(path), TSFileConfig.STRING_CHARSET));
         builder.declarePosition();
       }
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/memory/StatementMemorySourceVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/memory/StatementMemorySourceVisitor.java
@@ -21,8 +21,6 @@ package org.apache.iotdb.db.queryengine.plan.execution.memory;
 
 import org.apache.iotdb.common.rpc.thrift.TSchemaNode;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
-import org.apache.iotdb.commons.exception.IllegalPathException;
-import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.queryengine.plan.planner.plan.node.PlanNode;
 import org.apache.iotdb.commons.schema.column.ColumnHeader;
 import org.apache.iotdb.commons.schema.column.ColumnHeaderConstant;
@@ -57,6 +55,8 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import static org.apache.iotdb.db.queryengine.common.header.DatasetHeader.EMPTY_HEADER;
+import static org.apache.iotdb.db.utils.SchemaPathUtils.getFullPathWithNecessaryBackQuotes;
+import static org.apache.iotdb.db.utils.SchemaPathUtils.getTailNodeWithNecessaryBackQuotes;
 
 public class StatementMemorySourceVisitor
     extends StatementVisitor<StatementMemorySource, StatementMemorySourceContext> {
@@ -142,7 +142,10 @@ public class StatementMemorySourceVisitor
           tsBlockBuilder.getTimeColumnBuilder().writeLong(0L);
           tsBlockBuilder
               .getColumnBuilder(0)
-              .writeBinary(new Binary(node.getNodeName(), TSFileConfig.STRING_CHARSET));
+              .writeBinary(
+                  new Binary(
+                      getFullPathWithNecessaryBackQuotes(node.getNodeName()),
+                      TSFileConfig.STRING_CHARSET));
           tsBlockBuilder
               .getColumnBuilder(1)
               .writeBinary(
@@ -169,17 +172,13 @@ public class StatementMemorySourceVisitor
             .collect(Collectors.toCollection(TreeSet::new));
     matchedChildNodes.forEach(
         node -> {
-          try {
-            PartialPath nodePath = new PartialPath(node);
-            String nodeName = nodePath.getTailNode();
-            tsBlockBuilder.getTimeColumnBuilder().writeLong(0L);
-            tsBlockBuilder
-                .getColumnBuilder(0)
-                .writeBinary(new Binary(nodeName, TSFileConfig.STRING_CHARSET));
-            tsBlockBuilder.declarePosition();
-          } catch (IllegalPathException ignored) {
-            // definitely won't happen
-          }
+          tsBlockBuilder.getTimeColumnBuilder().writeLong(0L);
+          tsBlockBuilder
+              .getColumnBuilder(0)
+              .writeBinary(
+                  new Binary(
+                      getTailNodeWithNecessaryBackQuotes(node), TSFileConfig.STRING_CHARSET));
+          tsBlockBuilder.declarePosition();
         });
     return new StatementMemorySource(
         tsBlockBuilder.build(), context.getAnalysis().getRespDatasetHeader());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LogicalPlanBuilder.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/LogicalPlanBuilder.java
@@ -134,6 +134,7 @@ import static org.apache.iotdb.commons.schema.column.ColumnHeaderConstant.DEVICE
 import static org.apache.iotdb.commons.schema.column.ColumnHeaderConstant.ENDTIME;
 import static org.apache.iotdb.db.queryengine.plan.analyze.ExpressionTypeAnalyzer.analyzeExpression;
 import static org.apache.iotdb.db.queryengine.plan.planner.plan.node.process.TopKNode.LIMIT_VALUE_USE_TOP_K;
+import static org.apache.iotdb.db.utils.SchemaPathUtils.getFullPathWithNecessaryBackQuotes;
 
 public class LogicalPlanBuilder {
 
@@ -260,10 +261,10 @@ public class LogicalPlanBuilder {
           TSDataType outputViewPathType = null;
           // the path is view, use the view path as the output path
           if (sourceExpression.isViewExpression()) {
-            outputPath = sourceExpression.getViewPath().getFullPath();
+            outputPath = getFullPathWithNecessaryBackQuotes(sourceExpression.getViewPath());
             outputViewPathType = selectedPath.getSeriesType();
           } else {
-            outputPath = selectedPath.getFullPath();
+            outputPath = getFullPathWithNecessaryBackQuotes(selectedPath);
           }
           // the path has alias, use alias as the output path
           if (selectedPath.isMeasurementAliasExists()) {
@@ -392,7 +393,7 @@ public class LogicalPlanBuilder {
           new LastQueryTransformNode(
               context.getQueryId().genPlanNodeId(),
               planBuilder.getRoot(),
-              expression.getViewPath().getFullPath(),
+              getFullPathWithNecessaryBackQuotes(expression.getViewPath()),
               analysis.getType(expression).toString());
       lastQueryNode.addChild(transformNode);
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/OperatorTreeGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/OperatorTreeGenerator.java
@@ -305,6 +305,7 @@ import static org.apache.iotdb.db.queryengine.plan.expression.leaf.TimestampOper
 import static org.apache.iotdb.db.queryengine.plan.planner.plan.parameter.AggregationDescriptor.getAggregationTypeByFuncName;
 import static org.apache.iotdb.db.queryengine.plan.planner.plan.parameter.SeriesScanOptions.updateFilterUsingTTL;
 import static org.apache.iotdb.db.queryengine.plan.statement.component.Ordering.ASC;
+import static org.apache.iotdb.db.utils.SchemaPathUtils.getFullPathWithNecessaryBackQuotes;
 
 /** This Visitor is responsible for transferring PlanNode Tree to Operator Tree. */
 public class OperatorTreeGenerator implements PlanVisitor<Operator, LocalExecutionPlanContext> {
@@ -3678,12 +3679,14 @@ public class OperatorTreeGenerator implements PlanVisitor<Operator, LocalExecuti
     Filter filter = context.getGlobalTimeFilter();
 
     Map<IDeviceID, DeviceContext> deviceIDToContext = new HashMap<>();
+    Map<IDeviceID, String> deviceIDToDisplayPath = new HashMap<>();
     Map<IDeviceID, Long> ttlCache = new HashMap<>();
     for (Map.Entry<PartialPath, DeviceContext> entry :
         node.getDevicePathToContextMap().entrySet()) {
       PartialPath devicePath = entry.getKey();
       IDeviceID deviceID = devicePath.getIDeviceID();
       deviceIDToContext.put(deviceID, entry.getValue());
+      deviceIDToDisplayPath.put(deviceID, getFullPathWithNecessaryBackQuotes(devicePath));
       ttlCache.put(deviceID, DataNodeTTLCache.getInstance().getTTLForTree(deviceID));
     }
     ActiveDeviceRegionScanOperator regionScanOperator =
@@ -3691,6 +3694,7 @@ public class OperatorTreeGenerator implements PlanVisitor<Operator, LocalExecuti
             operatorContext,
             node.getPlanNodeId(),
             deviceIDToContext,
+            deviceIDToDisplayPath,
             filter,
             ttlCache,
             node.isOutputCount());
@@ -3717,6 +3721,7 @@ public class OperatorTreeGenerator implements PlanVisitor<Operator, LocalExecuti
     DataDriverContext dataDriverContext = (DataDriverContext) context.getDriverContext();
 
     Map<IDeviceID, Map<String, TimeseriesContext>> timeseriesToSchemaInfo = new HashMap<>();
+    Map<IDeviceID, Map<String, String>> timeseriesToDisplayPath = new HashMap<>();
     Map<IDeviceID, Long> ttlCache = new HashMap<>();
     for (Map.Entry<PartialPath, Map<PartialPath, List<TimeseriesContext>>> entryMap :
         node.getDeviceToTimeseriesSchemaInfo().entrySet()) {
@@ -3725,6 +3730,7 @@ public class OperatorTreeGenerator implements PlanVisitor<Operator, LocalExecuti
       Map<String, TimeseriesContext> timeseriesSchemaInfoMap =
           getTimeseriesSchemaInfoMap(entryMap, dataDriverContext);
       timeseriesToSchemaInfo.put(deviceID, timeseriesSchemaInfoMap);
+      timeseriesToDisplayPath.put(deviceID, getTimeseriesDisplayPathMap(entryMap));
       ttlCache.put(deviceID, DataNodeTTLCache.getInstance().getTTLForTree(deviceID));
     }
     ActiveTimeSeriesRegionScanOperator regionScanOperator =
@@ -3732,6 +3738,7 @@ public class OperatorTreeGenerator implements PlanVisitor<Operator, LocalExecuti
             operatorContext,
             node.getPlanNodeId(),
             timeseriesToSchemaInfo,
+            timeseriesToDisplayPath,
             filter,
             ttlCache,
             node.isOutputCount());
@@ -3740,6 +3747,26 @@ public class OperatorTreeGenerator implements PlanVisitor<Operator, LocalExecuti
     dataDriverContext.setQueryDataSourceType(QueryDataSourceType.TIME_SERIES_REGION_SCAN);
 
     return regionScanOperator;
+  }
+
+  private static Map<String, String> getTimeseriesDisplayPathMap(
+      Map.Entry<PartialPath, Map<PartialPath, List<TimeseriesContext>>> entryMap) {
+    Map<String, String> timeseriesDisplayPathMap = new HashMap<>();
+    for (PartialPath path : entryMap.getValue().keySet()) {
+      if (path instanceof MeasurementPath) {
+        timeseriesDisplayPathMap.put(
+            path.getMeasurement(), getFullPathWithNecessaryBackQuotes(path));
+      } else if (path instanceof AlignedPath) {
+        AlignedPath alignedPath = (AlignedPath) path;
+        PartialPath devicePath = alignedPath.getDevicePath();
+        for (String measurement : alignedPath.getMeasurementList()) {
+          timeseriesDisplayPathMap.put(
+              measurement,
+              getFullPathWithNecessaryBackQuotes(devicePath.concatAsMeasurementPath(measurement)));
+        }
+      }
+    }
+    return timeseriesDisplayPathMap;
   }
 
   private static Map<String, TimeseriesContext> getTimeseriesSchemaInfoMap(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/mem/MTreeBelowSGMemoryImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/mem/MTreeBelowSGMemoryImpl.java
@@ -1276,7 +1276,10 @@ public class MTreeBelowSGMemoryImpl {
             final PartialPath device = getPartialPathFromRootToNode(node.getAsMNode());
             final ShowDevicesResult result =
                 new ShowDevicesResult(
-                    device.getFullPath(), node.isAlignedNullable(), node.getSchemaTemplateId());
+                    device.getFullPath(),
+                    node.isAlignedNullable(),
+                    node.getSchemaTemplateId(),
+                    device.getNodes());
             result.setAttributeProvider(
                 k ->
                     attributeProvider.apply(
@@ -1749,8 +1752,8 @@ public class MTreeBelowSGMemoryImpl {
 
           @Override
           protected INodeSchemaInfo collectMNode(final IMemMNode node) {
-            return new ShowNodesResult(
-                getPartialPathFromRootToNode(node).getFullPath(), node.getMNodeType());
+            final PartialPath path = getPartialPathFromRootToNode(node);
+            return new ShowNodesResult(path.getFullPath(), node.getMNodeType(), path);
           }
         };
     collector.setTargetLevel(showNodesPlan.getLevel());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/MTreeBelowSGCachedImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/pbtree/MTreeBelowSGCachedImpl.java
@@ -1450,7 +1450,10 @@ public class MTreeBelowSGCachedImpl {
           protected IDeviceSchemaInfo collectEntity(IDeviceMNode<ICachedMNode> node) {
             PartialPath device = getPartialPathFromRootToNode(node.getAsMNode());
             return new ShowDevicesResult(
-                device.getFullPath(), node.isAlignedNullable(), node.getSchemaTemplateId());
+                device.getFullPath(),
+                node.isAlignedNullable(),
+                node.getSchemaTemplateId(),
+                device.getNodes());
           }
         };
     if (showDevicesPlan.usingSchemaTemplate()) {
@@ -1738,8 +1741,8 @@ public class MTreeBelowSGCachedImpl {
             showNodesPlan.getScope()) {
 
           protected INodeSchemaInfo collectMNode(ICachedMNode node) {
-            return new ShowNodesResult(
-                getPartialPathFromRootToNode(node).getFullPath(), node.getMNodeType());
+            final PartialPath path = getPartialPathFromRootToNode(node);
+            return new ShowNodesResult(path.getFullPath(), node.getMNodeType(), path);
           }
         };
     collector.setTargetLevel(showNodesPlan.getLevel());

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/read/resp/info/impl/ShowNodesResult.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/read/resp/info/impl/ShowNodesResult.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.schemaengine.schemaregion.read.resp.info.impl;
 
+import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.schema.node.MNodeType;
 import org.apache.iotdb.db.schemaengine.schemaregion.read.resp.info.INodeSchemaInfo;
 
@@ -27,10 +28,21 @@ import java.util.Objects;
 public class ShowNodesResult extends ShowSchemaResult implements INodeSchemaInfo {
 
   private final MNodeType nodeType;
+  private final PartialPath partialPath;
 
   public ShowNodesResult(String path, MNodeType nodeType) {
+    this(path, nodeType, null);
+  }
+
+  public ShowNodesResult(String path, MNodeType nodeType, PartialPath partialPath) {
     super(path);
     this.nodeType = nodeType;
+    this.partialPath = partialPath;
+  }
+
+  @Override
+  public PartialPath getPartialPath() {
+    return partialPath == null ? super.getPartialPath() : partialPath;
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/read/resp/info/impl/ShowTimeSeriesResult.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/read/resp/info/impl/ShowTimeSeriesResult.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.schemaengine.schemaregion.read.resp.info.impl;
 
+import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.schemaengine.schemaregion.read.resp.info.ITimeSeriesSchemaInfo;
 
 import org.apache.tsfile.enums.TSDataType;
@@ -40,6 +41,8 @@ public class ShowTimeSeriesResult extends ShowSchemaResult implements ITimeSerie
 
   private boolean isUnderAlignedDevice;
 
+  private PartialPath partialPath;
+
   public ShowTimeSeriesResult(
       String path,
       String alias,
@@ -47,16 +50,33 @@ public class ShowTimeSeriesResult extends ShowSchemaResult implements ITimeSerie
       Map<String, String> tags,
       Map<String, String> attributes,
       boolean isUnderAlignedDevice) {
+    this(path, alias, measurementSchema, tags, attributes, isUnderAlignedDevice, null);
+  }
+
+  public ShowTimeSeriesResult(
+      String path,
+      String alias,
+      IMeasurementSchema measurementSchema,
+      Map<String, String> tags,
+      Map<String, String> attributes,
+      boolean isUnderAlignedDevice,
+      PartialPath partialPath) {
     super(path);
     this.alias = alias;
     this.measurementSchema = measurementSchema;
     this.tags = tags;
     this.attributes = attributes;
     this.isUnderAlignedDevice = isUnderAlignedDevice;
+    this.partialPath = partialPath;
   }
 
   public ShowTimeSeriesResult() {
     super();
+  }
+
+  @Override
+  public PartialPath getPartialPath() {
+    return partialPath == null ? super.getPartialPath() : partialPath;
   }
 
   public String getAlias() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/tag/TagManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/tag/TagManager.java
@@ -322,7 +322,8 @@ public class TagManager {
                         node.getSchema(),
                         tagAndAttributePair.left,
                         tagAndAttributePair.right,
-                        node.getParent().getAsDeviceMNode().isAligned());
+                        node.getParent().getAsDeviceMNode().isAligned(),
+                        node.getPartialPath());
                 break;
               }
             }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/SchemaPathUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/SchemaPathUtils.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.utils;
+
+import org.apache.iotdb.commons.conf.IoTDBConstant;
+import org.apache.iotdb.commons.exception.IllegalPathException;
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.path.PathPatternUtil;
+import org.apache.iotdb.commons.utils.PathUtils;
+
+import org.apache.tsfile.common.constant.TsFileConstant;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+public final class SchemaPathUtils {
+
+  private SchemaPathUtils() {}
+
+  public static String getFullPathWithNecessaryBackQuotes(final PartialPath path) {
+    return getFullPathWithNecessaryBackQuotes(path.getNodes());
+  }
+
+  public static String getFullPathWithNecessaryBackQuotes(final String path) {
+    try {
+      return getFullPathWithNecessaryBackQuotes(new PartialPath(path));
+    } catch (IllegalPathException e) {
+      return getFullPathWithNecessaryBackQuotes(splitPathPreservingBackQuotes(path));
+    }
+  }
+
+  public static String getPathPatternWithNecessaryBackQuotes(final PartialPath pathPattern) {
+    return getPathPatternWithNecessaryBackQuotes(pathPattern.getNodes());
+  }
+
+  public static String getPathPatternWithNecessaryBackQuotes(final String pathPattern) {
+    try {
+      return getPathPatternWithNecessaryBackQuotes(new PartialPath(pathPattern));
+    } catch (IllegalPathException e) {
+      return getPathPatternWithNecessaryBackQuotes(splitPathPreservingBackQuotes(pathPattern));
+    }
+  }
+
+  public static String getTailNodeWithNecessaryBackQuotes(final String path) {
+    try {
+      return getNodeWithNecessaryBackQuotes(new PartialPath(path).getTailNode());
+    } catch (IllegalPathException e) {
+      final String[] nodes = splitPathPreservingBackQuotes(path);
+      return nodes.length == 0 ? "" : getNodeWithNecessaryBackQuotes(nodes[nodes.length - 1]);
+    }
+  }
+
+  public static String getNodeWithNecessaryBackQuotes(final String node) {
+    return getNodeWithNecessaryBackQuotes(node, false);
+  }
+
+  private static String getFullPathWithNecessaryBackQuotes(final String[] nodes) {
+    if (nodes.length == 0) {
+      return "";
+    }
+    final StringBuilder builder = new StringBuilder(getNodeWithNecessaryBackQuotes(nodes[0], true));
+    for (int i = 1; i < nodes.length; i++) {
+      builder
+          .append(TsFileConstant.PATH_SEPARATOR)
+          .append(getNodeWithNecessaryBackQuotes(nodes[i], false));
+    }
+    return builder.toString();
+  }
+
+  private static String getPathPatternWithNecessaryBackQuotes(final String[] nodes) {
+    if (nodes.length == 0) {
+      return "";
+    }
+    final StringBuilder builder =
+        new StringBuilder(getPathPatternNodeWithNecessaryBackQuotes(nodes[0], true));
+    for (int i = 1; i < nodes.length; i++) {
+      builder
+          .append(TsFileConstant.PATH_SEPARATOR)
+          .append(getPathPatternNodeWithNecessaryBackQuotes(nodes[i], false));
+    }
+    return builder.toString();
+  }
+
+  private static String[] splitPathPreservingBackQuotes(final String path) {
+    final List<String> nodes = new ArrayList<>();
+    final StringBuilder currentNode = new StringBuilder();
+    boolean inBackQuotes = false;
+    for (int i = 0; i < path.length(); i++) {
+      final char currentChar = path.charAt(i);
+      if (currentChar == TsFileConstant.BACK_QUOTE_STRING.charAt(0)) {
+        currentNode.append(currentChar);
+        if (inBackQuotes
+            && i + 1 < path.length()
+            && path.charAt(i + 1) == TsFileConstant.BACK_QUOTE_STRING.charAt(0)) {
+          currentNode.append(path.charAt(++i));
+        } else {
+          inBackQuotes = !inBackQuotes;
+        }
+      } else if (currentChar == TsFileConstant.PATH_SEPARATOR.charAt(0) && !inBackQuotes) {
+        nodes.add(currentNode.toString());
+        currentNode.setLength(0);
+      } else {
+        currentNode.append(currentChar);
+      }
+    }
+    nodes.add(currentNode.toString());
+    return nodes.toArray(new String[0]);
+  }
+
+  private static String getNodeWithNecessaryBackQuotes(final String node, final boolean isFirst) {
+    if (node == null
+        || (isFirst && IoTDBConstant.PATH_ROOT.equalsIgnoreCase(node))
+        || (node.startsWith(TsFileConstant.BACK_QUOTE_STRING)
+            && node.endsWith(TsFileConstant.BACK_QUOTE_STRING))) {
+      return node;
+    }
+    if (IoTDBConstant.reservedWords.contains(node.toUpperCase(Locale.ENGLISH))
+        || PathUtils.isRealNumber(node)
+        || !TsFileConstant.IDENTIFIER_PATTERN.matcher(node).matches()) {
+      return TsFileConstant.BACK_QUOTE_STRING
+          + node.replace(TsFileConstant.BACK_QUOTE_STRING, TsFileConstant.DOUBLE_BACK_QUOTE_STRING)
+          + TsFileConstant.BACK_QUOTE_STRING;
+    }
+    return node;
+  }
+
+  private static String getPathPatternNodeWithNecessaryBackQuotes(
+      final String node, final boolean isFirst) {
+    if (node == null || PathPatternUtil.hasWildcard(node)) {
+      return node;
+    }
+    return getNodeWithNecessaryBackQuotes(node, isFirst);
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/SchemaPathUtils.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/SchemaPathUtils.java
@@ -23,15 +23,17 @@ import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.path.PathPatternUtil;
-import org.apache.iotdb.commons.utils.PathUtils;
 
 import org.apache.tsfile.common.constant.TsFileConstant;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 public final class SchemaPathUtils {
+
+  private static final Pattern SQL_NUMERIC_NODE_PATTERN = Pattern.compile("\\d+([eE][+-]?\\d+)?");
 
   private SchemaPathUtils() {}
 
@@ -133,7 +135,7 @@ public final class SchemaPathUtils {
       return node;
     }
     if (IoTDBConstant.reservedWords.contains(node.toUpperCase(Locale.ENGLISH))
-        || PathUtils.isRealNumber(node)
+        || isSqlNumericNode(node)
         || !TsFileConstant.IDENTIFIER_PATTERN.matcher(node).matches()) {
       return TsFileConstant.BACK_QUOTE_STRING
           + node.replace(TsFileConstant.BACK_QUOTE_STRING, TsFileConstant.DOUBLE_BACK_QUOTE_STRING)
@@ -148,5 +150,9 @@ public final class SchemaPathUtils {
       return node;
     }
     return getNodeWithNecessaryBackQuotes(node, isFirst);
+  }
+
+  private static boolean isSqlNumericNode(final String node) {
+    return SQL_NUMERIC_NODE_PATTERN.matcher(node).matches();
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionTestUtil.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionTestUtil.java
@@ -383,7 +383,8 @@ public class SchemaRegionTestUtil {
                 timeSeriesSchemaInfo.getSchema(),
                 timeSeriesSchemaInfo.getTags(),
                 timeSeriesSchemaInfo.getAttributes(),
-                timeSeriesSchemaInfo.isUnderAlignedDevice()));
+                timeSeriesSchemaInfo.isUnderAlignedDevice(),
+                timeSeriesSchemaInfo.getPartialPath()));
       }
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/schema/SchemaPathDisplayOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/schema/SchemaPathDisplayOperatorTest.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.execution.operator.schema;
+
+import org.apache.iotdb.calc.execution.operator.Operator;
+import org.apache.iotdb.common.rpc.thrift.TSchemaNode;
+import org.apache.iotdb.commons.schema.column.ColumnHeaderConstant;
+import org.apache.iotdb.commons.schema.node.MNodeType;
+import org.apache.iotdb.db.queryengine.execution.operator.OperatorContext;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import org.apache.tsfile.common.conf.TSFileConfig;
+import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.read.common.block.TsBlock;
+import org.apache.tsfile.read.common.block.TsBlockBuilder;
+import org.apache.tsfile.utils.Binary;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class SchemaPathDisplayOperatorTest {
+
+  @Test
+  public void testChildPathsMergeDisplaysReservedNodesAndDeduplicatesRawPath() throws Exception {
+    TsBlockBuilder childBuilder =
+        new TsBlockBuilder(Arrays.asList(TSDataType.TEXT, TSDataType.TEXT));
+    childBuilder.getTimeColumnBuilder().writeLong(0L);
+    childBuilder
+        .getColumnBuilder(0)
+        .writeBinary(new Binary("root.sg.root", TSFileConfig.STRING_CHARSET));
+    childBuilder
+        .getColumnBuilder(1)
+        .writeBinary(
+            new Binary(
+                String.valueOf(MNodeType.DEVICE.getNodeType()), TSFileConfig.STRING_CHARSET));
+    childBuilder.declarePosition();
+
+    Operator child = new FixedTsBlockOperator(childBuilder.build());
+    NodeManageMemoryMergeOperator operator =
+        new NodeManageMemoryMergeOperator(
+            Mockito.mock(OperatorContext.class),
+            new HashSet<>(
+                Collections.singletonList(
+                    new TSchemaNode("root.sg.root", MNodeType.DEVICE.getNodeType()))),
+            child);
+
+    TsBlock first = operator.next();
+    assertEquals(1, first.getPositionCount());
+    assertEquals("root.sg.`root`", first.getColumn(0).getBinary(0).toString());
+    assertEquals("DEVICE", first.getColumn(1).getBinary(0).toString());
+
+    TsBlock second = operator.next();
+    assertEquals(0, second.getPositionCount());
+    assertFalse(operator.hasNext());
+  }
+
+  @Test
+  public void testChildNodesConvertDisplaysReservedTailNode() throws Exception {
+    TsBlockBuilder childBuilder =
+        new TsBlockBuilder(Arrays.asList(TSDataType.TEXT, TSDataType.TEXT));
+    childBuilder.getTimeColumnBuilder().writeLong(0L);
+    childBuilder
+        .getColumnBuilder(0)
+        .writeBinary(new Binary("root.sg.root", TSFileConfig.STRING_CHARSET));
+    childBuilder
+        .getColumnBuilder(1)
+        .writeBinary(
+            new Binary(
+                String.valueOf(MNodeType.DEVICE.getNodeType()), TSFileConfig.STRING_CHARSET));
+    childBuilder.declarePosition();
+
+    NodePathsConvertOperator operator =
+        new NodePathsConvertOperator(
+            Mockito.mock(OperatorContext.class), new FixedTsBlockOperator(childBuilder.build()));
+
+    TsBlock result = operator.next();
+    assertEquals(1, result.getPositionCount());
+    assertEquals("`root`", result.getColumn(0).getBinary(0).toString());
+  }
+
+  @Test
+  public void testOrderByHeatMatchesDisplayedTimeseriesPath() throws Exception {
+    TsBlockBuilder showTimeSeriesBuilder =
+        new TsBlockBuilder(
+            ColumnHeaderConstant.showTimeSeriesColumnHeaders.stream()
+                .map(header -> header.getColumnType())
+                .toList());
+    writeShowTimeSeriesRow(showTimeSeriesBuilder, "root.sg.a.s1");
+    writeShowTimeSeriesRow(showTimeSeriesBuilder, "root.sg.`root`.s1");
+
+    TsBlockBuilder lastQueryBuilder =
+        new TsBlockBuilder(Arrays.asList(TSDataType.TEXT, TSDataType.TEXT, TSDataType.TEXT));
+    lastQueryBuilder.getTimeColumnBuilder().writeLong(100L);
+    lastQueryBuilder
+        .getColumnBuilder(0)
+        .writeBinary(new Binary("root.sg.a.s1", TSFileConfig.STRING_CHARSET));
+    lastQueryBuilder.getColumnBuilder(1).writeBinary(new Binary("1", TSFileConfig.STRING_CHARSET));
+    lastQueryBuilder
+        .getColumnBuilder(2)
+        .writeBinary(new Binary(TSDataType.INT32.name(), TSFileConfig.STRING_CHARSET));
+    lastQueryBuilder.declarePosition();
+    lastQueryBuilder.getTimeColumnBuilder().writeLong(200L);
+    lastQueryBuilder
+        .getColumnBuilder(0)
+        .writeBinary(new Binary("root.sg.`root`.s1", TSFileConfig.STRING_CHARSET));
+    lastQueryBuilder.getColumnBuilder(1).writeBinary(new Binary("2", TSFileConfig.STRING_CHARSET));
+    lastQueryBuilder
+        .getColumnBuilder(2)
+        .writeBinary(new Binary(TSDataType.INT32.name(), TSFileConfig.STRING_CHARSET));
+    lastQueryBuilder.declarePosition();
+
+    SchemaQueryOrderByHeatOperator operator =
+        new SchemaQueryOrderByHeatOperator(
+            Mockito.mock(OperatorContext.class),
+            Arrays.asList(
+                new FixedTsBlockOperator(showTimeSeriesBuilder.build()),
+                new FixedTsBlockOperator(lastQueryBuilder.build())));
+
+    TsBlock result = null;
+    while (operator.hasNext()) {
+      result = operator.next();
+      if (result != null && !result.isEmpty()) {
+        break;
+      }
+    }
+
+    assertEquals(2, result.getPositionCount());
+    assertEquals("root.sg.`root`.s1", result.getColumn(0).getBinary(0).toString());
+    assertEquals("root.sg.a.s1", result.getColumn(0).getBinary(1).toString());
+  }
+
+  private static void writeShowTimeSeriesRow(TsBlockBuilder builder, String timeseries) {
+    builder.getTimeColumnBuilder().writeLong(0L);
+    builder.getColumnBuilder(0).writeBinary(new Binary(timeseries, TSFileConfig.STRING_CHARSET));
+    builder.getColumnBuilder(1).appendNull();
+    builder.getColumnBuilder(2).writeBinary(new Binary("root.sg", TSFileConfig.STRING_CHARSET));
+    builder
+        .getColumnBuilder(3)
+        .writeBinary(new Binary(TSDataType.INT32.name(), TSFileConfig.STRING_CHARSET));
+    builder.getColumnBuilder(4).writeBinary(new Binary("PLAIN", TSFileConfig.STRING_CHARSET));
+    builder
+        .getColumnBuilder(5)
+        .writeBinary(new Binary("UNCOMPRESSED", TSFileConfig.STRING_CHARSET));
+    builder.getColumnBuilder(6).appendNull();
+    builder.getColumnBuilder(7).appendNull();
+    builder.getColumnBuilder(8).appendNull();
+    builder.getColumnBuilder(9).appendNull();
+    builder.getColumnBuilder(10).appendNull();
+    builder.declarePosition();
+  }
+
+  private static class FixedTsBlockOperator implements Operator {
+    private final TsBlock block;
+    private boolean consumed;
+
+    private FixedTsBlockOperator(TsBlock block) {
+      this.block = block;
+    }
+
+    @Override
+    public OperatorContext getOperatorContext() {
+      return Mockito.mock(OperatorContext.class);
+    }
+
+    @Override
+    public TsBlock next() {
+      if (consumed) {
+        return null;
+      }
+      consumed = true;
+      return block;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return !consumed;
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public boolean isFinished() {
+      return consumed;
+    }
+
+    @Override
+    public long calculateMaxPeekMemory() {
+      return 0;
+    }
+
+    @Override
+    public long calculateMaxReturnSize() {
+      return 0;
+    }
+
+    @Override
+    public long calculateRetainedSizeAfterCallingNext() {
+      return 0;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+      return 0;
+    }
+
+    @Override
+    public ListenableFuture<?> isBlocked() {
+      return NOT_BLOCKED;
+    }
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/schema/SchemaQueryScanOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/schema/SchemaQueryScanOperatorTest.java
@@ -52,6 +52,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -84,6 +85,8 @@ public class SchemaQueryScanOperatorTest {
           driverContext.addOperatorContext(
               1, planNodeId, SchemaQueryScanOperator.class.getSimpleName());
       PartialPath partialPath = new PartialPath(META_SCAN_OPERATOR_TEST_SG + ".device0");
+      PartialPath reservedDevicePath =
+          new PartialPath(new String[] {"root", "MetaScanOperatorTest", "root"});
       ISchemaRegion schemaRegion = Mockito.mock(ISchemaRegion.class);
       Mockito.when(schemaRegion.getDatabaseFullPath()).thenReturn(META_SCAN_OPERATOR_TEST_SG);
       IDeviceSchemaInfo deviceSchemaInfo = Mockito.mock(IDeviceSchemaInfo.class);
@@ -92,6 +95,12 @@ public class SchemaQueryScanOperatorTest {
       Mockito.when(deviceSchemaInfo.isAligned()).thenReturn(false);
       Mockito.when(deviceSchemaInfo.getTemplateId()).thenReturn(-1);
       Mockito.when(deviceSchemaInfo.getPartialPath()).thenReturn(partialPath);
+      IDeviceSchemaInfo reservedDeviceSchemaInfo = Mockito.mock(IDeviceSchemaInfo.class);
+      Mockito.when(reservedDeviceSchemaInfo.getFullPath())
+          .thenReturn(META_SCAN_OPERATOR_TEST_SG + ".root");
+      Mockito.when(reservedDeviceSchemaInfo.isAligned()).thenReturn(false);
+      Mockito.when(reservedDeviceSchemaInfo.getTemplateId()).thenReturn(-1);
+      Mockito.when(reservedDeviceSchemaInfo.getPartialPath()).thenReturn(reservedDevicePath);
       operatorContext.setDriverContext(
           new SchemaDriverContext(fragmentInstanceContext, schemaRegion, 0));
       ISchemaSource<IDeviceSchemaInfo> deviceSchemaSource =
@@ -99,7 +108,7 @@ public class SchemaQueryScanOperatorTest {
               partialPath, false, 10, 0, true, null, SchemaConstant.ALL_MATCH_SCOPE);
       SchemaOperatorTestUtil.mockGetSchemaReader(
           deviceSchemaSource,
-          Collections.singletonList(deviceSchemaInfo).iterator(),
+          Arrays.asList(deviceSchemaInfo, reservedDeviceSchemaInfo).iterator(),
           schemaRegion,
           true);
       //
@@ -113,7 +122,7 @@ public class SchemaQueryScanOperatorTest {
         TsBlock tsBlock = devicesSchemaScanOperator.next();
         assertEquals(5, tsBlock.getValueColumnCount());
         assertTrue(tsBlock.getColumn(0) instanceof BinaryColumn);
-        assertEquals(1, tsBlock.getPositionCount());
+        assertEquals(2, tsBlock.getPositionCount());
         for (int i = 0; i < tsBlock.getPositionCount(); i++) {
           Assert.assertEquals(0, tsBlock.getTimeByIndex(i));
           for (int j = 0; j < columns.size(); j++) {
@@ -121,7 +130,9 @@ public class SchemaQueryScanOperatorTest {
               case 0:
                 assertEquals(
                     tsBlock.getColumn(j).getBinary(i).toString(),
-                    META_SCAN_OPERATOR_TEST_SG + ".device0");
+                    i == 0
+                        ? META_SCAN_OPERATOR_TEST_SG + ".device0"
+                        : META_SCAN_OPERATOR_TEST_SG + ".`root`");
                 break;
               case 1:
                 assertEquals(
@@ -146,7 +157,7 @@ public class SchemaQueryScanOperatorTest {
       // Assert failure if exception occurs
       SchemaOperatorTestUtil.mockGetSchemaReader(
           deviceSchemaSource,
-          Collections.singletonList(deviceSchemaInfo).iterator(),
+          Arrays.asList(deviceSchemaInfo, reservedDeviceSchemaInfo).iterator(),
           schemaRegion,
           false);
       try {
@@ -190,8 +201,11 @@ public class SchemaQueryScanOperatorTest {
       List<ITimeSeriesSchemaInfo> showTimeSeriesResults = new ArrayList<>();
       for (int i = 0; i < 10; i++) {
         ITimeSeriesSchemaInfo timeSeriesSchemaInfo = Mockito.mock(ITimeSeriesSchemaInfo.class);
+        PartialPath timeSeriesPath =
+            new PartialPath(new String[] {"root", "MetaScanOperatorTest", "device0", "s" + i});
         Mockito.when(timeSeriesSchemaInfo.getFullPath())
             .thenReturn(META_SCAN_OPERATOR_TEST_SG + ".device0." + "s" + i);
+        Mockito.when(timeSeriesSchemaInfo.getPartialPath()).thenReturn(timeSeriesPath);
         Mockito.when(timeSeriesSchemaInfo.getAlias()).thenReturn(null);
         Mockito.when(timeSeriesSchemaInfo.getSchema())
             .thenReturn(
@@ -201,6 +215,20 @@ public class SchemaQueryScanOperatorTest {
         Mockito.when(timeSeriesSchemaInfo.getAttributes()).thenReturn(null);
         showTimeSeriesResults.add(timeSeriesSchemaInfo);
       }
+      ITimeSeriesSchemaInfo reservedTimeSeriesSchemaInfo =
+          Mockito.mock(ITimeSeriesSchemaInfo.class);
+      Mockito.when(reservedTimeSeriesSchemaInfo.getFullPath())
+          .thenReturn(META_SCAN_OPERATOR_TEST_SG + ".root.s0");
+      Mockito.when(reservedTimeSeriesSchemaInfo.getPartialPath())
+          .thenReturn(new PartialPath(new String[] {"root", "MetaScanOperatorTest", "root", "s0"}));
+      Mockito.when(reservedTimeSeriesSchemaInfo.getAlias()).thenReturn(null);
+      Mockito.when(reservedTimeSeriesSchemaInfo.getSchema())
+          .thenReturn(
+              new MeasurementSchema(
+                  "s0", TSDataType.INT32, TSEncoding.PLAIN, CompressionType.UNCOMPRESSED));
+      Mockito.when(reservedTimeSeriesSchemaInfo.getTags()).thenReturn(null);
+      Mockito.when(reservedTimeSeriesSchemaInfo.getAttributes()).thenReturn(null);
+      showTimeSeriesResults.add(reservedTimeSeriesSchemaInfo);
 
       ISchemaRegion schemaRegion = Mockito.mock(ISchemaRegion.class);
       Mockito.when(schemaRegion.getDatabaseFullPath()).thenReturn(META_SCAN_OPERATOR_TEST_SG);
@@ -228,7 +256,7 @@ public class SchemaQueryScanOperatorTest {
         assertEquals(
             ColumnHeaderConstant.showTimeSeriesColumnHeaders.size(), tsBlock.getValueColumnCount());
         assertTrue(tsBlock.getColumn(0) instanceof BinaryColumn);
-        assertEquals(10, tsBlock.getPositionCount());
+        assertEquals(11, tsBlock.getPositionCount());
         for (int i = 0; i < tsBlock.getPositionCount(); i++) {
           Assert.assertEquals(0, tsBlock.getTimeByIndex(i));
           for (int j = 0; j < ColumnHeaderConstant.showTimeSeriesColumnHeaders.size(); j++) {
@@ -237,7 +265,11 @@ public class SchemaQueryScanOperatorTest {
             String value = binary == null ? "null" : binary.toString();
             switch (j) {
               case 0:
-                Assert.assertTrue(value.startsWith(META_SCAN_OPERATOR_TEST_SG + ".device0"));
+                assertEquals(
+                    i < 10
+                        ? META_SCAN_OPERATOR_TEST_SG + ".device0.s" + i
+                        : META_SCAN_OPERATOR_TEST_SG + ".`root`.s0",
+                    value);
                 break;
               case 1:
                 assertEquals("null", value);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/SchemaPathUtilsTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/SchemaPathUtilsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SchemaPathUtilsTest {
+
+  @Test
+  public void testDisplayDurationLikeNodeWithoutBackQuotes() {
+    assertEquals(
+        "root.sg.d1.123d", SchemaPathUtils.getFullPathWithNecessaryBackQuotes("root.sg.d1.123d"));
+    assertEquals(
+        "root.sg.d1.123h", SchemaPathUtils.getFullPathWithNecessaryBackQuotes("root.sg.d1.123h"));
+    assertEquals(
+        "root.sg.d1.123w", SchemaPathUtils.getFullPathWithNecessaryBackQuotes("root.sg.d1.123w"));
+  }
+
+  @Test
+  public void testDisplayNumericNodeWithBackQuotes() {
+    assertEquals(
+        "root.sg.d1.`001`", SchemaPathUtils.getFullPathWithNecessaryBackQuotes("root.sg.d1.001"));
+    assertEquals(
+        "root.sg.d1.`1e3`", SchemaPathUtils.getFullPathWithNecessaryBackQuotes("root.sg.d1.1e3"));
+    assertEquals(
+        "root.sg.d1.`0`", SchemaPathUtils.getFullPathWithNecessaryBackQuotes("root.sg.d1.0"));
+  }
+}


### PR DESCRIPTION
## Description

This PR fixes schema/metadata display paths so paths containing reserved words, numeric-looking nodes, or otherwise invalid raw identifiers are returned with necessary back quotes.

The change centralizes schema display-path formatting in SchemaPathUtils and applies it to schema scan results, child path/node results, last-query outputs used by order-by-heat, template path display, active schema scan output, and related in-memory schema result objects.

## Tests

- git diff --cached --check

Attempted but blocked by local Windows page-file/native-memory exhaustion before Maven could start or complete:

- mvn spotless:apply -pl iotdb-core/datanode
- mvn -pl iotdb-core/datanode -Dtest=SchemaPathDisplayOperatorTest,SchemaQueryScanOperatorTest test