### PR TITLE
[Pipe] Improve timeout diagnostics and DROP PIPE observability

### DIFF
--- a/iotdb-core/confignode/src/main/i18n/en/org/apache/iotdb/confignode/i18n/ConfigNodeMessages.java
+++ b/iotdb-core/confignode/src/main/i18n/en/org/apache/iotdb/confignode/i18n/ConfigNodeMessages.java
@@ -516,15 +516,23 @@ public final class ConfigNodeMessages {
   public static final String FAILED_TO_SET_PIPE_STATUS_BECAUSE = "Failed to set pipe status, because ";
   public static final String FAILED_TO_DROP_PIPE_BECAUSE = "Failed to drop pipe, because ";
   public static final String FAILED_TO_ALTER_PIPE_BECAUSE = "Failed to alter pipe, because ";
+  public static final String EXCEPTION_FAILED_TO_ALTER_PIPE_ARG_THE_PIPE_DOES_NOT_EXIST_29E0DCEB =
+      "Failed to alter pipe %s, the pipe does not exist";
+  public static final String EXCEPTION_FAILED_TO_ALTER_PIPE_ARG_THE_PIPE_IS_BEING_DROPPED_919F1E2B =
+      "Failed to alter pipe %s, the pipe is being dropped";
   public static final String FAILED_TO_CREATE_MULTIPLE_PIPES_BECAUSE = "Failed to create multiple pipes, because ";
   public static final String FAILED_TO_START_PIPE_BECAUSE_PIPE_DOES_NOT_EXIST =
       "Failed to start pipe %s, the pipe does not exist";
   public static final String FAILED_TO_START_PIPE_BECAUSE_PIPE_IS_ALREADY_DROPPED =
       "Failed to start pipe %s, the pipe is already dropped";
+  public static final String EXCEPTION_FAILED_TO_START_PIPE_ARG_THE_PIPE_IS_BEING_DROPPED_B41F4638 =
+      "Failed to start pipe %s, the pipe is being dropped";
   public static final String FAILED_TO_STOP_PIPE_BECAUSE_PIPE_DOES_NOT_EXIST =
       "Failed to stop pipe %s, the pipe does not exist";
   public static final String FAILED_TO_STOP_PIPE_BECAUSE_PIPE_IS_ALREADY_DROPPED =
       "Failed to stop pipe %s, the pipe is already dropped";
+  public static final String EXCEPTION_FAILED_TO_STOP_PIPE_ARG_THE_PIPE_IS_BEING_DROPPED_37AFB22B =
+      "Failed to stop pipe %s, the pipe is being dropped";
   public static final String FAILED_TO_HANDLE_LEADER_CHANGE_BECAUSE = "Failed to handle leader change, because ";
   public static final String FAILED_TO_HANDLE_META_CHANGES_BECAUSE = "Failed to handle meta changes, because ";
   public static final String GET_PIPEPLUGIN_JAR_FAILED_BECAUSE = "Get PipePlugin_Jar failed, because ";

--- a/iotdb-core/confignode/src/main/i18n/en/org/apache/iotdb/confignode/i18n/ManagerMessages.java
+++ b/iotdb-core/confignode/src/main/i18n/en/org/apache/iotdb/confignode/i18n/ManagerMessages.java
@@ -694,5 +694,8 @@ public final class ManagerMessages {
   public static final String MESSAGE_SUBSCRIPTIONOWNERLEASESYNCER_IS_STOPPED_SUCCESSFULLY_11442F29 = "SubscriptionOwnerLeaseSyncer is stopped successfully.";
   public static final String MESSAGE_NO_AVAILABLE_ARG_REGIONGROUP_FOR_DATABASE_ARG_REGIONGROUPS_VISIBLE_IN_PARTITIONINFO_AND_THEIR_LOADCACHE_STATUS_ARG_615F5D49 =
       "No available {} RegionGroup for Database: {}. RegionGroups visible in PartitionInfo and their LoadCache status: {}";
+  public static final String
+      MESSAGE_ARG_PLEASE_MANUALLY_CHECK_LATER_WHETHER_THE_PROCEDURE_IS_EXECUTED_SUCCESSFULLY_A82B739D =
+          "%s Please manually check later whether the procedure is executed successfully.";
 
 }

--- a/iotdb-core/confignode/src/main/i18n/en/org/apache/iotdb/confignode/i18n/ProcedureMessages.java
+++ b/iotdb-core/confignode/src/main/i18n/en/org/apache/iotdb/confignode/i18n/ProcedureMessages.java
@@ -1416,14 +1416,18 @@ public final class ProcedureMessages {
       "waiting to acquire the PipeTaskCoordinator lock because another Pipe operation is holding it.";
   public static final String MESSAGE_WAITING_TO_ACQUIRE_THE_CONFIGNODE_NODE_LOCK_BECAUSE_ANOTHER_NODE_PROCEDURE_IS_HOLDING_IT_56494E86 =
       "waiting to acquire the ConfigNode node lock because another node procedure is holding it.";
+  public static final String MESSAGE_WAITING_TO_ACQUIRE_THE_CONFIGNODE_NODE_LOCK_HELD_BY_ARG_PROCEDUREID_ARG_3F432041 =
+      "waiting to acquire the ConfigNode node lock held by %s (procedureId=%d).";
   public static final String MESSAGE_PIPE_REQUEST_OR_PLUGIN_VALIDATION_HAS_NOT_COMPLETED_A_PLUGIN_CHECK_OR_METADATA_ACCESS_MAY_BE_SLOW_57C36CEF =
       "Pipe request or plugin validation has not completed; a plugin check or metadata access may be slow.";
   public static final String MESSAGE_PIPE_METADATA_CALCULATION_HAS_NOT_COMPLETED_METADATA_ACCESS_OR_LOCAL_CALCULATION_MAY_BE_SLOW_DEBF2504 =
       "Pipe metadata calculation has not completed; metadata access or local calculation may be slow.";
-  public static final String MESSAGE_THE_CONFIGNODE_CONSENSUS_WRITE_HAS_NOT_RETURNED_THE_CONSENSUS_GROUP_MAY_BE_UNAVAILABLE_OR_SLOW_F8911CE7 =
-      "the ConfigNode consensus write has not returned; the consensus group may be unavailable or slow.";
-  public static final String MESSAGE_ONE_OR_MORE_DATANODES_HAVE_NOT_RESPONDED_TO_THE_PIPE_METADATA_PUSH_THEY_MAY_BE_UNAVAILABLE_OR_SLOW_11BBB333 =
-      "one or more DataNodes have not responded to the Pipe metadata push; they may be unavailable or slow.";
+  public static final String MESSAGE_THE_CONFIGNODE_CONSENSUS_WRITE_HAS_NOT_RETURNED_RUN_SHOW_CLUSTER_TO_CHECK_NODE_STATUS_B0A6E1A7 =
+      "the ConfigNode consensus write has not returned; run SHOW CLUSTER to check node status.";
+  public static final String MESSAGE_DATANODES_ARG_HAVE_NOT_RESPONDED_TO_THE_PIPE_METADATA_PUSH_RUN_SHOW_CLUSTER_TO_CHECK_THEIR_STATUS_9C2F806F =
+      "DataNodes %s have not responded to the Pipe metadata push; run SHOW CLUSTER to check their status.";
+  public static final String MESSAGE_THE_PIPE_METADATA_PUSH_HAS_NOT_COMPLETED_RUN_SHOW_CLUSTER_TO_CHECK_DATANODE_STATUS_A8F3F0A0 =
+      "the Pipe metadata push has not completed; run SHOW CLUSTER to check DataNode status.";
   public static final String MESSAGE_THE_PREVIOUS_ATTEMPT_FAILED_WITH_ARG_AND_THIS_STATE_IS_BEING_RETRIED_7A541F27 =
       "the previous attempt failed with '%s' and this state is being retried.";
   public static final String MESSAGE_THE_STATE_FAILED_WITH_ARG_AND_ROLLBACK_IS_PENDING_E7B43829 =

--- a/iotdb-core/confignode/src/main/i18n/en/org/apache/iotdb/confignode/i18n/ProcedureMessages.java
+++ b/iotdb-core/confignode/src/main/i18n/en/org/apache/iotdb/confignode/i18n/ProcedureMessages.java
@@ -1408,4 +1408,28 @@ public final class ProcedureMessages {
   public static final String MESSAGE_UNEXPECTED_DATAPARTITIONTABLEINTEGRITYCHECKPROCEDURESTATE_ARG_WHEN_SHOWING_PROGRESS_D3C07BA1 =
       "Unexpected DataPartitionTableIntegrityCheckProcedureState {} when showing progress";
 
+  public static final String MESSAGE_NO_PROCEDURE_WORKER_IS_CURRENTLY_AVAILABLE_WORKERS_MAY_BE_BUSY_OR_BLOCKED_BY_OTHER_PROCEDURES_AB0B1595 =
+      "no Procedure worker is currently available; workers may be busy or blocked by other procedures.";
+  public static final String MESSAGE_PIPE_OPERATION_ARG_TIMED_OUT_PROCEDUREID_ARG_STUCK_AT_ARG_REASON_ARG_THE_PROCEDURE_IS_STILL_RUNNING_7EEAC50E =
+      "Pipe operation %s timed out (procedureId=%d). Stuck at %s. Reason: %s. The procedure is still running.";
+  public static final String MESSAGE_WAITING_TO_ACQUIRE_THE_PIPETASKCOORDINATOR_LOCK_BECAUSE_ANOTHER_PIPE_OPERATION_IS_HOLDING_IT_25A3B6B8 =
+      "waiting to acquire the PipeTaskCoordinator lock because another Pipe operation is holding it.";
+  public static final String MESSAGE_WAITING_TO_ACQUIRE_THE_CONFIGNODE_NODE_LOCK_BECAUSE_ANOTHER_NODE_PROCEDURE_IS_HOLDING_IT_56494E86 =
+      "waiting to acquire the ConfigNode node lock because another node procedure is holding it.";
+  public static final String MESSAGE_PIPE_REQUEST_OR_PLUGIN_VALIDATION_HAS_NOT_COMPLETED_A_PLUGIN_CHECK_OR_METADATA_ACCESS_MAY_BE_SLOW_57C36CEF =
+      "Pipe request or plugin validation has not completed; a plugin check or metadata access may be slow.";
+  public static final String MESSAGE_PIPE_METADATA_CALCULATION_HAS_NOT_COMPLETED_METADATA_ACCESS_OR_LOCAL_CALCULATION_MAY_BE_SLOW_DEBF2504 =
+      "Pipe metadata calculation has not completed; metadata access or local calculation may be slow.";
+  public static final String MESSAGE_THE_CONFIGNODE_CONSENSUS_WRITE_HAS_NOT_RETURNED_THE_CONSENSUS_GROUP_MAY_BE_UNAVAILABLE_OR_SLOW_F8911CE7 =
+      "the ConfigNode consensus write has not returned; the consensus group may be unavailable or slow.";
+  public static final String MESSAGE_ONE_OR_MORE_DATANODES_HAVE_NOT_RESPONDED_TO_THE_PIPE_METADATA_PUSH_THEY_MAY_BE_UNAVAILABLE_OR_SLOW_11BBB333 =
+      "one or more DataNodes have not responded to the Pipe metadata push; they may be unavailable or slow.";
+  public static final String MESSAGE_THE_PREVIOUS_ATTEMPT_FAILED_WITH_ARG_AND_THIS_STATE_IS_BEING_RETRIED_7A541F27 =
+      "the previous attempt failed with '%s' and this state is being retried.";
+  public static final String MESSAGE_THE_STATE_FAILED_WITH_ARG_AND_ROLLBACK_IS_PENDING_E7B43829 =
+      "the state failed with '%s' and rollback is pending.";
+  public static final String MESSAGE_ROLLING_BACK_AFTER_FAILURE_ARG_474DF456 =
+      "rolling back after failure: %s.";
+  public static final String MESSAGE_ROLLING_BACK_AFTER_AN_EARLIER_FAILURE_850D0AF5 =
+      "rolling back after an earlier failure.";
 }

--- a/iotdb-core/confignode/src/main/i18n/zh/org/apache/iotdb/confignode/i18n/ConfigNodeMessages.java
+++ b/iotdb-core/confignode/src/main/i18n/zh/org/apache/iotdb/confignode/i18n/ConfigNodeMessages.java
@@ -480,15 +480,23 @@ public final class ConfigNodeMessages {
   public static final String FAILED_TO_SET_PIPE_STATUS_BECAUSE = "设置 pipe 状态失败，原因：";
   public static final String FAILED_TO_DROP_PIPE_BECAUSE = "删除 pipe 失败，原因：";
   public static final String FAILED_TO_ALTER_PIPE_BECAUSE = "修改 pipe 失败，原因：";
+  public static final String EXCEPTION_FAILED_TO_ALTER_PIPE_ARG_THE_PIPE_DOES_NOT_EXIST_29E0DCEB =
+      "修改 Pipe %s 失败，该 Pipe 不存在";
+  public static final String EXCEPTION_FAILED_TO_ALTER_PIPE_ARG_THE_PIPE_IS_BEING_DROPPED_919F1E2B =
+      "修改 Pipe %s 失败，该 Pipe 正在被删除";
   public static final String FAILED_TO_CREATE_MULTIPLE_PIPES_BECAUSE = "批量创建 pipe 失败，原因：";
   public static final String FAILED_TO_START_PIPE_BECAUSE_PIPE_DOES_NOT_EXIST =
       "启动 pipe %s 失败，pipe 不存在";
   public static final String FAILED_TO_START_PIPE_BECAUSE_PIPE_IS_ALREADY_DROPPED =
       "启动 pipe %s 失败，pipe 已被删除";
+  public static final String EXCEPTION_FAILED_TO_START_PIPE_ARG_THE_PIPE_IS_BEING_DROPPED_B41F4638 =
+      "启动 Pipe %s 失败，该 Pipe 正在被删除";
   public static final String FAILED_TO_STOP_PIPE_BECAUSE_PIPE_DOES_NOT_EXIST =
       "停止 pipe %s 失败，pipe 不存在";
   public static final String FAILED_TO_STOP_PIPE_BECAUSE_PIPE_IS_ALREADY_DROPPED =
       "停止 pipe %s 失败，pipe 已被删除";
+  public static final String EXCEPTION_FAILED_TO_STOP_PIPE_ARG_THE_PIPE_IS_BEING_DROPPED_37AFB22B =
+      "停止 Pipe %s 失败，该 Pipe 正在被删除";
   public static final String FAILED_TO_HANDLE_LEADER_CHANGE_BECAUSE = "处理 leader 变更失败，原因：";
   public static final String FAILED_TO_HANDLE_META_CHANGES_BECAUSE = "处理元数据变更失败，原因：";
   public static final String GET_PIPEPLUGIN_JAR_FAILED_BECAUSE = "获取 PipePlugin Jar 失败，原因：";

--- a/iotdb-core/confignode/src/main/i18n/zh/org/apache/iotdb/confignode/i18n/ManagerMessages.java
+++ b/iotdb-core/confignode/src/main/i18n/zh/org/apache/iotdb/confignode/i18n/ManagerMessages.java
@@ -673,5 +673,8 @@ public final class ManagerMessages {
   public static final String MESSAGE_SUBSCRIPTIONOWNERLEASESYNCER_IS_STOPPED_SUCCESSFULLY_11442F29 = "SubscriptionOwnerLeaseSyncer 已成功停止。";
   public static final String MESSAGE_NO_AVAILABLE_ARG_REGIONGROUP_FOR_DATABASE_ARG_REGIONGROUPS_VISIBLE_IN_PARTITIONINFO_AND_THEIR_LOADCACHE_STATUS_ARG_615F5D49 =
       "数据库 {} 没有可用的 {} RegionGroup。PartitionInfo 中可见的 RegionGroup 及其 LoadCache 状态：{}";
+  public static final String
+      MESSAGE_ARG_PLEASE_MANUALLY_CHECK_LATER_WHETHER_THE_PROCEDURE_IS_EXECUTED_SUCCESSFULLY_A82B739D =
+          "%s 请稍后手动检查该 Procedure 是否执行成功。";
 
 }

--- a/iotdb-core/confignode/src/main/i18n/zh/org/apache/iotdb/confignode/i18n/ProcedureMessages.java
+++ b/iotdb-core/confignode/src/main/i18n/zh/org/apache/iotdb/confignode/i18n/ProcedureMessages.java
@@ -1484,4 +1484,38 @@ public final class ProcedureMessages {
   public static final String
       MESSAGE_UNEXPECTED_DATAPARTITIONTABLEINTEGRITYCHECKPROCEDURESTATE_ARG_WHEN_SHOWING_PROGRESS_D3C07BA1 =
           "非预期的 DataPartitionTableIntegrityCheckProcedureState {}（显示进度时）";
+  public static final String
+      MESSAGE_PIPE_OPERATION_ARG_TIMED_OUT_PROCEDUREID_ARG_STUCK_AT_ARG_REASON_ARG_THE_PROCEDURE_IS_STILL_RUNNING_7EEAC50E =
+          "Pipe 操作 %s 超时（procedureId=%d）。卡在 %s。原因：%s。该 Procedure 仍在运行。";
+  public static final String
+      MESSAGE_NO_PROCEDURE_WORKER_IS_CURRENTLY_AVAILABLE_WORKERS_MAY_BE_BUSY_OR_BLOCKED_BY_OTHER_PROCEDURES_AB0B1595 =
+          "当前没有可用的 Procedure worker；worker 可能正忙或被其他 Procedure 阻塞。";
+  public static final String
+      MESSAGE_WAITING_TO_ACQUIRE_THE_PIPETASKCOORDINATOR_LOCK_BECAUSE_ANOTHER_PIPE_OPERATION_IS_HOLDING_IT_25A3B6B8 =
+          "正在等待获取 PipeTaskCoordinator 锁，因为另一个 Pipe 操作正在持有该锁。";
+  public static final String
+      MESSAGE_WAITING_TO_ACQUIRE_THE_CONFIGNODE_NODE_LOCK_BECAUSE_ANOTHER_NODE_PROCEDURE_IS_HOLDING_IT_56494E86 =
+          "正在等待获取 ConfigNode 节点锁，因为另一个节点 Procedure 正在持有该锁。";
+  public static final String
+      MESSAGE_PIPE_REQUEST_OR_PLUGIN_VALIDATION_HAS_NOT_COMPLETED_A_PLUGIN_CHECK_OR_METADATA_ACCESS_MAY_BE_SLOW_57C36CEF =
+          "Pipe 请求或插件校验尚未完成；插件检查或元数据访问可能过慢。";
+  public static final String
+      MESSAGE_PIPE_METADATA_CALCULATION_HAS_NOT_COMPLETED_METADATA_ACCESS_OR_LOCAL_CALCULATION_MAY_BE_SLOW_DEBF2504 =
+          "Pipe 元数据计算尚未完成；元数据访问或本地计算可能过慢。";
+  public static final String
+      MESSAGE_THE_CONFIGNODE_CONSENSUS_WRITE_HAS_NOT_RETURNED_THE_CONSENSUS_GROUP_MAY_BE_UNAVAILABLE_OR_SLOW_F8911CE7 =
+          "ConfigNode 共识写尚未返回；共识组可能不可用或响应过慢。";
+  public static final String
+      MESSAGE_ONE_OR_MORE_DATANODES_HAVE_NOT_RESPONDED_TO_THE_PIPE_METADATA_PUSH_THEY_MAY_BE_UNAVAILABLE_OR_SLOW_11BBB333 =
+          "一个或多个 DataNode 尚未响应 Pipe 元数据推送；这些 DataNode 可能不可用或响应过慢。";
+  public static final String
+      MESSAGE_THE_PREVIOUS_ATTEMPT_FAILED_WITH_ARG_AND_THIS_STATE_IS_BEING_RETRIED_7A541F27 =
+          "上一次尝试因“%s”失败，正在重试此状态。";
+  public static final String
+      MESSAGE_THE_STATE_FAILED_WITH_ARG_AND_ROLLBACK_IS_PENDING_E7B43829 =
+          "此状态因“%s”失败，正在等待回滚。";
+  public static final String MESSAGE_ROLLING_BACK_AFTER_FAILURE_ARG_474DF456 =
+      "正在回滚，失败原因：%s。";
+  public static final String MESSAGE_ROLLING_BACK_AFTER_AN_EARLIER_FAILURE_850D0AF5 =
+      "正在回滚此前发生的失败。";
 }

--- a/iotdb-core/confignode/src/main/i18n/zh/org/apache/iotdb/confignode/i18n/ProcedureMessages.java
+++ b/iotdb-core/confignode/src/main/i18n/zh/org/apache/iotdb/confignode/i18n/ProcedureMessages.java
@@ -1497,17 +1497,23 @@ public final class ProcedureMessages {
       MESSAGE_WAITING_TO_ACQUIRE_THE_CONFIGNODE_NODE_LOCK_BECAUSE_ANOTHER_NODE_PROCEDURE_IS_HOLDING_IT_56494E86 =
           "正在等待获取 ConfigNode 节点锁，因为另一个节点 Procedure 正在持有该锁。";
   public static final String
+      MESSAGE_WAITING_TO_ACQUIRE_THE_CONFIGNODE_NODE_LOCK_HELD_BY_ARG_PROCEDUREID_ARG_3F432041 =
+          "正在等待获取由 %s（procedureId=%d）持有的 ConfigNode 节点锁。";
+  public static final String
       MESSAGE_PIPE_REQUEST_OR_PLUGIN_VALIDATION_HAS_NOT_COMPLETED_A_PLUGIN_CHECK_OR_METADATA_ACCESS_MAY_BE_SLOW_57C36CEF =
           "Pipe 请求或插件校验尚未完成；插件检查或元数据访问可能过慢。";
   public static final String
       MESSAGE_PIPE_METADATA_CALCULATION_HAS_NOT_COMPLETED_METADATA_ACCESS_OR_LOCAL_CALCULATION_MAY_BE_SLOW_DEBF2504 =
           "Pipe 元数据计算尚未完成；元数据访问或本地计算可能过慢。";
   public static final String
-      MESSAGE_THE_CONFIGNODE_CONSENSUS_WRITE_HAS_NOT_RETURNED_THE_CONSENSUS_GROUP_MAY_BE_UNAVAILABLE_OR_SLOW_F8911CE7 =
-          "ConfigNode 共识写尚未返回；共识组可能不可用或响应过慢。";
+      MESSAGE_THE_CONFIGNODE_CONSENSUS_WRITE_HAS_NOT_RETURNED_RUN_SHOW_CLUSTER_TO_CHECK_NODE_STATUS_B0A6E1A7 =
+          "ConfigNode 共识写尚未返回；请执行 SHOW CLUSTER 检查节点状态。";
   public static final String
-      MESSAGE_ONE_OR_MORE_DATANODES_HAVE_NOT_RESPONDED_TO_THE_PIPE_METADATA_PUSH_THEY_MAY_BE_UNAVAILABLE_OR_SLOW_11BBB333 =
-          "一个或多个 DataNode 尚未响应 Pipe 元数据推送；这些 DataNode 可能不可用或响应过慢。";
+      MESSAGE_DATANODES_ARG_HAVE_NOT_RESPONDED_TO_THE_PIPE_METADATA_PUSH_RUN_SHOW_CLUSTER_TO_CHECK_THEIR_STATUS_9C2F806F =
+          "DataNode %s 尚未响应 Pipe 元数据推送；请执行 SHOW CLUSTER 检查其状态。";
+  public static final String
+      MESSAGE_THE_PIPE_METADATA_PUSH_HAS_NOT_COMPLETED_RUN_SHOW_CLUSTER_TO_CHECK_DATANODE_STATUS_A8F3F0A0 =
+          "Pipe 元数据推送尚未完成；请执行 SHOW CLUSTER 检查 DataNode 状态。";
   public static final String
       MESSAGE_THE_PREVIOUS_ATTEMPT_FAILED_WITH_ARG_AND_THIS_STATE_IS_BEING_RETRIED_7A541F27 =
           "上一次尝试因“%s”失败，正在重试此状态。";

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
@@ -2265,8 +2265,10 @@ public class ProcedureManager {
 
   private static String wrapTimeoutMessageForPipeProcedure(final TSStatus status) {
     if (isProcedureTimeout(status)) {
-      return status.getMessage()
-          + " Please manually check later whether the procedure is executed successfully.";
+      return String.format(
+          ManagerMessages
+              .MESSAGE_ARG_PLEASE_MANUALLY_CHECK_LATER_WHETHER_THE_PROCEDURE_IS_EXECUTED_SUCCESSFULLY_A82B739D,
+          status.getMessage());
     }
     return status.getMessage();
   }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
@@ -74,6 +74,7 @@ import org.apache.iotdb.confignode.procedure.impl.node.RemoveAINodeProcedure;
 import org.apache.iotdb.confignode.procedure.impl.node.RemoveConfigNodeProcedure;
 import org.apache.iotdb.confignode.procedure.impl.node.RemoveDataNodesProcedure;
 import org.apache.iotdb.confignode.procedure.impl.partition.DataPartitionTableIntegrityCheckProcedure;
+import org.apache.iotdb.confignode.procedure.impl.pipe.AbstractOperatePipeProcedureV2;
 import org.apache.iotdb.confignode.procedure.impl.pipe.plugin.CreatePipePluginProcedure;
 import org.apache.iotdb.confignode.procedure.impl.pipe.plugin.DropPipePluginProcedure;
 import org.apache.iotdb.confignode.procedure.impl.pipe.runtime.PipeHandleLeaderChangeProcedure;
@@ -1661,7 +1662,7 @@ public class ProcedureManager {
         return status;
       } else {
         return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage(), procedure));
       }
     } catch (final Exception e) {
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
@@ -1677,7 +1678,7 @@ public class ProcedureManager {
         return status;
       } else {
         return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage(), procedure));
       }
     } catch (final Exception e) {
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
@@ -1708,7 +1709,7 @@ public class ProcedureManager {
         return status;
       } else {
         return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage(), procedure));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
