### PR TITLE
[To dev/1.3] Fix empty deleteTimeseries requests

### DIFF
--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/SessionConnection.java
@@ -779,6 +779,9 @@ public class SessionConnection {
 
   protected void deleteTimeseries(List<String> paths)
       throws IoTDBConnectionException, StatementExecutionException {
+    if (paths.isEmpty()) {
+      return;
+    }
     callWithRetryAndVerify(() -> client.deleteTimeseries(sessionId, paths));
   }
 

--- a/iotdb-client/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
+++ b/iotdb-client/session/src/main/java/org/apache/iotdb/session/pool/SessionPool.java
@@ -1937,6 +1937,9 @@ public class SessionPool implements ISessionPool {
   @Override
   public void deleteTimeseries(List<String> paths)
       throws IoTDBConnectionException, StatementExecutionException {
+    if (paths.isEmpty()) {
+      return;
+    }
     ISession session = getSession();
     try {
       session.deleteTimeseries(paths);

--- a/iotdb-client/session/src/test/java/org/apache/iotdb/session/SessionConnectionTest.java
+++ b/iotdb-client/session/src/test/java/org/apache/iotdb/session/SessionConnectionTest.java
@@ -348,6 +348,14 @@ public class SessionConnectionTest {
   }
 
   @Test
+  public void testDeleteEmptyTimeseries()
+      throws IoTDBConnectionException, StatementExecutionException, TException {
+    sessionConnection.deleteTimeseries(Collections.emptyList());
+
+    Mockito.verify(client, Mockito.never()).deleteTimeseries(anyLong(), any());
+  }
+
+  @Test
   public void testDeleteData() throws IoTDBConnectionException, StatementExecutionException {
     sessionConnection.deleteData(new TSDeleteDataReq());
   }

--- a/iotdb-client/session/src/test/java/org/apache/iotdb/session/pool/SessionPoolTest.java
+++ b/iotdb-client/session/src/test/java/org/apache/iotdb/session/pool/SessionPoolTest.java
@@ -777,6 +777,17 @@ public class SessionPoolTest {
   }
 
   @Test
+  public void testDeleteEmptyTimeseriesList()
+      throws IoTDBConnectionException, StatementExecutionException {
+    sessionPool.deleteTimeseries(Collections.emptyList());
+
+    Mockito.verify(session, Mockito.never()).deleteTimeseries(Mockito.<List<String>>any());
+    assertEquals(
+        1,
+        ((ConcurrentLinkedDeque<ISession>) Whitebox.getInternalState(sessionPool, "queue")).size());
+  }
+
+  @Test
   public void testDeleteData() throws IoTDBConnectionException, StatementExecutionException {
     String path = "root.device1.temperature";
     long time = 2L;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/ClientRPCServiceImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/thrift/impl/ClientRPCServiceImpl.java
@@ -1512,6 +1512,9 @@ public class ClientRPCServiceImpl implements IClientRPCServiceWithHandler {
         return getNotLoggedInStatus();
       }
 
+      if (path.isEmpty()) {
+        return RpcUtils.getStatus(TSStatusCode.SUCCESS_STATUS);
+      }
       // Step 1: transfer from DeleteStorageGroupsReq to Statement
       DeleteTimeSeriesStatement statement =
           StatementGenerator.createDeleteTimeSeriesStatement(path);


### PR DESCRIPTION
Backport of #18012 to dev/1.3.

Cherry-picked from cd5c3a31195c0ef69b0bf3ccacfd10257bd43ddb.

Tests:
- mvn -Ddevelocity.off=true -pl iotdb-client/session -Dtest=SessionConnectionTest,SessionPoolTest test