### PR TITLE
Move IoTConsensus multi-data-dir region migration ITs to commit suite

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/IoTDBMigrateMultiRegionForIoTV1IT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/IoTDBMigrateMultiRegionForIoTV1IT.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -51,6 +52,7 @@ import static org.apache.iotdb.util.MagicUtils.makeItCloseQuietly;
 @RunWith(IoTDBTestRunner.class)
 public class IoTDBMigrateMultiRegionForIoTV1IT extends IoTDBRegionOperationReliabilityITFramework {
   private static final String MULTI_REGION_MIGRATE_FORMAT = "migrate region %s from %d to %d";
+  private static final String EXPAND_FORMAT = "extend region %d to %d";
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(IoTDBMigrateMultiRegionForIoTV1IT.class);
@@ -82,6 +84,10 @@ public class IoTDBMigrateMultiRegionForIoTV1IT extends IoTDBRegionOperationRelia
 
       Map<Integer, Set<Integer>> regionMap = getAllRegionMap(statement);
       Set<Integer> allDataNodeId = getAllDataNodes(statement);
+
+      // INSERTION1 only creates one schema region and one data region; with replication factor 1
+      // they are often placed on different DataNodes. Colocate them before multi-region migrate.
+      regionMap = ensureDataNodeHostsMultipleRegions(statement, client, regionMap);
 
       // With replication factor 1 every region lives on exactly one DataNode. Pick a source
       // DataNode that hosts at least two regions, then migrate all its regions to a fresh
@@ -168,6 +174,71 @@ public class IoTDBMigrateMultiRegionForIoTV1IT extends IoTDBRegionOperationRelia
       }
       LOGGER.info("Multi-region migrate test passed");
     }
+  }
+
+  private Map<Integer, Set<Integer>> ensureDataNodeHostsMultipleRegions(
+      Statement statement,
+      SyncConfigNodeIServiceClient client,
+      Map<Integer, Set<Integer>> regionMap)
+      throws Exception {
+    if (hasDataNodeHostingMultipleRegions(regionMap)) {
+      return regionMap;
+    }
+    List<Integer> regionIds = new ArrayList<>(regionMap.keySet());
+    Assert.assertTrue("Need at least two regions to colocate", regionIds.size() >= 2);
+
+    int firstRegion = regionIds.get(0);
+    int secondRegion = regionIds.get(1);
+    int targetDataNode = regionMap.get(secondRegion).iterator().next();
+    if (regionMap.get(firstRegion).contains(targetDataNode)) {
+      targetDataNode = regionMap.get(firstRegion).iterator().next();
+      regionGroupExpand(statement, client, secondRegion, targetDataNode);
+    } else {
+      regionGroupExpand(statement, client, firstRegion, targetDataNode);
+    }
+    return getAllRegionMap(statement);
+  }
+
+  private boolean hasDataNodeHostingMultipleRegions(Map<Integer, Set<Integer>> regionMap) {
+    return regionMap.values().stream()
+        .flatMap(Set::stream)
+        .collect(Collectors.groupingBy(dataNodeId -> dataNodeId, Collectors.counting()))
+        .values()
+        .stream()
+        .anyMatch(count -> count >= 2);
+  }
+
+  private void regionGroupExpand(
+      Statement statement,
+      SyncConfigNodeIServiceClient client,
+      int selectedRegion,
+      int targetDataNode)
+      throws Exception {
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .pollInterval(1, TimeUnit.SECONDS)
+        .until(
+            () -> {
+              statement.execute(String.format(EXPAND_FORMAT, selectedRegion, targetDataNode));
+              return true;
+            });
+
+    Predicate<TShowRegionResp> expandRegionPredicate =
+        tShowRegionResp -> {
+          Map<Integer, Set<Integer>> newRegionMap =
+              getRunningRegionMap(tShowRegionResp.getRegionInfoList());
+          Set<Integer> dataNodes = newRegionMap.get(selectedRegion);
+          return dataNodes != null && dataNodes.contains(targetDataNode);
+        };
+
+    awaitUntilSuccess(
+        client,
+        selectedRegion,
+        expandRegionPredicate,
+        Optional.of(targetDataNode),
+        Optional.empty());
+
+    LOGGER.info("Region {} has expanded to DataNode {}", selectedRegion, targetDataNode);
   }
 
   private int selectDataNodeHostingMultipleRegions(Map<Integer, Set<Integer>> regionMap) {

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/IoTDBMigrateMultiRegionForIoTV1IT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/IoTDBMigrateMultiRegionForIoTV1IT.java
@@ -190,12 +190,7 @@ public class IoTDBMigrateMultiRegionForIoTV1IT extends IoTDBRegionOperationRelia
     int firstRegion = regionIds.get(0);
     int secondRegion = regionIds.get(1);
     int targetDataNode = regionMap.get(secondRegion).iterator().next();
-    if (regionMap.get(firstRegion).contains(targetDataNode)) {
-      targetDataNode = regionMap.get(firstRegion).iterator().next();
-      regionGroupExpand(statement, client, secondRegion, targetDataNode);
-    } else {
-      regionGroupExpand(statement, client, firstRegion, targetDataNode);
-    }
+    regionGroupExpand(statement, client, firstRegion, targetDataNode);
     return getAllRegionMap(statement);
   }
 

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/IoTDBRegionMigrateWithDeletionMultiDataDirIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/IoTDBRegionMigrateWithDeletionMultiDataDirIT.java
@@ -17,15 +17,13 @@
  * under the License.
  */
 
