### PR TITLE
Fix stale auth cache denial after grants

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/auth/ClusterAuthorityFetcher.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/auth/ClusterAuthorityFetcher.java
@@ -119,9 +119,19 @@ public class ClusterAuthorityFetcher implements IAuthorityFetcher {
       if (remoteCheck) {
         return checkPrivilegeFromConfigNode(req).getStatus();
       }
-      return RpcUtils.getStatus(TSStatusCode.NO_PERMISSION);
+      return confirmCachedDenyFromConfigNode(req);
     }
     return checkPrivilegeFromConfigNode(req).getStatus();
+  }
+
+  // Cached denials can be stale when login repopulates a user during grant invalidation.
+  private TSStatus confirmCachedDenyFromConfigNode(TCheckUserPrivilegesReq req) {
+    TSStatus remoteStatus = checkPrivilegeFromConfigNode(req).getStatus();
+    if (remoteStatus.getCode() == TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode()
+        && CONNECTERROR.equals(remoteStatus.getMessage())) {
+      return RpcUtils.getStatus(TSStatusCode.NO_PERMISSION);
+    }
+    return remoteStatus;
   }
 
   @Override


### PR DESCRIPTION
This patch confirms locally cached permission denials with ConfigNode so a stale DataNode user cache cannot incorrectly reject a privilege that was just granted. If ConfigNode is unavailable, it preserves the previous local NO_PERMISSION result. Tests: mvn spotless:apply -pl iotdb-core/datanode; mvn -nsu -pl iotdb-core/datanode -Dtest=AuthorizerManagerTest -Dcheckstyle.skip=true test; mvn -nsu -pl integration-test -am -PTableSimpleIT -P with-integration-tests -DskipUTs -Dit.test=IoTDBAuthenticationTableIT#testAlter -DfailIfNoTests=false -Dfailsafe.failIfNoSpecifiedTests=false -Dcheckstyle.skip=true -Drat.skip=true verify.