### PR TITLE
[Fix] Initialize procedure worker list eagerly

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/procedure/ProcedureExecutor.java
@@ -69,8 +69,8 @@ public class ProcedureExecutor<Env> {
       new ThreadGroup(ThreadName.CONFIG_NODE_PROCEDURE_WORKER.getName());
 
   // Metrics may be scraped before init() and concurrently with initialization during a ConfigNode
-  // leader transition.
-  private volatile CopyOnWriteArrayList<WorkerThread> workerThreads;
+  // leader transition, so keep an always-present thread-safe list.
+  private final CopyOnWriteArrayList<WorkerThread> workerThreads = new CopyOnWriteArrayList<>();
 
   private TimeoutExecutorThread<Env> timeoutExecutor;
 
@@ -132,7 +132,7 @@ public class ProcedureExecutor<Env> {
         new TimeoutExecutorThread<>(
             this, threadGroup, ThreadName.CONFIG_NODE_WORKER_THREAD_MONITOR.getName());
     workId.set(0);
-    workerThreads = new CopyOnWriteArrayList<>();
+    workerThreads.clear();
     for (int i = 0; i < corePoolSize; i++) {
       workerThreads.add(new WorkerThread(threadGroup));
     }
@@ -1028,15 +1028,11 @@ public class ProcedureExecutor<Env> {
   }
 
   public int getWorkerThreadCount() {
-    final CopyOnWriteArrayList<WorkerThread> workers = workerThreads;
-    return workers == null ? 0 : workers.size();
+    return workerThreads.size();
   }
 
   public long getActiveWorkerThreadCount() {
-    final CopyOnWriteArrayList<WorkerThread> workers = workerThreads;
-    return workers == null
-        ? 0
-        : workers.stream().filter(worker -> worker.activeProcedure.get() != null).count();
+    return workerThreads.stream().filter(worker -> worker.activeProcedure.get() != null).count();
   }
 
   public boolean isRunning() {


### PR DESCRIPTION
## Description

Follow-up to #18338.

- Initialize `workerThreads` once as a final `CopyOnWriteArrayList` instead of publishing a mutable collection through a volatile reference.
- Clear and repopulate the list during initialization.
- Keep procedure metrics safe before and during ConfigNode leader initialization.

## Tests

- `mvn -pl iotdb-core/confignode -Dtest=TestProcedureExecutor -Ddevelocity.off=true test` (9 tests)
- Checkstyle and Spotless checks included in the Maven run
- `git diff --check`