### PR TITLE
[to dev/1.3] Prevent aligned LAST query from hanging with time filter

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBAlignedLastQueryWithTimeFilterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBAlignedLastQueryWithTimeFilterIT.java
@@ -59,10 +59,8 @@ public class IoTDBAlignedLastQueryWithTimeFilterIT {
               + "s1 INT32 encoding=RLE, s2 INT32 encoding=RLE, s3 INT32 encoding=RLE)");
       // The queried sensors only have values in the first chunk, while s3 extends the aligned
       // time-series statistics into the query's time range.
-      statement.execute(
-          "insert into root.last_query_filter.d1(time,s1,s2) aligned values(1,1,11)");
-      statement.execute(
-          "insert into root.last_query_filter.d1(time,s1,s2) aligned values(2,2,22)");
+      statement.execute("insert into root.last_query_filter.d1(time,s1,s2) aligned values(1,1,11)");
+      statement.execute("insert into root.last_query_filter.d1(time,s1,s2) aligned values(2,2,22)");
       statement.execute("insert into root.last_query_filter.d1(time,s3) aligned values(100,100)");
       statement.execute("insert into root.last_query_filter.d1(time,s3) aligned values(101,101)");
       statement.execute("flush");

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBAlignedLastQueryWithTimeFilterIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/aligned/IoTDBAlignedLastQueryWithTimeFilterIT.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iotdb.db.it.aligned;
+
+import org.apache.iotdb.it.env.EnvFactory;
+import org.apache.iotdb.it.framework.IoTDBTestRunner;
+import org.apache.iotdb.itbase.category.ClusterIT;
+import org.apache.iotdb.itbase.category.LocalStandaloneIT;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import static org.junit.Assert.assertFalse;
+
+@RunWith(IoTDBTestRunner.class)
+@Category({LocalStandaloneIT.class, ClusterIT.class})
+public class IoTDBAlignedLastQueryWithTimeFilterIT {
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    EnvFactory.getEnv()
+        .getConfig()
+        .getCommonConfig()
+        .setEnableLastCache(false)
+        .setEnableSeqSpaceCompaction(false)
+        .setEnableUnseqSpaceCompaction(false)
+        .setEnableCrossSpaceCompaction(false)
+        .setTargetChunkPointNum(2);
+    EnvFactory.getEnv().initClusterEnvironment();
+
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("create database root.last_query_filter");
+      statement.execute(
+          "create aligned timeseries root.last_query_filter.d1("
+              + "s1 INT32 encoding=RLE, s2 INT32 encoding=RLE, s3 INT32 encoding=RLE)");
+      // The queried sensors only have values in the first chunk, while s3 extends the aligned
+      // time-series statistics into the query's time range.
+      statement.execute(
+          "insert into root.last_query_filter.d1(time,s1,s2) aligned values(1,1,11)");
+      statement.execute(
+          "insert into root.last_query_filter.d1(time,s1,s2) aligned values(2,2,22)");
+      statement.execute("insert into root.last_query_filter.d1(time,s3) aligned values(100,100)");
+      statement.execute("insert into root.last_query_filter.d1(time,s3) aligned values(101,101)");
+      statement.execute("flush");
+    }
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    EnvFactory.getEnv().cleanClusterEnvironment();
+  }
+
+  @Test
+  public void testLastQuerySkipsFilteredSingletonAlignedChunk() throws Exception {
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.setQueryTimeout(10);
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              "select last s1,s2 from root.last_query_filter.d1 "
+                  + "where time >= 100 and time <= 101")) {
+        assertFalse(resultSet.next());
+      }
+    }
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/metadata/DiskAlignedChunkMetadataLoader.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/read/reader/chunk/metadata/DiskAlignedChunkMetadataLoader.java
@@ -75,9 +75,7 @@ public class DiskAlignedChunkMetadataLoader implements IChunkMetadataLoader {
       List<AlignedChunkMetadata> alignedChunkMetadataList =
           ((AlignedTimeSeriesMetadata) timeSeriesMetadata).getCopiedChunkMetadataList();
 
-      // when alignedChunkMetadataList.size() == 1, it means that the chunk statistics is same as
-      // the time series metadata, so we don't need to filter it again.
-      if (alignedChunkMetadataList.size() > 1) {
+      if (!alignedChunkMetadataList.isEmpty()) {
         // remove not satisfied ChunkMetaData
         final long t2 = System.nanoTime();
         alignedChunkMetadataList.removeIf(


### PR DESCRIPTION
## Description

Fix aligned multi-measurement LAST queries that may hang when a time filter excludes the only remaining chunk after selected-column pruning.

For aligned series, pruning chunks with no values in the selected measurements can leave a singleton chunk whose statistics differ from the time-series metadata statistics. `DiskAlignedChunkMetadataLoader` previously skipped time filtering when only one chunk remained, allowing an out-of-range chunk to enter the scan state machine without being consumed.

## Changes

- Apply chunk-level time filtering to every non-empty aligned chunk metadata list, including singleton lists.
- Add an integration test covering a multi-measurement LAST query whose selected measurements only exist outside the query time range.

## Testing

- Added `IoTDBAlignedLastQueryWithTimeFilterIT`.