@@ -1739,7 +1740,7 @@ public class ProcedureManager {
         return status;
       } else {
         return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage(), procedure));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
@@ -1786,7 +1787,7 @@ public class ProcedureManager {
         return status;
       } else {
         return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage(), procedure));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
@@ -2264,6 +2265,13 @@ public class ProcedureManager {
           + " Please manually check later whether the procedure is executed successfully.";
     }
     return message;
+  }
+
+  private static String wrapTimeoutMessageForPipeProcedure(
+      final String message, final AbstractOperatePipeProcedureV2 procedure) {
+    return PROCEDURE_TIMEOUT_MESSAGE.equals(message)
+        ? procedure.getTimeoutDiagnosticMessage()
+        : message;
   }
 
   public static void sleepWithoutInterrupt(final long timeToSleep) {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ProcedureManager.java
@@ -1662,7 +1662,7 @@ public class ProcedureManager {
         return status;
       } else {
         return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage(), procedure));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status, procedure));
       }
     } catch (final Exception e) {
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
@@ -1678,7 +1678,7 @@ public class ProcedureManager {
         return status;
       } else {
         return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage(), procedure));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status, procedure));
       }
     } catch (final Exception e) {
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
@@ -1709,7 +1709,7 @@ public class ProcedureManager {
         return status;
       } else {
         return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage(), procedure));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status, procedure));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
@@ -1740,7 +1740,7 @@ public class ProcedureManager {
         return status;
       } else {
         return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage(), procedure));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status, procedure));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
@@ -1787,7 +1787,7 @@ public class ProcedureManager {
         return status;
       } else {
         return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage(), procedure));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status, procedure));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
@@ -1804,12 +1804,12 @@ public class ProcedureManager {
       return status;
     } else {
       // if time out, optimistically believe that this procedure will execute successfully.
-      if (status.getMessage().equals(PROCEDURE_TIMEOUT_MESSAGE)) {
+      if (isProcedureTimeout(status)) {
         return new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
       }
       // otherwise, some exceptions must have occurred, throw them.
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
-          .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
+          .setMessage(wrapTimeoutMessageForPipeProcedure(status));
     }
   }
 
