### PR TITLE
[Test] Avoid metadata lease fencing in DataNode unit tests

### DIFF
--- a/iotdb-core/datanode/src/test/resources/iotdb-system.properties
+++ b/iotdb-core/datanode/src/test/resources/iotdb-system.properties
@@ -29,7 +29,7 @@ dn_sync_dir=target/sync
 dn_seed_config_node=127.0.0.1:10710
 
 # Unit tests do not receive ConfigNode heartbeats, so disable the background metadata lease check.
-check_dn_lease_status_interval_ms=9223372036854775807
+metadata_lease_fence_ms=9223372036854775807
 
 udf_lib_dir=target/ext/udf
 trigger_lib_dir=target/ext/trigger

--- a/iotdb-core/datanode/src/test/resources/iotdb-system.properties
+++ b/iotdb-core/datanode/src/test/resources/iotdb-system.properties
@@ -28,6 +28,9 @@ dn_internal_address=0.0.0.0
 dn_sync_dir=target/sync
 dn_seed_config_node=127.0.0.1:10710
 
+# Unit tests do not receive ConfigNode heartbeats, so disable the background metadata lease check.
+check_dn_lease_status_interval_ms=9223372036854775807
+
 udf_lib_dir=target/ext/udf
 trigger_lib_dir=target/ext/trigger
 pipe_lib_dir=target/ext/pipe


### PR DESCRIPTION
## Description

DataNode unit-test JVMs do not receive ConfigNode heartbeats. When a cache-related test class runs for more than the 20-second metadata lease threshold, the singleton `MetadataLeaseManager` fences the local caches and causes unrelated test failures such as `TreeViewTest`.

Configure the DataNode unit-test environment to disable the background metadata lease check. This only changes `src/test/resources`; production and integration-test configurations are unaffected. The metadata lease tests keep their coverage because they use independently constructed managers with injected clocks.

Setting the test-wide check interval avoids duplicating lease recovery setup across every cache test and also protects future unit tests that use the same guarded singletons.

### Verification

- `git diff --check`
- DataNode unit tests on Ubuntu: passed
- DataNode unit tests on Windows: passed

This PR has:
- [x] been self-reviewed.
- [x] added a comment explaining why metadata lease checking is disabled for unit tests.
- [x] updated the shared unit-test configuration to cover existing cache tests.

##### Key changed/added classes (or packages if there are too many classes) in this PR

- `iotdb-core/datanode/src/test/resources/iotdb-system.properties`