### PR TITLE
Pipe: disable serialize-by-region by default

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/plugin/PipeDataNodePluginAgentTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/plugin/PipeDataNodePluginAgentTest.java
@@ -151,17 +151,17 @@ public class PipeDataNodePluginAgentTest {
                     }))
             .getClass());
     Assert.assertEquals(
-        IoTDBDataRegionSyncSink.class,
+        IoTDBDataRegionAsyncSink.class,
         agent.dataRegion().reflectSink(new PipeParameters(new HashMap<>())).getClass());
     Assert.assertEquals(
-        IoTDBDataRegionAsyncSink.class,
+        IoTDBDataRegionSyncSink.class,
         agent
             .dataRegion()
             .reflectSink(
                 new PipeParameters(
                     new HashMap<String, String>() {
                       {
-                        put(PipeSinkConstant.CONNECTOR_SERIALIZE_BY_REGION_KEY, "false");
+                        put(PipeSinkConstant.CONNECTOR_SERIALIZE_BY_REGION_KEY, "true");
                       }
                     }))
             .getClass());

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/task/subtask/sink/PipeSinkSubtaskManagerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/task/subtask/sink/PipeSinkSubtaskManagerTest.java
@@ -33,20 +33,20 @@ import java.util.Map;
 public class PipeSinkSubtaskManagerTest {
 
   @Test
-  public void testGenerateAttributeSortedStringAddsRegionPrefixAndIgnoresRestartFlag() {
+  public void testGenerateAttributeSortedStringUsesSerializeByRegionAndIgnoresRestartFlag() {
     final Map<String, String> attributes = new HashMap<>();
     attributes.put("z", "1");
     attributes.put("a", "2");
     attributes.put(SystemConstant.RESTART_OR_NEWLY_ADDED_KEY, Boolean.TRUE.toString());
 
     Assert.assertEquals(
-        "data_region_-1_{a=2, z=1}",
+        "data_{a=2, z=1}",
         PipeSinkSubtaskManager.generateAttributeSortedString(
             new PipeParameters(new HashMap<>(attributes)), -1));
 
-    attributes.put(PipeSinkConstant.CONNECTOR_SERIALIZE_BY_REGION_KEY, Boolean.FALSE.toString());
+    attributes.put(PipeSinkConstant.CONNECTOR_SERIALIZE_BY_REGION_KEY, Boolean.TRUE.toString());
     Assert.assertEquals(
-        "data_{a=2, connector.serialize-by-region=false, z=1}",
+        "data_region_-1_{a=2, connector.serialize-by-region=true, z=1}",
         PipeSinkSubtaskManager.generateAttributeSortedString(
             new PipeParameters(new HashMap<>(attributes)), -1));
   }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/constant/PipeSinkConstant.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/config/constant/PipeSinkConstant.java
@@ -72,7 +72,7 @@ public class PipeSinkConstant {
 
   public static final String CONNECTOR_SERIALIZE_BY_REGION_KEY = "connector.serialize-by-region";
   public static final String SINK_SERIALIZE_BY_REGION_KEY = "sink.serialize-by-region";
-  public static final boolean CONNECTOR_SERIALIZE_BY_REGION_DEFAULT_VALUE = true;
+  public static final boolean CONNECTOR_SERIALIZE_BY_REGION_DEFAULT_VALUE = false;
 
   public static boolean isSerializeByRegionEnabled(final PipeParameters parameters) {
     return parameters.getBooleanOrDefault(


### PR DESCRIPTION
## Description

This PR changes the default value of connector.serialize-by-region / sink.serialize-by-region to false, so the serialize-by-region sink behavior added in #17946 is opt-in by default.

It also updates related unit expectations so the default data-region sink remains the async IoTDB thrift sink, while explicitly enabling serialize-by-region still selects the sync sink and uses region-prefixed subtask attributes.

## Tests

- git diff --check
- git diff --cached --check
- mvn spotless:apply -pl iotdb-core/node-commons,iotdb-core/datanode -DskipTests
- Attempted `mvn -pl iotdb-core/datanode -Dtest=PipeDataNodePluginAgentTest,PipeSinkSubtaskManagerTest test -Ddevelocity.off=true`, but it is blocked before running tests by existing datanode compile errors in generated/freemarker and queryengine/i18n sources, including missing `IFill` / `IFillFilter`, missing `ComparatorChain`, missing `Accumulator`, and missing `QueryMessages` constants.