### PR TITLE
Fix config region pipe privilege trimming

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/source/IoTDBConfigRegionSource.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/source/IoTDBConfigRegionSource.java
@@ -267,21 +267,16 @@ public class IoTDBConfigRegionSource extends IoTDBNonDataRegionSource {
     final ConfigPhysicalPlan plan =
         ((PipeConfigRegionWritePlanEvent) event).getConfigPhysicalPlan();
     final Boolean isTableDatabasePlan = isTableDatabasePlan(plan);
+    Optional<ConfigPhysicalPlan> result = Optional.of(plan);
     if (!Boolean.TRUE.equals(isTableDatabasePlan)) {
-      final Optional<ConfigPhysicalPlan> result =
-          treePrivilegeParseVisitor.process(plan, userEntity);
-      if (result.isPresent()) {
-        return Optional.of(
-            new PipeConfigRegionWritePlanEvent(result.get(), event.isGeneratedByPipe()));
-      }
+      result = treePrivilegeParseVisitor.process(plan, userEntity);
     }
-    if (!Boolean.FALSE.equals(isTableDatabasePlan)) {
-      final Optional<ConfigPhysicalPlan> result =
-          TABLE_PRIVILEGE_PARSE_VISITOR.process(plan, userEntity);
-      if (result.isPresent()) {
-        return Optional.of(
-            new PipeConfigRegionWritePlanEvent(result.get(), event.isGeneratedByPipe()));
-      }
+    if (result.isPresent() && !Boolean.FALSE.equals(isTableDatabasePlan)) {
+      result = TABLE_PRIVILEGE_PARSE_VISITOR.process(result.get(), userEntity);
+    }
+    if (result.isPresent()) {
+      return Optional.of(
+          new PipeConfigRegionWritePlanEvent(result.get(), event.isGeneratedByPipe()));
     }
     if (skipIfNoPrivileges) {
       return Optional.empty();

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/pipe/source/PipeConfigTreePrivilegeParseVisitorTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/pipe/source/PipeConfigTreePrivilegeParseVisitorTest.java
@@ -39,6 +39,7 @@ import org.apache.iotdb.confignode.consensus.request.write.pipe.payload.PipeDele
 import org.apache.iotdb.confignode.consensus.request.write.pipe.payload.PipeDeleteTimeSeriesPlan;
 import org.apache.iotdb.confignode.manager.ConfigManager;
 import org.apache.iotdb.confignode.manager.PermissionManager;
+import org.apache.iotdb.confignode.manager.pipe.event.PipeConfigRegionWritePlanEvent;
 import org.apache.iotdb.confignode.rpc.thrift.TDatabaseSchema;
 import org.apache.iotdb.confignode.rpc.thrift.TPermissionInfoResp;
 import org.apache.iotdb.confignode.service.ConfigNode;
@@ -52,6 +53,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
@@ -273,6 +275,47 @@ public class PipeConfigTreePrivilegeParseVisitorTest {
                 new SetTTLPlan(new String[] {"root", "db2", "device", "measurement"}, 100),
                 FAKE_USER_ENTITY)
             .isPresent());
+  }
+
+  @Test
+  public void testSourcePrivilegeTrimDoesNotFallbackToTableDefaultForTreePlan() throws Exception {
+    final PipeConfigRegionWritePlanEvent unauthorizedTreeEvent =
+        new PipeConfigRegionWritePlanEvent(
+            new SetTTLPlan(new String[] {"root", "db2", "device", "measurement"}, 100), false);
+
+    final TestIoTDBConfigRegionSource skipSource = new TestIoTDBConfigRegionSource(true);
+    Assert.assertFalse(skipSource.trimRealtimeEventByPrivilege(unauthorizedTreeEvent).isPresent());
+
+    final PipeConfigRegionWritePlanEvent trimmedTreeEvent =
+        (PipeConfigRegionWritePlanEvent)
+            skipSource
+                .trimRealtimeEventByPrivilege(
+                    new PipeConfigRegionWritePlanEvent(
+                        new SetTTLPlan(new String[] {"root", "*", "device", "measurement"}, 100),
+                        false))
+                .get();
+    Assert.assertArrayEquals(
+        new String[] {"root", "db", "device", "measurement"},
+        ((SetTTLPlan) trimmedTreeEvent.getConfigPhysicalPlan()).getPathPattern());
+
+    final TestIoTDBConfigRegionSource throwSource = new TestIoTDBConfigRegionSource(false);
+    Assert.assertThrows(
+        AccessDeniedException.class,
+        () -> throwSource.trimRealtimeEventByPrivilege(unauthorizedTreeEvent));
+  }
+
+  private static class TestIoTDBConfigRegionSource extends IoTDBConfigRegionSource {
+
+    private TestIoTDBConfigRegionSource(final boolean skip)
+        throws NoSuchFieldException, IllegalAccessException {
+      userEntity = new UserEntity(0L, "", "");
+      skipIfNoPrivileges = skip;
+
+      final Field visitorField =
+          IoTDBConfigRegionSource.class.getDeclaredField("treePrivilegeParseVisitor");
+      visitorField.setAccessible(true);
+      visitorField.set(this, new PipeConfigTreePrivilegeParseVisitor(skip));
+    }
   }
 
   private static class TestPermissionManager extends PermissionManager {


### PR DESCRIPTION
## Description
- Avoid falling back to the table privilege visitor when a tree/config plan is denied by tree privilege trimming.
- Preserve the trimmed plan between tree and table privilege visitor stages.
- Add regression coverage for unauthorized tree plans and partially trimmed tree plans.

## Reproduction
A minimal reproduction is covered by `PipeConfigTreePrivilegeParseVisitorTest#testSourcePrivilegeTrimDoesNotFallbackToTableDefaultForTreePlan`:
- Give the pipe source user READ_SCHEMA only on `root.db.device.**`.
- Feed `IoTDBConfigRegionSource` a realtime tree config plan, e.g. `SetTTLPlan(root.db2.device.measurement, 100)`.
- Before this fix, tree privilege trimming returns empty, but the table privilege visitor still runs and falls back to its default `visitPlan`, so the unauthorized tree plan is transferred instead of being skipped or rejected.
- For a partially matched tree plan such as `SetTTLPlan(root.*.device.measurement, 100)`, the fixed flow keeps the trimmed plan as `root.db.device.measurement`.

Run the regression test with:
```bash
mvn -pl iotdb-core/node-commons -DskipTests install
mvn -pl iotdb-core/confignode -Dtest=PipeConfigTreePrivilegeParseVisitorTest#testSourcePrivilegeTrimDoesNotFallbackToTableDefaultForTreePlan -Dsurefire.failIfNoSpecifiedTests=false test
```

## Tests
- mvn spotless:apply -pl iotdb-core/confignode
- mvn -pl iotdb-core/node-commons -DskipTests install
- mvn -pl iotdb-core/confignode -Dtest=PipeConfigTreePrivilegeParseVisitorTest -Dsurefire.failIfNoSpecifiedTests=false test