### PR TITLE
Update version to 2.0.11-SNAPSHOT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Apache IoTDB is a time series database for IoT data. It uses a distributed architecture with ConfigNodes (metadata/coordination) and DataNodes (storage/query). Data is stored in TsFile columnar format (separate repo: https://github.com/apache/tsfile). Current version is 2.0.7-SNAPSHOT.
+Apache IoTDB is a time series database for IoT data. It uses a distributed architecture with ConfigNodes (metadata/coordination) and DataNodes (storage/query). Data is stored in TsFile columnar format (separate repo: https://github.com/apache/tsfile). Current version is 2.0.11-SNAPSHOT.
 
 ## Build Commands
 

--- a/code-coverage/pom.xml
+++ b/code-coverage/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-parent</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-code-coverage</artifactId>
     <packaging>pom</packaging>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-parent</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-distribution</artifactId>
     <packaging>pom</packaging>
@@ -36,36 +36,36 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-server</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <type>zip</type>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-cli</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <type>zip</type>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-confignode</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <type>zip</type>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>library-udf</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>mqtt</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>rest</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -251,7 +251,7 @@
                 <dependency>
                     <groupId>org.apache.iotdb</groupId>
                     <artifactId>iotdb-ainode</artifactId>
-                    <version>2.0.7-SNAPSHOT</version>
+                    <version>2.0.11-SNAPSHOT</version>
                 </dependency>
             </dependencies>
             <build>

--- a/docker/ReadMe.md
+++ b/docker/ReadMe.md
@@ -108,7 +108,7 @@ docker run -d \
   -e AIN_CLUSTER_INGRESS_PORT=6667 \
   -e AIN_CLUSTER_INGRESS_USERNAME=root \
   -e AIN_CLUSTER_INGRESS_PASSWORD=root \
-  apache/iotdb:2.0.7-SNAPSHOT-ainode
+  apache/iotdb:2.0.11-SNAPSHOT-ainode
 ```
 
 ## Quick start

--- a/example/jdbc/pom.xml
+++ b/example/jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-examples</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>jdbc-example</artifactId>
     <name>IoTDB: Example: JDBC</name>

--- a/example/mqtt-customize/pom.xml
+++ b/example/mqtt-customize/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-examples</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>customize-mqtt-example</artifactId>
     <name>IoTDB: Example: Customized MQTT</name>

--- a/example/mqtt/pom.xml
+++ b/example/mqtt/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-examples</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>mqtt-example</artifactId>
     <name>IoTDB: Example: MQTT</name>

--- a/example/pipe-count-point-processor/pom.xml
+++ b/example/pipe-count-point-processor/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-examples</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>pipe-count-point-processor-example</artifactId>
     <name>IoTDB: Example: Pipe: Count Point Processor</name>

--- a/example/pipe-opc-ua-sink/pom.xml
+++ b/example/pipe-opc-ua-sink/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-examples</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pipe-opc-ua-sink-example</artifactId>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-parent</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-examples</artifactId>
     <packaging>pom</packaging>

--- a/example/rest-java-example/pom.xml
+++ b/example/rest-java-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-examples</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>rest-java-example</artifactId>
     <name>IoTDB: Example: Java Rest</name>

--- a/example/schema/pom.xml
+++ b/example/schema/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>iotdb-examples</artifactId>
         <groupId>org.apache.iotdb</groupId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>schema-example</artifactId>
     <name>IoTDB: Example: Schema</name>

--- a/example/session/pom.xml
+++ b/example/session/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-examples</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>client-example</artifactId>
     <name>IoTDB: Example: Session Client</name>

--- a/example/subscription/pom.xml
+++ b/example/subscription/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-examples</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>subscription-example</artifactId>
     <name>IoTDB: Example: Subscription Client</name>

--- a/example/trigger/pom.xml
+++ b/example/trigger/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-examples</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>trigger-example</artifactId>
     <name>IoTDB: Example: Trigger</name>

--- a/example/udf/pom.xml
+++ b/example/udf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-examples</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>udf-example</artifactId>
     <name>IoTDB: Example: UDF</name>

--- a/external-service-impl/mqtt/pom.xml
+++ b/external-service-impl/mqtt/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>external-service-impl</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>mqtt</artifactId>
     <name>IoTDB: External-Service-Impl: MQTT</name>
@@ -81,7 +81,7 @@
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-server</artifactId>
             <scope>provided</scope>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -119,13 +119,13 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>node-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -136,7 +136,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/external-service-impl/pom.xml
+++ b/external-service-impl/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-parent</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>external-service-impl</artifactId>
     <name>IoTDB: External-Service-Impl</name>
@@ -44,7 +44,7 @@
             <groupId>org.apache.iotdb</groupId>
             <artifactId>external-service-api</artifactId>
             <scope>provided</scope>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/external-service-impl/rest-openapi/pom.xml
+++ b/external-service-impl/rest-openapi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>external-service-impl</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>rest-openapi</artifactId>
     <name>IoTDB: External-Service-Impl: Rest-OpenAPI</name>

--- a/external-service-impl/rest/pom.xml
+++ b/external-service-impl/rest/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>external-service-impl</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>rest</artifactId>
     <name>IoTDB: External-Service-Impl: Rest</name>
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>rest-openapi</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <exclusions>
                 <!--
                     Keep jakarta.xml.bind-api 3.x for the Swagger/OpenAPI runtime. The
@@ -101,25 +101,25 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>node-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-server</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>calc-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-session</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -145,7 +145,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -163,7 +163,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-parent</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>integration-test</artifactId>
     <name>IoTDB: Integration-Test</name>
@@ -87,57 +87,57 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-server</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-session</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-subscription</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-jdbc</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>trigger-api</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>isession</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-confignode</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>node-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>calc-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tsfile</groupId>
@@ -147,7 +147,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>udf-api</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
@@ -157,7 +157,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-consensus</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -178,17 +178,17 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-confignode</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-cli</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
@@ -213,7 +213,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-server</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
@@ -240,19 +240,19 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>external-service-api</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>mqtt</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <!--We will integrate mqtt-jar-with-dependencies into lib by assembly plugin-->
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>rest</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <!--We will integrate rest-jar-with-dependencies into lib by assembly plugin-->
             <scope>provided</scope>
         </dependency>

--- a/iotdb-api/external-api/pom.xml
+++ b/iotdb-api/external-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-api</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>external-api</artifactId>
     <name>IoTDB: API: External API</name>

--- a/iotdb-api/external-service-api/pom.xml
+++ b/iotdb-api/external-service-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-api</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>external-service-api</artifactId>
     <name>IoTDB: API: External Service API</name>

--- a/iotdb-api/pipe-api/pom.xml
+++ b/iotdb-api/pipe-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-api</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>pipe-api</artifactId>
     <name>IoTDB: API: Pipe API</name>

--- a/iotdb-api/pom.xml
+++ b/iotdb-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-parent</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-api</artifactId>
     <packaging>pom</packaging>

--- a/iotdb-api/trigger-api/pom.xml
+++ b/iotdb-api/trigger-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-api</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>trigger-api</artifactId>
     <name>IoTDB: API: Trigger API</name>

--- a/iotdb-api/udf-api/pom.xml
+++ b/iotdb-api/udf-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-api</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>udf-api</artifactId>
     <name>IoTDB: API: UDF API</name>

--- a/iotdb-client/cli/pom.xml
+++ b/iotdb-client/cli/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-client</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-cli</artifactId>
     <name>IoTDB: Client: CLI</name>
@@ -37,47 +37,47 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-session</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-subscription</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-jdbc</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-antlr</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>node-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-server</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>calc-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>isession</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tsfile</groupId>
@@ -92,17 +92,17 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>pipe-api</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/iotdb-client/client-cpp/README.md
+++ b/iotdb-client/client-cpp/README.md
@@ -49,8 +49,8 @@ run:
 Example:
 
 ```bash
-unzip iotdb-session-cpp-2.0.7-SNAPSHOT-linux-x86_64-glibc2.28.zip
-export IOTDB_SESSION_HOME=$PWD/iotdb-session-cpp-2.0.7-SNAPSHOT-linux-x86_64-glibc2.28
+unzip iotdb-session-cpp-2.0.11-SNAPSHOT-linux-x86_64-glibc2.28.zip
+export IOTDB_SESSION_HOME=$PWD/iotdb-session-cpp-2.0.11-SNAPSHOT-linux-x86_64-glibc2.28
 ```
 
 The unpacked SDK contains public headers, one runtime library, CMake and

--- a/iotdb-client/client-cpp/README_zh.md
+++ b/iotdb-client/client-cpp/README_zh.md
@@ -49,8 +49,8 @@
 示例：
 
 ```bash
-unzip iotdb-session-cpp-2.0.7-SNAPSHOT-linux-x86_64-glibc2.28.zip
-export IOTDB_SESSION_HOME=$PWD/iotdb-session-cpp-2.0.7-SNAPSHOT-linux-x86_64-glibc2.28
+unzip iotdb-session-cpp-2.0.11-SNAPSHOT-linux-x86_64-glibc2.28.zip
+export IOTDB_SESSION_HOME=$PWD/iotdb-session-cpp-2.0.11-SNAPSHOT-linux-x86_64-glibc2.28
 ```
 
 解压后的 SDK 主要包含：

--- a/iotdb-client/client-cpp/pom.xml
+++ b/iotdb-client/client-cpp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-client</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>client-cpp</artifactId>
     <packaging>pom</packaging>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/iotdb-client/client-py/pom.xml
+++ b/iotdb-client/client-py/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-client</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-python-api</artifactId>
     <name>IoTDB: Client: Python-API</name>
@@ -34,19 +34,19 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-confignode</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/iotdb-client/isession/pom.xml
+++ b/iotdb-client/isession/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-client</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>isession</artifactId>
     <name>IoTDB: Client: isession</name>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tsfile</groupId>
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.thrift</groupId>

--- a/iotdb-client/jdbc/pom.xml
+++ b/iotdb-client/jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-client</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-jdbc</artifactId>
     <name>IoTDB: Client: Jdbc</name>
@@ -38,12 +38,12 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tsfile</groupId>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.thrift</groupId>

--- a/iotdb-client/pom.xml
+++ b/iotdb-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-parent</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-client</artifactId>
     <packaging>pom</packaging>

--- a/iotdb-client/service-rpc/pom.xml
+++ b/iotdb-client/service-rpc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-client</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>service-rpc</artifactId>
     <name>IoTDB: Client: Service-RPC</name>
@@ -55,12 +55,12 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.thrift</groupId>

--- a/iotdb-client/session/pom.xml
+++ b/iotdb-client/session/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-client</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-session</artifactId>
     <name>IoTDB: Client: Session</name>
@@ -37,17 +37,17 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>isession</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tsfile</groupId>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/iotdb-client/subscription/pom.xml
+++ b/iotdb-client/subscription/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-client</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-subscription</artifactId>
     <name>IoTDB: Client: Subscription</name>
@@ -32,32 +32,32 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>pipe-api</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>isession</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-session</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tsfile</groupId>

--- a/iotdb-core/ainode/pom.xml
+++ b/iotdb-core/ainode/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-core</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-ainode</artifactId>
     <name>IoTDB: Core: AINode</name>
@@ -33,31 +33,31 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-confignode</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-ainode</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-python-api</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/iotdb-core/antlr/pom.xml
+++ b/iotdb-core/antlr/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-core</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-antlr</artifactId>
     <name>IoTDB: Core: Antlr-Parser</name>

--- a/iotdb-core/calc-commons/pom.xml
+++ b/iotdb-core/calc-commons/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-core</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>calc-commons</artifactId>
     <name>IoTDB: Core: Calc Commons</name>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tsfile</groupId>
@@ -53,27 +53,27 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>node-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>udf-api</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>metrics-interface</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>pipe-api</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.airlift</groupId>

--- a/iotdb-core/confignode/pom.xml
+++ b/iotdb-core/confignode/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-core</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-confignode</artifactId>
     <name>IoTDB: Core: ConfigNode</name>
@@ -43,72 +43,72 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-subscription</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-consensus</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-server</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>calc-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>pipe-api</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>trigger-api</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>metrics-interface</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-confignode</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-ainode</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>node-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>udf-api</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tsfile</groupId>

--- a/iotdb-core/consensus/pom.xml
+++ b/iotdb-core/consensus/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-core</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-consensus</artifactId>
     <name>IoTDB: Core: Consensus</name>
@@ -39,32 +39,32 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>node-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>metrics-interface</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-consensus</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>pipe-api</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.ratis</groupId>

--- a/iotdb-core/datanode/pom.xml
+++ b/iotdb-core/datanode/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-core</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-server</artifactId>
     <name>IoTDB: Core: Data-Node (Server)</name>
@@ -37,17 +37,17 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-subscription</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-consensus</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tsfile</groupId>
@@ -62,87 +62,87 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>external-api</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>node-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>calc-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>isession</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-antlr</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-relational-grammar</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-consensus</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>external-service-api</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>udf-api</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>trigger-api</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>metrics-interface</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-confignode</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-ainode</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>pipe-api</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-session</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.airlift</groupId>
@@ -280,7 +280,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/iotdb-core/metrics/core/pom.xml
+++ b/iotdb-core/metrics/core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-metrics</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>metrics-core</artifactId>
     <name>IoTDB: Core: Metrics: API Impl</name>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>metrics-interface</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>

--- a/iotdb-core/metrics/interface/pom.xml
+++ b/iotdb-core/metrics/interface/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-metrics</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>metrics-interface</artifactId>
     <name>IoTDB: Core: Metrics: Metrics API</name>
@@ -33,17 +33,17 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-session</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>isession</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tsfile</groupId>

--- a/iotdb-core/metrics/pom.xml
+++ b/iotdb-core/metrics/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-core</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-metrics</artifactId>
     <packaging>pom</packaging>

--- a/iotdb-core/node-commons/pom.xml
+++ b/iotdb-core/node-commons/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-core</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>node-commons</artifactId>
     <name>IoTDB: Core: Node Commons</name>
@@ -38,12 +38,12 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>service-rpc</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-subscription</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tsfile</groupId>
@@ -53,52 +53,52 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>external-service-api</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-relational-grammar</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>udf-api</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>trigger-api</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>pipe-api</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-confignode</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-ainode</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-consensus</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tsfile</groupId>
@@ -108,12 +108,12 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>metrics-interface</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>

--- a/iotdb-core/pom.xml
+++ b/iotdb-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-parent</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-core</artifactId>
     <packaging>pom</packaging>

--- a/iotdb-core/relational-grammar/pom.xml
+++ b/iotdb-core/relational-grammar/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-core</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-relational-grammar</artifactId>
     <name>IoTDB: Core: Relational-Antlr-Parser</name>

--- a/iotdb-protocol/pom.xml
+++ b/iotdb-protocol/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-parent</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-protocol</artifactId>
     <packaging>pom</packaging>

--- a/iotdb-protocol/thrift-ainode/pom.xml
+++ b/iotdb-protocol/thrift-ainode/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-protocol</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-thrift-ainode</artifactId>
     <name>IoTDB: Protocol: Thrift AI Node</name>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <build>

--- a/iotdb-protocol/thrift-commons/pom.xml
+++ b/iotdb-protocol/thrift-commons/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-protocol</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-thrift-commons</artifactId>
     <name>IoTDB: Protocol: Thrift Commons</name>

--- a/iotdb-protocol/thrift-confignode/pom.xml
+++ b/iotdb-protocol/thrift-confignode/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-protocol</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-thrift-confignode</artifactId>
     <name>IoTDB: Protocol: Thrift Config Node</name>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <build>

--- a/iotdb-protocol/thrift-consensus/pom.xml
+++ b/iotdb-protocol/thrift-consensus/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-protocol</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-thrift-consensus</artifactId>
     <name>IoTDB: Protocol: Thrift Consensus</name>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/iotdb-protocol/thrift-datanode/pom.xml
+++ b/iotdb-protocol/thrift-datanode/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-protocol</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>iotdb-thrift</artifactId>
     <name>IoTDB: Protocol: Thrift Data Node</name>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>iotdb-thrift-commons</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.thrift</groupId>

--- a/library-udf/pom.xml
+++ b/library-udf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.iotdb</groupId>
         <artifactId>iotdb-parent</artifactId>
-        <version>2.0.7-SNAPSHOT</version>
+        <version>2.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>library-udf</artifactId>
     <name>IoTDB: UDF</name>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.apache.iotdb</groupId>
             <artifactId>udf-api</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     </parent>
     <groupId>org.apache.iotdb</groupId>
     <artifactId>iotdb-parent</artifactId>
-    <version>2.0.7-SNAPSHOT</version>
+    <version>2.0.11-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Apache IoTDB Project Parent POM</name>
     <description>This is the top level project that builds, packages the iotdb engine, client, and integration libs.</description>


### PR DESCRIPTION
## Summary

Update the master branch development version from `2.0.7-SNAPSHOT` to `2.0.11-SNAPSHOT` across Maven project metadata and the current-version documentation examples.

This keeps module parent versions, intra-project dependency versions, integration-test/code-coverage POMs, and current snapshot references aligned with the next development snapshot.

## Validation

- `git diff --check`
- `mvn validate -DskipTests`
- `mvn validate -f code-coverage/pom.xml -DskipTests`
- `mvn validate -f integration-test/pom.xml -P with-integration-tests -DskipTests`