### PR TITLE
[to dev/1.3] Add copy fallback for compaction hard links

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/performer/impl/RepairUnsortedFileCompactionPerformer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/performer/impl/RepairUnsortedFileCompactionPerformer.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.storageengine.dataregion.compaction.execute.performer.impl;
 
+import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.utils.CompactionUtils;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.utils.writer.AbstractCompactionWriter;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.utils.writer.RepairUnsortedFileCompactionWriter;
@@ -31,7 +32,6 @@ import org.apache.iotdb.db.storageengine.rescon.memory.TsFileResourceManager;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;
 
@@ -74,7 +74,7 @@ public class RepairUnsortedFileCompactionPerformer extends ReadPointCompactionPe
   private void prepareTargetFile() throws IOException {
     TsFileResource seqSourceFile = seqFiles.get(0);
     TsFileResource targetFile = targetFiles.get(0);
-    Files.createLink(targetFile.getTsFile().toPath(), seqSourceFile.getTsFile().toPath());
+    FileUtils.createLink(targetFile.getTsFile().toPath(), seqSourceFile.getTsFile().toPath(), true);
     ITimeIndex timeIndex = seqSourceFile.getTimeIndex();
     if (timeIndex instanceof DeviceTimeIndex) {
       targetFile.setTimeIndex(timeIndex);
@@ -82,9 +82,10 @@ public class RepairUnsortedFileCompactionPerformer extends ReadPointCompactionPe
       targetFile.setTimeIndex(CompactionUtils.buildDeviceTimeIndex(seqSourceFile));
     }
     if (seqSourceFile.modFileExists()) {
-      Files.createLink(
+      FileUtils.createLink(
           new File(seqSourceFile.getCompactionModFile().getFilePath()).toPath(),
-          new File(seqSourceFile.getModFile().getFilePath()).toPath());
+          new File(seqSourceFile.getModFile().getFilePath()).toPath(),
+          true);
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InnerSpaceCompactionTask.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.storageengine.dataregion.compaction.execute.task;
 
+import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.DiskSpaceInsufficientException;
@@ -443,14 +444,16 @@ public class InnerSpaceCompactionTask extends AbstractCompactionTask {
     for (int i = 0; i < filesView.renamedTargetFiles.size(); i++) {
       TsFileResource oldFile = filesView.skippedSourceFiles.get(i);
       TsFileResource newFile = filesView.renamedTargetFiles.get(i);
-      Files.createLink(newFile.getTsFile().toPath(), oldFile.getTsFile().toPath());
-      Files.createLink(
+      FileUtils.createLink(newFile.getTsFile().toPath(), oldFile.getTsFile().toPath(), true);
+      FileUtils.createLink(
           new File(newFile.getTsFilePath() + TsFileResource.RESOURCE_SUFFIX).toPath(),
-          new File(oldFile.getTsFilePath() + TsFileResource.RESOURCE_SUFFIX).toPath());
+          new File(oldFile.getTsFilePath() + TsFileResource.RESOURCE_SUFFIX).toPath(),
+          true);
       if (oldFile.modFileExists()) {
-        Files.createLink(
+        FileUtils.createLink(
             new File(newFile.getTsFilePath() + ModificationFile.FILE_SUFFIX).toPath(),
-            new File(oldFile.getTsFilePath() + ModificationFile.FILE_SUFFIX).toPath());
+            new File(oldFile.getTsFilePath() + ModificationFile.FILE_SUFFIX).toPath(),
+            true);
       }
       newFile.deserialize();
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InsertionCrossSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InsertionCrossSpaceCompactionTask.java
@@ -38,6 +38,7 @@ import org.apache.iotdb.db.storageengine.dataregion.tsfile.generator.TsFileNameG
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InsertionCrossSpaceCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/InsertionCrossSpaceCompactionTask.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.storageengine.dataregion.compaction.execute.task;
 
+import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.service.metrics.FileMetrics;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.constant.CompactionTaskType;
@@ -37,7 +38,6 @@ import org.apache.iotdb.db.storageengine.dataregion.tsfile.generator.TsFileNameG
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -218,14 +218,16 @@ public class InsertionCrossSpaceCompactionTask extends AbstractCompactionTask {
   private void prepareTargetFiles() throws IOException {
     File sourceTsFile = unseqFileToInsert.getTsFile();
     File targetTsFile = targetFile.getTsFile();
-    Files.createLink(targetTsFile.toPath(), sourceTsFile.toPath());
-    Files.createLink(
+    FileUtils.createLink(targetTsFile.toPath(), sourceTsFile.toPath(), true);
+    FileUtils.createLink(
         new File(targetTsFile.getPath() + TsFileResource.RESOURCE_SUFFIX).toPath(),
-        new File(sourceTsFile.getPath() + TsFileResource.RESOURCE_SUFFIX).toPath());
+        new File(sourceTsFile.getPath() + TsFileResource.RESOURCE_SUFFIX).toPath(),
+        true);
     if (unseqFileToInsert.getModFile().exists()) {
-      Files.createLink(
+      FileUtils.createLink(
           new File(targetTsFile.getPath() + ModificationFile.FILE_SUFFIX).toPath(),
-          new File(sourceTsFile.getPath() + ModificationFile.FILE_SUFFIX).toPath());
+          new File(sourceTsFile.getPath() + ModificationFile.FILE_SUFFIX).toPath(),
+          true);
     }
     targetFile.setProgressIndex(unseqFileToInsert.getMaxProgressIndex());
     targetFile.deserialize();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/RepairUnsortedFileCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/RepairUnsortedFileCompactionTask.java
@@ -19,8 +19,8 @@
 
 package org.apache.iotdb.db.storageengine.dataregion.compaction.execute.task;
 
-import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
+import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.constant.CompactionTaskType;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.performer.impl.RepairUnsortedFileCompactionPerformer;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.utils.CompactionUtils;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/RepairUnsortedFileCompactionTask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/compaction/execute/task/RepairUnsortedFileCompactionTask.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.storageengine.dataregion.compaction.execute.task;
 
+import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.constant.CompactionTaskType;
 import org.apache.iotdb.db.storageengine.dataregion.compaction.execute.performer.impl.RepairUnsortedFileCompactionPerformer;
@@ -35,7 +36,6 @@ import org.apache.iotdb.db.storageengine.rescon.memory.SystemInfo;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
@@ -169,9 +169,10 @@ public class RepairUnsortedFileCompactionTask extends InnerSpaceCompactionTask {
           filesView.sourceFilesInCompactionPerformer, filesView.targetFilesInPerformer);
     } else {
       if (sourceFile.modFileExists()) {
-        Files.createLink(
+        FileUtils.createLink(
             new File(filesView.targetFilesInPerformer.get(0).getModFile().getFilePath()).toPath(),
-            new File(sourceFile.getModFile().getFilePath()).toPath());
+            new File(sourceFile.getModFile().getFilePath()).toPath(),
+            true);
       }
     }
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/modification/ModificationFile.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/modification/ModificationFile.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.storageengine.dataregion.modification;
 
+import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.db.storageengine.dataregion.modification.io.LocalTextModificationAccessor;
 import org.apache.iotdb.db.storageengine.dataregion.modification.io.ModificationReader;
 import org.apache.iotdb.db.storageengine.dataregion.modification.io.ModificationWriter;
@@ -180,7 +181,7 @@ public class ModificationFile implements AutoCloseable {
       File hardlink = new File(filePath + hardlinkSuffix);
 
       try {
-        Files.createLink(Paths.get(hardlink.getAbsolutePath()), Paths.get(filePath));
+        FileUtils.createLink(Paths.get(hardlink.getAbsolutePath()), Paths.get(filePath), true);
         return new ModificationFile(hardlink.getAbsolutePath());
       } catch (FileAlreadyExistsException e) {
         // retry a different name if the file is already created

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/cross/InsertionCrossSpaceCompactionRecoverTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/cross/InsertionCrossSpaceCompactionRecoverTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iotdb.db.storageengine.dataregion.compaction.cross;
 
-import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.db.exception.MergeException;
@@ -55,6 +54,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -145,11 +145,10 @@ public class InsertionCrossSpaceCompactionRecoverTest extends AbstractCompaction
 
       File sourceTsFile = unseqResource1.getTsFile();
       File targetTsFile = targetFile.getTsFile();
-      FileUtils.createLink(targetTsFile.toPath(), sourceTsFile.toPath(), true);
-      FileUtils.createLink(
+      Files.createLink(targetTsFile.toPath(), sourceTsFile.toPath());
+      Files.createLink(
           new File(targetTsFile.getPath() + TsFileResource.RESOURCE_SUFFIX).toPath(),
-          new File(sourceTsFile.getPath() + TsFileResource.RESOURCE_SUFFIX).toPath(),
-          true);
+          new File(sourceTsFile.getPath() + TsFileResource.RESOURCE_SUFFIX).toPath());
     }
 
     // recover compaction, all source file should exist and target file should be deleted
@@ -232,16 +231,14 @@ public class InsertionCrossSpaceCompactionRecoverTest extends AbstractCompaction
 
       File sourceTsFile = unseqResource1.getTsFile();
       File targetTsFile = targetFile.getTsFile();
-      FileUtils.createLink(targetTsFile.toPath(), sourceTsFile.toPath(), true);
-      FileUtils.createLink(
+      Files.createLink(targetTsFile.toPath(), sourceTsFile.toPath());
+      Files.createLink(
           new File(targetTsFile.getPath() + TsFileResource.RESOURCE_SUFFIX).toPath(),
-          new File(sourceTsFile.getPath() + TsFileResource.RESOURCE_SUFFIX).toPath(),
-          true);
+          new File(sourceTsFile.getPath() + TsFileResource.RESOURCE_SUFFIX).toPath());
       if (unseqResource1.getModFile().exists()) {
-        FileUtils.createLink(
+        Files.createLink(
             new File(targetTsFile.getPath() + ModificationFile.FILE_SUFFIX).toPath(),
-            new File(sourceTsFile.getPath() + ModificationFile.FILE_SUFFIX).toPath(),
-            true);
+            new File(sourceTsFile.getPath() + ModificationFile.FILE_SUFFIX).toPath());
       }
     }
 
@@ -328,16 +325,14 @@ public class InsertionCrossSpaceCompactionRecoverTest extends AbstractCompaction
 
       File sourceTsFile = unseqResource1.getTsFile();
       File targetTsFile = targetFile.getTsFile();
-      FileUtils.createLink(targetTsFile.toPath(), sourceTsFile.toPath(), true);
-      FileUtils.createLink(
+      Files.createLink(targetTsFile.toPath(), sourceTsFile.toPath());
+      Files.createLink(
           new File(targetTsFile.getPath() + TsFileResource.RESOURCE_SUFFIX).toPath(),
-          new File(sourceTsFile.getPath() + TsFileResource.RESOURCE_SUFFIX).toPath(),
-          true);
+          new File(sourceTsFile.getPath() + TsFileResource.RESOURCE_SUFFIX).toPath());
       if (unseqResource1.getModFile().exists()) {
-        FileUtils.createLink(
+        Files.createLink(
             new File(targetTsFile.getPath() + ModificationFile.FILE_SUFFIX).toPath(),
-            new File(sourceTsFile.getPath() + ModificationFile.FILE_SUFFIX).toPath(),
-            true);
+            new File(sourceTsFile.getPath() + ModificationFile.FILE_SUFFIX).toPath());
       }
     }
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/cross/InsertionCrossSpaceCompactionRecoverTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/cross/InsertionCrossSpaceCompactionRecoverTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.db.storageengine.dataregion.compaction.cross;
 
+import org.apache.iotdb.commons.utils.FileUtils;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.db.exception.MergeException;
@@ -54,7 +55,6 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -145,10 +145,11 @@ public class InsertionCrossSpaceCompactionRecoverTest extends AbstractCompaction
 
       File sourceTsFile = unseqResource1.getTsFile();
       File targetTsFile = targetFile.getTsFile();
-      Files.createLink(targetTsFile.toPath(), sourceTsFile.toPath());
-      Files.createLink(
+      FileUtils.createLink(targetTsFile.toPath(), sourceTsFile.toPath(), true);
+      FileUtils.createLink(
           new File(targetTsFile.getPath() + TsFileResource.RESOURCE_SUFFIX).toPath(),
-          new File(sourceTsFile.getPath() + TsFileResource.RESOURCE_SUFFIX).toPath());
+          new File(sourceTsFile.getPath() + TsFileResource.RESOURCE_SUFFIX).toPath(),
+          true);
     }
 
     // recover compaction, all source file should exist and target file should be deleted
@@ -231,14 +232,16 @@ public class InsertionCrossSpaceCompactionRecoverTest extends AbstractCompaction
 
       File sourceTsFile = unseqResource1.getTsFile();
       File targetTsFile = targetFile.getTsFile();
-      Files.createLink(targetTsFile.toPath(), sourceTsFile.toPath());
-      Files.createLink(
+      FileUtils.createLink(targetTsFile.toPath(), sourceTsFile.toPath(), true);
+      FileUtils.createLink(
           new File(targetTsFile.getPath() + TsFileResource.RESOURCE_SUFFIX).toPath(),
-          new File(sourceTsFile.getPath() + TsFileResource.RESOURCE_SUFFIX).toPath());
+          new File(sourceTsFile.getPath() + TsFileResource.RESOURCE_SUFFIX).toPath(),
+          true);
       if (unseqResource1.getModFile().exists()) {
-        Files.createLink(
+        FileUtils.createLink(
             new File(targetTsFile.getPath() + ModificationFile.FILE_SUFFIX).toPath(),
-            new File(sourceTsFile.getPath() + ModificationFile.FILE_SUFFIX).toPath());
+            new File(sourceTsFile.getPath() + ModificationFile.FILE_SUFFIX).toPath(),
+            true);
       }
     }
 
@@ -325,14 +328,16 @@ public class InsertionCrossSpaceCompactionRecoverTest extends AbstractCompaction
 
       File sourceTsFile = unseqResource1.getTsFile();
       File targetTsFile = targetFile.getTsFile();
-      Files.createLink(targetTsFile.toPath(), sourceTsFile.toPath());
-      Files.createLink(
+      FileUtils.createLink(targetTsFile.toPath(), sourceTsFile.toPath(), true);
+      FileUtils.createLink(
           new File(targetTsFile.getPath() + TsFileResource.RESOURCE_SUFFIX).toPath(),
-          new File(sourceTsFile.getPath() + TsFileResource.RESOURCE_SUFFIX).toPath());
+          new File(sourceTsFile.getPath() + TsFileResource.RESOURCE_SUFFIX).toPath(),
+          true);
       if (unseqResource1.getModFile().exists()) {
-        Files.createLink(
+        FileUtils.createLink(
             new File(targetTsFile.getPath() + ModificationFile.FILE_SUFFIX).toPath(),
-            new File(sourceTsFile.getPath() + ModificationFile.FILE_SUFFIX).toPath());
+            new File(sourceTsFile.getPath() + ModificationFile.FILE_SUFFIX).toPath(),
+            true);
       }
     }
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/FileUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/FileUtils.java
@@ -70,6 +70,33 @@ public class FileUtils {
     }
   }
 
