### PR TITLE
[To dev/1.3] Reduce AirGap receiver log noise (#18424)

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/airgap/IoTDBAirGapReceiver.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/pipe/receiver/protocol/airgap/IoTDBAirGapReceiver.java
@@ -161,10 +161,6 @@ public class IoTDBAirGapReceiver extends WrappedRunnable {
     } else if (status.getCode() == TSStatusCode.REDIRECTION_RECOMMEND.getStatusCode()
         || status.getCode()
             == TSStatusCode.PIPE_RECEIVER_IDEMPOTENT_CONFLICT_EXCEPTION.getStatusCode()) {
-      LOGGER.info(
-          "Pipe air gap receiver {}: TSStatus {} is encountered at the air gap receiver, will ignore.",
-          receiverId,
-          resp.getStatus());
       ok();
     } else if (status.getCode()
         == TSStatusCode.PIPE_RECEIVER_TEMPORARY_UNAVAILABLE_EXCEPTION.getStatusCode()) {
@@ -173,8 +169,6 @@ public class IoTDBAirGapReceiver extends WrappedRunnable {
       } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();
       }
-      LOGGER.info(
-          "Temporary unavailable exception encountered at air gap receiver, will retry locally.");
       if (System.currentTimeMillis() - startTime
           < PipeConfig.getInstance().getPipeAirGapRetryMaxMs()) {
         handleReq(req, startTime);


### PR DESCRIPTION
## Summary

- Backport #18424 to `dev/1.3`.
- Remove the per-request INFO log for redirect and idempotent-conflict statuses in the AirGap receiver.
- Remove the repetitive INFO log emitted on each temporary-unavailable retry.

## Testing

- `mvn spotless:apply -pl iotdb-core/datanode`
- `git diff --check`
- `mvn -o -nsu -Ddevelocity.off=true compile -pl iotdb-core/datanode` (Checkstyle and Spotless pass; compilation reaches javac but is blocked by pre-existing cross-module/generated-API mismatches involving `areOptionsEnabled`, SQL parser accessors, and `shouldWaitForSchemaBeforeLoad`. The changed file reports no errors.)