### PR TITLE
Remove unused commons-codec dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,6 @@
         <cglib.version>3.3.0</cglib.version>
         <cmake.build.type>Release</cmake.build.type>
         <commons-cli.version>1.5.0</commons-cli.version>
-        <commons-codec.version>1.16.1</commons-codec.version>
         <commons-csv.version>1.10.0</commons-csv.version>
         <commons-math3.version>3.6.1</commons-math3.version>
         <commons-pool2.version>2.11.1</commons-pool2.version>
@@ -545,11 +544,6 @@
                 <groupId>jakarta.validation</groupId>
                 <artifactId>jakarta.validation-api</artifactId>
                 <version>${jakarta.validation-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>commons-codec</groupId>
-                <artifactId>commons-codec</artifactId>
-                <version>${commons-codec.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
## Summary
- remove the unused `commons-codec` version property
- remove the unused `commons-codec` dependencyManagement entry

## Notes
- The source tree no longer references `commons-codec` directly after the existing external commons migration.
- `commons-codec` is still present as a transitive dependency in the current build, so the dependency reference list is intentionally unchanged.
- I checked downstream dependency-cleanup candidates. This is the only generally applicable leftover for upstream master; the other removals are either already covered by existing master changes or tied to downstream feature/module removal.

## Testing
- `git diff --check`
- `python -m json.tool dependencies.json`
- `mvn -nsu dependency:tree -Dincludes=commons-codec:commons-codec -DskipTests -DskipITs`