### PR TITLE
Subscription IT: isolate owner transfer bootstrap data

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/subscription/it/consensus/local/tablemodel/IoTDBConsensusSubscriptionColumnFilterClusterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/subscription/it/consensus/local/tablemodel/IoTDBConsensusSubscriptionColumnFilterClusterIT.java
@@ -62,6 +62,7 @@ public class IoTDBConsensusSubscriptionColumnFilterClusterIT extends AbstractSub
         .setDataRegionConsensusProtocolClass(ConsensusFactory.IOT_CONSENSUS)
         .setSchemaReplicationFactor(1)
         .setDataReplicationFactor(2)
+        .setDefaultDataRegionGroupNumPerDatabase(1)
         .setAutoCreateSchemaEnabled(true)
         .setSubscriptionEnabled(true)
         .setPipeMemoryManagementEnabled(false)
@@ -82,13 +83,16 @@ public class IoTDBConsensusSubscriptionColumnFilterClusterIT extends AbstractSub
     final ConsensusSubscriptionTableITSupport.TestIdentifiers ids =
         ConsensusSubscriptionTableITSupport.newIdentifiers("cluster_owner_rebind");
     final String database = ids.getDatabase();
+    final String bootstrapTable = "bootstrap_table";
     final String table = "t1";
     final String schema = "tag1 STRING TAG, s1 INT64 FIELD, s2 DOUBLE FIELD, s3 BOOLEAN FIELD";
     SubscriptionTablePullConsumer ownerConsumer = null;
 
     try {
-      ConsensusSubscriptionTableITSupport.createDatabaseAndTable(database, table, schema);
-      ConsensusSubscriptionTableITSupport.insertRows(database, table, 0L, 1, true, true, true);
+      ConsensusSubscriptionTableITSupport.createDatabaseAndTable(
+          database, bootstrapTable, ConsensusSubscriptionTableITSupport.DEFAULT_TABLE_SCHEMA);
+      ConsensusSubscriptionTableITSupport.createTable(database, table, schema);
+      ConsensusSubscriptionTableITSupport.insertRows(database, bootstrapTable, 0L, 1, true);
       createOwnedConsensusTopic(ids.getTopic(), database, table, "column_name = \"s1\"");
 
       ownerConsumer = createOwnerConsumer(ids.consumer("owner1"), ids.consumerGroup("owner"), 1L);


### PR DESCRIPTION
## Description

The owner-transfer column-filter Cluster IT used a row in the subscribed table to create its initial DataRegion. With RF=2, replica-local consensus tail snapshots can differ and replay that setup row, making this owner-transfer test fail before it reaches the transfer logic.

- Bootstrap the existing DataRegion through a separate table excluded by the topic's exact table pattern.
- Keep the database at one DataRegion group so the bootstrap and tested tables exercise the same existing-region binding path.
- Leave the owner transfer, ALTER column-filter, and pre/post-transfer assertions unchanged.

This is an IT isolation change only; it does not modify subscription runtime semantics.

## Tests

- `mvn spotless:apply -pl integration-test -Pwith-integration-tests`
- `mvn test-compile -pl integration-test -Pwith-integration-tests -DskipTests`
- `mvn verify -DskipUTs '-Dit.test=IoTDBConsensusSubscriptionColumnFilterClusterIT' -DfailIfNoTests=false '-Dfailsafe.failIfNoSpecifiedTests=false' -pl integration-test -am -PTableClusterIT -Pwith-integration-tests` (1 test, 0 failures)