### PR TITLE
[Fix] Document allow-all access control no-op

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/security/AllowAllAccessControl.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/plan/relational/security/AllowAllAccessControl.java
@@ -109,9 +109,9 @@ public class AllowAllAccessControl implements AccessControl {
 
   @Override
   public void checkUserGlobalSysPrivilege(
-      IAuditEntity auditEntity,
-      AuditLogOperation auditLogOperation,
-      Supplier<String> auditObject) {}
+      IAuditEntity auditEntity, AuditLogOperation auditLogOperation, Supplier<String> auditObject) {
+    // Intentionally empty because this implementation permits every operation.
+  }
 
   @Override
   public boolean hasGlobalPrivilege(IAuditEntity entity, PrivilegeType privilegeType) {


### PR DESCRIPTION
## Description

This is a Sonar follow-up to #18351.

The overload added to AllowAllAccessControl is intentionally a no-op because this implementation permits every operation. This PR documents that intent inside the method body so it is no longer reported as an unexplained empty method.

There is no runtime behavior change.

### Verification

- DataNode validate lifecycle: passed
- Checkstyle: 0 violations
- Spotless and git diff --check: passed

<hr>

This PR has:
- [x] been self-reviewed.
- [x] documented the intentional no-op.