### PR TITLE
Fix RegionGroupCache activation race

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/region/RegionGroupCache.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/load/cache/region/RegionGroupCache.java
@@ -66,7 +66,7 @@ public class RegionGroupCache {
    * @param newHeartbeatSample The newest RegionHeartbeatSample
    * @param overwrite Able to overwrite Adding or Removing
    */
-  public void cacheHeartbeatSample(
+  public synchronized void cacheHeartbeatSample(
       int dataNodeId, RegionHeartbeatSample newHeartbeatSample, boolean overwrite) {
     // Only cache sample when the corresponding loadCache exists
     Optional.ofNullable(regionCacheMap.get(dataNodeId))
@@ -83,7 +83,7 @@ public class RegionGroupCache {
    *
    * @param dataNodeId the specified DataNode
    */
-  public void createRegionCache(int dataNodeId, TConsensusGroupId groupId) {
+  public synchronized void createRegionCache(int dataNodeId, TConsensusGroupId groupId) {
     regionCacheMap.put(dataNodeId, new RegionCache(dataNodeId, groupId));
   }
 
@@ -92,7 +92,7 @@ public class RegionGroupCache {
    *
    * @param dataNodeId the specified DataNode
    */
-  public void removeRegionCache(int dataNodeId) {
+  public synchronized void removeRegionCache(int dataNodeId) {
     regionCacheMap.remove(dataNodeId);
   }
 
@@ -100,7 +100,7 @@ public class RegionGroupCache {
    * Update currentStatistics based on the latest NodeHeartbeatSamples that cached in the
    * slidingWindow.
    */
-  public void updateCurrentStatistics() {
+  public synchronized void updateCurrentStatistics() {
     regionCacheMap.values().forEach(regionCache -> regionCache.updateCurrentStatistics(false));
     Map<Integer, RegionStatistics> regionStatisticsMap =
         regionCacheMap.entrySet().stream()


### PR DESCRIPTION
﻿## Description
Synchronize RegionGroupCache mutation and statistics update paths so periodic load-statistics refresh cannot overwrite a freshly activated RegionGroup's Running status with a stale Disabled status while RegionGroup creation is still finishing.

This addresses the intermittent no-available SchemaRegionGroup failure where PartitionInfo already sees the newly created RegionGroup but LoadCache still reports it as Disabled.

## Tests
- mvn spotless:apply -pl iotdb-core/confignode
- mvn -U -pl iotdb-core/confignode test "-Dtest=RegionGroupCacheTest,LoadManagerTest"
