### PR TITLE
Fix procedures stuck after submission-time deserialization failure

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
@@ -810,6 +810,13 @@ public class ProcedureExecutor<Env> {
     // Update metrics on start of a procedure
     procedure.updateMetricsOnSubmit(getEnvironment());
     RootProcedureStack<Env> stack = new RootProcedureStack<>();
+    // Persisting a newly submitted procedure may serialize and deserialize it through the
+    // consensus layer. If that process marks the procedure as failed before it is scheduled, the
+    // rollback stack still needs an entry so the executor can finish the failed procedure instead
+    // of leaving it in the active procedure map forever.
+    if (procedure.isFailed()) {
+      stack.addRollbackStep(procedure);
+    }
     rollbackStack.put(currentProcId, stack);
     procedures.put(currentProcId, procedure);
     scheduler.addBack(procedure);

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
@@ -211,6 +211,14 @@ public class ProcedureExecutor<Env> {
             runnableList.add(procedure);
           }
         });
+    // A submission-time deserialization failure may be persisted before a rollback stack index.
+    failedList.forEach(
+        procedure -> {
+          RootProcedureStack<Env> rootStack = rollbackStack.get(getRootProcedureId(procedure));
+          if (rootStack != null) {
+            initializeRollbackStackForFailedProcedure(rootStack, procedure);
+          }
+        });
     restoreLocks();
 
     waitingTimeoutList.forEach(timeoutExecutor::add);
