### PR TITLE
Remove deprecated-for-removal JDK API usages

### DIFF
--- a/iotdb-core/confignode/src/main/i18n/en/org/apache/iotdb/confignode/i18n/ProcedureMessages.java
+++ b/iotdb-core/confignode/src/main/i18n/en/org/apache/iotdb/confignode/i18n/ProcedureMessages.java
@@ -1213,9 +1213,6 @@ public final class ProcedureMessages {
   public static final String LOG_EXCEPTION_HAPPENED_WORKER_ARG_EXECUTE_PROCEDURE_ARG_6E3AD27D = "Exception happened when worker {} execute procedure {}";
   public static final String LOG_WORKER_STUCK_ARG_ARG_RUN_TIME_ARG_MS_FB612354 = "Worker stuck {}({}), run time {} ms";
   public static final String LOG_PROCEDURE_WORKERS_ARG_RUNNING_ARG_RUNNING_STUCK_1565936D = "Procedure workers: {} is running, {} is running and stuck";
-  public static final String LOG_PROCEDUREEXECUTOR_THREADGROUP_ARG_CONTAINS_RUNNING_THREADS_WHICH_USED_NON_PROCEDURE_BD865211 =
-      "ProcedureExecutor threadGroup {} contains running threads which are used by non-procedure"
-      + " module.";
   public static final String LOG_ADD_PROCEDURE_ARG_AS_ARG_TH_ROLLBACK_STEP_C71B2184 = "Add procedure {} as the {}th rollback step";
   public static final String LOG_STATEMACHINEPROCEDURE_PID_ARG_NOT_SET_NEXT_STATE_BUT_RETURN_HAS_7F93E63F =
       "StateMachineProcedure pid={} not set next state, but return HAS_MORE_STATE. It is likely that"

--- a/iotdb-core/confignode/src/main/i18n/zh/org/apache/iotdb/confignode/i18n/ProcedureMessages.java
+++ b/iotdb-core/confignode/src/main/i18n/zh/org/apache/iotdb/confignode/i18n/ProcedureMessages.java
@@ -1152,9 +1152,6 @@ public final class ProcedureMessages {
       "Worker 卡住 {}({})，运行时间 {} ms";
   public static final String LOG_PROCEDURE_WORKERS_ARG_RUNNING_ARG_RUNNING_STUCK_1565936D =
       "Procedure workers：{} 正在运行，{} 正在运行且卡住";
-  public static final String
-      LOG_PROCEDUREEXECUTOR_THREADGROUP_ARG_CONTAINS_RUNNING_THREADS_WHICH_USED_NON_PROCEDURE_BD865211 =
-          "ProcedureExecutor threadGroup {} 包含被非 procedure 模块使用的运行线程。";
   public static final String LOG_ADD_PROCEDURE_ARG_AS_ARG_TH_ROLLBACK_STEP_C71B2184 =
       "将 procedure {} 添加为第 {} 个回滚步骤";
   public static final String

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
@@ -65,7 +65,8 @@ public class ProcedureExecutor<Env> {
 
   private final ConcurrentHashMap<Long, Procedure<Env>> procedures = new ConcurrentHashMap<>();
 
-  private ThreadGroup threadGroup;
+  private final ThreadGroup threadGroup =
+      new ThreadGroup(ThreadName.CONFIG_NODE_PROCEDURE_WORKER.getName());
 
   private CopyOnWriteArrayList<WorkerThread> workerThreads;
 
@@ -122,7 +123,6 @@ public class ProcedureExecutor<Env> {
   public void init(int numThreads) {
     this.corePoolSize = numThreads;
     this.maxPoolSize = 10 * numThreads;
-    this.threadGroup = new ThreadGroup(ThreadName.CONFIG_NODE_PROCEDURE_WORKER.getName());
     this.timeoutExecutor =
         new TimeoutExecutorThread<>(
             this, threadGroup, ThreadName.CONFIG_NODE_TIMEOUT_EXECUTOR.getName());

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
@@ -1052,15 +1052,6 @@ public class ProcedureExecutor<Env> {
     for (WorkerThread workerThread : workerThreads) {
       workerThread.awaitTermination();
     }
-    try {
-      threadGroup.destroy();
-    } catch (IllegalThreadStateException e) {
-      LOG.warn(
-          ProcedureMessages
-              .LOG_PROCEDUREEXECUTOR_THREADGROUP_ARG_CONTAINS_RUNNING_THREADS_WHICH_USED_NON_PROCEDURE_BD865211,
-          this.threadGroup);
-      this.threadGroup.list();
-    }
   }
 
   public boolean isStarted(long procId) {

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/TestProcedureExecutor.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/TestProcedureExecutor.java
@@ -60,6 +60,19 @@ public class TestProcedureExecutor extends TestProcedureBase {
   }
 
   @Test
+  public void testRestartExecutor() {
+    procExecutor.stop();
+    procExecutor.join();
+
+    procExecutor.init(2);
+    procExecutor.startWorkers();
+
+    long procId = procExecutor.submitProcedure(new NoopProcedure());
+    ProcedureTestUtil.waitForProcedure(procExecutor, procId);
+    Assert.assertTrue(procExecutor.isFinished(procId));
+  }
+
+  @Test
   public void testProcedureFailedDuringSubmissionIsRolledBack() throws InterruptedException {
     TestProcEnv localEnv = new TestProcEnv();
     FailOnFirstUpdateProcedureStore localStore = new FailOnFirstUpdateProcedureStore();

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/IoTThreadFactory.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/concurrent/IoTThreadFactory.java
@@ -31,8 +31,7 @@ public class IoTThreadFactory implements ThreadFactory {
 
   /** Constructor of IoTThreadFactory. */
   public IoTThreadFactory(String poolName) {
-    SecurityManager s = System.getSecurityManager();
-    group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+    group = Thread.currentThread().getThreadGroup();
     // thread pool name format : pool-number-IoTDB-poolName-thread-
     this.namePrefix = "pool-" + poolNumber.getAndIncrement() + "-IoTDB-" + poolName + "-";
   }


### PR DESCRIPTION
## Summary

- replace `SecurityManager`-based thread group selection in `IoTThreadFactory` with the current thread's group
- remove the terminally deprecated `ThreadGroup.destroy()` call after procedure workers have terminated
- reuse one procedure worker `ThreadGroup` for the lifetime of each `ProcedureExecutor`
- add coverage for stopping and restarting the same executor instance
- remove the now-unused English and Chinese log message constants

## Why

JDK 17 reports `SecurityManager`, `System.getSecurityManager()`, and `ThreadGroup.destroy()` as deprecated and marked for removal. These usages produced three removal warnings during compilation and would prevent smooth migration to newer JDK releases.

For normal JDK 17 deployments, the thread factory behavior is unchanged because the previous non-SecurityManager path already selected `Thread.currentThread().getThreadGroup()`.

A ConfigNode keeps one `ProcedureExecutor` instance, but leader transitions repeatedly stop and initialize it. Reusing that executor's thread group preserves the existing named grouping while preventing a new empty group from accumulating after every leadership term now that `ThreadGroup.destroy()` has been removed.

## Validation

- `mvn spotless:apply -pl iotdb-core/node-commons,iotdb-core/confignode`
- English `test-compile` for `node-commons` and `confignode` with `-Xlint:removal`
- Chinese `test-compile` for both modules with `-P with-zh-locale` and `-Xlint:removal`
- `IoTDBThreadPoolFactoryTest`: 7 tests passed
- `TestProcedureExecutor`: 8 tests passed, including same-instance restart
- full workspace `jdeprscan --release 17 --for-removal`: no remaining deprecated-for-removal bytecode references
