### PR TITLE
Fix downgraded TsFileResource serialization

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/batch/IoTDBRegionMigrateNormalITForIoTV2BatchIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/batch/IoTDBRegionMigrateNormalITForIoTV2BatchIT.java
@@ -21,12 +21,20 @@ package org.apache.iotdb.confignode.it.regionmigration.pass.commit.batch;
 
 import org.apache.iotdb.commons.utils.KillPoint.KillNode;
 import org.apache.iotdb.confignode.it.regionmigration.IoTDBRegionOperationReliabilityITFramework;
+import org.apache.iotdb.it.env.EnvFactory;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.ClusterIT;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import static org.apache.iotdb.util.MagicUtils.makeItCloseQuietly;
 
 @Category({ClusterIT.class})
 @RunWith(IoTDBTestRunner.class)
@@ -40,5 +48,31 @@ public class IoTDBRegionMigrateNormalITForIoTV2BatchIT
   @Test
   public void normal3C3DTest() throws Exception {
     successTest(2, 3, 3, 3, noKillPoints(), noKillPoints(), KillNode.ALL_NODES);
+  }
+
+  @Test
+  public void migrateRegionWithDegradedTimeIndexTest() throws Exception {
+    // set TsFileResource memory to 0 to trigger degrading
+    EnvFactory.getEnv().getConfig().getCommonConfig().setQueryMemoryProportion("1:1:1:1:1:1:0");
+
+    successTest(1, 1, 1, 2, noKillPoints(), noKillPoints(), KillNode.ALL_NODES);
+
+    try (final Connection connection = makeItCloseQuietly(EnvFactory.getEnv().getConnection());
+        final Statement statement = makeItCloseQuietly(connection.createStatement())) {
+      assertCounts(statement, 1, 1);
+      statement.execute("INSERT INTO root.sg.d1(timestamp,speed,temperature) values(101, 3, 4)");
+      assertCounts(statement, 2, 2);
+    }
+  }
+
+  private static void assertCounts(
+      final Statement statement, final long expectedSpeedCount, final long expectedTemperatureCount)
+      throws Exception {
+    try (final ResultSet resultSet =
+        statement.executeQuery("select count(speed), count(temperature) from root.sg.d1")) {
+      Assert.assertTrue(resultSet.next());
+      Assert.assertEquals(expectedSpeedCount, resultSet.getLong(1));
+      Assert.assertEquals(expectedTemperatureCount, resultSet.getLong(2));
+    }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
@@ -283,7 +283,7 @@ public class TsFileResource implements PersistentResource, Cloneable {
 
   private void serializeTo(BufferedOutputStream outputStream) throws IOException {
     ReadWriteIOUtils.write(VERSION_NUMBER, outputStream);
-    timeIndex.serialize(outputStream);
+    getTimeIndexForSerialization().serialize(outputStream);
 
     ReadWriteIOUtils.write(maxPlanIndex, outputStream);
     ReadWriteIOUtils.write(minPlanIndex, outputStream);
@@ -315,6 +315,17 @@ public class TsFileResource implements PersistentResource, Cloneable {
     TsFileResourceBlockType.PIPE_MARK.serialize(outputStream);
     ReadWriteIOUtils.write(isGeneratedByIoTConsensusV2, outputStream);
     ReadWriteIOUtils.write(isGeneratedByPipe, outputStream);
+  }
+
+  private ITimeIndex getTimeIndexForSerialization() throws IOException {
+    if (!(timeIndex instanceof FileTimeIndex) || !resourceFileExists()) {
+      return timeIndex;
+    }
+
+    ITimeIndex timeIndexFromResourceFile = deserializeTimeIndexFromResourceFile();
+    return timeIndexFromResourceFile instanceof FileTimeIndex
+        ? timeIndex
+        : timeIndexFromResourceFile;
   }
 
   /** deserialize from disk */
@@ -694,20 +705,13 @@ public class TsFileResource implements PersistentResource, Cloneable {
       throws IOException {
     readLock();
     try {
-      if (!resourceFileExists()) {
-        throw new IOException(StorageEngineMessages.RESOURCE_FILE_NOT_FOUND);
-      }
-      try (InputStream inputStream =
-          FSFactoryProducer.getFSFactory()
-              .getBufferedInputStream(file.getPath() + RESOURCE_SUFFIX)) {
-        ReadWriteIOUtils.readByte(inputStream);
-        ITimeIndex timeIndexFromResourceFile =
-            ITimeIndex.createTimeIndex(inputStream, deserializer);
-        if (!(timeIndexFromResourceFile instanceof ArrayDeviceTimeIndex)) {
-          throw new IOException(
-              StorageEngineMessages.CANNOT_BUILD_DEVICE_TIME_INDEX + file.getPath());
+      try {
+        ITimeIndex timeIndexFromResourceFile = deserializeTimeIndexFromResourceFile(deserializer);
+        if (timeIndexFromResourceFile instanceof ArrayDeviceTimeIndex) {
+          return (ArrayDeviceTimeIndex) timeIndexFromResourceFile;
         }
-        return (ArrayDeviceTimeIndex) timeIndexFromResourceFile;
+        throw new IOException(
+            StorageEngineMessages.CANNOT_BUILD_DEVICE_TIME_INDEX + file.getPath());
       } catch (Exception e) {
         throw new IOException(
             String.format(
@@ -718,6 +722,22 @@ public class TsFileResource implements PersistentResource, Cloneable {
       }
     } finally {
       readUnlock();
+    }
+  }
+
+  private ITimeIndex deserializeTimeIndexFromResourceFile() throws IOException {
+    return deserializeTimeIndexFromResourceFile(IDeviceID.Deserializer.DEFAULT_DESERIALIZER);
+  }
+
+  private ITimeIndex deserializeTimeIndexFromResourceFile(IDeviceID.Deserializer deserializer)
+      throws IOException {
+    if (!resourceFileExists()) {
+      throw new IOException(StorageEngineMessages.RESOURCE_FILE_NOT_FOUND);
+    }
+    try (InputStream inputStream =
+        FSFactoryProducer.getFSFactory().getBufferedInputStream(file.getPath() + RESOURCE_SUFFIX)) {
+      ReadWriteIOUtils.readByte(inputStream);
+      return ITimeIndex.createTimeIndex(inputStream, deserializer);
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
@@ -322,10 +322,7 @@ public class TsFileResource implements PersistentResource, Cloneable {
       return timeIndex;
     }
 
-    ITimeIndex timeIndexFromResourceFile = deserializeTimeIndexFromResourceFile();
-    return timeIndexFromResourceFile instanceof FileTimeIndex
-        ? timeIndex
-        : timeIndexFromResourceFile;
+    return buildDeviceTimeIndex();
   }
 
   /** deserialize from disk */
@@ -723,10 +720,6 @@ public class TsFileResource implements PersistentResource, Cloneable {
     } finally {
       readUnlock();
     }
-  }
-
-  private ITimeIndex deserializeTimeIndexFromResourceFile() throws IOException {
-    return deserializeTimeIndexFromResourceFile(IDeviceID.Deserializer.DEFAULT_DESERIALIZER);
   }
 
   private ITimeIndex deserializeTimeIndexFromResourceFile(IDeviceID.Deserializer deserializer)

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResourceTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResourceTest.java
@@ -93,7 +93,7 @@ public class TsFileResourceTest {
     if (file.exists()) {
       FileUtils.delete(file);
     }
-    File resourceFile = new File(file.getName() + TsFileResource.RESOURCE_SUFFIX);
+    File resourceFile = new File(file.getPath() + TsFileResource.RESOURCE_SUFFIX);
     if (resourceFile.exists()) {
       FileUtils.delete(resourceFile);
     }
@@ -108,7 +108,22 @@ public class TsFileResourceTest {
   }
 
   @Test
-  public void testDegradeAndFileTimeIndex() {
+  public void testSerializeDegradedTimeIndex() throws IOException {
+    tsFileResource.serialize();
+    tsFileResource.degradeTimeIndex();
+
+    tsFileResource.serialize();
+
+    TsFileResource derTsFileResource = new TsFileResource(file);
+    derTsFileResource.deserialize();
+    Assert.assertEquals(
+        ITimeIndex.ARRAY_DEVICE_TIME_INDEX_TYPE, derTsFileResource.getTimeIndexType());
+    Assert.assertEquals(deviceToIndex.keySet(), derTsFileResource.getDevices());
+  }
+
+  @Test
+  public void testDegradeAndFileTimeIndex() throws IOException {
+    tsFileResource.serialize();
     Assert.assertEquals(ITimeIndex.ARRAY_DEVICE_TIME_INDEX_TYPE, tsFileResource.getTimeIndexType());
     tsFileResource.degradeTimeIndex();
     Assert.assertEquals(ITimeIndex.FILE_TIME_INDEX_TYPE, tsFileResource.getTimeIndexType());


### PR DESCRIPTION
## Description
This PR fixes TsFileResource serialization when the in-memory TimeIndex has been degraded to FileTimeIndex.

When a resource file already exists, serialization now preserves the device-level time index stored in the resource file instead of serializing the degraded in-memory FileTimeIndex directly.

## Tests
- mvn test -pl iotdb-core/datanode -Dtest=TsFileResourceTest
- mvn verify -DskipUTs '-Dit.test=IoTDBRegionMigrateNormalITForIoTV2BatchIT#migrateRegionWithDegradedTimeIndexTest' -DfailIfNoTests=false '-Dfailsafe.failIfNoSpecifiedTests=false' '-Drat.skip=true' -pl integration-test -am -P with-integration-tests -PClusterIT

## Follow-up
After rebasing to the latest master and reverting FileTimeIndex serialization, a local rerun of TsFileResourceTest was blocked by unrelated datanode compile errors in pipe classes.