### PR TITLE
Fix file descriptor leak in CLI CSV import (CSVParser never closed)

### DIFF
--- a/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/data/ImportData.java
+++ b/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/data/ImportData.java
@@ -525,8 +525,7 @@ public class ImportData extends AbstractDataTool {
   private static void importFromSingleFile(Session session, File file) {
     if (file.getName().endsWith(Constants.CSV_SUFFIXS)
         || file.getName().endsWith(Constants.TXT_SUFFIXS)) {
-      try {
-        CSVParser csvRecords = readCsvFile(file.getAbsolutePath());
+      try (CSVParser csvRecords = readCsvFile(file.getAbsolutePath())) {
         List<String> headerNames = csvRecords.getHeaderNames();
         Stream<CSVRecord> records = csvRecords.stream();
         if (headerNames.isEmpty()) {

--- a/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/data/ImportDataTable.java
+++ b/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/data/ImportDataTable.java
@@ -253,8 +253,7 @@ public class ImportDataTable extends AbstractImportData {
   protected void importFromCsvFile(File file) {
     if (file.getName().endsWith(Constants.CSV_SUFFIXS)
         || file.getName().endsWith(Constants.TXT_SUFFIXS)) {
-      try {
-        CSVParser csvRecords = readCsvFile(file.getAbsolutePath());
+      try (CSVParser csvRecords = readCsvFile(file.getAbsolutePath())) {
         List<String> headerNames = csvRecords.getHeaderNames();
         Stream<CSVRecord> records = csvRecords.stream();
         if (headerNames.isEmpty()) {

--- a/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/data/ImportDataTree.java
+++ b/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/data/ImportDataTree.java
@@ -146,8 +146,7 @@ public class ImportDataTree extends AbstractImportData {
   protected void importFromCsvFile(File file) {
     if (file.getName().endsWith(Constants.CSV_SUFFIXS)
         || file.getName().endsWith(Constants.TXT_SUFFIXS)) {
-      try {
-        CSVParser csvRecords = readCsvFile(file.getAbsolutePath());
+      try (CSVParser csvRecords = readCsvFile(file.getAbsolutePath())) {
         List<String> headerNames = csvRecords.getHeaderNames();
         Stream<CSVRecord> records = csvRecords.stream();
         if (headerNames.isEmpty()) {

--- a/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/schema/ImportSchemaTree.java
+++ b/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/schema/ImportSchemaTree.java
@@ -98,8 +98,7 @@ public class ImportSchemaTree extends AbstractImportSchema {
 
   @Override
   protected void importSchemaFromCsvFile(File file) {
-    try {
-      CSVParser csvRecords = readCsvFile(file.getAbsolutePath());
+    try (CSVParser csvRecords = readCsvFile(file.getAbsolutePath())) {
       List<String> headerNames = csvRecords.getHeaderNames();
       Stream<CSVRecord> records = csvRecords.stream();
       if (headerNames.isEmpty()) {

--- a/iotdb-client/cli/src/test/java/org/apache/iotdb/tool/ReadCsvFileResourceTest.java
+++ b/iotdb-client/cli/src/test/java/org/apache/iotdb/tool/ReadCsvFileResourceTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.tool;
+
+import org.apache.iotdb.tool.data.AbstractDataTool;
+
+import org.apache.commons.csv.CSVParser;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Resource-management guard for the CSV import paths. {@link AbstractDataTool#readCsvFile(String)}
+ * returns a {@link CSVParser} that owns the underlying {@code FileInputStream}; the import call
+ * sites (ImportData / ImportDataTree / ImportDataTable / ImportSchemaTree) now consume it inside a
+ * try-with-resources, so the parser — and the file descriptor it wraps — is released on every exit,
+ * including the empty-file / bad-header early returns that previously leaked it (bulk import over a
+ * directory could otherwise exhaust file descriptors with "Too many open files").
+ */
+public class ReadCsvFileResourceTest {
+
+  /** Reaches the protected static {@link AbstractDataTool#readCsvFile(String)} for the assertion. */
+  private static final class Probe extends AbstractDataTool {
+    static CSVParser open(String path) throws IOException {
+      return readCsvFile(path);
+    }
+  }
+
+  @Test
+  public void readCsvFileParserIsClosedByTryWithResources() throws IOException {
+    File csv = File.createTempFile("readCsvFileResource", ".csv");
+    csv.deleteOnExit();
+    try (FileWriter writer = new FileWriter(csv)) {
+      writer.write("Time,root.sg.d.s0\n1,10\n2,20\n");
+    }
+
+    CSVParser parser;
+    try (CSVParser opened = Probe.open(csv.getAbsolutePath())) {
+      parser = opened;
+      assertFalse("parser must be open inside the try block", opened.isClosed());
+      List<String> headerNames = opened.getHeaderNames();
+      assertFalse("header must be parsed", headerNames.isEmpty());
+      assertEquals("both data rows must be readable before close", 2L, opened.stream().count());
+    }
+
+    assertTrue(
+        "readCsvFile's parser (and the FileInputStream it wraps) must be closed on scope exit",
+        parser.isClosed());
+  }
+}


### PR DESCRIPTION
## Description

`AbstractDataTool.readCsvFile` returns a `CSVParser` that owns the underlying `FileInputStream`, but the CLI import call sites (`ImportData`, `ImportDataTree`, `ImportDataTable`, `ImportSchemaTree`) never closed it. The empty-file / invalid-header early returns leaked the file descriptor immediately, and importing a directory of many CSV files could exhaust the process limit with `Too many open files`.

This wraps the parser in a try-with-resources at each call site so it (and the `FileInputStream` it wraps) is closed on every exit path. The record `Stream` is fully consumed inside the block before the method returns, so closing on scope exit is safe. A test is added asserting the parser is closed after use.

This closes #18237.
