### PR TITLE
Fix oversized audit logs for tree batch writes

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/auth/AuthorityChecker.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/auth/AuthorityChecker.java
@@ -70,6 +70,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.iotdb.commons.schema.column.ColumnHeaderConstant.LIST_USER_COLUMN_HEADERS;
 import static org.apache.iotdb.commons.schema.column.ColumnHeaderConstant.LIST_USER_OR_ROLE_PRIVILEGES_COLUMN_HEADERS;
@@ -347,6 +348,33 @@ public class AuthorityChecker {
     }
     prompt.append("]");
     return new TSStatus(TSStatusCode.NO_PERMISSION.getStatusCode()).setMessage(prompt.toString());
+  }
+
+  public static String getPathListStringForLog(List<? extends PartialPath> pathList) {
+    return getPathListStringForLog(pathList.stream());
+  }
+
+  public static String getPathListStringForLog(Stream<? extends PartialPath> pathStream) {
+    final int maxSize = Math.max(1, CommonDescriptor.getInstance().getConfig().getPathLogMaxSize());
+    final List<String> paths =
+        pathStream
+            .limit((long) maxSize + 1)
+            .map(path -> String.valueOf(path))
+            .collect(Collectors.toList());
+    final boolean truncated = paths.size() > maxSize;
+    final int size = truncated ? maxSize : paths.size();
+
+    final StringBuilder result = new StringBuilder("[");
+    if (size > 0) {
+      result.append(paths.get(0));
+      for (int i = 1; i < size; i++) {
+        result.append(", ").append(paths.get(i));
+      }
+      if (truncated) {
+        result.append(", ...");
+      }
+    }
+    return result.append("]").toString();
   }
 
   public static boolean checkFullPathOrPatternPermission(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/auth/AuthorityChecker.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/auth/AuthorityChecker.java
@@ -70,7 +70,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.apache.iotdb.commons.schema.column.ColumnHeaderConstant.LIST_USER_COLUMN_HEADERS;
 import static org.apache.iotdb.commons.schema.column.ColumnHeaderConstant.LIST_USER_OR_ROLE_PRIVILEGES_COLUMN_HEADERS;
@@ -348,33 +347,6 @@ public class AuthorityChecker {
     }
     prompt.append("]");
     return new TSStatus(TSStatusCode.NO_PERMISSION.getStatusCode()).setMessage(prompt.toString());
-  }
-
-  public static String getPathListStringForLog(List<? extends PartialPath> pathList) {
-    return getPathListStringForLog(pathList.stream());
-  }
-
-  public static String getPathListStringForLog(Stream<? extends PartialPath> pathStream) {
-    final int maxSize = Math.max(1, CommonDescriptor.getInstance().getConfig().getPathLogMaxSize());
-    final List<String> paths =
-        pathStream
-            .limit((long) maxSize + 1)
-            .map(path -> String.valueOf(path))
-            .collect(Collectors.toList());
-    final boolean truncated = paths.size() > maxSize;
-    final int size = truncated ? maxSize : paths.size();
-
-    final StringBuilder result = new StringBuilder("[");
-    if (size > 0) {
-      result.append(paths.get(0));
-      for (int i = 1; i < size; i++) {
-        result.append(", ").append(paths.get(i));
-      }
-      if (truncated) {
-        result.append(", ...");
-      }
-    }
-    return result.append("]").toString();
   }
 
   public static boolean checkFullPathOrPatternPermission(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/security/TreeAccessCheckVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/security/TreeAccessCheckVisitor.java
@@ -181,6 +181,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -1154,14 +1155,14 @@ public class TreeAccessCheckVisitor extends StatementVisitor<TSStatus, TreeAcces
 
     if (AuthorityChecker.SUPER_USER.equals(context.getUsername())) {
       AUDIT_LOGGER.recordObjectAuthenticationAuditLog(
-          context.setResult(true),
-          () -> AuthorityChecker.getPathListStringForLog(statement.getPathsStream().distinct()));
+          context.setResult(true), statement::getPathsStringForLog);
       return SUCCEED;
     }
     return checkTimeSeriesPermission(
         context,
         () -> statement.getPathsStream().distinct().collect(Collectors.toList()),
-        PrivilegeType.WRITE_DATA);
+        PrivilegeType.WRITE_DATA,
+        statement::getPathsStringForLog);
   }
 
   @Override
