### PR TITLE
Fix IndexOutOfBoundsException caused by concurrent sort and delete on TVList

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/datastructure/AlignedTVList.java
@@ -642,7 +642,13 @@ public abstract class AlignedTVList extends TVList {
   }
 
   @Override
-  public int delete(long lowerBound, long upperBound) {
+  /*
+   * Must be synchronized with sort() on the same TVList instance: a query may sort
+   * this list in place (sort() is synchronized), and a concurrent delete would
+   * otherwise read the half-rebuilt indices and throw IndexOutOfBoundsException
+   * or delete wrong rows.
+   */
+  public synchronized int delete(long lowerBound, long upperBound) {
     int deletedNumber = 0;
     for (int i = 0; i < dataTypes.size(); i++) {
       deletedNumber += delete(lowerBound, upperBound, i).left;
@@ -650,7 +656,13 @@ public abstract class AlignedTVList extends TVList {
     return deletedNumber;
   }
 
-  public int deleteTime(long lowerBound, long upperBound) {
+  /*
+   * Must be synchronized with sort() on the same TVList instance: a query may sort
+   * this list in place (sort() is synchronized), and a concurrent delete would
+   * otherwise read the half-rebuilt indices and throw IndexOutOfBoundsException
+   * or delete wrong rows.
+   */
+  public synchronized int deleteTime(long lowerBound, long upperBound) {
     delete(lowerBound, upperBound);
     int prevDeletedCnt = this.timeDeletedCnt;
     for (int i = 0; i < rowCount; i++) {
@@ -693,12 +705,17 @@ public abstract class AlignedTVList extends TVList {
   /**
    * Delete points in a specific column.
    *
+   * <p>Must be synchronized with {@link #sort()} on the same TVList instance: a query may sort this
+   * list in place ({@code sort()} is synchronized), and a concurrent delete would otherwise read
+   * the half-rebuilt {@code indices} and throw IndexOutOfBoundsException or delete wrong rows.
+   *
    * @param lowerBound deletion lower bound
    * @param upperBound deletion upper bound
    * @param columnIndex column index to be deleted
    * @return Delete info pair. Left: deletedNumber int; right: ifDeleteColumn boolean
    */
-  public Pair<Integer, Boolean> delete(long lowerBound, long upperBound, int columnIndex) {
+  public synchronized Pair<Integer, Boolean> delete(
+      long lowerBound, long upperBound, int columnIndex) {
     if (columnIndex >= values.size()) {
       return new Pair<>(0, false);
     }
@@ -721,7 +738,13 @@ public abstract class AlignedTVList extends TVList {
     return new Pair<>(deletedNumber, deleteColumn);
   }
 
-  public void deleteColumn(int columnIndex) {
+  /*
+   * Must be synchronized with sort() on the same TVList instance: a query may sort
+   * this list in place (sort() is synchronized), and a concurrent delete would
+   * otherwise read the half-rebuilt indices and throw IndexOutOfBoundsException
+   * or delete wrong rows.
+   */
+  public synchronized void deleteColumn(int columnIndex) {
     if (bitMaps == null) {
       List<List<BitMap>> localBitMaps = new ArrayList<>(dataTypes.size());
       for (int j = 0; j < dataTypes.size(); j++) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/datastructure/TVList.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/utils/datastructure/TVList.java
@@ -580,7 +580,13 @@ public abstract class TVList implements WALEntryValue {
     return clone();
   }
 
-  public int delete(long lowerBound, long upperBound) {
+  /*
+   * Must be synchronized with sort() on the same TVList instance: a query may sort
+   * this list in place (sort() is synchronized), and a concurrent delete would
+   * otherwise read the half-rebuilt indices and throw IndexOutOfBoundsException
+   * or delete wrong rows.
+   */
+  public synchronized int delete(long lowerBound, long upperBound) {
     int deletedNumber = 0;
     long maxTime = Long.MIN_VALUE;
     long minTime = Long.MAX_VALUE;


### PR DESCRIPTION
## Description

Fix `IndexOutOfBoundsException: Index 0 out of bounds for length 0` thrown in
`AlignedTVList.deleteTime()` / `delete()` when a DELETE races with a query that
sorts the shared working TVList in place.

### Root cause
- Query path: `FileLoaderUtils.loadAlignedTimeSeriesMetadata()` -> ...
  -> `AlignedReadOnlyMemChunk.sortTvLists()` calls `AlignedTVList.sort()` in
  place on the shared (still writable) working TVList. `sort()` is
  `synchronized` on the TVList instance and rebuilds `indices` non-atomically
  (`indices = new ArrayList<>()` then fills it).
- Delete path: `AlignedTVList.deleteTime()` / `delete()` were **not**
  synchronized, so a concurrent DELETE could call `getValueIndex(0)` ->
  `indices.get(0)` while `indices` was momentarily empty ->
  `IndexOutOfBoundsException`, or read half-rebuilt indices and silently delete
  wrong rows.

### Fix
Make `delete()` / `deleteTime()` / `delete(column)` / `deleteColumn()` of
`AlignedTVList` (and `TVList.delete()` for the non-aligned path) `synchronized`
on the same TVList instance as `sort()`, matching the existing monitor already
used by `putAlignedValue` / `clone` / `cloneForFlushSort`.

### Delete path audit
All runtime delete paths converge to `TsFileProcessor.deleteDataInMemory()`
which holds `flushQueryLock.writeLock()`:
`DataRegion.deleteByDevice` / `deleteDataDirectly` ->
`deleteDataInUnsealedFiles` / `deleteDataInSealedFiles` /
`deleteDataDirectlyInFile` -> `TsFileProcessor.deleteDataInMemory` ->
`AbstractMemTable.delete` -> `AlignedWritableMemChunkGroup.delete/deleteTime` ->
`AlignedTVList.delete*`.

WAL recovery paths (`TsFilePlanRedoer`, `UnsealedTsFileRecoverPerformer`) call
`memTable.delete()` directly but only during single-threaded startup, so no
concurrent query/sort exists there.

Lock order stays consistent (`flushQueryLock` -> tvlist monitor on both delete
and query-clone paths; query in-place sort holds only the tvlist monitor because
the read lock is released before `sortTvLists()` runs), so no deadlock is
introduced.