### PR TITLE
Reject NaN disk space warning threshold during hot reload

### DIFF
--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/conf/CommonDescriptor.java
@@ -597,7 +597,9 @@ public class CommonDescriptor {
             properties.getProperty(
                 "disk_space_warning_threshold",
                 String.valueOf(config.getDiskSpaceWarningThreshold())));
-    if (diskSpaceWarningThreshold < 0 || diskSpaceWarningThreshold >= 1) {
+    if (!Double.isFinite(diskSpaceWarningThreshold)
+        || diskSpaceWarningThreshold < 0
+        || diskSpaceWarningThreshold >= 1) {
       throw new IOException(
           CommonMessages.EXCEPTION_DISK_SPACE_WARNING_THRESHOLD_MUST_BE_IN_0_1_BUT_WAS_7B345766
               + diskSpaceWarningThreshold

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/conf/CommonDescriptorDiskSpaceWarningThresholdTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/conf/CommonDescriptorDiskSpaceWarningThresholdTest.java
@@ -62,7 +62,7 @@ public class CommonDescriptorDiskSpaceWarningThresholdTest {
     final CommonDescriptor descriptor = CommonDescriptor.getInstance();
     final double original = descriptor.getConfig().getDiskSpaceWarningThreshold();
     try {
-      for (final String badValue : new String[] {"1.0", "1.5", "-0.1"}) {
+      for (final String badValue : new String[] {"NaN", "1.0", "1.5", "-0.1"}) {
         final TrimProperties properties = new TrimProperties();
         properties.setProperty(KEY, badValue);
         Assert.assertThrows(


### PR DESCRIPTION
## Description

The disk_space_warning_threshold configuration is required to be in [0, 1), but Double.parseDouble accepts NaN and all range comparisons with NaN return false. As a result, a hot reload can apply NaN to ConfigNode and DataNode, causing disk checks to move nodes into ReadOnly(DiskFull).

This PR rejects all non-finite values before applying the threshold. It also adds NaN to the existing invalid-value unit test and verifies that rejected values do not mutate the current configuration.

## Test

- mvn spotless:apply -pl iotdb-core/node-commons
- mvn test -pl iotdb-core/node-commons -am -Dtest=CommonDescriptorDiskSpaceWarningThresholdTest -Dsurefire.failIfNoSpecifiedTests=false

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added or updated unit tests to cover the new code path.

<hr>

##### Key changed classes in this PR

- CommonDescriptor
- CommonDescriptorDiskSpaceWarningThresholdTest