### PR TITLE
Fix DataNode restart readiness race in IoTDBConnectionsIT

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBConnectionsIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/session/it/IoTDBConnectionsIT.java
@@ -25,11 +25,13 @@ import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.schema.column.ColumnHeaderConstant;
 import org.apache.iotdb.confignode.rpc.thrift.TShowDataNodesResp;
 import org.apache.iotdb.it.env.EnvFactory;
+import org.apache.iotdb.it.env.cluster.node.DataNodeWrapper;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
 import org.apache.iotdb.itbase.category.TableClusterIT;
 import org.apache.iotdb.itbase.category.TableLocalStandaloneIT;
 import org.apache.iotdb.itbase.env.BaseEnv;
 
+import org.awaitility.Awaitility;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -244,10 +246,12 @@ public class IoTDBConnectionsIT {
       return;
     }
     int closedDataNodeId = (int) allDataNodeId.toArray()[0];
+    DataNodeWrapper closedDataNode =
+        EnvFactory.getEnv().dataNodeIdToWrapper(closedDataNodeId).orElseThrow();
     try (Connection connection =
             EnvFactory.getEnv()
                 .getConnection(
-                    EnvFactory.getEnv().dataNodeIdToWrapper(closedDataNodeId).get(),
+                    closedDataNode,
                     CommonDescriptor.getInstance().getConfig().getDefaultAdminName(),
                     CommonDescriptor.getInstance().getConfig().getAdminPassword(),
                     BaseEnv.TABLE_SQL_DIALECT);
@@ -269,7 +273,7 @@ public class IoTDBConnectionsIT {
     }
 
     // close the number closedDataNodeId datanode
-    EnvFactory.getEnv().dataNodeIdToWrapper(closedDataNodeId).get().stop();
+    closedDataNode.stop();
     try (SyncConfigNodeIServiceClient client =
         (SyncConfigNodeIServiceClient) EnvFactory.getEnv().getLeaderConfigNodeConnection()) {
 
@@ -319,7 +323,7 @@ public class IoTDBConnectionsIT {
     }
 
     // revert environment
-    EnvFactory.getEnv().dataNodeIdToWrapper(closedDataNodeId).get().start();
+    closedDataNode.start();
     try (SyncConfigNodeIServiceClient client =
         (SyncConfigNodeIServiceClient) EnvFactory.getEnv().getLeaderConfigNodeConnection()) {
       // Wait for restart check
@@ -341,6 +345,26 @@ public class IoTDBConnectionsIT {
         TimeUnit.SECONDS.sleep(1);
       }
     }
+
+    // The ConfigNode may report the restarted DataNode as Running before its client RPC service is
+    // ready. Wait for a direct connection so that subsequent tests do not race with the restart.
+    Awaitility.await()
+        .pollInterval(1, TimeUnit.SECONDS)
+        .atMost(30, TimeUnit.SECONDS)
+        .until(
+            () -> {
+              try (Connection ignored =
+                  EnvFactory.getEnv()
+                      .getWriteOnlyConnectionWithSpecifiedDataNode(
+                          closedDataNode,
+                          CommonDescriptor.getInstance().getConfig().getDefaultAdminName(),
+                          CommonDescriptor.getInstance().getConfig().getAdminPassword(),
+                          BaseEnv.TABLE_SQL_DIALECT)) {
+                return true;
+              } catch (SQLException e) {
+                return false;
+              }
+            });
   }
 
   @Test


### PR DESCRIPTION
## Description

### Root cause

`testClosedDataNodeGetConnections` currently finishes its restart wait once `SHOW DATANODES` no longer reports an `Unknown` node. That condition reflects heartbeat readiness, but it does not guarantee that the restarted DataNode's client RPC service is accepting connections.

In the failing Windows run, the restarted DataNode's internal RPC service was ready at `12:06:09.457`, while its client RPC service did not start until `12:06:10.945`. Subsequent test methods entered that gap and failed with a connection error or inconsistent multi-node results.

A fixed five-second delay added in #17290 previously masked this gap. It was removed by #17423 after Windows metric binding became asynchronous, exposing this separate lifecycle race.

### Fix

Cache the stopped DataNode wrapper and, after the existing ConfigNode status check, poll a direct table-dialect JDBC connection to that specific DataNode. The probe uses a write-only test connection so it creates only one physical session and cannot interfere with the connection-count assertions.

The one-second polling interval returns as soon as ClientRPC is ready, while the bounded 30-second timeout remains robust on slower CI workers. This verifies the actual client RPC and login path needed by the following tests instead of relying on another fixed sleep.

### Testing

- `IoTDBConnectionsIT` with `TableClusterIT`: 4 tests, 0 failures, 0 errors
- Integration-test Checkstyle and Spotless checks passed

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the reason for the readiness probe.
- [x] updated integration-test coverage for the DataNode restart path.
- [x] been tested in a test IoTDB cluster.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- `IoTDBConnectionsIT`