### PR TITLE
Fix downgraded TsFileResource serialization

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/IoTDBRegionMigrateNormalIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/IoTDBRegionMigrateNormalIT.java
@@ -21,12 +21,20 @@ package org.apache.iotdb.confignode.it.regionmigration.pass;
 
 import org.apache.iotdb.commons.utils.KillPoint.KillNode;
 import org.apache.iotdb.confignode.it.regionmigration.IoTDBRegionOperationReliabilityITFramework;
+import org.apache.iotdb.it.env.EnvFactory;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.ClusterIT;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import static org.apache.iotdb.util.MagicUtils.makeItCloseQuietly;
 
 @Category({ClusterIT.class})
 @RunWith(IoTDBTestRunner.class)
@@ -39,5 +47,31 @@ public class IoTDBRegionMigrateNormalIT extends IoTDBRegionOperationReliabilityI
   @Test
   public void normal3C3DTest() throws Exception {
     successTest(2, 3, 3, 3, noKillPoints(), noKillPoints(), KillNode.ALL_NODES);
+  }
+
+  @Test
+  public void migrateRegionWithDegradedTimeIndexTest() throws Exception {
+    // set TsFileResource memory to 0 to trigger degrading
+    EnvFactory.getEnv().getConfig().getCommonConfig().setQueryMemoryProportion("1:1:1:1:1:1:0");
+
+    successTest(1, 1, 1, 2, noKillPoints(), noKillPoints(), KillNode.ALL_NODES);
+
+    try (final Connection connection = makeItCloseQuietly(EnvFactory.getEnv().getConnection());
+        final Statement statement = makeItCloseQuietly(connection.createStatement())) {
+      assertCounts(statement, 1, 1);
+      statement.execute("INSERT INTO root.sg.d1(timestamp,speed,temperature) values(101, 3, 4)");
+      assertCounts(statement, 2, 2);
+    }
+  }
+
+  private static void assertCounts(
+      final Statement statement, final long expectedSpeedCount, final long expectedTemperatureCount)
+      throws Exception {
+    try (final ResultSet resultSet =
+        statement.executeQuery("select count(speed), count(temperature) from root.sg.d1")) {
+      Assert.assertTrue(resultSet.next());
+      Assert.assertEquals(expectedSpeedCount, resultSet.getLong(1));
+      Assert.assertEquals(expectedTemperatureCount, resultSet.getLong(2));
+    }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
@@ -248,7 +248,7 @@ public class TsFileResource implements Cloneable {
 
   private void serializeTo(BufferedOutputStream outputStream) throws IOException {
     ReadWriteIOUtils.write(VERSION_NUMBER, outputStream);
-    timeIndex.serialize(outputStream);
+    getTimeIndexForSerialization().serialize(outputStream);
 
     ReadWriteIOUtils.write(maxPlanIndex, outputStream);
     ReadWriteIOUtils.write(minPlanIndex, outputStream);
@@ -274,6 +274,14 @@ public class TsFileResource implements Cloneable {
     TsFileResourceBlockType.PIPE_MARK.serialize(outputStream);
     ReadWriteIOUtils.write(isGeneratedByPipeConsensus, outputStream);
     ReadWriteIOUtils.write(isGeneratedByPipe, outputStream);
+  }
+
+  private ITimeIndex getTimeIndexForSerialization() throws IOException {
+    if (!(timeIndex instanceof FileTimeIndex) || !resourceFileExists()) {
+      return timeIndex;
+    }
+
+    return buildDeviceTimeIndex();
   }
 
   /** deserialize from disk */

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResourceTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResourceTest.java
@@ -69,7 +69,7 @@ public class TsFileResourceTest {
     if (file.exists()) {
       FileUtils.delete(file);
     }
-    File resourceFile = new File(file.getName() + TsFileResource.RESOURCE_SUFFIX);
+    File resourceFile = new File(file.getPath() + TsFileResource.RESOURCE_SUFFIX);
     if (resourceFile.exists()) {
       FileUtils.delete(resourceFile);
     }
@@ -84,7 +84,21 @@ public class TsFileResourceTest {
   }
 
   @Test
-  public void testDegradeAndFileTimeIndex() {
+  public void testSerializeDegradedTimeIndex() throws IOException {
+    tsFileResource.serialize();
+    tsFileResource.degradeTimeIndex();
+
+    tsFileResource.serialize();
+
+    TsFileResource derTsFileResource = new TsFileResource(file);
+    derTsFileResource.deserialize();
+    Assert.assertEquals(ITimeIndex.DEVICE_TIME_INDEX_TYPE, derTsFileResource.getTimeIndexType());
+    Assert.assertEquals(deviceToIndex.keySet(), derTsFileResource.getDevices());
+  }
+
+  @Test
+  public void testDegradeAndFileTimeIndex() throws IOException {
+    tsFileResource.serialize();
     Assert.assertEquals(ITimeIndex.DEVICE_TIME_INDEX_TYPE, tsFileResource.getTimeIndexType());
     tsFileResource.degradeTimeIndex();
     Assert.assertEquals(ITimeIndex.FILE_TIME_INDEX_TYPE, tsFileResource.getTimeIndexType());


### PR DESCRIPTION
## Description
This PR backports the fix for serializing a TsFileResource whose in-memory TimeIndex has been degraded to FileTimeIndex.

When serializing a degraded resource and the .resource file still exists, TsFileResource now rebuilds a device time index through buildDeviceTimeIndex() for serialization instead of serializing FileTimeIndex directly.

It also adds coverage for region migration after TimeIndex degradation in an existing cluster IT class to avoid introducing another cluster restart path.

## Tests
- mvn spotless:apply -pl iotdb-core/datanode
- mvn spotless:apply -pl integration-test -P with-integration-tests
- mvn test -pl iotdb-core/datanode -Dtest=TsFileResourceTest (blocked: local dev/1.3 snapshot dependencies are not available without -am)
- mvn test -pl iotdb-core/datanode -am -Dtest=TsFileResourceTest '-Dsurefire.failIfNoSpecifiedTests=false' (blocked before datanode tests by generated thrift compilation errors: TProtocol.incrementRecursionDepth/decrementRecursionDepth not found in iotdb-thrift-commons)