### PR TITLE
[Backport][dev/1.3] Improve error message when auto-creating timeseries with null value

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBInsertMultiRowIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBInsertMultiRowIT.java
@@ -96,6 +96,23 @@ public class IoTDBInsertMultiRowIT {
   }
 
   @Test
+  public void testInsertAlignedSeriesAutoCreate() throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      try {
+        statement.execute(
+            "insert into root.aligned_auto_create.d1 (time, s1, s2) aligned values (0, null, 15.2)");
+        fail();
+      } catch (SQLException e) {
+        assertTrue(
+            e.getMessage(),
+            e.getMessage()
+                .contains(
+                    "Timeseries [root.aligned_auto_create.d1.s1] does not exist and its data type cannot be inferred from the null value"));
+      }
+    }
+  }
+
+  @Test
   public void testInsertMultiRow() throws SQLException {
     Statement st0 = connection.createStatement();
     st0.execute("insert into root.t1.wf01.wt01(timestamp, status) values (1, true)");

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBAutoCreateSchemaIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBAutoCreateSchemaIT.java
@@ -222,7 +222,7 @@ public class IoTDBAutoCreateSchemaIT extends AbstractSchemaIT {
         try {
           statement.execute(sql);
         } catch (SQLException e) {
-          Assert.assertTrue(e.getMessage().contains("Timeseris [root.sg0.d3.s1] does not exist"));
+          Assert.assertTrue(e.getMessage().contains("Timeseries [root.sg0.d3.s1] does not exist"));
         }
       }
     }

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBAutoCreateSchemaIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/schema/IoTDBAutoCreateSchemaIT.java
@@ -222,7 +222,7 @@ public class IoTDBAutoCreateSchemaIT extends AbstractSchemaIT {
         try {
           statement.execute(sql);
         } catch (SQLException e) {
-          Assert.assertTrue(e.getMessage().contains("Path [root.sg0.d3.s1] does not exist"));
+          Assert.assertTrue(e.getMessage().contains("Timeseris [root.sg0.d3.s1] does not exist"));
         }
       }
     }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/exception/metadata/PathNotExistException.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/exception/metadata/PathNotExistException.java
