### PR TITLE
[Backport 1.3] Avoid read lock when restoring degraded time index

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
@@ -43,6 +43,7 @@ import org.apache.iotdb.db.storageengine.rescon.disk.TierManager;
 
 import org.apache.tsfile.file.metadata.IChunkMetadata;
 import org.apache.tsfile.file.metadata.IDeviceID;
+import org.apache.tsfile.file.metadata.IDeviceID.Deserializer;
 import org.apache.tsfile.file.metadata.ITimeSeriesMetadata;
 import org.apache.tsfile.fileSystem.FSFactoryProducer;
 import org.apache.tsfile.fileSystem.fsFactory.FSFactory;
@@ -281,7 +282,7 @@ public class TsFileResource implements Cloneable {
       return timeIndex;
     }
 
-    return buildDeviceTimeIndex();
+    return deserializeTimeIndexFromResourceFile(Deserializer.DEFAULT_DESERIALIZER);
   }
 
   /** deserialize from disk */

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
@@ -43,7 +43,6 @@ import org.apache.iotdb.db.storageengine.rescon.disk.TierManager;
 
 import org.apache.tsfile.file.metadata.IChunkMetadata;
 import org.apache.tsfile.file.metadata.IDeviceID;
-import org.apache.tsfile.file.metadata.IDeviceID.Deserializer;
 import org.apache.tsfile.file.metadata.ITimeSeriesMetadata;
 import org.apache.tsfile.fileSystem.FSFactoryProducer;
 import org.apache.tsfile.fileSystem.fsFactory.FSFactory;
@@ -282,7 +281,7 @@ public class TsFileResource implements Cloneable {
       return timeIndex;
     }
 
-    return deserializeTimeIndexFromResourceFile(Deserializer.DEFAULT_DESERIALIZER);
+    return deserializeTimeIndexFromResourceFile();
   }
 
   /** deserialize from disk */
@@ -507,11 +506,8 @@ public class TsFileResource implements Cloneable {
       if (!resourceFileExists()) {
         throw new IOException("resource file not found");
       }
-      try (InputStream inputStream =
-          FSFactoryProducer.getFSFactory()
-              .getBufferedInputStream(file.getPath() + RESOURCE_SUFFIX)) {
-        ReadWriteIOUtils.readByte(inputStream);
-        ITimeIndex timeIndexFromResourceFile = ITimeIndex.createTimeIndex(inputStream);
+      try {
+        ITimeIndex timeIndexFromResourceFile = deserializeTimeIndexFromResourceFile();
         if (!(timeIndexFromResourceFile instanceof DeviceTimeIndex)) {
           throw new IOException("cannot build DeviceTimeIndex from resource " + file.getPath());
         }
@@ -522,6 +518,14 @@ public class TsFileResource implements Cloneable {
       }
     } finally {
       readUnlock();
+    }
+  }
+
+  private ITimeIndex deserializeTimeIndexFromResourceFile() throws IOException {
+    try (InputStream inputStream =
+        FSFactoryProducer.getFSFactory().getBufferedInputStream(file.getPath() + RESOURCE_SUFFIX)) {
+      ReadWriteIOUtils.readByte(inputStream);
+      return ITimeIndex.createTimeIndex(inputStream);
     }
   }
 


### PR DESCRIPTION
## Description

Backport of #18189 to dev/1.3.

When a TsFileResource uses FileTimeIndex, getTimeIndex directly deserializes the device time index from the resource file.

This avoids calling buildDeviceTimeIndex, whose read lock is unnecessary for this read-only restoration path and may cause lock contention.

The original commit was cherry-picked cleanly without conflicts.

## Verification

- git diff --check
- Attempted: mvn test -pl iotdb-core/datanode -Dtest=TsFileResourceTest -DskipUTs=false
- The targeted test could not start because the standalone datanode build could not resolve dev/1.3 reactor artifacts such as service-rpc and iotdb-consensus version 1.3.7-SNAPSHOT.

This PR has:
- [x] been self-reviewed.

##### Key changed/added classes

- TsFileResource