### PR TITLE
Fix JDBC reusing stale statement id after reconnect

### DIFF
--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBStatement.java
@@ -363,7 +363,14 @@ public class IoTDBStatement implements Statement {
     execReq.setTimeout((long) queryTimeout * 1000);
     TSExecuteStatementResp execResp =
         callWithRetryAndReconnect(
-            () -> client.executeStatementV2(execReq), TSExecuteStatementResp::getStatus);
+            () -> {
+              // reConnect() may have replaced the session/statement id, so refresh them on every
+              // attempt; otherwise the server reports "StatementId doesn't exist in this session".
+              execReq.setSessionId(sessionId);
+              execReq.setStatementId(stmtId);
+              return client.executeStatementV2(execReq);
+            },
+            TSExecuteStatementResp::getStatus);
 
     if (execResp.isSetOperationType() && execResp.getOperationType().equals("dropDB")) {
       connection.changeDefaultDatabase(null);
@@ -430,7 +437,13 @@ public class IoTDBStatement implements Statement {
     isCancelled = false;
     TSExecuteBatchStatementReq execReq = new TSExecuteBatchStatementReq(sessionId, batchSQLList);
     TSStatus execResp =
-        callWithRetryAndReconnect(() -> client.executeBatchStatement(execReq), status -> status);
+        callWithRetryAndReconnect(
+            () -> {
+              // reConnect() may have replaced the session id, so refresh it on every attempt.
+              execReq.setSessionId(sessionId);
+              return client.executeBatchStatement(execReq);
+            },
+            status -> status);
     int[] result = new int[batchSQLList.size()];
     boolean allSuccess = true;
     StringBuilder message = new StringBuilder(System.lineSeparator());
@@ -500,7 +513,14 @@ public class IoTDBStatement implements Statement {
     execReq.setJdbcQuery(true);
     TSExecuteStatementResp execResp =
         callWithRetryAndReconnect(
-            () -> client.executeQueryStatementV2(execReq), TSExecuteStatementResp::getStatus);
+            () -> {
+              // reConnect() may have replaced the session/statement id, so refresh them on every
+              // attempt; otherwise the server reports "StatementId doesn't exist in this session".
+              execReq.setSessionId(sessionId);
+              execReq.setStatementId(stmtId);
+              return client.executeQueryStatementV2(execReq);
+            },
+            TSExecuteStatementResp::getStatus);
     queryId = execResp.getQueryId();
     try {
       RpcUtils.verifySuccess(execResp.getStatus());
@@ -575,7 +595,14 @@ public class IoTDBStatement implements Statement {
     final TSExecuteStatementReq execReq = new TSExecuteStatementReq(sessionId, sql, stmtId);
     final TSExecuteStatementResp execResp =
         callWithRetryAndReconnect(
-            () -> client.executeUpdateStatement(execReq), TSExecuteStatementResp::getStatus);
+            () -> {
+              // reConnect() may have replaced the session/statement id, so refresh them on every
+              // attempt; otherwise the server reports "StatementId doesn't exist in this session".
+              execReq.setSessionId(sessionId);
+              execReq.setStatementId(stmtId);
+              return client.executeUpdateStatement(execReq);
+            },
+            TSExecuteStatementResp::getStatus);
     if (execResp.isSetQueryId()) {
       queryId = execResp.getQueryId();
     }


### PR DESCRIPTION
## Problem

When `IoTDBStatement.reConnect()` runs (e.g. a DataNode is restarted mid-query), `this.sessionId` and `this.stmtId` are refreshed — but the retry lambda still sends the originally-built `TSExecuteStatementReq` carrying the **old** session/statement ids.

On the server side, `ClientRPCServiceImpl.executeStatementInternal` resolves the session from the **current RPC connection** (`getCurrSessionAndUpdateIdleTime()`) while taking the `statementId` from the **request body**. After reconnect that yields new-session + old-statement-id, so `ClientSession.addQueryId` throws:

> StatementId: N doesn't exist in this session

which is mapped to `INTERNAL_SERVER_ERROR (305)`. This is the root cause of the recurring `query_restart_dn_show_dev` JDBC test failures: the test's `check_log_INTERNAL_SERVER_ERROR` greps the 305s and fails, even though the query results themselves are correct.

## Fix

Refresh `sessionId` (and `statementId`) on the request object inside every retry lambda, mirroring `SessionConnection` in the Java Session SDK, which already handles this correctly.

Affected methods in `IoTDBStatement`:
- `executeSQL` (`executeStatementV2`) — sessionId + statementId
- `executeQuerySQL` (`executeQueryStatementV2`) — sessionId + statementId
- `executeUpdateSQL` (`executeUpdateStatement`) — sessionId + statementId
- `executeBatchSQL` (`executeBatchStatement`) — sessionId (batch has no statement id)

## Verification

- `mvn spotless:apply -pl iotdb-client/jdbc` — clean
- `mvn compile -pl iotdb-client/jdbc` — BUILD SUCCESS