@@ -814,13 +822,26 @@ public class ProcedureExecutor<Env> {
     // consensus layer. If that process marks the procedure as failed before it is scheduled, the
     // rollback stack still needs an entry so the executor can finish the failed procedure instead
     // of leaving it in the active procedure map forever.
-    if (procedure.isFailed()) {
-      stack.addRollbackStep(procedure);
+    if (initializeRollbackStackForFailedProcedure(stack, procedure)) {
+      try {
+        store.update(procedure);
+      } catch (Exception e) {
+        LOG.error(ProcedureMessages.FAILED_TO_UPDATE_STORE_PROCEDURE, procedure, e);
+      }
     }
     rollbackStack.put(currentProcId, stack);
     procedures.put(currentProcId, procedure);
     scheduler.addBack(procedure);
     return procedure.getProcId();
+  }
+
+  private boolean initializeRollbackStackForFailedProcedure(
+      RootProcedureStack<Env> stack, Procedure<Env> procedure) {
+    if (procedure.isFailed() && !procedure.wasExecuted()) {
+      stack.addRollbackStep(procedure);
+      return true;
+    }
+    return false;
   }
 
   private class WorkerThread extends StoppableThread {

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/TestProcedureExecutor.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/TestProcedureExecutor.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class TestProcedureExecutor extends TestProcedureBase {
@@ -54,6 +55,34 @@ public class TestProcedureExecutor extends TestProcedureBase {
     TestProcEnv env = this.getEnv();
     AtomicInteger acc = env.getAcc();
     Assert.assertEquals(acc.get(), 1);
+  }
+
+  @Test
+  public void testProcedureFailedDuringSubmissionIsRolledBack() throws InterruptedException {
+    TestProcEnv localEnv = new TestProcEnv();
+    FailOnFirstUpdateProcedureStore localStore = new FailOnFirstUpdateProcedureStore();
+    ProcedureExecutor<TestProcEnv> localExecutor = new ProcedureExecutor<>(localEnv, localStore);
+    localEnv.setScheduler(localExecutor.getScheduler());
+    localStore.start();
+    localExecutor.init(1);
+    localExecutor.startWorkers();
+
+    try {
+      FailedDuringSubmissionProcedure procedure = new FailedDuringSubmissionProcedure();
+      long procId = localExecutor.submitProcedure(procedure);
+
+      Assert.assertTrue(procedure.awaitRollback(10, TimeUnit.SECONDS));
+      ProcedureTestUtil.waitForProcedure(localExecutor, procId);
+      Assert.assertTrue(localExecutor.isFinished(procId));
+      Assert.assertEquals(ProcedureState.ROLLEDBACK, procedure.getState());
+      Assert.assertEquals(0, procedure.getExecutionCount());
+      Assert.assertEquals(1, procedure.getRollbackCount());
+    } finally {
+      localStore.stop();
+      localExecutor.stop();
+      localExecutor.join();
+      localStore.cleanup();
+    }
   }
 
   @Test
@@ -221,6 +250,49 @@ public class TestProcedureExecutor extends TestProcedureBase {
 
     private int getExecutionCount() {
       return executionCount.get();
+    }
+  }
+
+  private static class FailOnFirstUpdateProcedureStore extends NoopProcedureStore {
+
+    private final AtomicBoolean firstUpdate = new AtomicBoolean(true);
+
+    @Override
+    public void update(Procedure procedure) {
+      if (firstUpdate.compareAndSet(true, false)) {
+        procedure.setFailure(new ProcedureException("Failed to deserialize procedure"));
+      }
+    }
+  }
+
+  private static class FailedDuringSubmissionProcedure extends Procedure<TestProcEnv> {
+
+    private final Semaphore rolledBack = new Semaphore(0);
+    private final AtomicInteger executionCount = new AtomicInteger();
+    private final AtomicInteger rollbackCount = new AtomicInteger();
+
+    @Override
+    protected Procedure<TestProcEnv>[] execute(TestProcEnv env) {
+      executionCount.incrementAndGet();
+      return null;
+    }
+
+    @Override
+    protected void rollback(TestProcEnv env) {
+      rollbackCount.incrementAndGet();
+      rolledBack.release();
+    }
+
+    private boolean awaitRollback(long timeout, TimeUnit unit) throws InterruptedException {
+      return rolledBack.tryAcquire(timeout, unit);
+    }
+
+    private int getExecutionCount() {
+      return executionCount.get();
+    }
+
+    private int getRollbackCount() {
+      return rollbackCount.get();
     }
   }
 }

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/TestProcedureExecutor.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/TestProcedureExecutor.java
@@ -31,6 +31,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -65,15 +67,47 @@ public class TestProcedureExecutor extends TestProcedureBase {
     localEnv.setScheduler(localExecutor.getScheduler());
     localStore.start();
     localExecutor.init(1);
-    localExecutor.startWorkers();
 
     try {
       FailedDuringSubmissionProcedure procedure = new FailedDuringSubmissionProcedure();
       long procId = localExecutor.submitProcedure(procedure);
 
+      boolean rollbackStackPersisted = localStore.isRollbackStackPersisted();
+      localExecutor.startWorkers();
+      Assert.assertTrue(rollbackStackPersisted);
       Assert.assertTrue(procedure.awaitRollback(10, TimeUnit.SECONDS));
       ProcedureTestUtil.waitForProcedure(localExecutor, procId);
       Assert.assertTrue(localExecutor.isFinished(procId));
+      Assert.assertEquals(ProcedureState.ROLLEDBACK, procedure.getState());
+      Assert.assertEquals(0, procedure.getExecutionCount());
+      Assert.assertEquals(1, procedure.getRollbackCount());
+    } finally {
+      localStore.stop();
+      localExecutor.stop();
+      localExecutor.join();
+      localStore.cleanup();
+    }
+  }
+
+  @Test
+  public void testFailedProcedureWithoutRollbackStackCanBeRecovered() throws InterruptedException {
+    FailedDuringSubmissionProcedure procedure = new FailedDuringSubmissionProcedure();
+    procedure.setProcId(0);
+    procedure.setProcRunnable();
+    procedure.setFailure(new ProcedureException("Failed to deserialize procedure"));
+
+    TestProcEnv localEnv = new TestProcEnv();
+    FailedProcedureStore localStore = new FailedProcedureStore(procedure);
+    ProcedureExecutor<TestProcEnv> localExecutor = new ProcedureExecutor<>(localEnv, localStore);
+    localEnv.setScheduler(localExecutor.getScheduler());
+    localStore.start();
+    localExecutor.init(1);
+    localExecutor.startWorkers();
+
+    try {
+      Assert.assertTrue(procedure.awaitRollback(10, TimeUnit.SECONDS));
+      ProcedureTestUtil.waitForProcedure(localExecutor, procedure.getProcId());
+      Assert.assertTrue(localExecutor.isFinished(procedure.getProcId()));
       Assert.assertEquals(ProcedureState.ROLLEDBACK, procedure.getState());
       Assert.assertEquals(0, procedure.getExecutionCount());
       Assert.assertEquals(1, procedure.getRollbackCount());
@@ -256,12 +290,33 @@ public class TestProcedureExecutor extends TestProcedureBase {
   private static class FailOnFirstUpdateProcedureStore extends NoopProcedureStore {
 
     private final AtomicBoolean firstUpdate = new AtomicBoolean(true);
+    private final AtomicBoolean rollbackStackPersisted = new AtomicBoolean(false);
 
     @Override
     public void update(Procedure procedure) {
       if (firstUpdate.compareAndSet(true, false)) {
         procedure.setFailure(new ProcedureException("Failed to deserialize procedure"));
+      } else if (procedure.isFailed() && procedure.wasExecuted()) {
+        rollbackStackPersisted.set(true);
       }
+    }
+
+    private boolean isRollbackStackPersisted() {
+      return rollbackStackPersisted.get();
+    }
+  }
+
+  private static class FailedProcedureStore extends NoopProcedureStore {
+
+    private final Procedure procedure;
+
+    private FailedProcedureStore(Procedure procedure) {
+      this.procedure = procedure;
+    }
+
+    @Override
+    public List<Procedure> load() {
+      return Collections.singletonList(procedure);
     }
   }
 


### PR DESCRIPTION
## Description

### Problem

Persisting a newly submitted procedure can serialize and deserialize it through the consensus layer. If deserialization marks the procedure as `FAILED` before it is added to the executor, the root rollback stack is empty. The worker then skips execution because the procedure is not `RUNNABLE`, but the procedure remains in the active map. `waitingProcedureFinished()` eventually reports `OVERLAP_WITH_EXISTING_TASK`, causing the DataNode to retry indefinitely and leaving the CLI request blocked.

### Fix

Initialize the root rollback stack with a newly submitted procedure when it is already failed. This lets the executor follow its normal rollback and cleanup path, transition the procedure to `ROLLEDBACK`, remove it from the active map, and expose the original failure to the caller.

### Tests

Added a unit test that simulates the first procedure-store update marking the procedure as failed and verifies that:

- `execute()` is not invoked.
- `rollback()` is invoked exactly once.
- the procedure reaches `ROLLEDBACK`.
- the executor removes the procedure from its active map.

Validation:

- `mvn spotless:apply -pl iotdb-core/confignode`
- `mvn test -pl iotdb-core/confignode -Dtest=TestProcedureExecutor -DfailIfNoTests=false`

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the why and intent of the code.
- [x] added or updated unit tests to cover the new code path.

<hr>

##### Key changed/added classes

- `ProcedureExecutor`
- `TestProcedureExecutor`