@@ -1242,11 +1243,19 @@ public class TreeAccessCheckVisitor extends StatementVisitor<TSStatus, TreeAcces
       IAuditEntity context,
       Supplier<List<? extends PartialPath>> checkedPathsSupplier,
       PrivilegeType permission) {
+    return checkTimeSeriesPermission(
+        context, checkedPathsSupplier, permission, checkedPaths -> checkedPaths.toString());
+  }
+
+  private static TSStatus checkTimeSeriesPermission(
+      IAuditEntity context,
+      Supplier<List<? extends PartialPath>> checkedPathsSupplier,
+      PrivilegeType permission,
+      Function<List<? extends PartialPath>, String> auditObjectFormatter) {
     context.setPrivilegeType(permission);
     if (AuthorityChecker.SUPER_USER.equals(context.getUsername())) {
       AUDIT_LOGGER.recordObjectAuthenticationAuditLog(
-          context.setResult(true),
-          () -> AuthorityChecker.getPathListStringForLog(checkedPathsSupplier.get()));
+          context.setResult(true), () -> auditObjectFormatter.apply(checkedPathsSupplier.get()));
       return SUCCEED;
     }
     List<? extends PartialPath> checkedPaths = checkedPathsSupplier.get();
@@ -1260,7 +1269,7 @@ public class TreeAccessCheckVisitor extends StatementVisitor<TSStatus, TreeAcces
       // Internal auditor no needs audit log
       AUDIT_LOGGER.recordObjectAuthenticationAuditLog(
           context.setResult(result.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()),
-          () -> AuthorityChecker.getPathListStringForLog(checkedPaths));
+          () -> auditObjectFormatter.apply(checkedPaths));
     }
     return result;
   }
@@ -1270,14 +1279,14 @@ public class TreeAccessCheckVisitor extends StatementVisitor<TSStatus, TreeAcces
     context.setPrivilegeType(permission);
     if (AuthorityChecker.SUPER_USER.equals(context.getUsername())) {
       AUDIT_LOGGER.recordObjectAuthenticationAuditLog(
-          context.setResult(true), () -> AuthorityChecker.getPathListStringForLog(checkedPaths));
+          context.setResult(true), checkedPaths::toString);
       return Collections.emptyList();
     }
     final List<Integer> results =
         AuthorityChecker.checkFullPathOrPatternListPermission(
             context.getUsername(), checkedPaths, permission);
     AUDIT_LOGGER.recordObjectAuthenticationAuditLog(
-        context.setResult(true), () -> AuthorityChecker.getPathListStringForLog(checkedPaths));
+        context.setResult(true), checkedPaths::toString);
     return results;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/security/TreeAccessCheckVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/security/TreeAccessCheckVisitor.java
@@ -1160,7 +1160,7 @@ public class TreeAccessCheckVisitor extends StatementVisitor<TSStatus, TreeAcces
     }
     return checkTimeSeriesPermission(
         context,
-        () -> statement.getPathsStream().distinct().collect(Collectors.toList()),
+        () -> statement.getPathsStream().distinct().toList(),
         PrivilegeType.WRITE_DATA,
         statement::getPathsStringForLog);
   }
