### PR TITLE
Fix duplicate table device attribute updates in multi-row insert

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBDeletionTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBDeletionTableIT.java
@@ -653,6 +653,24 @@ public class IoTDBDeletionTableIT {
               + "(3, 'blue', 'large', 13),"
               + "(4, 'red', 'small', 14)");
 
+      TestUtils.assertResultSetEqual(
+          statement.executeQuery("show devices from delete_by_attr_no_tag"),
+          "attr1,attr2,",
+          Collections.singleton("red,small,"));
+      TestUtils.assertResultSetEqual(
+          statement.executeQuery(
+              "show devices from delete_by_attr_no_tag "
+                  + "where attr1 = 'red' AND attr2 = 'small'"),
+          "attr1,attr2,",
+          Collections.singleton("red,small,"));
+      statement.execute(
+          "INSERT INTO delete_by_attr_no_tag(time, attr1, attr2, s1) VALUES "
+              + "(2, 'blue', 'large', 12),"
+              + "(4, 'red', 'small', 14)");
+      TestUtils.assertResultSetEqual(
+          statement.executeQuery("show devices from delete_by_attr_no_tag"),
+          "attr1,attr2,",
+          Collections.singleton("red,small,"));
       statement.execute(
           "DELETE FROM delete_by_attr_no_tag "
               + "WHERE time >= 2 AND time <= 4 AND attr1 = 'red' AND attr2 = 'small'");

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/InsertRows.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/sql/ast/InsertRows.java
@@ -31,11 +31,15 @@ import org.apache.iotdb.db.queryengine.plan.statement.crud.InsertRowStatement;
 import org.apache.iotdb.db.queryengine.plan.statement.crud.InsertRowsStatement;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.utils.Constants;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class InsertRows extends WrappedInsertStatement {
@@ -100,10 +104,26 @@ public class InsertRows extends WrappedInsertStatement {
 
   @Override
   public void validateDeviceSchema(Metadata metadata, MPPQueryContext context) {
+    final Map<String, Map<String, CoalescedDeviceSchemaValidation>> validationMap =
+        new LinkedHashMap<>();
     for (InsertRowStatement insertRowStatement :
         getInnerTreeStatement().getInsertRowStatementList()) {
-      metadata.validateDeviceSchema(createTableSchemaValidation(insertRowStatement), context);
+      final ITableDeviceSchemaValidation rowValidation =
+          createTableSchemaValidation(insertRowStatement);
+      validationMap
+          .computeIfAbsent(rowValidation.getDatabase(), key -> new LinkedHashMap<>())
+          .computeIfAbsent(
+              rowValidation.getTableName(),
+              tableName ->
+                  new CoalescedDeviceSchemaValidation(rowValidation.getDatabase(), tableName))
+          .add(
+              rowValidation.getDeviceIdList().get(0),
+              rowValidation.getAttributeColumnNameList(),
+              rowValidation.getAttributeValueList().get(0));
     }
+    validationMap.values().stream()
+        .flatMap(tableValidationMap -> tableValidationMap.values().stream())
+        .forEach(validation -> metadata.validateDeviceSchema(validation, context));
   }
 
   protected ITableDeviceSchemaValidation createTableSchemaValidation(
@@ -156,5 +176,98 @@ public class InsertRows extends WrappedInsertStatement {
         return Collections.singletonList(attributeValueList.toArray());
       }
     };
+  }
+
+  private static class CoalescedDeviceSchemaValidation implements ITableDeviceSchemaValidation {
+
+    private final String database;
+    private final String tableName;
+    private final Map<DeviceIdKey, Map<Integer, Object>> deviceAttributeValueMap =
+        new LinkedHashMap<>();
+    private final List<String> attributeColumnNameList = new ArrayList<>();
+    private final Map<String, Integer> attributeColumnIndexMap = new LinkedHashMap<>();
+
+    private CoalescedDeviceSchemaValidation(final String database, final String tableName) {
+      this.database = database;
+      this.tableName = tableName;
+    }
+
+    private void add(
+        final Object[] deviceId,
+        final List<String> attributeColumnNames,
+        final Object[] attributeValues) {
+      final Map<Integer, Object> attributeValueMap =
+          deviceAttributeValueMap.computeIfAbsent(
+              new DeviceIdKey(deviceId), key -> new HashMap<>());
+      for (int i = 0; i < attributeColumnNames.size(); i++) {
+        final int attributeColumnIndex =
+            attributeColumnIndexMap.computeIfAbsent(
+                attributeColumnNames.get(i),
+                attributeColumnName -> {
+                  attributeColumnNameList.add(attributeColumnName);
+                  return attributeColumnNameList.size() - 1;
+                });
+        if (i < attributeValues.length
+            && attributeValues[i] != null
+            && attributeValues[i] != Constants.NONE) {
+          attributeValueMap.put(attributeColumnIndex, attributeValues[i]);
+        }
+      }
+    }
+
+    @Override
+    public String getDatabase() {
+      return database;
+    }
+
+    @Override
+    public String getTableName() {
+      return tableName;
+    }
+
+    @Override
+    public List<Object[]> getDeviceIdList() {
+      final List<Object[]> deviceIdList = new ArrayList<>(deviceAttributeValueMap.size());
+      deviceAttributeValueMap.keySet().forEach(key -> deviceIdList.add(key.deviceId));
+      return deviceIdList;
+    }
+
+    @Override
+    public List<String> getAttributeColumnNameList() {
+      return attributeColumnNameList;
+    }
+
+    @Override
+    public List<Object[]> getAttributeValueList() {
+      final List<Object[]> attributeValueList = new ArrayList<>(deviceAttributeValueMap.size());
+      for (final Map<Integer, Object> attributeValueMap : deviceAttributeValueMap.values()) {
+        final Object[] attributeValues = new Object[attributeColumnNameList.size()];
+        Arrays.fill(attributeValues, Constants.NONE);
+        attributeValueMap.forEach((index, value) -> attributeValues[index] = value);
+        attributeValueList.add(attributeValues);
+      }
+      return attributeValueList;
+    }
+  }
+
+  private static class DeviceIdKey {
+
+    private final Object[] deviceId;
+
+    private DeviceIdKey(final Object[] deviceId) {
+      this.deviceId = (Object[]) deviceId.clone();
+    }
+
+    @Override
+    public boolean equals(final Object object) {
+      return this == object
+          || object instanceof DeviceIdKey
+              && Arrays.equals(deviceId, ((DeviceIdKey) object).deviceId);
+    }
+
+    @Override
+    public int hashCode() {
+      return Arrays.hashCode(deviceId);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Coalesce duplicate table devices in one multi-row `INSERT` before schema validation.
- For each `(database, table, deviceId)`, keep the last effective non-null attribute value per attribute; missing attributes and inserted `null` remain no-ops.
- Add coverage for no-tag table attribute-filtered deletion and the cache-hit duplicate-device update path.

## Root cause
A no-tag table is still an exact device match: its device id is the table plus an empty tag tuple. The real issue was that `InsertRows` validated repeated rows for the same device one by one, so multiple attribute updates in a single statement could be affected by validation/cache ordering instead of the final row state.

## Tests
- `mvn spotless:apply -pl iotdb-core/datanode,integration-test -P with-integration-tests`
- `mvn --% -o -Ddevelocity.off=true -pl iotdb-core/datanode -Dtest=TableDeviceSchemaValidatorTest test`
- `mvn --% -o -Ddevelocity.off=true install -DskipTests -pl iotdb-core/datanode -am`
- `mvn --% -o -Ddevelocity.off=true verify -DskipUTs -Dit.test=IoTDBDeletionTableIT#testDeleteDataByAttributeFilterWithoutTagColumns -DfailIfNoTests=false -Dfailsafe.failIfNoSpecifiedTests=false -pl integration-test -PTableClusterIT -P with-integration-tests`