### PR TITLE
Fix ConfigNode procedure metrics NPE during leader startup

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
@@ -68,7 +68,9 @@ public class ProcedureExecutor<Env> {
   private final ThreadGroup threadGroup =
       new ThreadGroup(ThreadName.CONFIG_NODE_PROCEDURE_WORKER.getName());
 
-  private CopyOnWriteArrayList<WorkerThread> workerThreads;
+  // Metrics may be scraped before init() and concurrently with initialization during a ConfigNode
+  // leader transition.
+  private volatile CopyOnWriteArrayList<WorkerThread> workerThreads;
 
   private TimeoutExecutorThread<Env> timeoutExecutor;
 
@@ -1026,11 +1028,15 @@ public class ProcedureExecutor<Env> {
   }
 
   public int getWorkerThreadCount() {
-    return workerThreads.size();
+    final CopyOnWriteArrayList<WorkerThread> workers = workerThreads;
+    return workers == null ? 0 : workers.size();
   }
 
   public long getActiveWorkerThreadCount() {
-    return workerThreads.stream().filter(worker -> worker.activeProcedure.get() != null).count();
+    final CopyOnWriteArrayList<WorkerThread> workers = workerThreads;
+    return workers == null
+        ? 0
+        : workers.stream().filter(worker -> worker.activeProcedure.get() != null).count();
   }
 
   public boolean isRunning() {

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/TestProcedureExecutor.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/procedure/TestProcedureExecutor.java
@@ -73,6 +73,21 @@ public class TestProcedureExecutor extends TestProcedureBase {
   }
 
   @Test
+  public void testWorkerThreadMetricsBeforeInitialization() {
+    TestProcEnv localEnv = new TestProcEnv();
+    ProcedureExecutor<TestProcEnv> localExecutor =
+        new ProcedureExecutor<>(localEnv, new NoopProcedureStore());
+    localEnv.setScheduler(localExecutor.getScheduler());
+
+    Assert.assertEquals(0, localExecutor.getWorkerThreadCount());
+    Assert.assertEquals(0, localExecutor.getActiveWorkerThreadCount());
+
+    localExecutor.init(2);
+    Assert.assertEquals(2, localExecutor.getWorkerThreadCount());
+    Assert.assertEquals(0, localExecutor.getActiveWorkerThreadCount());
+  }
+
+  @Test
   public void testProcedureFailedDuringSubmissionIsRolledBack() throws InterruptedException {
     TestProcEnv localEnv = new TestProcEnv();
     FailOnFirstUpdateProcedureStore localStore = new FailOnFirstUpdateProcedureStore();


### PR DESCRIPTION
## Description

### Problem

During a ConfigNode leader transition, procedure metrics can be registered before `ProcedureExecutor.init()` initializes `workerThreads`. If Prometheus scrapes metrics in this window, the procedure worker auto gauges dereference a null list and throw a `NullPointerException`.

Both the total worker count and active worker count accessors have the same lifecycle issue, although the active worker count was the one observed in the failure.

### Changes

- Make the `workerThreads` reference visible to concurrent metric reporter threads.
- Return zero from both worker metric accessors before the executor is initialized.
- Read the worker list through a local snapshot so each accessor uses one consistent reference.
- Add a regression test covering metric reads before initialization and the normal initialized state.

Returning zero represents the executor's pre-initialization state without changing the ConfigNode leader startup sequence or hiding unrelated metric failures in the common metrics framework.

### Alternatives considered

Moving metric registration after `ProcedureExecutor` startup would close the currently observed window, but it would change the registration timing of all ConfigNode leader metrics and would leave the metric accessors unsafe for other lifecycle callers. Handling the uninitialized state at the component boundary is smaller and more robust.

### Verification

- `mvn spotless:apply -pl iotdb-core/confignode`
- `mvn test -pl iotdb-core/confignode -Dtest=TestProcedureExecutor`
- `mvn compile -pl iotdb-core/confignode`

<hr>

This PR has:
- [x] been self-reviewed.
    - [x] concurrent read
- [x] added comments explaining the concurrency and lifecycle intent.
- [x] added unit tests to cover the new code path.

<hr>

##### Key changed/added classes

- `ProcedureExecutor`
- `TestProcedureExecutor`