@@ -1243,8 +1243,7 @@ public class TreeAccessCheckVisitor extends StatementVisitor<TSStatus, TreeAcces
       IAuditEntity context,
       Supplier<List<? extends PartialPath>> checkedPathsSupplier,
       PrivilegeType permission) {
-    return checkTimeSeriesPermission(
-        context, checkedPathsSupplier, permission, checkedPaths -> checkedPaths.toString());
+    return checkTimeSeriesPermission(context, checkedPathsSupplier, permission, Object::toString);
   }
 
   private static TSStatus checkTimeSeriesPermission(

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/security/TreeAccessCheckVisitor.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/security/TreeAccessCheckVisitor.java
@@ -1136,25 +1136,31 @@ public class TreeAccessCheckVisitor extends StatementVisitor<TSStatus, TreeAcces
   @Override
   public TSStatus visitInsertBase(InsertBaseStatement statement, TreeAccessCheckContext context) {
     context.setAuditLogOperation(AuditLogOperation.DML).setPrivilegeType(PrivilegeType.WRITE_DATA);
-    for (PartialPath path : statement.getDevicePaths()) {
-      // External users cannot modify the audit database.
-      if (includeByAuditTreeDB(path)
-          && !context.getUsername().equals(AuthorityChecker.INTERNAL_AUDIT_USER)) {
-        AUDIT_LOGGER.recordObjectAuthenticationAuditLog(context.setResult(false), path::toString);
-        return new TSStatus(TSStatusCode.NO_PERMISSION.getStatusCode())
-            .setMessage(getUnsupportedAuditDatabaseOperationMessage(TREE_MODEL_AUDIT_DATABASE));
-      }
+    // External users cannot modify the audit database.
+    final PartialPath unsupportedAuditPath =
+        context.getUsername().equals(AuthorityChecker.INTERNAL_AUDIT_USER)
+            ? null
+            : statement
+                .getDevicePathsStream()
+                .filter(Audit::includeByAuditTreeDB)
+                .findFirst()
+                .orElse(null);
+    if (unsupportedAuditPath != null) {
+      AUDIT_LOGGER.recordObjectAuthenticationAuditLog(
+          context.setResult(false), unsupportedAuditPath::toString);
+      return new TSStatus(TSStatusCode.NO_PERMISSION.getStatusCode())
+          .setMessage(getUnsupportedAuditDatabaseOperationMessage(TREE_MODEL_AUDIT_DATABASE));
     }
 
     if (AuthorityChecker.SUPER_USER.equals(context.getUsername())) {
       AUDIT_LOGGER.recordObjectAuthenticationAuditLog(
           context.setResult(true),
-          () -> statement.getPaths().stream().distinct().collect(Collectors.toList()).toString());
+          () -> AuthorityChecker.getPathListStringForLog(statement.getPathsStream().distinct()));
       return SUCCEED;
     }
     return checkTimeSeriesPermission(
         context,
-        () -> statement.getPaths().stream().distinct().collect(Collectors.toList()),
+        () -> statement.getPathsStream().distinct().collect(Collectors.toList()),
         PrivilegeType.WRITE_DATA);
   }
 
@@ -1239,7 +1245,8 @@ public class TreeAccessCheckVisitor extends StatementVisitor<TSStatus, TreeAcces
     context.setPrivilegeType(permission);
     if (AuthorityChecker.SUPER_USER.equals(context.getUsername())) {
       AUDIT_LOGGER.recordObjectAuthenticationAuditLog(
-          context.setResult(true), () -> checkedPathsSupplier.get().toString());
+          context.setResult(true),
+          () -> AuthorityChecker.getPathListStringForLog(checkedPathsSupplier.get()));
       return SUCCEED;
     }
     List<? extends PartialPath> checkedPaths = checkedPathsSupplier.get();
@@ -1253,7 +1260,7 @@ public class TreeAccessCheckVisitor extends StatementVisitor<TSStatus, TreeAcces
       // Internal auditor no needs audit log
       AUDIT_LOGGER.recordObjectAuthenticationAuditLog(
           context.setResult(result.getCode() == TSStatusCode.SUCCESS_STATUS.getStatusCode()),
-          checkedPaths::toString);
+          () -> AuthorityChecker.getPathListStringForLog(checkedPaths));
     }
     return result;
   }
