### PR TITLE
Fix MQTT measurement validation

### DIFF
--- a/external-service-impl/mqtt/src/main/java/org/apache/iotdb/mqtt/MPPPublishHandler.java
+++ b/external-service-impl/mqtt/src/main/java/org/apache/iotdb/mqtt/MPPPublishHandler.java
@@ -24,6 +24,7 @@ import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.queryengine.common.SqlDialect;
 import org.apache.iotdb.commons.queryengine.utils.TimestampPrecisionUtils;
 import org.apache.iotdb.commons.schema.table.column.TsTableColumnCategory;
+import org.apache.iotdb.commons.utils.PathUtils;
 import org.apache.iotdb.db.auth.AuthorityChecker;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
@@ -274,7 +275,9 @@ public class MPPPublishHandler extends AbstractInterceptHandler {
           DataNodeDevicePathCache.getInstance().getPartialPath(message.getDevice()));
       TimestampPrecisionUtils.checkTimestampPrecision(message.getTimestamp());
       statement.setTime(message.getTimestamp());
-      statement.setMeasurements(message.getMeasurements().toArray(new String[0]));
+      statement.setMeasurements(
+          PathUtils.checkIsLegalSingleMeasurementsAndUpdate(message.getMeasurements())
+              .toArray(new String[0]));
       if (message.getDataTypes() == null) {
         statement.setDataTypes(new TSDataType[message.getMeasurements().size()]);
         statement.setValues(message.getValues().toArray(new Object[0]));

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/mqtt/IoTDBMQTTServiceJsonIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/mqtt/IoTDBMQTTServiceJsonIT.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -479,6 +480,46 @@ public class IoTDBMQTTServiceJsonIT {
         }
         assertEquals(5, count);
       }
+    }
+  }
+
+  @Test
+  public void testIllegalMeasurementIsRejected() throws Exception {
+    try (final ISession session = EnvFactory.getEnv().getSessionConnection()) {
+      String payload =
+          "["
+              + "{\"device\":\"root.sg.invalid\",\"timestamp\":1,\"measurements\":[\"a.b\"],\"values\":[1]},"
+              + "{\"device\":\"root.sg.invalid\",\"timestamp\":2,\"measurements\":[\"valid\"],\"values\":[2]}"
+              + "]";
+
+      Awaitility.await()
+          .atMost(3, TimeUnit.MINUTES)
+          .pollInterval(1, TimeUnit.SECONDS)
+          .until(
+              () -> {
+                connection.publish("root.sg.invalid", payload.getBytes(), QoS.AT_LEAST_ONCE, false);
+                try (final SessionDataSet dataSet =
+                    session.executeQueryStatement(
+                        "select valid from root.sg.invalid where time = 2")) {
+                  return dataSet.hasNext();
+                } catch (StatementExecutionException e) {
+                  if (e.getMessage() != null && e.getMessage().contains("does not exist")) {
+                    return false;
+                  }
+                  throw e;
+                }
+              });
+
+      int timeseriesCount = 0;
+      try (final SessionDataSet dataSet =
+          session.executeQueryStatement("show timeseries root.sg.invalid.**")) {
+        while (dataSet.hasNext()) {
+          dataSet.next();
+          timeseriesCount++;
+        }
+      }
+      assertEquals(1, timeseriesCount);
+      assertFalse(session.checkTimeseriesExists("root.sg.invalid.a.b"));
     }
   }
 }


### PR DESCRIPTION
## Description

Validate tree-model MQTT measurements with `PathUtils.checkIsLegalSingleMeasurementsAndUpdate` before constructing the insert statement. This aligns MQTT writes with the RPC write path and rejects invalid single-node measurement names such as `a.b`.

Add an MQTT integration test that publishes an invalid measurement followed by a valid marker in the same payload, then verifies that only the valid timeseries is created.

## Tests

- `mvn test -pl external-service-impl/mqtt`
- `mvn verify -DskipUTs -Dit.test=IoTDBMQTTServiceJsonIT#testIllegalMeasurementIsRejected -DfailIfNoTests=false -Dfailsafe.failIfNoSpecifiedTests=false -Drat.skip=true -pl integration-test -am -P with-integration-tests`

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added integration tests.
- [x] been tested in a test IoTDB cluster.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- `MPPPublishHandler`
- `IoTDBMQTTServiceJsonIT`