### PR TITLE
Preserve Pipe sink exception root causes

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/sink/PipeSinkSubtask.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/agent/task/subtask/sink/PipeSinkSubtask.java
@@ -575,7 +575,7 @@ public class PipeSinkSubtask extends PipeAbstractSinkSubtask {
 
   @Override
   protected String getRootCause(final Throwable throwable) {
-    return ErrorHandlingCommonUtils.getRootCause(throwable).getMessage();
+    return ErrorHandlingCommonUtils.getRootCause(throwable).toString();
   }
 
   @Override

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/task/subtask/sink/PipeSinkSubtaskTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/agent/task/subtask/sink/PipeSinkSubtaskTest.java
@@ -20,10 +20,14 @@
 package org.apache.iotdb.db.pipe.agent.task.subtask.sink;
 
 import org.apache.iotdb.commons.conf.CommonDescriptor;
+import org.apache.iotdb.commons.exception.pipe.PipeRuntimeException;
+import org.apache.iotdb.commons.exception.pipe.PipeRuntimeSinkCriticalException;
 import org.apache.iotdb.commons.exception.pipe.PipeRuntimeSinkNonReportTimeConfigurableException;
 import org.apache.iotdb.commons.pipe.agent.task.connection.UnboundedBlockingPendingQueue;
 import org.apache.iotdb.commons.pipe.agent.task.progress.CommitterKey;
+import org.apache.iotdb.commons.pipe.event.EnrichedEvent;
 import org.apache.iotdb.commons.pipe.sink.protocol.PipeConnectorWithEventDiscard;
+import org.apache.iotdb.commons.utils.ErrorHandlingCommonUtils;
 import org.apache.iotdb.db.pipe.event.common.heartbeat.PipeHeartbeatEvent;
 import org.apache.iotdb.pipe.api.PipeConnector;
 import org.apache.iotdb.pipe.api.customizer.configuration.PipeConnectorRuntimeConfiguration;
@@ -270,6 +274,63 @@ public class PipeSinkSubtaskTest {
   }
 
   @Test
+  public void testTransferExceptionWithNullRootCauseMessageIncludesExceptionType()
+      throws Exception {
+    final PipeConnector connector = mock(PipeConnector.class);
+    final UnboundedBlockingPendingQueue<Event> pendingQueue =
+        mock(UnboundedBlockingPendingQueue.class);
+    final Event event = mock(Event.class);
+    final NullPointerException rootCause = new NullPointerException();
+
+    when(pendingQueue.waitedPoll()).thenReturn(event);
+    doThrow(rootCause).when(connector).transfer(any(Event.class));
+
+    final PipeSinkSubtask subtask =
+        new PipeSinkSubtask(
+            "PipeSinkSubtaskTest",
+            System.currentTimeMillis(),
+            "data_test",
+            "data_test",
+            0,
+            pendingQueue,
+            connector);
+
+    try {
+      subtask.executeOnce();
+      Assert.fail();
+    } catch (final PipeException e) {
+      Assert.assertTrue(e.getMessage().contains("root cause: java.lang.NullPointerException"));
+      Assert.assertFalse(e.getMessage().contains("root cause: null"));
+      Assert.assertSame(rootCause, e.getCause());
+    } finally {
+      subtask.close();
+    }
+  }
+
+  @Test
+  public void testOnFailurePreservesOriginalCause() {
+    final PipeConnector connector = mock(PipeConnector.class);
+    final UnboundedBlockingPendingQueue<Event> pendingQueue =
+        mock(UnboundedBlockingPendingQueue.class);
+    final EnrichedEvent event = mock(EnrichedEvent.class);
+    final NullPointerException rootCause = new NullPointerException();
+    final PipeException failure = new PipeException("transfer failed", rootCause);
+    final CapturingPipeSinkSubtask subtask = new CapturingPipeSinkSubtask(pendingQueue, connector);
+
+    subtask.prepareFailure(event);
+    try {
+      subtask.onFailure(failure);
+
+      final PipeRuntimeException reportedException = subtask.getReportedException();
+      Assert.assertTrue(reportedException instanceof PipeRuntimeSinkCriticalException);
+      Assert.assertSame(failure, reportedException.getCause());
+      Assert.assertSame(rootCause, ErrorHandlingCommonUtils.getRootCause(reportedException));
+    } finally {
+      subtask.close();
+    }
+  }
+
+  @Test
   public void testHeartbeatPreservesReceiverProbeDelayException() throws Exception {
     final long originalSleepIntervalInitMs =
         CommonDescriptor.getInstance().getConfig().getPipeSinkSubtaskSleepIntervalInitMs();
@@ -307,6 +368,38 @@ public class PipeSinkSubtaskTest {
       CommonDescriptor.getInstance()
           .getConfig()
           .setPipeSinkSubtaskSleepIntervalMaxMs(originalSleepIntervalMaxMs);
+    }
+  }
+
+  private static class CapturingPipeSinkSubtask extends PipeSinkSubtask {
+
+    private PipeRuntimeException reportedException;
+
+    private CapturingPipeSinkSubtask(
+        final UnboundedBlockingPendingQueue<Event> pendingQueue, final PipeConnector connector) {
+      super(
+          "PipeSinkSubtaskTest",
+          System.currentTimeMillis(),
+          "data_test",
+          "data_test",
+          0,
+          pendingQueue,
+          connector);
+    }
+
+    private void prepareFailure(final EnrichedEvent event) {
+      setLastEvent(event);
+      setLastExceptionEvent(event);
+      retryCount.set(MAX_RETRY_TIMES);
+    }
+
+    private PipeRuntimeException getReportedException() {
+      return reportedException;
+    }
+
+    @Override
+    protected void report(final EnrichedEvent event, final PipeRuntimeException exception) {
+      reportedException = exception;
     }
   }
 

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/exception/pipe/PipeRuntimeCriticalException.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/exception/pipe/PipeRuntimeCriticalException.java
@@ -36,6 +36,10 @@ public class PipeRuntimeCriticalException extends PipeRuntimeException {
     super(message);
   }
 
+  public PipeRuntimeCriticalException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
   public PipeRuntimeCriticalException(final String message, final long timeStamp) {
     super(message, timeStamp);
   }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/exception/pipe/PipeRuntimeException.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/exception/pipe/PipeRuntimeException.java
@@ -32,6 +32,10 @@ public abstract class PipeRuntimeException extends PipeException {
     super(message);
   }
 
+  protected PipeRuntimeException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
   protected PipeRuntimeException(final String message, final long timeStamp) {
     super(message, timeStamp);
   }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/exception/pipe/PipeRuntimeSinkCriticalException.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/exception/pipe/PipeRuntimeSinkCriticalException.java
@@ -36,6 +36,10 @@ public class PipeRuntimeSinkCriticalException extends PipeRuntimeCriticalExcepti
     super(message);
   }
 
