### PR TITLE
[To dev/1.3] Improve pipe runtime memory allocation

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTaskAgent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTaskAgent.java
@@ -19,7 +19,6 @@
 
 package org.apache.iotdb.db.pipe.agent.task;
 
-import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TPipeHeartbeatResp;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.concurrent.IoTThreadFactory;
@@ -44,9 +43,7 @@ import org.apache.iotdb.commons.pipe.agent.task.meta.PipeType;
 import org.apache.iotdb.commons.pipe.config.PipeConfig;
 import org.apache.iotdb.commons.pipe.config.constant.PipeSinkConstant;
 import org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant;
-import org.apache.iotdb.commons.pipe.config.constant.SystemConstant;
 import org.apache.iotdb.commons.pipe.resource.log.PipeLogger;
-import org.apache.iotdb.commons.utils.NodeUrlUtils;
 import org.apache.iotdb.consensus.exception.ConsensusException;
 import org.apache.iotdb.consensus.pipe.consensuspipe.ConsensusPipeName;
 import org.apache.iotdb.db.conf.IoTDBConfig;
@@ -55,7 +52,6 @@ import org.apache.iotdb.db.consensus.SchemaRegionConsensusImpl;
 import org.apache.iotdb.db.pipe.agent.PipeDataNodeAgent;
 import org.apache.iotdb.db.pipe.agent.task.builder.PipeDataNodeBuilder;
 import org.apache.iotdb.db.pipe.agent.task.builder.PipeDataNodeTaskBuilder;
-import org.apache.iotdb.db.pipe.agent.task.subtask.sink.PipeSinkSubtaskManager;
 import org.apache.iotdb.db.pipe.metric.overview.PipeDataNodeSinglePipeMetrics;
 import org.apache.iotdb.db.pipe.metric.overview.PipeTsFileToTabletsMetrics;
 import org.apache.iotdb.db.pipe.resource.PipeDataNodeResourceManager;
