### PR TITLE
[Pipe] Resume TsFile parsing after retryable failures

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/connection/PipeEventCollector.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/connection/PipeEventCollector.java
@@ -147,15 +147,12 @@ public class PipeEventCollector implements EventCollector {
       return;
     }
 
-    try {
-      sourceEvent.consumeTabletInsertionEventsWithRetry(
-          this::collectParsedRawTableEvent, "PipeEventCollector::parseAndCollectEvent");
-      if (sourceEvent.isGeneratedByHistoricalExtractor()) {
-        PipeTerminateEvent.markHistoricalTsFileSplit(
-            sourceEvent.getPipeName(), sourceEvent.getCreationTime(), regionId);
-      }
-    } finally {
-      sourceEvent.close();
+    sourceEvent.consumeTabletInsertionEventsWithRetry(
+        this::collectParsedRawTableEvent, "PipeEventCollector::parseAndCollectEvent");
+    sourceEvent.close();
+    if (sourceEvent.isGeneratedByHistoricalExtractor()) {
+      PipeTerminateEvent.markHistoricalTsFileSplit(
+          sourceEvent.getPipeName(), sourceEvent.getCreationTime(), regionId);
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/processor/PipeProcessorSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/processor/PipeProcessorSubtask.java
@@ -172,29 +172,24 @@ public class PipeProcessorSubtask extends PipeReportableSubtask {
           // We have to parse the privilege first, to avoid passing no-privilege data to processor
           if (event instanceof PipeTsFileInsertionEvent
               && ((PipeTsFileInsertionEvent) event).shouldParse4Privilege()) {
-            try (final PipeTsFileInsertionEvent tsFileInsertionEvent =
-                (PipeTsFileInsertionEvent) event) {
-              final AtomicReference<Exception> ex = new AtomicReference<>();
-              tsFileInsertionEvent.consumeTabletInsertionEventsWithRetry(
-                  event1 -> {
-                    try {
-                      pipeProcessor.process(event1, outputEventCollector);
-                    } catch (PipeRuntimeOutOfMemoryCriticalException e) {
-                      throw e;
-                    } catch (Exception e) {
-                      ex.set(e);
-                    }
-                  },
-                  "PipeProcessorSubtask::executeOnce");
-              if (tsFileInsertionEvent.isGeneratedByHistoricalExtractor()) {
-                PipeTerminateEvent.markHistoricalTsFileSplit(
-                    tsFileInsertionEvent.getPipeName(),
-                    tsFileInsertionEvent.getCreationTime(),
-                    regionId);
-              }
-              if (ex.get() != null) {
-                throw ex.get();
-              }
+            final PipeTsFileInsertionEvent tsFileInsertionEvent = (PipeTsFileInsertionEvent) event;
+            tsFileInsertionEvent.consumeTabletInsertionEventsWithRetry(
+                event1 -> {
+                  try {
+                    pipeProcessor.process(event1, outputEventCollector);
+                  } catch (PipeRuntimeOutOfMemoryCriticalException e) {
+                    throw e;
+                  } catch (Exception e) {
+                    throw new PipeException(e.getMessage(), e);
+                  }
+                },
+                "PipeProcessorSubtask::executeOnce");
+            tsFileInsertionEvent.close();
+            if (tsFileInsertionEvent.isGeneratedByHistoricalExtractor()) {
+              PipeTerminateEvent.markHistoricalTsFileSplit(
+                  tsFileInsertionEvent.getPipeName(),
+                  tsFileInsertionEvent.getCreationTime(),
+                  regionId);
             }
           } else {
             pipeProcessor.process((TsFileInsertionEvent) event, outputEventCollector);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEvent.java
@@ -790,7 +790,9 @@ public class PipeTsFileInsertionEvent extends PipeInsertionEvent
       return null;
     }
 
-    // Reacquire parser memory after a previous failure yielded the active parser slot.
+    // Reacquire parser memory after a previous failure yielded the active parser slot. This wait
+    // is already bounded to 20-40 seconds, while the exponential backoff below is only for retrying
+    // the current tablet without yielding its parser slot.
     waitForResourceEnough4Parsing((long) ((1 + Math.random()) * 20 * 1000));
 
     final PipeRawTabletInsertionEvent pendingEvent = pendingTabletInsertionEvent.get();
@@ -858,11 +860,11 @@ public class PipeTsFileInsertionEvent extends PipeInsertionEvent
         initialBackoffInMs > Long.MAX_VALUE / maxRetries
             ? Long.MAX_VALUE
             : initialBackoffInMs * maxRetries;
-    final int shift = Math.min(30, Math.max(0, retryCount - 1));
-    if (initialBackoffInMs > (maxBackoffInMs >> shift)) {
-      return maxBackoffInMs;
+    long backoffInMs = initialBackoffInMs;
+    for (int retry = 1; retry < retryCount && backoffInMs < maxBackoffInMs; retry++) {
+      backoffInMs = backoffInMs >= maxBackoffInMs - backoffInMs ? maxBackoffInMs : backoffInMs << 1;
     }
-    return Math.min(maxBackoffInMs, initialBackoffInMs << shift);
+    return backoffInMs;
   }
 
   private void logParserRetryOnOutOfMemory(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEvent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEvent.java
@@ -98,6 +98,13 @@ public class PipeTsFileInsertionEvent extends PipeInsertionEvent
   private final AtomicBoolean isClosed;
   private final AtomicReference<TsFileInsertionEventParser> eventParser;
   private final AtomicBoolean isTsFileParserMemoryReserved = new AtomicBoolean(false);
+  private final AtomicReference<Iterator<TabletInsertionEvent>> tabletInsertionEventIterator =
+      new AtomicReference<>();
+  private final AtomicReference<PipeRawTabletInsertionEvent> pendingTabletInsertionEvent =
+      new AtomicReference<>();
+  private final AtomicInteger parsedTabletInsertionEventCount = new AtomicInteger(0);
+  private final AtomicBoolean isTsFileParsingCompleted = new AtomicBoolean(false);
+  private final AtomicLong parsedPointCountForCount = new AtomicLong(0);
 
   // The point count of the TsFile. Used for metrics on IoTConsensusV2' receiver side.
   // May be updated after it is flushed. Should be negative if not set.
@@ -747,26 +754,68 @@ public class PipeTsFileInsertionEvent extends PipeInsertionEvent
 
   public void consumeTabletInsertionEventsWithRetry(
       final TabletInsertionEventConsumer consumer, final String callerName) throws Exception {
-    int tabletEventCount = 0;
     try {
-      final Iterable<TabletInsertionEvent> iterable = toTabletInsertionEvents();
-      final Iterator<TabletInsertionEvent> iterator = iterable.iterator();
-      while (iterator.hasNext()) {
-        final TabletInsertionEvent parsedEvent = iterator.next();
-        tabletEventCount++;
+      while (true) {
+        final PipeRawTabletInsertionEvent parsedEvent =
+            getNextTabletInsertionEventFromSavedProgress();
+        if (parsedEvent == null) {
+          isTsFileParsingCompleted.set(true);
+          releaseTsFileParserMemoryIfReserved();
+          return;
+        }
         consumeParsedTabletInsertionEventWithRetry(
-            consumer, callerName, tabletEventCount, parsedEvent);
+            consumer, callerName, parsedTabletInsertionEventCount.get(), parsedEvent);
+        pendingTabletInsertionEvent.compareAndSet(parsedEvent, null);
       }
     } catch (final PipeRuntimeOutOfMemoryCriticalException e) {
-      close();
+      // Yield the active parser slot to the next pipe while retaining the iterator and current
+      // tablet. The next retry resumes from this exact tablet instead of reparsing the TsFile.
+      releaseTsFileParserMemoryIfReserved();
       LOGGER.warn(
           DataNodePipeMessages.FAILED_TO_ALLOCATE_MEMORY_FOR_PARSING_TSFILE,
           callerName,
           getTsFile(),
-          tabletEventCount,
+          parsedTabletInsertionEventCount.get(),
           e);
       throw e;
+    } catch (final Exception e) {
+      releaseTsFileParserMemoryIfReserved();
+      throw e;
     }
+  }
+
+  private PipeRawTabletInsertionEvent getNextTabletInsertionEventFromSavedProgress()
+      throws Exception {
+    if (isTsFileParsingCompleted.get()) {
+      return null;
+    }
+
+    // Reacquire parser memory after a previous failure yielded the active parser slot.
+    waitForResourceEnough4Parsing((long) ((1 + Math.random()) * 20 * 1000));
+
+    final PipeRawTabletInsertionEvent pendingEvent = pendingTabletInsertionEvent.get();
+    if (pendingEvent != null) {
+      return pendingEvent;
+    }
+
+    Iterator<TabletInsertionEvent> iterator = tabletInsertionEventIterator.get();
+    if (iterator == null) {
+      if (!waitForTsFileClose()) {
+        LOGGER.warn(DataNodePipeMessages.PIPE_SKIPPING_TEMPORARY_TSFILE_S_PARSING_WHICH, tsFile);
+        return null;
+      }
+      iterator = initEventParser().toTabletInsertionEvents().iterator();
+      tabletInsertionEventIterator.set(iterator);
+    }
+
+    if (!iterator.hasNext()) {
+      return null;
+    }
+
+    final PipeRawTabletInsertionEvent nextEvent = (PipeRawTabletInsertionEvent) iterator.next();
+    pendingTabletInsertionEvent.set(nextEvent);
+    parsedTabletInsertionEventCount.incrementAndGet();
+    return nextEvent;
   }
 
   private void consumeParsedTabletInsertionEventWithRetry(
@@ -788,19 +837,32 @@ public class PipeTsFileInsertionEvent extends PipeInsertionEvent
         }
         if (memoryManager.shouldReleaseTsFileParserOnOutOfMemory(
             firstOutOfMemoryTimeInMs, ++retryCount)) {
-          releaseParsedTabletEvent(parsedEvent);
           throw e;
         }
         logParserRetryOnOutOfMemory(callerName, tabletEventCount, retryCount, e);
         try {
-          Thread.sleep(PipeConfig.getInstance().getPipeMemoryAllocateRetryIntervalInMs());
+          Thread.sleep(getParserRetryBackoffInMs(retryCount));
         } catch (final InterruptedException interruptedException) {
           Thread.currentThread().interrupt();
-          releaseParsedTabletEvent(parsedEvent);
           throw e;
         }
       }
     }
+  }
+
+  private long getParserRetryBackoffInMs(final int retryCount) {
+    final long initialBackoffInMs =
+        Math.max(1, PipeConfig.getInstance().getPipeMemoryAllocateRetryIntervalInMs());
+    final int maxRetries = Math.max(1, PipeConfig.getInstance().getPipeMemoryAllocateMaxRetries());
+    final long maxBackoffInMs =
+        initialBackoffInMs > Long.MAX_VALUE / maxRetries
+            ? Long.MAX_VALUE
+            : initialBackoffInMs * maxRetries;
+    final int shift = Math.min(30, Math.max(0, retryCount - 1));
+    if (initialBackoffInMs > (maxBackoffInMs >> shift)) {
+      return maxBackoffInMs;
+    }
+    return Math.min(maxBackoffInMs, initialBackoffInMs << shift);
   }
 
   private void logParserRetryOnOutOfMemory(
@@ -982,21 +1044,21 @@ public class PipeTsFileInsertionEvent extends PipeInsertionEvent
   }
 
   public long count(final boolean skipReportOnCommit) throws Exception {
-    AtomicLong count = new AtomicLong();
-
     if (shouldParseTime()) {
       try {
         consumeTabletInsertionEventsWithRetry(
             event -> {
-              count.addAndGet(event.count());
+              parsedPointCountForCount.addAndGet(event.count());
               if (skipReportOnCommit) {
                 event.skipReportOnCommit();
               }
             },
             "PipeTsFileInsertionEvent::count");
-        return count.get();
+        return parsedPointCountForCount.getAndSet(0);
       } finally {
-        close();
+        if (isTsFileParsingCompleted.get()) {
+          close();
+        }
       }
     }
 
@@ -1009,6 +1071,11 @@ public class PipeTsFileInsertionEvent extends PipeInsertionEvent
   /** Release the resource of {@link TsFileInsertionEventParser}. */
   @Override
   public void close() {
+    tabletInsertionEventIterator.set(null);
+    releaseParsedTabletEvent(pendingTabletInsertionEvent.getAndSet(null));
+    parsedTabletInsertionEventCount.set(0);
+    parsedPointCountForCount.set(0);
+    isTsFileParsingCompleted.set(false);
     eventParser.getAndUpdate(
         parser -> {
           if (Objects.nonNull(parser)) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/processor/aggregate/AggregateProcessor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/processor/aggregate/AggregateProcessor.java
@@ -542,32 +542,29 @@ public class AggregateProcessor implements PipeProcessor {
   public void process(
       final TsFileInsertionEvent tsFileInsertionEvent, final EventCollector eventCollector)
       throws Exception {
-    try {
-      if (tsFileInsertionEvent instanceof PipeTsFileInsertionEvent) {
-        final AtomicReference<Exception> ex = new AtomicReference<>();
-        ((PipeTsFileInsertionEvent) tsFileInsertionEvent)
-            .consumeTabletInsertionEventsWithRetry(
-                event -> {
-                  try {
-                    process(event, eventCollector);
-                  } catch (PipeRuntimeOutOfMemoryCriticalException e) {
-                    throw e;
-                  } catch (Exception e) {
-                    ex.set(e);
-                  }
-                },
-                "AggregateProcessor::process");
-        if (ex.get() != null) {
-          throw ex.get();
-        }
-      } else {
+    if (tsFileInsertionEvent instanceof PipeTsFileInsertionEvent) {
+      ((PipeTsFileInsertionEvent) tsFileInsertionEvent)
+          .consumeTabletInsertionEventsWithRetry(
+              event -> {
+                try {
+                  process(event, eventCollector);
+                } catch (PipeRuntimeOutOfMemoryCriticalException e) {
+                  throw e;
+                } catch (Exception e) {
+                  throw new PipeException(e.getMessage(), e);
+                }
+              },
+              "AggregateProcessor::process");
+      tsFileInsertionEvent.close();
+    } else {
+      try {
         for (final TabletInsertionEvent tabletInsertionEvent :
             tsFileInsertionEvent.toTabletInsertionEvents()) {
           process(tabletInsertionEvent, eventCollector);
         }
+      } finally {
+        tsFileInsertionEvent.close();
       }
-    } finally {
-      tsFileInsertionEvent.close();
     }
     // The timeProgressIndex shall only be reported by the output events
     // whose progressIndex is bounded with tablet events

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/processor/downsampling/DownSamplingProcessor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/processor/downsampling/DownSamplingProcessor.java
@@ -36,6 +36,7 @@ import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameters;
 import org.apache.iotdb.pipe.api.event.Event;
 import org.apache.iotdb.pipe.api.event.dml.insertion.TabletInsertionEvent;
 import org.apache.iotdb.pipe.api.event.dml.insertion.TsFileInsertionEvent;
+import org.apache.iotdb.pipe.api.exception.PipeException;
 
 import org.apache.tsfile.common.constant.TsFileConstant;
 
@@ -149,32 +150,29 @@ public abstract class DownSamplingProcessor implements PipeProcessor {
   public void process(TsFileInsertionEvent tsFileInsertionEvent, EventCollector eventCollector)
       throws Exception {
     if (shouldSplitFile) {
-      try {
-        if (tsFileInsertionEvent instanceof PipeTsFileInsertionEvent) {
-          final AtomicReference<Exception> ex = new AtomicReference<>();
-          ((PipeTsFileInsertionEvent) tsFileInsertionEvent)
-              .consumeTabletInsertionEventsWithRetry(
-                  event -> {
-                    try {
-                      process(event, eventCollector);
-                    } catch (PipeRuntimeOutOfMemoryCriticalException e) {
-                      throw e;
-                    } catch (Exception e) {
-                      ex.set(e);
-                    }
-                  },
-                  "DownSamplingProcessor::process");
-          if (ex.get() != null) {
-            throw ex.get();
-          }
-        } else {
+      if (tsFileInsertionEvent instanceof PipeTsFileInsertionEvent) {
+        ((PipeTsFileInsertionEvent) tsFileInsertionEvent)
+            .consumeTabletInsertionEventsWithRetry(
+                event -> {
+                  try {
+                    process(event, eventCollector);
+                  } catch (PipeRuntimeOutOfMemoryCriticalException e) {
+                    throw e;
+                  } catch (Exception e) {
+                    throw new PipeException(e.getMessage(), e);
+                  }
+                },
+                "DownSamplingProcessor::process");
+        tsFileInsertionEvent.close();
+      } else {
+        try {
           for (final TabletInsertionEvent tabletInsertionEvent :
               tsFileInsertionEvent.toTabletInsertionEvents()) {
             process(tabletInsertionEvent, eventCollector);
           }
+        } finally {
+          tsFileInsertionEvent.close();
         }
-      } finally {
-        tsFileInsertionEvent.close();
       }
     } else {
       eventCollector.collect(tsFileInsertionEvent);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/websocket/WebSocketSink.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/websocket/WebSocketSink.java
@@ -145,18 +145,15 @@ public class WebSocketSink implements PipeConnector, PipeConnectorWithEventDisca
       return;
     }
 
-    try {
-      ((PipeTsFileInsertionEvent) tsFileInsertionEvent)
-          .consumeTabletInsertionEventsWithRetry(
-              event -> {
-                // Skip report if any tablet events is added
-                ((PipeTsFileInsertionEvent) tsFileInsertionEvent).skipReportOnCommit();
-                transfer(event);
-              },
-              "WebSocketConnector::transfer");
-    } finally {
-      tsFileInsertionEvent.close();
-    }
+    ((PipeTsFileInsertionEvent) tsFileInsertionEvent)
+        .consumeTabletInsertionEventsWithRetry(
+            event -> {
+              // Skip report if any tablet events is added
+              ((PipeTsFileInsertionEvent) tsFileInsertionEvent).skipReportOnCommit();
+              transfer(event);
+            },
+            "WebSocketConnector::transfer");
+    tsFileInsertionEvent.close();
   }
 
   @Override

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/TsFileInsertionEventParserTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/TsFileInsertionEventParserTest.java
@@ -44,6 +44,7 @@ import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResource;
 import org.apache.iotdb.db.storageengine.dataregion.tsfile.TsFileResourceStatus;
 import org.apache.iotdb.pipe.api.access.Row;
 import org.apache.iotdb.pipe.api.event.dml.insertion.TabletInsertionEvent;
+import org.apache.iotdb.pipe.api.exception.PipeException;
 
 import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.common.conf.TSFileDescriptor;
@@ -185,38 +186,8 @@ public class TsFileInsertionEventParserTest {
   @Test
   public void testConsumeTabletInsertionEventsWithRetryPreservesProgressOnOutOfMemory()
       throws Exception {
-    nonalignedTsFile =
-        TsFileGeneratorUtils.generateNonAlignedTsFile(
-            "nonaligned-consume-oom.tsfile", 1, 1, 10, 0, 100, 10, 10);
-    resource = new TsFileResource(nonalignedTsFile);
-    resource.setStatusForTest(TsFileResourceStatus.NORMAL);
-
-    // The TsFile generator only creates the file, so mark the resource non-empty explicitly.
-    final IDeviceID deviceID = IDeviceID.Factory.DEFAULT_FACTORY.create("root.testsg.d0");
-    resource.updateStartTime(deviceID, 0);
-    resource.updateEndTime(deviceID, 9);
-
     final PipeTsFileInsertionEvent event =
-        new PipeTsFileInsertionEvent(
-            false,
-            "root",
-            resource,
-            null,
-            false,
-            false,
-            false,
-            null,
-            null,
-            0,
-            null,
-            new PrefixTreePattern("root"),
-            null,
-            null,
-            null,
-            null,
-            true,
-            Long.MIN_VALUE,
-            Long.MAX_VALUE);
+        createPipeTsFileInsertionEventForRetryTest("nonaligned-consume-oom.tsfile");
     final AtomicReference<PipeRawTabletInsertionEvent> parsedEventReference =
         new AtomicReference<>();
 
@@ -249,39 +220,38 @@ public class TsFileInsertionEventParserTest {
   }
 
   @Test
+  public void testConsumeTabletInsertionEventsWithRetryReleasesProgressWhenClosed()
+      throws Exception {
+    final PipeTsFileInsertionEvent event =
+        createPipeTsFileInsertionEventForRetryTest("nonaligned-consume-close.tsfile");
+    final AtomicReference<PipeRawTabletInsertionEvent> parsedEventReference =
+        new AtomicReference<>();
+
+    Assert.assertThrows(
+        PipeException.class,
+        () ->
+            event.consumeTabletInsertionEventsWithRetry(
+                parsedEvent -> {
+                  parsedEventReference.set(parsedEvent);
+                  throw new PipeException("expected failure");
+                },
+                "test"));
+
+    Assert.assertNotNull(parsedEventReference.get());
+    Assert.assertFalse(parsedEventReference.get().isReleased());
+    Assert.assertNotNull(getEventParser(event).get());
+
+    event.close();
+
+    Assert.assertTrue(parsedEventReference.get().isReleased());
+    Assert.assertNull(getEventParser(event).get());
+  }
+
+  @Test
   public void testConsumeTabletInsertionEventsWithRetryKeepsParserForTransientOutOfMemory()
       throws Exception {
-    nonalignedTsFile =
-        TsFileGeneratorUtils.generateNonAlignedTsFile(
-            "nonaligned-consume-transient-oom.tsfile", 1, 1, 10, 0, 100, 10, 10);
-    resource = new TsFileResource(nonalignedTsFile);
-    resource.setStatusForTest(TsFileResourceStatus.NORMAL);
-
-    final IDeviceID deviceID = IDeviceID.Factory.DEFAULT_FACTORY.create("root.testsg.d0");
-    resource.updateStartTime(deviceID, 0);
-    resource.updateEndTime(deviceID, 9);
-
     final PipeTsFileInsertionEvent event =
-        new PipeTsFileInsertionEvent(
-            false,
-            "root",
-            resource,
-            null,
-            false,
-            false,
-            false,
-            null,
-            null,
-            0,
-            null,
-            new PrefixTreePattern("root"),
-            null,
-            null,
-            null,
-            null,
-            true,
-            Long.MIN_VALUE,
-            Long.MAX_VALUE);
+        createPipeTsFileInsertionEventForRetryTest("nonaligned-consume-transient-oom.tsfile");
     final AtomicInteger retryCount = new AtomicInteger(0);
     final AtomicReference<PipeRawTabletInsertionEvent> parsedEventReference =
         new AtomicReference<>();
@@ -302,6 +272,40 @@ public class TsFileInsertionEventParserTest {
     Assert.assertNotNull(getEventParser(event).get());
 
     event.close();
+  }
+
+  private PipeTsFileInsertionEvent createPipeTsFileInsertionEventForRetryTest(final String fileName)
+      throws Exception {
+    nonalignedTsFile =
+        TsFileGeneratorUtils.generateNonAlignedTsFile(fileName, 1, 1, 10, 0, 100, 10, 10);
+    resource = new TsFileResource(nonalignedTsFile);
+    resource.setStatusForTest(TsFileResourceStatus.NORMAL);
+
+    // The TsFile generator only creates the file, so mark the resource non-empty explicitly.
+    final IDeviceID deviceID = IDeviceID.Factory.DEFAULT_FACTORY.create("root.testsg.d0");
+    resource.updateStartTime(deviceID, 0);
+    resource.updateEndTime(deviceID, 9);
+
+    return new PipeTsFileInsertionEvent(
+        false,
+        "root",
+        resource,
+        null,
+        false,
+        false,
+        false,
+        null,
+        null,
+        0,
+        null,
+        new PrefixTreePattern("root"),
+        null,
+        null,
+        null,
+        null,
+        true,
+        Long.MIN_VALUE,
+        Long.MAX_VALUE);
   }
 
   @Test

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/TsFileInsertionEventParserTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/TsFileInsertionEventParserTest.java
@@ -183,7 +183,7 @@ public class TsFileInsertionEventParserTest {
   }
 
   @Test
-  public void testConsumeTabletInsertionEventsWithRetryReleasesParserOnOutOfMemory()
+  public void testConsumeTabletInsertionEventsWithRetryPreservesProgressOnOutOfMemory()
       throws Exception {
     nonalignedTsFile =
         TsFileGeneratorUtils.generateNonAlignedTsFile(
@@ -233,8 +233,19 @@ public class TsFileInsertionEventParserTest {
 
     Assert.assertEquals("expected oom", exception.getMessage());
     Assert.assertNotNull(parsedEventReference.get());
-    Assert.assertTrue(parsedEventReference.get().isReleased());
-    Assert.assertNull(getEventParser(event).get());
+    Assert.assertFalse(parsedEventReference.get().isReleased());
+    Assert.assertNotNull(getEventParser(event).get());
+
+    final PipeRawTabletInsertionEvent eventAtFailure = parsedEventReference.get();
+    event.consumeTabletInsertionEventsWithRetry(
+        parsedEvent -> {
+          Assert.assertSame(eventAtFailure, parsedEvent);
+          parsedEvent.clearReferenceCount(getClass().getName());
+        },
+        "test");
+
+    Assert.assertTrue(eventAtFailure.isReleased());
+    event.close();
   }
 
   @Test


### PR DESCRIPTION
## Description

This is the parser progress recovery part of the Pipe resilience work. It is independent of #18260 and uses the existing parser memory reservation API on master.

### Preserve parsing progress

`PipeTsFileInsertionEvent` now retains:

- the tablet iterator created by the TsFile parser;
- the currently parsed but not successfully consumed tablet;
- the parsed tablet count and count-operation progress.

If tablet consumption fails, the event yields its active parser memory reservation but keeps the parser, iterator, and pending tablet. The next subtask retry reacquires parser memory and resumes from the exact same tablet object instead of reopening and reparsing the TsFile from the beginning.

### Parser lifecycle

Call sites that split Pipe TsFile events now close the parser only after successful completion. Processing exceptions stop at the failed tablet and propagate immediately. Non-Pipe TsFile implementations retain their original finally-close behavior.

Explicit event close and resource finalization still release the pending tablet and parser resources.

### OOM retry backoff

Local parser OOM retries use bounded exponential backoff derived from the existing Pipe memory retry interval and maximum retry count. When the retry policy decides to yield, later subtask retries resume from saved progress.

### Tests

`TsFileInsertionEventParserTest` verifies that an OOM does not close the parser and that the next retry receives the identical failed tablet object. The full parser test class passes.

<hr>

This PR has:
- [x] been self-reviewed.
    - [x] concurrent read and write
- [x] added comments explaining the progress and resource-lifecycle decisions.
- [x] added or updated unit tests for the retry path.

<hr>

##### Key changed/added classes

- `PipeTsFileInsertionEvent`
- `PipeProcessorSubtask`
- `PipeEventCollector`
- `AggregateProcessor`
- `DownSamplingProcessor`
- `WebSocketSink`
- `TsFileInsertionEventParserTest`