### PR TITLE
Fix IT log directory test class names

### DIFF
--- a/integration-test/src/main/java/org/apache/iotdb/it/env/MultiEnvFactory.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/MultiEnvFactory.java
@@ -33,9 +33,15 @@ public class MultiEnvFactory {
   private static final List<BaseEnv> envList = new ArrayList<>();
   private static final Logger logger = IoTDBTestLogger.logger;
   private static String currentMethodName;
+  private static String currentClassName;
 
   private MultiEnvFactory() {
     // Empty constructor
+  }
+
+  public static void setTestClassName(final String testClassName) {
+    currentClassName = testClassName;
+    envList.forEach(baseEnv -> baseEnv.setTestClassName(testClassName));
   }
 
   public static void setTestMethodName(final String testMethodName) {
@@ -56,7 +62,7 @@ public class MultiEnvFactory {
     for (int i = 0; i < num; ++i) {
       try {
         Class.forName(Config.JDBC_DRIVER_NAME);
-        envList.add(new MultiClusterEnv(startTime, i, currentMethodName));
+        envList.add(new MultiClusterEnv(startTime, i, currentClassName, currentMethodName));
       } catch (final ClassNotFoundException e) {
         logger.error("Create env error", e);
         System.exit(-1);

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/env/AbstractEnv.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/env/AbstractEnv.java
@@ -104,6 +104,7 @@ public abstract class AbstractEnv implements BaseEnv {
   protected List<ConfigNodeWrapper> configNodeWrapperList = Collections.emptyList();
   protected List<DataNodeWrapper> dataNodeWrapperList = Collections.emptyList();
   protected List<AbstractNodeWrapper> extraNodeWrappers = Collections.emptyList();
+  protected String testClassName = null;
   protected String testMethodName = null;
   protected int index = 0;
   protected long startTime;
@@ -332,6 +333,9 @@ public abstract class AbstractEnv implements BaseEnv {
   }
 
   public String getTestClassName() {
+    if (testClassName != null) {
+      return testClassName;
+    }
     final StackTraceElement[] stack = Thread.currentThread().getStackTrace();
     for (final StackTraceElement stackTraceElement : stack) {
       final String className = stackTraceElement.getClassName();
@@ -1226,6 +1230,17 @@ public abstract class AbstractEnv implements BaseEnv {
 
   public String getTestMethodName() {
     return testMethodName;
+  }
+
+  @Override
+  public void setTestClassName(final String testClassName) {
+    if (testClassName == null || testClassName.isEmpty()) {
+      this.testClassName = null;
+      return;
+    }
+    final int lastDotIndex = testClassName.lastIndexOf(".");
+    this.testClassName =
+        lastDotIndex >= 0 ? testClassName.substring(lastDotIndex + 1) : testClassName;
   }
 
   @Override

--- a/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/env/MultiClusterEnv.java
+++ b/integration-test/src/main/java/org/apache/iotdb/it/env/cluster/env/MultiClusterEnv.java
@@ -26,8 +26,17 @@ import org.apache.tsfile.utils.Pair;
 public class MultiClusterEnv extends AbstractEnv {
 
   public MultiClusterEnv(final long startTime, final int index, final String currentMethodName) {
+    this(startTime, index, null, currentMethodName);
+  }
+
+  public MultiClusterEnv(
+      final long startTime,
+      final int index,
+      final String currentClassName,
+      final String currentMethodName) {
     super(startTime);
     this.index = index;
+    setTestClassName(currentClassName);
     this.testMethodName = currentMethodName;
   }
 

--- a/integration-test/src/main/java/org/apache/iotdb/itbase/env/BaseEnv.java
+++ b/integration-test/src/main/java/org/apache/iotdb/itbase/env/BaseEnv.java
@@ -205,6 +205,10 @@ public interface BaseEnv {
   Connection getConnectionWithSpecifiedDataNode(
       DataNodeWrapper dataNode, String username, String password) throws SQLException;
 
+  default void setTestClassName(String testClassName) {
+    // Default no-op for env implementations that do not create local node log directories.
+  }
+
   void setTestMethodName(String testCaseName);
 
   void dumpTestJVMSnapshot();

--- a/integration-test/src/test/java/org/apache/iotdb/it/framework/IoTDBTestRunner.java
+++ b/integration-test/src/test/java/org/apache/iotdb/it/framework/IoTDBTestRunner.java
@@ -44,6 +44,11 @@ public class IoTDBTestRunner extends BlockJUnit4ClassRunner {
   @Override
   public void run(final RunNotifier notifier) {
     TimeZone.setDefault(TimeZone.getTimeZone("UTC+08:00"));
+    final String testClassName = getTestClass().getJavaClass().getSimpleName();
+    if (EnvType.getSystemEnvType() != EnvType.MultiCluster) {
+      EnvFactory.getEnv().setTestClassName(testClassName);
+    }
+    MultiEnvFactory.setTestClassName(testClassName);
     listener = new IoTDBTestListener(this.getName());
     notifier.addListener(listener);
     super.run(notifier);
@@ -54,9 +59,12 @@ public class IoTDBTestRunner extends BlockJUnit4ClassRunner {
     final Description description = describeChild(method);
     logger.info("Run {}", description.getMethodName());
     final long currentTime = System.currentTimeMillis();
+    final String testClassName = getTestClass().getJavaClass().getSimpleName();
     if (EnvType.getSystemEnvType() != EnvType.MultiCluster) {
+      EnvFactory.getEnv().setTestClassName(testClassName);
       EnvFactory.getEnv().setTestMethodName(description.getMethodName());
     }
+    MultiEnvFactory.setTestClassName(testClassName);
     MultiEnvFactory.setTestMethodName(description.getMethodName());
     if (Thread.currentThread().getName().equals("main")) {
       Thread.currentThread().setName("main-" + description.getMethodName());

--- a/integration-test/src/test/java/org/apache/iotdb/it/framework/IoTDBTestRunnerWithParameters.java
+++ b/integration-test/src/test/java/org/apache/iotdb/it/framework/IoTDBTestRunnerWithParameters.java
@@ -20,6 +20,8 @@
 package org.apache.iotdb.it.framework;
 
 import org.apache.iotdb.it.env.EnvFactory;
+import org.apache.iotdb.it.env.EnvType;
+import org.apache.iotdb.it.env.MultiEnvFactory;
 
 import org.junit.runner.Description;
 import org.junit.runner.notification.RunNotifier;
@@ -40,6 +42,11 @@ public class IoTDBTestRunnerWithParameters extends BlockJUnit4ClassRunnerWithPar
 
   @Override
   public void run(RunNotifier notifier) {
+    final String testClassName = getTestClass().getJavaClass().getSimpleName();
+    if (EnvType.getSystemEnvType() != EnvType.MultiCluster) {
+      EnvFactory.getEnv().setTestClassName(testClassName);
+    }
+    MultiEnvFactory.setTestClassName(testClassName);
     listener = new IoTDBTestListener(this.getName());
     notifier.addListener(listener);
     super.run(notifier);
@@ -50,7 +57,13 @@ public class IoTDBTestRunnerWithParameters extends BlockJUnit4ClassRunnerWithPar
     Description description = describeChild(method);
     logger.info("Run {}", description.getMethodName());
     long currentTime = System.currentTimeMillis();
-    EnvFactory.getEnv().setTestMethodName(description.getMethodName());
+    final String testClassName = getTestClass().getJavaClass().getSimpleName();
+    if (EnvType.getSystemEnvType() != EnvType.MultiCluster) {
+      EnvFactory.getEnv().setTestClassName(testClassName);
+      EnvFactory.getEnv().setTestMethodName(description.getMethodName());
+    }
+    MultiEnvFactory.setTestClassName(testClassName);
+    MultiEnvFactory.setTestMethodName(description.getMethodName());
     super.runChild(method, notifier);
     double timeCost = (System.currentTimeMillis() - currentTime) / 1000.0;
     String testName = description.getClassName() + "." + description.getMethodName();


### PR DESCRIPTION
## Summary
- Pass IT class names from IoTDB test runners into environments explicitly.
- Use the explicit class name for cluster node log directory names, with stack inference kept as a fallback.
- Propagate class names for multi-cluster and parameterized IT runners to avoid UNKNOWN-IT log buckets.

## Tests
- mvn spotless:apply -pl integration-test -P with-integration-tests
- mvn -pl integration-test -P with-integration-tests -DskipTests test-compile
- git diff --check