### PR TITLE
Improve error message when auto-creating timeseries with null value

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBInsertMultiRowIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBInsertMultiRowIT.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import static org.apache.iotdb.db.it.utils.TestUtils.assertNonQueryTestFail;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -93,6 +94,16 @@ public class IoTDBInsertMultiRowIT {
     }
 
     statement.close();
+  }
+
+  @Test
+  public void testInsertAlignedSeriesAutoCreate() throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      assertNonQueryTestFail(
+          statement,
+          "insert into root.aligned_auto_create.d1 (time, s1, s2) aligned values (0, null, 15.2)",
+          "Timeseries [root.aligned_auto_create.d1.s1] does not exist and its data type cannot be inferred from the null value");
+    }
   }
 
   @Test

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBAutoCreateSchemaIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBAutoCreateSchemaIT.java
@@ -222,7 +222,7 @@ public class IoTDBAutoCreateSchemaIT extends AbstractSchemaIT {
         try {
           statement.execute(sql);
         } catch (SQLException e) {
-          Assert.assertTrue(e.getMessage().contains("Path [root.sg0.d3.s1] does not exist"));
+          Assert.assertTrue(e.getMessage().contains("Timeseries [root.sg0.d3.s1] does not exist"));
         }
       }
     }

--- a/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/DataNodeSchemaMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/DataNodeSchemaMessages.java
@@ -659,6 +659,9 @@ public final class DataNodeSchemaMessages {
   public static final String ILLEGAL_PARAMETER_FAILED_CREATE_TIMESERIES_FMT =
       "%s. Failed to create timeseries for path %s";
   public static final String PATH_NOT_EXIST_WRONG_MESSAGE = "Path [%s] does not exist";
+  public static final String
+      EXCEPTION_TIMESERIES_ARG_DOES_NOT_EXIST_AND_ITS_DATA_TYPE_CANNOT_BE_INFERRED_FROM_THE_NULL_VALUE_36406D43 =
+          "Timeseries [%s] does not exist and its data type cannot be inferred from the null value";
   public static final String SOURCE_PATH_NOT_EXIST_WRONG_MESSAGE =
       "The source path [%s] of view [%s] does not exist.";
   public static final String NORMAL_TIMESERIES_NOT_EXIST_WRONG_MESSAGE =

--- a/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/DataNodeSchemaMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/DataNodeSchemaMessages.java
@@ -646,6 +646,9 @@ public final class DataNodeSchemaMessages {
   public static final String ILLEGAL_PARAMETER_FAILED_CREATE_TIMESERIES_FMT =
       "%s。为路径 %s 创建时间序列失败";
   public static final String PATH_NOT_EXIST_WRONG_MESSAGE = "路径 [%s] 不存在";
+  public static final String
+      EXCEPTION_TIMESERIES_ARG_DOES_NOT_EXIST_AND_ITS_DATA_TYPE_CANNOT_BE_INFERRED_FROM_THE_NULL_VALUE_36406D43 =
+          "时间序列 [%s] 不存在，且无法从 null 值推断其数据类型";
   public static final String SOURCE_PATH_NOT_EXIST_WRONG_MESSAGE =
       "源路径 [%s] 对应视图 [%s] 不存在。";
   public static final String NORMAL_TIMESERIES_NOT_EXIST_WRONG_MESSAGE =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/exception/metadata/PathNotExistException.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/exception/metadata/PathNotExistException.java
@@ -29,6 +29,9 @@ public class PathNotExistException extends MetadataException {
 
   private static final String PATH_NOT_EXIST_WRONG_MESSAGE =
       DataNodeSchemaMessages.PATH_NOT_EXIST_WRONG_MESSAGE;
+  private static final String TIMESERIES_NOT_EXIST_AND_DATA_TYPE_CANNOT_BE_INFERRED_FROM_NULL =
+      DataNodeSchemaMessages
+          .EXCEPTION_TIMESERIES_ARG_DOES_NOT_EXIST_AND_ITS_DATA_TYPE_CANNOT_BE_INFERRED_FROM_THE_NULL_VALUE_36406D43;
   private static final String SOURCE_PATH_NOT_EXIST_WRONG_MESSAGE =
       DataNodeSchemaMessages.SOURCE_PATH_NOT_EXIST_WRONG_MESSAGE;
 
@@ -47,6 +50,16 @@ public class PathNotExistException extends MetadataException {
   public PathNotExistException(String path) {
     super(
         String.format(PATH_NOT_EXIST_WRONG_MESSAGE, path),
+        TSStatusCode.PATH_NOT_EXIST.getStatusCode());
+  }
+
+  private PathNotExistException(String message, int errorCode) {
+    super(message, errorCode);
+  }
+
+  public static PathNotExistException forNullValue(String path) {
+    return new PathNotExistException(
+        String.format(TIMESERIES_NOT_EXIST_AND_DATA_TYPE_CANNOT_BE_INFERRED_FROM_NULL, path),
         TSStatusCode.PATH_NOT_EXIST.getStatusCode());
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertBaseStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertBaseStatement.java
@@ -230,7 +230,7 @@ public abstract class InsertBaseStatement extends Statement implements Accountab
     if (IoTDBDescriptor.getInstance().getConfig().isEnablePartialInsert()) {
       // if enable partial insert, mark failed measurements with exception
       if (measurementSchema == null) {
-        markFailedMeasurement(index, new PathNotExistException(fullPath));
+        markFailedMeasurement(index, createPathNotExistException(fullPath, dataType));
       } else if ((dataType != measurementSchema.getType()
           && !checkAndCastDataType(index, measurementSchema.getType()))) {
         markFailedMeasurement(
@@ -246,7 +246,7 @@ public abstract class InsertBaseStatement extends Statement implements Accountab
     } else {
       // if not enable partial insert, throw the exception directly
       if (measurementSchema == null) {
-        throw new PathNotExistException(fullPath);
+        throw createPathNotExistException(fullPath, dataType);
       } else if ((dataType != measurementSchema.getType()
           && !checkAndCastDataType(index, measurementSchema.getType()))) {
         throw new DataTypeMismatchException(
@@ -258,6 +258,13 @@ public abstract class InsertBaseStatement extends Statement implements Accountab
             getFirstValueOfIndex(index));
       }
     }
+  }
+
+  protected PathNotExistException createPathNotExistException(
+      String fullPath, TSDataType dataType) {
+    return dataType == null
+        ? PathNotExistException.forNullValue(fullPath)
+        : new PathNotExistException(fullPath);
   }
 
   protected abstract boolean checkAndCastDataType(int columnIndex, TSDataType dataType);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertRowStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertRowStatement.java
@@ -259,14 +259,16 @@ public class InsertRowStatement extends InsertBaseStatement implements ISchemaVa
       if (measurementSchemas[i] == null) {
         if (!IoTDBDescriptor.getInstance().getConfig().isEnablePartialInsert()) {
           throw new QueryProcessException(
-              new PathNotExistException(
-                  devicePath.getFullPath() + IoTDBConstant.PATH_SEPARATOR + measurements[i]));
+              createPathNotExistException(
+                  devicePath.getFullPath() + IoTDBConstant.PATH_SEPARATOR + measurements[i],
+                  getDataType(i)));
         } else {
           markFailedMeasurement(
               i,
               new QueryProcessException(
-                  new PathNotExistException(
-                      devicePath.getFullPath() + IoTDBConstant.PATH_SEPARATOR + measurements[i])));
+                  createPathNotExistException(
+                      devicePath.getFullPath() + IoTDBConstant.PATH_SEPARATOR + measurements[i],
+                      getDataType(i))));
         }
         continue;
       }


### PR DESCRIPTION
## Description

When an insert contains a `null` value for a non-existing timeseries, schema auto-creation skips that timeseries because its data type cannot be inferred. The subsequent error previously only reported that the path did not exist.

This PR:

- adds dedicated English and Chinese error messages explaining both that the timeseries does not exist and that its data type cannot be inferred from the `null` value;
- uses the dedicated error for missing measurements whose inferred data type is `null`, while preserving the existing error for other missing paths;
- updates `IoTDBInsertMultiRowIT#testInsertAlignedSeriesAutoCreate` to verify the JDBC error message.

## Tests

- `mvn test-compile -DskipTests`
- `mvn test-compile -P with-zh-locale -DskipTests`
- `IoTDBInsertMultiRowIT#testInsertAlignedSeriesAutoCreate`: 1 test run, 0 failures, 0 errors

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added integration tests.
- [x] been tested in a test IoTDB cluster.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- `PathNotExistException`
- `InsertBaseStatement`
- `InsertRowStatement`
- `DataNodeSchemaMessages`
- `IoTDBInsertMultiRowIT`
