### PR TITLE
[To dev/1.3] Fix write-back sink tree target database case

### DIFF
--- a/integration-test/src/test/java/org/apache/iotdb/pipe/it/manual/IoTDBPipeWriteBackSinkIT.java
+++ b/integration-test/src/test/java/org/apache/iotdb/pipe/it/manual/IoTDBPipeWriteBackSinkIT.java
@@ -44,13 +44,27 @@ public class IoTDBPipeWriteBackSinkIT extends AbstractPipeDualManualIT {
 
   @Test
   public void testWriteBackSinkWithTargetDatabaseForTreeModel() throws Exception {
+    testWriteBackSinkWithTargetDatabaseForTreeModel("root.target.db");
+  }
+
+  @Test
+  public void testWriteBackSinkPreservesTreeModelTargetDatabaseCase() throws Exception {
+    testWriteBackSinkWithTargetDatabaseForTreeModel("TargetDB");
+  }
+
+  private void testWriteBackSinkWithTargetDatabaseForTreeModel(final String targetDatabase)
+      throws Exception {
+    final String qualifiedTargetDatabase =
+        targetDatabase.startsWith("root.") ? targetDatabase : "root." + targetDatabase;
     TestUtils.executeNonQueries(
         senderEnv,
         Arrays.asList(
             "create database root.source",
             "create timeseries root.source.d1.s1 with datatype=INT32,encoding=PLAIN",
-            "create database root.target.db",
-            "create timeseries root.target.db.d1.s1 with datatype=INT32,encoding=PLAIN"),
+            "create database " + qualifiedTargetDatabase,
+            "create timeseries "
+                + qualifiedTargetDatabase
+                + ".d1.s1 with datatype=INT32,encoding=PLAIN"),
         null);
 
     try (final SyncConfigNodeIServiceClient client =
@@ -65,7 +79,7 @@ public class IoTDBPipeWriteBackSinkIT extends AbstractPipeDualManualIT {
       sourceAttributes.put("user", "root");
 
       sinkAttributes.put("sink", "write-back-sink");
-      sinkAttributes.put("sink.database", "root.target.db");
+      sinkAttributes.put("sink.database", targetDatabase);
       sinkAttributes.put("user", "root");
 
       final TSStatus status =
@@ -89,8 +103,8 @@ public class IoTDBPipeWriteBackSinkIT extends AbstractPipeDualManualIT {
 
     TestUtils.assertDataEventuallyOnEnv(
         senderEnv,
-        "select * from root.target.db.**",
-        "Time,root.target.db.d1.s1,",
+        "select * from " + qualifiedTargetDatabase + ".**",
+        "Time," + qualifiedTargetDatabase + ".d1.s1,",
         Collections.unmodifiableSet(new HashSet<>(Arrays.asList("1,1,", "2,2,"))));
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/writeback/WriteBackSink.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/writeback/WriteBackSink.java
@@ -64,7 +64,6 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Locale;
 import java.util.Objects;
 
 import static org.apache.iotdb.commons.conf.IoTDBConstant.MAX_DATABASE_NAME_LENGTH;
@@ -115,7 +114,7 @@ public class WriteBackSink implements PipeConnector {
       return validateAndNormalizeTreeModelDatabaseName(
           IoTDBConstant.PATH_ROOT
               + IoTDBConstant.PATH_SEPARATOR
-              + trimmedTargetDatabase.toLowerCase(Locale.ENGLISH));
+              + trimmedTargetDatabase);
     } catch (final Exception e) {
       throw new PipeException(
           String.format("The target database %s is invalid.", targetDatabase), e);

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/writeback/WriteBackSink.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/sink/protocol/writeback/WriteBackSink.java
@@ -112,9 +112,7 @@ public class WriteBackSink implements PipeConnector {
     try {
       PathUtils.checkAndReturnSingleMeasurement(trimmedTargetDatabase);
       return validateAndNormalizeTreeModelDatabaseName(
-          IoTDBConstant.PATH_ROOT
-              + IoTDBConstant.PATH_SEPARATOR
-              + trimmedTargetDatabase);
+          IoTDBConstant.PATH_ROOT + IoTDBConstant.PATH_SEPARATOR + trimmedTargetDatabase);
     } catch (final Exception e) {
       throw new PipeException(
           String.format("The target database %s is invalid.", targetDatabase), e);


### PR DESCRIPTION
Backport the tree-model write-back sink database case fix from 6a253567b08632bf4643241d4d324404d487eaec (#18398).\n\nThe 1.3 implementation lowercased non-root target database names before qualifying them as root paths. Preserve the configured case instead, and add a regression test for TargetDB -> root.TargetDB.\n\nThe original fix is already present in origin/master; this PR targets dev/1.3.