### PR TITLE
[AINode] Avoid stale Poetry metadata when regenerating dependency locks

### DIFF
--- a/iotdb-core/ainode/build_binary.py
+++ b/iotdb-core/ainode/build_binary.py
@@ -196,10 +196,11 @@ def install_dependencies(venv_python, venv_dir, script_dir):
         sys.exit(1)
     print(f"  Python version: {python_version_result.stdout.strip()}")
 
-    # Update lock file and install dependencies
+    # Regenerate the lock file without cached release metadata because a package's
+    # platform artifacts may still be uploading when Poetry first sees a release.
     print("Running poetry lock...")
     result = subprocess.run(
-        [str(poetry_exe), "lock"],
+        [str(poetry_exe), "lock", "--no-cache", "--regenerate"],
         cwd=str(script_dir),
         env=venv_env,
         check=False,


### PR DESCRIPTION
## Description

AINode packaging regenerates `poetry.lock` on every build. Poetry release metadata is cached persistently, so if the cache is populated while a package release is still uploading platform artifacts, later builds can keep generating a lock file with an incomplete artifact list. This can make installation fail even after compatible wheels are available.

This change runs `poetry lock --no-cache --regenerate` so each packaging build fetches current source metadata and recreates the lock file from scratch. This prevents persistent self-hosted runner caches from poisoning subsequent AINode builds.

### Verification

- Confirmed that Poetry 2.2.1 supports both `--no-cache` and `--regenerate` for `poetry lock`.
- Ran `python -m py_compile build_binary.py`.
- Ran `black --check build_binary.py`.
- Ran `isort --check-only --profile black build_binary.py`.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the why and intent of the code.

<hr>

##### Key changed/added classes

- `iotdb-core/ainode/build_binary.py`