### PR TITLE
[To dev/1.3] [Pipe] Relax flaky TsFile event test timeouts (#18332)

### DIFF
--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/PipeTsFileInsertionEventTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/PipeTsFileInsertionEventTest.java
@@ -37,7 +37,7 @@ import java.nio.file.Files;
 
 public class PipeTsFileInsertionEventTest {
 
-  @Test(timeout = 5000)
+  @Test(timeout = 60000)
   public void testRealtimeEventCanSkipWaitingForClosedStatusAfterTsFileSealed() throws Exception {
     final File tempDir = Files.createTempDirectory("pipeTsFileSealed").toFile();
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEventAdmissionTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/common/tsfile/PipeTsFileInsertionEventAdmissionTest.java
@@ -44,7 +44,7 @@ import java.util.concurrent.TimeoutException;
 
 public class PipeTsFileInsertionEventAdmissionTest {
 
-  @Test(timeout = 10000)
+  @Test(timeout = 60000)
   public void testParserAdmissionIsWokenWhenMemoryIsReleased() throws Exception {
     final CommonConfig commonConfig = CommonDescriptor.getInstance().getConfig();
     final PipeMemoryManager memoryManager = PipeDataNodeResourceManager.memory();


### PR DESCRIPTION
## Description

Cherry-pick #18332 (55a53f6d6fd21c838aa5c59a5b1e252996d3cf07) to dev/1.3.

This raises the two flaky Pipe TsFile event test timeouts to 60 seconds.

## Verification

mvn -pl iotdb-core/datanode -Dtest=PipeTsFileInsertionEventTest,PipeTsFileInsertionEventAdmissionTest test

- [x] Self-reviewed
- [x] Targeted unit tests passed