### PR TITLE
[Pipe] Relax flaky TsFile event test timeouts

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/PipeTsFileInsertionEventTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/PipeTsFileInsertionEventTest.java
@@ -242,7 +242,7 @@ public class PipeTsFileInsertionEventTest {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test(timeout = 60000)
   public void testRealtimeEventCanSkipWaitingForClosedStatusAfterTsFileSealed() throws Exception {
     final File tempDir = Files.createTempDirectory("pipeTsFileSealed").toFile();
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEventAdmissionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEventAdmissionTest.java
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeoutException;
 
 public class PipeTsFileInsertionEventAdmissionTest {
 
-  @Test(timeout = 10000)
+  @Test(timeout = 60000)
   public void testParserAdmissionIsWokenWhenMemoryIsReleased() throws Exception {
     final CommonConfig commonConfig = CommonDescriptor.getInstance().getConfig();
     final PipeMemoryManager memoryManager = PipeDataNodeResourceManager.memory();


### PR DESCRIPTION
## Description

The Windows DataNode unit-test job can run under heavy memory and CPU pressure. `PipeTsFileInsertionEventAdmissionTest` had a 10-second whole-method timeout, and the observed failure timed out on the first `CommonDescriptor.getInstance()` call during class initialization, before the parser-admission logic ran. The same JVM also reported `OutOfMemoryError: Java heap space` from Surefire's stream flusher.

Raise the outer safety timeout to 60 seconds for the two Pipe TsFile event tests that used 5/10-second whole-method limits. The admission test's behavior checks remain strict and unchanged: it still verifies the parser stays blocked for 200 ms and resumes within 3 seconds after memory is released.

## Verification

- DataNode Spotless: passed
- DataNode Checkstyle: 0 violations
- `git diff --check`: passed

The local targeted Maven run was blocked during reactor compilation because the installed Thrift 0.14.1 compiler generates `javax.annotation.Generated` sources on JDK 17. The PR CI uses the supported build environment and will provide the test result.