### PR TITLE
[Pipe] Fix config event race in idempotent table IT

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/tablemodel/manual/enhanced/IoTDBPipeIdempotentIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/dual/tablemodel/manual/enhanced/IoTDBPipeIdempotentIT.java
@@ -257,6 +257,11 @@ public class IoTDBPipeIdempotentIT extends AbstractPipeTableModelDualManualIT {
     TestUtils.executeNonQueries(
         database, BaseEnv.TABLE_SQL_DIALECT, senderEnv, beforeSqlList, null);
 
+    // Pipe transfers config events in order. Use a database event as a progress marker to ensure
+    // that all preparation statements have been applied on receiverEnv.
+    TableModelUtils.createDatabase(senderEnv, "test1");
+    TableModelUtils.hasDataBase("test1", receiverEnv);
+
     TestUtils.executeNonQuery(database, BaseEnv.TABLE_SQL_DIALECT, receiverEnv, testSql, null);
 
     // Create an idempotent conflict
@@ -265,6 +270,6 @@ public class IoTDBPipeIdempotentIT extends AbstractPipeTableModelDualManualIT {
     TableModelUtils.createDatabase(senderEnv, "test2");
 
     // Assume that the "database" is executed on receiverEnv
-    TestUtils.assertDataSizeEventuallyOnEnv(receiverEnv, "show databases", 3, null);
+    TestUtils.assertDataSizeEventuallyOnEnv(receiverEnv, "show databases", 4, null);
   }
 }


### PR DESCRIPTION
## Description

`IoTDBPipeIdempotentIT` executes preparation statements on the sender and immediately executes the conflict statement on the receiver. Since Pipe transfers config events asynchronously, the receiver may not have the required table or user yet, causing flaky `does not exist` errors before the idempotent conflict is created.

This change adds a database config event as a progress marker after the preparation statements and waits until it reaches the receiver. It also updates the final database count to include the marker database.

## Tests

- `mvn spotless:apply -pl integration-test -Pwith-integration-tests`
- The two originally failing methods passed together:
  - `testTableAlterUserIdempotent3`
  - `testSetTableColumnCommentIdempotent`
- Full `IoTDBPipeIdempotentIT`: 23 methods passed; one method hit a transient DataNode `Connection refused` error and passed when rerun separately.