### PR TITLE
[To dev/1.3] Enable CRC32 intrinsic for DataNode (#18239)

### DIFF
--- a/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.bat
+++ b/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.bat
@@ -125,6 +125,8 @@ set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:+UseAdaptiveSizePolicy
 set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -Xss512k
 @REM options below try to optimize safepoint stw time.
 set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:+UnlockDiagnosticVMOptions
+@REM Enable the CRC32 intrinsic on compiled paths to avoid the JNI critical fallback.
+set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:+UseCRC32Intrinsics
 set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:GuaranteedSafepointInterval=0
 @REM these two options print safepoints with pauses longer than 1000ms to the standard output. You can see these logs via redirection when starting in the background like "start-datanode.sh > log_datanode_safepoint.txt"
 set IOTDB_HEAP_OPTS=%IOTDB_HEAP_OPTS% -XX:SafepointTimeoutDelay=1000

--- a/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.sh
+++ b/iotdb-core/datanode/src/assembly/resources/conf/datanode-env.sh
@@ -316,6 +316,9 @@ IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Djdk.nio.maxCachedBufferSize=${MAX_CACHED_BUFFE
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:+CrashOnOutOfMemoryError"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:+UseAdaptiveSizePolicy"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -Xss512k"
+# Enable the CRC32 intrinsic on compiled paths to avoid the JNI critical fallback.
+IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:+UnlockDiagnosticVMOptions"
+IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:+UseCRC32Intrinsics"
 # these two options print safepoints with pauses longer than 1000ms to the standard output. You can see these logs via redirection when starting in the background like "start-datanode.sh > log_datanode_safepoint.log"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:SafepointTimeoutDelay=1000"
 IOTDB_JMX_OPTS="$IOTDB_JMX_OPTS -XX:+SafepointTimeout"


### PR DESCRIPTION
## Summary

- backport #18239 to dev/1.3
- enable the HotSpot CRC32 intrinsic in the default DataNode JVM options on Linux and Windows
- keep the change scoped to DataNode, where Pipe AirGap calculates CRC32 checksums

## Validation

- `git diff --check origin/dev/1.3...HEAD`
- `java -XX:+UnlockDiagnosticVMOptions -XX:+UseCRC32Intrinsics -version` (JDK 17)