+  public PipeRuntimeSinkCriticalException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
   public PipeRuntimeSinkCriticalException(final String message, final long timeStamp) {
     super(message, timeStamp);
   }

--- a/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/subtask/PipeAbstractSinkSubtask.java
+++ b/iotdb-core/node-commons/src/main/java/org/apache/iotdb/commons/pipe/agent/task/subtask/PipeAbstractSinkSubtask.java
@@ -176,7 +176,10 @@ public abstract class PipeAbstractSinkSubtask extends PipeReportableSubtask {
       // Print stack trace for better debugging
       PipeLogger.log(
           LOGGER::warn, throwable, PipeMessages.NON_CRITICAL_EXCEPTION_WILL_THROW_CRITICAL);
-      super.onFailure(new PipeRuntimeSinkCriticalException(throwable.getMessage()));
+      super.onFailure(
+          new PipeRuntimeSinkCriticalException(
+              throwable.getMessage() != null ? throwable.getMessage() : throwable.toString(),
+              throwable));
     }
   }
 
@@ -227,7 +230,8 @@ public abstract class PipeAbstractSinkSubtask extends PipeReportableSubtask {
           new PipeRuntimeSinkCriticalException(
               throwable.getMessage()
                   + PipeMessages.EXCEPTION_ROOT_CAUSE_A22E94DE
-                  + getRootCause(throwable)));
+                  + getRootCause(throwable),
+              throwable));
       LOGGER.warn(
           PipeMessages.HANDSHAKE_FAILED_STOPPING,
           outputPipeSink.getClass().getName(),
@@ -374,7 +378,7 @@ public abstract class PipeAbstractSinkSubtask extends PipeReportableSubtask {
                 event instanceof EnrichedEvent
                     ? ((EnrichedEvent) event).coreReportMessage()
                     : event,
-                ErrorHandlingCommonUtils.getRootCause(e).getMessage()),
+                ErrorHandlingCommonUtils.getRootCause(e).toString()),
             e);
       } else {
         LOGGER.info(


### PR DESCRIPTION
## Description

### Preserve diagnostic information

- Use `Throwable.toString()` for root-cause reporting so exceptions with a null message still include their exception type.
- Preserve the original throwable as the cause of `PipeRuntimeSinkCriticalException` instances.
- Add cause-aware constructors to the Pipe runtime exception hierarchy.

### Test coverage

- Add unit coverage for null root-cause messages.
- Add unit coverage verifying that failure reporting preserves the original cause chain.

### Testing

Not run locally because the machine does not have enough memory; CI will validate the change.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added or modified unit tests to cover the new code paths.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- `PipeAbstractSinkSubtask`
- `PipeSinkSubtask`
- `PipeRuntimeException` and its critical sink subclasses
- `PipeSinkSubtaskTest`