### PR TITLE
Fix table UDF result block splitting

### DIFF
--- a/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/relational/LargeResultTableFunction.java
+++ b/integration-test/src/main/java/org/apache/iotdb/db/query/udf/example/relational/LargeResultTableFunction.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.query.udf.example.relational;
+
+import org.apache.iotdb.udf.api.exception.UDFException;
+import org.apache.iotdb.udf.api.relational.TableFunction;
+import org.apache.iotdb.udf.api.relational.access.Record;
+import org.apache.iotdb.udf.api.relational.table.MapTableFunctionHandle;
+import org.apache.iotdb.udf.api.relational.table.TableFunctionAnalysis;
+import org.apache.iotdb.udf.api.relational.table.TableFunctionHandle;
+import org.apache.iotdb.udf.api.relational.table.TableFunctionProcessorProvider;
+import org.apache.iotdb.udf.api.relational.table.argument.Argument;
+import org.apache.iotdb.udf.api.relational.table.argument.DescribedSchema;
+import org.apache.iotdb.udf.api.relational.table.argument.ScalarArgument;
+import org.apache.iotdb.udf.api.relational.table.processor.TableFunctionDataProcessor;
+import org.apache.iotdb.udf.api.relational.table.specification.ParameterSpecification;
+import org.apache.iotdb.udf.api.relational.table.specification.ScalarParameterSpecification;
+import org.apache.iotdb.udf.api.relational.table.specification.TableParameterSpecification;
+import org.apache.iotdb.udf.api.type.Type;
+
+import org.apache.tsfile.block.column.ColumnBuilder;
+import org.apache.tsfile.common.conf.TSFileConfig;
+import org.apache.tsfile.utils.Binary;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class LargeResultTableFunction implements TableFunction {
+
+  private static final String TABLE_PARAMETER_NAME = "DATA";
+  private static final String REPEAT_COUNT_PARAMETER_NAME = "REPEAT_COUNT";
+  private static final String PAYLOAD_SIZE_PARAMETER_NAME = "PAYLOAD_SIZE";
+
+  @Override
+  public List<ParameterSpecification> getArgumentsSpecifications() {
+    return Arrays.asList(
+        TableParameterSpecification.builder()
+            .name(TABLE_PARAMETER_NAME)
+            .rowSemantics()
+            .passThroughColumns()
+            .build(),
+        ScalarParameterSpecification.builder()
+            .name(REPEAT_COUNT_PARAMETER_NAME)
+            .type(Type.INT32)
+            .build(),
+        ScalarParameterSpecification.builder()
+            .name(PAYLOAD_SIZE_PARAMETER_NAME)
+            .type(Type.INT32)
+            .build());
+  }
+
+  @Override
+  public TableFunctionAnalysis analyze(Map<String, Argument> arguments) throws UDFException {
+    MapTableFunctionHandle handle =
+        new MapTableFunctionHandle.Builder()
+            .addProperty(
+                REPEAT_COUNT_PARAMETER_NAME,
+                ((ScalarArgument) arguments.get(REPEAT_COUNT_PARAMETER_NAME)).getValue())
+            .addProperty(
+                PAYLOAD_SIZE_PARAMETER_NAME,
+                ((ScalarArgument) arguments.get(PAYLOAD_SIZE_PARAMETER_NAME)).getValue())
+            .build();
+    return TableFunctionAnalysis.builder()
+        .properColumnSchema(
+            DescribedSchema.builder()
+                .addField("repeat_index", Type.INT32)
+                .addField("payload", Type.STRING)
+                .build())
+        .requiredColumns(TABLE_PARAMETER_NAME, Collections.singletonList(0))
+        .handle(handle)
+        .build();
+  }
+
+  @Override
+  public TableFunctionHandle createTableFunctionHandle() {
+    return new MapTableFunctionHandle();
+  }
+
+  @Override
+  public TableFunctionProcessorProvider getProcessorProvider(
+      TableFunctionHandle tableFunctionHandle) {
+    return new TableFunctionProcessorProvider() {
+      @Override
+      public TableFunctionDataProcessor getDataProcessor() {
+        return new TableFunctionDataProcessor() {
+          private final int repeatCount =
+              (int)
+                  ((MapTableFunctionHandle) tableFunctionHandle)
+                      .getProperty(REPEAT_COUNT_PARAMETER_NAME);
+          private final String payloadSuffix =
+              "x"
+                  .repeat(
+                      (int)
+                          ((MapTableFunctionHandle) tableFunctionHandle)
+                              .getProperty(PAYLOAD_SIZE_PARAMETER_NAME));
+          private long recordIndex;
+
+          @Override
+          public void process(
+              Record input,
+              List<ColumnBuilder> properColumnBuilders,
+              ColumnBuilder passThroughIndexBuilder) {
+            for (int repeatIndex = 0; repeatIndex < repeatCount; repeatIndex++) {
+              properColumnBuilders.get(0).writeInt(repeatIndex);
+              properColumnBuilders
+                  .get(1)
+                  .writeBinary(
+                      new Binary(repeatIndex + ":" + payloadSuffix, TSFileConfig.STRING_CHARSET));
+              passThroughIndexBuilder.writeLong(recordIndex);
+            }
+            recordIndex++;
+          }
+        };
+      }
+    };
+  }
+}

--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/udf/IoTDBUserDefinedTableFunctionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/db/it/udf/IoTDBUserDefinedTableFunctionIT.java
@@ -26,13 +26,18 @@ import org.apache.iotdb.itbase.category.TableLocalStandaloneIT;
 
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.apache.iotdb.db.it.utils.TestUtils.tableAssertTestFail;
 import static org.apache.iotdb.db.it.utils.TestUtils.tableResultSetEqualTest;