@@ -1263,14 +1270,14 @@ public class TreeAccessCheckVisitor extends StatementVisitor<TSStatus, TreeAcces
     context.setPrivilegeType(permission);
     if (AuthorityChecker.SUPER_USER.equals(context.getUsername())) {
       AUDIT_LOGGER.recordObjectAuthenticationAuditLog(
-          context.setResult(true), checkedPaths::toString);
+          context.setResult(true), () -> AuthorityChecker.getPathListStringForLog(checkedPaths));
       return Collections.emptyList();
     }
     final List<Integer> results =
         AuthorityChecker.checkFullPathOrPatternListPermission(
             context.getUsername(), checkedPaths, permission);
     AUDIT_LOGGER.recordObjectAuthenticationAuditLog(
-        context.setResult(true), checkedPaths::toString);
+        context.setResult(true), () -> AuthorityChecker.getPathListStringForLog(checkedPaths));
     return results;
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertBaseStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertBaseStatement.java
@@ -234,11 +234,7 @@ public abstract class InsertBaseStatement extends Statement implements Accountab
 
   private static String getPathsStringForLog(Stream<? extends PartialPath> pathStream) {
     final int maxSize = Math.max(1, CommonDescriptor.getInstance().getConfig().getPathLogMaxSize());
-    final List<String> paths =
-        pathStream
-            .limit((long) maxSize + 1)
-            .map(path -> String.valueOf(path))
-            .collect(Collectors.toList());
+    final List<String> paths = pathStream.limit((long) maxSize + 1).map(String::valueOf).toList();
     final boolean truncated = paths.size() > maxSize;
     final int size = truncated ? maxSize : paths.size();
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertBaseStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertBaseStatement.java
@@ -59,6 +59,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public abstract class InsertBaseStatement extends Statement implements Accountable {
 
@@ -203,6 +204,19 @@ public abstract class InsertBaseStatement extends Statement implements Accountab
   @Override
   public List<PartialPath> getPaths() {
     return Collections.emptyList();
+  }
+
+  public Stream<PartialPath> getPathsStream() {
+    if (measurements == null) {
+      return Stream.empty();
+    }
+    return Arrays.stream(measurements)
+        .filter(Objects::nonNull)
+        .map(devicePath::concatAsMeasurementPath);
+  }
+
+  public Stream<PartialPath> getDevicePathsStream() {
+    return Stream.of(devicePath);
   }
 
   public abstract ISchemaValidation getSchemaValidation();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertBaseStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertBaseStatement.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.db.queryengine.plan.statement.crud;
 
 import org.apache.iotdb.calc.exception.QueryProcessException;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.exception.SemanticException;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.commons.queryengine.plan.planner.plan.parameter.InputLocation;
@@ -217,6 +218,41 @@ public abstract class InsertBaseStatement extends Statement implements Accountab
 
   public Stream<PartialPath> getDevicePathsStream() {
     return Stream.of(devicePath);
+  }
+
+  /** Returns a bounded log representation generated lazily from this statement's distinct paths. */
+  public String getPathsStringForLog() {
+    return getPathsStringForLog(getPathsStream().distinct());
+  }
+
+  /**
+   * Returns a bounded log representation of paths that were already collected for authorization.
+   */
+  public String getPathsStringForLog(List<? extends PartialPath> paths) {
+    return getPathsStringForLog(paths.stream());
+  }
+
+  private static String getPathsStringForLog(Stream<? extends PartialPath> pathStream) {
+    final int maxSize = Math.max(1, CommonDescriptor.getInstance().getConfig().getPathLogMaxSize());
+    final List<String> paths =
+        pathStream
+            .limit((long) maxSize + 1)
+            .map(path -> String.valueOf(path))
+            .collect(Collectors.toList());
+    final boolean truncated = paths.size() > maxSize;
+    final int size = truncated ? maxSize : paths.size();
+
+    final StringBuilder result = new StringBuilder("[");
+    if (size > 0) {
+      result.append(paths.get(0));
+      for (int i = 1; i < size; i++) {
+        result.append(", ").append(paths.get(i));
+      }
+      if (truncated) {
+        result.append(", ...");
+      }
+    }
+    return result.append("]").toString();
   }
 
   public abstract ISchemaValidation getSchemaValidation();

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertMultiTabletsStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertMultiTabletsStatement.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class InsertMultiTabletsStatement extends InsertBaseStatement {
 
@@ -96,6 +97,16 @@ public class InsertMultiTabletsStatement extends InsertBaseStatement {
       result.addAll(insertTabletStatement.getPaths());
     }
     return result;
+  }
+
+  @Override
+  public Stream<PartialPath> getPathsStream() {
+    return insertTabletStatementList.stream().flatMap(InsertTabletStatement::getPathsStream);
+  }
+
+  @Override
+  public Stream<PartialPath> getDevicePathsStream() {
+    return insertTabletStatementList.stream().map(InsertTabletStatement::getDevicePath);
   }
 
   @Override

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertRowsStatement.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertRowsStatement.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class InsertRowsStatement extends InsertBaseStatement {
 
@@ -115,6 +116,16 @@ public class InsertRowsStatement extends InsertBaseStatement {
       result.addAll(insertRowStatement.getPaths());
     }
     return result;
+  }
+
+  @Override
+  public Stream<PartialPath> getPathsStream() {
+    return insertRowStatementList.stream().flatMap(InsertRowStatement::getPathsStream);
+  }
+
+  @Override
+  public Stream<PartialPath> getDevicePathsStream() {
+    return insertRowStatementList.stream().map(InsertRowStatement::getDevicePath);
   }
 
   @Override

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/auth/AuthorityCheckerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/auth/AuthorityCheckerTest.java
@@ -24,11 +24,16 @@ import org.apache.iotdb.commons.conf.CommonConfig;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.MeasurementPath;
+import org.apache.iotdb.commons.path.PartialPath;
+import org.apache.iotdb.db.queryengine.plan.statement.crud.InsertRowsOfOneDeviceStatement;
 
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class AuthorityCheckerTest {
 
@@ -36,16 +41,76 @@ public class AuthorityCheckerTest {
   public void testLogReduce() throws IllegalPathException {
     final CommonConfig config = CommonDescriptor.getInstance().getConfig();
     final int oldSize = config.getPathLogMaxSize();
-    config.setPathLogMaxSize(1);
-    Assert.assertEquals(
-        "No permissions for this operation, please add privilege WRITE_DATA on [root.db.device.s1, ...]",
-        AuthorityChecker.getTSStatus(
-                Arrays.asList(0, 1),
-                Arrays.asList(
-                    new MeasurementPath("root.db.device.s1"),
-                    new MeasurementPath("root.db.device.s2")),
-                PrivilegeType.WRITE_DATA)
-            .getMessage());
-    config.setPathLogMaxSize(oldSize);
+    try {
+      config.setPathLogMaxSize(1);
+      Assert.assertEquals(
+          "No permissions for this operation, please add privilege WRITE_DATA on [root.db.device.s1, ...]",
+          AuthorityChecker.getTSStatus(
+                  Arrays.asList(0, 1),
+                  Arrays.asList(
+                      new MeasurementPath("root.db.device.s1"),
+                      new MeasurementPath("root.db.device.s2")),
+                  PrivilegeType.WRITE_DATA)
+              .getMessage());
+    } finally {
+      config.setPathLogMaxSize(oldSize);
+    }
+  }
+
+  @Test
+  public void testPathListStringForLog() throws IllegalPathException {
+    final CommonConfig config = CommonDescriptor.getInstance().getConfig();
+    final int oldSize = config.getPathLogMaxSize();
+    final List<MeasurementPath> paths =
+        Arrays.asList(
+            new MeasurementPath("root.db.device.s1"),
+            new MeasurementPath("root.db.device.s2"),
+            new MeasurementPath("root.db.device.s3"),
+            new MeasurementPath("root.db.device.s4"));
+    try {
+      config.setPathLogMaxSize(2);
+      Assert.assertEquals(
+          "[root.db.device.s1, root.db.device.s2, ...]",
+          AuthorityChecker.getPathListStringForLog(paths));
+      Assert.assertEquals(
+          "[root.db.device.s1, root.db.device.s2]",
+          AuthorityChecker.getPathListStringForLog(paths.subList(0, 2)));
+      Assert.assertEquals("[]", AuthorityChecker.getPathListStringForLog(Collections.emptyList()));
+
+      final AtomicInteger consumedPathCount = new AtomicInteger();
+      AuthorityChecker.getPathListStringForLog(
+          paths.stream().peek(path -> consumedPathCount.incrementAndGet()));
+      Assert.assertEquals(3, consumedPathCount.get());
+    } finally {
+      config.setPathLogMaxSize(oldSize);
+    }
+  }
+
+  @Test
+  public void testInsertPathStreamIsLazy() throws IllegalPathException {
+    final CommonConfig config = CommonDescriptor.getInstance().getConfig();
+    final int oldSize = config.getPathLogMaxSize();
+    final AtomicInteger createdPathCount = new AtomicInteger();
+    final PartialPath devicePath =
+        new PartialPath("root.db.device") {
+          @Override
+          public MeasurementPath concatAsMeasurementPath(String measurement) {
+            createdPathCount.incrementAndGet();
+            return super.concatAsMeasurementPath(measurement);
+          }
+        };
+    final InsertRowsOfOneDeviceStatement statement = new InsertRowsOfOneDeviceStatement();
+    statement.setDevicePath(devicePath);
+    statement.setMeasurements(new String[] {"s1", "s2", "s3", "s4"});
+
+    try {
+      config.setPathLogMaxSize(2);
+      Assert.assertEquals(
+          "[root.db.device.s1, root.db.device.s2, ...]",
+          AuthorityChecker.getPathListStringForLog(statement.getPathsStream().distinct()));
+      Assert.assertEquals(3, createdPathCount.get());
+    } finally {
+      config.setPathLogMaxSize(oldSize);
+    }
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/auth/AuthorityCheckerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/auth/AuthorityCheckerTest.java
@@ -24,16 +24,11 @@ import org.apache.iotdb.commons.conf.CommonConfig;
 import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.exception.IllegalPathException;
 import org.apache.iotdb.commons.path.MeasurementPath;
-import org.apache.iotdb.commons.path.PartialPath;
-import org.apache.iotdb.db.queryengine.plan.statement.crud.InsertRowsOfOneDeviceStatement;
 
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class AuthorityCheckerTest {
 
@@ -52,63 +47,6 @@ public class AuthorityCheckerTest {
                       new MeasurementPath("root.db.device.s2")),
                   PrivilegeType.WRITE_DATA)
               .getMessage());
-    } finally {
-      config.setPathLogMaxSize(oldSize);
-    }
-  }
-
-  @Test
-  public void testPathListStringForLog() throws IllegalPathException {
-    final CommonConfig config = CommonDescriptor.getInstance().getConfig();
-    final int oldSize = config.getPathLogMaxSize();
-    final List<MeasurementPath> paths =
-        Arrays.asList(
-            new MeasurementPath("root.db.device.s1"),
-            new MeasurementPath("root.db.device.s2"),
-            new MeasurementPath("root.db.device.s3"),
-            new MeasurementPath("root.db.device.s4"));
-    try {
-      config.setPathLogMaxSize(2);
-      Assert.assertEquals(
-          "[root.db.device.s1, root.db.device.s2, ...]",
-          AuthorityChecker.getPathListStringForLog(paths));
-      Assert.assertEquals(
-          "[root.db.device.s1, root.db.device.s2]",
-          AuthorityChecker.getPathListStringForLog(paths.subList(0, 2)));
-      Assert.assertEquals("[]", AuthorityChecker.getPathListStringForLog(Collections.emptyList()));
-
-      final AtomicInteger consumedPathCount = new AtomicInteger();
-      AuthorityChecker.getPathListStringForLog(
-          paths.stream().peek(path -> consumedPathCount.incrementAndGet()));
-      Assert.assertEquals(3, consumedPathCount.get());
-    } finally {
-      config.setPathLogMaxSize(oldSize);
-    }
-  }
-
-  @Test
-  public void testInsertPathStreamIsLazy() throws IllegalPathException {
-    final CommonConfig config = CommonDescriptor.getInstance().getConfig();
-    final int oldSize = config.getPathLogMaxSize();
-    final AtomicInteger createdPathCount = new AtomicInteger();
-    final PartialPath devicePath =
-        new PartialPath("root.db.device") {
-          @Override
-          public MeasurementPath concatAsMeasurementPath(String measurement) {
-            createdPathCount.incrementAndGet();
-            return super.concatAsMeasurementPath(measurement);
-          }
-        };
-    final InsertRowsOfOneDeviceStatement statement = new InsertRowsOfOneDeviceStatement();
-    statement.setDevicePath(devicePath);
-    statement.setMeasurements(new String[] {"s1", "s2", "s3", "s4"});
-
-    try {
-      config.setPathLogMaxSize(2);
-      Assert.assertEquals(
-          "[root.db.device.s1, root.db.device.s2, ...]",
-          AuthorityChecker.getPathListStringForLog(statement.getPathsStream().distinct()));
-      Assert.assertEquals(3, createdPathCount.get());
     } finally {
       config.setPathLogMaxSize(oldSize);
     }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/auth/TreeAccessTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/auth/TreeAccessTest.java
@@ -21,6 +21,8 @@ package org.apache.iotdb.db.auth;
 
 import org.apache.iotdb.commons.auth.entity.PrivilegeType;
 import org.apache.iotdb.commons.auth.entity.User;
+import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
 import org.apache.iotdb.commons.path.PartialPath;
 import org.apache.iotdb.db.queryengine.plan.relational.security.TreeAccessCheckContext;
 import org.apache.iotdb.db.queryengine.plan.relational.security.TreeAccessCheckVisitor;
@@ -37,6 +39,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.util.Collections;
+import java.util.List;
 
 public class TreeAccessTest {
 
@@ -233,6 +236,30 @@ public class TreeAccessTest {
         TSStatusCode.SUCCESS_STATUS.getStatusCode(),
         treeAccessCheckVisitor.checkUnsupportedAuditDatabaseWriteStatus(
             new TreeAccessCheckContext(10000L, "user1", ""), new PartialPath("root.sg")));
+  }
+
+  @Test
+  public void testPathLogLimitDoesNotLimitPermissionCheck() throws Exception {
+    final CommonConfig config = CommonDescriptor.getInstance().getConfig();
+    final int oldSize = config.getPathLogMaxSize();
+    final User user = new User("user1", "password");
+    user.grantPathPrivilege(new PartialPath("root.db.device.s1"), PrivilegeType.WRITE_DATA, false);
+    AuthorityChecker.getAuthorityFetcher().getAuthorCache().putUserCache(user.getName(), user);
+    final List<PartialPath> checkedPaths =
+        List.of(new PartialPath("root.db.device.s1"), new PartialPath("root.db.device.s2"));
+
+    try {
+      config.setPathLogMaxSize(1);
+      Assert.assertEquals(
+          TSStatusCode.NO_PERMISSION.getStatusCode(),
+          TreeAccessCheckVisitor.checkTimeSeriesPermission(
+                  new TreeAccessCheckContext(10000L, "user1", ""),
+                  () -> checkedPaths,
+                  PrivilegeType.WRITE_DATA)
+              .getCode());
+    } finally {
+      config.setPathLogMaxSize(oldSize);
+    }
   }
 
   private static class TestTreeAccessCheckVisitor extends TreeAccessCheckVisitor {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertBaseStatementTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/queryengine/plan/statement/crud/InsertBaseStatementTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.plan.statement.crud;
+
+import org.apache.iotdb.commons.conf.CommonConfig;
+import org.apache.iotdb.commons.conf.CommonDescriptor;
+import org.apache.iotdb.commons.exception.IllegalPathException;
+import org.apache.iotdb.commons.path.MeasurementPath;
+import org.apache.iotdb.commons.path.PartialPath;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class InsertBaseStatementTest {
+
+  @Test
+  public void testPathsStringForLog() throws IllegalPathException {
+    final CommonConfig config = CommonDescriptor.getInstance().getConfig();
+    final int oldSize = config.getPathLogMaxSize();
+    final InsertRowsOfOneDeviceStatement statement = new InsertRowsOfOneDeviceStatement();
+    final List<MeasurementPath> paths =
+        Arrays.asList(
+            new MeasurementPath("root.db.device.s1"),
+            new MeasurementPath("root.db.device.s2"),
+            new MeasurementPath("root.db.device.s3"),
+            new MeasurementPath("root.db.device.s4"));
+    try {
+      config.setPathLogMaxSize(2);
+      Assert.assertEquals(
+          "[root.db.device.s1, root.db.device.s2, ...]", statement.getPathsStringForLog(paths));
+      Assert.assertEquals(
+          "[root.db.device.s1, root.db.device.s2]",
+          statement.getPathsStringForLog(paths.subList(0, 2)));
+      Assert.assertEquals("[]", statement.getPathsStringForLog(Collections.emptyList()));
+    } finally {
+      config.setPathLogMaxSize(oldSize);
+    }
+  }
+
+  @Test
+  public void testPathsStringForLogIsLazy() throws IllegalPathException {
+    final CommonConfig config = CommonDescriptor.getInstance().getConfig();
+    final int oldSize = config.getPathLogMaxSize();
+    final AtomicInteger createdPathCount = new AtomicInteger();
+    final PartialPath devicePath =
+        new PartialPath("root.db.device") {
+          @Override
+          public MeasurementPath concatAsMeasurementPath(String measurement) {
+            createdPathCount.incrementAndGet();
+            return super.concatAsMeasurementPath(measurement);
+          }
+        };
+    final InsertRowsOfOneDeviceStatement statement = new InsertRowsOfOneDeviceStatement();
+    statement.setDevicePath(devicePath);
+    statement.setMeasurements(new String[] {"s1", "s2", "s3", "s4"});
+
+    try {
+      config.setPathLogMaxSize(2);
+      Assert.assertEquals(
+          "[root.db.device.s1, root.db.device.s2, ...]", statement.getPathsStringForLog());
+      Assert.assertEquals(3, createdPathCount.get());
+    } finally {
+      config.setPathLogMaxSize(oldSize);
+    }
+  }
+}


### PR DESCRIPTION
## Description

### Root cause

Tree-model batch inserts passed the complete distinct time-series path list to the object authentication audit logger. The object text is embedded in the `root.__audit` `log` field, so one audit record grew with every path in the batch. The root-user path also materialized the full path and device lists only for audit handling.

### Changes

- Reuse the existing `path_log_max_size` setting (default: 100) when formatting path lists for audit logs. Logs keep the first N distinct paths and append `...` when truncated; small-list formatting is unchanged.
- Add lazy path and device streams for insert statements, including rows of one device, multiple rows, tablets, and multiple tablets. Root-user audit handling no longer materializes complete flattened path/device lists.
- Keep the complete distinct path list for non-root authorization checks and truncate only the audit representation, so paths after the log threshold cannot bypass permission checks.
- Preserve the existing protection that rejects external writes to `root.__audit`, using a streaming first-match scan.

### Impact and compatibility

This bounds audit-record growth by the configured path count without changing the audit schema or adding configuration. Authorization semantics are unchanged.

### Validation

- `mvn spotless:apply -pl iotdb-core/datanode`
- `mvn test -pl iotdb-core/datanode -Dtest=AuthorityCheckerTest,TreeAccessTest`
  - 8 tests passed, 0 failures/errors/skips
  - Checkstyle and Spotless checks passed
- Independent code review completed with no blocker/P1/P2 findings.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for code coverage.
- [x] added comments explaining the "why" and the intent of the code wherever it would not be obvious to an unfamiliar reader.

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR

- `AuthorityChecker`
- `TreeAccessCheckVisitor`
- `InsertBaseStatement`
- `InsertRowsStatement`
- `InsertMultiTabletsStatement`
