### PR TITLE
[dev/1.3] Disable degraded time index migration IT

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/IoTDBRegionMigrateNormalIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/IoTDBRegionMigrateNormalIT.java
@@ -49,7 +49,6 @@ public class IoTDBRegionMigrateNormalIT extends IoTDBRegionOperationReliabilityI
     successTest(2, 3, 3, 3, noKillPoints(), noKillPoints(), KillNode.ALL_NODES);
   }
 
-  @Test
   public void migrateRegionWithDegradedTimeIndexTest() throws Exception {
     // set TsFileResource memory to 0 to trigger degrading
     EnvFactory.getEnv().getConfig().getCommonConfig().setQueryMemoryProportion("1:1:1:1:1:1:0");


### PR DESCRIPTION
## Description

This PR temporarily disables `IoTDBRegionMigrateNormalIT.migrateRegionWithDegradedTimeIndexTest` on `dev/1.3`.

The test was introduced by #18157. On current `dev/1.3`, `successTest()` calls `checkClusterStillWritable()` after a successful migration. That helper already writes the second row and verifies count = 2. After returning from `successTest()`, `migrateRegionWithDegradedTimeIndexTest` still expects count = 1 before doing its own insert, so the test fails deterministically with `expected:<1> but was:<2>`.

This change only disables the broken IT method on `dev/1.3` and does not change runtime behavior.

## Verification

- `mvn spotless:apply -pl integration-test -P with-integration-tests`
- `mvn test-compile -DskipTests -pl integration-test -P with-integration-tests` was attempted but did not reach compilation because `1.3.7-SNAPSHOT` IoTDB module artifacts are not available from the configured Maven repositories.
