### PR TITLE
Fix Region recovery validation before DataNode startup success

### DIFF
--- a/iotdb-core/consensus/src/main/i18n/en/org/apache/iotdb/consensus/i18n/IoTConsensusV2Messages.java
+++ b/iotdb-core/consensus/src/main/i18n/en/org/apache/iotdb/consensus/i18n/IoTConsensusV2Messages.java
@@ -39,9 +39,6 @@ public final class IoTConsensusV2Messages {
       "Failed to recover consensus from {} for {}, ignore it and continue recover other group, async backend checker thread will automatically deregister related pipe side effects for this failed consensus group.";
   public static final String FAILED_RECOVER_CONSENSUS_READ_DIR =
       "Failed to recover consensus from {} because read dir failed";
-  public static final String FAILED_RECOVER_CONSENSUS_SHORT =
-      "Failed to recover consensus from {}";
-
   // ===================== IoTConsensusV2 peer operations =====================
 
   public static final String START_DELETE_LOCAL_PEER =

--- a/iotdb-core/consensus/src/main/i18n/zh/org/apache/iotdb/consensus/i18n/IoTConsensusV2Messages.java
+++ b/iotdb-core/consensus/src/main/i18n/zh/org/apache/iotdb/consensus/i18n/IoTConsensusV2Messages.java
@@ -38,9 +38,6 @@ public final class IoTConsensusV2Messages {
       "从 {} 恢复共识组 {} 失败，忽略并继续恢复其他组，异步后台检查线程将自动注销该失败共识组的 pipe 副作用。";
   public static final String FAILED_RECOVER_CONSENSUS_READ_DIR =
       "从 {} 恢复共识失败，因为读取目录失败";
-  public static final String FAILED_RECOVER_CONSENSUS_SHORT =
-      "从 {} 恢复共识失败";
-
   // ===================== IoTConsensusV2 peer 操作 =====================
 
   public static final String START_DELETE_LOCAL_PEER =

--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/pipe/IoTConsensusV2.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/pipe/IoTConsensusV2.java
@@ -73,6 +73,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -125,15 +126,32 @@ public class IoTConsensusV2 implements IConsensus {
       throw new IOException(e);
     }
 
+    waitForRecovery(recoverFuture);
+  }
+
+  static void waitForRecovery(Future<Void> recoverFuture) throws IOException {
     try {
       recoverFuture.get();
-    } catch (CancellationException ce) {
-      LOGGER.info(IoTConsensusV2Messages.RECOVER_TASK_CANCELLED, ce);
-    } catch (ExecutionException ee) {
-      LOGGER.error(IoTConsensusV2Messages.RECOVER_FUTURE_EXCEPTION, ee);
-    } catch (InterruptedException ie) {
+    } catch (CancellationException e) {
+      throw new IOException(IoTConsensusV2Messages.RECOVER_TASK_CANCELLED, e);
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof CompletionException && cause.getCause() != null) {
+        cause = cause.getCause();
+      }
+      if (cause instanceof IOException) {
+        throw (IOException) cause;
+      }
+      if (cause instanceof RuntimeException) {
+        throw (RuntimeException) cause;
+      }
+      if (cause instanceof Error) {
+        throw (Error) cause;
+      }
+      throw new IOException(IoTConsensusV2Messages.RECOVER_FUTURE_EXCEPTION, cause);
+    } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      LOGGER.warn(IoTConsensusV2Messages.RECOVER_TASK_INTERRUPTED, ie);
+      throw new IOException(IoTConsensusV2Messages.RECOVER_TASK_INTERRUPTED, e);
     }
   }
 
