### PR TITLE
Pipe: Fix TsFile reference races and improve result set diffs

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/db/it/utils/TestUtils.java
+++ b/integration-test/src/test/java/org/apache/iotdb/db/it/utils/TestUtils.java
@@ -73,6 +73,7 @@ import static org.junit.Assert.fail;
 public class TestUtils {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TestUtils.class);
+  private static final int MAX_RESULT_SET_DIFF_ROWS = 20;
 
   public static final ZoneId DEFAULT_ZONE_ID = ZoneId.ofOffset("UTC", ZoneOffset.of("Z"));
 
@@ -790,7 +791,11 @@ public class TestUtils {
           System.out.println(builder);
         }
       }
-      assertEquals(expectedResult, actualRetSet);
+      if (expectedResult instanceof Set) {
+        assertStringSetEqual((Set<String>) expectedResult, (Set<String>) actualRetSet);
+      } else {
+        assertEquals(expectedResult, actualRetSet);
+      }
     } catch (final Exception e) {
       e.printStackTrace();
       Assert.fail(String.valueOf(e));
@@ -826,10 +831,55 @@ public class TestUtils {
         }
         actualRetSet.add(builder.toString());
       }
-      assertEquals(expectedRetSet, actualRetSet);
+      assertStringSetEqual(expectedRetSet, actualRetSet);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(String.valueOf(e));
+    }
+  }
+
+  private static void assertStringSetEqual(
+      final Set<String> expectedResult, final Set<String> actualResult) {
+    if (expectedResult.equals(actualResult)) {
+      return;
+    }
+
+    final List<String> missingRows = new ArrayList<>(expectedResult);
+    missingRows.removeAll(actualResult);
+    Collections.sort(missingRows);
+
+    final List<String> unexpectedRows = new ArrayList<>(actualResult);
+    unexpectedRows.removeAll(expectedResult);
+    Collections.sort(unexpectedRows);
+
+    final StringBuilder diff =
+        new StringBuilder("Result set mismatch: expected ")
+            .append(expectedResult.size())
+            .append(" rows but got ")
+            .append(actualResult.size())
+            .append(" rows.");
+    appendResultSetDiff(diff, "Missing rows", missingRows);
+    appendResultSetDiff(diff, "Unexpected rows", unexpectedRows);
+    fail(diff.toString());
+  }
+
+  private static void appendResultSetDiff(
+      final StringBuilder diff, final String title, final List<String> rows) {
+    diff.append(System.lineSeparator()).append(title).append(" (").append(rows.size()).append("):");
+    if (rows.isEmpty()) {
+      diff.append(" <none>");
+      return;
+    }
+
+    final int displayedRowCount = Math.min(rows.size(), MAX_RESULT_SET_DIFF_ROWS);
+    for (int i = 0; i < displayedRowCount; i++) {
+      diff.append(System.lineSeparator()).append("  ").append(rows.get(i));
+    }
+    if (rows.size() > displayedRowCount) {
+      diff.append(System.lineSeparator())
+          .append("  ... and ")
+          .append(rows.size() - displayedRowCount)
+          .append(" more");
     }
   }
 

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/tsfile/PipeTsFileResourceManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/tsfile/PipeTsFileResourceManager.java
@@ -122,23 +122,28 @@ public class PipeTsFileResourceManager {
 
     segmentLock.lock(hardlinkOrCopiedFile);
     try {
-      resultFile =
-          isTsFile
-              ? FileUtils.createHardLink(source, hardlinkOrCopiedFile)
-              : FileUtils.copyFile(source, hardlinkOrCopiedFile);
-
-      // If the file is not a hardlink or copied file, and there is no related hardlink or copied
-      // file in pipe dir, create a hardlink or copy it to pipe dir, maintain a reference count for
-      // the hardlink or copied file, and return the hardlink or copied file.
-      if (Objects.nonNull(pipeName)) {
-        pipeNameToPipeTsFileDirPathMap.putIfAbsent(
-            pipeName, hardlinkOrCopiedFile.getParentFile().getPath());
-        hardlinkOrCopiedFileToPipeTsFileResourceMap
-            .computeIfAbsent(pipeName, k -> new ConcurrentHashMap<>())
-            .put(resultFile.getPath(), new PipeTsFileResource(resultFile));
+      final PipeTsFileResource existingResource =
+          getResourceMap(pipeName).get(hardlinkOrCopiedFile.getPath());
+      if (existingResource != null) {
+        existingResource.increaseReferenceCount();
+        resultFile = existingResource.getFile();
       } else {
-        hardlinkOrCopiedFileToTsFilePublicResourceMap.put(
-            resultFile.getPath(), new PipeTsFilePublicResource(resultFile));
+        resultFile =
+            isTsFile
+                ? FileUtils.createHardLink(source, hardlinkOrCopiedFile)
+                : FileUtils.copyFile(source, hardlinkOrCopiedFile);
+
+        // Create the hardlink or copy and its reference-counted resource only when none exists.
+        if (Objects.nonNull(pipeName)) {
+          pipeNameToPipeTsFileDirPathMap.putIfAbsent(
+              pipeName, hardlinkOrCopiedFile.getParentFile().getPath());
+          hardlinkOrCopiedFileToPipeTsFileResourceMap
+              .computeIfAbsent(pipeName, k -> new ConcurrentHashMap<>())
+              .put(resultFile.getPath(), new PipeTsFileResource(resultFile));
+        } else {
+          hardlinkOrCopiedFileToTsFilePublicResourceMap.put(
+              resultFile.getPath(), new PipeTsFilePublicResource(resultFile));
+        }
       }
     } finally {
       segmentLock.unlock(hardlinkOrCopiedFile);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/tsfile/PipeTsFileResourceManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/tsfile/PipeTsFileResourceManager.java
@@ -148,7 +148,13 @@ public class PipeTsFileResourceManager {
     } finally {
       segmentLock.unlock(hardlinkOrCopiedFile);
     }
-    increasePublicReference(resultFile, pipeName, isTsFile);
+    try {
+      increasePublicReference(resultFile, pipeName, isTsFile);
+    } catch (final IOException e) {
+      // The private reference must not outlive a failed public reference increase.
+      decreaseFileReference(resultFile, pipeName, false);
+      throw e;
+    }
     return resultFile;
   }
 
@@ -233,6 +239,13 @@ public class PipeTsFileResourceManager {
    */
   public void decreaseFileReference(
       final File hardlinkOrCopiedFile, final @Nullable String pipeName) {
+    decreaseFileReference(hardlinkOrCopiedFile, pipeName, true);
+  }
+
+  private void decreaseFileReference(
+      final File hardlinkOrCopiedFile,
+      final @Nullable String pipeName,
+      final boolean decreasePublicReference) {
     segmentLock.lock(hardlinkOrCopiedFile);
     try {
       final String filePath = hardlinkOrCopiedFile.getPath();
@@ -247,7 +260,9 @@ public class PipeTsFileResourceManager {
 
     // Decrease the assigner's file to clear hard-link and memory cache
     // Note that it does not exist for historical files
-    decreasePublicReferenceIfExists(hardlinkOrCopiedFile, pipeName);
+    if (decreasePublicReference) {
+      decreasePublicReferenceIfExists(hardlinkOrCopiedFile, pipeName);
+    }
   }
 
   private void decreasePublicReferenceIfExists(final File file, final @Nullable String pipeName) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/tsfile/PipeTsFileResourceManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/tsfile/PipeTsFileResourceManager.java
@@ -402,6 +402,7 @@ public class PipeTsFileResourceManager {
     }
   }
 
+  /** Returns the shared public resource map when {@code pipeName} is null. */
   public Map<String, ? extends PipeTsFileResource> getResourceMap(final @Nullable String pipeName) {
     return Objects.nonNull(pipeName)
         ? hardlinkOrCopiedFileToPipeTsFileResourceMap.computeIfAbsent(

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/resource/PipeTsFileResourceManagerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/resource/PipeTsFileResourceManagerTest.java
@@ -47,6 +47,13 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.fail;
 
@@ -237,5 +244,60 @@ public class PipeTsFileResourceManagerTest {
     Assert.assertEquals(0, pipeTsFileResourceManager.getFileReferenceCount(pipeModFile, null));
     Assert.assertFalse(Files.exists(originFile.toPath()));
     Assert.assertFalse(Files.exists(originModFile.toPath()));
+  }
+
+  @Test
+  public void testConcurrentIncreaseTsFile() throws Exception {
+    final int concurrency = 64;
+    final File originTsFile = new File(TS_FILE_NAME);
+    final CountDownLatch readyLatch = new CountDownLatch(concurrency);
+    final CountDownLatch startLatch = new CountDownLatch(1);
+    final ExecutorService executor = Executors.newFixedThreadPool(concurrency);
+    final List<Future<File>> futures = new ArrayList<>(concurrency);
+
+    try {
+      for (int i = 0; i < concurrency; i++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  readyLatch.countDown();
+                  startLatch.await();
+                  return pipeTsFileResourceManager.increaseFileReference(
+                      originTsFile, true, PIPE_NAME);
+                }));
+      }
+
+      Assert.assertTrue(readyLatch.await(30, TimeUnit.SECONDS));
+      startLatch.countDown();
+
+      File pipeTsFile = null;
+      for (final Future<File> future : futures) {
+        final File referencedFile = future.get(30, TimeUnit.SECONDS);
+        if (pipeTsFile == null) {
+          pipeTsFile = referencedFile;
+        } else {
+          Assert.assertEquals(pipeTsFile, referencedFile);
+        }
+      }
+
+      Assert.assertNotNull(pipeTsFile);
+      Assert.assertEquals(
+          concurrency, pipeTsFileResourceManager.getFileReferenceCount(pipeTsFile, PIPE_NAME));
+      Assert.assertEquals(
+          concurrency, pipeTsFileResourceManager.getFileReferenceCount(pipeTsFile, null));
+      Assert.assertTrue(Files.exists(pipeTsFile.toPath()));
+
+      for (int i = 0; i < concurrency; i++) {
+        pipeTsFileResourceManager.decreaseFileReference(pipeTsFile, PIPE_NAME);
+      }
+      Assert.assertEquals(
+          0, pipeTsFileResourceManager.getFileReferenceCount(pipeTsFile, PIPE_NAME));
+      Assert.assertEquals(0, pipeTsFileResourceManager.getFileReferenceCount(pipeTsFile, null));
+      Assert.assertFalse(Files.exists(pipeTsFile.toPath()));
+    } finally {
+      startLatch.countDown();
+      executor.shutdownNow();
+      Assert.assertTrue(executor.awaitTermination(30, TimeUnit.SECONDS));
+    }
   }
 }

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/resource/PipeTsFileResourceManagerTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/resource/PipeTsFileResourceManagerTest.java
@@ -248,8 +248,34 @@ public class PipeTsFileResourceManagerTest {
 
   @Test
   public void testConcurrentIncreaseTsFile() throws Exception {
+    assertConcurrentIncreaseFileReference(new File(TS_FILE_NAME), true);
+  }
+
+  @Test
+  public void testConcurrentIncreaseCopiedFile() throws Exception {
+    assertConcurrentIncreaseFileReference(new File(MODS_FILE_NAME), false);
+  }
+
+  @Test
+  public void testIncreaseFileReferenceRollsBackOnPublicReferenceFailure() throws Exception {
+    final File originModFile = new File(MODS_FILE_NAME);
+    final File pipeModFile =
+        PipeTsFileResourceManager.getHardlinkOrCopiedFileInPipeDir(originModFile, PIPE_NAME);
+    final File publicModFile =
+        new File(pipeModFile.getParentFile().getParentFile(), pipeModFile.getName());
+    Assert.assertTrue(publicModFile.mkdirs());
+
+    Assert.assertThrows(
+        IOException.class,
+        () -> pipeTsFileResourceManager.increaseFileReference(originModFile, false, PIPE_NAME));
+
+    Assert.assertEquals(0, pipeTsFileResourceManager.getFileReferenceCount(pipeModFile, PIPE_NAME));
+    Assert.assertFalse(Files.exists(pipeModFile.toPath()));
+  }
+
+  private void assertConcurrentIncreaseFileReference(final File originFile, final boolean isTsFile)
+      throws Exception {
     final int concurrency = 64;
-    final File originTsFile = new File(TS_FILE_NAME);
     final CountDownLatch readyLatch = new CountDownLatch(concurrency);
     final CountDownLatch startLatch = new CountDownLatch(1);
     final ExecutorService executor = Executors.newFixedThreadPool(concurrency);
@@ -263,37 +289,36 @@ public class PipeTsFileResourceManagerTest {
                   readyLatch.countDown();
                   startLatch.await();
                   return pipeTsFileResourceManager.increaseFileReference(
-                      originTsFile, true, PIPE_NAME);
+                      originFile, isTsFile, PIPE_NAME);
                 }));
       }
 
       Assert.assertTrue(readyLatch.await(30, TimeUnit.SECONDS));
       startLatch.countDown();
 
