### PR TITLE
Remove obsolete DataNode audit log appender

### DIFF
--- a/iotdb-core/datanode/src/assembly/resources/conf/logback-datanode.xml
+++ b/iotdb-core/datanode/src/assembly/resources/conf/logback-datanode.xml
@@ -132,21 +132,6 @@
             <level>INFO</level>
         </filter>
     </appender>
-    <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="AUDIT">
-        <file>${IOTDB_HOME}/logs/log_datanode_audit.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${IOTDB_HOME}/logs/log-datanode-audit-%d{yyyyMMdd}.log.gz</fileNamePattern>
-            <maxHistory>30</maxHistory>
-        </rollingPolicy>
-        <append>true</append>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%d [%t] %-5p %C{25}:%L - %m %n</pattern>
-            <charset>utf-8</charset>
-        </encoder>
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>INFO</level>
-        </filter>
-    </appender>
     <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="QUERY_DEBUG">
         <file>${IOTDB_HOME}/logs/log_datanode_query_debug.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
@@ -235,9 +220,6 @@
     <logger level="info" name="org.apache.iotdb.db.conf"/>
     <logger level="info" name="org.apache.iotdb.db.cost.statistic">
         <appender-ref ref="FILE_COST_MEASURE"/>
-    </logger>
-    <logger level="info" name="IoTDB_AUDIT_LOGGER">
-        <appender-ref ref="AUDIT"/>
     </logger>
     <logger level="info" name="QUERY_DEBUG">
         <appender-ref ref="QUERY_DEBUG"/>

--- a/iotdb-core/datanode/src/test/resources/datanode1conf/logback.xml
+++ b/iotdb-core/datanode/src/test/resources/datanode1conf/logback.xml
@@ -132,21 +132,6 @@
             <level>INFO</level>
         </filter>
     </appender>
-    <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="AUDIT">
-        <file>${IOTDB_HOME}/logs/log_audit.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${IOTDB_HOME}/logs/log-audit-%d{yyyyMMdd}.log.gz</fileNamePattern>
-            <maxHistory>30</maxHistory>
-        </rollingPolicy>
-        <append>true</append>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%d [%t] %-5p %C{25}:%L - %m %n</pattern>
-            <charset>utf-8</charset>
-        </encoder>
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>INFO</level>
-        </filter>
-    </appender>
     <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="QUERY_DEBUG">
         <file>${IOTDB_HOME}/logs/log_query_debug.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
@@ -235,9 +220,6 @@
     <logger level="info" name="org.apache.iotdb.db.conf"/>
     <logger level="info" name="org.apache.iotdb.db.cost.statistic">
         <appender-ref ref="FILE_COST_MEASURE"/>
-    </logger>
-    <logger level="info" name="IoTDB_AUDIT_LOGGER">
-        <appender-ref ref="AUDIT"/>
     </logger>
     <logger level="info" name="QUERY_DEBUG">
         <appender-ref ref="QUERY_DEBUG"/>

--- a/iotdb-core/datanode/src/test/resources/datanode2conf/logback.xml
+++ b/iotdb-core/datanode/src/test/resources/datanode2conf/logback.xml
@@ -132,21 +132,6 @@
             <level>INFO</level>
         </filter>
     </appender>
-    <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="AUDIT">
-        <file>${IOTDB_HOME}/logs/log_audit.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${IOTDB_HOME}/logs/log-audit-%d{yyyyMMdd}.log.gz</fileNamePattern>
-            <maxHistory>30</maxHistory>
-        </rollingPolicy>
-        <append>true</append>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%d [%t] %-5p %C{25}:%L - %m %n</pattern>
-            <charset>utf-8</charset>
-        </encoder>
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>INFO</level>
-        </filter>
-    </appender>
     <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="QUERY_DEBUG">
         <file>${IOTDB_HOME}/logs/log_query_debug.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
@@ -235,9 +220,6 @@
     <logger level="info" name="org.apache.iotdb.db.conf"/>
     <logger level="info" name="org.apache.iotdb.db.cost.statistic">
         <appender-ref ref="FILE_COST_MEASURE"/>
-    </logger>
-    <logger level="info" name="IoTDB_AUDIT_LOGGER">
-        <appender-ref ref="AUDIT"/>
     </logger>
     <logger level="info" name="QUERY_DEBUG">
         <appender-ref ref="QUERY_DEBUG"/>

--- a/iotdb-core/datanode/src/test/resources/datanode3conf/logback.xml
+++ b/iotdb-core/datanode/src/test/resources/datanode3conf/logback.xml
@@ -132,21 +132,6 @@
             <level>INFO</level>
         </filter>
     </appender>
-    <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="AUDIT">
-        <file>${IOTDB_HOME}/logs/log_audit.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${IOTDB_HOME}/logs/log-audit-%d{yyyyMMdd}.log.gz</fileNamePattern>
-            <maxHistory>30</maxHistory>
-        </rollingPolicy>
-        <append>true</append>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%d [%t] %-5p %C{25}:%L - %m %n</pattern>
-            <charset>utf-8</charset>
-        </encoder>
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>INFO</level>
-        </filter>
-    </appender>
     <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="QUERY_DEBUG">
         <file>${IOTDB_HOME}/logs/log_query_debug.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
@@ -235,9 +220,6 @@
     <logger level="info" name="org.apache.iotdb.db.conf"/>
     <logger level="info" name="org.apache.iotdb.db.cost.statistic">
         <appender-ref ref="FILE_COST_MEASURE"/>
-    </logger>
-    <logger level="info" name="IoTDB_AUDIT_LOGGER">
-        <appender-ref ref="AUDIT"/>
     </logger>
     <logger level="info" name="QUERY_DEBUG">
         <appender-ref ref="QUERY_DEBUG"/>

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/IoTDBConstant.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/IoTDBConstant.java
@@ -106,7 +106,6 @@ public class IoTDBConstant {
           : VERSION.split("\\.")[0] + "." + VERSION.split("\\.")[1];
   public static final String VERSION_WITH_BUILD = VERSION + " (Build: " + BUILD_INFO + ")";
 
-  public static final String AUDIT_LOGGER_NAME = "IoTDB_AUDIT_LOGGER";
   public static final String SLOW_SQL_LOGGER_NAME = "SLOW_SQL";
   public static final String SAMPLED_QUERIES_LOGGER_NAME = "SAMPLED_QUERIES";
 


### PR DESCRIPTION
## Description

The DataNode Logback configuration still declares an `AUDIT` rolling file appender that targets `log_datanode_audit.log`, together with the `IoTDB_AUDIT_LOGGER` logger. The audit implementation has already been removed, so there are no remaining Java callers. However, Logback initializes the rolling file appender when the DataNode starts, which creates an unused audit log file.

This PR:

- removes the obsolete audit appender and logger from the production DataNode Logback configuration;
- removes the equivalent configuration from the three DataNode test configurations;
- removes the unused `AUDIT_LOGGER_NAME` constant.

This change only removes the obsolete standalone audit log file output. It does not change the existing audit privilege or authorization behavior.

## Verification

- `mvn spotless:apply -pl iotdb-core/node-commons`
- `mvn compile -pl iotdb-core/node-commons -DskipTests`
- validated all modified Logback XML files with `xmllint`
- confirmed that no audit appender, logger name, or audit log file reference remains in the affected modules

<hr>

This PR has:
- [x] been self-reviewed.

<hr>

##### Key changed files

- `iotdb-core/datanode/src/assembly/resources/conf/logback-datanode.xml`
- `iotdb-core/datanode/src/test/resources/datanode{1,2,3}conf/logback.xml`
- `iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/IoTDBConstant.java`