### PR TITLE
Fix pipe write reject retry handling

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataRegionStateMachine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataRegionStateMachine.java
@@ -248,7 +248,8 @@ public class DataRegionStateMachine extends BaseStateMachine {
     int retryTime = 0;
     while (retryTime < MAX_WRITE_RETRY_TIMES) {
       result = planNode.accept(new DataExecutionVisitor(), region);
-      if (needRetry(result.getCode())) {
+      // Let pipe retry with the original event instead of retrying a possibly mutated node here.
+      if (needRetry(result.getCode()) && !planNode.isGeneratedByPipe()) {
         retryTime++;
         logger.debug(
             "write operation failed because {}, retryTime: {}.", result.getCode(), retryTime);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataRegionStateMachineTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/consensus/statemachine/dataregion/DataRegionStateMachineTest.java
@@ -19,18 +19,26 @@
 
 package org.apache.iotdb.db.consensus.statemachine.dataregion;
 
+import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.queryengine.plan.planner.plan.node.IPlanVisitor;
+import org.apache.iotdb.commons.queryengine.plan.planner.plan.node.PlanNode;
 import org.apache.iotdb.commons.queryengine.plan.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertRowNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertRowsNode;
+import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.apache.tsfile.enums.TSDataType;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class DataRegionStateMachineTest {
@@ -118,5 +126,90 @@ public class DataRegionStateMachineTest {
     list.add(insertRowsNode);
     InsertNode mergedNode = list.get(0).mergeInsertNode(list);
     Assert.assertTrue(mergedNode instanceof InsertRowsNode);
+  }
+
+  @Test
+  public void testPipeGeneratedWriteProcessRejectSkipsStateMachineRetry() {
+    final DataRegionStateMachine stateMachine = new DataRegionStateMachine(null);
+    final RetryControlledPlanNode planNode = new RetryControlledPlanNode(true);
+
+    final TSStatus status = stateMachine.write(planNode);
+
+    Assert.assertEquals(TSStatusCode.WRITE_PROCESS_REJECT.getStatusCode(), status.getCode());
+    Assert.assertEquals(1, planNode.getAcceptCount());
+  }
+
+  @Test
+  public void testNonPipeWriteProcessRejectCanStillRetry() {
+    final DataRegionStateMachine stateMachine = new DataRegionStateMachine(null);
+    final RetryControlledPlanNode planNode = new RetryControlledPlanNode(false);
+
+    final TSStatus status = stateMachine.write(planNode);
+
+    Assert.assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), status.getCode());
+    Assert.assertEquals(2, planNode.getAcceptCount());
+  }
+
+  private static class RetryControlledPlanNode extends PlanNode {
+
+    private final boolean markAsPipeOnFirstAccept;
+    private int acceptCount = 0;
+
+    private RetryControlledPlanNode(final boolean markAsPipeOnFirstAccept) {
+      super(new PlanNodeId("test"));
+      this.markAsPipeOnFirstAccept = markAsPipeOnFirstAccept;
+    }
+
+    private int getAcceptCount() {
+      return acceptCount;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <R, C> R accept(final IPlanVisitor<R, C> visitor, final C context) {
+      ++acceptCount;
+      if (markAsPipeOnFirstAccept) {
+        markAsGeneratedByPipe();
+      }
+      return (R)
+          new TSStatus(
+              (acceptCount == 1 ? TSStatusCode.WRITE_PROCESS_REJECT : TSStatusCode.SUCCESS_STATUS)
+                  .getStatusCode());
+    }
+
+    @Override
+    public List<PlanNode> getChildren() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public void addChild(final PlanNode child) {
+      // No children.
+    }
+
+    @Override
+    public PlanNode clone() {
+      return new RetryControlledPlanNode(markAsPipeOnFirstAccept);
+    }
+
+    @Override
+    public int allowedChildCount() {
+      return NO_CHILD_ALLOWED;
+    }
+
+    @Override
+    public List<String> getOutputColumnNames() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    protected void serializeAttributes(final ByteBuffer byteBuffer) {
+      // This test node is never serialized.
+    }
+
+    @Override
+    protected void serializeAttributes(final DataOutputStream stream) throws IOException {
+      // This test node is never serialized.
+    }
   }
 }


### PR DESCRIPTION
## Description
- Skip the data region state machine internal WRITE_PROCESS_REJECT retry for pipe-generated plan nodes.
- Pipe writes should surface WRITE_PROCESS_REJECT to the sink so the sink retries the original event, instead of retrying a possibly mutated plan node inside the state machine and then acknowledging the event as successful.

## Why This Is Pipe-Only
- Normal client/consensus writes can also encounter WRITE_PROCESS_REJECT after part of a batch has reached storage, so the low-level partial-execution concern is not pipe-exclusive.
- However, the state machine retry for non-pipe writes was added to preserve normal/replication consensus write retry semantics, including the IOTDB-5706 consistency fix. Removing it globally would change existing write behavior and may reintroduce consistency or availability regressions.
- This PR intentionally keeps non-pipe retry behavior unchanged and only changes pipe writes, where the original event is still available and event-level retry is the correct retry boundary.
- A broader fix for all writes would need storage/write-path state to distinguish a pre-apply reject from a reject after partial application before deciding whether state-machine-level retry is safe.

## Tests
- mvn spotless:apply -pl iotdb-core/datanode
- mvn -nsu -pl iotdb-core/datanode -Dtest=DataRegionStateMachineTest -DfailIfNoTests=false test (blocked before tests: missing local/remote 2.0.11-SNAPSHOT module artifacts such as service-rpc, iotdb-consensus, node-commons, metrics-core)