### PR TITLE
Fix the validation logic when updating the maximum quota, and adopt the default quota value if no quota parameter is specified in the ALTER DATABASE statement

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/database/IoTDBDatabaseRegionControlIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/database/IoTDBDatabaseRegionControlIT.java
@@ -39,6 +39,7 @@ import org.junit.runner.RunWith;
 
 import java.io.IOException;
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Collections;
@@ -165,6 +166,53 @@ public class IoTDBDatabaseRegionControlIT {
   }
 
   @Test
+  public void testRecreateWithPartialMaxRegionGroupNumUsesDefaultCounterpart() throws SQLException {
+    try (final Connection connection = EnvFactory.getEnv().getConnection();
+        final Statement statement = connection.createStatement()) {
+      final String database = "root.rg_tree_create_schema";
+      statement.execute(String.format("CREATE DATABASE %s;", database));
+
+      try (final ResultSet resultSet =
+          statement.executeQuery("SHOW DATABASES DETAILS " + database)) {
+        Assert.assertTrue(resultSet.next());
+        Assert.assertEquals(
+            testDefaultSchemaRegionGroupNumPerDatabase,
+            resultSet.getInt("MaxSchemaRegionGroupNum"));
+        Assert.assertEquals(
+            testDefaultDataRegionGroupNumPerDatabase, resultSet.getInt("MaxDataRegionGroupNum"));
+        Assert.assertFalse(resultSet.next());
+      }
+
+      statement.execute(String.format("DROP DATABASE %s;", database));
+      statement.execute(
+          String.format("CREATE DATABASE %s WITH MAX_SCHEMA_REGION_GROUP_NUM=3;", database));
+
+      try (final ResultSet resultSet =
+          statement.executeQuery("SHOW DATABASES DETAILS " + database)) {
+        Assert.assertTrue(resultSet.next());
+        Assert.assertEquals(3, resultSet.getInt("MaxSchemaRegionGroupNum"));
+        Assert.assertEquals(
+            testDefaultDataRegionGroupNumPerDatabase, resultSet.getInt("MaxDataRegionGroupNum"));
+        Assert.assertFalse(resultSet.next());
+      }
+
+      final String dataDatabase = "root.rg_tree_create_data";
+      statement.execute(
+          String.format("CREATE DATABASE %s WITH MAX_DATA_REGION_GROUP_NUM=4;", dataDatabase));
+
+      try (final ResultSet resultSet =
+          statement.executeQuery("SHOW DATABASES DETAILS " + dataDatabase)) {
+        Assert.assertTrue(resultSet.next());
+        Assert.assertEquals(
+            testDefaultSchemaRegionGroupNumPerDatabase,
+            resultSet.getInt("MaxSchemaRegionGroupNum"));
+        Assert.assertEquals(4, resultSet.getInt("MaxDataRegionGroupNum"));
+        Assert.assertFalse(resultSet.next());
+      }
+    }
+  }
+
+  @Test
   public void testRegionGroupNumControlThroughAlter()
       throws SQLException, ClientManagerException, IOException, InterruptedException, TException {
     try (final Connection connection = EnvFactory.getEnv().getConnection();
@@ -233,6 +281,69 @@ public class IoTDBDatabaseRegionControlIT {
               });
       Assert.assertEquals(testSchemaRegionGroupNum, schemaRegionGroupNum.get());
       Assert.assertEquals(testDataRegionGroupNum, dataRegionGroupNum.get());
+    }
+  }
+
+  @Test
+  public void testAlterMaxDataRegionGroupNumCannotDecrease() throws SQLException {
+    try (final Connection connection = EnvFactory.getEnv().getConnection();
+        final Statement statement = connection.createStatement()) {
+      final String database = "root.rg_tree_decrease";
+      statement.execute(
+          String.format("CREATE DATABASE %s WITH MAX_DATA_REGION_GROUP_NUM=8;", database));
+      statement.execute(
+          String.format("ALTER DATABASE %s WITH MAX_DATA_REGION_GROUP_NUM=16;", database));
+
+      final SQLException exception =
+          Assert.assertThrows(
+              SQLException.class,
+              () ->
+                  statement.execute(
+                      String.format(
+                          "ALTER DATABASE %s WITH MAX_DATA_REGION_GROUP_NUM=12;", database)));
+      Assert.assertTrue(
+          exception.getMessage(),
+          exception
+              .getMessage()
+              .contains(
+                  "MaxDataRegionGroupNum should be greater than or equal to current max "
+                      + "DataRegionGroupNum: 16."));
+
+      try (final ResultSet resultSet =
+          statement.executeQuery("SHOW DATABASES DETAILS " + database)) {
+        Assert.assertTrue(resultSet.next());
+        Assert.assertEquals(16, resultSet.getInt("MaxDataRegionGroupNum"));
+        Assert.assertFalse(resultSet.next());
+      }
+
+      final String schemaDatabase = "root.rg_tree_decrease_schema";
+      statement.execute(
+          String.format("CREATE DATABASE %s WITH MAX_SCHEMA_REGION_GROUP_NUM=4;", schemaDatabase));
+      statement.execute(
+          String.format("ALTER DATABASE %s WITH MAX_SCHEMA_REGION_GROUP_NUM=5;", schemaDatabase));
+
+      final SQLException schemaException =
+          Assert.assertThrows(
+              SQLException.class,
+              () ->
+                  statement.execute(
+                      String.format(
+                          "ALTER DATABASE %s WITH MAX_SCHEMA_REGION_GROUP_NUM=3;",
+                          schemaDatabase)));
+      Assert.assertTrue(
+          schemaException.getMessage(),
+          schemaException
+              .getMessage()
+              .contains(
+                  "MaxSchemaRegionGroupNum should be greater than or equal to current max "
+                      + "SchemaRegionGroupNum: 5."));
+
+      try (final ResultSet resultSet =
+          statement.executeQuery("SHOW DATABASES DETAILS " + schemaDatabase)) {
+        Assert.assertTrue(resultSet.next());
+        Assert.assertEquals(5, resultSet.getInt("MaxSchemaRegionGroupNum"));
+        Assert.assertFalse(resultSet.next());
+      }
     }
   }
 

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/schema/IoTDBDatabaseMaxRegionGroupNumIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/schema/IoTDBDatabaseMaxRegionGroupNumIT.java
@@ -89,6 +89,22 @@ public class IoTDBDatabaseMaxRegionGroupNumIT {
           "database,max_schema_region_group_num,max_data_region_group_num,",
           Collections.singleton("test_create,3,4,"));
 
