### PR TITLE
Persist writer meta out of lock

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -330,7 +330,9 @@ public class IoTConsensusServerImpl {
           }
           searchIndex.incrementAndGet();
         }
-        updateWriterMetaOnSuccess(indexedConsensusRequest);
+        latestWriterMeta =
+            new WriterMeta(
+                indexedConsensusRequest.getLocalSeq(), indexedConsensusRequest.getPhysicalTime());
         // statistic the time of offering request into queue
         ioTConsensusServerMetrics.recordOfferRequestToQueueTime(
             System.nanoTime() - writeToStateMachineEndTime);
@@ -349,6 +351,7 @@ public class IoTConsensusServerImpl {
       return result;
     } finally {
       stateMachineLock.unlock();
+      persistLatestWriterMeta(false);
     }
   }
 
@@ -1041,9 +1044,7 @@ public class IoTConsensusServerImpl {
   }
 
   private void updateWriterMetaOnSuccess(final IndexedConsensusRequest indexedConsensusRequest) {
-    latestWriterMeta =
-        new WriterMeta(
-            indexedConsensusRequest.getLocalSeq(), indexedConsensusRequest.getPhysicalTime());
+
     persistLatestWriterMeta(false);
   }
 
@@ -1062,8 +1063,8 @@ public class IoTConsensusServerImpl {
     synchronized (writerMetaPersistLock) {
       final WriterMeta latestMeta = latestWriterMeta;
       if (latestMeta == null
-          || (latestMeta.getLastAllocatedLocalSeq() == lastPersistedWriterLocalSeq
-              && latestMeta.getLastAssignedPhysicalTimeMs() == lastPersistedWriterPhysicalTime)) {
+          || (latestMeta.getLastAllocatedLocalSeq() <= lastPersistedWriterLocalSeq
+              && latestMeta.getLastAssignedPhysicalTimeMs() <= lastPersistedWriterPhysicalTime)) {
         return;
       }
 


### PR DESCRIPTION
### Summary
- move writer meta persistence out of the state machine lock path
- update latest writer metadata on successful writes, then persist after releasing the lock
- avoid skipping persistence when either local sequence or physical time advances

