### PR TITLE
Fix ResultSetMetaData.getCatalogName throwing IndexOutOfBoundsException instead of SQLException for out-of-range columns

### DIFF
--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBResultMetadata.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBResultMetadata.java
@@ -83,6 +83,7 @@ public class IoTDBResultMetadata implements ResultSetMetaData {
   }) // ignore Cognitive Complexity of methods should not be too high
   @Override
   public String getCatalogName(int column) throws SQLException {
+    checkColumnIndex(column);
     String systemSchmea = "_system_schmea";
     String system = "_system";
     String systemUser = "_system_user";
@@ -92,9 +93,6 @@ public class IoTDBResultMetadata implements ResultSetMetaData {
     String systemNull = "";
     String columnName = columnInfoList.get(column - 1);
     List<String> listColumns = columnInfoList;
-    if (column < 1 || column > columnInfoList.size()) {
-      throw new SQLException(Constant.METHOD_NOT_SUPPORTED);
-    }
     if ("SHOW".equals(operationType)) {
       if ("count".equals(listColumns.get(0))) {
         return systemDatabase;

--- a/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBResultMetadataTest.java
+++ b/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBResultMetadataTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class IoTDBResultMetadataTest {
 
@@ -172,5 +173,27 @@ public class IoTDBResultMetadataTest {
     for (int i = 1; i <= types.length; i++) {
       assertEquals(metadata.getColumnType(i + 1), types[i - 1]);
     }
+  }
+
+  @Test
+  public void getCatalogNameOutOfRangeThrowsSQLExceptionNotIndexOutOfBounds() throws SQLException {
+    String[] columns = {"root.a.b.c1", "root.a.b.c2", "root.a.b.c3"};
+    metadata = new IoTDBResultMetadata(false, null, "LIST_USER", Arrays.asList(columns), null, false);
+
+    // out-of-range columns must throw SQLException, not a raw IndexOutOfBoundsException from
+    // columnInfoList.get(column - 1) running before the range check.
+    for (int badColumn : new int[] {0, columns.length + 1}) {
+      try {
+        metadata.getCatalogName(badColumn);
+        fail("getCatalogName(" + badColumn + ") should throw SQLException for an out-of-range column");
+      } catch (SQLException expected) {
+        // expected
+      } catch (IndexOutOfBoundsException e) {
+        fail("getCatalogName(" + badColumn + ") threw IndexOutOfBoundsException instead of SQLException");
+      }
+    }
+
+    // a valid column is unaffected by the added guard
+    assertEquals("_system_user", metadata.getCatalogName(1));
   }
 }


### PR DESCRIPTION
## Description

`IoTDBResultMetadata.getCatalogName` read `columnInfoList.get(column - 1)` before its range check, so an out-of-range column index threw a raw `IndexOutOfBoundsException` instead of the `SQLException` required by the `ResultSetMetaData` contract (the range check was therefore unreachable). This calls `checkColumnIndex(column)` first — as the seven sibling accessors in the class already do — and removes the now-redundant inline range check. `checkColumnIndex` is a strict superset of that check (it also rejects an empty column list) and throws a proper `SQLException`.

A test is added asserting that an out-of-range column throws `SQLException` rather than `IndexOutOfBoundsException`, and that a valid column is unaffected.

This closes #18241.
