### PR TITLE
Fix compaction test metadata lease cleanup

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/AbstractCompactionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/compaction/AbstractCompactionTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.storageengine.dataregion.compaction;
 
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.conf.IoTDBConstant;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.exception.MetadataException;
@@ -31,6 +32,7 @@ import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.exception.StorageEngineException;
 import org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext;
 import org.apache.iotdb.db.queryengine.plan.relational.metadata.fetcher.cache.TreeDeviceSchemaCacheManager;
+import org.apache.iotdb.db.schemaengine.lease.MetadataLeaseManager;
 import org.apache.iotdb.db.storageengine.buffer.BloomFilterCache;
 import org.apache.iotdb.db.storageengine.buffer.ChunkCache;
 import org.apache.iotdb.db.storageengine.buffer.TimeSeriesMetadataCache;
@@ -154,6 +156,9 @@ public class AbstractCompactionTest {
   private final long oldLongestExpiredTime =
       IoTDBDescriptor.getInstance().getConfig().getMaxExpiredTime();
 
+  private final long oldMetadataLeaseFenceMs =
+      CommonDescriptor.getInstance().getConfig().getMetadataLeaseFenceMs();
+
   protected static File STORAGE_GROUP_DIR =
       new File(
           TestConstant.BASE_OUTPUT_PATH
@@ -200,6 +205,8 @@ public class AbstractCompactionTest {
 
   public void setUp()
       throws IOException, WriteProcessException, MetadataException, InterruptedException {
+    CommonDescriptor.getInstance().getConfig().setMetadataLeaseFenceMs(Long.MAX_VALUE);
+    MetadataLeaseManager.getInstance().recoveryLeaseForTest(true);
     fileCount = 0;
     if (!SEQ_DIRS.exists()) {
       Assert.assertTrue(SEQ_DIRS.mkdirs());
@@ -495,6 +502,8 @@ public class AbstractCompactionTest {
         .getConfig()
         .setInnerCompactionTaskSelectionModsFileThreshold(oldModsFileSize);
     IoTDBDescriptor.getInstance().getConfig().setMaxExpiredTime(oldLongestExpiredTime);
+    CommonDescriptor.getInstance().getConfig().setMetadataLeaseFenceMs(oldMetadataLeaseFenceMs);
+    MetadataLeaseManager.getInstance().recoveryLeaseForTest(true);
     TSFileDescriptor.getInstance().getConfig().setGroupSizeInByte(oldChunkGroupSize);
 
     TSFileDescriptor.getInstance().getConfig().setMaxNumberOfPointsInPage(oldPagePointMaxNumber);


### PR DESCRIPTION
## Summary
- Preserve the original metadata lease fence timeout in AbstractCompactionTest.
- Restore the timeout and reset the metadata lease state during teardown.

## Motivation
Compaction unit tests temporarily keep the metadata lease available to avoid fenced local metadata cache failures. Without symmetric teardown cleanup, the global lease timeout and lease state can leak across tests and cause unrelated failures.
