### PR TITLE
Fix ConfigNode NPE when extend/reconstruct region targets a non-DataNode id

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/IoTDBRegionGroupExpandAndShrinkForIoTV1IT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/IoTDBRegionGroupExpandAndShrinkForIoTV1IT.java
@@ -36,6 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
@@ -116,6 +117,61 @@ public class IoTDBRegionGroupExpandAndShrinkForIoTV1IT
           // update regionMap every time
           regionMap = getAllRegionMap(statement);
         }
+      }
+    }
+  }
+
+  /**
+   * Regression test for TIMECHODB-0689: when the target id of "extend region" does not belong to
+   * any registered DataNode (e.g. it is a ConfigNode id or simply does not exist), the ConfigNode
+   * used to throw a NullPointerException in {@code checkExtendRegion} and the client only saw a
+   * misleading "Fail to connect to any config node" message. After the fix a clear, actionable
+   * error message must be returned instead.
+   */
+  @Test
+  public void extendRegionToInvalidDataNodeTest() throws Exception {
+    EnvFactory.getEnv()
+        .getConfig()
+        .getCommonConfig()
+        .setDataRegionConsensusProtocolClass(ConsensusFactory.IOT_CONSENSUS)
+        .setSchemaRegionConsensusProtocolClass(ConsensusFactory.RATIS_CONSENSUS)
+        .setDataReplicationFactor(1)
+        .setSchemaReplicationFactor(1);
+
+    EnvFactory.getEnv().initClusterEnvironment(1, 3);
+
+    try (final Connection connection = makeItCloseQuietly(EnvFactory.getEnv().getConnection());
+        final Statement statement = makeItCloseQuietly(connection.createStatement())) {
+      // prepare data so that at least one region exists
+      statement.execute(INSERTION1);
+      statement.execute(FLUSH_COMMAND);
+
+      Map<Integer, Set<Integer>> regionMap = getAllRegionMap(statement);
+      Set<Integer> allDataNodeId = getAllDataNodes(statement);
+      Assert.assertFalse(regionMap.isEmpty());
+
+      int selectedRegion = regionMap.keySet().iterator().next();
+      // an id that is guaranteed not to belong to any registered DataNode; a ConfigNode id triggers
+      // the exact same code path (getRegisteredDataNode returns an empty configuration whose
+      // location is null)
+      int invalidDataNodeId = 9999;
+      Assert.assertFalse(allDataNodeId.contains(invalidDataNodeId));
+
+      try {
+        statement.execute(String.format(EXPAND_FORMAT, selectedRegion, invalidDataNodeId));
+        Assert.fail("extend region to a non-existent DataNode is expected to fail");
+      } catch (SQLException e) {
+        String message = e.getMessage();
+        LOGGER.info("extend region to invalid DataNode failed as expected: {}", message);
+        Assert.assertNotNull(message);
+        // the ConfigNode must not crash with an NPE any more ...
+        Assert.assertFalse(
+            "ConfigNode should not throw NullPointerException, but got: " + message,
+            message.contains("NullPointerException"));
+        // ... and the client should receive a clear, correct error message
+        Assert.assertTrue(
+            "Expected a 'Cannot find Target DataNode' style error but got: " + message,
+            message.contains("Cannot find Target DataNode"));
       }
     }
   }

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/IoTDBRegionGroupExpandAndShrinkForIoTV1IT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/IoTDBRegionGroupExpandAndShrinkForIoTV1IT.java
@@ -168,10 +168,13 @@ public class IoTDBRegionGroupExpandAndShrinkForIoTV1IT
         Assert.assertFalse(
             "ConfigNode should not throw NullPointerException, but got: " + message,
             message.contains("NullPointerException"));
-        // ... and the client should receive a clear, correct error message
+        // ... and the submission must be rejected cleanly. "extend region" wraps every region's
+        // result, so the top-level message only reports the aggregate counts; the concrete "does
+        // not
+        // exist in the cluster" reason is carried in the per-region sub-status.
         Assert.assertTrue(
-            "Expected a 'Cannot find Target DataNode' style error but got: " + message,
-            message.contains("Cannot find Target DataNode"));
+            "Expected the extend submission to be rejected but got: " + message,
+            message.contains("failed to submit: 1"));
       }
     }
   }

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/IoTDBRegionReconstructForIoTV1IT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/IoTDBRegionReconstructForIoTV1IT.java
@@ -270,8 +270,8 @@ public class IoTDBRegionReconstructForIoTV1IT extends IoTDBRegionOperationReliab
             message.contains("NullPointerException"));
         // ... and the client should receive a clear, correct error message
         Assert.assertTrue(
-            "Expected a 'Cannot find Target DataNode' style error but got: " + message,
-            message.contains("Cannot find Target DataNode"));
+            "Expected a 'does not exist in the cluster' error but got: " + message,
+            message.contains("does not exist in the cluster"));
       }
     }
   }

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/IoTDBRegionReconstructForIoTV1IT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/IoTDBRegionReconstructForIoTV1IT.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Collections;
 import java.util.Map;
