### PR TITLE
Backport client fixes to rc/2.0.10: fix DATE NULL handling crash and add missing numeric getters for Column

### DIFF
--- a/iotdb-client/client-cpp/src/include/Column.h
+++ b/iotdb-client/client-cpp/src/include/Column.h
@@ -196,6 +196,9 @@ public:
   ColumnEncoding getEncoding() const override;
 
   int32_t getInt(int32_t position) const override;
+  int64_t getLong(int32_t position) const override;
+  float getFloat(int32_t position) const override;
+  double getDouble(int32_t position) const override;
   std::vector<int32_t> getInts() const override;
 
   bool mayHaveNull() const override;
@@ -220,6 +223,7 @@ public:
   ColumnEncoding getEncoding() const override;
 
   float getFloat(int32_t position) const override;
+  double getDouble(int32_t position) const override;
   std::vector<float> getFloats() const override;
 
   bool mayHaveNull() const override;
@@ -244,6 +248,7 @@ public:
   ColumnEncoding getEncoding() const override;
 
   int64_t getLong(int32_t position) const override;
+  double getDouble(int32_t position) const override;
   std::vector<int64_t> getLongs() const override;
 
   bool mayHaveNull() const override;

--- a/iotdb-client/client-cpp/src/include/Common.h
+++ b/iotdb-client/client-cpp/src/include/Common.h
@@ -185,7 +185,7 @@ public:
     case TSDataType::BLOB:
       return !stringV.is_initialized();
     case TSDataType::DATE:
-      return !dateV.is_initialized();
+      return !dateV.is_initialized() || dateV.value().is_not_a_date();
     default:
       return true;
     }

--- a/iotdb-client/client-cpp/src/session/Column.cpp
+++ b/iotdb-client/client-cpp/src/session/Column.cpp
@@ -152,6 +152,18 @@ int32_t IntColumn::getInt(int32_t position) const {
   return values_[position + arrayOffset_];
 }
 
+int64_t IntColumn::getLong(int32_t position) const {
+  return values_[position + arrayOffset_];
+}
+
+float IntColumn::getFloat(int32_t position) const {
+  return values_[position + arrayOffset_];
+}
+
+double IntColumn::getDouble(int32_t position) const {
+  return values_[position + arrayOffset_];
+}
+
 std::vector<int32_t> IntColumn::getInts() const {
   return values_;
 }
@@ -204,6 +216,10 @@ float FloatColumn::getFloat(int32_t position) const {
   return values_[position + arrayOffset_];
 }
 
+double FloatColumn::getDouble(int32_t position) const {
+  return values_[position + arrayOffset_];
+}
+
 std::vector<float> FloatColumn::getFloats() const {
   return values_;
 }
@@ -253,6 +269,10 @@ ColumnEncoding LongColumn::getEncoding() const {
 }
 
 int64_t LongColumn::getLong(int32_t position) const {
+  return values_[position + arrayOffset_];
+}
+
+double LongColumn::getDouble(int32_t position) const {
   return values_[position + arrayOffset_];
 }
 

