### PR TITLE
Fix table device recovery from schema snapshots

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/mem/snapshot/MemMTreeSnapshotUtil.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/schemaengine/schemaregion/mtree/impl/mem/snapshot/MemMTreeSnapshotUtil.java
@@ -246,9 +246,6 @@ public class MemMTreeSnapshotUtil {
       case INTERNAL_MNODE_TYPE:
         childrenNum = ReadWriteIOUtils.readInt(inputStream);
         node = deserializer.deserializeInternalMNode(inputStream);
-        if (ancestors.size() == 1) {
-          currentTableName.set(node.getName());
-        }
         break;
       case DATABASE_MNODE_TYPE:
         childrenNum = ReadWriteIOUtils.readInt(inputStream);
@@ -277,14 +274,18 @@ public class MemMTreeSnapshotUtil {
       case TABLE_MNODE_TYPE:
         childrenNum = ReadWriteIOUtils.readInt(inputStream);
         node = deserializer.deserializeTableDeviceMNode(inputStream);
-        if (ancestors.size() == 1) {
-          currentTableName.set(node.getName());
-        }
         deviceProcess.accept(node.getAsDeviceMNode());
-        tableDeviceProcess.accept(node.getAsDeviceMNode(), currentTableName.get());
         break;
       default:
         throw new IOException(DataNodeSchemaMessages.UNRECOGNIZED_MNODE_TYPE + type);
+    }
+
+    // The table-name node may also be a tree-model device in legacy mixed-model metadata.
+    if (ancestors.size() == 1) {
+      currentTableName.set(node.getName());
+    }
+    if (type == TABLE_MNODE_TYPE) {
+      tableDeviceProcess.accept(node.getAsDeviceMNode(), currentTableName.get());
     }
 
     regionStatistics.requestMemory(node.estimateSize());

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionManagementTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/metadata/schemaRegion/SchemaRegionManagementTest.java
@@ -140,6 +140,44 @@ public class SchemaRegionManagementTest extends AbstractSchemaRegionTest {
     }
   }
 
+  @Test
+  public void testLoadSnapshotWithTableDeviceBelowTopLevelTreeDevice() throws Exception {
+    if (!testParams.getTestModeName().equals("MemoryMode")) {
+      return;
+    }
+
+    final String schemaRegionConsensusProtocolClass =
+        config.getSchemaRegionConsensusProtocolClass();
+    config.setSchemaRegionConsensusProtocolClass(ConsensusFactory.RATIS_CONSENSUS);
+    try {
+      final ISchemaRegion schemaRegion = getSchemaRegion("root.sg", 0);
+
+      // Build a mixed-model tree where the table-name node is also a tree-model device.
+      schemaRegion.createTimeSeries(
+          SchemaRegionWritePlanFactory.getCreateTimeSeriesPlan(
+              new MeasurementPath("root.sg.t.s1"),
+              TSDataType.INT32,
+              TSEncoding.PLAIN,
+              CompressionType.UNCOMPRESSED,
+              null,
+              null,
+              null,
+              null),
+          -1);
+      SchemaRegionTestUtil.createTableDevice(
+          schemaRegion, "t", new String[] {"d1"}, Collections.emptyMap());
+
+      final File snapshotDir = new File(config.getSchemaDir() + File.separator + "snapshot");
+      Assert.assertTrue(snapshotDir.mkdir());
+      Assert.assertTrue(schemaRegion.createSnapshot(snapshotDir));
+
+      Assert.assertTrue(schemaRegion.loadSnapshot(snapshotDir));
+      Assert.assertEquals(1, schemaRegion.getSchemaRegionStatistics().getTableDevicesNumber("t"));
+    } finally {
+      config.setSchemaRegionConsensusProtocolClass(schemaRegionConsensusProtocolClass);
+    }
+  }
+
   private Template generateTemplate() throws IllegalPathException {
     Template template =
         new Template(


### PR DESCRIPTION
## Description

### Root cause

Schema snapshot deserialization tracked the current table name only when a database child was an internal node or a table-device node. In legacy mixed-model metadata, the table-name node can also be a tree-model device. A nested table device was therefore restored with a null table name, causing an NPE in table-device statistics recovery and preventing the DataNode from starting.

### Fix

- Track the current table name for every direct child of the database root.
- Recover table-device statistics only after that table name has been updated.
- Add a regression test that snapshots and restores a table device below a top-level tree-model device.

### Verification

- mvn spotless:apply -pl iotdb-core/datanode
- mvn test -pl iotdb-core/datanode -Dtest=SchemaRegionManagementTest
  - 24 tests run, 0 failures, 0 errors, 4 existing performance tests skipped

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the why and intent where it is not obvious.
- [x] added unit tests to cover the new code path.

<hr>

##### Key changed/added classes

- MemMTreeSnapshotUtil
- SchemaRegionManagementTest