### PR TITLE
Fix false disk-full read-only during concurrent snapshot directory de…

### DIFF
--- a/iotdb-core/node-commons/src/main/i18n/en/org/apache/iotdb/commons/i18n/UtilMessages.java
+++ b/iotdb-core/node-commons/src/main/i18n/en/org/apache/iotdb/commons/i18n/UtilMessages.java
@@ -112,6 +112,8 @@ public final class UtilMessages {
 
   public static final String ALL_FOLDERS_FULL_CHANGE_TO_READ_ONLY =
       "All folders are full, change system mode to read-only.";
+  public static final String CANNOT_SELECT_FOLDER_BUT_DISK_HAS_SPACE =
+      "Cannot select folder but disk still has available space, will not change to read-only.";
   public static final String FAILED_TO_PROCESS_FOLDER = "Failed to process folder {}";
   public static final String FAILED_TO_READ_FILE_STORE_PATH =
       "Failed to read file store path '{}'";

--- a/iotdb-core/node-commons/src/main/i18n/zh/org/apache/iotdb/commons/i18n/UtilMessages.java
+++ b/iotdb-core/node-commons/src/main/i18n/zh/org/apache/iotdb/commons/i18n/UtilMessages.java
@@ -110,6 +110,8 @@ public final class UtilMessages {
 
   public static final String ALL_FOLDERS_FULL_CHANGE_TO_READ_ONLY =
       "所有文件夹空间均已耗尽，系统切换为只读模式。";
+  public static final String CANNOT_SELECT_FOLDER_BUT_DISK_HAS_SPACE =
+      "无法选择文件夹但磁盘仍有可用空间，不切换为只读模式。";
   public static final String FAILED_TO_PROCESS_FOLDER = "处理文件夹 {} 失败";
   public static final String FAILED_TO_READ_FILE_STORE_PATH =
       "读取文件存储路径 '{}' 失败";

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/disk/FolderManager.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/disk/FolderManager.java
@@ -88,9 +88,7 @@ public class FolderManager {
       this.selectStrategy.setFolders(folders);
       this.selectStrategy.setFoldersStates(foldersStates);
     } catch (DiskSpaceInsufficientException e) {
-      logger.error(UtilMessages.ALL_FOLDERS_FULL_CHANGE_TO_READ_ONLY, e);
-      CommonDescriptor.getInstance().getConfig().setNodeStatus(NodeStatus.ReadOnly);
-      CommonDescriptor.getInstance().getConfig().setStatusReason(NodeStatus.DISK_FULL);
+      changeToReadOnlyIfDiskFull(e);
       throw e;
     }
   }
@@ -104,9 +102,7 @@ public class FolderManager {
     try {
       return folders.get(selectStrategy.nextFolderIndex());
     } catch (DiskSpaceInsufficientException e) {
-      logger.error(UtilMessages.ALL_FOLDERS_FULL_CHANGE_TO_READ_ONLY, e);
-      CommonDescriptor.getInstance().getConfig().setNodeStatus(NodeStatus.ReadOnly);
-      CommonDescriptor.getInstance().getConfig().setStatusReason(NodeStatus.DISK_FULL);
+      changeToReadOnlyIfDiskFull(e);
       throw e;
     }
   }
@@ -116,6 +112,24 @@ public class FolderManager {
         .anyMatch(
             folder ->
                 foldersStates.getOrDefault(folder, FolderState.ABNORMAL) == FolderState.HEALTHY);
+  }
+
+  private boolean hasFolderWithAvailableDiskSpace() {
+    return folders.stream()
+        .anyMatch(
+            folder ->
+                foldersStates.getOrDefault(folder, FolderState.ABNORMAL) == FolderState.HEALTHY
+                    && JVMCommonUtils.hasSpace(folder));
+  }
+
+  private void changeToReadOnlyIfDiskFull(DiskSpaceInsufficientException e) {
+    if (!hasFolderWithAvailableDiskSpace()) {
+      logger.error(UtilMessages.ALL_FOLDERS_FULL_CHANGE_TO_READ_ONLY, e);
+      CommonDescriptor.getInstance().getConfig().setNodeStatus(NodeStatus.ReadOnly);
+      CommonDescriptor.getInstance().getConfig().setStatusReason(NodeStatus.DISK_FULL);
+    } else {
+      logger.warn(UtilMessages.CANNOT_SELECT_FOLDER_BUT_DISK_HAS_SPACE, e);
+    }
   }
 
   @FunctionalInterface
@@ -135,9 +149,7 @@ public class FolderManager {
       try {
         folder = folders.get(selectStrategy.nextFolderIndex());
       } catch (DiskSpaceInsufficientException e) {
-        logger.error(UtilMessages.ALL_FOLDERS_FULL_CHANGE_TO_READ_ONLY, e);
-        CommonDescriptor.getInstance().getConfig().setNodeStatus(NodeStatus.ReadOnly);
-        CommonDescriptor.getInstance().getConfig().setStatusReason(NodeStatus.DISK_FULL);
+        changeToReadOnlyIfDiskFull(e);
         throw e;
       }
       try {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/disk/strategy/MinFolderOccupiedSpaceFirstStrategy.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/disk/strategy/MinFolderOccupiedSpaceFirstStrategy.java
@@ -120,8 +120,7 @@ public class MinFolderOccupiedSpaceFirstStrategy extends DirectoryStrategy {
       try {
         cachedOccupiedSpace[i] = JVMCommonUtils.getOccupiedSpace(folder);
       } catch (IOException | UncheckedIOException e) {
-        LOGGER.error(UtilMessages.CANNOT_CALCULATE_OCCUPIED_SPACE, folder, e);
-        cachedOccupiedSpace[i] = Long.MAX_VALUE;
+        LOGGER.warn(UtilMessages.CANNOT_CALCULATE_OCCUPIED_SPACE, folder, e);
       }
     }
     selectionsSinceRefresh = 0;

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/JVMCommonUtils.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/utils/JVMCommonUtils.java
@@ -28,10 +28,12 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.stream.Stream;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 
 public class JVMCommonUtils {
 
@@ -110,15 +112,23 @@ public class JVMCommonUtils {
     if (!Files.exists(folder)) {
       return 0;
     }
-    try (Stream<Path> s = Files.walk(folder)) {
-      return s.filter(p -> p.toFile().isFile())
-          .mapToLong(
-              p -> {
-                File file = p.toFile();
-                return file.exists() ? file.length() : 0L;
-              })
-          .sum();
-    }
+    final long[] occupiedSpace = {0L};
+    Files.walkFileTree(
+        folder,
+        new SimpleFileVisitor<Path>() {
+          @Override
+          public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+            occupiedSpace[0] += attrs.size();
+            return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public FileVisitResult visitFileFailed(Path file, IOException exc) {
+            // A file or directory may be deleted concurrently during traversal; ignore it.
+            return FileVisitResult.CONTINUE;
+          }
+        });
+    return occupiedSpace[0];
   }
 
   public static int getCpuCores() {

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/disk/MinFolderOccupiedSpaceFirstStrategyRealFsTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/disk/MinFolderOccupiedSpaceFirstStrategyRealFsTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iotdb.commons.disk;
 
+import org.apache.iotdb.commons.cluster.NodeStatus;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.disk.strategy.DirectoryStrategyType;
 import org.apache.iotdb.commons.disk.strategy.MinFolderOccupiedSpaceFirstStrategy;
@@ -34,8 +35,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
@@ -123,5 +126,63 @@ public class MinFolderOccupiedSpaceFirstStrategyRealFsTest {
     // The threshold is now reached: the next selection refreshes the cache via a real walk
     // and correctly avoids the now-largest folder 0, picking the least occupied folder 1.
     assertEquals(1, strategy.nextFolderIndex());
+  }
+
+  @Test
+  public void getNextFolderDoesNotEnterReadOnlyWhenDiskHasSpace() throws Exception {
+    Path snapshotRoot = Files.createTempDirectory("snapshot-root-");
+    tempDirs.add(snapshotRoot);
+    Path subDir = snapshotRoot.resolve("tod_sod0-71");
+    Files.createDirectories(subDir);
+    writeFileInPath(subDir, "a.bin", 1024);
+
+    List<String> singleFolder = Collections.singletonList(snapshotRoot.toFile().getAbsolutePath());
+    CommonDescriptor.getInstance().getConfig().setNodeStatus(NodeStatus.Running);
+
+    AtomicBoolean stop = new AtomicBoolean(false);
+    Thread deleter =
+        new Thread(
+            () -> {
+              while (!stop.get()) {
+                try {
+                  deleteRecursively(subDir);
+                  Files.createDirectories(subDir);
+                  writeFileInPath(subDir, "temp.bin", 512);
+                  Thread.sleep(1);
+                } catch (Exception ignored) {
+                  // Concurrent create/delete is expected in this test.
+                }
+              }
+            });
+    deleter.start();
+
+    try {
+      FolderManager folderManager =
+          new FolderManager(
+              singleFolder, DirectoryStrategyType.MIN_FOLDER_OCCUPIED_SPACE_FIRST_STRATEGY);
+      for (int i = 0; i < 100; i++) {
+        assertEquals(
+            NodeStatus.Running, CommonDescriptor.getInstance().getConfig().getNodeStatus());
+        assertEquals(singleFolder.get(0), folderManager.getNextFolder());
+      }
+    } finally {
+      stop.set(true);
+      deleter.join(5000);
+    }
+  }
+
+  private void writeFileInPath(Path folder, String name, int sizeBytes) throws IOException {
+    byte[] payload = new byte[sizeBytes];
+    Arrays.fill(payload, (byte) 1);
+    Files.write(folder.resolve(name), payload);
+  }
+
+  private static void deleteRecursively(Path path) throws IOException {
+    if (!Files.exists(path)) {
+      return;
+    }
+    try (Stream<Path> walk = Files.walk(path)) {
+      walk.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+    }
   }
 }

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/utils/JVMCommonUtilsTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/utils/JVMCommonUtilsTest.java
@@ -28,6 +28,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
 
 public class JVMCommonUtilsTest {
 
@@ -65,5 +69,49 @@ public class JVMCommonUtilsTest {
     Files.write(new File(dir, "b.txt").toPath(), payload);
     Assert.assertEquals(
         2L * payload.length, JVMCommonUtils.getOccupiedSpace(dir.getAbsolutePath()));
+  }
+
+  @Test
+  public void getOccupiedSpaceIgnoresConcurrentlyDeletedEntries() throws Exception {
+    File snapshotRoot = tempFolder.newFolder("snapshot");
+    File subDir = new File(snapshotRoot, "tod_sod0-71");
+    Assert.assertTrue(subDir.mkdirs());
+    byte[] payload = "snapshot-data".getBytes(StandardCharsets.UTF_8);
+    Files.write(new File(subDir, "a.bin").toPath(), payload);
+    Files.write(new File(snapshotRoot, "other.bin").toPath(), payload);
+
+    AtomicBoolean stop = new AtomicBoolean(false);
+    Thread deleter =
+        new Thread(
+            () -> {
+              while (!stop.get()) {
+                try {
+                  deleteRecursively(subDir.toPath());
+                  Files.createDirectories(subDir.toPath());
+                  Files.write(new File(subDir, "temp.bin").toPath(), payload);
+                } catch (IOException ignored) {
+                  // Concurrent create/delete is expected in this test.
+                }
+              }
+            });
+    deleter.start();
+
+    try {
+      for (int i = 0; i < 200; i++) {
+        JVMCommonUtils.getOccupiedSpace(snapshotRoot.getAbsolutePath());
+      }
+    } finally {
+      stop.set(true);
+      deleter.join(5000);
+    }
+  }
+
+  private static void deleteRecursively(Path path) throws IOException {
+    if (!Files.exists(path)) {
+      return;
+    }
+    try (Stream<Path> walk = Files.walk(path)) {
+      walk.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+    }
   }
 }


### PR DESCRIPTION
## Description

### Problem

During datanode removal, multiple DataRegions may concurrently migrate snapshots to the same target node. All snapshot staging directories share one root (`data/datanode/data/snapshot/`). While one region is receiving snapshots, `getNextFolder()` walks this shared root to compute occupied space; if another region deletes its staging subdirectory at the same time, `Files.walk` throws `NoSuchFileException`. This was misinterpreted as "folder full" → node switched to read-only (`DISK_FULL`) → snapshot transmission failed → region migration / datanode removal blocked.

### Fix

1. **`JVMCommonUtils.getOccupiedSpace`**: Replace `Files.walk` with `walkFileTree`; return `CONTINUE` in `visitFileFailed` to ignore entries deleted during traversal.
2. **`MinFolderOccupiedSpaceFirstStrategy`**: On refresh failure, keep the previous cached occupied space instead of setting `Long.MAX_VALUE`.
3. **`FolderManager`**: Only switch to read-only when no healthy folder has available disk space (`hasSpace()`), not merely when folder selection fails.

### Tests

- `JVMCommonUtilsTest.getOccupiedSpaceIgnoresConcurrentlyDeletedEntries`
- `MinFolderOccupiedSpaceFirstStrategyRealFsTest.getNextFolderDoesNotEnterReadOnlyWhenDiskHasSpace`

<hr>

This PR has:
- [x] been self-reviewed.
    - [x] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods.
- [ ] added or updated version, __license__, or notice information
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- `org.apache.iotdb.commons.utils.JVMCommonUtils`
- `org.apache.iotdb.commons.disk.strategy.MinFolderOccupiedSpaceFirstStrategy`
- `org.apache.iotdb.commons.disk.FolderManager`
- `org.apache.iotdb.commons.i18n.UtilMessages`