--- a/iotdb-client/client-cpp/src/session/Date.cpp
+++ b/iotdb-client/client-cpp/src/session/Date.cpp
@@ -53,9 +53,6 @@ int32_t parseDateExpressionToInt(const IoTDBDate& date) {
 }
 
 IoTDBDate parseIntToDate(int32_t dateInt) {
-  if (dateInt == EMPTY_DATE_INT) {
-    return IoTDBDate::notADate();
-  }
   const int year = dateInt / 10000;
   const int month = (dateInt % 10000) / 100;
   const int day = dateInt % 100;

--- a/iotdb-client/client-cpp/src/session/SessionC.cpp
+++ b/iotdb-client/client-cpp/src/session/SessionC.cpp
@@ -1487,8 +1487,10 @@ int32_t ts_row_record_get_date_int32(CRowRecord* record, int index) {
   if (index < 0 || index >= (int)record->cpp->fields.size())
     return 0;
   const Field& f = record->cpp->fields[index];
-  if (f.dataType != TSDataType::DATE || !f.dateV.is_initialized())
+  if (f.dataType != TSDataType::DATE || !f.dateV.is_initialized() ||
+      f.dateV.value().is_not_a_date()) {
     return 0;
+  }
   return parseDateExpressionToInt(f.dateV.value());
 }
 

--- a/iotdb-client/client-cpp/test/cpp/sessionCIT.cpp
+++ b/iotdb-client/client-cpp/test/cpp/sessionCIT.cpp
@@ -771,3 +771,33 @@ TEST_CASE("C API - RowRecord and delete data APIs", "[c_rowDelete]") {
   REQUIRE(ts_session_delete_timeseries(g_session, pblob) == TS_OK);
   REQUIRE(ts_session_delete_database(g_session, sg) == TS_OK);
 }
+
+TEST_CASE("C API - Query DATE 1000-01-01", "[c_dateMinYear]") {
+  CaseReporter cr("c_dateMinYear");
+
+  const char* path = "root.ctest.d1.s_date_min";
+  ensureTimeseries(g_session, path, TS_TYPE_DATE, TS_ENCODING_PLAIN, TS_COMPRESSION_SNAPPY);
+
+  const char* deviceId = "root.ctest.d1";
+  const char* measurements[] = {"s_date_min"};
+  TSDataType_C types[] = {TS_TYPE_DATE};
+  TSDate_C dateVal = {1000, 1, 1};
+  const void* vals[] = {&dateVal};
+  REQUIRE(ts_session_insert_record(g_session, deviceId, 1000LL, 1, measurements, types, vals) ==
+          TS_OK);
+
+  CSessionDataSet* dataSet = nullptr;
+  REQUIRE(ts_session_execute_query(g_session,
+                                   "select s_date_min from root.ctest.d1 where time=1000",
+                                   &dataSet) == TS_OK);
+  REQUIRE(dataSet != nullptr);
+  REQUIRE(ts_dataset_has_next(dataSet));
+  CRowRecord* record = ts_dataset_next(dataSet);
+  REQUIRE(record != nullptr);
+  REQUIRE_FALSE(ts_row_record_is_null(record, 0));
+  REQUIRE(ts_row_record_get_date_int32(record, 0) == 10000101);
+  ts_row_record_destroy(record);
+  ts_dataset_destroy(dataSet);
+
+  REQUIRE(ts_session_delete_timeseries(g_session, path) == TS_OK);
+}

--- a/iotdb-client/client-cpp/test/cpp/sessionIT.cpp
+++ b/iotdb-client/client-cpp/test/cpp/sessionIT.cpp
@@ -1037,3 +1037,31 @@ TEST_CASE("SessionPool getSession times out when exhausted", "[sessionPool]") {
   reused.release();
   pool->close();
 }
+
+TEST_CASE("Query DATE 1000-01-01", "[dateMinYear]") {
+  CaseReporter cr("dateMinYear");
+  const string timeseries = "root.test.d1.s_date_min";
+  if (session->checkTimeseriesExists(timeseries)) {
+    session->deleteTimeseries(timeseries);
+  }
+  session->createTimeseries(timeseries, TSDataType::DATE, TSEncoding::PLAIN,
+                            CompressionType::SNAPPY);
+
+  const string deviceId = "root.test.d1";
+  const vector<string> measurements = {"s_date_min"};
+  const vector<TSDataType::TSDataType> types = {TSDataType::DATE};
+  const IoTDBDate dateValue(1000, 1, 1);
+  vector<char*> values = {const_cast<char*>(reinterpret_cast<const char*>(&dateValue))};
+  session->insertRecord(deviceId, 1000LL, measurements, types, values);
+
+  unique_ptr<SessionDataSet> sessionDataSet =
+      session->executeQueryStatement("select s_date_min from root.test.d1 where time=1000");
+  REQUIRE(sessionDataSet->hasNext());
+  auto record = sessionDataSet->next();
+  REQUIRE(record->fields.size() == 1);
+  REQUIRE_FALSE(record->fields[0].isNull());
+  REQUIRE(record->fields[0].dateV.value() == dateValue);
+  REQUIRE(record->fields[0].dateV.value().toIsoExtendedString() == "1000-01-01");
+
+  session->deleteTimeseries(timeseries);
+}


### PR DESCRIPTION
## Description

Backport two C++ client fixes to `rc/2.0.10`: stop treating `EMPTY_DATE_INT` (10000101) as NULL when decoding query results so `1000-01-01` no longer crashes the C API, and add missing numeric widening getters on `Column` classes that the `[column]` IT already expected.

### Content1 ...

Fix DATE query crash: remove the `EMPTY_DATE_INT` sentinel check in `parseIntToDate`; NULL DATE is determined by the TsBlock null bitmap only. Harden `Field::isNull()` and `ts_row_record_get_date_int32()` for invalid dates.

### Content2 ...

Cherry-pick `a2368b2` (#17759): implement `getDouble()` / cross-type getters on `IntColumn`, `FloatColumn`, and `LongColumn` to align with Java TsFile and fix `Unsupported operation: getDouble` in `[column]` IT (and CALL INFERENCE FLOAT-as-DOUBLE reads).

### Content3 ...

Add IT coverage for querying `1000-01-01` via C++ Session and C API (`[dateMinYear]` / `[c_dateMinYear]`).

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [x] added integration tests.
- [x] been tested in a test IoTDB cluster.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- `iotdb-client/client-cpp/src/session/Date.cpp`
- `iotdb-client/client-cpp/src/include/Common.h`
- `iotdb-client/client-cpp/src/session/SessionC.cpp`
- `iotdb-client/client-cpp/src/session/Column.cpp`
- `iotdb-client/client-cpp/src/include/Column.h`
- `iotdb-client/client-cpp/test/cpp/sessionIT.cpp`
- `iotdb-client/client-cpp/test/cpp/sessionCIT.cpp`