### PR TITLE
[Fix] Address IoTConsensus retry path Sonar issues

### DIFF
--- a/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
+++ b/iotdb-core/consensus/src/main/java/org/apache/iotdb/consensus/iot/IoTConsensusServerImpl.java
@@ -122,6 +122,9 @@ public class IoTConsensusServerImpl {
   // write.
   private static final long WRITER_META_PERSIST_MIN_INTERVAL_MS = 1_000L;
   private static final Pattern SNAPSHOT_INDEX_PATTEN = Pattern.compile(".*[^\\d](?=(\\d+))");
+  private static final String WAIT_FOR_PREVIOUS_REQUEST_MESSAGE =
+      IoTConsensusMessages
+          .MESSAGE_THE_REQUEST_MUST_WAIT_FOR_THE_PREVIOUS_REQUEST_TO_COMPLETE_470849A7;
   private static final PerformanceOverviewMetrics PERFORMANCE_OVERVIEW_METRICS =
       PerformanceOverviewMetrics.getInstance();
   private final Logger logger = LoggerFactory.getLogger(IoTConsensusServerImpl.class);
@@ -1373,6 +1376,7 @@ public class IoTConsensusServerImpl {
      * order in follower the same as the leader. And besides order insurance, we can make the
      * deserialization of PlanNode to be concurrent
      */
+    @SuppressWarnings({"java:S3776", "java:S6541"}) // Keep lock-protected ordering state together.
     private TSStatus cacheAndInsertLatestNode(DeserializedBatchIndexedConsensusRequest request) {
       logger.debug(
           IoTConsensusMessages.CACHE_AND_INSERT_START,
@@ -1464,9 +1468,7 @@ public class IoTConsensusServerImpl {
             for (int j = i + 1; j < insertNodes.size(); j++) {
               subStatus.add(
                   RpcUtils.getStatus(
-                      TSStatusCode.WRITE_PROCESS_REJECT,
-                      IoTConsensusMessages
-                          .MESSAGE_THE_REQUEST_MUST_WAIT_FOR_THE_PREVIOUS_REQUEST_TO_COMPLETE_470849A7));
+                      TSStatusCode.WRITE_PROCESS_REJECT, WAIT_FOR_PREVIOUS_REQUEST_MESSAGE));
             }
             break;
           }


### PR DESCRIPTION
## Description

This is a follow-up to #18323. Sonar reported three issues in the lock-protected SyncLog ordering and retry path.

This PR:
- documents and narrowly suppresses the cognitive/brain-method warnings on the stateful queue path;
- introduces a short local alias for the generated i18n message constant so the retry response no longer exceeds the line-length limit.

The request ordering and retry behavior are unchanged.

### Verification

- ReplicateTest#syncLogWriteProcessErrorRetryPreservesRequestOrderTest: passed
- ReplicateTest#syncLogWriteProcessErrorTriggersLeaderRetryTest: passed
- Consensus compilation with the default and Chinese locales: passed
- Checkstyle: 0 violations
- Spotless and git diff --check: passed

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added a comment explaining the targeted Sonar suppression.
- [x] been covered by the existing retry-order regression tests.