### PR TITLE
[To dev/1.3] Reduce temporary allocations on insert path (#18240)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/memory/InsertNodeMemoryEstimator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/memory/InsertNodeMemoryEstimator.java
@@ -26,6 +26,7 @@ import org.apache.iotdb.common.rpc.thrift.TRegionReplicaSet;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.consensus.index.ProgressIndex;
 import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.commons.utils.TestOnly;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertMultiTabletsNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertNode;
@@ -135,6 +136,12 @@ public class InsertNodeMemoryEstimator {
   // from the actual result because the properties of the parent class are not added.
   private static final double INSERT_ROW_NODE_EXPANSION_FACTOR = 1.3;
 
+  // Composite insert nodes are estimated on write threads. Reuse the identity set between events,
+  // but discard unusually large sets to avoid retaining a large table on every write thread.
+  private static final int MAX_RETAINED_DEDUPLICATED_OBJECTS = 1024;
+  private static final ThreadLocal<Set<Object>> REUSABLE_DEDUPLICATED_OBJECTS =
+      ThreadLocal.withInitial(InsertNodeMemoryEstimator::newDeduplicatedObjectSet);
+
   public static long sizeOf(final InsertNode insertNode) {
     try {
       final String className = insertNode.getClass().getSimpleName();
@@ -218,35 +225,47 @@ public class InsertNodeMemoryEstimator {
 
   private static long sizeOfInsertRowsNode(final InsertRowsNode node) {
     final Set<Object> deduplicatedObjects =
-        newDeduplicatedObjectSetIfNeeded(node.getInsertRowNodeList());
-    long size = INSERT_ROWS_NODE_SIZE;
-    size += calculateFullInsertNodeSize(node, deduplicatedObjects);
-    size += sizeOfInsertRowNodeList(node.getInsertRowNodeList(), deduplicatedObjects);
-    size += sizeOfIntegerList(node.getInsertRowNodeIndexList());
-    size += sizeOfResults(node.getResults());
-    return size;
+        acquireDeduplicatedObjectSetIfNeeded(node.getInsertRowNodeList());
+    try {
+      long size = INSERT_ROWS_NODE_SIZE;
+      size += calculateFullInsertNodeSize(node, deduplicatedObjects);
+      size += sizeOfInsertRowNodeList(node.getInsertRowNodeList(), deduplicatedObjects);
+      size += sizeOfIntegerList(node.getInsertRowNodeIndexList());
+      size += sizeOfResults(node.getResults());
+      return size;
+    } finally {
+      releaseDeduplicatedObjectSet(deduplicatedObjects);
+    }
   }
 
   private static long sizeOfInsertRowsOfOneDeviceNode(final InsertRowsOfOneDeviceNode node) {
     final Set<Object> deduplicatedObjects =
-        newDeduplicatedObjectSetIfNeeded(node.getInsertRowNodeList());
-    long size = INSERT_ROWS_OF_ONE_DEVICE_NODE_SIZE;
-    size += calculateFullInsertNodeSize(node, deduplicatedObjects);
-    size += sizeOfInsertRowNodeList(node.getInsertRowNodeList(), deduplicatedObjects);
-    size += sizeOfIntegerList(node.getInsertRowNodeIndexList());
-    size += sizeOfResults(node.getResults());
-    return size;
+        acquireDeduplicatedObjectSetIfNeeded(node.getInsertRowNodeList());
+    try {
+      long size = INSERT_ROWS_OF_ONE_DEVICE_NODE_SIZE;
+      size += calculateFullInsertNodeSize(node, deduplicatedObjects);
+      size += sizeOfInsertRowNodeList(node.getInsertRowNodeList(), deduplicatedObjects);
+      size += sizeOfIntegerList(node.getInsertRowNodeIndexList());
+      size += sizeOfResults(node.getResults());
+      return size;
+    } finally {
+      releaseDeduplicatedObjectSet(deduplicatedObjects);
+    }
   }
 
   private static long sizeOfInsertMultiTabletsNode(final InsertMultiTabletsNode node) {
     final Set<Object> deduplicatedObjects =
-        newDeduplicatedObjectSetIfNeeded(node.getInsertTabletNodeList());
-    long size = INSERT_MULTI_TABLETS_NODE_SIZE;
-    size += calculateFullInsertNodeSize(node, deduplicatedObjects);
-    size += sizeOfInsertTabletNodeList(node.getInsertTabletNodeList(), deduplicatedObjects);
-    size += sizeOfIntegerList(node.getParentInsertTabletNodeIndexList());
-    size += sizeOfResults(node.getResults());
-    return size;
+        acquireDeduplicatedObjectSetIfNeeded(node.getInsertTabletNodeList());
+    try {
+      long size = INSERT_MULTI_TABLETS_NODE_SIZE;
+      size += calculateFullInsertNodeSize(node, deduplicatedObjects);
+      size += sizeOfInsertTabletNodeList(node.getInsertTabletNodeList(), deduplicatedObjects);
+      size += sizeOfIntegerList(node.getParentInsertTabletNodeIndexList());
+      size += sizeOfResults(node.getResults());
+      return size;
+    } finally {
+      releaseDeduplicatedObjectSet(deduplicatedObjects);
+    }
   }
 
   // ============================Device And Measurement===================================
@@ -708,8 +727,24 @@ public class InsertNodeMemoryEstimator {
     return Collections.newSetFromMap(new IdentityHashMap<>());
   }
 
-  private static Set<Object> newDeduplicatedObjectSetIfNeeded(final List<?> children) {
-    return children != null && children.size() > 1 ? newDeduplicatedObjectSet() : null;
+  private static Set<Object> acquireDeduplicatedObjectSetIfNeeded(final List<?> children) {
+    return children != null && children.size() > 1 ? REUSABLE_DEDUPLICATED_OBJECTS.get() : null;
+  }
+
+  private static void releaseDeduplicatedObjectSet(final Set<Object> deduplicatedObjects) {
+    if (deduplicatedObjects == null) {
+      return;
+    }
+    final boolean oversized = deduplicatedObjects.size() > MAX_RETAINED_DEDUPLICATED_OBJECTS;
+    deduplicatedObjects.clear();
+    if (oversized) {
+      REUSABLE_DEDUPLICATED_OBJECTS.remove();
+    }
+  }
+
+  @TestOnly
+  static void clearReusableDeduplicatedObjectsForTest() {
+    REUSABLE_DEDUPLICATED_OBJECTS.remove();
   }
 
   private static boolean shouldCountObject(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/DataNodeSchemaCache.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/DataNodeSchemaCache.java
@@ -327,6 +327,17 @@ public class DataNodeSchemaCache {
         database, deviceID, measurements, timeValuePairs, isAligned, measurementSchemas, false);
   }
 
+  public void updateLastCacheIfExists(
+      final String database,
+      final PartialPath deviceID,
+      final String[] measurements,
+      final LastCacheUpdateSource updateSource,
+      final boolean isAligned,
+      final IMeasurementSchema[] measurementSchemas) {
+    deviceSchemaCache.updateLastCache(
+        database, deviceID, measurements, updateSource, isAligned, measurementSchemas);
+  }
+
   /**
    * Update the {@link DeviceLastCache} on query.
    *

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/DeviceCacheEntry.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/DeviceCacheEntry.java
@@ -80,13 +80,22 @@ public class DeviceCacheEntry {
       return 0;
     }
     // Safe here because schema is invalidated by the whole entry
-    final int result =
-        (deviceSchema.compareAndSet(null, new DeviceNormalSchema(database, isAligned))
-            ? DeviceNormalSchema.INSTANCE_SIZE
-            : 0);
-    return deviceSchema.get() instanceof DeviceNormalSchema
-        ? result + ((DeviceNormalSchema) deviceSchema.get()).update(measurements, schemas)
-        : 0;
+    IDeviceSchema schema = deviceSchema.get();
+    int result = 0;
+    if (schema == null) {
+      final DeviceNormalSchema newSchema = new DeviceNormalSchema(database, isAligned);
+      if (deviceSchema.compareAndSet(null, newSchema)) {
+        schema = newSchema;
+        result = DeviceNormalSchema.INSTANCE_SIZE;
+      } else {
+        schema = deviceSchema.get();
+      }
+    }
+    if (!(schema instanceof DeviceNormalSchema)) {
+      return 0;
+    }
+    result += ((DeviceNormalSchema) schema).update(measurements, schemas);
+    return deviceSchema.get() == schema ? result : 0;
   }
 
   IDeviceSchema getDeviceSchema() {
@@ -134,6 +143,18 @@ public class DeviceCacheEntry {
 
   int tryUpdateLastCache(final String[] measurements, final TimeValuePair[] timeValuePairs) {
     return tryUpdateLastCache(measurements, timeValuePairs, false);
+  }
+
+  int tryUpdateLastCache(
+      final String[] measurements,
+      final @Nullable IMeasurementSchema[] measurementSchemas,
+      final LastCacheUpdateSource updateSource) {
+    final DeviceLastCache cache = lastCache.get();
+    final int result =
+        Objects.nonNull(cache)
+            ? cache.tryUpdate(measurements, measurementSchemas, updateSource)
+            : 0;
+    return Objects.nonNull(lastCache.get()) ? result : 0;
   }
 
   int tryUpdateLastCache(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/DeviceLastCache.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/DeviceLastCache.java
@@ -30,9 +30,9 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -84,7 +84,8 @@ public class DeviceLastCache {
       new TimeValuePair(Long.MIN_VALUE, EMPTY_PRIMITIVE_TYPE);
 
   // Time is seen as "" as a measurement
-  private final Map<String, TimeValuePair> measurement2CachedLastMap = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, TimeValuePair> measurement2CachedLastMap =
+      new ConcurrentHashMap<>();
 
   int initOrInvalidate(final String[] measurements, final boolean isInvalidate) {
     final AtomicInteger diff = new AtomicInteger(0);
@@ -131,7 +132,7 @@ public class DeviceLastCache {
       final @Nullable IMeasurementSchema[] measurementSchemas,
       final @Nonnull TimeValuePair[] timeValuePairs,
       final boolean invalidateNull) {
-    final AtomicInteger diff = new AtomicInteger(0);
+    int diff = 0;
     long lastTime = Long.MIN_VALUE;
 
     for (int i = 0; i < measurements.length; ++i) {
@@ -139,37 +140,87 @@ public class DeviceLastCache {
       if (Objects.isNull(measurement)) {
         continue;
       }
-      if (Objects.isNull(timeValuePairs[i])) {
+      final TimeValuePair timeValuePair = timeValuePairs[i];
+      if (Objects.isNull(timeValuePair)) {
         if (invalidateNull) {
-          diff.addAndGet(
-              -((int) RamUsageEstimator.sizeOf(measurement)
-                  + getTvPairEntrySize(measurement2CachedLastMap.remove(measurement))));
+          diff -=
+              (int) RamUsageEstimator.sizeOf(measurement)
+                  + getTvPairEntrySize(measurement2CachedLastMap.remove(measurement));
         }
         continue;
       }
 
-      final int finalI = i;
-      if (lastTime < timeValuePairs[i].getTimestamp()) {
-        lastTime = timeValuePairs[i].getTimestamp();
+      if (lastTime < timeValuePair.getTimestamp()) {
+        lastTime = timeValuePair.getTimestamp();
       }
-      measurement2CachedLastMap.computeIfPresent(
-          measurement,
-          (measurementName, tvPair) -> {
-            if (tvPair.getTimestamp() <= timeValuePairs[finalI].getTimestamp()) {
-              diff.addAndGet(getDiffSize(tvPair, timeValuePairs[finalI]));
-              return timeValuePairs[finalI];
-            }
-            return tvPair;
-          });
+      diff += tryUpdateCachedLast(measurement, timeValuePair);
     }
-    final long finalLastTime = lastTime;
-    measurement2CachedLastMap.computeIfPresent(
-        "",
-        (time, tvPair) ->
-            tvPair.getTimestamp() < finalLastTime
-                ? new TimeValuePair(finalLastTime, EMPTY_PRIMITIVE_TYPE)
-                : tvPair);
-    return diff.get();
+    tryUpdateLastTime(lastTime);
+    return diff;
+  }
+
+  int tryUpdate(
+      final @Nonnull String[] measurements,
+      final @Nullable IMeasurementSchema[] measurementSchemas,
+      final LastCacheUpdateSource updateSource) {
+    int diff = 0;
+    boolean hasValue = false;
+
+    for (int i = 0; i < measurements.length; ++i) {
+      final String measurement = getRawMeasurement(measurements, measurementSchemas, i);
+      if (Objects.isNull(measurement) || !updateSource.hasLastCacheValue(i)) {
+        continue;
+      }
+      hasValue = true;
+      diff += tryUpdateCachedLast(measurement, updateSource, i);
+    }
+    if (hasValue) {
+      tryUpdateLastTime(updateSource.getLastCacheTimestamp());
+    }
+    return diff;
+  }
+
+  private int tryUpdateCachedLast(
+      final String measurement, final LastCacheUpdateSource updateSource, final int index) {
+    final TimeValuePair cachedPair = measurement2CachedLastMap.get(measurement);
+    if (Objects.isNull(cachedPair)
+        || cachedPair.getTimestamp() > updateSource.getLastCacheTimestamp()) {
+      return 0;
+    }
+    final TimeValuePair newPair = updateSource.getLastCacheValue(index);
+    return Objects.nonNull(newPair) ? tryUpdateCachedLast(measurement, cachedPair, newPair) : 0;
+  }
+
+  private int tryUpdateCachedLast(final String measurement, final TimeValuePair newPair) {
+    return tryUpdateCachedLast(measurement, measurement2CachedLastMap.get(measurement), newPair);
+  }
+
+  private int tryUpdateCachedLast(
+      final String measurement, TimeValuePair cachedPair, final TimeValuePair newPair) {
+    while (Objects.nonNull(cachedPair) && cachedPair.getTimestamp() <= newPair.getTimestamp()) {
+      if (measurement2CachedLastMap.replace(measurement, cachedPair, newPair)) {
+        return getDiffSize(cachedPair, newPair);
+      }
+      cachedPair = measurement2CachedLastMap.get(measurement);
+    }
+    return 0;
+  }
+
+  private void tryUpdateLastTime(final long lastTime) {
+    if (lastTime == Long.MIN_VALUE) {
+      return;
+    }
+    TimeValuePair cachedPair = measurement2CachedLastMap.get("");
+    if (Objects.isNull(cachedPair) || cachedPair.getTimestamp() >= lastTime) {
+      return;
+    }
+    final TimeValuePair newPair = new TimeValuePair(lastTime, EMPTY_PRIMITIVE_TYPE);
+    while (Objects.nonNull(cachedPair) && cachedPair.getTimestamp() < lastTime) {
+      if (measurement2CachedLastMap.replace("", cachedPair, newPair)) {
+        return;
+      }
+      cachedPair = measurement2CachedLastMap.get("");
+    }
   }
 
   @Nullable

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/DeviceSchemaCache.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/DeviceSchemaCache.java
@@ -134,7 +134,7 @@ public class DeviceSchemaCache {
 
     dualKeyCache.update(
         device,
-        new DeviceCacheEntry(),
+        Objects.isNull(timeValuePairs) ? new DeviceCacheEntry() : null,
         initOrInvalidate
             ? entry ->
                 entry.setMeasurementSchema(
@@ -145,6 +145,25 @@ public class DeviceSchemaCache {
                         database2Use, isAligned, measurements, measurementSchemas)
                     + entry.tryUpdateLastCache(measurements, measurementSchemas, timeValuePairs),
         Objects.isNull(timeValuePairs));
+  }
+
+  void updateLastCache(
+      final String database,
+      final PartialPath device,
+      final String[] measurements,
+      final LastCacheUpdateSource updateSource,
+      final boolean isAligned,
+      final IMeasurementSchema[] measurementSchemas) {
+    final String previousDatabase = databasePool.putIfAbsent(database, database);
+    final String database2Use = Objects.nonNull(previousDatabase) ? previousDatabase : database;
+
+    dualKeyCache.update(
+        device,
+        null,
+        entry ->
+            entry.setMeasurementSchema(database2Use, isAligned, measurements, measurementSchemas)
+                + entry.tryUpdateLastCache(measurements, measurementSchemas, updateSource),
+        false);
   }
 
   public boolean getLastCache(final Map<PartialPath, Map<String, TimeValuePair>> inputMap) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/LastCacheUpdateSource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/LastCacheUpdateSource.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.plan.analyze.cache.schema;
+
+import org.apache.tsfile.read.TimeValuePair;
+
+/**
+ * Provides row values lazily when updating last cache on the write path.
+ *
+ * <p>{@link #getLastCacheValue(int)} is called only when the corresponding cache entry exists and
+ * its timestamp is eligible for update.
+ */
+public interface LastCacheUpdateSource {
+
+  long getLastCacheTimestamp();
+
+  boolean hasLastCacheValue(int index);
+
+  TimeValuePair getLastCacheValue(int index);
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertRowNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/plan/node/write/InsertRowNode.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.commons.utils.TimePartitionUtils;
 import org.apache.iotdb.db.queryengine.plan.analyze.IAnalysis;
 import org.apache.iotdb.db.queryengine.plan.analyze.cache.schema.DataNodeDevicePathCache;
 import org.apache.iotdb.db.queryengine.plan.analyze.cache.schema.DataNodeSchemaCache;
+import org.apache.iotdb.db.queryengine.plan.analyze.cache.schema.LastCacheUpdateSource;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeType;
@@ -57,7 +58,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-public class InsertRowNode extends InsertNode implements WALEntryValue {
+public class InsertRowNode extends InsertNode implements WALEntryValue, LastCacheUpdateSource {
 
   private static final byte TYPE_RAW_STRING = -1;
 
@@ -853,22 +854,44 @@ public class InsertRowNode extends InsertNode implements WALEntryValue {
   }
 
   public TimeValuePair composeTimeValuePair(int columnIndex) {
-    if (columnIndex >= values.length || Objects.isNull(dataTypes[columnIndex])) {
+    if (!canComposeTimeValuePair(columnIndex)) {
       return null;
     }
     Object value = values[columnIndex];
-    return Objects.nonNull(value)
-        ? new TimeValuePair(time, TsPrimitiveType.getByType(dataTypes[columnIndex], value))
-        : null;
+    return new TimeValuePair(time, TsPrimitiveType.getByType(dataTypes[columnIndex], value));
+  }
+
+  @Override
+  public long getLastCacheTimestamp() {
+    return time;
+  }
+
+  @Override
+  public boolean hasLastCacheValue(final int index) {
+    return canComposeTimeValuePair(index);
+  }
+
+  @Override
+  public TimeValuePair getLastCacheValue(final int index) {
+    return composeTimeValuePair(index);
+  }
+
+  private boolean canComposeTimeValuePair(final int columnIndex) {
+    return measurements != null
+        && columnIndex >= 0
+        && columnIndex < measurements.length
+        && measurements[columnIndex] != null
+        && values != null
+        && columnIndex < values.length
+        && values[columnIndex] != null
+        && dataTypes != null
+        && columnIndex < dataTypes.length
+        && dataTypes[columnIndex] != null;
   }
 
   public void updateLastCache(String databaseName) {
-    TimeValuePair[] timeValuePairs = new TimeValuePair[measurements.length];
-    for (int i = 0; i < measurements.length; i++) {
-      timeValuePairs[i] = composeTimeValuePair(i);
-    }
     DataNodeSchemaCache.getInstance()
         .updateLastCacheIfExists(
-            databaseName, devicePath, measurements, timeValuePairs, isAligned, measurementSchemas);
+            databaseName, devicePath, measurements, this, isAligned, measurementSchemas);
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/cache/DataNodeSchemaCacheTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/cache/DataNodeSchemaCacheTest.java
@@ -48,6 +48,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static org.apache.iotdb.commons.schema.SchemaConstant.ALL_MATCH_PATTERN;
@@ -270,36 +271,47 @@ public class DataNodeSchemaCacheTest {
   }
 
   @Test
-  public void testUpdateLastCacheWithAliasDoesNotCopyMeasurements() throws IllegalPathException {
+  public void testUpdateLastCacheLazilyWithAlias() throws IllegalPathException {
     final String database = "root.db";
     final PartialPath device = new PartialPath("root.db.d_alias");
     final MeasurementSchema s1 = new MeasurementSchema("s1", TSDataType.INT32);
+    final MeasurementSchema s2 = new MeasurementSchema("s2", TSDataType.INT32);
     final MeasurementPath s1Path = new MeasurementPath(device.concatNode("s1"), s1);
+    final AtomicInteger composedValueCount = new AtomicInteger();
 
     dataNodeSchemaCache.declareLastCache(database, s1Path);
 
     final InsertRowNode insertRowNode =
         new InsertRowNode(
-            new PlanNodeId("testUpdateLastCacheWithAliasDoesNotCopyMeasurements"),
+            new PlanNodeId("testUpdateLastCacheLazilyWithAlias"),
             device,
             false,
-            new String[] {"alias"},
-            new TSDataType[] {TSDataType.INT32},
-            new MeasurementSchema[] {s1},
+            new String[] {"alias", "uncachedAlias"},
+            new TSDataType[] {TSDataType.INT32, TSDataType.INT32},
+            new MeasurementSchema[] {s1, s2},
             1L,
-            new Object[] {1},
+            new Object[] {1, 2},
             false) {
           @Override
           public String[] getRawMeasurements() {
             throw new AssertionError("Last cache update should not copy raw measurements");
           }
+
+          @Override
+          public TimeValuePair composeTimeValuePair(final int columnIndex) {
+            composedValueCount.incrementAndGet();
+            return super.composeTimeValuePair(columnIndex);
+          }
         };
 
     insertRowNode.updateLastCache(database);
 
+    Assert.assertEquals(1, composedValueCount.get());
     Assert.assertEquals(
         new TimeValuePair(1L, new TsPrimitiveType.TsInt(1)),
         dataNodeSchemaCache.getLastCache(new MeasurementPath(device.concatNode("s1"), s1)));
+    Assert.assertNull(
+        dataNodeSchemaCache.getLastCache(new MeasurementPath(device.concatNode("s2"), s2)));
     Assert.assertNull(
         dataNodeSchemaCache.getLastCache(
             new MeasurementPath(

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/resource/memory/InsertNodeMemoryEstimatorPerformanceTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/resource/memory/InsertNodeMemoryEstimatorPerformanceTest.java
@@ -22,13 +22,20 @@ package org.apache.iotdb.db.pipe.resource.memory;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.PlanNodeId;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertRowNode;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertRowsNode;
 import org.apache.iotdb.db.queryengine.plan.planner.plan.node.write.InsertTabletNode;
+import org.apache.iotdb.db.utils.ManualPerformanceTestUtils;
+import org.apache.iotdb.db.utils.ManualPerformanceTestUtils.Measurement;
+import org.apache.iotdb.db.utils.ManualPerformanceTestUtils.Summary;
 
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.write.schema.MeasurementSchema;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
+
+import java.util.Locale;
 
 public class InsertNodeMemoryEstimatorPerformanceTest {
 
@@ -40,6 +47,18 @@ public class InsertNodeMemoryEstimatorPerformanceTest {
       "iotdb.pipe.insert.node.memory.estimator.perf.warmup.iterations";
   private static final String ITERATIONS_PROPERTY =
       "iotdb.pipe.insert.node.memory.estimator.perf.iterations";
+  private static final String REUSE_ENABLED_PROPERTY =
+      "iotdb.pipe.insert.node.memory.estimator.reuse.perf.enabled";
+  private static final String REUSE_ROWS_PROPERTY =
+      "iotdb.pipe.insert.node.memory.estimator.reuse.perf.rows";
+  private static final String REUSE_MEASUREMENTS_PROPERTY =
+      "iotdb.pipe.insert.node.memory.estimator.reuse.perf.measurements";
+  private static final String REUSE_WARMUP_ITERATIONS_PROPERTY =
+      "iotdb.pipe.insert.node.memory.estimator.reuse.perf.warmup.iterations";
+  private static final String REUSE_ITERATIONS_PROPERTY =
+      "iotdb.pipe.insert.node.memory.estimator.reuse.perf.iterations";
+  private static final String REUSE_ROUNDS_PROPERTY =
+      "iotdb.pipe.insert.node.memory.estimator.reuse.perf.rounds";
 
   private static volatile long benchmarkBlackhole;
 
@@ -71,12 +90,168 @@ public class InsertNodeMemoryEstimatorPerformanceTest {
         elapsedNanos / (double) iterations / 1_000_000.0);
   }
 
+  @Test
+  public void compositeInsertRowsReusableSetBenchmark() throws IllegalPathException {
+    Assume.assumeTrue(
+        String.format(
+            "Manual performance UT. Enable with -D%s=true, optionally tune -D%s, -D%s, -D%s, -D%s and -D%s.",
+            REUSE_ENABLED_PROPERTY,
+            REUSE_ROWS_PROPERTY,
+            REUSE_MEASUREMENTS_PROPERTY,
+            REUSE_WARMUP_ITERATIONS_PROPERTY,
+            REUSE_ITERATIONS_PROPERTY,
+            REUSE_ROUNDS_PROPERTY),
+        Boolean.getBoolean(REUSE_ENABLED_PROPERTY));
+    Assume.assumeTrue(
+        "Current-thread CPU time and allocation metrics are required.",
+        ManualPerformanceTestUtils.enableThreadMetrics());
+
+    final int rowCount = Integer.getInteger(REUSE_ROWS_PROPERTY, 10);
+    final int measurementCount = Integer.getInteger(REUSE_MEASUREMENTS_PROPERTY, 500);
+    final int warmupIterations = Integer.getInteger(REUSE_WARMUP_ITERATIONS_PROPERTY, 1_000);
+    final int iterations = Integer.getInteger(REUSE_ITERATIONS_PROPERTY, 20_000);
+    final int rounds = Integer.getInteger(REUSE_ROUNDS_PROPERTY, 5);
+    Assert.assertTrue(rowCount > 1);
+    Assert.assertTrue(measurementCount > 0);
+    Assert.assertTrue(warmupIterations > 0);
+    Assert.assertTrue(iterations > 0);
+    Assert.assertTrue(rounds > 0);
+
+    final InsertRowsNode insertRowsNode = createCompositeInsertRowsNode(rowCount, measurementCount);
+    InsertNodeMemoryEstimator.clearReusableDeduplicatedObjectsForTest();
+    final long freshSetEstimate = InsertNodeMemoryEstimator.sizeOf(insertRowsNode);
+    final long reusedSetEstimate = InsertNodeMemoryEstimator.sizeOf(insertRowsNode);
+    Assert.assertEquals(freshSetEstimate, reusedSetEstimate);
+
+    for (int i = 0; i < warmupIterations; ++i) {
+      if ((i & 1) == 0) {
+        runFreshSetEstimate(insertRowsNode);
+        runEstimate(insertRowsNode);
+      } else {
+        runEstimate(insertRowsNode);
+        runFreshSetEstimate(insertRowsNode);
+      }
+    }
+
+    final Measurement[] freshSetMeasurements = new Measurement[rounds];
+    final Measurement[] reusedSetMeasurements = new Measurement[rounds];
+    for (int i = 0; i < rounds; ++i) {
+      if ((i & 1) == 0) {
+        freshSetMeasurements[i] =
+            ManualPerformanceTestUtils.measure(
+                iterations,
+                InsertNodeMemoryEstimator::clearReusableDeduplicatedObjectsForTest,
+                () -> runEstimate(insertRowsNode));
+        reusedSetMeasurements[i] =
+            ManualPerformanceTestUtils.measure(iterations, () -> runEstimate(insertRowsNode));
+      } else {
+        reusedSetMeasurements[i] =
+            ManualPerformanceTestUtils.measure(iterations, () -> runEstimate(insertRowsNode));
+        freshSetMeasurements[i] =
+            ManualPerformanceTestUtils.measure(
+                iterations,
+                InsertNodeMemoryEstimator::clearReusableDeduplicatedObjectsForTest,
+                () -> runEstimate(insertRowsNode));
+      }
+    }
+    InsertNodeMemoryEstimator.clearReusableDeduplicatedObjectsForTest();
+
+    final Summary freshSetSummary =
+        ManualPerformanceTestUtils.summarize(freshSetMeasurements, iterations);
+    final Summary reusedSetSummary =
+        ManualPerformanceTestUtils.summarize(reusedSetMeasurements, iterations);
+    System.out.printf(
+        Locale.ROOT,
+        "InsertRows memory-estimator set-reuse benchmark: rows=%d, measurements=%d, warmups=%d, iterations/round=%d, rounds=%d%n",
+        rowCount,
+        measurementCount,
+        warmupIterations,
+        iterations,
+        rounds);
+    printSummary("legacy", freshSetSummary);
+    printSummary("optimized", reusedSetSummary);
+    System.out.printf(
+        Locale.ROOT,
+        "  change: CPU speedup=%.2fx, allocation reduction=%.1f%%, peak-heap reduction=%.1f%%%n",
+        ratio(
+            freshSetSummary.getCpuNanosPerOperation(), reusedSetSummary.getCpuNanosPerOperation()),
+        reduction(
+            freshSetSummary.getAllocatedBytesPerOperation(),
+            reusedSetSummary.getAllocatedBytesPerOperation()),
+        reduction(
+            freshSetSummary.getPeakHeapDeltaBytes(), reusedSetSummary.getPeakHeapDeltaBytes()));
+  }
+
   private static long runBenchmark(final InsertTabletNode insertTabletNode, final int iterations) {
     final long startTime = System.nanoTime();
     for (int i = 0; i < iterations; ++i) {
       benchmarkBlackhole = InsertNodeMemoryEstimator.sizeOf(insertTabletNode);
     }
     return System.nanoTime() - startTime;
+  }
+
+  private static void runFreshSetEstimate(final InsertRowsNode insertRowsNode) {
+    InsertNodeMemoryEstimator.clearReusableDeduplicatedObjectsForTest();
+    runEstimate(insertRowsNode);
+  }
+
+  private static void runEstimate(final InsertRowsNode insertRowsNode) {
+    benchmarkBlackhole = InsertNodeMemoryEstimator.sizeOf(insertRowsNode);
+  }
+
+  private static InsertRowsNode createCompositeInsertRowsNode(
+      final int rowCount, final int measurementCount) throws IllegalPathException {
+    final String[] measurements = new String[measurementCount];
+    final TSDataType[] dataTypes = new TSDataType[measurementCount];
+    final MeasurementSchema[] measurementSchemas = new MeasurementSchema[measurementCount];
+    final Object[] values = new Object[measurementCount];
+    for (int i = 0; i < measurementCount; ++i) {
+      measurements[i] = "s" + i;
+      dataTypes[i] = TSDataType.INT32;
+      measurementSchemas[i] = new MeasurementSchema(measurements[i], TSDataType.INT32);
+      values[i] = i;
+    }
+
+    final PlanNodeId planNodeId = new PlanNodeId("composite-memory-estimator");
+    final PartialPath devicePath = new PartialPath("root.memory_estimator.d1");
+    final InsertRowsNode insertRowsNode = new InsertRowsNode(planNodeId);
+    for (int i = 0; i < rowCount; ++i) {
+      insertRowsNode.addOneInsertRowNode(
+          new InsertRowNode(
+              planNodeId,
+              devicePath,
+              false,
+              measurements,
+              dataTypes,
+              measurementSchemas,
+              i,
+              values,
+              false),
+          i);
+    }
+    insertRowsNode.setDevicePath(devicePath);
+    insertRowsNode.setMeasurements(measurements);
+    insertRowsNode.setDataTypes(dataTypes);
+    insertRowsNode.setMeasurementSchemas(measurementSchemas);
+    return insertRowsNode;
+  }
+
+  private static void printSummary(final String label, final Summary summary) {
+    System.out.printf(
+        Locale.ROOT,
+        "  %-10s CPU=%.3f us/op, allocated=%.1f bytes/op, peak heap delta=%.3f MiB%n",
+        label,
+        summary.getCpuNanosPerOperation() / 1_000.0,
+        summary.getAllocatedBytesPerOperation(),
+        summary.getPeakHeapDeltaBytes() / 1024.0 / 1024.0);
+  }
+
+  private static double ratio(final double baseline, final double optimized) {
+    return optimized == 0 ? Double.POSITIVE_INFINITY : baseline / optimized;
+  }
+
+  private static double reduction(final double baseline, final double optimized) {
+    return baseline == 0 ? 0 : (baseline - optimized) * 100.0 / baseline;
   }
 
   private static InsertTabletNode createWideInsertTabletNode(final int columnCount)

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/DeviceLastCachePerformanceTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/DeviceLastCachePerformanceTest.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.plan.analyze.cache.schema;
+
+import org.apache.iotdb.db.utils.ManualPerformanceTestUtils;
+import org.apache.iotdb.db.utils.ManualPerformanceTestUtils.Measurement;
+import org.apache.iotdb.db.utils.ManualPerformanceTestUtils.Summary;
+
+import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.read.TimeValuePair;
+import org.apache.tsfile.utils.TsPrimitiveType;
+import org.apache.tsfile.write.schema.MeasurementSchema;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.util.Locale;
+
+public class DeviceLastCachePerformanceTest {
+
+  private static final String ENABLED_PROPERTY = "iotdb.last.cache.write.perf.enabled";
+  private static final String MEASUREMENTS_PROPERTY = "iotdb.last.cache.write.perf.measurements";
+  private static final String CACHED_INTERVAL_PROPERTY =
+      "iotdb.last.cache.write.perf.cached.interval";
+  private static final String WARMUP_ITERATIONS_PROPERTY =
+      "iotdb.last.cache.write.perf.warmup.iterations";
+  private static final String ITERATIONS_PROPERTY = "iotdb.last.cache.write.perf.iterations";
+  private static final String ROUNDS_PROPERTY = "iotdb.last.cache.write.perf.rounds";
+
+  private static volatile int benchmarkBlackhole;
+
+  @Test
+  public void sparseInitializedMeasurementsBenchmark() {
+    Assume.assumeTrue(
+        String.format(
+            "Manual performance UT. Enable with -D%s=true, optionally tune -D%s, -D%s, -D%s, -D%s and -D%s.",
+            ENABLED_PROPERTY,
+            MEASUREMENTS_PROPERTY,
+            CACHED_INTERVAL_PROPERTY,
+            WARMUP_ITERATIONS_PROPERTY,
+            ITERATIONS_PROPERTY,
+            ROUNDS_PROPERTY),
+        Boolean.getBoolean(ENABLED_PROPERTY));
+    Assume.assumeTrue(
+        "Current-thread CPU time and allocation metrics are required.",
+        ManualPerformanceTestUtils.enableThreadMetrics());
+
+    final int measurementCount = Integer.getInteger(MEASUREMENTS_PROPERTY, 1_000);
+    final int cachedInterval = Integer.getInteger(CACHED_INTERVAL_PROPERTY, 10);
+    final int warmupIterations = Integer.getInteger(WARMUP_ITERATIONS_PROPERTY, 1_000);
+    final int iterations = Integer.getInteger(ITERATIONS_PROPERTY, 20_000);
+    final int rounds = Integer.getInteger(ROUNDS_PROPERTY, 5);
+    Assert.assertTrue(measurementCount > 0);
+    Assert.assertTrue(cachedInterval > 0 && cachedInterval <= measurementCount);
+    Assert.assertTrue(warmupIterations > 0);
+    Assert.assertTrue(iterations > 0);
+    Assert.assertTrue(rounds > 0);
+
+    final Scenario legacy = createScenario(measurementCount, cachedInterval);
+    final Scenario optimized = createScenario(measurementCount, cachedInterval);
+    runLegacyUpdate(legacy);
+    runOptimizedUpdate(optimized);
+    assertCacheEquals(legacy, optimized);
+
+    for (int i = 0; i < warmupIterations; ++i) {
+      if ((i & 1) == 0) {
+        runLegacyUpdate(legacy);
+        runOptimizedUpdate(optimized);
+      } else {
+        runOptimizedUpdate(optimized);
+        runLegacyUpdate(legacy);
+      }
+    }
+
+    final Measurement[] legacyMeasurements = new Measurement[rounds];
+    final Measurement[] optimizedMeasurements = new Measurement[rounds];
+    for (int i = 0; i < rounds; ++i) {
+      if ((i & 1) == 0) {
+        legacyMeasurements[i] =
+            ManualPerformanceTestUtils.measure(iterations, () -> runLegacyUpdate(legacy));
+        optimizedMeasurements[i] =
+            ManualPerformanceTestUtils.measure(iterations, () -> runOptimizedUpdate(optimized));
+      } else {
+        optimizedMeasurements[i] =
+            ManualPerformanceTestUtils.measure(iterations, () -> runOptimizedUpdate(optimized));
+        legacyMeasurements[i] =
+            ManualPerformanceTestUtils.measure(iterations, () -> runLegacyUpdate(legacy));
+      }
+    }
+
+    assertCacheEquals(legacy, optimized);
+    final Summary legacySummary =
+        ManualPerformanceTestUtils.summarize(legacyMeasurements, iterations);
+    final Summary optimizedSummary =
+        ManualPerformanceTestUtils.summarize(optimizedMeasurements, iterations);
+    printResult(
+        measurementCount,
+        legacy.cachedMeasurementCount,
+        warmupIterations,
+        iterations,
+        rounds,
+        legacySummary,
+        optimizedSummary);
+  }
+
+  private static Scenario createScenario(final int measurementCount, final int cachedInterval) {
+    final String[] measurements = new String[measurementCount];
+    final MeasurementSchema[] measurementSchemas = new MeasurementSchema[measurementCount];
+    final int[] values = new int[measurementCount];
+    for (int i = 0; i < measurementCount; ++i) {
+      measurements[i] = "s" + i;
+      measurementSchemas[i] = new MeasurementSchema(measurements[i], TSDataType.INT32);
+      values[i] = i;
+    }
+
+    final int cachedMeasurementCount = (measurementCount + cachedInterval - 1) / cachedInterval;
+    final String[] cachedMeasurements = new String[cachedMeasurementCount];
+    for (int i = 0; i < cachedMeasurementCount; ++i) {
+      cachedMeasurements[i] = measurements[i * cachedInterval];
+    }
+
+    final DeviceLastCache cache = new DeviceLastCache();
+    cache.initOrInvalidate(cachedMeasurements, false);
+    return new Scenario(
+        cache,
+        measurements,
+        measurementSchemas,
+        new RowUpdateSource(values),
+        cachedMeasurementCount);
+  }
+
+  private static void runLegacyUpdate(final Scenario scenario) {
+    // Keep the eager implementation from origin/master for comparison.
+    final TimeValuePair[] timeValuePairs = new TimeValuePair[scenario.measurements.length];
+    for (int i = 0; i < scenario.measurements.length; ++i) {
+      timeValuePairs[i] = scenario.updateSource.getLastCacheValue(i);
+    }
+    benchmarkBlackhole =
+        scenario.cache.tryUpdate(
+            scenario.measurements, scenario.measurementSchemas, timeValuePairs, false);
+  }
+
+  private static void runOptimizedUpdate(final Scenario scenario) {
+    benchmarkBlackhole =
+        scenario.cache.tryUpdate(
+            scenario.measurements, scenario.measurementSchemas, scenario.updateSource);
+  }
+
+  private static void assertCacheEquals(
+      final Scenario expectedScenario, final Scenario actualScenario) {
+    for (final String measurement : expectedScenario.measurements) {
+      Assert.assertEquals(
+          expectedScenario.cache.getTimeValuePair(measurement),
+          actualScenario.cache.getTimeValuePair(measurement));
+    }
+  }
+
+  private static void printResult(
+      final int measurementCount,
+      final int cachedMeasurementCount,
+      final int warmupIterations,
+      final int iterations,
+      final int rounds,
+      final Summary legacy,
+      final Summary optimized) {
+    System.out.printf(
+        Locale.ROOT,
+        "Last-cache row-update benchmark: measurements=%d, initialized=%d, warmups=%d, iterations/round=%d, rounds=%d%n",
+        measurementCount,
+        cachedMeasurementCount,
+        warmupIterations,
+        iterations,
+        rounds);
+    printSummary("legacy", legacy);
+    printSummary("optimized", optimized);
+    System.out.printf(
+        Locale.ROOT,
+        "  change: CPU speedup=%.2fx, allocation reduction=%.1f%%, peak-heap reduction=%.1f%%%n",
+        ratio(legacy.getCpuNanosPerOperation(), optimized.getCpuNanosPerOperation()),
+        reduction(
+            legacy.getAllocatedBytesPerOperation(), optimized.getAllocatedBytesPerOperation()),
+        reduction(legacy.getPeakHeapDeltaBytes(), optimized.getPeakHeapDeltaBytes()));
+  }
+
+  private static void printSummary(final String label, final Summary summary) {
+    System.out.printf(
+        Locale.ROOT,
+        "  %-9s CPU=%.3f us/op, allocated=%.1f bytes/op, peak heap delta=%.3f MiB%n",
+        label,
+        summary.getCpuNanosPerOperation() / 1_000.0,
+        summary.getAllocatedBytesPerOperation(),
+        summary.getPeakHeapDeltaBytes() / 1024.0 / 1024.0);
+  }
+
+  private static double ratio(final double baseline, final double optimized) {
+    return optimized == 0 ? Double.POSITIVE_INFINITY : baseline / optimized;
+  }
+
+  private static double reduction(final double baseline, final double optimized) {
+    return baseline == 0 ? 0 : (baseline - optimized) * 100.0 / baseline;
+  }
+
+  private static final class Scenario {
+
+    private final DeviceLastCache cache;
+    private final String[] measurements;
+    private final MeasurementSchema[] measurementSchemas;
+    private final RowUpdateSource updateSource;
+    private final int cachedMeasurementCount;
+
+    private Scenario(
+        final DeviceLastCache cache,
+        final String[] measurements,
+        final MeasurementSchema[] measurementSchemas,
+        final RowUpdateSource updateSource,
+        final int cachedMeasurementCount) {
+      this.cache = cache;
+      this.measurements = measurements;
+      this.measurementSchemas = measurementSchemas;
+      this.updateSource = updateSource;
+      this.cachedMeasurementCount = cachedMeasurementCount;
+    }
+  }
+
+  private static final class RowUpdateSource implements LastCacheUpdateSource {
+
+    private final int[] values;
+
+    private RowUpdateSource(final int[] values) {
+      this.values = values;
+    }
+
+    @Override
+    public long getLastCacheTimestamp() {
+      return 1L;
+    }
+
+    @Override
+    public boolean hasLastCacheValue(final int index) {
+      return true;
+    }
+
+    @Override
+    public TimeValuePair getLastCacheValue(final int index) {
+      return new TimeValuePair(1L, new TsPrimitiveType.TsInt(values[index]));
+    }
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/DeviceLastCacheTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/analyze/cache/schema/DeviceLastCacheTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.plan.analyze.cache.schema;
+
+import org.apache.tsfile.read.TimeValuePair;
+import org.apache.tsfile.utils.TsPrimitiveType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class DeviceLastCacheTest {
+
+  @Test
+  public void testLazyUpdateOnlyComposesCachedMeasurements() {
+    final DeviceLastCache cache = new DeviceLastCache();
+    cache.initOrInvalidate(new String[] {"s1"}, false);
+    final AtomicInteger composedValueCount = new AtomicInteger();
+
+    cache.tryUpdate(
+        new String[] {"s1", "s2"},
+        null,
+        new LastCacheUpdateSource() {
+          @Override
+          public long getLastCacheTimestamp() {
+            return 1L;
+          }
+
+          @Override
+          public boolean hasLastCacheValue(final int index) {
+            return true;
+          }
+
+          @Override
+          public TimeValuePair getLastCacheValue(final int index) {
+            composedValueCount.incrementAndGet();
+            return new TimeValuePair(1L, new TsPrimitiveType.TsInt(index + 1));
+          }
+        });
+
+    Assert.assertEquals(1, composedValueCount.get());
+    Assert.assertEquals(
+        new TimeValuePair(1L, new TsPrimitiveType.TsInt(1)), cache.getTimeValuePair("s1"));
+    Assert.assertNull(cache.getTimeValuePair("s2"));
+  }
+}

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/ManualPerformanceTestUtils.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/utils/ManualPerformanceTestUtils.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.utils;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryType;
+import java.lang.management.MemoryUsage;
+import java.lang.management.ThreadMXBean;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public final class ManualPerformanceTestUtils {
+
+  private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
+  private static final com.sun.management.ThreadMXBean ALLOCATION_MX_BEAN =
+      THREAD_MX_BEAN instanceof com.sun.management.ThreadMXBean
+          ? (com.sun.management.ThreadMXBean) THREAD_MX_BEAN
+          : null;
+  private static final Runnable NO_OP = () -> {};
+
+  private ManualPerformanceTestUtils() {}
+
+  public static boolean enableThreadMetrics() {
+    if (!THREAD_MX_BEAN.isCurrentThreadCpuTimeSupported()
+        || ALLOCATION_MX_BEAN == null
+        || !ALLOCATION_MX_BEAN.isThreadAllocatedMemorySupported()) {
+      return false;
+    }
+    try {
+      if (!THREAD_MX_BEAN.isThreadCpuTimeEnabled()) {
+        THREAD_MX_BEAN.setThreadCpuTimeEnabled(true);
+      }
+      if (!ALLOCATION_MX_BEAN.isThreadAllocatedMemoryEnabled()) {
+        ALLOCATION_MX_BEAN.setThreadAllocatedMemoryEnabled(true);
+      }
+      final long threadId = Thread.currentThread().getId();
+      return THREAD_MX_BEAN.getCurrentThreadCpuTime() >= 0
+          && ALLOCATION_MX_BEAN.getThreadAllocatedBytes(threadId) >= 0;
+    } catch (final UnsupportedOperationException | SecurityException ignored) {
+      return false;
+    }
+  }
+
+  public static Measurement measure(final int iterations, final Runnable operation) {
+    return measure(iterations, NO_OP, operation);
+  }
+
+  public static Measurement measure(
+      final int iterations, final Runnable beforeEachIteration, final Runnable operation) {
+    final List<MemoryPoolMXBean> heapPools = getHeapMemoryPools();
+    System.gc();
+    System.runFinalization();
+    heapPools.forEach(MemoryPoolMXBean::resetPeakUsage);
+    final long baselineHeapBytes = getUsedHeapBytes(heapPools);
+
+    final long threadId = Thread.currentThread().getId();
+    final long allocatedBytesBefore = ALLOCATION_MX_BEAN.getThreadAllocatedBytes(threadId);
+    long cpuNanos = 0;
+    for (int i = 0; i < iterations; ++i) {
+      beforeEachIteration.run();
+      final long cpuNanosBefore = THREAD_MX_BEAN.getCurrentThreadCpuTime();
+      operation.run();
+      cpuNanos += THREAD_MX_BEAN.getCurrentThreadCpuTime() - cpuNanosBefore;
+    }
+    final long allocatedBytes =
+        ALLOCATION_MX_BEAN.getThreadAllocatedBytes(threadId) - allocatedBytesBefore;
+    final long peakHeapDeltaBytes = Math.max(0L, getPeakHeapBytes(heapPools) - baselineHeapBytes);
+    return new Measurement(cpuNanos, allocatedBytes, peakHeapDeltaBytes);
+  }
+
+  public static Summary summarize(final Measurement[] measurements, final int iterations) {
+    final long[] cpuNanos = new long[measurements.length];
+    final long[] allocatedBytes = new long[measurements.length];
+    final long[] peakHeapDeltaBytes = new long[measurements.length];
+    for (int i = 0; i < measurements.length; ++i) {
+      cpuNanos[i] = measurements[i].cpuNanos;
+      allocatedBytes[i] = measurements[i].allocatedBytes;
+      peakHeapDeltaBytes[i] = measurements[i].peakHeapDeltaBytes;
+    }
+    return new Summary(
+        median(cpuNanos) / iterations,
+        median(allocatedBytes) / iterations,
+        median(peakHeapDeltaBytes));
+  }
+
+  private static List<MemoryPoolMXBean> getHeapMemoryPools() {
+    final List<MemoryPoolMXBean> heapPools = new ArrayList<>();
+    for (final MemoryPoolMXBean memoryPool : ManagementFactory.getMemoryPoolMXBeans()) {
+      if (memoryPool.getType() == MemoryType.HEAP && memoryPool.isValid()) {
+        heapPools.add(memoryPool);
+      }
+    }
+    return heapPools;
+  }
+
+  private static long getUsedHeapBytes(final List<MemoryPoolMXBean> heapPools) {
+    long usedHeapBytes = 0;
+    for (final MemoryPoolMXBean heapPool : heapPools) {
+      final MemoryUsage usage = heapPool.getUsage();
+      if (usage != null) {
+        usedHeapBytes += usage.getUsed();
+      }
+    }
+    return usedHeapBytes;
+  }
+
+  private static long getPeakHeapBytes(final List<MemoryPoolMXBean> heapPools) {
+    long peakHeapBytes = 0;
+    for (final MemoryPoolMXBean heapPool : heapPools) {
+      final MemoryUsage peakUsage = heapPool.getPeakUsage();
+      if (peakUsage != null) {
+        peakHeapBytes += peakUsage.getUsed();
+      }
+    }
+    return peakHeapBytes;
+  }
+
+  private static double median(final long[] values) {
+    Arrays.sort(values);
+    final int middle = values.length / 2;
+    return (values.length & 1) == 1
+        ? values[middle]
+        : values[middle - 1] + (values[middle] - values[middle - 1]) / 2.0;
+  }
+
+  public static final class Measurement {
+
+    private final long cpuNanos;
+    private final long allocatedBytes;
+    private final long peakHeapDeltaBytes;
+
+    private Measurement(
+        final long cpuNanos, final long allocatedBytes, final long peakHeapDeltaBytes) {
+      this.cpuNanos = cpuNanos;
+      this.allocatedBytes = allocatedBytes;
+      this.peakHeapDeltaBytes = peakHeapDeltaBytes;
+    }
+  }
+
+  public static final class Summary {
+
+    private final double cpuNanosPerOperation;
+    private final double allocatedBytesPerOperation;
+    private final double peakHeapDeltaBytes;
+
+    private Summary(
+        final double cpuNanosPerOperation,
+        final double allocatedBytesPerOperation,
+        final double peakHeapDeltaBytes) {
+      this.cpuNanosPerOperation = cpuNanosPerOperation;
+      this.allocatedBytesPerOperation = allocatedBytesPerOperation;
+      this.peakHeapDeltaBytes = peakHeapDeltaBytes;
+    }
+
+    public double getCpuNanosPerOperation() {
+      return cpuNanosPerOperation;
+    }
+
+    public double getAllocatedBytesPerOperation() {
+      return allocatedBytesPerOperation;
+    }
+
+    public double getPeakHeapDeltaBytes() {
+      return peakHeapDeltaBytes;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- backport #18240 to dev/1.3
- reuse identity-deduplication sets across composite insert-node memory estimates
- compose last-cache values lazily only for cache entries that can be updated
- adapt the cache changes and opt-in benchmarks to the dev/1.3 DataNodeSchemaCache / DeviceLastCache layout

## Validation

- `mvn -pl iotdb-core/datanode spotless:apply`
- `mvn -o -nsu -pl iotdb-core/datanode -DskipTests test-compile`
- `mvn -o -nsu -pl iotdb-core/datanode -Dtest=DataNodeSchemaCacheTest,DeviceLastCacheTest test` (6 tests passed in each of the two configured Surefire executions)