### PR TITLE
[Pipe] Include pending historical events in remaining count

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/metric/overview/PipeDataNodeRemainingEventAndTimeOperator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/metric/overview/PipeDataNodeRemainingEventAndTimeOperator.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.db.pipe.metric.overview;
 import org.apache.iotdb.commons.enums.PipeRateAverage;
 import org.apache.iotdb.commons.pipe.config.PipeConfig;
 import org.apache.iotdb.commons.pipe.metric.PipeRemainingOperator;
+import org.apache.iotdb.db.pipe.source.dataregion.IoTDBDataRegionSource;
 import org.apache.iotdb.db.pipe.source.schemaregion.IoTDBSchemaRegionSource;
 import org.apache.iotdb.metrics.core.IoTDBMetricManager;
 import org.apache.iotdb.metrics.core.type.IoTDBHistogram;
@@ -41,6 +42,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class PipeDataNodeRemainingEventAndTimeOperator extends PipeRemainingOperator {
+
+  private final Set<IoTDBDataRegionSource> dataRegionSources =
+      Collections.newSetFromMap(new ConcurrentHashMap<>());
 
   // Calculate from schema region extractors directly for it requires less computation
   private final Set<IoTDBSchemaRegionSource> schemaRegionSources =
@@ -105,6 +109,10 @@ public class PipeDataNodeRemainingEventAndTimeOperator extends PipeRemainingOper
         tsfileEventCount.get()
             + rawTabletEventCount.get()
             + insertNodeEventCount.get()
+            + dataRegionSources.stream()
+                .map(IoTDBDataRegionSource::getHistoricalTsFileInsertionEventCount)
+                .reduce(Integer::sum)
+                .orElse(0)
             + schemaRegionSources.stream()
                 .map(IoTDBSchemaRegionSource::getUnTransferredEventCount)
                 .reduce(Long::sum)
@@ -185,6 +193,10 @@ public class PipeDataNodeRemainingEventAndTimeOperator extends PipeRemainingOper
   }
 
   //////////////////////////// Register & deregister (pipe integration) ////////////////////////////
+
+  void register(final IoTDBDataRegionSource source) {
+    dataRegionSources.add(source);
+  }
 
   void register(final IoTDBSchemaRegionSource source) {
     schemaRegionSources.add(source);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/metric/overview/PipeDataNodeSinglePipeMetrics.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/metric/overview/PipeDataNodeSinglePipeMetrics.java
@@ -202,11 +202,13 @@ public class PipeDataNodeSinglePipeMetrics implements IMetricSet {
   public void register(final IoTDBDataRegionSource source) {
     // The metric is global thus the regionId is omitted
     final String pipeID = source.getPipeName() + "_" + source.getCreationTime();
-    remainingEventAndTimeOperatorMap.computeIfAbsent(
-        pipeID,
-        k ->
-            new PipeDataNodeRemainingEventAndTimeOperator(
-                source.getPipeName(), source.getCreationTime()));
+    remainingEventAndTimeOperatorMap
+        .computeIfAbsent(
+            pipeID,
+            k ->
+                new PipeDataNodeRemainingEventAndTimeOperator(
+                    source.getPipeName(), source.getCreationTime()))
+        .register(source);
     if (Objects.nonNull(metricService)) {
       createMetrics(pipeID);
     }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/metric/overview/PipeDataNodeRemainingEventAndTimeOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/metric/overview/PipeDataNodeRemainingEventAndTimeOperatorTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.pipe.metric.overview;
+
+import org.apache.iotdb.db.pipe.source.dataregion.IoTDBDataRegionSource;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PipeDataNodeRemainingEventAndTimeOperatorTest {
+
+  @Test
+  public void testPendingHistoricalEventsAreIncludedInRemainingCount() {
+    final PipeDataNodeRemainingEventAndTimeOperator operator =
+        new PipeDataNodeRemainingEventAndTimeOperator("test_pipe", 1L);
+    final IoTDBDataRegionSource source = mock(IoTDBDataRegionSource.class);
+    when(source.getHistoricalTsFileInsertionEventCount()).thenReturn(2);
+
+    operator.register(source);
+
+    assertEquals(2, operator.getRemainingNonHeartbeatEvents());
+
+    operator.increaseTsFileEventCount();
+    assertEquals(3, operator.getRemainingNonHeartbeatEvents());
+  }
+}


### PR DESCRIPTION
## Summary

- register data region sources in the per-pipe remaining event operator
- include pending historical source resources that have not yet been materialized as events
- add a unit test covering pending historical events in the remaining count

This prevents the remaining event count from reporting zero while historical resources are still waiting in the source queue.

## Testing

- `mvn spotless:apply -pl iotdb-core/datanode` (passed)
- `mvn test -pl iotdb-core/datanode -Dtest=PipeDataNodeRemainingEventAndTimeOperatorTest -DfailIfNoTests=false` (timed out after 120 seconds without a compilation or test failure result)