+      statement.execute("create database test_create_schema with(max_schema_region_group_num=3)");
+      TestUtils.assertResultSetEqual(
+          statement.executeQuery(
+              "select database, max_schema_region_group_num, max_data_region_group_num "
+                  + "from information_schema.databases where database = 'test_create_schema'"),
+          "database,max_schema_region_group_num,max_data_region_group_num,",
+          Collections.singleton("test_create_schema,3," + DEFAULT_DATA_REGION_GROUP_NUM + ","));
+
+      statement.execute("create database test_create_data with(max_data_region_group_num=4)");
+      TestUtils.assertResultSetEqual(
+          statement.executeQuery(
+              "select database, max_schema_region_group_num, max_data_region_group_num "
+                  + "from information_schema.databases where database = 'test_create_data'"),
+          "database,max_schema_region_group_num,max_data_region_group_num,",
+          Collections.singleton("test_create_data," + DEFAULT_SCHEMA_REGION_GROUP_NUM + ",4,"));
+
       statement.execute("create database test_alter");
       statement.execute(
           "alter database test_alter set properties max_schema_region_group_num=3, max_data_region_group_num=4");
@@ -110,6 +126,63 @@ public class IoTDBDatabaseMaxRegionGroupNumIT {
           () ->
               statement.execute(
                   "create database test_deprecated with(schema_region_group_num=4, data_region_group_num=5)"));