-      File pipeTsFile = null;
+      File pipeFile = null;
       for (final Future<File> future : futures) {
         final File referencedFile = future.get(30, TimeUnit.SECONDS);
-        if (pipeTsFile == null) {
-          pipeTsFile = referencedFile;
+        if (pipeFile == null) {
+          pipeFile = referencedFile;
         } else {
-          Assert.assertEquals(pipeTsFile, referencedFile);
+          Assert.assertEquals(pipeFile, referencedFile);
         }
       }
 
-      Assert.assertNotNull(pipeTsFile);
+      Assert.assertNotNull(pipeFile);
       Assert.assertEquals(
-          concurrency, pipeTsFileResourceManager.getFileReferenceCount(pipeTsFile, PIPE_NAME));
+          concurrency, pipeTsFileResourceManager.getFileReferenceCount(pipeFile, PIPE_NAME));
       Assert.assertEquals(
-          concurrency, pipeTsFileResourceManager.getFileReferenceCount(pipeTsFile, null));
-      Assert.assertTrue(Files.exists(pipeTsFile.toPath()));
+          concurrency, pipeTsFileResourceManager.getFileReferenceCount(pipeFile, null));
+      Assert.assertTrue(Files.exists(pipeFile.toPath()));
 
       for (int i = 0; i < concurrency; i++) {
-        pipeTsFileResourceManager.decreaseFileReference(pipeTsFile, PIPE_NAME);
+        pipeTsFileResourceManager.decreaseFileReference(pipeFile, PIPE_NAME);
       }
