### PR TITLE
Fix findColumn NullPointerException for unknown column names (return SQLException)

### DIFF
--- a/iotdb-client/isession/src/main/java/org/apache/iotdb/isession/SessionDataSet.java
+++ b/iotdb-client/isession/src/main/java/org/apache/iotdb/isession/SessionDataSet.java
@@ -349,7 +349,7 @@ public class SessionDataSet implements ISessionDataSet {
       return ioTDBRpcDataSet.getBinary(columnName);
     }
 
-    public int findColumn(String columnName) {
+    public int findColumn(String columnName) throws StatementExecutionException {
       return ioTDBRpcDataSet.findColumn(columnName);
     }
 

--- a/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSet.java
+++ b/iotdb-client/jdbc/src/main/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSet.java
@@ -232,8 +232,12 @@ public class IoTDBJDBCResultSet implements ResultSet {
   }
 
   @Override
-  public int findColumn(String columnName) {
-    return ioTDBRpcDataSet.findColumn(columnName);
+  public int findColumn(String columnName) throws SQLException {
+    try {
+      return ioTDBRpcDataSet.findColumn(columnName);
+    } catch (StatementExecutionException e) {
+      throw new SQLException(e.getMessage());
+    }
   }
 
   @Override

--- a/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSetTest.java
+++ b/iotdb-client/jdbc/src/test/java/org/apache/iotdb/jdbc/IoTDBJDBCResultSetTest.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.sql.Types;
@@ -362,5 +363,42 @@ public class IoTDBJDBCResultSetTest {
     }
 
     return Collections.singletonList(tsBlock);
+  }
+
+  @Test
+  public void findColumnUnknownColumnThrowsSQLExceptionNotNpe() throws Exception {
+    List<String> columns = new ArrayList<>();
+    columns.add("root.vehicle.d0.s0");
+    List<String> dataTypeList = new ArrayList<>();
+    dataTypeList.add("INT32");
+    when(execResp.isSetColumns()).thenReturn(true);
+    when(execResp.getColumns()).thenReturn(columns);
+    when(execResp.isSetDataTypeList()).thenReturn(true);
+    when(execResp.getDataTypeList()).thenReturn(dataTypeList);
+    when(execResp.isSetOperationType()).thenReturn(true);
+    when(execResp.getOperationType()).thenReturn("QUERY");
+    when(execResp.isSetQueryId()).thenReturn(true);
+    when(execResp.getQueryId()).thenReturn(queryId);
+    when(execResp.isSetTableModel()).thenReturn(false);
+    when(execResp.isIgnoreTimeStamp()).thenReturn(false);
+    List<Integer> columnIndex2TsBlockColumnIndexList = new ArrayList<>();
+    columnIndex2TsBlockColumnIndexList.add(0);
+    when(execResp.getColumnIndex2TsBlockColumnIndexList())
+        .thenReturn(columnIndex2TsBlockColumnIndexList);
+
+    Assert.assertTrue(statement.execute("select s0 from root.vehicle.d0"));
+    try (ResultSet resultSet = statement.getResultSet()) {
+      // a known column resolves to its 1-based index
+      Assert.assertEquals(1, resultSet.findColumn("Time"));
+      // an unknown column must throw a clear SQLException, not a NullPointerException
+      try {
+        resultSet.findColumn("no_such_column");
+        Assert.fail("findColumn on an unknown column must throw SQLException");
+      } catch (SQLException e) {
+        Assert.assertTrue(
+            "message should name the missing column, got: " + e.getMessage(),
+            e.getMessage() != null && e.getMessage().contains("no_such_column"));
+      }
+    }
   }
 }

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBJDBCDataSet.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBJDBCDataSet.java
@@ -579,8 +579,12 @@ public class IoTDBJDBCDataSet {
     return getTimestamp(findColumn(columnName));
   }
 
-  public int findColumn(String columnName) {
-    return columnOrdinalMap.get(columnName);
+  public int findColumn(String columnName) throws StatementExecutionException {
+    Integer ordinal = columnOrdinalMap.get(columnName);
+    if (ordinal == null) {
+      throw new StatementExecutionException(RpcMessages.UNKNOWN_COLUMN_NAME + columnName);
+    }
+    return ordinal;
   }
 
   public String getValueByName(String columnName) throws StatementExecutionException {

--- a/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
+++ b/iotdb-client/service-rpc/src/main/java/org/apache/iotdb/rpc/IoTDBRpcDataSet.java
@@ -614,8 +614,12 @@ public class IoTDBRpcDataSet {
         : dataTypeForTsBlockColumn.get(tsBlockColumnIndex);
   }
 
-  public int findColumn(String columnName) {
-    return columnOrdinalMap.get(columnName);
+  public int findColumn(String columnName) throws StatementExecutionException {
+    Integer ordinal = columnOrdinalMap.get(columnName);
+    if (ordinal == null) {
+      throw new StatementExecutionException(RpcMessages.UNKNOWN_COLUMN_NAME + columnName);
+    }
+    return ordinal;
   }
 
   public String findColumnNameByIndex(int columnIndex) throws StatementExecutionException {


### PR DESCRIPTION
## Description

`IoTDBRpcDataSet.findColumn(String)` returned `columnOrdinalMap.get(columnName)` directly, so an unknown column name unboxed a `null` `Integer` into a `NullPointerException` instead of the `SQLException` that the `ResultSet.findColumn` contract requires. This guards the lookup and throws a checked `StatementExecutionException` (reusing the existing `UNKNOWN_COLUMN_NAME` message), mirroring the sibling `findColumnNameByIndex`. The JDBC boundary `IoTDBJDBCResultSet.findColumn` converts it to `SQLException` (like the existing `getBigDecimal` path), and `SessionDataSet.DataIterator.findColumn` propagates the checked exception, consistent with its sibling accessors. The identical NPE in the public `IoTDBJDBCDataSet.findColumn` is fixed the same way.

A test asserts that an unknown column name throws `SQLException` rather than `NullPointerException`, and that a valid column name still resolves.

This closes #18250.
