### PR TITLE
Avoid parsing fully matched historical table TsFiles

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/source/dataregion/historical/PipeHistoricalDataRegionTsFileAndDeletionSource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/source/dataregion/historical/PipeHistoricalDataRegionTsFileAndDeletionSource.java
@@ -1020,7 +1020,10 @@ public class PipeHistoricalDataRegionTsFileAndDeletionSource
             event);
       }
 
-      if (sloppyPattern || isDbNameCoveredByPattern) {
+      if (sloppyPattern
+          || isDbNameCoveredByPattern
+          || isTsFileResourceCoveredByTablePattern(
+              resource, filteredTsFileResources2TableNames.get(resource))) {
         event.skipParsingPattern();
       }
       if (sloppyTimeRange || isTsFileResourceCoveredByTimeRange(resource)) {
@@ -1065,6 +1068,21 @@ public class PipeHistoricalDataRegionTsFileAndDeletionSource
         && DataRegionConsensusImpl.getInstance() instanceof IoTConsensusV2
         && PipeTsFileEpochProgressIndexKeeper.getInstance()
             .containsTsFile(dataRegionId, tsFileDedupScopeID, resource.getTsFilePath());
+  }
+
+  private boolean isTsFileResourceCoveredByTablePattern(
+      final TsFileResource resource, final Set<String> tableNames) {
+    return isModelDetected
+        && isTableModel
+        && tablePattern.isTableModelDataAllowedToBeCaptured()
+        && Objects.nonNull(resource)
+        && Objects.nonNull(tableNames)
+        && !tableNames.isEmpty()
+        && tableNames.stream()
+            .allMatch(
+                tableName ->
+                    tablePattern.matchesDatabase(resource.getDatabaseName())
+                        && tablePattern.matchesTable(tableName));
   }
 
   private Event supplyDeletionEvent(final DeletionResource deletionResource) {


### PR DESCRIPTION
﻿## Description

Avoid parsing historical table TsFiles for pattern filtering when all table names in the TsFile resource are already fully covered by the table pattern.

## Verification

- mvn spotless:apply -pl iotdb-core/datanode
- mvn test -pl iotdb-core/datanode -am "-Dtest=PipeHistoricalDataRegionTsFileAndDeletionSourceTest" "-DfailIfNoTests=false" "-Dsurefire.failIfNoSpecifiedTests=false" "-Dcheckstyle.skip=true"
