### PR TITLE
[Fix] Prevent DataNode restart NPE during database deletion

### DIFF
--- a/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/schema/ClusterSchemaManager.java
+++ b/iotdb-core/confignode/src/main/java/org/apache/iotdb/confignode/manager/schema/ClusterSchemaManager.java
@@ -1448,8 +1448,11 @@ public class ClusterSchemaManager {
       // 1. if the alteringTableList is null, means that executing the drop database is going on
       if (Objects.isNull(alteringTableList)) {
         List<TsTable> relatedTables = usingTableMap.remove(databaseName);
-        relatedTables.forEach(
-            table -> speicalMapList.add(new NonCommittableTsTable(table.getTableName())));
+        // The database schema may already be removed while its deletion procedure is still running.
+        if (Objects.nonNull(relatedTables)) {
+          relatedTables.forEach(
+              table -> speicalMapList.add(new NonCommittableTsTable(table.getTableName())));
+        }
       } else {
         // 2. if the table has existed, the procedure is modifying it.
         // so the usingTableMap and specialStatusMap both hold it

--- a/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/ClusterSchemaManagerTest.java
+++ b/iotdb-core/confignode/src/test/java/org/apache/iotdb/confignode/manager/ClusterSchemaManagerTest.java
@@ -18,10 +18,21 @@
  */
 package org.apache.iotdb.confignode.manager;
 
+import org.apache.iotdb.commons.schema.table.TsTable;
+import org.apache.iotdb.commons.schema.table.TsTableInternalRPCUtil;
 import org.apache.iotdb.confignode.manager.schema.ClusterSchemaManager;
+import org.apache.iotdb.confignode.manager.schema.ClusterSchemaQuotaStatistics;
+import org.apache.iotdb.confignode.persistence.schema.ClusterSchemaInfo;
 
+import org.apache.tsfile.utils.Pair;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ClusterSchemaManagerTest {
 
@@ -36,5 +47,31 @@ public class ClusterSchemaManagerTest {
 
     // (resourceWeight * resource) / (createdStorageGroupNum * replicationFactor)
     Assert.assertEquals(20, ClusterSchemaManager.calcMaxRegionGroupNum(3, 1.0, 120, 2, 3, 5));
+  }
+
+  @Test
+  public void testGetAllTableInfoForDataNodeActivationWithDeletedDatabase() {
+    final IManager configManager = Mockito.mock(IManager.class);
+    final ProcedureManager procedureManager = Mockito.mock(ProcedureManager.class);
+    final ClusterSchemaInfo clusterSchemaInfo = Mockito.mock(ClusterSchemaInfo.class);
+
+    Mockito.when(configManager.getProcedureManager()).thenReturn(procedureManager);
+    Mockito.when(procedureManager.getAllExecutingTables())
+        .thenReturn(Collections.singletonMap("test", null));
+    Mockito.when(clusterSchemaInfo.getAllUsingTables()).thenReturn(new HashMap<>());
+    Mockito.when(clusterSchemaInfo.getAllPreDeleteTables()).thenReturn(new HashMap<>());
+    Mockito.when(clusterSchemaInfo.getAllPreCreateTables()).thenReturn(new HashMap<>());
+
+    final ClusterSchemaManager clusterSchemaManager =
+        new ClusterSchemaManager(
+            configManager, clusterSchemaInfo, Mockito.mock(ClusterSchemaQuotaStatistics.class));
+
+    final Pair<Map<String, List<TsTable>>, Map<String, List<TsTable>>> tableInfo =
+        TsTableInternalRPCUtil.deserializeTableInitializationInfo(
+            clusterSchemaManager.getAllTableInfoForDataNodeActivation());
+
+    Assert.assertTrue(tableInfo.left.isEmpty());
+    Assert.assertEquals(Collections.singleton("test"), tableInfo.right.keySet());
+    Assert.assertTrue(tableInfo.right.get("test").isEmpty());
   }
 }


### PR DESCRIPTION
## Description

### Problem

When a table-model database deletion procedure is still running after the database schema has already been removed, `getAllExecutingTables` reports the database with a null table list while `getAllUsingTables` no longer contains that database.

`getAllTableInfoForDataNodeActivation` previously called `forEach` on the missing table list. This caused a ConfigNode `NullPointerException` and repeatedly rejected DataNode restart requests and metadata lease cache recovery.

### Fix

Skip the non-committable table conversion when the deleting database is already absent from the using-table map. There are no remaining using tables to mark in that state, and the special database status is still serialized.

### Test

Added a unit test that reproduces the state where a database deletion is executing but the database has already been removed from the using-table map.

Tested with:

    mvn test -pl iotdb-core/confignode -Dtest=ClusterSchemaManagerTest

This PR has:
- [x] been self-reviewed.
    - [x] concurrent read and write
- [x] added comments explaining the why and intent of the code.
- [x] added unit tests to cover the new code path.

##### Key changed/added classes

- `ClusterSchemaManager`
- `ClusterSchemaManagerTest`