### PR TITLE
Fix C++ client DATE 1000-01-01 query crash

### DIFF
--- a/iotdb-client/client-cpp/src/include/Common.h
+++ b/iotdb-client/client-cpp/src/include/Common.h
@@ -185,7 +185,7 @@ public:
     case TSDataType::BLOB:
       return !stringV.is_initialized();
     case TSDataType::DATE:
-      return !dateV.is_initialized();
+      return !dateV.is_initialized() || dateV.value().is_not_a_date();
     default:
       return true;
     }

--- a/iotdb-client/client-cpp/src/session/Date.cpp
+++ b/iotdb-client/client-cpp/src/session/Date.cpp
@@ -53,9 +53,6 @@ int32_t parseDateExpressionToInt(const IoTDBDate& date) {
 }
 
 IoTDBDate parseIntToDate(int32_t dateInt) {
-  if (dateInt == EMPTY_DATE_INT) {
-    return IoTDBDate::notADate();
-  }
   const int year = dateInt / 10000;
   const int month = (dateInt % 10000) / 100;
   const int day = dateInt % 100;

--- a/iotdb-client/client-cpp/src/session/SessionC.cpp
+++ b/iotdb-client/client-cpp/src/session/SessionC.cpp
@@ -1495,8 +1495,10 @@ int32_t ts_row_record_get_date_int32(CRowRecord* record, int index) {
   if (index < 0 || index >= (int)record->cpp->fields.size())
     return 0;
   const Field& f = record->cpp->fields[index];
-  if (f.dataType != TSDataType::DATE || !f.dateV.is_initialized())
+  if (f.dataType != TSDataType::DATE || !f.dateV.is_initialized() ||
+      f.dateV.value().is_not_a_date()) {
     return 0;
+  }
   return parseDateExpressionToInt(f.dateV.value());
 }
 

--- a/iotdb-client/client-cpp/test/cpp/sessionCIT.cpp
+++ b/iotdb-client/client-cpp/test/cpp/sessionCIT.cpp
@@ -792,3 +792,33 @@ TEST_CASE("C API - RowRecord and delete data APIs", "[c_rowDelete]") {
   REQUIRE(ts_session_delete_timeseries(g_session, pblob) == TS_OK);
   REQUIRE(ts_session_delete_database(g_session, sg) == TS_OK);
 }
+
+TEST_CASE("C API - Query DATE 1000-01-01", "[c_dateMinYear]") {
+  CaseReporter cr("c_dateMinYear");
+
+  const char* path = "root.ctest.d1.s_date_min";
+  ensureTimeseries(g_session, path, TS_TYPE_DATE, TS_ENCODING_PLAIN, TS_COMPRESSION_SNAPPY);
+
+  const char* deviceId = "root.ctest.d1";
+  const char* measurements[] = {"s_date_min"};
+  TSDataType_C types[] = {TS_TYPE_DATE};
+  TSDate_C dateVal = {1000, 1, 1};
+  const void* vals[] = {&dateVal};
+  REQUIRE(ts_session_insert_record(g_session, deviceId, 1000LL, 1, measurements, types, vals) ==
+          TS_OK);
+
+  CSessionDataSet* dataSet = nullptr;
+  REQUIRE(ts_session_execute_query(g_session,
+                                   "select s_date_min from root.ctest.d1 where time=1000",
+                                   &dataSet) == TS_OK);
+  REQUIRE(dataSet != nullptr);
+  REQUIRE(ts_dataset_has_next(dataSet));
+  CRowRecord* record = ts_dataset_next(dataSet);
+  REQUIRE(record != nullptr);
+  REQUIRE_FALSE(ts_row_record_is_null(record, 0));
+  REQUIRE(ts_row_record_get_date_int32(record, 0) == 10000101);
+  ts_row_record_destroy(record);
+  ts_dataset_destroy(dataSet);
+
+  REQUIRE(ts_session_delete_timeseries(g_session, path) == TS_OK);
+}

--- a/iotdb-client/client-cpp/test/cpp/sessionIT.cpp
+++ b/iotdb-client/client-cpp/test/cpp/sessionIT.cpp
@@ -1062,3 +1062,31 @@ TEST_CASE("SessionPool getSession times out when exhausted", "[sessionPool]") {
   reused.release();
   pool->close();
 }
+
+TEST_CASE("Query DATE 1000-01-01", "[dateMinYear]") {
+  CaseReporter cr("dateMinYear");
+  const string timeseries = "root.test.d1.s_date_min";
+  if (session->checkTimeseriesExists(timeseries)) {
+    session->deleteTimeseries(timeseries);
+  }
+  session->createTimeseries(timeseries, TSDataType::DATE, TSEncoding::PLAIN,
+                            CompressionType::SNAPPY);
+
+  const string deviceId = "root.test.d1";
+  const vector<string> measurements = {"s_date_min"};
+  const vector<TSDataType::TSDataType> types = {TSDataType::DATE};
+  const IoTDBDate dateValue(1000, 1, 1);
+  vector<char*> values = {const_cast<char*>(reinterpret_cast<const char*>(&dateValue))};
+  session->insertRecord(deviceId, 1000LL, measurements, types, values);
+
+  unique_ptr<SessionDataSet> sessionDataSet =
+      session->executeQueryStatement("select s_date_min from root.test.d1 where time=1000");
+  REQUIRE(sessionDataSet->hasNext());
+  auto record = sessionDataSet->next();
+  REQUIRE(record->fields.size() == 1);
+  REQUIRE_FALSE(record->fields[0].isNull());
+  REQUIRE(record->fields[0].dateV.value() == dateValue);
+  REQUIRE(record->fields[0].dateV.value().toIsoExtendedString() == "1000-01-01");
+
+  session->deleteTimeseries(timeseries);
+}


### PR DESCRIPTION


## Description

Fix C++ client crash when querying DATE `1000-01-01`: `EMPTY_DATE_INT` (10000101) was wrongly treated as NULL during decode, but it is also the valid encoding for `1000-01-01`, causing C API `parseDateExpressionToInt` to throw.

<hr>

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods.
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for code coverage.
- [x] added integration tests.
- [x] been tested in a test IoTDB cluster.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- `iotdb-client/client-cpp/src/session/Date.cpp`
- `iotdb-client/client-cpp/src/include/Common.h`
- `iotdb-client/client-cpp/src/session/SessionC.cpp`
- `iotdb-client/client-cpp/test/cpp/sessionIT.cpp`
- `iotdb-client/client-cpp/test/cpp/sessionCIT.cpp`

---

**Test plan**

- [x] `session_tests.exe "[dateMinYear]"` passed
- [x] `session_c_tests.exe "[c_dateMinYear]"` passed
- [x] Full `session_tests` and `session_c_tests` passed against local IoTDB