### PR TITLE
Reject invalid WAL throttle thresholds before applying configuration

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBSetConfigurationIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/IoTDBSetConfigurationIT.java
@@ -179,6 +179,48 @@ public class IoTDBSetConfigurationIT {
   }
 
   @Test
+  public void testRejectedWalThrottleThresholdDoesNotUpdateConfiguration() {
+    String key = "wal_throttle_threshold_in_byte";
+    String validValue = "1073741824";
+    String defaultValue = "214748364800";
+    int dataNodeId = EnvFactory.getEnv().getConfigNodeWrapperList().size();
+    try (Connection connection = EnvFactory.getEnv().getConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("set configuration \"" + key + "\"=\"" + validValue + "\"");
+      assertAppliedConfiguration(0, key, validValue);
+      assertAppliedConfiguration(dataNodeId, key, validValue);
+
+      for (String invalidValue : Arrays.asList("bad", "9223372036854775808")) {
+        assertSetConfigurationFailed(
+            statement,
+            "set configuration \"" + key + "\"=\"" + invalidValue + "\"",
+            "NumberFormatException");
+        assertAppliedConfiguration(0, key, validValue);
+        assertAppliedConfiguration(dataNodeId, key, validValue);
+        Assert.assertTrue(
+            EnvFactory.getEnv().getNodeWrapperList().stream()
+                .allMatch(
+                    nodeWrapper ->
+                        checkConfigFileContains(nodeWrapper, key + "=" + validValue)
+                            && !checkConfigFileContains(nodeWrapper, key + "=" + invalidValue)));
+      }
+    } catch (Exception e) {
+      Assert.fail(e.getMessage());
+    } finally {
+      try (Connection connection = EnvFactory.getEnv().getConnection();
+          Statement statement = connection.createStatement()) {
+        statement.execute("set configuration \"" + key + "\"=\"" + defaultValue + "\"");
+      } catch (Exception e) {
+        Assert.fail(e.getMessage());
+      }
+    }
+    Assert.assertTrue(
+        EnvFactory.getEnv().getNodeWrapperList().stream()
+            .allMatch(
+                nodeWrapper -> checkConfigFileContains(nodeWrapper, key + "=" + defaultValue)));
+  }
+
+  @Test
   public void testHotReloadRegionMigrationFileRemoveSpeedLimit() {
     String key = "region_migration_file_remove_speed_limit_bytes_per_second";
     int dataNodeId = EnvFactory.getEnv().getConfigNodeWrapperList().size();

--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/ConfigManager.java
@@ -369,6 +369,8 @@ public class ConfigManager implements IManager {
   private final CNAuditLogger auditLogger;
 
   private static final String DATABASE = "\tDatabase=";
+  private static final List<String> WAL_THROTTLE_THRESHOLD_KEYS =
+      Arrays.asList("iot_consensus_throttle_threshold_in_byte", "wal_throttle_threshold_in_byte");
 
   public ConfigManager() throws IOException {
     // Build the persistence module
@@ -1791,6 +1793,17 @@ public class ConfigManager implements IManager {
 
   @Override
   public TSStatus setConfiguration(TSetConfigurationReq req) {
+    for (String key : WAL_THROTTLE_THRESHOLD_KEYS) {
+      String value = req.getConfigs().get(key);
+      if (value == null) {
+        continue;
+      }
+      try {
+        Long.parseLong(value.trim());
+      } catch (NumberFormatException e) {
+        return RpcUtils.getStatus(TSStatusCode.EXECUTE_STATEMENT_ERROR, e.toString());
+      }
+    }
     TSStatus tsStatus = new TSStatus(TSStatusCode.SUCCESS_STATUS.getStatusCode());
     int currentNodeId = CONF.getConfigNodeId();
     TSStatus consistentClusterConfigStatus =


### PR DESCRIPTION
## Description

V2-1146 exposed a consistency issue in SET CONFIGURATION for wal_throttle_threshold_in_byte. When an invalid text value or a value outside the long range was submitted, ConfigNode accepted and persisted it before DataNode rejected it. The statement returned status 301, but ConfigNode and DataNode then reported different applied values.

### Root cause

ConfigNode does not load the DataNode-specific WAL threshold, so its local hot-reload path could not validate the value before updating the configuration file and broadcasting the request.

### Fix

Validate both the current and deprecated WAL throttle threshold keys as long values at the ConfigNode entry point, before any local update or cluster broadcast. Invalid and overflowing values now return EXECUTE_STATEMENT_ERROR without changing applied configuration or configuration files.

### Verification

- Added an integration regression test that first applies a valid 1 GiB threshold.
- Verified that both bad and 9223372036854775808 are rejected.
- Verified that ConfigNode and DataNode applied values remain unchanged after rejection.
- Verified that neither invalid value is written to any node configuration file.
- Ran the targeted integration test and full English and Chinese locale reactor compilation.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added integration tests.
- [x] been tested in a test IoTDB cluster.

<hr>

##### Key changed/added classes in this PR

- ConfigManager
- IoTDBSetConfigurationIT