@@ -27,6 +27,8 @@ import java.util.List;
 public class PathNotExistException extends MetadataException {
 
   private static final String PATH_NOT_EXIST_WRONG_MESSAGE = "Path [%s] does not exist";
+  private static final String TIMESERIES_NOT_EXIST_AND_DATA_TYPE_CANNOT_BE_INFERRED_FROM_NULL =
+      "Timeseries [%s] does not exist and its data type cannot be inferred from the null value";
   private static final String SOURCE_PATH_NOT_EXIST_WRONG_MESSAGE =
       "The source path [%s] of view [%s] does not exist.";
 
@@ -45,6 +47,16 @@ public class PathNotExistException extends MetadataException {
   public PathNotExistException(String path) {
     super(
         String.format(PATH_NOT_EXIST_WRONG_MESSAGE, path),
+        TSStatusCode.PATH_NOT_EXIST.getStatusCode());
+  }
+
+  private PathNotExistException(String message, int errorCode) {
+    super(message, errorCode);
+  }
+
+  public static PathNotExistException forNullValue(String path) {
+    return new PathNotExistException(
+        String.format(TIMESERIES_NOT_EXIST_AND_DATA_TYPE_CANNOT_BE_INFERRED_FROM_NULL, path),
         TSStatusCode.PATH_NOT_EXIST.getStatusCode());
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertBaseStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertBaseStatement.java
@@ -170,7 +170,8 @@ public abstract class InsertBaseStatement extends Statement implements Accountab
       if (measurementSchemas[index] == null) {
         markFailedMeasurement(
             index,
-            new PathNotExistException(devicePath.concatNode(measurements[index]).getFullPath()));
+            createPathNotExistException(
+                devicePath.concatNode(measurements[index]).getFullPath(), dataTypes[index]));
       } else if ((dataTypes[index] != measurementSchemas[index].getType()
           && !checkAndCastDataType(index, measurementSchemas[index].getType()))) {
         markFailedMeasurement(
@@ -186,7 +187,8 @@ public abstract class InsertBaseStatement extends Statement implements Accountab
     } else {
       // if not enable partial insert, throw the exception directly
       if (measurementSchemas[index] == null) {
-        throw new PathNotExistException(devicePath.concatNode(measurements[index]).getFullPath());
+        throw createPathNotExistException(
+            devicePath.concatNode(measurements[index]).getFullPath(), dataTypes[index]);
       } else if ((dataTypes[index] != measurementSchemas[index].getType()
           && !checkAndCastDataType(index, measurementSchemas[index].getType()))) {
         throw new DataTypeMismatchException(
@@ -198,6 +200,13 @@ public abstract class InsertBaseStatement extends Statement implements Accountab
             getFirstValueOfIndex(index));
       }
     }
+  }
+
+  protected PathNotExistException createPathNotExistException(
+      String fullPath, TSDataType dataType) {
+    return dataType == null
+        ? PathNotExistException.forNullValue(fullPath)
+        : new PathNotExistException(fullPath);
   }
 
   protected abstract boolean checkAndCastDataType(int columnIndex, TSDataType dataType);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertRowStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertRowStatement.java
@@ -207,14 +207,16 @@ public class InsertRowStatement extends InsertBaseStatement implements ISchemaVa
       if (measurementSchemas[i] == null) {
         if (!IoTDBDescriptor.getInstance().getConfig().isEnablePartialInsert()) {
           throw new QueryProcessException(
-              new PathNotExistException(
-                  devicePath.getFullPath() + IoTDBConstant.PATH_SEPARATOR + measurements[i]));
+              createPathNotExistException(
+                  devicePath.getFullPath() + IoTDBConstant.PATH_SEPARATOR + measurements[i],
+                  getDataType(i)));
         } else {
           markFailedMeasurement(
               i,
               new QueryProcessException(
-                  new PathNotExistException(
-                      devicePath.getFullPath() + IoTDBConstant.PATH_SEPARATOR + measurements[i])));
+                  createPathNotExistException(
+                      devicePath.getFullPath() + IoTDBConstant.PATH_SEPARATOR + measurements[i],
+                      getDataType(i))));
         }
         continue;
       }


### PR DESCRIPTION
## Description

Backport of #18209 to `dev/1.3`.

When an insert contains a `null` value for a non-existing timeseries, schema auto-creation skips that timeseries because its data type cannot be inferred. The subsequent error previously only reported that the path did not exist.

This PR:

- reports that the timeseries does not exist and that its data type cannot be inferred from the `null` value;
- applies the dedicated error to both schema validation and raw-value type transfer while preserving the existing error for other missing paths;
- updates `IoTDBInsertMultiRowIT#testInsertAlignedSeriesAutoCreate` to verify the JDBC error message.

### dev/1.3 adaptation

`dev/1.3` does not contain the newer `DataNodeSchemaMessages` locale structure, so the message follows the existing branch convention and remains in `PathNotExistException`. The test also uses the branch-compatible explicit `SQLException` assertion.

## Tests

- `mvn spotless:apply -pl iotdb-core/datanode`
- `mvn spotless:apply -pl integration-test -P with-integration-tests`
- `mvn verify -DskipUTs -Dit.test=IoTDBInsertMultiRowIT#testInsertAlignedSeriesAutoCreate -DfailIfNoTests=false -Dfailsafe.failIfNoSpecifiedTests=false -pl integration-test -am -P with-integration-tests`
  - Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added integration tests.
- [x] been tested in a test IoTDB cluster.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- `PathNotExistException`
- `InsertBaseStatement`
- `InsertRowStatement`
- `IoTDBInsertMultiRowIT`
