### PR TITLE
[To dev/1.3] Fix Region recovery validation before DataNode startup success (#18311)

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/pipe/PipeConsensus.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/pipe/PipeConsensus.java
@@ -70,8 +70,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
@@ -116,7 +120,7 @@ public class PipeConsensus implements IConsensus {
 
   @Override
   public synchronized void start() throws IOException {
-    initAndRecover();
+    Future<Void> recoverFuture = initAndRecover();
 
     rpcService.initSyncedServiceImpl(new PipeConsensusRPCServiceProcessor(this, config.getPipe()));
     try {
@@ -125,50 +129,83 @@ public class PipeConsensus implements IConsensus {
       throw new IOException(e);
     }
 
+    waitForRecovery(recoverFuture);
+
     consensusPipeGuardian.start(
         CONSENSUS_PIPE_GUARDIAN_TASK_ID,
         this::checkAllConsensusPipe,
         config.getPipe().getConsensusPipeGuardJobIntervalInSeconds());
   }
 
-  private void initAndRecover() throws IOException {
+  static void waitForRecovery(Future<Void> recoverFuture) throws IOException {
+    try {
+      recoverFuture.get();
+    } catch (CancellationException e) {
+      throw new IOException("IoTV2 Recover Task is cancelled", e);
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof CompletionException && cause.getCause() != null) {
+        cause = cause.getCause();
+      }
+      if (cause instanceof IOException) {
+        throw (IOException) cause;
+      }
+      if (cause instanceof RuntimeException) {
+        throw (RuntimeException) cause;
+      }
+      if (cause instanceof Error) {
+        throw (Error) cause;
+      }
+      throw new IOException("Exception while waiting for recover future completion", cause);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("IoTV2 Recover Task is interrupted", e);
+    }
+  }
+
+  private Future<Void> initAndRecover() throws IOException {
     if (!storageDir.exists()) {
       // init
       if (!storageDir.mkdirs()) {
         LOGGER.warn("Unable to create consensus dir at {}", storageDir);
         throw new IOException(String.format("Unable to create consensus dir at %s", storageDir));
       }
+      return CompletableFuture.completedFuture(null);
     } else {
       // asynchronously recover, retry logic is implemented at PipeConsensusImpl
-      CompletableFuture<Void> future =
-          CompletableFuture.runAsync(
-                  () -> {
-                    try (DirectoryStream<Path> stream =
-                        Files.newDirectoryStream(storageDir.toPath())) {
-                      for (Path path : stream) {
-                        ConsensusGroupId consensusGroupId =
-                            parsePeerFileName(path.getFileName().toString());
-                        PipeConsensusServerImpl consensus =
-                            new PipeConsensusServerImpl(
-                                new Peer(consensusGroupId, thisNodeId, thisNode),
-                                registry.apply(consensusGroupId),
-                                path.toString(),
-                                new ArrayList<>(),
-                                config,
-                                consensusPipeManager,
-                                syncClientManager);
-                        stateMachineMap.put(consensusGroupId, consensus);
-                        checkPeerListAndStartIfEligible(consensusGroupId, consensus);
-                      }
-                    } catch (Exception e) {
-                      LOGGER.error("Failed to recover consensus from {}", storageDir, e);
-                    }
-                  })
-              .exceptionally(
-                  e -> {
-                    LOGGER.error("Failed to recover consensus from {}", storageDir, e);
-                    return null;
-                  });
+      return CompletableFuture.runAsync(
+          () -> {
+            try (DirectoryStream<Path> stream = Files.newDirectoryStream(storageDir.toPath())) {
+              for (Path path : stream) {
+                ConsensusGroupId consensusGroupId =
+                    parsePeerFileName(path.getFileName().toString());
+                IStateMachine stateMachine = registry.apply(consensusGroupId);
+                try {
+                  PipeConsensusServerImpl consensus =
+                      new PipeConsensusServerImpl(
+                          new Peer(consensusGroupId, thisNodeId, thisNode),
+                          stateMachine,
+                          path.toString(),
+                          new ArrayList<>(),
+                          config,
+                          consensusPipeManager,
+                          syncClientManager);
+                  stateMachineMap.put(consensusGroupId, consensus);
+                  checkPeerListAndStartIfEligible(consensusGroupId, consensus);
+                } catch (Exception e) {
+                  LOGGER.error(
+                      "Failed to recover consensus from {} for {}, ignore it and continue recover other group, async backend checker thread will automatically deregister related pipe side effects for this failed consensus group.",
+                      storageDir,
+                      consensusGroupId,
+                      e);
+                }
+              }
+            } catch (IOException e) {
+              LOGGER.error(
+                  "Failed to recover consensus from {} because read dir failed", storageDir, e);
+              throw new CompletionException(e);
+            }
+          });
     }
   }
 

--- a/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/pipe/PipeConsensusTest.java
+++ b/iotdb-core/consensus/src/test/java/org/apache/iotdb/consensus/pipe/PipeConsensusTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.consensus.pipe;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+public class PipeConsensusTest {
+
+  @Test
+  public void testWaitForRecoveryPropagatesRuntimeException() {
+    IllegalArgumentException cause = new IllegalArgumentException("missing DataRegion");
+    CompletableFuture<Void> recoverFuture = new CompletableFuture<>();
+    recoverFuture.completeExceptionally(cause);
+
+    IllegalArgumentException exception =
+        Assert.assertThrows(
+            IllegalArgumentException.class, () -> PipeConsensus.waitForRecovery(recoverFuture));
+
+    Assert.assertSame(cause, exception);
+  }
+
+  @Test
+  public void testWaitForRecoveryPropagatesIOExceptionWrappedByCompletionException() {
+    IOException cause = new IOException("failed to read consensus directory");
+    CompletableFuture<Void> recoverFuture = new CompletableFuture<>();
+    recoverFuture.completeExceptionally(new CompletionException(cause));
+
+    IOException exception =
+        Assert.assertThrows(IOException.class, () -> PipeConsensus.waitForRecovery(recoverFuture));
+
+    Assert.assertSame(cause, exception);
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/SchemaRegionConsensusImpl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/consensus/SchemaRegionConsensusImpl.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.db.consensus;
 
 import org.apache.iotdb.common.rpc.thrift.TConsensusGroupType;
 import org.apache.iotdb.common.rpc.thrift.TEndPoint;
+import org.apache.iotdb.commons.consensus.ConsensusGroupId;
 import org.apache.iotdb.commons.consensus.SchemaRegionId;
 import org.apache.iotdb.consensus.ConsensusFactory;
 import org.apache.iotdb.consensus.IConsensus;
@@ -30,9 +31,12 @@ import org.apache.iotdb.db.conf.IoTDBConfig;
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
 import org.apache.iotdb.db.consensus.statemachine.schemaregion.SchemaRegionStateMachine;
 import org.apache.iotdb.db.schemaengine.SchemaEngine;
+import org.apache.iotdb.db.schemaengine.schemaregion.ISchemaRegion;
 
 import org.apache.ratis.util.SizeInBytes;
 import org.apache.ratis.util.TimeDuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.TimeUnit;
 
@@ -41,6 +45,8 @@ import java.util.concurrent.TimeUnit;
  * schemaRegion's reading and writing
  */
 public class SchemaRegionConsensusImpl {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SchemaRegionConsensusImpl.class);
 
   private SchemaRegionConsensusImpl() {
     // do nothing
@@ -170,15 +176,26 @@ public class SchemaRegionConsensusImpl {
                               .build())
                       .setStorageDir(CONF.getSchemaRegionConsensusDir())
                       .build(),
-                  gid ->
-                      new SchemaRegionStateMachine(
-                          SchemaEngine.getInstance().getSchemaRegion((SchemaRegionId) gid)))
+                  SchemaRegionConsensusImplHolder::createSchemaRegionStateMachine)
               .orElseThrow(
                   () ->
                       new IllegalArgumentException(
                           String.format(
                               ConsensusFactory.CONSTRUCT_FAILED_MSG,
                               CONF.getSchemaRegionConsensusProtocolClass())));
+    }
+
+    private static SchemaRegionStateMachine createSchemaRegionStateMachine(ConsensusGroupId gid) {
+      ISchemaRegion schemaRegion = SchemaEngine.getInstance().getSchemaRegion((SchemaRegionId) gid);
+      if (schemaRegion == null) {
+        String errorMsg =
+            String.format(
+                "Failed to create state machine for consensus group %s, because schema region does not exist",
+                gid);
+        LOGGER.error(errorMsg);
+        throw new IllegalArgumentException(errorMsg);
+      }
+      return new SchemaRegionStateMachine(schemaRegion);
     }
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/DataNode.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/service/DataNode.java
@@ -169,6 +169,7 @@ public class DataNode extends ServerCommandLine implements DataNodeMBean {
 
   private boolean schemaRegionConsensusStarted = false;
   private boolean dataRegionConsensusStarted = false;
+  private long schemaEngineRecoveryTimeInMs;
   private static Thread watcherThread;
 
   public DataNode() {
@@ -710,12 +711,12 @@ public class DataNode extends ServerCommandLine implements DataNodeMBean {
       logger.error("Meet error while starting up.", e);
       throw new StartupException("Error in activating IoTDB DataNode.");
     }
-    logger.info("IoTDB DataNode has started.");
 
     try {
       long startTime = System.currentTimeMillis();
       SchemaRegionConsensusImpl.getInstance().start();
       long schemaRegionEndTime = System.currentTimeMillis();
+      logger.info("Recover schema successfully, which takes {} ms.", schemaEngineRecoveryTimeInMs);
       logger.info(
           "SchemaRegion consensus start successfully, which takes {} ms.",
           (schemaRegionEndTime - startTime));
@@ -731,6 +732,7 @@ public class DataNode extends ServerCommandLine implements DataNodeMBean {
     } catch (IOException e) {
       throw new StartupException(e);
     }
+    logger.info("IoTDB DataNode has started.");
   }
 
   void processPid() {
@@ -789,7 +791,9 @@ public class DataNode extends ServerCommandLine implements DataNodeMBean {
       }
     }
     long endTime = System.currentTimeMillis();
-    logger.info("Wait for all databases ready, which takes {} ms.", (endTime - startTime));
+    logger.info(
+        "Wait for local DataRegion recovery tasks to finish, which takes {} ms.",
+        (endTime - startTime));
     // Must init after SchemaEngine and StorageEngine prepared well
     DataNodeRegionManager.getInstance().init();
 
@@ -1153,8 +1157,7 @@ public class DataNode extends ServerCommandLine implements DataNodeMBean {
   private void initSchemaEngine() {
     long startTime = System.currentTimeMillis();
     SchemaEngine.getInstance().init();
-    long endTime = System.currentTimeMillis();
-    logger.info("Recover schema successfully, which takes {} ms.", (endTime - startTime));
+    schemaEngineRecoveryTimeInMs = System.currentTimeMillis() - startTime;
   }
 
   private void classLoader() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/StorageEngine.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/StorageEngine.java
@@ -218,7 +218,7 @@ public class StorageEngine implements IService {
               checkResults(futures, "StorageEngine failed to recover.");
               isReadyForReadAndWrite.set(true);
               LOGGER.info(
-                  "Storage Engine recover cost: {}s.",
+                  "Storage Engine local recovery tasks finished in {}s.",
                   (System.currentTimeMillis() - startRecoverTime) / 1000);
             },
             ThreadName.STORAGE_ENGINE_RECOVER_TRIGGER.getName());
@@ -247,7 +247,7 @@ public class StorageEngine implements IService {
               }
               dataRegionMap.put(dataRegionId, dataRegion);
               LOGGER.info(
-                  "Data regions have been recovered {}/{}",
+                  "Local DataRegion loading progress: {}/{}.",
                   readyDataRegionNum.incrementAndGet(),
                   recoverDataRegionNum);
               return null;

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -675,9 +675,6 @@ public class DataRegion implements IDataRegionForQuery {
       }
       logger.info(
           "The data region {}[{}] is created successfully", databaseName, dataRegionIdString);
-    } else {
-      logger.info(
-          "The data region {}[{}] is recovered successfully", databaseName, dataRegionIdString);
     }
   }
 


### PR DESCRIPTION
## Description

Backport #18311 (`cb6a309521dc274dfa79dd1a5720851dac2670ad`) to `dev/1.3`.

- Reject missing SchemaRegion state machines instead of surfacing an NPE.
- Emit schema recovery and DataNode startup success logs only after Region Consensus starts successfully.
- Clarify that the earlier DataRegion recovery logs describe local loading only.
- Propagate asynchronous Region recovery failures to the startup caller.

`dev/1.3` still uses the pre-rename `PipeConsensus` implementation, so the IoTConsensusV2 recovery changes are adapted there. This branch also needs to wait for the asynchronous recovery future before `start()` returns to provide the same startup-success guarantee.

## Verification

- `mvn spotless:apply -pl iotdb-core/datanode,iotdb-core/consensus`
- `mvn -pl iotdb-core/consensus -Dtest=PipeConsensusTest test`
- `mvn compile -pl iotdb-core/datanode`

<hr>

This PR has:
- [x] been self-reviewed.