-      Assert.assertEquals(
-          0, pipeTsFileResourceManager.getFileReferenceCount(pipeTsFile, PIPE_NAME));
-      Assert.assertEquals(0, pipeTsFileResourceManager.getFileReferenceCount(pipeTsFile, null));
-      Assert.assertFalse(Files.exists(pipeTsFile.toPath()));
+      Assert.assertEquals(0, pipeTsFileResourceManager.getFileReferenceCount(pipeFile, PIPE_NAME));
+      Assert.assertEquals(0, pipeTsFileResourceManager.getFileReferenceCount(pipeFile, null));
+      Assert.assertFalse(Files.exists(pipeFile.toPath()));
     } finally {
       startLatch.countDown();
       executor.shutdownNow();


### PR DESCRIPTION
## Description

`PipeTsFileResourceManager.increaseFileReference` checked whether a resource existed before entering the creation critical section. Historical and realtime extractors could both observe a missing resource, then create and put separate `PipeTsFileResource` instances for the same pipe file. The later put overwrote the first reference count, so releasing one event could delete a file that another event still needed. In the reported table pattern IT, this stopped realtime transfer and left the `t0` row missing.

This PR:

- rechecks the private resource map after acquiring the segment lock and reuses the resource created by another caller;
- covers both hard-linked TsFiles and copied sidecar files such as `.mods`/`.resource`;
- rolls back a private reference when creating the shared/public reference fails, preventing a leaked private reference and file;
- makes integration-test `Set<String>` assertions print concise missing and unexpected rows instead of two complete, highly repetitive sets (up to 20 rows per side).

The concurrent regression tests start 64 retain operations together and verify that both private and shared reference counts reach 64, then verify complete cleanup after all releases. A separate failure-path test verifies that a failed public reference increase leaves neither a private count nor a copied file behind.

## Validation

- `mvn -pl iotdb-core/datanode -Dtest=PipeTsFileResourceManagerTest test` (5 tests passed)
- `mvn -pl integration-test -P with-integration-tests -DskipTests test-compile`
- DataNode Checkstyle and Spotless checks
- Integration-test Checkstyle and Spotless checks
- `git diff --check`

This PR has:

- [x] been self-reviewed.
    - [x] concurrent write
- [x] added comments explaining the why and intent where needed.
- [x] added unit tests for concurrent hard-link and copied-file acquisition.
- [x] added a unit test for partial-reference failure rollback.

<hr>

##### Key changed/added classes

- `PipeTsFileResourceManager`
- `PipeTsFileResourceManagerTest`
- `TestUtils`