@@ -217,6 +218,60 @@ public class IoTDBRegionReconstructForIoTV1IT extends IoTDBRegionOperationReliab
           Assert.assertEquals("1.0", rowRecord.getField(1).getStringValue());
           break;
         }
+      }
+    }
+  }
+
+  /**
+   * Regression test for TIMECHODB-0689 (reconstruct path): targeting "reconstruct region" at an id
+   * that is not a registered DataNode (a ConfigNode id or a non-existent id) used to trigger a
+   * NullPointerException in {@code checkReconstructRegion}. After the fix a clear, correct error
+   * message must be returned instead of crashing the ConfigNode RPC.
+   */
+  @Test
+  public void reconstructRegionToInvalidDataNodeTest() throws Exception {
+    EnvFactory.getEnv()
+        .getConfig()
+        .getCommonConfig()
+        .setDataRegionConsensusProtocolClass(ConsensusFactory.IOT_CONSENSUS)
+        .setSchemaRegionConsensusProtocolClass(ConsensusFactory.RATIS_CONSENSUS)
+        .setDataReplicationFactor(1)
+        .setSchemaReplicationFactor(1);
+
+    EnvFactory.getEnv().initClusterEnvironment(1, 3);
+
+    try (Connection connection = makeItCloseQuietly(EnvFactory.getEnv().getConnection());
+        Statement statement = makeItCloseQuietly(connection.createStatement())) {
+      // prepare data so that at least one region exists
+      statement.execute(INSERTION1);
+      statement.execute(FLUSH_COMMAND);
+
+      Map<Integer, Set<Integer>> regionMap = getAllRegionMap(statement);
+      Set<Integer> allDataNodeId = getAllDataNodes(statement);
+      Assert.assertFalse(regionMap.isEmpty());
+
+      int selectedRegion = regionMap.keySet().iterator().next();
+      // an id that is guaranteed not to belong to any registered DataNode; a ConfigNode id triggers
+      // the exact same code path (getRegisteredDataNode returns an empty configuration whose
+      // location is null)
+      int invalidDataNodeId = 9999;
+      Assert.assertFalse(allDataNodeId.contains(invalidDataNodeId));
+
+      try {
+        statement.execute(String.format(RECONSTRUCT_FORMAT, selectedRegion, invalidDataNodeId));
+        Assert.fail("reconstruct region on a non-existent DataNode is expected to fail");
+      } catch (SQLException e) {
+        String message = e.getMessage();
+        LOGGER.info("reconstruct region on invalid DataNode failed as expected: {}", message);
+        Assert.assertNotNull(message);
+        // the ConfigNode must not crash with an NPE any more ...
+        Assert.assertFalse(
+            "ConfigNode should not throw NullPointerException, but got: " + message,
+            message.contains("NullPointerException"));
+        // ... and the client should receive a clear, correct error message
+        Assert.assertTrue(
+            "Expected a 'Cannot find Target DataNode' style error but got: " + message,
+            message.contains("Cannot find Target DataNode"));
       }
     }
   }

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/removedatanode/IoTDBRemoveDataNodeNormalIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/removedatanode/IoTDBRemoveDataNodeNormalIT.java
@@ -56,12 +56,14 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import static org.apache.iotdb.confignode.it.regionmigration.IoTDBRegionOperationReliabilityITFramework.getAllRegionMap;
 import static org.apache.iotdb.confignode.it.regionmigration.IoTDBRegionOperationReliabilityITFramework.getDataRegionMap;
 import static org.apache.iotdb.confignode.it.removedatanode.IoTDBRemoveDataNodeUtils.awaitUntilSuccess;
 import static org.apache.iotdb.confignode.it.removedatanode.IoTDBRemoveDataNodeUtils.generateRemoveString;
 import static org.apache.iotdb.confignode.it.removedatanode.IoTDBRemoveDataNodeUtils.getConnectionWithSQLType;
 import static org.apache.iotdb.confignode.it.removedatanode.IoTDBRemoveDataNodeUtils.restartDataNodes;
 import static org.apache.iotdb.confignode.it.removedatanode.IoTDBRemoveDataNodeUtils.selectRemoveDataNodes;
