### PR TITLE
Pipe: Handle hybrid meta progress indexes

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/agent/task/PipeConfigNodeTaskAgent.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/pipe/agent/task/PipeConfigNodeTaskAgent.java
@@ -52,6 +52,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -182,10 +183,13 @@ public class PipeConfigNodeTaskAgent extends PipeTaskAgent {
         }
 
         final ProgressIndex progressIndex = groupId2TaskMetaMap.get(regionId).getProgressIndex();
-        if (progressIndex instanceof MetaProgressIndex) {
-          if (((MetaProgressIndex) progressIndex).getIndex() + 1
-              < listeningQueueNewFirstIndex.get()) {
-            listeningQueueNewFirstIndex.set(((MetaProgressIndex) progressIndex).getIndex() + 1);
+        final Optional<MetaProgressIndex> metaProgressIndex =
+            Objects.isNull(progressIndex)
+                ? Optional.empty()
+                : progressIndex.getProgressIndexByType(MetaProgressIndex.class);
+        if (metaProgressIndex.isPresent()) {
+          if (metaProgressIndex.get().getIndex() + 1 < listeningQueueNewFirstIndex.get()) {
+            listeningQueueNewFirstIndex.set(metaProgressIndex.get().getIndex() + 1);
           }
         } else {
           // Do not clear "minimumProgressIndex"s related queues to avoid clearing

--- a/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/DataNodePipeMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/en/org/apache/iotdb/db/i18n/DataNodePipeMessages.java
@@ -434,6 +434,8 @@ public final class DataNodePipeMessages {
       "Failed to send request {} (watermark = {}) to {}";
   public static final String FAILED_TO_TRIGGER_COMBINE_WATERMARK_COUNT_PROGRESSINDEX =
       "Failed to trigger combine. watermark={}, count={}, progressIndex={}";
+  public static final String EXCEPTION_FAILED_TO_INITIALIZE_STATEPROGRESSINDEX_FROM_PROGRESS_INDEX_ARG_E95617F9 =
+      "Failed to initialize StateProgressIndex from progress index %s.";
   public static final String FAILURE_OCCURRED_WHEN_TRYING_TO_COMMIT_PROGRESS =
       "Failure occurred when trying to commit progress index. timestamp={}, count={}, "
           + "progressIndex={}";

--- a/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/DataNodePipeMessages.java
+++ b/iotdb-core/datanode/src/main/i18n/zh/org/apache/iotdb/db/i18n/DataNodePipeMessages.java
@@ -412,6 +412,8 @@ public final class DataNodePipeMessages {
       "发送 request {}（watermark = {}）到 {} 失败";
   public static final String FAILED_TO_TRIGGER_COMBINE_WATERMARK_COUNT_PROGRESSINDEX =
       "触发合并失败。watermark={}, count={}, progressIndex={}";
+  public static final String EXCEPTION_FAILED_TO_INITIALIZE_STATEPROGRESSINDEX_FROM_PROGRESS_INDEX_ARG_E95617F9 =
+      "无法从进度索引 %s 初始化 StateProgressIndex。";
   public static final String FAILURE_OCCURRED_WHEN_TRYING_TO_COMMIT_PROGRESS =
       "尝试提交进度索引时发生失败。timestamp={}, count={}, "
           + "progressIndex={}";

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTaskAgent.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/PipeDataNodeTaskAgent.java
@@ -240,11 +240,15 @@ public class PipeDataNodeTaskAgent extends PipeTaskAgent {
         }
 
         final ProgressIndex progressIndex = pipeTaskMeta.getProgressIndex();
-        if (progressIndex instanceof MetaProgressIndex) {
-          if (((MetaProgressIndex) progressIndex).getIndex() + 1
+        final Optional<MetaProgressIndex> metaProgressIndex =
+            Objects.isNull(progressIndex)
+                ? Optional.empty()
+                : progressIndex.getProgressIndexByType(MetaProgressIndex.class);
+        if (metaProgressIndex.isPresent()) {
+          if (metaProgressIndex.get().getIndex() + 1
               < schemaRegionId2ListeningQueueNewFirstIndex.getOrDefault(id, Long.MAX_VALUE)) {
             schemaRegionId2ListeningQueueNewFirstIndex.put(
-                id, ((MetaProgressIndex) progressIndex).getIndex() + 1);
+                id, metaProgressIndex.get().getIndex() + 1);
           }
         } else {
           // Do not clear "minimumProgressIndex"s related queues to avoid clearing

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/processor/aggregate/AggregateProcessor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/processor/aggregate/AggregateProcessor.java
@@ -351,19 +351,15 @@ public class AggregateProcessor implements PipeProcessor {
 
     // Restore window state
     final ProgressIndex index = pipeTaskMeta.getProgressIndex();
-    if (index == MinimumProgressIndex.INSTANCE) {
+    if (Objects.isNull(index) || index == MinimumProgressIndex.INSTANCE) {
       return;
     }
-    if (!(index instanceof TimeWindowStateProgressIndex)) {
-      throw new PipeException(
-          String.format(
-              DataNodePipeMessages
-                  .PIPE_EXCEPTION_THE_AGGREGATE_PROCESSOR_DOES_NOT_SUPPORT_PROGRESSINDEXTYPE_35351D27,
-              index.getType()));
-    }
-
     final TimeWindowStateProgressIndex timeWindowStateProgressIndex =
-        (TimeWindowStateProgressIndex) index;
+        index.getProgressIndexByType(TimeWindowStateProgressIndex.class).orElse(null);
+    // A pipe altered from another processor may not have window state yet.
+    if (Objects.isNull(timeWindowStateProgressIndex)) {
+      return;
+    }
     for (final Map.Entry<String, Pair<Long, ByteBuffer>> entry :
         timeWindowStateProgressIndex.getTimeSeries2TimestampWindowBufferPairMap().entrySet()) {
       final AtomicReference<TimeSeriesRuntimeState> stateReference =

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/processor/twostage/plugin/TwoStageCountProcessor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/processor/twostage/plugin/TwoStageCountProcessor.java
@@ -156,13 +156,7 @@ public class TwoStageCountProcessor implements PipeProcessor {
     outputSeries = parseOutputSeries(parameters);
 
     if (Objects.nonNull(pipeTaskMeta) && Objects.nonNull(pipeTaskMeta.getProgressIndex())) {
-      if (pipeTaskMeta.getProgressIndex() instanceof MinimumProgressIndex) {
-        pipeTaskMeta.updateProgressIndex(
-            new StateProgressIndex(Long.MIN_VALUE, new HashMap<>(), MinimumProgressIndex.INSTANCE));
-      }
-
-      final StateProgressIndex stateProgressIndex =
-          (StateProgressIndex) pipeTaskMeta.getProgressIndex();
+      final StateProgressIndex stateProgressIndex = initializeStateProgressIndex(pipeTaskMeta);
       localCommitProgressIndex.set(stateProgressIndex.getInnerProgressIndex());
       final Binary localCountState = stateProgressIndex.getState().get(LOCAL_COUNT_STATE_KEY);
       localCount.set(
@@ -189,6 +183,27 @@ public class TwoStageCountProcessor implements PipeProcessor {
       throws IllegalPathException {
     return new PartialPath(
         parameters.getStringByKeys(PROCESSOR_OUTPUT_SERIES_KEY, _PROCESSOR_OUTPUT_SERIES_KEY));
+  }
+
+  static StateProgressIndex initializeStateProgressIndex(final PipeTaskMeta pipeTaskMeta) {
+    final ProgressIndex progressIndex = pipeTaskMeta.getProgressIndex();
+    if (progressIndex instanceof StateProgressIndex stateProgressIndex) {
+      return stateProgressIndex;
+    }
+
+    final ProgressIndex updatedProgressIndex =
+        pipeTaskMeta.updateProgressIndex(
+            new StateProgressIndex(
+                Long.MIN_VALUE, Collections.emptyMap(), MinimumProgressIndex.INSTANCE));
+    return updatedProgressIndex
+        .getProgressIndexByType(StateProgressIndex.class)
+        .orElseThrow(
+            () ->
+                new PipeException(
+                    String.format(
+                        DataNodePipeMessages
+                            .EXCEPTION_FAILED_TO_INITIALIZE_STATEPROGRESSINDEX_FROM_PROGRESS_INDEX_ARG_E95617F9,
+                        updatedProgressIndex)));
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/source/dataregion/historical/PipeHistoricalDataRegionTsFileAndDeletionSource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/source/dataregion/historical/PipeHistoricalDataRegionTsFileAndDeletionSource.java
@@ -696,7 +696,7 @@ public class PipeHistoricalDataRegionTsFileAndDeletionSource
 
     resourceList.sort(
         (o1, o2) ->
-            startIndex instanceof TimeWindowStateProgressIndex
+            Objects.nonNull(getTimeWindowStateProgressIndex(startIndex))
                 ? Long.compare(o1.getFileStartTime(), o2.getFileStartTime())
                 : comparePersistentResourcesByProgressIndex(o1, o2));
   }
@@ -898,11 +898,11 @@ public class PipeHistoricalDataRegionTsFileAndDeletionSource
   }
 
   private boolean mayTsFileContainUnprocessedData(final TsFileResource resource) {
-    final ProgressIndex innerStartIndex = getInnerProgressIndex(startIndex);
-    if (innerStartIndex instanceof TimeWindowStateProgressIndex) {
+    final TimeWindowStateProgressIndex timeWindowStateProgressIndex =
+        getTimeWindowStateProgressIndex(startIndex);
+    if (Objects.nonNull(timeWindowStateProgressIndex)) {
       // The resource is closed thus the TsFileResource#getFileEndTime() is safe to use
-      return ((TimeWindowStateProgressIndex) innerStartIndex).getMinTime()
-          <= resource.getFileEndTime();
+      return timeWindowStateProgressIndex.getMinTime() <= resource.getFileEndTime();
     }
 
     if (pipeName.startsWith(PipeStaticMeta.CONSENSUS_PIPE_PREFIX)) {
@@ -939,6 +939,13 @@ public class PipeHistoricalDataRegionTsFileAndDeletionSource
     return progressIndex instanceof StateProgressIndex
         ? ((StateProgressIndex) progressIndex).getInnerProgressIndex()
         : Objects.isNull(progressIndex) ? MinimumProgressIndex.INSTANCE : progressIndex;
+  }
+
+  private TimeWindowStateProgressIndex getTimeWindowStateProgressIndex(
+      final ProgressIndex progressIndex) {
+    return Objects.isNull(progressIndex)
+        ? null
+        : progressIndex.getProgressIndexByType(TimeWindowStateProgressIndex.class).orElse(null);
   }
 
   private boolean isProgressIndexCoveredByTimePartitionProgressIndex(

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/TsFileResourceProgressIndexTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/TsFileResourceProgressIndexTest.java
@@ -54,6 +54,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import java.util.stream.IntStream;
 
@@ -215,6 +216,14 @@ public class TsFileResourceProgressIndexTest {
     @Override
     public ProgressIndexType getType() {
       throw new UnsupportedOperationException("method not implemented.");
+    }
+
+    @Override
+    public <T extends ProgressIndex> Optional<T> getProgressIndexByType(
+        final Class<T> progressIndexClass) {
+      return progressIndexClass.isInstance(this)
+          ? Optional.of(progressIndexClass.cast(this))
+          : Optional.empty();
     }
 
     @Override

--- a/iotdb-core/node-commons/src/main/i18n/en/org/apache/iotdb/commons/i18n/PipeMessages.java
+++ b/iotdb-core/node-commons/src/main/i18n/en/org/apache/iotdb/commons/i18n/PipeMessages.java
@@ -957,6 +957,8 @@ public final class PipeMessages {
   public static final String LOG_ORIGIN_REQUEST_TYPE_MISMATCH_EXPECTED_ARG_ACTUAL_ARG_D96D10AE = "Origin request type mismatch: expected {}, actual {}";
   public static final String LOG_ORIGIN_BODY_SIZE_MISMATCH_EXPECTED_ARG_ACTUAL_ARG_5D410B75 = "Origin body size mismatch: expected {}, actual {}";
   public static final String LOG_INVALID_SLICE_INDEX_EXPECTED_ARG_ACTUAL_ARG_2AC41628 = "Invalid slice index: expected {}, actual {}";
+  public static final String LOG_PIPE_ARG_ARG_ENCOUNTERED_AN_UNEXPECTED_HYBRIDPROGRESSINDEX_IN_ARG_PROGRESS_INDEX_ARG_7C578B17 =
+      "Pipe {}@{} encountered an unexpected HybridProgressIndex in {}. Progress index: {}.";
   public static final String EXCEPTION_DECOMPRESSED_LENGTH_SHOULD_BETWEEN_0_ARG_BUT_GOT_ARG_488B3073 = "Decompressed length should be between 0 and %d, but got %d.";
   public static final String EXCEPTION_COMMA_50AD1C01 = ", ";
   public static final String MESSAGE_NO_DATAPARTITIONTABLE_GENERATION_TASK_FOUND_4414BE55 = "No DataPartitionTable generation task found";

--- a/iotdb-core/node-commons/src/main/i18n/zh/org/apache/iotdb/commons/i18n/PipeMessages.java
+++ b/iotdb-core/node-commons/src/main/i18n/zh/org/apache/iotdb/commons/i18n/PipeMessages.java
@@ -923,6 +923,8 @@ public final class PipeMessages {
   public static final String LOG_ORIGIN_REQUEST_TYPE_MISMATCH_EXPECTED_ARG_ACTUAL_ARG_D96D10AE = "Origin request type 不匹配：期望 {}，实际 {}";
   public static final String LOG_ORIGIN_BODY_SIZE_MISMATCH_EXPECTED_ARG_ACTUAL_ARG_5D410B75 = "Origin body size 不匹配：期望 {}，实际 {}";
   public static final String LOG_INVALID_SLICE_INDEX_EXPECTED_ARG_ACTUAL_ARG_2AC41628 = "无效的 slice index：期望 {}，实际 {}";
+  public static final String LOG_PIPE_ARG_ARG_ENCOUNTERED_AN_UNEXPECTED_HYBRIDPROGRESSINDEX_IN_ARG_PROGRESS_INDEX_ARG_7C578B17 =
+      "Pipe {}@{} 在 {} 中遇到了非预期的 HybridProgressIndex。进度索引：{}。";
   public static final String EXCEPTION_DECOMPRESSED_LENGTH_SHOULD_BETWEEN_0_ARG_BUT_GOT_ARG_488B3073 = "解压后长度应介于 0 和 %d 之间，但实际为 %d。";
   public static final String EXCEPTION_COMMA_50AD1C01 = ", ";
   public static final String MESSAGE_NO_DATAPARTITIONTABLE_GENERATION_TASK_FOUND_4414BE55 = "未找到 DataPartitionTable 生成任务";

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/ProgressIndex.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/ProgressIndex.java
@@ -165,38 +165,8 @@ public abstract class ProgressIndex implements Accountable {
    * <p>{@link StateProgressIndex} and {@link HybridProgressIndex} are recursively unwrapped because
    * they may contain progress indexes from other causal chains.
    */
-  public final <T extends ProgressIndex> Optional<T> getProgressIndexByType(
-      final Class<T> progressIndexClass) {
-    if (progressIndexClass.isInstance(this)) {
-      return Optional.of(progressIndexClass.cast(this));
-    }
-
-    if (this instanceof StateProgressIndex) {
-      return ((StateProgressIndex) this)
-          .getInnerProgressIndex()
-          .getProgressIndexByType(progressIndexClass);
-    }
-
-    if (this instanceof HybridProgressIndex) {
-      final Map<Short, ProgressIndex> type2Index = ((HybridProgressIndex) this).getType2Index();
-
-      // Prefer a direct component over one nested in another composite progress index.
-      for (final ProgressIndex progressIndex : type2Index.values()) {
-        if (progressIndexClass.isInstance(progressIndex)) {
-          return Optional.of(progressIndexClass.cast(progressIndex));
-        }
-      }
-      for (final ProgressIndex progressIndex : type2Index.values()) {
-        final Optional<T> extractedProgressIndex =
-            progressIndex.getProgressIndexByType(progressIndexClass);
-        if (extractedProgressIndex.isPresent()) {
-          return extractedProgressIndex;
-        }
-      }
-    }
-
-    return Optional.empty();
-  }
+  public abstract <T extends ProgressIndex> Optional<T> getProgressIndexByType(
+      Class<T> progressIndexClass);
 
   /**
    * Get the sum of the tuples of each total order relation of the {@link ProgressIndex}, which is

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/ProgressIndex.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/ProgressIndex.java
@@ -34,6 +34,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -157,6 +158,45 @@ public abstract class ProgressIndex implements Accountable {
    * @return the type of this {@link ProgressIndex}
    */
   public abstract ProgressIndexType getType();
+
+  /**
+   * Extracts a progress index of the given type from this progress index.
+   *
+   * <p>{@link StateProgressIndex} and {@link HybridProgressIndex} are recursively unwrapped because
+   * they may contain progress indexes from other causal chains.
+   */
+  public final <T extends ProgressIndex> Optional<T> getProgressIndexByType(
+      final Class<T> progressIndexClass) {
+    if (progressIndexClass.isInstance(this)) {
+      return Optional.of(progressIndexClass.cast(this));
+    }
+
+    if (this instanceof StateProgressIndex) {
+      return ((StateProgressIndex) this)
+          .getInnerProgressIndex()
+          .getProgressIndexByType(progressIndexClass);
+    }
+
+    if (this instanceof HybridProgressIndex) {
+      final Map<Short, ProgressIndex> type2Index = ((HybridProgressIndex) this).getType2Index();
+
+      // Prefer a direct component over one nested in another composite progress index.
+      for (final ProgressIndex progressIndex : type2Index.values()) {
+        if (progressIndexClass.isInstance(progressIndex)) {
+          return Optional.of(progressIndexClass.cast(progressIndex));
+        }
+      }
+      for (final ProgressIndex progressIndex : type2Index.values()) {
+        final Optional<T> extractedProgressIndex =
+            progressIndex.getProgressIndexByType(progressIndexClass);
+        if (extractedProgressIndex.isPresent()) {
+          return extractedProgressIndex;
+        }
+      }
+    }
+
+    return Optional.empty();
+  }
 
   /**
    * Get the sum of the tuples of each total order relation of the {@link ProgressIndex}, which is

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/HybridProgressIndex.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/HybridProgressIndex.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
@@ -223,6 +224,30 @@ public class HybridProgressIndex extends ProgressIndex {
   @Override
   public ProgressIndexType getType() {
     return ProgressIndexType.HYBRID_PROGRESS_INDEX;
+  }
+
+  @Override
+  public <T extends ProgressIndex> Optional<T> getProgressIndexByType(
+      final Class<T> progressIndexClass) {
+    if (progressIndexClass.isInstance(this)) {
+      return Optional.of(progressIndexClass.cast(this));
+    }
+
+    final Map<Short, ProgressIndex> type2Index = getType2Index();
+    // Prefer a direct component over one nested in another composite progress index.
+    for (final ProgressIndex progressIndex : type2Index.values()) {
+      if (progressIndexClass.isInstance(progressIndex)) {
+        return Optional.of(progressIndexClass.cast(progressIndex));
+      }
+    }
+    for (final ProgressIndex progressIndex : type2Index.values()) {
+      final Optional<T> extractedProgressIndex =
+          progressIndex.getProgressIndexByType(progressIndexClass);
+      if (extractedProgressIndex.isPresent()) {
+        return extractedProgressIndex;
+      }
+    }
+    return Optional.empty();
   }
 
   @Override

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/IoTProgressIndex.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/IoTProgressIndex.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class IoTProgressIndex extends ProgressIndex {
@@ -195,6 +196,14 @@ public class IoTProgressIndex extends ProgressIndex {
   @Override
   public ProgressIndexType getType() {
     return ProgressIndexType.IOT_PROGRESS_INDEX;
+  }
+
+  @Override
+  public <T extends ProgressIndex> Optional<T> getProgressIndexByType(
+      final Class<T> progressIndexClass) {
+    return progressIndexClass.isInstance(this)
+        ? Optional.of(progressIndexClass.cast(this))
+        : Optional.empty();
   }
 
   @Override

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/MetaProgressIndex.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/MetaProgressIndex.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class MetaProgressIndex extends ProgressIndex {
@@ -151,6 +152,14 @@ public class MetaProgressIndex extends ProgressIndex {
 
   public ProgressIndexType getType() {
     return ProgressIndexType.META_PROGRESS_INDEX;
+  }
+
+  @Override
+  public <T extends ProgressIndex> Optional<T> getProgressIndexByType(
+      final Class<T> progressIndexClass) {
+    return progressIndexClass.isInstance(this)
+        ? Optional.of(progressIndexClass.cast(this))
+        : Optional.empty();
   }
 
   @Override

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/MinimumProgressIndex.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/MinimumProgressIndex.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.util.Optional;
 
 public class MinimumProgressIndex extends ProgressIndex {
 
@@ -80,6 +81,14 @@ public class MinimumProgressIndex extends ProgressIndex {
   @Override
   public ProgressIndexType getType() {
     return ProgressIndexType.MINIMUM_PROGRESS_INDEX;
+  }
+
+  @Override
+  public <T extends ProgressIndex> Optional<T> getProgressIndexByType(
+      final Class<T> progressIndexClass) {
+    return progressIndexClass.isInstance(this)
+        ? Optional.of(progressIndexClass.cast(this))
+        : Optional.empty();
   }
 
   @Override

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/RecoverProgressIndex.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/RecoverProgressIndex.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
@@ -200,6 +201,14 @@ public class RecoverProgressIndex extends ProgressIndex {
 
   public ProgressIndexType getType() {
     return ProgressIndexType.RECOVER_PROGRESS_INDEX;
+  }
+
+  @Override
+  public <T extends ProgressIndex> Optional<T> getProgressIndexByType(
+      final Class<T> progressIndexClass) {
+    return progressIndexClass.isInstance(this)
+        ? Optional.of(progressIndexClass.cast(this))
+        : Optional.empty();
   }
 
   @Override

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/SimpleProgressIndex.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/SimpleProgressIndex.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class SimpleProgressIndex extends ProgressIndex {
@@ -177,6 +178,14 @@ public class SimpleProgressIndex extends ProgressIndex {
 
   public ProgressIndexType getType() {
     return ProgressIndexType.SIMPLE_PROGRESS_INDEX;
+  }
+
+  @Override
+  public <T extends ProgressIndex> Optional<T> getProgressIndexByType(
+      final Class<T> progressIndexClass) {
+    return progressIndexClass.isInstance(this)
+        ? Optional.of(progressIndexClass.cast(this))
+        : Optional.empty();
   }
 
   @Override

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/StateProgressIndex.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/StateProgressIndex.java
@@ -36,6 +36,7 @@ import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
@@ -194,6 +195,14 @@ public class StateProgressIndex extends ProgressIndex {
   @Override
   public ProgressIndexType getType() {
     return ProgressIndexType.STATE_PROGRESS_INDEX;
+  }
+
+  @Override
+  public <T extends ProgressIndex> Optional<T> getProgressIndexByType(
+      final Class<T> progressIndexClass) {
+    return progressIndexClass.isInstance(this)
+        ? Optional.of(progressIndexClass.cast(this))
+        : getInnerProgressIndex().getProgressIndexByType(progressIndexClass);
   }
 
   @Override

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/TimePartitionProgressIndex.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/TimePartitionProgressIndex.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
@@ -231,6 +232,14 @@ public class TimePartitionProgressIndex extends ProgressIndex {
   @Override
   public ProgressIndexType getType() {
     return ProgressIndexType.TIME_PARTITION_PROGRESS_INDEX;
+  }
+
+  @Override
+  public <T extends ProgressIndex> Optional<T> getProgressIndexByType(
+      final Class<T> progressIndexClass) {
+    return progressIndexClass.isInstance(this)
+        ? Optional.of(progressIndexClass.cast(this))
+        : Optional.empty();
   }
 
   @Override

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/TimeWindowStateProgressIndex.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/TimeWindowStateProgressIndex.java
@@ -210,7 +210,7 @@ public class TimeWindowStateProgressIndex extends ProgressIndex {
     lock.writeLock().lock();
     try {
       if (!(progressIndex instanceof TimeWindowStateProgressIndex)) {
-        return this;
+        return ProgressIndex.blendProgressIndex(this, progressIndex);
       }
 
       final TimeWindowStateProgressIndex thisTimeWindowStateProgressIndex = this;

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/TimeWindowStateProgressIndex.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/consensus/index/impl/TimeWindowStateProgressIndex.java
@@ -39,6 +39,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
@@ -238,6 +239,14 @@ public class TimeWindowStateProgressIndex extends ProgressIndex {
   @Override
   public ProgressIndexType getType() {
     return ProgressIndexType.TIME_WINDOW_STATE_PROGRESS_INDEX;
+  }
+
+  @Override
+  public <T extends ProgressIndex> Optional<T> getProgressIndexByType(
+      final Class<T> progressIndexClass) {
+    return progressIndexClass.isInstance(this)
+        ? Optional.of(progressIndexClass.cast(this))
+        : Optional.empty();
   }
 
   @Override

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/source/IoTDBNonDataRegionSource.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/source/IoTDBNonDataRegionSource.java
@@ -20,8 +20,10 @@
 package org.apache.iotdb.commons.pipe.source;
 
 import org.apache.iotdb.commons.consensus.index.ProgressIndex;
+import org.apache.iotdb.commons.consensus.index.ProgressIndexType;
+import org.apache.iotdb.commons.consensus.index.impl.HybridProgressIndex;
 import org.apache.iotdb.commons.consensus.index.impl.MetaProgressIndex;
-import org.apache.iotdb.commons.consensus.index.impl.MinimumProgressIndex;
+import org.apache.iotdb.commons.consensus.index.impl.StateProgressIndex;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.exception.auth.AccessDeniedException;
 import org.apache.iotdb.commons.i18n.PipeMessages;
@@ -46,6 +48,7 @@ import org.apache.tsfile.utils.Pair;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -99,15 +102,15 @@ public abstract class IoTDBNonDataRegionSource extends IoTDBSource {
       return;
     }
 
-    final ProgressIndex progressIndex = pipeTaskMeta.getProgressIndex();
+    final MetaProgressIndex metaProgressIndex =
+        extractMetaProgressIndex(pipeTaskMeta.getProgressIndex());
     final long nextIndex =
-        progressIndex instanceof MinimumProgressIndex
+        Objects.isNull(metaProgressIndex)
                 // If the index is invalid, the queue is seen as cleared before and thus
                 // needs snapshot re-transferring
-                || !getListeningQueue()
-                    .isGivenNextIndexValid(((MetaProgressIndex) progressIndex).getIndex() + 1)
+                || !getListeningQueue().isGivenNextIndexValid(metaProgressIndex.getIndex() + 1)
             ? getNextIndexAfterSnapshot()
-            : ((MetaProgressIndex) progressIndex).getIndex() + 1;
+            : metaProgressIndex.getIndex() + 1;
     iterator = getListeningQueue().newIterator(nextIndex);
     super.start();
   }
@@ -296,10 +299,31 @@ public abstract class IoTDBNonDataRegionSource extends IoTDBSource {
     if (Objects.isNull(pipeTaskMeta)) {
       return 0L;
     }
-    return !(pipeTaskMeta.getProgressIndex() instanceof MinimumProgressIndex)
-        ? getListeningQueue().getTailIndex()
-            - ((MetaProgressIndex) pipeTaskMeta.getProgressIndex()).getIndex()
-            - 1
+    final MetaProgressIndex metaProgressIndex =
+        extractMetaProgressIndex(pipeTaskMeta.getProgressIndex());
+    return Objects.nonNull(metaProgressIndex)
+        ? getListeningQueue().getTailIndex() - metaProgressIndex.getIndex() - 1
         : getListeningQueue().getSize() + historicalEventsCount;
+  }
+
+  private static MetaProgressIndex extractMetaProgressIndex(final ProgressIndex progressIndex) {
+    if (progressIndex instanceof MetaProgressIndex) {
+      return (MetaProgressIndex) progressIndex;
+    }
+    if (progressIndex instanceof StateProgressIndex) {
+      return extractMetaProgressIndex(((StateProgressIndex) progressIndex).getInnerProgressIndex());
+    }
+    if (progressIndex instanceof HybridProgressIndex) {
+      final Map<Short, ProgressIndex> type2Index =
+          ((HybridProgressIndex) progressIndex).getType2Index();
+      final ProgressIndex metaProgressIndex =
+          type2Index.get(ProgressIndexType.META_PROGRESS_INDEX.getType());
+      if (metaProgressIndex instanceof MetaProgressIndex) {
+        return (MetaProgressIndex) metaProgressIndex;
+      }
+      return extractMetaProgressIndex(
+          type2Index.get(ProgressIndexType.STATE_PROGRESS_INDEX.getType()));
+    }
+    return null;
   }
 }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/source/IoTDBNonDataRegionSource.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/source/IoTDBNonDataRegionSource.java
@@ -20,10 +20,8 @@
 package org.apache.iotdb.commons.pipe.source;
 
 import org.apache.iotdb.commons.consensus.index.ProgressIndex;
-import org.apache.iotdb.commons.consensus.index.ProgressIndexType;
 import org.apache.iotdb.commons.consensus.index.impl.HybridProgressIndex;
 import org.apache.iotdb.commons.consensus.index.impl.MetaProgressIndex;
-import org.apache.iotdb.commons.consensus.index.impl.StateProgressIndex;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.exception.auth.AccessDeniedException;
 import org.apache.iotdb.commons.i18n.PipeMessages;
@@ -44,11 +42,12 @@ import org.apache.iotdb.pipe.api.event.Event;
 import org.apache.iotdb.pipe.api.exception.PipeException;
 
 import org.apache.tsfile.utils.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -56,6 +55,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @TreeModel
 @TableModel
 public abstract class IoTDBNonDataRegionSource extends IoTDBSource {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(IoTDBNonDataRegionSource.class);
 
   protected IoTDBTreePatternOperations treePattern;
   protected TablePattern tablePattern;
@@ -71,6 +72,7 @@ public abstract class IoTDBNonDataRegionSource extends IoTDBSource {
   // If the extractor is closed, it should not be started again. This is to avoid the case that
   // the extractor is closed and then be reused by processor.
   protected final AtomicBoolean hasBeenClosed = new AtomicBoolean(false);
+  private final AtomicBoolean hasWarnedUnexpectedHybridProgressIndex = new AtomicBoolean(false);
 
   protected PipeWritePlanEvent lastEvent = null;
 
@@ -102,8 +104,9 @@ public abstract class IoTDBNonDataRegionSource extends IoTDBSource {
       return;
     }
 
-    final MetaProgressIndex metaProgressIndex =
-        extractMetaProgressIndex(pipeTaskMeta.getProgressIndex());
+    final ProgressIndex progressIndex = pipeTaskMeta.getProgressIndex();
+    warnIfUnexpectedHybridProgressIndex(progressIndex);
+    final MetaProgressIndex metaProgressIndex = extractMetaProgressIndex(progressIndex);
     final long nextIndex =
         Objects.isNull(metaProgressIndex)
                 // If the index is invalid, the queue is seen as cleared before and thus
@@ -299,31 +302,31 @@ public abstract class IoTDBNonDataRegionSource extends IoTDBSource {
     if (Objects.isNull(pipeTaskMeta)) {
       return 0L;
     }
-    final MetaProgressIndex metaProgressIndex =
-        extractMetaProgressIndex(pipeTaskMeta.getProgressIndex());
+    final ProgressIndex progressIndex = pipeTaskMeta.getProgressIndex();
+    warnIfUnexpectedHybridProgressIndex(progressIndex);
+    final MetaProgressIndex metaProgressIndex = extractMetaProgressIndex(progressIndex);
     return Objects.nonNull(metaProgressIndex)
         ? getListeningQueue().getTailIndex() - metaProgressIndex.getIndex() - 1
         : getListeningQueue().getSize() + historicalEventsCount;
   }
 
   private static MetaProgressIndex extractMetaProgressIndex(final ProgressIndex progressIndex) {
-    if (progressIndex instanceof MetaProgressIndex) {
-      return (MetaProgressIndex) progressIndex;
+    return Objects.isNull(progressIndex)
+        ? null
+        : progressIndex.getProgressIndexByType(MetaProgressIndex.class).orElse(null);
+  }
+
+  private void warnIfUnexpectedHybridProgressIndex(final ProgressIndex progressIndex) {
+    if (Objects.nonNull(progressIndex)
+        && progressIndex.getProgressIndexByType(HybridProgressIndex.class).isPresent()
+        && hasWarnedUnexpectedHybridProgressIndex.compareAndSet(false, true)) {
+      LOGGER.warn(
+          PipeMessages
+              .LOG_PIPE_ARG_ARG_ENCOUNTERED_AN_UNEXPECTED_HYBRIDPROGRESSINDEX_IN_ARG_PROGRESS_INDEX_ARG_7C578B17,
+          pipeName,
+          creationTime,
+          getClass().getSimpleName(),
+          progressIndex);
     }
-    if (progressIndex instanceof StateProgressIndex) {
-      return extractMetaProgressIndex(((StateProgressIndex) progressIndex).getInnerProgressIndex());
-    }
-    if (progressIndex instanceof HybridProgressIndex) {
-      final Map<Short, ProgressIndex> type2Index =
-          ((HybridProgressIndex) progressIndex).getType2Index();
-      final ProgressIndex metaProgressIndex =
-          type2Index.get(ProgressIndexType.META_PROGRESS_INDEX.getType());
-      if (metaProgressIndex instanceof MetaProgressIndex) {
-        return (MetaProgressIndex) metaProgressIndex;
-      }
-      return extractMetaProgressIndex(
-          type2Index.get(ProgressIndexType.STATE_PROGRESS_INDEX.getType()));
-    }
-    return null;
   }
 }

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/consensus/index/ProgressIndexTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/consensus/index/ProgressIndexTest.java
@@ -17,83 +17,66 @@
  * under the License.
  */
 
-package org.apache.iotdb.db.pipe.processor.twostage.plugin;
+package org.apache.iotdb.commons.consensus.index;
 
-import org.apache.iotdb.commons.consensus.index.ProgressIndex;
 import org.apache.iotdb.commons.consensus.index.impl.HybridProgressIndex;
 import org.apache.iotdb.commons.consensus.index.impl.MetaProgressIndex;
 import org.apache.iotdb.commons.consensus.index.impl.SimpleProgressIndex;
 import org.apache.iotdb.commons.consensus.index.impl.StateProgressIndex;
 import org.apache.iotdb.commons.consensus.index.impl.TimeWindowStateProgressIndex;
-import org.apache.iotdb.commons.path.PartialPath;
-import org.apache.iotdb.commons.pipe.agent.task.meta.PipeTaskMeta;
-import org.apache.iotdb.pipe.api.customizer.parameter.PipeParameters;
 
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Collections;
 
-public class TwoStageCountProcessorTest {
+public class ProgressIndexTest {
 
   @Test
-  public void testOutputSeriesSupportsNewAndLegacyKeys() throws Exception {
-    Assert.assertEquals(
-        "root.db.d.s1", parseOutputSeries("processor.output.series", "root.db.d.s1").getFullPath());
-    Assert.assertEquals(
-        "root.db.d.s2", parseOutputSeries("processor.output-series", "root.db.d.s2").getFullPath());
-  }
-
-  @Test
-  public void testInitializeStateProgressIndexFromHybridProgressIndex() {
+  public void testGetProgressIndexByTypeFromStateWrappedHybridProgressIndex() {
     final MetaProgressIndex metaProgressIndex = new MetaProgressIndex(10L);
     final SimpleProgressIndex simpleProgressIndex = new SimpleProgressIndex(1, 2L);
     final ProgressIndex hybridProgressIndex =
         new HybridProgressIndex(metaProgressIndex)
             .updateToMinimumEqualOrIsAfterProgressIndex(simpleProgressIndex);
-    final PipeTaskMeta pipeTaskMeta = new PipeTaskMeta(hybridProgressIndex, 0);
-
     final StateProgressIndex stateProgressIndex =
-        TwoStageCountProcessor.initializeStateProgressIndex(pipeTaskMeta);
+        new StateProgressIndex(1L, Collections.emptyMap(), hybridProgressIndex);
 
-    Assert.assertSame(stateProgressIndex, pipeTaskMeta.getProgressIndex());
     Assert.assertEquals(
         metaProgressIndex,
         stateProgressIndex.getProgressIndexByType(MetaProgressIndex.class).orElse(null));
     Assert.assertEquals(
         simpleProgressIndex,
         stateProgressIndex.getProgressIndexByType(SimpleProgressIndex.class).orElse(null));
+    Assert.assertSame(
+        hybridProgressIndex,
+        stateProgressIndex.getProgressIndexByType(HybridProgressIndex.class).orElse(null));
+    Assert.assertFalse(
+        stateProgressIndex.getProgressIndexByType(TimeWindowStateProgressIndex.class).isPresent());
   }
 
   @Test
-  public void testInitializeStateProgressIndexFromTimeWindowStateProgressIndex() {
+  public void testTimeWindowStateProgressIndexBlendsWithOtherProgressIndexTypes() {
     final TimeWindowStateProgressIndex timeWindowStateProgressIndex =
         new TimeWindowStateProgressIndex(Collections.emptyMap());
-    final PipeTaskMeta pipeTaskMeta = new PipeTaskMeta(timeWindowStateProgressIndex, 0);
-
-    final StateProgressIndex stateProgressIndex =
-        TwoStageCountProcessor.initializeStateProgressIndex(pipeTaskMeta);
-    Assert.assertEquals(
-        timeWindowStateProgressIndex,
-        stateProgressIndex.getProgressIndexByType(TimeWindowStateProgressIndex.class).orElse(null));
-
     final SimpleProgressIndex simpleProgressIndex = new SimpleProgressIndex(1, 2L);
-    final ProgressIndex updatedProgressIndex =
-        pipeTaskMeta.updateProgressIndex(
-            new StateProgressIndex(1L, Collections.emptyMap(), simpleProgressIndex));
-    Assert.assertTrue(updatedProgressIndex instanceof StateProgressIndex);
+
+    final ProgressIndex blendedProgressIndex =
+        timeWindowStateProgressIndex.updateToMinimumEqualOrIsAfterProgressIndex(
+            simpleProgressIndex);
+    Assert.assertTrue(blendedProgressIndex instanceof HybridProgressIndex);
     Assert.assertEquals(
         timeWindowStateProgressIndex,
-        updatedProgressIndex
+        blendedProgressIndex
             .getProgressIndexByType(TimeWindowStateProgressIndex.class)
             .orElse(null));
     Assert.assertEquals(
         simpleProgressIndex,
-        updatedProgressIndex.getProgressIndexByType(SimpleProgressIndex.class).orElse(null));
-  }
+        blendedProgressIndex.getProgressIndexByType(SimpleProgressIndex.class).orElse(null));
 
-  private PartialPath parseOutputSeries(final String key, final String value) throws Exception {
-    return TwoStageCountProcessor.parseOutputSeries(
-        new PipeParameters(Collections.singletonMap(key, value)));
+    final ProgressIndex reverseBlendedProgressIndex =
+        simpleProgressIndex.updateToMinimumEqualOrIsAfterProgressIndex(
+            timeWindowStateProgressIndex);
+    Assert.assertEquals(blendedProgressIndex, reverseBlendedProgressIndex);
   }
 }

--- a/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/pipe/source/IoTDBNonDataRegionSourceTest.java
+++ b/iotdb-core/node-commons/src/test/java/org/apache/iotdb/commons/pipe/source/IoTDBNonDataRegionSourceTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.commons.pipe.source;
+
+import org.apache.iotdb.commons.consensus.index.ProgressIndex;
+import org.apache.iotdb.commons.consensus.index.impl.HybridProgressIndex;
+import org.apache.iotdb.commons.consensus.index.impl.MetaProgressIndex;
+import org.apache.iotdb.commons.consensus.index.impl.SimpleProgressIndex;
+import org.apache.iotdb.commons.consensus.index.impl.StateProgressIndex;
+import org.apache.iotdb.commons.exception.IllegalPathException;
+import org.apache.iotdb.commons.exception.auth.AccessDeniedException;
+import org.apache.iotdb.commons.pipe.agent.task.meta.PipeTaskMeta;
+import org.apache.iotdb.commons.pipe.datastructure.queue.listening.AbstractPipeListeningQueue;
+import org.apache.iotdb.commons.pipe.event.PipeSnapshotEvent;
+import org.apache.iotdb.commons.pipe.event.PipeWritePlanEvent;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Optional;
+
+public class IoTDBNonDataRegionSourceTest {
+
+  @Test
+  public void testStartWithStateWrappedHybridProgressIndex() throws Exception {
+    final AbstractPipeListeningQueue listeningQueue =
+        Mockito.mock(AbstractPipeListeningQueue.class);
+    Mockito.when(listeningQueue.isGivenNextIndexValid(11L)).thenReturn(true);
+
+    final ProgressIndex hybridProgressIndex =
+        new HybridProgressIndex(new MetaProgressIndex(10L))
+            .updateToMinimumEqualOrIsAfterProgressIndex(new SimpleProgressIndex(1, 2L));
+    final StateProgressIndex stateProgressIndex =
+        new StateProgressIndex(1L, Collections.emptyMap(), hybridProgressIndex);
+    final TestNonDataRegionSource source =
+        new TestNonDataRegionSource(listeningQueue, new PipeTaskMeta(stateProgressIndex, 0));
+
+    source.start();
+
+    Mockito.verify(listeningQueue).newIterator(11L);
+  }
+
+  @Test
+  public void testGetUnTransferredEventCountWithHybridProgressIndex() {
+    final AbstractPipeListeningQueue listeningQueue =
+        Mockito.mock(AbstractPipeListeningQueue.class);
+    Mockito.when(listeningQueue.getTailIndex()).thenReturn(20L);
+
+    final ProgressIndex hybridProgressIndex =
+        new HybridProgressIndex(new MetaProgressIndex(10L))
+            .updateToMinimumEqualOrIsAfterProgressIndex(new SimpleProgressIndex(1, 2L));
+    final TestNonDataRegionSource source =
+        new TestNonDataRegionSource(listeningQueue, new PipeTaskMeta(hybridProgressIndex, 0));
+
+    Assert.assertEquals(9L, source.getUnTransferredEventCount());
+  }
+
+  @Test
+  public void testGetUnTransferredEventCountWithHybridProgressIndexWithoutMetaIndex() {
+    final AbstractPipeListeningQueue listeningQueue =
+        Mockito.mock(AbstractPipeListeningQueue.class);
+    Mockito.when(listeningQueue.getSize()).thenReturn(7L);
+
+    final TestNonDataRegionSource source =
+        new TestNonDataRegionSource(
+            listeningQueue,
+            new PipeTaskMeta(new HybridProgressIndex(new SimpleProgressIndex(1, 2L)), 0));
+
+    Assert.assertEquals(7L, source.getUnTransferredEventCount());
+  }
+
+  private static final class TestNonDataRegionSource extends IoTDBNonDataRegionSource {
+
+    private final AbstractPipeListeningQueue listeningQueue;
+
+    private TestNonDataRegionSource(
+        final AbstractPipeListeningQueue listeningQueue, final PipeTaskMeta pipeTaskMeta) {
+      this.listeningQueue = listeningQueue;
+      this.pipeTaskMeta = pipeTaskMeta;
+    }
+
+    @Override
+    protected AbstractPipeListeningQueue getListeningQueue() {
+      return listeningQueue;
+    }
+
+    @Override
+    protected boolean needTransferSnapshot() {
+      return false;
+    }
+
+    @Override
+    protected void triggerSnapshot() {
+      // Do nothing
+    }
+
+    @Override
+    protected long getMaxBlockingTimeMs() {
+      return 0L;
+    }
+
+    @Override
+    protected boolean canSkipSnapshotPrivilegeCheck(final PipeSnapshotEvent event) {
+      return false;
+    }
+
+    @Override
+    protected void initSnapshotGenerator(final PipeSnapshotEvent event)
+        throws IOException, IllegalPathException {
+      // Do nothing
+    }
+
+    @Override
+    protected boolean hasNextEventInCurrentSnapshot() {
+      return false;
+    }
+
+    @Override
+    protected PipeWritePlanEvent getNextEventInCurrentSnapshot() {
+      return null;
+    }
+
+    @Override
+    protected Optional<PipeWritePlanEvent> trimRealtimeEventByPrivilege(
+        final PipeWritePlanEvent event) throws AccessDeniedException {
+      return Optional.of(event);
+    }
+
+    @Override
+    protected Optional<PipeWritePlanEvent> trimRealtimeEventByPipePattern(
+        final PipeWritePlanEvent event) {
+      return Optional.of(event);
+    }
+
+    @Override
+    protected boolean isTypeListened(final PipeWritePlanEvent event) {
+      return true;
+    }
+
+    @Override
+    protected void confineHistoricalEventTransferTypes(final PipeSnapshotEvent event) {
+      // Do nothing
+    }
+
+    @Override
+    protected void login(final @Nonnull String password) {
+      // Do nothing
+    }
+  }
+}


### PR DESCRIPTION
## Description

### Problem

IoTDBNonDataRegionSource assumed every non-minimum task progress was a MetaProgressIndex. Pipe task progress can also be merged into a HybridProgressIndex, and may be wrapped by a StateProgressIndex. This caused a ClassCastException while restoring a non-data-region source or calculating its remaining events during DataNode shutdown.

### Changes

- Extract the meta progress component from direct, hybrid, and state-wrapped progress indexes.
- Use that component for source recovery and remaining-event accounting.
- Conservatively fall back to snapshot recovery or full queue size when no meta component exists.
- Add unit coverage for hybrid, state-wrapped hybrid, and hybrid-without-meta cases.

### Verification

- mvn spotless:apply -pl iotdb-core/node-commons
- mvn test -pl iotdb-core/node-commons -Dtest=IoTDBNonDataRegionSourceTest

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added unit tests to cover new code paths.

<hr>

##### Key changed/added classes

- IoTDBNonDataRegionSource
- IoTDBNonDataRegionSourceTest