### PR TITLE
[Pipe] Enable CRC32 intrinsic for DataNode

### DIFF
--- a/scripts/conf/datanode-env.sh
+++ b/scripts/conf/datanode-env.sh
@@ -237,6 +237,9 @@ IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Djdk.nio.maxCachedBufferSize=${MAX_CACHED_BUFFE
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:+CrashOnOutOfMemoryError"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:+UseAdaptiveSizePolicy"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xss512k"
+# Enable the CRC32 intrinsic on compiled paths to avoid the JNI critical fallback.
+IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:+UnlockDiagnosticVMOptions"
+IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:+UseCRC32Intrinsics"
 # these two options print safepoints with pauses longer than 1000ms to the standard output. You can see these logs via redirection when starting in the background like "start-datanode.sh > log_datanode_safepoint.log"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:SafepointTimeoutDelay=1000"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:+SafepointTimeout"

--- a/scripts/conf/windows/datanode-env.bat
+++ b/scripts/conf/windows/datanode-env.bat
@@ -126,6 +126,8 @@ set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:+UseAdaptiveSizePolicy
 set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -Xss512k
 @REM options below try to optimize safepoint stw time.
 set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:+UnlockDiagnosticVMOptions
+@REM Enable the CRC32 intrinsic on compiled paths to avoid the JNI critical fallback.
+set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:+UseCRC32Intrinsics
 set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:GuaranteedSafepointInterval=0
 @REM these two options print safepoints with pauses longer than 1000ms to the standard output. You can see these logs via redirection when starting in the background like "start-datanode.sh > log_datanode_safepoint.txt"
 set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:SafepointTimeoutDelay=1000


### PR DESCRIPTION
## Description

Enable the HotSpot CRC32 intrinsic in the default DataNode JVM options on Linux and Windows.

- Add -XX:+UseCRC32Intrinsics to both DataNode environment scripts.
- Add -XX:+UnlockDiagnosticVMOptions before the intrinsic flag on Linux; Windows already enables it.
- Keep the change scoped to DataNode, where the AirGap sender and receiver calculate CRC32 checksums.

This reduces use of the JNI critical fallback after the CRC32 method is JIT compiled. Cold or interpreted execution may still use the fallback path.

### Verification

- Verified with JDK 17 that UseCRC32Intrinsics is true and reported as a command-line diagnostic option.
- Verified the diagnostic unlock option precedes the intrinsic option in both scripts.
- Ran git diff --check.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the intent of the JVM options.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- scripts/conf/datanode-env.sh
- scripts/conf/windows/datanode-env.bat