### PR TITLE
[To dev/1.3] Fix floating-point sentinel misuse in KDTree and SDT (#18302)

### DIFF
--- a/integration-test/src/main/java/org/apache/iotdb/itbase/constant/TestConstant.java
+++ b/integration-test/src/main/java/org/apache/iotdb/itbase/constant/TestConstant.java
@@ -56,7 +56,7 @@ public class TestConstant {
   public static final String DATA_TYPE_STR = ColumnHeaderConstant.DATATYPE;
   public static final String FUNCTION_TYPE_NATIVE = "native";
   public static final double DELTA = 1e-6;
-  public static final double NULL = Double.MIN_VALUE;
+  public static final double NULL = Double.NaN;
 
   public static String[] createSql =
       new String[] {

--- a/integration-test/src/test/java/org/apache/iotdb/db/it/udf/IoTDBUDTFBuiltinFunctionIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/udf/IoTDBUDTFBuiltinFunctionIT.java
@@ -2012,7 +2012,7 @@ public class IoTDBUDTFBuiltinFunctionIT {
       }
 
       // test 4
-      double[] r4 = {1704.0, 1702.0, 1702.0, 1701.0, 1703.0, 1704.0, 1705.0, 1706.0};
+      double[] r4 = {1704.0, 1702.0, 1702.0, 1701.0, 1703.0, 1702.0, 1705.0, 1706.0};
       try (ResultSet resultSet =
           statement.executeQuery(
               "select master_repair(s1,s2,s3,m1,m2,m3,'omega'='2','eta'='3.0','k'='5') from root.testMasterRepair.d1")) {
@@ -2032,7 +2032,7 @@ public class IoTDBUDTFBuiltinFunctionIT {
       }
 
       // test 5
-      double[] r5 = {1154.55, 1152.30, 1148.65, 1145.20, 1150.55, 1151.55, 1153.55, 1152.30};
+      double[] r5 = {1154.55, 1152.30, 1148.65, 1145.20, 1150.55, 1152.30, 1153.55, 1152.30};
       try (ResultSet resultSet =
           statement.executeQuery(
               "select master_repair(s1,s2,s3,m1,m2,m3,'omega'='2','eta'='3.0','k'='5','output_column'='2') from root.testMasterRepair.d1")) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/processor/downsampling/sdt/SwingingDoorTrendingFilter.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/processor/downsampling/sdt/SwingingDoorTrendingFilter.java
@@ -65,8 +65,8 @@ public class SwingingDoorTrendingFilter<T> {
   }
 
   private void init(final long firstTimestamp, final T firstValue) {
-    upperDoor = Double.MIN_VALUE;
-    lowerDoor = Double.MAX_VALUE;
+    upperDoor = Double.NEGATIVE_INFINITY;
+    lowerDoor = Double.POSITIVE_INFINITY;
 
     lastReadTimestamp = firstTimestamp;
     lastReadValue = firstValue;
@@ -145,8 +145,8 @@ public class SwingingDoorTrendingFilter<T> {
   }
 
   private void reset(final long timestamp, final T value) {
-    upperDoor = Double.MIN_VALUE;
-    lowerDoor = Double.MAX_VALUE;
+    upperDoor = Double.NEGATIVE_INFINITY;
+    lowerDoor = Double.POSITIVE_INFINITY;
 
     lastStoredTimestamp = timestamp;
     lastStoredValue = value;

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/processor/downsampling/sdt/SwingingDoorTrendingFilterTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/processor/downsampling/sdt/SwingingDoorTrendingFilterTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.pipe.processor.downsampling.sdt;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+
+public class SwingingDoorTrendingFilterTest {
+
+  @Test
+  public void testDecreasingTrendIsCompressed() throws Exception {
+    final SwingingDoorTrendingFilter<Integer> filter =
+        new SwingingDoorTrendingFilter<>(createProcessor(0, Long.MAX_VALUE, 0), 0, 10);
+
+    Assert.assertFalse(filter.filter(1, 9));
+  }
+
+  @Test
+  public void testDecreasingTrendIsCompressedAfterReset() throws Exception {
+    final SwingingDoorTrendingFilter<Integer> filter =
+        new SwingingDoorTrendingFilter<>(createProcessor(0, 10, 0), 0, 20);
+
+    Assert.assertTrue(filter.filter(10, 10));
+    Assert.assertFalse(filter.filter(11, 9));
+  }
+
+  private SwingingDoorTrendingSamplingProcessor createProcessor(
+      final long compressionMinTimeInterval,
+      final long compressionMaxTimeInterval,
+      final double compressionDeviation)
+      throws Exception {
+    final SwingingDoorTrendingSamplingProcessor processor =
+        new SwingingDoorTrendingSamplingProcessor();
+    setField(processor, "compressionMinTimeInterval", compressionMinTimeInterval);
+    setField(processor, "compressionMaxTimeInterval", compressionMaxTimeInterval);
+    setField(processor, "compressionDeviation", compressionDeviation);
+    return processor;
+  }
+
+  private void setField(final Object target, final String fieldName, final Object value)
+      throws Exception {
+    final Field field = target.getClass().getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+}

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/utils/KDTreeUtil.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/udf/utils/KDTreeUtil.java
@@ -270,13 +270,13 @@ public class KDTreeUtil {
       ArrayList<Double> min_v = new ArrayList<>();
       ArrayList<Double> max_v = new ArrayList<>();
       for (int i = 0; i < dimensions; i++) {
-        double min_temp = Double.MAX_VALUE;
-        double max_temp = Double.MIN_VALUE;
-        for (int j = 1; j < data.size(); j++) {
-          ArrayList<Double> d = data.get(j);
+        double min_temp = Double.POSITIVE_INFINITY;
+        double max_temp = Double.NEGATIVE_INFINITY;
+        for (ArrayList<Double> d : data) {
           if (d.get(i) < min_temp) {
             min_temp = d.get(i);
-          } else if (d.get(i) > max_temp) {
+          }
+          if (d.get(i) > max_temp) {
             max_temp = d.get(i);
           }
         }

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/udf/utils/KDTreeUtilTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/udf/utils/KDTreeUtilTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.commons.udf.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class KDTreeUtilTest {
+
+  @Test
+  public void testQueryUsesCompleteNodeBounds() {
+    ArrayList<ArrayList<Double>> data = new ArrayList<>();
+    data.add(point(4, 0));
+    data.add(point(-2, -2));
+    data.add(point(-5, 5));
+    data.add(point(1, -1));
+    data.add(point(-4, 5));
+    data.add(point(5, -5));
+    data.add(point(-5, 0));
+
+    KDTreeUtil tree = KDTreeUtil.build(data, 2);
+
+    Assert.assertEquals(point(5, -5), tree.query(point(0.25, -8.75), new double[] {1, 1}));
+  }
+
+  private ArrayList<Double> point(double first, double second) {
+    return new ArrayList<>(Arrays.asList(first, second));
+  }
+}


### PR DESCRIPTION
Backport #18302 to dev/1.3.

This initializes SDT slope doors with infinities, computes KDTree bounds across all points with correct floating-point sentinels, and uses NaN for the integration-test NULL sentinel so real zero values remain distinguishable.

Backport adaptation:
- dev/1.3 does not contain #17875, so SwingingDoorTrendingFilterTest includes only the two sentinel regression cases from #18302 and omits the unrelated extreme-timestamp case.

Tests:
- mvn spotless:apply -pl iotdb-core/node-commons,iotdb-core/datanode,integration-test -P with-integration-tests
- mvn test -pl iotdb-core/node-commons -Dtest=KDTreeUtilTest
- mvn test -pl iotdb-core/datanode -Dtest=SwingingDoorTrendingFilterTest

Not run:
- IoTDBUDTFBuiltinFunctionIT#testMasterRepair. The dev/1.3 reactor is blocked before the integration-test module by pre-existing generated-source issues: client-go RAT failures and a generated Thrift/API version mismatch.