### PR TITLE
Fix aggregation NPE when child input finishes early

### DIFF
--- a/iotdb-core/calc-commons/src/main/java/org/apache/iotdb/calc/execution/operator/process/AbstractConsumeAllOperator.java
+++ b/iotdb-core/calc-commons/src/main/java/org/apache/iotdb/calc/execution/operator/process/AbstractConsumeAllOperator.java
@@ -171,6 +171,7 @@ public abstract class AbstractConsumeAllOperator extends AbstractOperator
   protected void handleFinishedChild(int currentChildIndex) throws Exception {
     children.get(currentChildIndex).close();
     children.set(currentChildIndex, null);
+    inputTsBlocks[currentChildIndex] = null;
   }
 
   // endregion

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/TreeAggregator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/aggregation/TreeAggregator.java
@@ -92,17 +92,27 @@ public class TreeAggregator {
       checkArgument(
           inputLocationList.size() == 1,
           DataNodeQueryMessages.EXCEPTION_FINAL_OUTPUT_CAN_ONLY_BE_SINGLE_COLUMN_6D82F9E0);
+      InputLocation inputLocation = inputLocationList.get(0)[0];
+      if (tsBlock[inputLocation.getTsBlockIndex()] == null) {
+        return;
+      }
       Column finalResult =
-          tsBlock[inputLocationList.get(0)[0].getTsBlockIndex()].getColumn(
-              inputLocationList.get(0)[0].getValueColumnIndex());
+          tsBlock[inputLocation.getTsBlockIndex()].getColumn(inputLocation.getValueColumnIndex());
       accumulator.setFinal(finalResult);
     } else {
       for (InputLocation[] inputLocations : inputLocationList) {
         Column[] columns = new Column[inputLocations.length];
+        boolean hasMissingInput = false;
         for (int i = 0; i < inputLocations.length; i++) {
-          columns[i] =
-              tsBlock[inputLocations[i].getTsBlockIndex()].getColumn(
-                  inputLocations[i].getValueColumnIndex());
+          TsBlock inputTsBlock = tsBlock[inputLocations[i].getTsBlockIndex()];
+          if (inputTsBlock == null) {
+            hasMissingInput = true;
+            break;
+          }
+          columns[i] = inputTsBlock.getColumn(inputLocations[i].getValueColumnIndex());
+        }
+        if (hasMissingInput) {
+          continue;
         }
         accumulator.addIntermediate(columns);
       }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/AggregationOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/operator/process/AggregationOperator.java
@@ -161,6 +161,9 @@ public class AggregationOperator extends AbstractConsumeAllOperator {
       }
 
       for (int i = 0; i < inputOperatorsCount; i++) {
+        if (inputTsBlocks[i] == null) {
+          continue;
+        }
         inputTsBlocks[i] = inputTsBlocks[i].skipFirst();
         if (inputTsBlocks[i].isEmpty()) {
           inputTsBlocks[i] = null;

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/AggregationOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/AggregationOperatorTest.java
@@ -315,8 +315,7 @@ public class AggregationOperatorTest {
 
     List<Operator> children = new ArrayList<>();
     children.add(
-        new FixedTsBlockOperator(
-            driverContext.getOperatorContexts().get(0), buildEmptyTsBlock()));
+        new FixedTsBlockOperator(driverContext.getOperatorContexts().get(0), buildEmptyTsBlock()));
     children.add(
         new FixedTsBlockOperator(
             driverContext.getOperatorContexts().get(1), buildCountTsBlock(new long[] {0}, 5)));

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/AggregationOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/AggregationOperatorTest.java
@@ -294,6 +294,80 @@ public class AggregationOperatorTest {
   }
 
   @Test
+  public void testGroupByIntermediateResultWithFinishedEmptyChild() throws Exception {
+    QueryId queryId = new QueryId("stub_query_finished_empty_child");
+    FragmentInstanceId instanceId =
+        new FragmentInstanceId(new PlanFragmentId(queryId, 0), "stub-instance");
+    FragmentInstanceStateMachine stateMachine =
+        new FragmentInstanceStateMachine(instanceId, instanceNotificationExecutor);
+    FragmentInstanceContext fragmentInstanceContext =
+        createFragmentInstanceContext(instanceId, stateMachine);
+    DriverContext driverContext = new DriverContext(fragmentInstanceContext, 0);
+    driverContext.addOperatorContext(
+        1, new PlanNodeId("finished-empty-child"), FixedTsBlockOperator.class.getSimpleName());
+    driverContext.addOperatorContext(
+        2, new PlanNodeId("data-child"), FixedTsBlockOperator.class.getSimpleName());
+    driverContext.addOperatorContext(
+        3, new PlanNodeId("aggregation"), AggregationOperator.class.getSimpleName());
+    driverContext
+        .getOperatorContexts()
+        .forEach(operatorContext -> OperatorContext.setMaxRunTime(TEST_TIME_SLICE));
+
+    List<Operator> children = new ArrayList<>();
+    children.add(
+        new FixedTsBlockOperator(
+            driverContext.getOperatorContexts().get(0), buildEmptyTsBlock()));
+    children.add(
+        new FixedTsBlockOperator(
+            driverContext.getOperatorContexts().get(1), buildCountTsBlock(new long[] {0}, 5)));
+
+    List<InputLocation[]> inputLocationForCount = new ArrayList<>();
+    inputLocationForCount.add(new InputLocation[] {new InputLocation(0, 0)});
+    inputLocationForCount.add(new InputLocation[] {new InputLocation(1, 0)});
+
+    List<TreeAggregator> finalAggregators = new ArrayList<>();
+    finalAggregators.add(
+        new TreeAggregator(
+            AccumulatorFactory.createBuiltinAccumulators(
+                    Collections.singletonList(TAggregationType.COUNT),
+                    TSDataType.INT32,
+                    Collections.emptyList(),
+                    Collections.emptyMap(),
+                    true)
+                .get(0),
+            AggregationStep.FINAL,
+            inputLocationForCount));
+
+    GroupByTimeParameter groupByTimeParameter =
+        new GroupByTimeParameter(0, 100, new TimeDuration(0, 100), new TimeDuration(0, 100), true);
+    AggregationOperator aggregationOperator =
+        new AggregationOperator(
+            driverContext.getOperatorContexts().get(2),
+            finalAggregators,
+            initTimeRangeIterator(groupByTimeParameter, true, true, ZoneId.systemDefault()),
+            children,
+            false,
+            DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES);
+
+    int resultCount = 0;
+    while (true) {
+      ListenableFuture<?> blocked = aggregationOperator.isBlocked();
+      blocked.get();
+      if (!aggregationOperator.hasNext()) {
+        break;
+      }
+      TsBlock resultTsBlock = aggregationOperator.next();
+      if (resultTsBlock == null) {
+        continue;
+      }
+      assertEquals(0, resultTsBlock.getTimeColumn().getLong(0));
+      assertEquals(5, resultTsBlock.getColumn(0).getLong(0));
+      resultCount++;
+    }
+    assertEquals(1, resultCount);
+  }
+
+  @Test
   public void testGroupByIntermediateResultWithFinishedChild() throws Exception {
     QueryId queryId = new QueryId("stub_query_finished_child");
     FragmentInstanceId instanceId =
@@ -489,6 +563,10 @@ public class AggregationOperatorTest {
         children,
         false,
         DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES);
+  }
+
+  private TsBlock buildEmptyTsBlock() {
+    return new TsBlockBuilder(Collections.singletonList(TSDataType.INT64)).build();
   }
 
   private TsBlock buildCountTsBlock(long[] times, long... counts) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/AggregationOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/AggregationOperatorTest.java
@@ -53,6 +53,7 @@ import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.exception.write.WriteProcessException;
 import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.read.common.block.TsBlock;
+import org.apache.tsfile.read.common.block.TsBlockBuilder;
 import org.apache.tsfile.utils.TimeDuration;
 import org.apache.tsfile.write.schema.IMeasurementSchema;
 import org.apache.tsfile.write.schema.MeasurementSchema;
@@ -292,6 +293,85 @@ public class AggregationOperatorTest {
     assertEquals(4, count);
   }
 
+  @Test
+  public void testGroupByIntermediateResultWithFinishedChild() throws Exception {
+    QueryId queryId = new QueryId("stub_query_finished_child");
+    FragmentInstanceId instanceId =
+        new FragmentInstanceId(new PlanFragmentId(queryId, 0), "stub-instance");
+    FragmentInstanceStateMachine stateMachine =
+        new FragmentInstanceStateMachine(instanceId, instanceNotificationExecutor);
+    FragmentInstanceContext fragmentInstanceContext =
+        createFragmentInstanceContext(instanceId, stateMachine);
+    DriverContext driverContext = new DriverContext(fragmentInstanceContext, 0);
+    driverContext.addOperatorContext(
+        1, new PlanNodeId("finished-child-1"), FixedTsBlockOperator.class.getSimpleName());
+    driverContext.addOperatorContext(
+        2, new PlanNodeId("finished-child-2"), FixedTsBlockOperator.class.getSimpleName());
+    driverContext.addOperatorContext(
+        3, new PlanNodeId("aggregation"), AggregationOperator.class.getSimpleName());
+    driverContext
+        .getOperatorContexts()
+        .forEach(operatorContext -> OperatorContext.setMaxRunTime(TEST_TIME_SLICE));
+
+    List<Operator> children = new ArrayList<>();
+    children.add(
+        new FixedTsBlockOperator(
+            driverContext.getOperatorContexts().get(0), buildCountTsBlock(new long[] {0}, 3)));
+    children.add(
+        new FixedTsBlockOperator(
+            driverContext.getOperatorContexts().get(1),
+            buildCountTsBlock(new long[] {0, 100}, 5, 7)));
+
+    List<InputLocation[]> inputLocationForCount = new ArrayList<>();
+    inputLocationForCount.add(new InputLocation[] {new InputLocation(0, 0)});
+    inputLocationForCount.add(new InputLocation[] {new InputLocation(1, 0)});
+
+    List<TreeAggregator> finalAggregators = new ArrayList<>();
+    finalAggregators.add(
+        new TreeAggregator(
+            AccumulatorFactory.createBuiltinAccumulators(
+                    Collections.singletonList(TAggregationType.COUNT),
+                    TSDataType.INT32,
+                    Collections.emptyList(),
+                    Collections.emptyMap(),
+                    true)
+                .get(0),
+            AggregationStep.FINAL,
+            inputLocationForCount));
+
+    GroupByTimeParameter groupByTimeParameter =
+        new GroupByTimeParameter(0, 200, new TimeDuration(0, 100), new TimeDuration(0, 100), true);
+    AggregationOperator aggregationOperator =
+        new AggregationOperator(
+            driverContext.getOperatorContexts().get(2),
+            finalAggregators,
+            initTimeRangeIterator(groupByTimeParameter, true, true, ZoneId.systemDefault()),
+            children,
+            false,
+            DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES);
+
+    long[] expectedTimes = new long[] {0, 100};
+    long[] expectedCounts = new long[] {8, 7};
+    int count = 0;
+    while (true) {
+      ListenableFuture<?> blocked = aggregationOperator.isBlocked();
+      blocked.get();
+      if (!aggregationOperator.hasNext()) {
+        break;
+      }
+      TsBlock resultTsBlock = aggregationOperator.next();
+      if (resultTsBlock == null) {
+        continue;
+      }
+      for (int pos = 0; pos < resultTsBlock.getPositionCount(); pos++) {
+        assertEquals(expectedTimes[count], resultTsBlock.getTimeColumn().getLong(pos));
+        assertEquals(expectedCounts[count], resultTsBlock.getColumn(0).getLong(pos));
+        count++;
+      }
+    }
+    assertEquals(2, count);
+  }
+
   /**
    * @param aggregationTypes Aggregation function used in test
    * @param groupByTimeParameter group by time parameter
@@ -409,5 +489,70 @@ public class AggregationOperatorTest {
         children,
         false,
         DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES);
+  }
+
+  private TsBlock buildCountTsBlock(long[] times, long... counts) {
+    TsBlockBuilder builder = new TsBlockBuilder(Collections.singletonList(TSDataType.INT64));
+    for (int i = 0; i < times.length; i++) {
+      builder.getTimeColumnBuilder().writeLong(times[i]);
+      builder.getColumnBuilder(0).writeLong(counts[i]);
+      builder.declarePosition();
+    }
+    return builder.build();
+  }
+
+  private static class FixedTsBlockOperator implements Operator {
+
+    private final OperatorContext operatorContext;
+    private final TsBlock[] tsBlocks;
+    private int index;
+
+    private FixedTsBlockOperator(OperatorContext operatorContext, TsBlock... tsBlocks) {
+      this.operatorContext = operatorContext;
+      this.tsBlocks = tsBlocks;
+    }
+
+    @Override
+    public OperatorContext getOperatorContext() {
+      return operatorContext;
+    }
+
+    @Override
+    public TsBlock next() {
+      return tsBlocks[index++];
+    }
+
+    @Override
+    public boolean hasNext() {
+      return index < tsBlocks.length;
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public boolean isFinished() {
+      return !hasNext();
+    }
+
+    @Override
+    public long calculateMaxPeekMemory() {
+      return 0;
+    }
+
+    @Override
+    public long calculateMaxReturnSize() {
+      return 0;
+    }
+
+    @Override
+    public long calculateRetainedSizeAfterCallingNext() {
+      return 0;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+      return 0;
+    }
   }
 }


### PR DESCRIPTION
## Description
- Skip missing child TsBlocks when merging partial aggregation results.
- Avoid advancing null child input blocks after a child operator has finished.
- Add a regression test for group-by intermediate aggregation when one child has fewer windows than another.

## Tests
- `mvn -nsu -pl iotdb-core/datanode -am -Dtest=AggregationOperatorTest#testGroupByIntermediateResultWithFinishedChild -DfailIfNoTests=false "-Dsurefire.failIfNoSpecifiedTests=false" test`