### PR TITLE
Fix corrupted TsFile IT file selection

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBQueryWithCorruptedTsFileIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/relational/it/query/recent/IoTDBQueryWithCorruptedTsFileIT.java
@@ -44,6 +44,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
@@ -175,17 +176,19 @@ public class IoTDBQueryWithCorruptedTsFileIT {
       statement.execute("FLUSH");
     }
 
-    // 2. Find the generated TsFile in the data directory
-    File sequenceDir =
+    // 2. Find a generated TsFile in this database's data directory
+    File databaseSequenceDir =
         new File(
             EnvFactory.getEnv().getDataNodeWrapper(0).getDataNodeDir()
                 + File.separator
                 + "data"
                 + File.separator
-                + "sequence");
-    File tsFile = findTsFileRecursively(sequenceDir);
+                + "sequence"
+                + File.separator
+                + DATABASE_NAME);
+    File tsFile = findTsFileRecursively(databaseSequenceDir);
     if (tsFile == null) {
-      fail("Could not find TsFile in data directory: " + sequenceDir.getAbsolutePath());
+      fail("Could not find TsFile in data directory: " + databaseSequenceDir.getAbsolutePath());
     }
 
     // 3. Corrupt the data section of the TsFile
@@ -196,7 +199,13 @@ public class IoTDBQueryWithCorruptedTsFileIT {
         Statement statement = connection.createStatement()) {
       statement.execute("USE " + DATABASE_NAME);
       try {
-        statement.execute("SELECT * FROM " + tableName + " ORDER BY time");
+        try (ResultSet resultSet =
+            statement.executeQuery("SELECT * FROM " + tableName + " ORDER BY time")) {
+          while (resultSet.next()) {
+            // Consume all rows because corruption may be detected while fetching later result
+            // blocks.
+          }
+        }
         fail("Expected query on corrupted TsFile to fail");
       } catch (SQLException e) {
         assertTrue(


### PR DESCRIPTION
## Description

### Problem

`testNormalQueryWithCorruptedChunkDataOrPageReader` searched the entire DataNode `data/sequence` tree for the first TsFile. If another database had already created a TsFile, the test could corrupt that unrelated file and then incorrectly report that the target query succeeded.

The test also only called `Statement.execute`, so an exception raised while fetching a later result block could be missed.

### Changes

- Restrict the TsFile lookup to the test database's sequence directory.
- Execute the query with `executeQuery` and consume the full result set so delayed corruption errors are surfaced.

### Verification

- `mvn spotless:apply -pl integration-test -P with-integration-tests`
- `mvn test-compile -pl integration-test -P with-integration-tests -DskipTests`
- `git diff --check`

This PR has:
- [x] been self-reviewed.
- [x] modified an existing integration test to cover the intended code path deterministically.

##### Key changed/added classes

- `IoTDBQueryWithCorruptedTsFileIT`