### PR TITLE
Fix Pipe tablet memory resize admission limit

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManager.java
@@ -472,12 +472,23 @@ public class PipeMemoryManager {
         && (double) usedMemorySizeInBytesOfTsFiles < allowedMaxMemorySizeInBytesOfTsTiles();
   }
 
-  private boolean isHardEnoughForResizing(final PipeMemoryBlock block) {
+  private boolean isHardEnoughForResizing(
+      final PipeMemoryBlock block, final long extraMemoryInBytes) {
     if (block instanceof PipeTabletMemoryBlock) {
-      return isHardEnough4TabletParsing();
+      return (double) usedMemorySizeInBytesOfTablets
+                  + (double) extraMemoryInBytes
+                  + (double) usedMemorySizeInBytesOfTsFiles
+              < allowedMaxMemorySizeInBytesOfTabletsAndTsFiles()
+          && (double) usedMemorySizeInBytesOfTablets + (double) extraMemoryInBytes
+              < allowedMaxMemorySizeInBytesOfTablets();
     }
     if (block instanceof PipeTsFileMemoryBlock) {
-      return isHardEnough4TsFileSlicing();
+      return (double) usedMemorySizeInBytesOfTablets
+                  + (double) usedMemorySizeInBytesOfTsFiles
+                  + (double) extraMemoryInBytes
+              < allowedMaxMemorySizeInBytesOfTabletsAndTsFiles()
+          && (double) usedMemorySizeInBytesOfTsFiles + (double) extraMemoryInBytes
+              < allowedMaxMemorySizeInBytesOfTsTiles();
     }
     return true;
   }
@@ -710,7 +721,7 @@ public class PipeMemoryManager {
       // Dynamically resized data-structure blocks must obey the same admission thresholds as
       // blocks allocated with a non-zero initial size. Otherwise they can exhaust the pool and
       // prevent downstream consumers from allocating the memory needed to release them.
-      if (isHardEnoughForResizing(block)
+      if (isHardEnoughForResizing(block, sizeInBytes)
           && getTotalNonFloatingMemorySizeInBytes() - memoryBlock.getUsedMemoryInBytes()
               >= sizeInBytes) {
         memoryBlock.forceAllocateWithoutLimitation(sizeInBytes);

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManagerResizeTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManagerResizeTest.java
@@ -77,6 +77,29 @@ public class PipeMemoryManagerResizeTest {
   }
 
   @Test
+  public void testTabletResizeCannotCrossTabletHardLimit() {
+    final PipeMemoryManager manager =
+        new PipeMemoryManager(
+            new AtomicLongMemoryBlock(
+                "PipeMemoryManagerResizeTest",
+                null,
+                TOTAL_MEMORY_SIZE_IN_BYTES,
+                MemoryBlockType.DYNAMIC));
+    final PipeTabletMemoryBlock tablet = manager.forceAllocateForTabletWithRetry(0);
+
+    try {
+      Assert.assertThrows(
+          PipeRuntimeOutOfMemoryCriticalException.class,
+          () -> manager.forceResize(tablet, TABLET_MEMORY_SIZE_IN_BYTES));
+      Assert.assertEquals(0, tablet.getMemoryUsageInBytes());
+      Assert.assertEquals(0, manager.getUsedMemorySizeInBytes());
+      Assert.assertEquals(0, manager.getUsedMemorySizeInBytesOfTablets());
+    } finally {
+      manager.release(tablet);
+    }
+  }
+
+  @Test
   public void testTabletResizeLeavesMemoryForSinkForwardProgress() {
     final PipeMemoryManager manager =
         new PipeMemoryManager(


### PR DESCRIPTION
## Description

The Pipe tablet parser can reserve a zero-sized memory block and grow it with `forceResize()`. The resize path previously checked only the remaining Pipe memory, so one expansion could exceed the Tablet category hard limit. Subsequent small allocations could then be rejected.

This change checks projected category usage, including the pending resize amount, for Tablet and TsFile memory blocks before allocation. A rejected resize leaves the block and memory accounting unchanged.

The regression test covers a zero-sized Tablet block whose resize would cross the Tablet hard limit.

## Verification

- `mvn spotless:apply -pl iotdb-core/datanode`
- `mvn -o compile -pl iotdb-core/datanode -DskipTests -Dcheckstyle.skip=true`
- `PipeMemoryManagerResizeTest` compiled with the module test classpath and run via JUnitCore: 2 tests passed.

The Maven test goal exceeded the local five-minute test-compilation timeout; the GitHub Actions checks are running on the PR.