### PR TITLE
Harden query memory reservation deregistration ordering

### DIFF
--- a/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/DataNodeQueryMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/DataNodeQueryMessages.java
@@ -2748,8 +2748,8 @@ public final class DataNodeQueryMessages {
   public static final String QUERY_EXCEPTION_QUERY_IS_ABORTED_SINCE_IT_REQUESTS_MORE_MEMORY_THAN_CAN_D77C2921 =
       "Query is aborted since it requests more memory than can be allocated, bytesToReserve: %sB, "
           + "maxBytesCanReserve: %sB";
-  public static final String QUERY_EXCEPTION_RELATEDMEMORYRESERVED_CAN_T_BE_NULL_WHEN_FREEING_MEMORY_C80009F2 =
-      "RelatedMemoryReserved can't be null when freeing memory";
+  public static final String EXCEPTION_NO_MEMORY_RESERVATION_IS_REGISTERED_FOR_QUERY_ARG_AND_FRAGMENT_INSTANCE_ARG_06016520 =
+      "No memory reservation is registered for query %s and fragment instance %s.";
   public static final String QUERY_EXCEPTION_INTERRUPTED_BY_92FAED2D = "Interrupted By";
   public static final String QUERY_EXCEPTION_DRIVER_WAS_INTERRUPTED_737358E4 =
       "Driver was interrupted";

--- a/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/DataNodeQueryMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/DataNodeQueryMessages.java
@@ -3269,8 +3269,8 @@ public final class DataNodeQueryMessages {
 
 
       "查询已中止，因为其请求的内存超过可分配上限，bytesToReserve：%sB，maxBytesCanReserve：%sB";
-  public static final String QUERY_EXCEPTION_RELATEDMEMORYRESERVED_CAN_T_BE_NULL_WHEN_FREEING_MEMORY_C80009F2 =
-      "释放内存时 RelatedMemoryReserved 不能为 null";
+  public static final String EXCEPTION_NO_MEMORY_RESERVATION_IS_REGISTERED_FOR_QUERY_ARG_AND_FRAGMENT_INSTANCE_ARG_06016520 =
+      "查询 %s、FragmentInstance %s 未注册内存预留。";
   public static final String QUERY_EXCEPTION_INTERRUPTED_BY_92FAED2D =
       "被中断，原因：";
   public static final String QUERY_EXCEPTION_DRIVER_WAS_INTERRUPTED_737358E4 =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/memory/MemoryPool.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/memory/MemoryPool.java
@@ -206,10 +206,13 @@ public class MemoryPool {
   public void registerPlanNodeIdToQueryMemoryMap(
       String queryId, String fragmentInstanceId, String planNodeId) {
     synchronized (queryMemoryReservations) {
-      queryMemoryReservations
-          .computeIfAbsent(queryId, x -> new ConcurrentHashMap<>())
-          .computeIfAbsent(fragmentInstanceId, x -> new ConcurrentHashMap<>())
-          .putIfAbsent(planNodeId, 0L);
+      final Map<String, Map<String, Long>> queryRelatedMemory =
+          queryMemoryReservations.computeIfAbsent(queryId, x -> new ConcurrentHashMap<>());
+      final Map<String, Long> fragmentRelatedMemory =
+          queryRelatedMemory.computeIfAbsent(fragmentInstanceId, x -> new ConcurrentHashMap<>());
+      synchronized (fragmentRelatedMemory) {
+        fragmentRelatedMemory.putIfAbsent(planNodeId, 0L);
+      }
     }
   }
 
@@ -224,43 +227,44 @@ public class MemoryPool {
    */
   public void deRegisterFragmentInstanceFromQueryMemoryMap(
       String queryId, String fragmentInstanceId, boolean forceDeregister) {
-    Map<String, Map<String, Long>> queryRelatedMemory = queryMemoryReservations.get(queryId);
-    if (queryRelatedMemory != null) {
-      Map<String, Long> fragmentRelatedMemory = queryRelatedMemory.get(fragmentInstanceId);
-      boolean hasPotentialMemoryLeak = false;
-      // fragmentRelatedMemory could be null if the FI has not reserved any memory(For example,
-      // next() of root operator returns no data)
-      if (fragmentRelatedMemory != null) {
-        hasPotentialMemoryLeak =
-            fragmentRelatedMemory.values().stream().anyMatch(value -> value != 0L);
-      }
-      if (!forceDeregister && hasPotentialMemoryLeak) {
-        // If hasPotentialMemoryLeak is true, it means that LocalSourceChannel/LocalSourceHandles
-        // have not been closed.
-        // We should wait for them to be closed. Make sure this method is called again with
-        // forceDeregister == true, after all LocalSourceChannel/LocalSourceHandles are closed.
+    List<Map.Entry<String, Long>> invalidEntryList = null;
+    synchronized (queryMemoryReservations) {
+      final Map<String, Map<String, Long>> queryRelatedMemory =
+          queryMemoryReservations.get(queryId);
+      if (queryRelatedMemory == null) {
         return;
       }
-      synchronized (queryMemoryReservations) {
-        queryRelatedMemory.remove(fragmentInstanceId);
-        if (queryRelatedMemory.isEmpty()) {
-          queryMemoryReservations.remove(queryId);
+      final Map<String, Long> fragmentRelatedMemory = queryRelatedMemory.get(fragmentInstanceId);
+      if (fragmentRelatedMemory != null) {
+        synchronized (fragmentRelatedMemory) {
+          invalidEntryList =
+              fragmentRelatedMemory.entrySet().stream()
+                  .filter(entry -> entry.getValue() != 0L)
+                  .collect(Collectors.toList());
+          if (!forceDeregister && !invalidEntryList.isEmpty()) {
+            // The LocalSourceChannels/LocalSourceHandles have not been closed yet. The caller will
+            // invoke this method again with forceDeregister == true after closing them.
+            return;
+          }
+          queryRelatedMemory.remove(fragmentInstanceId, fragmentRelatedMemory);
         }
+      } else {
+        // fragmentRelatedMemory could be null if the FI has not reserved any memory (for example,
+        // next() of root operator returns no data).
+        queryRelatedMemory.remove(fragmentInstanceId);
       }
-      if (hasPotentialMemoryLeak) {
-        // hasPotentialMemoryLeak means that fragmentRelatedMemory is not null
-        List<Map.Entry<String, Long>> invalidEntryList =
-            fragmentRelatedMemory.entrySet().stream()
-                .filter(entry -> entry.getValue() != 0L)
-                .collect(Collectors.toList());
-        throw new MemoryLeakException(
-            String.format(
-                DataNodeQueryMessages
-                    .QUERY_EXCEPTION_PLANNODE_RELATED_MEMORY_IS_NOT_ZERO_WHEN_TRYING_TO_DEREGISTER_E01109C5,
-                queryId,
-                fragmentInstanceId,
-                invalidEntryList));
+      if (queryRelatedMemory.isEmpty()) {
+        queryMemoryReservations.remove(queryId);
       }
+    }
+    if (invalidEntryList != null && !invalidEntryList.isEmpty()) {
+      throw new MemoryLeakException(
+          String.format(
+              DataNodeQueryMessages
+                  .QUERY_EXCEPTION_PLANNODE_RELATED_MEMORY_IS_NOT_ZERO_WHEN_TRYING_TO_DEREGISTER_E01109C5,
+              queryId,
+              fragmentInstanceId,
+              invalidEntryList));
     }
   }
 
@@ -388,10 +392,17 @@ public class MemoryPool {
     Validate.isTrue(bytes > 0L);
 
     try {
-      queryMemoryReservations
-          .get(queryId)
-          .get(fragmentInstanceId)
-          .computeIfPresent(
+      while (true) {
+        final Map<String, Map<String, Long>> queryRelatedMemory =
+            queryMemoryReservations.get(queryId);
+        final Map<String, Long> fragmentRelatedMemory = queryRelatedMemory.get(fragmentInstanceId);
+        synchronized (fragmentRelatedMemory) {
+          // The fragment map may have been removed while this thread was waiting for its lock.
+          if (queryMemoryReservations.get(queryId) != queryRelatedMemory
+              || queryRelatedMemory.get(fragmentInstanceId) != fragmentRelatedMemory) {
+            continue;
+          }
+          fragmentRelatedMemory.computeIfPresent(
               planNodeId,
               (k, reservedMemory) -> {
                 if (reservedMemory < bytes) {
@@ -400,6 +411,9 @@ public class MemoryPool {
                 }
                 return reservedMemory - bytes;
               });
+          break;
+        }
+      }
     } catch (NullPointerException e) {
       throw new IllegalArgumentException(
           DataNodeQueryMessages
@@ -457,22 +471,40 @@ public class MemoryPool {
       String planNodeId,
       long bytesToReserve,
       long maxBytesCanReserve) {
-    long tryUsedBytes = memoryBlock.forceAllocateWithoutLimitation(bytesToReserve);
-    long queryRemainingBytes =
-        maxBytesCanReserve
-            - queryMemoryReservations
-                .get(queryId)
-                .get(fragmentInstanceId)
-                .merge(planNodeId, bytesToReserve, Long::sum);
-    return tryUsedBytes <= memoryBlock.getTotalMemorySizeInBytes() && queryRemainingBytes >= 0;
+    while (true) {
+      final Map<String, Map<String, Long>> queryRelatedMemory =
+          queryMemoryReservations.get(queryId);
+      final Map<String, Long> fragmentRelatedMemory = queryRelatedMemory.get(fragmentInstanceId);
+      synchronized (fragmentRelatedMemory) {
+        // Serialize reservation changes with fragment deregistration while allowing reservations
+        // for other fragments to proceed concurrently.
+        if (queryMemoryReservations.get(queryId) != queryRelatedMemory
+            || queryRelatedMemory.get(fragmentInstanceId) != fragmentRelatedMemory) {
+          continue;
+        }
+        final long tryUsedBytes = memoryBlock.forceAllocateWithoutLimitation(bytesToReserve);
+        final long queryRemainingBytes =
+            maxBytesCanReserve - fragmentRelatedMemory.merge(planNodeId, bytesToReserve, Long::sum);
+        return tryUsedBytes <= memoryBlock.getTotalMemorySizeInBytes() && queryRemainingBytes >= 0;
+      }
+    }
   }
 
   private void rollbackReserve(
       String queryId, String fragmentInstanceId, String planNodeId, long bytesToReserve) {
-    queryMemoryReservations
-        .get(queryId)
-        .get(fragmentInstanceId)
-        .merge(planNodeId, -bytesToReserve, Long::sum);
-    memoryBlock.release(bytesToReserve);
+    while (true) {
+      final Map<String, Map<String, Long>> queryRelatedMemory =
+          queryMemoryReservations.get(queryId);
+      final Map<String, Long> fragmentRelatedMemory = queryRelatedMemory.get(fragmentInstanceId);
+      synchronized (fragmentRelatedMemory) {
+        if (queryMemoryReservations.get(queryId) != queryRelatedMemory
+            || queryRelatedMemory.get(fragmentInstanceId) != fragmentRelatedMemory) {
+          continue;
+        }
+        fragmentRelatedMemory.merge(planNodeId, -bytesToReserve, Long::sum);
+        memoryBlock.release(bytesToReserve);
+        return;
+      }
+    }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/memory/MemoryPool.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/execution/memory/MemoryPool.java
@@ -391,34 +391,33 @@ public class MemoryPool {
     Validate.notNull(queryId, DataNodeQueryMessages.EXCEPTION_QUERYID_CAN_NOT_BE_NULL_DOT_16639DBE);
     Validate.isTrue(bytes > 0L);
 
-    try {
-      while (true) {
-        final Map<String, Map<String, Long>> queryRelatedMemory =
-            queryMemoryReservations.get(queryId);
-        final Map<String, Long> fragmentRelatedMemory = queryRelatedMemory.get(fragmentInstanceId);
-        synchronized (fragmentRelatedMemory) {
-          // The fragment map may have been removed while this thread was waiting for its lock.
-          if (queryMemoryReservations.get(queryId) != queryRelatedMemory
-              || queryRelatedMemory.get(fragmentInstanceId) != fragmentRelatedMemory) {
-            continue;
-          }
-          fragmentRelatedMemory.computeIfPresent(
-              planNodeId,
-              (k, reservedMemory) -> {
-                if (reservedMemory < bytes) {
-                  throw new IllegalArgumentException(
-                      DataNodeQueryMessages.FREE_MORE_MEMORY_THAN_HAS_BEEN_RESERVED);
-                }
-                return reservedMemory - bytes;
-              });
-          break;
-        }
+    while (true) {
+      final Map<String, Map<String, Long>> queryRelatedMemory =
+          queryMemoryReservations.get(queryId);
+      if (queryRelatedMemory == null) {
+        throw memoryReservationNotRegistered(queryId, fragmentInstanceId);
       }
-    } catch (NullPointerException e) {
-      throw new IllegalArgumentException(
-          DataNodeQueryMessages
-              .QUERY_EXCEPTION_RELATEDMEMORYRESERVED_CAN_T_BE_NULL_WHEN_FREEING_MEMORY_C80009F2,
-          e);
+      final Map<String, Long> fragmentRelatedMemory = queryRelatedMemory.get(fragmentInstanceId);
+      if (fragmentRelatedMemory == null) {
+        throw memoryReservationNotRegistered(queryId, fragmentInstanceId);
+      }
+      synchronized (fragmentRelatedMemory) {
+        // The fragment map may have been removed while this thread was waiting for its lock.
+        if (queryMemoryReservations.get(queryId) != queryRelatedMemory
+            || queryRelatedMemory.get(fragmentInstanceId) != fragmentRelatedMemory) {
+          continue;
+        }
+        fragmentRelatedMemory.computeIfPresent(
+            planNodeId,
+            (k, reservedMemory) -> {
+              if (reservedMemory < bytes) {
+                throw new IllegalArgumentException(
+                    DataNodeQueryMessages.FREE_MORE_MEMORY_THAN_HAS_BEEN_RESERVED);
+              }
+              return reservedMemory - bytes;
+            });
+        break;
+      }
     }
 
     memoryBlock.release(bytes);
@@ -474,7 +473,13 @@ public class MemoryPool {
     while (true) {
       final Map<String, Map<String, Long>> queryRelatedMemory =
           queryMemoryReservations.get(queryId);
+      if (queryRelatedMemory == null) {
+        throw memoryReservationNotRegistered(queryId, fragmentInstanceId);
+      }
       final Map<String, Long> fragmentRelatedMemory = queryRelatedMemory.get(fragmentInstanceId);
+      if (fragmentRelatedMemory == null) {
+        throw memoryReservationNotRegistered(queryId, fragmentInstanceId);
+      }
       synchronized (fragmentRelatedMemory) {
         // Serialize reservation changes with fragment deregistration while allowing reservations
         // for other fragments to proceed concurrently.
@@ -495,7 +500,13 @@ public class MemoryPool {
     while (true) {
       final Map<String, Map<String, Long>> queryRelatedMemory =
           queryMemoryReservations.get(queryId);
+      if (queryRelatedMemory == null) {
+        throw memoryReservationNotRegistered(queryId, fragmentInstanceId);
+      }
       final Map<String, Long> fragmentRelatedMemory = queryRelatedMemory.get(fragmentInstanceId);
+      if (fragmentRelatedMemory == null) {
+        throw memoryReservationNotRegistered(queryId, fragmentInstanceId);
+      }
       synchronized (fragmentRelatedMemory) {
         if (queryMemoryReservations.get(queryId) != queryRelatedMemory
             || queryRelatedMemory.get(fragmentInstanceId) != fragmentRelatedMemory) {
@@ -506,5 +517,15 @@ public class MemoryPool {
         return;
       }
     }
+  }
+
+  private IllegalArgumentException memoryReservationNotRegistered(
+      String queryId, String fragmentInstanceId) {
+    return new IllegalArgumentException(
+        String.format(
+            DataNodeQueryMessages
+                .EXCEPTION_NO_MEMORY_RESERVATION_IS_REGISTERED_FOR_QUERY_ARG_AND_FRAGMENT_INSTANCE_ARG_06016520,
+            queryId,
+            fragmentInstanceId));
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/memory/MemoryPoolTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/memory/MemoryPoolTest.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -471,6 +472,50 @@ public class MemoryPoolTest {
     }
   }
 
+  @SuppressWarnings("unchecked")
+  @Test(timeout = 15000L)
+  public void testDeregistrationWinsBeforeReserveAcquiresFragmentLock() throws Exception {
+    Field reservationsField = MemoryPool.class.getDeclaredField("queryMemoryReservations");
+    reservationsField.setAccessible(true);
+    Map<String, Map<String, Map<String, Long>>> reservations =
+        (Map<String, Map<String, Map<String, Long>>>) reservationsField.get(pool);
+
+    BlockingQueryMap blockingQueryMap = new BlockingQueryMap();
+    blockingQueryMap.putAll(reservations.get(QUERY_ID));
+    reservations.put(QUERY_ID, blockingQueryMap);
+
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    Future<Boolean> reservation = null;
+    try {
+      reservation =
+          executor.submit(
+              () -> {
+                blockingQueryMap.blockCurrentThreadOnGet();
+                return pool.tryReserveForTest(
+                    QUERY_ID, FRAGMENT_INSTANCE_ID, PLAN_NODE_ID, 256L, Long.MAX_VALUE);
+              });
+      Assert.assertTrue(blockingQueryMap.fragmentMapRead.await(5, TimeUnit.SECONDS));
+
+      pool.deRegisterFragmentInstanceFromQueryMemoryMap(QUERY_ID, FRAGMENT_INSTANCE_ID, false);
+      Assert.assertEquals(0, pool.getQueryMemoryReservationSize());
+      blockingQueryMap.allowGetToReturn.countDown();
+
+      try {
+        reservation.get(5, TimeUnit.SECONDS);
+        Assert.fail("Expected the reservation to fail after deregistration");
+      } catch (ExecutionException e) {
+        Assert.assertTrue(e.getCause() instanceof IllegalArgumentException);
+      }
+      Assert.assertEquals(0L, pool.getReservedBytes());
+    } finally {
+      blockingQueryMap.allowGetToReturn.countDown();
+      if (reservation != null) {
+        reservation.cancel(true);
+      }
+      executor.shutdownNow();
+    }
+  }
+
   private static class BlockingMemoryMap extends ConcurrentHashMap<String, Long> {
 
     private final CountDownLatch reservationStarted = new CountDownLatch(1);
@@ -519,6 +564,27 @@ public class MemoryPoolTest {
         Thread.currentThread().interrupt();
         throw new AssertionError(e);
       }
+    }
+  }
+
+  private static class BlockingQueryMap extends ConcurrentHashMap<String, Map<String, Long>> {
+
+    private final CountDownLatch fragmentMapRead = new CountDownLatch(1);
+    private final CountDownLatch allowGetToReturn = new CountDownLatch(1);
+    private volatile Thread blockedThread;
+
+    private void blockCurrentThreadOnGet() {
+      blockedThread = Thread.currentThread();
+    }
+
+    @Override
+    public Map<String, Long> get(Object key) {
+      Map<String, Long> result = super.get(key);
+      if (Thread.currentThread() == blockedThread) {
+        fragmentMapRead.countDown();
+        BlockingMemoryMap.await(allowGetToReturn);
+      }
+      return result;
     }
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/memory/MemoryPoolTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/memory/MemoryPoolTest.java
@@ -28,6 +28,21 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.lang.reflect.Field;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+
 public class MemoryPoolTest {
 
   MemoryPool pool;
@@ -389,5 +404,121 @@ public class MemoryPoolTest {
     Assert.assertEquals(256L, r.getReservedBytes());
     Assert.assertTrue(r.getFuture().isDone());
     Assert.assertEquals(256L, pool.getReservedBytes());
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test(timeout = 15000L)
+  public void testReserveIsAtomicWithFragmentDeregistration() throws Exception {
+    Field reservationsField = MemoryPool.class.getDeclaredField("queryMemoryReservations");
+    reservationsField.setAccessible(true);
+    Map<String, Map<String, Map<String, Long>>> reservations =
+        (Map<String, Map<String, Map<String, Long>>>) reservationsField.get(pool);
+
+    BlockingMemoryMap blockingMemoryMap = new BlockingMemoryMap();
+    blockingMemoryMap.put(PLAN_NODE_ID, 0L);
+    reservations.get(QUERY_ID).put(FRAGMENT_INSTANCE_ID, blockingMemoryMap);
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    Future<Boolean> reservation = null;
+    Future<?> deregistration = null;
+    try {
+      reservation =
+          executor.submit(
+              () ->
+                  pool.tryReserveForTest(
+                      QUERY_ID, FRAGMENT_INSTANCE_ID, PLAN_NODE_ID, 256L, Long.MAX_VALUE));
+      Assert.assertTrue(blockingMemoryMap.reservationStarted.await(5, TimeUnit.SECONDS));
+
+      deregistration =
+          executor.submit(
+              () ->
+                  pool.deRegisterFragmentInstanceFromQueryMemoryMap(
+                      QUERY_ID, FRAGMENT_INSTANCE_ID, false));
+
+      if (blockingMemoryMap.deregistrationSnapshotTaken.await(1, TimeUnit.SECONDS)) {
+        // Without synchronization, deregistration can snapshot zero and remove the fragment while
+        // the reservation update is in progress.
+        blockingMemoryMap.allowDeregistrationSnapshot.countDown();
+        deregistration.get(5, TimeUnit.SECONDS);
+        blockingMemoryMap.allowReservation.countDown();
+      } else {
+        // With the fix, deregistration waits for the reservation update and then observes 256.
+        blockingMemoryMap.allowReservation.countDown();
+        Assert.assertTrue(reservation.get(5, TimeUnit.SECONDS));
+        Assert.assertTrue(blockingMemoryMap.deregistrationSnapshotTaken.await(5, TimeUnit.SECONDS));
+        blockingMemoryMap.allowDeregistrationSnapshot.countDown();
+      }
+
+      Assert.assertTrue(reservation.get(5, TimeUnit.SECONDS));
+      deregistration.get(5, TimeUnit.SECONDS);
+      Assert.assertEquals(256L, pool.getQueryMemoryReservedBytes(QUERY_ID));
+      Assert.assertEquals(256L, pool.getReservedBytes());
+
+      pool.free(QUERY_ID, FRAGMENT_INSTANCE_ID, PLAN_NODE_ID, 256L);
+      pool.deRegisterFragmentInstanceFromQueryMemoryMap(QUERY_ID, FRAGMENT_INSTANCE_ID, false);
+      Assert.assertEquals(0, pool.getQueryMemoryReservationSize());
+      Assert.assertEquals(0L, pool.getReservedBytes());
+    } finally {
+      blockingMemoryMap.allowReservation.countDown();
+      blockingMemoryMap.allowDeregistrationSnapshot.countDown();
+      if (reservation != null) {
+        reservation.cancel(true);
+      }
+      if (deregistration != null) {
+        deregistration.cancel(true);
+      }
+      executor.shutdownNow();
+    }
+  }
+
+  private static class BlockingMemoryMap extends ConcurrentHashMap<String, Long> {
+
+    private final CountDownLatch reservationStarted = new CountDownLatch(1);
+    private final CountDownLatch allowReservation = new CountDownLatch(1);
+    private final CountDownLatch deregistrationSnapshotTaken = new CountDownLatch(1);
+    private final CountDownLatch allowDeregistrationSnapshot = new CountDownLatch(1);
+
+    @Override
+    public Long merge(
+        String key,
+        Long value,
+        BiFunction<? super Long, ? super Long, ? extends Long> remappingFunction) {
+      reservationStarted.countDown();
+      await(allowReservation);
+      return super.merge(key, value, remappingFunction);
+    }
+
+    @Override
+    public Collection<Long> values() {
+      Collection<Long> snapshot = new ArrayList<>(super.values());
+      waitForDeregistration();
+      return snapshot;
+    }
+
+    @Override
+    public Set<Map.Entry<String, Long>> entrySet() {
+      Set<Map.Entry<String, Long>> snapshot = new HashSet<>();
+      for (Map.Entry<String, Long> entry : super.entrySet()) {
+        snapshot.add(new AbstractMap.SimpleImmutableEntry<>(entry));
+      }
+      waitForDeregistration();
+      return snapshot;
+    }
+
+    private void waitForDeregistration() {
+      deregistrationSnapshotTaken.countDown();
+      await(allowDeregistrationSnapshot);
+    }
+
+    private static void await(CountDownLatch latch) {
+      try {
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+          throw new AssertionError();
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new AssertionError(e);
+      }
+    }
   }
 }


### PR DESCRIPTION
## Description

A table standalone integration test exposed this failure at the query-memory boundary:

```
SharedTsBlockQueue.remove()
  -> MemoryPool.free()
  -> the fragment reservation map has already been removed
```

The failure proves that a free reached `MemoryPool` after deregistration. It does **not** by itself prove that a new reservation raced with FI deregistration.

After auditing the production FI terminal path, the normal ordering is:

1. `clearShuffleSinkHandle()`;
2. `driver.close()`;
3. `releaseResourceWhenAllDriversAreClosed()`;
4. deregister the FI from `MemoryPool`.

Handle cleanup also cancels or completes pending reservation futures under the same future lock used when `MemoryPool.free()` grants them. I did not find a concrete normal-path caller that starts a new reservation after FI cleanup. The change below is therefore defensive hardening of the `MemoryPool` API boundary; it does not claim that the failure log demonstrates a production reserve/deregister race.

This is independent of the Pipe changes in #18266. That PR's head was based directly on `b8ff9eeaea0d2e5afd79446e8bb4cf654c8c8038` and touched only `PipeMemoryManager` and its test.

## Fix

- Serialize register, reserve, rollback, free, and deregister operations on the affected fragment reservation map.
- Revalidate the query/fragment map identities after acquiring the fragment lock so an operation never updates a detached map.
- If deregistration wins and removes the mapping, fail explicitly with `IllegalArgumentException` before allocating or releasing memory instead of retrying into a null dereference.
- Keep reservations for different fragments concurrent.

## Tests

Added deterministic coverage for both lock orderings:

- reservation enters the fragment map first, so deregistration waits and observes the reservation;
- deregistration removes the map first, then the waiting reservation resumes, fails explicitly, and leaves the global memory usage unchanged.

Executed:

- `mvn spotless:apply -pl iotdb-core/datanode`
- `mvn -o -nsu '-Ddevelocity.off=true' test -pl iotdb-core/datanode '-Dtest=MemoryPoolTest'`
  - 24 tests, 0 failures, 0 errors
  - Checkstyle: 0 violations
  - Spotless check: passed
- `mvn -o -nsu '-Ddevelocity.off=true' test-compile -pl iotdb-core/datanode -P with-zh-locale '-DskipTests'`
  - BUILD SUCCESS

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added deterministic tests for both concurrency orderings.
