### PR TITLE
Return one NULL row for last_by over a never-written device (#16985)

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBDeletionTableIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/IoTDBDeletionTableIT.java
@@ -81,6 +81,7 @@ import java.util.stream.Stream;
 import static org.apache.iotdb.relational.it.session.IoTDBSessionRelationalIT.genValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -3198,5 +3199,118 @@ public class IoTDBDeletionTableIT {
       String deleteAllTemplate = "DROP TABLE IF EXISTS vehicle%d";
       statement.execute(String.format(deleteAllTemplate, testNum));
     }
+  }
+
+  // A global aggregation without GROUP BY over zero matching rows must return exactly one row
+  // whose value is NULL (SQL standard, matching e.g. Trino), not zero rows. These cover the two
+  // empty-input shapes: a device that was never written, and a device whose data was deleted.
+
+  @Test
+  public void testLastByOverNeverWrittenDeviceReturnsSingleNullRow() throws SQLException {
+    try (Connection connection = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
+        Statement statement = connection.createStatement()) {
+      statement.execute("use test");
+      statement.execute("create table last_empty0(deviceId string tag, s0 int32 field)");
+      statement.execute("insert into last_empty0(time, deviceId, s0) values (1, 'd0', 1)");
+      statement.execute("flush");
+
+      // 'nope' was never written, so its device set resolves to zero devices.
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              "select last_by(s0, time) from last_empty0 where deviceId = 'nope'")) {
+        assertSingleAllNullRow(resultSet);
+      }
+    }
+  }
+
+  @Test
+  public void testThreeArgLastByOverNeverWrittenDeviceReturnsSingleNullRow() throws SQLException {
+    try (Connection connection = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
+        Statement statement = connection.createStatement()) {
+      statement.execute("use test");
+      statement.execute(
+          "create table last_empty4(deviceId string tag, s0 int32 field, s1 int32 field)");
+      statement.execute("insert into last_empty4(time, deviceId, s0, s1) values (1, 'd0', 1, 2)");
+      statement.execute("flush");
+
+      // 3-arg last_by(target, ordering, time) over a never-written device -> one NULL row.
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              "select last_by(s0, s1, time) from last_empty4 where deviceId = 'nope'")) {
+        assertSingleAllNullRow(resultSet);
+      }
+    }
+  }
+
+  @Test
+  public void testMultipleLastAggregatesOverNeverWrittenDeviceReturnSingleAllNullRow()
+      throws SQLException {
+    try (Connection connection = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
+        Statement statement = connection.createStatement()) {
+      statement.execute("use test");
+      statement.execute(
+          "create table last_empty1(deviceId string tag, s0 int32 field, s1 int64 field)");
+      statement.execute("insert into last_empty1(time, deviceId, s0, s1) values (1, 'd0', 1, 2)");
+      statement.execute("flush");
+
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              "select last_by(s0, time), last_by(s1, time) from last_empty1 where deviceId = 'nope'")) {
+        assertSingleAllNullRow(resultSet);
+      }
+    }
+  }
+
+  @Test
+  public void testLastByOverNeverWrittenDeviceWithGroupByReturnsNoRows() throws SQLException {
+    try (Connection connection = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
+        Statement statement = connection.createStatement()) {
+      statement.execute("use test");
+      statement.execute("create table last_empty2(deviceId string tag, s0 int32 field)");
+      statement.execute("insert into last_empty2(time, deviceId, s0) values (1, 'd0', 1)");
+      statement.execute("flush");
+
+      // The one-NULL-row rule is for no-GROUP-BY only; an empty group produces no rows.
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              "select deviceId, last_by(s0, time) from last_empty2 where deviceId = 'nope' group by deviceId")) {
+        assertFalse("GROUP BY over an empty group must return no rows", resultSet.next());
+      }
+    }
+  }
+
+  @Test
+  public void testLastByOverDeletedDeviceStillReturnsSingleNullRow() throws SQLException {
+    try (Connection connection = EnvFactory.getEnv().getConnection(BaseEnv.TABLE_SQL_DIALECT);
+        Statement statement = connection.createStatement()) {
+      statement.execute("use test");
+      statement.execute("create table last_empty3(deviceId string tag, s0 int32 field)");
+      statement.execute("insert into last_empty3(time, deviceId, s0) values (1, 'd0', 1)");
+      statement.execute("flush");
+      statement.execute("delete from last_empty3 where deviceId = 'd0'");
+
+      // The deleted device still exists in the schema; last_by must return one NULL row. Query
+      // twice to cover both the last-value-cache path and the recomputed path.
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              "select last_by(s0, time) from last_empty3 where deviceId = 'd0'")) {
+        assertSingleAllNullRow(resultSet);
+      }
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              "select last_by(s0, time) from last_empty3 where deviceId = 'd0'")) {
+        assertSingleAllNullRow(resultSet);
+      }
+    }
+  }
+
+  private void assertSingleAllNullRow(ResultSet resultSet) throws SQLException {
+    assertTrue("Expected exactly one result row, but got none", resultSet.next());
+    int columnCount = resultSet.getMetaData().getColumnCount();
+    for (int i = 1; i <= columnCount; i++) {
+      Object value = resultSet.getObject(i);
+      assertNull("Expected column " + i + " to be NULL, but got: " + value, value);
+    }
+    assertFalse("Expected exactly one result row, but got more than one", resultSet.next());
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/DataNodeTableOperatorGenerator.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/planner/DataNodeTableOperatorGenerator.java
@@ -1755,9 +1755,18 @@ public class DataNodeTableOperatorGenerator
     AbstractAggTableScanOperator.AbstractAggTableScanOperatorParameter parameter =
         constructAbstractAggTableScanOperatorParameter(node, context);
 
+    // When the device set resolves to zero devices AND there are no grouping
+    // keys (e.g. a global last/last_by over a device that was never written),
+    // fall back to the default aggregation operator, which already emits the
+    // single all-NULL row required for a global aggregation over empty input.
+    // The last-cache optimization has no device to read and would otherwise
+    // emit zero rows. A GROUP BY over an empty device set is intentionally left
+    // on the last-cache path, which already (correctly) returns zero rows.
     OptimizeType optimizeType =
-        canUseLastCacheOptimize(
-            parameter.getTableAggregators(), node, parameter.getTimeColumnName());
+        node.getDeviceEntries().isEmpty() && node.getGroupingKeys().isEmpty()
+            ? OptimizeType.NOOP
+            : canUseLastCacheOptimize(
+                parameter.getTableAggregators(), node, parameter.getTimeColumnName());
     if (optimizeType != OptimizeType.NOOP) {
       return constructLastQueryAggTableScanOperator(
           node, parameter, optimizeType == OptimizeType.LAST_ROW, context);


### PR DESCRIPTION
## Description

Per @Wei-hao-Li's clarification in #16985: an aggregate function should always return NULL when there is no input data (except `count`), consistent with SQL-standard engines such as Trino. So `select last_by(s0, time) from t where deviceId = 'never'` — where the device was never written — must return exactly one row whose value is NULL, not zero rows.

Root cause: for the last-cache-optimized `last` / `last_by` path, a device set that resolves to zero devices leaves `LastQueryAggTableScanOperator` with `allDeviceCount == 0`, so the device loop never runs and the operator returns no rows.

## How

Following review feedback, rather than special-casing the last-cache operator, the empty-device case is routed to the default aggregation operator, which already emits the single all-NULL row required for a global aggregation over empty input. One change in `DataNodeTableOperatorGenerator.visitAggregationTableScan`:

```java
OptimizeType optimizeType =
    node.getDeviceEntries().isEmpty() && node.getGroupingKeys().isEmpty()
        ? OptimizeType.NOOP
        : canUseLastCacheOptimize(
            parameter.getTableAggregators(), node, parameter.getTimeColumnName());
```

When the device set resolves to zero devices and there are no grouping keys, the last-cache optimization is skipped (`NOOP`) and planning falls to `DefaultAggTableScanOperator`. That operator builds an `EMPTY_DEVICE_ID` entry for an empty device set and its `hasNext()` is time-range-based, so the global aggregation still runs its time range once and each aggregator's no-input `evaluate()` writes NULL. The change in `LastQueryAggTableScanOperator` is reverted (net zero there).

Guards:

- GROUP BY over an empty device set is intentionally left on the last-cache path, which already (correctly) returns no rows — the one-NULL-row rule is for no-GROUP-BY global aggregation only.
- The deleted-device case is untouched: the device still exists, so `deviceEntries` is non-empty and planning is identical to before.

## Tests

`IoTDBDeletionTableIT`: a never-written device queried with 2-arg and 3-arg `last_by` returns one NULL row; multiple `last_by` aggregates return one all-NULL row; GROUP BY over a never-written device returns no rows; and a regression check that a deleted device still returns one NULL row (both the last-value-cache and recomputed paths).

## Scope

Scoped to the last-cache `last` / `last_by` path, which is where the zero-row behavior originated. Other aggregations (`max` / `min` / `sum` / `avg`) do not use the last-cache optimization, so their planning is unchanged by this guard.

Relates to #16985.
