### PR TITLE
Fix flaky WALNodeTest WAL roll assertion

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNodeTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/wal/node/WALNodeTest.java
@@ -366,6 +366,10 @@ public class WALNodeTest {
     walNode.onMemTableFlushed(memTable);
     walNode.onMemTableCreated(new PrimitiveMemTable(databasePath, dataRegionId), tsFilePath);
     Awaitility.await().until(() -> walNode.isAllWALEntriesConsumed());
+    // Wait for the sync task to finish rolling the WAL writer before checking the file names.
+    for (WALFlushListener walFlushListener : walFlushListeners) {
+      assertEquals(WALFlushListener.Status.SUCCESS, walFlushListener.waitForResult());
+    }
     // check existence of _0-0-0.wal file and _1-0-1.wal file
     assertTrue(
         new File(


### PR DESCRIPTION
Wait for all synchronous WAL flush listeners before asserting rolled WAL file names. This prevents the test from observing the buffer as idle before the sync task completes WAL rolling. Validation: targeted test passed, plus 10 consecutive repeated runs passed.