### PR TITLE
Pipe: Remove Ratis data region source restriction

### DIFF
--- a/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/DataNodePipeMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/DataNodePipeMessages.java
@@ -611,8 +611,6 @@ public final class DataNodePipeMessages {
       "The pipe cannot extract table model data when sql dialect is set to tree.";
   public static final String THE_PIPE_CANNOT_EXTRACT_TREE_MODEL_DATA =
       "The pipe cannot extract tree model data when sql dialect is set to table.";
-  public static final String THE_PIPE_CANNOT_TRANSFER_DATA_WHEN_DATA =
-      "The pipe cannot transfer data when data region is using ratis consensus.";
   public static final String THE_REFERENCE_COUNT_OF_THE_EVENT_CANNOT =
       "The reference count of the event {} cannot be increased, skipping it.";
   public static final String THE_REFERENCE_COUNT_OF_THE_REALTIME_EVENT =

--- a/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/DataNodePipeMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/DataNodePipeMessages.java
@@ -584,8 +584,6 @@ public final class DataNodePipeMessages {
       "The pipe cannot extract table model data when sql dialect is set to tree.";
   public static final String THE_PIPE_CANNOT_EXTRACT_TREE_MODEL_DATA =
       "The pipe cannot extract tree model data when sql dialect is set to table.";
-  public static final String THE_PIPE_CANNOT_TRANSFER_DATA_WHEN_DATA =
-      "The pipe cannot transfer data when data region is using ratis consensus.";
   public static final String THE_REFERENCE_COUNT_OF_THE_EVENT_CANNOT =
       "The reference count of the event {} cannot be increased, skipping it.";
   public static final String THE_REFERENCE_COUNT_OF_THE_REALTIME_EVENT =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/source/dataregion/IoTDBDataRegionSource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/source/dataregion/IoTDBDataRegionSource.java
@@ -27,8 +27,6 @@ import org.apache.iotdb.commons.pipe.datastructure.pattern.IoTDBTreePatternOpera
 import org.apache.iotdb.commons.pipe.datastructure.pattern.TreePattern;
 import org.apache.iotdb.commons.pipe.source.IoTDBSource;
 import org.apache.iotdb.commons.queryengine.common.SqlDialect;
-import org.apache.iotdb.consensus.ConsensusFactory;
-import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.i18n.DataNodePipeMessages;
 import org.apache.iotdb.db.pipe.event.common.heartbeat.PipeHeartbeatEvent;
 import org.apache.iotdb.db.pipe.metric.overview.PipeDataNodeSinglePipeMetrics;
@@ -151,14 +149,6 @@ public class IoTDBDataRegionSource extends IoTDBSource {
     }
     hasNoExtractionNeed = false;
     shouldExtractDeletion = insertionDeletionListeningOptionPair.getRight();
-
-    if (insertionDeletionListeningOptionPair.getLeft().equals(true)
-        && IoTDBDescriptor.getInstance()
-            .getConfig()
-            .getDataRegionConsensusProtocolClass()
-            .equals(ConsensusFactory.RATIS_CONSENSUS)) {
-      throw new PipeException(DataNodePipeMessages.THE_PIPE_CANNOT_TRANSFER_DATA_WHEN_DATA);
-    }
 
     // Validate source.pattern.format is within valid range
     validator


### PR DESCRIPTION
## Summary
- Remove the data region source validation that rejects pipe insertion extraction when data regions use Ratis consensus.
- Drop the now-unused i18n message.

## Tests
- mvn spotless:apply -pl iotdb-core/datanode
- mvn compile -pl iotdb-core/datanode (fails: existing generated thrift/antlr/API mismatch, e.g. missing TShowRepairDataPartitionTableProgressResp and parser contexts)