### PR TITLE
Fix inexact varargs calls

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/schema/IoTDBAlterColumnTypeIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/schema/IoTDBAlterColumnTypeIT.java
@@ -1397,8 +1397,7 @@ public class IoTDBAlterColumnTypeIT {
         standardSelectTest(session, from, to);
         standardAccumulatorQueryTest(session, from);
       } catch (Exception e) {
-        log.error("{}", e.getStackTrace());
-        log.info(e.getMessage());
+        log.error(e.getMessage(), e);
       }
 
       // alter the type to "to"
@@ -1537,8 +1536,7 @@ public class IoTDBAlterColumnTypeIT {
         // Accumulator query test
         standardAccumulatorQueryTest(session, from, newType);
       } catch (Exception e) {
-        log.error("{}", e.getStackTrace());
-        log.info(e.getMessage());
+        log.error(e.getMessage(), e);
       }
 
       if (from == TSDataType.DATE) {
@@ -1607,8 +1605,7 @@ public class IoTDBAlterColumnTypeIT {
         standardSelectTest(session, from, to);
         standardAccumulatorQueryTest(session, from);
       } catch (Exception e) {
-        log.error("{}", e.getStackTrace());
-        log.info(e.getMessage());
+        log.error(e.getMessage(), e);
       }
 
       // alter the type to "to"

--- a/iotdb-client/cli/src/main/i18n/en/org/apache/iotdb/cli/i18n/CliMessages.java
+++ b/iotdb-client/cli/src/main/i18n/en/org/apache/iotdb/cli/i18n/CliMessages.java
@@ -68,6 +68,9 @@ public final class CliMessages {
   public static final String TIMESTAMP_CANNOT_CONVERT = "Timestamp can not convert to %s";
   public static final String BLOB_CANNOT_CONVERT = "Blob can not convert to %s";
   public static final String CANNOT_CONVERT = "%s can not convert to %s";
+  public static final String
+      MESSAGE_INVALID_ARGS_REQUIRED_VALUES_FOR_OPTION_TABLE_NOT_PROVIDED_4BC3FCFA =
+          "Invalid args: Required values for option table not provided.";
 
   private CliMessages() {}
   // ---------------------------------------------------------------------------

--- a/iotdb-client/cli/src/main/i18n/zh/org/apache/iotdb/cli/i18n/CliMessages.java
+++ b/iotdb-client/cli/src/main/i18n/zh/org/apache/iotdb/cli/i18n/CliMessages.java
@@ -68,6 +68,9 @@ public final class CliMessages {
   public static final String TIMESTAMP_CANNOT_CONVERT = "Timestamp 无法转换为 %s";
   public static final String BLOB_CANNOT_CONVERT = "Blob 无法转换为 %s";
   public static final String CANNOT_CONVERT = "%s 无法转换为 %s";
+  public static final String
+      MESSAGE_INVALID_ARGS_REQUIRED_VALUES_FOR_OPTION_TABLE_NOT_PROVIDED_4BC3FCFA =
+          "参数无效：未提供 table 选项的必填值。";
 
   private CliMessages() {}
   // ---------------------------------------------------------------------------

--- a/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/data/ImportData.java
+++ b/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/data/ImportData.java
@@ -333,7 +333,8 @@ public class ImportData extends AbstractDataTool {
     if (!sqlDialectTree
         && Constants.CSV_SUFFIXS.equalsIgnoreCase(fileType)
         && StringUtils.isBlank(table)) {
-      ioTPrinter.println("Invalid args: Required values for option table not provided.");
+      ioTPrinter.println(
+          CliMessages.MESSAGE_INVALID_ARGS_REQUIRED_VALUES_FOR_OPTION_TABLE_NOT_PROVIDED_4BC3FCFA);
       System.exit(Constants.CODE_ERROR);
     }
   }

--- a/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/data/ImportDataTable.java
+++ b/iotdb-client/cli/src/main/java/org/apache/iotdb/tool/data/ImportDataTable.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.tool.data;
 
+import org.apache.iotdb.cli.i18n.CliMessages;
 import org.apache.iotdb.cli.utils.IoTPrinter;
 import org.apache.iotdb.isession.ITableSession;
 import org.apache.iotdb.isession.SessionDataSet;
@@ -134,7 +135,9 @@ public class ImportDataTable extends AbstractImportData {
               }
             }
           } else {
-            ioTPrinter.println(String.format(Constants.TARGET_TABLE_NOT_EXIST_MSG, null));
+            ioTPrinter.println(
+                CliMessages
+                    .MESSAGE_INVALID_ARGS_REQUIRED_VALUES_FOR_OPTION_TABLE_NOT_PROVIDED_4BC3FCFA);
             System.exit(1);
           }
         }


### PR DESCRIPTION
## Summary

- replace the ambiguous `String.format(..., null)` call in table CSV import with a localized missing-table-option message
- reuse the same localized message in the CLI argument validation path
- pass caught exceptions directly to SLF4J in `IoTDBAlterColumnTypeIT` so the complete stack trace is logged

## Why

JDK 17 reported four `non-varargs call of varargs method with inexact argument type` warnings: one in the CLI module and three in integration-test sources.

The CLI call passed `null` ambiguously to `String.format`, producing the awkward message `target table null does not exist`. The integration-test calls passed `StackTraceElement[]` to SLF4J varargs, which treated the array as formatting arguments instead of logging the exception stack trace.

<img width="1682" height="534" alt="image" src="https://github.com/user-attachments/assets/41a4b556-1e12-4d89-b73e-60eb5a07a6a5" />


## Validation

- `mvn spotless:apply -pl iotdb-client/cli`
- `mvn spotless:apply -pl integration-test -P with-integration-tests`
- full English `test-compile` with `-Xlint:all`: build success, no inexact-varargs warnings
- full Chinese locale `test-compile` with `-P with-zh-locale -Xlint:all`: build success, no inexact-varargs warnings
- integration-test `test-compile` with `-P with-integration-tests -Xlint:all`: build success, no inexact-varargs warnings
- `mvn test -pl iotdb-client/cli`: 9 tests passed
