### PR TITLE
[To dev/1.3] Fix flaky multilevel priority queue test

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/schedule/queue/MultilevelPriorityQueueTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/schedule/queue/MultilevelPriorityQueueTest.java
@@ -37,6 +37,9 @@ import org.mockito.Mockito;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.OptionalInt;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
 
 public class MultilevelPriorityQueueTest {
   @Test
@@ -57,12 +60,14 @@ public class MultilevelPriorityQueueTest {
                 }
               });
       t1.start();
-      Thread.sleep(100);
-      Assert.assertEquals(Thread.State.WAITING, t1.getState());
+      await()
+          .atMost(1, TimeUnit.MINUTES)
+          .untilAsserted(() -> Assert.assertEquals(Thread.State.WAITING, t1.getState()));
       DriverTask e2 = mockDriverTask(mockDriverTaskId(), false);
       queue.push(e2);
-      Thread.sleep(100);
-      Assert.assertEquals(Thread.State.TERMINATED, t1.getState());
+      await()
+          .atMost(1, TimeUnit.MINUTES)
+          .untilAsserted(() -> Assert.assertEquals(Thread.State.TERMINATED, t1.getState()));
       Assert.assertEquals(1, res.size());
       Assert.assertEquals(e2.getDriverTaskId().toString(), res.get(0).getDriverTaskId().toString());
     } catch (Exception e) {


### PR DESCRIPTION
## Description

Backport #18013 / 5467513eaa25cbe73758392502075c4713545318 to dev/1.3.

This replaces fixed sleeps in MultilevelPriorityQueueTest with Awaitility assertions to avoid flaky timing checks.

## Verification

- mvn -nsu -pl iotdb-core/datanode -Dtest=MultilevelPriorityQueueTest test failed before running tests because datanode main compilation used stale/incompatible local artifacts and could not resolve APIs such as IOUtils.readFully(...) and ProgressIndex.isEqualOrAfter(...).
- mvn -nsu -pl iotdb-core/node-commons,iotdb-core/datanode -am -DskipTests -Dtest=MultilevelPriorityQueueTest test also failed before reaching datanode because generated thrift sources referenced TProtocol.incrementRecursionDepth() / decrementRecursionDepth(), which are unavailable in the local thrift runtime.