@@ -42,6 +47,9 @@ import static org.junit.Assert.fail;
 @Category({TableLocalStandaloneIT.class, TableClusterIT.class})
 public class IoTDBUserDefinedTableFunctionIT {
   private static final String DATABASE_NAME = "test";
+  private static final int MAX_TSBLOCK_SIZE_IN_BYTES = 1024;
+  private static final int LARGE_RESULT_REPEAT_COUNT = 64;
+  private static final int LARGE_RESULT_PAYLOAD_SIZE = 128;
   private static final String[] sqls =
       new String[] {
         "CREATE DATABASE " + DATABASE_NAME,
@@ -57,6 +65,10 @@ public class IoTDBUserDefinedTableFunctionIT {
 
   @BeforeClass
   public static void setUp() throws Exception {
+    EnvFactory.getEnv()
+        .getConfig()
+        .getDataNodeCommonConfig()
+        .setMaxTsBlockSizeInByte(MAX_TSBLOCK_SIZE_IN_BYTES);
     EnvFactory.getEnv().initClusterEnvironment();
     insertData();
   }
@@ -180,6 +192,74 @@ public class IoTDBUserDefinedTableFunctionIT {
         expectedHeader,
         retArray,
         DATABASE_NAME);
+  }
+
+  @Test
+  public void testLargeResultIsSplitWithoutDataLoss() throws Exception {
+    SQLFunctionUtils.createUDF(
+        "large_result",
+        "org.apache.iotdb.db.query.udf.example.relational.LargeResultTableFunction");
+
+    Set<String> returnedRows = new HashSet<>();
+    try (Connection connection = EnvFactory.getEnv().getTableConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("USE " + DATABASE_NAME);
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              "SELECT * FROM large_result(vehicle, "
+                  + LARGE_RESULT_REPEAT_COUNT
+                  + ", "
+                  + LARGE_RESULT_PAYLOAD_SIZE
+                  + ")")) {
+        while (resultSet.next()) {
+          int repeatIndex = resultSet.getInt("repeat_index");
+          long time = resultSet.getLong("time");
+          Assert.assertTrue(repeatIndex >= 0 && repeatIndex < LARGE_RESULT_REPEAT_COUNT);
+          Assert.assertEquals(
+              repeatIndex + ":" + "x".repeat(LARGE_RESULT_PAYLOAD_SIZE),
+              resultSet.getString("payload"));
+          assertPassThroughColumns(resultSet, time);
+          Assert.assertTrue(
+              "Duplicate result row for time " + time + " and repeat index " + repeatIndex,
+              returnedRows.add(time + ":" + repeatIndex));
+        }
+      }
+    }
+
+    long[] inputTimes = new long[] {1, 2, 3, 5};
+    Assert.assertEquals(inputTimes.length * LARGE_RESULT_REPEAT_COUNT, returnedRows.size());
+    for (long time : inputTimes) {
+      for (int repeatIndex = 0; repeatIndex < LARGE_RESULT_REPEAT_COUNT; repeatIndex++) {
+        Assert.assertTrue(returnedRows.contains(time + ":" + repeatIndex));
+      }
+    }
+  }
+
+  private static void assertPassThroughColumns(ResultSet resultSet, long time) throws SQLException {
+    switch ((int) time) {
+      case 1:
+        Assert.assertEquals("d0", resultSet.getString("device_id"));
+        Assert.assertEquals(1, resultSet.getInt("s1"));
+        Assert.assertEquals(1, resultSet.getLong("s2"));
+        break;
+      case 2:
+        Assert.assertEquals("d0", resultSet.getString("device_id"));
+        Assert.assertNull(resultSet.getObject("s1"));
+        Assert.assertEquals(2, resultSet.getLong("s2"));
+        break;
+      case 3:
+        Assert.assertEquals("d0", resultSet.getString("device_id"));
+        Assert.assertEquals(3, resultSet.getInt("s1"));
+        Assert.assertEquals(3, resultSet.getLong("s2"));
+        break;
+      case 5:
+        Assert.assertEquals("d1", resultSet.getString("device_id"));
+        Assert.assertEquals(4, resultSet.getInt("s1"));
+        Assert.assertNull(resultSet.getObject("s2"));
+        break;
+      default:
+        Assert.fail("Unexpected pass-through time: " + time);
+    }
   }
 
   @Test

--- a/iotdb-core/calc-commons/src/main/java/org/apache/iotdb/calc/execution/operator/process/function/TableFunctionOperator.java
+++ b/iotdb-core/calc-commons/src/main/java/org/apache/iotdb/calc/execution/operator/process/function/TableFunctionOperator.java
@@ -19,6 +19,7 @@
 
 package org.apache.iotdb.calc.execution.operator.process.function;
 
+import org.apache.iotdb.calc.execution.operator.AbstractOperator;
 import org.apache.iotdb.calc.execution.operator.CommonOperatorContext;
 import org.apache.iotdb.calc.execution.operator.Operator;
 import org.apache.iotdb.calc.execution.operator.process.AggregationMergeSortOperator;
@@ -57,7 +58,7 @@ import java.util.Queue;
 import static com.google.common.base.Preconditions.checkArgument;
 
 // only one input source is supported now
