### PR TITLE
Fix write-back sink tree target database case

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/treemodel/manual/IoTDBPipeWriteBackSinkIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/treemodel/manual/IoTDBPipeWriteBackSinkIT.java
@@ -21,6 +21,7 @@ package org.apache.iotdb.pipe.it.dual.treemodel.manual;
 
 import org.apache.iotdb.common.rpc.thrift.TSStatus;
 import org.apache.iotdb.commons.client.sync.SyncConfigNodeIServiceClient;
+import org.apache.iotdb.commons.utils.PathUtils;
 import org.apache.iotdb.confignode.rpc.thrift.TCreatePipeReq;
 import org.apache.iotdb.db.it.utils.TestUtils;
 import org.apache.iotdb.it.framework.IoTDBTestRunner;
@@ -44,13 +45,26 @@ public class IoTDBPipeWriteBackSinkIT extends AbstractPipeDualTreeModelManualIT 
 
   @Test
   public void testWriteBackSinkWithTargetDatabaseForTreeModel() throws Exception {
+    testWriteBackSinkWithTargetDatabaseForTreeModel("root.target.db");
+  }
+
+  @Test
+  public void testWriteBackSinkPreservesTreeModelTargetDatabaseCase() throws Exception {
+    testWriteBackSinkWithTargetDatabaseForTreeModel("TargetDB");
+  }
+
+  private void testWriteBackSinkWithTargetDatabaseForTreeModel(final String targetDatabase)
+      throws Exception {
+    final String qualifiedTargetDatabase = PathUtils.qualifyDatabaseName(targetDatabase);
     TestUtils.executeNonQueries(
         senderEnv,
         Arrays.asList(
             "create database root.source",
             "create timeseries root.source.d1.s1 with datatype=INT32,encoding=PLAIN",
-            "create database root.target.db",
-            "create timeseries root.target.db.d1.s1 with datatype=INT32,encoding=PLAIN"),
+            "create database " + qualifiedTargetDatabase,
+            "create timeseries "
+                + qualifiedTargetDatabase
+                + ".d1.s1 with datatype=INT32,encoding=PLAIN"),
         null);
 
     try (final SyncConfigNodeIServiceClient client =
@@ -65,7 +79,7 @@ public class IoTDBPipeWriteBackSinkIT extends AbstractPipeDualTreeModelManualIT 
       sourceAttributes.put("user", "root");
 
       sinkAttributes.put("sink", "write-back-sink");
-      sinkAttributes.put("sink.database", "root.target.db");
+      sinkAttributes.put("sink.database", targetDatabase);
       sinkAttributes.put("user", "root");
 
       final TSStatus status =
@@ -89,8 +103,8 @@ public class IoTDBPipeWriteBackSinkIT extends AbstractPipeDualTreeModelManualIT 
 
     TestUtils.assertDataEventuallyOnEnv(
         senderEnv,
-        "select * from root.target.db.**",
-        "Time,root.target.db.d1.s1,",
+        "select * from " + qualifiedTargetDatabase + ".**",
+        "Time," + qualifiedTargetDatabase + ".d1.s1,",
         Collections.unmodifiableSet(new HashSet<>(Arrays.asList("1,1,", "2,2,"))));
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/writeback/WriteBackSink.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/writeback/WriteBackSink.java
@@ -345,10 +345,10 @@ public class WriteBackSink implements PipeConnector {
     // runtime model. Normalize one configured target database to both model names, and later use
     // the one matching the incoming event model.
     if (PathUtils.isTableModelDatabase(targetDatabase)) {
+      // Table-model database names are case-insensitive, while tree-model paths are case-sensitive.
       targetTableModelDatabaseName = targetDatabase.toLowerCase(Locale.ENGLISH);
       targetTreeModelDatabaseName =
-          validateAndNormalizeTreeModelDatabaseName(
-              PathUtils.qualifyDatabaseName(targetTableModelDatabaseName));
+          validateAndNormalizeTreeModelDatabaseName(PathUtils.qualifyDatabaseName(targetDatabase));
       return;
     }
 

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/sink/PipeSinkTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/sink/PipeSinkTest.java
@@ -500,7 +500,7 @@ public class PipeSinkTest {
           "testtarget", getWriteBackSinkDatabaseName(sink, "targetTableModelDatabaseName"));
       Assert.assertNull(getWriteBackSinkDatabaseName(sink, "invalidTargetTableModelDatabaseName"));
       Assert.assertEquals(
-          "root.testtarget", getWriteBackSinkDatabaseName(sink, "targetTreeModelDatabaseName"));
+          "root.TestTarget", getWriteBackSinkDatabaseName(sink, "targetTreeModelDatabaseName"));
     }
 
     try (final WriteBackSink sink = createCustomizedWriteBackSink("root.target")) {


### PR DESCRIPTION
## Summary

- preserve the original case when an unqualified write-back sink target database is mapped to a tree-model path
- continue normalizing the corresponding table-model database name to lowercase
- add unit and manual dual-tree integration regression coverage

## Testing

- `mvn -o -nsu test -pl iotdb-core/datanode -Dtest=PipeSinkTest#testWriteBackSinkTargetDatabaseCustomization`
- `mvn -nsu -pl integration-test -P with-integration-tests -P MultiClusterIT2DualTreeManual -DskipUTs -Dit.test=IoTDBPipeWriteBackSinkIT#testWriteBackSinkPreservesTreeModelTargetDatabaseCase -DfailIfNoTests=false -Dfailsafe.failIfNoSpecifiedTests=true -Drat.skip=true failsafe:integration-test@integration-test failsafe:verify@verify`