### PR TITLE
Fix two flaky multi-DataNode/multi-region ITs from #18046 (remove-DataNode selection + migrate precondition)

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/IoTDBMigrateMultiRegionForIoTV1IT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/IoTDBMigrateMultiRegionForIoTV1IT.java
@@ -68,7 +68,14 @@ public class IoTDBMigrateMultiRegionForIoTV1IT extends IoTDBRegionOperationRelia
         .setDataRegionConsensusProtocolClass(ConsensusFactory.IOT_CONSENSUS)
         .setSchemaRegionConsensusProtocolClass(ConsensusFactory.RATIS_CONSENSUS)
         .setDataReplicationFactor(1)
-        .setSchemaReplicationFactor(1);
+        .setSchemaReplicationFactor(1)
+        // Create 6 data region groups (> 5 DataNodes) so that, with replication factor 1, at least
+        // one DataNode is guaranteed by pigeonhole to host >= 2 regions - the precondition of
+        // selectDataNodeHostingMultipleRegions below. Under the default AUTO policy only ~2-3
+        // regions were created and a balanced spread could leave every DataNode with a single
+        // region, making this test flaky ("Cannot find a DataNode hosting at least two regions").
+        .setDataRegionGroupExtensionPolicy("CUSTOM")
+        .setDefaultDataRegionGroupNumPerDatabase(6);
 
     EnvFactory.getEnv().initClusterEnvironment(1, 5);
 

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/removedatanode/IoTDBRemoveDataNodeNormalIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/removedatanode/IoTDBRemoveDataNodeNormalIT.java
@@ -357,7 +357,7 @@ public class IoTDBRemoveDataNodeNormalIT {
         removeSuccess = true;
       } catch (ConditionTimeoutException e) {
         if (expectRemoveSuccess) {
-          LOGGER.error("Remove DataNodes timeout in 2 minutes");
+          LOGGER.error("Remove DataNodes timeout in 5 minutes");
           Assert.fail();
         }
       }

