### PR TITLE
Reduce pipe type conversion log frequency

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/transform/statement/PipeConvertedInsertRowStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/transform/statement/PipeConvertedInsertRowStatement.java
@@ -85,13 +85,13 @@ public class PipeConvertedInsertRowStatement extends InsertRowStatement {
 
   @Override
   protected boolean checkAndCastDataType(int columnIndex, TSDataType dataType) {
-    PipeLogger.log(
-        LOGGER::info,
-        "Pipe: Inserting row to %s.%s. Casting type from %s to %s.",
-        devicePath,
-        measurements[columnIndex],
-        dataTypes[columnIndex],
-        dataType);
+    if (LOGGER.isInfoEnabled()) {
+      PipeLogger.log(
+          LOGGER::info,
+          "Pipe: Inserting row. Casting type from %s to %s.",
+          dataTypes[columnIndex],
+          dataType);
+    }
     values[columnIndex] =
         ValueConverter.convert(dataTypes[columnIndex], dataType, values[columnIndex]);
     dataTypes[columnIndex] = dataType;
@@ -122,15 +122,12 @@ public class PipeConvertedInsertRowStatement extends InsertRowStatement {
       try {
         values[i] = ValueConverter.parse(values[i].toString(), dataTypes[i]);
       } catch (Exception e) {
-        PipeLogger.log(
-            LOGGER::warn,
-            "data type of %s.%s is not consistent, "
-                + "registered type %s, inserting timestamp %s, value %s",
-            devicePath,
-            measurements[i],
-            dataTypes[i],
-            time,
-            values[i]);
+        if (LOGGER.isWarnEnabled()) {
+          PipeLogger.log(
+              LOGGER::warn,
+              "Pipe: Failed to parse row value during data type conversion. Registered type %s.",
+              dataTypes[i]);
+        }
         if (!IoTDBDescriptor.getInstance().getConfig().isEnablePartialInsert()) {
           throw e;
         } else {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/transform/statement/PipeConvertedInsertTabletStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/transform/statement/PipeConvertedInsertTabletStatement.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.db.pipe.receiver.transform.statement;
 
+import org.apache.iotdb.commons.pipe.resource.log.PipeLogger;
 import org.apache.iotdb.db.pipe.receiver.transform.converter.ArrayConverter;
 import org.apache.iotdb.db.queryengine.plan.statement.crud.InsertTabletStatement;
 
@@ -89,12 +90,13 @@ public class PipeConvertedInsertTabletStatement extends InsertTabletStatement {
 
   @Override
   protected boolean checkAndCastDataType(int columnIndex, TSDataType dataType) {
-    LOGGER.info(
-        "Pipe: Inserting tablet to {}.{}. Casting type from {} to {}.",
-        devicePath,
-        measurements[columnIndex],
-        dataTypes[columnIndex],
-        dataType);
+    if (LOGGER.isInfoEnabled()) {
+      PipeLogger.log(
+          LOGGER::info,
+          "Pipe: Inserting tablet. Casting type from %s to %s.",
+          dataTypes[columnIndex],
+          dataType);
+    }
     columns[columnIndex] =
         ArrayConverter.convert(dataTypes[columnIndex], dataType, columns[columnIndex]);
     dataTypes[columnIndex] = dataType;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/visitor/PipeStatementDataTypeConvertExecutionVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/visitor/PipeStatementDataTypeConvertExecutionVisitor.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.pipe.receiver.visitor;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.pipe.config.PipeConfig;
 import org.apache.iotdb.commons.pipe.datastructure.pattern.IoTDBPipePattern;
+import org.apache.iotdb.commons.pipe.resource.log.PipeLogger;
 import org.apache.iotdb.db.pipe.event.common.tsfile.container.scan.TsFileInsertionScanDataContainer;
 import org.apache.iotdb.db.pipe.receiver.protocol.thrift.IoTDBDataNodeReceiver;
 import org.apache.iotdb.db.pipe.receiver.transform.statement.PipeConvertedInsertRowStatement;
@@ -73,7 +74,12 @@ public class PipeStatementDataTypeConvertExecutionVisitor
     try {
       return Optional.of(statementExecutor.execute(statement));
     } catch (final Exception e) {
-      LOGGER.warn("Failed to execute statement after data type conversion.", e);
+      if (LOGGER.isWarnEnabled()) {
+        PipeLogger.log(
+            LOGGER::warn,
+            "Pipe: Failed to execute statement after data type conversion. Exception type: %s.",
+            e.getClass().getName());
+      }
       return Optional.empty();
     }
   }


### PR DESCRIPTION
Backport 5aad9323c71ef5fdfd25b924dba010f37fb94ed9 / #18161 to dev/1.3.

Notes:
- dev/1.3 does not have the i18n message classes from master, so this keeps the existing raw log-message style while applying the equivalent log-frequency reduction.

Tests:
- mvn spotless:apply -pl iotdb-core/datanode
- mvn compile -pl iotdb-core/datanode