### PR TITLE
Fix stale deletion resource manager reuse

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/consensus/deletion/DeletionResourceManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/consensus/deletion/DeletionResourceManager.java
@@ -132,6 +132,9 @@ public class DeletionResourceManager implements AutoCloseable {
     LOGGER.info(DataNodePipeMessages.CLOSING_DELETION_RESOURCE_MANAGER_FOR, dataRegionId);
     this.deleteNode2ResourcesMap.clear();
     this.deletionBuffer.close();
+    if (DeletionResourceManagerHolder.CONSENSUS_GROUP_ID_2_INSTANCE_MAP != null) {
+      DeletionResourceManagerHolder.CONSENSUS_GROUP_ID_2_INSTANCE_MAP.remove(dataRegionId, this);
+    }
     LOGGER.info(
         DataNodePipeMessages.DELETION_RESOURCE_MANAGER_FOR_HAS_BEEN_SUCCESSFULLY, dataRegionId);
   }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/consensus/DeletionResourceTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/consensus/DeletionResourceTest.java
@@ -103,6 +103,16 @@ public class DeletionResourceTest {
   }
 
   @Test
+  public void testGetInstanceAfterCloseReturnsFreshManager() {
+    DeletionResourceManager closedDeletionResourceManager =
+        DeletionResourceManager.getInstance(FAKE_DATA_REGION_IDS[0]);
+    closedDeletionResourceManager.close();
+
+    deletionResourceManager = DeletionResourceManager.getInstance(FAKE_DATA_REGION_IDS[0]);
+    Assert.assertNotSame(closedDeletionResourceManager, deletionResourceManager);
+  }
+
+  @Test
   public void testAddBatchDeletionResource()
       throws IllegalPathException, IOException, InterruptedException {
     addBatchDeletionResource(true, 0);


### PR DESCRIPTION
## Description

DeletionResourceManager instances are cached by data region id. Closing a manager only closed its buffer and cleared in-memory resources, but left the closed instance in the singleton map. Later tests or callers using the same region id could retrieve the closed manager, fail to persist new deletions, and recover zero deletion resources.

This removes the closed manager from the singleton map and adds a regression test that verifies getInstance returns a fresh manager after close.

## Tests

- mvn -pl iotdb-core/datanode '-Dtest=DeletionResourceTest#testGetInstanceAfterCloseReturnsFreshManager,DeletionRecoverTest' -DfailIfNoTests=false '-Dcheckstyle.skip=true' '-Dspotless.skip=true' test
- mvn -pl iotdb-core/datanode '-Dcheckstyle.skip=true' spotless:apply