@@ -149,39 +167,35 @@ public class IoTConsensusV2 implements IConsensus {
     } else {
       // asynchronously recover, retry logic is implemented at IoTConsensusV2Impl
       return CompletableFuture.runAsync(
-              () -> {
-                try (DirectoryStream<Path> stream = Files.newDirectoryStream(storageDir.toPath())) {
-                  for (Path path : stream) {
-                    ConsensusGroupId consensusGroupId =
-                        parsePeerFileName(path.getFileName().toString());
-                    try {
-                      IoTConsensusV2ServerImpl consensus =
-                          new IoTConsensusV2ServerImpl(
-                              new Peer(consensusGroupId, thisNodeId, thisNode),
-                              registry.apply(consensusGroupId),
-                              new ArrayList<>(),
-                              config,
-                              syncClientManager);
-                      stateMachineMap.put(consensusGroupId, consensus);
-                      checkPeerListAndStartIfEligible(consensusGroupId, consensus);
-                    } catch (Exception e) {
-                      LOGGER.error(
-                          IoTConsensusV2Messages.FAILED_RECOVER_CONSENSUS,
-                          storageDir,
-                          consensusGroupId,
-                          e);
-                    }
-                  }
-                } catch (IOException e) {
+          () -> {
+            try (DirectoryStream<Path> stream = Files.newDirectoryStream(storageDir.toPath())) {
+              for (Path path : stream) {
+                ConsensusGroupId consensusGroupId =
+                    parsePeerFileName(path.getFileName().toString());
+                IStateMachine stateMachine = registry.apply(consensusGroupId);
+                try {
+                  IoTConsensusV2ServerImpl consensus =
+                      new IoTConsensusV2ServerImpl(
+                          new Peer(consensusGroupId, thisNodeId, thisNode),
+                          stateMachine,
+                          new ArrayList<>(),
+                          config,
+                          syncClientManager);
+                  stateMachineMap.put(consensusGroupId, consensus);
+                  checkPeerListAndStartIfEligible(consensusGroupId, consensus);
+                } catch (Exception e) {
                   LOGGER.error(
-                      IoTConsensusV2Messages.FAILED_RECOVER_CONSENSUS_READ_DIR, storageDir, e);
+                      IoTConsensusV2Messages.FAILED_RECOVER_CONSENSUS,
+                      storageDir,
+                      consensusGroupId,
+                      e);
                 }
-              })
-          .exceptionally(
-              e -> {
-                LOGGER.error(IoTConsensusV2Messages.FAILED_RECOVER_CONSENSUS_SHORT, storageDir, e);
-                return null;
-              });
+              }
+            } catch (IOException e) {
+              LOGGER.error(IoTConsensusV2Messages.FAILED_RECOVER_CONSENSUS_READ_DIR, storageDir, e);
+              throw new CompletionException(e);
+            }
+          });
     }
   }
 

--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/pipe/IoTConsensusV2Test.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/pipe/IoTConsensusV2Test.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.pipe;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+public class IoTConsensusV2Test {
+
+  @Test
+  public void testWaitForRecoveryPropagatesRuntimeException() {
+    IllegalArgumentException cause = new IllegalArgumentException("missing DataRegion");
+    CompletableFuture<Void> recoverFuture = new CompletableFuture<>();
+    recoverFuture.completeExceptionally(cause);
+
+    IllegalArgumentException exception =
+        Assert.assertThrows(
+            IllegalArgumentException.class, () -> IoTConsensusV2.waitForRecovery(recoverFuture));
+
+    Assert.assertSame(cause, exception);
+  }
+
+  @Test
+  public void testWaitForRecoveryPropagatesIOExceptionWrappedByCompletionException() {
+    IOException cause = new IOException("failed to read consensus directory");
+    CompletableFuture<Void> recoverFuture = new CompletableFuture<>();
+    recoverFuture.completeExceptionally(new CompletionException(cause));
+
+    IOException exception =
+        Assert.assertThrows(IOException.class, () -> IoTConsensusV2.waitForRecovery(recoverFuture));
+
+    Assert.assertSame(cause, exception);
+  }
+}

