### PR TITLE
[To dev/1.3] Fix MQTT measurement validation

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/mqtt/MPPPublishHandler.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/protocol/mqtt/MPPPublishHandler.java
@@ -20,6 +20,8 @@ package org.apache.iotdb.db.protocol.mqtt;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.conf.IoTDBConstant.ClientVersion;
+import org.apache.iotdb.commons.exception.MetadataException;
+import org.apache.iotdb.commons.utils.PathUtils;
 import org.apache.iotdb.db.auth.AuthorityChecker;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
@@ -144,7 +146,7 @@ public class MPPPublishHandler extends AbstractInterceptHandler {
               DataNodeDevicePathCache.getInstance().getPartialPath(event.getDevice()));
           TimestampPrecisionUtils.checkTimestampPrecision(event.getTimestamp());
           statement.setTime(event.getTimestamp());
-          statement.setMeasurements(event.getMeasurements().toArray(new String[0]));
+          statement.setMeasurements(checkMeasurements(event.getMeasurements()));
           if (event.getDataTypes() == null) {
             statement.setDataTypes(new TSDataType[event.getMeasurements().size()]);
             statement.setValues(event.getValues().toArray(new Object[0]));
@@ -193,6 +195,10 @@ public class MPPPublishHandler extends AbstractInterceptHandler {
       // release the payload of the message
       super.onPublish(msg);
     }
+  }
+
+  static String[] checkMeasurements(List<String> measurements) throws MetadataException {
+    return PathUtils.checkIsLegalSingleMeasurementsAndUpdate(measurements).toArray(new String[0]);
   }
 
   @Override

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/protocol/mqtt/MPPPublishHandlerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/protocol/mqtt/MPPPublishHandlerTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.iotdb.db.protocol.mqtt;
+
+import org.apache.iotdb.commons.exception.IllegalPathException;
+import org.apache.iotdb.commons.exception.MetadataException;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class MPPPublishHandlerTest {
+
+  @Test
+  public void testLegalMeasurement() throws MetadataException {
+    assertArrayEquals(
+        new String[] {"s1", "s2"}, MPPPublishHandler.checkMeasurements(Arrays.asList("s1", "s2")));
+  }
+
+  @Test(expected = IllegalPathException.class)
+  public void testIllegalMeasurement() throws MetadataException {
+    MPPPublishHandler.checkMeasurements(Collections.singletonList("a.b"));
+  }
+}


### PR DESCRIPTION
## Description

Backport #18215 to `dev/1.3`.

The 1.3 MQTT implementation remains in the DataNode module. This PR validates incoming MQTT measurement names with `PathUtils.checkIsLegalSingleMeasurementsAndUpdate` before constructing an insert statement, rejecting invalid single-node names such as `a.b`.

The master integration-test infrastructure is not present in 1.3, so this backport adds focused handler tests for both legal and illegal measurements.

## Tests

- `mvn test -pl iotdb-core/datanode -am -Dtest=MPPPublishHandlerTest -Dsurefire.failIfNoSpecifiedTests=false`

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for code coverage.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- `MPPPublishHandler`
- `MPPPublishHandlerTest`