### PR TITLE
Fix pipe drop stuck on blocking sink reconnect

### DIFF
--- a/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/DataNodePipeMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/DataNodePipeMessages.java
@@ -225,10 +225,20 @@ public final class DataNodePipeMessages {
       "PipeEventCollector: The event {} is already released, skipping it.";
   public static final String PIPE_CONNECTOR_SUBTASK_WAS_CLOSED_WITHIN_MS =
       "Pipe: connector subtask {} ({}) was closed within {} ms";
+  public static final String FAILED_TO_DISCARD_EVENTS_OF_PIPE_IN_CONNECTOR_SUBTASK =
+      "Failed to discard events of pipe {} in connector subtask {}.";
   public static final String PIPE_META_NOT_FOUND = "Pipe meta not found: ";
   public static final String PIPE_SINK_SUBTASKS_WITH_ATTRIBUTES_IS_BOUNDED =
       "Pipe sink subtasks with attributes {} is bounded with sinkExecutor {} and "
           + "callbackExecutor {}.";
+  public static final String PIPE_SINK_SUBTASK_CLOSE_OPERATION_STILL_RUNNING =
+      "is still running";
+  public static final String
+      PIPE_SINK_SUBTASK_CLOSE_OPERATION_WILL_RUN_AFTER_CURRENT_CONNECTOR_OPERATION =
+          "will run after the current connector operation finishes";
+  public static final String PIPE_SINK_SUBTASK_CLOSE_TIMED_OUT =
+      "Timed out after {} ms when closing pipe connector subtask {}. Continue dropping it. "
+          + "The close operation {}.";
   public static final String PIPE_SINK_SUBTASK_DELAYED_TO_AVOID_FREQUENT_HANDSHAKES =
       "Pipe sink subtask {} is delayed for {} ms before polling events to avoid frequent "
           + "handshakes after client borrow failures.";

--- a/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/DataNodePipeMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/DataNodePipeMessages.java
@@ -215,9 +215,17 @@ public final class DataNodePipeMessages {
       "PipeEventCollector：事件 {} 已被释放，跳过处理。";
   public static final String PIPE_CONNECTOR_SUBTASK_WAS_CLOSED_WITHIN_MS =
       "Pipe：connector 子任务 {} ({}) 在 {} ms 内已关闭";
+  public static final String FAILED_TO_DISCARD_EVENTS_OF_PIPE_IN_CONNECTOR_SUBTASK =
+      "Pipe {} 在 connector 子任务 {} 中的事件丢弃失败。";
   public static final String PIPE_META_NOT_FOUND = "未找到 pipe 元数据：";
   public static final String PIPE_SINK_SUBTASKS_WITH_ATTRIBUTES_IS_BOUNDED =
       "带属性 {} 的 Pipe sink 子任务绑定到 sinkExecutor {} 和 callbackExecutor {}。";
+  public static final String PIPE_SINK_SUBTASK_CLOSE_OPERATION_STILL_RUNNING = "仍在运行";
+  public static final String
+      PIPE_SINK_SUBTASK_CLOSE_OPERATION_WILL_RUN_AFTER_CURRENT_CONNECTOR_OPERATION =
+          "将在当前 connector 操作完成后运行";
+  public static final String PIPE_SINK_SUBTASK_CLOSE_TIMED_OUT =
+      "关闭 pipe connector 子任务超时 {} ms：{}。继续丢弃该子任务。关闭操作{}。";
   public static final String PIPE_SINK_SUBTASK_DELAYED_TO_AVOID_FREQUENT_HANDSHAKES =
       "Pipe sink 子任务 {} 在拉取事件前延迟 {} ms，以避免客户端借用失败后频繁握手。";
   public static final String PIPE_SKIPPING_TEMPORARY_TSFILE_WHICH_SHOULDN_T =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/sink/PipeSinkSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/sink/PipeSinkSubtask.java
@@ -288,7 +288,7 @@ public class PipeSinkSubtask extends PipeAbstractSinkSubtask {
         ((PipeConnectorWithEventDiscard) outputPipeSink).discardEventsOfPipe(committerKey);
       } catch (final Exception e) {
         LOGGER.warn(
-            "Failed to discard events of pipe {} in connector subtask {}.",
+            DataNodePipeMessages.FAILED_TO_DISCARD_EVENTS_OF_PIPE_IN_CONNECTOR_SUBTASK,
             committerKey.getPipeName(),
             getDisplayTaskID(),
             e);
@@ -370,12 +370,13 @@ public class PipeSinkSubtask extends PipeAbstractSinkSubtask {
         closeThread.interrupt();
       }
       LOGGER.warn(
-          "Timed out after {} ms when closing pipe connector subtask {}. Continue dropping it. The close operation {}.",
+          DataNodePipeMessages.PIPE_SINK_SUBTASK_CLOSE_TIMED_OUT,
           timeoutInMs,
           getDisplayTaskID(),
           closeStarted.get()
-              ? "is still running"
-              : "will run after the current connector operation finishes");
+              ? DataNodePipeMessages.PIPE_SINK_SUBTASK_CLOSE_OPERATION_STILL_RUNNING
+              : DataNodePipeMessages
+                  .PIPE_SINK_SUBTASK_CLOSE_OPERATION_WILL_RUN_AFTER_CURRENT_CONNECTOR_OPERATION);
       return false;
     }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/sink/PipeSinkSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/sink/PipeSinkSubtask.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.pipe.agent.task.subtask.sink;
 
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.exception.pipe.PipeRuntimeException;
 import org.apache.iotdb.commons.pipe.agent.task.connection.UnboundedBlockingPendingQueue;
 import org.apache.iotdb.commons.pipe.agent.task.progress.CommitterKey;
@@ -51,6 +52,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class PipeSinkSubtask extends PipeAbstractSinkSubtask {
 
@@ -69,6 +75,8 @@ public class PipeSinkSubtask extends PipeAbstractSinkSubtask {
   // the random delay of the batch transmission. Therefore, here we inject cron events
   // when no event can be pulled.
   public static final PipeHeartbeatEvent CRON_HEARTBEAT_EVENT = new PipeHeartbeatEvent(-1, false);
+  private final ReentrantLock outputPipeSinkOperationLock = new ReentrantLock();
+  private final Queue<CommitterKey> pendingDiscardCommitterKeys = new ConcurrentLinkedQueue<>();
 
   public PipeSinkSubtask(
       final String taskID,
@@ -132,15 +140,19 @@ public class PipeSinkSubtask extends PipeAbstractSinkSubtask {
       }
 
       if (event instanceof TabletInsertionEvent) {
-        outputPipeSink.transfer((TabletInsertionEvent) event);
-        PipeDataRegionSinkMetrics.getInstance().markTabletEvent(taskID);
+        if (executeOutputPipeSinkOperation(
+            () -> outputPipeSink.transfer((TabletInsertionEvent) event))) {
+          PipeDataRegionSinkMetrics.getInstance().markTabletEvent(taskID);
+        }
       } else if (event instanceof TsFileInsertionEvent) {
-        outputPipeSink.transfer((TsFileInsertionEvent) event);
-        PipeDataRegionSinkMetrics.getInstance().markTsFileEvent(taskID);
+        if (executeOutputPipeSinkOperation(
+            () -> outputPipeSink.transfer((TsFileInsertionEvent) event))) {
+          PipeDataRegionSinkMetrics.getInstance().markTsFileEvent(taskID);
+        }
       } else if (event instanceof PipeSchemaRegionWritePlanEvent) {
-        outputPipeSink.transfer(event);
-        if (((PipeSchemaRegionWritePlanEvent) event).getPlanNode().getType()
-            != PlanNodeType.DELETE_DATA) {
+        if (executeOutputPipeSinkOperation(() -> outputPipeSink.transfer(event))
+            && ((PipeSchemaRegionWritePlanEvent) event).getPlanNode().getType()
+                != PlanNodeType.DELETE_DATA) {
           // Only plan nodes in schema region will be marked, delete data node is currently not
           // taken into account
           PipeSchemaRegionSinkMetrics.getInstance().markSchemaEvent(taskID);
@@ -148,10 +160,12 @@ public class PipeSinkSubtask extends PipeAbstractSinkSubtask {
       } else if (event instanceof PipeHeartbeatEvent) {
         transferHeartbeatEvent((PipeHeartbeatEvent) event);
       } else {
-        outputPipeSink.transfer(
-            event instanceof UserDefinedEnrichedEvent
-                ? ((UserDefinedEnrichedEvent) event).getUserDefinedEvent()
-                : event);
+        executeOutputPipeSinkOperation(
+            () ->
+                outputPipeSink.transfer(
+                    event instanceof UserDefinedEnrichedEvent
+                        ? ((UserDefinedEnrichedEvent) event).getUserDefinedEvent()
+                        : event));
       }
 
       decreaseReferenceCountAndReleaseLastEvent(event, true);
@@ -169,7 +183,15 @@ public class PipeSinkSubtask extends PipeAbstractSinkSubtask {
       return 0;
     }
 
-    return ((PipeSinkWithSchedulingDelay) outputPipeSink).peekSchedulingDelayMs();
+    outputPipeSinkOperationLock.lock();
+    try {
+      discardPendingEventsOfPipeUnderLock();
+      return isClosed.get()
+          ? 0
+          : ((PipeSinkWithSchedulingDelay) outputPipeSink).peekSchedulingDelayMs();
+    } finally {
+      outputPipeSinkOperationLock.unlock();
+    }
   }
 
   @Override
@@ -178,8 +200,17 @@ public class PipeSinkSubtask extends PipeAbstractSinkSubtask {
       return 0;
     }
 
-    final long remainingSchedulingDelayMs =
-        ((PipeSinkWithSchedulingDelay) outputPipeSink).consumeSchedulingDelayMs();
+    final long remainingSchedulingDelayMs;
+    outputPipeSinkOperationLock.lock();
+    try {
+      discardPendingEventsOfPipeUnderLock();
+      remainingSchedulingDelayMs =
+          isClosed.get()
+              ? 0
+              : ((PipeSinkWithSchedulingDelay) outputPipeSink).consumeSchedulingDelayMs();
+    } finally {
+      outputPipeSinkOperationLock.unlock();
+    }
     if (remainingSchedulingDelayMs <= 0) {
       return 0;
     }
@@ -201,8 +232,13 @@ public class PipeSinkSubtask extends PipeAbstractSinkSubtask {
     }
 
     try {
-      outputPipeSink.heartbeat();
-      outputPipeSink.transfer(event);
+      if (!executeOutputPipeSinkOperation(
+          () -> {
+            outputPipeSink.heartbeat();
+            outputPipeSink.transfer(event);
+          })) {
+        return;
+      }
     } catch (final Exception e) {
       throw new PipeConnectionException(
           String.format(
@@ -219,6 +255,54 @@ public class PipeSinkSubtask extends PipeAbstractSinkSubtask {
   }
 
   @Override
+  protected boolean handshakeOutputPipeSink() throws Exception {
+    return executeOutputPipeSinkOperation(() -> outputPipeSink.handshake());
+  }
+
+  private boolean executeOutputPipeSinkOperation(final OutputPipeSinkOperation operation)
+      throws Exception {
+    outputPipeSinkOperationLock.lock();
+    try {
+      discardPendingEventsOfPipeUnderLock();
+      if (isClosed.get()) {
+        return false;
+      }
+
+      operation.execute();
+      discardPendingEventsOfPipeUnderLock();
+      return true;
+    } finally {
+      outputPipeSinkOperationLock.unlock();
+    }
+  }
+
+  private void discardPendingEventsOfPipeUnderLock() {
+    if (!(outputPipeSink instanceof PipeConnectorWithEventDiscard)) {
+      pendingDiscardCommitterKeys.clear();
+      return;
+    }
+
+    CommitterKey committerKey;
+    while ((committerKey = pendingDiscardCommitterKeys.poll()) != null) {
+      try {
+        ((PipeConnectorWithEventDiscard) outputPipeSink).discardEventsOfPipe(committerKey);
+      } catch (final Exception e) {
+        LOGGER.warn(
+            "Failed to discard events of pipe {} in connector subtask {}.",
+            committerKey.getPipeName(),
+            getDisplayTaskID(),
+            e);
+      }
+    }
+  }
+
+  @FunctionalInterface
+  private interface OutputPipeSinkOperation {
+
+    void execute() throws Exception;
+  }
+
+  @Override
   public void close() {
     if (!attributeSortedString.startsWith("schema_")) {
       PipeDataRegionSinkMetrics.getInstance().deregister(taskID);
@@ -229,12 +313,13 @@ public class PipeSinkSubtask extends PipeAbstractSinkSubtask {
     isClosed.set(true);
     try {
       final long startTime = System.currentTimeMillis();
-      outputPipeSink.close();
-      LOGGER.info(
-          DataNodePipeMessages.PIPE_CONNECTOR_SUBTASK_WAS_CLOSED_WITHIN_MS,
-          getDisplayTaskID(),
-          outputPipeSink,
-          System.currentTimeMillis() - startTime);
+      if (closeOutputPipeSink()) {
+        LOGGER.info(
+            DataNodePipeMessages.PIPE_CONNECTOR_SUBTASK_WAS_CLOSED_WITHIN_MS,
+            getDisplayTaskID(),
+            outputPipeSink,
+            System.currentTimeMillis() - startTime);
+      }
     } catch (final Exception e) {
       LOGGER.info(
           DataNodePipeMessages.EXCEPTION_OCCURRED_WHEN_CLOSING_PIPE_CONNECTOR_SUBTASK,
@@ -247,6 +332,57 @@ public class PipeSinkSubtask extends PipeAbstractSinkSubtask {
       // Should be called after outputPipeConnector.close()
       super.close();
     }
+  }
+
+  private boolean closeOutputPipeSink() throws Exception {
+    final AtomicReference<Exception> exception = new AtomicReference<>();
+    final AtomicBoolean closeStarted = new AtomicBoolean(false);
+    final Thread closeThread =
+        new Thread(
+            () -> {
+              outputPipeSinkOperationLock.lock();
+              try {
+                discardPendingEventsOfPipeUnderLock();
+                closeStarted.set(true);
+                outputPipeSink.close();
+              } catch (final Exception e) {
+                exception.set(e);
+              } finally {
+                outputPipeSinkOperationLock.unlock();
+              }
+            },
+            "PipeSinkSubtaskClose-" + getDisplayTaskID());
+    closeThread.setDaemon(true);
+    closeThread.start();
+
+    final long timeoutInMs =
+        Math.max(
+            1L, CommonDescriptor.getInstance().getConfig().getDnConnectionTimeoutInMS() * 2L / 3);
+    try {
+      closeThread.join(timeoutInMs);
+    } catch (final InterruptedException e) {
+      closeThread.interrupt();
+      Thread.currentThread().interrupt();
+      throw e;
+    }
+    if (closeThread.isAlive()) {
+      if (closeStarted.get()) {
+        closeThread.interrupt();
+      }
+      LOGGER.warn(
+          "Timed out after {} ms when closing pipe connector subtask {}. Continue dropping it. The close operation {}.",
+          timeoutInMs,
+          getDisplayTaskID(),
+          closeStarted.get()
+              ? "is still running"
+              : "will run after the current connector operation finishes");
+      return false;
+    }
+
+    if (exception.get() != null) {
+      throw exception.get();
+    }
+    return true;
   }
 
   /**
@@ -298,8 +434,21 @@ public class PipeSinkSubtask extends PipeAbstractSinkSubtask {
       decreaseHighPriorityTaskCount();
     }
 
-    if (outputPipeSink instanceof PipeConnectorWithEventDiscard) {
-      ((PipeConnectorWithEventDiscard) outputPipeSink).discardEventsOfPipe(committerKey);
+    discardOutputPipeSinkEventsOfPipe(committerKey);
+  }
+
+  private void discardOutputPipeSinkEventsOfPipe(final CommitterKey committerKey) {
+    if (!(outputPipeSink instanceof PipeConnectorWithEventDiscard)) {
+      return;
+    }
+
+    pendingDiscardCommitterKeys.offer(committerKey);
+    if (outputPipeSinkOperationLock.tryLock()) {
+      try {
+        discardPendingEventsOfPipeUnderLock();
+      } finally {
+        outputPipeSinkOperationLock.unlock();
+      }
     }
   }
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/task/subtask/sink/PipeSinkSubtaskTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/task/subtask/sink/PipeSinkSubtaskTest.java
@@ -110,14 +110,21 @@ public class PipeSinkSubtaskTest {
     failureThread.start();
     Assert.assertTrue(handshakeEntered.await(5, TimeUnit.SECONDS));
 
+    final CountDownLatch discardReturned = new CountDownLatch(1);
     final Thread discardThread =
-        new Thread(() -> subtask.discardEventsOfPipe(new CommitterKey("pipe", 1L, 1, -1)));
+        new Thread(
+            () -> {
+              try {
+                subtask.discardEventsOfPipe(new CommitterKey("pipe", 1L, 1, -1));
+              } finally {
+                discardReturned.countDown();
+              }
+            });
     discardThread.start();
-    discardThread.join(1000);
 
     try {
-      Assert.assertFalse(discardThread.isAlive());
-      Assert.assertFalse(discardEntered.await(100, TimeUnit.MILLISECONDS));
+      Assert.assertTrue(discardReturned.await(5, TimeUnit.SECONDS));
+      Assert.assertEquals(1L, discardEntered.getCount());
       Assert.assertFalse(discardDuringHandshake.get());
     } finally {
       releaseHandshake.countDown();

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/task/subtask/sink/PipeSinkSubtaskTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/task/subtask/sink/PipeSinkSubtaskTest.java
@@ -19,18 +19,29 @@
 
 package org.apache.iotdb.db.pipe.agent.task.subtask.sink;
 
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.pipe.agent.task.connection.UnboundedBlockingPendingQueue;
 import org.apache.iotdb.commons.pipe.agent.task.progress.CommitterKey;
 import org.apache.iotdb.commons.pipe.sink.protocol.PipeConnectorWithEventDiscard;
 import org.apache.iotdb.pipe.api.PipeConnector;
+import org.apache.iotdb.pipe.api.customizer.configuration.PipeConnectorRuntimeConfiguration;
+import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameterValidator;
+import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameters;
 import org.apache.iotdb.pipe.api.event.Event;
+import org.apache.iotdb.pipe.api.event.dml.insertion.TabletInsertionEvent;
+import org.apache.iotdb.pipe.api.exception.PipeConnectionException;
 import org.apache.iotdb.pipe.api.exception.PipeException;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -69,6 +80,149 @@ public class PipeSinkSubtaskTest {
   }
 
   @Test
+  public void testDiscardEventsOfPipeNotBlockedByConnectionRetry() throws Exception {
+    final CountDownLatch handshakeEntered = new CountDownLatch(1);
+    final CountDownLatch releaseHandshake = new CountDownLatch(1);
+    final CountDownLatch discardEntered = new CountDownLatch(1);
+    final AtomicBoolean discardDuringHandshake = new AtomicBoolean(false);
+    final PipeConnector connector =
+        new BlockingHandshakeConnector(
+            handshakeEntered,
+            releaseHandshake,
+            new CountDownLatch(0),
+            new AtomicBoolean(false),
+            discardEntered,
+            discardDuringHandshake);
+    final UnboundedBlockingPendingQueue<?> pendingQueue = mock(UnboundedBlockingPendingQueue.class);
+
+    final PipeSinkSubtask subtask =
+        new PipeSinkSubtask(
+            "PipeSinkSubtaskTest",
+            System.currentTimeMillis(),
+            "data_test",
+            "data_test",
+            0,
+            (UnboundedBlockingPendingQueue) pendingQueue,
+            connector);
+
+    final Thread failureThread =
+        new Thread(() -> subtask.onFailure(new PipeConnectionException("connection broken")));
+    failureThread.start();
+    Assert.assertTrue(handshakeEntered.await(5, TimeUnit.SECONDS));
+
+    final Thread discardThread =
+        new Thread(() -> subtask.discardEventsOfPipe(new CommitterKey("pipe", 1L, 1, -1)));
+    discardThread.start();
+    discardThread.join(1000);
+
+    try {
+      Assert.assertFalse(discardThread.isAlive());
+      Assert.assertFalse(discardEntered.await(100, TimeUnit.MILLISECONDS));
+      Assert.assertFalse(discardDuringHandshake.get());
+    } finally {
+      releaseHandshake.countDown();
+      failureThread.join(5000);
+      Assert.assertTrue(discardEntered.await(1, TimeUnit.SECONDS));
+      Assert.assertFalse(discardDuringHandshake.get());
+      subtask.close();
+    }
+  }
+
+  @Test
+  public void testCloseNotConcurrentWithConnectionRetry() throws Exception {
+    final int originalTimeout =
+        CommonDescriptor.getInstance().getConfig().getDnConnectionTimeoutInMS();
+    CommonDescriptor.getInstance().getConfig().setDnConnectionTimeoutInMS(30);
+
+    final CountDownLatch handshakeEntered = new CountDownLatch(1);
+    final CountDownLatch releaseHandshake = new CountDownLatch(1);
+    final CountDownLatch closeEntered = new CountDownLatch(1);
+    final AtomicBoolean closeDuringHandshake = new AtomicBoolean(false);
+    final PipeConnector connector =
+        new BlockingHandshakeConnector(
+            handshakeEntered,
+            releaseHandshake,
+            closeEntered,
+            closeDuringHandshake,
+            new CountDownLatch(0),
+            new AtomicBoolean(false));
+    final UnboundedBlockingPendingQueue<?> pendingQueue = mock(UnboundedBlockingPendingQueue.class);
+
+    final PipeSinkSubtask subtask =
+        new PipeSinkSubtask(
+            "PipeSinkSubtaskTest",
+            System.currentTimeMillis(),
+            "data_test",
+            "data_test",
+            0,
+            (UnboundedBlockingPendingQueue) pendingQueue,
+            connector);
+
+    final Thread failureThread =
+        new Thread(() -> subtask.onFailure(new PipeConnectionException("connection broken")));
+    failureThread.start();
+
+    try {
+      Assert.assertTrue(handshakeEntered.await(5, TimeUnit.SECONDS));
+
+      final long startTime = System.currentTimeMillis();
+      subtask.close();
+
+      Assert.assertTrue(System.currentTimeMillis() - startTime < 1000);
+      Assert.assertFalse(closeEntered.await(100, TimeUnit.MILLISECONDS));
+      Assert.assertFalse(closeDuringHandshake.get());
+    } finally {
+      releaseHandshake.countDown();
+      Assert.assertTrue(closeEntered.await(1, TimeUnit.SECONDS));
+      failureThread.join(5000);
+      Assert.assertFalse(closeDuringHandshake.get());
+      CommonDescriptor.getInstance().getConfig().setDnConnectionTimeoutInMS(originalTimeout);
+    }
+  }
+
+  @Test
+  public void testCloseDoesNotWaitForeverForConnectorClose() throws Exception {
+    final int originalTimeout =
+        CommonDescriptor.getInstance().getConfig().getDnConnectionTimeoutInMS();
+    CommonDescriptor.getInstance().getConfig().setDnConnectionTimeoutInMS(30);
+
+    final PipeConnector connector = mock(PipeConnector.class);
+    final UnboundedBlockingPendingQueue<?> pendingQueue = mock(UnboundedBlockingPendingQueue.class);
+    final CountDownLatch closeEntered = new CountDownLatch(1);
+    final CountDownLatch releaseClose = new CountDownLatch(1);
+
+    doAnswer(
+            invocation -> {
+              closeEntered.countDown();
+              releaseClose.await(2, TimeUnit.SECONDS);
+              return null;
+            })
+        .when(connector)
+        .close();
+
+    final PipeSinkSubtask subtask =
+        new PipeSinkSubtask(
+            "PipeSinkSubtaskTest",
+            System.currentTimeMillis(),
+            "data_test",
+            "data_test",
+            0,
+            (UnboundedBlockingPendingQueue) pendingQueue,
+            connector);
+
+    try {
+      final long startTime = System.currentTimeMillis();
+      subtask.close();
+
+      Assert.assertTrue(closeEntered.await(1, TimeUnit.SECONDS));
+      Assert.assertTrue(System.currentTimeMillis() - startTime < 1000);
+    } finally {
+      releaseClose.countDown();
+      CommonDescriptor.getInstance().getConfig().setDnConnectionTimeoutInMS(originalTimeout);
+    }
+  }
+
+  @Test
   public void testTransferExceptionUsesDisplayTaskID() throws Exception {
     final PipeConnector connector = mock(PipeConnector.class);
     final UnboundedBlockingPendingQueue<Event> pendingQueue =
@@ -102,6 +256,99 @@ public class PipeSinkSubtaskTest {
       Assert.assertFalse(e.getMessage().contains("Iotdb@2026"));
     } finally {
       subtask.close();
+    }
+  }
+
+  private static class BlockingHandshakeConnector
+      implements PipeConnector, PipeConnectorWithEventDiscard {
+
+    private final CountDownLatch handshakeEntered;
+    private final CountDownLatch releaseHandshake;
+    private final CountDownLatch closeEntered;
+    private final AtomicBoolean closeDuringHandshake;
+    private final CountDownLatch discardEntered;
+    private final AtomicBoolean discardDuringHandshake;
+    private volatile boolean handshaking;
+
+    private BlockingHandshakeConnector(
+        final CountDownLatch handshakeEntered, final CountDownLatch releaseHandshake) {
+      this(
+          handshakeEntered,
+          releaseHandshake,
+          new CountDownLatch(0),
+          new AtomicBoolean(false),
+          new CountDownLatch(0),
+          new AtomicBoolean(false));
+    }
+
+    private BlockingHandshakeConnector(
+        final CountDownLatch handshakeEntered,
+        final CountDownLatch releaseHandshake,
+        final CountDownLatch closeEntered,
+        final AtomicBoolean closeDuringHandshake,
+        final CountDownLatch discardEntered,
+        final AtomicBoolean discardDuringHandshake) {
+      this.handshakeEntered = handshakeEntered;
+      this.releaseHandshake = releaseHandshake;
+      this.closeEntered = closeEntered;
+      this.closeDuringHandshake = closeDuringHandshake;
+      this.discardEntered = discardEntered;
+      this.discardDuringHandshake = discardDuringHandshake;
+    }
+
+    @Override
+    public void validate(final PipeParameterValidator validator) throws Exception {
+      // No-op
+    }
+
+    @Override
+    public void customize(
+        final PipeParameters parameters, final PipeConnectorRuntimeConfiguration configuration)
+        throws Exception {
+      // No-op
+    }
+
+    @Override
+    public void handshake() throws Exception {
+      handshaking = true;
+      handshakeEntered.countDown();
+      try {
+        releaseHandshake.await(5, TimeUnit.SECONDS);
+      } finally {
+        handshaking = false;
+      }
+    }
+
+    @Override
+    public void heartbeat() throws Exception {
+      // No-op
+    }
+
+    @Override
+    public void transfer(final TabletInsertionEvent tabletInsertionEvent) throws Exception {
+      // No-op
+    }
+
+    @Override
+    public void transfer(final Event event) throws Exception {
+      // No-op
+    }
+
+    @Override
+    public void close() throws Exception {
+      if (handshaking) {
+        closeDuringHandshake.set(true);
+      }
+      closeEntered.countDown();
+    }
+
+    @Override
+    public void discardEventsOfPipe(
+        final String pipeName, final long creationTime, final int regionId) {
+      if (handshaking) {
+        discardDuringHandshake.set(true);
+      }
+      discardEntered.countDown();
     }
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/PipeTaskAgent.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/PipeTaskAgent.java
@@ -165,7 +165,16 @@ public abstract class PipeTaskAgent {
 
   public TPushPipeMetaRespExceptionMessage handleSinglePipeMetaChanges(
       final PipeMeta pipeMetaFromCoordinator) {
-    acquireWriteLock();
+    final String pipeName = pipeMetaFromCoordinator.getStaticMeta().getPipeName();
+    if (!tryWriteLockWithTimeOutInMs(
+        CommonDescriptor.getInstance().getConfig().getDnConnectionTimeoutInMS() * 2L / 3)) {
+      return new TPushPipeMetaRespExceptionMessage(
+          pipeName,
+          String.format(
+              "Timed out to wait for the pipe task agent write lock when handling single pipe meta changes for pipe %s.",
+              pipeName),
+          System.currentTimeMillis());
+    }
     try {
       return handleSinglePipeMetaChangesInternal(pipeMetaFromCoordinator);
     } finally {
@@ -368,7 +377,15 @@ public abstract class PipeTaskAgent {
   protected abstract void freezeRate(final String pipeName, final long creationTime);
 
   public TPushPipeMetaRespExceptionMessage handleDropPipe(final String pipeName) {
-    acquireWriteLock();
+    if (!tryWriteLockWithTimeOutInMs(
+        CommonDescriptor.getInstance().getConfig().getDnConnectionTimeoutInMS() * 2L / 3)) {
+      return new TPushPipeMetaRespExceptionMessage(
+          pipeName,
+          String.format(
+              "Timed out to wait for the pipe task agent write lock when dropping pipe %s.",
+              pipeName),
+          System.currentTimeMillis());
+    }
     try {
       return handleDropPipeInternal(pipeName);
     } finally {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/subtask/PipeAbstractSinkSubtask.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/subtask/PipeAbstractSinkSubtask.java
@@ -101,38 +101,24 @@ public abstract class PipeAbstractSinkSubtask extends PipeReportableSubtask {
     synchronized (this) {
       isSubmitted = false;
 
-      if (isClosed.get()) {
-        LOGGER.info(PipeMessages.ON_FAILURE_IGNORED_CONNECTOR_DROPPED, throwable);
-        clearReferenceCountAndReleaseLastEvent(null);
+      if (tryIgnoreFailure(throwable)) {
+        return;
+      }
+    }
+
+    if (throwable instanceof PipeConnectionException) {
+      // Retry to connect to the target system if the connection is broken. Do not hold the subtask
+      // lock here because handshaking with an external sink may block for a long time, while drop
+      // pipe needs the same lock to discard in-flight events.
+      if (onPipeConnectionException(throwable)) {
         return;
       }
 
-      // We assume that the event is cleared as the "lastEvent" in processor subtask and reaches the
-      // connector subtask. Then, it may fail because of released resource and block the other pipes
-      // using the same connector. We simply discard it.
-      if (lastExceptionEvent instanceof EnrichedEvent
-          && ((EnrichedEvent) lastExceptionEvent).isReleased()) {
-        LOGGER.info(PipeMessages.ON_FAILURE_IGNORED_EVENT_RELEASED, throwable);
-        submitSelf();
-        return;
-      }
-
-      // If lastExceptionEvent != lastEvent, it indicates that the lastEvent's reference has been
-      // changed because the pipe of it has been dropped. In that case, we just discard the event.
-      if (lastEvent != lastExceptionEvent) {
-        LOGGER.info(PipeMessages.ON_FAILURE_IGNORED_EVENT_PIPE_DROPPED, throwable);
-        clearReferenceCountAndReleaseLastExceptionEvent();
-        submitSelf();
-        return;
-      }
-
-      if (throwable instanceof PipeConnectionException) {
-        // Retry to connect to the target system if the connection is broken
-        // We should reconstruct the client before re-submit the subtask
-        if (onPipeConnectionException(throwable)) {
-          // return if the pipe task should be stopped
+      synchronized (this) {
+        if (tryIgnoreFailure(throwable)) {
           return;
         }
+
         if (PipeConfig.getInstance().isPipeSinkRetryLocallyForConnectionError()) {
           super.onFailure(
               new PipeRuntimeSinkNonReportTimeConfigurableException(
@@ -140,19 +126,57 @@ public abstract class PipeAbstractSinkSubtask extends PipeReportableSubtask {
           return;
         }
       }
+    }
 
-      // Handle exceptions if any available clients exist
-      // Notice that the PipeRuntimeConnectorCriticalException must be thrown here
-      // because the upper layer relies on this to stop all the related pipe tasks
-      // Other exceptions may cause the subtask to stop forever and can not be restarted
-      if (throwable instanceof PipeRuntimeSinkCriticalException) {
-        super.onFailure(throwable);
-      } else {
-        // Print stack trace for better debugging
-        PipeLogger.log(
-            LOGGER::warn, throwable, PipeMessages.NON_CRITICAL_EXCEPTION_WILL_THROW_CRITICAL);
-        super.onFailure(new PipeRuntimeSinkCriticalException(throwable.getMessage()));
+    synchronized (this) {
+      if (tryIgnoreFailure(throwable)) {
+        return;
       }
+      handleFailure(throwable);
+    }
+  }
+
+  private boolean tryIgnoreFailure(final Throwable throwable) {
+    if (isClosed.get()) {
+      LOGGER.info(PipeMessages.ON_FAILURE_IGNORED_CONNECTOR_DROPPED, throwable);
+      clearReferenceCountAndReleaseLastEvent(null);
+      return true;
+    }
+
+    // We assume that the event is cleared as the "lastEvent" in processor subtask and reaches the
+    // connector subtask. Then, it may fail because of released resource and block the other pipes
+    // using the same connector. We simply discard it.
+    if (lastExceptionEvent instanceof EnrichedEvent
+        && ((EnrichedEvent) lastExceptionEvent).isReleased()) {
+      LOGGER.info(PipeMessages.ON_FAILURE_IGNORED_EVENT_RELEASED, throwable);
+      submitSelf();
+      return true;
+    }
+
+    // If lastExceptionEvent != lastEvent, it indicates that the lastEvent's reference has been
+    // changed because the pipe of it has been dropped. In that case, we just discard the event.
+    if (lastEvent != lastExceptionEvent) {
+      LOGGER.info(PipeMessages.ON_FAILURE_IGNORED_EVENT_PIPE_DROPPED, throwable);
+      clearReferenceCountAndReleaseLastExceptionEvent();
+      submitSelf();
+      return true;
+    }
+
+    return false;
+  }
+
+  private void handleFailure(final Throwable throwable) {
+    // Handle exceptions if any available clients exist
+    // Notice that the PipeRuntimeConnectorCriticalException must be thrown here
+    // because the upper layer relies on this to stop all the related pipe tasks
+    // Other exceptions may cause the subtask to stop forever and can not be restarted
+    if (throwable instanceof PipeRuntimeSinkCriticalException) {
+      super.onFailure(throwable);
+    } else {
+      // Print stack trace for better debugging
+      PipeLogger.log(
+          LOGGER::warn, throwable, PipeMessages.NON_CRITICAL_EXCEPTION_WILL_THROW_CRITICAL);
+      super.onFailure(new PipeRuntimeSinkCriticalException(throwable.getMessage()));
     }
   }
 
@@ -169,7 +193,9 @@ public abstract class PipeAbstractSinkSubtask extends PipeReportableSubtask {
     int retry = 0;
     while (retry < MAX_RETRY_TIMES) {
       try {
-        outputPipeSink.handshake();
+        if (!handshakeOutputPipeSink()) {
+          return false;
+        }
         LOGGER.info(PipeMessages.HANDSHAKE_SUCCESS, outputPipeSink.getClass().getName());
         break;
       } catch (final Exception e) {
@@ -222,6 +248,11 @@ public abstract class PipeAbstractSinkSubtask extends PipeReportableSubtask {
     // For non enriched event, forever retry.
     // For enriched event, retry if connection is set up successfully.
     return false;
+  }
+
+  protected boolean handshakeOutputPipeSink() throws Exception {
+    outputPipeSink.handshake();
+    return true;
   }
 
   private long getHandshakeRetrySleepInterval(final Throwable throwable, final int retry) {

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/subtask/PipeSubtask.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/subtask/PipeSubtask.java
@@ -58,7 +58,7 @@ public abstract class PipeSubtask
   // For fail-over
   public static final int MAX_RETRY_TIMES = 5;
   protected final AtomicInteger retryCount = new AtomicInteger(0);
-  protected Event lastEvent;
+  protected volatile Event lastEvent;
 
   protected PipeSubtask(final String taskID, final long creationTime) {
     super();


### PR DESCRIPTION
## Summary

This PR prevents `DROP PIPE` from getting stuck when an external sink connector blocks during connection retry or close.

Changes:
- Do not hold the sink subtask monitor while retrying `handshake()` after `PipeConnectionException`.
- Serialize DataNode sink connector operations (`transfer`, `heartbeat`, retry `handshake`, `discardEventsOfPipe`, and `close`) with a connector-operation lock, so custom/internal connectors are not required to tolerate concurrent calls from drop/close paths.
- Keep drop bounded: if a connector operation is already running, connector-side discard/close is deferred instead of blocking the drop thread or calling the connector concurrently.
- Make sink connector `close()` bounded by a timeout during drop.
- Use bounded write-lock acquisition for single pipe meta push and drop handling, consistent with full pipe meta push.
- Add regression tests for drop/discard not being blocked by connection retry, close not running concurrently with retry handshake, and connector close not waiting forever.

## Positive effects

- `DROP PIPE` is no longer blocked indefinitely by a sink connector stuck in external network operations such as MQTT/Paho connect or publish retry.
- DataNode internal RPC/procedure worker threads are less likely to be held forever by pipe cleanup.
- Drop-time connector cleanup no longer assumes user-defined or internal connectors are thread-safe for concurrent `handshake`/`close`/`discard` calls.
- Pipe task agent write-lock waits during single meta push/drop become bounded, so ConfigNode can observe a timeout and rely on later metadata synchronization instead of waiting indefinitely.

## Potential negative effects

- DataNode sink connector operations are more strictly serialized. This is safer for connector implementations, but it may slightly delay connector-side discard/close behind a long-running transfer/handshake.
- If the current connector operation never returns, connector-side discard/close may remain deferred in a daemon close thread; drop still proceeds, but resource release and connector-internal event cleanup can be delayed.
- If connector `close()` itself starts and then blocks, drop proceeds after the timeout and the daemon close thread may remain alive until the connector returns.
- Timed write-lock acquisition may return a pipe meta push/drop timeout under heavy contention; this trades indefinite blocking for fail-fast behavior and relies on later pipe meta synchronization.

## Tests

- `mvn spotless:apply -pl iotdb-core/node-commons,iotdb-core/datanode`
- `git diff --check`
- `$env:MAVEN_OPTS='-Xmx768m'; mvn -pl iotdb-core/node-commons,iotdb-core/datanode -DskipTests "-Dcheckstyle.skip=true" "-Dspotless.check.skip=true" compile`
- `$env:MAVEN_OPTS='-Xmx768m'; mvn -pl iotdb-core/node-commons,iotdb-core/datanode -Dtest=PipeSinkSubtaskTest -DfailIfNoTests=false "-Dsurefire.failIfNoSpecifiedTests=false" "-Dcheckstyle.skip=true" "-Dspotless.check.skip=true" test`
- A normal test run without lowering local Maven heap hit Windows native memory/pagefile OOM before executing tests; the targeted test passed with the lower local Maven heap above.