### PR TITLE
[To dev/1.3] Reject database paths with empty nodes on ConfigNode (#18308)

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/schema/ClusterSchemaInfo.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/persistence/schema/ClusterSchemaInfo.java
@@ -458,7 +458,13 @@ public class ClusterSchemaInfo implements SnapshotProcessor {
   public void isDatabaseNameValid(String databaseName) throws MetadataException {
     databaseReadWriteLock.readLock().lock();
     try {
-      mTree.checkDatabaseAlreadySet(new PartialPath(databaseName));
+      final PartialPath databasePath = new PartialPath(databaseName);
+      for (final String node : databasePath.getNodes()) {
+        if (node.isEmpty()) {
+          throw new IllegalPathException(databaseName);
+        }
+      }
+      mTree.checkDatabaseAlreadySet(databasePath);
     } finally {
       databaseReadWriteLock.readLock().unlock();
     }

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/schema/ClusterSchemaInfoTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/persistence/schema/ClusterSchemaInfoTest.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.confignode.persistence.schema;
 
 import org.apache.iotdb.commons.exception.IllegalPathException;
+import org.apache.iotdb.commons.exception.MetadataException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.utils.PathUtils;
 import org.apache.iotdb.confignode.consensus.request.ConfigPhysicalPlanType;
@@ -36,6 +37,7 @@ import org.apache.iotdb.confignode.consensus.response.template.TemplateSetInfoRe
 import org.apache.iotdb.confignode.rpc.thrift.TDatabaseSchema;
 import org.apache.iotdb.db.schemaengine.template.Template;
 import org.apache.iotdb.db.schemaengine.template.TemplateInternalRPCUtil;
+import org.apache.iotdb.rpc.TSStatusCode;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.tsfile.enums.TSDataType;
@@ -115,6 +117,20 @@ public class ClusterSchemaInfoTest {
     Map<String, TDatabaseSchema> reloadResult =
         clusterSchemaInfo.getMatchedDatabaseSchemas(getStorageGroupReq).getSchemaMap();
     Assert.assertEquals(testMap, reloadResult);
+  }
+
+  @Test
+  public void testDatabasePathWithEmptyNodeIsInvalid() throws MetadataException {
+    clusterSchemaInfo.isDatabaseNameValid("root.database");
+
+    for (final String database : Arrays.asList("", "root.", "root..database", "root.database.")) {
+      try {
+        clusterSchemaInfo.isDatabaseNameValid(database);
+        Assert.fail("Expected IllegalPathException for database: " + database);
+      } catch (final IllegalPathException e) {
+        Assert.assertEquals(TSStatusCode.ILLEGAL_PATH.getStatusCode(), e.getErrorCode());
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
Backport #18308 to dev/1.3, cherry-picked from commit 5adcc2c5f888b3fb6677e71d01dabda2a88a457b.

ConfigNode now rejects database paths containing empty nodes before checking database conflicts, preventing invalid paths such as an empty name, root., root..database, or root.database. from entering metadata.

Adaptations for dev/1.3:
- dev/1.3 exposes the single-tree isDatabaseNameValid(String) API, so the validation reuses this branch's existing PartialPath and mTree flow.
- The regression test is adapted to the one-argument API; the table-model-specific valid-name check from master is not applicable on this branch.

Tests:
- mvn spotless:apply -pl iotdb-core/confignode
- mvn -pl iotdb-core/confignode -Dtest=ClusterSchemaInfoTest#testDatabasePathWithEmptyNodeIsInvalid test

Both commands passed, including ConfigNode compilation, Checkstyle, and Spotless checks.