+    }
+  }
+
+  @Test
+  public void testAlterMaxRegionGroupNumCannotDecrease() throws SQLException {
+    try (final Connection connection =
+            EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
+        final Statement statement = connection.createStatement()) {
+      statement.execute("create database test_decrease_data with(max_data_region_group_num=8)");
+      statement.execute(
+          "alter database test_decrease_data set properties max_data_region_group_num=16");
+
+      final SQLException exception =
+          Assert.assertThrows(
+              SQLException.class,
+              () ->
+                  statement.execute(
+                      "alter database test_decrease_data set properties max_data_region_group_num=12"));
+      Assert.assertTrue(
+          exception.getMessage(),
+          exception
+              .getMessage()
+              .contains(
+                  "MaxDataRegionGroupNum should be greater than or equal to current max "
+                      + "DataRegionGroupNum: 16."));
+
+      TestUtils.assertResultSetEqual(
+          statement.executeQuery(
+              "select database, max_data_region_group_num from information_schema.databases "
+                  + "where database = 'test_decrease_data'"),
+          "database,max_data_region_group_num,",
+          Collections.singleton("test_decrease_data,16,"));
+
+      statement.execute("create database test_decrease_schema with(max_schema_region_group_num=4)");
+      statement.execute(
+          "alter database test_decrease_schema set properties max_schema_region_group_num=5");
+
+      final SQLException schemaException =
+          Assert.assertThrows(
+              SQLException.class,
+              () ->
+                  statement.execute(
+                      "alter database test_decrease_schema set properties max_schema_region_group_num=3"));
+      Assert.assertTrue(
+          schemaException.getMessage(),
+          schemaException
+              .getMessage()
+              .contains(
+                  "MaxSchemaRegionGroupNum should be greater than or equal to current max "
+                      + "SchemaRegionGroupNum: 5."));
+
+      TestUtils.assertResultSetEqual(
+          statement.executeQuery(
+              "select database, max_schema_region_group_num from information_schema.databases "
+                  + "where database = 'test_decrease_schema'"),
+          "database,max_schema_region_group_num,",
+          Collections.singleton("test_decrease_schema,5,"));
     }
   }
 

