### PR TITLE
[To dev/1.3][Pipe] Fix pipe tablet memory self-lock during batching (#18266)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManager.java
@@ -209,6 +209,16 @@ public class PipeMemoryManager {
         && (double) usedMemorySizeInBytesOfTsFiles < allowedMaxMemorySizeInBytesOfTsTiles();
   }
 
+  private boolean isHardEnoughForResizing(final PipeMemoryBlock block) {
+    if (block instanceof PipeTabletMemoryBlock) {
+      return isHardEnough4TabletParsing();
+    }
+    if (block instanceof PipeTsFileMemoryBlock) {
+      return isHardEnough4TsFileSlicing();
+    }
+    return true;
+  }
+
   public synchronized PipeMemoryBlock forceAllocate(long sizeInBytes)
       throws PipeRuntimeOutOfMemoryCriticalException {
     if (!PIPE_MEMORY_MANAGEMENT_ENABLED) {
@@ -428,7 +438,11 @@ public class PipeMemoryManager {
     long sizeInBytes = targetSize - oldSize;
     final int memoryAllocateMaxRetries = PipeConfig.getInstance().getPipeMemoryAllocateMaxRetries();
     for (int i = 1; i <= memoryAllocateMaxRetries; i++) {
-      if (getTotalNonFloatingMemorySizeInBytes() - usedMemorySizeInBytes >= sizeInBytes) {
+      // Dynamically resized data-structure blocks must obey the same admission thresholds as
+      // blocks allocated with a non-zero initial size. Otherwise they can exhaust the pool and
+      // prevent downstream consumers from allocating the memory needed to release them.
+      if (isHardEnoughForResizing(block)
+          && getTotalNonFloatingMemorySizeInBytes() - usedMemorySizeInBytes >= sizeInBytes) {
         usedMemorySizeInBytes += sizeInBytes;
         if (oldSize == 0) {
           // If the memory block is not registered, we need to register it first.

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManagerResizeTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManagerResizeTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.pipe.resource.memory;
+
+import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
+import org.apache.iotdb.commons.exception.pipe.PipeRuntimeOutOfMemoryCriticalException;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PipeMemoryManagerResizeTest {
+
+  private final CommonConfig config = CommonDescriptor.getInstance().getConfig();
+
+  private boolean originalMemoryManagementEnabled;
+  private int originalAllocateMaxRetries;
+  private long originalAllocateRetryIntervalInMs;
+  private double originalFloatingMemoryProportion;
+  private double originalTabletRejectThreshold;
+  private double originalTsFileRejectThreshold;
+
+  @Before
+  public void setUp() {
+    originalMemoryManagementEnabled = config.getPipeMemoryManagementEnabled();
+    originalAllocateMaxRetries = config.getPipeMemoryAllocateMaxRetries();
+    originalAllocateRetryIntervalInMs = config.getPipeMemoryAllocateRetryIntervalInMs();
+    originalFloatingMemoryProportion = config.getPipeTotalFloatingMemoryProportion();
+    originalTabletRejectThreshold =
+        config.getPipeDataStructureTabletMemoryBlockAllocationRejectThreshold();
+    originalTsFileRejectThreshold =
+        config.getPipeDataStructureTsFileMemoryBlockAllocationRejectThreshold();
+
+    config.setPipeMemoryManagementEnabled(true);
+    config.setPipeMemoryAllocateMaxRetries(1);
+    config.setPipeMemoryAllocateRetryIntervalInMs(1);
+    config.setPipeTotalFloatingMemoryProportion(0.5);
+    config.setPipeDataStructureTabletMemoryBlockAllocationRejectThreshold(0.3);
+    config.setPipeDataStructureTsFileMemoryBlockAllocationRejectThreshold(0.3);
+  }
+
+  @After
+  public void tearDown() {
+    config.setPipeMemoryManagementEnabled(originalMemoryManagementEnabled);
+    config.setPipeMemoryAllocateMaxRetries(originalAllocateMaxRetries);
+    config.setPipeMemoryAllocateRetryIntervalInMs(originalAllocateRetryIntervalInMs);
+    config.setPipeTotalFloatingMemoryProportion(originalFloatingMemoryProportion);
+    config.setPipeDataStructureTabletMemoryBlockAllocationRejectThreshold(
+        originalTabletRejectThreshold);
+    config.setPipeDataStructureTsFileMemoryBlockAllocationRejectThreshold(
+        originalTsFileRejectThreshold);
+  }
+
+  @Test
+  public void testTabletResizeLeavesMemoryForSinkForwardProgress() {
+    final PipeMemoryManager manager = new PipeMemoryManager();
+    final long totalNonFloatingMemorySizeInBytes =
+        PipeMemoryManager.getTotalNonFloatingMemorySizeInBytes();
+    final long tabletMemorySizeInBytes =
+        (long)
+                (totalNonFloatingMemorySizeInBytes
+                    * (config.getPipeDataStructureTabletMemoryBlockAllocationRejectThreshold()
+                        + config.getPipeDataStructureTsFileMemoryBlockAllocationRejectThreshold()
+                            / 2))
+            + 1;
+    final long sinkMemorySizeInBytes = totalNonFloatingMemorySizeInBytes / 10;
+    final PipeTabletMemoryBlock retainedTablet =
+        manager.forceAllocateForTabletWithRetry(tabletMemorySizeInBytes);
+    final PipeTabletMemoryBlock pendingTablet = manager.forceAllocateForTabletWithRetry(0);
+    final PipeMemoryBlock sinkBatch = manager.forceAllocate(0);
+
+    try {
+      Assert.assertThrows(
+          PipeRuntimeOutOfMemoryCriticalException.class,
+          () -> manager.forceResize(pendingTablet, 1));
+      Assert.assertEquals(tabletMemorySizeInBytes, manager.getUsedMemorySizeInBytes());
+      Assert.assertEquals(tabletMemorySizeInBytes, manager.getUsedMemorySizeInBytesOfTablets());
+
+      manager.forceResize(sinkBatch, sinkMemorySizeInBytes);
+      Assert.assertEquals(
+          tabletMemorySizeInBytes + sinkMemorySizeInBytes, manager.getUsedMemorySizeInBytes());
+
+      manager.release(retainedTablet);
+      manager.forceResize(pendingTablet, 1);
+      Assert.assertEquals(1, manager.getUsedMemorySizeInBytesOfTablets());
+    } finally {
+      manager.release(retainedTablet);
+      manager.release(pendingTablet);
+      manager.release(sinkBatch);
+    }
+
+    Assert.assertEquals(0, manager.getUsedMemorySizeInBytes());
+  }
+}


### PR DESCRIPTION
## Description

Backport of #18266 to `dev/1.3`.

A realtime Pipe can retain raw tablet events whose zero-sized `PipeTabletMemoryBlock` instances are accounted through `forceResize`. Before this fix, resize checked only remaining non-floating memory and could exhaust the pool, preventing the sink batch from allocating the memory needed to transfer and release those tablets.

This change applies the existing tablet/TsFile hard admission thresholds when a typed data-structure block grows through resize. Normal blocks, including sink batch buffers, keep the existing total-memory check.

The cherry-pick conflict was adapted to the 1.3 memory-manager implementation, which tracks usage through `usedMemorySizeInBytes`. The regression test uses the branch's configured non-floating memory size.

## Tests

```
mvn test -pl iotdb-core/datanode -Dtest=PipeMemoryManagerResizeTest -DforkCount=0 -Dsurefire.forkNumber=0 -Ddevelocity.off=true
```

Result: 1 test run, 0 failures, 0 errors, 0 skipped. Checkstyle, Spotless, main compilation, and test compilation also passed.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the intent of the code.
- [x] added a unit test for the resized-tablet admission path.
