### PR TITLE
[Pipe] Prevent resizing released TsFile scan parser memory

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/parser/scan/TsFileInsertionEventScanParser.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/parser/scan/TsFileInsertionEventScanParser.java
@@ -165,6 +165,9 @@ public class TsFileInsertionEventScanParser extends TsFileInsertionEventParser {
       tsFileSequenceReader.position((long) TSFileConfig.MAGIC_STRING.getBytes().length + 1);
 
       prepareData();
+      if (Objects.isNull(chunkReader)) {
+        close();
+      }
     } catch (final Exception e) {
       close();
       throw e;
@@ -440,7 +443,7 @@ public class TsFileInsertionEventScanParser extends TsFileInsertionEventParser {
       } while (Objects.nonNull(chunkReader) && !chunkReader.hasNextSatisfiedPage());
 
       if (Objects.isNull(chunkReader)) {
-        close();
+        // Let the caller release the last tablet's memory before closing the parser.
         break;
       }
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/TsFileInsertionEventParserTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/TsFileInsertionEventParserTest.java
@@ -172,6 +172,16 @@ public class TsFileInsertionEventParserTest {
             null,
             null,
             false)) {
+      replaceAllocatedTabletMemory(
+          parser,
+          new PipeMemoryBlock(0) {
+            @Override
+            public void close() {
+              Assert.assertEquals(0, getMemoryUsageInBytes());
+              super.close();
+            }
+          });
+
       final Iterator<TabletInsertionEvent> iterator = parser.toTabletInsertionEvents().iterator();
 
       Assert.assertTrue(iterator.hasNext());


### PR DESCRIPTION
## Description

### Problem

When `TsFileInsertionEventScanParser` reached EOF while producing the final tablet, `prepareData()` closed the parser immediately. The iterator then tried to release the parser-side tablet memory in its `finally` block, which called `forceResize(0)` on an already released memory block and could continuously emit `forceResize: cannot resize a null or released memory block` warnings.

### Changes

- Defer parser close at EOF until after the final tablet memory accounting is released.
- Keep immediate cleanup in the constructor when a TsFile contains no tablet data.
- Strengthen the parser unit test to verify that tablet memory usage is zero before its block is closed.

### Tests

- `mvn spotless:apply -pl iotdb-core/datanode`
- `mvn -pl iotdb-core/datanode -Dtest=TsFileInsertionEventParserTest test` (21 tests, 0 failures, 3 skipped)

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the why and intent of the non-obvious close ordering.
- [x] modified an existing unit test to cover the regression.

<hr>

##### Key changed/added classes

- `TsFileInsertionEventScanParser`
- `TsFileInsertionEventParserTest`