@@ -1873,7 +1873,7 @@ public class ProcedureManager {
         return status;
       } else {
         return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
@@ -1889,7 +1889,7 @@ public class ProcedureManager {
         return status;
       } else {
         return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.PIPE_ERROR.getStatusCode()).setMessage(e.getMessage());
@@ -1906,7 +1906,7 @@ public class ProcedureManager {
         return status;
       } else {
         return new TSStatus(TSStatusCode.CREATE_TOPIC_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.CREATE_TOPIC_ERROR.getStatusCode())
@@ -1947,7 +1947,7 @@ public class ProcedureManager {
         return status;
       }
       return new TSStatus(TSStatusCode.ALTER_TOPIC_ERROR.getStatusCode())
-          .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
+          .setMessage(wrapTimeoutMessageForPipeProcedure(status));
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.ALTER_TOPIC_ERROR.getStatusCode())
           .setMessage(e.getMessage());
@@ -2043,7 +2043,7 @@ public class ProcedureManager {
         return status;
       } else {
         return new TSStatus(TSStatusCode.DROP_TOPIC_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.DROP_TOPIC_ERROR.getStatusCode()).setMessage(e.getMessage());
@@ -2059,7 +2059,7 @@ public class ProcedureManager {
         return status;
       } else {
         return new TSStatus(TSStatusCode.TOPIC_PUSH_META_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.TOPIC_PUSH_META_ERROR.getStatusCode())
@@ -2076,7 +2076,7 @@ public class ProcedureManager {
         return status;
       } else {
         return new TSStatus(TSStatusCode.CREATE_CONSUMER_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.CREATE_CONSUMER_ERROR.getStatusCode())
@@ -2093,7 +2093,7 @@ public class ProcedureManager {
         return status;
       } else {
         return new TSStatus(TSStatusCode.DROP_CONSUMER_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.DROP_CONSUMER_ERROR.getStatusCode())
@@ -2110,7 +2110,7 @@ public class ProcedureManager {
         return status;
       } else {
         return new TSStatus(TSStatusCode.CONSUMER_PUSH_META_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.CONSUMER_PUSH_META_ERROR.getStatusCode())
@@ -2127,7 +2127,7 @@ public class ProcedureManager {
         return status;
       } else {
         return new TSStatus(TSStatusCode.CONSUMER_PUSH_META_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.CONSUMER_PUSH_META_ERROR.getStatusCode())
@@ -2142,14 +2142,14 @@ public class ProcedureManager {
       TSStatus status = waitingProcedureFinished(procedure);
       if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         return status;
-      } else if (PROCEDURE_TIMEOUT_MESSAGE.equals(status.getMessage())) {
+      } else if (isProcedureTimeout(status)) {
         // we assume that a timeout has occurred in the procedure related to the pipe in the
         // subscription procedure
         return new TSStatus(TSStatusCode.SUBSCRIPTION_PIPE_TIMEOUT_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status));
       } else {
         return new TSStatus(TSStatusCode.SUBSCRIPTION_SUBSCRIBE_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.SUBSCRIPTION_SUBSCRIBE_ERROR.getStatusCode())
@@ -2164,14 +2164,14 @@ public class ProcedureManager {
       TSStatus status = waitingProcedureFinished(procedure);
       if (status.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
         return status;
-      } else if (PROCEDURE_TIMEOUT_MESSAGE.equals(status.getMessage())) {
+      } else if (isProcedureTimeout(status)) {
         // we assume that a timeout has occurred in the procedure related to the pipe in the
         // subscription procedure
         return new TSStatus(TSStatusCode.SUBSCRIPTION_PIPE_TIMEOUT_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status));
       } else {
         return new TSStatus(TSStatusCode.SUBSCRIPTION_UNSUBSCRIBE_ERROR.getStatusCode())
-            .setMessage(wrapTimeoutMessageForPipeProcedure(status.getMessage()));
+            .setMessage(wrapTimeoutMessageForPipeProcedure(status));
       }
     } catch (Exception e) {
       return new TSStatus(TSStatusCode.SUBSCRIPTION_UNSUBSCRIBE_ERROR.getStatusCode())
@@ -2229,7 +2229,7 @@ public class ProcedureManager {
     if (!procedure.isFinished()) {
       // The procedure is still executing
       status =
-          RpcUtils.getStatus(TSStatusCode.OVERLAP_WITH_EXISTING_TASK, PROCEDURE_TIMEOUT_MESSAGE);
+          RpcUtils.getStatus(TSStatusCode.INTERNAL_REQUEST_TIME_OUT, PROCEDURE_TIMEOUT_MESSAGE);
     } else {
       if (procedure.isSuccess()) {
         if (procedure.getResult() != null) {
@@ -2259,19 +2259,23 @@ public class ProcedureManager {
     return status;
   }
 
-  private static String wrapTimeoutMessageForPipeProcedure(String message) {
-    if (message.equals(PROCEDURE_TIMEOUT_MESSAGE)) {
-      return message
+  private static boolean isProcedureTimeout(final TSStatus status) {
+    return status.getCode() == TSStatusCode.INTERNAL_REQUEST_TIME_OUT.getStatusCode();
+  }
+
+  private static String wrapTimeoutMessageForPipeProcedure(final TSStatus status) {
+    if (isProcedureTimeout(status)) {
+      return status.getMessage()
           + " Please manually check later whether the procedure is executed successfully.";
     }
-    return message;
+    return status.getMessage();
   }
 
   private static String wrapTimeoutMessageForPipeProcedure(
-      final String message, final AbstractOperatePipeProcedureV2 procedure) {
-    return PROCEDURE_TIMEOUT_MESSAGE.equals(message)
+      final TSStatus status, final AbstractOperatePipeProcedureV2 procedure) {
+    return isProcedureTimeout(status)
         ? procedure.getTimeoutDiagnosticMessage()
-        : message;
+        : status.getMessage();
   }
 
   public static void sleepWithoutInterrupt(final long timeToSleep) {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/coordinator/runtime/heartbeat/PipeHeartbeatParser.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/coordinator/runtime/heartbeat/PipeHeartbeatParser.java
@@ -142,6 +142,11 @@ public class PipeHeartbeatParser {
       final int nodeId,
       final PipeHeartbeat pipeHeartbeat) {
     for (final PipeMeta pipeMetaFromCoordinator : pipeTaskInfo.get().getPipeMetaList()) {
+      if (PipeStatus.PRE_DELETE.equals(
+          pipeMetaFromCoordinator.getRuntimeMeta().getStatus().get())) {
+        continue;
+      }
+
       final PipeStaticMeta staticMeta = pipeMetaFromCoordinator.getStaticMeta();
       final PipeMeta pipeMetaFromAgent = pipeHeartbeat.getPipeMeta(staticMeta);
       if (pipeMetaFromAgent == null) {
@@ -292,6 +297,9 @@ public class PipeHeartbeatParser {
                         }
 
                         final PipeRuntimeMeta runtimeMeta = pipeMeta.getRuntimeMeta();
+                        if (PipeStatus.PRE_DELETE.equals(runtimeMeta.getStatus().get())) {
+                          return;
+                        }
                         if (!runtimeMeta.getStatus().get().equals(PipeStatus.STOPPED)) {
                           // Record the connector exception for each pipe affected
                           Map<Integer, PipeRuntimeException> exceptionMap =

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipeTaskInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipeTaskInfo.java
@@ -224,7 +224,9 @@ public class PipeTaskInfo implements SnapshotProcessor {
 
   private void checkAndUpdateRequestBeforeAlterPipeInternal(final TAlterPipeReq alterPipeRequest)
       throws PipeException {
-    if (!isPipeExisted(alterPipeRequest.getPipeName(), alterPipeRequest.isTableModel)) {
+    if (!isPipeExisted(alterPipeRequest.getPipeName(), alterPipeRequest.isTableModel)
+        || PipeStatus.PRE_DELETE.equals(
+            getPipeStatus(alterPipeRequest.getPipeName(), alterPipeRequest.isTableModel))) {
       final String exceptionMessage =
           String.format(
               "Failed to alter pipe %s, %s", alterPipeRequest.getPipeName(), PIPE_NOT_EXIST_MSG);
@@ -365,7 +367,7 @@ public class PipeTaskInfo implements SnapshotProcessor {
     }
 
     final PipeStatus pipeStatus = getPipeStatus(pipeName);
-    if (pipeStatus == PipeStatus.DROPPED) {
+    if (pipeStatus == PipeStatus.DROPPED || pipeStatus == PipeStatus.PRE_DELETE) {
       final String exceptionMessage =
           String.format(
               ConfigNodeMessages.FAILED_TO_START_PIPE_BECAUSE_PIPE_IS_ALREADY_DROPPED, pipeName);
@@ -385,7 +387,7 @@ public class PipeTaskInfo implements SnapshotProcessor {
     }
 
     final PipeStatus pipeStatus = getPipeStatus(pipeName, isTableModel);
-    if (pipeStatus == PipeStatus.DROPPED) {
+    if (pipeStatus == PipeStatus.DROPPED || pipeStatus == PipeStatus.PRE_DELETE) {
       final String exceptionMessage =
           String.format(
               ConfigNodeMessages.FAILED_TO_START_PIPE_BECAUSE_PIPE_IS_ALREADY_DROPPED, pipeName);
@@ -423,7 +425,7 @@ public class PipeTaskInfo implements SnapshotProcessor {
     }
 
     final PipeStatus pipeStatus = getPipeStatus(pipeName);
-    if (pipeStatus == PipeStatus.DROPPED) {
+    if (pipeStatus == PipeStatus.DROPPED || pipeStatus == PipeStatus.PRE_DELETE) {
       final String exceptionMessage =
           String.format(
               ConfigNodeMessages.FAILED_TO_STOP_PIPE_BECAUSE_PIPE_IS_ALREADY_DROPPED, pipeName);
@@ -443,7 +445,7 @@ public class PipeTaskInfo implements SnapshotProcessor {
     }
 
     final PipeStatus pipeStatus = getPipeStatus(pipeName, isTableModel);
-    if (pipeStatus == PipeStatus.DROPPED) {
+    if (pipeStatus == PipeStatus.DROPPED || pipeStatus == PipeStatus.PRE_DELETE) {
       final String exceptionMessage =
           String.format(
               ConfigNodeMessages.FAILED_TO_STOP_PIPE_BECAUSE_PIPE_IS_ALREADY_DROPPED, pipeName);
@@ -1125,6 +1127,10 @@ public class PipeTaskInfo implements SnapshotProcessor {
 
           final PipeRuntimeMeta runtimeMeta = pipeMeta.getRuntimeMeta();
 
+          if (PipeStatus.PRE_DELETE.equals(runtimeMeta.getStatus().get())) {
+            continue;
+          }
+
           // Keep user-stopped pipes out of the auto-restart flow. Otherwise, a failed STOPPED meta
           // sync can turn a manually stopped pipe into a runtime-stopped one and the next
           // PipeMetaSyncer round will restart it automatically.
@@ -1177,7 +1183,8 @@ public class PipeTaskInfo implements SnapshotProcessor {
         .forEach(
             pipeMeta -> {
               final PipeRuntimeMeta runtimeMeta = pipeMeta.getRuntimeMeta();
-              if (runtimeMeta.getIsStoppedByRuntimeException()) {
+              if (!PipeStatus.PRE_DELETE.equals(runtimeMeta.getStatus().get())
+                  && runtimeMeta.getIsStoppedByRuntimeException()) {
                 runtimeMeta.setExceptionsClearTime(exceptionsClearTime);
                 runtimeMeta.getStatus().set(PipeStatus.RUNNING);
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipeTaskInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/pipe/PipeTaskInfo.java
@@ -90,7 +90,6 @@ import java.util.stream.StreamSupport;
 
 import static org.apache.iotdb.commons.pipe.agent.plugin.builtin.BuiltinPipePlugin.IOTDB_THRIFT_CONNECTOR;
 import static org.apache.iotdb.commons.pipe.config.constant.PipeRPCMessageConstant.PIPE_ALREADY_EXIST_MSG;
-import static org.apache.iotdb.commons.pipe.config.constant.PipeRPCMessageConstant.PIPE_NOT_EXIST_MSG;
 
 public class PipeTaskInfo implements SnapshotProcessor {
 
@@ -224,12 +223,22 @@ public class PipeTaskInfo implements SnapshotProcessor {
 
   private void checkAndUpdateRequestBeforeAlterPipeInternal(final TAlterPipeReq alterPipeRequest)
       throws PipeException {
-    if (!isPipeExisted(alterPipeRequest.getPipeName(), alterPipeRequest.isTableModel)
-        || PipeStatus.PRE_DELETE.equals(
-            getPipeStatus(alterPipeRequest.getPipeName(), alterPipeRequest.isTableModel))) {
+    if (!isPipeExisted(alterPipeRequest.getPipeName(), alterPipeRequest.isTableModel)) {
       final String exceptionMessage =
           String.format(
-              "Failed to alter pipe %s, %s", alterPipeRequest.getPipeName(), PIPE_NOT_EXIST_MSG);
+              ConfigNodeMessages
+                  .EXCEPTION_FAILED_TO_ALTER_PIPE_ARG_THE_PIPE_DOES_NOT_EXIST_29E0DCEB,
+              alterPipeRequest.getPipeName());
+      LOGGER.info(exceptionMessage);
+      throw new PipeException(exceptionMessage);
+    }
+    if (PipeStatus.PRE_DELETE.equals(
+        getPipeStatus(alterPipeRequest.getPipeName(), alterPipeRequest.isTableModel))) {
+      final String exceptionMessage =
+          String.format(
+              ConfigNodeMessages
+                  .EXCEPTION_FAILED_TO_ALTER_PIPE_ARG_THE_PIPE_IS_BEING_DROPPED_919F1E2B,
+              alterPipeRequest.getPipeName());
       LOGGER.info(exceptionMessage);
       throw new PipeException(exceptionMessage);
     }
@@ -367,10 +376,19 @@ public class PipeTaskInfo implements SnapshotProcessor {
     }
 
     final PipeStatus pipeStatus = getPipeStatus(pipeName);
-    if (pipeStatus == PipeStatus.DROPPED || pipeStatus == PipeStatus.PRE_DELETE) {
+    if (pipeStatus == PipeStatus.DROPPED) {
       final String exceptionMessage =
           String.format(
               ConfigNodeMessages.FAILED_TO_START_PIPE_BECAUSE_PIPE_IS_ALREADY_DROPPED, pipeName);
+      LOGGER.warn(exceptionMessage);
+      throw new PipeException(exceptionMessage);
+    }
+    if (pipeStatus == PipeStatus.PRE_DELETE) {
+      final String exceptionMessage =
+          String.format(
+              ConfigNodeMessages
+                  .EXCEPTION_FAILED_TO_START_PIPE_ARG_THE_PIPE_IS_BEING_DROPPED_B41F4638,
+              pipeName);
       LOGGER.warn(exceptionMessage);
       throw new PipeException(exceptionMessage);
     }
@@ -387,10 +405,19 @@ public class PipeTaskInfo implements SnapshotProcessor {
     }
 
     final PipeStatus pipeStatus = getPipeStatus(pipeName, isTableModel);
-    if (pipeStatus == PipeStatus.DROPPED || pipeStatus == PipeStatus.PRE_DELETE) {
+    if (pipeStatus == PipeStatus.DROPPED) {
       final String exceptionMessage =
           String.format(
               ConfigNodeMessages.FAILED_TO_START_PIPE_BECAUSE_PIPE_IS_ALREADY_DROPPED, pipeName);
+      LOGGER.warn(exceptionMessage);
+      throw new PipeException(exceptionMessage);
+    }
+    if (pipeStatus == PipeStatus.PRE_DELETE) {
+      final String exceptionMessage =
+          String.format(
+              ConfigNodeMessages
+                  .EXCEPTION_FAILED_TO_START_PIPE_ARG_THE_PIPE_IS_BEING_DROPPED_B41F4638,
+              pipeName);
       LOGGER.warn(exceptionMessage);
       throw new PipeException(exceptionMessage);
     }
@@ -425,10 +452,19 @@ public class PipeTaskInfo implements SnapshotProcessor {
     }
 
     final PipeStatus pipeStatus = getPipeStatus(pipeName);
-    if (pipeStatus == PipeStatus.DROPPED || pipeStatus == PipeStatus.PRE_DELETE) {
+    if (pipeStatus == PipeStatus.DROPPED) {
       final String exceptionMessage =
           String.format(
               ConfigNodeMessages.FAILED_TO_STOP_PIPE_BECAUSE_PIPE_IS_ALREADY_DROPPED, pipeName);
+      LOGGER.warn(exceptionMessage);
+      throw new PipeException(exceptionMessage);
+    }
+    if (pipeStatus == PipeStatus.PRE_DELETE) {
+      final String exceptionMessage =
+          String.format(
+              ConfigNodeMessages
+                  .EXCEPTION_FAILED_TO_STOP_PIPE_ARG_THE_PIPE_IS_BEING_DROPPED_37AFB22B,
+              pipeName);
       LOGGER.warn(exceptionMessage);
       throw new PipeException(exceptionMessage);
     }
@@ -445,10 +481,19 @@ public class PipeTaskInfo implements SnapshotProcessor {
     }
 
     final PipeStatus pipeStatus = getPipeStatus(pipeName, isTableModel);
-    if (pipeStatus == PipeStatus.DROPPED || pipeStatus == PipeStatus.PRE_DELETE) {
+    if (pipeStatus == PipeStatus.DROPPED) {
       final String exceptionMessage =
           String.format(
               ConfigNodeMessages.FAILED_TO_STOP_PIPE_BECAUSE_PIPE_IS_ALREADY_DROPPED, pipeName);
+      LOGGER.warn(exceptionMessage);
+      throw new PipeException(exceptionMessage);
+    }
+    if (pipeStatus == PipeStatus.PRE_DELETE) {
+      final String exceptionMessage =
+          String.format(
+              ConfigNodeMessages
+                  .EXCEPTION_FAILED_TO_STOP_PIPE_ARG_THE_PIPE_IS_BEING_DROPPED_37AFB22B,
+              pipeName);
       LOGGER.warn(exceptionMessage);
       throw new PipeException(exceptionMessage);
     }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/env/ConfigNodeProcedureEnv.java
@@ -97,6 +97,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -104,6 +105,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class ConfigNodeProcedureEnv {
@@ -111,6 +113,7 @@ public class ConfigNodeProcedureEnv {
   private static final Logger LOG = LoggerFactory.getLogger(ConfigNodeProcedureEnv.class);
 
   private static final int RUNTIME_META_PUSH_RETRY_NUM = 1;
+  private static final Consumer<Set<Integer>> NO_OP_PENDING_DATA_NODE_TRACKER = ignored -> {};
 
   /** Add or remove node lock. */
   private final LockQueue nodeLock = new LockQueue();
@@ -615,6 +618,11 @@ public class ConfigNodeProcedureEnv {
 
   public Map<Integer, TPushPipeMetaResp> pushAllPipeMetaToDataNodes(
       List<ByteBuffer> pipeMetaBinaryList) {
+    return pushAllPipeMetaToDataNodes(pipeMetaBinaryList, NO_OP_PENDING_DATA_NODE_TRACKER);
+  }
+
+  public Map<Integer, TPushPipeMetaResp> pushAllPipeMetaToDataNodes(
+      List<ByteBuffer> pipeMetaBinaryList, final Consumer<Set<Integer>> pendingDataNodeTracker) {
     final Map<Integer, TDataNodeLocation> dataNodeLocationMap =
         configManager.getNodeManager().getRegisteredDataNodeLocations();
     final TPushPipeMetaReq request = new TPushPipeMetaReq().setPipeMetas(pipeMetaBinaryList);
@@ -623,13 +631,17 @@ public class ConfigNodeProcedureEnv {
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.PIPE_PUSH_ALL_META, request, dataNodeLocationMap);
     final long timeoutInMs = getRequiredPipeMetadataRequestTimeoutInMs();
-    sendRequiredMetadataRequest(clientHandler, timeoutInMs);
-    fillMissingPipePushMetaResponses(clientHandler, timeoutInMs);
-    return clientHandler.getResponseMap();
+    return sendPipeMetaRequest(clientHandler, timeoutInMs, false, pendingDataNodeTracker);
   }
 
   public Map<Integer, TPushPipeMetaResp> pushAllPipeMetaToDataNodesBestEffort(
       List<ByteBuffer> pipeMetaBinaryList) {
+    return pushAllPipeMetaToDataNodesBestEffort(
+        pipeMetaBinaryList, NO_OP_PENDING_DATA_NODE_TRACKER);
+  }
+
+  public Map<Integer, TPushPipeMetaResp> pushAllPipeMetaToDataNodesBestEffort(
+      List<ByteBuffer> pipeMetaBinaryList, final Consumer<Set<Integer>> pendingDataNodeTracker) {
     final Map<Integer, TDataNodeLocation> dataNodeLocationMap =
         configManager.getNodeManager().getRegisteredDataNodeLocations();
     final TPushPipeMetaReq request = new TPushPipeMetaReq().setPipeMetas(pipeMetaBinaryList);
@@ -637,12 +649,16 @@ public class ConfigNodeProcedureEnv {
     final DataNodeAsyncRequestContext<TPushPipeMetaReq, TPushPipeMetaResp> clientHandler =
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.PIPE_PUSH_ALL_META, request, dataNodeLocationMap);
-    final long timeoutInMs = sendBestEffortRuntimeMetaRequest(clientHandler);
-    fillMissingPipePushMetaResponses(clientHandler, timeoutInMs);
-    return clientHandler.getResponseMap();
+    return sendPipeMetaRequest(
+        clientHandler, getRuntimeMetaPushTimeoutInMs(), true, pendingDataNodeTracker);
   }
 
   public Map<Integer, TPushPipeMetaResp> pushSinglePipeMetaToDataNodes(ByteBuffer pipeMetaBinary) {
+    return pushSinglePipeMetaToDataNodes(pipeMetaBinary, NO_OP_PENDING_DATA_NODE_TRACKER);
+  }
+
+  public Map<Integer, TPushPipeMetaResp> pushSinglePipeMetaToDataNodes(
+      ByteBuffer pipeMetaBinary, final Consumer<Set<Integer>> pendingDataNodeTracker) {
     final Map<Integer, TDataNodeLocation> dataNodeLocationMap =
         configManager.getNodeManager().getRegisteredDataNodeLocations();
     final TPushSinglePipeMetaReq request = new TPushSinglePipeMetaReq().setPipeMeta(pipeMetaBinary);
@@ -651,12 +667,15 @@ public class ConfigNodeProcedureEnv {
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.PIPE_PUSH_SINGLE_META, request, dataNodeLocationMap);
     final long timeoutInMs = getRequiredPipeMetadataRequestTimeoutInMs();
-    sendRequiredMetadataRequest(clientHandler, timeoutInMs);
-    fillMissingPipePushMetaResponses(clientHandler, timeoutInMs);
-    return clientHandler.getResponseMap();
+    return sendPipeMetaRequest(clientHandler, timeoutInMs, false, pendingDataNodeTracker);
   }
 
   public Map<Integer, TPushPipeMetaResp> dropSinglePipeOnDataNodes(String pipeNameToDrop) {
+    return dropSinglePipeOnDataNodes(pipeNameToDrop, NO_OP_PENDING_DATA_NODE_TRACKER);
+  }
+
+  public Map<Integer, TPushPipeMetaResp> dropSinglePipeOnDataNodes(
+      String pipeNameToDrop, final Consumer<Set<Integer>> pendingDataNodeTracker) {
     final Map<Integer, TDataNodeLocation> dataNodeLocationMap =
         configManager.getNodeManager().getRegisteredDataNodeLocations();
     final TPushSinglePipeMetaReq request =
@@ -666,13 +685,16 @@ public class ConfigNodeProcedureEnv {
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.PIPE_PUSH_SINGLE_META, request, dataNodeLocationMap);
     final long timeoutInMs = getRequiredPipeMetadataRequestTimeoutInMs();
-    sendRequiredMetadataRequest(clientHandler, timeoutInMs);
-    fillMissingPipePushMetaResponses(clientHandler, timeoutInMs);
-    return clientHandler.getResponseMap();
+    return sendPipeMetaRequest(clientHandler, timeoutInMs, false, pendingDataNodeTracker);
   }
 
   public Map<Integer, TPushPipeMetaResp> pushMultiPipeMetaToDataNodes(
       List<ByteBuffer> pipeMetaBinaryList) {
+    return pushMultiPipeMetaToDataNodes(pipeMetaBinaryList, NO_OP_PENDING_DATA_NODE_TRACKER);
+  }
+
+  public Map<Integer, TPushPipeMetaResp> pushMultiPipeMetaToDataNodes(
+      List<ByteBuffer> pipeMetaBinaryList, final Consumer<Set<Integer>> pendingDataNodeTracker) {
     final Map<Integer, TDataNodeLocation> dataNodeLocationMap =
         configManager.getNodeManager().getRegisteredDataNodeLocations();
     final TPushMultiPipeMetaReq request =
@@ -682,9 +704,7 @@ public class ConfigNodeProcedureEnv {
         new DataNodeAsyncRequestContext<>(
             CnToDnAsyncRequestType.PIPE_PUSH_MULTI_META, request, dataNodeLocationMap);
     final long timeoutInMs = getRequiredPipeMetadataRequestTimeoutInMs();
-    sendRequiredMetadataRequest(clientHandler, timeoutInMs);
-    fillMissingPipePushMetaResponses(clientHandler, timeoutInMs);
-    return clientHandler.getResponseMap();
+    return sendPipeMetaRequest(clientHandler, timeoutInMs, false, pendingDataNodeTracker);
   }
 
   public Map<Integer, TPushPipeMetaResp> dropMultiPipeOnDataNodes(List<String> pipeNamesToDrop) {
@@ -971,6 +991,22 @@ public class ConfigNodeProcedureEnv {
     return dataNodeId >= 0
         && getLoadManager().getNodeStatus(dataNodeId) != NodeStatus.Unknown
         && getLoadManager().getNodeStatus(dataNodeId) != NodeStatus.Removing;
+  }
+
+  private static Map<Integer, TPushPipeMetaResp> sendPipeMetaRequest(
+      final DataNodeAsyncRequestContext<?, TPushPipeMetaResp> clientHandler,
+      final long timeoutInMs,
+      final boolean keepSilent,
+      final Consumer<Set<Integer>> pendingDataNodeTracker) {
+    pendingDataNodeTracker.accept(
+        Collections.unmodifiableSet(clientHandler.getNodeLocationMap().keySet()));
+    try {
+      sendRuntimeMetaRequest(clientHandler, keepSilent, timeoutInMs);
+      fillMissingPipePushMetaResponses(clientHandler, timeoutInMs);
+      return clientHandler.getResponseMap();
+    } finally {
+      pendingDataNodeTracker.accept(Collections.emptySet());
+    }
   }
 
   private static long sendBestEffortRuntimeMetaRequest(

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/StateMachineProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/StateMachineProcedure.java
@@ -133,6 +133,17 @@ public abstract class StateMachineProcedure<Env, TState> extends Procedure<Env> 
   }
 
   /**
+   * Returns whether the specified state is already present in the persisted state history.
+   *
+   * <p>The current state is included once it has been scheduled. This is useful when an append-only
+   * state is added to a procedure and the new execution path needs to coexist with procedures
+   * persisted by an older version.
+   */
+  protected final boolean hasReachedState(final TState state) {
+    return states.contains(getStateId(state));
+  }
+
+  /**
    * Add a child procedure to execute.
    *
    * @param childProcedure the child procedure

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/AbstractOperatePipeProcedureV2.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/AbstractOperatePipeProcedureV2.java
@@ -227,6 +227,16 @@ public abstract class AbstractOperatePipeProcedureV2
   /** Execute at state {@link OperatePipeTaskState#CALCULATE_INFO_FOR_TASK}. */
   public abstract void executeFromCalculateInfoForTask(ConfigNodeProcedureEnv env);
 
+  /** Whether this procedure uses the append-only {@link OperatePipeTaskState#PRE_DELETE} state. */
+  protected boolean shouldExecutePreDeleteState() {
+    return false;
+  }
+
+  /** Execute at state {@link OperatePipeTaskState#PRE_DELETE}. */
+  public void executeFromPreDelete(ConfigNodeProcedureEnv env) {
+    // Do nothing by default
+  }
+
   /**
    * Execute at state {@link OperatePipeTaskState#WRITE_CONFIG_NODE_CONSENSUS}.
    *
@@ -272,14 +282,29 @@ public abstract class AbstractOperatePipeProcedureV2
           break;
         case CALCULATE_INFO_FOR_TASK:
           executeFromCalculateInfoForTask(env);
-          setNextState(OperatePipeTaskState.WRITE_CONFIG_NODE_CONSENSUS);
+          setNextState(
+              shouldExecutePreDeleteState()
+                  ? OperatePipeTaskState.PRE_DELETE
+                  : OperatePipeTaskState.WRITE_CONFIG_NODE_CONSENSUS);
+          break;
+        case PRE_DELETE:
+          executeFromPreDelete(env);
+          setNextState(OperatePipeTaskState.OPERATE_ON_DATA_NODES);
           break;
         case WRITE_CONFIG_NODE_CONSENSUS:
           executeFromWriteConfigNodeConsensus(env);
+          if (shouldExecutePreDeleteState() && hasReachedState(OperatePipeTaskState.PRE_DELETE)) {
+            lastExecutionExceptionMessage = null;
+            return Flow.NO_MORE_STATE;
+          }
           setNextState(OperatePipeTaskState.OPERATE_ON_DATA_NODES);
           break;
         case OPERATE_ON_DATA_NODES:
           executeFromOperateOnDataNodes(env);
+          if (shouldExecutePreDeleteState() && hasReachedState(OperatePipeTaskState.PRE_DELETE)) {
+            setNextState(OperatePipeTaskState.WRITE_CONFIG_NODE_CONSENSUS);
+            break;
+          }
           lastExecutionExceptionMessage = null;
           return Flow.NO_MORE_STATE;
         default:
@@ -369,6 +394,9 @@ public abstract class AbstractOperatePipeProcedureV2
               e);
         }
         break;
+      case PRE_DELETE:
+        rollbackFromPreDelete(env);
+        break;
       case WRITE_CONFIG_NODE_CONSENSUS:
         try {
           // rollbackFromWriteConfigNodeConsensus can be called before
@@ -409,6 +437,10 @@ public abstract class AbstractOperatePipeProcedureV2
   public abstract void rollbackFromValidateTask(ConfigNodeProcedureEnv env);
 
   public abstract void rollbackFromCalculateInfoForTask(ConfigNodeProcedureEnv env);
+
+  public void rollbackFromPreDelete(ConfigNodeProcedureEnv env) {
+    // Do nothing by default
+  }
 
   public abstract void rollbackFromWriteConfigNodeConsensus(ConfigNodeProcedureEnv env);
 
@@ -477,6 +509,7 @@ public abstract class AbstractOperatePipeProcedureV2
       case CALCULATE_INFO_FOR_TASK:
         return ProcedureMessages
             .MESSAGE_PIPE_METADATA_CALCULATION_HAS_NOT_COMPLETED_METADATA_ACCESS_OR_LOCAL_CALCULATION_MAY_BE_SLOW_DEBF2504;
+      case PRE_DELETE:
       case WRITE_CONFIG_NODE_CONSENSUS:
         return ProcedureMessages
             .MESSAGE_THE_CONFIGNODE_CONSENSUS_WRITE_HAS_NOT_RETURNED_THE_CONSENSUS_GROUP_MAY_BE_UNAVAILABLE_OR_SLOW_F8911CE7;
@@ -520,6 +553,12 @@ public abstract class AbstractOperatePipeProcedureV2
                 ? PipeProcedureExecutionStage.ROLLBACK_CALCULATE_INFO_FOR_TASK
                 : PipeProcedureExecutionStage.CALCULATE_INFO_FOR_TASK;
         break;
+      case PRE_DELETE:
+        executionStage =
+            isRollback
+                ? PipeProcedureExecutionStage.ROLLBACK_PRE_DELETE
+                : PipeProcedureExecutionStage.PRE_DELETE;
+        break;
       case WRITE_CONFIG_NODE_CONSENSUS:
         executionStage =
             isRollback
@@ -544,10 +583,12 @@ public abstract class AbstractOperatePipeProcedureV2
     WAITING_FOR_NODE_LOCK,
     VALIDATE_TASK,
     CALCULATE_INFO_FOR_TASK,
+    PRE_DELETE,
     WRITE_CONFIG_NODE_CONSENSUS,
     OPERATE_ON_DATA_NODES,
     ROLLBACK_VALIDATE_TASK(true),
     ROLLBACK_CALCULATE_INFO_FOR_TASK(true),
+    ROLLBACK_PRE_DELETE(true),
     ROLLBACK_WRITE_CONFIG_NODE_CONSENSUS(true),
     ROLLBACK_OPERATE_ON_DATA_NODES(true);
 

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/AbstractOperatePipeProcedureV2.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/AbstractOperatePipeProcedureV2.java
@@ -27,6 +27,7 @@ import org.apache.iotdb.commons.pipe.config.constant.SystemConstant;
 import org.apache.iotdb.confignode.i18n.ProcedureMessages;
 import org.apache.iotdb.confignode.manager.pipe.metric.overview.PipeProcedureMetrics;
 import org.apache.iotdb.confignode.persistence.pipe.PipeTaskInfo;
+import org.apache.iotdb.confignode.procedure.Procedure;
 import org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv;
 import org.apache.iotdb.confignode.procedure.exception.ProcedureException;
 import org.apache.iotdb.confignode.procedure.impl.node.AbstractNodeProcedure;
@@ -53,6 +54,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -108,6 +111,8 @@ public abstract class AbstractOperatePipeProcedureV2
   private volatile PipeProcedureExecutionStage executionStage =
       PipeProcedureExecutionStage.WAITING_FOR_PROCEDURE_WORKER;
   private volatile String lastExecutionExceptionMessage;
+  private volatile Procedure<?> nodeLockOwnerProcedure;
+  private volatile Set<Integer> pendingDataNodeIds = Collections.emptySet();
 
   private static final String SKIP_PIPE_PROCEDURE_MESSAGE =
       "Try to start a RUNNING pipe or stop a STOPPED pipe, do nothing.";
@@ -136,6 +141,7 @@ public abstract class AbstractOperatePipeProcedureV2
     final ProcedureLockState procedureLockState = super.acquireLock(configNodeProcedureEnv);
     switch (procedureLockState) {
       case LOCK_ACQUIRED:
+        nodeLockOwnerProcedure = null;
         updateExecutionStage(getCurrentState(), false);
         if (pipeTaskInfo == null) {
           LOGGER.warn(
@@ -150,6 +156,7 @@ public abstract class AbstractOperatePipeProcedureV2
         }
         break;
       case LOCK_EVENT_WAIT:
+        nodeLockOwnerProcedure = configNodeProcedureEnv.getNodeLock().getLockOwnerProcedure();
         if (pipeTaskInfo == null) {
           LOGGER.warn(
               ProcedureMessages.PROCEDUREID_LOCK_EVENT_WAIT_WITHOUT_ACQUIRING_PIPE_LOCK,
@@ -227,16 +234,6 @@ public abstract class AbstractOperatePipeProcedureV2
   /** Execute at state {@link OperatePipeTaskState#CALCULATE_INFO_FOR_TASK}. */
   public abstract void executeFromCalculateInfoForTask(ConfigNodeProcedureEnv env);
 
-  /** Whether this procedure uses the append-only {@link OperatePipeTaskState#PRE_DELETE} state. */
-  protected boolean shouldExecutePreDeleteState() {
-    return false;
-  }
-
-  /** Execute at state {@link OperatePipeTaskState#PRE_DELETE}. */
-  public void executeFromPreDelete(ConfigNodeProcedureEnv env) {
-    // Do nothing by default
-  }
-
   /**
    * Execute at state {@link OperatePipeTaskState#WRITE_CONFIG_NODE_CONSENSUS}.
    *
@@ -282,29 +279,14 @@ public abstract class AbstractOperatePipeProcedureV2
           break;
         case CALCULATE_INFO_FOR_TASK:
           executeFromCalculateInfoForTask(env);
-          setNextState(
-              shouldExecutePreDeleteState()
-                  ? OperatePipeTaskState.PRE_DELETE
-                  : OperatePipeTaskState.WRITE_CONFIG_NODE_CONSENSUS);
-          break;
-        case PRE_DELETE:
-          executeFromPreDelete(env);
-          setNextState(OperatePipeTaskState.OPERATE_ON_DATA_NODES);
+          setNextState(OperatePipeTaskState.WRITE_CONFIG_NODE_CONSENSUS);
           break;
         case WRITE_CONFIG_NODE_CONSENSUS:
           executeFromWriteConfigNodeConsensus(env);
-          if (shouldExecutePreDeleteState() && hasReachedState(OperatePipeTaskState.PRE_DELETE)) {
-            lastExecutionExceptionMessage = null;
-            return Flow.NO_MORE_STATE;
-          }
           setNextState(OperatePipeTaskState.OPERATE_ON_DATA_NODES);
           break;
         case OPERATE_ON_DATA_NODES:
           executeFromOperateOnDataNodes(env);
-          if (shouldExecutePreDeleteState() && hasReachedState(OperatePipeTaskState.PRE_DELETE)) {
-            setNextState(OperatePipeTaskState.WRITE_CONFIG_NODE_CONSENSUS);
-            break;
-          }
           lastExecutionExceptionMessage = null;
           return Flow.NO_MORE_STATE;
         default:
@@ -394,9 +376,6 @@ public abstract class AbstractOperatePipeProcedureV2
               e);
         }
         break;
-      case PRE_DELETE:
-        rollbackFromPreDelete(env);
-        break;
       case WRITE_CONFIG_NODE_CONSENSUS:
         try {
           // rollbackFromWriteConfigNodeConsensus can be called before
@@ -438,10 +417,6 @@ public abstract class AbstractOperatePipeProcedureV2
 
   public abstract void rollbackFromCalculateInfoForTask(ConfigNodeProcedureEnv env);
 
-  public void rollbackFromPreDelete(ConfigNodeProcedureEnv env) {
-    // Do nothing by default
-  }
-
   public abstract void rollbackFromWriteConfigNodeConsensus(ConfigNodeProcedureEnv env);
 
   public abstract void rollbackFromOperateOnDataNodes(ConfigNodeProcedureEnv env)
@@ -476,10 +451,7 @@ public abstract class AbstractOperatePipeProcedureV2
   private String getTimeoutReason(final PipeProcedureExecutionStage currentExecutionStage) {
     final String failureMessage = getFailureMessage();
     if (currentExecutionStage.isRollback()) {
-      return failureMessage == null
-          ? ProcedureMessages.MESSAGE_ROLLING_BACK_AFTER_AN_EARLIER_FAILURE_850D0AF5
-          : String.format(
-              ProcedureMessages.MESSAGE_ROLLING_BACK_AFTER_FAILURE_ARG_474DF456, failureMessage);
+      return getRollbackTimeoutReason(failureMessage);
     }
     if (isFailed() && failureMessage != null) {
       return String.format(
@@ -493,33 +465,65 @@ public abstract class AbstractOperatePipeProcedureV2
           lastExecutionExceptionMessage);
     }
 
-    switch (currentExecutionStage) {
-      case WAITING_FOR_PROCEDURE_WORKER:
-        return ProcedureMessages
-            .MESSAGE_NO_PROCEDURE_WORKER_IS_CURRENTLY_AVAILABLE_WORKERS_MAY_BE_BUSY_OR_BLOCKED_BY_OTHER_PROCEDURES_AB0B1595;
-      case WAITING_FOR_PIPE_TASK_COORDINATOR_LOCK:
-        return ProcedureMessages
-            .MESSAGE_WAITING_TO_ACQUIRE_THE_PIPETASKCOORDINATOR_LOCK_BECAUSE_ANOTHER_PIPE_OPERATION_IS_HOLDING_IT_25A3B6B8;
-      case WAITING_FOR_NODE_LOCK:
-        return ProcedureMessages
-            .MESSAGE_WAITING_TO_ACQUIRE_THE_CONFIGNODE_NODE_LOCK_BECAUSE_ANOTHER_NODE_PROCEDURE_IS_HOLDING_IT_56494E86;
-      case VALIDATE_TASK:
-        return ProcedureMessages
-            .MESSAGE_PIPE_REQUEST_OR_PLUGIN_VALIDATION_HAS_NOT_COMPLETED_A_PLUGIN_CHECK_OR_METADATA_ACCESS_MAY_BE_SLOW_57C36CEF;
-      case CALCULATE_INFO_FOR_TASK:
-        return ProcedureMessages
-            .MESSAGE_PIPE_METADATA_CALCULATION_HAS_NOT_COMPLETED_METADATA_ACCESS_OR_LOCAL_CALCULATION_MAY_BE_SLOW_DEBF2504;
-      case PRE_DELETE:
-      case WRITE_CONFIG_NODE_CONSENSUS:
-        return ProcedureMessages
-            .MESSAGE_THE_CONFIGNODE_CONSENSUS_WRITE_HAS_NOT_RETURNED_THE_CONSENSUS_GROUP_MAY_BE_UNAVAILABLE_OR_SLOW_F8911CE7;
-      case OPERATE_ON_DATA_NODES:
-        return ProcedureMessages
-            .MESSAGE_ONE_OR_MORE_DATANODES_HAVE_NOT_RESPONDED_TO_THE_PIPE_METADATA_PUSH_THEY_MAY_BE_UNAVAILABLE_OR_SLOW_11BBB333;
-      default:
-        return ProcedureMessages
-            .MESSAGE_NO_PROCEDURE_WORKER_IS_CURRENTLY_AVAILABLE_WORKERS_MAY_BE_BUSY_OR_BLOCKED_BY_OTHER_PROCEDURES_AB0B1595;
+    return switch (currentExecutionStage) {
+      case WAITING_FOR_PROCEDURE_WORKER ->
+          ProcedureMessages
+              .MESSAGE_NO_PROCEDURE_WORKER_IS_CURRENTLY_AVAILABLE_WORKERS_MAY_BE_BUSY_OR_BLOCKED_BY_OTHER_PROCEDURES_AB0B1595;
+      case WAITING_FOR_PIPE_TASK_COORDINATOR_LOCK ->
+          ProcedureMessages
+              .MESSAGE_WAITING_TO_ACQUIRE_THE_PIPETASKCOORDINATOR_LOCK_BECAUSE_ANOTHER_PIPE_OPERATION_IS_HOLDING_IT_25A3B6B8;
+      case WAITING_FOR_NODE_LOCK -> getNodeLockTimeoutReason();
+      case VALIDATE_TASK ->
+          ProcedureMessages
+              .MESSAGE_PIPE_REQUEST_OR_PLUGIN_VALIDATION_HAS_NOT_COMPLETED_A_PLUGIN_CHECK_OR_METADATA_ACCESS_MAY_BE_SLOW_57C36CEF;
+      case CALCULATE_INFO_FOR_TASK ->
+          ProcedureMessages
+              .MESSAGE_PIPE_METADATA_CALCULATION_HAS_NOT_COMPLETED_METADATA_ACCESS_OR_LOCAL_CALCULATION_MAY_BE_SLOW_DEBF2504;
+      case WRITE_CONFIG_NODE_CONSENSUS ->
+          ProcedureMessages
+              .MESSAGE_THE_CONFIGNODE_CONSENSUS_WRITE_HAS_NOT_RETURNED_RUN_SHOW_CLUSTER_TO_CHECK_NODE_STATUS_B0A6E1A7;
+      case OPERATE_ON_DATA_NODES -> getDataNodeTimeoutReason();
+      case ROLLBACK_VALIDATE_TASK,
+          ROLLBACK_CALCULATE_INFO_FOR_TASK,
+          ROLLBACK_WRITE_CONFIG_NODE_CONSENSUS,
+          ROLLBACK_OPERATE_ON_DATA_NODES ->
+          getRollbackTimeoutReason(failureMessage);
+    };
+  }
+
+  private static String getRollbackTimeoutReason(final String failureMessage) {
+    return failureMessage == null
+        ? ProcedureMessages.MESSAGE_ROLLING_BACK_AFTER_AN_EARLIER_FAILURE_850D0AF5
+        : String.format(
+            ProcedureMessages.MESSAGE_ROLLING_BACK_AFTER_FAILURE_ARG_474DF456, failureMessage);
+  }
+
+  private String getNodeLockTimeoutReason() {
+    final Procedure<?> lockOwnerProcedure = nodeLockOwnerProcedure;
+    if (lockOwnerProcedure == null) {
+      return ProcedureMessages
+          .MESSAGE_WAITING_TO_ACQUIRE_THE_CONFIGNODE_NODE_LOCK_BECAUSE_ANOTHER_NODE_PROCEDURE_IS_HOLDING_IT_56494E86;
     }
+    final String operation =
+        lockOwnerProcedure instanceof AbstractOperatePipeProcedureV2
+            ? ((AbstractOperatePipeProcedureV2) lockOwnerProcedure).getOperation().name()
+            : lockOwnerProcedure.getClass().getSimpleName();
+    return String.format(
+        ProcedureMessages
+            .MESSAGE_WAITING_TO_ACQUIRE_THE_CONFIGNODE_NODE_LOCK_HELD_BY_ARG_PROCEDUREID_ARG_3F432041,
+        operation,
+        lockOwnerProcedure.getProcId());
+  }
+
+  private String getDataNodeTimeoutReason() {
+    final Set<Integer> currentPendingDataNodeIds = new TreeSet<>(pendingDataNodeIds);
+    return currentPendingDataNodeIds.isEmpty()
+        ? ProcedureMessages
+            .MESSAGE_THE_PIPE_METADATA_PUSH_HAS_NOT_COMPLETED_RUN_SHOW_CLUSTER_TO_CHECK_DATANODE_STATUS_A8F3F0A0
+        : String.format(
+            ProcedureMessages
+                .MESSAGE_DATANODES_ARG_HAVE_NOT_RESPONDED_TO_THE_PIPE_METADATA_PUSH_RUN_SHOW_CLUSTER_TO_CHECK_THEIR_STATUS_9C2F806F,
+            currentPendingDataNodeIds);
   }
 
   private String getFailureMessage() {
@@ -535,46 +539,35 @@ public abstract class AbstractOperatePipeProcedureV2
         : exception.getMessage();
   }
 
-  private void updateExecutionStage(final OperatePipeTaskState state, final boolean isRollback) {
+  protected final void updateExecutionStage(
+      final OperatePipeTaskState state, final boolean isRollback) {
     if (state == null) {
       executionStage = PipeProcedureExecutionStage.WAITING_FOR_PROCEDURE_WORKER;
       return;
     }
-    switch (state) {
-      case VALIDATE_TASK:
-        executionStage =
-            isRollback
-                ? PipeProcedureExecutionStage.ROLLBACK_VALIDATE_TASK
-                : PipeProcedureExecutionStage.VALIDATE_TASK;
-        break;
-      case CALCULATE_INFO_FOR_TASK:
-        executionStage =
-            isRollback
-                ? PipeProcedureExecutionStage.ROLLBACK_CALCULATE_INFO_FOR_TASK
-                : PipeProcedureExecutionStage.CALCULATE_INFO_FOR_TASK;
-        break;
-      case PRE_DELETE:
-        executionStage =
-            isRollback
-                ? PipeProcedureExecutionStage.ROLLBACK_PRE_DELETE
-                : PipeProcedureExecutionStage.PRE_DELETE;
-        break;
-      case WRITE_CONFIG_NODE_CONSENSUS:
-        executionStage =
-            isRollback
-                ? PipeProcedureExecutionStage.ROLLBACK_WRITE_CONFIG_NODE_CONSENSUS
-                : PipeProcedureExecutionStage.WRITE_CONFIG_NODE_CONSENSUS;
-        break;
-      case OPERATE_ON_DATA_NODES:
-        executionStage =
-            isRollback
-                ? PipeProcedureExecutionStage.ROLLBACK_OPERATE_ON_DATA_NODES
-                : PipeProcedureExecutionStage.OPERATE_ON_DATA_NODES;
-        break;
-      default:
-        executionStage = PipeProcedureExecutionStage.WAITING_FOR_PROCEDURE_WORKER;
-        break;
-    }
+    executionStage =
+        switch (state) {
+          case VALIDATE_TASK ->
+              isRollback
+                  ? PipeProcedureExecutionStage.ROLLBACK_VALIDATE_TASK
+                  : PipeProcedureExecutionStage.VALIDATE_TASK;
+          case CALCULATE_INFO_FOR_TASK ->
+              isRollback
+                  ? PipeProcedureExecutionStage.ROLLBACK_CALCULATE_INFO_FOR_TASK
+                  : PipeProcedureExecutionStage.CALCULATE_INFO_FOR_TASK;
+          case WRITE_CONFIG_NODE_CONSENSUS ->
+              isRollback
+                  ? PipeProcedureExecutionStage.ROLLBACK_WRITE_CONFIG_NODE_CONSENSUS
+                  : PipeProcedureExecutionStage.WRITE_CONFIG_NODE_CONSENSUS;
+          case OPERATE_ON_DATA_NODES ->
+              isRollback
+                  ? PipeProcedureExecutionStage.ROLLBACK_OPERATE_ON_DATA_NODES
+                  : PipeProcedureExecutionStage.OPERATE_ON_DATA_NODES;
+        };
+  }
+
+  protected final void setPendingDataNodeIds(final Set<Integer> pendingDataNodeIds) {
+    this.pendingDataNodeIds = pendingDataNodeIds;
   }
 
   private enum PipeProcedureExecutionStage {
@@ -583,12 +576,10 @@ public abstract class AbstractOperatePipeProcedureV2
     WAITING_FOR_NODE_LOCK,
     VALIDATE_TASK,
     CALCULATE_INFO_FOR_TASK,
-    PRE_DELETE,
     WRITE_CONFIG_NODE_CONSENSUS,
     OPERATE_ON_DATA_NODES,
     ROLLBACK_VALIDATE_TASK(true),
     ROLLBACK_CALCULATE_INFO_FOR_TASK(true),
-    ROLLBACK_PRE_DELETE(true),
     ROLLBACK_WRITE_CONFIG_NODE_CONSENSUS(true),
     ROLLBACK_OPERATE_ON_DATA_NODES(true);
 
@@ -620,7 +611,7 @@ public abstract class AbstractOperatePipeProcedureV2
     for (final PipeMeta pipeMeta : pipeTaskInfo.get().getPipeMetaList()) {
       pipeMetaBinaryList.add(copyAndFilterOutNonWorkingDataRegionPipeTasks(pipeMeta).serialize());
     }
-    return env.pushAllPipeMetaToDataNodes(pipeMetaBinaryList);
+    return env.pushAllPipeMetaToDataNodes(pipeMetaBinaryList, this::setPendingDataNodeIds);
   }
 
   /**
@@ -746,7 +737,8 @@ public abstract class AbstractOperatePipeProcedureV2
     for (final PipeMeta pipeMeta : pipeTaskInfo.get().getPipeMetaList()) {
       pipeMetaBinaryList.add(copyAndFilterOutNonWorkingDataRegionPipeTasks(pipeMeta).serialize());
     }
-    return env.pushAllPipeMetaToDataNodesBestEffort(pipeMetaBinaryList);
+    return env.pushAllPipeMetaToDataNodesBestEffort(
+        pipeMetaBinaryList, this::setPendingDataNodeIds);
   }
 
   protected void pushPipeMetaToDataNodesBestEffort(ConfigNodeProcedureEnv env) {
@@ -770,7 +762,8 @@ public abstract class AbstractOperatePipeProcedureV2
     return env.pushSinglePipeMetaToDataNodes(
         copyAndFilterOutNonWorkingDataRegionPipeTasks(
                 pipeTaskInfo.get().getPipeMetaByPipeName(pipeName))
-            .serialize());
+            .serialize(),
+        this::setPendingDataNodeIds);
   }
 
   protected Map<Integer, TPushPipeMetaResp> pushSinglePipeMetaToDataNodes(
@@ -778,7 +771,8 @@ public abstract class AbstractOperatePipeProcedureV2
     return env.pushSinglePipeMetaToDataNodes(
         copyAndFilterOutNonWorkingDataRegionPipeTasks(
                 pipeTaskInfo.get().getPipeMetaByPipeName(pipeName, isTableModel))
-            .serialize());
+            .serialize(),
+        this::setPendingDataNodeIds);
   }
 
   protected Map<Integer, TPushPipeMetaResp> pushSinglePipeMetaToDataNodes(
@@ -786,7 +780,8 @@ public abstract class AbstractOperatePipeProcedureV2
     return env.pushSinglePipeMetaToDataNodes(
         copyAndFilterOutNonWorkingDataRegionPipeTasks(
                 pipeTaskInfo.get().getPipeMetaByPipeStaticMeta(pipeStaticMeta))
-            .serialize());
+            .serialize(),
+        this::setPendingDataNodeIds);
   }
 
   protected Map<Integer, TPushPipeMetaResp> pushSinglePipeMetaToDataNodes4Realtime(
@@ -804,7 +799,8 @@ public abstract class AbstractOperatePipeProcedureV2
                       SystemConstant.RESTART_OR_NEWLY_ADDED_KEY, Boolean.FALSE.toString())));
     }
     return env.pushSinglePipeMetaToDataNodes(
-        copyAndFilterOutNonWorkingDataRegionPipeTasks(pipeMeta).serialize());
+        copyAndFilterOutNonWorkingDataRegionPipeTasks(pipeMeta).serialize(),
+        this::setPendingDataNodeIds);
   }
 
   protected Map<Integer, TPushPipeMetaResp> pushSinglePipeMetaToDataNodes4Realtime(
@@ -822,7 +818,8 @@ public abstract class AbstractOperatePipeProcedureV2
                       SystemConstant.RESTART_OR_NEWLY_ADDED_KEY, Boolean.FALSE.toString())));
     }
     return env.pushSinglePipeMetaToDataNodes(
-        copyAndFilterOutNonWorkingDataRegionPipeTasks(pipeMeta).serialize());
+        copyAndFilterOutNonWorkingDataRegionPipeTasks(pipeMeta).serialize(),
+        this::setPendingDataNodeIds);
   }
 
   protected Map<Integer, TPushPipeMetaResp> pushSinglePipeMetaToDataNodes4Realtime(
@@ -840,7 +837,8 @@ public abstract class AbstractOperatePipeProcedureV2
                       SystemConstant.RESTART_OR_NEWLY_ADDED_KEY, Boolean.FALSE.toString())));
     }
     return env.pushSinglePipeMetaToDataNodes(
-        copyAndFilterOutNonWorkingDataRegionPipeTasks(pipeMeta).serialize());
+        copyAndFilterOutNonWorkingDataRegionPipeTasks(pipeMeta).serialize(),
+        this::setPendingDataNodeIds);
   }
 
   /**
@@ -852,7 +850,7 @@ public abstract class AbstractOperatePipeProcedureV2
    */
   protected Map<Integer, TPushPipeMetaResp> dropSinglePipeOnDataNodes(
       String pipeName, ConfigNodeProcedureEnv env) {
-    return env.dropSinglePipeOnDataNodes(pipeName);
+    return env.dropSinglePipeOnDataNodes(pipeName, this::setPendingDataNodeIds);
   }
 
   public static PipeMeta copyAndFilterOutNonWorkingDataRegionPipeTasks(PipeMeta originalPipeMeta)

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/AbstractOperatePipeProcedureV2.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/AbstractOperatePipeProcedureV2.java
@@ -103,6 +103,12 @@ public abstract class AbstractOperatePipeProcedureV2
   // recovered procedure is already re-scheduled by the procedure framework.
   private transient boolean shouldYieldAfterExecution;
 
+  // These fields are only used to report where a running Pipe procedure is blocked when the caller
+  // times out. They do not affect procedure execution and do not need to be persisted.
+  private volatile PipeProcedureExecutionStage executionStage =
+      PipeProcedureExecutionStage.WAITING_FOR_PROCEDURE_WORKER;
+  private volatile String lastExecutionExceptionMessage;
+
   private static final String SKIP_PIPE_PROCEDURE_MESSAGE =
       "Try to start a RUNNING pipe or stop a STOPPED pipe, do nothing.";
 
@@ -118,6 +124,7 @@ public abstract class AbstractOperatePipeProcedureV2
   @Override
   protected ProcedureLockState acquireLock(ConfigNodeProcedureEnv configNodeProcedureEnv) {
     LOGGER.debug(ProcedureMessages.PROCEDUREID_TRY_TO_ACQUIRE_PIPE_LOCK, getProcId());
+    executionStage = PipeProcedureExecutionStage.WAITING_FOR_PIPE_TASK_COORDINATOR_LOCK;
     pipeTaskInfo = acquireLockInternal(configNodeProcedureEnv);
     if (pipeTaskInfo == null) {
       LOGGER.warn(ProcedureMessages.PROCEDUREID_FAILED_TO_ACQUIRE_PIPE_LOCK, getProcId());
@@ -125,9 +132,11 @@ public abstract class AbstractOperatePipeProcedureV2
       LOGGER.debug(ProcedureMessages.PROCEDUREID_ACQUIRED_PIPE_LOCK, getProcId());
     }
 
+    executionStage = PipeProcedureExecutionStage.WAITING_FOR_NODE_LOCK;
     final ProcedureLockState procedureLockState = super.acquireLock(configNodeProcedureEnv);
     switch (procedureLockState) {
       case LOCK_ACQUIRED:
+        updateExecutionStage(getCurrentState(), false);
         if (pipeTaskInfo == null) {
           LOGGER.warn(
               ProcedureMessages
@@ -192,6 +201,9 @@ public abstract class AbstractOperatePipeProcedureV2
             .updateTimer(this.getOperation().getName(), this.elapsedTime());
       }
       releasePipeTaskCoordinatorLock(configNodeProcedureEnv);
+      if (!isFinished()) {
+        executionStage = PipeProcedureExecutionStage.WAITING_FOR_PROCEDURE_WORKER;
+      }
     }
   }
 
@@ -236,6 +248,7 @@ public abstract class AbstractOperatePipeProcedureV2
   protected Flow executeFromState(ConfigNodeProcedureEnv env, OperatePipeTaskState state)
       throws InterruptedException {
     shouldYieldAfterExecution = false;
+    updateExecutionStage(state, false);
     if (pipeTaskInfo == null) {
       LOGGER.warn(
           ProcedureMessages.PROCEDUREID_PIPE_LOCK_IS_NOT_ACQUIRED_EXECUTEFROMSTATE_S_EXECUTION_WILL,
@@ -247,6 +260,7 @@ public abstract class AbstractOperatePipeProcedureV2
       switch (state) {
         case VALIDATE_TASK:
           if (!executeFromValidateTask(env)) {
+            lastExecutionExceptionMessage = null;
             LOGGER.info(ProcedureMessages.PROCEDUREID, getProcId(), SKIP_PIPE_PROCEDURE_MESSAGE);
             // On client side, the message returned after the successful execution of the pipe
             // command corresponding to this procedure is "Msg: The statement is executed
@@ -266,13 +280,16 @@ public abstract class AbstractOperatePipeProcedureV2
           break;
         case OPERATE_ON_DATA_NODES:
           executeFromOperateOnDataNodes(env);
+          lastExecutionExceptionMessage = null;
           return Flow.NO_MORE_STATE;
         default:
           throw new UnsupportedOperationException(
               String.format(
                   ProcedureMessages.UNKNOWN_STATE_DURING_EXECUTING_OPERATEPIPEPROCEDURE, state));
       }
+      lastExecutionExceptionMessage = null;
     } catch (Exception e) {
+      lastExecutionExceptionMessage = getExceptionMessage(e);
       // Retry before rollback
       if (getCycles() < RETRY_THRESHOLD) {
         LOGGER.warn(
@@ -319,6 +336,7 @@ public abstract class AbstractOperatePipeProcedureV2
   @Override
   protected void rollbackState(ConfigNodeProcedureEnv env, OperatePipeTaskState state)
       throws IOException, InterruptedException, ProcedureException {
+    updateExecutionStage(state, true);
     if (pipeTaskInfo == null) {
       LOGGER.warn(
           ProcedureMessages.PROCEDUREID_PIPE_LOCK_IS_NOT_ACQUIRED_ROLLBACKSTATE_S_EXECUTION_WILL,
@@ -410,6 +428,142 @@ public abstract class AbstractOperatePipeProcedureV2
   @Override
   protected OperatePipeTaskState getInitialState() {
     return OperatePipeTaskState.VALIDATE_TASK;
+  }
+
+  public final String getTimeoutDiagnosticMessage() {
+    final PipeProcedureExecutionStage currentExecutionStage = executionStage;
+    return String.format(
+        ProcedureMessages
+            .MESSAGE_PIPE_OPERATION_ARG_TIMED_OUT_PROCEDUREID_ARG_STUCK_AT_ARG_REASON_ARG_THE_PROCEDURE_IS_STILL_RUNNING_7EEAC50E,
+        getOperation().name(),
+        getProcId(),
+        currentExecutionStage.name(),
+        getTimeoutReason(currentExecutionStage));
+  }
+
+  private String getTimeoutReason(final PipeProcedureExecutionStage currentExecutionStage) {
+    final String failureMessage = getFailureMessage();
+    if (currentExecutionStage.isRollback()) {
+      return failureMessage == null
+          ? ProcedureMessages.MESSAGE_ROLLING_BACK_AFTER_AN_EARLIER_FAILURE_850D0AF5
+          : String.format(
+              ProcedureMessages.MESSAGE_ROLLING_BACK_AFTER_FAILURE_ARG_474DF456, failureMessage);
+    }
+    if (isFailed() && failureMessage != null) {
+      return String.format(
+          ProcedureMessages.MESSAGE_THE_STATE_FAILED_WITH_ARG_AND_ROLLBACK_IS_PENDING_E7B43829,
+          failureMessage);
+    }
+    if (lastExecutionExceptionMessage != null) {
+      return String.format(
+          ProcedureMessages
+              .MESSAGE_THE_PREVIOUS_ATTEMPT_FAILED_WITH_ARG_AND_THIS_STATE_IS_BEING_RETRIED_7A541F27,
+          lastExecutionExceptionMessage);
+    }
+
+    switch (currentExecutionStage) {
+      case WAITING_FOR_PROCEDURE_WORKER:
+        return ProcedureMessages
+            .MESSAGE_NO_PROCEDURE_WORKER_IS_CURRENTLY_AVAILABLE_WORKERS_MAY_BE_BUSY_OR_BLOCKED_BY_OTHER_PROCEDURES_AB0B1595;
+      case WAITING_FOR_PIPE_TASK_COORDINATOR_LOCK:
+        return ProcedureMessages
+            .MESSAGE_WAITING_TO_ACQUIRE_THE_PIPETASKCOORDINATOR_LOCK_BECAUSE_ANOTHER_PIPE_OPERATION_IS_HOLDING_IT_25A3B6B8;
+      case WAITING_FOR_NODE_LOCK:
+        return ProcedureMessages
+            .MESSAGE_WAITING_TO_ACQUIRE_THE_CONFIGNODE_NODE_LOCK_BECAUSE_ANOTHER_NODE_PROCEDURE_IS_HOLDING_IT_56494E86;
+      case VALIDATE_TASK:
+        return ProcedureMessages
+            .MESSAGE_PIPE_REQUEST_OR_PLUGIN_VALIDATION_HAS_NOT_COMPLETED_A_PLUGIN_CHECK_OR_METADATA_ACCESS_MAY_BE_SLOW_57C36CEF;
+      case CALCULATE_INFO_FOR_TASK:
+        return ProcedureMessages
+            .MESSAGE_PIPE_METADATA_CALCULATION_HAS_NOT_COMPLETED_METADATA_ACCESS_OR_LOCAL_CALCULATION_MAY_BE_SLOW_DEBF2504;
+      case WRITE_CONFIG_NODE_CONSENSUS:
+        return ProcedureMessages
+            .MESSAGE_THE_CONFIGNODE_CONSENSUS_WRITE_HAS_NOT_RETURNED_THE_CONSENSUS_GROUP_MAY_BE_UNAVAILABLE_OR_SLOW_F8911CE7;
+      case OPERATE_ON_DATA_NODES:
+        return ProcedureMessages
+            .MESSAGE_ONE_OR_MORE_DATANODES_HAVE_NOT_RESPONDED_TO_THE_PIPE_METADATA_PUSH_THEY_MAY_BE_UNAVAILABLE_OR_SLOW_11BBB333;
+      default:
+        return ProcedureMessages
+            .MESSAGE_NO_PROCEDURE_WORKER_IS_CURRENTLY_AVAILABLE_WORKERS_MAY_BE_BUSY_OR_BLOCKED_BY_OTHER_PROCEDURES_AB0B1595;
+    }
+  }
+
+  private String getFailureMessage() {
+    if (getException() != null) {
+      return getException().getMessage();
+    }
+    return lastExecutionExceptionMessage;
+  }
+
+  private static String getExceptionMessage(final Exception exception) {
+    return exception.getMessage() == null || exception.getMessage().isEmpty()
+        ? exception.getClass().getSimpleName()
+        : exception.getMessage();
+  }
+
+  private void updateExecutionStage(final OperatePipeTaskState state, final boolean isRollback) {
+    if (state == null) {
+      executionStage = PipeProcedureExecutionStage.WAITING_FOR_PROCEDURE_WORKER;
+      return;
+    }
+    switch (state) {
+      case VALIDATE_TASK:
+        executionStage =
+            isRollback
+                ? PipeProcedureExecutionStage.ROLLBACK_VALIDATE_TASK
+                : PipeProcedureExecutionStage.VALIDATE_TASK;
+        break;
+      case CALCULATE_INFO_FOR_TASK:
+        executionStage =
+            isRollback
+                ? PipeProcedureExecutionStage.ROLLBACK_CALCULATE_INFO_FOR_TASK
+                : PipeProcedureExecutionStage.CALCULATE_INFO_FOR_TASK;
+        break;
+      case WRITE_CONFIG_NODE_CONSENSUS:
+        executionStage =
+            isRollback
+                ? PipeProcedureExecutionStage.ROLLBACK_WRITE_CONFIG_NODE_CONSENSUS
+                : PipeProcedureExecutionStage.WRITE_CONFIG_NODE_CONSENSUS;
+        break;
+      case OPERATE_ON_DATA_NODES:
+        executionStage =
+            isRollback
+                ? PipeProcedureExecutionStage.ROLLBACK_OPERATE_ON_DATA_NODES
+                : PipeProcedureExecutionStage.OPERATE_ON_DATA_NODES;
+        break;
+      default:
+        executionStage = PipeProcedureExecutionStage.WAITING_FOR_PROCEDURE_WORKER;
+        break;
+    }
+  }
+
+  private enum PipeProcedureExecutionStage {
+    WAITING_FOR_PROCEDURE_WORKER,
+    WAITING_FOR_PIPE_TASK_COORDINATOR_LOCK,
+    WAITING_FOR_NODE_LOCK,
+    VALIDATE_TASK,
+    CALCULATE_INFO_FOR_TASK,
+    WRITE_CONFIG_NODE_CONSENSUS,
+    OPERATE_ON_DATA_NODES,
+    ROLLBACK_VALIDATE_TASK(true),
+    ROLLBACK_CALCULATE_INFO_FOR_TASK(true),
+    ROLLBACK_WRITE_CONFIG_NODE_CONSENSUS(true),
+    ROLLBACK_OPERATE_ON_DATA_NODES(true);
+
+    private final boolean rollback;
+
+    PipeProcedureExecutionStage() {
+      this(false);
+    }
+
+    PipeProcedureExecutionStage(final boolean rollback) {
+      this.rollback = rollback;
+    }
+
+    private boolean isRollback() {
+      return rollback;
+    }
   }
 
   /**

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/runtime/PipeMetaSyncProcedure.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/runtime/PipeMetaSyncProcedure.java
@@ -22,6 +22,7 @@ package org.apache.iotdb.confignode.procedure.impl.pipe.runtime;
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.consensus.index.impl.MinimumProgressIndex;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeMeta;
+import org.apache.iotdb.commons.pipe.agent.task.meta.PipeStatus;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeTaskMeta;
 import org.apache.iotdb.commons.pipe.config.PipeConfig;
 import org.apache.iotdb.commons.pipe.config.constant.PipeSourceConstant;
@@ -125,6 +126,9 @@ public class PipeMetaSyncProcedure extends AbstractOperatePipeProcedureV2 {
         .getPipeMetaList()
         .forEach(
             pipeMeta -> {
+              if (PipeStatus.PRE_DELETE.equals(pipeMeta.getRuntimeMeta().getStatus().get())) {
+                return;
+              }
               if (!pipeMeta.getStaticMeta().isSourceExternal()) {
                 return;
               }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/AlterPipeProcedureV2.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/AlterPipeProcedureV2.java
@@ -333,7 +333,7 @@ public class AlterPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
     pipeMetaBinaryList.add(
         copyAndFilterOutNonWorkingDataRegionPipeTasks(updatedPipeMeta).serialize());
 
-    return env.pushMultiPipeMetaToDataNodes(pipeMetaBinaryList);
+    return env.pushMultiPipeMetaToDataNodes(pipeMetaBinaryList, this::setPendingDataNodeIds);
   }
 
   @Override

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/DropPipeProcedureV2.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/DropPipeProcedureV2.java
@@ -30,6 +30,7 @@ import org.apache.iotdb.confignode.persistence.pipe.PipeTaskInfo;
 import org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv;
 import org.apache.iotdb.confignode.procedure.impl.pipe.AbstractOperatePipeProcedureV2;
 import org.apache.iotdb.confignode.procedure.impl.pipe.PipeTaskOperation;
+import org.apache.iotdb.confignode.procedure.state.pipe.task.OperatePipeTaskState;
 import org.apache.iotdb.confignode.procedure.store.ProcedureType;
 import org.apache.iotdb.consensus.exception.ConsensusException;
 import org.apache.iotdb.pipe.api.exception.PipeException;
@@ -132,15 +133,12 @@ public class DropPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
   }
 
   @Override
-  protected boolean shouldExecutePreDeleteState() {
-    return true;
-  }
+  public void executeFromWriteConfigNodeConsensus(ConfigNodeProcedureEnv env) throws PipeException {
+    LOGGER.info(
+        ProcedureMessages.DROPPIPEPROCEDUREV2_EXECUTEFROMWRITECONFIGNODECONSENSUS, pipeName);
 
-  @Override
-  public void executeFromPreDelete(ConfigNodeProcedureEnv env) throws PipeException {
     // Legacy procedures created without an explicit model do not persist pipeMetaToDrop. Restore
-    // it from PipeTaskInfo so a procedure recovered between CALCULATE_INFO_FOR_TASK and PRE_DELETE
-    // still exposes PRE_DELETE through SHOW PIPES.
+    // it from PipeTaskInfo so a recovered procedure can still expose PRE_DELETE through SHOW PIPES.
     if (!restorePipeMetaToDropIfNecessary()) {
       return;
     }
@@ -174,11 +172,7 @@ public class DropPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
     return pipeMetaToDrop != null;
   }
 
-  @Override
-  public void executeFromWriteConfigNodeConsensus(ConfigNodeProcedureEnv env) throws PipeException {
-    LOGGER.info(
-        ProcedureMessages.DROPPIPEPROCEDUREV2_EXECUTEFROMWRITECONFIGNODECONSENSUS, pipeName);
-
+  private void dropPipeOnConfigNode(final ConfigNodeProcedureEnv env) throws PipeException {
     TSStatus response;
     try {
       response =
@@ -199,7 +193,7 @@ public class DropPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
   }
 
   @Override
-  public void executeFromOperateOnDataNodes(ConfigNodeProcedureEnv env) {
+  public void executeFromOperateOnDataNodes(ConfigNodeProcedureEnv env) throws PipeException {
     LOGGER.info(ProcedureMessages.DROPPIPEPROCEDUREV2_EXECUTEFROMOPERATEONDATANODES, pipeName);
 
     String exceptionMessage;
@@ -213,17 +207,21 @@ public class DropPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
         droppedPipeMeta.getRuntimeMeta().getStatus().set(PipeStatus.DROPPED);
         exceptionMessage =
             parsePushPipeMetaExceptionForPipe(
-                pipeName, env.pushSinglePipeMetaToDataNodes(droppedPipeMeta.serialize()));
+                pipeName,
+                env.pushSinglePipeMetaToDataNodes(
+                    droppedPipeMeta.serialize(), this::setPendingDataNodeIds));
       }
     } catch (final IOException e) {
       exceptionMessage = e.getMessage();
     }
-    if (!exceptionMessage.isEmpty()) {
+    if (exceptionMessage != null && !exceptionMessage.isEmpty()) {
       LOGGER.warn(
           ProcedureMessages.FAILED_TO_DROP_PIPE_DETAILS_METADATA_WILL_BE_SYNCHRONIZED_LATER,
           pipeName,
           exceptionMessage);
     }
+    updateExecutionStage(OperatePipeTaskState.WRITE_CONFIG_NODE_CONSENSUS, false);
+    dropPipeOnConfigNode(env);
   }
 
   @Override
@@ -236,11 +234,6 @@ public class DropPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
   public void rollbackFromCalculateInfoForTask(ConfigNodeProcedureEnv env) {
     LOGGER.info(ProcedureMessages.DROPPIPEPROCEDUREV2_ROLLBACKFROMCALCULATEINFOFORTASK, pipeName);
     // Do nothing
-  }
-
-  @Override
-  public void rollbackFromPreDelete(ConfigNodeProcedureEnv env) {
-    // Keep PRE_DELETE so SHOW PIPES continues to expose that the drop did not complete.
   }
 
   @Override

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/DropPipeProcedureV2.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/DropPipeProcedureV2.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeMeta;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeStatus;
 import org.apache.iotdb.confignode.consensus.request.write.pipe.task.DropPipePlanV2;
+import org.apache.iotdb.confignode.consensus.request.write.pipe.task.SetPipeStatusPlanV2;
 import org.apache.iotdb.confignode.i18n.ConfigNodeMessages;
 import org.apache.iotdb.confignode.i18n.ProcedureMessages;
 import org.apache.iotdb.confignode.persistence.pipe.PipeTaskInfo;
@@ -131,6 +132,49 @@ public class DropPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
   }
 
   @Override
+  protected boolean shouldExecutePreDeleteState() {
+    return true;
+  }
+
+  @Override
+  public void executeFromPreDelete(ConfigNodeProcedureEnv env) throws PipeException {
+    // Legacy procedures created without an explicit model do not persist pipeMetaToDrop. Restore
+    // it from PipeTaskInfo so a procedure recovered between CALCULATE_INFO_FOR_TASK and PRE_DELETE
+    // still exposes PRE_DELETE through SHOW PIPES.
+    if (!restorePipeMetaToDropIfNecessary()) {
+      return;
+    }
+
+    TSStatus response;
+    try {
+      response =
+          env.getConfigManager()
+              .getConsensusManager()
+              .write(
+                  isTableModelSet
+                      ? new SetPipeStatusPlanV2(pipeName, PipeStatus.PRE_DELETE, isTableModel)
+                      : new SetPipeStatusPlanV2(pipeName, PipeStatus.PRE_DELETE));
+    } catch (ConsensusException e) {
+      LOGGER.warn(ConfigNodeMessages.FAILED_IN_THE_WRITE_API_EXECUTING_THE_CONSENSUS_LAYER_DUE, e);
+      response = new TSStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR.getStatusCode());
+      response.setMessage(e.getMessage());
+    }
+    if (response.getCode() != TSStatusCode.SUCCESS_STATUS.getStatusCode()) {
+      throw new PipeException(response.getMessage());
+    }
+  }
+
+  boolean restorePipeMetaToDropIfNecessary() {
+    if (pipeMetaToDrop == null) {
+      pipeMetaToDrop =
+          isTableModelSet
+              ? pipeTaskInfo.get().getPipeMetaByPipeName(pipeName, isTableModel)
+              : pipeTaskInfo.get().getPipeMetaByPipeName(pipeName);
+    }
+    return pipeMetaToDrop != null;
+  }
+
+  @Override
   public void executeFromWriteConfigNodeConsensus(ConfigNodeProcedureEnv env) throws PipeException {
     LOGGER.info(
         ProcedureMessages.DROPPIPEPROCEDUREV2_EXECUTEFROMWRITECONFIGNODECONSENSUS, pipeName);
@@ -192,6 +236,11 @@ public class DropPipeProcedureV2 extends AbstractOperatePipeProcedureV2 {
   public void rollbackFromCalculateInfoForTask(ConfigNodeProcedureEnv env) {
     LOGGER.info(ProcedureMessages.DROPPIPEPROCEDUREV2_ROLLBACKFROMCALCULATEINFOFORTASK, pipeName);
     // Do nothing
+  }
+
+  @Override
+  public void rollbackFromPreDelete(ConfigNodeProcedureEnv env) {
+    // Keep PRE_DELETE so SHOW PIPES continues to expose that the drop did not complete.
   }
 
   @Override

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/scheduler/LockQueue.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/scheduler/LockQueue.java
@@ -27,7 +27,7 @@ import java.util.ArrayDeque;
 public class LockQueue {
   private final ArrayDeque<Procedure<?>> deque = new ArrayDeque<>();
 
-  private Procedure<?> lockOwnerProcedure = null;
+  private volatile Procedure<?> lockOwnerProcedure = null;
 
   public boolean tryLock(Procedure<?> procedure) {
     if (lockOwnerProcedure == null) {
@@ -43,6 +43,10 @@ public class LockQueue {
     }
     lockOwnerProcedure = null;
     return true;
+  }
+
+  public Procedure<?> getLockOwnerProcedure() {
+    return lockOwnerProcedure;
   }
 
   public void waitProcedure(Procedure<?> procedure, ProcedureScheduler procedureScheduler) {

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/state/pipe/task/OperatePipeTaskState.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/state/pipe/task/OperatePipeTaskState.java
@@ -23,7 +23,5 @@ public enum OperatePipeTaskState {
   VALIDATE_TASK,
   CALCULATE_INFO_FOR_TASK,
   OPERATE_ON_DATA_NODES,
-  WRITE_CONFIG_NODE_CONSENSUS,
-  // Keep new states appended to preserve persisted state ordinals.
-  PRE_DELETE
+  WRITE_CONFIG_NODE_CONSENSUS
 }

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/state/pipe/task/OperatePipeTaskState.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/state/pipe/task/OperatePipeTaskState.java
@@ -23,5 +23,7 @@ public enum OperatePipeTaskState {
   VALIDATE_TASK,
   CALCULATE_INFO_FOR_TASK,
   OPERATE_ON_DATA_NODES,
-  WRITE_CONFIG_NODE_CONSENSUS
+  WRITE_CONFIG_NODE_CONSENSUS,
+  // Keep new states appended to preserve persisted state ordinals.
+  PRE_DELETE
 }

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlanSerDeTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/consensus/request/ConfigPhysicalPlanSerDeTest.java
@@ -1014,7 +1014,7 @@ public class ConfigPhysicalPlanSerDeTest {
   public void SetPipeStatusPlanV2Test() throws IOException {
     final SetPipeStatusPlanV2 setPipeStatusPlanV2 =
         new SetPipeStatusPlanV2(
-            "pipe", org.apache.iotdb.commons.pipe.agent.task.meta.PipeStatus.RUNNING, true);
+            "pipe", org.apache.iotdb.commons.pipe.agent.task.meta.PipeStatus.PRE_DELETE, true);
     final SetPipeStatusPlanV2 setPipeStatusPlanV21 =
         (SetPipeStatusPlanV2)
             ConfigPhysicalPlan.Factory.create(setPipeStatusPlanV2.serializeToByteBuffer());

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/consensus/response/pipe/PipeTableRespTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/consensus/response/pipe/PipeTableRespTest.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.commons.consensus.index.impl.MinimumProgressIndex;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeMeta;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeRuntimeMeta;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeStaticMeta;
+import org.apache.iotdb.commons.pipe.agent.task.meta.PipeStatus;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeTaskMeta;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeTemporaryMetaInCoordinator;
 import org.apache.iotdb.commons.pipe.config.constant.SystemConstant;
@@ -166,6 +167,17 @@ public class PipeTableRespTest {
     Assert.assertTrue(showPipeResult.get(1).isSetIsDegraded());
     Assert.assertFalse(showPipeResult.get(1).isIsDegraded());
     Assert.assertFalse(showPipeResult.get(2).isSetIsDegraded());
+  }
+
+  @Test
+  public void testConvertToTShowPipeRespIncludesPreDeleteStatus() {
+    final PipeTableResp pipeTableResp = constructPipeTableResp();
+    pipeTableResp.getAllPipeMeta().get(0).getRuntimeMeta().getStatus().set(PipeStatus.PRE_DELETE);
+
+    final List<TShowPipeInfo> showPipeResult =
+        pipeTableResp.convertToTShowPipeResp().getPipeInfoList();
+
+    Assert.assertEquals(PipeStatus.PRE_DELETE.name(), showPipeResult.get(0).getState());
   }
 
   @Test

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/pipe/coordinator/runtime/heartbeat/PipeHeartbeatParserTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/pipe/coordinator/runtime/heartbeat/PipeHeartbeatParserTest.java
@@ -215,6 +215,42 @@ public class PipeHeartbeatParserTest {
   }
 
   @Test
+  public void testParseHeartbeatDoesNotOverwritePreDeleteStatus() throws Exception {
+    CommonDescriptor.getInstance().getConfig().setSeperatedPipeHeartbeatEnabled(false);
+
+    final String pipeName = "preDeletePipe";
+    final PipeTaskInfo pipeTaskInfo = new PipeTaskInfo();
+    createPipe(pipeTaskInfo, pipeName, PipeStatus.RUNNING);
+
+    final PipeMeta pipeMeta = pipeTaskInfo.getPipeMetaByPipeName(pipeName);
+    final PipeRuntimeMeta runtimeMeta = pipeMeta.getRuntimeMeta();
+    runtimeMeta.getStatus().set(PipeStatus.PRE_DELETE);
+
+    final PipeTaskMeta agentTaskMeta =
+        new PipeTaskMeta(MinimumProgressIndex.INSTANCE, DATA_NODE_ID);
+    agentTaskMeta.trackExceptionMessage(new PipeRuntimeCriticalException("fresh failure", 300L));
+    final ConcurrentMap<Integer, PipeTaskMeta> agentPipeTasks = new ConcurrentHashMap<>();
+    agentPipeTasks.put(DATA_NODE_ID, agentTaskMeta);
+    final PipeHeartbeat heartbeat =
+        new PipeHeartbeat(
+            Collections.singletonList(
+                new PipeMeta(pipeMeta.getStaticMeta(), new PipeRuntimeMeta(agentPipeTasks))
+                    .serialize()),
+            Collections.singletonList(false),
+            Collections.singletonList(0L),
+            Collections.singletonList(0D),
+            null);
+
+    final ParserTestContext context = createParserTestContext(1, pipeTaskInfo);
+    context.parser.parseHeartbeat(DATA_NODE_ID, heartbeat);
+
+    Assert.assertEquals(PipeStatus.PRE_DELETE, runtimeMeta.getStatus().get());
+    Assert.assertFalse(
+        runtimeMeta.getConsensusGroupId2TaskMetaMap().get(DATA_NODE_ID).hasExceptionMessages());
+    verify(context.procedureManager, never()).pipeHandleMetaChange(anyBoolean(), anyBoolean());
+  }
+
+  @Test
   public void testParseHeartbeatRecordsPipeDegradedStatus() throws Exception {
     CommonDescriptor.getInstance().getConfig().setSeperatedPipeHeartbeatEnabled(false);
 

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/pipe/PipeTaskInfoAutoRestartTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/pipe/PipeTaskInfoAutoRestartTest.java
@@ -33,9 +33,11 @@ import org.apache.iotdb.commons.pipe.config.constant.SystemConstant;
 import org.apache.iotdb.confignode.consensus.request.write.pipe.task.CreatePipePlanV2;
 import org.apache.iotdb.confignode.consensus.request.write.pipe.task.DropPipePlanV2;
 import org.apache.iotdb.confignode.consensus.request.write.pipe.task.SetPipeStatusPlanV2;
+import org.apache.iotdb.confignode.i18n.ConfigNodeMessages;
 import org.apache.iotdb.confignode.rpc.thrift.TAlterPipeReq;
 import org.apache.iotdb.mpp.rpc.thrift.TPushPipeMetaResp;
 import org.apache.iotdb.mpp.rpc.thrift.TPushPipeMetaRespExceptionMessage;
+import org.apache.iotdb.pipe.api.exception.PipeException;
 import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.junit.Assert;
@@ -350,6 +352,45 @@ public class PipeTaskInfoAutoRestartTest {
     Assert.assertEquals(
         SystemConstant.PIPE_VISIBILITY_STRICT_VALUE,
         extractorAttributes.get(SystemConstant.PIPE_VISIBILITY_KEY));
+  }
+
+  @Test
+  public void testPreDeletePipeReportsDroppingInsteadOfNotExist() {
+    final String pipeName = "droppingPipe";
+    createPipe(pipeName, PipeStatus.STOPPED, true);
+    pipeTaskInfo.setPipeStatus(new SetPipeStatusPlanV2(pipeName, PipeStatus.PRE_DELETE, true));
+
+    final PipeException alterException =
+        Assert.assertThrows(
+            PipeException.class,
+            () ->
+                pipeTaskInfo.checkAndUpdateRequestBeforeAlterPipe(
+                    createAlterPipeRequest(pipeName, true)));
+    Assert.assertEquals(
+        String.format(
+            ConfigNodeMessages
+                .EXCEPTION_FAILED_TO_ALTER_PIPE_ARG_THE_PIPE_IS_BEING_DROPPED_919F1E2B,
+            pipeName),
+        alterException.getMessage());
+
+    final PipeException startException =
+        Assert.assertThrows(
+            PipeException.class, () -> pipeTaskInfo.checkBeforeStartPipe(pipeName, true));
+    Assert.assertEquals(
+        String.format(
+            ConfigNodeMessages
+                .EXCEPTION_FAILED_TO_START_PIPE_ARG_THE_PIPE_IS_BEING_DROPPED_B41F4638,
+            pipeName),
+        startException.getMessage());
+
+    final PipeException stopException =
+        Assert.assertThrows(
+            PipeException.class, () -> pipeTaskInfo.checkBeforeStopPipe(pipeName, true));
+    Assert.assertEquals(
+        String.format(
+            ConfigNodeMessages.EXCEPTION_FAILED_TO_STOP_PIPE_ARG_THE_PIPE_IS_BEING_DROPPED_37AFB22B,
+            pipeName),
+        stopException.getMessage());
   }
 
   private TAlterPipeReq createAlterPipeRequest(final String pipeName, final boolean isTableModel) {

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/AbstractOperatePipeProcedureV2Test.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/AbstractOperatePipeProcedureV2Test.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.confignode.procedure.impl.pipe;
 
+import org.apache.iotdb.confignode.i18n.ProcedureMessages;
 import org.apache.iotdb.confignode.persistence.pipe.PipeTaskInfo;
 import org.apache.iotdb.confignode.procedure.Procedure;
 import org.apache.iotdb.confignode.procedure.impl.StateMachineProcedure;
@@ -87,6 +88,33 @@ public class AbstractOperatePipeProcedureV2Test {
     Assert.assertTrue(procedure.hasException());
     Assert.assertFalse(procedure.isYieldAfterExecution(null));
     Assert.assertEquals(2, procedure.calculateExecutionCount);
+  }
+
+  @Test
+  public void testTimeoutDiagnosticReportsCurrentStateAndRetryReason() throws Exception {
+    final TestOperatePipeProcedure procedure = new TestOperatePipeProcedure();
+    procedure.failValidation = true;
+
+    procedure.executeFromState(null, OperatePipeTaskState.VALIDATE_TASK);
+
+    final String diagnosticMessage = procedure.getTimeoutDiagnosticMessage();
+    Assert.assertTrue(diagnosticMessage.contains("START_PIPE"));
+    Assert.assertTrue(diagnosticMessage.contains("VALIDATE_TASK"));
+    Assert.assertTrue(diagnosticMessage.contains("retry"));
+  }
+
+  @Test
+  public void testTimeoutDiagnosticReportsDataNodeOperation() throws Exception {
+    final TestOperatePipeProcedure procedure = new TestOperatePipeProcedure();
+
+    procedure.executeFromState(null, OperatePipeTaskState.OPERATE_ON_DATA_NODES);
+
+    final String diagnosticMessage = procedure.getTimeoutDiagnosticMessage();
+    Assert.assertTrue(diagnosticMessage.contains("OPERATE_ON_DATA_NODES"));
+    Assert.assertTrue(
+        diagnosticMessage.contains(
+            ProcedureMessages
+                .MESSAGE_ONE_OR_MORE_DATANODES_HAVE_NOT_RESPONDED_TO_THE_PIPE_METADATA_PUSH_THEY_MAY_BE_UNAVAILABLE_OR_SLOW_11BBB333));
   }
 
   private static class TestOperatePipeProcedure extends AbstractOperatePipeProcedureV2 {

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/AbstractOperatePipeProcedureV2Test.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/AbstractOperatePipeProcedureV2Test.java
@@ -30,6 +30,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class AbstractOperatePipeProcedureV2Test {
@@ -117,12 +119,59 @@ public class AbstractOperatePipeProcedureV2Test {
                 .MESSAGE_ONE_OR_MORE_DATANODES_HAVE_NOT_RESPONDED_TO_THE_PIPE_METADATA_PUSH_THEY_MAY_BE_UNAVAILABLE_OR_SLOW_11BBB333));
   }
 
+  @Test
+  public void testPreDeleteFlowAndStateOrdinalCompatibility() throws Exception {
+    Assert.assertEquals(0, OperatePipeTaskState.VALIDATE_TASK.ordinal());
+    Assert.assertEquals(1, OperatePipeTaskState.CALCULATE_INFO_FOR_TASK.ordinal());
+    Assert.assertEquals(2, OperatePipeTaskState.OPERATE_ON_DATA_NODES.ordinal());
+    Assert.assertEquals(3, OperatePipeTaskState.WRITE_CONFIG_NODE_CONSENSUS.ordinal());
+    Assert.assertEquals(4, OperatePipeTaskState.PRE_DELETE.ordinal());
+
+    final TestOperatePipeProcedure procedure = new TestOperatePipeProcedure();
+    procedure.preDeleteEnabled = true;
+
+    for (int i = 0; i < 5; i++) {
+      procedure.runOnce();
+    }
+
+    Assert.assertEquals(
+        List.of(
+            OperatePipeTaskState.VALIDATE_TASK,
+            OperatePipeTaskState.CALCULATE_INFO_FOR_TASK,
+            OperatePipeTaskState.PRE_DELETE,
+            OperatePipeTaskState.OPERATE_ON_DATA_NODES,
+            OperatePipeTaskState.WRITE_CONFIG_NODE_CONSENSUS),
+        procedure.executionOrder);
+  }
+
+  @Test
+  public void testLegacyDropFlowWithoutPreDeleteHistoryStillOperatesOnDataNodes() throws Exception {
+    final TestOperatePipeProcedure procedure = new TestOperatePipeProcedure();
+
+    // Schedule WRITE_CONFIG_NODE_CONSENSUS with the legacy flow, then continue with the new logic.
+    procedure.runOnce();
+    procedure.runOnce();
+    procedure.preDeleteEnabled = true;
+    procedure.runOnce();
+    procedure.runOnce();
+
+    Assert.assertEquals(
+        List.of(
+            OperatePipeTaskState.VALIDATE_TASK,
+            OperatePipeTaskState.CALCULATE_INFO_FOR_TASK,
+            OperatePipeTaskState.WRITE_CONFIG_NODE_CONSENSUS,
+            OperatePipeTaskState.OPERATE_ON_DATA_NODES),
+        procedure.executionOrder);
+  }
+
   private static class TestOperatePipeProcedure extends AbstractOperatePipeProcedureV2 {
 
     private int validateExecutionCount;
     private int calculateExecutionCount;
     private boolean failValidation;
     private boolean failCalculation;
+    private boolean preDeleteEnabled;
+    private final List<OperatePipeTaskState> executionOrder = new ArrayList<>();
 
     private TestOperatePipeProcedure() {
       pipeTaskInfo = new AtomicReference<>(new PipeTaskInfo());
@@ -141,6 +190,7 @@ public class AbstractOperatePipeProcedureV2Test {
     public boolean executeFromValidateTask(
         final org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv env)
         throws PipeException {
+      executionOrder.add(OperatePipeTaskState.VALIDATE_TASK);
       validateExecutionCount++;
       if (failValidation) {
         throw new PipeException("retry");
@@ -151,6 +201,7 @@ public class AbstractOperatePipeProcedureV2Test {
     @Override
     public void executeFromCalculateInfoForTask(
         final org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv env) {
+      executionOrder.add(OperatePipeTaskState.CALCULATE_INFO_FOR_TASK);
       calculateExecutionCount++;
       if (failCalculation) {
         throw new RuntimeException("retry");
@@ -158,15 +209,26 @@ public class AbstractOperatePipeProcedureV2Test {
     }
 
     @Override
+    protected boolean shouldExecutePreDeleteState() {
+      return preDeleteEnabled;
+    }
+
+    @Override
+    public void executeFromPreDelete(
+        final org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv env) {
+      executionOrder.add(OperatePipeTaskState.PRE_DELETE);
+    }
+
+    @Override
     public void executeFromWriteConfigNodeConsensus(
         final org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv env) {
-      // Do nothing
+      executionOrder.add(OperatePipeTaskState.WRITE_CONFIG_NODE_CONSENSUS);
     }
 
     @Override
     public void executeFromOperateOnDataNodes(
         final org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv env) {
-      // Do nothing
+      executionOrder.add(OperatePipeTaskState.OPERATE_ON_DATA_NODES);
     }
 
     @Override

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/AbstractOperatePipeProcedureV2Test.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/AbstractOperatePipeProcedureV2Test.java
@@ -19,7 +19,6 @@
 
 package org.apache.iotdb.confignode.procedure.impl.pipe;
 
-import org.apache.iotdb.confignode.i18n.ProcedureMessages;
 import org.apache.iotdb.confignode.persistence.pipe.PipeTaskInfo;
 import org.apache.iotdb.confignode.procedure.Procedure;
 import org.apache.iotdb.confignode.procedure.impl.StateMachineProcedure;
@@ -30,8 +29,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class AbstractOperatePipeProcedureV2Test {
@@ -108,60 +106,14 @@ public class AbstractOperatePipeProcedureV2Test {
   @Test
   public void testTimeoutDiagnosticReportsDataNodeOperation() throws Exception {
     final TestOperatePipeProcedure procedure = new TestOperatePipeProcedure();
+    procedure.setPendingDataNodeIdsForTest(Set.of(3, 1));
 
     procedure.executeFromState(null, OperatePipeTaskState.OPERATE_ON_DATA_NODES);
 
     final String diagnosticMessage = procedure.getTimeoutDiagnosticMessage();
     Assert.assertTrue(diagnosticMessage.contains("OPERATE_ON_DATA_NODES"));
-    Assert.assertTrue(
-        diagnosticMessage.contains(
-            ProcedureMessages
-                .MESSAGE_ONE_OR_MORE_DATANODES_HAVE_NOT_RESPONDED_TO_THE_PIPE_METADATA_PUSH_THEY_MAY_BE_UNAVAILABLE_OR_SLOW_11BBB333));
-  }
-
-  @Test
-  public void testPreDeleteFlowAndStateOrdinalCompatibility() throws Exception {
-    Assert.assertEquals(0, OperatePipeTaskState.VALIDATE_TASK.ordinal());
-    Assert.assertEquals(1, OperatePipeTaskState.CALCULATE_INFO_FOR_TASK.ordinal());
-    Assert.assertEquals(2, OperatePipeTaskState.OPERATE_ON_DATA_NODES.ordinal());
-    Assert.assertEquals(3, OperatePipeTaskState.WRITE_CONFIG_NODE_CONSENSUS.ordinal());
-    Assert.assertEquals(4, OperatePipeTaskState.PRE_DELETE.ordinal());
-
-    final TestOperatePipeProcedure procedure = new TestOperatePipeProcedure();
-    procedure.preDeleteEnabled = true;
-
-    for (int i = 0; i < 5; i++) {
-      procedure.runOnce();
-    }
-
-    Assert.assertEquals(
-        List.of(
-            OperatePipeTaskState.VALIDATE_TASK,
-            OperatePipeTaskState.CALCULATE_INFO_FOR_TASK,
-            OperatePipeTaskState.PRE_DELETE,
-            OperatePipeTaskState.OPERATE_ON_DATA_NODES,
-            OperatePipeTaskState.WRITE_CONFIG_NODE_CONSENSUS),
-        procedure.executionOrder);
-  }
-
-  @Test
-  public void testLegacyDropFlowWithoutPreDeleteHistoryStillOperatesOnDataNodes() throws Exception {
-    final TestOperatePipeProcedure procedure = new TestOperatePipeProcedure();
-
-    // Schedule WRITE_CONFIG_NODE_CONSENSUS with the legacy flow, then continue with the new logic.
-    procedure.runOnce();
-    procedure.runOnce();
-    procedure.preDeleteEnabled = true;
-    procedure.runOnce();
-    procedure.runOnce();
-
-    Assert.assertEquals(
-        List.of(
-            OperatePipeTaskState.VALIDATE_TASK,
-            OperatePipeTaskState.CALCULATE_INFO_FOR_TASK,
-            OperatePipeTaskState.WRITE_CONFIG_NODE_CONSENSUS,
-            OperatePipeTaskState.OPERATE_ON_DATA_NODES),
-        procedure.executionOrder);
+    Assert.assertTrue(diagnosticMessage.contains("DataNodes [1, 3]"));
+    Assert.assertTrue(diagnosticMessage.contains("SHOW CLUSTER"));
   }
 
   private static class TestOperatePipeProcedure extends AbstractOperatePipeProcedureV2 {
@@ -170,8 +122,6 @@ public class AbstractOperatePipeProcedureV2Test {
     private int calculateExecutionCount;
     private boolean failValidation;
     private boolean failCalculation;
-    private boolean preDeleteEnabled;
-    private final List<OperatePipeTaskState> executionOrder = new ArrayList<>();
 
     private TestOperatePipeProcedure() {
       pipeTaskInfo = new AtomicReference<>(new PipeTaskInfo());
@@ -179,6 +129,10 @@ public class AbstractOperatePipeProcedureV2Test {
 
     private Procedure<?>[] runOnce() throws InterruptedException {
       return execute(null);
+    }
+
+    private void setPendingDataNodeIdsForTest(final Set<Integer> pendingDataNodeIds) {
+      setPendingDataNodeIds(pendingDataNodeIds);
     }
 
     @Override
@@ -190,7 +144,6 @@ public class AbstractOperatePipeProcedureV2Test {
     public boolean executeFromValidateTask(
         final org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv env)
         throws PipeException {
-      executionOrder.add(OperatePipeTaskState.VALIDATE_TASK);
       validateExecutionCount++;
       if (failValidation) {
         throw new PipeException("retry");
@@ -201,7 +154,6 @@ public class AbstractOperatePipeProcedureV2Test {
     @Override
     public void executeFromCalculateInfoForTask(
         final org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv env) {
-      executionOrder.add(OperatePipeTaskState.CALCULATE_INFO_FOR_TASK);
       calculateExecutionCount++;
       if (failCalculation) {
         throw new RuntimeException("retry");
@@ -209,26 +161,15 @@ public class AbstractOperatePipeProcedureV2Test {
     }
 
     @Override
-    protected boolean shouldExecutePreDeleteState() {
-      return preDeleteEnabled;
-    }
-
-    @Override
-    public void executeFromPreDelete(
-        final org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv env) {
-      executionOrder.add(OperatePipeTaskState.PRE_DELETE);
-    }
-
-    @Override
     public void executeFromWriteConfigNodeConsensus(
         final org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv env) {
-      executionOrder.add(OperatePipeTaskState.WRITE_CONFIG_NODE_CONSENSUS);
+      // Do nothing
     }
 
     @Override
     public void executeFromOperateOnDataNodes(
         final org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv env) {
-      executionOrder.add(OperatePipeTaskState.OPERATE_ON_DATA_NODES);
+      // Do nothing
     }
 
     @Override

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/DropPipeProcedureV2Test.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/DropPipeProcedureV2Test.java
@@ -19,19 +19,59 @@
 
 package org.apache.iotdb.confignode.procedure.impl.pipe.task;
 
+import org.apache.iotdb.common.rpc.thrift.TSStatus;
+import org.apache.iotdb.commons.pipe.agent.task.meta.PipeRuntimeMeta;
+import org.apache.iotdb.commons.pipe.agent.task.meta.PipeStaticMeta;
+import org.apache.iotdb.commons.pipe.agent.task.meta.PipeStatus;
+import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlan;
+import org.apache.iotdb.confignode.consensus.request.write.pipe.task.CreatePipePlanV2;
+import org.apache.iotdb.confignode.consensus.request.write.pipe.task.SetPipeStatusPlanV2;
+import org.apache.iotdb.confignode.manager.ConfigManager;
+import org.apache.iotdb.confignode.manager.consensus.ConsensusManager;
+import org.apache.iotdb.confignode.persistence.pipe.PipeTaskInfo;
+import org.apache.iotdb.confignode.procedure.env.ConfigNodeProcedureEnv;
 import org.apache.iotdb.confignode.procedure.store.ProcedureFactory;
+import org.apache.iotdb.pipe.api.exception.PipeException;
+import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.apache.tsfile.utils.PublicBAOS;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
 import java.io.DataOutputStream;
 import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class DropPipeProcedureV2Test {
+
+  private static class TestDropPipeProcedureV2 extends DropPipeProcedureV2 {
+
+    private TestDropPipeProcedureV2() {
+      super();
+    }
+
+    private TestDropPipeProcedureV2(final String pipeName) throws PipeException {
+      super(pipeName);
+    }
+
+    private TestDropPipeProcedureV2(final String pipeName, final boolean isTableModel)
+        throws PipeException {
+      super(pipeName, isTableModel);
+    }
+
+    private void setPipeTaskInfo(final PipeTaskInfo pipeTaskInfo) {
+      this.pipeTaskInfo = new AtomicReference<>(pipeTaskInfo);
+    }
+  }
+
   @Test
   public void serializeDeserializeTest() {
     PublicBAOS byteArrayOutputStream = new PublicBAOS();
@@ -71,5 +111,92 @@ public class DropPipeProcedureV2Test {
     } catch (Exception e) {
       fail();
     }
+  }
+
+  @Test
+  public void testPreDeleteWritesStatusBeforeFinalDrop() throws Exception {
+    final String pipeName = "testPipe";
+    final PipeTaskInfo pipeTaskInfo = createPipeTaskInfo(pipeName);
+    final TestDropPipeProcedureV2 proc = new TestDropPipeProcedureV2(pipeName, false);
+    proc.setPipeTaskInfo(pipeTaskInfo);
+    proc.executeFromCalculateInfoForTask(Mockito.mock(ConfigNodeProcedureEnv.class));
+
+    final ConfigNodeProcedureEnv env = Mockito.mock(ConfigNodeProcedureEnv.class);
+    final ConfigManager configManager = Mockito.mock(ConfigManager.class);
+    final ConsensusManager consensusManager = Mockito.mock(ConsensusManager.class);
+    Mockito.when(env.getConfigManager()).thenReturn(configManager);
+    Mockito.when(configManager.getConsensusManager()).thenReturn(consensusManager);
+    Mockito.when(consensusManager.write(Mockito.any(ConfigPhysicalPlan.class)))
+        .thenReturn(new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode()));
+
+    proc.executeFromPreDelete(env);
+
+    final ArgumentCaptor<ConfigPhysicalPlan> planCaptor =
+        ArgumentCaptor.forClass(ConfigPhysicalPlan.class);
+    Mockito.verify(consensusManager).write(planCaptor.capture());
+    assertEquals(
+        new SetPipeStatusPlanV2(pipeName, PipeStatus.PRE_DELETE, false), planCaptor.getValue());
+  }
+
+  @Test
+  public void testRecoveredLegacyProcedureRestoresPipeMetaBeforePreDelete() throws Exception {
+    final String pipeName = "testPipe";
+    final PipeTaskInfo pipeTaskInfo = createPipeTaskInfo(pipeName);
+    final TestDropPipeProcedureV2 proc = new TestDropPipeProcedureV2(pipeName);
+    proc.setPipeTaskInfo(pipeTaskInfo);
+    proc.executeFromCalculateInfoForTask(Mockito.mock(ConfigNodeProcedureEnv.class));
+
+    final PublicBAOS byteArrayOutputStream = new PublicBAOS();
+    proc.serialize(new DataOutputStream(byteArrayOutputStream));
+    final ByteBuffer byteBuffer =
+        ByteBuffer.wrap(byteArrayOutputStream.getBuf(), 0, byteArrayOutputStream.size());
+    byteBuffer.getShort();
+    final TestDropPipeProcedureV2 recoveredProc = new TestDropPipeProcedureV2();
+    recoveredProc.deserialize(byteBuffer);
+    recoveredProc.setPipeTaskInfo(pipeTaskInfo);
+
+    assertFalse(recoveredProc.isTableModelSet());
+    assertNull(recoveredProc.getPipeMetaToDrop());
+    assertTrue(recoveredProc.restorePipeMetaToDropIfNecessary());
+    assertEquals(pipeTaskInfo.getPipeMetaByPipeName(pipeName), recoveredProc.getPipeMetaToDrop());
+  }
+
+  @Test
+  public void testPreDeletePipeIsNotAutoRestarted() {
+    final String pipeName = "testPipe";
+    final PipeTaskInfo pipeTaskInfo = createPipeTaskInfo(pipeName);
+    pipeTaskInfo
+        .getPipeMetaByPipeName(pipeName)
+        .getRuntimeMeta()
+        .getStatus()
+        .set(PipeStatus.PRE_DELETE);
+    pipeTaskInfo
+        .getPipeMetaByPipeName(pipeName)
+        .getRuntimeMeta()
+        .setIsStoppedByRuntimeException(true);
+
+    assertFalse(pipeTaskInfo.autoRestart());
+    assertEquals(
+        PipeStatus.PRE_DELETE,
+        pipeTaskInfo.getPipeMetaByPipeName(pipeName).getRuntimeMeta().getStatus().get());
+    assertTrue(
+        pipeTaskInfo
+            .getPipeMetaByPipeName(pipeName)
+            .getRuntimeMeta()
+            .getIsStoppedByRuntimeException());
+  }
+
+  private PipeTaskInfo createPipeTaskInfo(final String pipeName) {
+    final PipeTaskInfo pipeTaskInfo = new PipeTaskInfo();
+    pipeTaskInfo.createPipe(
+        new CreatePipePlanV2(
+            new PipeStaticMeta(
+                pipeName,
+                System.currentTimeMillis(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap()),
+            new PipeRuntimeMeta()));
+    return pipeTaskInfo;
   }
 }

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/DropPipeProcedureV2Test.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/impl/pipe/task/DropPipeProcedureV2Test.java
@@ -25,6 +25,7 @@ import org.apache.iotdb.commons.pipe.agent.task.meta.PipeStaticMeta;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeStatus;
 import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlan;
 import org.apache.iotdb.confignode.consensus.request.write.pipe.task.CreatePipePlanV2;
+import org.apache.iotdb.confignode.consensus.request.write.pipe.task.DropPipePlanV2;
 import org.apache.iotdb.confignode.consensus.request.write.pipe.task.SetPipeStatusPlanV2;
 import org.apache.iotdb.confignode.manager.ConfigManager;
 import org.apache.iotdb.confignode.manager.consensus.ConsensusManager;
@@ -114,7 +115,7 @@ public class DropPipeProcedureV2Test {
   }
 
   @Test
-  public void testPreDeleteWritesStatusBeforeFinalDrop() throws Exception {
+  public void testWriteConsensusMarksPreDeleteBeforeFinalDrop() throws Exception {
     final String pipeName = "testPipe";
     final PipeTaskInfo pipeTaskInfo = createPipeTaskInfo(pipeName);
     final TestDropPipeProcedureV2 proc = new TestDropPipeProcedureV2(pipeName, false);
@@ -129,13 +130,39 @@ public class DropPipeProcedureV2Test {
     Mockito.when(consensusManager.write(Mockito.any(ConfigPhysicalPlan.class)))
         .thenReturn(new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode()));
 
-    proc.executeFromPreDelete(env);
+    proc.executeFromWriteConfigNodeConsensus(env);
 
     final ArgumentCaptor<ConfigPhysicalPlan> planCaptor =
         ArgumentCaptor.forClass(ConfigPhysicalPlan.class);
     Mockito.verify(consensusManager).write(planCaptor.capture());
     assertEquals(
         new SetPipeStatusPlanV2(pipeName, PipeStatus.PRE_DELETE, false), planCaptor.getValue());
+  }
+
+  @Test
+  public void testDataNodeStageCommitsFinalDrop() throws Exception {
+    final String pipeName = "testPipe";
+    final PipeTaskInfo pipeTaskInfo = createPipeTaskInfo(pipeName);
+    final TestDropPipeProcedureV2 proc = new TestDropPipeProcedureV2(pipeName, false);
+    proc.setPipeTaskInfo(pipeTaskInfo);
+    proc.executeFromCalculateInfoForTask(Mockito.mock(ConfigNodeProcedureEnv.class));
+
+    final ConfigNodeProcedureEnv env = Mockito.mock(ConfigNodeProcedureEnv.class);
+    final ConfigManager configManager = Mockito.mock(ConfigManager.class);
+    final ConsensusManager consensusManager = Mockito.mock(ConsensusManager.class);
+    Mockito.when(env.getConfigManager()).thenReturn(configManager);
+    Mockito.when(configManager.getConsensusManager()).thenReturn(consensusManager);
+    Mockito.when(env.pushSinglePipeMetaToDataNodes(Mockito.any(ByteBuffer.class), Mockito.any()))
+        .thenReturn(Collections.emptyMap());
+    Mockito.when(consensusManager.write(Mockito.any(ConfigPhysicalPlan.class)))
+        .thenReturn(new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode()));
+
+    proc.executeFromOperateOnDataNodes(env);
+
+    final ArgumentCaptor<ConfigPhysicalPlan> planCaptor =
+        ArgumentCaptor.forClass(ConfigPhysicalPlan.class);
+    Mockito.verify(consensusManager).write(planCaptor.capture());
+    assertEquals(new DropPipePlanV2(pipeName, false), planCaptor.getValue());
   }
 
   @Test

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/PipeTaskAgent.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/PipeTaskAgent.java
@@ -220,6 +220,12 @@ public abstract class PipeTaskAgent {
       return;
     }
 
+    // PRE_DELETE is a coordinator-only marker. The drop procedure will push DROPPED explicitly
+    // after the marker is persisted, so task agents should retain their current runtime state here.
+    if (metaFromCoordinator.getRuntimeMeta().getStatus().get() == PipeStatus.PRE_DELETE) {
+      return;
+    }
+
     if (metaFromCoordinator.getRuntimeMeta().getStatus().get() == PipeStatus.DROPPED) {
       dropPipe(pipeName, creationTime);
       return;

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/meta/PipeStatus.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/meta/PipeStatus.java
@@ -25,6 +25,7 @@ public enum PipeStatus {
   RUNNING((byte) 0),
   STOPPED((byte) 1),
   DROPPED((byte) 2),
+  PRE_DELETE((byte) 3),
   ;
 
   private final byte type;
@@ -45,6 +46,8 @@ public enum PipeStatus {
         return PipeStatus.STOPPED;
       case 2:
         return PipeStatus.DROPPED;
+      case 3:
+        return PipeStatus.PRE_DELETE;
       default:
         throw new IllegalArgumentException(SchemaMessages.SCHEMA_INVALID_INPUT + type);
     }

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/pipe/task/PipeMetaDeSerTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/pipe/task/PipeMetaDeSerTest.java
@@ -51,6 +51,14 @@ import java.util.concurrent.ConcurrentHashMap;
 public class PipeMetaDeSerTest {
 
   @Test
+  public void testPipeStatusTypeCompatibility() {
+    Assert.assertEquals((byte) 0, PipeStatus.RUNNING.getType());
+    Assert.assertEquals((byte) 1, PipeStatus.STOPPED.getType());
+    Assert.assertEquals((byte) 2, PipeStatus.DROPPED.getType());
+    Assert.assertEquals((byte) 3, PipeStatus.PRE_DELETE.getType());
+  }
+
+  @Test
   public void test() throws IOException {
     final PipeStaticMeta pipeStaticMeta =
         new PipeStaticMeta(
@@ -153,6 +161,11 @@ public class PipeMetaDeSerTest {
         .get(456)
         .trackExceptionMessage(new PipeRuntimeSinkCriticalException("test456"));
 
+    runtimeByteBuffer = pipeRuntimeMeta.serialize();
+    pipeRuntimeMeta1 = PipeRuntimeMeta.deserialize(runtimeByteBuffer);
+    Assert.assertEquals(pipeRuntimeMeta, pipeRuntimeMeta1);
+
+    pipeRuntimeMeta.getStatus().set(PipeStatus.PRE_DELETE);
     runtimeByteBuffer = pipeRuntimeMeta.serialize();
     pipeRuntimeMeta1 = PipeRuntimeMeta.deserialize(runtimeByteBuffer);
     Assert.assertEquals(pipeRuntimeMeta, pipeRuntimeMeta1);


### PR DESCRIPTION
## Description

This PR improves the observability of Pipe control procedures, especially when the client times out while the Procedure continues running in the background.

### Improve timeout diagnostics for Pipe control statements

When CREATE PIPE, ALTER PIPE, START PIPE, STOP PIPE, or DROP PIPE times out while waiting for its Procedure, the returned diagnostic message now includes:

- the Pipe operation and Procedure ID
- the current execution or rollback stage
- a stage-specific possible cause, or the latest retry/failure exception when available
- an explicit reminder that the Procedure is still running in the background

The diagnostic state is volatile and non-persistent, so it does not affect Procedure execution or recovery. Internal consensus Pipe procedures retain their optimistic timeout behavior.

### Make timed-out DROP PIPE observable through SHOW PIPES

The new DROP PIPE flow is:

~~~text
VALIDATE_TASK
  -> CALCULATE_INFO_FOR_TASK
  -> PRE_DELETE
  -> OPERATE_ON_DATA_NODES
  -> WRITE_CONFIG_NODE_CONSENSUS
~~~

At PRE_DELETE, ConfigNode persists the Pipe runtime status as PRE_DELETE. Therefore:

- while the Drop Procedure is unfinished, SHOW PIPES still returns the Pipe with state PRE_DELETE
- after DataNode cleanup completes, the final ConfigNode consensus write removes the Pipe metadata
- heartbeat parsing, metadata synchronization, failure recording, and auto-restart cannot overwrite PRE_DELETE
- START PIPE, STOP PIPE, and ALTER PIPE reject a Pipe in PRE_DELETE; DROP PIPE can still be retried
- task agents treat PRE_DELETE as a coordinator-only marker and wait for the explicit DROPPED metadata

### Compatibility

The implementation reuses DropPipeProcedureV2 while preserving persisted data compatibility:

- OperatePipeTaskState.PRE_DELETE is appended at ordinal 4; existing ordinals 0-3 are unchanged
- PipeStatus.PRE_DELETE uses byte code 3; existing codes 0-2 are unchanged
- persisted state history distinguishes the new flow from recovered legacy Procedures
- legacy Procedures already at WRITE_CONFIG_NODE_CONSENSUS or OPERATE_ON_DATA_NODES continue with the old ordering
- legacy Procedures that did not persist pipeMetaToDrop restore it from PipeTaskInfo before entering PRE_DELETE

### Tests

Added coverage for:

- timeout diagnostics and execution stages
- new and legacy Drop Procedure state ordering
- Procedure state ordinal and Pipe status byte compatibility
- legacy Procedure recovery without persisted pipeMetaToDrop
- PRE_DELETE consensus-plan and runtime-metadata serialization
- SHOW PIPES output
- heartbeat protection and auto-restart protection

Local verification:

- Spotless passed for node-commons and confignode
- ConfigNode and Node Commons Checkstyle passed
- PipeMetaDeSerTest: 3 tests passed
- focused state-machine tests: 7 tests passed
- focused Drop serialization/recovery/auto-restart tests passed
- all modified ConfigNode main sources and focused tests passed isolated compilation
- git diff --check passed

The complete ConfigNode Maven test invocation is currently blocked locally by pre-existing generated Thrift/cache API mismatches in this checkout.

<hr>

This PR has:

- [x] been self-reviewed
  - [x] concurrent read and write
- [x] preserved persisted Procedure and Pipe status compatibility
- [x] added comments explaining the compatibility and lifecycle decisions
- [x] added unit tests for the new behavior and recovery paths

<hr>

##### Key changed/added classes

- AbstractOperatePipeProcedureV2
- DropPipeProcedureV2
- OperatePipeTaskState
- StateMachineProcedure
- PipeStatus
- PipeTaskAgent
- PipeTaskInfo
- PipeHeartbeatParser
- PipeMetaSyncProcedure
- ProcedureManager