@@ -108,37 +104,17 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_END_TIME_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_HISTORY_ENABLE_DEFAULT_VALUE;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_HISTORY_ENABLE_KEY;
-import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_HISTORY_END_TIME_KEY;
-import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_HISTORY_START_TIME_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_MODE_DEFAULT_VALUE;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_MODE_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_MODE_QUERY_VALUE;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_MODE_SNAPSHOT_VALUE;
-import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_PATH_EXCLUSION_KEY;
-import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_PATH_INCLUSION_KEY;
-import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_PATH_KEY;
-import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_PATTERN_EXCLUSION_KEY;
-import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_PATTERN_INCLUSION_KEY;
-import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_PATTERN_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_REALTIME_ENABLE_DEFAULT_VALUE;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_REALTIME_ENABLE_KEY;
-import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.EXTRACTOR_START_TIME_KEY;
-import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_END_TIME_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_HISTORY_ENABLE_KEY;
-import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_HISTORY_END_TIME_KEY;
-import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_HISTORY_START_TIME_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_MODE_KEY;
-import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_PATH_EXCLUSION_KEY;
-import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_PATH_INCLUSION_KEY;
-import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_PATH_KEY;
-import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_PATTERN_EXCLUSION_KEY;
-import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_PATTERN_INCLUSION_KEY;
-import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_PATTERN_KEY;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_REALTIME_ENABLE_KEY;
-import static org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant.SOURCE_START_TIME_KEY;
 
 public class PipeDataNodeTaskAgent extends PipeTaskAgent {
 
@@ -197,9 +173,7 @@ public class PipeDataNodeTaskAgent extends PipeTaskAgent {
           || needConstructDataRegionTask
           || needConstructSchemaRegionTask) {
         calculateMemoryUsage(
-            pipeStaticMeta,
-            Collections.singletonList(new Pair<>(consensusGroupId, pipeTaskMeta)),
-            false);
+            pipeStaticMeta, Collections.singletonList(new Pair<>(consensusGroupId, pipeTaskMeta)));
 
         final PipeDataNodeTask pipeTask =
             new PipeDataNodeTaskBuilder(pipeStaticMeta, consensusGroupId, pipeTaskMeta).build();
@@ -821,21 +795,11 @@ public class PipeDataNodeTaskAgent extends PipeTaskAgent {
       return;
     }
 
-    final PipeMeta pipeMetaInAgent = pipeMetaKeeper.getPipeMeta(staticMeta.getPipeName());
-    final boolean ignoreRegisteredSinkSubtasks =
-        Objects.nonNull(pipeMetaInAgent)
-            && (!pipeMetaInAgent.getStaticMeta().equals(staticMeta)
-                || PipeStatus.DROPPED.equals(pipeMetaInAgent.getRuntimeMeta().getStatus().get()));
-    calculateMemoryUsage(
-        staticMeta,
-        collectPipeTasksToBeCreated(pipeMetaFromCoordinator),
-        ignoreRegisteredSinkSubtasks);
+    calculateMemoryUsage(staticMeta, collectPipeTasksToBeCreated(pipeMetaFromCoordinator));
   }
 
   private void calculateMemoryUsage(
-      final PipeStaticMeta staticMeta,
-      final List<Pair<Integer, PipeTaskMeta>> pipeTasksToBeCreated,
-      final boolean ignoreRegisteredSinkSubtasks)
+      final PipeStaticMeta staticMeta, final List<Pair<Integer, PipeTaskMeta>> pipeTasksToBeCreated)
       throws IllegalPathException {
     if (!PipeConfig.getInstance().isPipeEnableMemoryCheck()
         || !isInnerSource(staticMeta.getExtractorParameters())
@@ -849,8 +813,7 @@ public class PipeDataNodeTaskAgent extends PipeTaskAgent {
     }
 
     final MemoryEstimation memoryEstimation =
-        calculateIncrementalMemoryUsage(
-            staticMeta, pipeTasksToBeCreated, ignoreRegisteredSinkSubtasks);
+        calculateIncrementalMemoryUsage(staticMeta, pipeTasksToBeCreated);
     calculateInsertNodeQueueMemory(
         staticMeta.getExtractorParameters(), memoryEstimation.dataRegionTaskCount);
 
@@ -919,48 +882,19 @@ public class PipeDataNodeTaskAgent extends PipeTaskAgent {
 
   private MemoryEstimation calculateIncrementalMemoryUsage(
       final PipeStaticMeta staticMeta,
-      final List<Pair<Integer, PipeTaskMeta>> pipeTasksToBeCreated,
-      final boolean ignoreRegisteredSinkSubtasks) {
-    long needMemory = 0;
+      final List<Pair<Integer, PipeTaskMeta>> pipeTasksToBeCreated) {
     int dataRegionTaskCount = 0;
-    final Set<String> sinkSubtasksToBeCreated = new HashSet<>();
 
     for (final Pair<Integer, PipeTaskMeta> regionIdAndTaskMeta : pipeTasksToBeCreated) {
-      final int regionId = regionIdAndTaskMeta.getLeft();
-      final PipeTaskMeta pipeTaskMeta = regionIdAndTaskMeta.getRight();
-      final PipeParameters sourceParameters =
-          PipeDataNodeTaskBuilder.blendUserAndSystemParameters(
-              staticMeta.getExtractorParameters(), pipeTaskMeta);
-      final PipeParameters sinkParameters =
-          PipeDataNodeTaskBuilder.blendUserAndSystemParameters(
-              staticMeta.getConnectorParameters(), pipeTaskMeta);
-      PipeDataNodeTaskBuilder.preprocessParameters(sourceParameters, sinkParameters);
-
-      final boolean isDataRegionTask = isDataRegionTask(regionId);
-      if (isDataRegionTask) {
+      if (isDataRegionTask(regionIdAndTaskMeta.getLeft())) {
         dataRegionTaskCount++;
-        needMemory += calculateTsFileParserMemory(sourceParameters, sinkParameters);
-      }
-
-      final String sinkSubtaskId =
-          PipeSinkSubtaskManager.generateAttributeSortedString(sinkParameters, regionId);
-      if (isDataRegionTask
-          && !sinkSubtasksToBeCreated.contains(sinkSubtaskId)
-          && (ignoreRegisteredSinkSubtasks
-              || !PipeSinkSubtaskManager.instance()
-                  .hasRegisteredSubtasks(sinkParameters, regionId))) {
-        sinkSubtasksToBeCreated.add(sinkSubtaskId);
-        final int sinkSubtaskNum =
-            PipeSinkSubtaskManager.calculateSinkSubtaskNum(sinkParameters, regionId);
-        needMemory += calculateSinkBatchMemory(sinkParameters) * sinkSubtaskNum;
-        needMemory +=
-            calculateSendTsFileReadBufferMemory(sourceParameters, sinkParameters) * sinkSubtaskNum;
       }
     }
 
-    if (dataRegionTaskCount > 0) {
-      needMemory += calculateAssignerMemory(staticMeta.getExtractorParameters());
-    }
+    // TsFile parser, sink batch, and TsFile read buffer memory are allocated dynamically from
+    // PipeMemoryManager only while they are active.
+    final long needMemory =
+        dataRegionTaskCount > 0 ? calculateAssignerMemory(staticMeta.getExtractorParameters()) : 0;
     return new MemoryEstimation(needMemory, dataRegionTaskCount);
   }
 
@@ -1037,210 +971,6 @@ public class PipeDataNodeTaskAgent extends PipeTaskAgent {
       LOGGER.warn(message);
       throw new PipeException(message);
     }
-  }
-
-  private long calculateTsFileParserMemory(
-      final PipeParameters sourceParameters, final PipeParameters sinkParameters) {
-
-    // If the source is not history, we do not need to allocate memory
-    boolean isExtractorHistory =
-        sourceParameters.getBooleanOrDefault(
-                SystemConstant.RESTART_OR_NEWLY_ADDED_KEY,
-                SystemConstant.RESTART_OR_NEWLY_ADDED_DEFAULT_VALUE)
-            || sourceParameters.getBooleanOrDefault(
-                Arrays.asList(EXTRACTOR_HISTORY_ENABLE_KEY, SOURCE_HISTORY_ENABLE_KEY),
-                EXTRACTOR_HISTORY_ENABLE_DEFAULT_VALUE);
-
-    // If the source is history, and has start/end time, we need to allocate memory
-    boolean isTSFileParser =
-        isExtractorHistory
-            && sourceParameters.hasAnyAttributes(
-                EXTRACTOR_HISTORY_START_TIME_KEY, SOURCE_HISTORY_START_TIME_KEY);
-
-    isTSFileParser =
-        isTSFileParser
-            || (isExtractorHistory
-                && sourceParameters.hasAnyAttributes(
-                    EXTRACTOR_HISTORY_END_TIME_KEY, SOURCE_HISTORY_END_TIME_KEY));
-
-    // if the source has start/end time, we need to allocate memory
-    isTSFileParser =
-        isTSFileParser
-            || sourceParameters.hasAnyAttributes(SOURCE_START_TIME_KEY, EXTRACTOR_START_TIME_KEY);
-
-    isTSFileParser =
-        isTSFileParser
-            || sourceParameters.hasAnyAttributes(SOURCE_END_TIME_KEY, EXTRACTOR_END_TIME_KEY);
-
-    // If the source has pattern or path, we need to allocate memory
-    isTSFileParser =
-        isTSFileParser
-            || sourceParameters.hasAnyAttributes(
-                EXTRACTOR_PATTERN_KEY,
-                SOURCE_PATTERN_KEY,
-                EXTRACTOR_PATTERN_INCLUSION_KEY,
-                SOURCE_PATTERN_INCLUSION_KEY,
-                EXTRACTOR_PATTERN_EXCLUSION_KEY,
-                SOURCE_PATTERN_EXCLUSION_KEY);
-
-    isTSFileParser =
-        isTSFileParser
-            || sourceParameters.hasAnyAttributes(
-                EXTRACTOR_PATH_KEY,
-                SOURCE_PATH_KEY,
-                EXTRACTOR_PATH_INCLUSION_KEY,
-                SOURCE_PATH_INCLUSION_KEY,
-                EXTRACTOR_PATH_EXCLUSION_KEY,
-                SOURCE_PATH_EXCLUSION_KEY);
-
-    // If the source is not hybrid, we do need to allocate memory
-    isTSFileParser =
-        isTSFileParser
-            || !PipeSinkConstant.CONNECTOR_FORMAT_HYBRID_VALUE.equals(
-                sinkParameters.getStringOrDefault(
-                    Arrays.asList(
-                        PipeSinkConstant.CONNECTOR_FORMAT_KEY, PipeSinkConstant.SINK_FORMAT_KEY),
-                    PipeSinkConstant.CONNECTOR_FORMAT_HYBRID_VALUE));
-
-    if (!isTSFileParser) {
-      return 0;
-    }
-
-    return PipeConfig.getInstance().getTsFileParserMemory();
-  }
-
-  private static long calculateSinkBatchMemory(final PipeParameters sinkParameters) {
-    final String format =
-        sinkParameters.getStringOrDefault(
-            Arrays.asList(PipeSinkConstant.CONNECTOR_FORMAT_KEY, PipeSinkConstant.SINK_FORMAT_KEY),
-            PipeSinkConstant.CONNECTOR_FORMAT_HYBRID_VALUE);
-    final boolean usingTsFileBatch = PipeSinkConstant.CONNECTOR_FORMAT_TS_FILE_VALUE.equals(format);
-
-    // TsFile format always uses a batch. Other formats only use a batch when batch mode is enabled.
-    final boolean needUseBatch =
-        usingTsFileBatch
-            || sinkParameters.getBooleanOrDefault(
-                Arrays.asList(
-                    PipeSinkConstant.CONNECTOR_IOTDB_BATCH_MODE_ENABLE_KEY,
-                    PipeSinkConstant.SINK_IOTDB_BATCH_MODE_ENABLE_KEY),
-                PipeSinkConstant.CONNECTOR_IOTDB_BATCH_MODE_ENABLE_DEFAULT_VALUE);
-
-    if (!needUseBatch) {
-      return 0;
-    }
-
-    final long batchSizeInBytes =
-        sinkParameters.getLongOrDefault(
-            Arrays.asList(
-                PipeSinkConstant.CONNECTOR_IOTDB_BATCH_SIZE_KEY,
-                PipeSinkConstant.SINK_IOTDB_BATCH_SIZE_KEY),
-            usingTsFileBatch
-                ? PipeSinkConstant.CONNECTOR_IOTDB_TS_FILE_BATCH_SIZE_DEFAULT_VALUE
-                : PipeSinkConstant.CONNECTOR_IOTDB_PLAIN_BATCH_SIZE_DEFAULT_VALUE);
-
-    return batchSizeInBytes * calculateBatchShardCount(sinkParameters, usingTsFileBatch);
-  }
-
-  private static long calculateBatchShardCount(
-      final PipeParameters sinkParameters, final boolean usingTsFileBatch) {
-    if (usingTsFileBatch
-        || !sinkParameters.getBooleanOrDefault(
-            Arrays.asList(
-                PipeSinkConstant.CONNECTOR_LEADER_CACHE_ENABLE_KEY,
-                PipeSinkConstant.SINK_LEADER_CACHE_ENABLE_KEY),
-            PipeSinkConstant.CONNECTOR_LEADER_CACHE_ENABLE_DEFAULT_VALUE)) {
-      return 1;
-    }
-
-    // Plain batches always allocate the default batch and may lazily allocate one batch per target
-    // endpoint when leader cache splits events by endpoint.
-    return 1L + calculateTargetEndPointCount(sinkParameters);
-  }
-
-  private static int calculateTargetEndPointCount(final PipeParameters sinkParameters) {
-    final Set<TEndPoint> targetEndPoints = new HashSet<>();
-    try {
-      addTargetEndPoint(
-          targetEndPoints,
-          sinkParameters,
-          PipeSinkConstant.CONNECTOR_IOTDB_IP_KEY,
-          PipeSinkConstant.CONNECTOR_IOTDB_HOST_KEY,
-          PipeSinkConstant.CONNECTOR_IOTDB_PORT_KEY);
-      addTargetEndPoint(
-          targetEndPoints,
-          sinkParameters,
-          PipeSinkConstant.SINK_IOTDB_IP_KEY,
-          PipeSinkConstant.SINK_IOTDB_HOST_KEY,
-          PipeSinkConstant.SINK_IOTDB_PORT_KEY);
-      if (sinkParameters.hasAttribute(PipeSinkConstant.CONNECTOR_IOTDB_NODE_URLS_KEY)) {
-        targetEndPoints.addAll(
-            NodeUrlUtils.parseTEndPointUrls(
-                Arrays.asList(
-                    sinkParameters
-                        .getStringByKeys(PipeSinkConstant.CONNECTOR_IOTDB_NODE_URLS_KEY)
-                        .replace(" ", "")
-                        .split(","))));
-      }
-      if (sinkParameters.hasAttribute(PipeSinkConstant.SINK_IOTDB_NODE_URLS_KEY)) {
-        targetEndPoints.addAll(
-            NodeUrlUtils.parseTEndPointUrls(
-                Arrays.asList(
-                    sinkParameters
-                        .getStringByKeys(PipeSinkConstant.SINK_IOTDB_NODE_URLS_KEY)
-                        .replace(" ", "")
-                        .split(","))));
-      }
-    } catch (final Exception ignored) {
-      return 1;
-    }
-    return Math.max(1, targetEndPoints.size());
-  }
-
-  private static void addTargetEndPoint(
-      final Set<TEndPoint> targetEndPoints,
-      final PipeParameters sinkParameters,
-      final String ipKey,
-      final String hostKey,
-      final String portKey) {
-    if (sinkParameters.hasAttribute(ipKey) && sinkParameters.hasAttribute(portKey)) {
-      targetEndPoints.add(
-          new TEndPoint(
-              sinkParameters.getStringByKeys(ipKey), sinkParameters.getIntByKeys(portKey)));
-    }
-    if (sinkParameters.hasAttribute(hostKey) && sinkParameters.hasAttribute(portKey)) {
-      targetEndPoints.add(
-          new TEndPoint(
-              sinkParameters.getStringByKeys(hostKey), sinkParameters.getIntByKeys(portKey)));
-    }
-  }
-
-  private static long calculateSendTsFileReadBufferMemory(
-      final PipeParameters sourceParameters, final PipeParameters sinkParameters) {
-    // If the source is history enable, we need to transfer tsfile
-    boolean needTransferTsFile =
-        sourceParameters.getBooleanOrDefault(
-                SystemConstant.RESTART_OR_NEWLY_ADDED_KEY,
-                SystemConstant.RESTART_OR_NEWLY_ADDED_DEFAULT_VALUE)
-            || sourceParameters.getBooleanOrDefault(
-                Arrays.asList(EXTRACTOR_HISTORY_ENABLE_KEY, SOURCE_HISTORY_ENABLE_KEY),
-                EXTRACTOR_HISTORY_ENABLE_DEFAULT_VALUE);
-
-    String format =
-        sinkParameters.getStringOrDefault(
-            Arrays.asList(PipeSinkConstant.CONNECTOR_FORMAT_KEY, PipeSinkConstant.SINK_FORMAT_KEY),
-            PipeSinkConstant.CONNECTOR_FORMAT_HYBRID_VALUE);
-
-    // If the sink format is tsfile and hybrid, we need to transfer tsfile
-    needTransferTsFile =
-        needTransferTsFile
-            || PipeSinkConstant.CONNECTOR_FORMAT_HYBRID_VALUE.equals(format)
-            || PipeSinkConstant.CONNECTOR_FORMAT_TS_FILE_VALUE.equals(format);
-
-    if (!needTransferTsFile) {
-      return 0;
-    }
-
-    return PipeConfig.getInstance().getPipeSinkReadFileBufferSize();
   }
 
   private long calculateAssignerMemory(final PipeParameters sourceParameters) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEvent.java
@@ -479,39 +479,38 @@ public class PipeTsFileInsertionEvent extends EnrichedEvent
   }
 
   public void consumeTabletInsertionEventsWithRetry(
-      final TabletInsertionEventConsumer consumer, final String callerName) throws PipeException {
-    final Iterable<TabletInsertionEvent> iterable = toTabletInsertionEvents();
-    final Iterator<TabletInsertionEvent> iterator = iterable.iterator();
+      final TabletInsertionEventConsumer consumer, final String callerName) throws Exception {
     int tabletEventCount = 0;
-    while (iterator.hasNext()) {
-      final TabletInsertionEvent parsedEvent = iterator.next();
-      tabletEventCount++;
-      int retryCount = 0;
-      while (true) {
-        // If failed due do insufficient memory, retry until success to avoid race among multiple
-        // processor threads
+    try {
+      final Iterable<TabletInsertionEvent> iterable = toTabletInsertionEvents();
+      final Iterator<TabletInsertionEvent> iterator = iterable.iterator();
+      while (iterator.hasNext()) {
+        final TabletInsertionEvent parsedEvent = iterator.next();
+        tabletEventCount++;
         try {
           consumer.consume((PipeRawTabletInsertionEvent) parsedEvent);
-          break;
         } catch (final PipeRuntimeOutOfMemoryCriticalException e) {
-          if (retryCount++ % 100 == 0) {
-            LOGGER.warn(
-                "{}: failed to allocate memory for parsing TsFile {}, tablet event no. {}, retry count is {}, will keep retrying.",
-                callerName,
-                getTsFile(),
-                tabletEventCount,
-                retryCount);
-          } else if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(
-                "{}: failed to allocate memory for parsing TsFile {}, tablet event no. {}, retry count is {}, will keep retrying.",
-                callerName,
-                getTsFile(),
-                tabletEventCount,
-                retryCount,
-                e);
-          }
+          releaseParsedTabletEvent(parsedEvent);
+          throw e;
         }
       }
+    } catch (final PipeRuntimeOutOfMemoryCriticalException e) {
+      close();
+      LOGGER.warn(
+          "{}: failed to allocate memory for parsing TsFile {}, tablet event no. {}, will release parser memory and retry the TsFile event later.",
+          callerName,
+          getTsFile(),
+          tabletEventCount,
+          e);
+      throw e;
+    }
+  }
+
+  private void releaseParsedTabletEvent(final TabletInsertionEvent parsedEvent) {
+    if (parsedEvent instanceof PipeRawTabletInsertionEvent
+        && ((PipeRawTabletInsertionEvent) parsedEvent).getReferenceCount() == 0
+        && !((PipeRawTabletInsertionEvent) parsedEvent).isReleased()) {
+      ((PipeRawTabletInsertionEvent) parsedEvent).clearReferenceCount(getClass().getName());
     }
   }
 
@@ -634,7 +633,7 @@ public class PipeTsFileInsertionEvent extends EnrichedEvent
     }
   }
 
-  public long count(final boolean skipReportOnCommit) throws IOException {
+  public long count(final boolean skipReportOnCommit) throws Exception {
     AtomicLong count = new AtomicLong();
 
     if (shouldParseTime()) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/container/TsFileInsertionDataContainer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/container/TsFileInsertionDataContainer.java
@@ -23,7 +23,6 @@ import org.apache.iotdb.commons.path.PatternTreeMap;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeTaskMeta;
 import org.apache.iotdb.commons.pipe.datastructure.pattern.PipePattern;
 import org.apache.iotdb.commons.pipe.event.EnrichedEvent;
-import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.pipe.metric.overview.PipeTsFileToTabletsMetrics;
 import org.apache.iotdb.db.pipe.resource.PipeDataNodeResourceManager;
 import org.apache.iotdb.db.pipe.resource.memory.PipeMemoryBlock;
@@ -93,9 +92,7 @@ public abstract class TsFileInsertionDataContainer implements AutoCloseable {
 
     // Allocate empty memory block, will be resized later.
     this.allocatedMemoryBlockForTablet =
-        PipeDataNodeResourceManager.memory()
-            .forceAllocateForTabletWithRetry(
-                IoTDBDescriptor.getInstance().getConfig().getPipeDataStructureTabletSizeInBytes());
+        PipeDataNodeResourceManager.memory().forceAllocateForTabletWithRetry(0);
 
     if (LOGGER.isDebugEnabled()) {
       LOGGER.debug(
@@ -163,6 +160,13 @@ public abstract class TsFileInsertionDataContainer implements AutoCloseable {
       PipeTsFileToTabletsMetrics.getInstance().recordTabletGenerated(taskID, tabletMemorySize);
     } catch (final Exception e) {
       LOGGER.warn("Failed to record tablet metrics for pipe {}", pipeName, e);
+    }
+  }
+
+  protected void releaseTabletMemoryBlock() {
+    if (allocatedMemoryBlockForTablet != null
+        && allocatedMemoryBlockForTablet.getMemoryUsageInBytes() > 0) {
+      PipeDataNodeResourceManager.memory().forceResize(allocatedMemoryBlockForTablet, 0);
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/container/query/TsFileInsertionQueryDataContainer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/container/query/TsFileInsertionQueryDataContainer.java
@@ -484,6 +484,7 @@ public class TsFileInsertionQueryDataContainer extends TsFileInsertionDataContai
                   final Tablet tablet = tabletIterator.next();
                   // Record tablet metrics
                   recordTabletMetrics(tablet);
+                  releaseTabletMemoryBlock();
                   final boolean isAligned =
                       deviceIsAlignedMap.getOrDefault(new PlainDeviceID(tablet.deviceId), false);
                   boolean isLast;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/container/scan/TsFileInsertionScanDataContainer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/container/scan/TsFileInsertionScanDataContainer.java
@@ -24,7 +24,6 @@ import org.apache.iotdb.commons.pipe.agent.task.meta.PipeTaskMeta;
 import org.apache.iotdb.commons.pipe.config.PipeConfig;
 import org.apache.iotdb.commons.pipe.datastructure.pattern.PipePattern;
 import org.apache.iotdb.commons.pipe.event.EnrichedEvent;
-import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.pipe.event.common.tablet.PipeRawTabletInsertionEvent;
 import org.apache.iotdb.db.pipe.event.common.tablet.PipeTabletUtils;
 import org.apache.iotdb.db.pipe.event.common.tablet.PipeTabletUtils.TabletStringInternPool;
@@ -139,12 +138,9 @@ public class TsFileInsertionScanDataContainer extends TsFileInsertionDataContain
     filter = Objects.nonNull(timeFilterExpression) ? timeFilterExpression.getFilter() : null;
 
     this.allocatedMemoryBlockForBatchData =
-        PipeDataNodeResourceManager.memory()
-            .forceAllocateForTabletWithRetry(
-                IoTDBDescriptor.getInstance().getConfig().getPipeDataStructureTabletSizeInBytes());
+        PipeDataNodeResourceManager.memory().forceAllocateForTabletWithRetry(0);
     this.allocatedMemoryBlockForChunk =
-        PipeDataNodeResourceManager.memory()
-            .forceAllocateForTabletWithRetry(PipeConfig.getInstance().getPipeMaxReaderChunkSize());
+        PipeDataNodeResourceManager.memory().forceAllocateForTabletWithRetry(0);
 
     try {
       currentModifications =
@@ -209,6 +205,9 @@ public class TsFileInsertionScanDataContainer extends TsFileInsertionDataContain
                     throw new NoSuchElementException();
                   }
 
+                  // Release the previous parser-owned tablet buffer before allocating the next
+                  // tablet.
+                  releaseTabletMemoryBlock();
                   // currentIsAligned is initialized when TsFileInsertionScanDataContainer is
                   // constructed.
                   // When the getNextTablet function is called, currentIsAligned may be updated,
@@ -230,6 +229,9 @@ public class TsFileInsertionScanDataContainer extends TsFileInsertionDataContain
                         sourceEvent,
                         isLast);
                   } finally {
+                    // The raw event owns the generated tablet; only release the parser-side memory
+                    // accounting.
+                    releaseTabletMemoryBlock();
                     if (isLast) {
                       recordParseEndTimeIfNecessary();
                       close();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/processor/aggregate/AggregateProcessor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/processor/aggregate/AggregateProcessor.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.commons.consensus.index.ProgressIndex;
 import org.apache.iotdb.commons.consensus.index.impl.MinimumProgressIndex;
 import org.apache.iotdb.commons.consensus.index.impl.TimeWindowStateProgressIndex;
 import org.apache.iotdb.commons.exception.IllegalPathException;
+import org.apache.iotdb.commons.exception.pipe.PipeRuntimeOutOfMemoryCriticalException;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeTaskMeta;
 import org.apache.iotdb.commons.pipe.config.plugin.env.PipeTaskProcessorRuntimeEnvironment;
 import org.apache.iotdb.commons.pipe.event.EnrichedEvent;
@@ -523,6 +524,8 @@ public class AggregateProcessor implements PipeProcessor {
                 event -> {
                   try {
                     process(event, eventCollector);
+                  } catch (PipeRuntimeOutOfMemoryCriticalException e) {
+                    throw e;
                   } catch (Exception e) {
                     ex.set(e);
                   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/processor/downsampling/DownSamplingProcessor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/processor/downsampling/DownSamplingProcessor.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.pipe.processor.downsampling;
 
 import org.apache.iotdb.commons.consensus.DataRegionId;
+import org.apache.iotdb.commons.exception.pipe.PipeRuntimeOutOfMemoryCriticalException;
 import org.apache.iotdb.commons.pipe.config.plugin.env.PipeTaskProcessorRuntimeEnvironment;
 import org.apache.iotdb.db.pipe.event.common.tablet.PipeInsertNodeTabletInsertionEvent;
 import org.apache.iotdb.db.pipe.event.common.tablet.PipeRawTabletInsertionEvent;
@@ -156,6 +157,8 @@ public abstract class DownSamplingProcessor implements PipeProcessor {
                   event -> {
                     try {
                       process(event, eventCollector);
+                    } catch (PipeRuntimeOutOfMemoryCriticalException e) {
+                      throw e;
                     } catch (Exception e) {
                       ex.set(e);
                     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManager.java
@@ -326,13 +326,6 @@ public class PipeMemoryManager {
     }
 
     final long oldSize = block.getMemoryUsageInBytes();
-    if (oldSize == 0) {
-      // If the memory block is not registered, we need to register it first.
-      // Otherwise, the memory usage will be inconsistent.
-      // See registerMemoryBlock for more details.
-      allocatedBlocks.add(block);
-    }
-
     if (oldSize >= targetSize) {
       usedMemorySizeInBytes -= oldSize - targetSize;
       if (block instanceof PipeTabletMemoryBlock) {
@@ -347,6 +340,8 @@ public class PipeMemoryManager {
       if (targetSize == 0) {
         allocatedBlocks.remove(block);
       }
+
+      this.notifyAll();
       return;
     }
 
@@ -355,6 +350,12 @@ public class PipeMemoryManager {
     for (int i = 1; i <= memoryAllocateMaxRetries; i++) {
       if (getTotalNonFloatingMemorySizeInBytes() - usedMemorySizeInBytes >= sizeInBytes) {
         usedMemorySizeInBytes += sizeInBytes;
+        if (oldSize == 0) {
+          // If the memory block is not registered, we need to register it first.
+          // Otherwise, the memory usage will be inconsistent.
+          // See registerMemoryBlock for more details.
+          allocatedBlocks.add(block);
+        }
         if (block instanceof PipeTabletMemoryBlock) {
           usedMemorySizeInBytesOfTablets += sizeInBytes;
         }
@@ -486,6 +487,9 @@ public class PipeMemoryManager {
     if (getTotalNonFloatingMemorySizeInBytes() - usedMemorySizeInBytes
         >= memoryInBytesNeededToBeAllocated) {
       usedMemorySizeInBytes += memoryInBytesNeededToBeAllocated;
+      if (block.getMemoryUsageInBytes() == 0) {
+        allocatedBlocks.add(block);
+      }
       if (block instanceof PipeTabletMemoryBlock) {
         usedMemorySizeInBytesOfTablets += memoryInBytesNeededToBeAllocated;
       }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/payload/evolvable/batch/PipeTabletEventBatch.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/payload/evolvable/batch/PipeTabletEventBatch.java
@@ -60,8 +60,7 @@ public abstract class PipeTabletEventBatch implements AutoCloseable {
 
     // limit in buffer size
     this.maxBatchSizeInBytes = requestMaxBatchSizeInBytes;
-    this.allocatedMemoryBlock =
-        PipeDataNodeResourceManager.memory().forceAllocate(requestMaxBatchSizeInBytes);
+    this.allocatedMemoryBlock = PipeDataNodeResourceManager.memory().forceAllocate(0);
     if (recordMetric != null) {
       this.recordMetric = recordMetric;
     } else {
@@ -96,6 +95,10 @@ public abstract class PipeTabletEventBatch implements AutoCloseable {
             events.add((EnrichedEvent) event);
           }
         } catch (final Exception e) {
+          if (events.isEmpty()) {
+            clearBatchData();
+            resetMemoryUsage();
+          }
           // If the event is not added to the batch, we need to decrease the reference count.
           ((EnrichedEvent) event)
               .decreaseReferenceCount(PipeTransferBatchReqBuilder.class.getName(), false);
@@ -125,7 +128,27 @@ public abstract class PipeTabletEventBatch implements AutoCloseable {
   protected abstract boolean constructBatch(final TabletInsertionEvent event)
       throws WALPipeException, IOException;
 
+  protected void increaseTotalBufferSizeAndUpdateMemoryBlock(final long bufferSize) {
+    if (bufferSize <= 0) {
+      return;
+    }
+
+    final long newTotalBufferSize = Math.min(totalBufferSize + bufferSize, maxBatchSizeInBytes);
+    PipeDataNodeResourceManager.memory().forceResize(allocatedMemoryBlock, newTotalBufferSize);
+    totalBufferSize = newTotalBufferSize;
+  }
+
+  protected void releaseAllocatedMemoryBlock() {
+    PipeDataNodeResourceManager.memory().forceResize(allocatedMemoryBlock, 0);
+  }
+
+  protected void clearBatchData() {}
+
   public boolean shouldEmit() {
+    if (events.isEmpty()) {
+      return false;
+    }
+
     final long diff = System.currentTimeMillis() - firstEventProcessingTime;
     if (totalBufferSize >= maxBatchSizeInBytes || diff >= maxDelayInMs) {
       recordMetric.accept(diff, totalBufferSize, events.size());
@@ -137,23 +160,26 @@ public abstract class PipeTabletEventBatch implements AutoCloseable {
   public synchronized void onSuccess() {
     events.clear();
 
-    totalBufferSize = 0;
-
-    firstEventProcessingTime = Long.MIN_VALUE;
+    resetMemoryUsage();
   }
 
   @Override
   public synchronized void close() {
+    if (isClosed) {
+      return;
+    }
     isClosed = true;
 
     clearEventsReferenceCount(PipeTabletEventBatch.class.getName());
     events.clear();
+    clearBatchData();
+    resetMemoryUsage();
     allocatedMemoryBlock.close();
   }
 
   /**
-   * Discard all events of the given pipe. This method only clears the reference count of the events
-   * and discard them, but do not modify other objects (such as buffers) for simplicity.
+   * Discard all events of the given pipe. This method only clears the reference count of the
+   * events. If some events remain, cached batch data is kept unchanged for simplicity.
    */
   public synchronized void discardEventsOfPipe(
       final String pipeNameToDrop, final long creationTimeToDrop, final int regionId) {
@@ -161,14 +187,27 @@ public abstract class PipeTabletEventBatch implements AutoCloseable {
   }
 
   public synchronized void discardEventsOfPipe(final CommitterKey committerKey) {
-    events.removeIf(
-        event -> {
-          if (isEventFromPipe(event, committerKey)) {
-            event.clearReferenceCount(IoTDBDataRegionAsyncSink.class.getName());
-            return true;
-          }
-          return false;
-        });
+    final boolean hasDiscardedEvents =
+        events.removeIf(
+            event -> {
+              if (isEventFromPipe(event, committerKey)) {
+                event.clearReferenceCount(IoTDBDataRegionAsyncSink.class.getName());
+                return true;
+              }
+              return false;
+            });
+    if (hasDiscardedEvents && events.isEmpty()) {
+      clearBatchData();
+      resetMemoryUsage();
+    }
+  }
+
+  private void resetMemoryUsage() {
+    totalBufferSize = 0;
+
+    releaseAllocatedMemoryBlock();
+
+    firstEventProcessingTime = Long.MIN_VALUE;
   }
 
   private static boolean isEventFromPipe(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/payload/evolvable/batch/PipeTabletEventPlainBatch.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/payload/evolvable/batch/PipeTabletEventPlainBatch.java
@@ -54,8 +54,7 @@ public class PipeTabletEventPlainBatch extends PipeTabletEventBatch {
 
   @Override
   protected boolean constructBatch(final TabletInsertionEvent event) throws IOException {
-    final int bufferSize = buildTabletInsertionBuffer(event);
-    totalBufferSize += bufferSize;
+    final long bufferSize = buildTabletInsertionBuffer(event);
     pipe2BytesAccumulated.compute(
         new Pair<>(
             ((EnrichedEvent) event).getPipeName(), ((EnrichedEvent) event).getCreationTime()),
@@ -66,8 +65,13 @@ public class PipeTabletEventPlainBatch extends PipeTabletEventBatch {
 
   @Override
   public synchronized void onSuccess() {
-    super.onSuccess();
+    clearBatchData();
 
+    super.onSuccess();
+  }
+
+  @Override
+  protected void clearBatchData() {
     insertNodeBuffers.clear();
     tabletBuffers.clear();
 
@@ -86,7 +90,7 @@ public class PipeTabletEventPlainBatch extends PipeTabletEventBatch {
     return pipe2BytesAccumulated;
   }
 
-  private int buildTabletInsertionBuffer(final TabletInsertionEvent event) throws IOException {
+  private long buildTabletInsertionBuffer(final TabletInsertionEvent event) throws IOException {
     final ByteBuffer buffer;
     if (event instanceof PipeInsertNodeTabletInsertionEvent) {
       final PipeInsertNodeTabletInsertionEvent pipeInsertNodeTabletInsertionEvent =
@@ -95,6 +99,7 @@ public class PipeTabletEventPlainBatch extends PipeTabletEventBatch {
       // deserializing if possible
       final InsertNode insertNode = pipeInsertNodeTabletInsertionEvent.getInsertNode();
       buffer = insertNode.serializeToByteBuffer();
+      increaseTotalBufferSizeAndUpdateMemoryBlock(buffer.limit());
       insertNodeBuffers.add(buffer);
     } else {
       final PipeRawTabletInsertionEvent pipeRawTabletInsertionEvent =
@@ -105,6 +110,7 @@ public class PipeTabletEventPlainBatch extends PipeTabletEventBatch {
         ReadWriteIOUtils.write(pipeRawTabletInsertionEvent.isAligned(), outputStream);
         buffer = ByteBuffer.wrap(byteArrayOutputStream.getBuf(), 0, byteArrayOutputStream.size());
       }
+      increaseTotalBufferSizeAndUpdateMemoryBlock(buffer.limit());
       tabletBuffers.add(buffer);
     }
     return buffer.limit();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/payload/evolvable/batch/PipeTabletEventTsFileBatch.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/payload/evolvable/batch/PipeTabletEventTsFileBatch.java
@@ -156,6 +156,7 @@ public class PipeTabletEventTsFileBatch extends PipeTabletEventBatch {
       final PipeInsertNodeTabletInsertionEvent insertNodeTabletInsertionEvent =
           (PipeInsertNodeTabletInsertionEvent) event;
       final List<Tablet> tablets = insertNodeTabletInsertionEvent.convertToTablets();
+      increaseTotalBufferSizeAndUpdateMemoryBlock(calculateTabletsSizeInBytes(tablets));
       for (int i = 0; i < tablets.size(); ++i) {
         final Tablet tablet = tablets.get(i);
         if (tablet.rowSize == 0) {
@@ -174,6 +175,7 @@ public class PipeTabletEventTsFileBatch extends PipeTabletEventBatch {
       if (tablet.rowSize == 0) {
         return true;
       }
+      increaseTotalBufferSizeAndUpdateMemoryBlock(calculateTabletSizeInBytes(tablet));
       bufferTablet(
           rawTabletInsertionEvent.getPipeName(),
           rawTabletInsertionEvent.getCreationTime(),
@@ -189,16 +191,23 @@ public class PipeTabletEventTsFileBatch extends PipeTabletEventBatch {
     return true;
   }
 
+  private long calculateTabletsSizeInBytes(final List<Tablet> tablets) {
+    return tablets.stream()
+        .filter(tablet -> tablet.rowSize > 0)
+        .mapToLong(PipeTabletEventTsFileBatch::calculateTabletSizeInBytes)
+        .sum();
+  }
+
+  private static long calculateTabletSizeInBytes(final Tablet tablet) {
+    return PipeMemoryWeightUtil.calculateTabletSizeInBytes(tablet) * 2;
+  }
+
   private void bufferTablet(
       final String pipeName,
       final long creationTime,
       final Tablet tablet,
       final boolean isAligned) {
     new PipeTabletEventSorter(tablet).deduplicateAndSortTimestampsIfNecessary();
-
-    // TODO: Currently, PipeTsFileBuilderV2 still uses a fallback builder, so memory table writing
-    // and storing temporary tablets require double the memory.
-    totalBufferSize += PipeMemoryWeightUtil.calculateTabletSizeInBytes(tablet) * 2;
 
     pipeName2WeightMap.compute(
         new Pair<>(pipeName, creationTime),
@@ -465,8 +474,13 @@ public class PipeTabletEventTsFileBatch extends PipeTabletEventBatch {
 
   @Override
   public synchronized void onSuccess() {
-    super.onSuccess();
+    clearBatchData();
 
+    super.onSuccess();
+  }
+
+  @Override
+  protected void clearBatchData() {
     pipeName2WeightMap.clear();
 
     tabletList.clear();
@@ -479,13 +493,6 @@ public class PipeTabletEventTsFileBatch extends PipeTabletEventBatch {
 
   @Override
   public synchronized void close() {
-    super.close();
-
-    pipeName2WeightMap.clear();
-
-    tabletList.clear();
-    isTabletAlignedList.clear();
-
     if (Objects.nonNull(fileWriter)) {
       try {
         fileWriter.close();
@@ -511,6 +518,8 @@ public class PipeTabletEventTsFileBatch extends PipeTabletEventBatch {
 
       fileWriter = null;
     }
+
+    super.close();
   }
 
   protected File createFile() throws IOException {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/airgap/IoTDBDataRegionAirGapSink.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/airgap/IoTDBDataRegionAirGapSink.java
@@ -32,6 +32,8 @@ import org.apache.iotdb.db.pipe.event.common.terminate.PipeTerminateEvent;
 import org.apache.iotdb.db.pipe.event.common.tsfile.PipeTsFileInsertionEvent;
 import org.apache.iotdb.db.pipe.metric.overview.PipeResourceMetrics;
 import org.apache.iotdb.db.pipe.metric.sink.PipeDataRegionSinkMetrics;
+import org.apache.iotdb.db.pipe.resource.PipeDataNodeResourceManager;
+import org.apache.iotdb.db.pipe.resource.memory.PipeTsFileMemoryBlock;
 import org.apache.iotdb.db.pipe.sink.payload.evolvable.batch.PipeTabletEventBatch;
 import org.apache.iotdb.db.pipe.sink.payload.evolvable.batch.PipeTabletEventPlainBatch;
 import org.apache.iotdb.db.pipe.sink.payload.evolvable.batch.PipeTabletEventTsFileBatch;
@@ -435,10 +437,13 @@ public class IoTDBDataRegionAirGapSink extends IoTDBDataNodeAirGapSink {
       final AirGapSocket socket,
       final boolean isMultiFile)
       throws PipeException, IOException {
-    final int readFileBufferSize = PIPE_CONFIG.getPipeSinkReadFileBufferSize();
-    final byte[] readBuffer = new byte[readFileBufferSize];
-    long position = 0;
-    try (final RandomAccessFile reader = new RandomAccessFile(file, "r")) {
+    final int readFileBufferSize = getReadFileBufferSize(file);
+    try (final PipeTsFileMemoryBlock ignored =
+            PipeDataNodeResourceManager.memory()
+                .forceAllocateForTsFileWithRetry(readFileBufferSize);
+        final RandomAccessFile reader = new RandomAccessFile(file, "r")) {
+      final byte[] readBuffer = new byte[readFileBufferSize];
+      long position = 0;
       while (true) {
         mayLimitRateAndRecordIO(readFileBufferSize);
         final int readLength = reader.read(readBuffer);
@@ -468,6 +473,11 @@ public class IoTDBDataRegionAirGapSink extends IoTDBDataNodeAirGapSink {
         }
       }
     }
+  }
+
+  private int getReadFileBufferSize(final File file) {
+    return (int)
+        Math.min((long) PIPE_CONFIG.getPipeSinkReadFileBufferSize(), Math.max(file.length(), 1L));
   }
 
   private boolean sendBatch(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/legacy/IoTDBLegacyPipeSink.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/legacy/IoTDBLegacyPipeSink.java
@@ -36,6 +36,8 @@ import org.apache.iotdb.db.pipe.event.common.tablet.PipeInsertNodeTabletInsertio
 import org.apache.iotdb.db.pipe.event.common.tablet.PipeRawTabletInsertionEvent;
 import org.apache.iotdb.db.pipe.event.common.terminate.PipeTerminateEvent;
 import org.apache.iotdb.db.pipe.event.common.tsfile.PipeTsFileInsertionEvent;
+import org.apache.iotdb.db.pipe.resource.PipeDataNodeResourceManager;
+import org.apache.iotdb.db.pipe.resource.memory.PipeTsFileMemoryBlock;
 import org.apache.iotdb.db.pipe.sink.payload.legacy.TsFilePipeData;
 import org.apache.iotdb.db.storageengine.StorageEngine;
 import org.apache.iotdb.db.storageengine.dataregion.DataRegion;
@@ -414,8 +416,12 @@ public class IoTDBLegacyPipeSink implements PipeConnector {
     long position = 0;
 
     // Try small piece to rebase the file position.
-    final byte[] buffer = new byte[PipeConfig.getInstance().getPipeSinkReadFileBufferSize()];
-    try (final RandomAccessFile randomAccessFile = new RandomAccessFile(file, "r")) {
+    final int readFileBufferSize = getReadFileBufferSize(file);
+    try (final PipeTsFileMemoryBlock ignored =
+            PipeDataNodeResourceManager.memory()
+                .forceAllocateForTsFileWithRetry(readFileBufferSize);
+        final RandomAccessFile randomAccessFile = new RandomAccessFile(file, "r")) {
+      final byte[] buffer = new byte[readFileBufferSize];
       while (true) {
         final int dataLength = randomAccessFile.read(buffer);
         if (dataLength == -1) {
@@ -449,6 +455,13 @@ public class IoTDBLegacyPipeSink implements PipeConnector {
               ipAddress, port, e.getMessage()),
           e);
     }
+  }
+
+  private int getReadFileBufferSize(final File file) {
+    return (int)
+        Math.min(
+            (long) PipeConfig.getInstance().getPipeSinkReadFileBufferSize(),
+            Math.max(file.length(), 1L));
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/pipeconsensus/PipeConsensusSyncSink.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/pipeconsensus/PipeConsensusSyncSink.java
@@ -37,6 +37,8 @@ import org.apache.iotdb.db.pipe.consensus.PipeConsensusSinkMetrics;
 import org.apache.iotdb.db.pipe.event.common.heartbeat.PipeHeartbeatEvent;
 import org.apache.iotdb.db.pipe.event.common.tablet.PipeInsertNodeTabletInsertionEvent;
 import org.apache.iotdb.db.pipe.event.common.tsfile.PipeTsFileInsertionEvent;
+import org.apache.iotdb.db.pipe.resource.PipeDataNodeResourceManager;
+import org.apache.iotdb.db.pipe.resource.memory.PipeTsFileMemoryBlock;
 import org.apache.iotdb.db.pipe.sink.protocol.pipeconsensus.payload.builder.PipeConsensusSyncBatchReqBuilder;
 import org.apache.iotdb.db.pipe.sink.protocol.pipeconsensus.payload.request.PipeConsensusTabletInsertNodeReq;
 import org.apache.iotdb.db.pipe.sink.protocol.pipeconsensus.payload.request.PipeConsensusTsFilePieceReq;
@@ -361,10 +363,13 @@ public class PipeConsensusSyncSink extends IoTDBSink {
       final TCommitId tCommitId,
       final TConsensusGroupId tConsensusGroupId)
       throws PipeException, IOException {
-    final int readFileBufferSize = PipeConfig.getInstance().getPipeSinkReadFileBufferSize();
-    final byte[] readBuffer = new byte[readFileBufferSize];
-    long position = 0;
-    try (final RandomAccessFile reader = new RandomAccessFile(file, "r")) {
+    final int readFileBufferSize = getReadFileBufferSize(file);
+    try (final PipeTsFileMemoryBlock ignored =
+            PipeDataNodeResourceManager.memory()
+                .forceAllocateForTsFileWithRetry(readFileBufferSize);
+        final RandomAccessFile reader = new RandomAccessFile(file, "r")) {
+      final byte[] readBuffer = new byte[readFileBufferSize];
+      long position = 0;
       while (true) {
         final int readLength = reader.read(readBuffer);
         if (readLength == -1) {
@@ -425,6 +430,13 @@ public class PipeConsensusSyncSink extends IoTDBSink {
         }
       }
     }
+  }
+
+  private int getReadFileBufferSize(final File file) {
+    return (int)
+        Math.min(
+            (long) PipeConfig.getInstance().getPipeSinkReadFileBufferSize(),
+            Math.max(file.length(), 1L));
   }
 
   private TEndPoint getFollowerUrl() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/pipeconsensus/handler/PipeConsensusTsFileInsertionEventHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/pipeconsensus/handler/PipeConsensusTsFileInsertionEventHandler.java
@@ -29,6 +29,8 @@ import org.apache.iotdb.consensus.pipe.thrift.TCommitId;
 import org.apache.iotdb.consensus.pipe.thrift.TPipeConsensusTransferResp;
 import org.apache.iotdb.db.pipe.consensus.PipeConsensusSinkMetrics;
 import org.apache.iotdb.db.pipe.event.common.tsfile.PipeTsFileInsertionEvent;
+import org.apache.iotdb.db.pipe.resource.PipeDataNodeResourceManager;
+import org.apache.iotdb.db.pipe.resource.memory.PipeTsFileMemoryBlock;
 import org.apache.iotdb.db.pipe.sink.protocol.pipeconsensus.PipeConsensusAsyncSink;
 import org.apache.iotdb.db.pipe.sink.protocol.pipeconsensus.payload.request.PipeConsensusTsFilePieceReq;
 import org.apache.iotdb.db.pipe.sink.protocol.pipeconsensus.payload.request.PipeConsensusTsFilePieceWithModReq;
@@ -67,7 +69,8 @@ public class PipeConsensusTsFileInsertionEventHandler
   private final boolean transferMod;
 
   private final int readFileBufferSize;
-  private final byte[] readBuffer;
+  private PipeTsFileMemoryBlock memoryBlock;
+  private byte[] readBuffer;
   private long position;
 
   private RandomAccessFile reader;
@@ -101,8 +104,15 @@ public class PipeConsensusTsFileInsertionEventHandler
     transferMod = event.isWithMod();
     currentFile = transferMod ? modFile : tsFile;
 
-    readFileBufferSize = PipeConfig.getInstance().getPipeSinkReadFileBufferSize();
-    readBuffer = new byte[readFileBufferSize];
+    final long maxFileLength =
+        transferMod && Objects.nonNull(modFile)
+            ? Math.max(tsFile.length(), modFile.length())
+            : tsFile.length();
+    readFileBufferSize =
+        (int)
+            Math.min(
+                (long) PipeConfig.getInstance().getPipeSinkReadFileBufferSize(),
+                Math.max(maxFileLength, 1L));
     position = 0;
 
     reader =
@@ -122,6 +132,12 @@ public class PipeConsensusTsFileInsertionEventHandler
 
     this.client = client;
     client.setShouldReturnSelf(false);
+
+    if (readBuffer == null) {
+      memoryBlock =
+          PipeDataNodeResourceManager.memory().forceAllocateForTsFileWithRetry(readFileBufferSize);
+      readBuffer = new byte[readFileBufferSize];
+    }
 
     final int readLength = reader.read(readBuffer);
     if (readLength == -1) {
@@ -233,6 +249,8 @@ public class PipeConsensusTsFileInsertionEventHandler
           client.returnSelf();
         }
 
+        releaseReadBufferMemoryBlock();
+
         long duration = System.nanoTime() - createTime;
         metric.recordConnectorTsFileTransferTimer(duration);
       }
@@ -292,10 +310,20 @@ public class PipeConsensusTsFileInsertionEventHandler
       connector.addFailureEventToRetryQueue(event);
       metric.recordRetryCounter();
 
+      releaseReadBufferMemoryBlock();
+
       if (client != null) {
         client.setShouldReturnSelf(true);
         client.returnSelf();
       }
+    }
+  }
+
+  private void releaseReadBufferMemoryBlock() {
+    if (memoryBlock != null) {
+      memoryBlock.close();
+      memoryBlock = null;
+      readBuffer = null;
     }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/pipeconsensus/payload/builder/PipeConsensusTransferBatchReqBuilder.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/pipeconsensus/payload/builder/PipeConsensusTransferBatchReqBuilder.java
@@ -69,6 +69,7 @@ public abstract class PipeConsensusTransferBatchReqBuilder implements AutoClosea
   protected long firstEventProcessingTime = Long.MIN_VALUE;
 
   // limit in buffer size
+  protected final long maxBatchSizeInBytes;
   protected final PipeMemoryBlock allocatedMemoryBlock;
   protected long totalBufferSize = 0;
 
@@ -90,33 +91,12 @@ public abstract class PipeConsensusTransferBatchReqBuilder implements AutoClosea
     this.consensusGroupId = consensusGroupId;
     this.thisDataNodeId = thisDataNodeId;
 
-    final long requestMaxBatchSizeInBytes =
+    maxBatchSizeInBytes =
         parameters.getLongOrDefault(
             Arrays.asList(CONNECTOR_IOTDB_BATCH_SIZE_KEY, SINK_IOTDB_BATCH_SIZE_KEY),
             CONNECTOR_IOTDB_PLAIN_BATCH_SIZE_DEFAULT_VALUE);
 
-    allocatedMemoryBlock =
-        PipeDataNodeResourceManager.memory()
-            .tryAllocate(requestMaxBatchSizeInBytes)
-            .setShrinkMethod(oldMemory -> Math.max(oldMemory / 2, 0))
-            .setShrinkCallback(
-                (oldMemory, newMemory) ->
-                    LOGGER.info(
-                        "The batch size limit has shrunk from {} to {}.", oldMemory, newMemory))
-            .setExpandMethod(
-                oldMemory -> Math.min(Math.max(oldMemory, 1) * 2, requestMaxBatchSizeInBytes))
-            .setExpandCallback(
-                (oldMemory, newMemory) ->
-                    LOGGER.info(
-                        "The batch size limit has expanded from {} to {}.", oldMemory, newMemory));
-
-    if (getMaxBatchSizeInBytes() != requestMaxBatchSizeInBytes) {
-      LOGGER.info(
-          "PipeConsensusTransferBatchReqBuilder: the max batch size is adjusted from {} to {} due to the "
-              + "memory restriction",
-          requestMaxBatchSizeInBytes,
-          getMaxBatchSizeInBytes());
-    }
+    allocatedMemoryBlock = PipeDataNodeResourceManager.memory().forceAllocate(0);
   }
 
   /**
@@ -131,27 +111,74 @@ public abstract class PipeConsensusTransferBatchReqBuilder implements AutoClosea
       return false;
     }
 
-    final long requestCommitId = ((EnrichedEvent) event).getCommitId();
+    final EnrichedEvent enrichedEvent = (EnrichedEvent) event;
+    final long requestCommitId = enrichedEvent.getCommitId();
 
     // The deduplication logic here is to avoid the accumulation of the same event in a batch when
     // retrying.
     if ((events.isEmpty() || !events.get(events.size() - 1).equals(event))) {
-      events.add(event);
-      requestCommitIds.add(requestCommitId);
-      final int bufferSize = buildTabletInsertionBuffer(event);
-
-      ((EnrichedEvent) event)
-          .increaseReferenceCount(PipeConsensusTransferBatchReqBuilder.class.getName());
-
-      if (firstEventProcessingTime == Long.MIN_VALUE) {
-        firstEventProcessingTime = System.currentTimeMillis();
+      if (!enrichedEvent.increaseReferenceCount(
+          PipeConsensusTransferBatchReqBuilder.class.getName())) {
+        LOGGER.warn("Cannot increase reference count for event {}, ignore it.", event);
+        return shouldEmit();
       }
 
-      totalBufferSize += bufferSize;
+      final int previousEventsSize = events.size();
+      final int previousRequestCommitIdsSize = requestCommitIds.size();
+      final int previousBatchReqsSize = batchReqs.size();
+      try {
+        events.add(event);
+        requestCommitIds.add(requestCommitId);
+        final int bufferSize = buildTabletInsertionBuffer(event);
+        increaseTotalBufferSizeAndUpdateMemoryBlock(bufferSize);
+
+        if (firstEventProcessingTime == Long.MIN_VALUE) {
+          firstEventProcessingTime = System.currentTimeMillis();
+        }
+      } catch (final Exception e) {
+        rollbackTo(previousEventsSize, previousRequestCommitIdsSize, previousBatchReqsSize);
+        if (events.isEmpty()) {
+          resetMemoryUsage();
+        }
+        enrichedEvent.decreaseReferenceCount(
+            PipeConsensusTransferBatchReqBuilder.class.getName(), false);
+        throw e;
+      }
     }
 
-    return totalBufferSize >= getMaxBatchSizeInBytes()
-        || System.currentTimeMillis() - firstEventProcessingTime >= maxDelayInMs;
+    return shouldEmit();
+  }
+
+  private boolean shouldEmit() {
+    return !events.isEmpty()
+        && (totalBufferSize >= getMaxBatchSizeInBytes()
+            || System.currentTimeMillis() - firstEventProcessingTime >= maxDelayInMs);
+  }
+
+  private void increaseTotalBufferSizeAndUpdateMemoryBlock(final long bufferSize) {
+    if (bufferSize <= 0) {
+      return;
+    }
+
+    final long newTotalBufferSize =
+        Math.min(totalBufferSize + bufferSize, getMaxBatchSizeInBytes());
+    PipeDataNodeResourceManager.memory().forceResize(allocatedMemoryBlock, newTotalBufferSize);
+    totalBufferSize = newTotalBufferSize;
+  }
+
+  private void rollbackTo(
+      final int previousEventsSize,
+      final int previousRequestCommitIdsSize,
+      final int previousBatchReqsSize) {
+    events.subList(previousEventsSize, events.size()).clear();
+    requestCommitIds.subList(previousRequestCommitIdsSize, requestCommitIds.size()).clear();
+    batchReqs.subList(previousBatchReqsSize, batchReqs.size()).clear();
+  }
+
+  private void resetMemoryUsage() {
+    firstEventProcessingTime = Long.MIN_VALUE;
+    totalBufferSize = 0;
+    PipeDataNodeResourceManager.memory().forceResize(allocatedMemoryBlock, 0);
   }
 
   public synchronized void onSuccess() {
@@ -160,9 +187,7 @@ public abstract class PipeConsensusTransferBatchReqBuilder implements AutoClosea
     events.clear();
     requestCommitIds.clear();
 
-    firstEventProcessingTime = Long.MIN_VALUE;
-
-    totalBufferSize = 0;
+    resetMemoryUsage();
   }
 
   public PipeConsensusTabletBatchReq toTPipeConsensusBatchTransferReq() throws IOException {
@@ -170,7 +195,7 @@ public abstract class PipeConsensusTransferBatchReqBuilder implements AutoClosea
   }
 
   protected long getMaxBatchSizeInBytes() {
-    return allocatedMemoryBlock.getMemoryUsageInBytes();
+    return maxBatchSizeInBytes;
   }
 
   public boolean isEmpty() {
@@ -213,6 +238,9 @@ public abstract class PipeConsensusTransferBatchReqBuilder implements AutoClosea
         ((EnrichedEvent) event).clearReferenceCount(this.getClass().getName());
       }
     }
+    batchReqs.clear();
+    events.clear();
+    requestCommitIds.clear();
     allocatedMemoryBlock.close();
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/thrift/async/handler/PipeTransferTsFileHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/thrift/async/handler/PipeTransferTsFileHandler.java
@@ -123,11 +123,15 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
     // the memory of the TsFile event is not released, so the memory is not enough for slicing. This
     // will cause a deadlock.
     waitForResourceEnough4Slicing((long) ((1 + Math.random()) * 20 * 1000)); // 20 - 40 seconds
+    final long maxFileLength =
+        transferMod && Objects.nonNull(modFile)
+            ? Math.max(tsFile.length(), modFile.length())
+            : tsFile.length();
     readFileBufferSize =
         (int)
             Math.min(
-                PipeConfig.getInstance().getPipeSinkReadFileBufferSize(),
-                transferMod ? Math.max(tsFile.length(), modFile.length()) : tsFile.length());
+                (long) PipeConfig.getInstance().getPipeSinkReadFileBufferSize(),
+                Math.max(maxFileLength, 1L));
     position = 0;
 
     isSealSignalSent = new AtomicBoolean(false);
@@ -141,21 +145,6 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
       final IoTDBDataNodeAsyncClientManager clientManager,
       final AsyncPipeDataTransferServiceClient client)
       throws TException, IOException {
-    // Delay creation of resources to avoid OOM or too many open files
-    if (readBuffer == null) {
-      memoryBlock =
-          PipeDataNodeResourceManager.memory()
-              .forceAllocateForTsFileWithRetry(
-                  PipeConfig.getInstance().isPipeSinkReadFileBufferMemoryControlEnabled()
-                      ? readFileBufferSize
-                      : 0);
-      readBuffer = new byte[readFileBufferSize];
-    }
-
-    if (reader == null) {
-      reader = transferMod ? new RandomAccessFile(modFile, "r") : new RandomAccessFile(tsFile, "r");
-    }
-
     this.clientManager = clientManager;
     this.client = client;
 
@@ -166,6 +155,17 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
           sink.isClosed() ? "CLOSED" : "NOT CLOSED",
           tsFile);
       return;
+    }
+
+    // Delay creation of resources to avoid OOM or too many open files
+    if (readBuffer == null) {
+      memoryBlock =
+          PipeDataNodeResourceManager.memory().forceAllocateForTsFileWithRetry(readFileBufferSize);
+      readBuffer = new byte[readFileBufferSize];
+    }
+
+    if (reader == null) {
+      reader = transferMod ? new RandomAccessFile(modFile, "r") : new RandomAccessFile(tsFile, "r");
     }
 
     client.setShouldReturnSelf(false);
@@ -254,6 +254,7 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
       super.onComplete(response);
     } finally {
       if (sink.isClosed()) {
+        releaseReadBufferMemoryBlock();
         returnClientIfNecessary();
       }
     }
@@ -317,6 +318,7 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
               referenceCount);
         }
 
+        releaseReadBufferMemoryBlock();
         returnClientIfNecessary();
       }
 
@@ -359,6 +361,7 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
     try {
       super.onError(exception);
     } finally {
+      releaseReadBufferMemoryBlock();
       returnClientIfNecessary();
     }
   }
@@ -410,6 +413,7 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
       LOGGER.warn("Failed to close file reader or delete tsFile when failed to transfer file.", e);
     } finally {
       try {
+        releaseReadBufferMemoryBlock();
         returnClientIfNecessary();
       } finally {
         if (eventsHadBeenAddedToRetryQueue.compareAndSet(false, true)) {
@@ -466,10 +470,14 @@ public class PipeTransferTsFileHandler extends PipeTransferTrackableHandler {
   @Override
   public void close() {
     super.close();
+    releaseReadBufferMemoryBlock();
+  }
 
+  private void releaseReadBufferMemoryBlock() {
     if (memoryBlock != null) {
       memoryBlock.close();
       memoryBlock = null;
+      readBuffer = null;
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/thrift/sync/IoTDBDataRegionSyncSink.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/thrift/sync/IoTDBDataRegionSyncSink.java
@@ -22,10 +22,12 @@ package org.apache.iotdb.db.pipe.sink.protocol.thrift.sync;
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.pipe.agent.task.progress.CommitterKey;
+import org.apache.iotdb.commons.pipe.config.PipeConfig;
 import org.apache.iotdb.commons.pipe.event.EnrichedEvent;
 import org.apache.iotdb.commons.pipe.sink.client.IoTDBSyncClient;
 import org.apache.iotdb.commons.pipe.sink.limiter.TsFileSendRateLimiter;
 import org.apache.iotdb.commons.pipe.sink.payload.thrift.request.PipeTransferFilePieceReq;
+import org.apache.iotdb.commons.pipe.sink.payload.thrift.response.PipeTransferFilePieceResp;
 import org.apache.iotdb.commons.utils.RetryUtils;
 import org.apache.iotdb.db.pipe.event.common.heartbeat.PipeHeartbeatEvent;
 import org.apache.iotdb.db.pipe.event.common.schema.PipeSchemaRegionWritePlanEvent;
@@ -35,6 +37,8 @@ import org.apache.iotdb.db.pipe.event.common.terminate.PipeTerminateEvent;
 import org.apache.iotdb.db.pipe.event.common.tsfile.PipeTsFileInsertionEvent;
 import org.apache.iotdb.db.pipe.metric.overview.PipeResourceMetrics;
 import org.apache.iotdb.db.pipe.metric.sink.PipeDataRegionSinkMetrics;
+import org.apache.iotdb.db.pipe.resource.PipeDataNodeResourceManager;
+import org.apache.iotdb.db.pipe.resource.memory.PipeTsFileMemoryBlock;
 import org.apache.iotdb.db.pipe.sink.client.IoTDBDataNodeSyncClientManager;
 import org.apache.iotdb.db.pipe.sink.payload.evolvable.batch.PipeTabletEventBatch;
 import org.apache.iotdb.db.pipe.sink.payload.evolvable.batch.PipeTabletEventPlainBatch;
@@ -68,6 +72,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.file.NoSuchFileException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -520,6 +525,130 @@ public class IoTDBDataRegionSyncSink extends IoTDBDataNodeSyncSink {
     }
 
     LOGGER.info("Successfully transferred file {}.", tsFile);
+  }
+
+  @Override
+  protected void transferFilePieces(
+      final Map<Pair<String, Long>, Double> pipe2WeightMap,
+      final File file,
+      final Pair<IoTDBSyncClient, Boolean> clientAndStatus,
+      final boolean isMultiFile)
+      throws PipeException, IOException {
+    final int readFileBufferSize = getReadFileBufferSize(file);
+    try (final PipeTsFileMemoryBlock ignored =
+            PipeDataNodeResourceManager.memory()
+                .forceAllocateForTsFileWithRetry(readFileBufferSize);
+        final RandomAccessFile reader = new RandomAccessFile(file, "r")) {
+      final byte[] readBuffer = new byte[readFileBufferSize];
+      long position = 0;
+      int readLength;
+      while ((readLength = readNextFilePiece(reader, readBuffer, readFileBufferSize)) != -1) {
+        position =
+            transferFilePiece(
+                pipe2WeightMap,
+                file,
+                clientAndStatus,
+                isMultiFile,
+                readBuffer,
+                position,
+                readLength,
+                reader);
+      }
+    }
+  }
+
+  private int readNextFilePiece(
+      final RandomAccessFile reader, final byte[] readBuffer, final int readFileBufferSize)
+      throws IOException {
+    mayLimitRateAndRecordIO(readFileBufferSize);
+    return reader.read(readBuffer);
+  }
+
+  private long transferFilePiece(
+      final Map<Pair<String, Long>, Double> pipe2WeightMap,
+      final File file,
+      final Pair<IoTDBSyncClient, Boolean> clientAndStatus,
+      final boolean isMultiFile,
+      final byte[] readBuffer,
+      final long position,
+      final int readLength,
+      final RandomAccessFile reader)
+      throws PipeException, IOException {
+    final byte[] payLoad = buildFilePiecePayload(readBuffer, readLength);
+    final PipeTransferFilePieceResp resp =
+        doTransferFilePiece(pipe2WeightMap, file, clientAndStatus, isMultiFile, payLoad, position);
+    return handleTransferFilePieceResp(file, clientAndStatus, reader, position + readLength, resp);
+  }
+
+  private byte[] buildFilePiecePayload(final byte[] readBuffer, final int readLength) {
+    return readLength == readBuffer.length
+        ? readBuffer
+        : Arrays.copyOfRange(readBuffer, 0, readLength);
+  }
+
+  private PipeTransferFilePieceResp doTransferFilePiece(
+      final Map<Pair<String, Long>, Double> pipe2WeightMap,
+      final File file,
+      final Pair<IoTDBSyncClient, Boolean> clientAndStatus,
+      final boolean isMultiFile,
+      final byte[] payLoad,
+      final long position)
+      throws PipeException, IOException {
+    try {
+      final TPipeTransferReq req =
+          compressIfNeeded(
+              isMultiFile
+                  ? getTransferMultiFilePieceReq(file.getName(), position, payLoad)
+                  : getTransferSingleFilePieceReq(file.getName(), position, payLoad));
+      pipe2WeightMap.forEach(
+          (namePair, weight) ->
+              rateLimitIfNeeded(
+                  namePair.getLeft(),
+                  namePair.getRight(),
+                  clientAndStatus.getLeft().getEndPoint(),
+                  (long) (req.getBody().length * weight)));
+      return PipeTransferFilePieceResp.fromTPipeTransferResp(
+          clientAndStatus.getLeft().pipeTransfer(req));
+    } catch (final Exception e) {
+      clientAndStatus.setRight(false);
+      throw new PipeConnectionException(
+          String.format("Network error when transfer file %s, because %s.", file, e.getMessage()),
+          e);
+    }
+  }
+
+  private long handleTransferFilePieceResp(
+      final File file,
+      final Pair<IoTDBSyncClient, Boolean> clientAndStatus,
+      final RandomAccessFile reader,
+      final long nextPosition,
+      final PipeTransferFilePieceResp resp)
+      throws PipeException, IOException {
+    final TSStatus status = resp.getStatus();
+    if (status.getCode() == TSStatusCode.PIPE_TRANSFER_FILE_OFFSET_RESET.getStatusCode()) {
+      reader.seek(resp.getEndWritingOffset());
+      LOGGER.info("Redirect file position to {}.", resp.getEndWritingOffset());
+      return resp.getEndWritingOffset();
+    }
+
+    if (status.getCode() == TSStatusCode.PIPE_CONFIG_RECEIVER_HANDSHAKE_NEEDED.getStatusCode()) {
+      getClientManager().sendHandshakeReq(clientAndStatus);
+    }
+
+    if (status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()
+        && status.getCode() != TSStatusCode.REDIRECTION_RECOMMEND.getStatusCode()) {
+      receiverStatusHandler.handle(
+          resp.getStatus(),
+          String.format("Transfer file %s error, result status %s.", file, resp.getStatus()),
+          file.getName());
+    }
+    return nextPosition;
+  }
+
+  private int getReadFileBufferSize(final File file) {
+    return (int)
+        Math.min(
+            PipeConfig.getInstance().getPipeSinkReadFileBufferSize(), Math.max(file.length(), 1L));
   }
 
   @Override

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTaskAgentTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTaskAgentTest.java
@@ -23,19 +23,13 @@ import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeMeta;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeRuntimeMeta;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeStaticMeta;
-import org.apache.iotdb.commons.pipe.config.PipeConfig;
-import org.apache.iotdb.commons.pipe.config.constant.PipeSinkConstant;
-import org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant;
 import org.apache.iotdb.db.pipe.agent.PipeDataNodeAgent;
-import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameters;
 import org.apache.iotdb.pipe.api.exception.PipeException;
 
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.lang.reflect.Method;
 import java.util.HashMap;
-import java.util.Map;
 
 public class PipeDataNodeTaskAgentTest {
 
@@ -73,87 +67,5 @@ public class PipeDataNodeTaskAgentTest {
           .getConfig()
           .setPipeTotalFloatingMemoryProportion(originalPipeTotalFloatingMemoryProportion);
     }
-  }
-
-  @Test
-  public void testPlainBatchMemoryIncludesLeaderCacheEndpointShards() throws Exception {
-    final Map<String, String> sinkAttributes = new HashMap<>();
-    sinkAttributes.put(
-        PipeSinkConstant.CONNECTOR_FORMAT_KEY, PipeSinkConstant.CONNECTOR_FORMAT_TABLET_VALUE);
-    sinkAttributes.put(PipeSinkConstant.CONNECTOR_IOTDB_BATCH_SIZE_KEY, "1024");
-    sinkAttributes.put(
-        PipeSinkConstant.CONNECTOR_IOTDB_NODE_URLS_KEY, "127.0.0.1:6667, 127.0.0.2:6667");
-    sinkAttributes.put(PipeSinkConstant.CONNECTOR_IOTDB_IP_KEY, "127.0.0.3");
-    sinkAttributes.put(PipeSinkConstant.CONNECTOR_IOTDB_PORT_KEY, "6667");
-
-    Assert.assertEquals(
-        4 * 1024L, invokeCalculateSinkBatchMemory(new PipeParameters(sinkAttributes)));
-
-    sinkAttributes.put(
-        PipeSinkConstant.CONNECTOR_LEADER_CACHE_ENABLE_KEY, Boolean.FALSE.toString());
-    Assert.assertEquals(1024L, invokeCalculateSinkBatchMemory(new PipeParameters(sinkAttributes)));
-  }
-
-  @Test
-  public void testTsFileBatchMemoryIgnoresLeaderCacheEndpointShards() throws Exception {
-    final Map<String, String> sinkAttributes = new HashMap<>();
-    sinkAttributes.put(
-        PipeSinkConstant.CONNECTOR_FORMAT_KEY, PipeSinkConstant.CONNECTOR_FORMAT_TS_FILE_VALUE);
-    sinkAttributes.put(PipeSinkConstant.CONNECTOR_IOTDB_BATCH_SIZE_KEY, "2048");
-    sinkAttributes.put(
-        PipeSinkConstant.CONNECTOR_IOTDB_NODE_URLS_KEY, "127.0.0.1:6667,127.0.0.2:6667");
-
-    Assert.assertEquals(2048L, invokeCalculateSinkBatchMemory(new PipeParameters(sinkAttributes)));
-  }
-
-  @Test
-  public void testPlainBatchMemoryReturnsZeroWhenBatchModeIsDisabled() throws Exception {
-    final Map<String, String> sinkAttributes = new HashMap<>();
-    sinkAttributes.put(
-        PipeSinkConstant.CONNECTOR_FORMAT_KEY, PipeSinkConstant.CONNECTOR_FORMAT_TABLET_VALUE);
-    sinkAttributes.put(
-        PipeSinkConstant.CONNECTOR_IOTDB_BATCH_MODE_ENABLE_KEY, Boolean.FALSE.toString());
-    sinkAttributes.put(PipeSinkConstant.CONNECTOR_IOTDB_BATCH_SIZE_KEY, "1024");
-
-    Assert.assertEquals(0L, invokeCalculateSinkBatchMemory(new PipeParameters(sinkAttributes)));
-  }
-
-  @Test
-  public void testSendTsFileReadBufferMemoryUsesSinkReadFileBufferSize() throws Exception {
-    final Map<String, String> sourceAttributes = new HashMap<>();
-    sourceAttributes.put(PipeSourceConstant.EXTRACTOR_HISTORY_ENABLE_KEY, Boolean.FALSE.toString());
-
-    final Map<String, String> sinkAttributes = new HashMap<>();
-    sinkAttributes.put(
-        PipeSinkConstant.CONNECTOR_FORMAT_KEY, PipeSinkConstant.CONNECTOR_FORMAT_TABLET_VALUE);
-    Assert.assertEquals(
-        0L,
-        invokeCalculateSendTsFileReadBufferMemory(
-            new PipeParameters(sourceAttributes), new PipeParameters(sinkAttributes)));
-
-    sinkAttributes.put(
-        PipeSinkConstant.CONNECTOR_FORMAT_KEY, PipeSinkConstant.CONNECTOR_FORMAT_HYBRID_VALUE);
-    Assert.assertEquals(
-        PipeConfig.getInstance().getPipeSinkReadFileBufferSize(),
-        invokeCalculateSendTsFileReadBufferMemory(
-            new PipeParameters(sourceAttributes), new PipeParameters(sinkAttributes)));
-  }
-
-  private long invokeCalculateSinkBatchMemory(final PipeParameters sinkParameters)
-      throws Exception {
-    final Method method =
-        PipeDataNodeTaskAgent.class.getDeclaredMethod(
-            "calculateSinkBatchMemory", PipeParameters.class);
-    method.setAccessible(true);
-    return (long) method.invoke(null, sinkParameters);
-  }
-
-  private long invokeCalculateSendTsFileReadBufferMemory(
-      final PipeParameters sourceParameters, final PipeParameters sinkParameters) throws Exception {
-    final Method method =
-        PipeDataNodeTaskAgent.class.getDeclaredMethod(
-            "calculateSendTsFileReadBufferMemory", PipeParameters.class, PipeParameters.class);
-    method.setAccessible(true);
-    return (long) method.invoke(null, sourceParameters, sinkParameters);
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/TsFileInsertionDataContainerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/TsFileInsertionDataContainerTest.java
@@ -20,10 +20,13 @@
 package org.apache.iotdb.db.pipe.event;
 
 import org.apache.iotdb.commons.conf.CommonDescriptor;
+import org.apache.iotdb.commons.exception.pipe.PipeRuntimeOutOfMemoryCriticalException;
 import org.apache.iotdb.commons.pipe.config.PipeConfig;
 import org.apache.iotdb.commons.pipe.datastructure.pattern.IoTDBPipePattern;
 import org.apache.iotdb.commons.pipe.datastructure.pattern.PipePattern;
 import org.apache.iotdb.commons.pipe.datastructure.pattern.PrefixPipePattern;
+import org.apache.iotdb.db.pipe.event.common.tablet.PipeRawTabletInsertionEvent;
+import org.apache.iotdb.db.pipe.event.common.tsfile.PipeTsFileInsertionEvent;
 import org.apache.iotdb.db.pipe.event.common.tsfile.container.TsFileInsertionDataContainer;
 import org.apache.iotdb.db.pipe.event.common.tsfile.container.query.TsFileInsertionQueryDataContainer;
 import org.apache.iotdb.db.pipe.event.common.tsfile.container.scan.AlignedSinglePageWholeChunkReader;
@@ -37,6 +40,7 @@ import org.apache.iotdb.db.storageengine.dataregion.compaction.utils.CompactionT
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResourceStatus;
 import org.apache.iotdb.pipe.api.access.Row;
+import org.apache.iotdb.pipe.api.event.dml.insertion.TabletInsertionEvent;
 
 import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.common.conf.TSFileDescriptor;
@@ -78,6 +82,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -135,6 +140,80 @@ public class TsFileInsertionDataContainerTest {
     final long startTime = System.currentTimeMillis();
     testToTabletInsertionEvents(false);
     System.out.println(System.currentTimeMillis() - startTime);
+  }
+
+  @Test
+  public void testScanContainerReleasesTabletMemoryAfterRawTabletGenerated() throws Exception {
+    nonalignedTsFile =
+        TsFileGeneratorUtils.generateNonAlignedTsFile(
+            "nonaligned-release-tablet-memory.tsfile", 1, 1, 10, 0, 100, 10, 10);
+
+    try (final TsFileInsertionScanDataContainer container =
+        new TsFileInsertionScanDataContainer(
+            nonalignedTsFile,
+            new PrefixPipePattern("root"),
+            Long.MIN_VALUE,
+            Long.MAX_VALUE,
+            null,
+            null,
+            false)) {
+      final Iterator<TabletInsertionEvent> iterator =
+          container.toTabletInsertionEvents().iterator();
+
+      Assert.assertTrue(iterator.hasNext());
+      final TabletInsertionEvent event = iterator.next();
+      Assert.assertTrue(event instanceof PipeRawTabletInsertionEvent);
+      Assert.assertEquals(0, getAllocatedTabletMemory(container).getMemoryUsageInBytes());
+
+      ((PipeRawTabletInsertionEvent) event).clearReferenceCount(getClass().getName());
+    }
+  }
+
+  @Test
+  public void testConsumeTabletInsertionEventsWithRetryReleasesContainerOnOutOfMemory()
+      throws Exception {
+    nonalignedTsFile =
+        TsFileGeneratorUtils.generateNonAlignedTsFile(
+            "nonaligned-consume-oom.tsfile", 1, 1, 10, 0, 100, 10, 10);
+    resource = new TsFileResource(nonalignedTsFile);
+    resource.setStatusForTest(TsFileResourceStatus.NORMAL);
+
+    // The TsFile generator only creates the file, so mark the resource non-empty explicitly.
+    final IDeviceID deviceID = new PlainDeviceID("root.testsg.d0");
+    resource.updateStartTime(deviceID, 0);
+    resource.updateEndTime(deviceID, 9);
+
+    final PipeTsFileInsertionEvent event =
+        new PipeTsFileInsertionEvent(
+            resource,
+            null,
+            false,
+            false,
+            false,
+            null,
+            0,
+            null,
+            new PrefixPipePattern("root"),
+            Long.MIN_VALUE,
+            Long.MAX_VALUE);
+    final AtomicReference<PipeRawTabletInsertionEvent> parsedEventReference =
+        new AtomicReference<>();
+
+    final PipeRuntimeOutOfMemoryCriticalException exception =
+        Assert.assertThrows(
+            PipeRuntimeOutOfMemoryCriticalException.class,
+            () ->
+                event.consumeTabletInsertionEventsWithRetry(
+                    parsedEvent -> {
+                      parsedEventReference.set(parsedEvent);
+                      throw new PipeRuntimeOutOfMemoryCriticalException("expected oom");
+                    },
+                    "test"));
+
+    Assert.assertEquals("expected oom", exception.getMessage());
+    Assert.assertNotNull(parsedEventReference.get());
+    Assert.assertTrue(parsedEventReference.get().isReleased());
+    Assert.assertNull(getDataContainer(event).get());
   }
 
   @Test
@@ -1135,6 +1214,22 @@ public class TsFileInsertionDataContainerTest {
         TsFileInsertionScanDataContainer.class.getDeclaredField("allocatedMemoryBlockForBatchData");
     field.setAccessible(true);
     return (PipeMemoryBlock) field.get(parser);
+  }
+
+  private PipeMemoryBlock getAllocatedTabletMemory(final TsFileInsertionDataContainer container)
+      throws NoSuchFieldException, IllegalAccessException {
+    final Field field =
+        TsFileInsertionDataContainer.class.getDeclaredField("allocatedMemoryBlockForTablet");
+    field.setAccessible(true);
+    return (PipeMemoryBlock) field.get(container);
+  }
+
+  @SuppressWarnings("unchecked")
+  private AtomicReference<TsFileInsertionDataContainer> getDataContainer(
+      final PipeTsFileInsertionEvent event) throws NoSuchFieldException, IllegalAccessException {
+    final Field field = PipeTsFileInsertionEvent.class.getDeclaredField("dataContainer");
+    field.setAccessible(true);
+    return (AtomicReference<TsFileInsertionDataContainer>) field.get(event);
   }
 
   private long calculatePipeMaxReaderChunkSizeForSinglePageAlignedChunk(final File tsFile)


### PR DESCRIPTION
This PR cherry-picks 35cf94a780ab6fe7f105cf1a021e2143f8b503bc (#18051) to dev/1.3.

Adaptations for dev/1.3:
- Keep dev/1.3 pipeconsensus/container structure instead of master iotconsensusv2/parser/i18n layout.
- Port dynamic pipe runtime memory allocation changes for TsFile parsing, batching, and file transfer buffers.

Validation:
- mvn spotless:apply -pl iotdb-core/datanode
- mvn -Ddevelocity.off=true test -pl iotdb-core/datanode -Dtest=TsFileInsertionDataContainerTest
- mvn -Ddevelocity.off=true test -pl iotdb-core/datanode -Dtest=PipeDataNodeTaskAgentTest