### PR TITLE
Fix pipe tablet memory resize admission limit (#18413)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManager.java
@@ -472,12 +472,23 @@ public class PipeMemoryManager {
         && (double) usedMemorySizeInBytesOfTsFiles < allowedMaxMemorySizeInBytesOfTsTiles();
   }
 
-  private boolean isHardEnoughForResizing(final PipeMemoryBlock block) {
+  private boolean isHardEnoughForResizing(
+      final PipeMemoryBlock block, final long extraMemoryInBytes) {
     if (block instanceof PipeTabletMemoryBlock) {
-      return isHardEnough4TabletParsing();
+      return (double) usedMemorySizeInBytesOfTablets
+                  + (double) extraMemoryInBytes
+                  + (double) usedMemorySizeInBytesOfTsFiles
+              < allowedMaxMemorySizeInBytesOfTabletsAndTsFiles()
+          && (double) usedMemorySizeInBytesOfTablets + (double) extraMemoryInBytes
+              < allowedMaxMemorySizeInBytesOfTablets();
     }
     if (block instanceof PipeTsFileMemoryBlock) {
-      return isHardEnough4TsFileSlicing();
+      return (double) usedMemorySizeInBytesOfTablets
+                  + (double) usedMemorySizeInBytesOfTsFiles
+                  + (double) extraMemoryInBytes
+              < allowedMaxMemorySizeInBytesOfTabletsAndTsFiles()
+          && (double) usedMemorySizeInBytesOfTsFiles + (double) extraMemoryInBytes
+              < allowedMaxMemorySizeInBytesOfTsTiles();
     }
     return true;
   }
@@ -705,7 +716,7 @@ public class PipeMemoryManager {
       // Dynamically resized data-structure blocks must obey the same admission thresholds as
       // blocks allocated with a non-zero initial size. Otherwise they can exhaust the pool and
       // prevent downstream consumers from allocating the memory needed to release them.
-      if (isHardEnoughForResizing(block)
+      if (isHardEnoughForResizing(block, sizeInBytes)
           && getTotalNonFloatingMemorySizeInBytes() - usedMemorySizeInBytes >= sizeInBytes) {
         usedMemorySizeInBytes += sizeInBytes;
         if (oldSize == 0) {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManagerResizeTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/pipe/resource/memory/PipeMemoryManagerResizeTest.java
@@ -71,6 +71,30 @@ public class PipeMemoryManagerResizeTest {
   }
 
   @Test
+  public void testTabletResizeCannotCrossTabletHardLimit() {
+    final PipeMemoryManager manager = new PipeMemoryManager();
+    final PipeTabletMemoryBlock tablet = manager.forceAllocateForTabletWithRetry(0);
+    final long tabletMemorySizeInBytes =
+        (long)
+                (PipeMemoryManager.getTotalNonFloatingMemorySizeInBytes()
+                    * (config.getPipeDataStructureTabletMemoryBlockAllocationRejectThreshold()
+                        + config.getPipeDataStructureTsFileMemoryBlockAllocationRejectThreshold()
+                            / 2))
+            + 1;
+
+    try {
+      Assert.assertThrows(
+          PipeRuntimeOutOfMemoryCriticalException.class,
+          () -> manager.forceResize(tablet, tabletMemorySizeInBytes));
+      Assert.assertEquals(0, tablet.getMemoryUsageInBytes());
+      Assert.assertEquals(0, manager.getUsedMemorySizeInBytes());
+      Assert.assertEquals(0, manager.getUsedMemorySizeInBytesOfTablets());
+    } finally {
+      manager.release(tablet);
+    }
+  }
+
+  @Test
   public void testTabletResizeLeavesMemoryForSinkForwardProgress() {
     final PipeMemoryManager manager = new PipeMemoryManager();
     final long totalNonFloatingMemorySizeInBytes =


### PR DESCRIPTION
Cherry-pick of 5be170d6a1ffa992fff8ef2e83206dbf2c49bb3f for dev/1.3. Applies tablet/tsfile hard-limit admission checks to dynamically resized memory blocks and adds a regression test. Spotless passed; targeted Maven test was blocked by existing unrelated compilation errors.