+import static org.apache.iotdb.confignode.it.removedatanode.IoTDBRemoveDataNodeUtils.selectRemoveDataNodesWithoutRegionConflict;
 import static org.apache.iotdb.util.MagicUtils.makeItCloseQuietly;
 
 @Category({ClusterIT.class})
@@ -286,8 +288,17 @@ public class IoTDBRemoveDataNodeNormalIT {
         allDataNodeId.add(result.getInt(ColumnHeaderConstant.NODE_ID));
       }
 
-      // Select data nodes to remove
-      final Set<Integer> removeDataNodes = selectRemoveDataNodes(allDataNodeId, removeDataNodeNum);
+      // Select data nodes to remove. When removing more than one DataNode we must avoid picking two
+      // DataNodes that host replicas of the same consensus group, otherwise the
+      // RemoveDataNodesProcedure would try to migrate two replicas of one group at once, which the
+      // ConfigNode rejects ("Only one replica of the same consensus group is allowed to be migrated
+      // at the same time."). Selecting purely at random therefore makes this test flaky, so use a
+      // conflict-free selection.
+      final Set<Integer> removeDataNodes =
+          removeDataNodeNum > 1
+              ? selectRemoveDataNodesWithoutRegionConflict(
+                  allDataNodeId, removeDataNodeNum, getAllRegionMap(statement))
+              : selectRemoveDataNodes(allDataNodeId, removeDataNodeNum);
 
       List<DataNodeWrapper> removeDataNodeWrappers =
           removeDataNodes.stream()

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/removedatanode/IoTDBRemoveDataNodeUtils.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/removedatanode/IoTDBRemoveDataNodeUtils.java
@@ -35,8 +35,10 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -71,6 +73,59 @@ public class IoTDBRemoveDataNodeUtils {
     List<Integer> shuffledDataNodeIds = new ArrayList<>(allDataNodeId);
     Collections.shuffle(shuffledDataNodeIds);
     return new HashSet<>(shuffledDataNodeIds.subList(0, removeDataNodeNum));
+  }
+
+  /**
+   * Select {@code removeDataNodeNum} DataNodes to remove such that no two of them host a replica of
+   * the same consensus group. Removing two DataNodes that share a region group would make the
+   * generated {@code RemoveDataNodesProcedure} try to migrate two replicas of the same group at
+   * once, which the ConfigNode rejects ("Only one replica of the same consensus group is allowed to
+   * be migrated at the same time."). Randomly picking DataNodes (see {@link
+   * #selectRemoveDataNodes}) therefore makes multi-DataNode-remove tests flaky; this method keeps
+   * the selection valid and deterministic-enough for such tests.
+   *
+   * @param allDataNodeId all registered DataNode ids
+   * @param removeDataNodeNum how many DataNodes to remove
+   * @param regionMap regionId -&gt; the set of DataNode ids hosting a replica of that region group
+   *     (all region types)
+   * @return the selected DataNode ids, or throws if no conflict-free selection of the requested
+   *     size exists
+   */
+  public static Set<Integer> selectRemoveDataNodesWithoutRegionConflict(
+      Set<Integer> allDataNodeId, int removeDataNodeNum, Map<Integer, Set<Integer>> regionMap) {
+    // dataNodeId -> the set of region groups it hosts a replica of
+    Map<Integer, Set<Integer>> dataNodeToRegions = new HashMap<>();
+    for (Integer dataNodeId : allDataNodeId) {
+      dataNodeToRegions.put(dataNodeId, new HashSet<>());
+    }
+    regionMap.forEach(
+        (regionId, dataNodeIds) ->
+            dataNodeIds.forEach(
+                dataNodeId ->
+                    dataNodeToRegions
+                        .computeIfAbsent(dataNodeId, id -> new HashSet<>())
+                        .add(regionId)));
+
+    List<Integer> shuffledDataNodeIds = new ArrayList<>(allDataNodeId);
+    Collections.shuffle(shuffledDataNodeIds);
+
+    Set<Integer> selected = new HashSet<>();
+    Set<Integer> coveredRegions = new HashSet<>();
+    for (Integer dataNodeId : shuffledDataNodeIds) {
+      Set<Integer> regions = dataNodeToRegions.getOrDefault(dataNodeId, Collections.emptySet());
+      if (Collections.disjoint(coveredRegions, regions)) {
+        selected.add(dataNodeId);
+        coveredRegions.addAll(regions);
+        if (selected.size() == removeDataNodeNum) {
+          return selected;
+        }
+      }
+    }
+    throw new IllegalStateException(
+        String.format(
+            "Cannot select %d DataNodes to remove without a same-region-group conflict. "
+                + "allDataNodeId=%s, regionMap=%s",
+            removeDataNodeNum, allDataNodeId, regionMap));
   }
 
   public static void restartDataNodes(List<DataNodeWrapper> dataNodeWrappers) {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
@@ -870,19 +870,24 @@ public class ProcedureManager {
   private TSStatus checkReconstructRegion(
       TReconstructRegionReq req,
       TConsensusGroupId regionId,
-      TDataNodeLocation targetDataNode,
+      @Nullable TDataNodeLocation targetDataNode,
       TDataNodeLocation coordinator) {
-    String failMessage =
-        regionOperationCommonCheck(
-            regionId,
-            targetDataNode,
-            Arrays.asList(
-                new Pair<>("Target DataNode", targetDataNode),
-                new Pair<>("Coordinator", coordinator)),
-            req.getModel());
-
-    ConfigNodeConfig conf = ConfigNodeDescriptor.getInstance().getConf();
-    if (configManager
+    String failMessage;
+    // regionOperationCommonCheck reports "Cannot find Target DataNode" when targetDataNode is null
+    // (e.g. the requested id belongs to a ConfigNode or does not exist), so the following branches
+    // are only reached when targetDataNode is non-null. Keeping it as the first branch of the
+    // if-else chain avoids dereferencing a null targetDataNode.
+    if ((failMessage =
+            regionOperationCommonCheck(
+                regionId,
+                targetDataNode,
+                Arrays.asList(
+                    new Pair<>("Target DataNode", targetDataNode),
+                    new Pair<>("Coordinator", coordinator)),
+                req.getModel()))
+        != null) {
+      // need to do nothing more
+    } else if (configManager
             .getPartitionManager()
             .getAllReplicaSetsMap(regionId.getType())
             .get(regionId)
@@ -912,17 +917,24 @@ public class ProcedureManager {
   private TSStatus checkExtendRegion(
       TExtendRegionReq req,
       TConsensusGroupId regionId,
-      TDataNodeLocation targetDataNode,
+      @Nullable TDataNodeLocation targetDataNode,
       TDataNodeLocation coordinator) {
-    String failMessage =
-        regionOperationCommonCheck(
-            regionId,
-            targetDataNode,
-            Arrays.asList(
-                new Pair<>("Target DataNode", targetDataNode),
-                new Pair<>("Coordinator", coordinator)),
-            req.getModel());
-    if (configManager
+    String failMessage;
+    // regionOperationCommonCheck reports "Cannot find Target DataNode" when targetDataNode is null
+    // (e.g. the requested id belongs to a ConfigNode or does not exist), so the following branches
+    // are only reached when targetDataNode is non-null. Keeping it as the first branch of the
+    // if-else chain avoids dereferencing a null targetDataNode.
+    if ((failMessage =
+            regionOperationCommonCheck(
+                regionId,
+                targetDataNode,
+                Arrays.asList(
+                    new Pair<>("Target DataNode", targetDataNode),
+                    new Pair<>("Coordinator", coordinator)),
+                req.getModel()))
+        != null) {
+      // need to do nothing more
+    } else if (configManager
         .getPartitionManager()
         .getAllReplicaSets(targetDataNode.getDataNodeId())
         .stream()

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
@@ -870,24 +870,18 @@ public class ProcedureManager {
   private TSStatus checkReconstructRegion(
       TReconstructRegionReq req,
       TConsensusGroupId regionId,
-      @Nullable TDataNodeLocation targetDataNode,
+      TDataNodeLocation targetDataNode,
       TDataNodeLocation coordinator) {
-    String failMessage;
-    // regionOperationCommonCheck reports "Cannot find Target DataNode" when targetDataNode is null
-    // (e.g. the requested id belongs to a ConfigNode or does not exist), so the following branches
-    // are only reached when targetDataNode is non-null. Keeping it as the first branch of the
-    // if-else chain avoids dereferencing a null targetDataNode.
-    if ((failMessage =
-            regionOperationCommonCheck(
-                regionId,
-                targetDataNode,
-                Arrays.asList(
-                    new Pair<>("Target DataNode", targetDataNode),
-                    new Pair<>("Coordinator", coordinator)),
-                req.getModel()))
-        != null) {
-      // need to do nothing more
-    } else if (configManager
+    String failMessage =
+        regionOperationCommonCheck(
+            regionId,
+            targetDataNode,
+            Arrays.asList(
+                new Pair<>("Target DataNode", targetDataNode),
+                new Pair<>("Coordinator", coordinator)),
+            req.getModel());
+
+    if (configManager
             .getPartitionManager()
             .getAllReplicaSetsMap(regionId.getType())
             .get(regionId)
@@ -917,24 +911,17 @@ public class ProcedureManager {
   private TSStatus checkExtendRegion(
       TExtendRegionReq req,
       TConsensusGroupId regionId,
-      @Nullable TDataNodeLocation targetDataNode,
+      TDataNodeLocation targetDataNode,
       TDataNodeLocation coordinator) {
-    String failMessage;
-    // regionOperationCommonCheck reports "Cannot find Target DataNode" when targetDataNode is null
-    // (e.g. the requested id belongs to a ConfigNode or does not exist), so the following branches
-    // are only reached when targetDataNode is non-null. Keeping it as the first branch of the
-    // if-else chain avoids dereferencing a null targetDataNode.
-    if ((failMessage =
-            regionOperationCommonCheck(
-                regionId,
-                targetDataNode,
-                Arrays.asList(
-                    new Pair<>("Target DataNode", targetDataNode),
-                    new Pair<>("Coordinator", coordinator)),
-                req.getModel()))
-        != null) {
-      // need to do nothing more
-    } else if (configManager
+    String failMessage =
+        regionOperationCommonCheck(
+            regionId,
+            targetDataNode,
+            Arrays.asList(
+                new Pair<>("Target DataNode", targetDataNode),
+                new Pair<>("Coordinator", coordinator)),
+            req.getModel());
+    if (configManager
         .getPartitionManager()
         .getAllReplicaSets(targetDataNode.getDataNodeId())
         .stream()
@@ -1257,10 +1244,29 @@ public class ProcedureManager {
     return new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
   }
 
+  /**
+   * Resolve the location of a registered DataNode, or return {@code null} if the given id does not
+   * belong to any registered DataNode (e.g. it is a ConfigNode id or simply does not exist). {@link
+   * org.apache.iotdb.confignode.manager.node.NodeManager#getRegisteredDataNode} returns an empty
+   * {@link TDataNodeConfiguration} whose location is {@code null} in that case, so callers must not
+   * dereference the result blindly.
+   */
+  private TDataNodeLocation getRegisteredDataNodeLocationOrNull(int dataNodeId) {
+    return configManager.getNodeManager().getRegisteredDataNode(dataNodeId).getLocation();
+  }
+
   public TSStatus reconstructRegion(TReconstructRegionReq req) {
     RegionMaintainHandler handler = env.getRegionMaintainHandler();
     final TDataNodeLocation targetDataNode =
-        configManager.getNodeManager().getRegisteredDataNode(req.getDataNodeId()).getLocation();
+        getRegisteredDataNodeLocationOrNull(req.getDataNodeId());
+    if (targetDataNode == null) {
+      // The target id is not a registered DataNode. Reject here instead of pushing a null down into
+      // checkReconstructRegion, which would otherwise throw a NullPointerException.
+      return new TSStatus(TSStatusCode.RECONSTRUCT_REGION_ERROR.getStatusCode())
+          .setMessage(
+              String.format(
+                  "Target DataNode %s does not exist in the cluster", req.getDataNodeId()));
+    }
     try (AutoCloseableLock ignoredLock =
         AutoCloseableLock.acquire(env.getSubmitRegionMigrateLock())) {
       List<ReconstructRegionProcedure> procedures = new ArrayList<>();
@@ -1364,7 +1370,15 @@ public class ProcedureManager {
 
       // find target dn
       final TDataNodeLocation targetDataNode =
-          configManager.getNodeManager().getRegisteredDataNode(req.getDataNodeId()).getLocation();
+          getRegisteredDataNodeLocationOrNull(req.getDataNodeId());
+      if (targetDataNode == null) {
+        // The target id is not a registered DataNode. Reject here instead of pushing a null down
+        // into checkExtendRegion, which would otherwise throw a NullPointerException.
+        return new TSStatus(TSStatusCode.EXTEND_REGION_ERROR.getStatusCode())
+            .setMessage(
+                String.format(
+                    "Target DataNode %s does not exist in the cluster", req.getDataNodeId()));
+      }
       // select coordinator for adding peer
       RegionMaintainHandler handler = env.getRegionMaintainHandler();
       // TODO: choose the DataNode which has lowest load


### PR DESCRIPTION
## Problem

Running `extend region <regionId> to <nodeId>` (or `reconstruct region <regionId> on <nodeId>`) where `<nodeId>` does **not** belong to any registered DataNode — e.g. it is a **ConfigNode id** or simply a **non-existent id** like `9999` — crashes the ConfigNode RPC handler with a `NullPointerException`, and the client only sees a misleading error:

```
Msg: org.apache.iotdb.jdbc.IoTDBSQLException: 305: Error in calling method extendRegion,
because: Fail to connect to any config node. Please check status of ConfigNodes or logs of connected DataNode
```

ConfigNode log:

```
ERROR o.a.t.ProcessFunction:47 - Internal error processing extendRegion
java.lang.NullPointerException: Cannot invoke
  "org.apache.iotdb.common.rpc.thrift.TDataNodeLocation.getDataNodeId()" because "targetDataNode" is null
        at org.apache.iotdb.confignode.manager.ProcedureManager.checkExtendRegion(ProcedureManager.java:...)
        at org.apache.iotdb.confignode.manager.ProcedureManager.extendOneRegion(ProcedureManager.java:...)
        ...
```

## Root cause

`NodeManager.getRegisteredDataNode(id)` is backed by `registeredDataNodes.getOrDefault(id, new TDataNodeConfiguration())`, so for an unregistered id it returns an **empty** `TDataNodeConfiguration` whose `location` is `null`. In `extendOneRegion` / `reconstructRegion`:

```java
final TDataNodeLocation targetDataNode =
    configManager.getNodeManager().getRegisteredDataNode(req.getDataNodeId()).getLocation(); // -> null
```

`targetDataNode` becomes `null`, and `checkExtendRegion` / `checkReconstructRegion` then dereference `targetDataNode.getDataNodeId()`, throwing the NPE out of the Thrift handler — which the client reports as the generic "Fail to connect to any config node".

## Fix

Detect the invalid target at the **resolution layer**, not inside the check methods. `extendOneRegion` and `reconstructRegion` now resolve the target through a small `getRegisteredDataNodeLocationOrNull` helper and, when the id is not a registered DataNode, return immediately with a clear message:

```
Target DataNode <id> does not exist in the cluster
```

This mirrors the existing `migrateRegion` pattern (which already resolves and validates `fromId`/`toId` up front), so `checkExtendRegion` / `checkReconstructRegion` only ever receive a non-null target and are left in their original form.

## Tests

Added two regression integration tests asserting the operation is rejected cleanly and never surfaces a `NullPointerException`:

- `IoTDBRegionGroupExpandAndShrinkForIoTV1IT#extendRegionToInvalidDataNodeTest`
- `IoTDBRegionReconstructForIoTV1IT#reconstructRegionToInvalidDataNodeTest`

(`extend`/`remove region` wrap every region's status via `processExtendOrRemoveRegions`, so the JDBC top-level message shows the aggregate `Total regions: 1, ..., failed to submit: 1` and the concrete reason is carried in the per-region sub-status; the extend test asserts on the aggregate + absence of NPE, while the reconstruct test — which returns its `TSStatus` directly — asserts the full "does not exist in the cluster" message.)

### Drive-by: fix a pre-existing flaky test

While validating CI I found `IoTDBRemoveDataNodeNormalIT.success1C5DRemoveTwoDataNodesUseSQL` (added in #18046) is flaky, unrelated to this change. It removes **two randomly chosen** DataNodes and asserts success, but if both happen to host a replica of the same consensus group the ConfigNode correctly rejects the request:

```
Only one replica of the same consensus group is allowed to be migrated at the same time.
```

Added `IoTDBRemoveDataNodeUtils#selectRemoveDataNodesWithoutRegionConflict`, which selects DataNodes whose region sets are pairwise disjoint, and use it whenever more than one DataNode is removed.

All three tests pass locally.