### PR TITLE
[To dev/1.3] [Pipe] Prevent receiver statement exception log floods (#18318)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/thrift/IoTDBDataNodeReceiver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/thrift/IoTDBDataNodeReceiver.java
@@ -117,6 +117,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.iotdb.commons.utils.ErrorHandlingCommonUtils.getRootCause;
+
 public class IoTDBDataNodeReceiver extends IoTDBFileReceiver {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IoTDBDataNodeReceiver.class);
@@ -916,7 +918,7 @@ public class IoTDBDataNodeReceiver extends IoTDBFileReceiver {
   }
 
   private void logStatementExceptionIfNecessary(final Statement statement, final Exception e) {
-    if (shouldLogStatementException(receiverId.get(), statement, e)) {
+    if (shouldLogStatementException(statement, e)) {
       PipeLogger.log(
           LOGGER::warn,
           e,
@@ -926,16 +928,25 @@ public class IoTDBDataNodeReceiver extends IoTDBFileReceiver {
     }
   }
 
-  static boolean shouldLogStatementException(
-      final long receiverId, final Statement statement, final Exception e) {
-    // Use the reducer cache as a gate. The actual stack trace is logged only when it passes.
-    return LoggerPeriodicalLogReducer.log(
-        message -> {},
-        "Receiver id = %s, statement = %s, exception = %s, message = %s",
-        receiverId,
-        Objects.isNull(statement) ? null : statement.getPipeLoggingString(),
-        e.getClass().getName(),
-        e.getMessage());
+  static boolean shouldLogStatementException(final Statement statement, final Exception e) {
+    final Throwable rootCause = getRootCause(e);
+    final StackTraceElement[] rootCauseStackTrace = rootCause.getStackTrace();
+    final StackTraceElement rootCauseLocation =
+        rootCauseStackTrace.length > 0 ? rootCauseStackTrace[0] : null;
+
+    // Reduce exceptions raised from the same code location regardless of receiver, statement
+    // content, or dynamic exception message. Different statement types and failure locations are
+    // still logged independently.
+    return LoggerPeriodicalLogReducer.shouldLog(
+        IoTDBDataNodeReceiver.class.getName()
+            + '|'
+            + (Objects.isNull(statement)
+                ? Statement.class.getName()
+                : statement.getClass().getName())
+            + '|'
+            + rootCause.getClass().getName()
+            + '|'
+            + rootCauseLocation);
   }
 
   private TSStatus executeStatementWithRetryOnDataTypeMismatch(final Statement statement) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertRowsStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertRowsStatement.java
@@ -181,6 +181,24 @@ public class InsertRowsStatement extends InsertBaseStatement {
   }
 
   @Override
+  public String getPipeLoggingString() {
+    if (Objects.isNull(insertRowStatementList) || insertRowStatementList.isEmpty()) {
+      return "InsertRowsStatement{rowCount=0}";
+    }
+
+    final int rowCount = insertRowStatementList.size();
+    return "InsertRowsStatement{"
+        + "rowCount="
+        + rowCount
+        + ", firstRow="
+        + insertRowStatementList.get(0).getPipeLoggingString()
+        + (rowCount > 1
+            ? ", lastRow=" + insertRowStatementList.get(rowCount - 1).getPipeLoggingString()
+            : "")
+        + '}';
+  }
+
+  @Override
   public String toString() {
     return "InsertRowsStatement{" + "insertRowStatementList=" + insertRowStatementList + '}';
   }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/receiver/protocol/thrift/IoTDBDataNodeReceiverTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/receiver/protocol/thrift/IoTDBDataNodeReceiverTest.java
@@ -20,6 +20,8 @@
 package org.apache.iotdb.db.pipe.receiver.protocol.thrift;
 
 import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.queryengine.plan.statement.crud.InsertRowStatement;
+import org.apache.iotdb.db.queryengine.plan.statement.crud.InsertRowsStatement;
 import org.apache.iotdb.db.queryengine.plan.statement.crud.LoadTsFileStatement;
 import org.apache.iotdb.db.storageengine.load.active.ActiveLoadPathHelper;
 import org.apache.iotdb.db.storageengine.load.config.LoadTsFileConfigurator;
@@ -29,6 +31,7 @@ import org.junit.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Map;
 
 public class IoTDBDataNodeReceiverTest {
@@ -89,25 +92,72 @@ public class IoTDBDataNodeReceiverTest {
   }
 
   @Test
-  public void testRepeatedStatementExceptionLogIsReduced() throws Exception {
-    final Path tsFile = Files.createTempFile("pipe-load-log-reducer", ".tsfile");
-    try {
-      final LoadTsFileStatement statement =
-          IoTDBDataNodeReceiver.buildLoadTsFileStatementForSync(
-              "root.test.sg_0", tsFile.toString(), true, true);
-      final long receiverId = System.nanoTime();
-      final Exception exception = new RuntimeException("repeated receiver exception " + receiverId);
+  public void testStatementExceptionLogIsReducedByFailureLocation() {
+    final InsertRowStatement firstStatement = new InsertRowStatement();
+    firstStatement.setTime(1);
+    firstStatement.setValues(new Object[] {"first statement value"});
+    final InsertRowStatement secondStatement = new InsertRowStatement();
+    secondStatement.setTime(2);
+    secondStatement.setValues(new Object[] {"second statement value"});
 
-      Assert.assertTrue(
-          IoTDBDataNodeReceiver.shouldLogStatementException(receiverId, statement, exception));
-      Assert.assertFalse(
-          IoTDBDataNodeReceiver.shouldLogStatementException(receiverId, statement, exception));
-      Assert.assertTrue(
-          IoTDBDataNodeReceiver.shouldLogStatementException(
-              receiverId, statement, new RuntimeException("another receiver exception")));
-    } finally {
-      Files.deleteIfExists(tsFile);
-    }
+    final String testId = Long.toString(System.nanoTime());
+    final String sameFailureLocation = "sameFailureLocation" + testId;
+    Assert.assertTrue(
+        IoTDBDataNodeReceiver.shouldLogStatementException(
+            firstStatement, newStatementException("first message", sameFailureLocation)));
+    Assert.assertFalse(
+        IoTDBDataNodeReceiver.shouldLogStatementException(
+            secondStatement, newStatementException("second message", sameFailureLocation)));
+    Assert.assertTrue(
+        IoTDBDataNodeReceiver.shouldLogStatementException(
+            secondStatement,
+            newStatementException("second message", "differentFailureLocation" + testId)));
+    Assert.assertTrue(
+        IoTDBDataNodeReceiver.shouldLogStatementException(
+            new InsertRowsStatement(),
+            newStatementException("second message", sameFailureLocation)));
+  }
+
+  @Test
+  public void testInsertRowsPipeLoggingStringIsCompact() {
+    final InsertRowStatement firstStatement = new InsertRowStatement();
+    firstStatement.setTime(1);
+    firstStatement.setValues(new Object[] {"first secret value"});
+    final InsertRowStatement middleStatement = new InsertRowStatement();
+    middleStatement.setTime(2);
+    middleStatement.setValues(new Object[] {"middle secret value"});
+    final InsertRowStatement lastStatement = new InsertRowStatement();
+    lastStatement.setTime(3);
+    lastStatement.setValues(new Object[] {"last secret value"});
+
+    final InsertRowsStatement statement = new InsertRowsStatement();
+    statement.setInsertRowStatementList(
+        Arrays.asList(firstStatement, middleStatement, lastStatement));
+
+    final String pipeLoggingString = statement.getPipeLoggingString();
+    Assert.assertTrue(pipeLoggingString.contains("rowCount=3"));
+    Assert.assertTrue(pipeLoggingString.contains("firstRow="));
+    Assert.assertTrue(pipeLoggingString.contains("time=1"));
+    Assert.assertTrue(pipeLoggingString.contains("lastRow="));
+    Assert.assertTrue(pipeLoggingString.contains("time=3"));
+    Assert.assertFalse(pipeLoggingString.contains("time=2"));
+    Assert.assertFalse(pipeLoggingString.contains("first secret value"));
+    Assert.assertFalse(pipeLoggingString.contains("middle secret value"));
+    Assert.assertFalse(pipeLoggingString.contains("last secret value"));
+  }
+
+  private static Exception newStatementException(
+      final String message, final String failureLocation) {
+    final NullPointerException rootCause = new NullPointerException(message);
+    rootCause.setStackTrace(
+        new StackTraceElement[] {
+          new StackTraceElement(
+              IoTDBDataNodeReceiverTest.class.getName(),
+              failureLocation,
+              "IoTDBDataNodeReceiverTest.java",
+              1)
+        });
+    return new RuntimeException("wrapper " + message, rootCause);
   }
 
   @Test


### PR DESCRIPTION
## Description

Backport #18318 (11aa5069a6d260394c1db0c17e6a0a2ff1221d8a) to dev/1.3.

- Reduce repeated pipe receiver statement exception stack traces by statement type, root-cause type, and failure location, independent of receiver IDs and dynamic messages.
- Keep InsertRowsStatement pipe log summaries compact and exclude inserted values.
- Add unit coverage for failure-location reduction and compact InsertRowsStatement logging.

The dev/1.3 branch predates the DataNode pipe i18n message layer used on master, so the backport retains the existing 1.3 log templates and adapts only the reduction key and logging summary behavior.

## Verification

- mvn -o -nsu spotless:apply -pl iotdb-core/datanode
- mvn -o -nsu -pl iotdb-core/datanode -Dtest=IoTDBDataNodeReceiverTest test

<hr>

This PR has:
- [x] been self-reviewed.