### PR TITLE
[Pipe] Preserve parser fairness and OOM retry state

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/container/scan/TsFileInsertionScanDataContainer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/container/scan/TsFileInsertionScanDataContainer.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.pipe.event.common.tsfile.container.scan;
 
 import org.apache.iotdb.commons.exception.IllegalPathException;
+import org.apache.iotdb.commons.exception.pipe.PipeRuntimeOutOfMemoryCriticalException;
 import org.apache.iotdb.commons.pipe.agent.task.meta.PipeTaskMeta;
 import org.apache.iotdb.commons.pipe.config.PipeConfig;
 import org.apache.iotdb.commons.pipe.datastructure.pattern.PipePattern;
@@ -352,6 +353,10 @@ public class TsFileInsertionScanDataContainer extends TsFileInsertionDataContain
       }
       PipeTabletUtils.compactBitMaps(tablet);
       return tablet;
+    } catch (final PipeRuntimeOutOfMemoryCriticalException e) {
+      // Keep the parser state so the caller can yield its parser slot and retry from the same
+      // unconsumed data after memory is available again.
+      throw e;
     } catch (final Exception e) {
       close();
       throw new PipeException("Failed to get next tablet insertion event.", e);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManager.java
@@ -71,6 +71,7 @@ public class PipeMemoryManager {
   private final Map<PipeIdentity, ArrayDeque<PipeRegionIdentity>>
       waitingTsFileParserRegionOrderByPipe = new HashMap<>();
   private final ArrayDeque<PipeIdentity> waitingTsFileParserPipeOrder = new ArrayDeque<>();
+  private PipeIdentity lastAdmittedWaitingTsFileParserPipe;
 
   // Only non-zero memory blocks will be added to this set.
   private final Set<PipeMemoryBlock> allocatedBlocks = new HashSet<>();
@@ -177,7 +178,8 @@ public class PipeMemoryManager {
     final PipeIdentity pipeIdentity = new PipeIdentity(pipeName, creationTime);
     final PipeRegionIdentity pipeRegionIdentity =
         new PipeRegionIdentity(pipeIdentity, dataRegionId);
-    enqueueTsFileParserReservationRequest(pipeRegionIdentity, reservationKey);
+    final boolean wasRequestAlreadyWaiting =
+        enqueueTsFileParserReservationRequest(pipeRegionIdentity, reservationKey);
 
     final int globalLimit = Math.max(1, PIPE_CONFIG.getPipeTsFileParserInFlightMaxNum());
     final int perPipeRegionLimit =
@@ -212,6 +214,9 @@ public class PipeMemoryManager {
     }
 
     removeTsFileParserReservationRequest(pipeRegionIdentity, reservationKey, true);
+    if (wasRequestAlreadyWaiting) {
+      lastAdmittedWaitingTsFileParserPipe = pipeIdentity;
+    }
     reservedTsFileParserCount++;
     reservedTsFileParserCountByPipe.merge(pipeIdentity, 1, Integer::sum);
     reservedTsFileParserCountByPipeRegion.put(pipeRegionIdentity, reservedCountOfPipeRegion + 1);
@@ -262,10 +267,11 @@ public class PipeMemoryManager {
       reservedTsFileParserCountByPipe.put(pipeIdentity, reservedCountOfPipe - 1);
     }
     reservedTsFileParserCount--;
+    clearTsFileParserAdmissionCursorIfIdle();
     notifyNextTsFileParserMemoryReservationInternal();
   }
 
-  private void enqueueTsFileParserReservationRequest(
+  private boolean enqueueTsFileParserReservationRequest(
       final PipeRegionIdentity pipeRegionIdentity,
       final TsFileParserMemoryReservation reservationKey) {
     final LinkedHashSet<TsFileParserMemoryReservation> requestsOfPipeRegion =
@@ -282,7 +288,7 @@ public class PipeMemoryManager {
               regionOrder.addLast(key);
               return new LinkedHashSet<>();
             });
-    requestsOfPipeRegion.add(reservationKey);
+    return !requestsOfPipeRegion.add(reservationKey);
   }
 
   public synchronized void notifyNextTsFileParserMemoryReservation() {
@@ -322,7 +328,14 @@ public class PipeMemoryManager {
 
   private PipeRegionIdentity getNextEligibleTsFileParserPipeRegion(
       final int perPipeRegionLimit, final boolean requirePipeWithoutReservedParser) {
+    PipeRegionIdentity firstEligiblePipeRegion = null;
+    boolean hasVisitedLastAdmittedPipe = lastAdmittedWaitingTsFileParserPipe == null;
     for (final PipeIdentity pipeIdentity : waitingTsFileParserPipeOrder) {
+      final boolean isLastAdmittedPipe = pipeIdentity.equals(lastAdmittedWaitingTsFileParserPipe);
+      if (isLastAdmittedPipe) {
+        hasVisitedLastAdmittedPipe = true;
+      }
+
       // Under soft memory pressure, reserve the hard-threshold headroom for a pipe that has no
       // parser yet. Otherwise a busy pipe at the queue head can block every pipe behind it.
       if (requirePipeWithoutReservedParser
@@ -335,14 +348,32 @@ public class PipeMemoryManager {
       if (regionOrder == null) {
         continue;
       }
+      PipeRegionIdentity eligiblePipeRegion = null;
       for (final PipeRegionIdentity pipeRegionIdentity : regionOrder) {
         if (reservedTsFileParserCountByPipeRegion.getOrDefault(pipeRegionIdentity, 0)
             < perPipeRegionLimit) {
-          return pipeRegionIdentity;
+          eligiblePipeRegion = pipeRegionIdentity;
+          break;
         }
       }
+      if (eligiblePipeRegion == null) {
+        continue;
+      }
+
+      if (firstEligiblePipeRegion == null) {
+        firstEligiblePipeRegion = eligiblePipeRegion;
+      }
+      if (hasVisitedLastAdmittedPipe && !isLastAdmittedPipe) {
+        return eligiblePipeRegion;
+      }
     }
-    return null;
+    return firstEligiblePipeRegion;
+  }
+
+  private void clearTsFileParserAdmissionCursorIfIdle() {
+    if (reservedTsFileParserCount == 0 && waitingTsFileParserPipeOrder.isEmpty()) {
+      lastAdmittedWaitingTsFileParserPipe = null;
+    }
   }
 
   private void removeTsFileParserReservationRequest(
@@ -365,6 +396,9 @@ public class PipeMemoryManager {
         if (regionOrder.isEmpty()) {
           waitingTsFileParserRegionOrderByPipe.remove(pipeIdentity);
           waitingTsFileParserPipeOrder.remove(pipeIdentity);
+          if (!rotateAfterAdmission) {
+            clearTsFileParserAdmissionCursorIfIdle();
+          }
           return;
         }
       }
@@ -376,6 +410,8 @@ public class PipeMemoryManager {
     if (rotateAfterAdmission) {
       waitingTsFileParserPipeOrder.remove(pipeIdentity);
       waitingTsFileParserPipeOrder.addLast(pipeIdentity);
+    } else {
+      clearTsFileParserAdmissionCursorIfIdle();
     }
   }
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/TsFileInsertionDataContainerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/TsFileInsertionDataContainerTest.java
@@ -185,6 +185,47 @@ public class TsFileInsertionDataContainerTest {
   }
 
   @Test
+  public void testScanContainerKeepsIteratorOnOutOfMemory() throws Exception {
+    nonalignedTsFile =
+        TsFileGeneratorUtils.generateNonAlignedTsFile(
+            "nonaligned-retry-tablet-memory.tsfile", 1, 1, 10, 0, 100, 10, 10);
+
+    try (final TsFileInsertionScanDataContainer container =
+        new TsFileInsertionScanDataContainer(
+            nonalignedTsFile,
+            new PrefixPipePattern("root"),
+            Long.MIN_VALUE,
+            Long.MAX_VALUE,
+            null,
+            null,
+            false)) {
+      final AtomicInteger memoryUsageReadCount = new AtomicInteger(0);
+      replaceAllocatedTabletMemory(
+          container,
+          new PipeMemoryBlock(0) {
+            @Override
+            public long getMemoryUsageInBytes() {
+              if (memoryUsageReadCount.incrementAndGet() == 2) {
+                throw new PipeRuntimeOutOfMemoryCriticalException("expected oom");
+              }
+              return super.getMemoryUsageInBytes();
+            }
+          });
+
+      final Iterator<TabletInsertionEvent> iterator =
+          container.toTabletInsertionEvents().iterator();
+      final PipeRuntimeOutOfMemoryCriticalException exception =
+          Assert.assertThrows(PipeRuntimeOutOfMemoryCriticalException.class, iterator::next);
+      Assert.assertEquals("expected oom", exception.getMessage());
+
+      Assert.assertTrue(iterator.hasNext());
+      final TabletInsertionEvent event = iterator.next();
+      Assert.assertTrue(event instanceof PipeRawTabletInsertionEvent);
+      ((PipeRawTabletInsertionEvent) event).clearReferenceCount(getClass().getName());
+    }
+  }
+
+  @Test
   public void testConsumeTabletInsertionEventsWithRetryPreservesProgressOnOutOfMemory()
       throws Exception {
     final PipeTsFileInsertionEvent event =
@@ -1307,6 +1348,16 @@ public class TsFileInsertionDataContainerTest {
         TsFileInsertionDataContainer.class.getDeclaredField("allocatedMemoryBlockForTablet");
     field.setAccessible(true);
     return (PipeMemoryBlock) field.get(container);
+  }
+
+  private void replaceAllocatedTabletMemory(
+      final TsFileInsertionDataContainer container, final PipeMemoryBlock replacement)
+      throws NoSuchFieldException, IllegalAccessException {
+    final Field field =
+        TsFileInsertionDataContainer.class.getDeclaredField("allocatedMemoryBlockForTablet");
+    field.setAccessible(true);
+    ((PipeMemoryBlock) field.get(container)).close();
+    field.set(container, replacement);
   }
 
   @SuppressWarnings("unchecked")

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManagerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManagerTest.java
@@ -193,6 +193,43 @@ public class PipeMemoryManagerTest {
   }
 
   @Test
+  public void testPipeFairnessSurvivesTransientSingleRegionQueueGap() {
+    commonConfig.setPipeTsFileParserInFlightMaxNum(1);
+    commonConfig.setPipeTsFileParserInFlightMaxNumPerPipeRegion(1);
+
+    final Reservation blocker = new Reservation("blocker", 0);
+    final Reservation multiRegion1 = new Reservation("multi", 1, "1");
+    final Reservation multiRegion2 = new Reservation("multi", 1, "2");
+    final Reservation multiRegion3 = new Reservation("multi", 1, "3");
+    final Reservation singleFirst = new Reservation("single", 2, "1");
+    final Reservation singleSecond = new Reservation("single", 2, "1");
+
+    Assert.assertTrue(tryAcquire(blocker));
+    Assert.assertFalse(tryAcquire(multiRegion1));
+    Assert.assertFalse(tryAcquire(multiRegion2));
+    Assert.assertFalse(tryAcquire(multiRegion3));
+    Assert.assertFalse(tryAcquire(singleFirst));
+
+    release(blocker);
+    Assert.assertTrue(tryAcquire(multiRegion1));
+    release(multiRegion1);
+
+    Assert.assertTrue(tryAcquire(singleFirst));
+    release(singleFirst);
+
+    // The single-region pipe temporarily has no admission request while it advances to its next
+    // TsFile, so the multi-region pipe can use the otherwise idle parser slot.
+    Assert.assertTrue(tryAcquire(multiRegion2));
+    Assert.assertFalse(tryAcquire(singleSecond));
+    release(multiRegion2);
+
+    // Once the single-region pipe is waiting again, the remembered pipe-level cursor must prevent
+    // another region of the multi-region pipe from taking a second consecutive turn.
+    Assert.assertFalse(tryAcquire(multiRegion3));
+    Assert.assertTrue(tryAcquire(singleSecond));
+  }
+
+  @Test
   public void testSoftMemoryHeadroomIsReservedForPipeWithoutParser() {
     commonConfig.setPipeTsFileParserInFlightMaxNum(2);
     commonConfig.setPipeTsFileParserInFlightMaxNumPerPipeRegion(2);


### PR DESCRIPTION
## Description

Backport of #18305 to `dev/1.3`.

The fair TsFile parser admission prerequisite has landed in `dev/1.3` through #18295. This PR is rebased on that commit and now contains only the follow-up fix.

### Preserve fairness across temporary queue gaps

The TsFile parser scheduler removed a single-region Pipe from the waiting order after admitting its only pending request. If that Pipe re-entered while a multi-region Pipe still had queued requests, queue insertion order could give the multi-region Pipe consecutive admissions. This change keeps a pipe-level admission cursor across temporary gaps, advances it only for requests that actually waited, and clears it once parser reservations and waiters are both idle.

### Preserve scan parser state on critical OOM

A critical OOM while resizing memory for the next Tablet was handled by the generic exception path, which closed the scan parser even though the current data had not been consumed. The scan container now propagates this retryable OOM without closing so the caller can yield the parser slot and retry from the same iterator position. Other exceptions retain the existing close-and-wrap behavior.

This also preserves the two parser diagnostics required by the V1-498 test procedure:

- `failed to consume parsed tablet from TsFile`
- `failed to allocate memory for parsing TsFile`

### Verification

- `.\mvnw.cmd clean test -pl iotdb-core/datanode -am '-Dtest=PipeMemoryManagerTest,TsFileInsertionDataContainerTest' '-Dsurefire.failIfNoSpecifiedTests=false' '-DskipITs' '-Ddevelocity.off=true'`
- Targeted suite: 22 tests, 0 failures, 0 errors.
- Checkstyle and Spotless checks passed as part of the reactor build.
- The rebased fix is patch-equivalent to the previously tested fix, and the worktree content is unchanged.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining non-obvious scheduling decisions.
- [x] added unit tests for the new admission and retry paths.

<hr>

##### Key changed/added classes

- `PipeMemoryManager`
- `PipeTsFileInsertionEvent`
- `TsFileInsertionScanDataContainer`
- `PipeMemoryManagerTest`
- `TsFileInsertionDataContainerTest`