### PR TITLE
[To dev/1.3] [Pipe] Release tablet memory before closing TsFile scan parser (#18350)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/container/scan/TsFileInsertionScanDataContainer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/container/scan/TsFileInsertionScanDataContainer.java
@@ -160,6 +160,9 @@ public class TsFileInsertionScanDataContainer extends TsFileInsertionDataContain
       tsFileSequenceReader.position((long) TSFileConfig.MAGIC_STRING.getBytes().length + 1);
 
       prepareData();
+      if (Objects.isNull(chunkReader)) {
+        close();
+      }
     } catch (final Exception e) {
       close();
       throw e;
@@ -390,7 +393,7 @@ public class TsFileInsertionScanDataContainer extends TsFileInsertionDataContain
       } while (Objects.nonNull(chunkReader) && !chunkReader.hasNextSatisfiedPage());
 
       if (Objects.isNull(chunkReader)) {
-        close();
+        // Let the caller release the last tablet's memory before closing the parser.
         break;
       }
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/TsFileInsertionDataContainerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/event/TsFileInsertionDataContainerTest.java
@@ -172,6 +172,16 @@ public class TsFileInsertionDataContainerTest {
             null,
             null,
             false)) {
+      replaceAllocatedTabletMemory(
+          container,
+          new PipeMemoryBlock(0) {
+            @Override
+            public void close() {
+              Assert.assertEquals(0, getMemoryUsageInBytes());
+              super.close();
+            }
+          });
+
       final Iterator<TabletInsertionEvent> iterator =
           container.toTabletInsertionEvents().iterator();
 


### PR DESCRIPTION
## Description

Backport #18350 (`a6ac4cba687a98a1dbc0babe72f590da9ce9be8f`) to `dev/1.3`.

- Defer closing the TsFile scan container until the final tablet's memory has been released.
- Close immediately when initialization finds no readable chunk.
- Add regression coverage that verifies allocated tablet memory is zero before the memory block is closed.

The `dev/1.3` branch still uses `TsFileInsertionScanDataContainer`, so the parser and test names were adapted to the older container API while preserving the original behavior.

## Verification

- `mvn -o -nsu spotless:apply -pl iotdb-core/datanode`
- `mvn -o -nsu -pl iotdb-core/datanode '-Dtest=TsFileInsertionDataContainerTest#testScanContainerReleasesTabletMemoryAfterRawTabletGenerated' test` (1 test passed, 0 failures)

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added or modified unit tests.