### PR TITLE
Fix table cache database existence lookup

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/table/DataNodeTableCache.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/table/DataNodeTableCache.java
@@ -571,18 +571,21 @@ public class DataNodeTableCache implements ITableCache {
     }
   }
 
-  public boolean isDatabaseExist(final String database) {
+  public boolean isDatabaseExist(String database) {
+    database = PathUtils.unQualifyDatabaseName(database);
     if (databaseTableMap.containsKey(database)) {
       return true;
     }
     if (getTablesInConfigNode(Collections.singletonMap(database, Collections.emptyMap()))
         .containsKey(database)) {
-      readWriteLock.readLock().lock();
+      readWriteLock.writeLock().lock();
       try {
-        databaseTableMap.computeIfAbsent(database, k -> new ConcurrentHashMap<>());
+        if (Objects.isNull(databaseTableMap.putIfAbsent(database, new ConcurrentHashMap<>()))) {
+          instanceVersion.incrementAndGet();
+        }
         return true;
       } finally {
-        readWriteLock.readLock().unlock();
+        readWriteLock.writeLock().unlock();
       }
     }
     return false;

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/schemaengine/table/DataNodeTableCacheTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/schemaengine/table/DataNodeTableCacheTest.java
@@ -59,6 +59,23 @@ public class DataNodeTableCacheTest {
   }
 
   @Test
+  public void isDatabaseExistAcceptsQualifiedDatabaseName() {
+    final DataNodeTableCache cache = DataNodeTableCache.getInstance();
+    cache.invalid(TABLE_CACHE_TEST_DATABASE);
+    try {
+      cache.preUpdateTable(TABLE_CACHE_TEST_DATABASE, createTable(TABLE_NAME), null);
+      cache.commitUpdateTable(TABLE_CACHE_TEST_DATABASE, TABLE_NAME, null);
+      final long versionBeforeCheck = cache.getInstanceVersion();
+
+      Assert.assertTrue(cache.isDatabaseExist(TABLE_CACHE_TEST_DATABASE));
+
+      Assert.assertEquals(versionBeforeCheck, cache.getInstanceVersion());
+    } finally {
+      cache.invalid(TABLE_CACHE_TEST_DATABASE);
+    }
+  }
+
+  @Test
   public void commitUpdateTableIsIdempotent() {
     final DataNodeTableCache cache = DataNodeTableCache.getInstance();
     cache.invalid(TABLE_CACHE_TEST_DATABASE);


### PR DESCRIPTION
## Summary
- normalize table-model database names in DataNodeTableCache#isDatabaseExist
- write newly discovered database cache entries under the write lock
- add a regression test for qualified database names hitting the local table cache

## Tests
- mvn spotless:apply -pl iotdb-core/datanode
- git diff --check
- mvn -pl iotdb-core/datanode -Dtest=DataNodeTableCacheTest test (fails during datanode compile before running tests; existing/generated-code symbols missing, e.g. AGGREGATION_OPERATOR_FROM_RAW_DATA, IFill, Accumulator, LinearFill)