--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/removedatanode/IoTDBRemoveDataNodeUtils.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/removedatanode/IoTDBRemoveDataNodeUtils.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -81,8 +82,9 @@ public class IoTDBRemoveDataNodeUtils {
    * generated {@code RemoveDataNodesProcedure} try to migrate two replicas of the same group at
    * once, which the ConfigNode rejects ("Only one replica of the same consensus group is allowed to
    * be migrated at the same time."). Randomly picking DataNodes (see {@link
-   * #selectRemoveDataNodes}) therefore makes multi-DataNode-remove tests flaky; this method keeps
-   * the selection valid and deterministic-enough for such tests.
+   * #selectRemoveDataNodes}) therefore makes multi-DataNode-remove tests flaky; this method instead
+   * searches exhaustively (with backtracking) for a conflict-free selection, so it fails only when
+   * no such selection exists rather than when an unlucky pick order dead-ends.
    *
    * @param allDataNodeId all registered DataNode ids
    * @param removeDataNodeNum how many DataNodes to remove
@@ -106,26 +108,65 @@ public class IoTDBRemoveDataNodeUtils {
                         .computeIfAbsent(dataNodeId, id -> new HashSet<>())
                         .add(regionId)));
 
+    // Shuffle so that, when several conflict-free selections exist, a random one is returned (keeps
+    // the coverage of this test varied across runs).
     List<Integer> shuffledDataNodeIds = new ArrayList<>(allDataNodeId);
     Collections.shuffle(shuffledDataNodeIds);
 
-    Set<Integer> selected = new HashSet<>();
-    Set<Integer> coveredRegions = new HashSet<>();
-    for (Integer dataNodeId : shuffledDataNodeIds) {
-      Set<Integer> regions = dataNodeToRegions.getOrDefault(dataNodeId, Collections.emptySet());
-      if (Collections.disjoint(coveredRegions, regions)) {
-        selected.add(dataNodeId);
-        coveredRegions.addAll(regions);
-        if (selected.size() == removeDataNodeNum) {
-          return selected;
-        }
-      }
+    // Search exhaustively (with backtracking) for a set of DataNodes whose hosted region groups are
+    // pairwise disjoint. A single-pass greedy that unconditionally commits to the first shuffled
+    // DataNode can dead-end and wrongly throw even though a valid conflict-free selection exists -
+    // e.g. when that first DataNode happens to share a consensus group with every other DataNode -
+    // which made this test flaky.
+    Set<Integer> selected = new LinkedHashSet<>();
+    if (searchConflictFreeDataNodes(
+        shuffledDataNodeIds, 0, removeDataNodeNum, new HashSet<>(), selected, dataNodeToRegions)) {
+      return selected;
     }
     throw new IllegalStateException(
         String.format(
             "Cannot select %d DataNodes to remove without a same-region-group conflict. "
                 + "allDataNodeId=%s, regionMap=%s",
             removeDataNodeNum, allDataNodeId, regionMap));
+  }
+
+  /**
+   * Depth-first search with backtracking for {@code need} DataNodes whose hosted region groups are
+   * pairwise disjoint. On success returns {@code true} and leaves the chosen ids in {@code
+   * selected}; on failure returns {@code false} with {@code selected} restored to its prior state.
+   *
+   * @param dataNodeIds candidate DataNode ids (iterated from {@code start} onwards)
+   * @param start index to start picking from, so each combination is visited at most once
+   * @param need how many DataNodes must be selected in total
+   * @param coveredRegions region groups already covered by the currently-selected DataNodes
+   * @param selected the DataNodes chosen so far (mutated during the search)
+   * @param dataNodeToRegions dataNodeId -&gt; the region groups it hosts a replica of
+   */
+  private static boolean searchConflictFreeDataNodes(
+      List<Integer> dataNodeIds,
+      int start,
+      int need,
+      Set<Integer> coveredRegions,
+      Set<Integer> selected,
+      Map<Integer, Set<Integer>> dataNodeToRegions) {
+    if (selected.size() == need) {
+      return true;
+    }
+    for (int i = start; i < dataNodeIds.size(); i++) {
+      Integer dataNodeId = dataNodeIds.get(i);
+      Set<Integer> regions = dataNodeToRegions.getOrDefault(dataNodeId, Collections.emptySet());
+      if (Collections.disjoint(coveredRegions, regions)) {
+        selected.add(dataNodeId);
+        Set<Integer> nextCovered = new HashSet<>(coveredRegions);
+        nextCovered.addAll(regions);
+        if (searchConflictFreeDataNodes(
+            dataNodeIds, i + 1, need, nextCovered, selected, dataNodeToRegions)) {
+          return true;
+        }
+        selected.remove(dataNodeId);
+      }
+    }
+    return false;
   }
 
   public static void restartDataNodes(List<DataNodeWrapper> dataNodeWrappers) {


### PR DESCRIPTION
## Description

Two integration tests added by #18046 (*Support multiple regions in MIGRATE REGION and multiple DataNodes in REMOVE DATANODE*) are flaky on the every-PR `Simple`/`ClusterIT` pipeline. Both flakes are test-side only; no production code is touched.

### 1. `IoTDBRemoveDataNodeNormalIT.success1C5DRemoveTwoDataNodesUseSQL`

The test removes two DataNodes at once and selects them via `IoTDBRemoveDataNodeUtils.selectRemoveDataNodesWithoutRegionConflict`, which must avoid picking two DataNodes that host replicas of the same consensus group (otherwise the ConfigNode rejects the removal: *"Only one replica of the same consensus group is allowed to be migrated at the same time."*). #18075 introduced this selector to replace the previous random pick.

However the selector was a **single-pass greedy over a shuffled DataNode list with no backtracking**: it unconditionally commits to the first shuffled DataNode and never reconsiders it. When removing 2 DataNodes it therefore throws `IllegalStateException` whenever the first shuffled DataNode shares a consensus group with **every** other DataNode (a "hub" in the region-sharing graph) — even though a valid conflict-free pair still exists among the other DataNodes. In the 1C5D layout (5 data-region groups at factor 2, balanced to ~2 replicas per DataNode, plus one schema-region group at factor 3) such a hub commonly exists, so a fraction of runs aborted with `IllegalStateException` **before** `REMOVE DATANODE` was ever submitted.

**Fix:** replace the greedy with an **exhaustive depth-first search with backtracking** (`searchConflictFreeDataNodes`) that visits each combination at most once and fails only when no conflict-free set of the requested size actually exists. The initial `Collections.shuffle` is kept, so when several valid selections exist a random one is still returned. The search space is tiny (a handful of DataNodes), so the cost is negligible, and this also future-proofs the helper for `removeDataNodeNum > 2`. Also corrected a stale log line that reported *"timeout in 2 minutes"* while `awaitUntilSuccess` actually waits 5 minutes.

### 2. `IoTDBMigrateMultiRegionForIoTV1IT.multiRegionMigrateTest`

The test runs on 1C5D with **replication factor 1** and, as a precondition, requires a source DataNode hosting **at least two regions** (`selectDataNodeHostingMultipleRegions`), otherwise it fails with `RuntimeException: Cannot find a DataNode hosting at least two regions`. Under the default `AUTO` data-region policy a single insert created only ~2-3 factor-1 regions; when the balanced allocator spread them across the 5 DataNodes with at most one region each, the precondition was not met and the test errored intermittently (observed on this PR's CI, unrelated to the change itself).

**Fix:** force the `CUSTOM` data-region policy with 6 data-region groups per database. With 6 regions over 5 DataNodes at replication factor 1, pigeonhole guarantees at least one DataNode hosts ≥ 2 regions, and — since each factor-1 region lives on a single DataNode — another DataNode is always available as a conflict-free migration destination.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code.
- [x] modified existing integration tests to remove flakiness.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
- `IoTDBRemoveDataNodeUtils` (integration-test) — exhaustive backtracking conflict-free DataNode selection replacing the non-backtracking greedy.
- `IoTDBRemoveDataNodeNormalIT` (integration-test) — corrected stale timeout log message.
- `IoTDBMigrateMultiRegionForIoTV1IT` (integration-test) — deterministic region layout so the "source DataNode with ≥2 regions" precondition always holds.
