### PR TITLE
Fix process metric precision

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/metrics/ProcessMetrics.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/metrics/ProcessMetrics.java
@@ -56,7 +56,7 @@ public class ProcessMetrics implements IMetricSet {
   private static final String PROCESS = "process";
   private static final String LINUX_RSS_PREFIX = "VmRSS:";
   private long lastUpdateTime = 0L;
-  private volatile long processCpuLoad = 0L;
+  private volatile double processCpuLoad = 0.0D;
   private volatile long processCpuTime = 0L;
 
   public ProcessMetrics() {
@@ -89,7 +89,7 @@ public class ProcessMetrics implements IMetricSet {
         a -> {
           if (System.currentTimeMillis() - lastUpdateTime > MetricConstant.UPDATE_INTERVAL) {
             lastUpdateTime = System.currentTimeMillis();
-            processCpuLoad = (long) (sunOsMxBean.getProcessCpuLoad() * 100);
+            processCpuLoad = sunOsMxBean.getProcessCpuLoad() * 100;
             processCpuTime = sunOsMxBean.getProcessCpuTime();
           }
           return processCpuLoad;
@@ -104,7 +104,7 @@ public class ProcessMetrics implements IMetricSet {
         bean -> {
           if (System.currentTimeMillis() - lastUpdateTime > MetricConstant.UPDATE_INTERVAL) {
             lastUpdateTime = System.currentTimeMillis();
-            processCpuLoad = (long) (sunOsMxBean.getProcessCpuLoad() * 100);
+            processCpuLoad = sunOsMxBean.getProcessCpuLoad() * 100;
             processCpuTime = sunOsMxBean.getProcessCpuTime();
           }
           return processCpuTime;
@@ -162,7 +162,7 @@ public class ProcessMetrics implements IMetricSet {
         SystemMetric.PROCESS_MEM_RATIO.toString(),
         MetricLevel.IMPORTANT,
         this,
-        a -> Math.round(getProcessMemoryRatio()),
+        a -> getProcessMemoryRatio(),
         Tag.NAME.toString(),
         PROCESS);
   }


### PR DESCRIPTION
## Summary

- Preserve fractional values in the process CPU load metric
- Preserve fractional values in the process memory ratio metric

This prevents low CPU usage from being reported as zero and avoids rounding process memory utilization to a whole percentage.

## Verification

- `mvn spotless:apply -pl iotdb-core/datanode`
- `mvn compile -pl iotdb-core/datanode -DskipTests`