-package org.apache.iotdb.confignode.it.regionmigration.pass.daily.iotv1;
+package org.apache.iotdb.confignode.it.regionmigration.pass.commit;
 
 import org.apache.iotdb.consensus.ConsensusFactory;
-import org.apache.iotdb.isession.SessionConfig;
 import org.apache.iotdb.it.env.EnvFactory;
 import org.apache.iotdb.it.env.cluster.node.DataNodeWrapper;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
-import org.apache.iotdb.itbase.category.TableClusterIT;
-import org.apache.iotdb.itbase.env.BaseEnv;
+import org.apache.iotdb.itbase.category.ClusterIT;
 
 import org.apache.tsfile.utils.Pair;
 import org.awaitility.Awaitility;
@@ -45,21 +43,23 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.iotdb.confignode.it.regionmigration.IoTDBRegionOperationReliabilityITFramework.getAllDataNodes;
 import static org.apache.iotdb.confignode.it.regionmigration.IoTDBRegionOperationReliabilityITFramework.getDataRegionMapWithLeader;
-import static org.apache.iotdb.confignode.it.regionmigration.pass.daily.iotv1.RegionMigrateFileAssertions.MULTI_DATA_DIRS;
-import static org.apache.iotdb.confignode.it.regionmigration.pass.daily.iotv1.RegionMigrateFileAssertions.awaitModsVisibleOnReplicas;
-import static org.apache.iotdb.confignode.it.regionmigration.pass.daily.iotv1.RegionMigrateFileAssertions.awaitRegionReplicas;
-import static org.apache.iotdb.confignode.it.regionmigration.pass.daily.iotv1.RegionMigrateFileAssertions.awaitTsFileResourceVisibleOnReplicas;
-import static org.apache.iotdb.confignode.it.regionmigration.pass.daily.iotv1.RegionMigrateFileAssertions.awaitTsFileVisibleOnReplicas;
-import static org.apache.iotdb.confignode.it.regionmigration.pass.daily.iotv1.RegionMigrateFileAssertions.getReplicaDataNodeIds;
+import static org.apache.iotdb.confignode.it.regionmigration.pass.commit.RegionMigrateFileAssertions.MULTI_DATA_DIRS;
+import static org.apache.iotdb.confignode.it.regionmigration.pass.commit.RegionMigrateFileAssertions.awaitModsVisibleOnReplicas;
+import static org.apache.iotdb.confignode.it.regionmigration.pass.commit.RegionMigrateFileAssertions.awaitRegionReplicas;
+import static org.apache.iotdb.confignode.it.regionmigration.pass.commit.RegionMigrateFileAssertions.awaitTsFileResourceVisibleOnReplicas;
+import static org.apache.iotdb.confignode.it.regionmigration.pass.commit.RegionMigrateFileAssertions.awaitTsFileVisibleOnReplicas;
+import static org.apache.iotdb.confignode.it.regionmigration.pass.commit.RegionMigrateFileAssertions.getReplicaDataNodeIds;
 
 /**
- * Table-model twin of {@link IoTDBRegionMigrateWithDeletionMultiDataDirIT}: a deletion (mods) must
- * survive IoTConsensus region migration across multiple data dirs, asserted through the relational
- * (table) SQL dialect so the table-model cluster CI covers the same snapshot mods-transfer path.
+ * Tree-model coverage for IoTConsensus region migration over multiple data dirs: a deletion (mods)
+ * must survive the snapshot transfer to the migrated peer. With several data dirs the snapshot
+ * fragments of one TsFile can be received into different folders, so the receiver groups companion
+ * files and the loader relinks them into one data dir; if that breaks, the migrated replica loses
+ * the deletion. See the table-model twin {@link IoTDBRegionMigrateWithDeletionMultiDataDirTableIT}.
  */
 @RunWith(IoTDBTestRunner.class)
