### PR TITLE
Fix flaky pipe idempotent table IT

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/tablemodel/manual/enhanced/IoTDBPipeIdempotentIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/tablemodel/manual/enhanced/IoTDBPipeIdempotentIT.java
@@ -251,6 +251,9 @@ public class IoTDBPipeIdempotentIT extends AbstractPipeTableModelDualManualIT {
       Assert.assertEquals(TSStatusCode.SUCCESS_STATUS.getStatusCode(), status.getCode());
     }
 
+    // Pipe creation does not wait for the historical database snapshot to be applied.
+    TableModelUtils.hasDataBase(database, receiverEnv);
+
     TestUtils.executeNonQueries(
         database, BaseEnv.TABLE_SQL_DIALECT, senderEnv, beforeSqlList, null);
 


### PR DESCRIPTION
## Description

Fix a race in `IoTDBPipeIdempotentIT.testCreateTableIdempotent`.

`createPipe` returns before the historical table-model database snapshot is necessarily applied on the receiver. The test could therefore execute `USE test` against the receiver too early and fail with `500: Unknown database test`.

Wait for the exact database to appear on the receiver with `TableModelUtils.hasDataBase` before continuing the idempotency assertions.

## Tests

- `mvn test-compile -DskipTests -pl integration-test -P with-integration-tests`
- `mvn verify -DskipUTs -Dit.test=IoTDBPipeIdempotentIT#testCreateTableIdempotent -DfailIfNoTests=false -Dfailsafe.failIfNoSpecifiedTests=false -pl integration-test -PMultiClusterIT2DualTableManualEnhanced -P with-integration-tests`

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the why and intent of the code.
- [x] modified an existing integration test to cover the synchronization point.
- [x] been tested in a local dual-cluster IoTDB test environment.

<hr>

##### Key changed classes

- `IoTDBPipeIdempotentIT`