-public class TableFunctionOperator implements ProcessOperator {
+public class TableFunctionOperator extends AbstractOperator implements ProcessOperator {
 
   private static final long INSTANCE_SIZE =
       RamUsageEstimator.shallowSizeOfInstance(AggregationMergeSortOperator.class);
@@ -65,11 +66,11 @@ public class TableFunctionOperator implements ProcessOperator {
   private static final int DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES =
       TSFileDescriptor.getInstance().getConfig().getMaxTsBlockSizeInBytes();
 
-  private final CommonOperatorContext operatorContext;
   private final Operator inputOperator;
   private final TableFunctionProcessorProvider processorProvider;
   private final PartitionRecognizer partitionRecognizer;
   private final TsBlockBuilder properBlockBuilder;
+  private final int maxTsBlockLineNumber;
   private final int properChannelCount;
   private final boolean needPassThrough;
   private final PartitionCache partitionCache;
@@ -109,6 +110,8 @@ public class TableFunctionOperator implements ProcessOperator {
     this.needPassThrough = properChannelCount != outputDataTypes.size();
     this.partitionState = null;
     this.properBlockBuilder = new TsBlockBuilder(outputDataTypes.subList(0, properChannelCount));
+    this.maxTsBlockLineNumber =
+        TSFileDescriptor.getInstance().getConfig().getMaxTsBlockLineNumber();
     this.partitionCache = new PartitionCache();
     this.resultTsBlocks = new LinkedList<>();
     this.requireRecordSnapshot = requireRecordSnapshot;
@@ -148,8 +151,8 @@ public class TableFunctionOperator implements ProcessOperator {
 
   @Override
   public TsBlock next() throws Exception {
-    if (!resultTsBlocks.isEmpty()) {
-      return resultTsBlocks.poll();
+    if (retainedTsBlock != null || !resultTsBlocks.isEmpty()) {
+      return getNextResultTsBlock();
     }
     if (partitionState == null) {
       partitionState = partitionRecognizer.nextState();
@@ -172,7 +175,7 @@ public class TableFunctionOperator implements ProcessOperator {
         resultTsBlocks.addAll(buildTsBlock(properColumnBuilders, passThroughIndexBuilder));
         partitionCache.clear();
         consumeCurrentPartitionState();
-        return resultTsBlocks.poll();
+        return getNextResultTsBlock();
       }
       if (stateType == PartitionState.StateType.NEW_PARTITION) {
         if (processor != null) {
@@ -182,7 +185,7 @@ public class TableFunctionOperator implements ProcessOperator {
           partitionCache.clear();
           destroyProcessor(processor);
           processor = null;
-          return resultTsBlocks.poll();
+          return getNextResultTsBlock();
         } else {
           processor = processorProvider.getDataProcessor();
           processor.beforeStart(ioTDBLocal);
@@ -196,8 +199,70 @@ public class TableFunctionOperator implements ProcessOperator {
       }
       consumeCurrentPartitionState();
       resultTsBlocks.addAll(buildTsBlock(properColumnBuilders, passThroughIndexBuilder));
-      return resultTsBlocks.poll();
+      return getNextResultTsBlock();
     }
+  }
+
+  private TsBlock getNextResultTsBlock() {
+    if (retainedTsBlock == null) {
+      retainedTsBlock = resultTsBlocks.poll();
+      startOffset = 0;
+    }
+    return retainedTsBlock == null ? null : getResultFromRetainedTsBlock();
+  }
+
+  @Override
+  public TsBlock getResultFromRetainedTsBlock() {
+    int remainingPositionCount = retainedTsBlock.getPositionCount() - startOffset;
+    int candidatePositionCount =
+        Math.min(remainingPositionCount, Math.max(1, maxTsBlockLineNumber));
+    int resultPositionCount = getMaxResultPositionCount(candidatePositionCount);
+    TsBlock result =
+        startOffset == 0 && resultPositionCount == retainedTsBlock.getPositionCount()
+            ? retainedTsBlock
+            : copyTsBlockRegion(retainedTsBlock, startOffset, resultPositionCount);
+    startOffset += resultPositionCount;
+    if (startOffset == retainedTsBlock.getPositionCount()) {
+      retainedTsBlock = null;
+      startOffset = 0;
+    }
+    return result;
+  }
+
+  private int getMaxResultPositionCount(int candidatePositionCount) {
+    if (getRegionSizeInBytes(candidatePositionCount) <= maxReturnSize) {
+      return candidatePositionCount;
+    }
+
+    // A row is indivisible, so keep the existing one-row-at-a-time fallback when a single row is
+    // larger than maxReturnSize.
+    int left = 1;
+    int right = candidatePositionCount - 1;
+    while (left < right) {
+      int mid = left + (right - left + 1) / 2;
+      if (getRegionSizeInBytes(mid) <= maxReturnSize) {
+        left = mid;
+      } else {
+        right = mid - 1;
+      }
+    }
+    return left;
+  }
+
+  private long getRegionSizeInBytes(int positionCount) {
+    // getRegion() keeps the source column's backing arrays and estimates a region's size from their
+    // capacity. Copying the region first makes variable-width columns report the logical size of
+    // exactly the rows being considered.
+    return copyTsBlockRegion(retainedTsBlock, startOffset, positionCount).getSizeInBytes();
+  }
+
+  private TsBlock copyTsBlockRegion(TsBlock source, int offset, int positionCount) {
+    Column[] valueColumns = new Column[source.getValueColumnCount()];
+    for (int i = 0; i < valueColumns.length; i++) {
+      valueColumns[i] = source.getColumn(i).getRegionCopy(offset, positionCount);
+    }
+    return new TsBlock(
+        positionCount, source.getTimeColumn().getRegionCopy(offset, positionCount), valueColumns);
   }
 
   private List<ColumnBuilder> getProperColumnBuilders() {
@@ -265,13 +330,17 @@ public class TableFunctionOperator implements ProcessOperator {
 
   @Override
   public boolean hasNext() throws Exception {
-    return !finished || !resultTsBlocks.isEmpty();
+    return !finished || retainedTsBlock != null || !resultTsBlocks.isEmpty();
   }
 
   @Override
   public void close() throws Exception {
     partitionCache.close();
     inputOperator.close();
+    resultTsBlocks.clear();
+    resultTsBlock = null;
+    retainedTsBlock = null;
+    startOffset = 0;
     if (processor != null) {
       destroyProcessor(processor);
       processor = null;
@@ -281,7 +350,7 @@ public class TableFunctionOperator implements ProcessOperator {
 
   @Override
   public boolean isFinished() throws Exception {
-    return finished;
+    return finished && retainedTsBlock == null && resultTsBlocks.isEmpty();
   }
 
   @Override
@@ -292,7 +361,7 @@ public class TableFunctionOperator implements ProcessOperator {
 
   @Override
   public long calculateMaxReturnSize() {
-    return Math.max(DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES, properBlockBuilder.getRetainedSizeInBytes());
+    return maxReturnSize;
   }
 
   @Override

--- a/iotdb-core/calc-commons/src/main/java/org/apache/iotdb/calc/execution/operator/process/function/TableFunctionOperator.java
+++ b/iotdb-core/calc-commons/src/main/java/org/apache/iotdb/calc/execution/operator/process/function/TableFunctionOperator.java
@@ -19,7 +19,6 @@
 
 package org.apache.iotdb.calc.execution.operator.process.function;
 
-import org.apache.iotdb.calc.execution.operator.AbstractOperator;
 import org.apache.iotdb.calc.execution.operator.CommonOperatorContext;
 import org.apache.iotdb.calc.execution.operator.Operator;
 import org.apache.iotdb.calc.execution.operator.process.AggregationMergeSortOperator;
@@ -44,8 +43,10 @@ import org.apache.tsfile.read.common.block.TsBlockBuilder;
 import org.apache.tsfile.read.common.block.column.LongColumn;
 import org.apache.tsfile.read.common.block.column.LongColumnBuilder;
 import org.apache.tsfile.read.common.block.column.RunLengthEncodedColumn;
+import org.apache.tsfile.read.common.block.column.TsBlockSerde;
 import org.apache.tsfile.utils.RamUsageEstimator;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -58,18 +59,17 @@ import java.util.Queue;
 import static com.google.common.base.Preconditions.checkArgument;
 
 // only one input source is supported now
-public class TableFunctionOperator extends AbstractOperator implements ProcessOperator {
+public class TableFunctionOperator implements ProcessOperator {
 
   private static final long INSTANCE_SIZE =
       RamUsageEstimator.shallowSizeOfInstance(AggregationMergeSortOperator.class);
 
-  private static final int DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES =
-      TSFileDescriptor.getInstance().getConfig().getMaxTsBlockSizeInBytes();
-
+  private final CommonOperatorContext operatorContext;
   private final Operator inputOperator;
   private final TableFunctionProcessorProvider processorProvider;
   private final PartitionRecognizer partitionRecognizer;
   private final TsBlockBuilder properBlockBuilder;
+  private final int maxTsBlockSizeInBytes;
   private final int maxTsBlockLineNumber;
   private final int properChannelCount;
   private final boolean needPassThrough;
@@ -84,6 +84,7 @@ public class TableFunctionOperator extends AbstractOperator implements ProcessOp
   private boolean finished = false;
 
   private final Queue<TsBlock> resultTsBlocks;
+  private final TsBlockSerde tsBlockSerde;
 
   public TableFunctionOperator(
       CommonOperatorContext operatorContext,
@@ -110,10 +111,13 @@ public class TableFunctionOperator extends AbstractOperator implements ProcessOp
     this.needPassThrough = properChannelCount != outputDataTypes.size();
     this.partitionState = null;
     this.properBlockBuilder = new TsBlockBuilder(outputDataTypes.subList(0, properChannelCount));
+    this.maxTsBlockSizeInBytes =
+        TSFileDescriptor.getInstance().getConfig().getMaxTsBlockSizeInBytes();
     this.maxTsBlockLineNumber =
         TSFileDescriptor.getInstance().getConfig().getMaxTsBlockLineNumber();
     this.partitionCache = new PartitionCache();
     this.resultTsBlocks = new LinkedList<>();
+    this.tsBlockSerde = new TsBlockSerde();
     this.requireRecordSnapshot = requireRecordSnapshot;
     this.ioTDBLocal = ioTDBLocal;
   }
@@ -151,8 +155,8 @@ public class TableFunctionOperator extends AbstractOperator implements ProcessOp
 
   @Override
   public TsBlock next() throws Exception {
-    if (retainedTsBlock != null || !resultTsBlocks.isEmpty()) {
-      return getNextResultTsBlock();
+    if (!resultTsBlocks.isEmpty()) {
+      return resultTsBlocks.poll();
     }
     if (partitionState == null) {
       partitionState = partitionRecognizer.nextState();
@@ -175,7 +179,7 @@ public class TableFunctionOperator extends AbstractOperator implements ProcessOp
         resultTsBlocks.addAll(buildTsBlock(properColumnBuilders, passThroughIndexBuilder));
         partitionCache.clear();
         consumeCurrentPartitionState();
-        return getNextResultTsBlock();
+        return resultTsBlocks.poll();
       }
       if (stateType == PartitionState.StateType.NEW_PARTITION) {
         if (processor != null) {
@@ -185,7 +189,7 @@ public class TableFunctionOperator extends AbstractOperator implements ProcessOp
           partitionCache.clear();
           destroyProcessor(processor);
           processor = null;
-          return getNextResultTsBlock();
+          return resultTsBlocks.poll();
         } else {
           processor = processorProvider.getDataProcessor();
           processor.beforeStart(ioTDBLocal);
@@ -199,70 +203,8 @@ public class TableFunctionOperator extends AbstractOperator implements ProcessOp
       }
       consumeCurrentPartitionState();
       resultTsBlocks.addAll(buildTsBlock(properColumnBuilders, passThroughIndexBuilder));
-      return getNextResultTsBlock();
+      return resultTsBlocks.poll();
     }
-  }
-
-  private TsBlock getNextResultTsBlock() {
-    if (retainedTsBlock == null) {
-      retainedTsBlock = resultTsBlocks.poll();
-      startOffset = 0;
-    }
-    return retainedTsBlock == null ? null : getResultFromRetainedTsBlock();
-  }
-
-  @Override
-  public TsBlock getResultFromRetainedTsBlock() {
-    int remainingPositionCount = retainedTsBlock.getPositionCount() - startOffset;
-    int candidatePositionCount =
-        Math.min(remainingPositionCount, Math.max(1, maxTsBlockLineNumber));
-    int resultPositionCount = getMaxResultPositionCount(candidatePositionCount);
-    TsBlock result =
-        startOffset == 0 && resultPositionCount == retainedTsBlock.getPositionCount()
-            ? retainedTsBlock
-            : copyTsBlockRegion(retainedTsBlock, startOffset, resultPositionCount);
-    startOffset += resultPositionCount;
-    if (startOffset == retainedTsBlock.getPositionCount()) {
-      retainedTsBlock = null;
-      startOffset = 0;
-    }
-    return result;
-  }
-
-  private int getMaxResultPositionCount(int candidatePositionCount) {
-    if (getRegionSizeInBytes(candidatePositionCount) <= maxReturnSize) {
-      return candidatePositionCount;
-    }
-
-    // A row is indivisible, so keep the existing one-row-at-a-time fallback when a single row is
-    // larger than maxReturnSize.
-    int left = 1;
-    int right = candidatePositionCount - 1;
-    while (left < right) {
-      int mid = left + (right - left + 1) / 2;
-      if (getRegionSizeInBytes(mid) <= maxReturnSize) {
-        left = mid;
-      } else {
-        right = mid - 1;
-      }
-    }
-    return left;
-  }
-
-  private long getRegionSizeInBytes(int positionCount) {
-    // getRegion() keeps the source column's backing arrays and estimates a region's size from their
-    // capacity. Copying the region first makes variable-width columns report the logical size of
-    // exactly the rows being considered.
-    return copyTsBlockRegion(retainedTsBlock, startOffset, positionCount).getSizeInBytes();
-  }
-
-  private TsBlock copyTsBlockRegion(TsBlock source, int offset, int positionCount) {
-    Column[] valueColumns = new Column[source.getValueColumnCount()];
-    for (int i = 0; i < valueColumns.length; i++) {
-      valueColumns[i] = source.getColumn(i).getRegionCopy(offset, positionCount);
-    }
-    return new TsBlock(
-        positionCount, source.getTimeColumn().getRegionCopy(offset, positionCount), valueColumns);
   }
 
   private List<ColumnBuilder> getProperColumnBuilders() {
@@ -274,7 +216,8 @@ public class TableFunctionOperator extends AbstractOperator implements ProcessOp
   }
 
   private List<TsBlock> buildTsBlock(
-      List<ColumnBuilder> properColumnBuilders, ColumnBuilder passThroughIndexBuilder) {
+      List<ColumnBuilder> properColumnBuilders, ColumnBuilder passThroughIndexBuilder)
+      throws IOException {
     int positionCount = 0;
     if (properChannelCount > 0) {
       // if there is proper column, use its position count
@@ -306,14 +249,50 @@ public class TableFunctionOperator extends AbstractOperator implements ProcessOp
         int subBlockPositionCount = passThroughColumns[0].getPositionCount();
         TsBlock subProperBlock = properBlock.getRegion(builtCount, subBlockPositionCount);
         builtCount += subBlockPositionCount;
-        result.add(subProperBlock.appendValueColumns(passThroughColumns));
+        addSplitTsBlocks(result, subProperBlock.appendValueColumns(passThroughColumns));
       }
     } else {
-      // split the proper block into smaller blocks
-      result.add(properBlock);
+      addSplitTsBlocks(result, properBlock);
     }
     properBlockBuilder.reset();
     return result;
+  }
+
+  private void addSplitTsBlocks(List<TsBlock> result, TsBlock source) throws IOException {
+    int offset = 0;
+    while (offset < source.getPositionCount()) {
+      int candidatePositionCount =
+          Math.min(source.getPositionCount() - offset, Math.max(1, maxTsBlockLineNumber));
+      int resultPositionCount =
+          getMaxSerializedPositionCount(source, offset, candidatePositionCount);
+      result.add(source.getRegion(offset, resultPositionCount));
+      offset += resultPositionCount;
+    }
+  }
+
+  private int getMaxSerializedPositionCount(TsBlock source, int offset, int candidatePositionCount)
+      throws IOException {
+    if (getSerializedSizeInBytes(source, offset, candidatePositionCount) <= maxTsBlockSizeInBytes) {
+      return candidatePositionCount;
+    }
+
+    // A row is indivisible, so return it alone if it is larger than maxTsBlockSizeInBytes.
+    int left = 1;
+    int right = candidatePositionCount - 1;
+    while (left < right) {
+      int mid = left + (right - left + 1) / 2;
+      if (getSerializedSizeInBytes(source, offset, mid) <= maxTsBlockSizeInBytes) {
+        left = mid;
+      } else {
+        right = mid - 1;
+      }
+    }
+    return left;
+  }
+
+  private int getSerializedSizeInBytes(TsBlock source, int offset, int positionCount)
+      throws IOException {
+    return tsBlockSerde.serialize(source.getRegion(offset, positionCount)).remaining();
   }
 
   private void consumeCurrentPartitionState() {
@@ -330,7 +309,7 @@ public class TableFunctionOperator extends AbstractOperator implements ProcessOp
 
   @Override
   public boolean hasNext() throws Exception {
-    return !finished || retainedTsBlock != null || !resultTsBlocks.isEmpty();
+    return !finished || !resultTsBlocks.isEmpty();
   }
 
   @Override
@@ -338,9 +317,6 @@ public class TableFunctionOperator extends AbstractOperator implements ProcessOp
     partitionCache.close();
     inputOperator.close();
     resultTsBlocks.clear();
-    resultTsBlock = null;
-    retainedTsBlock = null;
-    startOffset = 0;
     if (processor != null) {
       destroyProcessor(processor);
       processor = null;
@@ -350,18 +326,18 @@ public class TableFunctionOperator extends AbstractOperator implements ProcessOp
 
   @Override
   public boolean isFinished() throws Exception {
-    return finished && retainedTsBlock == null && resultTsBlocks.isEmpty();
+    return finished && resultTsBlocks.isEmpty();
   }
 
   @Override
   public long calculateMaxPeekMemory() {
     return inputOperator.calculateMaxPeekMemory()
-        + Math.max(DEFAULT_MAX_TSBLOCK_SIZE_IN_BYTES, properBlockBuilder.getRetainedSizeInBytes());
+        + Math.max(maxTsBlockSizeInBytes, properBlockBuilder.getRetainedSizeInBytes());
   }
 
   @Override
   public long calculateMaxReturnSize() {
-    return maxReturnSize;
+    return maxTsBlockSizeInBytes;
   }
 
   @Override

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/process/tvf/TableFunctionOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/process/tvf/TableFunctionOperatorTest.java
@@ -297,8 +297,14 @@ public class TableFunctionOperatorTest {
   }
 
   @Test
-  public void testVariableWidthResultsAreSplitByActualSize() throws Exception {
-    QueryId queryId = new QueryId("large_finish_result");
+  public void testVariableWidthResultsAreSplitBySerializedSize() throws Exception {
+    assertVariableWidthResultsAreSplitBySerializedSize(false);
+    assertVariableWidthResultsAreSplitBySerializedSize(true);
+  }
+
+  private void assertVariableWidthResultsAreSplitBySerializedSize(boolean withPassThrough)
+      throws Exception {
+    QueryId queryId = new QueryId("large_finish_result_" + withPassThrough);
     FragmentInstanceId instanceId =
         new FragmentInstanceId(new PlanFragmentId(queryId, 0), "stub-instance");
     FragmentInstanceStateMachine stateMachine =
@@ -326,18 +332,23 @@ public class TableFunctionOperatorTest {
                   Record input,
                   List<ColumnBuilder> properColumnBuilders,
                   ColumnBuilder passThroughIndexBuilder) {
-                // Initialize the splitter with a narrow result block.
+                // Produce a narrow block before the wide result returned by finish().
                 properColumnBuilders.get(0).writeBinary(narrowValue);
+                if (passThroughIndexBuilder != null) {
+                  passThroughIndexBuilder.writeLong(0);
+                }
               }
 
               @Override
               public void finish(
                   List<ColumnBuilder> properColumnBuilders, ColumnBuilder passThroughIndexBuilder) {
-                // This second result block exceeds both maxLineNumber and maxBlockSize. Reusing a
-                // row-count estimate from the narrow block must not let an oversized slice pass
-                // through.
+                // This result exceeds both limits and must be split after pass-through columns are
+                // appended.
                 for (int i = 0; i < wideRowCount; i++) {
                   properColumnBuilders.get(0).writeBinary(wideValue);
+                  if (passThroughIndexBuilder != null) {
+                    passThroughIndexBuilder.writeLong(0);
+                  }
                 }
               }
             };
@@ -406,11 +417,13 @@ public class TableFunctionOperatorTest {
             provider,
             singleRowChild,
             Collections.singletonList(TSDataType.INT64),
-            Collections.singletonList(TSDataType.TEXT),
+            withPassThrough
+                ? Arrays.asList(TSDataType.TEXT, TSDataType.INT64)
+                : Collections.singletonList(TSDataType.TEXT),
             1,
             Collections.singletonList(0),
-            Collections.emptyList(),
-            false,
+            withPassThrough ? Collections.singletonList(0) : Collections.emptyList(),
+            withPassThrough,
             Collections.emptyList(),
             false,
             mock(IoTDBLocal.class))) {
@@ -423,12 +436,14 @@ public class TableFunctionOperatorTest {
         returnedBlocks++;
         returnedRows += block.getPositionCount();
         Assert.assertTrue(block.getPositionCount() <= maxLineNumber);
-        Assert.assertTrue(block.getSizeInBytes() <= maxBlockSize);
         Assert.assertTrue(new TsBlockSerde().serialize(block).remaining() <= maxBlockSize);
         for (int i = 0; i < block.getPositionCount(); i++) {
           int expectedLength =
               returnedRows - block.getPositionCount() + i == 0 ? 6 : wideValueLength;
           assertEquals(expectedLength, block.getColumn(0).getBinary(i).getLength());
+          if (withPassThrough) {
+            assertEquals(1, block.getColumn(1).getLong(i));
+          }
         }
       }
     }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/process/tvf/TableFunctionOperatorTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/execution/operator/process/tvf/TableFunctionOperatorTest.java
@@ -21,9 +21,11 @@ package org.apache.iotdb.db.queryengine.execution.operator.process.tvf;
 
 import org.apache.iotdb.calc.execution.operator.Operator;
 import org.apache.iotdb.calc.execution.operator.process.function.PartitionRecognizer;
+import org.apache.iotdb.calc.execution.operator.process.function.TableFunctionOperator;
 import org.apache.iotdb.calc.execution.operator.process.function.partition.PartitionState;
 import org.apache.iotdb.calc.execution.operator.process.function.partition.Slice;
 import org.apache.iotdb.commons.concurrent.IoTDBThreadPoolFactory;
+import org.apache.iotdb.commons.queryengine.plan.planner.plan.node.PlanNodeId;
 import org.apache.iotdb.db.queryengine.common.FragmentInstanceId;
 import org.apache.iotdb.db.queryengine.common.PlanFragmentId;
 import org.apache.iotdb.db.queryengine.common.QueryId;
@@ -31,13 +33,19 @@ import org.apache.iotdb.db.queryengine.execution.driver.DriverContext;
 import org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext;
 import org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceStateMachine;
 import org.apache.iotdb.db.queryengine.execution.operator.OperatorContext;
+import org.apache.iotdb.udf.api.IoTDBLocal;
 import org.apache.iotdb.udf.api.relational.access.Record;
+import org.apache.iotdb.udf.api.relational.table.TableFunctionProcessorProvider;
+import org.apache.iotdb.udf.api.relational.table.processor.TableFunctionDataProcessor;
 
+import org.apache.tsfile.block.column.ColumnBuilder;
 import org.apache.tsfile.common.conf.TSFileConfig;
+import org.apache.tsfile.common.conf.TSFileDescriptor;
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.read.common.block.TsBlock;
 import org.apache.tsfile.read.common.block.TsBlockBuilder;
 import org.apache.tsfile.read.common.block.column.RunLengthEncodedColumn;
+import org.apache.tsfile.read.common.block.column.TsBlockSerde;
 import org.apache.tsfile.utils.Binary;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -53,6 +61,7 @@ import static org.apache.iotdb.calc.plan.planner.CommonOperatorUtils.TIME_COLUMN
 import static org.apache.iotdb.db.queryengine.execution.fragment.FragmentInstanceContext.createFragmentInstanceContext;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 public class TableFunctionOperatorTest {
   private static final ExecutorService instanceNotificationExecutor =
@@ -285,6 +294,147 @@ public class TableFunctionOperatorTest {
       e.printStackTrace();
       fail(e.getMessage());
     }
+  }
+
+  @Test
+  public void testVariableWidthResultsAreSplitByActualSize() throws Exception {
+    QueryId queryId = new QueryId("large_finish_result");
+    FragmentInstanceId instanceId =
+        new FragmentInstanceId(new PlanFragmentId(queryId, 0), "stub-instance");
+    FragmentInstanceStateMachine stateMachine =
+        new FragmentInstanceStateMachine(instanceId, instanceNotificationExecutor);
+    FragmentInstanceContext fragmentInstanceContext =
+        createFragmentInstanceContext(instanceId, stateMachine);
+    DriverContext driverContext = new DriverContext(fragmentInstanceContext, 0);
+    OperatorContext operatorContext =
+        driverContext.addOperatorContext(
+            0, new PlanNodeId("tvf"), TableFunctionOperator.class.getSimpleName());
+    int maxLineNumber = TSFileDescriptor.getInstance().getConfig().getMaxTsBlockLineNumber();
+    int maxBlockSize = TSFileDescriptor.getInstance().getConfig().getMaxTsBlockSizeInBytes();
+    Assert.assertTrue(maxLineNumber >= 3);
+    int wideRowCount = maxLineNumber + 1;
+    int wideValueLength = maxBlockSize / (maxLineNumber - 1) + 1;
+    Binary narrowValue = new Binary("narrow", TSFileConfig.STRING_CHARSET);
+    Binary wideValue = new Binary(new byte[wideValueLength]);
+    TableFunctionProcessorProvider provider =
+        new TableFunctionProcessorProvider() {
+          @Override
+          public TableFunctionDataProcessor getDataProcessor() {
+            return new TableFunctionDataProcessor() {
+              @Override
+              public void process(
+                  Record input,
+                  List<ColumnBuilder> properColumnBuilders,
+                  ColumnBuilder passThroughIndexBuilder) {
+                // Initialize the splitter with a narrow result block.
+                properColumnBuilders.get(0).writeBinary(narrowValue);
+              }
+
+              @Override
+              public void finish(
+                  List<ColumnBuilder> properColumnBuilders, ColumnBuilder passThroughIndexBuilder) {
+                // This second result block exceeds both maxLineNumber and maxBlockSize. Reusing a
+                // row-count estimate from the narrow block must not let an oversized slice pass
+                // through.
+                for (int i = 0; i < wideRowCount; i++) {
+                  properColumnBuilders.get(0).writeBinary(wideValue);
+                }
+              }
+            };
+          }
+        };
+
+    Operator singleRowChild =
+        new Operator() {
+          private boolean consumed;
+
+          @Override
+          public OperatorContext getOperatorContext() {
+            return operatorContext;
+          }
+
+          @Override
+          public TsBlock next() {
+            TsBlockBuilder builder =
+                new TsBlockBuilder(1, Collections.singletonList(TSDataType.INT64));
+            builder.getColumnBuilder(0).writeLong(1);
+            builder.declarePosition();
+            consumed = true;
+            return builder.build(
+                new RunLengthEncodedColumn(TIME_COLUMN_TEMPLATE, builder.getPositionCount()));
+          }
+
+          @Override
+          public boolean hasNext() {
+            return !consumed;
+          }
+
+          @Override
+          public void close() {}
+
+          @Override
+          public boolean isFinished() {
+            return consumed;
+          }
+
+          @Override
+          public long calculateMaxPeekMemory() {
+            return 0;
+          }
+
+          @Override
+          public long calculateMaxReturnSize() {
+            return 0;
+          }
+
+          @Override
+          public long calculateRetainedSizeAfterCallingNext() {
+            return 0;
+          }
+
+          @Override
+          public long ramBytesUsed() {
+            return 0;
+          }
+        };
+
+    int returnedRows = 0;
+    int returnedBlocks = 0;
+    try (TableFunctionOperator operator =
+        new TableFunctionOperator(
+            operatorContext,
+            provider,
+            singleRowChild,
+            Collections.singletonList(TSDataType.INT64),
+            Collections.singletonList(TSDataType.TEXT),
+            1,
+            Collections.singletonList(0),
+            Collections.emptyList(),
+            false,
+            Collections.emptyList(),
+            false,
+            mock(IoTDBLocal.class))) {
+      while (!operator.isFinished()) {
+        operator.isBlocked();
+        TsBlock block = operator.next();
+        if (block == null) {
+          continue;
+        }
+        returnedBlocks++;
+        returnedRows += block.getPositionCount();
+        Assert.assertTrue(block.getPositionCount() <= maxLineNumber);
+        Assert.assertTrue(block.getSizeInBytes() <= maxBlockSize);
+        Assert.assertTrue(new TsBlockSerde().serialize(block).remaining() <= maxBlockSize);
+        for (int i = 0; i < block.getPositionCount(); i++) {
+          int expectedLength =
+              returnedRows - block.getPositionCount() + i == 0 ? 6 : wideValueLength;
+          assertEquals(expectedLength, block.getColumn(0).getBinary(i).getLength());
+        }
+      }
+    }
+
+    assertEquals(wideRowCount + 1, returnedRows);
+    Assert.assertTrue(returnedBlocks > 2);
   }
 
   private void checkIteratorSimply(Slice slice, List<List<Object>> expected) {


### PR DESCRIPTION
## Description

### Problem

A table-model UDF may produce a large result block when processing a partition containing a large device. Previously, `TableFunctionOperator` returned the generated `TsBlock` directly without enforcing the configured row-count or byte-size limits.

As a result, a sufficiently large UDF result could eventually exceed the RPC frame limit, for example the 64 MB Thrift frame limit.

### Design

`TableFunctionOperator` now splits generated result blocks before returning them to downstream operators.

For each output fragment, the operator:

1. Limits the candidate row count using `max_tsblock_line_number`.
2. Checks the candidate block against `max_tsblock_size_in_bytes`.
3. Uses binary search to find the largest row prefix that fits within the byte-size limit.
4. Retains the remaining rows and returns them in subsequent calls to `next()`.

Binary search was selected because row sizes may vary significantly for variable-width types such as `TEXT`, `STRING`, and `BLOB`. Calculating a fixed row count from the average size of an earlier block would be cheaper, but could allow later blocks containing wider values to exceed the configured byte-size limit.

The size check uses a copied region instead of `TsBlock.getRegion()`. A zero-copy region keeps the source columns' backing arrays, so its reported size may reflect backing capacity rather than the exact logical contents of the selected rows. Copying the selected region provides an accurate size for variable-width data and prevents a small returned fragment from retaining a large source block.

The splitting logic is applied when results are dequeued, so blocks generated by both `process()` and `finish()` follow the same path. This also keeps the splitting behavior independent of pass-through column construction.

### Configuration and behavior

This PR introduces no new configuration.

The implementation uses the existing configurations:

- `max_tsblock_size_in_bytes`, whose default value is `131072`.
- `max_tsblock_line_number`, whose default value is `1000`.

The existing configuration validation remains unchanged. The operator defensively returns at least one row per call so that execution always makes progress, even if the configured line limit is invalid or a single row is larger than the byte-size target.

Rows are indivisible. Therefore, if one individual row is larger than `max_tsblock_size_in_bytes`, that row is returned alone. Preventing a single value larger than the RPC frame limit would require a separate rejection or value-level fragmentation policy.

The following behaviors are preserved:

- Result row ordering is unchanged.
- Empty UDF output still produces no result block.
- All queued and retained fragments are returned before the operator reports that it is finished.
- Retained result blocks are released when the operator is closed.

### Alternative designs

An alternative was to calculate a fixed maximum row count from the average row size of the first result block. Although this avoids repeated size checks, it is not reliable when different calls produce values with significantly different widths.

Another alternative was to serialize every candidate block and use its serialized length directly. This would closely match the transport representation but would couple the execution operator to the serialization layer and add repeated serialization overhead. The implemented design follows the existing operator memory-size contract, while the unit test additionally verifies that the serialized result also remains within the configured limit.

### Tests

Added `testVariableWidthResultsAreSplitByActualSize` to cover variable-width output:

- `process()` first produces a narrow `TEXT` result.
- `finish()` then produces a wide `TEXT` result exceeding both the configured row-count and byte-size limits.
- The test verifies that the result is split into multiple blocks.
- Every returned block respects `max_tsblock_line_number`.
- Every returned block respects `max_tsblock_size_in_bytes`.
- The actual serialized size of every returned block is also checked.
- The total row count, row ordering, and value lengths are verified.

The following targeted test was run successfully:

```shell
mvn test -pl iotdb-core/datanode -am \
  -Dtest=TableFunctionOperatorTest \
  -DfailIfNoTests=false \
  -Dsurefire.failIfNoSpecifiedTests=false
```

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever it would not be obvious to an unfamiliar reader.
- [x] added or updated unit tests to cover the new code paths.
- [ ] been tested in a test IoTDB cluster.

<hr>

##### Key changed/added classes

- `TableFunctionOperator`
  - Adds row-count and byte-size-aware result splitting.
  - Manages queued and retained result fragments.
  - Copies returned regions to obtain accurate variable-width sizes and release large backing arrays.
  - Updates completion, memory estimation, and cleanup behavior.

- `TableFunctionOperatorTest`
  - Adds coverage for variable-width UDF results exceeding both row-count and byte-size limits.
  - Verifies logical and serialized result sizes.