--- a/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/DataNodeMiscMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/DataNodeMiscMessages.java
@@ -371,8 +371,9 @@ public final class DataNodeMiscMessages {
   public static final String SETTING_UP_DATANODE = "Setting up IoTDB DataNode...";
   public static final String RECOVER_SCHEMA = "Recover the schema...";
   public static final String DATANODE_FAILED_SETUP = "IoTDB DataNode failed to set up.";
-  public static final String WAIT_DATABASES_READY =
-      "Wait for all databases ready, which takes {} ms.";
+  public static final String
+      MISC_LOG_WAIT_FOR_LOCAL_DATAREGION_RECOVERY_TASKS_TO_FINISH_WHICH_TAKES_ARG_MS_8B33DC6C =
+          "Wait for local DataRegion recovery tasks to finish, which takes {} ms.";
   public static final String PREPARE_PIPE_RESOURCES =
       "Prepare pipe resources successfully, which takes {} ms.";
   public static final String RECOVER_SCHEMA_SUCCESSFULLY =

--- a/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/DataNodeSchemaMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/DataNodeSchemaMessages.java
@@ -730,6 +730,7 @@ public final class DataNodeSchemaMessages {
       "This view contains aggregation function(s) named [%s]";
   public static final String EXCEPTION_OPERATORCONTEXT_IS_NULL_D15B1EDB = "operatorContext is null";
   public static final String EXCEPTION_CHILD_OPERATOR_IS_NULL_8860113C = "child operator is null";
+  public static final String EXCEPTION_FAILED_TO_CREATE_STATE_MACHINE_FOR_CONSENSUS_GROUP_ARG_BECAUSE_SCHEMA_REGION_DOES_NOT_EXIST_610DAE67 = "Failed to create state machine for consensus group %s, because schema region does not exist";
   public static final String EXCEPTION_DOT_9D9B854A = ".";
   public static final String EMPTY_MESSAGE = "";
   public static final String EXCEPTION_COMMA_50AD1C01 = ", ";

--- a/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/StorageEngineMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/StorageEngineMessages.java
@@ -559,10 +559,11 @@ public final class StorageEngineMessages {
   // ---------------------------------------------------------------------------
   // Additional log messages
   // ---------------------------------------------------------------------------
-  public static final String STORAGE_LOG_STORAGE_ENGINE_RECOVER_COST_S_C8AEE9D9 =
-      "Storage Engine recover cost: {}s.";
-  public static final String STORAGE_LOG_DATA_REGIONS_HAVE_BEEN_RECOVERED_D5BD3A80 =
-      "Data regions have been recovered {}/{}";
+  public static final String
+      STORAGE_LOG_STORAGE_ENGINE_LOCAL_RECOVERY_TASKS_FINISHED_IN_ARGS_03F9135F =
+          "Storage Engine local recovery tasks finished in {}s.";
+  public static final String STORAGE_LOG_LOCAL_DATAREGION_LOADING_PROGRESS_ARG_ARG_8146929B =
+      "Local DataRegion loading progress: {}/{}.";
   public static final String STORAGE_LOG_TSFILE_RESOURCE_RECOVER_COST_S_41F074E0 =
       "TsFile Resource recover cost: {}s.";
   public static final String STORAGE_LOG_CONSTRUCT_A_DATA_REGION_INSTANCE_THE_DATABASE_IS_THREAD_17A16BDF =
@@ -617,8 +618,6 @@ public final class StorageEngineMessages {
       "The TsFiles of data region {}[{}] has recovered completely {}/{}.";
   public static final String STORAGE_LOG_THE_DATA_REGION_IS_CREATED_SUCCESSFULLY_B991F1D4 =
       "The data region {}[{}] is created successfully";
-  public static final String STORAGE_LOG_THE_DATA_REGION_IS_RECOVERED_SUCCESSFULLY_5AAFF7B7 =
-      "The data region {}[{}] is recovered successfully";
   public static final String STORAGE_LOG_WON_T_INSERT_TABLET_BECAUSE_REGION_IS_DELETED_34D893A7 =
       "Won't insert tablet {}, because region is deleted";
   public static final String STORAGE_LOG_ASYNC_CLOSE_TSFILE_FILE_START_TIME_FILE_END_TIME_65020832 =

--- a/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/DataNodeMiscMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/DataNodeMiscMessages.java
@@ -370,8 +370,9 @@ public final class DataNodeMiscMessages {
   public static final String SETTING_UP_DATANODE = "正在配置 IoTDB DataNode...";
   public static final String RECOVER_SCHEMA = "正在恢复 Schema...";
   public static final String DATANODE_FAILED_SETUP = "IoTDB DataNode 启动失败。";
-  public static final String WAIT_DATABASES_READY =
-      "等待所有数据库就绪，耗时 {} 毫秒。";
+  public static final String
+      MISC_LOG_WAIT_FOR_LOCAL_DATAREGION_RECOVERY_TASKS_TO_FINISH_WHICH_TAKES_ARG_MS_8B33DC6C =
+          "等待本地 DataRegion 恢复任务结束，耗时 {} 毫秒。";
   public static final String PREPARE_PIPE_RESOURCES =
       "Pipe 资源准备完成，耗时 {} 毫秒。";
   public static final String RECOVER_SCHEMA_SUCCESSFULLY =

--- a/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/DataNodeSchemaMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/DataNodeSchemaMessages.java
@@ -718,6 +718,7 @@ public final class DataNodeSchemaMessages {
       "该视图包含名为 [%s] 的聚合函数";
   public static final String EXCEPTION_OPERATORCONTEXT_IS_NULL_D15B1EDB = "operatorContext 不能为空";
   public static final String EXCEPTION_CHILD_OPERATOR_IS_NULL_8860113C = "child operator 不能为空";
+  public static final String EXCEPTION_FAILED_TO_CREATE_STATE_MACHINE_FOR_CONSENSUS_GROUP_ARG_BECAUSE_SCHEMA_REGION_DOES_NOT_EXIST_610DAE67 = "共识组 %s 的状态机创建失败，因为 SchemaRegion 不存在";
   public static final String EXCEPTION_DOT_9D9B854A = ".";
   public static final String EMPTY_MESSAGE = "";
   public static final String EXCEPTION_COMMA_50AD1C01 = ", ";

--- a/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/StorageEngineMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/StorageEngineMessages.java
@@ -559,10 +559,11 @@ public final class StorageEngineMessages {
   // ---------------------------------------------------------------------------
   // 补充日志消息
   // ---------------------------------------------------------------------------
-  public static final String STORAGE_LOG_STORAGE_ENGINE_RECOVER_COST_S_C8AEE9D9 =
-      "存储引擎恢复耗时：{}s。";
-  public static final String STORAGE_LOG_DATA_REGIONS_HAVE_BEEN_RECOVERED_D5BD3A80 =
-      "DataRegion 已恢复 {}/{}";
+  public static final String
+      STORAGE_LOG_STORAGE_ENGINE_LOCAL_RECOVERY_TASKS_FINISHED_IN_ARGS_03F9135F =
+          "存储引擎本地恢复任务已完成，耗时：{}s。";
+  public static final String STORAGE_LOG_LOCAL_DATAREGION_LOADING_PROGRESS_ARG_ARG_8146929B =
+      "本地 DataRegion 加载进度：{}/{}。";
   public static final String STORAGE_LOG_TSFILE_RESOURCE_RECOVER_COST_S_41F074E0 =
       "TsFileResource 恢复耗时：{}s。";
   public static final String STORAGE_LOG_CONSTRUCT_A_DATA_REGION_INSTANCE_THE_DATABASE_IS_THREAD_17A16BDF =
@@ -613,8 +614,6 @@ public final class StorageEngineMessages {
       "DataRegion {}[{}] 的 TsFiles 已完全恢复 {}/{}。";
   public static final String STORAGE_LOG_THE_DATA_REGION_IS_CREATED_SUCCESSFULLY_B991F1D4 =
       "DataRegion {}[{}] 创建成功";
-  public static final String STORAGE_LOG_THE_DATA_REGION_IS_RECOVERED_SUCCESSFULLY_5AAFF7B7 =
-      "DataRegion {}[{}] 恢复成功";
   public static final String STORAGE_LOG_WON_T_INSERT_TABLET_BECAUSE_REGION_IS_DELETED_34D893A7 =
       "不会插入 tablet {}，原因：Region 已删除";
   public static final String STORAGE_LOG_ASYNC_CLOSE_TSFILE_FILE_START_TIME_FILE_END_TIME_65020832 =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/SchemaRegionConsensusImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/SchemaRegionConsensusImpl.java
@@ -23,6 +23,7 @@ import org.apache.iotdb.common.rpc.thrift.TConsensusGroupType;
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
 import org.apache.iotdb.commons.conf.CommonConfig;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
+import org.apache.iotdb.commons.consensus.ConsensusGroupId;
 import org.apache.iotdb.commons.consensus.SchemaRegionId;
 import org.apache.iotdb.consensus.ConsensusFactory;
 import org.apache.iotdb.consensus.IConsensus;
@@ -31,10 +32,14 @@ import org.apache.iotdb.consensus.config.RatisConfig;
 import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.consensus.statemachine.schemaregion.SchemaRegionStateMachine;
+import org.apache.iotdb.db.i18n.DataNodeSchemaMessages;
 import org.apache.iotdb.db.schemaengine.SchemaEngine;
+import org.apache.iotdb.db.schemaengine.schemaregion.ISchemaRegion;
 
 import org.apache.ratis.util.SizeInBytes;
 import org.apache.ratis.util.TimeDuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.TimeUnit;
 
@@ -43,6 +48,8 @@ import java.util.concurrent.TimeUnit;
  * schemaRegion's reading and writing
  */
 public class SchemaRegionConsensusImpl {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SchemaRegionConsensusImpl.class);
 
   private SchemaRegionConsensusImpl() {
     // do nothing
@@ -184,15 +191,27 @@ public class SchemaRegionConsensusImpl {
                               .build())
                       .setStorageDir(CONF.getSchemaRegionConsensusDir())
                       .build(),
-                  gid ->
-                      new SchemaRegionStateMachine(
-                          SchemaEngine.getInstance().getSchemaRegion((SchemaRegionId) gid)))
+                  SchemaRegionConsensusImplHolder::createSchemaRegionStateMachine)
               .orElseThrow(
                   () ->
                       new IllegalArgumentException(
                           String.format(
                               ConsensusFactory.CONSTRUCT_FAILED_MSG,
                               CONF.getSchemaRegionConsensusProtocolClass())));
+    }
+
+    private static SchemaRegionStateMachine createSchemaRegionStateMachine(ConsensusGroupId gid) {
+      ISchemaRegion schemaRegion = SchemaEngine.getInstance().getSchemaRegion((SchemaRegionId) gid);
+      if (schemaRegion == null) {
+        String errorMsg =
+            String.format(
+                DataNodeSchemaMessages
+                    .EXCEPTION_FAILED_TO_CREATE_STATE_MACHINE_FOR_CONSENSUS_GROUP_ARG_BECAUSE_SCHEMA_REGION_DOES_NOT_EXIST_610DAE67,
+                gid);
+        LOGGER.error(errorMsg);
+        throw new IllegalArgumentException(errorMsg);
+      }
+      return new SchemaRegionStateMachine(schemaRegion);
     }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -190,6 +190,7 @@ public class DataNode extends ServerCommandLine implements DataNodeMBean {
 
   private volatile boolean schemaRegionConsensusStarted = false;
   private volatile boolean dataRegionConsensusStarted = false;
+  private long schemaEngineRecoveryTimeInMs;
   private static Thread watcherThread;
   protected DataNodeContext context;
 
@@ -817,12 +818,11 @@ public class DataNode extends ServerCommandLine implements DataNodeMBean {
       logger.error(DataNodeMiscMessages.MEET_ERROR_STARTING_UP, e);
       throw e;
     }
-    logger.info(DataNodeMiscMessages.IOTDB_DATANODE_HAS_STARTED);
-
     try {
       long startTime = System.currentTimeMillis();
       SchemaRegionConsensusImpl.getInstance().start();
       long schemaRegionEndTime = System.currentTimeMillis();
+      logger.info(DataNodeMiscMessages.RECOVER_SCHEMA_SUCCESSFULLY, schemaEngineRecoveryTimeInMs);
       logger.info(
           DataNodeMiscMessages
               .MISC_LOG_SCHEMAREGION_CONSENSUS_START_SUCCESSFULLY_WHICH_TAKES_MS_3D1B8523,
@@ -840,6 +840,7 @@ public class DataNode extends ServerCommandLine implements DataNodeMBean {
     } catch (IOException e) {
       throw new StartupException(e);
     }
+    logger.info(DataNodeMiscMessages.IOTDB_DATANODE_HAS_STARTED);
   }
 
   void processPid() {
@@ -899,7 +900,10 @@ public class DataNode extends ServerCommandLine implements DataNodeMBean {
       }
     }
     long endTime = System.currentTimeMillis();
-    logger.info(DataNodeMiscMessages.WAIT_DATABASES_READY, (endTime - startTime));
+    logger.info(
+        DataNodeMiscMessages
+            .MISC_LOG_WAIT_FOR_LOCAL_DATAREGION_RECOVERY_TASKS_TO_FINISH_WHICH_TAKES_ARG_MS_8B33DC6C,
+        (endTime - startTime));
     // Must init after SchemaEngine and StorageEngine prepared well
     DataNodeRegionManager.getInstance().init();
 
@@ -1333,8 +1337,7 @@ public class DataNode extends ServerCommandLine implements DataNodeMBean {
   private void initSchemaEngine() {
     long startTime = System.currentTimeMillis();
     SchemaEngine.getInstance().init();
-    long endTime = System.currentTimeMillis();
-    logger.info(DataNodeMiscMessages.RECOVER_SCHEMA_SUCCESSFULLY, (endTime - startTime));
+    schemaEngineRecoveryTimeInMs = System.currentTimeMillis() - startTime;
   }
 
   private void classLoader() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/StorageEngine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/StorageEngine.java
@@ -237,7 +237,8 @@ public class StorageEngine implements IService {
               checkResults(futures, StorageEngineMessages.STORAGE_ENGINE_FAILED_TO_RECOVER);
               isReadyForReadAndWrite.set(true);
               LOGGER.info(
-                  StorageEngineMessages.STORAGE_LOG_STORAGE_ENGINE_RECOVER_COST_S_C8AEE9D9,
+                  StorageEngineMessages
+                      .STORAGE_LOG_STORAGE_ENGINE_LOCAL_RECOVERY_TASKS_FINISHED_IN_ARGS_03F9135F,
                   (System.currentTimeMillis() - startRecoverTime) / 1000);
             },
             ThreadName.STORAGE_ENGINE_RECOVER_TRIGGER.getName());
@@ -267,7 +268,8 @@ public class StorageEngine implements IService {
               }
               dataRegionMap.put(dataRegionId, dataRegion);
               LOGGER.info(
-                  StorageEngineMessages.STORAGE_LOG_DATA_REGIONS_HAVE_BEEN_RECOVERED_D5BD3A80,
+                  StorageEngineMessages
+                      .STORAGE_LOG_LOCAL_DATAREGION_LOADING_PROGRESS_ARG_ARG_8146929B,
                   readyDataRegionNum.incrementAndGet(),
                   recoverDataRegionNum);
               return null;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -786,11 +786,6 @@ public class DataRegion implements IDataRegionForQuery {
           StorageEngineMessages.STORAGE_LOG_THE_DATA_REGION_IS_CREATED_SUCCESSFULLY_B991F1D4,
           databaseName,
           dataRegionIdString);
-    } else {
-      logger.info(
-          StorageEngineMessages.STORAGE_LOG_THE_DATA_REGION_IS_RECOVERED_SUCCESSFULLY_5AAFF7B7,
-          databaseName,
-          dataRegionIdString);
     }
   }
 


### PR DESCRIPTION
## Description

### Reject missing Region state machines

`SchemaRegionConsensusImpl` now resolves the `ISchemaRegion` before constructing its state machine. If the region does not exist, it logs and throws an `IllegalArgumentException` containing the consensus group id instead of passing `null` into `SchemaRegionStateMachine` and surfacing an NPE.

This keeps the SchemaRegion factory consistent with the existing DataRegion null check.

### Report startup success only after consistency validation

- The schema recovery success log is emitted only after SchemaRegion Consensus `start()` returns successfully.
- The DataNode started log is emitted only after both Region Consensus implementations have started.
- Startup-time DataRegion messages now explicitly describe local loading tasks, and the per-region recovered-successfully message that ran before Consensus validation has been removed.

Therefore a missing SchemaRegion cannot produce schema recovery, SchemaRegion Consensus, or DataNode startup success logs. A missing DataRegion cannot produce DataRegion Consensus or DataNode startup success logs.

### Propagate IoTConsensusV2 registry failures

IoTConsensusV2 previously waited for its asynchronous recovery future but swallowed both failures inside the task and failures returned by the future. The state-machine registry lookup now runs outside the recover-and-continue block, and registry/directory failures are propagated to the startup caller. This makes the existing missing-DataRegion exception effective for IoTConsensusV2 as well.

### Localized diagnostics

Added matching English and Chinese diagnostic messages for the missing SchemaRegion case and kept the updated recovery logs in locale parity.

### Verification

- `mvn spotless:apply -pl iotdb-core/datanode,iotdb-core/consensus`
- `mvn -pl iotdb-core/consensus -Dtest=IoTConsensusV2Test test`
- `mvn -pl iotdb-core/consensus -Dtest=IoTConsensusV2Test test -P with-zh-locale`
- Compiled `DataNode` and `SchemaRegionConsensusImpl` against both English and Chinese message sources with JDK 17.
- Compiled the changed DataNode message classes for both locales and verified identical public key sets.

A full local DataNode `test-compile` is still blocked by unrelated existing FMPP-generated source/API mismatches under `target/generated-sources/freemarker`.

<hr>

This PR has:
- [x] been self-reviewed.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- `SchemaRegionConsensusImpl`
- `IoTConsensusV2`
- `DataNode`
- `StorageEngine` / `DataRegion`
- DataNode and Consensus i18n messages
- `IoTConsensusV2Test`