+  public static void createLink(Path link, Path existing, boolean fallBackToCopy)
+      throws IOException {
+    try {
+      Files.createLink(link, existing);
+    } catch (IOException e) {
+      if (!fallBackToCopy) {
+        throw e;
+      }
+      try {
+        Files.copy(existing, link);
+      } catch (IOException copyException) {
+        copyException.addSuppressed(e);
+        throw copyException;
+      }
+    } catch (UnsupportedOperationException e) {
+      if (!fallBackToCopy) {
+        throw e;
+      }
+      try {
+        Files.copy(existing, link);
+      } catch (IOException copyException) {
+        copyException.addSuppressed(e);
+        throw copyException;
+      }
+    }
+  }
+
   public static void deleteFileOrDirectory(File file) {
     deleteFileOrDirectory(file, false);
   }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/FileUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/FileUtils.java
@@ -74,17 +74,7 @@ public class FileUtils {
       throws IOException {
     try {
       Files.createLink(link, existing);
-    } catch (IOException e) {
-      if (!fallBackToCopy) {
-        throw e;
-      }
-      try {
-        Files.copy(existing, link);
-      } catch (IOException copyException) {
-        copyException.addSuppressed(e);
-        throw copyException;
-      }
-    } catch (UnsupportedOperationException e) {
+    } catch (IOException | UnsupportedOperationException e) {
       if (!fallBackToCopy) {
         throw e;
       }


### PR DESCRIPTION
## Description

Backport of #18045 to `dev/1.3`.

This PR adds a shared `FileUtils.createLink(..., fallBackToCopy)` helper and uses it in compaction-related file linking paths.

When hard-link creation is unsupported or fails, these paths now fall back to copying the source file instead of failing immediately.

## Changes

- Add a `FileUtils.createLink(Path, Path, boolean)` helper with optional copy fallback.
- Use the helper in compaction target preparation paths.
- Replace remaining compaction hard-link calls with the helper, including recovery tests.

## Verification

- Searched compaction sources/tests for remaining `Files.createLink` / `createHardlink` usage; none remain.
- Compile/build checks were not run per instruction.
