### PR TITLE
Fix sonar cannot analyse because it requires JDK 21

### DIFF
--- a/.github/workflows/sonar-codecov.yml
+++ b/.github/workflows/sonar-codecov.yml
@@ -71,11 +71,11 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'apache/iotdb' || github.event_name == 'push'
     steps:
       - uses: actions/checkout@v5
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
           distribution: corretto
-          java-version: 17
+          java-version: 21
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache Maven packages


### PR DESCRIPTION
This pull request updates the Java version used in the GitHub Actions workflow for Sonar and Codecov analysis. The workflow now uses JDK 21 instead of JDK 17.

CI/CD configuration:

* Updated the `Set up JDK` step in `.github/workflows/sonar-codecov.yml` to use JDK 21 (`java-version: 21`) instead of JDK 17 (`java-version: 17`).