### PR TITLE
[to dev/1.3] Remove incorrect timeout reassignment after query planning

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/MPPQueryContext.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/common/MPPQueryContext.java
@@ -189,7 +189,10 @@ public class MPPQueryContext {
     return queryType;
   }
 
-  /** the max executing time of query in ms. Unit: millisecond */
+  /**
+   * Returns the total query timeout in milliseconds, measured from {@link #getStartTime()}. This
+   * value never represents the remaining timeout.
+   */
   public long getTimeOut() {
     return timeOut;
   }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/QueryExecution.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/execution/QueryExecution.java
@@ -176,10 +176,6 @@ public class QueryExecution implements IQueryExecution {
     doLogicalPlan();
     doDistributedPlan();
 
-    // update timeout after finishing plan stage
-    context.setTimeOut(
-        context.getTimeOut() - (System.currentTimeMillis() - context.getStartTime()));
-
     stateMachine.transitionToPlanned();
     if (context.getQueryType() == QueryType.READ) {
       initResultHandle();


### PR DESCRIPTION
The context.setTimeOut() call in QueryExecution.start() mutated timeOut from the total timeout duration to the remaining time after planning. However, all consumers (checkTimeOutForQuery, cleanUpStaleQueries, timeout exception messages) assume timeOut holds the total duration. This caused stale query cleanup to trigger earlier than expected and incorrect deadline values in timeout error messages.

This was already fixed on the master branch by commit fddf0a6eaa as part of https://github.com/apache/iotdb/pull/15031.