### PR TITLE
Fix degraded time index region migration IT configuration

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/batch/IoTDBRegionMigrateNormalITForIoTV2BatchIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/confignode/it/regionmigration/pass/commit/batch/IoTDBRegionMigrateNormalITForIoTV2BatchIT.java
@@ -53,7 +53,7 @@ public class IoTDBRegionMigrateNormalITForIoTV2BatchIT
   @Test
   public void migrateRegionWithDegradedTimeIndexTest() throws Exception {
     // set TsFileResource memory to 0 to trigger degrading
-    EnvFactory.getEnv().getConfig().getCommonConfig().setQueryMemoryProportion("1:1:1:1:1:1:0");
+    EnvFactory.getEnv().getConfig().getCommonConfig().setQueryMemoryProportion("1:1:1:1:1:1:0:1:1");
 
     successTest(1, 1, 1, 2, noKillPoints(), noKillPoints(), KillNode.ALL_NODES);
 


### PR DESCRIPTION
## Description

The cluster IT failure observed in #18336 was unrelated to the WAL throttle change. `IoTDBRegionMigrateNormalITForIoTV2BatchIT#migrateRegionWithDegradedTimeIndexTest` still configured `chunk_timeseriesmeta_free_memory_proportion` with seven values.

After #18298, DataNode startup accepts the legacy eight-part form or the current nine-part form. Both DataNodes therefore rejected the seven-part test configuration during startup, leaving only the ConfigNode in the cluster.

This PR updates the test to use the current nine-part format while keeping the TimeIndex proportion at `0`, preserving the test's degraded-time-index behavior.

## Tests

- `mvn clean verify -DskipUTs -Dit.test=IoTDBRegionMigrateNormalITForIoTV2BatchIT#migrateRegionWithDegradedTimeIndexTest -DfailIfNoTests=false -Dfailsafe.failIfNoSpecifiedTests=false -pl integration-test -am -PClusterIT -P with-integration-tests`
  - Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
