### PR TITLE
[Fix] Address TsFile scan parser Sonar issues

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/parser/scan/TsFileInsertionEventScanParser.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/event/common/tsfile/parser/scan/TsFileInsertionEventScanParser.java
@@ -477,6 +477,7 @@ public class TsFileInsertionEventScanParser extends TsFileInsertionEventParser {
     }
   }
 
+  @SuppressWarnings("java:S6541") // Keep aligned and scalar type dispatch together.
   private boolean putValueToColumns(final BatchData data, final Tablet tablet, final int rowIndex) {
     boolean isNeedFillTime = false;
     if (data.getDataType() == TSDataType.VECTOR) {
@@ -614,6 +615,7 @@ public class TsFileInsertionEventScanParser extends TsFileInsertionEventParser {
     return isNeedFillTime;
   }
 
+  @SuppressWarnings("java:S6541") // Keep marker transitions in one parser state machine.
   private void moveToNextChunkReader()
       throws IOException, IllegalStateException, IllegalPathException {
     ChunkHeader chunkHeader;


### PR DESCRIPTION
## Description

This is a Sonar follow-up to #18305 and #18350. Sonar reported two brain-method warnings in the TsFile scan parser.

The affected methods are the parser hot paths for:
- aligned/scalar value-type dispatch;
- TsFile marker transitions and chunk-reader state.

This PR documents and narrowly suppresses those two warnings. Splitting either method would spread state-machine context across extra calls; parser behavior is unchanged.

### Verification

- TsFileInsertionEventParserTest: 21 run, 0 failures, 0 errors, 3 existing conditional skips
- DataNode compilation: passed
- Checkstyle: 0 violations
- Spotless and git diff --check: passed

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the targeted Sonar suppressions.
- [x] been covered by the existing parser unit tests.