--- a/iotdb-core/confignode/src/main/i18n/en/org/apache/iotdb/confignode/i18n/ManagerMessages.java
+++ b/iotdb-core/confignode/src/main/i18n/en/org/apache/iotdb/confignode/i18n/ManagerMessages.java
@@ -598,6 +598,9 @@ public final class ManagerMessages {
   public static final String MESSAGE_CURRENT_SCHEMAREGIONGROUPNUM_ARG_ALTER_SCHEMAREGIONGROUPNUM_ARG_F7495BC2 = "Current SchemaRegionGroupNum: %d, Alter SchemaRegionGroupNum: %d";
   public static final String MESSAGE_FAILED_ALTER_DATABASE_DATAREGIONGROUPNUM_COULD_ONLY_INCREASED_84283EB5 = "Failed to alter database. The DataRegionGroupNum could only be increased. ";
   public static final String MESSAGE_CURRENT_DATAREGIONGROUPNUM_ARG_ALTER_DATAREGIONGROUPNUM_ARG_61C6E978 = "Current DataRegionGroupNum: %d, Alter DataRegionGroupNum: %d";
+  public static final String MESSAGE_ARG_SHOULD_BE_GREATER_THAN_OR_EQUAL_TO_CURRENT_MIN_ARG_REGIONGROUPNUM_ARG_B81D93DF = "%s should be greater than or equal to current min %sRegionGroupNum: %d.";
+  public static final String MESSAGE_ARG_SHOULD_BE_GREATER_THAN_OR_EQUAL_TO_CURRENT_MAX_ARG_REGIONGROUPNUM_ARG_3D170323 = "%s should be greater than or equal to current max %sRegionGroupNum: %d.";
+  public static final String MESSAGE_ARG_SHOULD_BE_GREATER_THAN_OR_EQUAL_TO_ALLOCATED_ARG_REGIONGROUPNUM_ARG_994394A1 = "%s should be greater than or equal to allocated %sRegionGroupNum: %d.";
   public static final String MESSAGE_FAILED_CREATE_DATABASE_SCHEMAREPLICATIONFACTOR_SHOULD_POSITIVE_8847F33C = "Failed to create database. The schemaReplicationFactor should be positive.";
   public static final String MESSAGE_FAILED_CREATE_DATABASE_DATAREPLICATIONFACTOR_SHOULD_POSITIVE_C2565B7E = "Failed to create database. The dataReplicationFactor should be positive.";
   public static final String MESSAGE_FAILED_CREATE_DATABASE_TIMEPARTITIONORIGIN_SHOULD_NON_NEGATIVE_BD0595C9 = "Failed to create database. The timePartitionOrigin should be non-negative.";

--- a/iotdb-core/confignode/src/main/i18n/zh/org/apache/iotdb/confignode/i18n/ManagerMessages.java
+++ b/iotdb-core/confignode/src/main/i18n/zh/org/apache/iotdb/confignode/i18n/ManagerMessages.java
@@ -590,6 +590,9 @@ public final class ManagerMessages {
   public static final String MESSAGE_CURRENT_SCHEMAREGIONGROUPNUM_ARG_ALTER_SCHEMAREGIONGROUPNUM_ARG_F7495BC2 = "当前 SchemaRegionGroupNum：%d，待修改的 SchemaRegionGroupNum：%d";
   public static final String MESSAGE_FAILED_ALTER_DATABASE_DATAREGIONGROUPNUM_COULD_ONLY_INCREASED_84283EB5 = "修改数据库失败。DataRegionGroupNum 只能增加。";
   public static final String MESSAGE_CURRENT_DATAREGIONGROUPNUM_ARG_ALTER_DATAREGIONGROUPNUM_ARG_61C6E978 = "当前 DataRegionGroupNum：%d，待修改的 DataRegionGroupNum：%d";
+  public static final String MESSAGE_ARG_SHOULD_BE_GREATER_THAN_OR_EQUAL_TO_CURRENT_MIN_ARG_REGIONGROUPNUM_ARG_B81D93DF = "%s 应大于等于当前最小 %sRegionGroupNum：%d。";
+  public static final String MESSAGE_ARG_SHOULD_BE_GREATER_THAN_OR_EQUAL_TO_CURRENT_MAX_ARG_REGIONGROUPNUM_ARG_3D170323 = "%s 应大于等于当前最大 %sRegionGroupNum：%d。";
+  public static final String MESSAGE_ARG_SHOULD_BE_GREATER_THAN_OR_EQUAL_TO_ALLOCATED_ARG_REGIONGROUPNUM_ARG_994394A1 = "%s 应大于等于已分配的 %sRegionGroupNum：%d。";
   public static final String MESSAGE_FAILED_CREATE_DATABASE_SCHEMAREPLICATIONFACTOR_SHOULD_POSITIVE_8847F33C = "创建数据库失败。schemaReplicationFactor 应为正数。";
   public static final String MESSAGE_FAILED_CREATE_DATABASE_DATAREPLICATIONFACTOR_SHOULD_POSITIVE_C2565B7E = "创建数据库失败。dataReplicationFactor 应为正数。";
   public static final String MESSAGE_FAILED_CREATE_DATABASE_TIMEPARTITIONORIGIN_SHOULD_NON_NEGATIVE_BD0595C9 = "创建数据库失败。timePartitionOrigin 应为非负数。";

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/schema/ClusterSchemaManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/schema/ClusterSchemaManager.java
@@ -934,16 +934,16 @@ public class ClusterSchemaManager {
                       .FAILED_TO_CREATE_DATABASE_THE_DATAREGIONGROUPNUM_SHOULD_BE_POSITIVE);
     }
 
-    if (databaseSchema.isSetMaxSchemaRegionGroupNum()) {
+    if (!isErrorStatus(errorResp) && databaseSchema.isSetMaxSchemaRegionGroupNum()) {
       errorResp =
           validateMaxRegionGroupNumOnCreation(databaseSchema, TConsensusGroupType.SchemaRegion);
     }
-    if (databaseSchema.isSetMaxDataRegionGroupNum()) {
+    if (!isErrorStatus(errorResp) && databaseSchema.isSetMaxDataRegionGroupNum()) {
       errorResp =
           validateMaxRegionGroupNumOnCreation(databaseSchema, TConsensusGroupType.DataRegion);
     }
 
-    if (errorResp != null) {
+    if (isErrorStatus(errorResp)) {
       LOGGER.warn(ConfigNodeMessages.EXECUTE_SETDATABASE_WITH_RESULT, databaseSchema, errorResp);
       return errorResp;
     }
@@ -956,6 +956,10 @@ public class ClusterSchemaManager {
     }
 
     return StatusUtils.OK;
+  }
+
+  private static boolean isErrorStatus(final TSStatus status) {
+    return status != null && status.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode();
   }
 
   private static TSStatus validateMaxRegionGroupNumOnCreation(
@@ -1021,8 +1025,23 @@ public class ClusterSchemaManager {
       return new TSStatus(TSStatusCode.DATABASE_CONFIG_ERROR.getStatusCode())
           .setMessage(
               String.format(
-                  "%s should be greater than or equal to current min %sRegionGroupNum: %d.",
-                  fieldName, isSchemaRegion ? "Schema" : "Data", minRegionGroupNum));
+                  ManagerMessages
+                      .MESSAGE_ARG_SHOULD_BE_GREATER_THAN_OR_EQUAL_TO_CURRENT_MIN_ARG_REGIONGROUPNUM_ARG_B81D93DF,
+                  fieldName,
+                  isSchemaRegion ? "Schema" : "Data",
+                  minRegionGroupNum));
+    }
+
+    final int currentMaxRegionGroupNum = getMaxRegionGroupNum(database, consensusGroupType);
+    if (maxRegionGroupNum < currentMaxRegionGroupNum) {
+      return new TSStatus(TSStatusCode.DATABASE_CONFIG_ERROR.getStatusCode())
+          .setMessage(
+              String.format(
+                  ManagerMessages
+                      .MESSAGE_ARG_SHOULD_BE_GREATER_THAN_OR_EQUAL_TO_CURRENT_MAX_ARG_REGIONGROUPNUM_ARG_3D170323,
+                  fieldName,
+                  isSchemaRegion ? "Schema" : "Data",
+                  currentMaxRegionGroupNum));
     }
 
     final int allocatedRegionGroupCount;
@@ -1037,8 +1056,11 @@ public class ClusterSchemaManager {
       return new TSStatus(TSStatusCode.DATABASE_CONFIG_ERROR.getStatusCode())
           .setMessage(
               String.format(
-                  "%s should be greater than or equal to allocated %sRegionGroupNum: %d.",
-                  fieldName, isSchemaRegion ? "Schema" : "Data", allocatedRegionGroupCount));
+                  ManagerMessages
+                      .MESSAGE_ARG_SHOULD_BE_GREATER_THAN_OR_EQUAL_TO_ALLOCATED_ARG_REGIONGROUPNUM_ARG_994394A1,
+                  fieldName,
+                  isSchemaRegion ? "Schema" : "Data",
+                  allocatedRegionGroupCount));
     }
 
     return StatusUtils.OK;


### PR DESCRIPTION
The new value cannot be less than the current maximum quota. 
<img width="1200" height="261" alt="image" src="https://github.com/user-attachments/assets/0c5bfe23-7e8d-4634-baf9-ec5c2c6b3de3" />

The quota uses the default value if unspecified in the ALTER DATABASE statement.
<img width="1096" height="364" alt="image" src="https://github.com/user-attachments/assets/86800147-4c91-4d4c-9a0f-b2907a5a6b2e" />
