### PR TITLE
[To dev/1.3] Fix the AlignedTVListIterator / memtable read index problem

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
@@ -1924,8 +1924,7 @@ public abstract class AlignedTVList extends TVList {
         }
 
         int nextRowIndex = index + 1;
-        while (nextRowIndex < rows
-            && isAllValueColumnsDeleted(getValueIndex(nextRowIndex))) {
+        while (nextRowIndex < rows && isAllValueColumnsDeleted(getValueIndex(nextRowIndex))) {
           nextRowIndex++;
         }
         long time = getTime(index);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
@@ -1454,8 +1454,7 @@ public abstract class AlignedTVList extends TVList {
       while (index < rows && !findValidRow) {
         // all columns values are deleted
         int convertedScanOrderValueIndex = getValueIndex(getScanOrderIndex(index));
-        if ((allValueColDeletedMap != null
-            && allValueColDeletedMap.isMarked(convertedScanOrderValueIndex))) {
+        if (isAllValueColumnsDeleted(convertedScanOrderValueIndex)) {
           index++;
           continue;
         }
@@ -1488,9 +1487,7 @@ public abstract class AlignedTVList extends TVList {
         while (index + 1 < rows
             && getTime(getScanOrderIndex(index + 1)) == getTime(getScanOrderIndex(index))) {
           index++;
-          // skip all-Null rows if allValueColDeletedMap exists
-          if (allValueColDeletedMap == null
-              || !allValueColDeletedMap.isMarked(getValueIndex(getScanOrderIndex(index)))) {
+          if (!isAllValueColumnsDeleted(getValueIndex(getScanOrderIndex(index)))) {
             for (int columnIndex = 0; columnIndex < dataTypeList.size(); columnIndex++) {
               if (!scanOrder.isAscending() && selectedIndices[columnIndex] != -1) {
                 // non -1 value means it already set the latest point index
@@ -1656,8 +1653,7 @@ public abstract class AlignedTVList extends TVList {
           break;
         }
         // skip invalid row
-        if ((allValueColDeletedMap != null
-                && allValueColDeletedMap.isMarked(getValueIndex(getScanOrderIndex(index))))
+        if (isAllValueColumnsDeleted(getValueIndex(getScanOrderIndex(index)))
             || !isTimeSatisfied(time)) {
           timeInvalidInfo =
               timeInvalidInfo == null
@@ -1668,9 +1664,7 @@ public abstract class AlignedTVList extends TVList {
         }
         int nextRowIndex = index + 1;
         while (nextRowIndex < rows
-            && ((allValueColDeletedMap != null
-                    && allValueColDeletedMap.isMarked(
-                        getValueIndex(getScanOrderIndex(nextRowIndex))))
+            && (isAllValueColumnsDeleted(getValueIndex(getScanOrderIndex(nextRowIndex)))
                 || !isTimeSatisfied(getTime(getScanOrderIndex(nextRowIndex))))) {
           timeInvalidInfo =
               timeInvalidInfo == null
@@ -1925,14 +1919,13 @@ public abstract class AlignedTVList extends TVList {
           break;
         }
         // skip empty row
-        if (allValueColDeletedMap != null && allValueColDeletedMap.isMarked(getValueIndex(index))) {
+        if (isAllValueColumnsDeleted(getValueIndex(index))) {
           continue;
         }
 
         int nextRowIndex = index + 1;
         while (nextRowIndex < rows
-            && (allValueColDeletedMap != null
-                && allValueColDeletedMap.isMarked(getValueIndex(nextRowIndex)))) {
+            && isAllValueColumnsDeleted(getValueIndex(nextRowIndex))) {
           nextRowIndex++;
         }
         long time = getTime(index);
@@ -1962,8 +1955,7 @@ public abstract class AlignedTVList extends TVList {
         }
         for (int sortedRowIndex = startIndex; sortedRowIndex < index; sortedRowIndex++) {
           // skip empty row
-          if (allValueColDeletedMap != null
-              && allValueColDeletedMap.isMarked(getValueIndex(sortedRowIndex))) {
+          if (isAllValueColumnsDeleted(getValueIndex(sortedRowIndex))) {
             continue;
           }
           long time = getTime(sortedRowIndex);
@@ -2042,6 +2034,14 @@ public abstract class AlignedTVList extends TVList {
 
     public int[] getSelectedIndices() {
       return selectedIndices;
+    }
+
+    private boolean isAllValueColumnsDeleted(int valueIndex) {
+      // A sorted row-count snapshot can point to value indices appended after the snapshot.
+      return allValueColDeletedMap != null
+          && valueIndex >= 0
+          && valueIndex < allValueColDeletedMap.getSize()
+          && allValueColDeletedMap.isMarked(valueIndex);
     }
 
     public int getSelectedIndex(int column) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AlignedTVListIteratorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/memtable/AlignedTVListIteratorTest.java
@@ -167,6 +167,40 @@ public class AlignedTVListIteratorTest {
   }
 
   @Test
+  public void testIteratorWithStaleRowCountAfterSort() {
+    AlignedTVList tvList =
+        AlignedTVList.newAlignedList(
+            Arrays.asList(TSDataType.INT32, TSDataType.INT32, TSDataType.INT32));
+    for (int i = 100; i < 110; i++) {
+      tvList.putAlignedValue(i, new Object[] {i, i, i});
+    }
+    int staleRowCount = tvList.rowCount();
+    for (int i = 1; i <= 2; i++) {
+      tvList.putAlignedValue(i, new Object[] {i, i, i});
+    }
+    tvList.delete(1, 2);
+    tvList.sort();
+
+    AlignedTVList.AlignedTVListIterator iterator =
+        tvList.iterator(
+            Ordering.ASC,
+            staleRowCount,
+            null,
+            Arrays.asList(TSDataType.INT32, TSDataType.INT32, TSDataType.INT32),
+            Arrays.asList(0, 1, 2),
+            null,
+            null,
+            null,
+            100);
+    int count = 0;
+    while (iterator.hasNextTimeValuePair()) {
+      iterator.nextTimeValuePair();
+      count++;
+    }
+    Assert.assertEquals(staleRowCount - 2, count);
+  }
+
+  @Test
   public void testAlignedWithDeletionsInTVList() throws IOException {
     Map<TVList, Integer> tvListMap =
         buildAlignedSingleTvListMap(Collections.singletonList(new TimeRange(1, 1000)));


### PR DESCRIPTION
Backport #18158 to `dev/1.3`.

## Summary
- Guard `AlignedTVListIterator` against stale row-count snapshots when checking the all-value-column deletion bitmap.
- Add a regression test for sorted `AlignedTVList` iteration after appending and deleting rows.

## Tests
- `mvn -pl iotdb-core/datanode -Dtest=AlignedTVListIteratorTest -DskipITs test`
- `mvn -pl iotdb-core/datanode spotless:check`