-@Category({TableClusterIT.class})
-public class IoTDBRegionMigrateWithDeletionMultiDataDirTableIT {
+@Category({ClusterIT.class})
+public class IoTDBRegionMigrateWithDeletionMultiDataDirIT {
 
   @Before
   public void setUp() throws Exception {
@@ -79,12 +79,11 @@ public class IoTDBRegionMigrateWithDeletionMultiDataDirTableIT {
 
   @Test
   public void testRegionMigratePreservesDeletionWithMultiDataDirs() throws Exception {
-    try (Connection connection = EnvFactory.getEnv().getTableConnection();
+    try (Connection connection = EnvFactory.getEnv().getConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("CREATE DATABASE test");
-      statement.execute("USE test");
-      statement.execute("CREATE TABLE t1 (s1 INT64 FIELD)");
-      statement.execute("INSERT INTO t1 (time, s1) VALUES (100, 100), (200, 200), (300, 300)");
+      statement.execute("CREATE DATABASE root.db");
+      statement.execute(
+          "INSERT INTO root.db.d1(timestamp, s1) VALUES (100, 100), (200, 200), (300, 300)");
       statement.execute("FLUSH");
 
       Map<Integer, Pair<Integer, Set<Integer>>> dataRegionMapWithLeader =
@@ -94,14 +93,14 @@ public class IoTDBRegionMigrateWithDeletionMultiDataDirTableIT {
       Set<Integer> initialReplicaDataNodeIds =
           getReplicaDataNodeIds(statement, dataRegionIdForTest);
 
-      awaitTsFileVisibleOnReplicas("test", dataRegionIdForTest, initialReplicaDataNodeIds);
+      awaitTsFileVisibleOnReplicas("root.db", dataRegionIdForTest, initialReplicaDataNodeIds);
       awaitTsFileResourceVisibleOnReplicas(
-          statement, "test", dataRegionIdForTest, initialReplicaDataNodeIds);
+          statement, "root.db", dataRegionIdForTest, initialReplicaDataNodeIds);
 
-      statement.execute("DELETE FROM t1 WHERE time <= 200");
+      statement.execute("DELETE FROM root.db.d1.s1 WHERE time <= 200");
       statement.execute("FLUSH");
-      awaitModsVisibleOnReplicas("test", dataRegionIdForTest, initialReplicaDataNodeIds);
-      assertDeletionVisibleOnAllReplicas(statement, dataRegionIdForTest, 1);
+      awaitModsVisibleOnReplicas("root.db", dataRegionIdForTest, initialReplicaDataNodeIds);
+      assertDeletionVisibleOnAllReplicas(dataRegionIdForTest, 1);
 
       Pair<Integer, Set<Integer>> leaderAndNodes = dataRegionMapWithLeader.get(dataRegionIdForTest);
       Set<Integer> allDataNodes = getAllDataNodes(statement);
@@ -119,15 +118,19 @@ public class IoTDBRegionMigrateWithDeletionMultiDataDirTableIT {
               "migrate region %d from %d to %d", dataRegionIdForTest, leaderId, destDataNodeId));
 
       awaitRegionReplicas(statement, dataRegionIdForTest, Set.of(followerId, destDataNodeId));
-      awaitModsVisibleOnReplicas("test", dataRegionIdForTest, Set.of(destDataNodeId));
+      awaitModsVisibleOnReplicas("root.db", dataRegionIdForTest, Set.of(destDataNodeId));
 
-      assertDeletionVisibleOnAllReplicas(statement, dataRegionIdForTest, 1);
+      assertDeletionVisibleOnAllReplicas(dataRegionIdForTest, 1);
     }
   }
 
-  private void assertDeletionVisibleOnAllReplicas(
-      Statement statement, int dataRegionId, int expectedCount) throws Exception {
-    Set<Integer> replicaDataNodeIds = getReplicaDataNodeIds(statement, dataRegionId);
+  private void assertDeletionVisibleOnAllReplicas(int dataRegionId, int expectedCount)
+      throws Exception {
+    Set<Integer> replicaDataNodeIds;
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      replicaDataNodeIds = getReplicaDataNodeIds(statement, dataRegionId);
+    }
     for (int dataNodeId : replicaDataNodeIds) {
       DataNodeWrapper dataNodeWrapper =
           EnvFactory.getEnv().dataNodeIdToWrapper(dataNodeId).orElseThrow();
@@ -141,21 +144,15 @@ public class IoTDBRegionMigrateWithDeletionMultiDataDirTableIT {
 
   private void assertDeletionVisibleOnReplica(DataNodeWrapper dataNodeWrapper, int expectedCount)
       throws Exception {
-    try (Connection connection =
-            EnvFactory.getEnv()
-                .getConnection(
-                    dataNodeWrapper,
-                    SessionConfig.DEFAULT_USER,
-                    SessionConfig.DEFAULT_PASSWORD,
-                    BaseEnv.TABLE_SQL_DIALECT);
+    try (Connection connection = EnvFactory.getEnv().getConnection(dataNodeWrapper);
         Statement dataNodeStatement = connection.createStatement()) {
-      dataNodeStatement.execute("USE test");
-      try (ResultSet countResultSet = dataNodeStatement.executeQuery("SELECT COUNT(s1) FROM t1")) {
+      try (ResultSet countResultSet =
+          dataNodeStatement.executeQuery("SELECT COUNT(s1) FROM root.db.d1")) {
         Assert.assertTrue(countResultSet.next());
         Assert.assertEquals(expectedCount, countResultSet.getLong(1));
       }
       try (ResultSet deletedRangeResultSet =
-          dataNodeStatement.executeQuery("SELECT s1 FROM t1 WHERE time <= 200")) {
+          dataNodeStatement.executeQuery("SELECT s1 FROM root.db.d1 WHERE time <= 200")) {
         Assert.assertFalse(deletedRangeResultSet.next());
       }
     }

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/IoTDBRegionMigrateWithDeletionMultiDataDirTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/IoTDBRegionMigrateWithDeletionMultiDataDirTableIT.java
@@ -17,13 +17,15 @@
  * under the License.
  */
 
-package org.apache.iotdb.confignode.it.regionmigration.pass.daily.iotv1;
+package org.apache.iotdb.confignode.it.regionmigration.pass.commit;
 
 import org.apache.iotdb.consensus.ConsensusFactory;
+import org.apache.iotdb.isession.SessionConfig;
 import org.apache.iotdb.it.env.EnvFactory;
 import org.apache.iotdb.it.env.cluster.node.DataNodeWrapper;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
-import org.apache.iotdb.itbase.category.ClusterIT;
+import org.apache.iotdb.itbase.category.TableClusterIT;
+import org.apache.iotdb.itbase.env.BaseEnv;
 
 import org.apache.tsfile.utils.Pair;
 import org.awaitility.Awaitility;
@@ -43,23 +45,21 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.iotdb.confignode.it.regionmigration.IoTDBRegionOperationReliabilityITFramework.getAllDataNodes;
 import static org.apache.iotdb.confignode.it.regionmigration.IoTDBRegionOperationReliabilityITFramework.getDataRegionMapWithLeader;
-import static org.apache.iotdb.confignode.it.regionmigration.pass.daily.iotv1.RegionMigrateFileAssertions.MULTI_DATA_DIRS;
-import static org.apache.iotdb.confignode.it.regionmigration.pass.daily.iotv1.RegionMigrateFileAssertions.awaitModsVisibleOnReplicas;
-import static org.apache.iotdb.confignode.it.regionmigration.pass.daily.iotv1.RegionMigrateFileAssertions.awaitRegionReplicas;
-import static org.apache.iotdb.confignode.it.regionmigration.pass.daily.iotv1.RegionMigrateFileAssertions.awaitTsFileResourceVisibleOnReplicas;
-import static org.apache.iotdb.confignode.it.regionmigration.pass.daily.iotv1.RegionMigrateFileAssertions.awaitTsFileVisibleOnReplicas;
-import static org.apache.iotdb.confignode.it.regionmigration.pass.daily.iotv1.RegionMigrateFileAssertions.getReplicaDataNodeIds;
+import static org.apache.iotdb.confignode.it.regionmigration.pass.commit.RegionMigrateFileAssertions.MULTI_DATA_DIRS;
+import static org.apache.iotdb.confignode.it.regionmigration.pass.commit.RegionMigrateFileAssertions.awaitModsVisibleOnReplicas;
+import static org.apache.iotdb.confignode.it.regionmigration.pass.commit.RegionMigrateFileAssertions.awaitRegionReplicas;
+import static org.apache.iotdb.confignode.it.regionmigration.pass.commit.RegionMigrateFileAssertions.awaitTsFileResourceVisibleOnReplicas;
+import static org.apache.iotdb.confignode.it.regionmigration.pass.commit.RegionMigrateFileAssertions.awaitTsFileVisibleOnReplicas;
+import static org.apache.iotdb.confignode.it.regionmigration.pass.commit.RegionMigrateFileAssertions.getReplicaDataNodeIds;
 
 /**
- * Tree-model coverage for IoTConsensus region migration over multiple data dirs: a deletion (mods)
- * must survive the snapshot transfer to the migrated peer. With several data dirs the snapshot
- * fragments of one TsFile can be received into different folders, so the receiver groups companion
- * files and the loader relinks them into one data dir; if that breaks, the migrated replica loses
- * the deletion. See the table-model twin {@link IoTDBRegionMigrateWithDeletionMultiDataDirTableIT}.
+ * Table-model twin of {@link IoTDBRegionMigrateWithDeletionMultiDataDirIT}: a deletion (mods) must
+ * survive IoTConsensus region migration across multiple data dirs, asserted through the relational
+ * (table) SQL dialect so the table-model cluster CI covers the same snapshot mods-transfer path.
  */
 @RunWith(IoTDBTestRunner.class)
-@Category({ClusterIT.class})
-public class IoTDBRegionMigrateWithDeletionMultiDataDirIT {
+@Category({TableClusterIT.class})
+public class IoTDBRegionMigrateWithDeletionMultiDataDirTableIT {
 
   @Before
   public void setUp() throws Exception {
@@ -79,11 +79,12 @@ public class IoTDBRegionMigrateWithDeletionMultiDataDirIT {
 
   @Test
   public void testRegionMigratePreservesDeletionWithMultiDataDirs() throws Exception {
-    try (Connection connection = EnvFactory.getEnv().getConnection();
+    try (Connection connection = EnvFactory.getEnv().getTableConnection();
         Statement statement = connection.createStatement()) {
-      statement.execute("CREATE DATABASE root.db");
-      statement.execute(
-          "INSERT INTO root.db.d1(timestamp, s1) VALUES (100, 100), (200, 200), (300, 300)");
+      statement.execute("CREATE DATABASE test");
+      statement.execute("USE test");
+      statement.execute("CREATE TABLE t1 (s1 INT64 FIELD)");
+      statement.execute("INSERT INTO t1 (time, s1) VALUES (100, 100), (200, 200), (300, 300)");
       statement.execute("FLUSH");
 
       Map<Integer, Pair<Integer, Set<Integer>>> dataRegionMapWithLeader =
@@ -93,14 +94,14 @@ public class IoTDBRegionMigrateWithDeletionMultiDataDirIT {
       Set<Integer> initialReplicaDataNodeIds =
           getReplicaDataNodeIds(statement, dataRegionIdForTest);
 
-      awaitTsFileVisibleOnReplicas("root.db", dataRegionIdForTest, initialReplicaDataNodeIds);
+      awaitTsFileVisibleOnReplicas("test", dataRegionIdForTest, initialReplicaDataNodeIds);
       awaitTsFileResourceVisibleOnReplicas(
-          statement, "root.db", dataRegionIdForTest, initialReplicaDataNodeIds);
+          statement, "test", dataRegionIdForTest, initialReplicaDataNodeIds);
 
-      statement.execute("DELETE FROM root.db.d1.s1 WHERE time <= 200");
+      statement.execute("DELETE FROM t1 WHERE time <= 200");
       statement.execute("FLUSH");
-      awaitModsVisibleOnReplicas("root.db", dataRegionIdForTest, initialReplicaDataNodeIds);
-      assertDeletionVisibleOnAllReplicas(dataRegionIdForTest, 1);
+      awaitModsVisibleOnReplicas("test", dataRegionIdForTest, initialReplicaDataNodeIds);
+      assertDeletionVisibleOnAllReplicas(statement, dataRegionIdForTest, 1);
 
       Pair<Integer, Set<Integer>> leaderAndNodes = dataRegionMapWithLeader.get(dataRegionIdForTest);
       Set<Integer> allDataNodes = getAllDataNodes(statement);
@@ -118,19 +119,15 @@ public class IoTDBRegionMigrateWithDeletionMultiDataDirIT {
               "migrate region %d from %d to %d", dataRegionIdForTest, leaderId, destDataNodeId));
 
       awaitRegionReplicas(statement, dataRegionIdForTest, Set.of(followerId, destDataNodeId));
-      awaitModsVisibleOnReplicas("root.db", dataRegionIdForTest, Set.of(destDataNodeId));
+      awaitModsVisibleOnReplicas("test", dataRegionIdForTest, Set.of(destDataNodeId));
 
-      assertDeletionVisibleOnAllReplicas(dataRegionIdForTest, 1);
+      assertDeletionVisibleOnAllReplicas(statement, dataRegionIdForTest, 1);
     }
   }
 
-  private void assertDeletionVisibleOnAllReplicas(int dataRegionId, int expectedCount)
-      throws Exception {
-    Set<Integer> replicaDataNodeIds;
-    try (Connection connection = EnvFactory.getEnv().getConnection();
-        Statement statement = connection.createStatement()) {
-      replicaDataNodeIds = getReplicaDataNodeIds(statement, dataRegionId);
-    }
+  private void assertDeletionVisibleOnAllReplicas(
+      Statement statement, int dataRegionId, int expectedCount) throws Exception {
+    Set<Integer> replicaDataNodeIds = getReplicaDataNodeIds(statement, dataRegionId);
     for (int dataNodeId : replicaDataNodeIds) {
       DataNodeWrapper dataNodeWrapper =
           EnvFactory.getEnv().dataNodeIdToWrapper(dataNodeId).orElseThrow();
@@ -144,15 +141,21 @@ public class IoTDBRegionMigrateWithDeletionMultiDataDirIT {
 
   private void assertDeletionVisibleOnReplica(DataNodeWrapper dataNodeWrapper, int expectedCount)
       throws Exception {
-    try (Connection connection = EnvFactory.getEnv().getConnection(dataNodeWrapper);
+    try (Connection connection =
+            EnvFactory.getEnv()
+                .getConnection(
+                    dataNodeWrapper,
+                    SessionConfig.DEFAULT_USER,
+                    SessionConfig.DEFAULT_PASSWORD,
+                    BaseEnv.TABLE_SQL_DIALECT);
         Statement dataNodeStatement = connection.createStatement()) {
-      try (ResultSet countResultSet =
-          dataNodeStatement.executeQuery("SELECT COUNT(s1) FROM root.db.d1")) {
+      dataNodeStatement.execute("USE test");
+      try (ResultSet countResultSet = dataNodeStatement.executeQuery("SELECT COUNT(s1) FROM t1")) {
         Assert.assertTrue(countResultSet.next());
         Assert.assertEquals(expectedCount, countResultSet.getLong(1));
       }
       try (ResultSet deletedRangeResultSet =
-          dataNodeStatement.executeQuery("SELECT s1 FROM root.db.d1 WHERE time <= 200")) {
+          dataNodeStatement.executeQuery("SELECT s1 FROM t1 WHERE time <= 200")) {
         Assert.assertFalse(deletedRangeResultSet.next());
       }
     }

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/RegionMigrateFileAssertions.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/RegionMigrateFileAssertions.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iotdb.confignode.it.regionmigration.pass.daily.iotv1;
+package org.apache.iotdb.confignode.it.regionmigration.pass.commit;
 
 import org.apache.iotdb.it.env.EnvFactory;
 import org.apache.iotdb.it.env.cluster.node.DataNodeWrapper;


### PR DESCRIPTION
## Description

### Content1
Move IoTConsensus multi-data-dir region migration ITs from `pass/daily/iotv1` to `pass/commit`, updating package names and static imports so they run in the commit CI suite instead of daily.

### Content2
Fix `IoTDBMigrateMultiRegionForIoTV1IT.multiRegionMigrateTest`, which failed in ClusterIT (1C3D) because `INSERTION1` only creates one schema region and one data region; with replication factor 1 they are often placed on different DataNodes, so no DataNode hosts two regions. Before multi-region migrate, colocate regions via `extend region` when needed.

<hr>

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods.
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for code coverage.
- [x] added integration tests.
- [x] been tested in a test IoTDB cluster.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- `org.apache.iotdb.confignode.it.regionmigration.pass.commit` — 3 IT classes moved from `pass.daily.iotv1`:
  - `IoTDBRegionMigrateWithDeletionMultiDataDirIT`
  - `IoTDBRegionMigrateWithDeletionMultiDataDirTableIT`
  - `RegionMigrateFileAssertions`
- `IoTDBMigrateMultiRegionForIoTV1IT` — fix region colocation before multi-region migrate

**Test plan**
- [x] `IoTDBRegionMigrateWithDeletionMultiDataDirIT` (ClusterIT)
- [x] `IoTDBRegionMigrateWithDeletionMultiDataDirTableIT` (TableClusterIT)
- [x] `IoTDBMigrateMultiRegionForIoTV1IT` (ClusterIT)