### PR TITLE
Fix encrypted password pull consumer commit mode

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/subscription/it/triple/treemodel/regression/param/IoTDBEncryptedPasswordPullConsumerIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/subscription/it/triple/treemodel/regression/param/IoTDBEncryptedPasswordPullConsumerIT.java
@@ -152,6 +152,7 @@ public class IoTDBEncryptedPasswordPullConsumerIT extends AbstractSubscriptionTr
         .encryptedPassword(encryptedPassword)
         .consumerId("consumer_" + consumerGroupId)
         .consumerGroupId(consumerGroupId)
+        .autoCommit(false)
         .buildPullConsumer();
   }
 


### PR DESCRIPTION
## Description
- Set the encrypted-password pull consumer regression test to manual commit mode.
- Keep it consistent with consume_data(), which explicitly commits polled messages.
- Avoid a race where the default auto-commit worker commits the same message before the test's manual commit, causing a partially accepted duplicate commit.

## Verification
- mvn spotless:apply -pl integration-test -P with-integration-tests
- git diff --check -- integration-test/src/test/java/org/apache/iotdb/subscription/it/triple/treemodel/regression/param/IoTDBEncryptedPasswordPullConsumerIT.java
- mvn -Ddevelocity.off=true verify -DskipUTs -Dit.test=IoTDBEncryptedPasswordPullConsumerIT#testSubscribeWithEncryptedPassword -DfailIfNoTests=false -Dfailsafe.failIfNoSpecifiedTests=false -pl integration-test -P with-integration-tests,MultiClusterIT2SubscriptionTreeRegressionMisc (target test was discovered, but skipped locally because the test cluster failed to start: SeedConfigNode not alive / Empty configNode set)